### PR TITLE
fix(policy): split Claude Code from permissive policies

### DIFF
--- a/agents/hermes/policy-permissive.yaml
+++ b/agents/hermes/policy-permissive.yaml
@@ -40,27 +40,6 @@ process:
 
 network_policies:
 
-  claude_code:
-    name: claude_code
-    endpoints:
-      - host: api.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-      - host: statsig.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-      - host: sentry.io
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-    binaries:
-      - { path: "/**" }
-
   nvidia:
     name: nvidia
     endpoints:

--- a/agents/openclaw/policy-permissive.yaml
+++ b/agents/openclaw/policy-permissive.yaml
@@ -36,27 +36,6 @@ process:
 
 network_policies:
 
-  claude_code:
-    name: claude_code
-    endpoints:
-      - host: api.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-      - host: statsig.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-      - host: sentry.io
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-    binaries:
-      - { path: "/**" }
-
   nvidia:
     name: nvidia
     endpoints:

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -72,6 +72,9 @@ After selecting a tier, a combined preset and access-mode screen lets you includ
 Tier-default presets are pre-selected; additional presets can be added from the full list.
 NemoClaw filters tier defaults by the active agent's supported integrations.
 For example, Hermes onboarding omits the Brave Search preset because Hermes does not use NemoClaw's OpenClaw web-search configuration.
+Claude Code direct egress is not included in any tier or `shields down` permissive policy.
+If you install and run the Claude Code CLI inside the sandbox with its own credentials, apply the `claude-code` preset explicitly.
+Normal NemoClaw Anthropic inference still routes through the OpenShell gateway.
 
 Tier definitions are stored in `nemoclaw-blueprint/policies/tiers.yaml`.
 

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -160,6 +160,7 @@ NemoClaw ships preset policy files in `nemoclaw-blueprint/policies/presets/` for
 |---|---|---|
 | `brave` | Brave Search API. | Agent can issue search queries. |
 | `brew` | Homebrew (Linuxbrew) package manager. The sandbox base image includes the `brew` binary; this preset opens network egress to GitHub and the Homebrew formulae index so `brew install` can fetch bottles. | Allows installing arbitrary Homebrew packages, which may contain malicious code. |
+| `claude-code` | Claude Code CLI API, telemetry, and crash-report endpoints. | Allows a separately installed Claude Code CLI to reach Anthropic and telemetry hosts with its own credentials. Do not use this preset for NemoClaw inference routing. |
 | `discord` | Discord REST API, WebSocket gateway, CDN. | CDN endpoint (`cdn.discordapp.com`) allows GET to any path. WebSocket uses `access: full` (no inspection). |
 | `github` | GitHub and GitHub REST API. | Gives agent read/write access to repositories and issues via `git`. |
 | `huggingface` | Hugging Face Hub (download-only) and inference router. | Allows downloading arbitrary models and datasets. POST is restricted to the inference router only. |
@@ -451,7 +452,7 @@ The agent never receives the provider API key.
 | Default | The agent talks to `inference.local`. The host owns the credential and upstream endpoint. |
 | What you can change | You cannot configure this architecture. The system always enforces it. |
 | Risk if bypassed | If the agent could reach an inference endpoint directly (by adding it to the network policy), it would need an API key. Since the sandbox does not contain credentials, this acts as defense-in-depth. However, adding an inference provider's host to the network policy without going through OpenShell routing could let the agent use a stolen or hardcoded key. |
-| Recommendation | Do not add inference provider hosts (such as `api.openai.com` or `api.anthropic.com`) to the network policy. Use OpenShell inference routing instead. |
+| Recommendation | Do not add inference provider hosts (such as `api.openai.com` or `api.anthropic.com`) to the network policy for NemoClaw model traffic. Use OpenShell inference routing instead. The `claude-code` preset is a separate opt-in exception for running the Claude Code CLI with its own credentials, not a way to configure NemoClaw inference. |
 
 ### Provider Trust Tiers
 
@@ -522,7 +523,7 @@ The following patterns weaken security without providing meaningful benefit.
 | Adding endpoints to the baseline policy for one-off requests | Adding an endpoint to the baseline policy makes it permanently reachable across all sandbox instances. | Use operator approval. Approved endpoints persist within the sandbox instance but reset when you destroy and recreate the sandbox. |
 | Relying solely on the entrypoint for capability drops | The entrypoint drops dangerous capabilities using `capsh`, but this is best-effort. If `capsh` is unavailable or `CAP_SETPCAP` is not in the bounding set, the container runs with the default capability set. | Pass `--cap-drop=ALL` at the container runtime level as defense-in-depth. |
 | Leaving `/sandbox/.openclaw` writable on sensitive workloads | This directory contains the OpenClaw gateway configuration. A writable `.openclaw` lets the agent disable CORS, redirect inference routing, or weaken gateway protections. | Lock config for always-on assistants handling sensitive data. |
-| Adding inference provider hosts to the network policy | Direct network access to an inference host bypasses credential isolation and usage tracking. | Use OpenShell inference routing instead of adding hosts like `api.openai.com` or `api.anthropic.com` to the network policy. |
+| Adding inference provider hosts to the network policy for NemoClaw inference | Direct network access to an inference host bypasses credential isolation and usage tracking. | Use OpenShell inference routing instead of adding hosts like `api.openai.com` or `api.anthropic.com` to the network policy. Apply `claude-code` only when intentionally running the separate Claude Code CLI inside the sandbox. |
 | Disabling device auth for remote deployments | Without device auth, any device on the network can connect to the gateway without pairing. Combined with a cloudflared tunnel, this makes the dashboard publicly accessible and unauthenticated. | Keep `NEMOCLAW_DISABLE_DEVICE_AUTH` at its default (`0`). Only set it to `1` for local headless or development environments. |
 
 ## Known Limitations

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -42,27 +42,6 @@ process:
 network_policies:
   # ── Base policy endpoints (all methods, all paths) ──
 
-  claude_code:
-    name: claude_code
-    endpoints:
-      - host: api.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-      - host: statsig.anthropic.com
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-      - host: sentry.io
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: full
-    binaries:
-      - { path: "/**" }
-
   nvidia:
     name: nvidia
     endpoints:

--- a/nemoclaw-blueprint/policies/presets/claude-code.yaml
+++ b/nemoclaw-blueprint/policies/presets/claude-code.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: claude-code
+  description: "Claude Code API, telemetry, and crash-report access"
+
+network_policies:
+  claude_code:
+    name: claude_code
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: statsig.anthropic.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: sentry.io
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/claude }
+      - { path: /usr/bin/claude }
+      - { path: /tmp/npm-global/bin/claude }
+      - { path: /home/linuxbrew/.linuxbrew/bin/claude }
+      # Claude Code is distributed as an npm CLI, so OpenShell may observe
+      # the Node runtime instead of the shim that launched it.
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -145,9 +145,9 @@ selectFromList(items, options)
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 20 presets", () => {
+    it("returns all 21 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(20);
+      expect(presets.length).toBe(21);
     });
 
     it("each preset has name and description", () => {
@@ -165,6 +165,7 @@ describe("policies", () => {
       const expected = [
         "brave",
         "brew",
+        "claude-code",
         "discord",
         "github",
         "huggingface",
@@ -1639,6 +1640,64 @@ exit 1
           expect.arrayContaining(baselineReadWrite),
         );
       }
+    });
+
+    it("Claude Code hosts require the explicit claude-code preset", () => {
+      const claudeHosts = new Set(["api.anthropic.com", "statsig.anthropic.com", "sentry.io"]);
+      const permissivePolicyPaths = [
+        "nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
+        "agents/openclaw/policy-permissive.yaml",
+        "agents/hermes/policy-permissive.yaml",
+      ];
+
+      for (const relativePath of permissivePolicyPaths) {
+        const parsed = parseRepoYaml(relativePath) as {
+          network_policies?: Record<string, { endpoints?: Array<{ host?: string }> }>;
+        };
+        expect(parsed.network_policies, relativePath).not.toHaveProperty("claude_code");
+        const hosts = Object.values(parsed.network_policies ?? {})
+          .flatMap((policy) => policy.endpoints ?? [])
+          .map((endpoint) => endpoint.host)
+          .filter((host): host is string => typeof host === "string");
+        expect(hosts.filter((host) => claudeHosts.has(host)), relativePath).toEqual([]);
+      }
+
+      const preset = parseRepoYaml("nemoclaw-blueprint/policies/presets/claude-code.yaml") as {
+        preset?: { name?: string };
+        network_policies?: Record<
+          string,
+          {
+            endpoints?: Array<{
+              host?: string;
+              port?: number;
+              protocol?: string;
+              enforcement?: string;
+              access?: string;
+              rules?: unknown[];
+            }>;
+            binaries?: Array<{ path?: string }>;
+          }
+        >;
+      };
+      const claudePolicy = preset.network_policies?.claude_code;
+      expect(preset.preset?.name).toBe("claude-code");
+      expect(claudePolicy).toBeDefined();
+      expect((claudePolicy?.endpoints ?? []).map((endpoint) => endpoint.host).sort()).toEqual(
+        [...claudeHosts].sort(),
+      );
+      for (const endpoint of claudePolicy?.endpoints ?? []) {
+        expect(endpoint.port).toBe(443);
+        expect(endpoint.protocol).toBe("rest");
+        expect(endpoint.enforcement).toBe("enforce");
+        expect(endpoint).not.toHaveProperty("access");
+        expect(endpoint.rules).toEqual(
+          expect.arrayContaining([
+            { allow: { method: "GET", path: "/**" } },
+            { allow: { method: "POST", path: "/**" } },
+          ]),
+        );
+      }
+      expect((claudePolicy?.binaries ?? []).map((binary) => binary.path)).not.toContain("/**");
     });
 
     it("brew preset whitelists the PATH wrapper and Homebrew-managed entrypoints (#3913)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Removes Claude Code-specific egress from the permissive sandbox policies and moves it behind an explicit `claude-code` preset. This keeps `shields down` from granting Anthropic/telemetry endpoints unless users intentionally opt into Claude Code access.

## Related Issue
Fixes #4073 

## Changes
- Removed the `claude_code` block from the global permissive policy.
- Removed duplicated `claude_code` blocks from OpenClaw and Hermes agent-specific permissive policies.
- Added a built-in `claude-code` policy preset with explicit REST rules and scoped binary allowlist.
- Updated policy preset tests to include the new preset and block regressions where Claude Code hosts reappear in permissive policies.
- Updated network policy docs to clarify that Claude Code direct egress is opt-in and separate from NemoClaw Anthropic inference routing.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification run:
- [x] `npm run validate:configs` passes
- [x] `npm run build:cli` passes
- [x] `npx vitest run test/policies.test.ts` passes
- [x] `npx vitest run test/validate-blueprint.test.ts test/security-binaries-restriction.test.ts` passes
- [x] `git diff --check` passes

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: 1PoPTRoN <vrxn.arp1traj@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code configuration preset that must be explicitly applied to enable Claude Code CLI networking.

* **Changes**
  * Removed Claude Code hosts and broad binary allow rules from permissive policy tiers so they are no longer implicitly allowed.

* **Documentation**
  * Clarified that Claude Code direct access is excluded by default and requires the explicit preset; updated best-practices and network-policies reference.

* **Tests**
  * Updated tests to include the new preset and verify Claude Code endpoints are isolated from permissive policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->