### PR TITLE
test(e2e): retry inference switch verification

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -74,6 +74,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # gosu for privilege separation (gateway vs sandbox user).
 # Install from GitHub release with checksum verification instead of
 # Debian's packaged gosu can lag upstream. Pinned to 1.19 (2025-09).
+# Binary release asset downloads can be slower than hash fetches; keep
+# longer bounded transfer timeouts while preserving checksum verification.
 # hadolint ignore=DL4006
 RUN arch="$(dpkg --print-architecture)" \
     && case "$arch" in \
@@ -81,7 +83,8 @@ RUN arch="$(dpkg --print-architecture)" \
         arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
         *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
     esac \
-    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
+    && curl --proto '=https' --tlsv1.2 -fsSL \
+        --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
         -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
     && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
     && chmod +x /usr/local/bin/gosu \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -81,7 +81,8 @@ RUN arch="$(dpkg --print-architecture)" \
         arm64) gosu_asset="gosu-arm64"; gosu_sha256="3a8ef022d82c0bc4a98bcb144e77da714c25fcfa64dccc57f6aba7ae47ff1a44" ;; \
         *) echo "Unsupported architecture for gosu: $arch" >&2; exit 1 ;; \
     esac \
-    && curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 120 \
+        -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.19/${gosu_asset}" \
     && echo "${gosu_sha256}  /usr/local/bin/gosu" | sha256sum -c - \
     && chmod +x /usr/local/bin/gosu \
     && gosu --version

--- a/test/e2e/lib/inference-switch-retry.sh
+++ b/test/e2e/lib/inference-switch-retry.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared retry helpers for inference-switch E2Es. These tests still verify the
+# final OpenShell route, sandbox config, and live inference after this helper
+# returns. The --no-verify fallback is only used after verified route-setting
+# attempts fail with transient upstream/network symptoms.
+
+is_transient_inference_set_failure() {
+  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|502|503|504|temporar' <<<"$1"
+}
+
+log_inference_switch_retry_info() {
+  if declare -F info >/dev/null 2>&1; then
+    info "$1"
+  else
+    printf '\033[1;34m  [info]\033[0m %s\n' "$1"
+  fi
+}
+
+run_inference_set_with_retry() {
+  local attempts="${NEMOCLAW_SWITCH_SET_ATTEMPTS:-3}"
+  if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'Invalid NEMOCLAW_SWITCH_SET_ATTEMPTS=%s; expected a positive integer.\n' "$attempts" >&2
+    return 2
+  fi
+  if [ "$#" -eq 0 ]; then
+    printf 'run_inference_set_with_retry requires an inference set command.\n' >&2
+    return 2
+  fi
+
+  local attempt rc output fallback_output
+  local -a command=("$@")
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    output=$("${command[@]}" 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+
+    if ! is_transient_inference_set_failure "$output" || [ "$attempt" -ge "$attempts" ]; then
+      if is_transient_inference_set_failure "$output"; then
+        log_inference_switch_retry_info "Verified inference switch failed after ${attempts} transient attempt(s); retrying with --no-verify before live route checks..."
+        fallback_output=$("${command[@]}" --no-verify 2>&1)
+        rc=$?
+        printf '%s\n%s\n' "$output" "$fallback_output"
+        return "$rc"
+      fi
+      printf '%s\n' "$output"
+      return "$rc"
+    fi
+
+    log_inference_switch_retry_info "Verified inference switch attempt ${attempt}/${attempts} hit a transient failure; retrying..."
+    sleep $((attempt * 5))
+  done
+
+  printf 'Inference switch retry loop completed without running an attempt.\n' >&2
+  return 1
+}

--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -44,38 +44,6 @@ section() {
 }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
-is_transient_inference_set_failure() {
-  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|502|503|504|temporar' <<<"$1"
-}
-
-run_inference_set_with_retry() {
-  local attempt rc output fallback_output
-  local attempts="${NEMOCLAW_SWITCH_SET_ATTEMPTS:-3}"
-  for attempt in $(seq 1 "$attempts"); do
-    output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" 2>&1)
-    rc=$?
-    if [ "$rc" -eq 0 ]; then
-      printf '%s\n' "$output"
-      return 0
-    fi
-
-    if ! is_transient_inference_set_failure "$output" || [ "$attempt" -ge "$attempts" ]; then
-      if is_transient_inference_set_failure "$output"; then
-        info "Verified Hermes inference switch failed after ${attempts} transient attempt(s); retrying with --no-verify before live route checks..."
-        fallback_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --no-verify 2>&1)
-        rc=$?
-        printf '%s\n%s\n' "$output" "$fallback_output"
-        return "$rc"
-      fi
-      printf '%s\n' "$output"
-      return "$rc"
-    fi
-
-    info "Verified Hermes inference switch attempt ${attempt}/${attempts} hit a transient failure; retrying..."
-    sleep $((attempt * 5))
-  done
-}
-
 parse_chat_content() {
   python3 -c "
 import json, sys
@@ -397,6 +365,8 @@ else
 fi
 
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=test/e2e/lib/inference-switch-retry.sh
+. "${E2E_DIR}/lib/inference-switch-retry.sh"
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-hermes-inference-switch}"
 SWITCH_PROVIDER="${NEMOCLAW_SWITCH_PROVIDER:-nvidia-prod}"
 SWITCH_MODEL="${NEMOCLAW_SWITCH_MODEL:-z-ai/glm-5.1}"
@@ -501,7 +471,7 @@ pid_before="$(hermes_gateway_pid)"
 ENV_HASH_BEFORE=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sha256sum /sandbox/.hermes/.env 2>/dev/null | awk '{print $1}') || true
 
 info "Switching Hermes to ${SWITCH_PROVIDER} / ${SWITCH_MODEL} with nemohermes inference set..."
-switch_output=$(run_inference_set_with_retry)
+switch_output=$(run_inference_set_with_retry nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL")
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemohermes inference set completed without --sandbox"

--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -44,6 +44,38 @@ section() {
 }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
+is_transient_inference_set_failure() {
+  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|502|503|504|temporar' <<<"$1"
+}
+
+run_inference_set_with_retry() {
+  local attempt rc output fallback_output
+  local attempts="${NEMOCLAW_SWITCH_SET_ATTEMPTS:-3}"
+  for attempt in $(seq 1 "$attempts"); do
+    output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+
+    if ! is_transient_inference_set_failure "$output" || [ "$attempt" -ge "$attempts" ]; then
+      if is_transient_inference_set_failure "$output"; then
+        info "Verified Hermes inference switch failed after ${attempts} transient attempt(s); retrying with --no-verify before live route checks..."
+        fallback_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --no-verify 2>&1)
+        rc=$?
+        printf '%s\n%s\n' "$output" "$fallback_output"
+        return "$rc"
+      fi
+      printf '%s\n' "$output"
+      return "$rc"
+    fi
+
+    info "Verified Hermes inference switch attempt ${attempt}/${attempts} hit a transient failure; retrying..."
+    sleep $((attempt * 5))
+  done
+}
+
 parse_chat_content() {
   python3 -c "
 import json, sys
@@ -469,7 +501,7 @@ pid_before="$(hermes_gateway_pid)"
 ENV_HASH_BEFORE=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sha256sum /sandbox/.hermes/.env 2>/dev/null | awk '{print $1}') || true
 
 info "Switching Hermes to ${SWITCH_PROVIDER} / ${SWITCH_MODEL} with nemohermes inference set..."
-switch_output=$(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" 2>&1)
+switch_output=$(run_inference_set_with_retry)
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemohermes inference set completed without --sandbox"

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -44,6 +44,38 @@ section() {
 }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
+is_transient_inference_set_failure() {
+  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|502|503|504|temporar' <<<"$1"
+}
+
+run_inference_set_with_retry() {
+  local attempt rc output fallback_output
+  local attempts="${NEMOCLAW_SWITCH_SET_ATTEMPTS:-3}"
+  for attempt in $(seq 1 "$attempts"); do
+    output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+
+    if ! is_transient_inference_set_failure "$output" || [ "$attempt" -ge "$attempts" ]; then
+      if is_transient_inference_set_failure "$output"; then
+        info "Verified inference switch failed after ${attempts} transient attempt(s); retrying with --no-verify before live route checks..."
+        fallback_output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" --no-verify 2>&1)
+        rc=$?
+        printf '%s\n%s\n' "$output" "$fallback_output"
+        return "$rc"
+      fi
+      printf '%s\n' "$output"
+      return "$rc"
+    fi
+
+    info "Verified inference switch attempt ${attempt}/${attempts} hit a transient failure; retrying..."
+    sleep $((attempt * 5))
+  done
+}
+
 run_with_timeout() {
   local seconds="$1"
   shift
@@ -391,7 +423,7 @@ pass "nemoclaw and openshell are on PATH"
 section "Phase 3: Switch inference"
 pid_before="$(openclaw_gateway_pid)"
 info "Switching ${SANDBOX_NAME} to ${SWITCH_PROVIDER} / ${SWITCH_MODEL}..."
-switch_output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" 2>&1)
+switch_output=$(run_inference_set_with_retry)
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemoclaw inference set completed"

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -44,38 +44,6 @@ section() {
 }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
-is_transient_inference_set_failure() {
-  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|502|503|504|temporar' <<<"$1"
-}
-
-run_inference_set_with_retry() {
-  local attempt rc output fallback_output
-  local attempts="${NEMOCLAW_SWITCH_SET_ATTEMPTS:-3}"
-  for attempt in $(seq 1 "$attempts"); do
-    output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" 2>&1)
-    rc=$?
-    if [ "$rc" -eq 0 ]; then
-      printf '%s\n' "$output"
-      return 0
-    fi
-
-    if ! is_transient_inference_set_failure "$output" || [ "$attempt" -ge "$attempts" ]; then
-      if is_transient_inference_set_failure "$output"; then
-        info "Verified inference switch failed after ${attempts} transient attempt(s); retrying with --no-verify before live route checks..."
-        fallback_output=$(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME" --no-verify 2>&1)
-        rc=$?
-        printf '%s\n%s\n' "$output" "$fallback_output"
-        return "$rc"
-      fi
-      printf '%s\n' "$output"
-      return "$rc"
-    fi
-
-    info "Verified inference switch attempt ${attempt}/${attempts} hit a transient failure; retrying..."
-    sleep $((attempt * 5))
-  done
-}
-
 run_with_timeout() {
   local seconds="$1"
   shift
@@ -327,6 +295,8 @@ fi
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/e2e/lib/openclaw-json.sh
 . "${E2E_DIR}/lib/openclaw-json.sh"
+# shellcheck source=test/e2e/lib/inference-switch-retry.sh
+. "${E2E_DIR}/lib/inference-switch-retry.sh"
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-openclaw-inference-switch}"
 SWITCH_PROVIDER="${NEMOCLAW_SWITCH_PROVIDER:-nvidia-prod}"
 SWITCH_MODEL="${NEMOCLAW_SWITCH_MODEL:-z-ai/glm-5.1}"
@@ -423,7 +393,7 @@ pass "nemoclaw and openshell are on PATH"
 section "Phase 3: Switch inference"
 pid_before="$(openclaw_gateway_pid)"
 info "Switching ${SANDBOX_NAME} to ${SWITCH_PROVIDER} / ${SWITCH_MODEL}..."
-switch_output=$(run_inference_set_with_retry)
+switch_output=$(run_inference_set_with_retry nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME")
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemoclaw inference set completed"


### PR DESCRIPTION
## Summary
The nightly flake sweep showed `openclaw-inference-switch-e2e` and `hermes-inference-switch-e2e` as high-frequency failures, mostly due to transient live endpoint verification timeouts during `inference set`. This PR retries transient verification failures and falls back to `--no-verify` only after repeated transient failures, while keeping the later route/config/live-request assertions as the real correctness gate.

## Changes
- Add shared inference-switch retry helpers in `test/e2e/lib/inference-switch-retry.sh`.
- Validate `NEMOCLAW_SWITCH_SET_ATTEMPTS` as a positive integer before retrying.
- Retry verified `nemoclaw inference set` / `nemohermes inference set` attempts when failures look transient.
- After repeated transient verification failures, retry once with `--no-verify`; subsequent route, config, sandbox inference, and agent/API request checks still validate the switched route.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>