### PR TITLE
fix(docker): align in-container healthcheck with delivery chain on OpenShell-managed runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -757,12 +757,63 @@ RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]; then \
 # Health check: poll the gateway's /health endpoint so Docker (and Compose)
 # can detect and restart unhealthy containers in standalone deployments.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/1430
+#
+# Two-stage probe so Docker health does not contradict the NemoClaw delivery
+# chain on runtimes where the dashboard port lives in a different network
+# namespace (e.g. DGX Spark / aarch64 with OpenShell-managed forwarding).
+# The reporter saw `nemoclaw status` Ready + the host forward succeed while
+# Docker marked the container unhealthy because the in-container curl could
+# not see the dashboard listener. See #3975.
+#
+#   1. Direct in-container probe (HTTP 200) — definitive when it works,
+#      preserves the original Compose/standalone health signal.
+#   2. ONLY on curl exit 7 ("Couldn't connect"), fall back to verifying
+#      ALL of:
+#        - the OpenClaw gateway process started by nemoclaw-start is
+#          still alive (via pgrep --ignore-ancestors), AND
+#        - the gateway log file exists and is non-empty (proves the
+#          process started and emitted its banner; rules out cases
+#          where the gateway never came up).
+#      Exit 7 means the in-container TCP connect was refused by the
+#      kernel because nothing is bound to the dashboard port inside
+#      this network namespace — the namespace-mismatch shape reported
+#      in #3975. A connect timeout (curl exit 28) is treated as a real
+#      failure: a listener exists but is not responding (wedged HTTP
+#      server), and we want Docker to restart in that case.
+#
+# Tradeoff: this fallback also fires in a standalone deployment where the
+# gateway process is alive but the configured dashboard port is wrong or
+# the listener never came up. We accept that residual risk because it
+# requires a misconfiguration the start-period (45s) already gives the
+# wizard a chance to fix, and the existing host-side delivery chain
+# probes (verify-deployment.ts, host port forward, sandbox status) still
+# catch it from outside.
+#
+# The process pattern matches both `openclaw gateway run` (the launcher
+# command nemoclaw-start runs) and `openclaw-gateway` (the re-execed
+# binary form OpenClaw switches into after startup). This is the same
+# variant set the host-side gateway-stop script in services.ts matches.
+#
+# pgrep uses --ignore-ancestors so it cannot self-match the healthcheck
+# shell that Docker spawns to run this CMD — that shell's argv contains
+# the literal 'openclaw gateway' string we're searching for, and
+# without --ignore-ancestors `pgrep -f` would happily report it as the
+# live gateway even after the real process exited (procps 4.0+ supports
+# this flag; the base image pins procps to 2:4.0.4-9).
+#
+# We deliberately do not fall back on HTTP 4xx/5xx — those mean the gateway
+# answered with a failure inside this container, which is a real bad signal.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
     CMD port="${NEMOCLAW_DASHBOARD_PORT:-${OPENCLAW_GATEWAY_PORT:-}}"; \
         if [ -z "$port" ]; then \
             port="$(python3 -c 'import os; from urllib.parse import urlparse; raw = os.environ.get("CHAT_UI_URL") or "http://127.0.0.1:18789"; raw = raw if "://" in raw else "http://" + raw; u = urlparse(raw); print(u.port or 18789)' 2>/dev/null || printf '18789')"; \
         fi; \
-        curl -sf "http://127.0.0.1:${port}/health"
+        rc=0; \
+        curl -sf --max-time 3 "http://127.0.0.1:${port}/health" > /dev/null 2>&1 || rc=$?; \
+        if [ "$rc" = 0 ]; then exit 0; fi; \
+        if [ "$rc" != 7 ]; then exit 1; fi; \
+        pgrep --ignore-ancestors -f 'openclaw[ -]gateway' > /dev/null 2>&1 || exit 1; \
+        [ -s /tmp/gateway.log ]
 
 # Entrypoint runs as root to start the gateway as the gateway user,
 # then drops to sandbox for agent commands. See nemoclaw-start.sh.

--- a/src/lib/actions/sandbox/docker-health.test.ts
+++ b/src/lib/actions/sandbox/docker-health.test.ts
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { getSandboxDockerHealth } from "../../../../dist/lib/actions/sandbox/docker-health";
+import type { SandboxEntry } from "../../../../dist/lib/state/registry";
+
+function fixture({
+  driver = "docker",
+  psNames = "openshell-cluster-nemoclaw\nopenshell-my-assistant-12ab\nopenshell-other-aa11",
+  healthRaw = "unhealthy\n",
+  throwOnInspect = false,
+  knownSandboxes = ["my-assistant"],
+}: {
+  driver?: string | null;
+  psNames?: string;
+  healthRaw?: string;
+  throwOnInspect?: boolean;
+  knownSandboxes?: string[];
+} = {}) {
+  const sandbox: Partial<SandboxEntry> = { name: "my-assistant", openshellDriver: driver };
+  return {
+    getSandbox: () => sandbox as SandboxEntry,
+    listSandboxNames: () => knownSandboxes,
+    dockerPsNames: () => psNames,
+    dockerInspectHealth: () => {
+      if (throwOnInspect) throw new Error("docker inspect crashed");
+      return healthRaw;
+    },
+  };
+}
+
+describe("getSandboxDockerHealth", () => {
+  it("returns the docker container health when the sandbox runs on the docker driver", () => {
+    const deps = fixture({ healthRaw: "healthy\n" });
+    expect(getSandboxDockerHealth("my-assistant", deps)).toEqual({
+      state: "healthy",
+      containerName: "openshell-my-assistant-12ab",
+    });
+  });
+
+  it("normalizes whitespace and uppercase Docker health values", () => {
+    const deps = fixture({ healthRaw: "  UnHealthy \n" });
+    expect(getSandboxDockerHealth("my-assistant", deps).state).toBe("unhealthy");
+  });
+
+  it("returns state 'starting' during the start-period window", () => {
+    const deps = fixture({ healthRaw: "starting" });
+    expect(getSandboxDockerHealth("my-assistant", deps).state).toBe("starting");
+  });
+
+  it("returns state 'none' when the container has no HEALTHCHECK at all", () => {
+    const deps = fixture({ healthRaw: "none" });
+    expect(getSandboxDockerHealth("my-assistant", deps).state).toBe("none");
+  });
+
+  it("returns state 'none' for non-docker-driver sandboxes (k3s / kubernetes etc.)", () => {
+    const deps = fixture({ driver: "kubernetes" });
+    expect(getSandboxDockerHealth("my-assistant", deps)).toEqual({
+      state: "none",
+      containerName: null,
+    });
+  });
+
+  it("returns state 'none' when no docker container is found for the sandbox", () => {
+    const deps = fixture({ psNames: "openshell-cluster-nemoclaw\n" });
+    expect(getSandboxDockerHealth("my-assistant", deps).state).toBe("none");
+  });
+
+  it("matches an exact container name when no per-instance suffix is present", () => {
+    const deps = fixture({
+      psNames: "openshell-my-assistant\nopenshell-other-aa11",
+      healthRaw: "healthy",
+    });
+    expect(getSandboxDockerHealth("my-assistant", deps).containerName).toBe(
+      "openshell-my-assistant",
+    );
+  });
+
+  it("does not select another sandbox's container when its name is a prefix", () => {
+    const deps = fixture({
+      psNames: "openshell-my-assistant-12ab\nopenshell-cluster-nemoclaw",
+    });
+    expect(getSandboxDockerHealth("my", deps)).toEqual({
+      state: "none",
+      containerName: null,
+    });
+  });
+
+  it("prefers an exact-name match even when the docker ps listing returns a suffixed candidate first", () => {
+    const deps = fixture({
+      psNames: "openshell-my-assistant\nopenshell-my\n",
+      healthRaw: "healthy",
+      knownSandboxes: ["my", "my-assistant"],
+    });
+    expect(getSandboxDockerHealth("my", deps).containerName).toBe("openshell-my");
+  });
+
+  it("does not steal another sandbox's container when names share a hyphenated prefix and the suffix is hyphen-free", () => {
+    const deps = fixture({
+      psNames: "openshell-my-assistant-prod\n",
+      knownSandboxes: ["my-assistant", "my-assistant-prod"],
+    });
+    expect(getSandboxDockerHealth("my-assistant", deps)).toEqual({
+      state: "none",
+      containerName: null,
+    });
+  });
+
+  it("attributes a hyphenated container to the longest registered sandbox name", () => {
+    const deps = fixture({
+      psNames: "openshell-my-assistant-prod-abc\n",
+      knownSandboxes: ["my-assistant", "my-assistant-prod"],
+      healthRaw: "healthy",
+    });
+    // Looking up the shorter sandbox name must not match the longer
+    // sandbox's container, even when the suffix after each candidate
+    // prefix is hyphen-free.
+    expect(getSandboxDockerHealth("my-assistant", deps).containerName).toBe(null);
+  });
+
+  it("returns state 'unknown' when docker inspect throws", () => {
+    const deps = fixture({ throwOnInspect: true });
+    const result = getSandboxDockerHealth("my-assistant", deps);
+    expect(result.state).toBe("unknown");
+    expect(result.containerName).toBe("openshell-my-assistant-12ab");
+  });
+});

--- a/src/lib/actions/sandbox/docker-health.test.ts
+++ b/src/lib/actions/sandbox/docker-health.test.ts
@@ -97,6 +97,20 @@ describe("getSandboxDockerHealth", () => {
     expect(getSandboxDockerHealth("my", deps).containerName).toBe("openshell-my");
   });
 
+  it("prefers the exact-name container over a docker-runtime-suffixed sibling", () => {
+    // openshell-my-12ab is a same-sandbox alternate container left over
+    // from an earlier OpenShell run; only `my` is registered, so the
+    // longest-known-name heuristic alone would still resolve the
+    // suffixed candidate to `my` and could return it depending on
+    // docker ps ordering. The exact name must always win.
+    const deps = fixture({
+      psNames: "openshell-my-12ab\nopenshell-my\n",
+      healthRaw: "healthy",
+      knownSandboxes: ["my"],
+    });
+    expect(getSandboxDockerHealth("my", deps).containerName).toBe("openshell-my");
+  });
+
   it("does not steal another sandbox's container when names share a hyphenated prefix and the suffix is hyphen-free", () => {
     const deps = fixture({
       psNames: "openshell-my-assistant-prod\n",

--- a/src/lib/actions/sandbox/docker-health.ts
+++ b/src/lib/actions/sandbox/docker-health.ts
@@ -71,6 +71,13 @@ function resolveDockerDriverSandboxContainer(
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line === ourExact || line.startsWith(ourPrefix));
+  // Prefer the exact-name container before considering suffixed ones.
+  // Without this short-circuit, a suffixed `openshell-<name>-<id>` whose
+  // <id> is a docker runtime suffix (not a registered sandbox name) would
+  // resolve to our sandbox via the longest-match heuristic and beat the
+  // co-existing exact `openshell-<name>` if it appeared earlier in
+  // `docker ps`.
+  if (candidates.includes(ourExact)) return ourExact;
   for (const candidate of candidates) {
     const stripped = candidate.replace(/^openshell-/, "");
     // Find the longest known sandbox whose container name pattern

--- a/src/lib/actions/sandbox/docker-health.ts
+++ b/src/lib/actions/sandbox/docker-health.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { dockerContainerInspectFormat } from "../../adapters/docker/inspect";
+import { dockerCapture } from "../../adapters/docker/run";
+import * as registry from "../../state/registry";
+
+export type DockerHealthState =
+  | "healthy"
+  | "unhealthy"
+  | "starting"
+  | "none"
+  | "unknown";
+
+export interface SandboxDockerHealth {
+  state: DockerHealthState;
+  containerName: string | null;
+}
+
+interface ResolveDeps {
+  getSandbox: (name: string) => registry.SandboxEntry | null;
+  listSandboxNames: () => string[];
+  dockerPsNames: () => string;
+  dockerInspectHealth: (containerName: string) => string;
+}
+
+const defaultDeps: ResolveDeps = {
+  getSandbox: (name) => registry.getSandbox(name),
+  listSandboxNames: () => registry.listSandboxes().sandboxes.map((entry) => entry.name),
+  dockerPsNames: () =>
+    dockerCapture(["ps", "--format", "{{.Names}}"], { ignoreError: true }),
+  dockerInspectHealth: (containerName) =>
+    dockerContainerInspectFormat(
+      "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+      containerName,
+      { ignoreError: true },
+    ),
+};
+
+function resolveDockerDriverSandboxContainer(
+  sandboxName: string,
+  deps: ResolveDeps,
+): string | null {
+  try {
+    if (deps.getSandbox(sandboxName)?.openshellDriver !== "docker") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  // OpenShell names sandbox containers either as `openshell-<sandbox>`
+  // (no suffix) or `openshell-<sandbox>-<id>` where <id> is a runtime
+  // identifier appended by openshell. Two ambiguities to avoid:
+  //
+  //   1. A sandbox name can be a prefix of another sandbox name
+  //      (`my` vs `my-assistant`).
+  //   2. Even with a hyphen-free suffix, a sandbox name can be a prefix
+  //      of another sandbox name whose own suffix is hyphen-free
+  //      (`my-assistant` vs `my-assistant-prod`).
+  //
+  // To disambiguate, resolve each candidate to the LONGEST registered
+  // sandbox name it could belong to. We only accept a candidate when
+  // that resolved owner is the sandbox we are looking up. This also
+  // gives the right answer for the `openshell-<sandbox>` exact form.
+  const ourPrefix = `openshell-${sandboxName}-`;
+  const ourExact = `openshell-${sandboxName}`;
+  const knownSandboxes = new Set(deps.listSandboxNames());
+  knownSandboxes.add(sandboxName);
+  const candidates = deps
+    .dockerPsNames()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line === ourExact || line.startsWith(ourPrefix));
+  for (const candidate of candidates) {
+    const stripped = candidate.replace(/^openshell-/, "");
+    // Find the longest known sandbox whose container name pattern
+    // matches this candidate. Longest-first defeats prefix collisions.
+    const owner = [...knownSandboxes]
+      .filter(
+        (name) => stripped === name || stripped.startsWith(`${name}-`),
+      )
+      .sort((a, b) => b.length - a.length)[0];
+    if (owner === sandboxName) return candidate;
+  }
+  return null;
+}
+
+function normalizeHealthState(raw: string): DockerHealthState {
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "healthy") return "healthy";
+  if (trimmed === "unhealthy") return "unhealthy";
+  if (trimmed === "starting") return "starting";
+  if (trimmed === "none" || trimmed === "") return "none";
+  return "unknown";
+}
+
+/**
+ * Read the Docker `.State.Health.Status` for a sandbox container managed by
+ * the docker driver. Returns `state: "none"` when the sandbox is not on the
+ * docker driver, or when the inspect call fails for any reason — callers
+ * use this to surface the Docker healthcheck signal alongside NemoClaw's
+ * own delivery-chain probes. See #3975 for the mismatch this helps explain.
+ */
+export function getSandboxDockerHealth(
+  sandboxName: string,
+  depsOverride: Partial<ResolveDeps> = {},
+): SandboxDockerHealth {
+  const deps: ResolveDeps = { ...defaultDeps, ...depsOverride };
+  const containerName = resolveDockerDriverSandboxContainer(sandboxName, deps);
+  if (!containerName) return { state: "none", containerName: null };
+  let raw = "";
+  try {
+    raw = deps.dockerInspectHealth(containerName);
+  } catch {
+    return { state: "unknown", containerName };
+  }
+  return { state: normalizeHealthState(raw), containerName };
+}

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -2,29 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import * as agentRuntime from "../../agent/runtime";
-import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
-import { parseSandboxPhase } from "../../state/gateway";
-import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
-import { parseGatewayInference } from "../../inference/config";
-import {
-  probeProviderHealth,
-  type ProviderHealthProbeOptions,
-  type ProviderHealthStatus,
-} from "../../inference/health";
-import * as nim from "../../inference/nim";
-import * as onboardSession from "../../state/onboard-session";
-import type { Session } from "../../state/onboard-session";
-import {
-  captureOpenshellForStatus,
-  isCommandTimeout,
-} from "../../adapters/openshell/runtime";
 import {
   detectOpenShellStateRpcResultIssue,
   printOpenShellStateRpcIssue,
 } from "../../adapters/openshell/gateway-drift";
-import * as registry from "../../state/registry";
 import { resolveOpenshell } from "../../adapters/openshell/resolve";
+import {
+  captureOpenshellForStatus,
+  isCommandTimeout,
+} from "../../adapters/openshell/runtime";
+import * as agentRuntime from "../../agent/runtime";
+import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
+import { D, G, R, RD, YW } from "../../cli/terminal-style";
+import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
+import { parseGatewayInference } from "../../inference/config";
+import {
+  type ProviderHealthProbeOptions,
+  type ProviderHealthStatus,
+  probeProviderHealth,
+} from "../../inference/health";
+import * as nim from "../../inference/nim";
+import * as sandboxVersion from "../../sandbox/version";
+import * as shields from "../../shields";
+import { parseSandboxPhase } from "../../state/gateway";
+import type { Session } from "../../state/onboard-session";
+import * as onboardSession from "../../state/onboard-session";
+import * as registry from "../../state/registry";
+import {
+  createSystemDeps as createSessionDeps,
+  getActiveSandboxSessions,
+} from "../../state/sandbox-session";
+import { getSandboxDockerHealth } from "./docker-health";
+import { classifyGatewayFailure, getLayerHeader } from "./gateway-failure-classifier";
 import type { SandboxGatewayState } from "./gateway-state";
 import {
   getReconciledSandboxGatewayState,
@@ -32,18 +41,10 @@ import {
   printGatewayLifecycleHint,
   printWrongGatewayActiveGuidance,
 } from "./gateway-state";
-import { classifyGatewayFailure, getLayerHeader } from "./gateway-failure-classifier";
 import {
   isSandboxGatewayRunningForStatus,
   probeSandboxInferenceGatewayHealth,
 } from "./process-recovery";
-import {
-  createSystemDeps as createSessionDeps,
-  getActiveSandboxSessions,
-} from "../../state/sandbox-session";
-import * as sandboxVersion from "../../sandbox/version";
-import * as shields from "../../shields";
-import { D, G, R, RD, YW } from "../../cli/terminal-style";
 
 type ProbeProviderHealth = (
   provider: string,
@@ -388,6 +389,38 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
         console.log(`    ${D}${CLI_NAME} ${sandboxName} connect${R}  (auto-recovers on connect)`);
         console.log("  Or manually inside the sandbox:");
         console.log(`    ${D}${agentRuntime.getGatewayCommand(sessionAgent)}${R}`);
+      }
+    }
+  }
+
+  // Surface the Docker healthcheck signal as its own line so users can
+  // tell when it disagrees with NemoClaw's own delivery-chain probes
+  // (sandbox phase, OpenClaw process, host port forward). On runtimes
+  // where the dashboard port lives in a different network namespace
+  // (e.g. DGX Spark / aarch64 with OpenShell-managed forwarding), the
+  // in-container /health curl can fail even though the delivery chain
+  // is fine — older images without the #3975 healthcheck fallback will
+  // emit a stale "unhealthy" here while the rest of `status` shows the
+  // sandbox is reachable. We deliberately do not downgrade the signal
+  // automatically: the in-sandbox `isSandboxGatewayRunningForStatus`
+  // probe uses the same 127.0.0.1 endpoint Docker checks, so it cannot
+  // independently confirm that Docker's reading is stale. (#3975)
+  if (lookup.state === "present") {
+    const dockerHealth = getSandboxDockerHealth(sandboxName);
+    if (dockerHealth.state !== "none" && dockerHealth.state !== "unknown") {
+      if (dockerHealth.state === "healthy") {
+        console.log(`    Docker health: ${G}healthy${R}`);
+      } else if (dockerHealth.state === "starting") {
+        console.log(`    Docker health: ${D}starting${R}`);
+      } else {
+        console.log(`    Docker health: ${RD}unhealthy${R}`);
+        console.log(
+          `      ${D}This is the in-container Docker probe; compare with the host-side delivery${R}`,
+        );
+        console.log(
+          `      ${D}chain above. A mismatch can be a stale signal on OpenShell-managed${R}`,
+        );
+        console.log(`      ${D}runtimes — see #3975.${R}`);
       }
     }
   }

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -285,6 +285,95 @@ describe("sandbox provisioning: image health checks (#1430)", () => {
     }
   });
 
+  // #3975: on runtime shapes where the dashboard port lives in a different
+  // network namespace (DGX Spark / OpenShell-managed forwarding), the
+  // in-container curl probe sees "connection refused" while the actual
+  // delivery chain is fine. The healthcheck must not contradict that by
+  // failing the container outright — it falls back to verifying that the
+  // OpenClaw gateway process is still alive in this container.
+  describe("falls back to local liveness when the in-container dashboard port has no listener (#3975)", () => {
+    function runProductionHealthProbe({
+      curlExit,
+      pgrepExit,
+      gatewayLog = "gateway log line\n",
+    }: {
+      curlExit: number;
+      pgrepExit: number;
+      gatewayLog?: string;
+    }) {
+      const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-health-fallback-"));
+      const logPath = path.join(tmp, "gateway.log");
+      const rawCommand = dockerHealthCommandBetween(
+        dockerfile,
+        "# Health check: poll the gateway's /health endpoint",
+        "# Entrypoint runs as root",
+      );
+      const command = rawCommand.replaceAll("/tmp/gateway.log", logPath);
+
+      if (gatewayLog !== "") {
+        fs.writeFileSync(logPath, gatewayLog);
+      }
+
+      try {
+        const probe = runLoggedDockerShell(command, tmp, [
+          `curl() { printf "curl %s\\n" "$*" >> "$call_log"; return ${curlExit}; }`,
+          `pgrep() { printf "pgrep %s\\n" "$*" >> "$call_log"; return ${pgrepExit}; }`,
+        ]);
+        return probe;
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    }
+
+    it("reports healthy when in-container curl works (Docker-driver / standalone)", () => {
+      const probe = runProductionHealthProbe({ curlExit: 0, pgrepExit: 1, gatewayLog: "" });
+      expect(probe.result.status).toBe(0);
+      expect(probe.calls).toContain("curl");
+      // Fast path: should not consult pgrep at all.
+      expect(probe.calls).not.toContain("pgrep");
+    });
+
+    it("reports healthy when curl gets connection refused but openclaw is alive and started (DGX Spark / OpenShell-managed)", () => {
+      const probe = runProductionHealthProbe({ curlExit: 7, pgrepExit: 0 });
+      expect(probe.result.status).toBe(0);
+      expect(probe.calls).toContain("curl");
+      // --ignore-ancestors prevents pgrep from self-matching the
+      // healthcheck shell whose argv contains the gateway pattern.
+      // The [ -] class matches both `openclaw gateway` (launcher) and
+      // `openclaw-gateway` (re-execed binary).
+      expect(probe.calls).toContain("pgrep --ignore-ancestors -f openclaw[ -]gateway");
+    });
+
+    it("reports unhealthy when curl times out (wedged HTTP server, not namespace mismatch)", () => {
+      // A connect timeout means a listener exists but is not responding,
+      // e.g. a wedged HTTP server. We deliberately do not fall back to the
+      // process check there — Docker should restart the container.
+      const probe = runProductionHealthProbe({ curlExit: 28, pgrepExit: 0 });
+      expect(probe.result.status).toBe(1);
+      expect(probe.calls).not.toContain("pgrep");
+    });
+
+    it("reports unhealthy when curl gets connection refused and openclaw is not running", () => {
+      const probe = runProductionHealthProbe({ curlExit: 7, pgrepExit: 1 });
+      expect(probe.result.status).toBe(1);
+    });
+
+    it("reports unhealthy when curl gets connection refused and the gateway log was never written (openclaw never started)", () => {
+      const probe = runProductionHealthProbe({ curlExit: 7, pgrepExit: 0, gatewayLog: "" });
+      expect(probe.result.status).toBe(1);
+    });
+
+    it("does not fall back when curl reports an HTTP error (gateway answered with failure)", () => {
+      const probe = runProductionHealthProbe({ curlExit: 22, pgrepExit: 0 });
+      expect(probe.result.status).toBe(1);
+      // HTTP errors from the in-container probe should bypass the fallback;
+      // a 4xx/5xx means the gateway is reachable and unhappy, not a
+      // namespace mismatch — so pgrep should not run.
+      expect(probe.calls).not.toContain("pgrep");
+    });
+  });
+
   it.each([
     [
       "base image",


### PR DESCRIPTION
## Summary

The Dockerfile HEALTHCHECK ran an in-container `curl http://127.0.0.1:${port}/health`. On runtime shapes where the dashboard port lives in a different network namespace (DGX Spark / aarch64 with OpenShell-managed forwarding), that probe gets connection-refused even though the OpenShell host forward and `nemoclaw status` show the sandbox as Ready, so Docker marks the container unhealthy and contradicts the actual delivery chain (#3975).

## Related Issue

Fixes #3975.

## Changes

- **Dockerfile**: layered HEALTHCHECK. Fast path remains the direct curl. ONLY on curl exit 7 ("Couldn't connect") we now fall back to verifying the OpenClaw gateway process is alive (`pgrep --ignore-ancestors -f 'openclaw[ -]gateway'` — the same launcher/re-exec variant set the host stop script in `tunnel/services.ts` already uses, and `--ignore-ancestors` prevents the healthcheck shell from self-matching) AND that `/tmp/gateway.log` is non-empty (proves the gateway came up). Curl timeouts (exit 28) and HTTP 4xx/5xx still fail, so wedged or broken gateways are still restarted.
- **src/lib/actions/sandbox/status.ts** + new **docker-health.ts**: surface the raw Docker health state in `nemoclaw status` so older images without the fallback can still tell users when Docker's signal disagrees with the delivery chain, with a pointer back to this issue. The new lookup resolves sandbox container names using the longest-matching registered sandbox name so it cannot accidentally surface another sandbox's health (e.g. for `my` vs `my-assistant`, or `my-assistant` vs `my-assistant-prod`).
- **Tests**: regression coverage in `test/sandbox-provisioning.test.ts` (fast-path success, namespace-mismatch fallback, wedged-server timeout stays unhealthy, HTTP error stays unhealthy, missing log stays unhealthy) and unit tests in `src/lib/actions/sandbox/docker-health.test.ts` (driver detection, exact-match preference, prefix disambiguation).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes for the changed slice (`test/sandbox-provisioning.test.ts`, `src/lib/actions/sandbox/*`) — full `npm test` had pre-existing failures in `src/lib/inference/local.test.ts` and `test/cli.test.ts` that reproduce on `upstream/main` and are unrelated to this change
- [x] Tests added for new and changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] `codex review` clean on the diff after iteration (only `[P3]` about the untracked `issue-*.md` scratch note remained, which is not part of the commit)
- [ ] `make docs` builds without warnings (doc changes only) — N/A

Note: DGX Spark / aarch64 hardware was not available locally, so the bug was reproduced at the unit/fixture level by demonstrating that the existing `curl 127.0.0.1:${port}/health` healthcheck command exits 7 when no listener is bound — the exact shape the reporter saw — while the host-side delivery chain stays reachable. The new tests assert the layered probe handles that case without masking real failure modes.

---

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved container health checking with dynamic port detection and a fallback verification when the primary HTTP probe fails.
  * Status command now shows a dedicated Docker health line for active sandboxes with clearer healthy/starting/unhealthy distinctions.

* **Tests**
  * Added extensive tests covering healthcheck behavior, fallback logic, container selection, and reported states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->