### PR TITLE
test(ci): stabilize WSL platform vitest fixtures

### DIFF
--- a/src/lib/sandbox-base-image.test.ts
+++ b/src/lib/sandbox-base-image.test.ts
@@ -17,11 +17,11 @@ import {
 } from "../../dist/lib/sandbox-base-image";
 
 const tmpRoots: string[] = [];
-const emptyGitConfig = path.join(
-  os.tmpdir(),
-  `nemoclaw-empty-gitconfig-${process.pid}-${Date.now()}`,
-);
-fs.writeFileSync(emptyGitConfig, "");
+const emptyGitConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-empty-gitconfig-"));
+tmpRoots.push(emptyGitConfigDir);
+const emptyGitConfig = path.join(emptyGitConfigDir, "gitconfig");
+const emptyGitConfigFd = fs.openSync(emptyGitConfig, "wx", 0o600);
+fs.closeSync(emptyGitConfigFd);
 
 const gitEnv = {
   ...process.env,

--- a/src/lib/sandbox-base-image.test.ts
+++ b/src/lib/sandbox-base-image.test.ts
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
 import {
   baseImageInputsChangedSinceMain,
@@ -17,9 +17,15 @@ import {
 } from "../../dist/lib/sandbox-base-image";
 
 const tmpRoots: string[] = [];
+const emptyGitConfig = path.join(
+  os.tmpdir(),
+  `nemoclaw-empty-gitconfig-${process.pid}-${Date.now()}`,
+);
+fs.writeFileSync(emptyGitConfig, "");
+
 const gitEnv = {
   ...process.env,
-  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_GLOBAL: emptyGitConfig,
   GIT_CONFIG_NOSYSTEM: "1",
   GIT_TERMINAL_PROMPT: "0",
   GIT_AUTHOR_NAME: "Test User",
@@ -79,6 +85,10 @@ afterEach(() => {
   for (const root of tmpRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+afterAll(() => {
+  fs.rmSync(emptyGitConfig, { force: true });
 });
 
 describe("sandbox base image helpers", () => {

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -5801,6 +5801,7 @@ runner.runShell = (command, opts = {}) => {
 registry.updateSandbox = (_name, update) => updates.push(update);
 
 Object.defineProperty(process, "platform", { value: "linux" });
+Object.defineProperty(process, "getuid", { value: () => 1000 });
 platform.isWsl = () => false;
 
 const { setupNim } = require(${onboardPath});


### PR DESCRIPTION
## Summary
Stabilizes the WSL platform Vitest job by removing two Linux/WSL test-fixture assumptions that caused repeated main failures. The git fixture now uses a real empty global config file instead of `/dev/null`, and the user-local Ollama onboarding test explicitly simulates a non-root Linux user.

## Changes
- Replace `GIT_CONFIG_GLOBAL=/dev/null` in `src/lib/sandbox-base-image.test.ts` with a real empty temporary config file that is removed after the suite.
- Stub `process.getuid()` in the user-local Ollama install onboarding fixture so the test exercises the intended non-root/no-passwordless-sudo path even when WSL CI runs as root.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Ensured temporary global git config files are removed after the test run to improve cleanup.
  * Adjusted test environment to simulate a non-root user for the Ollama installation fallback scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->