### PR TITLE
test(core): add unit tests for shellQuote utility

### DIFF
--- a/src/lib/core/shell-quote.test.ts
+++ b/src/lib/core/shell-quote.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest';
+import {shellQuote} from './shell-quote';
+
+describe('shellQuote', () => {
+    it("wraps a simple string in single quotes", () => {
+        expect(shellQuote("hello world")).toBe("'hello world'");
+    });
+
+    it("doesnt change a single word", () => {
+        expect(shellQuote("hello")).toBe("'hello'");
+    });
+
+    it("escapes embedded single quotes", () => {
+        expect(shellQuote("it's a test")).toBe("'it'\\''s a test'");
+    });
+
+    it("handles empty string", () => {
+        expect(shellQuote("")).toBe("''");
+    });
+
+    it("handles words with special characters", () => {
+        expect(shellQuote("hello$world")).toBe("'hello$world'");
+    }); 
+    it("handles strings with only single quotes", () => {
+        expect(shellQuote("''")).toBe("''\\'''\\'''");
+    });
+})


### PR DESCRIPTION
## Summary

Adds unit tests for the `shellQuote` utility in `src/lib/core/shell-quote.ts`. The function had no test coverage despite being used to safely interpolate values into bash `-c` strings.

## Changes

- Add `src/lib/core/shell-quote.test.ts` covering: simple strings, single-word wrapping, embedded single-quote escaping, empty string, special shell characters (`$`), and strings consisting entirely of single quotes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Atulya Singh <atulyarajsingh@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for shell quote functionality to ensure reliable behavior across various input scenarios including edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->