### PR TITLE
test: fix crash-loop gateway PID detection

### DIFF
--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -110,7 +110,8 @@ sandbox_exec() {
 # oldest live `openclaw` process when gateway.log proves it reached ready.
 gateway_pid() {
   local script
-  script=$(cat <<'SH'
+  script=$(
+    cat <<'SH'
 set -eu
 pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
   $2 == "openclaw-gateway" || $0 ~ /openclaw[[:space:]]+gateway([[:space:]]|$)/ || $0 ~ /openclaw-gateway/ { print $1 }

--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -102,15 +102,26 @@ sandbox_exec() {
   openshell sandbox exec --name "$SANDBOX_NAME" -- "$@" 2>&1
 }
 
-# Get the current openclaw gateway PID inside the sandbox, or empty string.
-# The gateway re-execs to argv `openclaw-gateway` after startup (it spawns
-# from the launcher whose argv is `openclaw gateway run`). Match either form
-# via `[o]penclaw[ -]gateway` — bracket trick prevents pgrep self-match,
-# `[ -]` accepts both the launcher (space) and the post-rename (dash). `-o`
-# returns the OLDEST match (the long-lived launcher 262 in the typical
-# parent/child tree); env is inherited so NODE_OPTIONS reads the same.
+# Get the current OpenClaw gateway PID inside the sandbox, or empty string.
+# OpenClaw process labels vary by runtime/build: some expose argv as
+# `openclaw gateway run`, some re-title as `openclaw-gateway`, and current
+# 2026.5.x builds can show only `openclaw` in pgrep/ps even after the gateway
+# is ready. Prefer explicit gateway argv/title matches, then fall back to the
+# oldest live `openclaw` process when gateway.log proves it reached ready.
 gateway_pid() {
-  sandbox_exec sh -c "pgrep -fo '[o]penclaw[ -]gateway'" | tr -d '[:space:]'
+  local script
+  script=$(cat <<'SH'
+set -eu
+pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
+  $2 == "openclaw-gateway" || $0 ~ /openclaw[[:space:]]+gateway([[:space:]]|$)/ || $0 ~ /openclaw-gateway/ { print $1 }
+' | sort -n | head -n 1)"
+if [ -z "$pid" ] && grep -Eq "\[gateway\] (ready|http server listening)" /tmp/gateway.log 2>/dev/null; then
+  pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '$2 == "openclaw" { print $1 }' | sort -n | head -n 1)"
+fi
+printf "%s\n" "$pid"
+SH
+  )
+  sandbox_exec sh -c "$script" | awk '/^[0-9]+$/ { print; exit }'
 }
 
 # Read /tmp/nemoclaw-proxy-env.sh — the single source of truth for the
@@ -232,8 +243,8 @@ gateway_diagnostics() {
   sandbox_exec sh -c "tail -n 60 /tmp/gateway.log 2>&1 || echo '(no gateway.log)'" | sed 's/^/    /'
   echo "  [nemoclaw status]"
   nemoclaw "$SANDBOX_NAME" status 2>&1 | head -30 | sed 's/^/    /'
-  echo "  [openshell sandbox containers / pod]"
-  openshell sandbox info --name "$SANDBOX_NAME" 2>&1 | head -20 | sed 's/^/    /' || true
+  echo "  [openshell sandbox get]"
+  openshell sandbox get "$SANDBOX_NAME" 2>&1 | head -40 | sed 's/^/    /' || true
   if [ -n "$pid" ]; then
     echo "  [reported pid: $pid]"
     echo "  [/proc/${pid} listing]"


### PR DESCRIPTION
## Summary
- make the #2478 crash-loop E2E gateway PID detector tolerate current OpenClaw process labels
- prefer explicit `openclaw gateway` / `openclaw-gateway` matches, then fall back to the oldest live `openclaw` process only after `gateway.log` proves the gateway reached ready/listening
- replace stale `openshell sandbox info --name` diagnostics with supported `openshell sandbox get <name>`

## Why
Run 26262708948 failed with "Gateway never came up after onboard", but diagnostics showed the gateway was actually healthy: `pgrep` found `311 openclaw`, `gateway.log` contained `http server listening` and `gateway ready`, and `nemoclaw status` reported sandbox `Phase: Ready` with healthy inference. The E2E matcher only looked for `openclaw gateway` / `openclaw-gateway`, so current OpenClaw process-title shape produced a false negative.

## Validation
- `bash -n test/e2e/test-issue-2478-crash-loop-recovery.sh`
- `git diff --check`
- synthetic parser checks for explicit `openclaw gateway run`, retitled `openclaw-gateway`, plain `openclaw` with ready gateway log, and plain `openclaw` without ready log


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved gateway process identification during crash-loop recovery to more reliably pick the correct gateway instance, using explicit label/argument patterns and a readiness-based fallback.
  * Updated sandbox diagnostic capture to produce a clearer sandbox state snapshot for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->