### PR TITLE
fix(e2e): pre-release dashboard port forward before rebuild in channels-stop-start

### DIFF
--- a/test/e2e/test-channels-stop-start.sh
+++ b/test/e2e/test-channels-stop-start.sh
@@ -510,6 +510,13 @@ run_rebuild() {
   local phase="$1"
   local log="/tmp/nc-channels-${ACTIVE_AGENT}-rebuild-${phase}.log"
   local msg
+  # Pre-release the dashboard port forward before rebuild to avoid a race where
+  # the rebuild's ensureDashboardForward finds the old forward still host-bound,
+  # rolls back the newly-created sandbox, and fails with "Dashboard port became
+  # host-bound during sandbox build".  Other E2E tests (test-rebuild-hermes.sh)
+  # already follow this pattern.
+  openshell forward stop "$ACTIVE_SANDBOX" 2>/dev/null || true
+  sleep 1
   info "Rebuilding ${ACTIVE_SANDBOX} for ${phase}..."
   if nemoclaw "$ACTIVE_SANDBOX" rebuild --yes >"$log" 2>&1; then
     msg="${ACTIVE_AGENT}: rebuild completed after ${phase}"


### PR DESCRIPTION
## Summary

The `channels-stop-start-e2e` nightly job fails during the Hermes rebuild after "channels stop all" because the old sandbox's dashboard port forward on port 8642 is still host-bound when `ensureDashboardForward` runs. Since the sandbox was already created with `CHAT_UI_URL=8642` baked in, the code cannot reallocate to a fallback port and rolls back the newly-created sandbox.

This adds a pre-release of the dashboard port forward before calling `nemoclaw rebuild --yes`, following the same pattern already used by `test-rebuild-hermes.sh` (line 149).

## Related Issue

Fixes #4146

## Changes

- `test/e2e/test-channels-stop-start.sh`: add `openshell forward stop` + brief sleep before every `nemoclaw rebuild` invocation in `run_rebuild()` to prevent the dashboard port race condition

## Validation

The pattern `openshell forward stop <port|sandbox> >/dev/null 2>&1 || true` is well-established across the E2E suite:
- `test/e2e/test-rebuild-hermes.sh:149` — stops port 8642 before rebuild
- `test/e2e/test-sandbox-survival.sh:152,498` — stops port 18789 before operations
- `test/e2e/test-onboard-repair.sh:120,216,368` — same pattern

- Original failing run: [26347272005](https://github.com/NVIDIA/NemoClaw/actions/runs/26347272005) on `42ac98dc84b9493cb50dcb3edd0f7c0f8d1831c5`
- Targeted job: `channels-stop-start-e2e (#77559129186)` — 169/170 checks passed, only the Hermes stop-all rebuild failed

> **Note:** A custom-e2e validation run could not be created because the CI token lacks `workflows` scope for pushing workflow files. The fix mirrors existing patterns in the E2E suite.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>