### PR TITLE
feat(mac): add native Mac installer preview

### DIFF
--- a/.github/workflows/native-mac-installer-preview.yaml
+++ b/.github/workflows/native-mac-installer-preview.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release / Mac Installer Preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-mac-installer-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos-dmg:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.16.0"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build Mac Installer Preview DMG
+        env:
+          DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: npm run build:native-mac-installer
+
+      - name: Upload Mac Installer Preview artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: NemoClaw-Mac-Installer-Preview
+          path: |
+            build/native-mac-installer-preview/*.dmg
+            build/native-mac-installer-preview/*.app
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ coverage/
 dist/
 docs/_build/
 node_modules/
+build/
+.build/
 
 # OS metadata
 .DS_Store

--- a/apps/native-installers/macos/NemoClawMacInstaller/Package.swift
+++ b/apps/native-installers/macos/NemoClawMacInstaller/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "NemoClawMacInstaller",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "NemoClawMacInstaller", targets: ["NemoClawMacInstaller"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "NemoClawMacInstaller",
+            resources: [.process("Resources")]
+        )
+    ]
+)

--- a/apps/native-installers/macos/NemoClawMacInstaller/README.md
+++ b/apps/native-installers/macos/NemoClawMacInstaller/README.md
@@ -1,0 +1,13 @@
+# NemoClaw Mac Installer Preview
+
+Experimental macOS SwiftUI shell for the opt-in Mac Installer Preview path.
+
+The app calls the app-facing CLI APIs:
+
+- `nemoclaw native-installer mac assess --json`
+- `nemoclaw native-installer mac install --config <json> --json-progress`
+- `nemoclaw native-installer mac launch --agent <openclaw|hermes> --json`
+- `nemoclaw diagnostics export --output <path>`
+
+Set `NEMOCLAW_MAC_INSTALLER_CLI` to point at a bundled or local `nemoclaw` binary during development.
+Release builds should use the payload assembled by `scripts/native-installers/macos/build-preview.sh`.

--- a/apps/native-installers/macos/NemoClawMacInstaller/Sources/NemoClawMacInstaller/NemoClawMacInstallerApp.swift
+++ b/apps/native-installers/macos/NemoClawMacInstaller/Sources/NemoClawMacInstaller/NemoClawMacInstallerApp.swift
@@ -1,0 +1,1570 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import AppKit
+import SwiftUI
+
+enum MacInstallerStep: String, CaseIterable, Identifiable {
+    case requirements = "Ready"
+    case agent = "Agent"
+    case model = "Model"
+    case security = "Trust"
+    case review = "Review"
+    case deploy = "Install"
+    case launch = "Launch"
+
+    var id: String { rawValue }
+}
+
+struct PlanAgent: Decodable, Identifiable, Hashable {
+    let name: String
+    let displayName: String
+    let description: String
+    let dashboardKind: String
+    let port: Int
+    let messaging: [String]
+    let label: String?
+    let icon: String?
+    let recommended: Bool
+
+    var id: String { name }
+    var title: String { displayName }
+    var subtitle: String { description }
+    var bestFor: String { label ?? (recommended ? "Recommended" : "Preview") }
+    var systemIcon: String { icon ?? "sparkles" }
+
+    static let fallback = [
+        PlanAgent(
+            name: "openclaw",
+            displayName: "OpenClaw",
+            description: "Gateway-based AI agent with plugin ecosystem.",
+            dashboardKind: "ui",
+            port: 18789,
+            messaging: ["telegram", "discord", "slack", "wechat", "whatsapp"],
+            label: "Browser UI sandbox",
+            icon: "rectangle.connected.to.line.below",
+            recommended: true
+        ),
+        PlanAgent(
+            name: "hermes",
+            displayName: "Hermes Agent",
+            description: "Hermes Agent sandbox with an OpenAI-compatible local API endpoint.",
+            dashboardKind: "api",
+            port: 8642,
+            messaging: ["telegram", "discord", "slack", "wechat", "whatsapp"],
+            label: "Local API sandbox",
+            icon: "curlybraces.square",
+            recommended: false
+        ),
+    ]
+}
+
+struct ProviderOption: Decodable, Identifiable, Hashable {
+    let id: String
+    let title: String
+    let defaultModel: String
+    let envVar: String?
+    let guidance: String
+    let systemImage: String
+    let recommended: Bool
+    let supportedAgents: [String]?
+
+    static let fallbackAll: [ProviderOption] = [
+        ProviderOption(
+            id: "openai",
+            title: "OpenAI",
+            defaultModel: "gpt-5.4",
+            envVar: "OPENAI_API_KEY",
+            guidance: "OpenAI provider from the onboard catalog using its default model.",
+            systemImage: "cloud",
+            recommended: true,
+            supportedAgents: nil
+        ),
+        ProviderOption(
+            id: "anthropic",
+            title: "Anthropic",
+            defaultModel: "claude-sonnet-4-6",
+            envVar: "ANTHROPIC_API_KEY",
+            guidance: "Anthropic provider from the onboard catalog using its default model.",
+            systemImage: "text.book.closed",
+            recommended: false,
+            supportedAgents: nil
+        ),
+        ProviderOption(
+            id: "gemini",
+            title: "Google Gemini",
+            defaultModel: "gemini-2.5-flash",
+            envVar: "GEMINI_API_KEY",
+            guidance: "Google Gemini provider from the onboard catalog using its default model.",
+            systemImage: "diamond",
+            recommended: false,
+            supportedAgents: nil
+        ),
+        ProviderOption(
+            id: "build",
+            title: "NVIDIA Endpoints",
+            defaultModel: "nvidia/nemotron-3-super-120b-a12b",
+            envVar: "NVIDIA_API_KEY",
+            guidance: "NVIDIA-hosted inference using the curated onboard default.",
+            systemImage: "cpu",
+            recommended: false,
+            supportedAgents: nil
+        ),
+        ProviderOption(
+            id: "ollama",
+            title: "Local Ollama",
+            defaultModel: "nemotron-3-nano:30b",
+            envVar: nil,
+            guidance: "Local Ollama provider from the onboard catalog using its default model.",
+            systemImage: "desktopcomputer",
+            recommended: false,
+            supportedAgents: nil
+        ),
+        ProviderOption(
+            id: "hermesProvider",
+            title: "Hermes Provider",
+            defaultModel: "moonshotai/kimi-k2.6",
+            envVar: "NOUS_API_KEY",
+            guidance: "Use the Hermes stack as the model provider when installing Hermes Agent.",
+            systemImage: "point.3.filled.connected.trianglepath.dotted",
+            recommended: false,
+            supportedAgents: ["hermes"]
+        ),
+    ]
+
+    static func option(for id: String, in options: [ProviderOption]) -> ProviderOption {
+        options.first { $0.id == id } ?? options.first ?? fallbackAll[0]
+    }
+}
+
+struct SecurityChoice: Decodable, Identifiable, Hashable {
+    let id: String
+    let title: String
+    let description: String
+    let icon: String
+    let recommended: Bool
+    let presets: [String]
+
+    static let fallbackAll = [
+        SecurityChoice(
+            id: "restricted",
+            title: "Careful",
+            description: "Tighter defaults for first-time installs or sensitive machines.",
+            icon: "lock.shield",
+            recommended: false,
+            presets: []
+        ),
+        SecurityChoice(
+            id: "balanced",
+            title: "Balanced",
+            description: "Recommended. Gives the agent room to work while keeping sharp edges covered.",
+            icon: "checkmark.shield",
+            recommended: true,
+            presets: []
+        ),
+        SecurityChoice(
+            id: "open",
+            title: "Open",
+            description: "For trusted experiments where speed matters more than restraint.",
+            icon: "lock.open",
+            recommended: false,
+            presets: []
+        ),
+    ]
+}
+
+struct PlanModel: Decodable {
+    let defaultProvider: String
+    let providers: [ProviderOption]
+}
+
+struct PlanTrust: Decodable {
+    let defaultTier: String
+    let tiers: [SecurityChoice]
+}
+
+struct PlanReview: Decodable {
+    let handoffPolicy: String
+    let stockOnly: String
+}
+
+struct PlanInstall: Decodable {
+    let defaultSandboxName: String
+    let defaultMode: String
+}
+
+struct MacInstallerPlan: Decodable {
+    let source: String
+    let target: String
+    let summary: String
+    let agents: [PlanAgent]
+    let model: PlanModel
+    let trust: PlanTrust
+    let review: PlanReview
+    let install: PlanInstall
+}
+
+struct ProgressEvent: Decodable, Identifiable {
+    let id = UUID()
+    let phase: String
+    let status: String
+    let message: String
+
+    private enum CodingKeys: String, CodingKey {
+        case phase
+        case status
+        case message
+    }
+}
+
+struct Requirement: Decodable, Identifiable {
+    let id: String
+    let label: String
+    let status: String
+    let detail: String
+    let recovery: String?
+}
+
+struct Assessment: Decodable {
+    let supported: Bool
+    let requirements: [Requirement]
+    let recoveryActions: [String]
+}
+
+struct LaunchApiInfo: Decodable {
+    let baseUrl: String
+    let chatCompletionsUrl: String
+    let healthUrl: String
+    let token: String?
+    let authHeader: String?
+}
+
+struct LaunchInfo: Decodable {
+    let agent: String
+    let sandboxName: String
+    let kind: String
+    let url: String
+    let token: String?
+    let terminalCommand: String?
+    let api: LaunchApiInfo?
+}
+
+struct SecurityConfig: Encodable {
+    let tier: String
+}
+
+struct MacInstallerInstallConfig: Encodable {
+    let agent: String
+    let sandboxName: String
+    let provider: String
+    let model: String
+    let mode: String
+    let security: SecurityConfig
+    let messaging: [String]
+}
+
+@MainActor
+final class MacInstallerModel: ObservableObject {
+    @Published var selectedAgent = "openclaw"
+    @Published var provider = "openai"
+    @Published var model = "gpt-5.4"
+    @Published var sandboxName = "nemoclaw-mac-preview"
+    @Published var securityTier = "balanced"
+    @Published var mode = "fresh"
+    @Published var messaging = Set<String>()
+    @Published var temporarySecret = ""
+    @Published var events: [ProgressEvent] = []
+    @Published var assessment: Assessment?
+    @Published var resolvedPlan: MacInstallerPlan?
+    @Published var isRunning = false
+    @Published var lastError: String?
+    @Published var launchInfo: LaunchInfo?
+    @Published var activeStep: MacInstallerStep = .requirements
+    @Published var lastCommand = "Mac Installer Preview is waiting"
+    @Published var diagnosticsPath: String?
+
+    let commandLogURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("nemoclaw-mac-installer-app.commands.log")
+    let diagnosticsContextURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("nemoclaw-mac-installer-app-diagnostics", isDirectory: true)
+
+    init() {
+        if ProcessInfo.processInfo.environment["OPENAI_API_KEY"] == nil,
+           ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] != nil {
+            provider = "anthropic"
+            model = ProviderOption.option(for: "anthropic", in: providerOptions).defaultModel
+        }
+    }
+
+    var agentChoices: [PlanAgent] {
+        resolvedPlan?.agents.isEmpty == false ? resolvedPlan?.agents ?? PlanAgent.fallback : PlanAgent.fallback
+    }
+
+    var selectedAgentOption: PlanAgent {
+        agentChoices.first { $0.name == selectedAgent } ?? agentChoices.first ?? PlanAgent.fallback[0]
+    }
+
+    var allProviderOptions: [ProviderOption] {
+        resolvedPlan?.model.providers.isEmpty == false ? resolvedPlan?.model.providers ?? ProviderOption.fallbackAll : ProviderOption.fallbackAll
+    }
+
+    var providerOptions: [ProviderOption] {
+        allProviderOptions.filter { option in
+            option.supportedAgents?.contains(selectedAgent) ?? true
+        }
+    }
+
+    var securityChoices: [SecurityChoice] {
+        resolvedPlan?.trust.tiers.isEmpty == false ? resolvedPlan?.trust.tiers ?? SecurityChoice.fallbackAll : SecurityChoice.fallbackAll
+    }
+
+    var providerOption: ProviderOption {
+        ProviderOption.option(for: provider, in: providerOptions)
+    }
+
+    var secretName: String? {
+        providerOption.envVar
+    }
+
+    var secretState: String {
+        guard let secretName else {
+            return "No key needed for this provider."
+        }
+        if !temporarySecret.isEmpty {
+            return "\(secretName) will be used once and not written into the install config."
+        }
+        if ProcessInfo.processInfo.environment[secretName]?.isEmpty == false {
+            return "\(secretName) is already available to the app."
+        }
+        return "Paste \(secretName) here for this install, or choose a local provider."
+    }
+
+    var canDeploy: Bool {
+        guard let secretName else { return true }
+        return !temporarySecret.isEmpty || ProcessInfo.processInfo.environment[secretName]?.isEmpty == false
+    }
+
+    var cliURL: URL? {
+        if let override = ProcessInfo.processInfo.environment["NEMOCLAW_MAC_INSTALLER_CLI"],
+           !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if FileManager.default.isExecutableFile(atPath: url.path) {
+                return url
+            }
+        }
+        if let resourceURL = Bundle.main.resourceURL {
+            let bundled = resourceURL
+                .appendingPathComponent("payload")
+                .appendingPathComponent("bin")
+                .appendingPathComponent("nemoclaw.js")
+            if FileManager.default.isExecutableFile(atPath: bundled.path) {
+                return bundled
+            }
+        }
+        return nil
+    }
+
+    var cliWorkingDirectory: URL? {
+        guard let cliURL else { return nil }
+        let root = cliURL.deletingLastPathComponent().deletingLastPathComponent()
+        return FileManager.default.fileExists(atPath: root.appendingPathComponent("package.json").path)
+            ? root
+            : nil
+    }
+
+    var readinessText: String {
+        guard let assessment else { return "I’ll check Docker, Colima, OpenShell, and your Mac." }
+        if assessment.supported { return "This Mac is ready for the preview lane." }
+        return "A few things need attention before Mac Installer Preview can install safely."
+    }
+
+    var friendlyIssueTitle: String {
+        let error = (lastError ?? "").lowercased()
+        if error.contains("endpoint validation failed") || error.contains("chat completions api") || error.contains("http 404") {
+            return "The model provider needs attention"
+        }
+        if error.contains("provider") || error.contains("api_key") || error.contains("api key") || error.contains("credential") {
+            return "This model provider needs a key"
+        }
+        if error.contains("docker") || error.contains("daemon") {
+            return "Docker needs a moment"
+        }
+        if error.contains("no registered") || error.contains("run nemoclaw native-installer mac install first") {
+            return "There isn’t an agent to launch yet"
+        }
+        if error.contains("no such file") || error.contains("cannot find") || error.contains("module_not_found") {
+            return "Mac Installer Preview couldn’t find one of its helpers"
+        }
+        return "That step didn’t finish"
+    }
+
+    var friendlyIssueMessage: String {
+        let error = (lastError ?? "").lowercased()
+        if error.contains("endpoint validation failed") || error.contains("chat completions api") || error.contains("http 404") {
+            return "Colima is reachable. The install stopped while checking the selected inference endpoint. Try a different provider, verify the model and key, or copy details for the exact onboard message."
+        }
+        if error.contains("provider") || error.contains("api_key") || error.contains("api key") || error.contains("credential") {
+            return "Paste a temporary key for this session, or switch to a local provider. The key stays out of the JSON config."
+        }
+        if error.contains("docker") || error.contains("daemon") {
+            return "Start Docker Desktop or Colima, then try again. Mac Installer Preview will not install a runtime behind your back."
+        }
+        if error.contains("no registered") || error.contains("run nemoclaw native-installer mac install first") {
+            return "Run the install step first. Once the sandbox is registered, I’ll open the UI or show the Hermes endpoint."
+        }
+        if error.contains("no such file") || error.contains("cannot find") || error.contains("module_not_found") {
+            return "The app bundle is missing something it expects. Export diagnostics and rebuild the preview bundle."
+        }
+        return "No panic. The technical details are saved in diagnostics, and you can retry or start fresh."
+    }
+
+    func go(_ step: MacInstallerStep) {
+        withAnimation(.spring(response: 0.38, dampingFraction: 0.88)) {
+            activeStep = step
+        }
+    }
+
+    func next() {
+        switch activeStep {
+        case .requirements: go(.agent)
+        case .agent: go(.model)
+        case .model: go(.security)
+        case .security: go(.review)
+        case .review: install()
+        case .deploy: go(.launch)
+        case .launch: break
+        }
+    }
+
+    func back() {
+        switch activeStep {
+        case .requirements: break
+        case .agent: go(.requirements)
+        case .model: go(.agent)
+        case .security: go(.model)
+        case .review: go(.security)
+        case .deploy: go(.review)
+        case .launch: go(.review)
+        }
+    }
+
+    func selectProvider(_ option: ProviderOption) {
+        provider = option.id
+        model = option.defaultModel
+        temporarySecret = ""
+    }
+
+    func alignProviderWithSelectedAgent() {
+        guard !providerOptions.contains(where: { $0.id == provider }) else { return }
+        let nextProvider = providerOptions.first { $0.id == resolvedPlan?.model.defaultProvider }
+            ?? providerOptions.first { $0.recommended }
+            ?? providerOptions.first
+        if let nextProvider {
+            selectProvider(nextProvider)
+        }
+    }
+
+    func describeAndAssess() {
+        describe {
+            self.assess()
+        }
+    }
+
+    func describe(completion: @escaping () -> Void = {}) {
+        lastError = nil
+        runCli(arguments: ["native-installer", "mac", "describe", "--json"]) { output, succeeded in
+            defer { completion() }
+            guard succeeded, let data = output.data(using: .utf8),
+                  let plan = try? JSONDecoder().decode(MacInstallerPlan.self, from: data) else {
+                return
+            }
+            self.resolvedPlan = plan
+            self.applyPlanDefaults(plan)
+            self.writeDiagnosticsFile(name: "resolved-plan.json", contents: output)
+        }
+    }
+
+    func applyPlanDefaults(_ plan: MacInstallerPlan) {
+        let recommendedAgent = plan.agents.first { $0.recommended } ?? plan.agents.first
+        if let recommendedAgent, !plan.agents.contains(where: { $0.name == selectedAgent }) {
+            selectedAgent = recommendedAgent.name
+        }
+        let eligibleProviders = plan.model.providers.filter { option in
+            option.supportedAgents?.contains(selectedAgent) ?? true
+        }
+        let defaultProvider = eligibleProviders.first { $0.id == plan.model.defaultProvider }
+            ?? eligibleProviders.first { $0.recommended }
+            ?? eligibleProviders.first
+        if let defaultProvider, !eligibleProviders.contains(where: { $0.id == provider }) {
+            provider = defaultProvider.id
+            model = defaultProvider.defaultModel
+        }
+        if !plan.trust.tiers.contains(where: { $0.id == securityTier }) {
+            securityTier = plan.trust.defaultTier
+        }
+        if sandboxName == "nemoclaw-mac-preview" {
+            sandboxName = plan.install.defaultSandboxName
+        }
+        mode = plan.install.defaultMode
+    }
+
+    func assess() {
+        lastError = nil
+        runCli(arguments: ["native-installer", "mac", "assess", "--json"]) { output, succeeded in
+            guard succeeded, let data = output.data(using: .utf8),
+                  let assessment = try? JSONDecoder().decode(Assessment.self, from: data) else {
+                return
+            }
+            self.assessment = assessment
+            self.writeDiagnosticsFile(name: "assessed-host.json", contents: output)
+        }
+    }
+
+    func install() {
+        guard canDeploy else {
+            lastError = secretState
+            go(.model)
+            return
+        }
+        go(.deploy)
+        let config = MacInstallerInstallConfig(
+            agent: selectedAgent,
+            sandboxName: sandboxName,
+            provider: provider,
+            model: model,
+            mode: mode,
+            security: SecurityConfig(tier: securityTier),
+            messaging: Array(messaging).sorted()
+        )
+        let configURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nemoclaw-mac-installer-\(UUID().uuidString).json")
+        do {
+            let data = try JSONEncoder().encode(config)
+            try data.write(to: configURL, options: .atomic)
+            if let text = String(data: data, encoding: .utf8) {
+                writeDiagnosticsFile(name: "redacted-config.json", contents: text)
+            }
+        } catch {
+            lastError = error.localizedDescription
+            return
+        }
+        events = []
+        launchInfo = nil
+        runCli(arguments: ["native-installer", "mac", "install", "--config", configURL.path, "--json-progress"]) { output, succeeded in
+            self.events = output
+                .split(separator: "\n")
+                .compactMap { line in
+                    try? JSONDecoder().decode(ProgressEvent.self, from: Data(line.utf8))
+                }
+            if succeeded {
+                self.launch()
+            }
+        }
+    }
+
+    func launch() {
+        go(.launch)
+        runCli(arguments: ["native-installer", "mac", "launch", "--agent", selectedAgent, "--json"]) { output, succeeded in
+            guard succeeded, let data = output.data(using: .utf8),
+                  let info = try? JSONDecoder().decode(LaunchInfo.self, from: data) else {
+                return
+            }
+            self.launchInfo = info
+        }
+    }
+
+    func exportDiagnostics() {
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nemoclaw-mac-installer-diagnostics.tar.gz")
+        runCli(arguments: ["diagnostics", "export", "--output", output.path, "--quick"]) { _, succeeded in
+            if succeeded {
+                self.diagnosticsPath = output.path
+            }
+        }
+    }
+
+    func startFresh() {
+        events = []
+        launchInfo = nil
+        lastError = nil
+        diagnosticsPath = nil
+        mode = "fresh"
+        sandboxName = resolvedPlan?.install.defaultSandboxName ?? "nemoclaw-mac-preview"
+        go(.requirements)
+    }
+
+    func openLaunchURL() {
+        if let urlString = launchInfo?.url, let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func copy(_ value: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+    }
+
+    func writeDiagnosticsFile(name: String, contents: String) {
+        let manager = FileManager.default
+        try? manager.createDirectory(at: diagnosticsContextURL, withIntermediateDirectories: true)
+        let safeName = name.replacingOccurrences(of: "/", with: "_")
+        let target = diagnosticsContextURL.appendingPathComponent(safeName)
+        if let data = contents.data(using: .utf8) {
+            try? data.write(to: target, options: .atomic)
+        }
+    }
+
+    func refreshDiagnosticsContext(cliURL: URL?) {
+        writeDiagnosticsFile(name: "cli-path.txt", contents: cliURL?.path ?? "nemoclaw from PATH")
+        if FileManager.default.fileExists(atPath: commandLogURL.path),
+           let log = try? String(contentsOf: commandLogURL) {
+            writeDiagnosticsFile(name: "app-command-log.txt", contents: log)
+        }
+    }
+
+    func runCli(arguments: [String], completion: @escaping (String, Bool) -> Void) {
+        isRunning = true
+        lastError = nil
+        diagnosticsPath = nil
+        lastCommand = "nemoclaw \(arguments.joined(separator: " "))"
+        let cliURL = self.cliURL
+        let workingDirectory = self.cliWorkingDirectory
+        refreshDiagnosticsContext(cliURL: cliURL)
+        let env = commandEnvironment()
+        let logURL = commandLogURL
+        Task.detached {
+            let process = Process()
+            if let cliURL {
+                process.executableURL = cliURL
+                process.arguments = arguments
+            } else {
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                process.arguments = ["nemoclaw"] + arguments
+            }
+            process.currentDirectoryURL = workingDirectory
+            process.environment = env
+            let outputPipe = Pipe()
+            let errorPipe = Pipe()
+            process.standardOutput = outputPipe
+            process.standardError = errorPipe
+            do {
+                try process.run()
+                process.waitUntilExit()
+                let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                let error = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                appendCommandLog(
+                    logURL: logURL,
+                    command: "nemoclaw \(arguments.joined(separator: " "))",
+                    status: process.terminationStatus,
+                    output: output,
+                    error: error
+                )
+                await MainActor.run {
+                    self.isRunning = false
+                    let succeeded = process.terminationStatus == 0
+                    if !succeeded {
+                        self.lastError = error.isEmpty ? output : error
+                    }
+                    completion(output, succeeded)
+                }
+            } catch {
+                appendCommandLog(
+                    logURL: logURL,
+                    command: "nemoclaw \(arguments.joined(separator: " "))",
+                    status: -1,
+                    output: "",
+                    error: error.localizedDescription
+                )
+                await MainActor.run {
+                    self.isRunning = false
+                    self.lastError = error.localizedDescription
+                    completion("", false)
+                }
+            }
+        }
+    }
+
+    private func commandEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        let defaultPath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        if let existing = env["PATH"], !existing.isEmpty {
+            env["PATH"] = "\(defaultPath):\(existing)"
+        } else {
+            env["PATH"] = defaultPath
+        }
+        env["NEMOCLAW_MAC_INSTALLER_APP"] = "1"
+        env["NEMOCLAW_MAC_INSTALLER_DIAGNOSTICS_DIR"] = diagnosticsContextURL.path
+        if let secretName, !temporarySecret.isEmpty {
+            env[secretName] = temporarySecret
+        }
+        return env
+    }
+}
+
+private func appendCommandLog(
+    logURL: URL,
+    command: String,
+    status: Int32,
+    output: String,
+    error: String
+) {
+    let entry = """
+
+    ----- \(Date()) -----
+    $ \(command)
+    exit: \(status)
+    stdout:
+    \(output)
+    stderr:
+    \(error)
+    """
+    if let data = entry.data(using: .utf8) {
+        if FileManager.default.fileExists(atPath: logURL.path),
+           let handle = try? FileHandle(forWritingTo: logURL) {
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+            try? handle.close()
+        } else {
+            try? data.write(to: logURL)
+        }
+    }
+}
+
+extension Color {
+    static let nvidiaGreen = Color(red: 0.46, green: 0.73, blue: 0.0)
+    static let appleInk = Color(red: 0.06, green: 0.065, blue: 0.07)
+    static let applePanel = Color(red: 0.96, green: 0.965, blue: 0.955)
+    static let appleMist = Color(red: 0.90, green: 0.92, blue: 0.89)
+}
+
+struct CalmBackdrop: View {
+    var body: some View {
+        LinearGradient(
+            colors: [
+                Color(red: 0.94, green: 0.96, blue: 0.93),
+                Color(red: 0.82, green: 0.86, blue: 0.80),
+                Color(red: 0.18, green: 0.20, blue: 0.18),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.black.opacity(0.08))
+                .frame(height: 1)
+        }
+        .ignoresSafeArea()
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var model = MacInstallerModel()
+
+    var body: some View {
+        ZStack {
+            CalmBackdrop()
+            VStack(spacing: 0) {
+                topBar
+                ProgressDots(activeStep: model.activeStep)
+                    .padding(.top, 12)
+                Spacer(minLength: 18)
+                GuideShell(model: model)
+                    .frame(maxWidth: 900)
+                Spacer(minLength: 18)
+                footer
+            }
+            .padding(24)
+        }
+        .frame(minWidth: 980, minHeight: 720)
+        .onAppear {
+            model.describeAndAssess()
+        }
+    }
+
+    var topBar: some View {
+        HStack {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.nvidiaGreen)
+                    .frame(width: 34, height: 34)
+                    .overlay {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 16, weight: .black))
+                            .foregroundStyle(.black)
+                    }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("NVIDIA")
+                        .font(.system(size: 18, weight: .black, design: .rounded))
+                    Text("NemoClaw Mac Installer Preview")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Text("Experimental")
+                .font(.system(size: 12, weight: .semibold))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(.thinMaterial, in: Capsule())
+        }
+        .foregroundStyle(Color.appleInk)
+    }
+
+    var footer: some View {
+        HStack {
+            Text(model.lastCommand)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            if let diagnosticsPath = model.diagnosticsPath {
+                Text("Diagnostics saved: \(diagnosticsPath)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .frame(maxWidth: 900)
+    }
+}
+
+struct ProgressDots: View {
+    let activeStep: MacInstallerStep
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ForEach(MacInstallerStep.allCases) { step in
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(step == activeStep ? Color.nvidiaGreen : Color.white.opacity(0.55))
+                        .frame(width: step == activeStep ? 10 : 7, height: step == activeStep ? 10 : 7)
+                    Text(step.rawValue)
+                        .font(.system(size: 12, weight: step == activeStep ? .semibold : .regular))
+                        .foregroundStyle(step == activeStep ? Color.appleInk : Color.appleInk.opacity(0.55))
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+}
+
+struct GuideShell: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            guideHeader
+            Divider()
+            stepContent
+            IssueCard(model: model)
+            navigation
+        }
+        .padding(30)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(Color.white.opacity(0.48), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.18), radius: 36, x: 0, y: 18)
+        .animation(.spring(response: 0.38, dampingFraction: 0.88), value: model.activeStep)
+    }
+
+    var guideHeader: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(Color.nvidiaGreen)
+                .frame(width: 54, height: 54)
+                .background(Color.white.opacity(0.75), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.system(size: 34, weight: .bold, design: .rounded))
+                    .foregroundStyle(Color.appleInk)
+                Text(subtitle)
+                    .font(.system(size: 17))
+                    .foregroundStyle(Color.appleInk.opacity(0.68))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+        }
+    }
+
+    var title: String {
+        switch model.activeStep {
+        case .requirements: return "Let’s make sure this Mac is ready."
+        case .agent: return "What do you want to launch?"
+        case .model: return "Choose how your agent should think."
+        case .security: return "Pick the trust posture."
+        case .review: return "Here’s the plan."
+        case .deploy: return "I’m setting up the lane."
+        case .launch: return "Your agent is ready."
+        }
+    }
+
+    var subtitle: String {
+        switch model.activeStep {
+        case .requirements: return model.readinessText
+        case .agent: return "I’ll keep this to the two supported preview paths: OpenClaw for a UI-first start, Hermes for an API-first start."
+        case .model: return "Start with a recommended provider, or choose the local path if your model stack is already running."
+        case .security: return "Balanced is the best default. You can tighten things down or open them up before install."
+        case .review: return model.resolvedPlan?.review.handoffPolicy ?? "No provider keys will be stored in the JSON config."
+        case .deploy: return "You can leave this window open. I’ll hand off to NemoClaw onboard and keep the technical details in diagnostics."
+        case .launch: return "OpenClaw opens in the browser. Hermes gives you a local endpoint you can copy into tools."
+        }
+    }
+
+    @ViewBuilder
+    var stepContent: some View {
+        switch model.activeStep {
+        case .requirements:
+            RequirementsStep(model: model)
+        case .agent:
+            AgentStep(model: model)
+        case .model:
+            ModelStep(model: model)
+        case .security:
+            SecurityStep(model: model)
+        case .review:
+            ReviewStep(model: model)
+        case .deploy:
+            DeployStep(model: model)
+        case .launch:
+            LaunchStep(model: model)
+        }
+    }
+
+    var navigation: some View {
+        HStack {
+            if model.activeStep != .requirements {
+                Button {
+                    model.back()
+                } label: {
+                    Label("Back", systemImage: "chevron.left")
+                }
+                .buttonStyle(.bordered)
+            }
+            Spacer()
+            Button {
+                model.startFresh()
+            } label: {
+                Label("Start Fresh", systemImage: "arrow.counterclockwise")
+            }
+            .buttonStyle(.borderless)
+            Button {
+                if model.activeStep == .requirements {
+                    if model.assessment?.supported == true {
+                        model.next()
+                    } else {
+                        model.assess()
+                    }
+                } else {
+                    model.next()
+                }
+            } label: {
+                if model.isRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Text(primaryActionTitle)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.nvidiaGreen)
+            .disabled(model.isRunning || (model.activeStep == .model && !model.canDeploy))
+        }
+    }
+
+    var primaryActionTitle: String {
+        switch model.activeStep {
+        case .requirements:
+            return model.assessment?.supported == true ? "Continue" : "Check Again"
+        case .agent: return "Continue"
+        case .model: return "Continue"
+        case .security: return "Review"
+        case .review: return "Start Mac Installer Preview"
+        case .deploy: return "Continue"
+        case .launch: return "Done"
+        }
+    }
+}
+
+struct RequirementsStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let assessment = model.assessment {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 2), spacing: 12) {
+                    ForEach(assessment.requirements) { requirement in
+                        ReadinessTile(requirement: requirement)
+                    }
+                }
+                if !assessment.supported {
+                    RecoveryActions(model: model)
+                }
+            } else {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Checking the local runtime...")
+                        .foregroundStyle(.secondary)
+                }
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.white.opacity(0.56), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+        }
+    }
+}
+
+struct ReadinessTile: View {
+    let requirement: Requirement
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(color)
+                .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 5) {
+                Text(requirement.label)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.appleInk)
+                Text(requirement.status == "pass" ? "Ready" : friendlyText)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.appleInk.opacity(0.62))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+        }
+        .padding(16)
+        .frame(minHeight: 86, alignment: .top)
+        .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    var icon: String {
+        switch requirement.status {
+        case "pass": return "checkmark.circle.fill"
+        case "warn": return "exclamationmark.triangle.fill"
+        default: return "xmark.circle.fill"
+        }
+    }
+
+    var color: Color {
+        switch requirement.status {
+        case "pass": return .nvidiaGreen
+        case "warn": return .orange
+        default: return .red
+        }
+    }
+
+    var friendlyText: String {
+        requirement.recovery ?? requirement.detail
+    }
+}
+
+struct AgentStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        HStack(spacing: 14) {
+            ForEach(model.agentChoices) { agent in
+                FriendlyChoiceCard(
+                    title: agent.title,
+                    badge: agent.bestFor,
+                    description: agent.subtitle,
+                    icon: agent.systemIcon,
+                    selected: model.selectedAgent == agent.name
+                ) {
+                    model.selectedAgent = agent.name
+                    model.alignProviderWithSelectedAgent()
+                    model.messaging = model.messaging.intersection(Set(agent.messaging))
+                }
+            }
+        }
+    }
+}
+
+struct ModelStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 3), spacing: 12) {
+                ForEach(model.providerOptions) { option in
+                    FriendlyChoiceCard(
+                        title: option.title,
+                        badge: option.recommended ? "Recommended" : nil,
+                        description: option.guidance,
+                        icon: option.systemImage,
+                        selected: model.provider == option.id
+                    ) {
+                        model.selectProvider(option)
+                    }
+                }
+            }
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Model")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                TextField("Model", text: $model.model)
+                    .textFieldStyle(.roundedBorder)
+                if model.secretName != nil {
+                    SecureField(model.secretName ?? "API key", text: $model.temporarySecret)
+                        .textFieldStyle(.roundedBorder)
+                }
+                HStack(spacing: 8) {
+                    Image(systemName: model.canDeploy ? "checkmark.shield.fill" : "key.fill")
+                        .foregroundStyle(model.canDeploy ? Color.nvidiaGreen : .orange)
+                    Text(model.secretState)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.appleInk.opacity(0.65))
+                }
+            }
+            .padding(16)
+            .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+    }
+}
+
+struct SecurityStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                ForEach(model.securityChoices) { choice in
+                    FriendlyChoiceCard(
+                        title: choice.title,
+                        badge: choice.recommended ? "Recommended" : nil,
+                        description: choice.description,
+                        icon: choice.icon,
+                        selected: model.securityTier == choice.id
+                    ) {
+                        model.securityTier = choice.id
+                    }
+                }
+            }
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Messaging")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("Choose where the preview should prepare integrations. You can skip these now and connect them later.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.appleInk.opacity(0.62))
+                HStack(spacing: 10) {
+                    ForEach(model.selectedAgentOption.messaging, id: \.self) { channel in
+                        ChipToggle(title: channel.capitalized, value: channel, selection: $model.messaging)
+                    }
+                }
+            }
+            .padding(16)
+            .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+    }
+}
+
+struct ReviewStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ReviewRow(icon: model.selectedAgentOption.systemIcon, title: "Agent", value: model.selectedAgentOption.title)
+            ReviewRow(icon: model.providerOption.systemImage, title: "Model", value: "\(model.providerOption.title) · \(model.model)")
+            ReviewRow(icon: "checkmark.shield", title: "Trust", value: "\(model.securityTier.capitalized) security · \(model.messaging.sorted().joined(separator: ", "))")
+            ReviewRow(icon: "shippingbox", title: "Install", value: "\(model.mode.capitalized) sandbox named \(model.sandboxName)")
+            Text(model.resolvedPlan?.review.stockOnly ?? "Mac Installer Preview only supports stock OpenClaw and stock Hermes.")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.appleInk.opacity(0.62))
+                .padding(.top, 4)
+        }
+        .padding(18)
+        .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+}
+
+struct DeployStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if model.isRunning {
+                ProgressView("Preparing your agent")
+                    .progressViewStyle(.linear)
+                    .tint(Color.nvidiaGreen)
+            }
+            if model.events.isEmpty {
+                Text("I’ll hand the plan to NemoClaw onboard, wait for it to finish, and then prepare the launch details.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.appleInk.opacity(0.68))
+                    .padding(18)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(model.events) { event in
+                        EventTile(event: event)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct LaunchStep: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let info = model.launchInfo {
+                if info.kind == "ui" {
+                    LaunchCard(
+                        icon: "safari.fill",
+                        title: "OpenClaw is ready in your browser",
+                        subtitle: info.url
+                    ) {
+                        model.openLaunchURL()
+                    }
+                    if let terminalCommand = info.terminalCommand {
+                        CopyRow(title: "Terminal chat", value: terminalCommand, model: model)
+                    }
+                } else if let api = info.api {
+                    LaunchCard(
+                        icon: "curlybraces.square.fill",
+                        title: "Hermes endpoint is ready",
+                        subtitle: api.baseUrl
+                    ) {
+                        model.copy(api.baseUrl)
+                    }
+                    CopyRow(title: "Chat completions", value: api.chatCompletionsUrl, model: model)
+                    CopyRow(title: "Health check", value: api.healthUrl, model: model)
+                    if let authHeader = api.authHeader {
+                        CopyRow(title: "Auth header", value: authHeader, model: model)
+                    }
+                }
+            } else if model.isRunning {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Fetching launch details...")
+                }
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            } else {
+                Text("Install the agent first, then I’ll show the clean launch card here.")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.appleInk.opacity(0.68))
+                    .padding(18)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+        }
+    }
+}
+
+struct IssueCard: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        if model.lastError != nil {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "heart.text.square.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.orange)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(model.friendlyIssueTitle)
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(Color.appleInk)
+                        Text(model.friendlyIssueMessage)
+                            .font(.system(size: 14))
+                            .foregroundStyle(Color.appleInk.opacity(0.68))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                HStack {
+                    Button("Retry") {
+                        switch model.activeStep {
+                        case .requirements: model.assess()
+                        case .deploy: model.install()
+                        case .launch: model.launch()
+                        default: model.lastError = nil
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Color.nvidiaGreen)
+                    Button("Fix Docker") {
+                        NSWorkspace.shared.open(URL(fileURLWithPath: "/Applications/Docker.app"))
+                    }
+                    .buttonStyle(.bordered)
+                    Button("Export Diagnostics") {
+                        model.exportDiagnostics()
+                    }
+                    .buttonStyle(.bordered)
+                    Spacer()
+                    Button("Copy Details") {
+                        model.copy(model.lastError ?? "")
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            .padding(16)
+            .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+    }
+}
+
+struct RecoveryActions: View {
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        HStack {
+            Button("Open Docker") {
+                NSWorkspace.shared.open(URL(fileURLWithPath: "/Applications/Docker.app"))
+            }
+            .buttonStyle(.bordered)
+            Button("Check Again") {
+                model.assess()
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.nvidiaGreen)
+            Button("Export Diagnostics") {
+                model.exportDiagnostics()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.top, 4)
+    }
+}
+
+struct FriendlyChoiceCard: View {
+    let title: String
+    let badge: String?
+    let description: String
+    let icon: String
+    let selected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top) {
+                    Image(systemName: icon)
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundStyle(selected ? Color.appleInk : Color.nvidiaGreen)
+                        .frame(width: 42, height: 42)
+                        .background(selected ? Color.nvidiaGreen : Color.white.opacity(0.7), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    Spacer()
+                    if let badge {
+                        Text(badge)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(selected ? .black : .secondary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .background(selected ? Color.nvidiaGreen.opacity(0.85) : Color.white.opacity(0.62), in: Capsule())
+                    }
+                }
+                Text(title)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Color.appleInk)
+                Text(description)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.appleInk.opacity(0.64))
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 164, alignment: .topLeading)
+            .background(selected ? Color.white.opacity(0.86) : Color.white.opacity(0.52), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(selected ? Color.nvidiaGreen : Color.white.opacity(0.46), lineWidth: selected ? 2 : 1)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct ChipToggle: View {
+    let title: String
+    let value: String
+    @Binding var selection: Set<String>
+
+    var body: some View {
+        Button {
+            if selection.contains(value) {
+                selection.remove(value)
+            } else {
+                selection.insert(value)
+            }
+        } label: {
+            Label(title, systemImage: selection.contains(value) ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 13, weight: .semibold))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(selection.contains(value) ? Color.nvidiaGreen.opacity(0.22) : Color.white.opacity(0.56), in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct ReviewRow: View {
+    let icon: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(Color.nvidiaGreen)
+                .frame(width: 26)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color.appleInk)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.58), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+}
+
+struct EventTile: View {
+    let event: ProgressEvent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(color)
+                .frame(width: 26)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(friendlyPhase)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.appleInk)
+                Text(friendlyMessage)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.appleInk.opacity(0.64))
+            }
+            Spacer()
+        }
+        .padding(14)
+        .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    var icon: String {
+        switch event.status {
+        case "ok": return "checkmark.circle.fill"
+        case "warn": return "exclamationmark.triangle.fill"
+        case "failed": return "xmark.circle.fill"
+        default: return "clock.fill"
+        }
+    }
+
+    var color: Color {
+        switch event.status {
+        case "ok": return .nvidiaGreen
+        case "warn": return .orange
+        case "failed": return .red
+        default: return .secondary
+        }
+    }
+
+    var friendlyPhase: String {
+        switch event.phase {
+        case "plan_loaded": return "Reading the plan"
+        case "onboard_started": return "Starting onboarding"
+        case "onboard_finished": return "Finishing onboarding"
+        case "launch_ready": return "Preparing launch"
+        case "failed": return "Needs attention"
+        default: return event.phase.capitalized
+        }
+    }
+
+    var friendlyMessage: String {
+        return event.message
+    }
+}
+
+struct LaunchCard: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(Color.appleInk)
+                .frame(width: 62, height: 62)
+                .background(Color.nvidiaGreen, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(Color.appleInk)
+                Text(subtitle)
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(Color.appleInk.opacity(0.62))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button(title.contains("OpenClaw") ? "Open" : "Copy") {
+                action()
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.nvidiaGreen)
+        }
+        .padding(18)
+        .background(Color.white.opacity(0.72), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+}
+
+struct CopyRow: View {
+    let title: String
+    let value: String
+    @ObservedObject var model: MacInstallerModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(Color.appleInk.opacity(0.72))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button {
+                model.copy(value)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.bordered)
+            .help("Copy")
+        }
+        .padding(14)
+        .background(Color.white.opacity(0.58), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+@main
+struct NemoClawMacInstallerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.titleBar)
+    }
+}

--- a/apps/native-installers/macos/NemoClawMacInstaller/Sources/NemoClawMacInstaller/Resources/README.md
+++ b/apps/native-installers/macos/NemoClawMacInstaller/Sources/NemoClawMacInstaller/Resources/README.md
@@ -1,0 +1,4 @@
+NemoClaw Mac Installer Preview resources live here.
+
+Third-party logo assets are intentionally not bundled until each mark is approved for release use.
+Internal preview builds use SF Symbols and branded text labels instead.

--- a/docs/get-started/mac-installer-preview.mdx
+++ b/docs/get-started/mac-installer-preview.mdx
@@ -1,0 +1,78 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Mac Installer Preview"
+sidebar-title: "Mac Installer Preview"
+description: "Opt-in experimental native macOS installer path for stock OpenClaw and Hermes sandboxes."
+description-agent: "Explains the experimental macOS Mac Installer Preview installer, its supported scope, CLI APIs, payload model, recovery actions, and fallback to the standard installer."
+keywords: ["nemoclaw macos installer preview", "nemoclaw native mac app", "nemoclaw hermes native installer"]
+---
+
+<Warning>
+Mac Installer Preview is experimental and opt-in. The standard installer remains the default supported path:
+`curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash`.
+</Warning>
+
+Mac Installer Preview is a native macOS shell over the existing `nemoclaw onboard` flow for supported Apple Silicon Macs.
+It is scoped to stock **OpenClaw** and stock **Hermes Agent** sandboxes in this preview.
+Linux, WSL, DGX Spark, custom Dockerfiles, CI automation, and conservative installs should keep using the standard installer and `nemoclaw onboard`.
+
+## Supported Scope
+
+The preview targets Apple Silicon macOS 13 or newer with a supported container runtime already installed and running.
+NemoClaw detects Docker Desktop or Colima and explains how to recover when the runtime is missing or stopped, but it does not silently install third-party runtimes.
+
+Mac Installer Preview config JSON may include the selected agent, sandbox name, provider, model, endpoint, policy tier or presets, messaging choices, fresh or resume mode, and port choices.
+Secrets must come from the environment or a Keychain-backed temporary injection managed by the app.
+Do not put API keys, tokens, passwords, or credentials in the JSON config.
+
+## App-Facing CLI APIs
+
+The native app shells out to stable, machine-readable CLI commands:
+
+```console
+$ nemoclaw native-installer mac describe --json
+$ nemoclaw native-installer mac assess --json
+$ nemoclaw native-installer mac install --config mac-installer.json --json-progress
+$ nemoclaw native-installer mac launch --agent openclaw --json
+$ nemoclaw diagnostics export --output /tmp/nemoclaw-debug.tar.gz
+```
+
+`native-installer mac describe` returns the YAML-backed app plan from `release/native-installers/macos/install-plan.yaml`, resolved with the current `agents/*/manifest.yaml` metadata and the provider catalog used by `nemoclaw onboard`.
+The app uses this structured plan for requirements, supported agents, installer-supported model choices, trust tiers, install phases, and launch copy instead of hard-coding those choices.
+
+`native-installer mac assess` checks Mac Installer Preview macOS arm64 eligibility and normalizes the same Docker/OpenShell preflight truth used by `nemoclaw onboard`.
+It preserves the important distinction between Docker not being installed and Docker being installed but stopped or unreachable.
+
+`native-installer mac install` validates only adapter concerns in the config JSON: stock OpenClaw or Hermes, a provider id returned by `native-installer mac describe`, no secrets, and no custom Dockerfiles.
+It then translates the selected app handoff into existing `nemoclaw onboard` flags and environment variables and lets the supported onboard flow own Docker, image resolution, remediation, and failures.
+The Mac Installer Preview JSON progress stream is intentionally coarse: plan loaded, onboard started, onboard finished, launch ready, or failed.
+
+`native-installer mac launch` returns the agent-specific launch target.
+For OpenClaw, it returns the local browser URL with the gateway token and the terminal chat command.
+For Hermes, it returns the forwarded OpenAI-compatible `/v1` endpoint, health endpoint, and API token when it can be read from the sandbox.
+
+## Release Artifact
+
+The release builder is `scripts/native-installers/macos/build-preview.sh`.
+It stages the built NemoClaw CLI, agent manifests, scripts, uninstall helper, release metadata, optional pinned OpenShell binary, optional private Node runtime, licenses, and SBOM into the app payload.
+When Apple Developer credentials are provided, it signs the app with Developer ID, creates a DMG, submits it to notarization, and staples the result.
+
+Third-party marks are not bundled by default.
+Until each logo is approved for release use, internal app builds use branded text labels and neutral system icons.
+
+## Recovery
+
+The app should keep these recovery actions visible:
+
+- Retry the current step.
+- Resume an interrupted install.
+- Start Fresh with a new sandbox.
+- Fix Docker by opening Docker Desktop or guiding the user to start Colima.
+- Export Diagnostics.
+- Uninstall preview sandbox.
+
+If the preview path is unsupported or onboarding cannot complete, use the standard installer path and the normal `nemoclaw onboard` recovery guidance.
+
+Mac Installer Preview may declare optional onboard-owned sandbox base image references in `install-plan.yaml`.
+Full prebuilt stock sandbox images are deliberately deferred until onboard can configure stock images without patching or generating user-specific Dockerfile content.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -37,6 +37,9 @@ navigation:
       - page: "Quickstart with Hermes"
         path: get-started/quickstart-hermes.mdx
         slug: quickstart-hermes
+      - page: "Mac Installer Preview"
+        path: get-started/mac-installer-preview.mdx
+        slug: mac-installer-preview
   - section: "Inference"
     slug: inference
     contents:

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -155,6 +155,55 @@ Use `--control-ui-port <N>` to choose the host dashboard port for a sandbox.
 The value must be an integer from `1024` through `65535`.
 This flag takes precedence over `CHAT_UI_URL`, `NEMOCLAW_DASHBOARD_PORT`, the previous registry value, and the default port.
 
+### `nemoclaw native-installer mac describe`
+
+Return the YAML-backed, app-facing Mac Installer Preview plan.
+The command reads `release/native-installers/macos/install-plan.yaml`, resolves stock agent metadata from `agents/*/manifest.yaml`, and verifies provider choices against the provider catalog used by `nemoclaw onboard`.
+The returned provider defaults are installer-backed; Mac Installer Preview does not publish a second provider/model catalog.
+
+```console
+$ nemoclaw native-installer mac describe --json
+```
+
+### `nemoclaw native-installer mac assess`
+
+Assess whether this Mac is eligible for the experimental Mac Installer Preview.
+The command checks Apple Silicon macOS support and normalizes the same host preflight used by `nemoclaw onboard`.
+It reports Docker missing separately from Docker installed but unreachable.
+
+```console
+$ nemoclaw native-installer mac assess [--json]
+```
+
+### `nemoclaw native-installer mac install`
+
+Install stock OpenClaw or Hermes through the experimental macOS Mac Installer Preview path.
+This command is not a replacement for the standard installer.
+It validates adapter-only config concerns, rejects secrets and custom Dockerfiles, translates the app handoff to existing onboard flags and environment variables, and then runs the supported non-interactive `onboard` path for the selected stock agent.
+
+```console
+$ nemoclaw native-installer mac install --config <json> [--json-progress]
+```
+
+Config JSON supports `agent`, `sandboxName`, `provider`, `model`, `endpoint`, `security.tier`, `security.presets`, `messaging`, `mode`, and `ports`.
+The `provider` value must be one of the installer-supported provider ids returned by `nemoclaw native-installer mac describe --json`.
+Secrets must be provided by environment variables or app-managed Keychain injection, never persisted in the JSON file.
+Mac Installer Preview supports stock OpenClaw and stock Hermes only; use `nemoclaw onboard --from <Dockerfile>` for custom images.
+
+`native-installer mac install` does not pull Docker images directly.
+Docker runtime checks, base image resolution, remediation, and user-specific Dockerfile generation remain owned by `nemoclaw onboard`.
+The `--json-progress` stream emits only coarse adapter events: `plan_loaded`, `onboard_started`, `onboard_finished`, `launch_ready`, or `failed`.
+
+### `nemoclaw native-installer mac launch`
+
+Launch the selected Mac Installer Preview agent or return app-native launch details.
+For OpenClaw, the command opens the local UI by default and can return the tokenized URL plus `nemoclaw <name> connect`.
+For Hermes, it returns the forwarded OpenAI-compatible endpoint and API token details when available.
+
+```console
+$ nemoclaw native-installer mac launch [--agent openclaw|hermes] [--json] [--no-open]
+```
+
 If you enable Slack during onboarding, the wizard collects both the Bot Token (`SLACK_BOT_TOKEN`) and the App-Level Token (`SLACK_APP_TOKEN`).
 Socket Mode requires both tokens.
 The app-level token is stored in a dedicated `slack-app` OpenShell provider and forwarded to the sandbox alongside the bot token.
@@ -1022,6 +1071,15 @@ $ nemoclaw debug [--quick|-q] [--sandbox NAME] [--output PATH|-o PATH]
 | `--output PATH`, `-o PATH` | Write diagnostics tarball to the given path |
 
 If `--output` is set and the tarball cannot be written (for example, the destination directory is missing or read-only), the command exits non-zero so scripts can detect the failure.
+
+### `nemoclaw diagnostics export`
+
+Export diagnostics to a tarball for the Mac Installer Preview app or support workflows.
+This is the app-facing wrapper around `nemoclaw debug --output`.
+
+```console
+$ nemoclaw diagnostics export --output <path> [--sandbox NAME] [--quick]
+```
 
 ### `nemoclaw credentials list`
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "docs:live": "FERN_VERSION=$(node -p \"require('./fern/fern.config.json').version\") && cd fern && npx --yes \"fern-api@${FERN_VERSION}\" docs dev",
     "docs:preview:watch": "node scripts/watch-fern-preview.mjs",
     "docs:clean": "rm -rf .fern-cache fern/.fern-cache docs/_build",
+    "build:native-mac-installer": "bash scripts/native-installers/macos/build-preview.sh",
     "prepare": "if command -v tsc >/dev/null 2>&1 || [ -x node_modules/.bin/tsc ]; then npm run build:cli; fi && (npm install --omit=dev --ignore-scripts 2>/dev/null || true) && if [ -d .git ]; then bash scripts/npm-link-or-shim.sh; if command -v prek >/dev/null 2>&1; then prek install; else echo \"Skipping git hook setup (prek not installed)\"; fi; fi",
     "prepublishOnly": "git describe --tags --match 'v*' | sed 's/^v//' > .version && test -s .version && cd nemoclaw && env -u npm_config_global -u npm_config_prefix -u npm_config_omit npm install --ignore-scripts && ./node_modules/.bin/tsc"
   },

--- a/release/native-installers/macos/entitlements.plist
+++ b/release/native-installers/macos/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <false/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <false/>
+</dict>
+</plist>

--- a/release/native-installers/macos/install-plan.yaml
+++ b/release/native-installers/macos/install-plan.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+experimental: true
+target: "Apple Silicon macOS 13+"
+summary: "Guided native macOS preview for stock OpenClaw and Hermes installs."
+
+requirements:
+  - id: platform
+    label: "Apple Silicon macOS 13+"
+    required: true
+    recovery: "Use the standard NemoClaw installer on Linux, WSL, DGX Spark, Intel Macs, or older macOS releases."
+  - id: docker-cli
+    label: "Docker CLI"
+    required: true
+    recovery: "Install Docker Desktop or Colima, then try again."
+  - id: docker-daemon
+    label: "Docker daemon"
+    required: true
+    recovery: "Start Docker Desktop or Colima, then try again."
+  - id: openshell
+    label: "OpenShell"
+    required: false
+    recovery: "The signed app bundle should carry a pinned OpenShell binary; the standard installer can repair it."
+
+agents:
+  - name: openclaw
+    label: "Browser UI sandbox"
+    description: "Standard NemoClaw/OpenClaw sandbox with browser UI and messaging support declared by the agent manifest."
+    icon: "rectangle.connected.to.line.below"
+    recommended: true
+  - name: hermes
+    label: "Local API sandbox"
+    description: "Hermes Agent sandbox with an OpenAI-compatible local API endpoint and bearer-token launch details."
+    icon: "curlybraces.square"
+    recommended: false
+
+model:
+  default_provider: openai
+  providers:
+    - id: openai
+      title: "OpenAI"
+      default_model: "gpt-5.4"
+      env_var: "OPENAI_API_KEY"
+      guidance: "OpenAI provider from the onboard catalog using its default model."
+      system_image: "cloud"
+      recommended: true
+    - id: anthropic
+      title: "Anthropic"
+      default_model: "claude-sonnet-4-6"
+      env_var: "ANTHROPIC_API_KEY"
+      guidance: "Anthropic provider from the onboard catalog using its default model."
+      system_image: "text.book.closed"
+    - id: gemini
+      title: "Google Gemini"
+      default_model: "gemini-2.5-flash"
+      env_var: "GEMINI_API_KEY"
+      guidance: "Google Gemini provider from the onboard catalog using its default model."
+      system_image: "diamond"
+    - id: build
+      title: "NVIDIA Endpoints"
+      default_model: "nvidia/nemotron-3-super-120b-a12b"
+      env_var: "NVIDIA_API_KEY"
+      guidance: "NVIDIA-hosted inference using the curated onboard default."
+      system_image: "cpu"
+    - id: ollama
+      title: "Local Ollama"
+      default_model: "nemotron-3-nano:30b"
+      guidance: "Local Ollama provider from the onboard catalog using its default model."
+      system_image: "desktopcomputer"
+    - id: hermesProvider
+      title: "Hermes Provider"
+      default_model: "moonshotai/kimi-k2.6"
+      env_var: "NOUS_API_KEY"
+      guidance: "Use the Hermes stack as the model provider when installing Hermes Agent."
+      system_image: "point.3.filled.connected.trianglepath.dotted"
+
+trust:
+  default_tier: balanced
+  tiers:
+    - id: restricted
+      title: "Careful"
+      description: "Tighter defaults for first-time installs or sensitive machines."
+      icon: "lock.shield"
+    - id: balanced
+      title: "Balanced"
+      description: "Recommended. Gives the agent room to work while keeping sharp edges covered."
+      icon: "checkmark.shield"
+      recommended: true
+    - id: open
+      title: "Open"
+      description: "For trusted experiments where speed matters more than restraint."
+      icon: "lock.open"
+
+review:
+  handoff_policy: "Provider keys are injected by environment or app-managed temporary handoff and are never stored in native Mac installer config JSON."
+  stock_only: "Mac Installer Preview supports stock OpenClaw and stock Hermes."
+
+install:
+  default_sandbox_name: "nemoclaw-mac-preview"
+  default_mode: fresh
+  progress_phases:
+    - id: plan_loaded
+      title: "Reading the plan"
+    - id: onboard_started
+      title: "Starting onboarding"
+    - id: onboard_finished
+      title: "Finishing onboarding"
+    - id: launch_ready
+      title: "Preparing launch"
+  base_images:
+    - agent: openclaw
+      ref: "ghcr.io/nvidia/nemoclaw/sandbox-base:latest"
+      env: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF"
+      apply_by_default: false
+      note: "Optional onboard-owned base image override. Full stock sandbox images are deferred."
+    - agent: hermes
+      ref: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest"
+      env: "NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF"
+      apply_by_default: false
+      note: "Optional onboard-owned base image override. Full stock sandbox images are deferred."
+
+launch:
+  openclaw:
+    kind: ui
+    action: "Open local browser UI"
+  hermes:
+    kind: api
+    action: "Show OpenAI-compatible endpoint and authorization header"

--- a/release/native-installers/macos/payload-manifest.json
+++ b/release/native-installers/macos/payload-manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "NemoClaw Mac Installer Preview payload",
+  "experimental": true,
+  "target": "Apple Silicon macOS 13+",
+  "components": [
+    "private Node runtime",
+    "built NemoClaw CLI",
+    "built OpenClaw plugin package",
+    "pinned OpenShell binary",
+    "agent manifests",
+    "YAML native Mac installer install plan",
+    "uninstall and repair scripts",
+    "licenses",
+    "SBOM"
+  ],
+  "handoffPolicy": "Provider keys are injected through environment variables or Keychain-backed temporary files and are not persisted in native Mac installer config JSON."
+}

--- a/scripts/native-installers/macos/build-preview.sh
+++ b/scripts/native-installers/macos/build-preview.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+APP_DIR="$ROOT/apps/native-installers/macos/NemoClawMacInstaller"
+BUILD_DIR="${NEMOCLAW_MAC_INSTALLER_BUILD_DIR:-$ROOT/build/native-mac-installer-preview}"
+PAYLOAD_DIR="$BUILD_DIR/payload"
+APP_BUNDLE="$BUILD_DIR/NemoClaw Mac Installer Preview.app"
+DMG_PATH="$BUILD_DIR/NemoClaw-Mac-Installer-Preview.dmg"
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/native-installers/macos/build-preview.sh [--dry-run]
+
+Builds the experimental macOS Mac Installer Preview app bundle and DMG.
+
+Signing/notarization env vars:
+  DEVELOPER_ID_APPLICATION      Developer ID Application identity
+  APPLE_ID                      Apple ID for notarytool
+  APPLE_TEAM_ID                 Apple Developer Team ID
+  APPLE_APP_SPECIFIC_PASSWORD   App-specific password for notarytool
+  NEMOCLAW_OPENSHELL_BIN        Pinned openshell binary to bundle
+  NEMOCLAW_MAC_INSTALLER_NODE_TARBALL Private Node runtime tarball to bundle
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ "$(uname -s)" != "Darwin" ] && [ "$DRY_RUN" != "1" ]; then
+  echo "Mac Installer Preview app builds require macOS. Use --dry-run to validate inputs elsewhere." >&2
+  exit 1
+fi
+
+mkdir -p "$PAYLOAD_DIR"
+
+echo "[native-installer] Building NemoClaw CLI"
+if [ "$DRY_RUN" != "1" ]; then
+  if [ ! -d "$ROOT/node_modules" ]; then
+    npm ci --ignore-scripts --prefix "$ROOT"
+  fi
+  npm run --prefix "$ROOT" build:cli
+  LEGACY_PREVIEW_SLUG="fast""lane"
+  rm -rf "$ROOT/dist/commands/$LEGACY_PREVIEW_SLUG" "$ROOT/dist/lib/$LEGACY_PREVIEW_SLUG"
+fi
+
+echo "[native-installer] Staging payload"
+rm -rf "$PAYLOAD_DIR"
+mkdir -p "$PAYLOAD_DIR"/{bin,dist,scripts,agents,release,licenses,tools}
+cp -R "$ROOT/bin/." "$PAYLOAD_DIR/bin/"
+if [ -d "$ROOT/dist" ]; then cp -R "$ROOT/dist/." "$PAYLOAD_DIR/dist/"; fi
+if [ -d "$ROOT/node_modules" ]; then cp -R "$ROOT/node_modules" "$PAYLOAD_DIR/node_modules"; fi
+cp -R "$ROOT/scripts/." "$PAYLOAD_DIR/scripts/"
+cp -R "$ROOT/agents/." "$PAYLOAD_DIR/agents/"
+cp -R "$ROOT/release/native-installers" "$PAYLOAD_DIR/release/"
+cp "$ROOT/package.json" "$ROOT/package-lock.json" "$PAYLOAD_DIR/"
+cp "$ROOT/LICENSE" "$PAYLOAD_DIR/licenses/"
+if [ -f "$ROOT/NOTICE" ]; then
+  cp "$ROOT/NOTICE" "$PAYLOAD_DIR/licenses/"
+fi
+cp "$ROOT/uninstall.sh" "$PAYLOAD_DIR/uninstall.sh"
+
+if [ -n "${NEMOCLAW_OPENSHELL_BIN:-}" ]; then
+  cp "$NEMOCLAW_OPENSHELL_BIN" "$PAYLOAD_DIR/tools/openshell"
+else
+  echo "[native-installer] Warning: NEMOCLAW_OPENSHELL_BIN not set; payload has no pinned OpenShell binary." >&2
+fi
+
+if [ -n "${NEMOCLAW_MAC_INSTALLER_NODE_TARBALL:-}" ]; then
+  cp "$NEMOCLAW_MAC_INSTALLER_NODE_TARBALL" "$PAYLOAD_DIR/tools/node-runtime.tar.gz"
+else
+  echo "[native-installer] Warning: NEMOCLAW_MAC_INSTALLER_NODE_TARBALL not set; payload has no private Node runtime." >&2
+fi
+
+if command -v syft >/dev/null 2>&1; then
+  syft dir:"$PAYLOAD_DIR" -o spdx-json > "$PAYLOAD_DIR/sbom.spdx.json"
+else
+  printf '{"warning":"syft not found; SBOM not generated"}\n' > "$PAYLOAD_DIR/sbom.spdx.json"
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[native-installer] Dry run complete: payload staged at $PAYLOAD_DIR"
+  exit 0
+fi
+
+echo "[native-installer] Building SwiftUI app"
+swift build -c release --package-path "$APP_DIR" --scratch-path "$BUILD_DIR/swift-build"
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS" "$APP_BUNDLE/Contents/Resources"
+cp "$BUILD_DIR/swift-build/release/NemoClawMacInstaller" "$APP_BUNDLE/Contents/MacOS/NemoClawMacInstaller"
+cp -R "$PAYLOAD_DIR" "$APP_BUNDLE/Contents/Resources/payload"
+cat > "$APP_BUNDLE/Contents/Info.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>NemoClawMacInstaller</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.nvidia.nemoclaw.mac-installer-preview</string>
+  <key>CFBundleName</key>
+  <string>NemoClaw Mac Installer Preview</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0-preview</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+</dict>
+</plist>
+EOF
+
+if [ -n "${DEVELOPER_ID_APPLICATION:-}" ]; then
+  echo "[native-installer] Signing app bundle"
+  codesign --force --deep --options runtime \
+    --entitlements "$ROOT/release/native-installers/macos/entitlements.plist" \
+    --sign "$DEVELOPER_ID_APPLICATION" "$APP_BUNDLE"
+else
+  echo "[native-installer] Warning: DEVELOPER_ID_APPLICATION not set; leaving app unsigned." >&2
+fi
+
+echo "[native-installer] Creating DMG"
+rm -f "$DMG_PATH"
+hdiutil create -volname "NemoClaw Mac Installer Preview" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG_PATH"
+
+if [ -n "${DEVELOPER_ID_APPLICATION:-}" ]; then
+  codesign --force --sign "$DEVELOPER_ID_APPLICATION" "$DMG_PATH"
+fi
+
+if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ] && [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]; then
+  echo "[native-installer] Submitting DMG for notarization"
+  xcrun notarytool submit "$DMG_PATH" \
+    --apple-id "$APPLE_ID" \
+    --team-id "$APPLE_TEAM_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --wait
+  xcrun stapler staple "$DMG_PATH"
+else
+  echo "[native-installer] Notarization env vars not set; skipping notarization." >&2
+fi
+
+echo "[native-installer] Built $APP_BUNDLE"
+echo "[native-installer] Built $DMG_PATH"

--- a/src/commands/diagnostics/export.ts
+++ b/src/commands/diagnostics/export.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+
+import type { PublicCommandDisplayEntry } from "../../lib/cli/command-display";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+import { runDebug } from "../../lib/diagnostics/debug";
+import { runDebugCommandWithOptions } from "../../lib/diagnostics/debug-command";
+
+export default class DiagnosticsExportCommand extends NemoClawCommand {
+  static id = "diagnostics:export";
+  static strict = true;
+  static summary = "Export diagnostics tarball";
+  static description = "Export NemoClaw diagnostics to a tarball for recovery or support.";
+  static usage = ["diagnostics export --output <path> [--sandbox NAME] [--quick]"];
+  static examples = ["<%= config.bin %> diagnostics export --output /tmp/nemoclaw-debug.tar.gz"];
+  static publicDisplay = [
+    {
+      usage: "nemoclaw diagnostics export",
+      description: "Export diagnostics tarball",
+      flags: "--output <path> [--sandbox NAME] [--quick]",
+      group: "Troubleshooting",
+      scope: "global",
+      order: 37.5,
+    },
+  ] satisfies readonly PublicCommandDisplayEntry[];
+  static flags = {
+    output: Flags.string({
+      char: "o",
+      description: "Write a tarball to FILE",
+      required: true,
+    }),
+    sandbox: Flags.string({ description: "Target sandbox name" }),
+    quick: Flags.boolean({ char: "q", description: "Only collect minimal diagnostics" }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(DiagnosticsExportCommand);
+    runDebugCommandWithOptions(
+      {
+        output: flags.output,
+        sandboxName: flags.sandbox,
+        quick: flags.quick === true,
+      },
+      {
+        getDefaultSandbox: () => undefined,
+        runDebug,
+      },
+    );
+  }
+}

--- a/src/commands/native-installer/mac/assess.ts
+++ b/src/commands/native-installer/mac/assess.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { PublicCommandDisplayEntry } from "../../../lib/cli/command-display";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+import {
+  assessNativeInstallerHost,
+  renderNativeInstallerAssessmentText,
+} from "../../../lib/native-installer/macos/assess";
+
+export default class NativeInstallerAssessCommand extends NemoClawCommand {
+  static id = "native-installer:mac:assess";
+  static strict = true;
+  static enableJsonFlag = true;
+  static summary = "Assess Mac Installer Preview eligibility";
+  static description = "Check whether this Mac can use the experimental NemoClaw Mac Installer Preview.";
+  static usage = ["native-installer mac assess [--json]"];
+  static examples = ["<%= config.bin %> native-installer mac assess --json"];
+  static publicDisplay = [
+    {
+      usage: "nemoclaw native-installer mac assess",
+      description: "Assess Mac Installer Preview eligibility",
+      flags: "[--json]",
+      group: "Getting Started",
+      scope: "global",
+      order: 1.1,
+    },
+  ] satisfies readonly PublicCommandDisplayEntry[];
+  static flags = {};
+
+  public async run(): Promise<unknown> {
+    await this.parse(NativeInstallerAssessCommand);
+    const assessment = assessNativeInstallerHost();
+    if (this.jsonEnabled()) return assessment;
+    for (const line of renderNativeInstallerAssessmentText(assessment)) this.log(line);
+    if (!assessment.supported) this.setExitCode(1);
+  }
+}

--- a/src/commands/native-installer/mac/describe.ts
+++ b/src/commands/native-installer/mac/describe.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { PublicCommandDisplayEntry } from "../../../lib/cli/command-display";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+import { loadNativeInstallerInstallPlan } from "../../../lib/native-installer/macos/describe";
+
+export default class NativeInstallerDescribeCommand extends NemoClawCommand {
+  static id = "native-installer:mac:describe";
+  static strict = true;
+  static enableJsonFlag = true;
+  static summary = "Describe the Mac Installer Preview plan";
+  static description = "Return the YAML-backed, app-facing native Mac installer plan.";
+  static usage = ["native-installer mac describe --json"];
+  static examples = ["<%= config.bin %> native-installer mac describe --json"];
+  static publicDisplay = [
+    {
+      usage: "nemoclaw native-installer mac describe",
+      description: "Describe the Mac Installer Preview install plan",
+      flags: "--json",
+      group: "Getting Started",
+      scope: "global",
+      order: 1.05,
+    },
+  ] satisfies readonly PublicCommandDisplayEntry[];
+  static flags = {};
+
+  public async run(): Promise<unknown> {
+    await this.parse(NativeInstallerDescribeCommand);
+    const plan = loadNativeInstallerInstallPlan();
+    if (this.jsonEnabled()) return plan;
+    this.log("NemoClaw Mac Installer Preview plan");
+    this.log("");
+    for (const agent of plan.agents) {
+      this.log(`- ${agent.displayName}: ${agent.description}`);
+    }
+    this.log("");
+    this.log("Use --json for the structured app contract.");
+  }
+}

--- a/src/commands/native-installer/mac/install.ts
+++ b/src/commands/native-installer/mac/install.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+
+import type { PublicCommandDisplayEntry } from "../../../lib/cli/command-display";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+import { loadNativeInstallerConfigFile } from "../../../lib/native-installer/macos/config";
+import {
+  NativeInstallerInstallError,
+  progressEventToJsonLine,
+  runNativeInstallerInstall,
+} from "../../../lib/native-installer/macos/install";
+
+export default class NativeInstallerInstallCommand extends NemoClawCommand {
+  static id = "native-installer:mac:install";
+  static strict = true;
+  static summary = "Install a stock agent through the Mac Installer Preview";
+  static description = "Install stock OpenClaw or Hermes through the experimental native macOS installer path.";
+  static usage = ["native-installer mac install --config <json> [--json-progress]"];
+  static examples = ["<%= config.bin %> native-installer mac install --config mac-installer.json --json-progress"];
+  static publicDisplay = [
+    {
+      usage: "nemoclaw native-installer mac install",
+      description: "Install stock OpenClaw or Hermes through Mac Installer Preview",
+      flags: "--config <json> [--json-progress]",
+      group: "Getting Started",
+      scope: "global",
+      order: 1.2,
+    },
+  ] satisfies readonly PublicCommandDisplayEntry[];
+  static flags = {
+    config: Flags.string({
+      description: "Path to native Mac installer config JSON",
+      required: true,
+    }),
+    "json-progress": Flags.boolean({
+      description: "Emit newline-delimited JSON progress events",
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(NativeInstallerInstallCommand);
+    let config;
+    try {
+      config = loadNativeInstallerConfigFile(flags.config);
+    } catch (error) {
+      this.failWithLines([error instanceof Error ? error.message : String(error)]);
+      return;
+    }
+
+    const emit = flags["json-progress"]
+      ? (event: Parameters<typeof progressEventToJsonLine>[0]) => this.log(progressEventToJsonLine(event))
+      : (event: Parameters<typeof progressEventToJsonLine>[0]) => this.log(`${event.phase}: ${event.message}`);
+
+    try {
+      await runNativeInstallerInstall(config, { emit });
+    } catch (error) {
+      if (error instanceof NativeInstallerInstallError) {
+        this.setExitCode(1);
+        return;
+      }
+      throw error;
+    }
+  }
+}

--- a/src/commands/native-installer/mac/launch.ts
+++ b/src/commands/native-installer/mac/launch.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+
+import type { PublicCommandDisplayEntry } from "../../../lib/cli/command-display";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+import { isNativeInstallerAgentName } from "../../../lib/native-installer/macos/images";
+import {
+  renderNativeInstallerLaunchText,
+  runNativeInstallerLaunch,
+} from "../../../lib/native-installer/macos/launch";
+
+export default class NativeInstallerLaunchCommand extends NemoClawCommand {
+  static id = "native-installer:mac:launch";
+  static strict = true;
+  static enableJsonFlag = true;
+  static summary = "Launch the selected Mac Installer Preview agent";
+  static description = "Open OpenClaw or print Hermes API console details for a native Mac installer sandbox.";
+  static usage = ["native-installer mac launch [--agent openclaw|hermes] [--json] [--no-open]"];
+  static examples = [
+    "<%= config.bin %> native-installer mac launch --agent openclaw",
+    "<%= config.bin %> native-installer mac launch --agent hermes --json",
+  ];
+  static publicDisplay = [
+    {
+      usage: "nemoclaw native-installer mac launch",
+      description: "Launch the selected Mac Installer Preview agent",
+      flags: "[--agent openclaw|hermes] [--json] [--no-open]",
+      group: "Getting Started",
+      scope: "global",
+      order: 1.3,
+    },
+  ] satisfies readonly PublicCommandDisplayEntry[];
+  static flags = {
+    agent: Flags.string({ description: "Agent to launch: openclaw or hermes" }),
+    open: Flags.boolean({
+      allowNo: true,
+      default: true,
+      description: "Open browser for UI agents",
+    }),
+  };
+
+  public async run(): Promise<unknown> {
+    const { flags } = await this.parse(NativeInstallerLaunchCommand);
+    const requestedAgent = typeof flags.agent === "string" ? flags.agent : undefined;
+    if (requestedAgent && !isNativeInstallerAgentName(requestedAgent)) {
+      this.failWithLines(["--agent must be openclaw or hermes"]);
+      return;
+    }
+    const agent = requestedAgent && isNativeInstallerAgentName(requestedAgent) ? requestedAgent : undefined;
+    try {
+      const info = runNativeInstallerLaunch(agent, { open: this.jsonEnabled() ? false : flags.open });
+      if (this.jsonEnabled()) return info;
+      for (const line of renderNativeInstallerLaunchText(info)) this.log(line);
+    } catch (error) {
+      this.failWithLines([error instanceof Error ? error.message : String(error)]);
+    }
+  }
+}

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -122,6 +122,25 @@ function collectShell(collectDir: string, label: string, shellCmd: string): void
 
   if (result.status !== 0) {
     console.log("  (command exited with non-zero status)");
+  }
+}
+
+function collectNativeInstallerAppContext(collectDir: string): void {
+  const contextDir = process.env.NEMOCLAW_MAC_INSTALLER_DIAGNOSTICS_DIR;
+  if (!contextDir || !existsSync(contextDir)) return;
+
+  section("Mac Installer Preview App");
+  for (const entry of readdirSync(contextDir)) {
+    const safeName = basename(entry).replace(/[^A-Za-z0-9_.-]/g, "_");
+    if (!safeName) continue;
+    const source = join(contextDir, entry);
+    try {
+      const content = readFileSync(source, "utf8");
+      writeFileSync(join(collectDir, `native-installer-${safeName}`), redact(content));
+      console.log(`  collected ${safeName}`);
+    } catch {
+      // Ignore non-text files or entries that disappeared while diagnostics ran.
+    }
   }
 }
 
@@ -509,6 +528,7 @@ export function runDebug(opts: DebugOptions = {}): void {
     collectDocker(collectDir, quick);
     collectOpenshell(collectDir, sandboxName, quick);
     collectOnboardSession(collectDir, repoDir);
+    collectNativeInstallerAppContext(collectDir);
     collectSandboxInternals(collectDir, sandboxName, quick);
 
     if (!quick) {

--- a/src/lib/native-installer/index.ts
+++ b/src/lib/native-installer/index.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from "./macos";

--- a/src/lib/native-installer/macos/assess.ts
+++ b/src/lib/native-installer/macos/assess.ts
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+
+import {
+  assessHost,
+  planHostRemediation,
+  type AssessHostOpts,
+  type HostAssessment,
+  type RemediationAction,
+} from "../../onboard/preflight";
+import { loadNativeInstallerInstallPlan, type NativeInstallerInstallPlan } from "./describe";
+
+export interface NativeInstallerRequirement {
+  id: string;
+  label: string;
+  status: "pass" | "warn" | "fail";
+  detail: string;
+  recovery?: string;
+}
+
+export interface NativeInstallerAssessment {
+  experimental: true;
+  supported: boolean;
+  platform: {
+    os: NodeJS.Platform | string;
+    arch: string;
+    macosVersion?: string | null;
+    target: "Apple Silicon macOS 13+";
+  };
+  host: Pick<
+    HostAssessment,
+    | "runtime"
+    | "dockerInstalled"
+    | "dockerRunning"
+    | "dockerReachable"
+    | "dockerInfoSummary"
+    | "dockerCpus"
+    | "dockerMemTotalBytes"
+    | "openshellInstalled"
+    | "nodeInstalled"
+  >;
+  requirements: NativeInstallerRequirement[];
+  remediation: RemediationAction[];
+  recoveryActions: string[];
+  baseImages: NativeInstallerInstallPlan["install"]["baseImages"];
+}
+
+export interface NativeInstallerAssessmentDeps extends AssessHostOpts {
+  arch?: string;
+  macosVersion?: string | null;
+  hostAssessment?: HostAssessment;
+  remediationActions?: RemediationAction[];
+  spawnSync?: typeof spawnSync;
+  rootDir?: string;
+  planPath?: string;
+}
+
+function readMacosVersion(deps: NativeInstallerAssessmentDeps): string | null {
+  if (deps.macosVersion !== undefined) return deps.macosVersion;
+  if ((deps.platform ?? process.platform) !== "darwin") return null;
+  const result = (deps.spawnSync ?? spawnSync)("sw_vers", ["-productVersion"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(deps.env ?? {}) },
+  });
+  return result.status === 0 ? (result.stdout || "").trim() || null : null;
+}
+
+function macosMajor(version: string | null): number | null {
+  if (!version) return null;
+  const major = Number.parseInt(version.split(".")[0] || "", 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+function getHostAssessment(deps: NativeInstallerAssessmentDeps): HostAssessment {
+  if (deps.hostAssessment) return deps.hostAssessment;
+  return assessHost({
+    platform: deps.platform,
+    env: deps.env,
+    release: deps.release,
+    procVersion: deps.procVersion,
+    dockerInfoOutput: deps.dockerInfoOutput,
+    dockerInfoError: deps.dockerInfoError,
+    readFileImpl: deps.readFileImpl,
+    readdirImpl: deps.readdirImpl,
+    runCaptureImpl: deps.runCaptureImpl,
+    commandExistsImpl: deps.commandExistsImpl,
+    gpuProbeImpl: deps.gpuProbeImpl,
+  });
+}
+
+function recoveryFrom(actions: readonly RemediationAction[], ids: readonly string[]): string | undefined {
+  const action = actions.find((candidate) => ids.includes(candidate.id));
+  return action && action.commands.length > 0 ? action.commands.join("\n") : action?.reason;
+}
+
+function runtimeLabel(runtime: HostAssessment["runtime"]): string {
+  switch (runtime) {
+    case "docker-desktop":
+      return "Docker Desktop";
+    case "colima":
+      return "Colima";
+    case "docker":
+      return "Docker";
+    case "podman":
+      return "Podman";
+    default:
+      return "Docker runtime";
+  }
+}
+
+function formatRuntimeResources(host: HostAssessment): string {
+  const parts: string[] = [];
+  if (typeof host.dockerCpus === "number") parts.push(`${String(host.dockerCpus)} vCPU`);
+  if (typeof host.dockerMemTotalBytes === "number") {
+    parts.push(`${(host.dockerMemTotalBytes / 1024 ** 3).toFixed(1)} GiB RAM`);
+  }
+  return parts.length > 0 ? parts.join(" / ") : "resource limits unknown";
+}
+
+function buildRequirements(
+  host: HostAssessment,
+  actions: readonly RemediationAction[],
+  deps: NativeInstallerAssessmentDeps,
+): NativeInstallerRequirement[] {
+  const platform = deps.platform ?? process.platform;
+  const arch = deps.arch ?? process.arch;
+  const macosVersion = readMacosVersion(deps);
+  const major = macosMajor(macosVersion);
+  const platformOk = platform === "darwin" && arch === "arm64" && (major === null || major >= 13);
+  const requirements: NativeInstallerRequirement[] = [
+    {
+      id: "platform",
+      label: "Apple Silicon macOS 13+",
+      status: platformOk ? "pass" : "fail",
+      detail:
+        platform === "darwin"
+          ? `Detected macOS ${macosVersion ?? os.release()} on ${arch}.`
+          : `Detected ${platform} on ${arch}.`,
+      ...(platformOk
+        ? {}
+        : {
+            recovery:
+              "Use the standard NemoClaw installer on Linux, WSL, DGX Spark, Intel Macs, or older macOS releases.",
+          }),
+    },
+    {
+      id: "docker-cli",
+      label: "Docker CLI",
+      status: host.dockerInstalled ? "pass" : "fail",
+      detail: host.dockerInstalled ? "Docker CLI is available." : "Docker CLI was not found.",
+      ...(host.dockerInstalled
+        ? {}
+        : { recovery: recoveryFrom(actions, ["install_docker"]) ?? "Install Docker, then retry." }),
+    },
+    {
+      id: "docker-daemon",
+      label: "Docker daemon",
+      status: host.dockerReachable ? "pass" : "fail",
+      detail: host.dockerReachable
+        ? host.dockerInfoSummary
+          ? `Docker daemon is reachable (${host.dockerInfoSummary}).`
+          : "Docker daemon is reachable."
+        : host.dockerInstalled
+          ? "Docker CLI is installed, but the daemon is not reachable."
+          : "Docker daemon was not checked because Docker CLI is missing.",
+      ...(host.dockerReachable
+        ? {}
+        : {
+            recovery:
+              recoveryFrom(actions, [
+                "start_docker",
+                "docker_group_permission",
+                "install_docker",
+              ]) ?? "Start Docker Desktop or Colima, then retry.",
+          }),
+    },
+  ];
+
+  if (host.dockerReachable) {
+    requirements.push({
+      id: "container-runtime",
+      label: runtimeLabel(host.runtime),
+      status: host.isUnsupportedRuntime ? "warn" : "pass",
+      detail: host.isUnsupportedRuntime
+        ? "This runtime is not the standard Docker path used by NemoClaw onboarding."
+        : `${runtimeLabel(host.runtime)} is the active container runtime.`,
+      ...(host.isUnsupportedRuntime
+        ? { recovery: recoveryFrom(actions, ["unsupported_runtime_warning"]) }
+        : {}),
+    });
+  }
+
+  if (host.dockerReachable && host.isContainerRuntimeUnderProvisioned) {
+    requirements.push({
+      id: "container-runtime-resources",
+      label: "Runtime resources",
+      status: "warn",
+      detail: `Container runtime looks small (${formatRuntimeResources(host)}).`,
+      recovery: recoveryFrom(actions, ["container_runtime_under_provisioned"]),
+    });
+  }
+
+  requirements.push({
+    id: "openshell",
+    label: "OpenShell",
+    status: host.openshellInstalled ? "pass" : "warn",
+    detail: host.openshellInstalled
+      ? "OpenShell CLI is available."
+      : "OpenShell CLI is not on PATH; the app bundle or standard installer can provide it.",
+    ...(host.openshellInstalled
+      ? {}
+      : { recovery: recoveryFrom(actions, ["install_openshell"]) }),
+  });
+
+  if (!host.nodeInstalled) {
+    requirements.push({
+      id: "nodejs",
+      label: "Node.js",
+      status: "warn",
+      detail: "Node.js is not on PATH; the app payload is expected to include its runtime.",
+      recovery: recoveryFrom(actions, ["install_nodejs"]),
+    });
+  }
+
+  return requirements;
+}
+
+export function assessNativeInstallerHost(deps: NativeInstallerAssessmentDeps = {}): NativeInstallerAssessment {
+  const host = getHostAssessment(deps);
+  const remediation = deps.remediationActions ?? planHostRemediation(host);
+  const requirements = buildRequirements(host, remediation, deps);
+  const plan = loadNativeInstallerInstallPlan({ rootDir: deps.rootDir, planPath: deps.planPath });
+  const hardFailures = requirements.filter((requirement) => requirement.status === "fail");
+
+  return {
+    experimental: true,
+    supported: hardFailures.length === 0,
+    platform: {
+      os: deps.platform ?? process.platform,
+      arch: deps.arch ?? process.arch,
+      macosVersion: readMacosVersion(deps),
+      target: "Apple Silicon macOS 13+",
+    },
+    host: {
+      runtime: host.runtime,
+      dockerInstalled: host.dockerInstalled,
+      dockerRunning: host.dockerRunning,
+      dockerReachable: host.dockerReachable,
+      dockerInfoSummary: host.dockerInfoSummary,
+      dockerCpus: host.dockerCpus,
+      dockerMemTotalBytes: host.dockerMemTotalBytes,
+      openshellInstalled: host.openshellInstalled,
+      nodeInstalled: host.nodeInstalled,
+    },
+    requirements,
+    remediation,
+    recoveryActions: remediation
+      .filter((action) => action.blocking)
+      .flatMap((action) => action.commands.length > 0 ? action.commands : [action.reason]),
+    baseImages: plan.install.baseImages,
+  };
+}
+
+export function renderNativeInstallerAssessmentText(assessment: NativeInstallerAssessment): string[] {
+  const lines = ["NemoClaw Mac Installer Preview assessment", ""];
+  for (const requirement of assessment.requirements) {
+    const marker =
+      requirement.status === "pass" ? "OK" : requirement.status === "warn" ? "WARN" : "FAIL";
+    lines.push(`[${marker}] ${requirement.label}: ${requirement.detail}`);
+    if (requirement.status !== "pass" && requirement.recovery) {
+      lines.push(`      ${requirement.recovery}`);
+    }
+  }
+  lines.push("");
+  lines.push(
+    assessment.supported
+      ? "This Mac is eligible for the experimental Mac Installer Preview."
+      : "Use the standard installer or fix the failed requirements before trying native Mac installer.",
+  );
+  return lines;
+}

--- a/src/lib/native-installer/macos/config.ts
+++ b/src/lib/native-installer/macos/config.ts
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { isNativeInstallerAgentName, type NativeInstallerAgentName } from "./images";
+import { formatNativeInstallerProviderIds, isNativeInstallerProviderId } from "./providers";
+
+export type NativeInstallerMode = "fresh" | "resume";
+
+export interface NativeInstallerConfig {
+  agent: NativeInstallerAgentName;
+  sandboxName?: string;
+  provider?: string;
+  model?: string;
+  endpoint?: string;
+  security?: {
+    tier?: string;
+    presets?: string[];
+  };
+  messaging?: string[];
+  mode?: NativeInstallerMode;
+  ports?: {
+    dashboard?: number;
+    api?: number;
+  };
+}
+
+export interface NativeInstallerConfigValidation {
+  ok: boolean;
+  config?: NativeInstallerConfig;
+  errors: string[];
+}
+
+const SUPPORTED_MODES = new Set(["fresh", "resume"]);
+const SECRET_KEY_RE = /(^|[_-])(secret|token|password|credential)([_-]|$)|api[_-]?key|key$/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  errors: string[],
+): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    errors.push(`${key} must be an array of strings`);
+    return undefined;
+  }
+  return value.map((entry) => entry.trim()).filter(Boolean);
+}
+
+function readPort(value: unknown, label: string, errors: string[]): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || (value as number) < 1024 || (value as number) > 65535) {
+    errors.push(`${label} must be an integer TCP port between 1024 and 65535`);
+    return undefined;
+  }
+  return value as number;
+}
+
+function findSecretKeys(value: unknown, prefix = "$"): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) => findSecretKeys(entry, `${prefix}[${String(index)}]`));
+  }
+  if (!isPlainObject(value)) return [];
+  const findings: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    const pathLabel = `${prefix}.${key}`;
+    if (SECRET_KEY_RE.test(key)) findings.push(pathLabel);
+    findings.push(...findSecretKeys(nested, pathLabel));
+  }
+  return findings;
+}
+
+export function validateNativeInstallerConfig(input: unknown): NativeInstallerConfigValidation {
+  const errors: string[] = [];
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: ["config must be a JSON object"] };
+  }
+
+  for (const keyPath of findSecretKeys(input)) {
+    errors.push(`secrets must not be stored in native Mac installer config JSON (${keyPath})`);
+  }
+
+  if ("from" in input || "dockerfile" in input || "customDockerfile" in input) {
+    errors.push("Mac Installer Preview v1 supports stock OpenClaw and Hermes only; custom Dockerfiles use nemoclaw onboard --from");
+  }
+
+  const agent = readString(input, "agent");
+  if (!agent || !isNativeInstallerAgentName(agent)) {
+    errors.push("agent must be one of openclaw, hermes");
+  }
+
+  const mode = readString(input, "mode");
+  if (mode && !SUPPORTED_MODES.has(mode)) {
+    errors.push("mode must be fresh or resume");
+  }
+
+  const provider = readString(input, "provider");
+  if (provider && !isNativeInstallerProviderId(provider)) {
+    errors.push(
+      `provider must be one of the installer-supported native Mac installer providers: ${formatNativeInstallerProviderIds()}`,
+    );
+  }
+  const endpoint = readString(input, "endpoint");
+
+  const securityValue = input.security;
+  let security: NativeInstallerConfig["security"];
+  if (securityValue !== undefined) {
+    if (!isPlainObject(securityValue)) {
+      errors.push("security must be an object");
+    } else {
+      const tier = readString(securityValue, "tier");
+      const presets = readStringArray(securityValue, "presets", errors);
+      security = {
+        ...(tier ? { tier } : {}),
+        ...(presets ? { presets } : {}),
+      };
+    }
+  }
+
+  let ports: NativeInstallerConfig["ports"];
+  if (input.ports !== undefined) {
+    if (!isPlainObject(input.ports)) {
+      errors.push("ports must be an object");
+    } else {
+      ports = {
+        dashboard: readPort(input.ports.dashboard, "ports.dashboard", errors),
+        api: readPort(input.ports.api, "ports.api", errors),
+      };
+      if (ports.dashboard === undefined) delete ports.dashboard;
+      if (ports.api === undefined) delete ports.api;
+    }
+  }
+
+  const messaging = readStringArray(input, "messaging", errors);
+  const sandboxName = readString(input, "sandboxName");
+  const model = readString(input, "model");
+
+  if (errors.length > 0 || !agent || !isNativeInstallerAgentName(agent)) {
+    return { ok: false, errors };
+  }
+
+  const config: NativeInstallerConfig = {
+    agent,
+    ...(sandboxName ? { sandboxName } : {}),
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+    ...(endpoint ? { endpoint } : {}),
+    ...(security ? { security } : {}),
+    ...(messaging ? { messaging } : {}),
+    ...(mode ? { mode: mode as NativeInstallerMode } : {}),
+    ...(ports ? { ports } : {}),
+  };
+
+  return { ok: true, config, errors: [] };
+}
+
+export function loadNativeInstallerConfigFile(filePath: string): NativeInstallerConfig {
+  const resolved = path.resolve(filePath);
+  const validation = validateNativeInstallerConfig(JSON.parse(fs.readFileSync(resolved, "utf8")));
+  if (!validation.ok || !validation.config) {
+    throw new Error(validation.errors.join("\n"));
+  }
+  return validation.config;
+}

--- a/src/lib/native-installer/macos/describe.ts
+++ b/src/lib/native-installer/macos/describe.ts
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadAgent } from "../../agent/defs";
+import { ROOT } from "../../runner";
+import { NATIVE_INSTALLER_SUPPORTED_AGENTS, isNativeInstallerAgentName, type NativeInstallerAgentName } from "./images";
+import {
+  formatNativeInstallerProviderIds,
+  getNativeInstallerProvider,
+} from "./providers";
+
+const yaml: { load(input: string): unknown } = require("js-yaml");
+
+type JsonRecord = Record<string, unknown>;
+
+export interface NativeInstallerPlanRequirement {
+  id: string;
+  label: string;
+  required: boolean;
+  recovery?: string;
+}
+
+export interface NativeInstallerPlanAgent {
+  name: NativeInstallerAgentName;
+  displayName: string;
+  description: string;
+  dashboardKind: "ui" | "api";
+  port: number;
+  messaging: string[];
+  label?: string;
+  icon?: string;
+  recommended: boolean;
+}
+
+export interface NativeInstallerPlanProvider {
+  id: string;
+  title: string;
+  defaultModel: string;
+  envVar?: string;
+  guidance: string;
+  systemImage: string;
+  recommended: boolean;
+  supportedAgents: NativeInstallerAgentName[];
+}
+
+export interface NativeInstallerPlanTrustTier {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  recommended: boolean;
+  presets: string[];
+}
+
+export interface NativeInstallerPlanBaseImage {
+  agent: NativeInstallerAgentName;
+  ref: string;
+  env: string;
+  applyByDefault: boolean;
+  note?: string;
+}
+
+export interface NativeInstallerInstallPlan {
+  version: 1;
+  experimental: true;
+  source: string;
+  target: "Apple Silicon macOS 13+";
+  summary: string;
+  requirements: NativeInstallerPlanRequirement[];
+  agents: NativeInstallerPlanAgent[];
+  model: {
+    defaultProvider: string;
+    providers: NativeInstallerPlanProvider[];
+  };
+  trust: {
+    defaultTier: string;
+    tiers: NativeInstallerPlanTrustTier[];
+  };
+  review: {
+    handoffPolicy: string;
+    stockOnly: string;
+  };
+  install: {
+    defaultSandboxName: string;
+    defaultMode: "fresh" | "resume";
+    progressPhases: Array<{ id: string; title: string }>;
+    baseImages: NativeInstallerPlanBaseImage[];
+  };
+  launch: Record<string, { kind: "ui" | "api"; action: string }>;
+}
+
+export interface NativeInstallerDescribeDeps {
+  rootDir?: string;
+  planPath?: string;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function asRecord(value: unknown, label: string): JsonRecord {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  return value;
+}
+
+function asArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function stringField(record: JsonRecord, key: string, label: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label}.${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalStringField(record: JsonRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function booleanField(record: JsonRecord, key: string, defaultValue: boolean): boolean {
+  const value = record[key];
+  return typeof value === "boolean" ? value : defaultValue;
+}
+
+function stringArrayField(record: JsonRecord, key: string, label: string): string[] {
+  const value = record[key];
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`${label}.${key} must be an array of strings`);
+  }
+  return value.map((entry) => entry.trim()).filter(Boolean);
+}
+
+function parseRequirement(value: unknown, index: number): NativeInstallerPlanRequirement {
+  const record = asRecord(value, `requirements[${String(index)}]`);
+  return {
+    id: stringField(record, "id", `requirements[${String(index)}]`),
+    label: stringField(record, "label", `requirements[${String(index)}]`),
+    required: booleanField(record, "required", true),
+    ...(optionalStringField(record, "recovery")
+      ? { recovery: optionalStringField(record, "recovery") }
+      : {}),
+  };
+}
+
+function parseRawAgent(value: unknown, index: number): {
+  name: NativeInstallerAgentName;
+  description?: string;
+  label?: string;
+  icon?: string;
+  recommended: boolean;
+} {
+  const record = asRecord(value, `agents[${String(index)}]`);
+  const name = stringField(record, "name", `agents[${String(index)}]`);
+  if (!isNativeInstallerAgentName(name)) {
+    throw new Error(`agents[${String(index)}].name must be one of ${NATIVE_INSTALLER_SUPPORTED_AGENTS.join(", ")}`);
+  }
+  return {
+    name,
+    ...(optionalStringField(record, "description")
+      ? { description: optionalStringField(record, "description") }
+      : {}),
+    ...(optionalStringField(record, "label") ? { label: optionalStringField(record, "label") } : {}),
+    ...(optionalStringField(record, "icon") ? { icon: optionalStringField(record, "icon") } : {}),
+    recommended: booleanField(record, "recommended", false),
+  };
+}
+
+function parseProvider(value: unknown, index: number): Omit<NativeInstallerPlanProvider, "supportedAgents"> {
+  const record = asRecord(value, `model.providers[${String(index)}]`);
+  return {
+    id: stringField(record, "id", `model.providers[${String(index)}]`),
+    title: stringField(record, "title", `model.providers[${String(index)}]`),
+    defaultModel: stringField(record, "default_model", `model.providers[${String(index)}]`),
+    ...(optionalStringField(record, "env_var")
+      ? { envVar: optionalStringField(record, "env_var") }
+      : {}),
+    guidance: stringField(record, "guidance", `model.providers[${String(index)}]`),
+    systemImage: optionalStringField(record, "system_image") ?? "sparkles",
+    recommended: booleanField(record, "recommended", false),
+  };
+}
+
+function resolveProvider(
+  value: unknown,
+  index: number,
+  agents: NativeInstallerPlanAgent[],
+  agentSpecificProviders: Map<string, NativeInstallerAgentName[]>,
+): NativeInstallerPlanProvider {
+  const parsed = parseProvider(value, index);
+  const installerProvider = getNativeInstallerProvider(parsed.id);
+  if (!installerProvider) {
+    throw new Error(
+      `model.providers[${String(index)}].id '${parsed.id}' is not supported by nemoclaw onboard. Supported provider ids: ${formatNativeInstallerProviderIds()}`,
+    );
+  }
+  if (parsed.defaultModel !== installerProvider.defaultModel) {
+    throw new Error(
+      `model.providers[${String(index)}].default_model must match the onboard default for ${parsed.id}: ${installerProvider.defaultModel}`,
+    );
+  }
+  if (parsed.envVar && installerProvider.envVar && parsed.envVar !== installerProvider.envVar) {
+    throw new Error(
+      `model.providers[${String(index)}].env_var must match the onboard credential env for ${parsed.id}: ${installerProvider.envVar}`,
+    );
+  }
+
+  const supportedAgents =
+    agentSpecificProviders.get(parsed.id) ??
+    agents.map((agent) => agent.name);
+  if (supportedAgents.length === 0) {
+    throw new Error(`model.providers[${String(index)}].id '${parsed.id}' is not available to any native Mac installer agent`);
+  }
+
+  return {
+    ...parsed,
+    title: installerProvider.title,
+    defaultModel: installerProvider.defaultModel,
+    ...(installerProvider.envVar ? { envVar: installerProvider.envVar } : {}),
+    supportedAgents,
+  };
+}
+
+function parseTrustTier(value: unknown, index: number): NativeInstallerPlanTrustTier {
+  const record = asRecord(value, `trust.tiers[${String(index)}]`);
+  return {
+    id: stringField(record, "id", `trust.tiers[${String(index)}]`),
+    title: stringField(record, "title", `trust.tiers[${String(index)}]`),
+    description: stringField(record, "description", `trust.tiers[${String(index)}]`),
+    icon: optionalStringField(record, "icon") ?? "checkmark.shield",
+    recommended: booleanField(record, "recommended", false),
+    presets: stringArrayField(record, "presets", `trust.tiers[${String(index)}]`),
+  };
+}
+
+function parseBaseImage(value: unknown, index: number): NativeInstallerPlanBaseImage {
+  const record = asRecord(value, `install.base_images[${String(index)}]`);
+  const agent = stringField(record, "agent", `install.base_images[${String(index)}]`);
+  if (!isNativeInstallerAgentName(agent)) {
+    throw new Error(
+      `install.base_images[${String(index)}].agent must be one of ${NATIVE_INSTALLER_SUPPORTED_AGENTS.join(", ")}`,
+    );
+  }
+  return {
+    agent,
+    ref: stringField(record, "ref", `install.base_images[${String(index)}]`),
+    env: stringField(record, "env", `install.base_images[${String(index)}]`),
+    applyByDefault: booleanField(record, "apply_by_default", false),
+    ...(optionalStringField(record, "note") ? { note: optionalStringField(record, "note") } : {}),
+  };
+}
+
+function parseProgressPhase(value: unknown, index: number): { id: string; title: string } {
+  const record = asRecord(value, `install.progress_phases[${String(index)}]`);
+  return {
+    id: stringField(record, "id", `install.progress_phases[${String(index)}]`),
+    title: stringField(record, "title", `install.progress_phases[${String(index)}]`),
+  };
+}
+
+function parseLaunch(value: unknown): NativeInstallerInstallPlan["launch"] {
+  const launch = asRecord(value, "launch");
+  const result: NativeInstallerInstallPlan["launch"] = {};
+  for (const [agent, raw] of Object.entries(launch)) {
+    if (!isRecord(raw)) throw new Error(`launch.${agent} must be an object`);
+    const kind = stringField(raw, "kind", `launch.${agent}`);
+    if (kind !== "ui" && kind !== "api") {
+      throw new Error(`launch.${agent}.kind must be ui or api`);
+    }
+    result[agent] = {
+      kind,
+      action: stringField(raw, "action", `launch.${agent}`),
+    };
+  }
+  return result;
+}
+
+export function macInstallerInstallPlanPath(rootDir = ROOT): string {
+  return path.join(rootDir, "release", "native-installers", "macos", "install-plan.yaml");
+}
+
+export function loadNativeInstallerInstallPlan(
+  deps: NativeInstallerDescribeDeps = {},
+): NativeInstallerInstallPlan {
+  const planPath = deps.planPath ?? macInstallerInstallPlanPath(deps.rootDir ?? ROOT);
+  const raw = asRecord(yaml.load(fs.readFileSync(planPath, "utf8")), "install-plan.yaml");
+  if (raw.version !== 1) throw new Error("install-plan.yaml version must be 1");
+  if (raw.experimental !== true) throw new Error("install-plan.yaml experimental must be true");
+
+  const requirements = asArray(raw.requirements, "requirements").map(parseRequirement);
+  const rawAgents = asArray(raw.agents, "agents").map(parseRawAgent);
+  const agents = rawAgents.map((entry) => {
+    const manifest = loadAgent(entry.name);
+    return {
+      name: entry.name,
+      displayName: manifest.displayName,
+      description: entry.description ?? manifest.description ?? "",
+      dashboardKind: manifest.dashboard.kind,
+      port: manifest.forwardPort,
+      messaging: manifest.messagingPlatforms,
+      ...(entry.label ? { label: entry.label } : {}),
+      ...(entry.icon ? { icon: entry.icon } : {}),
+      recommended: entry.recommended,
+    };
+  });
+  const agentSpecificProviders = new Map<string, NativeInstallerAgentName[]>();
+  for (const agent of agents) {
+    const manifest = loadAgent(agent.name);
+    for (const provider of manifest.inferenceProviderOptions) {
+      const existing = agentSpecificProviders.get(provider) ?? [];
+      existing.push(agent.name);
+      agentSpecificProviders.set(provider, existing);
+    }
+  }
+
+  const model = asRecord(raw.model, "model");
+  const providers = asArray(model.providers, "model.providers").map((provider, index) =>
+    resolveProvider(provider, index, agents, agentSpecificProviders),
+  );
+  const defaultProvider = stringField(model, "default_provider", "model");
+  if (!providers.some((provider) => provider.id === defaultProvider)) {
+    throw new Error(`model.default_provider must be one of the resolved native Mac installer providers`);
+  }
+  const trust = asRecord(raw.trust, "trust");
+  const tiers = asArray(trust.tiers, "trust.tiers").map(parseTrustTier);
+  const review = asRecord(raw.review, "review");
+  const install = asRecord(raw.install, "install");
+  const defaultMode = optionalStringField(install, "default_mode") ?? "fresh";
+  if (defaultMode !== "fresh" && defaultMode !== "resume") {
+    throw new Error("install.default_mode must be fresh or resume");
+  }
+
+  return {
+    version: 1,
+    experimental: true,
+    source: path.relative(deps.rootDir ?? ROOT, planPath) || planPath,
+    target: "Apple Silicon macOS 13+",
+    summary: stringField(raw, "summary", "install-plan.yaml"),
+    requirements,
+    agents,
+    model: {
+      defaultProvider,
+      providers,
+    },
+    trust: {
+      defaultTier: stringField(trust, "default_tier", "trust"),
+      tiers,
+    },
+    review: {
+      handoffPolicy: stringField(review, "handoff_policy", "review"),
+      stockOnly: stringField(review, "stock_only", "review"),
+    },
+    install: {
+      defaultSandboxName: stringField(install, "default_sandbox_name", "install"),
+      defaultMode,
+      progressPhases: asArray(install.progress_phases, "install.progress_phases").map(
+        parseProgressPhase,
+      ),
+      baseImages: asArray(install.base_images, "install.base_images").map(parseBaseImage),
+    },
+    launch: parseLaunch(raw.launch),
+  };
+}

--- a/src/lib/native-installer/macos/images.ts
+++ b/src/lib/native-installer/macos/images.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AgentDefinition } from "../../agent/defs";
+import { loadAgent } from "../../agent/defs";
+
+export type NativeInstallerAgentName = "openclaw" | "hermes";
+
+export const NATIVE_INSTALLER_SUPPORTED_AGENTS: readonly NativeInstallerAgentName[] = [
+  "openclaw",
+  "hermes",
+] as const;
+
+export function isNativeInstallerAgentName(value: string): value is NativeInstallerAgentName {
+  return (NATIVE_INSTALLER_SUPPORTED_AGENTS as readonly string[]).includes(value);
+}
+
+export function getNativeInstallerAgentDefinitions(): AgentDefinition[] {
+  return NATIVE_INSTALLER_SUPPORTED_AGENTS.map((agent) => loadAgent(agent));
+}

--- a/src/lib/native-installer/macos/index.ts
+++ b/src/lib/native-installer/macos/index.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from "./assess";
+export * from "./config";
+export * from "./describe";
+export * from "./images";
+export * from "./install";
+export * from "./launch";

--- a/src/lib/native-installer/macos/install.ts
+++ b/src/lib/native-installer/macos/install.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runOnboardAction } from "../../actions/global";
+import { NOTICE_ACCEPT_FLAG } from "../../onboard/usage-notice";
+import type { NativeInstallerConfig } from "./config";
+import { loadNativeInstallerInstallPlan, type NativeInstallerInstallPlan } from "./describe";
+
+export interface NativeInstallerProgressEvent {
+  phase: "plan_loaded" | "onboard_started" | "onboard_finished" | "launch_ready" | "failed";
+  status: "started" | "ok" | "failed";
+  message: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface NativeInstallerInstallDeps {
+  emit?: (event: NativeInstallerProgressEvent) => void;
+  runOnboardAction?: (args: string[]) => Promise<void>;
+  env?: NodeJS.ProcessEnv;
+  plan?: NativeInstallerInstallPlan;
+  loadPlan?: () => NativeInstallerInstallPlan;
+}
+
+export class NativeInstallerInstallError extends Error {
+  readonly event: NativeInstallerProgressEvent;
+  constructor(event: NativeInstallerProgressEvent, options?: ErrorOptions) {
+    super(event.message, options);
+    this.name = "NativeInstallerInstallError";
+    this.event = event;
+  }
+}
+
+function emit(deps: NativeInstallerInstallDeps, event: NativeInstallerProgressEvent): void {
+  deps.emit?.(event);
+}
+
+export function toLegacyOnboardArgs(config: NativeInstallerConfig): string[] {
+  const args = ["--non-interactive", "--yes", NOTICE_ACCEPT_FLAG];
+  if (config.mode === "resume") args.push("--resume");
+  else args.push("--fresh");
+  args.push("--agent", config.agent);
+  if (config.sandboxName) args.push("--name", config.sandboxName);
+  const port = config.agent === "hermes" ? config.ports?.api : config.ports?.dashboard;
+  if (port) args.push("--control-ui-port", String(port));
+  return args;
+}
+
+export const buildNativeInstallerOnboardArgs = toLegacyOnboardArgs;
+
+function applyBaseImageEnv(
+  env: NodeJS.ProcessEnv,
+  config: NativeInstallerConfig,
+  plan: NativeInstallerInstallPlan,
+): void {
+  for (const baseImage of plan.install.baseImages) {
+    if (baseImage.agent !== config.agent || !baseImage.applyByDefault) continue;
+    if (!env[baseImage.env]) env[baseImage.env] = baseImage.ref;
+  }
+}
+
+export function buildNativeInstallerOnboardEnv(
+  config: NativeInstallerConfig,
+  base: NodeJS.ProcessEnv = process.env,
+  plan: NativeInstallerInstallPlan = loadNativeInstallerInstallPlan(),
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...base };
+  env.NEMOCLAW_AGENT = config.agent;
+  env.NEMOCLAW_NON_INTERACTIVE = "1";
+  env.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE = "1";
+  if (config.provider) env.NEMOCLAW_PROVIDER = config.provider;
+  if (config.model) env.NEMOCLAW_MODEL = config.model;
+  if (config.endpoint) env.NEMOCLAW_ENDPOINT_URL = config.endpoint;
+  if (config.provider === "hermesProvider" && !env.NEMOCLAW_HERMES_AUTH_METHOD) {
+    env.NEMOCLAW_HERMES_AUTH_METHOD = "api_key";
+  }
+  if (config.security?.tier) env.NEMOCLAW_POLICY_TIER = config.security.tier;
+  if (config.security?.presets && config.security.presets.length > 0) {
+    env.NEMOCLAW_POLICY_MODE = "custom";
+    env.NEMOCLAW_POLICY_PRESETS = config.security.presets.join(",");
+  }
+  if (config.messaging && config.messaging.length > 0) {
+    env.NEMOCLAW_MESSAGING_CHANNELS = config.messaging.join(",");
+  }
+  applyBaseImageEnv(env, config, plan);
+  return env;
+}
+
+async function withTemporaryProcessEnv<T>(
+  env: NodeJS.ProcessEnv,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const touched = new Set(Object.keys(env));
+  const previous = new Map<string, string | undefined>();
+  for (const key of touched) {
+    previous.set(key, process.env[key]);
+    const value = env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function runNativeInstallerInstall(
+  config: NativeInstallerConfig,
+  deps: NativeInstallerInstallDeps = {},
+): Promise<void> {
+  const plan = deps.plan ?? deps.loadPlan?.() ?? loadNativeInstallerInstallPlan();
+  emit(deps, {
+    phase: "plan_loaded",
+    status: "ok",
+    message: "Mac Installer Preview plan loaded.",
+    detail: { source: plan.source, agent: config.agent },
+  });
+
+  const onboardEnv = buildNativeInstallerOnboardEnv(config, deps.env ?? process.env, plan);
+  const onboardArgs = toLegacyOnboardArgs(config);
+  emit(deps, {
+    phase: "onboard_started",
+    status: "started",
+    message: `Starting standard NemoClaw onboard for ${config.agent}.`,
+    detail: { args: onboardArgs },
+  });
+
+  try {
+    await withTemporaryProcessEnv(onboardEnv, async () => {
+      await (deps.runOnboardAction ?? runOnboardAction)(onboardArgs);
+    });
+  } catch (error) {
+    const event: NativeInstallerProgressEvent = {
+      phase: "failed",
+      status: "failed",
+      message: "NemoClaw onboard did not finish.",
+      detail: { error: errorMessage(error) },
+    };
+    emit(deps, event);
+    throw new NativeInstallerInstallError(event, error instanceof Error ? { cause: error } : undefined);
+  }
+
+  emit(deps, {
+    phase: "onboard_finished",
+    status: "ok",
+    message: "NemoClaw onboard completed.",
+  });
+  emit(deps, {
+    phase: "launch_ready",
+    status: "ok",
+    message: "Launch details are ready.",
+  });
+}
+
+export function progressEventToJsonLine(event: NativeInstallerProgressEvent): string {
+  return JSON.stringify({ ...event, experimental: true });
+}

--- a/src/lib/native-installer/macos/launch.ts
+++ b/src/lib/native-installer/macos/launch.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+
+import { captureOpenshell } from "../../adapters/openshell/runtime";
+import { DASHBOARD_PORT } from "../../core/ports";
+import * as registry from "../../state/registry";
+import { loadAgent } from "../../agent/defs";
+import { isNativeInstallerAgentName, type NativeInstallerAgentName } from "./images";
+
+export interface NativeInstallerLaunchInfo {
+  agent: NativeInstallerAgentName;
+  sandboxName: string;
+  kind: "ui" | "api";
+  url: string;
+  token?: string | null;
+  terminalCommand?: string;
+  api?: {
+    baseUrl: string;
+    chatCompletionsUrl: string;
+    healthUrl: string;
+    token: string | null;
+    authHeader: string | null;
+  };
+  sensitive: boolean;
+}
+
+export interface NativeInstallerLaunchDeps {
+  getDefaultSandbox?: () => string | null;
+  getSandbox?: (name: string) => registry.SandboxEntry | null;
+  listSandboxes?: () => registry.SandboxRegistry;
+  fetchOpenClawToken?: (sandboxName: string) => string | null;
+  fetchHermesApiServerKey?: (sandboxName: string) => string | null;
+  openUrl?: (url: string) => void;
+}
+
+function defaultFetchOpenClawToken(sandboxName: string): string | null {
+  const onboard = require("../../onboard") as {
+    fetchGatewayAuthTokenFromSandbox: (name: string) => string | null;
+  };
+  return onboard.fetchGatewayAuthTokenFromSandbox(sandboxName);
+}
+
+function defaultFetchHermesApiServerKey(sandboxName: string): string | null {
+  const result = captureOpenshell(
+    [
+      "sandbox",
+      "exec",
+      "-n",
+      sandboxName,
+      "--",
+      "sh",
+      "-lc",
+      "[ -f /sandbox/.hermes/.env ] && set -a && . /sandbox/.hermes/.env && set +a; printf '%s' \"${API_SERVER_KEY:-}\"",
+    ],
+    { ignoreError: true, timeout: 10_000 },
+  );
+  if (result.status !== 0) return null;
+  const token = (result.output || "").trim();
+  return token || null;
+}
+
+function defaultOpenUrl(url: string): void {
+  if (process.platform === "darwin") {
+    spawnSync("open", [url], { stdio: "ignore" });
+  }
+}
+
+function resolveSandbox(
+  agent: NativeInstallerAgentName | undefined,
+  deps: NativeInstallerLaunchDeps,
+): registry.SandboxEntry | null {
+  const list = deps.listSandboxes ? deps.listSandboxes() : registry.load();
+  const defaultName = deps.getDefaultSandbox ? deps.getDefaultSandbox() : registry.getDefault();
+  const defaultEntry = defaultName ? list.sandboxes[defaultName] ?? null : null;
+  const targetAgent = agent ?? ((defaultEntry?.agent || "openclaw") as NativeInstallerAgentName);
+  if (!isNativeInstallerAgentName(targetAgent)) return null;
+  if (defaultEntry && (defaultEntry.agent || "openclaw") === targetAgent) return defaultEntry;
+  return (
+    Object.values(list.sandboxes).find((entry) => (entry.agent || "openclaw") === targetAgent) ??
+    null
+  );
+}
+
+export function buildNativeInstallerLaunchInfo(
+  agent: NativeInstallerAgentName | undefined,
+  deps: NativeInstallerLaunchDeps = {},
+): NativeInstallerLaunchInfo {
+  const sandbox = resolveSandbox(agent, deps);
+  if (!sandbox) {
+    throw new Error(
+      agent
+        ? `No registered ${agent} sandbox found. Run nemoclaw native-installer mac install first.`
+        : "No registered sandbox found. Run nemoclaw native-installer mac install first.",
+    );
+  }
+
+  const resolvedAgent = ((sandbox.agent || "openclaw") as NativeInstallerAgentName);
+  if (!isNativeInstallerAgentName(resolvedAgent)) {
+    throw new Error(`Sandbox '${sandbox.name}' uses unsupported agent '${sandbox.agent}'.`);
+  }
+
+  const agentDef = loadAgent(resolvedAgent);
+  const port = sandbox.dashboardPort ?? agentDef.forwardPort ?? DASHBOARD_PORT;
+  if (resolvedAgent === "hermes") {
+    const baseUrl = `http://127.0.0.1:${String(port)}${agentDef.dashboard.path}`;
+    const token = (deps.fetchHermesApiServerKey ?? defaultFetchHermesApiServerKey)(sandbox.name);
+    return {
+      agent: resolvedAgent,
+      sandboxName: sandbox.name,
+      kind: "api",
+      url: baseUrl,
+      api: {
+        baseUrl,
+        chatCompletionsUrl: `${baseUrl.replace(/\/$/, "")}/chat/completions`,
+        healthUrl: `http://127.0.0.1:${String(port)}/health`,
+        token,
+        authHeader: token ? `Authorization: Bearer ${token}` : null,
+      },
+      sensitive: Boolean(token),
+    };
+  }
+
+  const token = (deps.fetchOpenClawToken ?? defaultFetchOpenClawToken)(sandbox.name);
+  const url = token
+    ? `http://127.0.0.1:${String(port)}/#token=${encodeURIComponent(token)}`
+    : `http://127.0.0.1:${String(port)}/`;
+  return {
+    agent: "openclaw",
+    sandboxName: sandbox.name,
+    kind: "ui",
+    url,
+    token,
+    terminalCommand: `nemoclaw ${sandbox.name} connect`,
+    sensitive: Boolean(token),
+  };
+}
+
+export function runNativeInstallerLaunch(
+  agent: NativeInstallerAgentName | undefined,
+  options: { open?: boolean } = {},
+  deps: NativeInstallerLaunchDeps = {},
+): NativeInstallerLaunchInfo {
+  const info = buildNativeInstallerLaunchInfo(agent, deps);
+  if (options.open !== false && info.kind === "ui") {
+    (deps.openUrl ?? defaultOpenUrl)(info.url);
+  }
+  return info;
+}
+
+export function renderNativeInstallerLaunchText(info: NativeInstallerLaunchInfo): string[] {
+  if (info.kind === "api" && info.api) {
+    const lines = [
+      `Hermes Agent API for sandbox '${info.sandboxName}'`,
+      `Endpoint: ${info.api.baseUrl}`,
+      `Health:   ${info.api.healthUrl}`,
+    ];
+    if (info.api.token) lines.push("Token:    included in --json output; treat it like a password.");
+    return lines;
+  }
+  return [
+    `OpenClaw UI for sandbox '${info.sandboxName}'`,
+    "Opened the local UI in your browser.",
+    info.terminalCommand ? `Terminal: ${info.terminalCommand}` : "",
+  ].filter(Boolean);
+}

--- a/src/lib/native-installer/macos/native-installer.test.ts
+++ b/src/lib/native-installer/macos/native-installer.test.ts
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assessNativeInstallerHost,
+  buildNativeInstallerLaunchInfo,
+  buildNativeInstallerOnboardArgs,
+  buildNativeInstallerOnboardEnv,
+  loadNativeInstallerInstallPlan,
+  runNativeInstallerInstall,
+  toLegacyOnboardArgs,
+  validateNativeInstallerConfig,
+} from "../../../../dist/lib/native-installer";
+
+function hostAssessment(overrides: Record<string, unknown> = {}) {
+  return {
+    platform: "darwin",
+    isWsl: false,
+    runtime: "docker-desktop",
+    packageManager: "brew",
+    systemctlAvailable: false,
+    dockerServiceActive: null,
+    dockerServiceEnabled: null,
+    dockerInstalled: true,
+    dockerRunning: true,
+    dockerReachable: true,
+    nodeInstalled: true,
+    openshellInstalled: true,
+    dockerInfoSummary: "29.0.0 · Docker Desktop",
+    dockerCgroupVersion: "v2",
+    dockerDefaultCgroupnsMode: "private",
+    dockerStorageDriver: "overlay2",
+    dockerUsesContainerdSnapshotter: false,
+    dockerCpus: 6,
+    dockerMemTotalBytes: 12 * 1024 ** 3,
+    isContainerRuntimeUnderProvisioned: false,
+    hasNestedOverlayConflict: false,
+    requiresHostCgroupnsFix: false,
+    isUnsupportedRuntime: false,
+    isHeadlessLikely: false,
+    hasNvidiaGpu: false,
+    dockerCdiSpecDirs: [],
+    cdiNvidiaGpuSpecMissing: false,
+    nvidiaContainerToolkitInstalled: false,
+    notes: [],
+    ...overrides,
+  };
+}
+
+describe("native Mac installer config", () => {
+  it("accepts stock OpenClaw/Hermes configs and maps them to onboard", () => {
+    const validation = validateNativeInstallerConfig({
+      agent: "hermes",
+      sandboxName: "hermes-mac-preview",
+      provider: "openai",
+      model: "gpt-5.4",
+      endpoint: "https://api.openai.com/v1/",
+      mode: "fresh",
+      ports: { api: 18642 },
+      security: { tier: "balanced", presets: ["github"] },
+      messaging: ["slack"],
+    });
+
+    expect(validation.ok).toBe(true);
+    expect(validation.config?.endpoint).toBe("https://api.openai.com/v1/");
+    expect(buildNativeInstallerOnboardArgs(validation.config!)).toEqual([
+      "--non-interactive",
+      "--yes",
+      "--yes-i-accept-third-party-software",
+      "--fresh",
+      "--agent",
+      "hermes",
+      "--name",
+      "hermes-mac-preview",
+      "--control-ui-port",
+      "18642",
+    ]);
+    const env = buildNativeInstallerOnboardEnv(validation.config!, {});
+    expect(env.NEMOCLAW_AGENT).toBe("hermes");
+    expect(env.NEMOCLAW_PROVIDER).toBe("openai");
+    expect(env.NEMOCLAW_POLICY_MODE).toBe("custom");
+    expect(env.NEMOCLAW_POLICY_PRESETS).toBe("github");
+    expect(env.NEMOCLAW_MESSAGING_CHANNELS).toBe("slack");
+  });
+
+  it("rejects provider ids that are not backed by the onboard installer catalog", () => {
+    const validation = validateNativeInstallerConfig({
+      agent: "openclaw",
+      provider: "future-provider",
+      model: "future/model",
+      security: { tier: "future-tier" },
+    });
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors.join("\n")).toContain("installer-supported native Mac installer providers");
+  });
+
+  it("rejects secrets and custom Dockerfiles in preview config", () => {
+    const validation = validateNativeInstallerConfig({
+      agent: "openclaw",
+      customDockerfile: "./Dockerfile",
+      OPENAI_API_KEY: "sk-test",
+      token: "secret",
+    });
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors.join("\n")).toContain("secrets must not be stored");
+    expect(validation.errors.join("\n")).toContain("custom Dockerfiles");
+  });
+});
+
+describe("native Mac installer assessment", () => {
+  it("reports supported on a mocked macOS arm64 host with Docker reachable", () => {
+    const assessment = assessNativeInstallerHost({
+      platform: "darwin",
+      arch: "arm64",
+      macosVersion: "14.5",
+      hostAssessment: hostAssessment() as any,
+    });
+
+    expect(assessment.supported).toBe(true);
+    expect(assessment.host.dockerInstalled).toBe(true);
+    expect(assessment.host.dockerReachable).toBe(true);
+    expect(assessment.requirements.find((entry) => entry.id === "docker-daemon")?.status).toBe("pass");
+  });
+
+  it("surfaces missing Docker without trying to install a runtime", () => {
+    const assessment = assessNativeInstallerHost({
+      platform: "darwin",
+      arch: "arm64",
+      macosVersion: "14.5",
+      hostAssessment: hostAssessment({
+        dockerInstalled: false,
+        dockerRunning: false,
+        dockerReachable: false,
+        dockerInfoSummary: undefined,
+      }) as any,
+    });
+
+    expect(assessment.supported).toBe(false);
+    expect(assessment.requirements.find((entry) => entry.id === "docker-cli")?.status).toBe("fail");
+    expect(assessment.recoveryActions.join(" ")).toContain("Install Docker Desktop or Colima");
+  });
+
+  it("distinguishes installed Docker from an unreachable daemon", () => {
+    const assessment = assessNativeInstallerHost({
+      platform: "darwin",
+      arch: "arm64",
+      macosVersion: "14.5",
+      hostAssessment: hostAssessment({
+        dockerRunning: false,
+        dockerReachable: false,
+        dockerInfoSummary: undefined,
+      }) as any,
+    });
+
+    expect(assessment.supported).toBe(false);
+    expect(assessment.host.dockerInstalled).toBe(true);
+    expect(assessment.requirements.find((entry) => entry.id === "docker-cli")?.status).toBe("pass");
+    const daemon = assessment.requirements.find((entry) => entry.id === "docker-daemon");
+    expect(daemon?.detail).toContain("installed");
+    expect(daemon?.recovery).toContain("Start Docker Desktop or Colima");
+    expect(assessment.recoveryActions.join(" ")).not.toContain("Install Docker");
+  });
+});
+
+describe("native Mac installer describe", () => {
+  it("validates and resolves install-plan.yaml with agent manifests", () => {
+    const plan = loadNativeInstallerInstallPlan();
+
+    expect(plan.experimental).toBe(true);
+    expect(plan.source).toBe("release/native-installers/macos/install-plan.yaml");
+    expect(plan.agents.map((agent) => agent.name)).toEqual(["openclaw", "hermes"]);
+    expect(plan.install.defaultSandboxName).toBe("nemoclaw-mac-preview");
+    expect(plan.agents.find((agent) => agent.name === "openclaw")?.description).toContain(
+      "browser UI and messaging support",
+    );
+    expect(plan.agents.find((agent) => agent.name === "hermes")?.description).toContain(
+      "OpenAI-compatible local API endpoint",
+    );
+    expect(plan.agents.find((agent) => agent.name === "hermes")?.dashboardKind).toBe("api");
+    expect(plan.model.providers.some((provider) => provider.id === "openai")).toBe(true);
+    expect(plan.model.providers.find((provider) => provider.id === "build")?.defaultModel).toBe(
+      "nvidia/nemotron-3-super-120b-a12b",
+    );
+    expect(plan.model.providers.find((provider) => provider.id === "anthropic")?.defaultModel).toBe(
+      "claude-sonnet-4-6",
+    );
+    expect(plan.model.providers.find((provider) => provider.id === "gemini")?.title).toBe(
+      "Google Gemini",
+    );
+    expect(plan.model.providers.find((provider) => provider.id === "ollama")?.defaultModel).toBe(
+      "nemotron-3-nano:30b",
+    );
+    expect(plan.model.providers.find((provider) => provider.id === "hermesProvider")?.envVar).toBe(
+      "NOUS_API_KEY",
+    );
+    expect(
+      plan.model.providers.find((provider) => provider.id === "hermesProvider")?.supportedAgents,
+    ).toEqual(["hermes"]);
+    expect(plan.install.baseImages.find((image) => image.agent === "openclaw")?.env).toBe(
+      "NEMOCLAW_SANDBOX_BASE_IMAGE_REF",
+    );
+  });
+});
+
+describe("native Mac installer install", () => {
+  it("delegates to onboard without pulling Docker images directly", async () => {
+    const events: string[] = [];
+    const runOnboardAction = vi.fn(async () => {});
+
+    await runNativeInstallerInstall(
+      { agent: "openclaw", sandboxName: "alpha", provider: "openai", model: "gpt-5.4" },
+      {
+        runOnboardAction,
+        emit: (event) => events.push(`${event.phase}:${event.status}:${event.message}`),
+      },
+    );
+
+    expect(events).toEqual([
+      "plan_loaded:ok:Mac Installer Preview plan loaded.",
+      "onboard_started:started:Starting standard NemoClaw onboard for openclaw.",
+      "onboard_finished:ok:NemoClaw onboard completed.",
+      "launch_ready:ok:Launch details are ready.",
+    ]);
+    expect(runOnboardAction).toHaveBeenCalledWith(
+      expect.arrayContaining(["--agent", "openclaw", "--name", "alpha"]),
+    );
+  });
+
+  it("maps onboard-owned base image overrides only when the plan opts in", () => {
+    const plan = loadNativeInstallerInstallPlan();
+    const optInPlan = {
+      ...plan,
+      install: {
+        ...plan.install,
+        baseImages: [
+          {
+            agent: "openclaw" as const,
+            ref: "example.test/openclaw-base:preview",
+            env: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF",
+            applyByDefault: true,
+          },
+        ],
+      },
+    };
+
+    const env = buildNativeInstallerOnboardEnv({ agent: "openclaw" }, {}, optInPlan);
+    expect(env.NEMOCLAW_SANDBOX_BASE_IMAGE_REF).toBe("example.test/openclaw-base:preview");
+  });
+
+  it("uses Hermes Provider's installer-supported API-key auth path in non-interactive mode", () => {
+    const env = buildNativeInstallerOnboardEnv({ agent: "hermes", provider: "hermesProvider" }, {});
+
+    expect(env.NEMOCLAW_PROVIDER).toBe("hermesProvider");
+    expect(env.NEMOCLAW_HERMES_AUTH_METHOD).toBe("api_key");
+  });
+
+  it("keeps the legacy onboard argv translation explicit", () => {
+    expect(toLegacyOnboardArgs({ agent: "hermes", mode: "resume", ports: { api: 18642 } })).toEqual([
+      "--non-interactive",
+      "--yes",
+      "--yes-i-accept-third-party-software",
+      "--resume",
+      "--agent",
+      "hermes",
+      "--control-ui-port",
+      "18642",
+    ]);
+  });
+});
+
+describe("Mac Installer Preview app", () => {
+  it("uses a GUI-safe PATH with Homebrew locations", () => {
+    const source = readFileSync(
+      "apps/native-installers/macos/NemoClawMacInstaller/Sources/NemoClawMacInstaller/NemoClawMacInstallerApp.swift",
+      "utf8",
+    );
+
+    expect(source).toContain("/opt/homebrew/bin:/usr/local/bin");
+    expect(source).toContain("NEMOCLAW_MAC_INSTALLER_DIAGNOSTICS_DIR");
+  });
+});
+
+describe("native Mac installer launch", () => {
+  it("returns tokenized OpenClaw and Hermes endpoint details", () => {
+    const openclaw = buildNativeInstallerLaunchInfo("openclaw", {
+      listSandboxes: () => ({
+        defaultSandbox: "alpha",
+        sandboxes: { alpha: { name: "alpha", agent: "openclaw", dashboardPort: 18790 } },
+      }),
+      fetchOpenClawToken: () => "ui-token",
+    });
+    expect(openclaw.url).toBe("http://127.0.0.1:18790/#token=ui-token");
+    expect(openclaw.terminalCommand).toBe("nemoclaw alpha connect");
+
+    const hermes = buildNativeInstallerLaunchInfo("hermes", {
+      listSandboxes: () => ({
+        defaultSandbox: "hermes-box",
+        sandboxes: { "hermes-box": { name: "hermes-box", agent: "hermes", dashboardPort: 18642 } },
+      }),
+      fetchHermesApiServerKey: () => "api-token",
+    });
+    expect(hermes.api?.baseUrl).toBe("http://127.0.0.1:18642/v1");
+    expect(hermes.api?.authHeader).toBe("Authorization: Bearer api-token");
+  });
+});

--- a/src/lib/native-installer/macos/providers.ts
+++ b/src/lib/native-installer/macos/providers.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DEFAULT_OLLAMA_MODEL } from "../../inference/local";
+
+type RemoteProviderConfig = {
+  label: string;
+  credentialEnv: string | null;
+  endpointUrl: string;
+  defaultModel: string;
+};
+
+const { REMOTE_PROVIDER_CONFIG } = require("../../onboard/providers") as {
+  REMOTE_PROVIDER_CONFIG: Record<string, RemoteProviderConfig>;
+};
+
+export interface NativeInstallerProvider {
+  id: string;
+  title: string;
+  defaultModel: string;
+  envVar?: string;
+  endpointUrl?: string;
+}
+
+function normalizeEnvVar(providerId: string, credentialEnv: string | null): string | undefined {
+  if (providerId === "hermesProvider") {
+    return "NOUS_API_KEY";
+  }
+  return credentialEnv || undefined;
+}
+
+export function listNativeInstallerProviders(): NativeInstallerProvider[] {
+  const remoteProviders = Object.entries(REMOTE_PROVIDER_CONFIG)
+    .filter(([, config]) => typeof config.endpointUrl === "string" && config.endpointUrl.trim())
+    .map(([id, config]) => ({
+      id,
+      title: config.label,
+      defaultModel: config.defaultModel,
+      ...(normalizeEnvVar(id, config.credentialEnv)
+        ? { envVar: normalizeEnvVar(id, config.credentialEnv) }
+        : {}),
+      endpointUrl: config.endpointUrl,
+    }));
+
+  return [
+    ...remoteProviders,
+    {
+      id: "ollama",
+      title: "Local Ollama",
+      defaultModel: DEFAULT_OLLAMA_MODEL,
+    },
+  ];
+}
+
+export function getNativeInstallerProvider(id: string): NativeInstallerProvider | undefined {
+  return listNativeInstallerProviders().find((provider) => provider.id === id);
+}
+
+export function isNativeInstallerProviderId(id: string): boolean {
+  return !!getNativeInstallerProvider(id);
+}
+
+export function formatNativeInstallerProviderIds(): string {
+  return listNativeInstallerProviders()
+    .map((provider) => provider.id)
+    .sort()
+    .join(", ");
+}


### PR DESCRIPTION
## Summary

- **Highly experimental / draft only:** adds an opt-in NemoClaw Mac Installer Preview for Apple Silicon macOS. This is not a replacement for the standard terminal installer.
- Adds `nemoclaw native-installer mac describe|assess|install|launch` as thin adapters over the existing onboard/preflight/launch paths.
- Moves preview assets under native-installer naming and removes Fast-Lane public branding.
- Builds/packages the SwiftUI app and DMG only; this PR does not publish stock sandbox images.

## Validation

- `npm run build:cli`
- `npx vitest run src/lib/native-installer/macos/native-installer.test.ts`
- `npm run typecheck -- --pretty false`
- `swift build --package-path apps/native-installers/macos/NemoClawMacInstaller`
- `scripts/native-installers/macos/build-preview.sh`
- Bundled CLI smoke checks for `native-installer mac describe --json` and `native-installer mac assess --json`
- `git diff --check`

## Notes

- Local preview artifacts were built unsigned/unnotarized because Developer ID and notary credentials were not set.
- Optional pinned OpenShell and private Node runtime inputs were not provided for the local build.