### PR TITLE
fix(e2e): pin old gateway base for resolved digests

### DIFF
--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -125,6 +125,17 @@ real_docker="${NEMOCLAW_REAL_DOCKER:-/usr/bin/docker}"
 base_ref="${NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF:?}"
 old_openclaw="${NEMOCLAW_OLD_OPENCLAW_VERSION:?}"
 log_file="${NEMOCLAW_OLD_DOCKER_WRAPPER_LOG:-/tmp/nemoclaw-e2e-openshell-gateway-old-docker.log}"
+base_tag="ghcr.io/nvidia/nemoclaw/sandbox-base:latest"
+if [ "${1:-}" = "pull" ]; then
+  for arg in "$@"; do
+    if [ "$arg" = "$base_tag" ]; then
+      printf 'rewrite pull %s -> %s\n' "$base_tag" "$base_ref" >>"$log_file"
+      "$real_docker" pull "$base_ref"
+      "$real_docker" tag "$base_ref" "$base_tag"
+      exit 0
+    fi
+  done
+fi
 if [ "${1:-}" != "build" ]; then
   exec "$real_docker" "$@"
 fi
@@ -522,6 +533,10 @@ run_installer_payload() {
     >"$log_file" 2>&1 || {
     diag "${label} installer log tail:"
     tail -120 "$log_file" 2>/dev/null || true
+    if [ -f "$OLD_DOCKER_WRAPPER_LOG" ]; then
+      diag "old installer docker wrapper activity:"
+      cat "$OLD_DOCKER_WRAPPER_LOG" || true
+    fi
     fail "${label} NemoClaw installer failed"
   }
   load_shell_path

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -187,49 +187,30 @@ if [ "$rewrote_base" = "0" ]; then
   args+=("--build-arg" "BASE_IMAGE=${base_ref}")
   printf 'add build-arg BASE_IMAGE=%s\n' "$base_ref" >>"$log_file"
 fi
+exec "$real_docker" "${args[@]}"
+EOF
+  chmod 755 "${OLD_DOCKER_WRAPPER_DIR}/docker"
+}
 
-dockerfile=""
-context=""
-next_value_for=""
-for arg in "${args[@]}"; do
-  if [ "$next_value_for" = "file" ]; then
-    dockerfile="$arg"
-    next_value_for=""
-    continue
-  fi
-  if [ -n "$next_value_for" ]; then
-    next_value_for=""
-    continue
-  fi
-  case "$arg" in
-    -f|--file)
-      next_value_for="file"
-      ;;
-    -t|--tag|--target|--platform|--build-arg|--label|--cache-from|--cache-to|--add-host|--network|--output|--progress|--secret|--ssh)
-      next_value_for="other"
-      ;;
-    --file=*)
-      dockerfile="${arg#--file=}"
-      ;;
-    -*)
-      ;;
-    *)
-      context="$arg"
-      ;;
-  esac
-done
-if [ -z "$dockerfile" ]; then
-  if [ -f Dockerfile ]; then
-    dockerfile="Dockerfile"
-  elif [ -n "$context" ]; then
-    dockerfile="${context%/}/Dockerfile"
-  fi
-fi
-if [ ! -f "$dockerfile" ] && [ -n "$context" ] && [ -f "${context%/}/${dockerfile}" ]; then
-  dockerfile="${context%/}/${dockerfile}"
-fi
-if [ -f "$dockerfile" ] && grep -q "min_openclaw_version" "$dockerfile"; then
-  python3 - "$dockerfile" "$old_openclaw" <<'PY'
+patch_old_installer_fixture() {
+  local installer="$1"
+  python3 - "$installer" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = '  legacy_script="${source_root}/install.sh"\n'
+insertion = r"""  if [[ -n "${NEMOCLAW_OLD_OPENCLAW_VERSION:-}" && -f "$payload_script" ]]; then
+    python3 - "$payload_script" <<'NEMOCLAW_OLD_PAYLOAD_PIN_PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+needle = '    spin "Cloning ${_CLI_DISPLAY} source" clone_nemoclaw_ref "$release_ref" "$nemoclaw_src"\n'
+hook = r'''    if [[ -n "${NEMOCLAW_OLD_OPENCLAW_VERSION:-}" ]]; then
+      python3 - "$nemoclaw_src/Dockerfile" "$NEMOCLAW_OLD_OPENCLAW_VERSION" <<'NEMOCLAW_OLD_DOCKERFILE_PIN_PY'
 from pathlib import Path
 import sys
 
@@ -248,12 +229,24 @@ if injection not in text:
         raise SystemExit(f"{path}: old OpenClaw version gate not found")
     text = text.replace(marker, injection + marker, 1)
     path.write_text(text, encoding="utf-8")
+print(f"INFO: Forced OpenClaw {version} in old upgrade fixture Dockerfile", flush=True)
+NEMOCLAW_OLD_DOCKERFILE_PIN_PY
+    fi
+'''
+if hook not in text:
+    if needle not in text:
+        raise SystemExit(f"{path}: old source clone hook not found")
+    text = text.replace(needle, needle + hook, 1)
+    path.write_text(text, encoding="utf-8")
+NEMOCLAW_OLD_PAYLOAD_PIN_PY
+  fi
+"""
+if insertion not in text:
+    if needle not in text:
+        raise SystemExit(f"{path}: old bootstrap payload hook not found")
+    text = text.replace(needle, needle + insertion, 1)
+    path.write_text(text, encoding="utf-8")
 PY
-  printf 'force Dockerfile OpenClaw version %s in %s\n' "$old_openclaw" "$dockerfile" >>"$log_file"
-fi
-exec "$real_docker" "${args[@]}"
-EOF
-  chmod 755 "${OLD_DOCKER_WRAPPER_DIR}/docker"
 }
 
 cleanup() {
@@ -619,6 +612,7 @@ install_old_nemoclaw_and_claw() {
   create_old_docker_wrapper
   info "Pinning old ${OLD_NEMOCLAW_REF} OpenClaw base build to ${OLD_OPENCLAW_VERSION}"
   download_old_curl_installer "$installer"
+  patch_old_installer_fixture "$installer"
   run_installer_payload "old ${OLD_NEMOCLAW_REF}" "$OLD_NEMOCLAW_REF" "$installer" "$OLD_INSTALL_LOG"
   if [ -f "$OLD_DOCKER_WRAPPER_LOG" ]; then
     diag "old installer docker wrapper activity:"

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -142,7 +142,7 @@ while [ "$#" -gt 0 ]; do
         shift 2
         continue
       fi
-      if [ "$#" -ge 2 ] && [ "$2" = "BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest" ]; then
+      if [ "$#" -ge 2 ] && [ "${2#BASE_IMAGE=}" != "$2" ]; then
         args+=("--build-arg" "BASE_IMAGE=${base_ref}")
         rewrote_base=1
         printf 'rewrite build-arg %s -> BASE_IMAGE=%s\n' "$2" "$base_ref" >>"$log_file"
@@ -157,7 +157,7 @@ while [ "$#" -gt 0 ]; do
       shift
       continue
       ;;
-    --build-arg=BASE_IMAGE=ghcr.io/nvidia/nemoclaw/sandbox-base:latest)
+    --build-arg=BASE_IMAGE=*)
       args+=("--build-arg=BASE_IMAGE=${base_ref}")
       rewrote_base=1
       printf 'rewrite build-arg %s -> BASE_IMAGE=%s\n' "$1" "$base_ref" >>"$log_file"
@@ -544,6 +544,19 @@ install_old_nemoclaw_and_claw() {
   if [ -f "$OLD_DOCKER_WRAPPER_LOG" ]; then
     diag "old installer docker wrapper activity:"
     cat "$OLD_DOCKER_WRAPPER_LOG" || true
+  fi
+  local wrong_old_openclaw
+  wrong_old_openclaw="$(
+    grep -Eo "OpenClaw [0-9]{4}\\.[0-9]+\\.[0-9]+ is current \\(>= ${OLD_OPENCLAW_VERSION}\\)" "$OLD_INSTALL_LOG" 2>/dev/null \
+      | awk '{print $2}' \
+      | grep -v "^${OLD_OPENCLAW_VERSION}$" \
+      | head -n 1 || true
+  )"
+  if [ -n "$wrong_old_openclaw" ]; then
+    fail "old ${OLD_NEMOCLAW_REF} fixture used OpenClaw ${wrong_old_openclaw} instead of pinned ${OLD_OPENCLAW_VERSION}"
+  fi
+  if ! grep -q "OpenClaw ${OLD_OPENCLAW_VERSION}\\|openclaw@${OLD_OPENCLAW_VERSION}" "$OLD_INSTALL_LOG" 2>/dev/null; then
+    fail "old ${OLD_NEMOCLAW_REF} fixture did not show pinned OpenClaw ${OLD_OPENCLAW_VERSION}"
   fi
   rm -f "$installer"
 

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -187,6 +187,70 @@ if [ "$rewrote_base" = "0" ]; then
   args+=("--build-arg" "BASE_IMAGE=${base_ref}")
   printf 'add build-arg BASE_IMAGE=%s\n' "$base_ref" >>"$log_file"
 fi
+
+dockerfile=""
+context=""
+next_value_for=""
+for arg in "${args[@]}"; do
+  if [ "$next_value_for" = "file" ]; then
+    dockerfile="$arg"
+    next_value_for=""
+    continue
+  fi
+  if [ -n "$next_value_for" ]; then
+    next_value_for=""
+    continue
+  fi
+  case "$arg" in
+    -f|--file)
+      next_value_for="file"
+      ;;
+    -t|--tag|--target|--platform|--build-arg|--label|--cache-from|--cache-to|--add-host|--network|--output|--progress|--secret|--ssh)
+      next_value_for="other"
+      ;;
+    --file=*)
+      dockerfile="${arg#--file=}"
+      ;;
+    -*)
+      ;;
+    *)
+      context="$arg"
+      ;;
+  esac
+done
+if [ -z "$dockerfile" ]; then
+  if [ -f Dockerfile ]; then
+    dockerfile="Dockerfile"
+  elif [ -n "$context" ]; then
+    dockerfile="${context%/}/Dockerfile"
+  fi
+fi
+if [ ! -f "$dockerfile" ] && [ -n "$context" ] && [ -f "${context%/}/${dockerfile}" ]; then
+  dockerfile="${context%/}/${dockerfile}"
+fi
+if [ -f "$dockerfile" ] && grep -q "min_openclaw_version" "$dockerfile"; then
+  python3 - "$dockerfile" "$old_openclaw" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+version = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+marker = "RUN set -eu; \\\n    MIN_VER=$(grep -m 1 'min_openclaw_version'"
+injection = (
+    "# E2E old-upgrade fixture: force the historical OpenClaw before the old Dockerfile's version gate.\n"
+    "RUN rm -rf /usr/local/lib/node_modules/openclaw /usr/local/bin/openclaw \\\n"
+    f"    && npm install -g --no-audit --no-fund --no-progress \"openclaw@{version}\" \\\n"
+    "    && openclaw --version\n\n"
+)
+if injection not in text:
+    if marker not in text:
+        raise SystemExit(f"{path}: old OpenClaw version gate not found")
+    text = text.replace(marker, injection + marker, 1)
+    path.write_text(text, encoding="utf-8")
+PY
+  printf 'force Dockerfile OpenClaw version %s in %s\n' "$old_openclaw" "$dockerfile" >>"$log_file"
+fi
 exec "$real_docker" "${args[@]}"
 EOF
   chmod 755 "${OLD_DOCKER_WRAPPER_DIR}/docker"


### PR DESCRIPTION
## Summary
- make the old gateway-upgrade Docker wrapper rewrite any `BASE_IMAGE=*` build arg, including resolved sandbox-base digests
- keep the v0.0.36 fixture on the historical sandbox base instead of inheriting current OpenClaw from main
- add a guard that fails clearly if the old fixture consumes a newer OpenClaw than the pinned `2026.4.24`

## Why
The full nightly showed `openshell-gateway-upgrade-e2e` failing before upgrade validation: the old v0.0.36 install received a resolved current sandbox-base digest containing OpenClaw 2026.5.18. Because the old Dockerfile treats 2026.4.24 as a minimum, it skipped installing the intended OpenClaw and then the old source-shape patch failed.

## Test plan
- `bash -n test/e2e/test-openshell-gateway-upgrade.sh`
- `git diff --check`
- dispatch `E2E / Nightly` with `jobs=openshell-gateway-upgrade-e2e` against this PR head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened regression tests: improved handling of base-image pulls and build arguments, injection of historical runtime-version handling during builds, and pre/post-install checks to ensure the expected runtime is selected. Installer failures now include captured wrapper activity logs for easier diagnosis.

Note: This release contains no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->