### PR TITLE
Revert #4045 crash-loop gateway PID detector

### DIFF
--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -102,27 +102,15 @@ sandbox_exec() {
   openshell sandbox exec --name "$SANDBOX_NAME" -- "$@" 2>&1
 }
 
-# Get the current OpenClaw gateway PID inside the sandbox, or empty string.
-# OpenClaw process labels vary by runtime/build: some expose argv as
-# `openclaw gateway run`, some re-title as `openclaw-gateway`, and current
-# 2026.5.x builds can show only `openclaw` in pgrep/ps even after the gateway
-# is ready. Prefer explicit gateway argv/title matches, then fall back to the
-# oldest live `openclaw` process when gateway.log proves it reached ready.
+# Get the current openclaw gateway PID inside the sandbox, or empty string.
+# The gateway re-execs to argv `openclaw-gateway` after startup (it spawns
+# from the launcher whose argv is `openclaw gateway run`). Match either form
+# via `[o]penclaw[ -]gateway` — bracket trick prevents pgrep self-match,
+# `[ -]` accepts both the launcher (space) and the post-rename (dash). `-o`
+# returns the OLDEST match (the long-lived launcher 262 in the typical
+# parent/child tree); env is inherited so NODE_OPTIONS reads the same.
 gateway_pid() {
-  local script
-  script=$(
-    cat <<'SH'
-set -eu
-pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '
-  $2 == "openclaw-gateway" || $0 ~ /openclaw[[:space:]]+gateway([[:space:]]|$)/ || $0 ~ /openclaw-gateway/ { print $1 }
-' | sort -n | head -n 1)"
-if [ -z "$pid" ] && grep -Eq "\[gateway\] (ready|http server listening)" /tmp/gateway.log 2>/dev/null; then
-  pid="$(ps -eo pid=,comm=,args= 2>/dev/null | awk '$2 == "openclaw" { print $1 }' | sort -n | head -n 1)"
-fi
-printf "%s\n" "$pid"
-SH
-  )
-  sandbox_exec sh -c "$script" | awk '/^[0-9]+$/ { print; exit }'
+  sandbox_exec sh -c "pgrep -fo '[o]penclaw[ -]gateway'" | tr -d '[:space:]'
 }
 
 # Read /tmp/nemoclaw-proxy-env.sh — the single source of truth for the
@@ -244,8 +232,8 @@ gateway_diagnostics() {
   sandbox_exec sh -c "tail -n 60 /tmp/gateway.log 2>&1 || echo '(no gateway.log)'" | sed 's/^/    /'
   echo "  [nemoclaw status]"
   nemoclaw "$SANDBOX_NAME" status 2>&1 | head -30 | sed 's/^/    /'
-  echo "  [openshell sandbox get]"
-  openshell sandbox get "$SANDBOX_NAME" 2>&1 | head -40 | sed 's/^/    /' || true
+  echo "  [openshell sandbox containers / pod]"
+  openshell sandbox info --name "$SANDBOX_NAME" 2>&1 | head -20 | sed 's/^/    /' || true
   if [ -n "$pid" ]; then
     echo "  [reported pid: $pid]"
     echo "  [/proc/${pid} listing]"


### PR DESCRIPTION
## Summary
- Revert the crash-loop E2E PID-detector change from #4045.
- #4045 adapted `test-issue-2478-crash-loop-recovery.sh` for the OpenClaw 2026.5.x process-title shape seen after #3820.
- #4051 reverted #3820 and the latest sandbox is back on OpenClaw 2026.4.24, where the pre-#3820 detector is the known-good path.

## Why
- The known-good pre-#3820 run at `80ee341686d695147c5cd118d1049c32f52d5af9` passed `issue-2478-crash-loop-recovery-e2e`.
- The current failing run on reverted main showed `openclaw-gateway` alive, `[gateway] ready`, sandbox `Ready`, and `Agent: OpenClaw v2026.4.24`, but the #4045 detector still returned empty.

## Validation
- `bash -n test/e2e/test-issue-2478-crash-loop-recovery.sh`
- `git diff --check`
- `git diff --stat 80ee341686d695147c5cd118d1049c32f52d5af9 -- test/e2e/test-issue-2478-crash-loop-recovery.sh` is empty; the test file now matches the known-good pre-#3820 version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced crash-loop recovery testing with simplified process detection and improved diagnostic capabilities for system troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->