### PR TITLE
fix(e2e): pin old gateway base fallback

### DIFF
--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -173,7 +173,8 @@ if [ "$rewrote_openclaw" = "0" ]; then
   printf 'add build-arg OPENCLAW_VERSION=%s\n' "$old_openclaw" >>"$log_file"
 fi
 if [ "$rewrote_base" = "0" ]; then
-  printf 'no BASE_IMAGE override seen; old Dockerfile default remains unchanged\n' >>"$log_file"
+  args+=("--build-arg" "BASE_IMAGE=${base_ref}")
+  printf 'add build-arg BASE_IMAGE=%s\n' "$base_ref" >>"$log_file"
 fi
 exec "$real_docker" "${args[@]}"
 EOF


### PR DESCRIPTION
## Summary
- force the old gateway-upgrade Docker wrapper to add the historical BASE_IMAGE build arg when the old installer does not pass one
- keep the old install fixture pinned to the intended sandbox base digest instead of falling through to the mutable current base
- preserve wrapper diagnostics by logging the added BASE_IMAGE fallback

## Why
The openshell-gateway-upgrade E2E prepares a v0.0.36 install before exercising the current upgrade path. PR #4041 pinned the old OpenClaw version, but if the old installer does not pass `BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest`, the wrapper only logged that no override was seen and left the old Dockerfile default in place. That allowed the fixture to consume a current base containing OpenClaw 2026.5.18, causing the old `rcf_patch.py` Patch 4 to fail before the upgrade path ran.

## Test plan
- `bash -n test/e2e/test-openshell-gateway-upgrade.sh`
- `git diff --check`
- `npm run typecheck:cli`
- `npm run test -- test/onboard-openshell-version.test.ts`

Fixes the nightly `openshell-gateway-upgrade-e2e` preparation failure after PR #4041.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Docker wrapper generator logic for upgrade regression testing to properly handle base image configuration when no override is specified, ensuring accurate testing scenarios during gateway upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->