### PR TITLE
fix(messaging): open Discord DMs for configured guilds

### DIFF
--- a/scripts/generate-openclaw-config.py
+++ b/scripts/generate-openclaw-config.py
@@ -505,6 +505,7 @@ def build_config(env: dict | None = None) -> dict:
             env.get("NEMOCLAW_DISCORD_GUILDS_B64", "e30=") or "e30="
         ).decode("utf-8")
     )
+    _has_discord_guilds = any(str(guild_id).strip() for guild_id in _discord_guilds)
     _telegram_config = json.loads(
         base64.b64decode(
             env.get("NEMOCLAW_TELEGRAM_CONFIG_B64", "e30=") or "e30="
@@ -565,7 +566,10 @@ def build_config(env: dict | None = None) -> dict:
             account["proxy"] = proxy_url
         if ch == "telegram":
             account["groupPolicy"] = "open"
-        if ch in _allowed_ids and _allowed_ids[ch]:
+        if ch == "discord" and _has_discord_guilds and not _allowed_ids.get(ch):
+            account["dmPolicy"] = "open"
+            account["allowFrom"] = ["*"]
+        elif ch in _allowed_ids and _allowed_ids[ch]:
             account["dmPolicy"] = "allowlist"
             account["allowFrom"] = _allowed_ids[ch]
             if ch == "slack":
@@ -597,7 +601,7 @@ def build_config(env: dict | None = None) -> dict:
     # allowFrom.json — not the openclaw.json accounts.<id>.allowFrom mechanism
     # that telegram/discord/slack use.
 
-    if "discord" in _ch_cfg and _discord_guilds:
+    if "discord" in _ch_cfg and _has_discord_guilds:
         _ch_cfg["discord"].update(
             {"groupPolicy": "allowlist", "guilds": _discord_guilds}
         )

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -535,6 +535,12 @@ describe("generate-openclaw-config.py: config generation", () => {
       dmPolicy: "allowlist",
       allowFrom: allowedUsers,
     });
+    expect(config.channels.discord.groupPolicy).toBe("allowlist");
+    expect(config.channels.discord.guilds).toEqual({
+      "1491590992753590594": {
+        requireMention: true,
+      },
+    });
   });
 
   it("#3894: routes Discord gateway traffic through OpenClaw's managed proxy", () => {

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -471,6 +471,45 @@ describe("generate-openclaw-config.py: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
+  it("#4070: opens Discord DMs to configured guild members when the user allowlist is empty", () => {
+    const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
+    const discordGuilds = Buffer.from(
+      JSON.stringify({
+        "1491590992753590594": {
+          requireMention: true,
+        },
+      }),
+    ).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+      NEMOCLAW_DISCORD_GUILDS_B64: discordGuilds,
+    });
+
+    expect(config.channels.discord.accounts.default).toMatchObject({
+      dmPolicy: "open",
+      allowFrom: ["*"],
+    });
+  });
+
+  it("does not open Discord DMs when the guild config has no valid guild id", () => {
+    const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
+    const discordGuilds = Buffer.from(
+      JSON.stringify({
+        " ": {
+          requireMention: true,
+        },
+      }),
+    ).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+      NEMOCLAW_DISCORD_GUILDS_B64: discordGuilds,
+    });
+
+    expect(config.channels.discord.accounts.default.dmPolicy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.allowFrom).toBeUndefined();
+    expect(config.channels.discord.guilds).toBeUndefined();
+  });
+
   it("#3894: routes Discord gateway traffic through OpenClaw's managed proxy", () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const config = runConfigScript({

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -510,6 +510,33 @@ describe("generate-openclaw-config.py: config generation", () => {
     expect(config.channels.discord.guilds).toBeUndefined();
   });
 
+  it("keeps an explicit Discord user allowlist when guilds are configured", () => {
+    const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
+    const discordGuilds = Buffer.from(
+      JSON.stringify({
+        "1491590992753590594": {
+          requireMention: true,
+        },
+      }),
+    ).toString("base64");
+    const allowedUsers = ["1005536447329222676"];
+    const allowedIds = Buffer.from(
+      JSON.stringify({
+        discord: allowedUsers,
+      }),
+    ).toString("base64");
+    const config = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+      NEMOCLAW_DISCORD_GUILDS_B64: discordGuilds,
+      NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: allowedIds,
+    });
+
+    expect(config.channels.discord.accounts.default).toMatchObject({
+      dmPolicy: "allowlist",
+      allowFrom: allowedUsers,
+    });
+  });
+
   it("#3894: routes Discord gateway traffic through OpenClaw's managed proxy", () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const config = runConfigScript({


### PR DESCRIPTION
## Summary
- Fixes #4070
- When Discord has configured guild IDs but no explicit user allowlist, emit OpenClaw Discord `dmPolicy: "open"` with `allowFrom: ["*"]` so DMs do not fall back to pairing.
- Treat blank guild config keys as absent so invalid/empty guild config does not accidentally open DMs.

## Repro
- Added a regression test that failed on `origin/main`: the generated Discord account lacked `dmPolicy`/`allowFrom` and therefore kept OpenClaw's default pairing path.

## Verification
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-npm-cache-4070 npx vitest run test/generate-openclaw-config.test.ts --project cli`
- `python3 -m py_compile scripts/generate-openclaw-config.py`
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-npm-cache-4070 npm run typecheck:cli`
- `git diff --check`

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord DM policy defaults to open (dmPolicy: open, allowFrom: ["*"]) when guilds are configured but no Discord user allowlist exists.

* **Bug Fixes**
  * Empty or whitespace-only Discord guild entries are ignored when generating configuration, preventing invalid guild blocks.

* **Tests**
  * Added tests for Discord DM allowlist behaviors and guild-handling scenarios (open DM policy, omitted guilds, and allowlist-enabled cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->