### PR TITLE
fix(advisor): restore findings expansion

### DIFF
--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -248,6 +248,39 @@ describe("PR review advisor", () => {
     expect(followUp).toContain("<summary>Since last review details</summary>");
   });
 
+  it("escapes advisor finding text before rendering sticky comments", () => {
+    const result = normalizeReviewResult(validResult({
+      summary: {
+        recommendation: "merge_after_fixes",
+        confidence: "high",
+        oneLine: "Review found one fixable issue.",
+        topItem: "top @team <b> **x**",
+      },
+      findings: [
+        {
+          severity: "blocker",
+          category: "correctness",
+          file: "src/<bad>(1).ts",
+          line: 7,
+          title: "</details> @team **boom** [x](https://bad.invalid)",
+          description: "first\n### injected <script>",
+          recommendation: "ping @here & fix _now_",
+          evidence: "`code` <tag>",
+        },
+      ],
+    }), metadata());
+    const comment = buildComment({ summary: renderSummary(result), result });
+
+    expect(comment).toContain("**Top item:** top &#64;team &lt;b&gt; \\*\\*x\\*\\*");
+    expect(comment).toContain("&lt;/details&gt; &#64;team \\*\\*boom\\*\\* \\[x\\]\\(https://bad.invalid\\)");
+    expect(comment).toContain("src/&lt;bad&gt;\\(1\\).ts:7");
+    expect(comment).toContain("first ### injected &lt;script&gt;");
+    expect(comment).toContain("ping &#64;here &amp; fix \\_now\\_");
+    expect(comment).toContain("\\`code\\` &lt;tag&gt;");
+    expect(comment).not.toContain("</details> @team");
+    expect(comment).not.toContain("### injected <script>");
+  });
+
   it("normalizes output that validates against the JSON schema", () => {
     const schema = JSON.parse(fs.readFileSync(path.join(ROOT, "tools/pr-review-advisor/schema.json"), "utf8"));
     const ajv = new Ajv2020({ strict: false });

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -208,7 +208,9 @@ describe("PR review advisor", () => {
     expect(summary).not.toContain("## Security review");
     expect(detailed).toContain("## Acceptance coverage");
     expect(detailed).toContain("## Security review");
-    expect(comment).not.toContain("<details>");
+    expect(comment).toContain("<details>");
+    expect(comment).toContain("<summary>Review findings</summary>");
+    expect(comment).toContain("### 🛠️ Needs attention");
     expect(comment).not.toContain("Full advisor summary");
     expect(comment).not.toContain("## Acceptance coverage");
     expect(comment).not.toContain("## Security review");
@@ -242,6 +244,8 @@ describe("PR review advisor", () => {
       result: followUpResult,
     });
     expect(followUp).toContain("**Since last review:** 1 prior item resolved, 1 still applies, 1 new item found");
+    expect(followUp).toContain("<summary>Review findings</summary>");
+    expect(followUp).toContain("<summary>Since last review details</summary>");
   });
 
   it("normalizes output that validates against the JSON schema", () => {

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -22,7 +22,15 @@ type ReviewAdvisorResult = {
       newItems?: number;
     };
   };
-  findings?: Array<{ severity?: string; title?: string }>;
+  findings?: Array<{
+    severity?: string;
+    title?: string;
+    file?: string | null;
+    line?: number | null;
+    description?: string;
+    recommendation?: string;
+    evidence?: string;
+  }>;
   reviewCompleteness?: {
     limitations?: string[];
   };
@@ -78,6 +86,8 @@ export function buildComment({
   const warningCount = result?.findings?.filter((finding) => finding.severity === "warning").length ?? 0;
   const suggestionCount = result?.findings?.filter((finding) => finding.severity === "suggestion").length ?? 0;
   const secondary = buildSecondarySummary(result);
+  const findingsDetails = renderFindingsDetails(result);
+  const previousReviewDetails = renderPreviousReviewDetails(result);
   const details = runUrl
     ? `\n[Workflow run details](${runUrl})`
     : "";
@@ -85,7 +95,7 @@ export function buildComment({
 ## PR Review Advisor
 
 **Findings:** ${blockerCount} needs attention, ${warningCount} worth checking, ${suggestionCount} nice ideas
-${secondary}${details}
+${secondary}${findingsDetails}${previousReviewDetails}${details}
 
 This is an automated advisory review. A human maintainer must make the final merge decision.
 
@@ -105,6 +115,48 @@ function topFindingTitle(result?: ReviewAdvisorResult): string | undefined {
   return result?.findings?.find((finding) => finding.severity === "blocker")?.title ||
     result?.findings?.find((finding) => finding.severity === "warning")?.title ||
     result?.findings?.find((finding) => finding.severity === "suggestion")?.title;
+}
+
+function renderFindingsDetails(result?: ReviewAdvisorResult): string {
+  if (!result?.findings?.length) return "";
+  const sections = [
+    { summary: "🛠️ Needs attention", findings: result.findings.filter((finding) => finding.severity === "blocker") },
+    { summary: "🔎 Worth checking", findings: result.findings.filter((finding) => finding.severity === "warning") },
+    { summary: "🌱 Nice ideas", findings: result.findings.filter((finding) => finding.severity === "suggestion") },
+  ];
+  const lines: string[] = ["", "<details>", "<summary>Review findings</summary>", ""];
+  for (const section of sections) {
+    lines.push(`### ${section.summary}`);
+    if (section.findings.length === 0) {
+      lines.push("- _None._");
+    } else {
+      for (const finding of section.findings.slice(0, 20)) {
+        lines.push(formatFinding(finding));
+      }
+    }
+    lines.push("");
+  }
+  lines.push("</details>", "");
+  return `${lines.join("\n")}\n`;
+}
+
+function renderPreviousReviewDetails(result?: ReviewAdvisorResult): string {
+  const sinceLastReview = result?.summary?.sinceLastReview;
+  if (!sinceLastReview || !result?.findings?.length) return "";
+  const lines: string[] = ["<details>", "<summary>Since last review details</summary>", ""];
+  lines.push("Current findings:");
+  for (const finding of result.findings.slice(0, 20)) lines.push(formatFinding(finding));
+  lines.push("", "</details>", "");
+  return `${lines.join("\n")}\n`;
+}
+
+function formatFinding(finding: NonNullable<ReviewAdvisorResult["findings"]>[number]): string {
+  const title = finding.title || "Review finding";
+  const location = finding.file ? ` (${finding.file}${finding.line ? `:${finding.line}` : ""})` : "";
+  const lines = [`- **${title}**${location}${finding.description ? `: ${finding.description}` : ""}`];
+  if (finding.recommendation) lines.push(`  - Recommendation: ${finding.recommendation}`);
+  if (finding.evidence) lines.push(`  - Evidence: ${finding.evidence}`);
+  return lines.join("\n");
 }
 
 function countLabel(count: unknown, singular: string, plural = `${singular}s`): string {

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -108,7 +108,7 @@ function buildSecondarySummary(result?: ReviewAdvisorResult): string {
     return `**Since last review:** ${countLabel(sinceLastReview.resolved, "prior item")} resolved, ${countLabel(sinceLastReview.stillApplies, "still applies", "still apply")}, ${countLabel(sinceLastReview.newItems, "new item")} found\n`;
   }
   const topItem = result?.summary?.topItem || topFindingTitle(result);
-  return topItem ? `**Top item:** ${topItem}\n` : "";
+  return topItem ? `**Top item:** ${escapeCommentText(topItem)}\n` : "";
 }
 
 function topFindingTitle(result?: ReviewAdvisorResult): string | undefined {
@@ -151,12 +151,32 @@ function renderPreviousReviewDetails(result?: ReviewAdvisorResult): string {
 }
 
 function formatFinding(finding: NonNullable<ReviewAdvisorResult["findings"]>[number]): string {
-  const title = finding.title || "Review finding";
-  const location = finding.file ? ` (${finding.file}${finding.line ? `:${finding.line}` : ""})` : "";
-  const lines = [`- **${title}**${location}${finding.description ? `: ${finding.description}` : ""}`];
-  if (finding.recommendation) lines.push(`  - Recommendation: ${finding.recommendation}`);
-  if (finding.evidence) lines.push(`  - Evidence: ${finding.evidence}`);
+  const title = escapeCommentText(finding.title || "Review finding");
+  const location = formatFindingLocation(finding);
+  const description = finding.description ? `: ${escapeCommentText(finding.description)}` : "";
+  const lines = [`- **${title}**${location}${description}`];
+  if (finding.recommendation) {
+    lines.push(`  - Recommendation: ${escapeCommentText(finding.recommendation)}`);
+  }
+  if (finding.evidence) lines.push(`  - Evidence: ${escapeCommentText(finding.evidence)}`);
   return lines.join("\n");
+}
+
+function formatFindingLocation(finding: NonNullable<ReviewAdvisorResult["findings"]>[number]): string {
+  if (!finding.file) return "";
+  const line = Number.isInteger(finding.line) && Number(finding.line) > 0 ? `:${finding.line}` : "";
+  return ` (${escapeCommentText(finding.file)}${line})`;
+}
+
+function escapeCommentText(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replace(/([\\`*_\[\]()!|])/g, "\\$1")
+    .replaceAll("@", "&#64;");
 }
 
 function countLabel(count: unknown, singular: string, plural = `${singular}s`): string {


### PR DESCRIPTION
## Summary
- restore expandable PR Review Advisor finding details in the sticky comment
- group expanded findings under Needs attention, Worth checking, and Nice ideas
- add a follow-up expansion for since-last-review runs

## Test
- npm --prefix pr-3834-pr-review-advisor test -- pr-review-advisor.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR review comments now include richer, collapsible "Review findings" and "Since last review details" sections with per-finding fields (location, description, recommendation, evidence).

* **Bug Fixes / Security**
  * Finding text and summary lines are now HTML-escaped to prevent untrusted markup from rendering.

* **Tests**
  * Updated tests to verify stricter framing of sticky comments and proper escaping of injected/malformed content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->