### PR TITLE
feat(messaging): add serializable applier boundary

### DIFF
--- a/src/lib/messaging/applier/index.ts
+++ b/src/lib/messaging/applier/index.ts
@@ -1,8 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export * from "./channels";
-export * from "./compiler";
-export * from "./hooks";
-export * from "./applier";
-export * from "./manifest";
+export * from "./setup-applier";
+export type * from "./types";

--- a/src/lib/messaging/applier/setup-applier.test.ts
+++ b/src/lib/messaging/applier/setup-applier.test.ts
@@ -200,6 +200,34 @@ describe("MessagingSetupApplier", () => {
     expect(JSON.stringify(result)).not.toContain("slack-token");
   });
 
+  it("redacts OpenShell provider failure output", async () => {
+    const plan = await planOnboard({ TELEGRAM_BOT_TOKEN: "tokensecretvalue" }, [
+      "telegram",
+    ]);
+    const runOpenshell: MessagingOpenShellRunner = (args) => {
+      if (args[0] === "provider" && args[1] === "get") {
+        return { status: 1 };
+      }
+      return {
+        status: 1,
+        stderr: "provider rejected TELEGRAM_BOT_TOKEN=tokensecretvalue",
+      };
+    };
+
+    let message = "";
+    try {
+      MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+        env: { TELEGRAM_BOT_TOKEN: "tokensecretvalue" },
+        runOpenshell,
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain("TELEGRAM_BOT_TOKEN=toke");
+    expect(message).not.toContain("tokensecretvalue");
+  });
+
   it("applies agent config render plans into sandbox files through OpenShell", async () => {
     const plan = await planOnboard({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" }, [
       "telegram",

--- a/src/lib/messaging/applier/setup-applier.test.ts
+++ b/src/lib/messaging/applier/setup-applier.test.ts
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { createBuiltInChannelManifestRegistry } from "../channels";
+import { FAKE_TELEGRAM_HOOK_REGISTRATIONS } from "../channels/telegram/hooks/fakes";
+import { FAKE_WECHAT_HOOK_REGISTRATIONS } from "../channels/wechat/hooks/fakes";
+import { MessagingWorkflowPlanner } from "../compiler";
+import { MessagingHookRegistry, runMessagingHook } from "../hooks";
+import { FAKE_COMMON_HOOK_REGISTRATIONS } from "../hooks/common";
+import type { ChannelHookSpec } from "../manifest";
+import type { SandboxMessagingPlan } from "../manifest";
+import { MessagingSetupApplier } from "./setup-applier";
+import { MESSAGING_SETUP_APPLIER_ENV_KEY, type MessagingOpenShellRunner } from "./types";
+
+async function withEnv<T>(
+  values: Readonly<Record<string, string | undefined>>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = Object.fromEntries(
+    Object.keys(values).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(values)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function planner(): MessagingWorkflowPlanner {
+  return new MessagingWorkflowPlanner(
+    createBuiltInChannelManifestRegistry(),
+    new MessagingHookRegistry([
+      ...FAKE_COMMON_HOOK_REGISTRATIONS,
+      ...FAKE_TELEGRAM_HOOK_REGISTRATIONS,
+      ...FAKE_WECHAT_HOOK_REGISTRATIONS,
+    ]),
+  );
+}
+
+async function planOnboard(
+  env: Readonly<Record<string, string | undefined>>,
+  selectedChannels: readonly string[],
+): Promise<SandboxMessagingPlan> {
+  return withEnv(env, () =>
+    planner().planOnboard({
+      sandboxName: "demo",
+      agent: "openclaw",
+      isInteractive: false,
+      selectedChannels,
+    }),
+  );
+}
+
+describe("MessagingSetupApplier", () => {
+  it("stores a serializable SandboxMessagingPlan in env without rejecting repeated aliases", async () => {
+    const plan = await planOnboard({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" }, [
+      "telegram",
+    ]);
+    const repeated = { value: "same" };
+    const planWithAlias = {
+      ...plan,
+      agentRender: [
+        {
+          channelId: "telegram",
+          kind: "json-fragment",
+          agent: "openclaw",
+          target: "openclaw.json",
+          path: "x",
+          value: [repeated, repeated],
+          templateRefs: [],
+        },
+      ],
+    } satisfies SandboxMessagingPlan;
+    const env: NodeJS.ProcessEnv = {};
+
+    MessagingSetupApplier.writePlanToEnv(planWithAlias, { env });
+
+    const decoded = MessagingSetupApplier.readPlanFromEnv({ env });
+    expect(env[MESSAGING_SETUP_APPLIER_ENV_KEY]).toBeTruthy();
+    expect(decoded?.sandboxName).toBe("demo");
+    expect(decoded?.agentRender[0]).toMatchObject({
+      channelId: "telegram",
+      kind: "json-fragment",
+    });
+
+    const cyclic = { ...plan } as Record<string, unknown>;
+    cyclic.self = cyclic;
+    expect(() => MessagingSetupApplier.encodePlan(cyclic as never)).toThrow(/cycle/);
+  });
+
+  it("lists hook requests by phase without executing hook implementations", async () => {
+    const plan = await planOnboard({ WECHAT_ACCOUNT_ID: "wechat-account" }, ["wechat"]);
+
+    expect(MessagingSetupApplier.listHookRequests(plan, "enroll")).toEqual([
+      expect.objectContaining({
+        sandboxName: "demo",
+        channelId: "wechat",
+        hookId: "wechat-host-qr",
+        phase: "enroll",
+        handler: "wechat.ilinkLogin",
+      }),
+    ]);
+    expect(MessagingSetupApplier.listHookRequests(plan, "post-agent-install")).toEqual([
+      expect.objectContaining({
+        sandboxName: "demo",
+        channelId: "wechat",
+        hookId: "wechat-seed-openclaw-account",
+        phase: "post-agent-install",
+        handler: "wechat.seedOpenClawAccount",
+      }),
+    ]);
+  });
+
+  it("upserts OpenShell generic providers from plan credential bindings", async () => {
+    const plan = await planOnboard(
+      {
+        TELEGRAM_BOT_TOKEN: "123456:telegram-token",
+        SLACK_BOT_TOKEN: "xoxb-slack-token",
+        SLACK_APP_TOKEN: "xapp-slack-token",
+      },
+      ["telegram", "slack"],
+    );
+    const calls: Array<{
+      args: readonly string[];
+      env?: Readonly<Record<string, string>>;
+    }> = [];
+    const runOpenshell: MessagingOpenShellRunner = (args, options) => {
+      calls.push({ args, env: options?.env });
+      if (args[0] === "provider" && args[1] === "get") {
+        return { status: args[2] === "demo-slack-bridge" ? 0 : 1 };
+      }
+      return { status: 0 };
+    };
+
+    const result = MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+      env: {
+        TELEGRAM_BOT_TOKEN: "123456:telegram-token",
+        SLACK_BOT_TOKEN: "xoxb-slack-token",
+        SLACK_APP_TOKEN: "xapp-slack-token",
+      },
+      runOpenshell,
+    });
+
+    expect(calls.map((call) => call.args)).toEqual([
+      ["provider", "get", "demo-telegram-bridge"],
+      [
+        "provider",
+        "create",
+        "--name",
+        "demo-telegram-bridge",
+        "--type",
+        "generic",
+        "--credential",
+        "TELEGRAM_BOT_TOKEN",
+      ],
+      ["provider", "get", "demo-slack-bridge"],
+      ["provider", "update", "demo-slack-bridge", "--credential", "SLACK_BOT_TOKEN"],
+      ["provider", "get", "demo-slack-app"],
+      [
+        "provider",
+        "create",
+        "--name",
+        "demo-slack-app",
+        "--type",
+        "generic",
+        "--credential",
+        "SLACK_APP_TOKEN",
+      ],
+    ]);
+    expect(calls[1]?.env).toEqual({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" });
+    expect(result.upserted.map((entry) => `${entry.action}:${entry.providerName}`)).toEqual([
+      "create:demo-telegram-bridge",
+      "update:demo-slack-bridge",
+      "create:demo-slack-app",
+    ]);
+    expect(result.sandboxCreateProviderArgs).toEqual([
+      "--provider",
+      "demo-telegram-bridge",
+      "--provider",
+      "demo-slack-bridge",
+      "--provider",
+      "demo-slack-app",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("telegram-token");
+    expect(JSON.stringify(result)).not.toContain("slack-token");
+  });
+
+  it("applies agent config render plans into sandbox files through OpenShell", async () => {
+    const plan = await planOnboard({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" }, [
+      "telegram",
+    ]);
+    const files: Record<string, string> = {
+      "/sandbox/.openclaw/openclaw.json": JSON.stringify({
+        agents: {
+          list: ["default"],
+        },
+      }),
+    };
+    const calls: Array<{ args: readonly string[]; input?: string }> = [];
+    const runOpenshell: MessagingOpenShellRunner = (args, options) => {
+      calls.push({ args, input: options?.input });
+      const target = String(args.at(-1));
+      if (args.includes("cat") && !options?.input) {
+        return { status: files[target] === undefined ? 1 : 0, stdout: files[target] ?? "" };
+      }
+      if (options?.input !== undefined) {
+        files[target] = options.input;
+        return { status: 0 };
+      }
+      return { status: 1 };
+    };
+
+    const result = await MessagingSetupApplier.applyAgentConfigAtOpenShell(plan, {
+      runOpenshell,
+    });
+
+    expect(calls.map((call) => call.args)).toEqual([
+      [
+        "sandbox",
+        "exec",
+        "--name",
+        "demo",
+        "--",
+        "cat",
+        "/sandbox/.openclaw/openclaw.json",
+      ],
+      [
+        "sandbox",
+        "exec",
+        "--name",
+        "demo",
+        "--",
+        "sh",
+        "-c",
+        'mkdir -p "$(dirname "$1")" && cat > "$1"',
+        "sh",
+        "/sandbox/.openclaw/openclaw.json",
+      ],
+    ]);
+    expect(calls[1]?.input).toBeTruthy();
+    const openclawConfig = JSON.parse(files["/sandbox/.openclaw/openclaw.json"] ?? "{}");
+    expect(openclawConfig.agents.list).toEqual(["default"]);
+    expect(openclawConfig.channels.telegram.accounts.default).toMatchObject({
+      botToken: "openshell:resolve:env:TELEGRAM_BOT_TOKEN",
+      enabled: true,
+      groupPolicy: "open",
+    });
+    expect(openclawConfig.channels.telegram.groups["*"]).toEqual({
+      requireMention: "{{telegramConfig.requireMention}}",
+    });
+    expect(result.appliedTargets).toEqual(["/sandbox/.openclaw/openclaw.json"]);
+    expect(result.appliedHooks).toEqual([]);
+    expect(result.unresolvedTemplateRefs).toEqual(
+      expect.arrayContaining(["proxyUrl", "telegramConfig.requireMention"]),
+    );
+  });
+
+  it("runs post-install hook implementations and writes their build-file outputs", async () => {
+    const plan = await planOnboard(
+      {
+        WECHAT_ACCOUNT_ID: "wechat-account",
+        WECHAT_BASE_URL: "https://ilinkai.wechat.example",
+        WECHAT_USER_ID: "wechat-user",
+      },
+      ["wechat"],
+    );
+    const registry = new MessagingHookRegistry(FAKE_WECHAT_HOOK_REGISTRATIONS);
+    const files: Record<string, string> = {
+      "/sandbox/.openclaw/openclaw.json": JSON.stringify({
+        plugins: {
+          entries: {
+            acpx: {
+              enabled: false,
+            },
+          },
+        },
+      }),
+    };
+
+    const result = await MessagingSetupApplier.applyAgentConfigAtOpenShell(plan, {
+      runOpenshell: (args, options) => {
+        const command = String(args[7] ?? "");
+        const target =
+          options?.input !== undefined && command.includes("chmod")
+            ? String(args.at(-2))
+            : String(args.at(-1));
+        if (args.includes("cat") && options?.input === undefined) {
+          return { status: files[target] === undefined ? 1 : 0, stdout: files[target] ?? "" };
+        }
+        if (options?.input !== undefined) {
+          files[target] = options.input;
+          return { status: 0 };
+        }
+        return { status: 1 };
+      },
+      runHook: (request) => {
+        const hook = {
+          id: request.hookId,
+          phase: request.phase,
+          handler: request.handler,
+          inputs: request.inputKeys,
+          outputs: request.outputs,
+          onFailure: request.onFailure,
+        } satisfies ChannelHookSpec;
+        return runMessagingHook(hook, registry, {
+          channelId: request.channelId,
+          inputs: request.inputs,
+        });
+      },
+    });
+
+    expect(JSON.parse(files["/sandbox/.openclaw/openclaw-weixin/accounts.json"] ?? "[]")).toEqual(
+      ["wechat-account"],
+    );
+    expect(
+      JSON.parse(
+        files["/sandbox/.openclaw/openclaw-weixin/accounts/wechat-account.json"] ?? "{}",
+      ),
+    ).toMatchObject({
+      token: "openshell:resolve:env:WECHAT_BOT_TOKEN",
+      baseUrl: "https://ilinkai.wechat.example",
+      userId: "wechat-user",
+    });
+    const openclawConfig = JSON.parse(files["/sandbox/.openclaw/openclaw.json"] ?? "{}");
+    expect(openclawConfig.plugins.entries.acpx.enabled).toBe(false);
+    expect(openclawConfig.plugins.entries["openclaw-weixin"].enabled).toBe(true);
+    expect(openclawConfig.plugins.installs["openclaw-weixin"].spec).toBe(
+      "@tencent-weixin/openclaw-weixin@2.4.2",
+    );
+    expect(openclawConfig.plugins.load.paths).toEqual([
+      "/sandbox/.openclaw/extensions/openclaw-weixin",
+    ]);
+    expect(openclawConfig.channels["openclaw-weixin"].accounts["wechat-account"]).toEqual({
+      enabled: true,
+    });
+    expect(result.appliedTargets).toEqual([
+      "/sandbox/.openclaw/openclaw-weixin/accounts.json",
+      "/sandbox/.openclaw/openclaw-weixin/accounts/wechat-account.json",
+      "/sandbox/.openclaw/openclaw.json",
+    ]);
+    expect(result.appliedHooks).toEqual(["wechat:wechat-seed-openclaw-account"]);
+  });
+
+  it("applies policy presets directly from the serializable plan", async () => {
+    const plan = await planOnboard({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" }, [
+      "telegram",
+    ]);
+    const policyCalls: string[][] = [];
+
+    const result = MessagingSetupApplier.applyPolicyAtOpenShell(plan, {
+      applyPresets: (sandboxName, presetNames) => {
+        policyCalls.push([sandboxName, ...presetNames]);
+        return true;
+      },
+    });
+
+    expect(policyCalls).toEqual([["demo", "telegram"]]);
+    expect(result).toEqual({
+      appliedPresets: ["telegram"],
+    });
+  });
+});

--- a/src/lib/messaging/applier/setup-applier.ts
+++ b/src/lib/messaging/applier/setup-applier.ts
@@ -1,0 +1,742 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+import YAML from "yaml";
+
+import type {
+  ChannelHookPhase,
+  MessagingAgentId,
+  MessagingSerializableValue,
+  SandboxMessagingAgentRenderPlan,
+  SandboxMessagingChannelPlan,
+  SandboxMessagingCredentialBindingPlan,
+  SandboxMessagingEnvLinesRenderPlan,
+  SandboxMessagingJsonRenderPlan,
+  SandboxMessagingPlan,
+} from "../manifest";
+import type { MessagingHookOutputMap } from "../hooks";
+import {
+  MESSAGING_SETUP_APPLIER_ENV_KEY,
+  type MessagingCredentialApplyOptions,
+  type MessagingCredentialApplyResult,
+  type MessagingHookApplyRequest,
+  type MessagingHookApplyRunner,
+  type MessagingOpenShellRunner,
+  type MessagingPolicyApplyOptions,
+  type MessagingPolicyApplyResult,
+  type MessagingSetupEnvOptions,
+} from "./types";
+
+type MessagingCredentialApplyEntry = MessagingCredentialApplyResult["upserted"][number];
+type MessagingCredentialReuseEntry = MessagingCredentialApplyResult["reused"][number];
+type MessagingMissingCredentialEntry = MessagingCredentialApplyResult["missing"][number];
+type MessagingCredentialBindingLike = Pick<
+  SandboxMessagingCredentialBindingPlan,
+  "channelId" | "credentialId" | "providerName" | "providerEnvKey"
+>;
+
+const AGENT_CONFIG_HOOK_PHASES = new Set<ChannelHookPhase>([
+  "apply",
+  "post-agent-install",
+]);
+
+export class MessagingSetupApplier {
+  static encodePlan(plan: SandboxMessagingPlan): string {
+    assertSandboxMessagingPlan(plan);
+    assertJsonSerializable(plan);
+    return Buffer.from(JSON.stringify(plan), "utf8").toString("base64");
+  }
+
+  static decodePlan(encoded: string): SandboxMessagingPlan {
+    const raw = Buffer.from(encoded, "base64").toString("utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    assertSandboxMessagingPlan(parsed);
+    return parsed;
+  }
+
+  static writePlanToEnv(
+    plan: SandboxMessagingPlan,
+    options: MessagingSetupEnvOptions = {},
+  ): void {
+    const env = options.env ?? process.env;
+    env[options.envKey ?? MESSAGING_SETUP_APPLIER_ENV_KEY] = this.encodePlan(plan);
+  }
+
+  static readPlanFromEnv(options: MessagingSetupEnvOptions = {}): SandboxMessagingPlan | null {
+    const env = options.env ?? process.env;
+    const value = env[options.envKey ?? MESSAGING_SETUP_APPLIER_ENV_KEY];
+    return value ? this.decodePlan(value) : null;
+  }
+
+  static requirePlanFromEnv(options: MessagingSetupEnvOptions = {}): SandboxMessagingPlan {
+    const plan = this.readPlanFromEnv(options);
+    if (!plan) {
+      throw new Error(`${options.envKey ?? MESSAGING_SETUP_APPLIER_ENV_KEY} is not set.`);
+    }
+    return plan;
+  }
+
+  static clearPlanEnv(options: MessagingSetupEnvOptions = {}): void {
+    const env = options.env ?? process.env;
+    delete env[options.envKey ?? MESSAGING_SETUP_APPLIER_ENV_KEY];
+  }
+
+  static listHookRequests(
+    plan: SandboxMessagingPlan,
+    phase?: ChannelHookPhase,
+  ): MessagingHookApplyRequest[] {
+    assertSandboxMessagingPlan(plan);
+    return plan.channels.flatMap((channel) =>
+      channel.hooks
+        .filter((hook) => !phase || hook.phase === phase)
+        .map((hook) => toHookApplyRequest(plan, channel, hook)),
+    );
+  }
+
+  static async applyAgentConfigAtOpenShell(
+    plan: SandboxMessagingPlan,
+    options: {
+      readonly runOpenshell: MessagingOpenShellRunner;
+      readonly runHook?: MessagingHookApplyRunner;
+    },
+  ): Promise<{
+    readonly appliedTargets: readonly string[];
+    readonly appliedHooks: readonly string[];
+    readonly unresolvedTemplateRefs: readonly string[];
+  }> {
+    assertSandboxMessagingPlan(plan);
+    const hookRequests = hookRequestsForPhases(plan, AGENT_CONFIG_HOOK_PHASES);
+    if (hookRequests.length > 0 && !options.runHook) {
+      throw new Error("Messaging agent config hooks require a hook runner.");
+    }
+
+    const appliedHooks: string[] = [];
+    const appliedTargets: string[] = [];
+    for (const request of hookRequests.filter((hook) => hook.phase === "apply")) {
+      await runApplyHook(request, options.runHook, plan, options.runOpenshell, {
+        appliedHooks,
+        appliedTargets,
+      });
+    }
+
+    for (const [target, render] of groupRenderByTarget(plan.agentRender)) {
+      const resolvedTarget = resolveSandboxAgentConfigTarget(target, plan.agent);
+      const kind = render[0]?.kind;
+      if (!kind) continue;
+      if (render.some((entry) => entry.kind !== kind)) {
+        throw new Error(`Cannot apply mixed messaging render kinds to ${target}.`);
+      }
+      const existing = readSandboxFile(plan.sandboxName, resolvedTarget, options.runOpenshell);
+      const contents =
+        kind === "json-fragment"
+          ? applyJsonFragments(
+              existing,
+              render.filter(isJsonRender),
+              resolvedTarget,
+            )
+          : applyEnvLines(existing, render.filter(isEnvLinesRender));
+      writeSandboxFile(plan.sandboxName, resolvedTarget, contents, options.runOpenshell);
+      appliedTargets.push(resolvedTarget);
+    }
+
+    for (const request of hookRequests.filter((hook) => hook.phase === "post-agent-install")) {
+      await runApplyHook(request, options.runHook, plan, options.runOpenshell, {
+        appliedHooks,
+        appliedTargets,
+      });
+    }
+
+    return {
+      appliedTargets: uniqueStrings(appliedTargets),
+      appliedHooks,
+      unresolvedTemplateRefs: uniqueStrings(
+        plan.agentRender.flatMap((render) => render.templateRefs),
+      ),
+    };
+  }
+
+  static applyCredentialsAtOpenShell(
+    plan: SandboxMessagingPlan,
+    options: MessagingCredentialApplyOptions,
+  ): MessagingCredentialApplyResult {
+    assertSandboxMessagingPlan(plan);
+    const env = options.env ?? process.env;
+    const runOpenshell = options.runOpenshell;
+    const upserted: MessagingCredentialApplyEntry[] = [];
+    const reused: MessagingCredentialReuseEntry[] = [];
+    const missing: MessagingMissingCredentialEntry[] = [];
+
+    for (const binding of plan.credentialBindings) {
+      const credential = readCredentialEnv(env, binding.providerEnvKey);
+      if (!credential) {
+        if (providerExistsInGateway(binding.providerName, runOpenshell)) {
+          reused.push(toReuseEntry(binding));
+        } else {
+          missing.push(toMissingEntry(binding));
+        }
+        continue;
+      }
+
+      const action = providerExistsInGateway(binding.providerName, runOpenshell)
+        ? "update"
+        : "create";
+      const result = runOpenshell(
+        buildProviderArgs(action, binding.providerName, binding.providerEnvKey),
+        {
+          ignoreError: true,
+          env: { [binding.providerEnvKey]: credential },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      const status = result.status ?? 0;
+      if (status !== 0) {
+        throw new Error(
+          `Failed to ${action} messaging provider '${binding.providerName}': ${compactOutput(result)}`,
+        );
+      }
+      upserted.push({
+        channelId: binding.channelId,
+        credentialId: binding.credentialId,
+        providerName: binding.providerName,
+        envKey: binding.providerEnvKey,
+        action,
+      });
+    }
+
+    const providerNames = uniqueStrings([
+      ...upserted.map((entry) => entry.providerName),
+      ...reused.map((entry) => entry.providerName),
+    ]);
+
+    return {
+      upserted,
+      reused,
+      missing,
+      providerNames,
+      sandboxCreateProviderArgs: providerNames.flatMap((providerName) => [
+        "--provider",
+        providerName,
+      ]),
+    };
+  }
+
+  static applyPolicyAtOpenShell(
+    plan: SandboxMessagingPlan,
+    options: MessagingPolicyApplyOptions,
+  ): MessagingPolicyApplyResult {
+    assertSandboxMessagingPlan(plan);
+    const activePresets = uniqueStrings(plan.networkPolicy.presets);
+    if (activePresets.length > 0 && !options.applyPresets(plan.sandboxName, activePresets)) {
+      throw new Error(`Failed to apply messaging policy preset(s): ${activePresets.join(", ")}`);
+    }
+
+    return {
+      appliedPresets: activePresets,
+    };
+  }
+}
+
+function hookRequestsForPhases(
+  plan: SandboxMessagingPlan,
+  phases: ReadonlySet<ChannelHookPhase>,
+): MessagingHookApplyRequest[] {
+  return plan.channels.flatMap((channel) =>
+    channel.hooks
+      .filter((hook) => phases.has(hook.phase))
+      .map((hook) => toHookApplyRequest(plan, channel, hook)),
+  );
+}
+
+function toHookApplyRequest(
+  plan: SandboxMessagingPlan,
+  channel: SandboxMessagingChannelPlan,
+  hook: SandboxMessagingChannelPlan["hooks"][number],
+): MessagingHookApplyRequest {
+  const inputs = buildHookInputMap(plan, channel);
+  const selectedInputs = hook.inputs
+    ? Object.fromEntries(
+        hook.inputs
+          .filter((inputKey) => Object.hasOwn(inputs, inputKey))
+          .map((inputKey) => [inputKey, inputs[inputKey] as MessagingSerializableValue]),
+      )
+    : inputs;
+
+  return {
+    sandboxName: plan.sandboxName,
+    agent: plan.agent,
+    channelId: channel.channelId,
+    hookId: hook.id,
+    phase: hook.phase,
+    handler: hook.handler,
+    inputKeys: hook.inputs,
+    inputs: selectedInputs,
+    outputs: hook.outputs,
+    onFailure: hook.onFailure,
+  };
+}
+
+function buildHookInputMap(
+  plan: SandboxMessagingPlan,
+  channel: SandboxMessagingChannelPlan,
+): Record<string, MessagingSerializableValue> {
+  const inputs: Record<string, MessagingSerializableValue> = {};
+  for (const input of channel.inputs) {
+    if (input.value === undefined) continue;
+    inputs[input.inputId] = input.value;
+    if (input.statePath) inputs[input.statePath] = input.value;
+  }
+  for (const credential of plan.credentialBindings) {
+    if (credential.channelId !== channel.channelId) continue;
+    inputs[`credential.${credential.credentialId}.placeholder`] = credential.placeholder;
+  }
+  return inputs;
+}
+
+async function runApplyHook(
+  request: MessagingHookApplyRequest,
+  runner: MessagingHookApplyRunner | undefined,
+  plan: SandboxMessagingPlan,
+  runOpenshell: MessagingOpenShellRunner,
+  applied: {
+    readonly appliedHooks: string[];
+    readonly appliedTargets: string[];
+  },
+): Promise<void> {
+  if (!runner) return;
+  try {
+    const result = await runner(request);
+    applied.appliedHooks.push(`${request.channelId}:${request.hookId}`);
+    if (result?.outputs) {
+      applied.appliedTargets.push(
+        ...applyHookBuildFileOutputs(plan, result.outputs, runOpenshell),
+      );
+    }
+  } catch (error) {
+    if (request.onFailure === "skip-channel") return;
+    throw error;
+  }
+}
+
+function assertSandboxMessagingPlan(value: unknown): asserts value is SandboxMessagingPlan {
+  if (
+    !isObject(value) ||
+    value.schemaVersion !== 1 ||
+    typeof value.sandboxName !== "string" ||
+    typeof value.agent !== "string" ||
+    typeof value.workflow !== "string" ||
+    !Array.isArray(value.channels) ||
+    !Array.isArray(value.credentialBindings) ||
+    !isObject(value.networkPolicy) ||
+    !Array.isArray(value.agentRender) ||
+    !Array.isArray(value.buildSteps) ||
+    !Array.isArray(value.stateUpdates) ||
+    !Array.isArray(value.healthChecks)
+  ) {
+    throw new Error("Expected a serializable SandboxMessagingPlan.");
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertJsonSerializable(
+  value: unknown,
+  path = "$",
+  visiting: Set<object> = new Set(),
+): void {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "undefined"
+  ) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    assertAcyclicObject(value, path, visiting, () => {
+      value.forEach((entry, index) => assertJsonSerializable(entry, `${path}[${index}]`, visiting));
+    });
+    return;
+  }
+  if (typeof value === "object" && value !== null) {
+    assertAcyclicObject(value, path, visiting, () => {
+      for (const [key, entry] of Object.entries(value)) {
+        assertJsonSerializable(entry, `${path}.${key}`, visiting);
+      }
+    });
+    return;
+  }
+  throw new Error(`Messaging setup plan is not JSON-serializable at ${path}.`);
+}
+
+function assertAcyclicObject(
+  value: object,
+  path: string,
+  visiting: Set<object>,
+  visit: () => void,
+): void {
+  if (visiting.has(value)) {
+    throw new Error(`Messaging setup plan contains a cycle at ${path}.`);
+  }
+  visiting.add(value);
+  try {
+    visit();
+  } finally {
+    visiting.delete(value);
+  }
+}
+
+function groupRenderByTarget(
+  render: readonly SandboxMessagingAgentRenderPlan[],
+): ReadonlyMap<string, SandboxMessagingAgentRenderPlan[]> {
+  const groups = new Map<string, SandboxMessagingAgentRenderPlan[]>();
+  for (const entry of render) {
+    const group = groups.get(entry.target) ?? [];
+    group.push(entry);
+    groups.set(entry.target, group);
+  }
+  return groups;
+}
+
+function isJsonRender(
+  render: SandboxMessagingAgentRenderPlan,
+): render is SandboxMessagingJsonRenderPlan {
+  return render.kind === "json-fragment";
+}
+
+function isEnvLinesRender(
+  render: SandboxMessagingAgentRenderPlan,
+): render is SandboxMessagingEnvLinesRenderPlan {
+  return render.kind === "env-lines";
+}
+
+function applyJsonFragments(
+  existing: string | undefined,
+  render: readonly SandboxMessagingJsonRenderPlan[],
+  target: string,
+): string {
+  const format = target.endsWith(".yaml") || target.endsWith(".yml") ? "yaml" : "json";
+  const root = parseStructuredConfig(existing, target, format);
+  for (const entry of render) {
+    setJsonPath(root, entry.path, entry.value);
+  }
+  return format === "yaml" ? YAML.stringify(root) : `${JSON.stringify(root, null, 2)}\n`;
+}
+
+function parseStructuredConfig(
+  existing: string | undefined,
+  target: string,
+  format: "json" | "yaml",
+): Record<string, MessagingSerializableValue> {
+  if (!existing || existing.trim().length === 0) return {};
+  const parsed = format === "yaml" ? YAML.parse(existing) : (JSON.parse(existing) as unknown);
+  if (!isObject(parsed)) {
+    throw new Error(`Messaging agent config target ${target} must contain an object.`);
+  }
+  return parsed as Record<string, MessagingSerializableValue>;
+}
+
+function setJsonPath(
+  root: Record<string, MessagingSerializableValue>,
+  path: string,
+  value: MessagingSerializableValue,
+): void {
+  const segments = path.split(".").filter(Boolean);
+  if (segments.length === 0) {
+    throw new Error("Messaging render path must not be empty.");
+  }
+  let cursor: Record<string, MessagingSerializableValue> = root;
+  for (const segment of segments.slice(0, -1)) {
+    const next = cursor[segment];
+    if (!isObject(next)) {
+      const created: Record<string, MessagingSerializableValue> = {};
+      cursor[segment] = created;
+      cursor = created;
+    } else {
+      cursor = next as Record<string, MessagingSerializableValue>;
+    }
+  }
+  cursor[segments[segments.length - 1] as string] = value;
+}
+
+function applyEnvLines(
+  existing: string | undefined,
+  render: readonly SandboxMessagingEnvLinesRenderPlan[],
+): string {
+  const desired = new Map<string, string>();
+  const rawDesiredLines: string[] = [];
+  for (const entry of render) {
+    for (const line of entry.lines) {
+      const key = readEnvLineKey(line);
+      if (key) {
+        desired.set(key, line);
+      } else {
+        rawDesiredLines.push(line);
+      }
+    }
+  }
+
+  const written = new Set<string>();
+  const output = (existing ?? "")
+    .split(/\n/)
+    .filter((line, index, lines) => line.length > 0 || index < lines.length - 1)
+    .map((line) => {
+      const key = readEnvLineKey(line);
+      if (!key || !desired.has(key)) return line;
+      written.add(key);
+      return desired.get(key) as string;
+    });
+
+  for (const [key, line] of desired) {
+    if (!written.has(key)) output.push(line);
+  }
+  output.push(...rawDesiredLines);
+  return output.length > 0 ? `${output.join("\n")}\n` : "";
+}
+
+function readEnvLineKey(line: string): string | null {
+  const index = line.indexOf("=");
+  if (index <= 0) return null;
+  const key = line.slice(0, index).trim();
+  return key.length > 0 ? key : null;
+}
+
+function applyHookBuildFileOutputs(
+  plan: SandboxMessagingPlan,
+  outputs: MessagingHookOutputMap,
+  runOpenshell: MessagingOpenShellRunner,
+): string[] {
+  const appliedTargets: string[] = [];
+  for (const output of Object.values(outputs)) {
+    if (output.kind !== "build-file") continue;
+    const file = readHookBuildFile(output.value);
+    const target = resolveHookBuildFileTarget(file.path, plan.agent);
+    const contents =
+      file.merge !== undefined
+        ? applyStructuredMerge(
+            readSandboxFile(plan.sandboxName, target, runOpenshell),
+            file.merge,
+            target,
+          )
+        : serializeHookBuildFileContent(file.content, target);
+    writeSandboxFile(plan.sandboxName, target, contents, runOpenshell, file.mode);
+    appliedTargets.push(target);
+  }
+  return appliedTargets;
+}
+
+function readHookBuildFile(value: MessagingSerializableValue): {
+  readonly path: string;
+  readonly mode?: string;
+  readonly content?: MessagingSerializableValue;
+  readonly merge?: MessagingSerializableValue;
+} {
+  if (!isObject(value) || typeof value.path !== "string" || value.path.trim().length === 0) {
+    throw new Error("Messaging build-file hook output must include a non-empty path.");
+  }
+  const file = value as Record<string, MessagingSerializableValue | undefined>;
+  const path = value.path;
+  const mode = value.mode;
+  if (file.content === undefined && file.merge === undefined) {
+    throw new Error(`Messaging build-file '${path}' must include content or merge.`);
+  }
+  if (mode !== undefined && typeof mode !== "string") {
+    throw new Error(`Messaging build-file '${path}' mode must be a string.`);
+  }
+  return {
+    path,
+    mode,
+    content: file.content,
+    merge: file.merge,
+  };
+}
+
+function applyStructuredMerge(
+  existing: string | undefined,
+  patch: MessagingSerializableValue,
+  target: string,
+): string {
+  if (!isObject(patch)) {
+    throw new Error(`Messaging build-file merge for ${target} must be an object.`);
+  }
+  const format = target.endsWith(".yaml") || target.endsWith(".yml") ? "yaml" : "json";
+  const root = parseStructuredConfig(existing, target, format);
+  mergeObjects(root, patch);
+  return format === "yaml" ? YAML.stringify(root) : `${JSON.stringify(root, null, 2)}\n`;
+}
+
+function mergeObjects(
+  target: Record<string, MessagingSerializableValue>,
+  patch: Record<string, MessagingSerializableValue>,
+): void {
+  for (const [key, value] of Object.entries(patch)) {
+    const existing = target[key];
+    if (isObject(existing) && isObject(value)) {
+      mergeObjects(
+        existing as Record<string, MessagingSerializableValue>,
+        value as Record<string, MessagingSerializableValue>,
+      );
+      continue;
+    }
+    target[key] = value;
+  }
+}
+
+function serializeHookBuildFileContent(
+  content: MessagingSerializableValue | undefined,
+  target: string,
+): string {
+  if (content === undefined) return "";
+  if (typeof content === "string") return content.endsWith("\n") ? content : `${content}\n`;
+  if (target.endsWith(".yaml") || target.endsWith(".yml")) return YAML.stringify(content);
+  return `${JSON.stringify(content, null, 2)}\n`;
+}
+
+function resolveHookBuildFileTarget(path: string, agent: MessagingAgentId): string {
+  if (path.startsWith("/")) return path;
+  if (path === "openclaw.json") return resolveSandboxAgentConfigTarget(path, "openclaw");
+  if (path === "config.yaml" && agent === "hermes") {
+    return resolveSandboxAgentConfigTarget("~/.hermes/config.yaml", agent);
+  }
+  if (path === ".env" && agent === "hermes") {
+    return resolveSandboxAgentConfigTarget("~/.hermes/.env", agent);
+  }
+  if (agent === "openclaw") return `/sandbox/.openclaw/${path}`;
+  if (agent === "hermes") return `/sandbox/.hermes/${path}`;
+  throw new Error(`Cannot resolve messaging build-file target '${path}' for ${agent}.`);
+}
+
+function resolveSandboxAgentConfigTarget(target: string, agent: MessagingAgentId): string {
+  if (target.startsWith("/")) return target;
+  if (agent === "openclaw" && target === "openclaw.json") {
+    return "/sandbox/.openclaw/openclaw.json";
+  }
+  if (target.startsWith("~/.openclaw/")) {
+    return `/sandbox/.openclaw/${target.slice("~/.openclaw/".length)}`;
+  }
+  if (target.startsWith("~/.hermes/")) {
+    return `/sandbox/.hermes/${target.slice("~/.hermes/".length)}`;
+  }
+  throw new Error(`Cannot resolve messaging agent config target '${target}' for ${agent}.`);
+}
+
+function readSandboxFile(
+  sandboxName: string,
+  target: string,
+  runOpenshell: MessagingOpenShellRunner,
+): string | undefined {
+  const result = runOpenshell(
+    ["sandbox", "exec", "--name", sandboxName, "--", "cat", target],
+    {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const status = result.status ?? 0;
+  return status === 0 ? String(result.stdout ?? "") : undefined;
+}
+
+function writeSandboxFile(
+  sandboxName: string,
+  target: string,
+  contents: string,
+  runOpenshell: MessagingOpenShellRunner,
+  mode?: string,
+): void {
+  const result = runOpenshell(
+    [
+      "sandbox",
+      "exec",
+      "--name",
+      sandboxName,
+      "--",
+      "sh",
+      "-c",
+      mode
+        ? 'mkdir -p "$(dirname "$1")" && cat > "$1" && chmod "$2" "$1"'
+        : 'mkdir -p "$(dirname "$1")" && cat > "$1"',
+      "sh",
+      target,
+      ...(mode ? [mode] : []),
+    ],
+    {
+      input: contents,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  const status = result.status ?? 0;
+  if (status !== 0) {
+    throw new Error(
+      `Failed to apply messaging agent config '${target}': ${compactOutput(result)}`,
+    );
+  }
+}
+
+function readCredentialEnv(env: NodeJS.ProcessEnv, envKey: string): string | null {
+  const raw = env[envKey];
+  if (typeof raw !== "string") return null;
+  const normalized = raw.replace(/\r/g, "").trim();
+  return normalized || null;
+}
+
+function providerExistsInGateway(
+  providerName: string,
+  runOpenshell: MessagingOpenShellRunner,
+): boolean {
+  const result = runOpenshell(["provider", "get", providerName], {
+    ignoreError: true,
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  return (result.status ?? 0) === 0;
+}
+
+function buildProviderArgs(
+  action: "create" | "update",
+  providerName: string,
+  credentialEnv: string,
+): string[] {
+  return action === "create"
+    ? [
+        "provider",
+        "create",
+        "--name",
+        providerName,
+        "--type",
+        "generic",
+        "--credential",
+        credentialEnv,
+      ]
+    : ["provider", "update", providerName, "--credential", credentialEnv];
+}
+
+function toReuseEntry(binding: MessagingCredentialBindingLike): MessagingCredentialReuseEntry {
+  return {
+    channelId: binding.channelId,
+    credentialId: binding.credentialId,
+    providerName: binding.providerName,
+    envKey: binding.providerEnvKey,
+  };
+}
+
+function toMissingEntry(binding: MessagingCredentialBindingLike): MessagingMissingCredentialEntry {
+  return {
+    channelId: binding.channelId,
+    credentialId: binding.credentialId,
+    providerName: binding.providerName,
+    envKey: binding.providerEnvKey,
+  };
+}
+
+function compactOutput(result: { readonly stdout?: unknown; readonly stderr?: unknown }): string {
+  const output = `${String(result.stderr ?? "")}${String(result.stdout ?? "")}`
+    .replace(/\r/g, "")
+    .trim();
+  return output || "OpenShell command failed.";
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}

--- a/src/lib/messaging/applier/setup-applier.ts
+++ b/src/lib/messaging/applier/setup-applier.ts
@@ -4,6 +4,7 @@
 import { Buffer } from "node:buffer";
 import YAML from "yaml";
 
+import { redact } from "../../security/redact";
 import type {
   ChannelHookPhase,
   MessagingAgentId,
@@ -731,7 +732,7 @@ function toMissingEntry(binding: MessagingCredentialBindingLike): MessagingMissi
 }
 
 function compactOutput(result: { readonly stdout?: unknown; readonly stderr?: unknown }): string {
-  const output = `${String(result.stderr ?? "")}${String(result.stdout ?? "")}`
+  const output = redact(`${String(result.stderr ?? "")}${String(result.stdout ?? "")}`)
     .replace(/\r/g, "")
     .trim();
   return output || "OpenShell command failed.";

--- a/src/lib/messaging/applier/types.ts
+++ b/src/lib/messaging/applier/types.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ChannelHookFailureMode,
+  ChannelHookOutputSpec,
+  ChannelHookPhase,
+  MessagingAgentId,
+  MessagingChannelId,
+  SandboxMessagingHookReferencePlan,
+  SandboxMessagingPlan,
+} from "../manifest";
+import type { MessagingHookInputMap, MessagingHookOutputMap, MessagingHookRunResult } from "../hooks";
+
+export const MESSAGING_SETUP_APPLIER_ENV_KEY = "NEMOCLAW_MESSAGING_PLAN_B64";
+
+export interface MessagingSetupEnvOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly envKey?: string;
+}
+
+export interface MessagingHookApplyRequest {
+  readonly sandboxName: string;
+  readonly agent: MessagingAgentId;
+  readonly channelId: MessagingChannelId;
+  readonly hookId: string;
+  readonly phase: ChannelHookPhase;
+  readonly handler: string;
+  readonly inputKeys?: readonly string[];
+  readonly inputs: MessagingHookInputMap;
+  readonly outputs?: readonly ChannelHookOutputSpec[];
+  readonly onFailure?: ChannelHookFailureMode;
+}
+
+export type MessagingHookApplyRunner = (
+  request: MessagingHookApplyRequest,
+) =>
+  | void
+  | MessagingHookRunResult
+  | { readonly outputs?: MessagingHookOutputMap }
+  | Promise<void | MessagingHookRunResult | { readonly outputs?: MessagingHookOutputMap }>;
+
+export interface MessagingOpenShellRunOptions {
+  readonly ignoreError?: boolean;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly input?: string;
+  readonly stdio?: readonly unknown[];
+}
+
+export interface MessagingOpenShellRunResult {
+  readonly status?: number | null;
+  readonly stdout?: unknown;
+  readonly stderr?: unknown;
+}
+
+export type MessagingOpenShellRunner = (
+  args: readonly string[],
+  options?: MessagingOpenShellRunOptions,
+) => MessagingOpenShellRunResult;
+
+export interface MessagingCredentialApplyOptions extends MessagingSetupEnvOptions {
+  readonly runOpenshell: MessagingOpenShellRunner;
+}
+
+export interface MessagingCredentialApplyResult {
+  readonly upserted: readonly {
+    readonly channelId: MessagingChannelId;
+    readonly credentialId: string;
+    readonly providerName: string;
+    readonly envKey: string;
+    readonly action: "create" | "update";
+  }[];
+  readonly reused: readonly {
+    readonly channelId: MessagingChannelId;
+    readonly credentialId: string;
+    readonly providerName: string;
+    readonly envKey: string;
+  }[];
+  readonly missing: readonly {
+    readonly channelId: MessagingChannelId;
+    readonly credentialId: string;
+    readonly providerName: string;
+    readonly envKey: string;
+  }[];
+  readonly providerNames: readonly string[];
+  readonly sandboxCreateProviderArgs: readonly string[];
+}
+
+export interface MessagingPolicyApplyOptions {
+  readonly applyPresets: (sandboxName: string, presetNames: string[]) => boolean;
+}
+
+export interface MessagingPolicyApplyResult {
+  readonly appliedPresets: readonly string[];
+}
+
+export type MessagingSerializablePlan = SandboxMessagingPlan;
+export type MessagingSerializableHook = SandboxMessagingHookReferencePlan;

--- a/src/lib/messaging/channels/manifests.test.ts
+++ b/src/lib/messaging/channels/manifests.test.ts
@@ -37,19 +37,17 @@ function renderJson(manifest: ChannelManifest): string {
 }
 
 function expectTokenPasteEnrollHook(manifest: ChannelManifest, outputIds: readonly string[]): void {
-  expect(manifest.hooks).toEqual([
-    {
-      id: `${manifest.id}-token-paste`,
-      phase: "enroll",
-      handler: COMMON_TOKEN_PASTE_HOOK_HANDLER_ID,
-      outputs: outputIds.map((id) => ({
-        id,
-        kind: "secret",
-        required: true,
-      })),
-      onFailure: "skip-channel",
-    },
-  ]);
+  expect(manifest.hooks).toContainEqual({
+    id: `${manifest.id}-token-paste`,
+    phase: "enroll",
+    handler: COMMON_TOKEN_PASTE_HOOK_HANDLER_ID,
+    outputs: outputIds.map((id) => ({
+      id,
+      kind: "secret",
+      required: true,
+    })),
+    onFailure: "skip-channel",
+  });
 }
 
 describe("built-in channel manifests", () => {
@@ -151,6 +149,13 @@ describe("built-in channel manifests", () => {
     expect(renderJson(telegramManifest)).toContain("channels.telegram.groups");
     expect(renderJson(telegramManifest)).toContain("telegramConfig.requireMention");
     expectTokenPasteEnrollHook(telegramManifest, ["botToken"]);
+    expect(telegramManifest.hooks).toContainEqual({
+      id: "telegram-reachability",
+      phase: "reachability-check",
+      handler: "telegram.getMeReachability",
+      inputs: ["botToken"],
+      onFailure: "abort",
+    });
   });
 
   it("declares Discord guild and allowlist render intent for both agents", () => {

--- a/src/lib/messaging/channels/telegram/hooks/fakes.test.ts
+++ b/src/lib/messaging/channels/telegram/hooks/fakes.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { MessagingHookRegistry, runMessagingHook } from "../../../hooks";
+import { telegramManifest } from "../manifest";
+import {
+  FAKE_TELEGRAM_HOOK_REGISTRATIONS,
+  TELEGRAM_GET_ME_REACHABILITY_HOOK_ID,
+} from "./fakes";
+
+describe("Telegram fake hook implementations", () => {
+  it("declares the reachability hook without exposing the token in outputs", async () => {
+    const registry = new MessagingHookRegistry(FAKE_TELEGRAM_HOOK_REGISTRATIONS);
+    const hook = telegramManifest.hooks.find((entry) => entry.phase === "reachability-check");
+
+    if (!hook) throw new Error("missing Telegram reachability hook");
+
+    await expect(
+      runMessagingHook(hook, registry, {
+        channelId: "telegram",
+        inputs: {
+          botToken: "123456:telegram-token",
+        },
+      }),
+    ).resolves.toEqual({
+      hookId: "telegram-reachability",
+      handlerId: TELEGRAM_GET_ME_REACHABILITY_HOOK_ID,
+      phase: "reachability-check",
+      outputs: {},
+    });
+  });
+});

--- a/src/lib/messaging/channels/telegram/hooks/fakes.ts
+++ b/src/lib/messaging/channels/telegram/hooks/fakes.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MessagingHookHandler, MessagingHookRegistration } from "../../../hooks";
+
+export const TELEGRAM_GET_ME_REACHABILITY_HOOK_ID = "telegram.getMeReachability";
+
+export const fakeTelegramGetMeReachabilityHook: MessagingHookHandler = (context) => {
+  const token = context.inputs?.botToken;
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("Telegram reachability check requires botToken.");
+  }
+  return {};
+};
+
+export const FAKE_TELEGRAM_HOOK_REGISTRATIONS: readonly MessagingHookRegistration[] = [
+  {
+    id: TELEGRAM_GET_ME_REACHABILITY_HOOK_ID,
+    handler: fakeTelegramGetMeReachabilityHook,
+  },
+] as const;

--- a/src/lib/messaging/channels/telegram/manifest.ts
+++ b/src/lib/messaging/channels/telegram/manifest.ts
@@ -145,5 +145,12 @@ export const telegramManifest = {
       ],
       onFailure: "skip-channel",
     },
+    {
+      id: "telegram-reachability",
+      phase: "reachability-check",
+      handler: "telegram.getMeReachability",
+      inputs: ["botToken"],
+      onFailure: "abort",
+    },
   ],
 } as const satisfies ChannelManifest;

--- a/src/lib/messaging/channels/wechat/hooks/fakes.test.ts
+++ b/src/lib/messaging/channels/wechat/hooks/fakes.test.ts
@@ -95,6 +95,13 @@ describe("WeChat fake hook implementations", () => {
           value: {
             path: "openclaw.json",
             merge: {
+              plugins: {
+                entries: {
+                  "openclaw-weixin": {
+                    enabled: true,
+                  },
+                },
+              },
               channels: {
                 "openclaw-weixin": {
                   accounts: {

--- a/src/lib/messaging/channels/wechat/hooks/fakes.ts
+++ b/src/lib/messaging/channels/wechat/hooks/fakes.ts
@@ -15,6 +15,9 @@ const FAKE_WECHAT_BASE_URL = "https://ilinkai.wechat.example";
 const FAKE_WECHAT_USER_ID = "fake-wechat-user";
 const FAKE_WECHAT_TOKEN_PLACEHOLDER = "openshell:resolve:env:WECHAT_BOT_TOKEN";
 const FAKE_WECHAT_SAVED_AT = "2026-01-01T00:00:00.000Z";
+const WECHAT_PLUGIN_ID = "openclaw-weixin";
+const WECHAT_PLUGIN_INSTALL_PATH = "/sandbox/.openclaw/extensions/openclaw-weixin";
+const WECHAT_PLUGIN_SPEC = "@tencent-weixin/openclaw-weixin@2.4.2";
 
 export const fakeWechatIlinkLoginHook: MessagingHookHandler = () => ({
   outputs: {
@@ -80,14 +83,25 @@ export const fakeWechatSeedOpenClawAccountHook: MessagingHookHandler = (context)
           path: "openclaw.json",
           merge: {
             plugins: {
+              installs: {
+                [WECHAT_PLUGIN_ID]: {
+                  source: "npm",
+                  spec: WECHAT_PLUGIN_SPEC,
+                  installPath: WECHAT_PLUGIN_INSTALL_PATH,
+                },
+              },
+              load: {
+                paths: [WECHAT_PLUGIN_INSTALL_PATH],
+              },
               entries: {
-                "openclaw-weixin": {
+                [WECHAT_PLUGIN_ID]: {
                   enabled: true,
                 },
               },
             },
             channels: {
-              "openclaw-weixin": {
+              [WECHAT_PLUGIN_ID]: {
+                channelConfigUpdatedAt: FAKE_WECHAT_SAVED_AT,
                 accounts: {
                   [accountId]: {
                     enabled: true,

--- a/src/lib/messaging/channels/wechat/manifest.ts
+++ b/src/lib/messaging/channels/wechat/manifest.ts
@@ -135,6 +135,7 @@ export const wechatManifest = {
       id: "wechat-seed-openclaw-account",
       phase: "post-agent-install",
       handler: "wechat.seedOpenClawAccount",
+      agents: ["openclaw"],
       inputs: [
         "wechatConfig.accountId",
         "wechatConfig.baseUrl",

--- a/src/lib/messaging/compiler/engines/agent-render-engine.ts
+++ b/src/lib/messaging/compiler/engines/agent-render-engine.ts
@@ -8,7 +8,12 @@ import type {
   SandboxMessagingJsonRenderPlan,
 } from "../../manifest";
 import type { ManifestCompilerContext } from "../types";
-import { resolveCredentialTemplatesInLines, resolveCredentialTemplatesInValue } from "./template";
+import {
+  collectTemplateReferencesInLines,
+  collectTemplateReferencesInValue,
+  resolveCredentialTemplatesInLines,
+  resolveCredentialTemplatesInValue,
+} from "./template";
 
 export function planAgentRender(
   manifest: ChannelManifest,
@@ -18,6 +23,10 @@ export function planAgentRender(
     .filter((render) => render.agent === context.agent)
     .map((render) => {
       if (render.kind === "json-fragment") {
+        const value = resolveCredentialTemplatesInValue(
+          render.fragment.value,
+          manifest.credentials,
+        );
         return {
           channelId: manifest.id,
           renderId: render.id,
@@ -25,17 +34,20 @@ export function planAgentRender(
           agent: render.agent,
           target: render.target,
           path: render.fragment.path,
-          value: resolveCredentialTemplatesInValue(render.fragment.value, manifest.credentials),
+          value,
+          templateRefs: collectTemplateReferencesInValue(value),
         } satisfies SandboxMessagingJsonRenderPlan;
       }
 
+      const lines = resolveCredentialTemplatesInLines(render.lines, manifest.credentials);
       return {
         channelId: manifest.id,
         renderId: render.id,
         kind: "env-lines",
         agent: render.agent,
         target: render.target,
-        lines: resolveCredentialTemplatesInLines(render.lines, manifest.credentials),
+        lines,
+        templateRefs: collectTemplateReferencesInLines(lines),
       } satisfies SandboxMessagingEnvLinesRenderPlan;
     });
 }

--- a/src/lib/messaging/compiler/engines/build-step-engine.ts
+++ b/src/lib/messaging/compiler/engines/build-step-engine.ts
@@ -4,12 +4,17 @@
 import type {
   ChannelHookOutputSpec,
   ChannelManifest,
+  MessagingAgentId,
   SandboxMessagingBuildStepPlan,
 } from "../../manifest";
 
-export function planBuildSteps(manifest: ChannelManifest): SandboxMessagingBuildStepPlan[] {
-  return manifest.hooks.flatMap((hook) =>
-    (hook.outputs ?? [])
+export function planBuildSteps(
+  manifest: ChannelManifest,
+  agent: MessagingAgentId,
+): SandboxMessagingBuildStepPlan[] {
+  return manifest.hooks.flatMap((hook) => {
+    if (hook.agents && !hook.agents.includes(agent)) return [];
+    return (hook.outputs ?? [])
       .filter(isBuildStepOutput)
       .map((output) => ({
         channelId: manifest.id,
@@ -18,8 +23,8 @@ export function planBuildSteps(manifest: ChannelManifest): SandboxMessagingBuild
         handler: hook.handler,
         outputId: output.id,
         required: output.required === true,
-      })),
-  );
+      }));
+  });
 }
 
 function isBuildStepOutput(

--- a/src/lib/messaging/compiler/engines/template.ts
+++ b/src/lib/messaging/compiler/engines/template.ts
@@ -9,6 +9,7 @@ import type {
 
 const CREDENTIAL_PLACEHOLDER_PATTERN =
   /\{\{\s*credential\.([A-Za-z0-9_-]+)\.placeholder\s*\}\}/g;
+const TEMPLATE_REFERENCE_PATTERN = /\{\{\s*([^}]+?)\s*\}\}/g;
 
 export function resolveSandboxNameTemplate(
   value: MessagingTemplateString,
@@ -43,6 +44,27 @@ export function resolveCredentialTemplatesInLines(
   return lines.map((line) => resolveCredentialTemplatesInString(line, credentials));
 }
 
+export function collectTemplateReferencesInValue(
+  value: MessagingSerializableValue,
+): string[] {
+  if (typeof value === "string") return collectTemplateReferencesInString(value);
+  if (Array.isArray(value)) {
+    return unique(value.flatMap((entry) => collectTemplateReferencesInValue(entry)));
+  }
+  if (value && typeof value === "object") {
+    return unique(
+      Object.values(value).flatMap((entry) => collectTemplateReferencesInValue(entry)),
+    );
+  }
+  return [];
+}
+
+export function collectTemplateReferencesInLines(
+  lines: readonly MessagingTemplateString[],
+): string[] {
+  return unique(lines.flatMap((line) => collectTemplateReferencesInString(line)));
+}
+
 function resolveCredentialTemplatesInString(
   value: MessagingTemplateString,
   credentials: readonly ChannelCredentialSpec[],
@@ -51,4 +73,16 @@ function resolveCredentialTemplatesInString(
     const credential = credentials.find((entry) => entry.id === credentialId);
     return credential?.placeholder ?? match;
   });
+}
+
+function collectTemplateReferencesInString(value: MessagingTemplateString): string[] {
+  return unique(
+    [...value.matchAll(TEMPLATE_REFERENCE_PATTERN)]
+      .map((match) => match[1]?.trim())
+      .filter((reference): reference is string => typeof reference === "string" && reference.length > 0),
+  );
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
 }

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createBuiltInChannelManifestRegistry } from "../channels";
+import { FAKE_TELEGRAM_HOOK_REGISTRATIONS } from "../channels/telegram/hooks/fakes";
 import { FAKE_WECHAT_HOOK_REGISTRATIONS } from "../channels/wechat/hooks/fakes";
 import { MessagingHookRegistry } from "../hooks";
 import { FAKE_COMMON_HOOK_REGISTRATIONS } from "../hooks/common";
@@ -21,6 +22,7 @@ function compiler(): ManifestCompiler {
     createBuiltInChannelManifestRegistry(),
     new MessagingHookRegistry([
       ...FAKE_COMMON_HOOK_REGISTRATIONS,
+      ...FAKE_TELEGRAM_HOOK_REGISTRATIONS,
       ...FAKE_WECHAT_HOOK_REGISTRATIONS,
     ]),
   );
@@ -182,6 +184,11 @@ describe("ManifestCompiler", () => {
     expect(plan.healthChecks.every((check) => check.requiredBefore === "lifecycle-success")).toBe(
       true,
     );
+    expect(
+      plan.agentRender.find(
+        (render) => render.channelId === "telegram" && render.kind === "json-fragment",
+      )?.templateRefs,
+    ).toEqual(expect.arrayContaining(["proxyUrl", "allowedIds.telegram.values"]));
   });
 
   it("compiles Hermes render and WeChat agent policy alias intent", async () => {
@@ -211,6 +218,7 @@ describe("ManifestCompiler", () => {
     expect(JSON.stringify(plan.agentRender)).toContain(
       "WEIXIN_TOKEN=openshell:resolve:env:WECHAT_BOT_TOKEN",
     );
+    expect(plan.buildSteps).toEqual([]);
     expect(
       plan.channels
         .find((channel) => channel.channelId === "wechat")
@@ -367,6 +375,7 @@ describe("ManifestCompiler", () => {
   });
 
   it("compiles a non-built-in channel manifest through the same generic path", async () => {
+    const hookCalls: string[] = [];
     const customManifest = {
       schemaVersion: 1,
       id: "matrix",
@@ -419,23 +428,40 @@ describe("ManifestCompiler", () => {
             },
           ],
         },
+        {
+          id: "matrix-host-probe",
+          phase: "reachability-check",
+          handler: "matrix.probeHost",
+          inputs: ["roomId"],
+          onFailure: "abort",
+        },
       ],
     } as const satisfies ChannelManifest;
     const hooks = new MessagingHookRegistry([
       {
         id: "matrix.enroll",
-        handler: () => ({
-          outputs: {
-            accessToken: {
-              kind: "secret",
-              value: "raw-matrix-token",
+        handler: () => {
+          hookCalls.push("enroll");
+          return {
+            outputs: {
+              accessToken: {
+                kind: "secret",
+                value: "raw-matrix-token",
+              },
+              roomId: {
+                kind: "config",
+                value: "!room:example.com",
+              },
             },
-            roomId: {
-              kind: "config",
-              value: "!room:example.com",
-            },
-          },
-        }),
+          };
+        },
+      },
+      {
+        id: "matrix.probeHost",
+        handler: (context) => {
+          hookCalls.push(`reachability:${String(context.inputs?.roomId)}`);
+          return {};
+        },
       },
     ]);
     const plan = await new ManifestCompiler(
@@ -474,6 +500,16 @@ describe("ManifestCompiler", () => {
         policyKeys: ["matrix"],
         source: "manifest",
       },
+    ]);
+    expect(plan.channels[0]?.hooks).toContainEqual(
+      expect.objectContaining({
+        phase: "reachability-check",
+        handler: "matrix.probeHost",
+      }),
+    );
+    expect(hookCalls).toEqual([
+      "enroll",
+      "reachability:!room:example.com",
     ]);
     expect(JSON.stringify(plan)).not.toContain("raw-matrix-token");
   });

--- a/src/lib/messaging/compiler/manifest-compiler.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
+  ChannelHookSpec,
   ChannelInputSpec,
   ChannelManifest,
   ChannelManifestRegistry,
@@ -14,7 +15,11 @@ import type {
   SandboxMessagingPlan,
 } from "../manifest";
 import { MessagingHookRegistry, runMessagingHook } from "../hooks";
-import type { MessagingHookInputMap, MessagingHookOutputMap } from "../hooks";
+import type {
+  MessagingHookInputMap,
+  MessagingHookOutputMap,
+  MessagingHookRunResult,
+} from "../hooks";
 import { planAgentRender } from "./engines/agent-render-engine";
 import { planBuildSteps } from "./engines/build-step-engine";
 import { planCredentialBindings } from "./engines/credential-binding-engine";
@@ -30,7 +35,7 @@ export class ManifestCompiler {
   ) {}
 
   async compile(context: ManifestCompilerContext): Promise<SandboxMessagingPlan> {
-    const manifests = this.resolveRequestedManifests(context);
+    const manifests = this.resolveManifests(requestedChannelIds(context), context);
     const channels = [];
     for (const manifest of manifests) {
       channels.push(await this.compileChannel(manifest, context));
@@ -41,6 +46,18 @@ export class ManifestCompiler {
     const activeManifests = manifests.filter((manifest) =>
       isChannelActive(manifest.id, context),
     );
+    const credentialBindings = activeManifests.flatMap((manifest) =>
+      planCredentialBindings(manifest, context, inputRegistry.get(manifest.id) ?? []),
+    );
+    const networkPolicy = planNetworkPolicy(activeManifests, context);
+    const agentRender = activeManifests.flatMap((manifest) =>
+      planAgentRender(manifest, context),
+    );
+    const buildSteps = activeManifests.flatMap((manifest) =>
+      planBuildSteps(manifest, context.agent),
+    );
+    const stateUpdates = activeManifests.flatMap((manifest) => planStateUpdates(manifest));
+    const healthChecks = activeManifests.flatMap((manifest) => planHealthChecks(manifest));
 
     return {
       schemaVersion: 1,
@@ -48,22 +65,20 @@ export class ManifestCompiler {
       agent: context.agent,
       workflow: context.workflow,
       channels,
-      credentialBindings: activeManifests.flatMap((manifest) =>
-        planCredentialBindings(manifest, context, inputRegistry.get(manifest.id) ?? []),
-      ),
-      networkPolicy: planNetworkPolicy(activeManifests, context),
-      agentRender: activeManifests.flatMap((manifest) => planAgentRender(manifest, context)),
-      buildSteps: activeManifests.flatMap((manifest) => planBuildSteps(manifest)),
-      stateUpdates: activeManifests.flatMap((manifest) => planStateUpdates(manifest)),
-      healthChecks: activeManifests.flatMap((manifest) => planHealthChecks(manifest)),
+      credentialBindings,
+      networkPolicy,
+      agentRender,
+      buildSteps,
+      stateUpdates,
+      healthChecks,
     };
   }
 
-  private resolveRequestedManifests(context: ManifestCompilerContext): ChannelManifest[] {
-    const requestedIds = new Set([
-      ...context.selectedChannels,
-      ...(context.configuredChannels ?? []),
-    ]);
+  private resolveManifests(
+    channelIds: readonly MessagingChannelId[],
+    context: ManifestCompilerContext,
+  ): ChannelManifest[] {
+    const requestedIds = new Set(channelIds);
     const supportedIds =
       context.supportedChannelIds && context.supportedChannelIds.length > 0
         ? new Set(context.supportedChannelIds)
@@ -104,10 +119,25 @@ export class ManifestCompiler {
       inputs: await resolveChannelInputs(manifest, context, this.hooks, {
         runEnrollment:
           selected && active && isEnrollmentWorkflow(context.workflow) && context.isInteractive,
+        runEnrollmentChecks: selected && active && isEnrollmentWorkflow(context.workflow),
       }),
-      hooks: manifest.hooks.map((hook) => cloneHookReference(manifest.id, hook)),
+      hooks: manifest.hooks
+        .filter((hook) => isHookForAgent(hook, context.agent))
+        .map((hook) => cloneHookReference(manifest.id, hook)),
     };
   }
+}
+
+function isHookForAgent(hook: ChannelHookSpec, agent: ManifestCompilerContext["agent"]): boolean {
+  return !hook.agents || hook.agents.includes(agent);
+}
+
+function requestedChannelIds(context: ManifestCompilerContext): MessagingChannelId[] {
+  return uniqueChannels([...context.selectedChannels, ...(context.configuredChannels ?? [])]);
+}
+
+function uniqueChannels(channelIds: readonly MessagingChannelId[]): MessagingChannelId[] {
+  return [...new Set(channelIds)];
 }
 
 function isEnrollmentWorkflow(workflow: ManifestCompilerContext["workflow"]): boolean {
@@ -134,6 +164,7 @@ function cloneHookReference(
     id: hook.id,
     phase: hook.phase,
     handler: hook.handler,
+    agents: hook.agents ? [...hook.agents] : undefined,
     inputs: hook.inputs ? [...hook.inputs] : undefined,
     outputs: hook.outputs?.map((output) => ({ ...output })),
     onFailure: hook.onFailure,
@@ -144,22 +175,21 @@ async function resolveChannelInputs(
   manifest: ChannelManifest,
   context: ManifestCompilerContext,
   hooks: MessagingHookRegistry,
-  options: { readonly runEnrollment: boolean },
+  options: { readonly runEnrollment: boolean; readonly runEnrollmentChecks: boolean },
 ): Promise<SandboxMessagingInputReference[]> {
   let inputs = manifest.inputs.map((input) => resolveChannelInput(manifest, input, context));
+  let hookInputs = buildCompilerHookInputs(manifest, inputs);
+  inputs = applyCredentialAvailability(manifest, inputs, context);
   const enrollmentHooks = options.runEnrollment
-    ? manifest.hooks.filter((hook) => hook.phase === "enroll")
+    ? manifest.hooks
+        .filter((hook) => isHookForAgent(hook, context.agent))
+        .filter((hook) => hook.phase === "enroll")
     : [];
 
-  if (enrollmentHooks.length === 0) {
-    return applyCredentialAvailability(manifest, inputs, context);
-  }
-
   for (const hook of enrollmentHooks) {
-    const result = await runMessagingHook(hook, hooks, {
-      channelId: manifest.id,
-      inputs: toHookInputMap(inputs),
-    });
+    const result = await runCompilerHook(manifest, hook, hooks, hookInputs);
+    if (!result) continue;
+    hookInputs = mergeHookOutputsIntoInputs(manifest, hookInputs, result.outputs);
     inputs = applyCredentialAvailability(
       manifest,
       mergeEnrollmentOutputs(inputs, result.outputs),
@@ -167,7 +197,33 @@ async function resolveChannelInputs(
     );
   }
 
+  if (options.runEnrollmentChecks && hasRequiredInputsAvailable(manifest, inputs)) {
+    for (const hook of manifest.hooks
+      .filter((entry) => isHookForAgent(entry, context.agent))
+      .filter((entry) => entry.phase === "reachability-check")
+      .filter((entry) => hasDeclaredHookInputs(hookInputs, entry))) {
+      await runCompilerHook(manifest, hook, hooks, hookInputs);
+    }
+  }
+
   return inputs;
+}
+
+async function runCompilerHook(
+  manifest: ChannelManifest,
+  hook: ChannelHookSpec,
+  hooks: MessagingHookRegistry,
+  inputs: MessagingHookInputMap,
+): Promise<MessagingHookRunResult | null> {
+  try {
+    return await runMessagingHook(hook, hooks, {
+      channelId: manifest.id,
+      inputs: selectDeclaredHookInputs(hook, inputs),
+    });
+  } catch (error) {
+    if (hook.onFailure === "skip-channel") return null;
+    throw error;
+  }
 }
 
 function resolveChannelInput(
@@ -242,16 +298,70 @@ function applyCredentialAvailability(
   });
 }
 
-function toHookInputMap(
+function hasRequiredInputsAvailable(
+  manifest: ChannelManifest,
   inputs: readonly SandboxMessagingInputReference[],
-): MessagingHookInputMap {
+): boolean {
+  const byId = new Map(inputs.map((input) => [input.inputId, input]));
+  return manifest.inputs.every((input) => {
+    if (!input.required) return true;
+    const resolved = byId.get(input.id);
+    if (!resolved) return false;
+    return resolved.kind === "secret"
+      ? resolved.credentialAvailable === true
+      : resolved.value !== undefined;
+  });
+}
+
+function buildCompilerHookInputs(
+  manifest: ChannelManifest,
+  inputs: readonly SandboxMessagingInputReference[],
+): Record<string, MessagingSerializableValue> {
+  const inputSpecs = new Map(manifest.inputs.map((input) => [input.id, input]));
   const entries: Array<[string, MessagingSerializableValue]> = [];
   for (const input of inputs) {
-    if (input.value === undefined) continue;
-    entries.push([input.inputId, input.value]);
-    if (input.statePath) entries.push([input.statePath, input.value]);
+    const spec = inputSpecs.get(input.inputId);
+    const value = input.value ?? (spec ? readInputEnvValue(spec) : undefined);
+    if (value === undefined) continue;
+    entries.push([input.inputId, value]);
+    if (input.statePath) entries.push([input.statePath, value]);
   }
   return Object.fromEntries(entries);
+}
+
+function mergeHookOutputsIntoInputs(
+  manifest: ChannelManifest,
+  inputs: Record<string, MessagingSerializableValue>,
+  outputs: MessagingHookOutputMap,
+): Record<string, MessagingSerializableValue> {
+  const next = { ...inputs };
+  const inputSpecs = new Map(manifest.inputs.map((input) => [input.id, input]));
+  for (const [outputId, output] of Object.entries(outputs)) {
+    if (output.kind !== "secret" && output.kind !== "config") continue;
+    next[outputId] = output.value;
+    const statePath = inputSpecs.get(outputId)?.statePath;
+    if (statePath) next[statePath] = output.value;
+  }
+  return next;
+}
+
+function hasDeclaredHookInputs(
+  inputs: MessagingHookInputMap,
+  hook: ChannelHookSpec,
+): boolean {
+  return (hook.inputs ?? []).every((inputKey) => Object.hasOwn(inputs, inputKey));
+}
+
+function selectDeclaredHookInputs(
+  hook: ChannelHookSpec,
+  inputs: MessagingHookInputMap,
+): MessagingHookInputMap | undefined {
+  if (!hook.inputs || hook.inputs.length === 0) return undefined;
+  return Object.fromEntries(
+    hook.inputs
+      .filter((inputKey) => Object.hasOwn(inputs, inputKey))
+      .map((inputKey) => [inputKey, inputs[inputKey] as MessagingSerializableValue]),
+  );
 }
 
 function mergeEnrollmentOutputs(

--- a/src/lib/messaging/compiler/workflow-planner.test.ts
+++ b/src/lib/messaging/compiler/workflow-planner.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createBuiltInChannelManifestRegistry } from "../channels";
+import { FAKE_TELEGRAM_HOOK_REGISTRATIONS } from "../channels/telegram/hooks/fakes";
 import { FAKE_WECHAT_HOOK_REGISTRATIONS } from "../channels/wechat/hooks/fakes";
 import { MessagingHookRegistry } from "../hooks";
 import { FAKE_COMMON_HOOK_REGISTRATIONS } from "../hooks/common";
@@ -14,6 +15,7 @@ function planner(): MessagingWorkflowPlanner {
     createBuiltInChannelManifestRegistry(),
     new MessagingHookRegistry([
       ...FAKE_COMMON_HOOK_REGISTRATIONS,
+      ...FAKE_TELEGRAM_HOOK_REGISTRATIONS,
       ...FAKE_WECHAT_HOOK_REGISTRATIONS,
     ]),
   );

--- a/src/lib/messaging/compiler/workflow-planner.ts
+++ b/src/lib/messaging/compiler/workflow-planner.ts
@@ -85,7 +85,7 @@ export class MessagingWorkflowPlanner {
       onlyConfiguredChannels(context.disabledChannels, configuredChannels),
       [context.channelId],
     );
-    this.assertSupportedChannels(configuredChannels, context);
+    this.assertSupportedChannels([...configuredChannels, context.channelId], context);
 
     return this.compileWorkflow(context, {
       workflow: "remove-channel",

--- a/src/lib/messaging/manifest/types.test.ts
+++ b/src/lib/messaging/manifest/types.test.ts
@@ -254,6 +254,7 @@ const telegramPlan = {
         botToken: "openshell:resolve:env:TELEGRAM_BOT_TOKEN",
         enabled: true,
       },
+      templateRefs: [],
     },
   ],
   buildSteps: [],

--- a/src/lib/messaging/manifest/types.ts
+++ b/src/lib/messaging/manifest/types.ts
@@ -135,9 +135,12 @@ export interface ChannelRebuildHydrationSpec {
 /** Lifecycle phase where a referenced hook may run. */
 export type ChannelHookPhase =
   | "enroll"
+  | "reachability-check"
   | "apply"
   | "post-agent-install"
-  | "health-check";
+  | "health-check"
+  | "diagnostic"
+  | "status";
 
 /** How the planner/applier should treat a hook failure. */
 export type ChannelHookFailureMode = "abort" | "skip-channel";
@@ -147,6 +150,7 @@ export interface ChannelHookSpec {
   readonly id: string;
   readonly phase: ChannelHookPhase;
   readonly handler: string;
+  readonly agents?: readonly MessagingAgentId[];
   readonly inputs?: readonly string[];
   readonly outputs?: readonly ChannelHookOutputSpec[];
   readonly onFailure?: ChannelHookFailureMode;
@@ -255,6 +259,7 @@ export interface SandboxMessagingJsonRenderPlan
   readonly kind: "json-fragment";
   readonly path: MessagingStatePath;
   readonly value: MessagingSerializableValue;
+  readonly templateRefs: readonly string[];
 }
 
 /** Compiled env-file lines ready for an applier/render engine. */
@@ -262,6 +267,7 @@ export interface SandboxMessagingEnvLinesRenderPlan
   extends SandboxMessagingAgentRenderBasePlan {
   readonly kind: "env-lines";
   readonly lines: readonly MessagingTemplateString[];
+  readonly templateRefs: readonly string[];
 }
 
 /** Build-time input the applier may pass into sandbox create/rebuild. */


### PR DESCRIPTION
## Summary
Adds the serializable messaging applier boundary for phase 1 of the manifest-based messaging redesign. The applier consumes `SandboxMessagingPlan` directly, applies generic OpenShell credential/config/policy work, and adds compiler support for manifest-declared reachability hooks without moving production conflict detection.

## Related Issue
Fixes #3996
Part of #3896

## Changes
- Add `src/lib/messaging/applier/` with env transport, serialization checks, OpenShell credential provider application, policy application, agent config rendering, and hook-returned `build-file` application.
- Add Telegram `reachability-check` hook metadata plus fake reachability hook implementation for phase-1 tests.
- Run reachability hooks during manifest compilation after enrollment input availability is known while keeping raw secrets out of returned plans.
- Make WeChat post-install account seeding visible through hook-returned build files and apply those outputs to OpenClaw account files and `openclaw.json`.
- Filter hook/build-step planning by agent so OpenClaw-only WeChat work does not appear in Hermes plans.
- Add focused tests for applier behavior, reachability hooks, hook-returned file writes, serialization, and secret hygiene.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted checks run:
- `npm test -- --project cli src/lib/messaging`
- `npm run typecheck:cli`
- `npm run lint -- src/lib/messaging`
- `npm run source-shape:check`
- `git diff --check`

Full pre-commit CLI tests were not marked as passing because an unrelated host debug-output assertion failed in `test/cli.test.ts:1434`.

---
Signed-off-by: San Dang <sdang@nvidia.com>
