### PR TITLE
docs: update prerequisites Docker-driver wording

### DIFF
--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -19,7 +19,11 @@ Before getting started, check the prerequisites to ensure you have the necessary
 | RAM      | 8 GB           | 16 GB            |
 | Disk     | 20 GB free     | 40 GB free       |
 
-The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon and OpenShell gateway run alongside the export pipeline. The pipeline buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
+The sandbox image is approximately 2.4 GB compressed.
+During image push, the Docker daemon and OpenShell gateway run alongside the export pipeline.
+The pipeline buffers decompressed layers in memory.
+On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer.
+If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
 
 ## Software
 

--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -19,7 +19,7 @@ Before getting started, check the prerequisites to ensure you have the necessary
 | RAM      | 8 GB           | 16 GB            |
 | Disk     | 20 GB free     | 40 GB free       |
 
-The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, k3s, and the OpenShell gateway run alongside the export pipeline. The pipeline buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
+The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon and OpenShell gateway run alongside the export pipeline. The pipeline buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer. If you cannot add memory, configuring at least 8 GB of swap can work around the issue at the cost of slower performance.
 
 ## Software
 
@@ -52,7 +52,7 @@ Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway sta
 </Warning>
 
 <Note title="Docker storage driver">
-On Linux hosts running Docker 26 or later with the [containerd image store](https://docs.docker.com/engine/storage/containerd/) enabled (the install-time default for fresh `docker-ce` installations on Ubuntu 24.04 and similar distros), `nemoclaw onboard` transparently builds a `fuse-overlayfs`-enabled cluster image to bypass a kernel-level nested-overlay limitation in k3s.
+On Linux hosts running Docker 26 or later with the [containerd image store](https://docs.docker.com/engine/storage/containerd/) enabled (the install-time default for fresh `docker-ce` installations on Ubuntu 24.04 and similar distros), `nemoclaw onboard` transparently builds a `fuse-overlayfs`-enabled OpenShell gateway image to bypass a kernel-level nested-overlay limitation.
 No manual setup is required.
 See the [troubleshooting guide](/reference/troubleshooting) for the override knobs and a manual `daemon.json` alternative.
 </Note>

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -61,7 +61,10 @@ Then re-run the installer.
 
 ### Image push fails with out-of-memory errors
 
-The sandbox image is approximately 2.4 GB compressed. During image push, the Docker daemon, k3s, and the OpenShell gateway run alongside the export pipeline, which buffers decompressed layers in memory. On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer.
+The sandbox image is approximately 2.4 GB compressed.
+During image push, the Docker daemon and OpenShell gateway run alongside the export pipeline.
+The pipeline buffers decompressed layers in memory.
+On machines with less than 8 GB of RAM, this combined usage can trigger the OOM killer.
 
 If you cannot add memory, configure at least 8 GB of swap to work around the issue at the cost of slower performance.
 


### PR DESCRIPTION
## Summary

- Remove the stale top-level `k3s` RAM-consumer wording from prerequisites
- Reword the Docker storage driver note around the OpenShell gateway image instead of a k3s-specific limitation
- Keep the change scoped to the remaining prerequisites wording; `docs/reference/architecture.mdx` already describes the Docker-driver topology on current `main`

Part of NVIDIA/NemoClaw#3432

Signed-off-by: Glenn-Agent <glenn_agent@163.com>

## Verification

- `npm run docs:strict` (passes; existing Fern upgrade warnings only)
- `git diff --check`
- `git verify-commit HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified hardware prerequisites to specify which runtime components run during sandbox image push and to update image-building behavior when using newer Docker setups.
  * Expanded troubleshooting guidance for "image push OOM" errors, explaining memory buffering during export and advising minimum RAM considerations (≈8 GB).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->