### PR TITLE
test(e2e): update cloudflared tunnel pin

### DIFF
--- a/test/e2e/test-tunnel-lifecycle.sh
+++ b/test/e2e/test-tunnel-lifecycle.sh
@@ -116,7 +116,7 @@ preflight() {
   if ! command -v cloudflared >/dev/null 2>&1; then
     # Install via Cloudflare's GPG-signed APT repo — trust anchor for secret-bearing
     # CI; APT verifies GPG-signed Release → package SHA256 (no per-version SHA pin).
-    local cf_version="${CLOUDFLARED_VERSION:-2026.5.0}"
+    local cf_version="${CLOUDFLARED_VERSION:-2026.5.1}"
     log "Installing cloudflared ${cf_version} via Cloudflare APT repo..."
     sudo mkdir -p --mode=0755 /usr/share/keyrings
     curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \


### PR DESCRIPTION
## Summary
The latest nightly flake sweep shows `tunnel-lifecycle-e2e` failing before tunnel startup because the Cloudflare APT repository no longer serves the pinned `cloudflared=2026.5.0*` package. This PR updates the E2E pin to the currently published signed APT package version, `2026.5.1`.

## Changes
- Update `test/e2e/test-tunnel-lifecycle.sh` default `CLOUDFLARED_VERSION` from `2026.5.0` to `2026.5.1`.
- Keep the existing Cloudflare GPG-signed APT repository install path and explicit version pin behavior.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default cloudflared version to 2026.5.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->