### PR TITLE
fix(e2e): handle top-level payloads in openclaw agent JSON output

### DIFF
--- a/test/e2e/test-bedrock-runtime-compatible-anthropic.sh
+++ b/test/e2e/test-bedrock-runtime-compatible-anthropic.sh
@@ -710,7 +710,7 @@ for idx, char in enumerate(text):
         doc = json.loads(text[idx:])
     except Exception:
         continue
-    payloads = ((doc.get("result") or {}).get("payloads") or [])
+    payloads = ((doc.get("result") or doc).get("payloads") or [])
     parts = [p.get("text") for p in payloads if isinstance(p, dict) and isinstance(p.get("text"), str)]
     print("\n".join(parts))
     break

--- a/test/e2e/test-launchable-smoke.sh
+++ b/test/e2e/test-launchable-smoke.sh
@@ -528,7 +528,7 @@ try:
     doc = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-result = doc.get('result') or {}
+result = doc.get('result') or doc
 parts = []
 for p in result.get('payloads') or []:
     if isinstance(p, dict) and isinstance(p.get('text'), str):

--- a/test/e2e/test-messaging-compatible-endpoint.sh
+++ b/test/e2e/test-messaging-compatible-endpoint.sh
@@ -531,7 +531,7 @@ try:
     doc = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-result = doc.get('result') or {}
+result = doc.get('result') or doc
 parts = []
 for p in result.get('payloads') or []:
     if isinstance(p, dict) and isinstance(p.get('text'), str):

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -281,7 +281,7 @@ try:
     doc = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-result = doc.get("result") or {}
+result = doc.get("result") or doc
 parts = []
 for payload in result.get("payloads") or []:
     if isinstance(payload, dict) and isinstance(payload.get("text"), str):

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -390,7 +390,7 @@ try:
     doc = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
-result = doc.get('result') or {}
+result = doc.get('result') or doc
 parts = []
 for p in result.get('payloads') or []:
     if isinstance(p, dict) and isinstance(p.get('text'), str):


### PR DESCRIPTION
Fixes #4031

## Summary

Five nightly E2E tests fail because their inline Python extractors assume `openclaw agent --json` output nests payloads under `result.payloads`, but OpenClaw ≥ 2026.5.18 now returns `payloads` at the top level of the JSON envelope. The fix makes the extraction resilient to both schemas: `doc.get("result") or doc` falls back to the document root when there is no `result` wrapper.

### Root cause

OpenClaw's agent JSON output changed from:
```json
{"result": {"payloads": [{"text": "..."}]}}
```
to:
```json
{"payloads": [{"text": "..."}]}
```

The E2E test scripts hardcoded `doc.get("result") or {}` which yields `{}` under the new schema, so `.get("payloads")` always returns `[]` → empty reply → assertion failure.

### Changes

| File | Line | Change |
|------|------|--------|
| `test/e2e/test-bedrock-runtime-compatible-anthropic.sh` | 713 | `(doc.get("result") or {}).get("payloads")` → `(doc.get("result") or doc).get("payloads")` |
| `test/e2e/test-launchable-smoke.sh` | 531 | `doc.get('result') or {}` → `doc.get('result') or doc` |
| `test/e2e/test-messaging-compatible-endpoint.sh` | 534 | `doc.get('result') or {}` → `doc.get('result') or doc` |
| `test/e2e/test-openclaw-inference-switch.sh` | 284 | `doc.get("result") or {}` → `doc.get("result") or doc` |
| `test/e2e/test-sandbox-operations.sh` | 393 | `doc.get('result') or {}` → `doc.get('result') or doc` |

### Nightly run

- **Run:** https://github.com/NVIDIA/NemoClaw/actions/runs/26260886472
- **Failed jobs (5 of 9, this PR):** `sandbox-operations-e2e`, `bedrock-runtime-compatible-anthropic-e2e`, `messaging-compatible-endpoint-e2e`, `openclaw-inference-switch-e2e`, `launchable-smoke-e2e`
- **Remaining 4 failures** (unrelated, tracked separately): RCF patch compat, gateway PID pattern, Kimi trajectory semicolon, Slack API 404

### Validation

The extraction pattern `doc.get("result") or doc` is backwards-compatible:
- **Old schema** (`{"result": {"payloads": [...]}}`): `doc.get("result")` returns truthy dict → uses it → `.get("payloads")` works
- **New schema** (`{"payloads": [...]}`): `doc.get("result")` returns `None` → falls back to `doc` → `.get("payloads")` works

Custom E2E workflow validation was not run (PAT lacks `workflow` scope to push `.github/workflows/` changes). The fix is a minimal, mechanically-verified single-expression change across 5 files.

## Test plan

- [ ] Verify nightly E2E passes after merge (all 5 affected jobs should go green)
- [ ] Confirm the fix is backwards-compatible if OpenClaw reverts the schema change

Signed-off-by: Hung Le <hple@nvidia.com>

