### PR TITLE
test: match OpenClaw argv in crash-loop PID probe

### DIFF
--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -108,8 +108,8 @@ sandbox_exec() {
 # 2026.5.x builds can show only `openclaw` in pgrep/ps even after the gateway
 # is ready. Prefer explicit gateway argv/title matches, then fall back to the
 # oldest live `openclaw` argv process when gateway.log proves it reached ready.
-# The fallback matches argv as well as comm because hosted Linux ps can show the
-# process comm as `node` even when pgrep reports argv as plain `openclaw`.
+# The fallback uses pgrep because hosted Linux diagnostics show pgrep can see
+# `311 openclaw` even when the ps columns used above still miss the process.
 gateway_pid() {
   local script
   script=$(
@@ -119,9 +119,7 @@ pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
   $2 == "openclaw-gateway" || $0 ~ /openclaw[[:space:]]+gateway([[:space:]]|$)/ || $0 ~ /openclaw-gateway/ { print $1 }
 ' | sort -n | head -n 1)"
 if [ -z "$pid" ] && grep -Eq "\[gateway\] (ready|http server listening)" /tmp/gateway.log 2>/dev/null; then
-  pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
-    $2 == "openclaw" || $0 ~ /(^|[[:space:]])openclaw([[:space:]]|$)/ { print $1 }
-  ' | sort -n | head -n 1)"
+  pid="$(pgrep -fo '[o]penclaw' 2>/dev/null || true)"
 fi
 printf "%s\n" "$pid"
 SH

--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -107,7 +107,9 @@ sandbox_exec() {
 # `openclaw gateway run`, some re-title as `openclaw-gateway`, and current
 # 2026.5.x builds can show only `openclaw` in pgrep/ps even after the gateway
 # is ready. Prefer explicit gateway argv/title matches, then fall back to the
-# oldest live `openclaw` process when gateway.log proves it reached ready.
+# oldest live `openclaw` argv process when gateway.log proves it reached ready.
+# The fallback matches argv as well as comm because hosted Linux ps can show the
+# process comm as `node` even when pgrep reports argv as plain `openclaw`.
 gateway_pid() {
   local script
   script=$(
@@ -117,7 +119,9 @@ pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
   $2 == "openclaw-gateway" || $0 ~ /openclaw[[:space:]]+gateway([[:space:]]|$)/ || $0 ~ /openclaw-gateway/ { print $1 }
 ' | sort -n | head -n 1)"
 if [ -z "$pid" ] && grep -Eq "\[gateway\] (ready|http server listening)" /tmp/gateway.log 2>/dev/null; then
-  pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '$2 == "openclaw" { print $1 }' | sort -n | head -n 1)"
+  pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
+    $2 == "openclaw" || $0 ~ /(^|[[:space:]])openclaw([[:space:]]|$)/ { print $1 }
+  ' | sort -n | head -n 1)"
 fi
 printf "%s\n" "$pid"
 SH


### PR DESCRIPTION
## Summary
- extend the #2478 crash-loop E2E gateway PID fallback to match `openclaw` in argv, not only process comm
- keep the fallback gated on `gateway.log` showing ready/listening so unrelated OpenClaw processes do not satisfy the probe

## Why
PR #4045 fixed explicit `openclaw gateway` / `openclaw-gateway` matching and stale diagnostics, but the rerun still showed the gateway as a plain `openclaw` argv process while `ps` comm can be `node` on hosted runners. The log proves the gateway is healthy (`gateway ready`, `Phase: Ready`, healthy inference), so this remains a PID matcher false negative.

## Validation
- `bash -n test/e2e/test-issue-2478-crash-loop-recovery.sh`
- `git diff --check origin/main..HEAD`
- synthetic checks for explicit gateway argv, retitled gateway, plain comm fallback, plain argv fallback, and no fallback before gateway ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved crash-loop recovery test robustness by enhancing process detection and selection to better handle inconsistent process metadata and identify the appropriate running process once readiness is signaled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->