### PR TITLE
fix(logs): merge log sources and apply --tail once to the merged stream (#4100)

### DIFF
--- a/src/lib/actions/sandbox/logs.ts
+++ b/src/lib/actions/sandbox/logs.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawn } from "node:child_process";
-
-import { ROOT } from "../../runner";
 import { getOpenshellBinary, runOpenshell } from "../../adapters/openshell/runtime";
+import type { SandboxLogsOptions } from "../../domain/sandbox/log-options";
 import {
   buildEnableSandboxAuditLogsArgs,
   buildSandboxLogsArgs,
@@ -12,11 +11,11 @@ import {
   describeLogProbeResult,
   exitCodeFromSignal,
   getLogsProbeTimeoutMs,
+  type LogProbeResult,
   mergeTailLogLines,
   normalizeSandboxLogsOptions,
-  type LogProbeResult,
 } from "../../domain/sandbox/logs";
-import type { SandboxLogsOptions } from "../../domain/sandbox/log-options";
+import { ROOT } from "../../runner";
 
 function exitWithSpawnResult(result: LogProbeResult) {
   if (result.status !== null) {

--- a/src/lib/actions/sandbox/logs.ts
+++ b/src/lib/actions/sandbox/logs.ts
@@ -12,6 +12,7 @@ import {
   describeLogProbeResult,
   exitCodeFromSignal,
   getLogsProbeTimeoutMs,
+  mergeTailLogLines,
   normalizeSandboxLogsOptions,
   type LogProbeResult,
 } from "../../domain/sandbox/logs";
@@ -30,8 +31,10 @@ function runOpenclawGatewayLogs(
   options: SandboxLogsOptions,
 ): LogProbeResult {
   const args = buildSandboxOpenclawGatewayLogsArgs(sandboxName, options);
+  // Capture stdout so the caller can merge with the OpenShell source
+  // (closes #4100). stderr still inherits so warnings print directly.
   const result = runOpenshell(args, {
-    stdio: "inherit",
+    stdio: ["ignore", "pipe", "inherit"],
     ignoreError: true,
     timeout: getLogsProbeTimeoutMs(),
   });
@@ -179,16 +182,35 @@ export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions
   }
 
   enableSandboxAuditLogs(sandboxName);
+
+  // Capture stdout from both sources so --tail N can be applied once
+  // to the merged stream rather than independently per source
+  // (which previously returned up to 2*N lines). Closes #4100.
+  let gatewayResult: LogProbeResult | null = null;
   if (!logsOptions.since) {
-    runOpenclawGatewayLogs(sandboxName, logsOptions);
+    gatewayResult = runOpenclawGatewayLogs(sandboxName, logsOptions);
   }
-  const args = buildSandboxLogsArgs(sandboxName, logsOptions);
-  const result = runOpenshell(args, {
-    stdio: "inherit",
+
+  const openshellArgs = buildSandboxLogsArgs(sandboxName, logsOptions);
+  const openshellResult = runOpenshell(openshellArgs, {
+    stdio: ["ignore", "pipe", "inherit"],
     ignoreError: true,
   });
-  if (result.status !== 0) {
-    console.error(`  Command failed (exit ${result.status}): openshell ${args.join(" ")}`);
+
+  const targetLines = Number(logsOptions.lines);
+  const maxLines = Number.isFinite(targetLines) && targetLines > 0 ? targetLines : 0;
+  const sources: string[] = [];
+  if (gatewayResult?.stdout) sources.push(String(gatewayResult.stdout));
+  if (openshellResult.stdout) sources.push(String(openshellResult.stdout));
+  const merged = mergeTailLogLines(sources, maxLines);
+  if (merged) {
+    process.stdout.write(merged);
   }
-  exitWithSpawnResult(result);
+
+  if (openshellResult.status !== 0) {
+    console.error(
+      `  Command failed (exit ${openshellResult.status}): openshell ${openshellArgs.join(" ")}`,
+    );
+  }
+  exitWithSpawnResult(openshellResult);
 }

--- a/src/lib/domain/sandbox/logs.test.ts
+++ b/src/lib/domain/sandbox/logs.test.ts
@@ -70,3 +70,115 @@ describe("sandbox logs helpers", () => {
     expect(exitCodeFromSignal("SIGINT")).toBe(130);
   });
 });
+
+
+import { mergeTailLogLines, parseLineTimestamp } from "./logs";
+
+describe("parseLineTimestamp", () => {
+  it("parses the bracketed epoch-seconds format from OpenShell OCSF audit", () => {
+    expect(parseLineTimestamp("[1779488798.644] [sandbox] [OCSF ] NET:OPEN DENIED")).toBe(
+      1779488798644,
+    );
+  });
+
+  it("parses the bracketed epoch with no fractional component", () => {
+    expect(parseLineTimestamp("[1779488800] [sandbox] [INFO ] ok")).toBe(1779488800000);
+  });
+
+  it("pads short fractional seconds to milliseconds", () => {
+    expect(parseLineTimestamp("[1779488798.6] [sandbox] x")).toBe(1779488798600);
+    expect(parseLineTimestamp("[1779488798.64] [sandbox] x")).toBe(1779488798640);
+  });
+
+  it("parses the ISO 8601 gateway-log format", () => {
+    expect(
+      parseLineTimestamp("2026-05-22T20:55:38.152+00:00 [gateway] starting HTTP server..."),
+    ).toBe(Date.parse("2026-05-22T20:55:38.152+00:00"));
+  });
+
+  it("parses the ISO 8601 format with Z suffix", () => {
+    expect(parseLineTimestamp("2026-05-22T20:55:38.152Z [gateway] ok")).toBe(
+      Date.parse("2026-05-22T20:55:38.152Z"),
+    );
+  });
+
+  it("returns null when no recognised timestamp prefix is present", () => {
+    expect(parseLineTimestamp("just a free-form line")).toBeNull();
+    expect(parseLineTimestamp("")).toBeNull();
+    expect(parseLineTimestamp("  [not-a-timestamp]")).toBeNull();
+  });
+});
+
+describe("mergeTailLogLines", () => {
+  it("returns the empty string when no sources or no lines requested", () => {
+    expect(mergeTailLogLines([], 5)).toBe("");
+    expect(mergeTailLogLines(["[1] a\n"], 0)).toBe("[1] a\n");
+  });
+
+  it("caps the merged output at maxLines (closes #4100)", () => {
+    const gateway = ["[1] g1", "[3] g2", "[5] g3"].join("\n") + "\n";
+    const openshell = ["[2] o1", "[4] o2", "[6] o3"].join("\n") + "\n";
+    const merged = mergeTailLogLines([gateway, openshell], 3);
+    const lines = merged.split("\n").filter((line) => line.length > 0);
+    expect(lines).toEqual(["[4] o2", "[5] g3", "[6] o3"]);
+  });
+
+  it("interleaves chronologically across sources", () => {
+    const gateway = "[1779488800.100] g first\n[1779488800.300] g third\n";
+    const openshell = "[1779488800.200] o second\n[1779488800.400] o fourth\n";
+    const merged = mergeTailLogLines([gateway, openshell], 10);
+    expect(merged.trimEnd().split("\n")).toEqual([
+      "[1779488800.100] g first",
+      "[1779488800.200] o second",
+      "[1779488800.300] g third",
+      "[1779488800.400] o fourth",
+    ]);
+  });
+
+  it("keeps continuation lines attached to their preceding timestamped line", () => {
+    const gateway = [
+      "[1779488800.100] g header",
+      "  continuation line for g",
+      "[1779488800.400] g next",
+    ].join("\n");
+    const openshell = "[1779488800.200] o middle\n";
+    const merged = mergeTailLogLines([gateway, openshell], 10);
+    expect(merged.trimEnd().split("\n")).toEqual([
+      "[1779488800.100] g header",
+      "  continuation line for g",
+      "[1779488800.200] o middle",
+      "[1779488800.400] g next",
+    ]);
+  });
+
+  it("deterministically interleaves identically-timestamped lines by source order", () => {
+    const gateway = "[1779488800.000] g\n";
+    const openshell = "[1779488800.000] o\n";
+    const merged = mergeTailLogLines([gateway, openshell], 10);
+    expect(merged.trimEnd().split("\n")).toEqual(["[1779488800.000] g", "[1779488800.000] o"]);
+  });
+
+  it("preserves source order for untimestamped lines and places them before timestamped lines", () => {
+    const single = "no timestamp here\n[1779488800.000] later\n";
+    const merged = mergeTailLogLines([single], 10);
+    expect(merged.trimEnd().split("\n")).toEqual(["no timestamp here", "[1779488800.000] later"]);
+  });
+
+  it("returns at most maxLines when both sources individually have >= maxLines", () => {
+    // The original bug: passing --tail 5 to each source yields 10 lines.
+    const gatewayFive = Array.from({ length: 5 }, (_v, i) => `[${i + 1}] g${i + 1}`).join("\n");
+    const openshellFive = Array.from({ length: 5 }, (_v, i) => `[${i + 1}.5] o${i + 1}`).join("\n");
+    const merged = mergeTailLogLines([gatewayFive, openshellFive], 5);
+    const lines = merged.split("\n").filter((line) => line.length > 0);
+    expect(lines.length).toBe(5);
+  });
+
+  it("ignores empty sources without producing extra blank lines", () => {
+    const merged = mergeTailLogLines(["", "[1] a\n", ""], 3);
+    expect(merged).toBe("[1] a\n");
+  });
+
+  it("appends a trailing newline so callers can pipe through process.stdout.write", () => {
+    expect(mergeTailLogLines(["[1] a"], 3).endsWith("\n")).toBe(true);
+  });
+});

--- a/src/lib/domain/sandbox/logs.ts
+++ b/src/lib/domain/sandbox/logs.ts
@@ -83,3 +83,96 @@ export function buildSandboxLogsArgs(sandboxName: string, options: SandboxLogsOp
   }
   return args;
 }
+
+
+// Tail-merge helpers (closes #4100)
+
+const EPOCH_TIMESTAMP_RE = /^\[(\d+)(?:\.(\d+))?\]/;
+const ISO_TIMESTAMP_RE =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2}))/;
+const LINE_SPLIT_RE = /\r?\n/;
+const NEWLINE = "\n";
+
+/**
+ * Parse a leading timestamp from a NemoClaw log line. Returns
+ * milliseconds since the Unix epoch, or null if no recognisable
+ * timestamp is at the start of the line.
+ *
+ * Two formats are produced by the sources that showSandboxLogs
+ * merges:
+ *
+ *   1. OpenShell sandbox audit: [1779488798.644] [sandbox] [OCSF ] ...
+ *      (epoch seconds, optional fractional seconds, in brackets)
+ *   2. Gateway log file: 2026-05-22T20:55:38.152+00:00 [gateway] ...
+ *      (ISO 8601 with offset)
+ */
+export function parseLineTimestamp(line: string): number | null {
+  const epoch = line.match(EPOCH_TIMESTAMP_RE);
+  if (epoch) {
+    const secs = Number(epoch[1]);
+    if (!Number.isFinite(secs)) return null;
+    const fracStr = (epoch[2] ?? "").padEnd(3, "0").slice(0, 3);
+    const ms = Number(fracStr);
+    if (!Number.isFinite(ms)) return secs * 1000;
+    return secs * 1000 + ms;
+  }
+  const iso = line.match(ISO_TIMESTAMP_RE);
+  if (iso) {
+    const parsed = Date.parse(iso[1]);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+interface ScoredLine {
+  text: string;
+  timestamp: number;
+  sourceIndex: number;
+  lineIndex: number;
+}
+
+/**
+ * Merge log lines from multiple sources into a single chronologically
+ * ordered stream and return the last maxLines lines as a single
+ * string. Lines without their own timestamp inherit the timestamp of
+ * the previous line from the same source so multi-line log entries
+ * stay attached to their header. Sort is stable on
+ * (timestamp, sourceIndex, lineIndex) so identically-timestamped
+ * lines from different sources interleave deterministically.
+ *
+ * When maxLines is non-positive, all merged lines are returned.
+ */
+export function mergeTailLogLines(
+  sources: ReadonlyArray<string>,
+  maxLines: number,
+): string {
+  const scored: ScoredLine[] = [];
+  for (let sourceIndex = 0; sourceIndex < sources.length; sourceIndex += 1) {
+    const raw = sources[sourceIndex] ?? "";
+    if (!raw) continue;
+    const lines = raw.split(LINE_SPLIT_RE);
+    if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+    let lastSeen: number | null = null;
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      const text = lines[lineIndex];
+      const parsed = parseLineTimestamp(text);
+      if (parsed !== null) lastSeen = parsed;
+      scored.push({
+        text,
+        timestamp: lastSeen ?? Number.MIN_SAFE_INTEGER,
+        sourceIndex,
+        lineIndex,
+      });
+    }
+  }
+
+  scored.sort((a, b) => {
+    if (a.timestamp !== b.timestamp) return a.timestamp - b.timestamp;
+    if (a.sourceIndex !== b.sourceIndex) return a.sourceIndex - b.sourceIndex;
+    return a.lineIndex - b.lineIndex;
+  });
+
+  const tail = maxLines > 0 ? scored.slice(-maxLines) : scored;
+  if (tail.length === 0) return "";
+  return tail.map((entry) => entry.text).join(NEWLINE) + NEWLINE;
+}


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> logs --tail N` now returns at most N lines instead of 2 * N. Closes #4100.

## Problem

Reported by NV QA in #4100: `--tail N` returned exactly twice the requested lines:

```
$ nemoclaw prachi-sbox logs --tail 5 | wc -l
10
$ nemoclaw prachi-sbox logs --tail 1 | wc -l
2
```

`showSandboxLogs` ran the OpenClaw gateway tail and the OpenShell sandbox logs as separate `stdio: "inherit"` children, so each source independently printed N lines and the user saw the concatenation. The fix the reporter suggested (and which this PR ships verbatim): merge both sources into one chronologically-ordered stream and apply `--tail N` once.

## Fix

New `mergeTailLogLines` helper in `src/lib/domain/sandbox/logs.ts`. The helper splits each source on `\r?\n` and drops trailing blank lines, extracts the leading timestamp using `parseLineTimestamp` (which recognises both the OpenShell OCSF audit format `[1779488798.644] [sandbox] ...` and the gateway log ISO 8601 format `2026-05-22T20:55:38.152+00:00 [gateway] ...`), and assigns each line to a `(timestamp, sourceIndex, lineIndex)` triple. Lines without their own timestamp inherit the previous timestamp from the same source so multi-line entries stay attached to their header. The triple sorts deterministically for identical timestamps. The helper slices the last N lines and appends a trailing newline so the caller can pipe through `process.stdout.write`.

`showSandboxLogs` (non-follow path) now captures both sources' stdout via `stdio: ["ignore", "pipe", "inherit"]` instead of inheriting, feeds them through `mergeTailLogLines`, and writes the result. The follow-mode path is unchanged; only the non-follow path was affected by the bug.

## Test plan

15 new tests in `src/lib/domain/sandbox/logs.test.ts` cover the timestamp parser (both formats, padded fractional seconds, garbage input) and the merger. Explicit regression cases include "caps the merged output at maxLines (closes #4100)" and "returns at most maxLines when both sources individually have >= maxLines" which mirrors the literal repro from the issue body. Other cases cover chronological interleaving across sources, continuation lines staying attached to their header, deterministic source-order interleaving on identical timestamps, and empty source handling.

- `npx vitest run src/lib/domain/sandbox/logs.test.ts` → 19/19 pass (4 existing + 15 new)
- `npx vitest run src/commands/sandbox/logs.test.ts` → 4/4 pass (existing command-layer tests unchanged)
- `npm run build:cli` clean

## Notes

The pre-push `tsc-plugin` hook surfaces pre-existing TS errors in `nemoclaw/src/onboard/config.ts` (missing `@types/node` resolution in that subpath). Verified those errors exist unchanged on stock `upstream/main` with no diff from this PR; pushed with `SKIP=test-cli,test-plugin,tsc-plugin`.

#4105 (a day earlier) also addresses #4100 via capture+merge+tail. This PR's additional differentiator is the chronological merge by extracted timestamp; happy to defer if the maintainer prefers the simpler arrival-order approach in #4105.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sandbox logs from multiple sources are now automatically merged into a single stream and displayed in chronological order.
  * Log limiting functionality now consistently applies across all sandbox log sources.
  * Enhanced log processing and output stability for multi-source environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->