### PR TITLE
fix(policy): clarify jira curl validation

### DIFF
--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -178,10 +178,10 @@ $ nemoclaw my-assistant policy-add github --yes
 $ nemoclaw my-assistant policy-add jira --yes
 ```
 
-The `jira` preset intentionally allows Node.js access to Atlassian Cloud and
-does not allow `curl`. When validating it manually, avoid plain `curl -s`
-against `auth.atlassian.com`: Atlassian can return an empty redirect body even
-when the request succeeds. Use an explicit status probe instead:
+The `jira` preset intentionally allows Node.js access to Atlassian Cloud and does not allow `curl`.
+When validating it manually, avoid plain `curl -s` against `auth.atlassian.com`.
+Atlassian can return an empty redirect body even when the request succeeds.
+Use an explicit status probe instead:
 
 ```console
 $ node -e "require('https').get('https://api.atlassian.com', r => console.log(r.statusCode))"

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -178,6 +178,20 @@ $ nemoclaw my-assistant policy-add github --yes
 $ nemoclaw my-assistant policy-add jira --yes
 ```
 
+The `jira` preset intentionally allows Node.js access to Atlassian Cloud and
+does not allow `curl`. When validating it manually, avoid plain `curl -s`
+against `auth.atlassian.com`: Atlassian can return an empty redirect body even
+when the request succeeds. Use an explicit status probe instead:
+
+```console
+$ node -e "require('https').get('https://api.atlassian.com', r => console.log(r.statusCode))"
+$ curl -sS -o /dev/null -w '%{http_code}' --max-time 10 https://auth.atlassian.com
+```
+
+Before approval, the curl probe should report `000` or a local policy denial.
+After approving the blocked request in OpenShell, it should report an HTTP
+status such as `301` or `200`.
+
 Remove access when the task is done:
 
 ```console

--- a/nemoclaw-blueprint/policies/presets/jira.yaml
+++ b/nemoclaw-blueprint/policies/presets/jira.yaml
@@ -32,3 +32,4 @@ network_policies:
           - allow: { method: POST, path: "/**" }
     binaries:
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -145,10 +145,10 @@ export async function addSandboxPolicy(
     console.log(`  Endpoints that would be opened: ${endpoints.join(", ")}`);
   }
 
-  const messagingWarning = policies.getMessagingPresetWarning(answer);
-  if (messagingWarning) {
+  const presetWarning = policies.getPresetValidationWarning(answer);
+  if (presetWarning) {
     console.log("");
-    console.log(`  ${messagingWarning}`);
+    console.log(`  ${presetWarning}`);
     console.log("");
   }
 

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -211,6 +211,21 @@ const MESSAGING_PRESET_LABELS: Record<string, string> = {
 };
 
 function getMessagingPresetWarning(presetName: string): string | null {
+  if (presetName === "jira") {
+    return [
+      "Jira preset validation uses per-binary policy signals.",
+      "Node HTTPS is allowed for Atlassian API traffic:",
+      'node -e "require(\'https\').get(\'https://api.atlassian.com\', r => console.log(r.statusCode))"',
+      "curl is intentionally not in the preset binary allowlist. Avoid plain",
+      "curl -s probes for auth.atlassian.com: Atlassian can return an empty",
+      "redirect body, which looks the same as a blocked request. Use an",
+      "observable status probe instead:",
+      "curl -sS -o /dev/null -w '%{http_code}' --max-time 10 https://auth.atlassian.com",
+      "Before approval, expect 000 or a local policy denial; after approval,",
+      "expect an HTTP status such as 301 or 200.",
+    ].join("\n  ");
+  }
+
   const label = MESSAGING_PRESET_LABELS[presetName];
   if (!label) return null;
   const lines = [

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -210,7 +210,7 @@ const MESSAGING_PRESET_LABELS: Record<string, string> = {
   whatsapp: "WhatsApp",
 };
 
-function getMessagingPresetWarning(presetName: string): string | null {
+function getPresetValidationWarning(presetName: string): string | null {
   if (presetName === "jira") {
     return [
       "Jira preset validation uses per-binary policy signals.",
@@ -1214,7 +1214,7 @@ export {
   listPresets,
   loadPreset,
   getPresetEndpoints,
-  getMessagingPresetWarning,
+  getPresetValidationWarning,
   setupPolicyPresetSupported,
   filterSetupPolicyPresets,
   listSetupPolicyPresets,

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -14,6 +14,7 @@
 #   TC-NET-05: Hot-reload (policy change without sandbox restart)
 #   TC-NET-06: Permissive policy mode (open all egress)
 #   TC-NET-07: Inference exemption + direct provider blocked
+#   TC-NET-08: Jira per-binary policy enforcement
 #   TC-NET-09: SSRF validation (dangerous IPs rejected)
 #
 # Prerequisites:
@@ -377,6 +378,95 @@ fetch('$target_url', {signal: AbortSignal.timeout(15000)})
 }
 
 # =============================================================================
+# TC-NET-08: Jira per-binary policy enforcement
+# =============================================================================
+test_net_08_jira_per_binary_enforcement() {
+  log "=== TC-NET-08: Jira Per-Binary Policy Enforcement ==="
+
+  log "  Step 1: Applying jira preset..."
+  if ! apply_preset "jira"; then
+    fail "TC-NET-08: Setup" "Could not apply jira preset"
+    return
+  fi
+
+  log "  Step 2: Verify Node HTTPS can reach Atlassian API..."
+  local node_response
+  node_response=$(sandbox_exec "node -e \"
+const https = require('https');
+const req = https.get('https://api.atlassian.com', (res) => {
+  console.log('NODE_STATUS_' + res.statusCode);
+  res.resume();
+});
+req.setTimeout(30000, () => {
+  console.log('NODE_ERROR_TIMEOUT');
+  req.destroy();
+});
+req.on('error', (error) => console.log('NODE_ERROR_' + (error.code || error.message)));
+\"" 2>&1) || true
+  log "  Node response: $node_response"
+
+  if echo "$node_response" | grep -qE "NODE_STATUS_[23][0-9][0-9]"; then
+    pass "TC-NET-08: Node reaches Atlassian API after jira preset ($node_response)"
+  elif echo "$node_response" | grep -qE "NODE_STATUS_403|NODE_ERROR_"; then
+    fail "TC-NET-08: Node policy" "Node did not reach Atlassian API after jira preset ($node_response)"
+    return
+  else
+    fail "TC-NET-08: Node policy" "Unexpected Node response ($node_response)"
+    return
+  fi
+
+  log "  Step 3: Verify curl remains blocked by the Jira preset..."
+  local curl_before
+  curl_before=$(sandbox_exec "set +e
+OUT=\$(curl -sS -o /dev/null -w 'CURL_STATUS_%{http_code} CURL_APPCONNECT_%{time_appconnect}' --max-time 10 https://auth.atlassian.com 2>&1)
+RC=\$?
+echo \"\$OUT CURL_RC_\$RC\"
+" 2>&1) || true
+  log "  Curl before explicit approval: $curl_before"
+
+  if echo "$curl_before" | grep -qE "CURL_STATUS_[23][0-9][0-9]"; then
+    fail "TC-NET-08: Curl pre-approval" "curl reached Atlassian without explicit approval ($curl_before)"
+    return
+  elif echo "$curl_before" | grep -qE "CURL_STATUS_000|CURL_STATUS_403|CURL_RC_[1-9]|denied|policy|forbidden"; then
+    if echo "$curl_before" | grep -qE "CURL_APPCONNECT_0(\.0+)?( |$)"; then
+      pass "TC-NET-08: curl blocked before explicit approval and before outbound TLS ($curl_before)"
+    else
+      fail "TC-NET-08: Curl pre-approval" "curl was denied but appeared to establish outbound TLS ($curl_before)"
+      return
+    fi
+  else
+    fail "TC-NET-08: Curl pre-approval" "Unexpected curl denial signal ($curl_before)"
+    return
+  fi
+
+  log "  Step 4: Explicitly allow curl to auth.atlassian.com via OpenShell policy update..."
+  if ! openshell policy update "$SANDBOX_NAME" \
+    --add-endpoint auth.atlassian.com:443:read-only:rest:enforce \
+    --binary /usr/bin/curl \
+    --binary /usr/local/bin/curl \
+    --wait 2>&1 | tee -a "$LOG_FILE"; then
+    fail "TC-NET-08: Curl approval" "Could not apply explicit curl approval"
+    return
+  fi
+  sleep 5
+
+  log "  Step 5: Verify curl reaches Atlassian after explicit approval..."
+  local curl_after
+  curl_after=$(sandbox_exec "set +e
+OUT=\$(curl -sS -o /dev/null -w 'CURL_STATUS_%{http_code}' --max-time 10 https://auth.atlassian.com 2>&1)
+RC=\$?
+echo \"\$OUT CURL_RC_\$RC\"
+" 2>&1) || true
+  log "  Curl after explicit approval: $curl_after"
+
+  if echo "$curl_after" | grep -qE "CURL_STATUS_[23][0-9][0-9]"; then
+    pass "TC-NET-08: curl reaches Atlassian after explicit approval ($curl_after)"
+  else
+    fail "TC-NET-08: Curl post-approval" "curl did not reach Atlassian after explicit approval ($curl_after)"
+  fi
+}
+
+# =============================================================================
 # TC-NET-07: Inference exemption + direct provider blocked
 # =============================================================================
 test_net_07_inference_exemption() {
@@ -565,6 +655,7 @@ main() {
   test_net_02_whitelist_access
   test_net_03_live_policy_add
   test_net_04_dry_run
+  test_net_08_jira_per_binary_enforcement
   test_net_05_hot_reload
   test_net_07_inference_exemption
   test_net_09_ssrf_validation

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -446,6 +446,16 @@ describe("policies", () => {
       expect(warning).toContain('dns.resolve("gateway.discord.gg")');
     });
 
+    it("adds Jira validation guidance that makes blocked versus redirected curl observable", () => {
+      const warning = policies.getMessagingPresetWarning("jira");
+
+      expect(warning).toContain("curl -s");
+      expect(warning).toContain("curl -sS -o /dev/null -w '%{http_code}'");
+      expect(warning).toContain("000");
+      expect(warning).toContain("Node HTTPS");
+      expect(warning).toContain("https://api.atlassian.com");
+    });
+
     it("returns null for non-messaging presets", () => {
       expect(policies.getMessagingPresetWarning("npm")).toBeNull();
       expect(policies.getMessagingPresetWarning("pypi")).toBeNull();

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -421,9 +421,9 @@ describe("policies", () => {
     });
   });
 
-  describe("getMessagingPresetWarning", () => {
+  describe("getPresetValidationWarning", () => {
     it("returns a warning for the telegram preset that mentions re-running onboard", () => {
-      const warning = policies.getMessagingPresetWarning("telegram");
+      const warning = policies.getPresetValidationWarning("telegram");
       expect(warning).toBeTruthy();
       expect(warning).toContain("telegram");
       expect(warning).toContain("Telegram");
@@ -431,13 +431,13 @@ describe("policies", () => {
     });
 
     it("returns a warning for discord, slack, and wechat", () => {
-      expect(policies.getMessagingPresetWarning("discord")).toContain("Discord");
-      expect(policies.getMessagingPresetWarning("slack")).toContain("Slack");
-      expect(policies.getMessagingPresetWarning("wechat")).toContain("WeChat");
+      expect(policies.getPresetValidationWarning("discord")).toContain("Discord");
+      expect(policies.getPresetValidationWarning("slack")).toContain("Slack");
+      expect(policies.getPresetValidationWarning("wechat")).toContain("WeChat");
     });
 
     it("adds Discord validation guidance for Node probes instead of curl or DNS-only checks", () => {
-      const warning = policies.getMessagingPresetWarning("discord");
+      const warning = policies.getPresetValidationWarning("discord");
 
       expect(warning).toContain("curl");
       expect(warning).toContain("preset binary allowlist");
@@ -447,7 +447,7 @@ describe("policies", () => {
     });
 
     it("adds Jira validation guidance that makes blocked versus redirected curl observable", () => {
-      const warning = policies.getMessagingPresetWarning("jira");
+      const warning = policies.getPresetValidationWarning("jira");
 
       expect(warning).toContain("curl -s");
       expect(warning).toContain("curl -sS -o /dev/null -w '%{http_code}'");
@@ -456,16 +456,16 @@ describe("policies", () => {
       expect(warning).toContain("https://api.atlassian.com");
     });
 
-    it("returns null for non-messaging presets", () => {
-      expect(policies.getMessagingPresetWarning("npm")).toBeNull();
-      expect(policies.getMessagingPresetWarning("pypi")).toBeNull();
-      expect(policies.getMessagingPresetWarning("github")).toBeNull();
-      expect(policies.getMessagingPresetWarning("brew")).toBeNull();
+    it("returns null for presets without extra validation guidance", () => {
+      expect(policies.getPresetValidationWarning("npm")).toBeNull();
+      expect(policies.getPresetValidationWarning("pypi")).toBeNull();
+      expect(policies.getPresetValidationWarning("github")).toBeNull();
+      expect(policies.getPresetValidationWarning("brew")).toBeNull();
     });
 
     it("returns null for unknown preset names", () => {
-      expect(policies.getMessagingPresetWarning("")).toBeNull();
-      expect(policies.getMessagingPresetWarning("nonexistent")).toBeNull();
+      expect(policies.getPresetValidationWarning("")).toBeNull();
+      expect(policies.getPresetValidationWarning("nonexistent")).toBeNull();
     });
   });
 

--- a/test/policy-add-remove-session-sync.test.ts
+++ b/test/policy-add-remove-session-sync.test.ts
@@ -79,7 +79,7 @@ policies.listPresets = () => ${JSON.stringify(presetNamesAvailable.map((name) =>
 policies.getAppliedPresets = () => ${JSON.stringify(appliedPresets)};
 policies.loadPreset = (name) => ({ name, network_policies: {} });
 policies.getPresetEndpoints = () => [];
-policies.getMessagingPresetWarning = () => null;
+policies.getPresetValidationWarning = () => null;
 policies.selectFromList = async (items) => items[0]?.name || null;
 policies.applyPreset = (sandboxName, presetName) => {
   calls.apply.push({ sandboxName, presetName });

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -545,6 +545,24 @@ describe("huggingface preset", () => {
   });
 });
 
+describe("jira preset", () => {
+  const JIRA_PRESET_PATH = new URL(
+    "../nemoclaw-blueprint/policies/presets/jira.yaml",
+    import.meta.url,
+  );
+  const jiraPreset = loadYaml<PolicyPreset>(JIRA_PRESET_PATH);
+
+  it("regression #3758: Jira allows Node but not curl", () => {
+    const binaries = (jiraPreset.network_policies?.atlassian?.binaries ?? [])
+      .map((binary) => binary.path)
+      .sort();
+
+    expect(binaries).toEqual(["/usr/bin/node", "/usr/local/bin/node"]);
+    expect(binaries).not.toContain("/usr/bin/curl");
+    expect(binaries).not.toContain("/usr/local/bin/curl");
+  });
+});
+
 describe("messaging WebSocket presets", () => {
   const DISCORD_PRESET_PATH = new URL(
     "../nemoclaw-blueprint/policies/presets/discord.yaml",


### PR DESCRIPTION
## Summary
- keep the Jira preset Node-only while allowing both common Node binary paths
- add Jira policy-add guidance so curl validation distinguishes blocked `000` from Atlassian empty redirects
- document the manual Node and curl status probes for Jira policy validation

## Repro / Root Cause
- `auth.atlassian.com` can return an empty-body 301, so `curl -s --max-time 10 https://auth.atlassian.com` prints nothing even when the request succeeds
- the preset should still enforce binary scoping: Node is allowed for Atlassian API traffic; curl is not part of the preset and should only work after explicit OpenShell approval

## Tests
- `npm run build:cli`
- `npx vitest run test/policies.test.ts test/validate-blueprint.test.ts test/validate-config-schemas.test.ts`
- `node dist/nemoclaw.js test-sb policy-add jira --dry-run`
- `git diff --check`

Fixes #3758

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Jira integration guidance with explicit manual-validation steps and probe examples showing Node.js HTTPS checks and curl-based pre/post-approval behavior.

* **Improvements**
  * Adjusted Jira preset to recognize an additional Node.js executable path for sandboxed access while keeping curl excluded by default.

* **Tests**
  * Added unit and end-to-end tests covering Jira preset validation warnings and per-binary enforcement (Node.js allowed, curl blocked until approved).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->