### PR TITLE
test: resolve Slack proof OpenClaw root

### DIFF
--- a/test/e2e/lib/slack-api-proof.sh
+++ b/test/e2e/lib/slack-api-proof.sh
@@ -212,11 +212,12 @@ function resolveOpenClawRoot() {
     }
   } catch {}
   try {
-    const discovered = execFileSync(
-      "find",
-      ["/usr/local", "/tmp/npm-global", "/sandbox", "-path", "*/dist/extensions/slack/test-api.js", "-print", "-quit"],
-      { encoding: "utf8" },
-    ).trim();
+    const searchRoots = ["/usr/local", "/tmp/npm-global", "/sandbox"].filter((root) => fs.existsSync(root));
+    const discovered = searchRoots.length
+      ? execFileSync("find", [...searchRoots, "-path", "*/dist/extensions/slack/test-api.js", "-print", "-quit"], {
+          encoding: "utf8",
+        }).trim()
+      : "";
     if (discovered) addCandidate(path.resolve(discovered, "../../../.."));
   } catch {}
   addCandidate("/usr/local/lib/node_modules/openclaw");

--- a/test/e2e/lib/slack-api-proof.sh
+++ b/test/e2e/lib/slack-api-proof.sh
@@ -164,6 +164,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 
 function fail(message) {
@@ -173,14 +174,57 @@ function fail(message) {
 
 function resolveOpenClawRoot() {
   const candidates = [];
-  if (process.env.OPENCLAW_PACKAGE_ROOT) candidates.push(process.env.OPENCLAW_PACKAGE_ROOT);
+  const seen = new Set();
+  const addCandidate = (candidate) => {
+    if (!candidate) return;
+    const normalized = path.resolve(candidate);
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      candidates.push(normalized);
+    }
+  };
+  const addPathWalk = (start) => {
+    if (!start) return;
+    let current = path.resolve(start);
+    for (let depth = 0; depth < 8; depth += 1) {
+      addCandidate(current);
+      if (path.basename(current) === "openclaw") addCandidate(current);
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  };
+
+  addCandidate(process.env.OPENCLAW_PACKAGE_ROOT);
   try {
     const globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
-    if (globalRoot) candidates.push(path.join(globalRoot, "openclaw"));
+    if (globalRoot) addCandidate(path.join(globalRoot, "openclaw"));
   } catch {}
-  candidates.push("/usr/local/lib/node_modules/openclaw");
+  try {
+    const require = createRequire(import.meta.url);
+    addCandidate(path.dirname(require.resolve("openclaw/package.json")));
+  } catch {}
+  try {
+    const openclawBin = execFileSync("sh", ["-lc", "command -v openclaw || true"], { encoding: "utf8" }).trim();
+    if (openclawBin) {
+      const realBin = execFileSync("readlink", ["-f", openclawBin], { encoding: "utf8" }).trim();
+      addPathWalk(path.dirname(realBin));
+    }
+  } catch {}
+  try {
+    const discovered = execFileSync(
+      "find",
+      ["/usr/local", "/tmp/npm-global", "/sandbox", "-path", "*/dist/extensions/slack/test-api.js", "-print", "-quit"],
+      { encoding: "utf8" },
+    ).trim();
+    if (discovered) addCandidate(path.resolve(discovered, "../../../.."));
+  } catch {}
+  addCandidate("/usr/local/lib/node_modules/openclaw");
+  addCandidate("/tmp/npm-global/lib/node_modules/openclaw");
+
   for (const candidate of candidates) {
-    if (candidate && fs.existsSync(path.join(candidate, "dist/extensions/slack/test-api.js"))) {
+    if (fs.existsSync(path.join(candidate, "dist/extensions/slack/test-api.js"))) {
+      console.error(`OpenClaw Slack test API root: ${candidate}`);
       return candidate;
     }
   }


### PR DESCRIPTION
## Summary
- make the M-S17 Slack channel @mention proof resolve OpenClaw from more than fixed global install paths
- discover the package root via `OPENCLAW_PACKAGE_ROOT`, `npm root -g`, `require.resolve`, the `openclaw` executable, and bounded filesystem lookup
- log the resolved Slack test API root when found to improve future E2E diagnostics

## Why
Recent messaging-providers E2E runs intermittently fail M-S17 with:

```
OpenClaw Slack test API not found in: /tmp/npm-global/lib/node_modules/openclaw, /usr/local/lib/node_modules/openclaw
```

Passing runs show the same `UNDICI-EHPA` warnings, so the warnings are noise; the real flake is path-layout discovery for `dist/extensions/slack/test-api.js`.

## Validation
- `bash -n test/e2e/lib/slack-api-proof.sh test/e2e/test-messaging-providers.sh`
- `git diff --check`

## Related evidence
- Run 26262708948: M-S17 failed with missing OpenClaw Slack test API
- Runs 26260886472 and 26261117406: same intermittent signature
- Run 26261748162: same warnings but M-S17 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved internal Slack API test tooling: broadened runtime-root discovery, expanded lookup paths for the test artifact, de-duplicated candidate selection to avoid repeats, and clearer failure messages when the test artifact cannot be located.

---

*Note: This release contains no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->