### PR TITLE
fix(connect): fail fast when gateway is down

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -172,18 +172,16 @@ function sleepSync(ms: number): void {
   });
 }
 
+const GATEWAY_UNAVAILABLE_RE =
+  /No gateway configured|No active gateway|Connection refused|client error \(Connect\)|tcp connect error|Status:\s*Disconnected/i;
+
 function isBlockingGatewayLifecycle(
   lifecycle: ReturnType<typeof getNamedGatewayLifecycleState>,
 ): boolean {
   if (lifecycle.state === "named_unreachable" || lifecycle.state === "named_unhealthy") {
     return true;
   }
-  return (
-    lifecycle.state === "missing_named" &&
-    /No gateway configured|No active gateway|Connection refused|Status:\s*Disconnected/i.test(
-      lifecycle.status || "",
-    )
-  );
+  return lifecycle.state === "missing_named" && GATEWAY_UNAVAILABLE_RE.test(lifecycle.status || "");
 }
 
 function failConnectReadinessGatewayUnavailable(
@@ -206,9 +204,7 @@ function failConnectReadinessGatewayUnavailable(
 }
 
 function outputShowsGatewayUnavailable(output = ""): boolean {
-  return /No gateway configured|No active gateway|Connection refused|client error \(Connect\)|tcp connect error|Status:\s*Disconnected/i.test(
-    output,
-  );
+  return GATEWAY_UNAVAILABLE_RE.test(output);
 }
 
 function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -33,8 +33,9 @@ import {
   createSystemDeps as createSessionDeps,
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
+import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import { runSetupDnsProxy } from "../dns";
-import { ensureLiveSandboxOrExit } from "./gateway-state";
+import { ensureLiveSandboxOrExit, printGatewayLifecycleHint } from "./gateway-state";
 import { checkAndRecoverSandboxProcesses } from "./process-recovery";
 import {
   applyOpenShellVmDnsMonkeypatch,
@@ -50,6 +51,11 @@ export type SandboxConnectOptions = {
 type SpawnLikeResult = {
   status: number | null;
   signal?: NodeJS.Signals | null;
+};
+
+type SandboxListProbe = {
+  status: number | null;
+  output: string;
 };
 
 type SandboxInferenceRouteProbe = {
@@ -164,6 +170,55 @@ function sleepSync(ms: number): void {
     stdio: "ignore",
     timeout: ms + 1_000,
   });
+}
+
+function isBlockingGatewayLifecycle(
+  lifecycle: ReturnType<typeof getNamedGatewayLifecycleState>,
+): boolean {
+  if (lifecycle.state === "named_unreachable" || lifecycle.state === "named_unhealthy") {
+    return true;
+  }
+  return (
+    lifecycle.state === "missing_named" &&
+    /No gateway configured|No active gateway|Connection refused|Status:\s*Disconnected/i.test(
+      lifecycle.status || "",
+    )
+  );
+}
+
+function failConnectReadinessGatewayUnavailable(
+  sandboxName: string,
+  detailOutput = "",
+): never {
+  console.error("");
+  console.error(
+    `  OpenShell gateway is not running or unreachable; cannot verify sandbox '${sandboxName}' readiness.`,
+  );
+  if (detailOutput.trim()) {
+    console.error(detailOutput.trimEnd());
+    printGatewayLifecycleHint(detailOutput, sandboxName, console.error);
+  }
+  console.error("  Recovery:");
+  console.error("    1. Run: openshell gateway start --name nemoclaw");
+  console.error(`    2. If the gateway cannot be restarted, run: ${CLI_NAME} onboard`);
+  console.error(`    3. Retry: ${CLI_NAME} ${sandboxName} connect`);
+  process.exit(1);
+}
+
+function outputShowsGatewayUnavailable(output = ""): boolean {
+  return /No gateway configured|No active gateway|Connection refused|client error \(Connect\)|tcp connect error|Status:\s*Disconnected/i.test(
+    output,
+  );
+}
+
+function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {
+  const lifecycle = getNamedGatewayLifecycleState();
+  if (isBlockingGatewayLifecycle(lifecycle)) {
+    failConnectReadinessGatewayUnavailable(
+      sandboxName,
+      lifecycle.status || lifecycle.gatewayInfo || "",
+    );
+  }
 }
 
 function probeSandboxInferenceRoute(
@@ -646,15 +701,27 @@ export async function connectSandbox(
   const deadline = startedAt + timeout * 1000;
   const elapsedSec = () => Math.floor((Date.now() - startedAt) / 1000);
   const remainingMs = () => Math.max(1, deadline - Date.now());
-  const runSandboxList = () =>
-    captureOpenshell(["sandbox", "list"], {
+  const runSandboxList = (): SandboxListProbe => {
+    const result = captureOpenshell(["sandbox", "list"], {
       ignoreError: true,
       timeout: remainingMs(),
-    }).output;
+    });
+    return { status: result.status, output: result.output };
+  };
 
-  const list = runSandboxList();
+  const listProbe = runSandboxList();
+  const listCommandFailed = listProbe.status !== 0;
+  if (listCommandFailed) {
+    if (outputShowsGatewayUnavailable(listProbe.output)) {
+      failConnectReadinessGatewayUnavailable(sandboxName, listProbe.output);
+    }
+  }
+  const list = listProbe.output;
   if (!isSandboxReady(list, sandboxName)) {
     const status = parseSandboxStatus(list, sandboxName);
+    if (!listCommandFailed && status && /^unknown$/i.test(status)) {
+      failIfGatewayBlocksConnectReadiness(sandboxName);
+    }
     const TERMINAL = new Set([
       "Failed",
       "Error",
@@ -678,13 +745,24 @@ export async function connectSandbox(
       const sleepFor = Math.min(interval, remainingMs() / 1000);
       if (sleepFor <= 0) break;
       spawnSync("sleep", [String(sleepFor)]);
-      const poll = runSandboxList();
+      const pollProbe = runSandboxList();
+      const pollCommandFailed = pollProbe.status !== 0;
+      if (pollCommandFailed) {
+        if (outputShowsGatewayUnavailable(pollProbe.output)) {
+          failConnectReadinessGatewayUnavailable(sandboxName, pollProbe.output);
+        }
+      }
+      const poll = pollProbe.output;
       const elapsed = elapsedSec();
       if (isSandboxReady(poll, sandboxName)) {
         ready = true;
         break;
       }
-      const cur = parseSandboxStatus(poll, sandboxName) || "unknown";
+      const parsedCur = parseSandboxStatus(poll, sandboxName);
+      const cur = parsedCur || "unknown";
+      if (!pollCommandFailed && parsedCur && /^unknown$/i.test(parsedCur)) {
+        failIfGatewayBlocksConnectReadiness(sandboxName);
+      }
       if (cur !== "unknown") everSeen = true;
       if (TERMINAL.has(cur)) {
         console.error("");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3835,6 +3835,95 @@ describe("CLI dispatch", () => {
     expect(calls).toContain("sandbox connect alpha");
   });
 
+  it(
+    "fails fast with gateway recovery guidance when connect readiness sees a disconnected gateway",
+    () => {
+      const home = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-cli-connect-gateway-down-"),
+      );
+      const localBin = path.join(home, "bin");
+      const registryDir = path.join(home, ".nemoclaw");
+      const markerFile = path.join(home, "openshell-calls");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(registryDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(registryDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            alpha: {
+              name: "alpha",
+              model: "test-model",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+            },
+          },
+          defaultSandbox: "alpha",
+        }),
+        { mode: 0o600 },
+      );
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          `marker_file=${JSON.stringify(markerFile)}`,
+          'printf \'%s\\n\' "$*" >> "$marker_file"',
+          'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+          "  echo 'Sandbox:'",
+          "  echo",
+          "  echo '  Id: abc'",
+          "  echo '  Name: alpha'",
+          "  echo '  Namespace: openshell'",
+          "  echo '  Phase: Pending'",
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          "  echo 'alpha   unknown   103s ago'",
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "status" ]; then',
+          "  echo 'Server Status'",
+          "  echo",
+          "  echo '  Gateway: nemoclaw'",
+          "  echo '  Status: Disconnected'",
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "gateway" ] && [ "$2" = "info" ] && [ "$3" = "-g" ] && [ "$4" = "nemoclaw" ]; then',
+          "  echo 'Gateway Info'",
+          "  echo",
+          "  echo '  Gateway: nemoclaw'",
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "connect" ] && [ "$3" = "alpha" ]; then',
+          "  echo 'should-not-connect' >> \"$marker_file\"",
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv(
+        "alpha connect",
+        {
+          HOME: home,
+          NEMOCLAW_CONNECT_TIMEOUT: "1",
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+        },
+        execTimeout(10_000),
+      );
+
+      expect(r.code).toBe(1);
+      expect(r.out).toContain("OpenShell gateway is not running or unreachable");
+      expect(r.out).toContain("nemoclaw onboard");
+      expect(r.out).not.toContain("Timed out after 1s");
+      const calls = fs.readFileSync(markerFile, "utf8").trim().split("\n").filter(Boolean);
+      expect(calls).toContain("status");
+      expect(calls).not.toContain("should-not-connect");
+    },
+    testTimeout(15_000),
+  );
+
   it("prints recovery guidance when readiness polling hits a terminal sandbox state", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-connect-failed-"));
     const localBin = path.join(home, "bin");


### PR DESCRIPTION
## Summary
- fail fast during `nemoclaw <sandbox> connect` readiness polling when the named NemoClaw/OpenShell gateway is down or unreachable
- include recovery guidance to restart the named gateway or rerun `nemoclaw onboard`
- preserve stuck-sandbox timeout behavior when readiness has a concrete non-terminal phase such as `Provisioning`
- add a regression test for `unknown` readiness status plus disconnected gateway lifecycle

Supersedes #3853 with the same patch squashed onto current `main` to avoid the commit signature/merge-commit issues on that branch.

Fixes #3821

## Test Plan
- [x] `git diff --check`
- [ ] `npm test -- test/cli.test.ts -t "fails fast with gateway recovery guidance"` (not run locally: dependencies are not installed in this worktree; CI will run)
- Prior PR #3853 evidence before the squash: PR CI green; `sandbox-operations-e2e` passed on previous head; latest E2E advisor requires `sandbox-operations-e2e` for current head and it will need to be re-run here.

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox connection readiness to detect OpenShell gateway unavailability earlier and fail fast with clearer, actionable error messages and recovery steps.

* **Tests**
  * Added CLI test coverage ensuring connect attempts fail promptly when the gateway is reported disconnected, validating exit behavior and user guidance without entering the normal connect flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->