### PR TITLE
fix(policy): include sandbox-scoped custom presets in gateway-active matching (#3590)

### DIFF
--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -1002,9 +1002,38 @@ function listCustomPresets(sandboxName: string): PresetInfo[] {
 }
 
 /**
+ * True when every `network_policies` key declared in `content` is present in
+ * `gatewayPolicyNames`. Works for both built-in preset YAML and the custom
+ * preset YAML stored under a sandbox's registry entry — keeping a single
+ * matching rule means `policy-list` and `status` stay consistent for either
+ * preset source. (#3590)
+ */
+function presetMatchesGateway(
+  content: string | null,
+  gatewayPolicyNames: ReadonlySet<string>,
+): boolean {
+  const entries = extractPresetEntries(content);
+  if (!entries) return false;
+
+  let presetPolicies;
+  try {
+    const presetParsed = YAML.parse("network_policies:\n" + entries);
+    presetPolicies = presetParsed?.network_policies;
+  } catch {
+    return false;
+  }
+
+  if (!presetPolicies || typeof presetPolicies !== "object") return false;
+
+  const presetKeys = Object.keys(presetPolicies);
+  return presetKeys.length > 0 && presetKeys.every((k) => gatewayPolicyNames.has(k));
+}
+
+/**
  * Query the gateway for the currently loaded policy and determine which
  * presets are actually enforced by matching network_policies entries
- * against known preset definitions.
+ * against known preset definitions. Considers both built-in presets and
+ * sandbox-scoped custom presets recorded in the registry. (#3590)
  *
  * Returns an array of preset names whose network_policies keys are all
  * found in the gateway's loaded policy, or `null` when the gateway
@@ -1040,30 +1069,17 @@ function getGatewayPresets(sandboxName: string): string[] | null {
   }
 
   const gatewayPolicyNames = new Set(Object.keys(gatewayPolicies));
-  const matched = [];
+  const matched: string[] = [];
 
   for (const preset of listPresets()) {
-    const content = loadPresetForSandbox(sandboxName, preset.name);
-    if (!content) continue;
-    const entries = extractPresetEntries(content);
-    if (!entries) continue;
-
-    let presetPolicies;
-    try {
-      const wrapped = "network_policies:\n" + entries;
-      const presetParsed = YAML.parse(wrapped);
-      presetPolicies = presetParsed?.network_policies;
-    } catch {
-      continue;
-    }
-
-    if (!presetPolicies || typeof presetPolicies !== "object") continue;
-
-    // A preset is considered "active on gateway" if ALL of its
-    // network_policies keys exist in the gateway's loaded policy.
-    const presetKeys = Object.keys(presetPolicies);
-    if (presetKeys.length > 0 && presetKeys.every((k) => gatewayPolicyNames.has(k))) {
+    if (presetMatchesGateway(loadPresetForSandbox(sandboxName, preset.name), gatewayPolicyNames)) {
       matched.push(preset.name);
+    }
+  }
+
+  for (const entry of registry.getCustomPolicies(sandboxName)) {
+    if (presetMatchesGateway(entry.content, gatewayPolicyNames)) {
+      matched.push(entry.name);
     }
   }
 

--- a/test/repro-2010.test.ts
+++ b/test/repro-2010.test.ts
@@ -60,13 +60,48 @@ function buildGatewayYaml(presetNames: string[]): string {
 }
 
 /**
- * Call getGatewayPresets() in a subprocess with a stubbed runCapture
- * that returns the given YAML (or throws if null).
+ * Build a fake gateway YAML that includes both built-in presets and the
+ * given custom preset entries — used to assert custom preset matching. (#3590)
  */
-function callGetGatewayPresets(gatewayYaml: string | null): string[] | null {
+function buildGatewayYamlWithCustom(
+  presetNames: string[],
+  customPresets: Array<{ name: string; content: string }>,
+): string {
+  const names = JSON.stringify(presetNames);
+  const custom = JSON.stringify(customPresets);
+  const { stdout } = runScript(`
+    const parts = ["version: 1", "", "network_policies:"];
+    for (const name of ${names}) {
+      const content = policies.loadPreset(name);
+      if (!content) continue;
+      const entries = policies.extractPresetEntries(content);
+      if (!entries) continue;
+      parts.push(entries);
+    }
+    for (const c of ${custom}) {
+      const entries = policies.extractPresetEntries(c.content);
+      if (!entries) continue;
+      parts.push(entries);
+    }
+    process.stdout.write("Version: 3\\nHash: abc123\\nUpdated: 2026-01-01\\n---\\n" + parts.join("\\n"));
+  `);
+  return stdout;
+}
+
+/**
+ * Call getGatewayPresets() in a subprocess with a stubbed runCapture
+ * that returns the given YAML (or throws if null). Optionally include
+ * registry-recorded custom presets so the matching loop sees them. (#3590)
+ */
+function callGetGatewayPresets(
+  gatewayYaml: string | null,
+  customPresets: Array<{ name: string; content: string }> = [],
+): string[] | null {
   const yamlArg = gatewayYaml !== null ? JSON.stringify(gatewayYaml) : "null";
+  const customArg = JSON.stringify(customPresets);
   const { stdout } = runScript(`
     const yaml = ${yamlArg};
+    const customPresets = ${customArg};
     // Replace the closed-over runCapture by re-requiring the module cache entry
     const mod = require.cache[${JSON.stringify(POLICIES_PATH)}];
     // Stub: replace getGatewayPresets with one that uses our fake runCapture
@@ -95,15 +130,21 @@ function callGetGatewayPresets(gatewayYaml: string | null): string[] | null {
     }
     const keys = new Set(Object.keys(gp));
     const matched = [];
+    const matchContent = (content) => {
+      const e = policies.extractPresetEntries(content); if (!e) return false;
+      let pp;
+      try { pp = YAML.parse("network_policies:\\n" + e); } catch { return false; }
+      const np = pp && pp.network_policies;
+      if (!np || typeof np !== "object") return false;
+      const pk = Object.keys(np);
+      return pk.length > 0 && pk.every(k => keys.has(k));
+    };
     for (const preset of policies.listPresets()) {
       const c = policies.loadPreset(preset.name); if (!c) continue;
-      const e = policies.extractPresetEntries(c); if (!e) continue;
-      let pp;
-      try { pp = YAML.parse("network_policies:\\n" + e); } catch { continue; }
-      const np = pp && pp.network_policies;
-      if (!np || typeof np !== "object") continue;
-      const pk = Object.keys(np);
-      if (pk.length > 0 && pk.every(k => keys.has(k))) matched.push(preset.name);
+      if (matchContent(c)) matched.push(preset.name);
+    }
+    for (const entry of customPresets) {
+      if (matchContent(entry.content)) matched.push(entry.name);
     }
     process.stdout.write(JSON.stringify(matched));
     runner.runCapture = origRunCapture;
@@ -141,6 +182,34 @@ describe("issue #2010 — policy state inconsistency", () => {
       const yaml = "Version: 1\n---\nversion: 1\nfilesystem_policy:\n  read_only: true";
       const result = callGetGatewayPresets(yaml);
       expect(result).toEqual([]);
+    });
+
+    it("includes a custom preset whose network_policies are enforced on the gateway (#3590)", () => {
+      const custom = [
+        {
+          name: "slack-files-upload",
+          content: `preset:
+  name: slack-files-upload
+  description: "Slack file upload URL access"
+
+network_policies:
+  slack-files-upload:
+    name: slack-files-upload
+    endpoints:
+      - host: files.slack.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        tls: terminate
+        rules:
+          - allow: { method: POST, path: "/upload/**" }
+`,
+        },
+      ];
+      const yaml = buildGatewayYamlWithCustom(["telegram"], custom);
+      const result = callGetGatewayPresets(yaml, custom);
+      expect(result).toContain("telegram");
+      expect(result).toContain("slack-files-upload");
     });
   });
 


### PR DESCRIPTION
## Summary
`policy-list` was reporting custom presets applied via `policy-add --from-file` as "recorded locally, not active on gateway" even when the gateway's loaded policy contained the matching `network_policies` keys. The matching loop iterated only built-in presets and never consulted the sandbox-scoped custom-preset registry.

## Related Issue
Fixes #3590. Supersedes #3641 (truffle-dev), which carries the same fix but is blocked on a stale-fork base-image build failure unrelated to the diff.

## Changes
- `src/lib/policy/index.ts`: extract per-preset match logic into `presetMatchesGateway(content, gatewayPolicyNames)`. Refactor `getGatewayPresets` to use the helper for built-in presets and add a second pass over `registry.getCustomPolicies(sandboxName)` so custom presets show ● when their `network_policies` keys are present on the gateway. Same matching rule as built-ins — keeps `policy-list` and `status` consistent across both sources.
- `test/repro-2010.test.ts`: extend `callGetGatewayPresets` to accept custom-preset entries and add the `slack-files-upload` scenario from #3590 verbatim.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx vitest run test/repro-2010.test.ts` → **10/10 pass**, including the new "includes a custom preset whose network_policies are enforced on the gateway (#3590)" test.
- [x] `npm run build:cli` clean.
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes (display-only fix, no contract change)

⚠️ Committed with `--no-verify` (user-authorized): the pre-commit `Test (CLI)` hook (full vitest with v8 coverage) hits unrelated timeout flakes on this macOS workstation (Defender + Spotlight contention). The new test passes cleanly in isolation. CI on Linux runners is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway preset matching now validates policies against the gateway configuration.
  * Custom presets are now properly included when matching presets to the gateway.

* **Tests**
  * Added test coverage for custom preset validation against gateway policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->