### PR TITLE
fix(policy): allow OpenClaw plugin npm registry access

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -39,11 +39,11 @@ The following endpoint groups are allowed by default:
 | --- | --- | --- | --- |
 | `nvidia` | `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443` | `/usr/local/bin/openclaw` | POST to inference and embedding paths, GET to model listings |
 | `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
-| `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
+| `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
 | `openclaw_docs` | `docs.openclaw.ai:443` | `/usr/local/bin/openclaw` | GET only |
-| `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw`, npm/Node helper binaries (openclaw plugins install) | L4 tunnel |
+| `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw`, npm/Node helper binaries (`openclaw plugins install`) | L4 tunnel |
 
-All endpoints use TLS termination and are enforced at port 443.
+REST endpoints use TLS termination and method/path enforcement at port 443. The `npm_registry` baseline uses L4 passthrough (`tls: skip`) for Node 22/undici compatibility and remains scoped to `registry.npmjs.org:443`.
 
 <Note>
 GitHub access (`github.com`, `api.github.com`) is not included in the baseline policy.

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -43,7 +43,8 @@ The following endpoint groups are allowed by default:
 | `openclaw_docs` | `docs.openclaw.ai:443` | `/usr/local/bin/openclaw` | GET only |
 | `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw`, npm/Node helper binaries (`openclaw plugins install`) | L4 tunnel |
 
-REST endpoints use TLS termination and method/path enforcement at port 443. The `npm_registry` baseline uses L4 passthrough (`tls: skip`) for Node 22/undici compatibility and remains scoped to `registry.npmjs.org:443`.
+REST endpoints use TLS termination and method/path enforcement at port 443.
+The `npm_registry` baseline uses L4 passthrough (`tls: skip`) for Node 22/undici compatibility and remains scoped to `registry.npmjs.org:443`.
 
 <Note>
 GitHub access (`github.com`, `api.github.com`) is not included in the baseline policy.

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -38,10 +38,10 @@ The following endpoint groups are allowed by default:
 | Policy | Endpoints | Binaries | Rules |
 | --- | --- | --- | --- |
 | `nvidia` | `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443` | `/usr/local/bin/openclaw` | POST to inference and embedding paths, GET to model listings |
-| `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
+| `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
 | `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
 | `openclaw_docs` | `docs.openclaw.ai:443` | `/usr/local/bin/openclaw` | GET only |
-| `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw` only (openclaw plugins install) | GET only |
+| `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw`, npm/Node helper binaries (openclaw plugins install) | L4 tunnel |
 
 All endpoints use TLS termination and are enforced at port 443.
 

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -134,6 +134,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   openclaw_api:
     name: openclaw_api
@@ -162,20 +163,24 @@ network_policies:
       - { path: /usr/local/bin/openclaw }
 
   # npm registry — needed for `openclaw plugins install` only.
-  # Restricted to the openclaw binary so agents cannot use npm directly.
-  # Users who need npm/node access should add the npm policy preset during onboard.
-  # Ref: https://github.com/NVIDIA/NemoClaw/issues/1458
+  # OpenClaw shells out through npm's Node entrypoint when installing external
+  # package plugins, so this baseline allows the helper binaries but only for
+  # read-only registry access. Users who need broader npm access should add
+  # the npm policy preset during onboard.
+  # Ref: https://github.com/NVIDIA/NemoClaw/issues/4104
   npm_registry:
     name: npm_registry
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
+        tls: skip
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/npm* }
+      - { path: /usr/local/bin/node* }
+      - { path: /usr/bin/npm* }
+      - { path: /usr/bin/node* }
 
   # Messaging endpoints (telegram, discord, slack) are intentionally NOT in
   # the baseline — #1705 removed them so every sandbox does not silently

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -149,6 +149,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   openclaw_docs:
     name: openclaw_docs
@@ -164,9 +165,10 @@ network_policies:
 
   # npm registry — needed for `openclaw plugins install` only.
   # OpenClaw shells out through npm's Node entrypoint when installing external
-  # package plugins, so this baseline allows the helper binaries but only for
-  # read-only registry access. Users who need broader npm access should add
-  # the npm policy preset during onboard.
+  # package plugins, so this baseline allows the helper binaries only to the
+  # registry host. L4 passthrough matches the npm preset because Node 22's
+  # undici stack does not work reliably through REST/TLS inspection. Users who
+  # need broader npm access should add the npm policy preset during onboard.
   # Ref: https://github.com/NVIDIA/NemoClaw/issues/4104
   npm_registry:
     name: npm_registry

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -350,6 +350,16 @@ describe("base sandbox policy", () => {
     ]);
   });
 
+  it("regression #4104: clawhub allows openclaw plugin install binaries", () => {
+    const np = policy.network_policies ?? {};
+    const binaries = (np.clawhub?.binaries ?? []).map((b) => b.path).sort();
+    expect(binaries).toEqual([
+      "/usr/bin/node",
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+    ]);
+  });
+
   it("does not reference the absent Claude CLI binary", () => {
     const serialized = JSON.stringify(policy.network_policies ?? {});
     expect(serialized).not.toContain("/usr/local/bin/claude");
@@ -409,17 +419,35 @@ describe("base sandbox policy", () => {
     expect(slackHosts).toEqual([]);
   });
 
-  it("regression #1458: baseline npm_registry must not include npm or node binaries", () => {
+  it("regression #4104: baseline npm_registry allows OpenClaw plugin install helper binaries", () => {
     const np = policy.network_policies ?? {};
     const npmRegistry = np.npm_registry;
     expect(npmRegistry).toBeDefined();
+    const endpoints = npmRegistry?.endpoints ?? [];
+    expect(endpoints).toEqual([
+      expect.objectContaining({
+        host: "registry.npmjs.org",
+        port: 443,
+        access: "full",
+        tls: "skip",
+      }),
+    ]);
+    expect(endpoints[0]).not.toHaveProperty("protocol");
+    expect(endpoints[0]).not.toHaveProperty("rules");
+
     const binaries = npmRegistry?.binaries;
     expect(Array.isArray(binaries)).toBe(true);
     const paths = (binaries ?? []).map((b) => b.path).sort();
-    // Only openclaw CLI should reach the npm registry by default.
-    // npm/node being in this list lets the agent bypass 'none' policy preset.
-    // Exact allowlist — adding any binary here requires a deliberate review.
-    expect(paths).toEqual(["/usr/local/bin/openclaw"]);
+    // `openclaw plugins install <package>` shells out through npm's Node
+    // entrypoint, so the default plugin-install path needs these helper
+    // binaries even when the broader npm preset is not selected.
+    expect(paths).toEqual([
+      "/usr/bin/node*",
+      "/usr/bin/npm*",
+      "/usr/local/bin/node*",
+      "/usr/local/bin/npm*",
+      "/usr/local/bin/openclaw",
+    ]);
   });
 });
 

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -360,6 +360,16 @@ describe("base sandbox policy", () => {
     ]);
   });
 
+  it("regression #4104: openclaw_api mirrors Node binary paths used by OpenClaw flows", () => {
+    const np = policy.network_policies ?? {};
+    const binaries = (np.openclaw_api?.binaries ?? []).map((b) => b.path).sort();
+    expect(binaries).toEqual([
+      "/usr/bin/node",
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+    ]);
+  });
+
   it("does not reference the absent Claude CLI binary", () => {
     const serialized = JSON.stringify(policy.network_policies ?? {});
     expect(serialized).not.toContain("/usr/local/bin/claude");
@@ -439,8 +449,8 @@ describe("base sandbox policy", () => {
     expect(Array.isArray(binaries)).toBe(true);
     const paths = (binaries ?? []).map((b) => b.path).sort();
     // `openclaw plugins install <package>` shells out through npm's Node
-    // entrypoint, so the default plugin-install path needs these helper
-    // binaries even when the broader npm preset is not selected.
+    // entrypoint. Keep this baseline L4 tunnel limited to the registry host;
+    // broader package-manager access still requires the opt-in npm preset.
     expect(paths).toEqual([
       "/usr/bin/node*",
       "/usr/bin/npm*",


### PR DESCRIPTION
## Summary
- allow the default npm registry policy to support OpenClaw plugin installs by permitting npm/Node helper binaries
- switch the baseline `registry.npmjs.org` entry to the same L4 tunnel shape used by the npm preset for Node 22/undici compatibility
- keep ClawHub/OpenClaw API compatible with both `/usr/local/bin/node` and `/usr/bin/node`, and update policy docs/tests

## Scope
- This PR fixes the default policy block from #4104.
- Follow-up diagnostic/error-message improvement is tracked separately in #4127 so this policy fix stays narrow.

## Verification
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4104-npm-cache npm run build:cli`
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4104-npm-cache npx vitest run test/policies.test.ts test/security-binaries-restriction.test.ts test/validate-blueprint.test.ts`
- Linux live repro on `aits-center`:
  - before: `openclaw plugins install @openclaw/microsoft-speech` failed with `registry.npmjs.org` `policy_denied`
  - after applying the fixed policy: scoped npm lookup reached the real registry response instead of `policy_denied`, and `openclaw plugins install` returned 0 using the bundled `microsoft` fallback
- Follow-up docs-only nit: `NPM_CONFIG_CACHE=/tmp/nemoclaw-4104-npm-cache npx vitest run test/validate-blueprint.test.ts`

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

Fixes #4104


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified network policy docs to describe npm registry access, port 443 enforcement, and TLS passthrough behavior.

* **Improvements**
  * Expanded registry access to support additional Node/npm helper binaries used during plugin installation.
  * Changed registry access model from REST GET-only to L4 passthrough with TLS skip for better Node.js compatibility.

* **Tests**
  * Added validation tests for sandbox policy binary allowlists and registry endpoint configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->