### PR TITLE
test(e2e): classify OpenClaw live switch timeouts

### DIFF
--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -44,6 +44,21 @@ section() {
 }
 info() { printf '\033[1;34m  [info]\033[0m %s\n' "$1"; }
 
+is_transient_live_http_code() {
+  case "${1:-}" in
+    502 | 503 | 504) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+http_status_from_response() {
+  sed -n 's/^__NEMOCLAW_HTTP_STATUS__=//p' <<<"$1" | tail -1
+}
+
+http_body_from_response() {
+  sed '/^__NEMOCLAW_HTTP_STATUS__=/d' <<<"$1"
+}
+
 run_with_timeout() {
   local seconds="$1"
   shift
@@ -214,7 +229,7 @@ print("OK")
 }
 
 check_sandbox_inference() {
-  local payload payload_arg response rc content attempt last_fail
+  local payload payload_arg response rc content attempt last_fail http_code body remote transient=0
   payload=$(SWITCH_MODEL="$SWITCH_MODEL" python3 -c '
 import json
 import os
@@ -225,18 +240,27 @@ print(json.dumps({
 }))
 ')
   payload_arg="$(printf '%q' "$payload")"
+  remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
   last_fail=""
 
   for attempt in 1 2 3; do
     rc=0
-    response=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc \
-      "curl -sS --max-time 90 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' -d $payload_arg" \
-      2>&1) || rc=$?
+    transient=0
+    response=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc "$remote" 2>&1) || rc=$?
+    http_code=$(http_status_from_response "$response")
+    [ -n "$http_code" ] || http_code="000"
+    body=$(http_body_from_response "$response")
 
     if [ "$rc" -ne 0 ]; then
-      last_fail="curl failed with exit ${rc}: ${response:0:300}"
+      [ "$rc" -eq 28 ] && transient=1
+      last_fail="curl failed with exit ${rc}; HTTP ${http_code}: ${body:0:300}"
+    elif is_transient_live_http_code "$http_code"; then
+      transient=1
+      last_fail="transient HTTP ${http_code}: ${body:0:300}"
+    elif [ "$http_code" != "200" ]; then
+      last_fail="HTTP ${http_code}: ${body:0:300}"
     else
-      content=$(printf '%s' "$response" | parse_chat_content 2>/dev/null) || content=""
+      content=$(printf '%s' "$body" | parse_chat_content 2>/dev/null) || content=""
       if grep -qi "PONG" <<<"$content"; then
         pass "Sandbox inference.local returned PONG with ${SWITCH_MODEL}"
         return
@@ -250,7 +274,11 @@ print(json.dumps({
     }
   done
 
-  fail "Sandbox inference.local did not work after switch: ${last_fail}"
+  if [ "$transient" -eq 1 ]; then
+    skip "Sandbox inference.local transient failure after switch; route/config checks already passed"
+  else
+    fail "Sandbox inference.local did not work after switch: ${last_fail}"
+  fi
 }
 
 check_openclaw_agent_turn() {
@@ -278,6 +306,8 @@ check_openclaw_agent_turn() {
 
   if [ "$rc" -eq 0 ] && grep -qE '(^|[^0-9])42([^0-9]|$)' <<<"$reply"; then
     pass "OpenClaw agent answered through the switched inference route"
+  elif [ "$rc" -eq 124 ]; then
+    skip "OpenClaw agent turn timed out after switch; route/config checks already passed"
   else
     fail "OpenClaw agent turn failed after switch (exit ${rc}); reply='${reply:0:200}', raw='${raw:0:200}'"
   fi


### PR DESCRIPTION
## Summary
The latest nightly flake sweep shows `openclaw-inference-switch-e2e` repeatedly passing route/config/hash assertions, then failing during post-switch live requests when `inference.local` or the OpenClaw agent turn times out. This PR mirrors the Hermes stabilization by keeping route/config regressions blocking while classifying explicit post-switch live timeout/5xx probes as transient skips.

## Changes
- Capture HTTP status for the post-switch OpenClaw `inference.local` probe.
- Track transient state structurally from curl exit 28 or HTTP 502/503/504.
- Convert post-switch `inference.local` transient exhaustion to SKIP after route/config/session checks have passed.
- Convert OpenClaw agent command timeout (`exit 124`) to SKIP after route/config/session checks have passed.
- Preserve FAIL for wrong-content responses, unexpected HTTP statuses, and all route/config/hash/session regressions.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resilience by implementing transient failure detection for HTTP status codes (502/503/504), distinguishing temporary from permanent errors
  * Enhanced timeout handling to properly classify timeout scenarios in endpoint tests
  * Added utilities for more robust HTTP response parsing and status classification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->