### PR TITLE
fix(sandbox): recover gateway before maintenance sandbox-list retry

### DIFF
--- a/src/commands/backup-all.ts
+++ b/src/commands/backup-all.ts
@@ -15,6 +15,6 @@ export default class BackupAllCommand extends NemoClawCommand {
 
   public async run(): Promise<void> {
     await this.parse(BackupAllCommand);
-    runBackupAllAction();
+    await runBackupAllAction();
   }
 }

--- a/src/lib/actions/gateway-drift-preflight.test.ts
+++ b/src/lib/actions/gateway-drift-preflight.test.ts
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import type { OpenShellStateRpcIssue } from "../adapters/openshell/gateway-drift";
 
@@ -41,6 +41,7 @@ describe("gateway drift preflight for maintenance actions", () => {
   let detectPreflightIssueSpy: MockInstance;
   let detectResultIssueSpy: MockInstance;
   let printIssueSpy: MockInstance;
+  let recoverNamedGatewayRuntimeSpy: MockInstance;
 
   beforeEach(async () => {
     spies = [];
@@ -54,6 +55,7 @@ describe("gateway drift preflight for maintenance actions", () => {
     const sandboxVersion = requireDist("../../../dist/lib/sandbox/version.js");
     const upgradeDomain = requireDist("../../../dist/lib/domain/maintenance/upgrade.js");
     const rebuild = requireDist("../../../dist/lib/actions/sandbox/rebuild.js");
+    const gatewayRuntime = requireDist("../../../dist/lib/gateway-runtime-action.js");
 
     detectPreflightIssueSpy = vi
       .spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue")
@@ -78,6 +80,9 @@ describe("gateway drift preflight for maintenance actions", () => {
     classifyUpgradeableSandboxesSpy = vi
       .spyOn(upgradeDomain, "classifyUpgradeableSandboxes")
       .mockReturnValue({ stale: [], unknown: [] });
+    recoverNamedGatewayRuntimeSpy = vi
+      .spyOn(gatewayRuntime, "recoverNamedGatewayRuntime")
+      .mockResolvedValue({ recovered: true });
 
     spies.push(
       detectPreflightIssueSpy,
@@ -86,6 +91,7 @@ describe("gateway drift preflight for maintenance actions", () => {
       captureOpenshellSpy,
       backupSandboxStateSpy,
       classifyUpgradeableSandboxesSpy,
+      recoverNamedGatewayRuntimeSpy,
       vi.spyOn(registry, "listSandboxes").mockReturnValue({
         sandboxes: [{ name: "alpha", provider: "nvidia-prod", model: "nemotron" }],
       } as never),
@@ -108,10 +114,10 @@ describe("gateway drift preflight for maintenance actions", () => {
     errorSpy.mockRestore();
   });
 
-  it("backup-all fails before sandbox list when gateway image drift is detected", () => {
+  it("backup-all fails before sandbox list when gateway image drift is detected", async () => {
     detectPreflightIssueSpy.mockReturnValue(driftIssue);
 
-    expect(() => backupAll()).toThrow("process.exit(1)");
+    await expect(backupAll()).rejects.toThrow("process.exit(1)");
 
     expect(printIssueSpy).toHaveBeenCalledWith(
       driftIssue,
@@ -119,9 +125,24 @@ describe("gateway drift preflight for maintenance actions", () => {
     );
     expect(captureOpenshellSpy).not.toHaveBeenCalled();
     expect(backupSandboxStateSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
   });
 
-  it("backup-all fails closed on protobuf mismatch instead of treating sandboxes as stopped", () => {
+  it("backup-all recovers the named gateway and retries the sandbox list before backing up", async () => {
+    captureOpenshellSpy
+      .mockReturnValueOnce({ status: 1, output: "client error (Connect): Connection refused" })
+      .mockReturnValueOnce({ status: 0, output: "alpha Ready" });
+
+    await backupAll();
+
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith();
+    expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(1, ["sandbox", "list"]);
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(2, ["sandbox", "list"]);
+    expect(backupSandboxStateSpy).toHaveBeenCalledWith("alpha");
+  });
+
+  it("backup-all fails closed on protobuf mismatch instead of treating sandboxes as stopped", async () => {
     const protobufIssue: OpenShellStateRpcIssue = {
       kind: "protobuf_mismatch",
       output: "Sandbox.metadata: SandboxResponse.sandbox: invalid wire type value: 6",
@@ -129,7 +150,7 @@ describe("gateway drift preflight for maintenance actions", () => {
     captureOpenshellSpy.mockReturnValue({ status: 1, output: protobufIssue.output });
     detectResultIssueSpy.mockReturnValue(protobufIssue);
 
-    expect(() => backupAll()).toThrow("process.exit(1)");
+    await expect(backupAll()).rejects.toThrow("process.exit(1)");
 
     expect(printIssueSpy).toHaveBeenCalledWith(
       protobufIssue,
@@ -137,6 +158,7 @@ describe("gateway drift preflight for maintenance actions", () => {
     );
     expect(captureOpenshellSpy).toHaveBeenCalledWith(["sandbox", "list"]);
     expect(backupSandboxStateSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
   });
 
   it("upgrade-sandboxes fails before sandbox list when gateway image drift is detected", async () => {
@@ -150,6 +172,23 @@ describe("gateway drift preflight for maintenance actions", () => {
     );
     expect(captureOpenshellSpy).not.toHaveBeenCalled();
     expect(classifyUpgradeableSandboxesSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+  });
+
+  it("upgrade-sandboxes recovers the named gateway and retries before classifying sandboxes", async () => {
+    captureOpenshellSpy
+      .mockReturnValueOnce({ status: 1, output: "client error (Connect): Connection refused" })
+      .mockReturnValueOnce({ status: 0, output: "alpha Ready" });
+
+    await upgradeSandboxes({ check: true });
+
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith();
+    expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
+    expect(classifyUpgradeableSandboxesSpy).toHaveBeenCalledWith(
+      [{ name: "alpha", provider: "nvidia-prod", model: "nemotron" }],
+      new Set(["alpha"]),
+      expect.any(Function),
+    );
   });
 
   it("upgrade-sandboxes fails closed on protobuf mismatch before classifying stopped sandboxes", async () => {
@@ -168,5 +207,6 @@ describe("gateway drift preflight for maintenance actions", () => {
     );
     expect(captureOpenshellSpy).toHaveBeenCalledWith(["sandbox", "list"]);
     expect(classifyUpgradeableSandboxesSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/gateway-drift-preflight.test.ts
+++ b/src/lib/actions/gateway-drift-preflight.test.ts
@@ -135,11 +135,23 @@ describe("gateway drift preflight for maintenance actions", () => {
 
     await backupAll();
 
-    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith();
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
+      recoverableStates: ["missing_named", "named_unhealthy", "named_unreachable"],
+    });
     expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
     expect(captureOpenshellSpy).toHaveBeenNthCalledWith(1, ["sandbox", "list"]);
     expect(captureOpenshellSpy).toHaveBeenNthCalledWith(2, ["sandbox", "list"]);
     expect(backupSandboxStateSpy).toHaveBeenCalledWith("alpha");
+  });
+
+  it("backup-all does not recover generic sandbox list failures", async () => {
+    captureOpenshellSpy.mockReturnValue({ status: 1, output: "usage: openshell sandbox list" });
+
+    await expect(backupAll()).rejects.toThrow("process.exit(1)");
+
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+    expect(captureOpenshellSpy).toHaveBeenCalledTimes(1);
+    expect(backupSandboxStateSpy).not.toHaveBeenCalled();
   });
 
   it("backup-all fails closed on protobuf mismatch instead of treating sandboxes as stopped", async () => {
@@ -182,13 +194,25 @@ describe("gateway drift preflight for maintenance actions", () => {
 
     await upgradeSandboxes({ check: true });
 
-    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith();
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
+      recoverableStates: ["missing_named", "named_unhealthy", "named_unreachable"],
+    });
     expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
     expect(classifyUpgradeableSandboxesSpy).toHaveBeenCalledWith(
       [{ name: "alpha", provider: "nvidia-prod", model: "nemotron" }],
       new Set(["alpha"]),
       expect.any(Function),
     );
+  });
+
+  it("upgrade-sandboxes does not recover generic sandbox list failures", async () => {
+    captureOpenshellSpy.mockReturnValue({ status: 1, output: "unknown option: --json" });
+
+    await expect(upgradeSandboxes({ check: true })).rejects.toThrow("process.exit(1)");
+
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+    expect(captureOpenshellSpy).toHaveBeenCalledTimes(1);
+    expect(classifyUpgradeableSandboxesSpy).not.toHaveBeenCalled();
   });
 
   it("upgrade-sandboxes fails closed on protobuf mismatch before classifying stopped sandboxes", async () => {

--- a/src/lib/actions/global.test.ts
+++ b/src/lib/actions/global.test.ts
@@ -58,7 +58,7 @@ describe("global cli action facade", () => {
     await runSetupAction(["--fresh"]);
     await runSetupSparkAction(["--name", "alpha"]);
     await runDeployAction("gpu-alpha");
-    runBackupAllAction();
+    await runBackupAllAction();
     await runGarbageCollectImagesAction({ dryRun: true });
     showRootHelp();
     showVersion();

--- a/src/lib/actions/global.ts
+++ b/src/lib/actions/global.ts
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { runDeployAction as executeDeployAction } from "./deploy";
+import { runOpenshell } from "../adapters/openshell/runtime";
 import {
   type GarbageCollectImagesOptions,
   type UpgradeSandboxesOptions,
 } from "../domain/lifecycle/options";
+import { recoverNamedGatewayRuntime as recoverNamedGatewayRuntimeAction } from "../gateway-runtime-action";
+import { runDeployAction as executeDeployAction } from "./deploy";
 import {
   backupAll as executeBackupAllAction,
   garbageCollectImages as executeGarbageCollectImagesAction,
@@ -15,8 +17,6 @@ import {
   runSetupAction as executeSetupAction,
   runSetupSparkAction as executeSetupSparkAction,
 } from "./onboard";
-import { recoverNamedGatewayRuntime as recoverNamedGatewayRuntimeAction } from "../gateway-runtime-action";
-import { runOpenshell } from "../adapters/openshell/runtime";
 import { help, version } from "./root-help";
 
 type GatewayRecovery = { recovered: boolean };
@@ -51,8 +51,8 @@ export async function runDeployAction(instanceName?: string): Promise<void> {
   await executeDeployAction(instanceName);
 }
 
-export function runBackupAllAction(): void {
-  executeBackupAllAction();
+export async function runBackupAllAction(): Promise<void> {
+  await executeBackupAllAction();
 }
 
 export async function runUpgradeSandboxesAction(

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -2,22 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import { prompt as askPrompt } from "../credentials/store";
-import {
-  type GarbageCollectImagesOptions,
-  normalizeGarbageCollectImagesOptions,
-} from "../domain/lifecycle/options";
-import { CLI_NAME } from "../cli/branding";
 import { dockerListImagesFormat, dockerRmi } from "../adapters/docker";
-import { findOrphanedSandboxImages, parseSandboxImageRows } from "../domain/maintenance/images";
-import { captureOpenshell } from "../adapters/openshell/runtime";
 import {
   detectOpenShellStateRpcPreflightIssue,
   detectOpenShellStateRpcResultIssue,
   printOpenShellStateRpcIssue,
 } from "../adapters/openshell/gateway-drift";
-import * as registry from "../state/registry";
+import { CLI_NAME } from "../cli/branding";
+import { prompt as askPrompt } from "../credentials/store";
+import {
+  type GarbageCollectImagesOptions,
+  normalizeGarbageCollectImagesOptions,
+} from "../domain/lifecycle/options";
+import { findOrphanedSandboxImages, parseSandboxImageRows } from "../domain/maintenance/images";
+import {
+  captureSandboxListWithGatewayRecovery,
+  printSandboxListFailureWithRecoveryContext,
+} from "../openshell-sandbox-list";
 import { parseLiveSandboxNames } from "../runtime-recovery";
+import * as registry from "../state/registry";
 import * as sandboxState from "../state/sandbox";
 
 const useColor = !process.env.NO_COLOR && !!process.stdout.isTTY;
@@ -29,7 +32,7 @@ const R = useColor ? "\x1b[0m" : "";
 const RD = useColor ? "\x1b[1;31m" : "";
 const YW = useColor ? "\x1b[1;33m" : "";
 
-export function backupAll(): void {
+export async function backupAll(): Promise<void> {
   const { sandboxes } = registry.listSandboxes();
   if (sandboxes.length === 0) {
     console.log("  No sandboxes registered. Nothing to back up.");
@@ -45,7 +48,8 @@ export function backupAll(): void {
     process.exit(1);
   }
 
-  const liveList = captureOpenshell(["sandbox", "list"]);
+  const liveListRecovery = await captureSandboxListWithGatewayRecovery();
+  const liveList = liveListRecovery.result;
   const resultIssue = detectOpenShellStateRpcResultIssue(liveList);
   if (resultIssue) {
     printOpenShellStateRpcIssue(resultIssue, {
@@ -55,8 +59,7 @@ export function backupAll(): void {
     process.exit(1);
   }
   if (liveList.status !== 0) {
-    console.error("  Failed to query running sandboxes from OpenShell.");
-    console.error("  Ensure OpenShell is running: openshell status");
+    printSandboxListFailureWithRecoveryContext(liveListRecovery);
     process.exit(liveList.status || 1);
   }
   const liveNames = parseLiveSandboxNames(liveList.output || "");

--- a/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
@@ -125,9 +125,23 @@ describe("rebuild gateway drift preflight", () => {
       "Sandbox 'alpha' is not running.",
     );
 
-    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith();
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
+      recoverableStates: ["missing_named", "named_unhealthy", "named_unreachable"],
+    });
     expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
     expect(captureOpenshellSpy).toHaveBeenNthCalledWith(1, ["sandbox", "list"]);
     expect(captureOpenshellSpy).toHaveBeenNthCalledWith(2, ["sandbox", "list"]);
+  });
+
+  it("does not recover generic sandbox list failures", async () => {
+    detectPreflightIssueSpy.mockReturnValue(null);
+    captureOpenshellSpy.mockReturnValue({ status: 1, output: "unknown option: sandbox list" });
+
+    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
+      "Failed to query running sandboxes from OpenShell.",
+    );
+
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+    expect(captureOpenshellSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import type { OpenShellStateRpcIssue } from "../../adapters/openshell/gateway-drift";
 
@@ -33,7 +33,10 @@ describe("rebuild gateway drift preflight", () => {
   let errorSpy: MockInstance;
   let spies: MockInstance[];
   let checkAgentVersionSpy: MockInstance;
+  let detectPreflightIssueSpy: MockInstance;
+  let captureOpenshellSpy: MockInstance;
   let printIssueSpy: MockInstance;
+  let recoverNamedGatewayRuntimeSpy: MockInstance;
 
   beforeEach(async () => {
     spies = [];
@@ -41,25 +44,40 @@ describe("rebuild gateway drift preflight", () => {
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     const gatewayDrift = requireDist("../../../../dist/lib/adapters/openshell/gateway-drift.js");
+    const openshellRuntime = requireDist("../../../../dist/lib/adapters/openshell/runtime.js");
+    const gatewayRuntime = requireDist("../../../../dist/lib/gateway-runtime-action.js");
     const registry = requireDist("../../../../dist/lib/state/registry.js");
     const resolve = requireDist("../../../../dist/lib/adapters/openshell/resolve.js");
     const sandboxSession = requireDist("../../../../dist/lib/state/sandbox-session.js");
+    const onboardSession = requireDist("../../../../dist/lib/state/onboard-session.js");
     const sandboxVersion = requireDist("../../../../dist/lib/sandbox/version.js");
+    const agentRuntime = requireDist("../../../../dist/lib/agent/runtime.js");
 
     printIssueSpy = vi
       .spyOn(gatewayDrift, "printOpenShellStateRpcIssue")
       .mockImplementation(() => undefined);
+    detectPreflightIssueSpy = vi
+      .spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue")
+      .mockReturnValue(driftIssue);
     checkAgentVersionSpy = vi
       .spyOn(sandboxVersion, "checkAgentVersion")
       .mockReturnValue({ expectedVersion: "0.1.0", sandboxVersion: "0.0.1" } as never);
+    captureOpenshellSpy = vi
+      .spyOn(openshellRuntime, "captureOpenshell")
+      .mockReturnValue({ status: 0, output: "alpha Ready" });
+    recoverNamedGatewayRuntimeSpy = vi
+      .spyOn(gatewayRuntime, "recoverNamedGatewayRuntime")
+      .mockResolvedValue({ recovered: true });
 
     spies.push(
-      vi.spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue").mockReturnValue(driftIssue),
+      detectPreflightIssueSpy,
       vi.spyOn(gatewayDrift, "detectOpenShellStateRpcResultIssue").mockReturnValue(null),
+      captureOpenshellSpy,
+      recoverNamedGatewayRuntimeSpy,
       printIssueSpy,
       vi.spyOn(registry, "getSandbox").mockReturnValue({
         name: "alpha",
-        provider: "nvidia-prod",
+        provider: "ollama-local",
         model: "nvidia/nemotron",
         policies: [],
         nimContainer: null,
@@ -70,6 +88,9 @@ describe("rebuild gateway drift preflight", () => {
         detected: false,
         sessions: [],
       }),
+      vi.spyOn(onboardSession, "loadSession").mockReturnValue(null),
+      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null),
+      vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw"),
       checkAgentVersionSpy,
     );
 
@@ -90,5 +111,23 @@ describe("rebuild gateway drift preflight", () => {
       expect.objectContaining({ command: "nemoclaw alpha rebuild" }),
     );
     expect(checkAgentVersionSpy).not.toHaveBeenCalled();
+    expect(captureOpenshellSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+  });
+
+  it("recovers the named gateway and retries the liveness query before deciding running state", async () => {
+    detectPreflightIssueSpy.mockReturnValue(null);
+    captureOpenshellSpy
+      .mockReturnValueOnce({ status: 1, output: "client error (Connect): Connection refused" })
+      .mockReturnValueOnce({ status: 0, output: "beta Ready" });
+
+    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
+      "Sandbox 'alpha' is not running.",
+    );
+
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith();
+    expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(1, ["sandbox", "list"]);
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(2, ["sandbox", "list"]);
   });
 });

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -34,13 +34,17 @@ import {
   printOpenShellStateRpcIssue,
 } from "../../adapters/openshell/gateway-drift";
 import { resolveOpenshell } from "../../adapters/openshell/resolve";
-import { captureOpenshell, runOpenshell } from "../../adapters/openshell/runtime";
+import { runOpenshell } from "../../adapters/openshell/runtime";
 import { loadAgent } from "../../agent/defs";
-import * as agentRuntime from "../../agent/runtime";
 import { ensureAgentBaseImage } from "../../agent/onboard";
+import * as agentRuntime from "../../agent/runtime";
 import { RD as _RD, B, D, G, R, YW } from "../../cli/terminal-style";
 import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
 import * as nim from "../../inference/nim";
+import {
+  captureSandboxListWithGatewayRecovery,
+  printSandboxListFailureWithRecoveryContext,
+} from "../../openshell-sandbox-list";
 import * as policies from "../../policy";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
 import * as sandboxVersion from "../../sandbox/version";
@@ -387,7 +391,8 @@ export async function rebuildSandbox(
 
   // Step 1: Ensure sandbox is live for backup
   log("Checking sandbox liveness: openshell sandbox list");
-  const isLive = captureOpenshell(["sandbox", "list"]);
+  const liveRecovery = await captureSandboxListWithGatewayRecovery();
+  const isLive = liveRecovery.result;
   log(
     `openshell sandbox list exit=${isLive.status}, output=${(isLive.output || "").substring(0, 200)}`,
   );
@@ -401,8 +406,7 @@ export async function rebuildSandbox(
     return;
   }
   if (isLive.status !== 0) {
-    console.error("  Failed to query running sandboxes from OpenShell.");
-    console.error("  Ensure OpenShell is running: openshell status");
+    printSandboxListFailureWithRecoveryContext(liveRecovery);
     bail("Failed to query running sandboxes from OpenShell.", isLive.status || 1);
     return;
   }

--- a/src/lib/actions/upgrade-sandboxes.ts
+++ b/src/lib/actions/upgrade-sandboxes.ts
@@ -2,28 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import { CLI_NAME } from "../cli/branding";
-import { prompt as askPrompt } from "../credentials/store";
-import {
-  normalizeUpgradeSandboxesOptions,
-  type UpgradeSandboxesOptions,
-} from "../domain/lifecycle/options";
-import { captureOpenshell } from "../adapters/openshell/runtime";
 import {
   detectOpenShellStateRpcPreflightIssue,
   detectOpenShellStateRpcResultIssue,
   printOpenShellStateRpcIssue,
 } from "../adapters/openshell/gateway-drift";
-import * as registry from "../state/registry";
-import { parseLiveSandboxNames } from "../runtime-recovery";
-import { rebuildSandbox } from "./sandbox/rebuild";
-import * as sandboxVersion from "../sandbox/version";
+import { CLI_NAME } from "../cli/branding";
 import { B, D, G, R, YW } from "../cli/terminal-style";
+import { prompt as askPrompt } from "../credentials/store";
+import {
+  normalizeUpgradeSandboxesOptions,
+  type UpgradeSandboxesOptions,
+} from "../domain/lifecycle/options";
 import {
   classifyUpgradeableSandboxes,
   shouldSkipUpgradeConfirmation,
   splitRebuildableSandboxes,
 } from "../domain/maintenance/upgrade";
+import {
+  captureSandboxListWithGatewayRecovery,
+  printSandboxListFailureWithRecoveryContext,
+} from "../openshell-sandbox-list";
+import { parseLiveSandboxNames } from "../runtime-recovery";
+import * as sandboxVersion from "../sandbox/version";
+import * as registry from "../state/registry";
+import { rebuildSandbox } from "./sandbox/rebuild";
 
 // ── Upgrade sandboxes (#1904) ────────────────────────────────────
 // Detect sandboxes running stale agent versions and offer to rebuild them.
@@ -51,7 +54,8 @@ export async function upgradeSandboxes(
     process.exit(1);
   }
 
-  const liveResult = captureOpenshell(["sandbox", "list"]);
+  const liveRecovery = await captureSandboxListWithGatewayRecovery();
+  const liveResult = liveRecovery.result;
   const resultIssue = detectOpenShellStateRpcResultIssue(liveResult);
   if (resultIssue) {
     printOpenShellStateRpcIssue(resultIssue, {
@@ -61,8 +65,7 @@ export async function upgradeSandboxes(
     process.exit(1);
   }
   if (liveResult.status !== 0) {
-    console.error("  Failed to query running sandboxes from OpenShell.");
-    console.error("  Ensure OpenShell is running: openshell status");
+    printSandboxListFailureWithRecoveryContext(liveRecovery);
     process.exit(liveResult.status || 1);
   }
   const liveNames = parseLiveSandboxNames(liveResult.output || "");

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -69,11 +69,28 @@ export function getNamedGatewayLifecycleState() {
   };
 }
 
+type NamedGatewayLifecycleStateName = ReturnType<typeof getNamedGatewayLifecycleState>["state"];
+
+export type RecoverNamedGatewayRuntimeOptions = {
+  recoverableStates?: readonly NamedGatewayLifecycleStateName[];
+};
+
 /** Attempt to recover the named NemoClaw gateway after a restart or connectivity loss. */
-export async function recoverNamedGatewayRuntime() {
+export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRuntimeOptions = {}) {
+  const recoverableStates = new Set<NamedGatewayLifecycleStateName>(
+    options.recoverableStates ?? [
+      "missing_named",
+      "named_unhealthy",
+      "named_unreachable",
+      "connected_other",
+    ],
+  );
   const before = getNamedGatewayLifecycleState();
   if (before.state === "healthy_named") {
     return { recovered: true, before, after: before, attempted: false };
+  }
+  if (!recoverableStates.has(before.state)) {
+    return { recovered: false, before, after: before, attempted: false };
   }
 
   runOpenshell(["gateway", "select", "nemoclaw"], {
@@ -87,7 +104,8 @@ export async function recoverNamedGatewayRuntime() {
   }
 
   const shouldStartGateway = [before.state, after.state].some((state) =>
-    ["missing_named", "named_unhealthy", "named_unreachable", "connected_other"].includes(state),
+    recoverableStates.has(state) &&
+      ["missing_named", "named_unhealthy", "named_unreachable", "connected_other"].includes(state),
   );
 
   if (shouldStartGateway) {

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, it, expect } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 // Import from compiled dist/ for correct coverage attribution.
@@ -13,6 +15,7 @@ import {
   LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV,
   QWEN3_6_OLLAMA_MODEL,
   getOllamaContainerPort,
+  resetOllamaContainerPortCache,
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
   getLocalProviderBaseUrl,
@@ -33,6 +36,40 @@ import {
 
 describe("local inference helpers", () => {
   const originalSandboxHostUrl = process.env[LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV];
+  const originalPath = process.env.PATH;
+  let fakeDockerDir: string | null = null;
+
+  beforeAll(() => {
+    fakeDockerDir = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-fake-docker-"));
+    const fakeDockerPath = path.join(fakeDockerDir, "docker");
+    writeFileSync(
+      fakeDockerPath,
+      [
+        "#!/bin/sh",
+        "if [ \"$1\" = \"info\" ]; then",
+        "  printf '%s\\n' 'Server: Docker Engine'",
+        "  exit 0",
+        "fi",
+        "exit 1",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(fakeDockerPath, 0o755);
+    process.env.PATH = `${fakeDockerDir}${path.delimiter}${originalPath ?? ""}`;
+    resetOllamaContainerPortCache();
+  });
+
+  afterAll(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    if (fakeDockerDir) {
+      rmSync(fakeDockerDir, { recursive: true, force: true });
+    }
+    resetOllamaContainerPortCache();
+  });
 
   afterEach(() => {
     if (originalSandboxHostUrl === undefined) {

--- a/src/lib/openshell-sandbox-list.ts
+++ b/src/lib/openshell-sandbox-list.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { detectOpenShellStateRpcResultIssue } from "./adapters/openshell/gateway-drift";
+import { stripAnsi } from "./adapters/openshell/client";
 import { captureOpenshell } from "./adapters/openshell/runtime";
 import { recoverNamedGatewayRuntime } from "./gateway-runtime-action";
 
@@ -13,13 +14,25 @@ export type SandboxListRecoveryResult = {
   recoverySucceeded: boolean;
 };
 
+export function isRecoverableSandboxListGatewayFailure(result: SandboxListResult): boolean {
+  if (result.status === 0 || detectOpenShellStateRpcResultIssue(result)) {
+    return false;
+  }
+  const output = stripAnsi(String(result.output || ""));
+  return /Connection refused|client error \(Connect\)|tcp connect error|No active gateway|No gateway configured|Status:\s*Disconnected/i.test(
+    output,
+  );
+}
+
 export async function captureSandboxListWithGatewayRecovery(): Promise<SandboxListRecoveryResult> {
   const initial = captureOpenshell(["sandbox", "list"]);
-  if (initial.status === 0 || detectOpenShellStateRpcResultIssue(initial)) {
+  if (!isRecoverableSandboxListGatewayFailure(initial)) {
     return { result: initial, recoveryAttempted: false, recoverySucceeded: false };
   }
 
-  const recovery = await recoverNamedGatewayRuntime();
+  const recovery = await recoverNamedGatewayRuntime({
+    recoverableStates: ["missing_named", "named_unhealthy", "named_unreachable"],
+  });
   if (!recovery.recovered) {
     return { result: initial, recoveryAttempted: true, recoverySucceeded: false };
   }

--- a/src/lib/openshell-sandbox-list.ts
+++ b/src/lib/openshell-sandbox-list.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { detectOpenShellStateRpcResultIssue } from "./adapters/openshell/gateway-drift";
+import { captureOpenshell } from "./adapters/openshell/runtime";
+import { recoverNamedGatewayRuntime } from "./gateway-runtime-action";
+
+type SandboxListResult = ReturnType<typeof captureOpenshell>;
+
+export type SandboxListRecoveryResult = {
+  result: SandboxListResult;
+  recoveryAttempted: boolean;
+  recoverySucceeded: boolean;
+};
+
+export async function captureSandboxListWithGatewayRecovery(): Promise<SandboxListRecoveryResult> {
+  const initial = captureOpenshell(["sandbox", "list"]);
+  if (initial.status === 0 || detectOpenShellStateRpcResultIssue(initial)) {
+    return { result: initial, recoveryAttempted: false, recoverySucceeded: false };
+  }
+
+  const recovery = await recoverNamedGatewayRuntime();
+  if (!recovery.recovered) {
+    return { result: initial, recoveryAttempted: true, recoverySucceeded: false };
+  }
+
+  return {
+    result: captureOpenshell(["sandbox", "list"]),
+    recoveryAttempted: true,
+    recoverySucceeded: true,
+  };
+}
+
+export function printSandboxListFailureWithRecoveryContext(
+  recoveryResult: SandboxListRecoveryResult,
+): void {
+  console.error("  Failed to query running sandboxes from OpenShell.");
+  if (recoveryResult.recoveryAttempted) {
+    if (recoveryResult.recoverySucceeded) {
+      console.error("  The NemoClaw OpenShell gateway was recovered, but the sandbox query still failed.");
+    } else {
+      console.error("  NemoClaw tried to recover its OpenShell gateway, but recovery did not complete.");
+    }
+  }
+  console.error("  Ensure OpenShell is running: openshell status");
+}


### PR DESCRIPTION
## Summary
- add a shared `openshell sandbox list` wrapper that recovers the named NemoClaw OpenShell gateway and retries once when the initial list command fails without a known gateway-drift/schema mismatch
- use the retry wrapper from `backup-all`, `upgrade-sandboxes`, and rebuild's pre-backup liveness check
- keep gateway image drift and protobuf/schema mismatch paths fail-closed before recovery so they are not treated as stopped sandboxes

Fixes #3986.

## Validation
- `npm run build:cli`
- `npx vitest run src/lib/actions/gateway-drift-preflight.test.ts src/lib/actions/sandbox/rebuild-gateway-drift.test.ts src/lib/actions/global.test.ts src/commands/global-oclif-command-adapters.test.ts`
- `npm run typecheck:cli`
- `npm run checks`
- `npx @biomejs/biome check src/lib/openshell-sandbox-list.ts src/lib/actions/maintenance.ts src/lib/actions/upgrade-sandboxes.ts src/lib/actions/sandbox/rebuild.ts src/lib/actions/gateway-drift-preflight.test.ts src/lib/actions/sandbox/rebuild-gateway-drift.test.ts src/lib/actions/global.ts src/lib/actions/global.test.ts src/commands/backup-all.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backup operations now wait for completion before returning.
  * Recovery now retries sandbox-list queries when transient gateway/connectivity issues occur and avoids recovery for non-recoverable failures.

* **Improvements**
  * Richer failure diagnostics that indicate whether gateway recovery was attempted and succeeded.
  * Rebuild/upgrade flows now integrate gateway-recovery-aware sandbox listing for more reliable operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->