### PR TITLE
fix: fail debug for unknown sandbox

### DIFF
--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -205,6 +205,30 @@ function collectDmesg(collectDir: string): void {
 // Auto-detect sandbox name
 // ---------------------------------------------------------------------------
 
+function sandboxExists(sandboxName: string): boolean {
+  try {
+    const registry = listSandboxes();
+    if (registry.sandboxes.some((sandbox) => sandbox.name === sandboxName)) {
+      return true;
+    }
+  } catch {
+    /* registry unreadable — fall through to openshell probe */
+  }
+
+  if (!commandExists("openshell")) return true;
+
+  try {
+    execFileSync("openshell", ["sandbox", "get", sandboxName], {
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function detectSandboxName(): string {
   // First, check the local registry for the default sandbox. This is
   // the authoritative source — it reflects the user's actual onboard
@@ -560,10 +584,17 @@ export function runDebug(opts: DebugOptions = {}): void {
   const repoDir = join(__dirname, "..", "..", "..");
 
   // Resolve sandbox name
-  let sandboxName =
+  const requestedSandboxName =
     opts.sandboxName ?? process.env.NEMOCLAW_SANDBOX ?? process.env.SANDBOX_NAME ?? "";
+  let sandboxName = requestedSandboxName;
   if (!sandboxName) {
     sandboxName = detectSandboxName();
+  }
+
+  if (requestedSandboxName && !sandboxExists(sandboxName)) {
+    error(`Sandbox '${sandboxName}' does not exist.`);
+    process.exitCode = 1;
+    return;
   }
 
   // Create temp collection directory

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -205,6 +205,21 @@ function collectDmesg(collectDir: string): void {
 // Auto-detect sandbox name
 // ---------------------------------------------------------------------------
 
+function errorOutput(error: unknown): string {
+  if (typeof error !== "object" || error === null) return String(error);
+  const { message, stderr, stdout } = error as { message?: unknown; stderr?: unknown; stdout?: unknown };
+  return [message, stdout, stderr]
+    .map((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : typeof value === "string" ? value : ""))
+    .join("\n");
+}
+
+function isMissingSandboxError(error: unknown): boolean {
+  return /not\s*found|notfound|does not exist/i.test(errorOutput(error));
+}
+
+/**
+ * Returns whether a sandbox exists, while propagating ambiguous openshell probe failures.
+ */
 function sandboxExists(sandboxName: string): boolean {
   try {
     const registry = listSandboxes();
@@ -221,11 +236,12 @@ function sandboxExists(sandboxName: string): boolean {
     execFileSync("openshell", ["sandbox", "get", sandboxName], {
       encoding: "utf-8",
       timeout: 10_000,
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     return true;
-  } catch {
-    return false;
+  } catch (probeError) {
+    if (isMissingSandboxError(probeError)) return false;
+    throw probeError;
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1498,6 +1498,35 @@ describe("CLI dispatch", () => {
     expect(fs.existsSync(output)).toBe(false);
   });
 
+  it("debug --sandbox propagates ambiguous openshell probe failures", testTimeoutOptions(30_000), () => {
+    const env = createDebugCommandTestEnv("nemoclaw-cli-debug-probe-failure-");
+    const localBin = env.PATH?.split(path.delimiter)[0];
+    if (!localBin) throw new Error("Expected debug test PATH to include a fake bin dir");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+        "  echo 'NAME'",
+        "  echo 'mybox'",
+        "  exit 0",
+        "fi",
+        "echo 'gateway unavailable' >&2",
+        "exit 1",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const output = path.join(env.HOME, "probe-failure-debug.tar.gz");
+
+    const r = runWithEnv(`debug --quick --sandbox probe-target --output ${output}`, env, 30000);
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("gateway unavailable");
+    expect(r.out).not.toContain("Sandbox 'probe-target' does not exist.");
+    expect(r.out).not.toContain("Tarball written");
+    expect(fs.existsSync(output)).toBe(false);
+  });
+
   it("debug --sandbox without a name exits 1", () => {
     const r = run("debug --sandbox");
     expect(r.code).not.toBe(0);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1466,6 +1466,38 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
   });
 
+  it("debug --sandbox exits non-zero for an unknown sandbox and leaves no tarball", testTimeoutOptions(30_000), () => {
+    const env = createDebugCommandTestEnv("nemoclaw-cli-debug-unknown-sandbox-");
+    const localBin = env.PATH?.split(path.delimiter)[0];
+    if (!localBin) throw new Error("Expected debug test PATH to include a fake bin dir");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+        "  echo 'NAME'",
+        "  echo 'mybox'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "mybox" ]; then',
+        "  echo 'mybox Ready'",
+        "  exit 0",
+        "fi",
+        "echo 'sandbox not found' >&2",
+        "exit 1",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const output = path.join(env.HOME, "unknown-debug.tar.gz");
+
+    const r = runWithEnv(`debug --quick --sandbox does-not-exist --output ${output}`, env, 30000);
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Sandbox 'does-not-exist' does not exist.");
+    expect(r.out).not.toContain("Tarball written");
+    expect(fs.existsSync(output)).toBe(false);
+  });
+
   it("debug --sandbox without a name exits 1", () => {
     const r = run("debug --sandbox");
     expect(r.code).not.toBe(0);


### PR DESCRIPTION
## Summary
- make `nemoclaw debug --sandbox NAME` fail before collecting diagnostics when the named sandbox can be verified missing
- avoid writing a debug tarball for unknown explicit sandbox names
- add CLI coverage for the negative path while preserving the existing no-OpenShell fallback behavior

Fixes #4099

## Tests
- `npm run build:cli`
- `npm test -- --run test/cli.test.ts -t "debug --sandbox"`
- `npm run typecheck:cli`
- `git diff --check`
- `npm run lint -- --quiet` (passes; existing unrelated Biome warning in `src/lib/onboard/child-exit-tracker.test.ts`)

Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added sandbox existence verification: if a requested sandbox can't be found, diagnostics now exit with an error and do not produce output.
  * Improved handling of probe failures: when the sandbox probe itself fails, diagnostics report the probe error and stop without creating output.

* **Tests**
  * Added integration tests covering non-existent sandbox and sandbox-probe failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->