### PR TITLE
fix(onboard): clarify messaging skip prompt

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7823,7 +7823,7 @@ async function setupMessagingChannels(
       output.write(`    [${i + 1}] ${marker} ${ch.name} — ${ch.description}${status}\n`);
     });
     output.write("\n");
-    output.write(`  Press 1-${availableChannels.length} to toggle, Enter when done: `);
+    output.write(`  Press 1-${availableChannels.length} to toggle, Enter when done (none selected skips): `);
   };
 
   showList();

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1838,6 +1838,18 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
+  it("tells users that selecting no messaging channels skips the step", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src", "lib", "onboard.ts"),
+      "utf-8",
+    );
+
+    assert.match(
+      source,
+      /Press 1-\$\{availableChannels\.length\} to toggle, Enter when done \(none selected skips\):/,
+    );
+  });
+
   it("migrates a legacy credentials.json into env so setupInference can register the provider", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-resume-cred-"));


### PR DESCRIPTION
## Summary
- Clarify the messaging channel selector prompt so users know selecting no channels skips the step
- Add a regression test that keeps the skip wording in the onboarding prompt

Supersedes #3480.
Fixes #3471.

## Verification
- `git diff --check`
- `npm test -- test/onboard.test.ts -t "selecting no messaging channels skips"` *(blocked locally: `vitest: command not found`; this worktree has no `node_modules`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the messaging channel setup prompt to explicitly state that pressing Enter without selecting any channels will skip this step.

* **Tests**
  * Added test coverage to verify the updated setup prompt messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->