### PR TITLE
fix(e2e): pass --no-verify to inference set in switch E2E tests

### DIFF
--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -469,7 +469,7 @@ pid_before="$(hermes_gateway_pid)"
 ENV_HASH_BEFORE=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sha256sum /sandbox/.hermes/.env 2>/dev/null | awk '{print $1}') || true
 
 info "Switching Hermes to ${SWITCH_PROVIDER} / ${SWITCH_MODEL} with nemohermes inference set..."
-switch_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" 2>&1)
+switch_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --no-verify 2>&1)
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemohermes inference set completed without --sandbox"

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -391,7 +391,7 @@ pass "nemoclaw and openshell are on PATH"
 section "Phase 3: Switch inference"
 pid_before="$(openclaw_gateway_pid)"
 info "Switching ${SANDBOX_NAME} to ${SWITCH_PROVIDER} / ${SWITCH_MODEL}..."
-switch_output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" 2>&1)
+switch_output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" --no-verify 2>&1)
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemoclaw inference set completed"


### PR DESCRIPTION
## Summary

The `hermes-inference-switch-e2e` and `openclaw-inference-switch-e2e` nightly jobs fail because the `nemohermes inference set` / `nemoclaw inference set` verification request to the `nvidia-prod` endpoint for model `z-ai/glm-5.1` times out at `https://integrate.api.nvidia.com/v1/chat/completions`. These E2E tests validate the inference switch mechanism (route, config patching, hashes, live requests via `inference.local`), not external model endpoint availability. Adding `--no-verify` skips the remote health check that is orthogonal to the test surface.

## Related Issue

Fixes #4145

## Changes

- `test/e2e/test-hermes-inference-switch.sh`: add `--no-verify` to `nemohermes inference set` call
- `test/e2e/test-openclaw-inference-switch.sh`: add `--no-verify` to `nemoclaw inference set` call

## Validation

The `--no-verify` flag is a first-class CLI option (see `src/lib/actions/inference-set.ts:309`, `src/lib/cli/public-display-defaults.ts:74`). It is already used throughout the onboard flow (`src/lib/onboard.ts:5550, 5637, 5714, 5796, 5840`) and in sandbox connect (`src/lib/actions/sandbox/connect.ts:277`). The E2E tests continue to validate the full switch path — route assertion, config.yaml patching, config hash integrity, Hermes gateway PID stability, `.env` immutability, and live inference through `inference.local` — the only step removed is the upfront remote endpoint probe.

- Original failing run: [26347272005](https://github.com/NVIDIA/NemoClaw/actions/runs/26347272005) on `42ac98dc84b9493cb50dcb3edd0f7c0f8d1831c5`
- Targeted jobs: `hermes-inference-switch-e2e (#77559129270)`, `openclaw-inference-switch-e2e (#77559129278)`

> **Note:** A custom-e2e validation run could not be created because the CI token lacks `workflows` scope for pushing workflow files. The fix is mechanical (adding a documented flag) and does not alter test assertions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>