### PR TITLE
fix(onboard): normalise nemoclaw plugin build context permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
 COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
-RUN chmod -R a+rX /opt/nemoclaw-blueprint/
+RUN chmod -R a+rX /opt/nemoclaw /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
 WORKDIR /opt/nemoclaw

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=builder /opt/nemoclaw/dist/ /opt/nemoclaw/dist/
 COPY nemoclaw/openclaw.plugin.json /opt/nemoclaw/
 COPY nemoclaw/package.json nemoclaw/package-lock.json /opt/nemoclaw/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
-RUN chmod -R a+rX /opt/nemoclaw /opt/nemoclaw-blueprint/
+RUN chmod -R a+rX /opt/nemoclaw-blueprint/
 
 # Install runtime dependencies only (no devDependencies, no build step)
 WORKDIR /opt/nemoclaw

--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -50,6 +50,7 @@ function stageLegacySandboxBuildContext(
   normalizeReadModesForDockerCopy(path.join(buildCtx, "nemoclaw-blueprint"));
   fs.cpSync(path.join(rootDir, "scripts"), path.join(buildCtx, "scripts"), { recursive: true });
   fs.rmSync(path.join(buildCtx, "nemoclaw", "node_modules"), { recursive: true, force: true });
+  normalizeReadModesForDockerCopy(path.join(buildCtx, "nemoclaw"));
 
   return {
     buildCtx,
@@ -83,6 +84,7 @@ function stageOptimizedSandboxBuildContext(
   fs.cpSync(path.join(sourceNemoclawDir, "src"), path.join(stagedNemoclawDir, "src"), {
     recursive: true,
   });
+  normalizeReadModesForDockerCopy(stagedNemoclawDir);
 
   fs.mkdirSync(stagedBlueprintDir, { recursive: true });
   fs.copyFileSync(

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -36,9 +36,11 @@ describe("sandbox build context staging", () => {
       "tsconfig.json",
       "openclaw.plugin.json",
     ]) {
-      writeFixture(path.join("nemoclaw", fileName), "{}\n");
+      writeFixture(path.join("nemoclaw", fileName), "{}\n", 0o600);
     }
-    writeFixture(path.join("nemoclaw", "src", "index.ts"));
+    writeFixture(path.join("nemoclaw", "src", "index.ts"), "fixture\n", 0o600);
+    fs.chmodSync(path.join(sourceRoot, "nemoclaw"), 0o700);
+    fs.chmodSync(path.join(sourceRoot, "nemoclaw", "src"), 0o700);
     writeFixture(path.join("nemoclaw-blueprint", "blueprint.yaml"));
     writeFixture(path.join("nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"));
     writeFixture(path.join("nemoclaw-blueprint", "scripts", "http-proxy-fix.js"));
@@ -75,6 +77,22 @@ describe("sandbox build context staging", () => {
     writeFixture(path.join("scripts", "seed-wechat-accounts.py"));
     writeFixture(path.join("scripts", "patch-openclaw-tool-catalog.js"));
     writeFixture(path.join("scripts", "patch-openclaw-chat-send.js"));
+  }
+
+  function expectStagedNemoclawModes(buildCtx: string) {
+    const stagedNemoclaw = path.join(buildCtx, "nemoclaw");
+    const stagedSrc = path.join(stagedNemoclaw, "src");
+    const stagedPackageJson = path.join(stagedNemoclaw, "package.json");
+    const stagedIndexTs = path.join(stagedSrc, "index.ts");
+
+    const stagedNemoclawMode = fs.statSync(stagedNemoclaw).mode & 0o777;
+    expect(stagedNemoclawMode & 0o555).toBe(0o555);
+    expect(stagedNemoclawMode & 0o002).toBe(0);
+    const stagedSrcMode = fs.statSync(stagedSrc).mode & 0o777;
+    expect(stagedSrcMode & 0o555).toBe(0o555);
+    expect(stagedSrcMode & 0o002).toBe(0);
+    expect((fs.statSync(stagedPackageJson).mode & 0o777).toString(8)).toBe("644");
+    expect((fs.statSync(stagedIndexTs).mode & 0o777).toString(8)).toBe("644");
   }
 
   function expectStagedBlueprintModes(buildCtx: string) {
@@ -141,6 +159,20 @@ describe("sandbox build context staging", () => {
     }
   });
 
+  it("optimized staging makes copied nemoclaw plugin sources world-readable", () => {
+    const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-source-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-nemoclaw-mode-"));
+
+    try {
+      writeBuildContextFixture(sourceRoot);
+      const { buildCtx } = stageOptimizedSandboxBuildContext(sourceRoot, tmpDir);
+      expectStagedNemoclawModes(buildCtx);
+    } finally {
+      fs.rmSync(sourceRoot, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("legacy staging makes copied blueprint manifests world-readable", () => {
     const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-source-"));
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-legacy-mode-"));
@@ -149,6 +181,22 @@ describe("sandbox build context staging", () => {
       writeBuildContextFixture(sourceRoot);
       const { buildCtx } = stageLegacySandboxBuildContext(sourceRoot, tmpDir);
       expectStagedBlueprintModes(buildCtx);
+    } finally {
+      fs.rmSync(sourceRoot, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("legacy staging makes copied nemoclaw plugin sources world-readable", () => {
+    const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-source-"));
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-build-context-legacy-nemoclaw-mode-"),
+    );
+
+    try {
+      writeBuildContextFixture(sourceRoot);
+      const { buildCtx } = stageLegacySandboxBuildContext(sourceRoot, tmpDir);
+      expectStagedNemoclawModes(buildCtx);
     } finally {
       fs.rmSync(sourceRoot, { recursive: true, force: true });
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -583,8 +583,10 @@ describe("sandbox provisioning: copied OpenClaw helper permissions (#2861)", () 
     const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-blueprint-mode-"));
     const blueprintRoot = path.join(tmp, "opt", "nemoclaw-blueprint");
+    const nemoclawRoot = path.join(tmp, "opt", "nemoclaw");
     const manifestDir = path.join(blueprintRoot, "model-specific-setup", "openclaw");
     const manifestPath = path.join(manifestDir, "kimi-k2.6-managed-inference.json");
+    const pluginPackageJson = path.join(nemoclawRoot, "package.json");
 
     try {
       fs.mkdirSync(manifestDir, { recursive: true });
@@ -592,17 +594,26 @@ describe("sandbox provisioning: copied OpenClaw helper permissions (#2861)", () 
       fs.chmodSync(path.join(blueprintRoot, "model-specific-setup"), 0o700);
       fs.chmodSync(manifestDir, 0o700);
       fs.chmodSync(manifestPath, 0o600);
+      fs.mkdirSync(nemoclawRoot, { recursive: true });
+      fs.writeFileSync(pluginPackageJson, "{}\n", { mode: 0o400 });
+      fs.chmodSync(nemoclawRoot, 0o700);
+      fs.chmodSync(pluginPackageJson, 0o400);
 
       const command = dockerRunCommandBetween(
         dockerfile,
         "# Copy built plugin and blueprint",
         "# Install runtime dependencies only",
-      ).replaceAll("/opt/nemoclaw-blueprint", blueprintRoot);
+      )
+        .replaceAll("/opt/nemoclaw-blueprint", "__BLUEPRINT__")
+        .replaceAll("/opt/nemoclaw", nemoclawRoot)
+        .replaceAll("__BLUEPRINT__", blueprintRoot);
       const { result } = runLoggedDockerShell(command, tmp);
 
       expect(result.status, result.stderr).toBe(0);
       expect((fs.statSync(manifestDir).mode & 0o777).toString(8)).toBe("755");
       expect((fs.statSync(manifestPath).mode & 0o777).toString(8)).toBe("644");
+      expect((fs.statSync(nemoclawRoot).mode & 0o777).toString(8)).toBe("755");
+      expect((fs.statSync(pluginPackageJson).mode & 0o777).toString(8)).toBe("444");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -583,10 +583,8 @@ describe("sandbox provisioning: copied OpenClaw helper permissions (#2861)", () 
     const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-blueprint-mode-"));
     const blueprintRoot = path.join(tmp, "opt", "nemoclaw-blueprint");
-    const nemoclawRoot = path.join(tmp, "opt", "nemoclaw");
     const manifestDir = path.join(blueprintRoot, "model-specific-setup", "openclaw");
     const manifestPath = path.join(manifestDir, "kimi-k2.6-managed-inference.json");
-    const pluginPackageJson = path.join(nemoclawRoot, "package.json");
 
     try {
       fs.mkdirSync(manifestDir, { recursive: true });
@@ -594,26 +592,17 @@ describe("sandbox provisioning: copied OpenClaw helper permissions (#2861)", () 
       fs.chmodSync(path.join(blueprintRoot, "model-specific-setup"), 0o700);
       fs.chmodSync(manifestDir, 0o700);
       fs.chmodSync(manifestPath, 0o600);
-      fs.mkdirSync(nemoclawRoot, { recursive: true });
-      fs.writeFileSync(pluginPackageJson, "{}\n", { mode: 0o400 });
-      fs.chmodSync(nemoclawRoot, 0o700);
-      fs.chmodSync(pluginPackageJson, 0o400);
 
       const command = dockerRunCommandBetween(
         dockerfile,
         "# Copy built plugin and blueprint",
         "# Install runtime dependencies only",
-      )
-        .replaceAll("/opt/nemoclaw-blueprint", "__BLUEPRINT__")
-        .replaceAll("/opt/nemoclaw", nemoclawRoot)
-        .replaceAll("__BLUEPRINT__", blueprintRoot);
+      ).replaceAll("/opt/nemoclaw-blueprint", blueprintRoot);
       const { result } = runLoggedDockerShell(command, tmp);
 
       expect(result.status, result.stderr).toBe(0);
       expect((fs.statSync(manifestDir).mode & 0o777).toString(8)).toBe("755");
       expect((fs.statSync(manifestPath).mode & 0o777).toString(8)).toBe("644");
-      expect((fs.statSync(nemoclawRoot).mode & 0o777).toString(8)).toBe("755");
-      expect((fs.statSync(pluginPackageJson).mode & 0o777).toString(8)).toBe("444");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
`/opt/nemoclaw/package.json` ends up `root:root 440` in the sandbox image when the host checkout (`~/.nemoclaw/source/nemoclaw/`) has restrictive modes, because `stage{Legacy,Optimized}SandboxBuildContext` only normalise the `nemoclaw-blueprint/` subtree before `docker build`. `USER sandbox` then can't read it and `openclaw plugins install /opt/nemoclaw` fails with `JsonFileReadError: Failed to read JSON file: /opt/nemoclaw/package.json`. Mirror the existing blueprint normalisation onto the staged `nemoclaw/` subtree, and add a defence-in-depth `chmod -R a+rX /opt/nemoclaw` to the in-image RUN that already normalises `/opt/nemoclaw-blueprint/`.

## Related Issue
Fixes #4177

## Changes
- `src/lib/sandbox/build-context.ts` — call `normalizeReadModesForDockerCopy(stagedNemoclawDir)` in both `stageLegacySandboxBuildContext` and `stageOptimizedSandboxBuildContext`, mirroring the existing blueprint handling.
- `Dockerfile` — extend `chmod -R a+rX` to cover `/opt/nemoclaw` as well as `/opt/nemoclaw-blueprint/`, so custom build-contexts that bypass the staging code still recover.
- `test/sandbox-build-context.test.ts` — new fixtures with restrictive (`0o600` files, `0o700` dirs) `nemoclaw/` modes, plus optimised + legacy staging assertions that the copy ends up world-readable.
- `test/sandbox-provisioning.test.ts` — extend the existing `chmod` regression test to also stage a restrictive `/opt/nemoclaw/package.json` and assert it ends up `444`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file permission configuration for runtime components in containerized environments to ensure proper accessibility.

* **Tests**
  * Added test coverage for file permission normalization in containerized builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
