### PR TITLE
test(ci): keep WSL gitconfig fixture suite scoped

### DIFF
--- a/src/lib/sandbox-base-image.test.ts
+++ b/src/lib/sandbox-base-image.test.ts
@@ -18,7 +18,6 @@ import {
 
 const tmpRoots: string[] = [];
 const emptyGitConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-empty-gitconfig-"));
-tmpRoots.push(emptyGitConfigDir);
 const emptyGitConfig = path.join(emptyGitConfigDir, "gitconfig");
 const emptyGitConfigFd = fs.openSync(emptyGitConfig, "wx", 0o600);
 fs.closeSync(emptyGitConfigFd);
@@ -88,7 +87,7 @@ afterEach(() => {
 });
 
 afterAll(() => {
-  fs.rmSync(emptyGitConfig, { force: true });
+  fs.rmSync(emptyGitConfigDir, { recursive: true, force: true });
 });
 
 describe("sandbox base image helpers", () => {


### PR DESCRIPTION
## Summary
Follow-up to PR #4137 review feedback: keep the temporary git config fixture alive for the full `sandbox-base-image` test suite. This prevents per-test cleanup from deleting the suite-wide `GIT_CONFIG_GLOBAL` file after the first test.

## Changes
- Stop registering the suite-wide temporary git config directory in the per-test `tmpRoots` cleanup list.
- Remove the full temporary git config directory in `afterAll` once the suite is finished.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup logic for sandbox base image tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->