### PR TITLE
fix(e2e): preserve explicit old base arg

### DIFF
--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -135,6 +135,9 @@ rewrote_base=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --build-arg)
+      if [ "$#" -ge 2 ] && [ "${2#BASE_IMAGE=}" != "$2" ]; then
+        rewrote_base=1
+      fi
       if [ "$#" -ge 2 ] && [ "${2#OPENCLAW_VERSION=}" != "$2" ]; then
         args+=("--build-arg" "OPENCLAW_VERSION=${old_openclaw}")
         rewrote_openclaw=1
@@ -163,6 +166,9 @@ while [ "$#" -gt 0 ]; do
       printf 'rewrite build-arg %s -> BASE_IMAGE=%s\n' "$1" "$base_ref" >>"$log_file"
       shift
       continue
+      ;;
+    --build-arg=BASE_IMAGE=*)
+      rewrote_base=1
       ;;
   esac
   args+=("$1")


### PR DESCRIPTION
## Summary
- address the unresolved CodeRabbit comment from PR #4047
- mark any explicit `BASE_IMAGE` Docker build arg as present, not just the mutable `:latest` literal
- keep the #4047 fallback path for old installers that pass no `BASE_IMAGE` at all

## Why
PR #4047 fixed the nightly gateway-upgrade fixture by appending a pinned `BASE_IMAGE` when the old installer omitted one. CodeRabbit correctly noted that `rewrote_base` was only set for the `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` literal, so a caller-provided non-latest `BASE_IMAGE` could receive a second fallback arg and be overridden by Docker last-arg-wins behavior.

## Test plan
- `bash -n test/e2e/test-openshell-gateway-upgrade.sh`
- `git diff --check`
- shell wrapper smoke: verified no-BASE adds pinned fallback, latest rewrites to pinned fallback, explicit custom BASE_IMAGE does not add pinned fallback
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run test -- test/onboard-openshell-version.test.ts`

Follow-up to PR #4047.

Resolves CodeRabbit thread: https://github.com/NVIDIA/NemoClaw/pull/4047#discussion_r3285482039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Docker wrapper in test suite to correctly handle pre-specified build arguments, preventing duplicate argument injection and ensuring reliable test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->