### PR TITLE
fix(install): bootstrap OpenShell on git-clone source installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1365,6 +1365,21 @@ install_nemoclaw() {
     spin "Building ${_CLI_DISPLAY} CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
     spin "Building ${_CLI_DISPLAY} plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
     spin "Linking ${_CLI_DISPLAY} CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
+
+    # Bootstrap OpenShell when the source checkout is being used as a fresh
+    # install entrypoint (e.g. `git clone … && bash install.sh`) and the host
+    # has no openshell on PATH. Skipping here previously left the user at a
+    # circular preflight error ("Run the NemoClaw installer or
+    # scripts/install-openshell.sh") even though they were running the
+    # installer. A developer who already has a managed openshell on PATH
+    # keeps their existing binary — install-openshell.sh is only invoked
+    # when openshell is genuinely missing. See #3989.
+    if truthy_env "${NEMOCLAW_DEFER_OPENSHELL_INSTALL:-}"; then
+      info "Deferring OpenShell CLI installation until after pre-upgrade backup."
+    elif ! command_exists openshell; then
+      spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
+      prefer_user_local_openshell
+    fi
   else
     if [[ -f "$package_json" ]]; then
       info "Installer payload is not a persistent source checkout — installing from GitHub…"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -981,6 +981,26 @@ prefer_user_local_openshell() {
   fi
 }
 
+# Run scripts/install-openshell.sh during install_nemoclaw when appropriate.
+# - mode=force:      always invoke (GitHub-clone branch — fresh install path)
+# - mode=if-missing: invoke only when openshell is absent from PATH
+#                    (source-checkout branch — preserves developer autonomy
+#                    over their own openshell version)
+# Both modes defer when NEMOCLAW_DEFER_OPENSHELL_INSTALL=1 so the pre-upgrade
+# backup flow can run before any version bump.
+maybe_install_openshell_during_install() {
+  local mode="${1:-force}"
+  if truthy_env "${NEMOCLAW_DEFER_OPENSHELL_INSTALL:-}"; then
+    info "Deferring OpenShell CLI installation until after pre-upgrade backup."
+    return 0
+  fi
+  if [[ "$mode" == "if-missing" ]] && command_exists openshell; then
+    return 0
+  fi
+  spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
+  prefer_user_local_openshell
+}
+
 ensure_cli_shim() {
   local cli_bin="${1:-$_CLI_BIN}"
   local npm_bin shim_path node_path node_dir cli_path expected_shim
@@ -1374,12 +1394,7 @@ install_nemoclaw() {
     # installer. A developer who already has a managed openshell on PATH
     # keeps their existing binary — install-openshell.sh is only invoked
     # when openshell is genuinely missing. See #3989.
-    if truthy_env "${NEMOCLAW_DEFER_OPENSHELL_INSTALL:-}"; then
-      info "Deferring OpenShell CLI installation until after pre-upgrade backup."
-    elif ! command_exists openshell; then
-      spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
-      prefer_user_local_openshell
-    fi
+    maybe_install_openshell_during_install if-missing
   else
     if [[ -f "$package_json" ]]; then
       info "Installer payload is not a persistent source checkout — installing from GitHub…"
@@ -1419,15 +1434,10 @@ install_nemoclaw() {
     # onboard, so any later skip of onboard (preflight blocking,
     # interrupted session) leaves openshell stale below blueprint's
     # min_openshell_version even though the new NemoClaw declared a higher
-    # floor. The source-checkout branch intentionally skips this — a developer
-    # running ./scripts/install.sh manages their own openshell. The script is
-    # idempotent on the happy path. See #2272.
-    if truthy_env "${NEMOCLAW_DEFER_OPENSHELL_INSTALL:-}"; then
-      info "Deferring OpenShell CLI installation until after pre-upgrade backup."
-    else
-      spin "Installing OpenShell CLI" bash "${NEMOCLAW_SOURCE_ROOT}/scripts/install-openshell.sh"
-      prefer_user_local_openshell
-    fi
+    # floor. The source-checkout branch invokes the same helper in
+    # `if-missing` mode so developers keep autonomy when openshell is already
+    # on PATH. The script is idempotent on the happy path. See #2272, #3989.
+    maybe_install_openshell_during_install force
   fi
 
   refresh_path

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -334,6 +334,7 @@ exit 98
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_DEFER_OPENSHELL_INSTALL: "1",
         NPM_PREFIX: prefix,
         GIT_LOG_PATH: gitLog,
       },
@@ -425,6 +426,7 @@ exit 98
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_DEFER_OPENSHELL_INSTALL: "1",
         NPM_PREFIX: prefix,
       },
     });
@@ -636,6 +638,7 @@ fi`,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_DEFER_OPENSHELL_INSTALL: "1",
         NPM_PREFIX: prefix,
         NPM_LOG_PATH: npmLog,
         PYTHON_LOG_PATH: pythonLog,
@@ -655,6 +658,174 @@ fi`,
     const gitCalls = fs.existsSync(gitLog) ? fs.readFileSync(gitLog, "utf-8") : "";
     expect(gitCalls).not.toMatch(/submodule/);
   });
+
+  it(
+    "source-checkout: installs OpenShell when missing from PATH (#3989)",
+    { timeout: 20000 },
+    () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-source-osh-"));
+      const fakeBin = path.join(tmp, "bin");
+      const prefix = path.join(tmp, "prefix");
+      const npmLog = path.join(tmp, "npm.log");
+      const opensellLog = path.join(tmp, "install-openshell.log");
+      fs.mkdirSync(fakeBin);
+      fs.mkdirSync(path.join(tmp, ".git"));
+      fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+      writeNodeStub(fakeBin);
+      writeNpmStub(
+        fakeBin,
+        `printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
+if [ "$1" = "pack" ]; then
+  tmpdir="$4"
+  mkdir -p "$tmpdir/package"
+  tar -czf "$tmpdir/openclaw-2026.3.11.tgz" -C "$tmpdir" package
+  exit 0
+fi
+if [ "$1" = "install" ]; then exit 0; fi
+if [ "$1" = "run" ] && { [ "$2" = "build" ] || [ "$2" = "build:cli" ] || [ "$2" = "--if-present" ]; }; then exit 0; fi
+if [ "$1" = "link" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "nemoclaw v0.1.0-test"; exit 0; fi
+if [ "$1" = "onboard" ]; then exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi`,
+      );
+
+      fs.writeFileSync(
+        path.join(tmp, "package.json"),
+        JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+      );
+      fs.mkdirSync(path.join(tmp, "nemoclaw"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmp, "nemoclaw", "package.json"),
+        JSON.stringify({ name: "nemoclaw-plugin", version: "0.1.0" }, null, 2),
+      );
+
+      fs.mkdirSync(path.join(tmp, "scripts"), { recursive: true });
+      writeExecutable(
+        path.join(tmp, "scripts", "install-openshell.sh"),
+        `#!/usr/bin/env bash
+printf 'install-openshell.sh invoked\\n' >> "$INSTALL_OPENSHELL_LOG"
+exit 0
+`,
+      );
+      fs.mkdirSync(path.join(tmp, "bin", "lib"), { recursive: true });
+      fs.writeFileSync(path.join(tmp, "bin", "lib", "usage-notice.js"), "process.exit(0);\n");
+      fs.writeFileSync(path.join(tmp, "bin", "lib", "usage-notice.json"), "{}\n");
+
+      const result = spawnSync("bash", [INSTALLER], {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmp,
+          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+          NEMOCLAW_REPO_ROOT: tmp,
+          NPM_PREFIX: prefix,
+          NPM_LOG_PATH: npmLog,
+          INSTALL_OPENSHELL_LOG: opensellLog,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(opensellLog)).toBe(true);
+      expect(fs.readFileSync(opensellLog, "utf-8")).toMatch(/install-openshell\.sh invoked/);
+    },
+  );
+
+  it(
+    "source-checkout: skips OpenShell install when openshell is already on PATH (#3989)",
+    { timeout: 20000 },
+    () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-source-osh-skip-"));
+      const fakeBin = path.join(tmp, "bin");
+      const prefix = path.join(tmp, "prefix");
+      const npmLog = path.join(tmp, "npm.log");
+      const opensellLog = path.join(tmp, "install-openshell.log");
+      fs.mkdirSync(fakeBin);
+      fs.mkdirSync(path.join(tmp, ".git"));
+      fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
+
+      writeNodeStub(fakeBin);
+      writeExecutable(
+        path.join(fakeBin, "openshell"),
+        `#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "openshell 0.0.39"; exit 0; fi
+exit 0
+`,
+      );
+      writeNpmStub(
+        fakeBin,
+        `printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
+if [ "$1" = "pack" ]; then
+  tmpdir="$4"
+  mkdir -p "$tmpdir/package"
+  tar -czf "$tmpdir/openclaw-2026.3.11.tgz" -C "$tmpdir" package
+  exit 0
+fi
+if [ "$1" = "install" ]; then exit 0; fi
+if [ "$1" = "run" ] && { [ "$2" = "build" ] || [ "$2" = "build:cli" ] || [ "$2" = "--if-present" ]; }; then exit 0; fi
+if [ "$1" = "link" ]; then
+  cat > "$NPM_PREFIX/bin/nemoclaw" <<'EOS'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "nemoclaw v0.1.0-test"; exit 0; fi
+if [ "$1" = "onboard" ]; then exit 0; fi
+exit 0
+EOS
+  chmod +x "$NPM_PREFIX/bin/nemoclaw"
+  exit 0
+fi`,
+      );
+
+      fs.writeFileSync(
+        path.join(tmp, "package.json"),
+        JSON.stringify({ name: "nemoclaw", version: "0.1.0" }, null, 2),
+      );
+      fs.mkdirSync(path.join(tmp, "nemoclaw"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmp, "nemoclaw", "package.json"),
+        JSON.stringify({ name: "nemoclaw-plugin", version: "0.1.0" }, null, 2),
+      );
+
+      fs.mkdirSync(path.join(tmp, "scripts"), { recursive: true });
+      writeExecutable(
+        path.join(tmp, "scripts", "install-openshell.sh"),
+        `#!/usr/bin/env bash
+printf 'install-openshell.sh invoked\\n' >> "$INSTALL_OPENSHELL_LOG"
+exit 0
+`,
+      );
+      fs.mkdirSync(path.join(tmp, "bin", "lib"), { recursive: true });
+      fs.writeFileSync(path.join(tmp, "bin", "lib", "usage-notice.js"), "process.exit(0);\n");
+      fs.writeFileSync(path.join(tmp, "bin", "lib", "usage-notice.json"), "{}\n");
+
+      const result = spawnSync("bash", [INSTALLER], {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmp,
+          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+          NEMOCLAW_REPO_ROOT: tmp,
+          NPM_PREFIX: prefix,
+          NPM_LOG_PATH: npmLog,
+          INSTALL_OPENSHELL_LOG: opensellLog,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(opensellLog)).toBe(false);
+    },
+  );
 
   it("auto-resumes an interrupted onboarding session during install", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-resume-"));
@@ -1995,6 +2166,7 @@ exit 0`,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_DEFER_OPENSHELL_INSTALL: "1",
         NPM_PREFIX: prefix,
         GIT_LOG_PATH: gitLog,
       },
@@ -2071,6 +2243,7 @@ fi`,
         PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_DEFER_OPENSHELL_INSTALL: "1",
         NPM_PREFIX: prefix,
         GIT_LOG_PATH: gitLog,
       },
@@ -3664,6 +3837,7 @@ exit 0`,
         env: {
           HOME: tmp,
           PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          NEMOCLAW_DEFER_OPENSHELL_INSTALL: "1",
           ...env,
         },
       },

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -667,7 +667,7 @@ fi`,
       const fakeBin = path.join(tmp, "bin");
       const prefix = path.join(tmp, "prefix");
       const npmLog = path.join(tmp, "npm.log");
-      const opensellLog = path.join(tmp, "install-openshell.log");
+      const openshellLog = path.join(tmp, "install-openshell.log");
       fs.mkdirSync(fakeBin);
       fs.mkdirSync(path.join(tmp, ".git"));
       fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
@@ -730,13 +730,13 @@ exit 0
           NEMOCLAW_REPO_ROOT: tmp,
           NPM_PREFIX: prefix,
           NPM_LOG_PATH: npmLog,
-          INSTALL_OPENSHELL_LOG: opensellLog,
+          INSTALL_OPENSHELL_LOG: openshellLog,
         },
       });
 
       expect(result.status).toBe(0);
-      expect(fs.existsSync(opensellLog)).toBe(true);
-      expect(fs.readFileSync(opensellLog, "utf-8")).toMatch(/install-openshell\.sh invoked/);
+      expect(fs.existsSync(openshellLog)).toBe(true);
+      expect(fs.readFileSync(openshellLog, "utf-8")).toMatch(/install-openshell\.sh invoked/);
     },
   );
 
@@ -748,7 +748,7 @@ exit 0
       const fakeBin = path.join(tmp, "bin");
       const prefix = path.join(tmp, "prefix");
       const npmLog = path.join(tmp, "npm.log");
-      const opensellLog = path.join(tmp, "install-openshell.log");
+      const openshellLog = path.join(tmp, "install-openshell.log");
       fs.mkdirSync(fakeBin);
       fs.mkdirSync(path.join(tmp, ".git"));
       fs.mkdirSync(path.join(prefix, "bin"), { recursive: true });
@@ -818,12 +818,12 @@ exit 0
           NEMOCLAW_REPO_ROOT: tmp,
           NPM_PREFIX: prefix,
           NPM_LOG_PATH: npmLog,
-          INSTALL_OPENSHELL_LOG: opensellLog,
+          INSTALL_OPENSHELL_LOG: openshellLog,
         },
       });
 
       expect(result.status).toBe(0);
-      expect(fs.existsSync(opensellLog)).toBe(false);
+      expect(fs.existsSync(openshellLog)).toBe(false);
     },
   );
 


### PR DESCRIPTION
## Summary
On a fresh host, `git clone NemoClaw && bash install.sh` lands in the source-checkout branch of `install_nemoclaw`, which intentionally skipped the OpenShell CLI install — the assumption being that a developer running `./scripts/install.sh` manages their own openshell. End users following the documented install flow still ended up at the [3/3] Onboarding step with the circular hint "Run the NemoClaw installer or `scripts/install-openshell.sh`", telling them to re-run the installer they were already inside.

## Related Issue
Fixes #3989

## Changes
- `scripts/install.sh`: in the source-checkout branch, invoke `scripts/install-openshell.sh` when `command_exists openshell` is false. The bootstrap respects `NEMOCLAW_DEFER_OPENSHELL_INSTALL=1`, matching the existing GitHub-clone branch contract. A developer who already has openshell on PATH keeps autonomy: any version skips the install.
- `test/install-preflight.test.ts`: two new tests covering the source-checkout bootstrap (invoke when missing, skip when present). Existing source-checkout tests opt in to `NEMOCLAW_DEFER_OPENSHELL_INSTALL=1` so they don't fetch openshell over the network.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now consistently ensures the OpenShell CLI is available during setup for both persistent source checkouts and cloned installs.
  * Added a configurable defer option and smarter install modes to control whether/install when OpenShell is installed.

* **Tests**
  * Expanded installer tests to verify OpenShell install behavior and added source-checkout scenarios; tests pass the defer flag in preflight runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
