### PR TITLE
docs: add newcomer contribution path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,31 @@ Open an issue when you encounter one of the following situations.
 - A feature proposal with a design — not a "please build this" request.
 - Security vulnerabilities must follow [SECURITY.md](SECURITY.md) — **not** GitHub issues.
 
+## Where to Start
+
+New contributors can start with small, focused work that is easy to review.
+
+- Bug reports: include the command, platform, expected behavior, actual
+  behavior, and any relevant logs.
+- Bug fixes: keep the patch scoped to the reported behavior and add or update
+  focused tests when practical.
+- Documentation fixes: update the source documentation and run the documented
+  doc checks.
+- Tests: add coverage for an existing behavior gap or a regression that can be
+  reproduced locally.
+- Examples and integrations: open a discussion first if the change adds a new
+  workflow, provider, or external dependency.
+- Feature proposals: describe the use case, design, and expected maintenance
+  cost before opening a large PR.
+
+For starter tasks, look for issues labeled [`good first issue`](https://github.com/NVIDIA/NemoClaw/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22).
+If a change is large, user-facing, or design-heavy, ask first in
+[GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions) or the
+project Discord linked from the [README](README.md#community).
+
+All contributors are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+in project spaces and public community channels.
+
 ## Prerequisites
 
 Install the following before you begin.
@@ -189,6 +214,10 @@ Follow these steps to submit a pull request.
 2. Make your changes with tests.
 3. Run the relevant checks. For code changes, run `make check` and `npm test`. For doc-only changes, run `npx prek run --all-files` and `npm run docs`.
 4. Open a PR.
+
+Every PR must include the required DCO sign-off line from the pull request
+template. Use `git commit -s` or add the `Signed-off-by:` trailer manually with
+the same name and email configured for your commits.
 
 ### Commit Messages
 


### PR DESCRIPTION
## Summary
Adds a newcomer-friendly starting path to `CONTRIBUTING.md`, including contribution types, starter issue guidance, community channels, Code of Conduct expectations, and the existing DCO sign-off requirement.

## Related Issue
Fixes #3826

## Changes
- Added a "Where to Start" section for first-time contributors.
- Linked the `good first issue` label, GitHub Discussions, README community channels, and Code of Conduct.
- Documented that PRs need the DCO sign-off line already required by the PR template.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification:

- `npx --yes markdownlint-cli2 CONTRIBUTING.md`
- `git diff --check`

This was implemented with Codex assistance, with the final patch manually reviewed and kept scoped to the requested contributing-guide update.

---
Signed-off-by: Omri Ben Zvi <omribz156@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with a new "Where to Start" section for new contributors
  * Added guidance on types of work to open and where to ask for input (GitHub Discussions/Discord)
  * Clarified DCO sign-off requirement for all pull requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->