### PR TITLE
fix(docs): route Windows no-distro installs to bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ The script installs Node.js if it is not already present, then runs the guided o
 > It installs Node.js via nvm and NemoClaw via npm, both into user-local directories.
 > Docker must be installed and running before you run the installer. Installing Docker may require elevated privileges on Linux.
 
+#### Windows PowerShell
+
+On Windows, run the Windows bootstrap from PowerShell before the Linux installer.
+Do not run `curl.exe -fsSL https://www.nvidia.com/nemoclaw.sh | bash` directly in PowerShell.
+If WSL is enabled but no Linux distro is registered, Windows `bash.exe` exits before NemoClaw can run or print guidance.
+
+```powershell
+Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/bootstrap-windows.ps1' -OutFile "$env:TEMP\bootstrap-windows.ps1"; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\bootstrap-windows.ps1"
+```
+
+The bootstrap enables WSL 2 when needed, installs or opens Ubuntu, prepares Docker Desktop, and then prints the standard installer command to run inside Ubuntu.
+
 ```bash
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -17,6 +17,18 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 Make sure you have completed reviewing the [Prerequisites](/get-started/prerequisites) before following this guide.
 </Note>
 
+## Windows PowerShell Users
+
+On Windows, run the [Windows bootstrap](/get-started/windows-preparation) from PowerShell before the Linux installer.
+Do not run `curl.exe -fsSL https://www.nvidia.com/nemoclaw.sh | bash` directly in PowerShell.
+If WSL is enabled but no Linux distro is registered, Windows `bash.exe` exits before NemoClaw can run or print guidance.
+
+```powershell
+Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/bootstrap-windows.ps1' -OutFile "$env:TEMP\bootstrap-windows.ps1"; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\bootstrap-windows.ps1"
+```
+
+The bootstrap enables WSL 2 when needed, installs or opens Ubuntu, prepares Docker Desktop, and then prints the standard installer command to run inside Ubuntu.
+
 ## Install NemoClaw and Onboard OpenClaw Agent
 
 Download and run the installer script.

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -32,6 +32,9 @@ Open Windows PowerShell on the Windows host and run the bootstrap script:
 $ Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/bootstrap-windows.ps1' -OutFile "$env:TEMP\bootstrap-windows.ps1"; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\bootstrap-windows.ps1"
 ```
 
+Use this PowerShell command instead of running the Linux `curl | bash` installer from PowerShell.
+On a fresh Windows machine with WSL enabled but no registered Linux distro, Windows `bash.exe` exits before the NemoClaw installer can run or print guidance.
+
 The command downloads the script to a temporary file before running it.
 `-ExecutionPolicy Bypass` applies only to that PowerShell process and avoids local policy blocking the downloaded script.
 Run it from Windows, not from inside WSL.
@@ -76,6 +79,8 @@ After reboot, open an elevated PowerShell again:
 ```console
 $ wsl --install -d Ubuntu
 ```
+
+If your Windows image requires the explicit Ubuntu 24.04 package, use `wsl --install -d Ubuntu-24.04` instead, or pass `-DistroName Ubuntu-24.04` to the bootstrap script.
 
 Let the distribution launch and complete first-run setup (pick a Unix username and password), then type `exit` to return to PowerShell.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -58,6 +58,9 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 </llms-only>
 
+On Windows, run the [Windows bootstrap](/get-started/windows-preparation) from PowerShell first.
+Do not run the Linux `curl | bash` command directly in PowerShell when no WSL distro is registered.
+
 For more detailed guidance on getting started, refer to [Quickstart](/get-started/quickstart).
 
 ---

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -12,6 +12,12 @@
 
         curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
+    This is the Windows host entry point. Do not run
+    curl.exe -fsSL https://www.nvidia.com/nemoclaw.sh | bash directly in
+    Windows PowerShell. On a fresh machine with WSL enabled but no registered
+    Linux distro, Windows bash.exe exits before NemoClaw's Linux installer can
+    run or print guidance.
+
     This script intentionally does not duplicate the full Windows installer.
     It leaves Node.js, NemoClaw CLI installation, Ollama/provider setup, and
     onboarding to scripts/install.sh and nemoclaw onboard.
@@ -659,7 +665,8 @@ function Ensure-UbuntuWsl {
 
     $distros = Get-WslDistros
     if ($distros -notcontains $DistroName) {
-        Write-Status "$DistroName is not registered yet. It will be installed during the final Ubuntu handoff."
+        Write-Status "$DistroName is not registered yet. The bootstrap will install it during the final Ubuntu handoff."
+        Write-Status "Do not run the Linux curl|bash installer from Windows PowerShell before first-run setup completes; Windows bash.exe will exit before NemoClaw can run."
         $script:InstallDistroAtHandoff = $true
         return
     }
@@ -815,7 +822,7 @@ function Write-InstallerHandoff {
     Write-Host 'Windows preparation is complete.' -ForegroundColor Green
     Write-Host ''
     if ($script:InstallDistroAtHandoff) {
-        Write-Host "Ubuntu will install and launch now. After first-run setup completes, run this command inside Ubuntu to install NemoClaw:" -ForegroundColor Cyan
+        Write-Host "Ubuntu will install and launch now. Complete first-run setup, then run this command inside Ubuntu to install NemoClaw:" -ForegroundColor Cyan
     } else {
         Write-Host "An Ubuntu window is opening. Run this command inside Ubuntu to install NemoClaw:" -ForegroundColor Cyan
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Route Windows users away from running the Linux `curl | bash` installer directly in PowerShell when WSL has no registered distro. The Linux installer cannot intercept that failure because Windows `bash.exe` exits before `install.sh` runs, so this PR makes the Windows bootstrap path explicit in the main install entry points and in the bootstrap handoff messaging.

## Related Issue
Fixes #3974

## Changes
- Add Windows PowerShell bootstrap guidance before the standard installer command in the README and Quickstart.
- Add a docs landing-page reminder that Windows users should bootstrap from PowerShell before using the Linux installer inside Ubuntu.
- Clarify the Windows preparation page for the no-registered-distro failure and document the Ubuntu 24.04 distro override.
- Update `scripts/bootstrap-windows.ps1` help/no-distro/handoff text so the path stays actionable when Ubuntu is not registered yet.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional focused validation:
- [x] `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-links --local-only README.md docs/index.mdx docs/get-started/quickstart.mdx docs/get-started/windows-preparation.mdx`
- [x] `npm run docs:strict` (0 errors; Fern reported 2 warnings without details)
- [x] `npm run source-shape:check`
- [x] `git diff --check`

Caveat: I did not add a PowerShell/WSL test because the reported failure happens before NemoClaw's Linux installer process starts, and this repo does not appear to have a local Windows host bootstrap harness for `scripts/bootstrap-windows.ps1`.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows PowerShell bootstrap script instructions across installation guides
  * Clarified WSL 2 and Ubuntu setup process for Windows users
  * Added warnings to prevent running Linux installer directly in PowerShell
  * Included guidance for Ubuntu 24.04 WSL package requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->