### PR TITLE
fix(plugin): make /nemoclaw status reflect real onboard state

### DIFF
--- a/nemoclaw/src/commands/slash.test.ts
+++ b/nemoclaw/src/commands/slash.test.ts
@@ -138,39 +138,54 @@ describe("commands/slash", () => {
   // -------------------------------------------------------------------------
 
   describe("status", () => {
-    it("reports no operations when state is blank", () => {
+    const onboardConfig: NemoClawOnboardConfig = {
+      endpointType: "build",
+      endpointUrl: "https://api.build.nvidia.com/v1",
+      ncpPartner: null,
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      profile: "default",
+      credentialEnv: "NVIDIA_API_KEY",
+      onboardedAt: "2026-03-01T00:00:00.000Z",
+    };
+
+    it("reports the onboard hint when no onboard config exists", () => {
       const result = handleSlashCommand(makeCtx("status"), makeApi());
-      expect(result.text).toContain("No operations performed yet");
+      expect(result.text).toContain("No onboard configuration found");
+      expect(result.text).toContain("nemoclaw onboard");
     });
 
-    it("reports state when last action exists", () => {
-      mockedLoadState.mockReturnValue({
-        ...blankState(),
-        lastRunId: "run-123",
-        lastAction: "deploy",
-        blueprintVersion: "1.0.0",
-        sandboxName: "test-sandbox",
-        createdAt: "2026-03-01T00:00:00.000Z",
-        updatedAt: "2026-03-01T00:00:00.000Z",
-      });
+    it("reports sandbox, endpoint, provider, and model when onboarded", () => {
+      mockedLoadOnboardConfig.mockReturnValue(onboardConfig);
+      mockedDescribeOnboardEndpoint.mockReturnValue("build (https://api.build.nvidia.com/v1)");
+      mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Endpoints");
+      const api = makeApi();
+      api.pluginConfig = { sandboxName: "prachi-restricted" };
+      const result = handleSlashCommand(makeCtx("status"), api);
+      expect(result.text).toContain("NemoClaw Status");
+      expect(result.text).toContain("Sandbox: prachi-restricted");
+      expect(result.text).toContain("Endpoint: build (https://api.build.nvidia.com/v1)");
+      expect(result.text).toContain("Provider: NVIDIA Endpoints");
+      expect(result.text).toContain("Model: nvidia/nemotron-3-super-120b-a12b");
+      expect(result.text).toContain("Onboarded: 2026-03-01T00:00:00.000Z");
+      expect(result.text).not.toContain("No operations performed yet");
+    });
+
+    it("falls back to default sandbox name when pluginConfig is empty", () => {
+      mockedLoadOnboardConfig.mockReturnValue(onboardConfig);
+      mockedDescribeOnboardEndpoint.mockReturnValue("build (...)");
+      mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Endpoints");
       const result = handleSlashCommand(makeCtx("status"), makeApi());
-      expect(result.text).toContain("Last action: deploy");
-      expect(result.text).toContain("Blueprint: 1.0.0");
-      expect(result.text).toContain("Run ID: run-123");
-      expect(result.text).toContain("Sandbox: test-sandbox");
+      expect(result.text).toContain("Sandbox: openclaw");
     });
 
     it("includes rebuild info when present", () => {
+      mockedLoadOnboardConfig.mockReturnValue(onboardConfig);
+      mockedDescribeOnboardEndpoint.mockReturnValue("build (...)");
+      mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Endpoints");
       mockedLoadState.mockReturnValue({
         ...blankState(),
-        lastRunId: "run-789",
-        lastAction: "rebuild",
-        blueprintVersion: "2.0.0",
-        sandboxName: "sb",
         lastRebuildAt: "2026-04-15T10:00:00Z",
         lastRebuildBackupPath: "/backups/rebuild-001",
-        createdAt: "2026-03-01T00:00:00.000Z",
-        updatedAt: "2026-03-01T00:00:00.000Z",
       });
       const result = handleSlashCommand(makeCtx("status"), makeApi());
       expect(result.text).toContain("Last rebuild: 2026-04-15T10:00:00Z");
@@ -178,15 +193,12 @@ describe("commands/slash", () => {
     });
 
     it("includes rollback snapshot when present", () => {
+      mockedLoadOnboardConfig.mockReturnValue(onboardConfig);
+      mockedDescribeOnboardEndpoint.mockReturnValue("build (...)");
+      mockedDescribeOnboardProvider.mockReturnValue("NVIDIA Endpoints");
       mockedLoadState.mockReturnValue({
         ...blankState(),
-        lastRunId: "run-456",
-        lastAction: "migrate",
-        blueprintVersion: "2.0.0",
-        sandboxName: "sb",
         migrationSnapshot: "/snapshots/snap-001",
-        createdAt: "2026-03-01T00:00:00.000Z",
-        updatedAt: "2026-03-01T00:00:00.000Z",
       });
       const result = handleSlashCommand(makeCtx("status"), makeApi());
       expect(result.text).toContain("Rollback snapshot: /snapshots/snap-001");

--- a/nemoclaw/src/commands/slash.ts
+++ b/nemoclaw/src/commands/slash.ts
@@ -12,7 +12,12 @@
  *   /nemoclaw          - show help
  */
 
-import type { PluginCommandContext, PluginCommandResult, OpenClawPluginApi } from "../index.js";
+import {
+  getPluginConfig,
+  type OpenClawPluginApi,
+  type PluginCommandContext,
+  type PluginCommandResult,
+} from "../index.js";
 import { loadState } from "../blueprint/state.js";
 import {
   describeOnboardEndpoint,
@@ -24,13 +29,13 @@ import { slashConfigShow } from "./config-show.js";
 
 export function handleSlashCommand(
   ctx: PluginCommandContext,
-  _api: OpenClawPluginApi,
+  api: OpenClawPluginApi,
 ): PluginCommandResult {
   const subcommand = ctx.args?.trim().split(/\s+/)[0] ?? "";
 
   switch (subcommand) {
     case "status":
-      return slashStatus();
+      return slashStatus(api);
     case "eject":
       return slashEject();
     case "onboard":
@@ -69,25 +74,27 @@ function slashHelp(): PluginCommandResult {
   };
 }
 
-function slashStatus(): PluginCommandResult {
-  const state = loadState();
+function slashStatus(api: OpenClawPluginApi): PluginCommandResult {
+  const onboardConfig = loadOnboardConfig();
+  const { sandboxName } = getPluginConfig(api);
 
-  if (!state.lastAction) {
+  if (!onboardConfig) {
     return {
-      text: "**NemoClaw**: No operations performed yet. Run `nemoclaw onboard` to get started.",
+      text: "**NemoClaw**: No onboard configuration found. Run `nemoclaw onboard` to get started.",
     };
   }
 
   const lines = [
     "**NemoClaw Status**",
     "",
-    `Last action: ${state.lastAction}`,
-    `Blueprint: ${state.blueprintVersion ?? "unknown"}`,
-    `Run ID: ${state.lastRunId ?? "none"}`,
-    `Sandbox: ${state.sandboxName ?? "none"}`,
-    `Updated: ${state.updatedAt}`,
+    `Sandbox: ${sandboxName}`,
+    `Endpoint: ${describeOnboardEndpoint(onboardConfig)}`,
+    `Provider: ${describeOnboardProvider(onboardConfig)}`,
+    `Model: ${onboardConfig.model}`,
+    `Onboarded: ${onboardConfig.onboardedAt}`,
   ];
 
+  const state = loadState();
   if (state.migrationSnapshot) {
     lines.push("", `Rollback snapshot: ${state.migrationSnapshot}`);
   }


### PR DESCRIPTION
## Summary
- `/nemoclaw status` in the OpenClaw TUI always printed *"No operations performed yet. Run `nemoclaw onboard` to get started."*, even after a successful onboard and a running sandbox. Root cause: `slashStatus` gated its output on `state.lastAction`, but nothing in production code ever calls `saveState()`, so that field is permanently `null`.
- Derive the response from sources that are actually populated: `loadOnboardConfig()` (already used by `/nemoclaw onboard`) and the plugin config sandbox name. Keep the rebuild and migration-snapshot lines behind their state guards so a future blueprint runner that wires up `saveState()` picks them up automatically.

Refs #4010

Note: this PR addresses the misleading status output portion of #4010; subcommand autocomplete remains tracked on the issue.

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

## Test plan
- [x] `npx vitest run` (plugin) — 457/457 pass, including the updated status tests
- [x] `npm run typecheck:cli` and plugin `tsc --noEmit`
- [x] `npx @biomejs/biome lint` and `format` on touched files
- [x] Manual verification inside an onboarded sandbox: `/nemoclaw status` shows sandbox name, endpoint, provider, model, and onboarded timestamp instead of the misleading hint

## Manual verification output

Verified on Ubuntu 20.04 / Docker 24.0.7 / OpenShell 0.0.39 against a sandbox built from this branch (`6eb2d4e3f`), reproducing the exact steps from #4010.

Sandbox plugin loaded the fix:
```
$ grep -c "No onboard configuration found" /sandbox/.openclaw/extensions/nemoclaw/dist/commands/slash.js
1
$ grep -c "No operations performed yet"     /sandbox/.openclaw/extensions/nemoclaw/dist/commands/slash.js
0
```

`/nemoclaw status` inside `openclaw tui`:
```
NemoClaw Status

Sandbox: openclaw
Endpoint: Managed Inference Route (inference.local)
Provider: NVIDIA Endpoints
Model: nvidia/nemotron-3-super-120b-a12b
Onboarded: 2026-05-22T06:48:41.153Z
```

Pre-fix the same command always returned *"NemoClaw: No operations performed yet. Run `nemoclaw onboard` to get started."* regardless of onboard state — confirmed gone.

Fallback path (no onboard config → "No onboard configuration found" hint) is exercised by the new unit test `"reports the onboard hint when no onboard config exists"` in `nemoclaw/src/commands/slash.test.ts`.

## Security note

`Endpoint` is rendered via `describeOnboardEndpoint`, which already redacts URL userinfo and `token`/`key`/`secret`/`auth`/`sig`/`credential`/`password` query params. No new credential disclosure surface; the new `slashStatus` does not emit the credential env-var name (the existing `slashOnboard` already did and is unchanged).

