### PR TITLE
perf: enable OpenClaw Tool Search to reduce tool schema latency

### DIFF
--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -695,6 +695,7 @@ def build_config(env: dict | None = None) -> dict:
         },
         "models": {"mode": "merge", "providers": providers},
         "channels": {"defaults": {}, **_ch_cfg},
+        "tools": {"toolSearch": True},
         "update": {"checkOnStart": False},
         # Disable bundled plugins/channels that hit the L7 proxy at startup
         # and either crash or hang the gateway:
@@ -733,15 +734,13 @@ def build_config(env: dict | None = None) -> dict:
     }
 
     if env.get("NEMOCLAW_WEB_SEARCH_ENABLED", "") == "1":
-        config["tools"] = {
-            "web": {
-                "search": {
-                    "enabled": True,
-                    "provider": "brave",
-                    "apiKey": "openshell:resolve:env:BRAVE_API_KEY",
-                },
-                "fetch": {"enabled": True},
-            }
+        config.setdefault("tools", {})["web"] = {
+            "search": {
+                "enabled": True,
+                "provider": "brave",
+                "apiKey": "openshell:resolve:env:BRAVE_API_KEY",
+            },
+            "fetch": {"enabled": True},
         }
 
     return config

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -529,13 +529,25 @@ describe("generate-openclaw-config.py: config generation", () => {
     });
   });
 
+  it("enables native OpenClaw Tool Search by default", () => {
+    const config = runConfigScript();
+    expect(config.tools?.toolSearch).toBe(true);
+  });
+
   it("enables web search when env is '1'", () => {
     const config = runConfigScript({ NEMOCLAW_WEB_SEARCH_ENABLED: "1" });
-    expect(config.tools?.web?.search?.enabled).toBe(true);
+    expect(config.tools?.toolSearch).toBe(true);
+    expect(config.tools?.web?.search).toEqual({
+      enabled: true,
+      provider: "brave",
+      apiKey: "openshell:resolve:env:BRAVE_API_KEY",
+    });
+    expect(config.tools?.web?.fetch?.enabled).toBe(true);
   });
 
   it("omits web search when env is not set", () => {
     const config = runConfigScript();
+    expect(config.tools?.toolSearch).toBe(true);
     expect(config.tools?.web).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Enable OpenClaw native Tool Search in generated `openclaw.json` via `tools.toolSearch: true`.
- Preserve Brave/web search config by adding `tools.web.search` under the existing tools object.
- Add focused generator tests for the default and web-search config shapes.

## Context
This mitigates NemoClaw #2600/#2598 and upstream openclaw/openclaw#14785 by using the native Tool Search path available in OpenClaw 2026.5.18, so OpenClaw can expose compact tool-search controls instead of sending every full tool schema when many tools are available.

## Tests
- `npx vitest run test/generate-openclaw-config.test.ts`
- `npx vitest run test/openclaw-tool-catalog-patch.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenClaw tool search functionality is now enabled by default in generated configuration

* **Bug Fixes**
  * Fixed configuration generation to properly preserve existing tool settings when web search is enabled, preventing accidental loss of tool configurations during updates

* **Tests**
  * Expanded test coverage to verify tool search enablement and web search configuration handling across different scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->