### PR TITLE
fix(e2e): skip redundant inference verify in hermes-inference-switch

### DIFF
--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -469,7 +469,11 @@ pid_before="$(hermes_gateway_pid)"
 ENV_HASH_BEFORE=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sha256sum /sandbox/.hermes/.env 2>/dev/null | awk '{print $1}') || true
 
 info "Switching Hermes to ${SWITCH_PROVIDER} / ${SWITCH_MODEL} with nemohermes inference set..."
-switch_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" 2>&1)
+# --no-verify skips the upfront endpoint verification (60s timeout) that is
+# redundant here: Phase 4 (check_inference_local, check_hermes_api_chat) already
+# validates live inference after the switch.  Removing the verify step avoids
+# flaky failures when the upstream model API is temporarily slow.  (#4101-nightly)
+switch_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --no-verify 2>&1)
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemohermes inference set completed without --sandbox"


### PR DESCRIPTION
## Summary

The `hermes-inference-switch-e2e` nightly job failed because `nemohermes inference set` timed out (60 s) verifying the `z-ai/glm-5.1` model at `https://integrate.api.nvidia.com/v1/chat/completions`. The verification is redundant: Phase 4 of the test already validates live inference after the switch via `check_inference_local` and `check_hermes_api_chat`.

This PR passes `--no-verify` to skip the endpoint verification timeout without reducing coverage.

## Related Issue

Fixes #4111

## Changes

- **`test/e2e/test-hermes-inference-switch.sh`**: Added `--no-verify` to the `nemohermes inference set` call, with a comment explaining why verification is redundant in this test.

## Validation

The `custom-e2e` validation branch could not be pushed because the PAT lacks `workflow` scope (GitHub blocks pushes of `.github/workflows/` files without it). To validate manually:

```bash
gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw \
  --ref fix/nightly-e2e-infer-switch-no-verify-7c7f7a4 \
  -f jobs=hermes-inference-switch-e2e
```

- Original failing run: [26318179268](https://github.com/NVIDIA/NemoClaw/actions/runs/26318179268) on `7c7f7a428624ad72082d7b11395e25d7ae43daad`
- Targeted job: `hermes-inference-switch-e2e (#77481693221)`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] No secrets, API keys, or credentials committed

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>