### PR TITLE
fix(policy): allow openclaw npm plugin installs

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -38,12 +38,13 @@ The following endpoint groups are allowed by default:
 | Policy | Endpoints | Binaries | Rules |
 | --- | --- | --- | --- |
 | `nvidia` | `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443` | `/usr/local/bin/openclaw` | POST to inference and embedding paths, GET to model listings |
-| `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
-| `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
+| `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
+| `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
 | `openclaw_docs` | `docs.openclaw.ai:443` | `/usr/local/bin/openclaw` | GET only |
-| `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw` only (openclaw plugins install) | GET only |
+| `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw`, npm/Node helper binaries (`openclaw plugins install`) | L4 tunnel |
 
-All endpoints use TLS termination and are enforced at port 443.
+REST endpoints use TLS termination and method/path enforcement at port 443.
+The `npm_registry` baseline uses L4 passthrough (`tls: skip`) for Node 22/undici compatibility and remains scoped to `registry.npmjs.org:443`.
 
 <Note>
 GitHub access (`github.com`, `api.github.com`) is not included in the baseline policy.

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -124,7 +124,7 @@ Endpoint rules restrict allowed HTTP methods and URL paths.
 
 | Aspect | Detail |
 |---|---|
-| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `integrate.api.nvidia.com` allows POST only to inference and embedding paths and GET to model listings). Read-only endpoints such as `docs.openclaw.ai`, the `npm_registry` baseline entry, and the `pypi` preset allow GET only (PyPI also allows HEAD). The `npm` preset is an intentional exception: npm/Yarn registry traffic uses L4 pass-through for Node 22 undici CONNECT compatibility. |
+| Default | Some endpoints allow GET and POST on `/**` (for example, `clawhub.ai`). Others restrict methods and paths to specific API routes (for example, `integrate.api.nvidia.com` allows POST only to inference and embedding paths and GET to model listings). Read-only endpoints such as `docs.openclaw.ai` and the `pypi` preset allow GET only (PyPI also allows HEAD). The `npm_registry` baseline entry and the `npm` preset are intentional exceptions: npm/Yarn registry traffic uses L4 pass-through for Node 22 undici CONNECT compatibility. |
 | What you can change | Add methods (PUT, DELETE, PATCH) or restrict paths to specific prefixes. |
 | Risk if relaxed | Allowing all methods on an API endpoint gives the agent write and delete access. For example, allowing DELETE on `api.github.com` lets the agent delete repositories. |
 | Recommendation | Use GET-only rules for endpoints that the agent only reads. Add write methods only for endpoints where the agent must create or modify resources. Restrict paths to specific API routes when possible. |

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -134,6 +134,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   openclaw_api:
     name: openclaw_api
@@ -148,6 +149,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   openclaw_docs:
     name: openclaw_docs
@@ -162,20 +164,25 @@ network_policies:
       - { path: /usr/local/bin/openclaw }
 
   # npm registry — needed for `openclaw plugins install` only.
-  # Restricted to the openclaw binary so agents cannot use npm directly.
-  # Users who need npm/node access should add the npm policy preset during onboard.
-  # Ref: https://github.com/NVIDIA/NemoClaw/issues/1458
+  # OpenClaw shells out through npm's Node entrypoint when installing external
+  # package plugins, so this baseline allows those helper binaries only to the
+  # registry host. L4 passthrough matches the npm preset because Node 22's
+  # undici stack does not work reliably through REST/TLS inspection. Users who
+  # need broader package-manager access should add the npm policy preset.
+  # Ref: https://github.com/NVIDIA/NemoClaw/issues/4015
   npm_registry:
     name: npm_registry
     endpoints:
       - host: registry.npmjs.org
         port: 443
-        protocol: rest
-        enforcement: enforce
-        rules:
-          - allow: { method: GET, path: "/**" }
+        access: full
+        tls: skip
     binaries:
       - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/npm* }
+      - { path: /usr/local/bin/node* }
+      - { path: /usr/bin/npm* }
+      - { path: /usr/bin/node* }
 
   # Messaging endpoints (telegram, discord, slack) are intentionally NOT in
   # the baseline — #1705 removed them so every sandbox does not silently

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -350,6 +350,26 @@ describe("base sandbox policy", () => {
     ]);
   });
 
+  it("regression #4015: clawhub allows Node helper paths used by OpenClaw plugin resolution", () => {
+    const np = policy.network_policies ?? {};
+    const binaries = (np.clawhub?.binaries ?? []).map((b) => b.path).sort();
+    expect(binaries).toEqual([
+      "/usr/bin/node",
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+    ]);
+  });
+
+  it("regression #4015: openclaw_api mirrors Node helper paths used by OpenClaw flows", () => {
+    const np = policy.network_policies ?? {};
+    const binaries = (np.openclaw_api?.binaries ?? []).map((b) => b.path).sort();
+    expect(binaries).toEqual([
+      "/usr/bin/node",
+      "/usr/local/bin/node",
+      "/usr/local/bin/openclaw",
+    ]);
+  });
+
   it("does not reference the absent Claude CLI binary", () => {
     const serialized = JSON.stringify(policy.network_policies ?? {});
     expect(serialized).not.toContain("/usr/local/bin/claude");
@@ -409,17 +429,35 @@ describe("base sandbox policy", () => {
     expect(slackHosts).toEqual([]);
   });
 
-  it("regression #1458: baseline npm_registry must not include npm or node binaries", () => {
+  it("regression #4015: baseline npm_registry supports openclaw plugin install helpers", () => {
     const np = policy.network_policies ?? {};
     const npmRegistry = np.npm_registry;
     expect(npmRegistry).toBeDefined();
+    const endpoints = npmRegistry?.endpoints ?? [];
+    expect(endpoints).toEqual([
+      expect.objectContaining({
+        host: "registry.npmjs.org",
+        port: 443,
+        access: "full",
+        tls: "skip",
+      }),
+    ]);
+    expect(endpoints[0]).not.toHaveProperty("protocol");
+    expect(endpoints[0]).not.toHaveProperty("rules");
+
     const binaries = npmRegistry?.binaries;
     expect(Array.isArray(binaries)).toBe(true);
     const paths = (binaries ?? []).map((b) => b.path).sort();
-    // Only openclaw CLI should reach the npm registry by default.
-    // npm/node being in this list lets the agent bypass 'none' policy preset.
-    // Exact allowlist — adding any binary here requires a deliberate review.
-    expect(paths).toEqual(["/usr/local/bin/openclaw"]);
+    // `openclaw plugins install <package>` shells out through npm's Node
+    // entrypoint. Keep this baseline tunnel limited to the registry host;
+    // broader package-manager access still requires the opt-in npm preset.
+    expect(paths).toEqual([
+      "/usr/bin/node*",
+      "/usr/bin/npm*",
+      "/usr/local/bin/node*",
+      "/usr/local/bin/npm*",
+      "/usr/local/bin/openclaw",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix baseline OpenClaw plugin install egress by making `npm_registry` use the same L4 passthrough shape as the npm preset for Node 22/undici CONNECT compatibility.
- Allow the npm/node helper binaries that `openclaw plugins install <package>` shells through, while keeping the tunnel scoped to `registry.npmjs.org:443`.
- Add `/usr/bin/node` to the baseline `clawhub` and `openclaw_api` binary allowlists for sandbox images where OpenClaw helper flows resolve Node there.
- Update network policy docs/security guidance to describe the `npm_registry` L4 exception.

Closes #4015.

## Repro
On existing local sandbox `repro-3113-mac` with npm applied, the live policy still had `npm_registry` as REST GET-only with only `/usr/local/bin/openclaw`, and `clawhub`/`openclaw_api` lacked `/usr/bin/node`.

```text
openshell sandbox exec --name repro-3113-mac --timeout 120 -- bash -lc 'openclaw plugins install @openclaw/microsoft-speech 2>&1; echo __EXIT__$?'
Resolving clawhub:@openclaw/microsoft-speech…
fetch failed | other side closed
__EXIT__1
```

## Verification
- `./node_modules/.bin/vitest run --project cli test/validate-blueprint.test.ts -t "regression #4015"`
- `npm_config_cache=$PWD/.npm-cache npm run build:cli`
- `./node_modules/.bin/vitest run --project cli test/policies.test.ts test/validate-blueprint.test.ts`
- `npm_config_cache=$PWD/.npm-cache npm run typecheck:cli`
- `git diff --check`

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined network policy documentation for default allowed endpoints and npm registry traffic handling
  * Clarified security best practices regarding read-only endpoints and npm registry exceptions

* **Tests**
  * Added regression checks for network policy binary allowlists and npm registry endpoint configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->