### PR TITLE
fix(install): add Docker group access security note in install flow and docs

### DIFF
--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -34,6 +34,13 @@ On Linux, the installer can install Docker, start the Docker service, and add yo
 If the group change is not active in the current shell, the installer exits with `newgrp docker` guidance before it starts onboarding.
 If you choose the native Linux Ollama install path, the onboard wizard also requires `zstd` for Ollama archive extraction.
 
+<Warning title="Docker group access">
+NemoClaw needs Docker access.
+On personal Linux development machines, adding your user to the docker group is the standard way to run Docker without sudo.
+Docker group members can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path.
+For background, review Docker's [daemon attack surface guidance](https://docs.docker.com/engine/security/#docker-daemon-attack-surface).
+</Warning>
+
 On Debian and Ubuntu, NemoClaw installs `zstd` with `apt-get` if it is missing; on other Linux distributions, install `zstd` before onboarding.
 
 On macOS, NemoClaw uses the Docker-driver OpenShell gateway path with Docker Desktop or Colima.

--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -36,8 +36,8 @@ If you choose the native Linux Ollama install path, the onboard wizard also requ
 
 <Warning title="Docker group access">
 NemoClaw needs Docker access.
-On personal Linux development machines, adding your user to the docker group is the standard way to run Docker without sudo.
-Docker group members can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path.
+On personal Linux development machines, adding your user to the `docker` group is the standard way to run Docker without sudo.
+Members of the `docker` group can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path.
 For background, review Docker's [daemon attack surface guidance](https://docs.docker.com/engine/security/#docker-daemon-attack-surface).
 </Warning>
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -80,6 +80,13 @@ On Linux, if the Docker daemon is running but you see "permission denied" errors
 The installer can add your user to the group, but Linux does not activate that membership in the current shell automatically.
 Add your user and activate the group in the current shell:
 
+<Warning title="Docker group access">
+NemoClaw needs Docker access.
+On personal Linux development machines, adding your user to the docker group is the standard way to run Docker without sudo.
+Docker group members can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path.
+For background, review Docker's [daemon attack surface guidance](https://docs.docker.com/engine/security/#docker-daemon-attack-surface).
+</Warning>
+
 ```console
 $ sudo usermod -aG docker $USER
 $ newgrp docker

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -82,8 +82,8 @@ Add your user and activate the group in the current shell:
 
 <Warning title="Docker group access">
 NemoClaw needs Docker access.
-On personal Linux development machines, adding your user to the docker group is the standard way to run Docker without sudo.
-Docker group members can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path.
+On personal Linux development machines, adding your user to the `docker` group is the standard way to run Docker without sudo.
+Members of the `docker` group can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path.
 For background, review Docker's [daemon attack surface guidance](https://docs.docker.com/engine/security/#docker-daemon-attack-surface).
 </Warning>
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2126,7 +2126,10 @@ ensure_docker() {
   # need to run usermod.
   if ! id -nG "$current_user" 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
     info "Your user '$current_user' is not in the docker group."
-    info "The next step uses sudo to add you to the group so docker works without sudo. You may be prompted for your password."
+    info "NemoClaw needs Docker access. On personal Linux development machines, adding your user to the docker group is the standard way to run Docker without sudo."
+    info "Docker group members can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path."
+    info "Background: https://docs.docker.com/engine/security/#docker-daemon-attack-surface"
+    info "You may be prompted for your password."
     sudo usermod -aG docker "$current_user"
     needs_group_refresh=1
   fi

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -625,7 +625,11 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
         kind: "sudo",
         reason:
           "Docker is installed and the service is running, but the current user cannot reach the daemon. " +
-          "This usually means your user is not in the docker group.",
+          "This usually means your user is not in the docker group. " +
+          "NemoClaw needs Docker access. " +
+          "On personal Linux development machines, adding your user to the docker group is the standard way to run Docker without sudo. " +
+          "Docker group members can control the daemon with root-level impact, so grant this access only to trusted local accounts; on shared or managed systems, use your organization's approved Docker access path. " +
+          "Background: https://docs.docker.com/engine/security/#docker-daemon-attack-surface.",
         commands: [
           "sudo usermod -aG docker $USER",
           "newgrp docker   # or log out and back in",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds Docker group security context to the Linux install and onboarding guidance so users understand both why NemoClaw needs Docker access and the privilege impact of granting it.

## Changes
- Added Docker group access warnings to the prerequisites and troubleshooting docs.
- Updated installer output to explain that Docker group access is the standard Linux Docker setup path for trusted local accounts.
- Updated onboard preflight remediation text with the same Docker access and security wording.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Docker security guidance across setup and troubleshooting: added warning callouts about required Docker access, daemon attack-surface links, and notes that group membership grants root-level control and should be limited on shared systems.
* **Chores**
  * Updated installer messaging to provide clearer Docker-group guidance, expanded security rationale, and a note that you may be prompted for your password.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->