### PR TITLE
fix(onboard): surface Telegram group privacy setup

### DIFF
--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -39,6 +39,8 @@ For details, refer to [Commands](/reference/commands).
 
 Telegram uses a bot token from [BotFather](https://t.me/BotFather).
 Open Telegram, send `/newbot` to [@BotFather](https://t.me/BotFather), follow the prompts, and copy the token.
+For Telegram group chats, disable privacy mode before testing group replies: in @BotFather, run `/setprivacy`, choose the bot, then choose **Disable**.
+After changing privacy mode, remove the bot from each Telegram group and add it back so Telegram applies the new delivery setting to that group.
 `TELEGRAM_ALLOWED_IDS` is a comma-separated list of Telegram user IDs for DM access.
 Group chats stay open by default so rebuilt sandboxes do not silently drop Telegram group messages because of an empty group allowlist.
 Set `TELEGRAM_REQUIRE_MENTION=1` to make the bot reply in Telegram groups only when users mention it.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -898,6 +898,8 @@ Check the gateway logs and blocked-request output with `openshell term`, and loo
 
 Bot tokens for Telegram (`getUpdates`), Discord (gateway), and Slack (Socket Mode) only allow one active consumer per token. If two NemoClaw sandboxes are configured with the same bot token, each one kicks the other off its polling connection and neither delivers messages. `nemoclaw status` still reports the bridge as running because the gateway process itself is alive.
 
+For Telegram group chats, first check BotFather privacy mode. New Telegram bots default to privacy mode enabled, which prevents group messages from reaching `getUpdates` even when the user mentions the bot. In @BotFather, run `/setprivacy`, choose the bot, and choose **Disable**. Then remove the bot from the affected group and add it back; Telegram applies the privacy-mode change to group delivery only after the bot rejoins.
+
 To diagnose, open a shell in the sandbox and inspect the gateway log:
 
 ```console

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -898,7 +898,10 @@ Check the gateway logs and blocked-request output with `openshell term`, and loo
 
 Bot tokens for Telegram (`getUpdates`), Discord (gateway), and Slack (Socket Mode) only allow one active consumer per token. If two NemoClaw sandboxes are configured with the same bot token, each one kicks the other off its polling connection and neither delivers messages. `nemoclaw status` still reports the bridge as running because the gateway process itself is alive.
 
-For Telegram group chats, first check BotFather privacy mode. New Telegram bots default to privacy mode enabled, which prevents group messages from reaching `getUpdates` even when the user mentions the bot. In @BotFather, run `/setprivacy`, choose the bot, and choose **Disable**. Then remove the bot from the affected group and add it back; Telegram applies the privacy-mode change to group delivery only after the bot rejoins.
+For Telegram group chats, first check BotFather privacy mode.
+New Telegram bots default to privacy mode enabled, which prevents group messages from reaching `getUpdates` even when the user mentions the bot.
+In @BotFather, run `/setprivacy`, choose the bot, and choose **Disable**.
+Then remove the bot from the affected group and add it back; Telegram applies the privacy-mode change to group delivery only after the bot rejoins.
 
 To diagnose, open a shell in the sandbox and inspect the gateway log:
 

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KNOWN_CHANNELS } from "../sandbox/channels";
+import { setupSelectedMessagingChannels } from "./messaging-channel-setup";
+
+vi.mock("../credentials/store", () => ({
+  getCredential: vi.fn(() => null),
+  normalizeCredentialValue: vi.fn((value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
+  ),
+  prompt: vi.fn(async () => ""),
+  saveCredential: vi.fn(),
+}));
+
+vi.mock("./host-qr-dispatch", () => ({
+  dispatchHostQrLogin: vi.fn(),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("setupSelectedMessagingChannels", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("#4068 prints Telegram group privacy-mode setup guidance during onboarding", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-token";
+    process.env.TELEGRAM_REQUIRE_MENTION = "1";
+    process.env.TELEGRAM_ALLOWED_IDS = "123456789";
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    await setupSelectedMessagingChannels(
+      ["telegram"],
+      new Set(["telegram"]),
+      [{ name: "telegram", ...KNOWN_CHANNELS.telegram }],
+    );
+
+    const output = logs.join("\n");
+    expect(output).toContain("disable privacy mode in @BotFather");
+    expect(output).toContain("/setprivacy -> your bot -> Disable");
+    expect(output).toContain("remove and re-add the bot to each group");
+    expect(output).toContain("reply mode already set: @mentions only");
+  });
+});

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -84,6 +84,9 @@ export async function setupSelectedMessagingChannels(
         continue;
       }
     }
+    for (const line of ch.setupNotes ?? []) {
+      console.log(`  ${line}`);
+    }
     if (ch.appTokenEnvKey) {
       const existingAppToken = getMessagingToken(ch.appTokenEnvKey);
       if (existingAppToken) {

--- a/src/lib/sandbox/channels.ts
+++ b/src/lib/sandbox/channels.ts
@@ -7,6 +7,7 @@ export interface ChannelBase {
   description: string;
   help: string;
   label: string;
+  setupNotes?: readonly string[];
   userIdEnvKey?: string;
   userIdHelp?: string;
   userIdLabel?: string;
@@ -57,6 +58,10 @@ export const KNOWN_CHANNELS: Record<string, ChannelDef> = {
     description: "Telegram bot messaging",
     help: "Create a bot via @BotFather on Telegram, then copy the token.",
     label: "Telegram Bot Token",
+    setupNotes: [
+      "For Telegram group chats, disable privacy mode in @BotFather (/setprivacy -> your bot -> Disable).",
+      "After changing privacy mode, remove and re-add the bot to each group before testing @mentions.",
+    ],
     userIdEnvKey: "TELEGRAM_ALLOWED_IDS",
     userIdHelp: "Send /start to @userinfobot on Telegram to get your numeric user ID.",
     userIdLabel: "Telegram User ID (for DM access)",


### PR DESCRIPTION
## Summary
- print Telegram group-chat setup notes during messaging channel onboarding
- document BotFather privacy-mode disablement and remove/re-add requirement for Telegram groups
- add focused coverage that onboarding surfaces the guidance

Fixes #4068.

## Testing
- npx vitest run src/lib/onboard/messaging-channel-setup.test.ts src/lib/sandbox/channels.test.ts
- npm run source-shape:check
- npx @biomejs/biome lint src/lib/onboard/messaging-channel-setup.ts src/lib/onboard/messaging-channel-setup.test.ts src/lib/sandbox/channels.ts
- npm run checks
- npm run typecheck:cli
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Telegram group-chat setup and troubleshooting guidance (disable BotFather privacy mode and re-add bot)

* **New Features**
  * Onboarding now displays per-channel setup guidance notes during messaging channel configuration

* **Tests**
  * Added test coverage to verify messaging channel setup displays Telegram guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## DevTest / QA Preconditions
- DevTest cases 6051865 / 6051855 are not tracked as in-repo artifacts in this repository; repository search did not find a precondition file to update in this diff.
- This PR updates the product-side onboarding output, public setup docs, troubleshooting docs, and unit coverage.
- The DevTest precondition update should be synced in the external QA/DevTest system with: disable Telegram BotFather privacy mode, then remove and re-add the bot to each affected group.

