### PR TITLE
fix(debug): validate explicit --sandbox is in the registry (#4099)

### DIFF
--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -7,7 +7,10 @@ import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
 import { CLI_NAME } from "../lib/cli/branding";
 import { runDebug } from "../lib/diagnostics/debug";
 import type { DebugOptions } from "../lib/diagnostics/debug";
-import type { RunDebugCommandDeps } from "../lib/diagnostics/debug-command";
+import type {
+  ExplicitSandboxValidation,
+  RunDebugCommandDeps,
+} from "../lib/diagnostics/debug-command";
 import { runDebugCommandWithOptions } from "../lib/diagnostics/debug-command";
 import type { CaptureOpenshellResult } from "../lib/adapters/openshell/client";
 import { captureOpenshellCommand } from "../lib/adapters/openshell/client";
@@ -59,8 +62,23 @@ function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return defaultSandbox;
   };
 
+  const validateExplicitSandbox = (name: string): ExplicitSandboxValidation => {
+    const { sandboxes } = registry.listSandboxes();
+    if (!sandboxes.find((sandbox) => sandbox.name === name)) {
+      return {
+        ok: false,
+        message:
+          `${RD}Error:${R} sandbox '${name}' is not in the local registry.\n` +
+          `  Use ${B}${CLI_NAME} sandbox list${R} to see available sandboxes, ` +
+          `or run ${B}${CLI_NAME} onboard${R} to create one.`,
+      };
+    }
+    return { ok: true };
+  };
+
   return {
     getDefaultSandbox,
+    validateExplicitSandbox,
     runDebug,
   };
 }

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -21,4 +21,62 @@ describe("debug command", () => {
       sandboxName: "alpha",
     });
   });
+
+  it("calls runDebug when explicit --sandbox passes validation", () => {
+    const runDebug = vi.fn();
+    const validateExplicitSandbox = vi.fn(() => ({ ok: true as const }));
+    runDebugCommandWithOptions(
+      { sandboxName: "alpha" },
+      {
+        getDefaultSandbox: () => undefined,
+        validateExplicitSandbox,
+        runDebug,
+      },
+    );
+    expect(validateExplicitSandbox).toHaveBeenCalledWith("alpha");
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
+  });
+
+  it("fails when explicit --sandbox is not in the registry and does not call runDebug", () => {
+    const runDebug = vi.fn();
+    const fail = vi.fn((_msg: string, _code?: number) => {
+      throw new Error("fail-called");
+    }) as unknown as (message: string, exitCode?: number) => never;
+    const validateExplicitSandbox = vi.fn(() => ({
+      ok: false as const,
+      message: "Error: sandbox 'does-not-exist' is not in the local registry.",
+    }));
+    expect(() =>
+      runDebugCommandWithOptions(
+        { sandboxName: "does-not-exist", output: "/tmp/x.tgz" },
+        {
+          getDefaultSandbox: () => undefined,
+          validateExplicitSandbox,
+          runDebug,
+          fail,
+        },
+      ),
+    ).toThrow("fail-called");
+    expect(validateExplicitSandbox).toHaveBeenCalledWith("does-not-exist");
+    expect(fail).toHaveBeenCalledWith(
+      expect.stringContaining("is not in the local registry"),
+      1,
+    );
+    expect(runDebug).not.toHaveBeenCalled();
+  });
+
+  it("does not call validateExplicitSandbox when --sandbox is absent", () => {
+    const runDebug = vi.fn();
+    const validateExplicitSandbox = vi.fn();
+    runDebugCommandWithOptions(
+      { quick: true },
+      {
+        getDefaultSandbox: () => "alpha",
+        validateExplicitSandbox,
+        runDebug,
+      },
+    );
+    expect(validateExplicitSandbox).not.toHaveBeenCalled();
+    expect(runDebug).toHaveBeenCalledWith({ quick: true, sandboxName: "alpha" });
+  });
 });

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -3,14 +3,33 @@
 
 import type { DebugOptions } from "./debug";
 
+export type ExplicitSandboxValidation = { ok: true } | { ok: false; message: string };
+
 export interface RunDebugCommandDeps {
   getDefaultSandbox: () => string | undefined;
+  validateExplicitSandbox?: (name: string) => ExplicitSandboxValidation;
   runDebug: (options: DebugOptions) => void;
+  fail?: (message: string, exitCode?: number) => never;
+}
+
+function defaultFail(message: string, exitCode = 1): never {
+  console.error(message);
+  process.exit(exitCode);
 }
 
 export function runDebugCommandWithOptions(options: DebugOptions, deps: RunDebugCommandDeps): void {
   const opts = { ...options };
-  if (!opts.sandboxName) {
+  if (opts.sandboxName) {
+    const validate = deps.validateExplicitSandbox;
+    if (validate) {
+      const result = validate(opts.sandboxName);
+      if (!result.ok) {
+        const fail = deps.fail ?? defaultFail;
+        fail(result.message, 1);
+        return;
+      }
+    }
+  } else {
     opts.sandboxName = deps.getDefaultSandbox();
   }
   deps.runDebug(opts);


### PR DESCRIPTION
## Summary

`nemoclaw debug --sandbox NAME` now validates that `NAME` exists in the local
registry before collecting diagnostics. Unknown sandboxes exit non-zero with a
clear error and produce no tarball, matching the expected UX in #4099.

## Problem

Before this change, `nemoclaw debug --sandbox does-not-exist --output X` exited
0 and wrote a partial tarball, masking the unknown-sandbox condition reported
by NV QA in #4099. The unknown-sandbox warning was only emitted when the
*default* sandbox was missing (via `getDefaultSandbox` in `src/commands/debug.ts`);
the explicit `--sandbox` path went straight to `runDebug`.

The fix adds `validateExplicitSandbox` to `RunDebugCommandDeps`. When `--sandbox`
is explicit, the dispatcher runs the validator first; on validation failure it
prints a clear error to stderr and exits non-zero via an injectable `fail` dep
(defaults to `console.error` + `process.exit`). The default-sandbox path is
unchanged so existing behavior on `nemoclaw debug` with no flag still applies.

## Test plan

- [x] New unit tests in `src/lib/diagnostics/debug-command.test.ts` cover all four
      branches: default fallback, explicit sandbox passes validation, explicit
      sandbox fails validation, no `--sandbox` flag bypasses the validator.
- [x] `npx vitest run src/lib/diagnostics/` -> 18/18 pass.
- [x] `npx vitest run src/commands/global-oclif-command-adapters.test.ts` -> 8/8 pass.
- [x] Reproduced and verified in nemoclaw-test container against current `upstream/main`:

  Before:
  ```
  $ nemoclaw debug --sandbox does-not-exist --output /tmp/bad.tar.gz
  ... debug output ...
  $ echo $?
  0
  $ ls -la /tmp/bad.tar.gz
  -rw-r--r-- 1 root root 3332 May 24 04:12 /tmp/bad.tar.gz
  ```

  After:
  ```
  $ node ./bin/nemoclaw.js debug --sandbox does-not-exist --output /tmp/bad.tar.gz
  Error: sandbox 'does-not-exist' is not in the local registry.
    Use nemoclaw sandbox list to see available sandboxes, or run nemoclaw onboard to create one.
  $ echo $?
  1
  $ ls -la /tmp/bad.tar.gz
  ls: cannot access '/tmp/bad.tar.gz': No such file or directory
  ```

- [x] Smoke checked `nemoclaw debug --quick` (no `--sandbox`) still completes
      normally with exit 0.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug command now validates explicit sandbox names against the local registry and provides helpful error messages with guidance for unavailable sandboxes.

* **Tests**
  * Added test coverage for sandbox name validation scenarios, including successful validation, validation failures, and default sandbox fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->