### PR TITLE
fix(runtime): use prependSystemContext to prevent runtime instructions leaking into chat UI

### DIFF
--- a/nemoclaw/src/runtime-context.test.ts
+++ b/nemoclaw/src/runtime-context.test.ts
@@ -129,14 +129,14 @@ describe("registerRuntimeContext", () => {
     registerRuntimeContext(api, defaultConfig);
 
     const result = (await api._trigger("before_prompt_build", {}, {})) as {
-      prependContext: string;
+      prependSystemContext: string;
     };
 
-    expect(result.prependContext).toContain("<nemoclaw-runtime>");
-    expect(result.prependContext).toContain('OpenShell sandbox "openclaw"');
-    expect(result.prependContext).toContain("Network policy:");
-    expect(result.prependContext).toContain("Filesystem policy:");
-    expect(result.prependContext).toContain("</nemoclaw-runtime>");
+    expect(result.prependSystemContext).toContain("<nemoclaw-runtime>");
+    expect(result.prependSystemContext).toContain('OpenShell sandbox "openclaw"');
+    expect(result.prependSystemContext).toContain("Network policy:");
+    expect(result.prependSystemContext).toContain("Filesystem policy:");
+    expect(result.prependSystemContext).toContain("</nemoclaw-runtime>");
   });
 
   it("uses the persisted sandbox name in the injected context", async () => {
@@ -145,9 +145,9 @@ describe("registerRuntimeContext", () => {
     registerRuntimeContext(api, defaultConfig);
 
     const result = (await api._trigger("before_prompt_build", {}, {})) as {
-      prependContext: string;
+      prependSystemContext: string;
     };
 
-    expect(result.prependContext).toContain('OpenShell sandbox "my-assistant"');
+    expect(result.prependSystemContext).toContain('OpenShell sandbox "my-assistant"');
   });
 });

--- a/nemoclaw/src/runtime-context.ts
+++ b/nemoclaw/src/runtime-context.ts
@@ -76,6 +76,6 @@ function buildRuntimeContextText(summary: RuntimeSummary): string {
  */
 export function registerRuntimeContext(api: OpenClawPluginApi, pluginConfig: NemoClawConfig): void {
   api.on("before_prompt_build", () => ({
-    prependContext: buildRuntimeContextText(getRuntimeSummary(pluginConfig)),
+    prependSystemContext: buildRuntimeContextText(getRuntimeSummary(pluginConfig)),
   }));
 }


### PR DESCRIPTION
## Summary

Fixes #4019 — system runtime instructions (`<nemoclaw-runtime>` block) leaking into the chat UI on the third message.

## Root Cause

`registerRuntimeContext()` was using `prependContext` in the `before_prompt_build` hook return. In the OpenClaw host, `prependContext` prepends content to the **user-visible conversation prompt**, which means the sandbox policy instructions could appear in the chat UI — especially with models like Nemotron 3 Super 120B via Ollama that may echo prepended context.

## Fix

Switch from `prependContext` to `prependSystemContext`, which injects into the **system prompt** (invisible to users). This matches the intent of these instructions as system-level runtime context that should never be displayed to the user.

## Changes

- `nemoclaw/src/runtime-context.ts`: `prependContext` → `prependSystemContext` (1 line)
- `nemoclaw/src/runtime-context.test.ts`: Updated test expectations to match (3 test assertions)

## Testing

```
npx vitest run nemoclaw/src/runtime-context.test.ts
# ✓ 6 tests passed (runtime-context.test.ts)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted how the runtime summary is injected into system prompts so agent turns consistently include the runtime wrapper and sandbox/network/filesystem policy text, and persisted sandbox names are respected.

* **Tests**
  * Updated tests to validate the new prompt-injection behavior and the presence of the runtime wrapper and policy content in system prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: kagura-agent <kagura.agent.ai@gmail.com>