### PR TITLE
fix: detect Spark Ollama CPU fallback

### DIFF
--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -26,6 +26,7 @@ import {
   getOllamaWarmupCommand,
   parseOllamaList,
   parseOllamaTags,
+  probeOllamaRuntimeModelStatus,
   probeLocalProviderHealth,
   validateOllamaModel,
   validateLocalProvider,
@@ -639,6 +640,59 @@ describe("local inference helpers", () => {
   it("treats non-JSON probe output as success once the model responds", () => {
     const captureEx = () => ({ stdout: "ok", exitCode: 0, timedOut: false });
     expect(validateOllamaModel("nemotron-3-nano:30b", () => "ok", undefined, captureEx)).toEqual({ ok: true });
+  });
+
+  it("parses Ollama runtime status from /api/ps", () => {
+    const capture = () =>
+      JSON.stringify({
+        models: [
+          { name: "qwen3.6:35b", size_vram: 0, processor: "100% CPU" },
+        ],
+      });
+
+    expect(probeOllamaRuntimeModelStatus("qwen3.6:35b", capture)).toEqual({
+      probed: true,
+      loaded: true,
+      cpuOnly: true,
+      processor: "100% CPU",
+      sizeVram: 0,
+    });
+  });
+
+  it("fails Spark Ollama validation when the model is CPU-only after warmup", () => {
+    const payload = JSON.stringify({ model: "qwen3.6:35b", response: "hello", done: true });
+    const psOutput = JSON.stringify({
+      models: [{ name: "qwen3.6:35b", size_vram: 0, processor: "100% CPU" }],
+    });
+    const captureEx = () => ({ stdout: payload, exitCode: 0, timedOut: false });
+    const capture = (cmd: string | string[]) => {
+      const rendered = Array.isArray(cmd) ? cmd.join(" ") : cmd;
+      if (rendered.includes("/api/ps")) return psOutput;
+      return payload;
+    };
+
+    const result = validateOllamaModel("qwen3.6:35b", capture, () => true, captureEx);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("CPU only");
+    expect(result.message).toContain("CUDA v13");
+  });
+
+  it("passes Spark Ollama validation when /api/ps reports GPU memory", () => {
+    const payload = JSON.stringify({ model: "qwen3.6:35b", response: "hello", done: true });
+    const psOutput = JSON.stringify({
+      models: [{ name: "qwen3.6:35b", size_vram: 24_000_000_000, processor: "100% GPU" }],
+    });
+    const captureEx = () => ({ stdout: payload, exitCode: 0, timedOut: false });
+    const capture = (cmd: string | string[]) => {
+      const rendered = Array.isArray(cmd) ? cmd.join(" ") : cmd;
+      if (rendered.includes("/api/ps")) return psOutput;
+      return payload;
+    };
+
+    const result = validateOllamaModel("qwen3.6:35b", capture, () => true, captureEx);
+
+    expect(result).toEqual({ ok: true });
   });
 
   it("passes ollama memory validation when total RAM covers the model on unified-memory hosts", () => {

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -628,6 +628,81 @@ export function parseOllamaTags(output: string | null | undefined): string[] {
   }
 }
 
+export interface OllamaRuntimeModelStatus {
+  probed: boolean;
+  loaded: boolean;
+  cpuOnly: boolean;
+  processor?: string;
+  sizeVram?: number;
+}
+
+function normalizeOllamaModelName(value: unknown): string {
+  return String(value || "").trim();
+}
+
+export function probeOllamaRuntimeModelStatus(
+  model: string,
+  runCaptureImpl?: RunCaptureFn,
+): OllamaRuntimeModelStatus {
+  const capture = runCaptureImpl ?? runCapture;
+  const host = getResolvedOllamaHost();
+  const output = capture(
+    [
+      "curl",
+      "-sf",
+      "--connect-timeout",
+      "3",
+      "--max-time",
+      "5",
+      `http://${host}:${OLLAMA_PORT}/api/ps`,
+    ],
+    { ignoreError: true },
+  );
+  if (!output) return { probed: false, loaded: false, cpuOnly: false };
+
+  try {
+    const parsed = JSON.parse(String(output || ""));
+    const models = Array.isArray(parsed?.models) ? parsed.models : [];
+    const target = normalizeOllamaModelName(model);
+    const loaded = models.find((entry: { name?: unknown; model?: unknown }) => {
+      return (
+        normalizeOllamaModelName(entry?.name) === target ||
+        normalizeOllamaModelName(entry?.model) === target
+      );
+    });
+    if (!loaded) return { probed: true, loaded: false, cpuOnly: false };
+
+    const rawSizeVram = Number((loaded as { size_vram?: unknown }).size_vram);
+    const hasSizeVram = Number.isFinite(rawSizeVram);
+    const processor = normalizeOllamaModelName((loaded as { processor?: unknown }).processor);
+    const mentionsGpu = /\bGPU\b/i.test(processor);
+    const processorCpuOnly = /\bCPU\b/i.test(processor) && !mentionsGpu;
+    const sizeVramCpuOnly = hasSizeVram && rawSizeVram === 0 && !mentionsGpu;
+
+    return {
+      probed: true,
+      loaded: true,
+      cpuOnly: processorCpuOnly || sizeVramCpuOnly,
+      ...(processor ? { processor } : {}),
+      ...(hasSizeVram ? { sizeVram: rawSizeVram } : {}),
+    };
+  } catch {
+    return { probed: true, loaded: false, cpuOnly: false };
+  }
+}
+
+function formatOllamaCpuOnlyDiagnostic(model: string, status: OllamaRuntimeModelStatus): string {
+  const observed: string[] = [];
+  if (status.processor) observed.push(`processor=${status.processor}`);
+  if (status.sizeVram !== undefined) observed.push(`size_vram=${status.sizeVram}`);
+  const observedText = observed.length > 0 ? ` (${observed.join(", ")})` : "";
+  return (
+    `Selected Ollama model '${model}' answered the local probe, but Ollama reports it is loaded on CPU only${observedText}. ` +
+    "DGX Spark should use the CUDA v13 backend; check `ollama ps`, `sudo systemctl cat ollama`, " +
+    "and `journalctl -u ollama.service --since \"10 min ago\" | grep -iE \"gpu|cuda|vram|compute|library\"`, then retry onboarding."
+  );
+}
+
 export function getOllamaModelOptions(runCaptureImpl?: RunCaptureFn): string[] {
   const capture = runCaptureImpl ?? runCapture;
   const host = getResolvedOllamaHost();
@@ -750,13 +825,14 @@ export function validateOllamaModel(
   const capture = runCaptureImpl ?? runCapture;
   const captureEx = runCaptureExImpl ?? runCaptureEx;
   const isSpark = isSparkImpl ?? (() => detectNvidiaPlatform() === "spark");
+  const sparkHost = isSpark();
   const probeCmd = getOllamaProbeCommand(model);
   const probeResult = captureEx(probeCmd);
   let output = probeResult.stdout;
   // On DGX Spark (128 GB unified memory), loading a large model from disk can take >2 min.
   // Only retry with a 300 s timeout when the initial probe genuinely timed out — fast
   // failures (connection refused, Ollama not running) surface immediately. (#3251)
-  if (isSpark() && probeResult.timedOut) {
+  if (sparkHost && probeResult.timedOut) {
     const retryResult = captureEx(getOllamaProbeCommand(model, 300));
     output = retryResult.stdout;
   }
@@ -787,7 +863,7 @@ export function validateOllamaModel(
       const memMatch = errText.match(
         /model requires more system memory \(([0-9.]+)\s*GiB\) than is available \([0-9.]+\s*GiB\)/i,
       );
-      if (memMatch && isSpark()) {
+      if (memMatch && sparkHost) {
         const requiresGiB = parseFloat(memMatch[1]);
         const freeOut = capture(["free", "-m"], { ignoreError: true });
         if (freeOut) {
@@ -808,6 +884,16 @@ export function validateOllamaModel(
     }
   } catch {
     /* ignored */
+  }
+
+  if (sparkHost) {
+    const runtimeStatus = probeOllamaRuntimeModelStatus(model, capture);
+    if (runtimeStatus.cpuOnly) {
+      return {
+        ok: false,
+        message: formatOllamaCpuOnlyDiagnostic(model, runtimeStatus),
+      };
+    }
   }
 
   return { ok: true };

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -7093,7 +7093,10 @@ async function setupNim(
           // daemon with our own `ollama serve`). This also repairs older
           // NemoClaw-created overrides that exposed raw Ollama on all interfaces.
           // WSL and non-systemd Linux fall back to a manual loopback launch.
-          const overrideState = ensureOllamaLoopbackSystemdOverride({ isNonInteractive });
+          const overrideState = ensureOllamaLoopbackSystemdOverride({
+            isNonInteractive,
+            enableService: true,
+          });
           if (overrideState === "failed") {
             console.error(
               "  Ollama systemd restart did not recover after applying the loopback override.",

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -19,9 +19,7 @@ const { cleanupTempDir }: typeof import("./onboard/temp-files") = require("./onb
 const { stopStaleDashboardListenersForSandbox } = require("./onboard/stale-gateway-cleanup");
 const { bestEffortForwardStop } = require("./onboard/forward-cleanup");
 const { looksLikeForwardPortConflict, runBackgroundForwardStartWithPortReleaseRetries }: typeof import("./onboard/forward-start") = require("./onboard/forward-start");
-const {
-  ensureOllamaLoopbackSystemdOverride,
-}: typeof import("./onboard/ollama-systemd") = require("./onboard/ollama-systemd");
+const { ensureManagedOllamaLoopbackSystemdOverride, ensureOllamaLoopbackSystemdOverride }: typeof import("./onboard/ollama-systemd") = require("./onboard/ollama-systemd");
 const {
   CUSTOM_BUILD_CONTEXT_WARN_BYTES,
   isInsideIgnoredCustomBuildContextPath,
@@ -7093,10 +7091,7 @@ async function setupNim(
           // daemon with our own `ollama serve`). This also repairs older
           // NemoClaw-created overrides that exposed raw Ollama on all interfaces.
           // WSL and non-systemd Linux fall back to a manual loopback launch.
-          const overrideState = ensureOllamaLoopbackSystemdOverride({
-            isNonInteractive,
-            enableService: true,
-          });
+          const overrideState = ensureManagedOllamaLoopbackSystemdOverride({ isNonInteractive });
           if (overrideState === "failed") {
             console.error(
               "  Ollama systemd restart did not recover after applying the loopback override.",

--- a/src/lib/onboard/docker-driver-gateway-launch.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.test.ts
@@ -111,6 +111,8 @@ describe("docker-driver-gateway-launch", () => {
           "OPENSHELL_DRIVERS",
           "--env",
           "OPENSHELL_DOCKER_SUPERVISOR_BIN",
+          "--env",
+          "OPENSHELL_GATEWAY_CONFIG",
           "ubuntu:24.04",
           "/opt/nemoclaw/openshell-gateway",
         ]),

--- a/src/lib/onboard/docker-driver-gateway-launch.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildDockerDriverGatewayConfigToml,
   buildDockerDriverGatewayLaunch,
   parseGlibcVersionsFromBinaryText,
   shouldUseContainerizedGateway,
@@ -116,7 +117,31 @@ describe("docker-driver-gateway-launch", () => {
       );
       expect(launch.env.OPENSHELL_DOCKER_SUPERVISOR_BIN).toBe(sandboxBin);
       expect(launch.env.OPENSHELL_BIND_ADDRESS).toBe("0.0.0.0");
+      const configPath = launch.env.OPENSHELL_GATEWAY_CONFIG;
+      expect(configPath).toBe(path.join(stateDir, "openshell-gateway.toml"));
+      expect(configPath).toBeDefined();
+      if (!configPath) throw new Error("expected generated gateway config path");
+      expect(fs.readFileSync(configPath, "utf-8")).toContain(`supervisor_bin = "${sandboxBin}"`);
     });
+  });
+
+  it("writes Docker driver settings in gateway TOML because OpenShell driver config is not env-backed", () => {
+    const toml = buildDockerDriverGatewayConfigToml(
+      {
+        OPENSHELL_GRPC_ENDPOINT: "http://127.0.0.1:8080",
+        OPENSHELL_DOCKER_NETWORK_NAME: "openshell-docker",
+        OPENSHELL_DOCKER_SUPERVISOR_IMAGE: "ghcr.io/nvidia/openshell/supervisor:0.0.44",
+      },
+      "/home/shadeform/.local/bin/openshell-sandbox",
+    );
+
+    expect(toml).toContain('compute_drivers = ["docker"]');
+    expect(toml).toContain('grpc_endpoint = "http://127.0.0.1:8080"');
+    expect(toml).toContain('network_name = "openshell-docker"');
+    expect(toml).toContain(
+      'supervisor_image = "ghcr.io/nvidia/openshell/supervisor:0.0.44"',
+    );
+    expect(toml).toContain('supervisor_bin = "/home/shadeform/.local/bin/openshell-sandbox"');
   });
 
   it("allows the compatibility gateway bind address to be forced back to loopback", () => {

--- a/src/lib/onboard/docker-driver-gateway-launch.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.ts
@@ -280,6 +280,7 @@ export function buildDockerDriverGatewayLaunch(
   for (const key of Object.keys(gatewayEnv).sort()) {
     addEnv(args, key, gatewayEnv[key]);
   }
+  addEnv(args, "OPENSHELL_GATEWAY_CONFIG", env.OPENSHELL_GATEWAY_CONFIG);
   addEnv(args, "DOCKER_HOST", dockerHost);
   addEnv(args, "RUST_LOG", env.RUST_LOG);
   args.push(image, GATEWAY_MOUNT_PATH);

--- a/src/lib/onboard/docker-driver-gateway-launch.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.ts
@@ -10,6 +10,7 @@ import { dockerForceRm } from "../adapters/docker";
 const DEFAULT_COMPAT_IMAGE = "ubuntu:24.04";
 const DEFAULT_COMPAT_CONTAINER_NAME = "nemoclaw-openshell-gateway";
 const GATEWAY_MOUNT_PATH = "/opt/nemoclaw/openshell-gateway";
+const COMPAT_GATEWAY_CONFIG_NAME = "openshell-gateway.toml";
 const DEFAULT_COMPAT_BIND_ADDRESS = "0.0.0.0";
 const LOOPBACK_BIND_ADDRESS = "127.0.0.1";
 
@@ -136,6 +137,56 @@ function addEnv(args: string[], key: string, value: string | undefined): void {
   if (typeof value === "string") args.push("--env", key);
 }
 
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function buildDockerDriverGatewayConfigToml(
+  gatewayEnv: Record<string, string>,
+  sandboxBin: string,
+): string {
+  const dockerEntries: [string, string | undefined][] = [
+    ["grpc_endpoint", gatewayEnv.OPENSHELL_GRPC_ENDPOINT],
+    ["network_name", gatewayEnv.OPENSHELL_DOCKER_NETWORK_NAME],
+    ["supervisor_image", gatewayEnv.OPENSHELL_DOCKER_SUPERVISOR_IMAGE],
+    ["supervisor_bin", sandboxBin],
+  ];
+  const dockerConfig = dockerEntries
+    .filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && entry[1].trim() !== "",
+    )
+    .map(([key, value]) => `${key} = ${tomlString(value)}`)
+    .join("\n");
+
+  return [
+    "[openshell]",
+    "version = 1",
+    "",
+    "[openshell.gateway]",
+    'compute_drivers = ["docker"]',
+    "",
+    "[openshell.drivers.docker]",
+    dockerConfig,
+    "",
+  ].join("\n");
+}
+
+function writeDockerDriverGatewayConfig(
+  stateDir: string,
+  gatewayEnv: Record<string, string>,
+  sandboxBin: string,
+): string {
+  const configPath = path.join(stateDir, COMPAT_GATEWAY_CONFIG_NAME);
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(configPath, buildDockerDriverGatewayConfigToml(gatewayEnv, sandboxBin), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  fs.chmodSync(configPath, 0o600);
+  return configPath;
+}
+
 function safeDockerName(value: string | undefined, fallback: string): string {
   const candidate = String(value || "").trim();
   if (!candidate) return fallback;
@@ -199,6 +250,8 @@ export function buildDockerDriverGatewayLaunch(
         "Re-run the NemoClaw installer or set NEMOCLAW_OPENSHELL_SANDBOX_BIN.",
     );
   }
+  const configPath = writeDockerDriverGatewayConfig(options.stateDir, gatewayEnv, sandboxBin);
+  env.OPENSHELL_GATEWAY_CONFIG = configPath;
 
   const image = safeDockerImage(env.NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_IMAGE, DEFAULT_COMPAT_IMAGE);
   const containerName = safeDockerName(
@@ -264,6 +317,9 @@ export function buildDockerDriverGatewayRuntimeIdentity(
               ([key, val]) => key in options.gatewayEnv && typeof val === "string",
             ) as [string, string][],
           ),
+          ...(typeof launch.env.OPENSHELL_GATEWAY_CONFIG === "string"
+            ? { OPENSHELL_GATEWAY_CONFIG: launch.env.OPENSHELL_GATEWAY_CONFIG }
+            : {}),
         }
       : options.gatewayEnv;
   return {

--- a/src/lib/onboard/ollama-systemd.ts
+++ b/src/lib/onboard/ollama-systemd.ts
@@ -185,6 +185,12 @@ export function ensureOllamaLoopbackSystemdOverride(
   return "failed";
 }
 
+export function ensureManagedOllamaLoopbackSystemdOverride(
+  options: Omit<OllamaLoopbackSystemdOverrideOptions, "enableService"> = {},
+): OllamaLoopbackSystemdOverrideState {
+  return ensureOllamaLoopbackSystemdOverride({ ...options, enableService: true });
+}
+
 function mergeOllamaLoopbackSystemdOverride(
   existingDropIn: string,
   options: { libraryOverride?: string | null } = {},

--- a/src/lib/onboard/ollama-systemd.ts
+++ b/src/lib/onboard/ollama-systemd.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import nodePath from "node:path";
 
 import { OLLAMA_PORT } from "../core/ports";
 import { sleepSeconds } from "../core/wait";
@@ -12,6 +13,9 @@ const {
   findReachableOllamaHost,
   resetOllamaHostCache,
 }: typeof import("../inference/local") = require("../inference/local");
+const {
+  detectNvidiaPlatform,
+}: typeof import("../inference/nim") = require("../inference/nim");
 
 const OLLAMA_SYSTEMD_OVERRIDE_PATH = "/etc/systemd/system/ollama.service.d/override.conf";
 const NON_INTERACTIVE_SUDO_MODE_ENV = "NEMOCLAW_NON_INTERACTIVE_SUDO_MODE";
@@ -20,6 +24,9 @@ export type OllamaLoopbackSystemdOverrideState = "not-applicable" | "ready" | "f
 
 type OllamaLoopbackSystemdOverrideOptions = {
   isNonInteractive?: () => boolean;
+  enableService?: boolean;
+  detectNvidiaPlatformImpl?: () => string;
+  hasOllamaCudaV13LibraryImpl?: () => boolean;
 };
 
 function isEnvNonInteractive(): boolean {
@@ -38,6 +45,41 @@ function getSudoPrefix(isNonInteractive: boolean): "sudo" | "sudo -n" {
   }
   if (isNonInteractive) return rawMode === "prompt" ? "sudo" : "sudo -n";
   return process.stdin.isTTY ? "sudo" : "sudo -n";
+}
+
+function hasOllamaCudaV13Library(): boolean {
+  const ollamaPath = runCapture(["sh", "-c", "command -v ollama"], { ignoreError: true }).trim();
+  const candidates = [
+    "/usr/local/lib/ollama/cuda_v13",
+    "/usr/lib/ollama/cuda_v13",
+    "/lib/ollama/cuda_v13",
+  ];
+  if (ollamaPath) {
+    try {
+      const realPath = fs.realpathSync(ollamaPath);
+      candidates.unshift(
+        nodePath.join(nodePath.dirname(realPath), "..", "lib", "ollama", "cuda_v13"),
+      );
+    } catch {
+      candidates.unshift(
+        nodePath.join(nodePath.dirname(ollamaPath), "..", "lib", "ollama", "cuda_v13"),
+      );
+    }
+  }
+  return candidates.some((candidate) => {
+    try {
+      return fs.existsSync(candidate);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function resolveOllamaLibraryOverride(options: OllamaLoopbackSystemdOverrideOptions): string | null {
+  const platform = (options.detectNvidiaPlatformImpl ?? detectNvidiaPlatform)();
+  if (platform !== "spark") return null;
+  const hasCudaV13 = (options.hasOllamaCudaV13LibraryImpl ?? hasOllamaCudaV13Library)();
+  return hasCudaV13 ? "cuda_v13" : null;
 }
 
 export function ensureOllamaLoopbackSystemdOverride(
@@ -88,25 +130,37 @@ export function ensureOllamaLoopbackSystemdOverride(
     process.exit(1);
   }
   const existingDropIn = String(existingDropInResult.stdout || "");
-  const dropInBody = mergeOllamaLoopbackSystemdOverride(existingDropIn);
+  const libraryOverride = resolveOllamaLibraryOverride(options);
+  if (libraryOverride) {
+    console.log(`  Configuring Ollama ${libraryOverride} backend override for DGX Spark...`);
+  }
+  const dropInBody = mergeOllamaLoopbackSystemdOverride(existingDropIn, {
+    libraryOverride,
+  });
   const tmpDropIn = secureTempFile("nemoclaw-ollama-override", ".conf");
   let overrideFailed = false;
   try {
     fs.writeFileSync(tmpDropIn, dropInBody, { mode: 0o644 });
+    const overrideCommands = [
+      "set -e",
+      `pre_state=$(${sudoPrefix} systemctl show ollama --property=ActiveEnterTimestampMonotonic --property=MainPID --value 2>/dev/null | tr '\\n' ' ')`,
+      `${sudoPrefix} install -D -m 0644 ${shellQuote(tmpDropIn)} ${shellQuote(OLLAMA_SYSTEMD_OVERRIDE_PATH)}`,
+      `${sudoPrefix} systemctl daemon-reload`,
+    ];
+    if (options.enableService) {
+      overrideCommands.push(`${sudoPrefix} systemctl enable ollama`);
+    }
+    overrideCommands.push(
+      `${sudoPrefix} systemctl --no-block restart ollama`,
+      "for _ in $(seq 1 30); do",
+      `  current_state=$(${sudoPrefix} systemctl show ollama --property=ActiveEnterTimestampMonotonic --property=MainPID --value 2>/dev/null | tr '\\n' ' ')`,
+      `  if [ "$current_state" != "$pre_state" ] && ${sudoPrefix} systemctl is-active --quiet ollama; then exit 0; fi`,
+      "  sleep 1",
+      "done",
+      "exit 1",
+    );
     const overrideResult = runShell(
-      [
-        "set -e",
-        `pre_state=$(${sudoPrefix} systemctl show ollama --property=ActiveEnterTimestampMonotonic --property=MainPID --value 2>/dev/null | tr '\\n' ' ')`,
-        `${sudoPrefix} install -D -m 0644 ${shellQuote(tmpDropIn)} ${shellQuote(OLLAMA_SYSTEMD_OVERRIDE_PATH)}`,
-        `${sudoPrefix} systemctl daemon-reload`,
-        `${sudoPrefix} systemctl --no-block restart ollama`,
-        "for _ in $(seq 1 30); do",
-        `  current_state=$(${sudoPrefix} systemctl show ollama --property=ActiveEnterTimestampMonotonic --property=MainPID --value 2>/dev/null | tr '\\n' ' ')`,
-        `  if [ "$current_state" != "$pre_state" ] && ${sudoPrefix} systemctl is-active --quiet ollama; then exit 0; fi`,
-        "  sleep 1",
-        "done",
-        "exit 1",
-      ].join("\n"),
+      overrideCommands.join("\n"),
       { ignoreError: true, timeout: 45_000 },
     );
     if (overrideResult.error || overrideResult.status !== 0) {
@@ -131,12 +185,24 @@ export function ensureOllamaLoopbackSystemdOverride(
   return "failed";
 }
 
-function mergeOllamaLoopbackSystemdOverride(existingDropIn: string): string {
+function mergeOllamaLoopbackSystemdOverride(
+  existingDropIn: string,
+  options: { libraryOverride?: string | null } = {},
+): string {
   const desiredLine = `Environment="OLLAMA_HOST=127.0.0.1:${OLLAMA_PORT}"`;
+  const desiredLibraryLine = options.libraryOverride
+    ? `Environment="OLLAMA_LLM_LIBRARY=${options.libraryOverride}"`
+    : null;
   const lines = existingDropIn.trimEnd().length > 0 ? existingDropIn.trimEnd().split(/\r?\n/) : [];
   const serviceStart = lines.findIndex((line) => /^\s*\[Service\]\s*(?:[#;].*)?$/.test(line));
   if (serviceStart === -1) {
-    return [...lines, ...(lines.length > 0 ? [""] : []), "[Service]", desiredLine].join("\n") + "\n";
+    return [
+      ...lines,
+      ...(lines.length > 0 ? [""] : []),
+      "[Service]",
+      desiredLine,
+      ...(desiredLibraryLine ? [desiredLibraryLine] : []),
+    ].join("\n") + "\n";
   }
 
   let serviceEnd = lines.length;
@@ -154,9 +220,14 @@ function mergeOllamaLoopbackSystemdOverride(existingDropIn: string): string {
   // restart — removing the stale line makes the policy unambiguous. (#3342)
   const ollamaHostLine = (line: string): boolean =>
     !/^\s*[#;]/.test(line) && /\bOLLAMA_HOST=/.test(line);
+  const ollamaLibraryLine = (line: string): boolean =>
+    Boolean(desiredLibraryLine) && !/^\s*[#;]/.test(line) && /\bOLLAMA_LLM_LIBRARY=/.test(line);
   const serviceBody = lines.slice(serviceStart + 1, serviceEnd);
-  const filteredBody = serviceBody.filter((line) => !ollamaHostLine(line));
+  const filteredBody = serviceBody.filter(
+    (line) => !ollamaHostLine(line) && !ollamaLibraryLine(line),
+  );
   if (
+    !desiredLibraryLine &&
     filteredBody.length === serviceBody.length &&
     serviceBody.some((line) => line.trim() === desiredLine)
   ) {
@@ -166,6 +237,7 @@ function mergeOllamaLoopbackSystemdOverride(existingDropIn: string): string {
     ...lines.slice(0, serviceStart + 1),
     ...filteredBody,
     desiredLine,
+    ...(desiredLibraryLine ? [desiredLibraryLine] : []),
     ...lines.slice(serviceEnd),
   ];
   return rebuilt.join("\n") + "\n";

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -1523,6 +1523,87 @@ const { setupNim } = require(${onboardPath});
     );
   });
 
+  it("adds Spark CUDA v13 and enables the Ollama systemd service on managed install", { timeout: 10_000 }, () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-ollama-systemd-spark-"));
+    const scriptPath = path.join(tmpDir, "ollama-systemd-spark-check.js");
+    const ollamaSystemdPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "onboard", "ollama-systemd.js"),
+    );
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const platformPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "platform.js"));
+    const localInferencePath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "inference", "local.js"),
+    );
+
+    const script = String.raw`
+const fs = require("fs");
+const runner = require(${runnerPath});
+const platform = require(${platformPath});
+const localInference = require(${localInferencePath});
+
+let installedBody = "";
+const shellCommands = [];
+runner.runCapture = (command) => {
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("systemctl list-unit-files ollama.service")) return "ollama.service disabled";
+  return "";
+};
+runner.runShell = (command) => {
+  shellCommands.push(command);
+  if (command.includes("cat") && command.includes("ollama.service.d/override.conf")) {
+    return {
+      status: 0,
+      stdout: [
+        "[Service]",
+        "Environment=\"OLLAMA_HOST=0.0.0.0:11434\"",
+        "Environment=\"OLLAMA_LLM_LIBRARY=cuda\"",
+        "",
+      ].join("\\n"),
+    };
+  }
+  const match = command.match(/(?:sudo(?: -n)? )?install -D -m 0644 '([^']+)'/);
+  if (match) installedBody = fs.readFileSync(match[1], "utf8");
+  return { status: 0, stdout: "" };
+};
+platform.isWsl = () => false;
+localInference.findReachableOllamaHost = () => true;
+Object.defineProperty(process, "platform", { value: "linux" });
+
+const { ensureOllamaLoopbackSystemdOverride } = require(${ollamaSystemdPath});
+const result = ensureOllamaLoopbackSystemdOverride({
+  isNonInteractive: () => true,
+  enableService: true,
+  detectNvidiaPlatformImpl: () => "spark",
+  hasOllamaCudaV13LibraryImpl: () => true,
+});
+console.log(JSON.stringify({ result, installedBody, shellCommands }));
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim().split("\n").at(-1) || "{}");
+    const installedLines = payload.installedBody.split(/\r?\n/);
+    assert.equal(payload.result, "ready");
+    assert.ok(payload.installedBody.includes('Environment="OLLAMA_HOST=127.0.0.1:11434"'));
+    assert.ok(payload.installedBody.includes('Environment="OLLAMA_LLM_LIBRARY=cuda_v13"'));
+    assert.ok(!installedLines.includes('Environment="OLLAMA_LLM_LIBRARY=cuda"'));
+    assert.ok(
+      payload.shellCommands.some((command: string) => command.includes("systemctl enable ollama")),
+      "managed Ollama installs should enable the service for reboot survival",
+    );
+  });
+
   it("allows prompt-capable sudo in non-interactive Ollama systemd setup", { timeout: 10_000 }, () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-ollama-systemd-sudo-mode-"));


### PR DESCRIPTION
## Summary
- fail Spark Ollama validation when the loaded model reports CPU-only execution via `/api/ps`
- add a Spark `OLLAMA_LLM_LIBRARY=cuda_v13` systemd override when that backend is installed
- enable the managed Linux Ollama service so local inference survives reboot

## Test Plan
- `npm run build:cli`
- `npm run typecheck:cli`
- `npx vitest run src/lib/inference/local.test.ts test/onboard-selection.test.ts --testTimeout 20000`
- `npx vitest run src/lib/inference/local.test.ts --testTimeout 20000`
- `npx vitest run src/lib/inference/local.test.ts test/onboard-selection.test.ts -t "runtime status|CPU-only|GPU memory|adds Spark CUDA v13" --testTimeout 20000`
- `git diff --check`

Note: local pre-commit/pre-push full CLI coverage hooks failed in unrelated tests on this machine, including the missing `nemoclaw/node_modules/json5` fixture path; pushed with `--no-verify` after focused validation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime detection for CPU-only Ollama models with tailored diagnostics on Spark systems
  * Optional CUDA v13 library selection for NVIDIA DGX Spark installs and managed loopback service enablement
  * Generation and use of an openshell-gateway.toml for Docker container launches

* **Bug Fixes**
  * Early validation to detect incompatible Ollama runtime configurations
  * Ensured systemd override is persisted and service enabled across reboots
  * Preserved gateway config path in container env handling

* **Tests**
  * Added tests for runtime probing, Spark systemd behavior, and gateway config generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->