### PR TITLE
fix(cli): apply --tail limit once to merged log sources (#4100)

### DIFF
--- a/src/lib/actions/sandbox/logs.ts
+++ b/src/lib/actions/sandbox/logs.ts
@@ -4,7 +4,7 @@
 import { spawn } from "node:child_process";
 
 import { ROOT } from "../../runner";
-import { getOpenshellBinary, runOpenshell } from "../../adapters/openshell/runtime";
+import { captureOpenshell, getOpenshellBinary, runOpenshell } from "../../adapters/openshell/runtime";
 import {
   buildEnableSandboxAuditLogsArgs,
   buildSandboxLogsArgs,
@@ -179,16 +179,60 @@ export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions
   }
 
   enableSandboxAuditLogs(sandboxName);
-  if (!logsOptions.since) {
-    runOpenclawGatewayLogs(sandboxName, logsOptions);
+
+  if (logsOptions.since) {
+    // --since mode: only openshell logs, pipe directly
+    const args = buildSandboxLogsArgs(sandboxName, logsOptions);
+    const result = runOpenshell(args, {
+      stdio: "inherit",
+      ignoreError: true,
+    });
+    if (result.status !== 0) {
+      console.error(`  Command failed (exit ${result.status}): openshell ${args.join(" ")}`);
+    }
+    exitWithSpawnResult(result);
+    return;
   }
-  const args = buildSandboxLogsArgs(sandboxName, logsOptions);
-  const result = runOpenshell(args, {
-    stdio: "inherit",
+
+  // Capture both sources, merge, then apply --tail once.
+  const merged: string[] = [];
+  let lastResult: LogProbeResult = { status: 0 };
+
+  const gwArgs = buildSandboxOpenclawGatewayLogsArgs(sandboxName, logsOptions);
+  const gwResult = captureOpenshell(gwArgs, {
+    ignoreError: true,
+    timeout: getLogsProbeTimeoutMs(),
+  });
+  if (gwResult.status !== 0) {
+    console.error(
+      `  OpenClaw log source unavailable (${describeLogProbeResult(gwResult)}): ` +
+        `openshell ${gwArgs.join(" ")}`,
+    );
+  }
+  if (gwResult.output) {
+    const lines = gwResult.output.replace(/\n$/, "").split("\n");
+    merged.push(...lines);
+  }
+
+  const osArgs = buildSandboxLogsArgs(sandboxName, logsOptions);
+  const osResult = captureOpenshell(osArgs, {
     ignoreError: true,
   });
-  if (result.status !== 0) {
-    console.error(`  Command failed (exit ${result.status}): openshell ${args.join(" ")}`);
+  if (osResult.status !== 0) {
+    console.error(`  Command failed (exit ${osResult.status}): openshell ${osArgs.join(" ")}`);
   }
-  exitWithSpawnResult(result);
+  lastResult = osResult;
+  if (osResult.output) {
+    const lines = osResult.output.replace(/\n$/, "").split("\n");
+    merged.push(...lines);
+  }
+
+  const limit = Number(logsOptions.lines);
+  const tailed = Number.isFinite(limit) && limit > 0 ? merged.slice(-limit) : merged;
+
+  if (tailed.length > 0) {
+    process.stdout.write(tailed.join("\n") + "\n");
+  }
+
+  exitWithSpawnResult(lastResult);
 }

--- a/test/sandbox-logs-tail-merge.test.ts
+++ b/test/sandbox-logs-tail-merge.test.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureOpenshell = vi.hoisted(() => vi.fn());
+const runOpenshell = vi.hoisted(() => vi.fn());
+const getOpenshellBinary = vi.hoisted(() => vi.fn(() => "/usr/bin/openshell"));
+
+vi.mock("../src/lib/adapters/openshell/runtime", () => ({
+  captureOpenshell,
+  runOpenshell,
+  getOpenshellBinary,
+}));
+
+vi.mock("../src/lib/runner", () => ({ ROOT: "/tmp/test-root" }));
+
+import { showSandboxLogs } from "../src/lib/actions/sandbox/logs";
+
+describe("showSandboxLogs tail merge", () => {
+  let stdoutLines: string[];
+  let stderrLines: string[];
+  const originalExit = process.exit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stdoutLines = [];
+    stderrLines = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stdoutLines.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      stderrLines.push(args.join(" "));
+    });
+    // Mock process.exit to throw so we can catch it
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new ExitError(code ?? 0);
+    }) as never);
+  });
+
+  class ExitError extends Error {
+    code: number;
+    constructor(code: number) {
+      super(`process.exit(${code})`);
+      this.code = code;
+    }
+  }
+
+  it("merges two sources and applies --tail once", () => {
+    // Gateway returns 5 lines
+    const gwLines = Array.from({ length: 5 }, (_, i) => `[gw] gateway line ${i + 1}`);
+    // OpenShell returns 5 lines
+    const osLines = Array.from({ length: 5 }, (_, i) => `[os] openshell line ${i + 1}`);
+
+    // First captureOpenshell call = gateway, second = openshell
+    captureOpenshell
+      .mockReturnValueOnce({ status: 0, output: gwLines.join("\n") + "\n" })
+      .mockReturnValueOnce({ status: 0, output: osLines.join("\n") + "\n" });
+
+    // enableSandboxAuditLogs calls runOpenshell
+    runOpenshell.mockReturnValue({ status: 0 });
+
+    try {
+      showSandboxLogs("test-sbox", { follow: false, lines: "5", since: null });
+    } catch (e) {
+      if (!(e instanceof ExitError)) throw e;
+      expect(e.code).toBe(0);
+    }
+
+    // Should output exactly 5 lines (last 5 of merged 10)
+    const output = stdoutLines.join("");
+    const outputLines = output.trim().split("\n");
+    expect(outputLines).toHaveLength(5);
+    // Last 5 of [gw1..gw5, os1..os5] = [os1..os5]
+    expect(outputLines).toEqual(osLines);
+  });
+
+  it("returns all lines when total is less than tail limit", () => {
+    const gwLines = ["[gw] line 1", "[gw] line 2"];
+    const osLines = ["[os] line 1"];
+
+    captureOpenshell
+      .mockReturnValueOnce({ status: 0, output: gwLines.join("\n") + "\n" })
+      .mockReturnValueOnce({ status: 0, output: osLines.join("\n") + "\n" });
+
+    runOpenshell.mockReturnValue({ status: 0 });
+
+    try {
+      showSandboxLogs("test-sbox", { follow: false, lines: "10", since: null });
+    } catch (e) {
+      if (!(e instanceof ExitError)) throw e;
+      expect(e.code).toBe(0);
+    }
+
+    const output = stdoutLines.join("");
+    const outputLines = output.trim().split("\n");
+    // Total 3 lines, tail 10 → all 3
+    expect(outputLines).toHaveLength(3);
+  });
+
+  it("handles one source failing gracefully", () => {
+    // Gateway fails
+    captureOpenshell
+      .mockReturnValueOnce({ status: 1, output: "" })
+      .mockReturnValueOnce({
+        status: 0,
+        output: ["[os] line 1", "[os] line 2", "[os] line 3"].join("\n") + "\n",
+      });
+
+    runOpenshell.mockReturnValue({ status: 0 });
+
+    try {
+      showSandboxLogs("test-sbox", { follow: false, lines: "5", since: null });
+    } catch (e) {
+      if (!(e instanceof ExitError)) throw e;
+      expect(e.code).toBe(0);
+    }
+
+    const output = stdoutLines.join("");
+    const outputLines = output.trim().split("\n");
+    expect(outputLines).toHaveLength(3);
+  });
+
+  it("uses inherit stdio for --since mode (no merge needed)", () => {
+    runOpenshell.mockReturnValue({ status: 0 });
+
+    try {
+      showSandboxLogs("test-sbox", { follow: false, lines: "5", since: "5m" });
+    } catch (e) {
+      if (!(e instanceof ExitError)) throw e;
+    }
+
+    // --since mode should use runOpenshell (inherit), not captureOpenshell
+    // runOpenshell called twice: once for enableSandboxAuditLogs, once for logs
+    expect(runOpenshell).toHaveBeenCalledTimes(2);
+    expect(captureOpenshell).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> logs --tail N` returns exactly **2×N lines** instead of at most `N`. The tail limit is applied independently to each log source (OpenClaw gateway and OpenShell/OCSF) and the results are concatenated, doubling the expected output.

Closes #4100

## Changes

**`src/lib/actions/sandbox/logs.ts`** — `showSandboxLogs()` non-follow path:
- Switch from `runOpenshell` (`stdio: "inherit"`) to `captureOpenshell` for both log sources so output is captured into memory
- Merge captured lines from both sources into a single array
- Apply `--tail N` once to the merged array (`merged.slice(-limit)`)
- Write the tailed result to stdout

The `--follow` path (streaming) and `--since` path (single-source) are unchanged.

## Testing

- Added `test/sandbox-logs-tail-merge.test.ts` with 4 tests:
  - Verifies `--tail 5` on two sources of 5 lines each outputs exactly 5 (not 10)
  - Verifies output ≤ tail when total lines < limit
  - Verifies graceful degradation when one source fails
  - Verifies `--since` mode bypasses merge logic (uses `runOpenshell` directly)
- Existing `src/commands/sandbox/logs.test.ts` — all 4 tests pass
- `tsc --noEmit` — no new errors (only pre-existing `@aws-sdk` missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox logs output by merging multiple log sources and applying line limits consistently to the merged results.

* **Tests**
  * Added comprehensive test suite for sandbox logs behavior, including tail-merge validation across multiple log sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->