### PR TITLE
fix(preflight): reject WDDM placeholder GPU names on non-NVIDIA firmware

### DIFF
--- a/src/lib/inference/nim.test.ts
+++ b/src/lib/inference/nim.test.ts
@@ -318,6 +318,67 @@ describe("nim", () => {
       }
     });
 
+    // Regression #3988: WSL2 d3d12 shims (e.g. Snapdragon X "nvidia-smi.exe")
+    // return a generic name like "JMJWOA-Generic-GPU" for non-NVIDIA hardware.
+    // The primary path used to accept any name from nvidia-smi, which made the
+    // preflight report "NVIDIA GPU detected" on hosts with no NVIDIA hardware.
+    it("rejects WDDM placeholder names on hosts without NVIDIA firmware (#3988)", () => {
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "JMJWOA-Generic-GPU, 65471\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        // Snapdragon X WSL2 has no DMI / devicetree NVIDIA platform marker, so
+        // the firmware classification falls through to "linux" and the
+        // placeholder name is not vouched for.
+        withFirmwareModel("Microsoft Corporation Virtual Machine", () => {
+          expect(nimModule.detectGpu()).toBeNull();
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    // Real DGX Spark legitimately reports "NVIDIA JMJWOA-Generic-GPU" via the
+    // primary nvidia-smi path on some firmware revisions (#3510). The Spark
+    // firmware platform tag must continue to vouch for the device even when
+    // the name itself does not match a known NVIDIA family.
+    it("accepts placeholder names when firmware confirms NVIDIA platform (#3510)", () => {
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "JMJWOA-Generic-GPU, 131072\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        withFirmwareModel("NVIDIA DGX Spark", () => {
+          expect(nimModule.detectGpu()).toMatchObject({
+            type: "nvidia",
+            name: "JMJWOA-Generic-GPU",
+            count: 1,
+            totalMemoryMB: 131072,
+            platform: "spark",
+          });
+        });
+      } finally {
+        restore();
+      }
+    });
+
     it("detects GB10 unified-memory GPUs as Spark-capable NVIDIA devices", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {
         if (!Array.isArray(cmd)) throw new Error("expected argv array");

--- a/src/lib/inference/nim.test.ts
+++ b/src/lib/inference/nim.test.ts
@@ -347,6 +347,33 @@ describe("nim", () => {
       }
     });
 
+    // Even when the WDDM shim returns the placeholder with an `NVIDIA ` prefix
+    // (e.g. "NVIDIA JMJWOA-Generic-GPU"), `\bNVIDIA\b` alone is not enough to
+    // vouch for the device on generic Linux firmware — the placeholder family
+    // must keep requiring a firmware platform vouch. Regression guard for the
+    // CodeRabbit review comment on #4062.
+    it("rejects vendor-prefixed WDDM placeholders on generic firmware (#3988)", () => {
+      const runCapture = vi.fn((cmd: string | string[]) => {
+        if (!Array.isArray(cmd)) throw new Error("expected argv array");
+        if (
+          cmd[0] === "nvidia-smi" &&
+          cmd.some((a: string) => a.includes("name,memory.total"))
+        ) {
+          return "NVIDIA JMJWOA-Generic-GPU, 65471\n";
+        }
+        return "";
+      });
+      const { nimModule, restore } = loadNimWithMockedRunner(runCapture);
+
+      try {
+        withFirmwareModel("Microsoft Corporation Virtual Machine", () => {
+          expect(nimModule.detectGpu()).toBeNull();
+        });
+      } finally {
+        restore();
+      }
+    });
+
     // Real DGX Spark legitimately reports "NVIDIA JMJWOA-Generic-GPU" via the
     // primary nvidia-smi path on some firmware revisions (#3510). The Spark
     // firmware platform tag must continue to vouch for the device even when

--- a/src/lib/inference/nim.ts
+++ b/src/lib/inference/nim.ts
@@ -24,6 +24,20 @@ import { VLLM_PORT } from "../core/ports";
 const UNIFIED_MEMORY_GPU_TAGS = ["GB10", "Thor", "Orin", "Xavier", "Jetson", "Tegra"];
 const NIM_STATUS_PROBE_TIMEOUT_MS = 5000;
 
+// On Windows-on-ARM (Snapdragon X) WSL2 hosts, a d3d12/WDDM shim publishes a
+// `nvidia-smi.exe` that returns a placeholder name (e.g. "JMJWOA-Generic-GPU")
+// even though the system has no NVIDIA hardware. Real DGX Spark legitimately
+// reports the same string (see #3510), distinguished by the firmware platform.
+// Accept a name as NVIDIA when it either advertises the vendor explicitly or
+// matches a known NVIDIA product family; otherwise the caller must cross-check
+// against `detectNvidiaPlatform()` before trusting the nvidia-smi output.
+const NVIDIA_GPU_NAME_PATTERN =
+  /\bNVIDIA\b|\b(GeForce|Tesla|Quadro|RTX|GTX|TITAN|H100|H200|A100|A40|A10|L40|L4|GB1\d|GB200|GB300|Grace[\s_-]+Hopper)\b/i;
+
+function isPlausibleNvidiaGpuName(name: string): boolean {
+  return !!name && NVIDIA_GPU_NAME_PATTERN.test(name);
+}
+
 export interface NimModel {
   name: string;
   image: string;
@@ -277,23 +291,36 @@ export function detectGpu(): GpuDetection | null {
         parsed.push({ name, memoryMB });
       }
       if (parsed.length > 0) {
-        const totalMemoryMB = parsed.reduce(
+        const platform = detectNvidiaPlatform();
+        // Reject WDDM/d3d12 placeholder names on hosts where firmware does not
+        // confirm an NVIDIA platform. Otherwise a Snapdragon X WSL2 nvidia-smi
+        // shim returning "JMJWOA-Generic-GPU" would be reported as a real
+        // NVIDIA GPU. Real DGX Spark uses the same placeholder but has
+        // firmware platform "spark", which keeps the #3510 path working.
+        const firmwareConfirmsNvidia =
+          platform === "spark" || platform === "station" || platform === "jetson";
+        const trusted = firmwareConfirmsNvidia
+          ? parsed
+          : parsed.filter((p: ParsedGpu) => isPlausibleNvidiaGpuName(p.name));
+        if (trusted.length === 0) {
+          return null;
+        }
+        const totalMemoryMB = trusted.reduce(
           (sum: number, p: ParsedGpu) => sum + p.memoryMB,
           0,
         );
-        const firstName = parsed[0].name;
+        const firstName = trusted[0].name;
         // Only surface a single name when every GPU reports the same model;
         // a mixed-GPU host would otherwise be misreported as `Nx <firstName>`.
         const allSameName =
-          !!firstName && parsed.every((p: ParsedGpu) => p.name === firstName);
-        const platform = detectNvidiaPlatform();
+          !!firstName && trusted.every((p: ParsedGpu) => p.name === firstName);
         return {
           type: "nvidia",
           ...(allSameName ? { name: firstName } : {}),
-          gpus: parsed.map((p) => ({ name: p.name, memoryMB: p.memoryMB })),
-          count: parsed.length,
+          gpus: trusted.map((p) => ({ name: p.name, memoryMB: p.memoryMB })),
+          count: trusted.length,
           totalMemoryMB,
-          perGpuMB: parsed[0].memoryMB,
+          perGpuMB: trusted[0].memoryMB,
           nimCapable: canRunNimWithMemory(totalMemoryMB),
           platform,
           spark: platform === "spark",

--- a/src/lib/inference/nim.ts
+++ b/src/lib/inference/nim.ts
@@ -34,8 +34,18 @@ const NIM_STATUS_PROBE_TIMEOUT_MS = 5000;
 const NVIDIA_GPU_NAME_PATTERN =
   /\bNVIDIA\b|\b(GeForce|Tesla|Quadro|RTX|GTX|TITAN|H100|H200|A100|A40|A10|L40|L4|GB1\d|GB200|GB300|Grace[\s_-]+Hopper)\b/i;
 
+// Names that have been observed both on legitimate NVIDIA unified-memory
+// hardware (DGX Spark — #3510) and on Windows-on-ARM WSL2 d3d12 shims with no
+// NVIDIA silicon. Even with an `NVIDIA ` vendor prefix the name alone is not
+// sufficient — the caller must cross-check `detectNvidiaPlatform()`.
+const NVIDIA_GPU_NAME_DENYLIST_PATTERN = /\bJMJWOA-Generic-GPU\b/i;
+
 function isPlausibleNvidiaGpuName(name: string): boolean {
-  return !!name && NVIDIA_GPU_NAME_PATTERN.test(name);
+  return (
+    !!name &&
+    !NVIDIA_GPU_NAME_DENYLIST_PATTERN.test(name) &&
+    NVIDIA_GPU_NAME_PATTERN.test(name)
+  );
 }
 
 export interface NimModel {


### PR DESCRIPTION
## Summary
On Snapdragon X WSL2 hosts (Windows on ARM, no NVIDIA hardware), a d3d12/WDDM `nvidia-smi.exe` shim is published into the WSL distro and returns `JMJWOA-Generic-GPU` as the GPU name. `detectGpu()`'s primary `nvidia-smi --query-gpu=name,memory.total` path accepted any non-empty name, so preflight reported a fake "NVIDIA GPU detected (JMJWOA-Generic-GPU, 65471 MB)" and onboard proceeded down GPU-enabled code paths that later broke in rebuild's stricter CDI check.

Real DGX Spark legitimately reports the same placeholder string (see #3510), so the rejection must be conditional: trust the name when it contains `NVIDIA` or a known NVIDIA product family, otherwise require the firmware platform to vouch for it (`spark` / `station` / `jetson`).

## Related Issue
Fixes #3988

## Changes
- `src/lib/inference/nim.ts`: add `isPlausibleNvidiaGpuName()` and `NVIDIA_GPU_NAME_PATTERN`. Primary `detectGpu()` path filters parsed rows through this check unless `detectNvidiaPlatform()` already classifies the host as `spark`/`station`/`jetson`; if all rows fail validation, returns `null` instead of fabricating an NVIDIA GPU.
- `src/lib/inference/nim.test.ts`: two regression tests — Snapdragon X-style WSL2 placeholder rejected on generic Linux firmware; same placeholder accepted under DGX Spark firmware.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU detection on Windows-on-ARM by filtering implausible placeholder GPU names when platform firmware does not confirm an NVIDIA device; trusted detection is preserved when firmware identifies known NVIDIA platforms (e.g., DGX Spark).

* **Tests**
  * Added regression tests covering rejection of placeholder names, vendor-prefixed placeholders, and acceptance when firmware validates the NVIDIA platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->