### PR TITLE
fix(onboard): back up workspace state before sandbox recreate

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -188,7 +188,8 @@ Before deleting an existing sandbox during recreation, NemoClaw backs up the wor
 This applies whether the existing sandbox is ready or marked not-ready, so cross-version upgrades that pass `NEMOCLAW_RECREATE_SANDBOX=1` no longer drop user files under `/sandbox/.openclaw/workspace/`.
 The behaviour matches `nemoclaw <name> rebuild --force`.
 NemoClaw aborts the recreate when the backup cannot complete in full — including when individual state directories or files fail mid-backup — so failed entries are not silently dropped on delete.
-Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` to skip the pre-recreate backup; the destination sandbox starts with a fresh workspace.
+Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` to skip the pre-recreate backup.
+The destination sandbox starts with a fresh workspace.
 
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -184,6 +184,11 @@ In interactive mode, the wizard asks for confirmation before delete and recreate
 In non-interactive mode, NemoClaw recreates automatically when the stored selection is readable and differs; if NemoClaw cannot read the stored selection, NemoClaw reuses by default.
 Set `NEMOCLAW_RECREATE_SANDBOX=1` to force recreation even when no drift is detected.
 
+Before deleting a ready sandbox during recreation, NemoClaw backs up the workspace state (agents, extensions, workspace, skills, hooks, identity, devices, canvas, cron, memory, telegram, wechat, credentials) and restores it into the new sandbox once it is live.
+This matches the behaviour of `nemoclaw <name> rebuild --force` and protects against accidental data loss on cross-version upgrades that pass `NEMOCLAW_RECREATE_SANDBOX=1`.
+If a backup cannot be taken (for example, the sandbox is no longer reachable), onboarding aborts so user data is preserved.
+Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` to skip the pre-recreate backup; the destination sandbox starts with a fresh workspace.
+
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.
 The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -184,9 +184,10 @@ In interactive mode, the wizard asks for confirmation before delete and recreate
 In non-interactive mode, NemoClaw recreates automatically when the stored selection is readable and differs; if NemoClaw cannot read the stored selection, NemoClaw reuses by default.
 Set `NEMOCLAW_RECREATE_SANDBOX=1` to force recreation even when no drift is detected.
 
-Before deleting a ready sandbox during recreation, NemoClaw backs up the workspace state (agents, extensions, workspace, skills, hooks, identity, devices, canvas, cron, memory, telegram, wechat, credentials) and restores it into the new sandbox once it is live.
-This matches the behaviour of `nemoclaw <name> rebuild --force` and protects against accidental data loss on cross-version upgrades that pass `NEMOCLAW_RECREATE_SANDBOX=1`.
-If a backup cannot be taken (for example, the sandbox is no longer reachable), onboarding aborts so user data is preserved.
+Before deleting an existing sandbox during recreation, NemoClaw backs up the workspace state (agents, extensions, workspace, skills, hooks, identity, devices, canvas, cron, memory, telegram, wechat, credentials) and restores it into the new sandbox once it is live.
+This applies whether the existing sandbox is ready or marked not-ready, so cross-version upgrades that pass `NEMOCLAW_RECREATE_SANDBOX=1` no longer drop user files under `/sandbox/.openclaw/workspace/`.
+The behaviour matches `nemoclaw <name> rebuild --force`.
+NemoClaw aborts the recreate when the backup cannot complete in full — including when individual state directories or files fail mid-backup — so failed entries are not silently dropped on delete.
 Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` to skip the pre-recreate backup; the destination sandbox starts with a fresh workspace.
 
 Before creating the gateway, the wizard runs preflight checks.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3323,24 +3323,16 @@ async function createSandbox(
       const rotatedNames = credentialRotation.changedProviders.join(", ");
       console.log(`  Messaging credential(s) rotated: ${rotatedNames}`);
       console.log("  Rebuilding sandbox to propagate new credentials to the L7 proxy...");
-      const result = backupSandboxBeforeRecreate({ sandboxName });
-      if (!result.ok) {
-        console.error("  Pass --recreate-sandbox to force recreation without backup.");
-        upsertMessagingProviders(messagingTokenDefs);
-        const reusedPort3 = ensureDashboardForward(sandboxName, chatUiUrl);
-        process.env.CHAT_UI_URL = `http://127.0.0.1:${reusedPort3}`;
-        updateReusedSandboxMetadata(
-          sandboxName,
-          agent,
-          model,
-          provider,
-          reusedPort3,
-          !selectionDrift.unknown,
-          effectiveSandboxGpuConfig,
-        );
-        return sandboxName;
+      if (!shouldSkipPreRecreateBackup(process.env)) {
+        const result = backupSandboxBeforeRecreate({ sandboxName });
+        if (!result.ok) {
+          console.error(
+            "  Set NEMOCLAW_RECREATE_WITHOUT_BACKUP=1 to recreate without preserving state.",
+          );
+          process.exit(1);
+        }
+        pendingStateRestore = result.backup;
       }
-      pendingStateRestore = result.backup;
     }
 
     if (recreateForAgentDrift) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -501,6 +501,10 @@ import type {
   OpenShellInstallResult,
 } from "./onboard/openshell-install";
 import { decidePolicyCarryForward } from "./onboard/policy-carryforward";
+import {
+  backupSandboxBeforeRecreate,
+  shouldSkipPreRecreateBackup,
+} from "./onboard/sandbox-backup-on-recreate";
 import { getSuggestedPolicyPresets } from "./onboard/policy-presets";
 import {
   computeSetupPresetSuggestions as computeSetupPresetSuggestionsImpl,
@@ -3309,48 +3313,12 @@ async function createSandbox(
       }
     }
 
-    // Back up workspace state before destroying the sandbox when triggered
-    // by credential rotation, so files can be restored after recreation.
     if (credentialRotation.changed && existingSandboxState === "ready") {
       const rotatedNames = credentialRotation.changedProviders.join(", ");
       console.log(`  Messaging credential(s) rotated: ${rotatedNames}`);
       console.log("  Rebuilding sandbox to propagate new credentials to the L7 proxy...");
-      try {
-        const backup = sandboxState.backupSandboxState(sandboxName);
-        if (backup.success) {
-          note(
-            `  ✓ State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
-          );
-          pendingStateRestore = backup;
-        } else {
-          console.error("  State backup failed — aborting rebuild to prevent data loss.");
-          console.error("  Pass --recreate-sandbox to force recreation without backup.");
-          upsertMessagingProviders(messagingTokenDefs);
-          // Update stored hashes so the next onboard doesn't re-detect rotation.
-          const abortHashes: Record<string, string> = {};
-          for (const { envKey, token } of messagingTokenDefs) {
-            const hash = token ? hashCredential(token) : null;
-            if (hash) abortHashes[envKey] = hash;
-          }
-          if (Object.keys(abortHashes).length > 0) {
-            registry.updateSandbox(sandboxName, { providerCredentialHashes: abortHashes });
-          }
-          const reusedPort3 = ensureDashboardForward(sandboxName, chatUiUrl);
-          process.env.CHAT_UI_URL = `http://127.0.0.1:${reusedPort3}`;
-          updateReusedSandboxMetadata(
-            sandboxName,
-            agent,
-            model,
-          provider,
-          reusedPort3,
-          !selectionDrift.unknown,
-          effectiveSandboxGpuConfig,
-        );
-        return sandboxName;
-        }
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        console.error(`  State backup threw: ${errorMessage} — aborting rebuild.`);
+      const result = backupSandboxBeforeRecreate({ sandboxName });
+      if (!result.ok) {
         console.error("  Pass --recreate-sandbox to force recreation without backup.");
         upsertMessagingProviders(messagingTokenDefs);
         const abortHashes: Record<string, string> = {};
@@ -3361,19 +3329,20 @@ async function createSandbox(
         if (Object.keys(abortHashes).length > 0) {
           registry.updateSandbox(sandboxName, { providerCredentialHashes: abortHashes });
         }
-        const reusedPort4 = ensureDashboardForward(sandboxName, chatUiUrl);
-        process.env.CHAT_UI_URL = `http://127.0.0.1:${reusedPort4}`;
+        const reusedPort3 = ensureDashboardForward(sandboxName, chatUiUrl);
+        process.env.CHAT_UI_URL = `http://127.0.0.1:${reusedPort3}`;
         updateReusedSandboxMetadata(
           sandboxName,
           agent,
           model,
           provider,
-          reusedPort4,
+          reusedPort3,
           !selectionDrift.unknown,
           effectiveSandboxGpuConfig,
         );
         return sandboxName;
       }
+      pendingStateRestore = result.backup;
     }
 
     if (recreateForAgentDrift) {
@@ -3405,9 +3374,22 @@ async function createSandbox(
     });
     if (decision.overrideNote !== null) note(decision.overrideNote);
 
+    if (
+      pendingStateRestore === null &&
+      existingSandboxState === "ready" &&
+      !shouldSkipPreRecreateBackup(process.env)
+    ) {
+      note("  Backing up workspace state before recreating sandbox...");
+      const result = backupSandboxBeforeRecreate({ sandboxName });
+      if (!result.ok) {
+        console.error("  Set NEMOCLAW_RECREATE_WITHOUT_BACKUP=1 to recreate without preserving state.");
+        process.exit(1);
+      }
+      pendingStateRestore = result.backup;
+    }
+
     note(`  Deleting and recreating sandbox '${sandboxName}'...`);
 
-    // Destroy old sandbox and clean up its host-side Docker image.
     runOpenshell(["sandbox", "delete", sandboxName], { ignoreError: true });
     if (previousEntry?.imageTag) {
       const rmiResult = dockerRmi(previousEntry.imageTag, {
@@ -4038,13 +4020,11 @@ async function createSandbox(
   });
   registry.setDefault(sandboxName);
 
-  // Restore workspace state if we backed it up during credential rotation or
-  // before a breaking OpenShell gateway upgrade.
   if (restoreBackupPath) {
     note(
       pendingStateRestoreBackupPath
         ? "  Restoring workspace state from pre-upgrade backup..."
-        : "  Restoring workspace state after credential rotation...",
+        : "  Restoring workspace state from pre-recreate backup...",
     );
     const restore = sandboxState.restoreSandboxState(sandboxName, restoreBackupPath);
     if (restore.success) {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3321,14 +3321,6 @@ async function createSandbox(
       if (!result.ok) {
         console.error("  Pass --recreate-sandbox to force recreation without backup.");
         upsertMessagingProviders(messagingTokenDefs);
-        const abortHashes: Record<string, string> = {};
-        for (const { envKey, token } of messagingTokenDefs) {
-          const hash = token ? hashCredential(token) : null;
-          if (hash) abortHashes[envKey] = hash;
-        }
-        if (Object.keys(abortHashes).length > 0) {
-          registry.updateSandbox(sandboxName, { providerCredentialHashes: abortHashes });
-        }
         const reusedPort3 = ensureDashboardForward(sandboxName, chatUiUrl);
         process.env.CHAT_UI_URL = `http://127.0.0.1:${reusedPort3}`;
         updateReusedSandboxMetadata(
@@ -3374,11 +3366,7 @@ async function createSandbox(
     });
     if (decision.overrideNote !== null) note(decision.overrideNote);
 
-    if (
-      pendingStateRestore === null &&
-      existingSandboxState === "ready" &&
-      !shouldSkipPreRecreateBackup(process.env)
-    ) {
+    if (pendingStateRestore === null && !shouldSkipPreRecreateBackup(process.env)) {
       note("  Backing up workspace state before recreating sandbox...");
       const result = backupSandboxBeforeRecreate({ sandboxName });
       if (!result.ok) {

--- a/src/lib/onboard/sandbox-backup-on-recreate.test.ts
+++ b/src/lib/onboard/sandbox-backup-on-recreate.test.ts
@@ -3,19 +3,23 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import type { BackupResult } from "../../../dist/lib/state/sandbox";
 import {
   backupSandboxBeforeRecreate,
   shouldSkipPreRecreateBackup,
 } from "../../../dist/lib/onboard/sandbox-backup-on-recreate";
 
-function makeBackup(overrides: Record<string, unknown> = {}): unknown {
+function makeBackup(overrides: Partial<BackupResult> = {}): BackupResult {
   return {
     success: true,
     backedUpDirs: ["workspace", "skills"],
     failedDirs: [],
     backedUpFiles: ["UPGRADE_MARKER.md"],
     failedFiles: [],
-    manifest: { backupPath: "/tmp/backups/x", timestamp: "2026-05-25T00:00:00Z" },
+    manifest: {
+      backupPath: "/tmp/backups/x",
+      timestamp: "2026-05-25T00:00:00Z",
+    } as BackupResult["manifest"],
     ...overrides,
   };
 }
@@ -38,7 +42,7 @@ describe("backupSandboxBeforeRecreate", () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining("State backed up"));
   });
 
-  it("treats partial backup as ok and warns", () => {
+  it("returns ok:false with failureKind=partial when some entries failed", () => {
     const backup = makeBackup({
       success: false,
       backedUpDirs: ["workspace"],
@@ -46,16 +50,30 @@ describe("backupSandboxBeforeRecreate", () => {
       backedUpFiles: [],
       failedFiles: ["bad.bin"],
     });
-    const log = vi.fn();
+    const errorLog = vi.fn();
     const result = backupSandboxBeforeRecreate({
       sandboxName: "my-assistant",
       backupImpl: () => backup,
-      log,
-      errorLog: vi.fn(),
+      log: vi.fn(),
+      errorLog,
     });
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe("partial");
     expect(result.backup).toBe(backup);
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("Partial backup"));
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("Partial backup"));
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("Aborting recreate"));
+  });
+
+  it("rejects backup result missing manifest backupPath", () => {
+    const backup = makeBackup({ manifest: undefined });
+    const errorLog = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      backupImpl: () => backup,
+      log: vi.fn(),
+      errorLog,
+    });
+    expect(result.ok).toBe(false);
   });
 
   it("returns ok:false with failureKind=empty when nothing was backed up", () => {

--- a/src/lib/onboard/sandbox-backup-on-recreate.test.ts
+++ b/src/lib/onboard/sandbox-backup-on-recreate.test.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  backupSandboxBeforeRecreate,
+  shouldSkipPreRecreateBackup,
+} from "../../../dist/lib/onboard/sandbox-backup-on-recreate";
+
+function makeBackup(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    success: true,
+    backedUpDirs: ["workspace", "skills"],
+    failedDirs: [],
+    backedUpFiles: ["UPGRADE_MARKER.md"],
+    failedFiles: [],
+    manifest: { backupPath: "/tmp/backups/x", timestamp: "2026-05-25T00:00:00Z" },
+    ...overrides,
+  };
+}
+
+describe("backupSandboxBeforeRecreate", () => {
+  it("returns ok with backup result on success", () => {
+    const backup = makeBackup();
+    const backupImpl = vi.fn().mockReturnValue(backup);
+    const log = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      backupImpl,
+      log,
+      errorLog: vi.fn(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.backup).toBe(backup);
+    expect(result.failureKind).toBe("none");
+    expect(backupImpl).toHaveBeenCalledWith("my-assistant");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("State backed up"));
+  });
+
+  it("treats partial backup as ok and warns", () => {
+    const backup = makeBackup({
+      success: false,
+      backedUpDirs: ["workspace"],
+      failedDirs: ["skills"],
+      backedUpFiles: [],
+      failedFiles: ["bad.bin"],
+    });
+    const log = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      backupImpl: () => backup,
+      log,
+      errorLog: vi.fn(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.backup).toBe(backup);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Partial backup"));
+  });
+
+  it("returns ok:false with failureKind=empty when nothing was backed up", () => {
+    const backup = makeBackup({
+      success: false,
+      backedUpDirs: [],
+      failedDirs: ["workspace"],
+      backedUpFiles: [],
+      failedFiles: [],
+    });
+    const errorLog = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      backupImpl: () => backup,
+      errorLog,
+      log: vi.fn(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe("empty");
+    expect(result.backup).toBeNull();
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("aborting recreate"));
+  });
+
+  it("returns ok:false with failureKind=threw when backup throws", () => {
+    const errorLog = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      backupImpl: () => {
+        throw new Error("disk full");
+      },
+      errorLog,
+      log: vi.fn(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe("threw");
+    expect(result.errorMessage).toBe("disk full");
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("State backup threw"));
+  });
+});
+
+describe("shouldSkipPreRecreateBackup", () => {
+  it("returns true when NEMOCLAW_RECREATE_WITHOUT_BACKUP=1", () => {
+    expect(shouldSkipPreRecreateBackup({ NEMOCLAW_RECREATE_WITHOUT_BACKUP: "1" })).toBe(true);
+  });
+
+  it("returns false for any other value", () => {
+    expect(shouldSkipPreRecreateBackup({})).toBe(false);
+    expect(shouldSkipPreRecreateBackup({ NEMOCLAW_RECREATE_WITHOUT_BACKUP: "0" })).toBe(false);
+    expect(shouldSkipPreRecreateBackup({ NEMOCLAW_RECREATE_WITHOUT_BACKUP: "true" })).toBe(false);
+  });
+});

--- a/src/lib/onboard/sandbox-backup-on-recreate.ts
+++ b/src/lib/onboard/sandbox-backup-on-recreate.ts
@@ -13,7 +13,7 @@ export interface PreRecreateBackupOptions {
   errorLog?: (msg: string) => void;
 }
 
-export type PreRecreateBackupFailureKind = "none" | "empty" | "threw";
+export type PreRecreateBackupFailureKind = "none" | "partial" | "empty" | "threw";
 
 export interface PreRecreateBackupResult {
   ok: boolean;
@@ -30,17 +30,18 @@ export function backupSandboxBeforeRecreate(
   const backupImpl = opts.backupImpl ?? sandboxState.backupSandboxState;
   try {
     const backup = backupImpl(opts.sandboxName);
-    if (backup.success) {
+    if (backup.success && backup.manifest?.backupPath) {
       log(
         `  ✓ State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
       );
       return { ok: true, backup, failureKind: "none" };
     }
     if (backup.backedUpDirs.length > 0 || backup.backedUpFiles.length > 0) {
-      log(
-        `  ⚠ Partial backup: ${backup.backedUpDirs.length} dirs / ${backup.backedUpFiles.length} files saved; ${backup.failedDirs.length} dirs / ${backup.failedFiles.length} files failed.`,
+      errorLog(
+        `  Partial backup: ${backup.backedUpDirs.length} dirs / ${backup.backedUpFiles.length} files saved; ${backup.failedDirs.length} dirs / ${backup.failedFiles.length} files failed.`,
       );
-      return { ok: true, backup, failureKind: "none" };
+      errorLog("  Aborting recreate — failed entries would be lost on delete.");
+      return { ok: false, backup, failureKind: "partial" };
     }
     errorLog("  State backup failed — aborting recreate to prevent data loss.");
     return { ok: false, backup: null, failureKind: "empty" };

--- a/src/lib/onboard/sandbox-backup-on-recreate.ts
+++ b/src/lib/onboard/sandbox-backup-on-recreate.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as sandboxState from "../state/sandbox";
+import type { BackupResult } from "../state/sandbox";
+
+export type SandboxBackupImpl = (sandboxName: string) => BackupResult;
+
+export interface PreRecreateBackupOptions {
+  sandboxName: string;
+  backupImpl?: SandboxBackupImpl;
+  log?: (msg: string) => void;
+  errorLog?: (msg: string) => void;
+}
+
+export type PreRecreateBackupFailureKind = "none" | "empty" | "threw";
+
+export interface PreRecreateBackupResult {
+  ok: boolean;
+  backup: BackupResult | null;
+  failureKind: PreRecreateBackupFailureKind;
+  errorMessage?: string;
+}
+
+export function backupSandboxBeforeRecreate(
+  opts: PreRecreateBackupOptions,
+): PreRecreateBackupResult {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const errorLog = opts.errorLog ?? ((m: string) => console.error(m));
+  const backupImpl = opts.backupImpl ?? sandboxState.backupSandboxState;
+  try {
+    const backup = backupImpl(opts.sandboxName);
+    if (backup.success) {
+      log(
+        `  ✓ State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
+      );
+      return { ok: true, backup, failureKind: "none" };
+    }
+    if (backup.backedUpDirs.length > 0 || backup.backedUpFiles.length > 0) {
+      log(
+        `  ⚠ Partial backup: ${backup.backedUpDirs.length} dirs / ${backup.backedUpFiles.length} files saved; ${backup.failedDirs.length} dirs / ${backup.failedFiles.length} files failed.`,
+      );
+      return { ok: true, backup, failureKind: "none" };
+    }
+    errorLog("  State backup failed — aborting recreate to prevent data loss.");
+    return { ok: false, backup: null, failureKind: "empty" };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    errorLog(`  State backup threw: ${message} — aborting recreate.`);
+    return { ok: false, backup: null, failureKind: "threw", errorMessage: message };
+  }
+}
+
+export function shouldSkipPreRecreateBackup(env: NodeJS.ProcessEnv): boolean {
+  return env.NEMOCLAW_RECREATE_WITHOUT_BACKUP === "1";
+}

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -3183,6 +3183,152 @@ const { createSandbox } = require(${onboardPath});
   );
 
   it(
+    "recreate-sandbox flag backs up and restores when existing sandbox is not ready",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-recreate-notready-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "recreate-notready.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
+      const sandboxStatePath = JSON.stringify(
+        path.join(repoRoot, "dist", "lib", "state", "sandbox.js"),
+      );
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
+const registry = require(${registryPath});
+const sandboxState = require(${sandboxStatePath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+const events = [];
+let sandboxDeleted = false;
+runner.run = (command) => {
+  const cmd = _n(command);
+  events.push({ kind: "run", cmd });
+  if (cmd.includes("sandbox delete")) sandboxDeleted = true;
+  return { status: 0 };
+};
+runner.runCapture = (command) => {
+  const cmd = _n(command);
+  if (cmd.includes("sandbox get my-assistant")) return "my-assistant";
+  if (cmd.includes("sandbox list")) {
+    return sandboxDeleted ? "my-assistant Ready" : "my-assistant NotReady";
+  }
+  if (cmd.includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
+  return "";
+};
+registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
+registry.registerSandbox = () => true;
+registry.updateSandbox = () => true;
+registry.setDefault = () => true;
+registry.removeSandbox = () => true;
+
+sandboxState.backupSandboxState = (name) => {
+  events.push({ kind: "backup", name });
+  return {
+    success: true,
+    backedUpDirs: ["workspace"],
+    failedDirs: [],
+    backedUpFiles: ["UPGRADE_MARKER.md"],
+    failedFiles: [],
+    manifest: { backupPath: "/tmp/fake-backup-notready", timestamp: "2026-05-25T00:00:00Z" },
+  };
+};
+sandboxState.restoreSandboxState = (name, backupPath) => {
+  events.push({ kind: "restore", name, backupPath });
+  return {
+    success: true,
+    restoredDirs: ["workspace"],
+    failedDirs: [],
+    restoredFiles: ["UPGRADE_MARKER.md"],
+    failedFiles: [],
+  };
+};
+
+const preflight = require(${JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard", "preflight.js"))});
+preflight.checkPortAvailable = async () => ({ ok: true });
+
+childProcess.spawn = (...args) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.unref = () => {};
+  child.pid = 4245;
+  events.push({ kind: "spawn", cmd: _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]) });
+  process.nextTick(() => {
+    child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.emit("close", 0);
+  });
+  return child;
+};
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  process.env.NEMOCLAW_RECREATE_SANDBOX = "1";
+  const sandboxName = await createSandbox(null, "gpt-5.4", "nvidia-prod", null, "my-assistant");
+  console.log(JSON.stringify({ sandboxName, events }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const payloadLine = result.stdout
+        .trim()
+        .split("\n")
+        .slice()
+        .reverse()
+        .find((line) => line.startsWith("{") && line.endsWith("}"));
+      assert.ok(payloadLine, `expected JSON payload in stdout:\n${result.stdout}`);
+      const payload = JSON.parse(payloadLine);
+
+      const events = payload.events as Array<{ kind: string; cmd?: string; name?: string; backupPath?: string }>;
+      const backupIndex = events.findIndex((e) => e.kind === "backup");
+      const deleteIndex = events.findIndex(
+        (e) => e.kind === "run" && (e.cmd || "").includes("sandbox delete"),
+      );
+      const restoreIndex = events.findIndex((e) => e.kind === "restore");
+
+      assert.ok(backupIndex >= 0, "should call backupSandboxState for not-ready sandbox");
+      assert.ok(deleteIndex > backupIndex, "backup must happen before sandbox delete");
+      assert.ok(restoreIndex > deleteIndex, "restore must happen after sandbox recreate");
+    },
+  );
+
+  it(
     "recreating a sandbox preserves the user's policy preset selections",
     { timeout: 60_000 },
     async () => {
@@ -3691,6 +3837,7 @@ const { createSandbox } = require(${onboardPath});
         ...process.env,
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_RECREATE_WITHOUT_BACKUP: "1",
       };
       delete env["NEMOCLAW_NON_INTERACTIVE"];
       delete env["NEMOCLAW_RECREATE_SANDBOX"];

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -2872,6 +2872,7 @@ const { createSandbox } = require(${onboardPath});
 (async () => {
   process.env.OPENSHELL_GATEWAY = "nemoclaw";
   process.env.NEMOCLAW_RECREATE_SANDBOX = "1";
+  process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "1";
   const sandboxName = await createSandbox(null, "gpt-5.4", "nvidia-prod", null, "my-assistant");
   console.log(JSON.stringify({ sandboxName, commands }));
 })().catch((error) => {
@@ -2909,6 +2910,274 @@ const { createSandbox } = require(${onboardPath});
       assert.ok(
         payload.commands.some((entry: CommandEntry) => entry.command.includes("sandbox create")),
         "should create a new sandbox when --recreate-sandbox is set",
+      );
+    },
+  );
+
+  it(
+    "recreate-sandbox flag backs up and restores workspace state",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-recreate-backup-"));
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "recreate-backup.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
+      const sandboxStatePath = JSON.stringify(
+        path.join(repoRoot, "dist", "lib", "state", "sandbox.js"),
+      );
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
+const registry = require(${registryPath});
+const sandboxState = require(${sandboxStatePath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+const events = [];
+runner.run = (command) => {
+  events.push({ kind: "run", cmd: _n(command) });
+  return { status: 0 };
+};
+runner.runCapture = (command) => {
+  const cmd = _n(command);
+  if (cmd.includes("sandbox get my-assistant")) return "my-assistant";
+  if (cmd.includes("sandbox list")) return "my-assistant Ready";
+  if (cmd.includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
+  return "";
+};
+registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
+registry.registerSandbox = () => true;
+registry.updateSandbox = () => true;
+registry.setDefault = () => true;
+registry.removeSandbox = () => true;
+
+sandboxState.backupSandboxState = (name) => {
+  events.push({ kind: "backup", name });
+  return {
+    success: true,
+    backedUpDirs: ["workspace", "skills"],
+    failedDirs: [],
+    backedUpFiles: ["UPGRADE_MARKER.md"],
+    failedFiles: [],
+    manifest: { backupPath: "/tmp/fake-backup-path", timestamp: "2026-05-25T00:00:00Z" },
+  };
+};
+sandboxState.restoreSandboxState = (name, backupPath) => {
+  events.push({ kind: "restore", name, backupPath });
+  return {
+    success: true,
+    restoredDirs: ["workspace", "skills"],
+    failedDirs: [],
+    restoredFiles: ["UPGRADE_MARKER.md"],
+    failedFiles: [],
+  };
+};
+
+const preflight = require(${JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard", "preflight.js"))});
+preflight.checkPortAvailable = async () => ({ ok: true });
+
+childProcess.spawn = (...args) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.unref = () => {};
+  child.pid = 4243;
+  events.push({ kind: "spawn", cmd: _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]) });
+  process.nextTick(() => {
+    child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.emit("close", 0);
+  });
+  return child;
+};
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  process.env.NEMOCLAW_RECREATE_SANDBOX = "1";
+  const sandboxName = await createSandbox(null, "gpt-5.4", "nvidia-prod", null, "my-assistant");
+  console.log(JSON.stringify({ sandboxName, events }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const payloadLine = result.stdout
+        .trim()
+        .split("\n")
+        .slice()
+        .reverse()
+        .find((line) => line.startsWith("{") && line.endsWith("}"));
+      assert.ok(payloadLine, `expected JSON payload in stdout:\n${result.stdout}`);
+      const payload = JSON.parse(payloadLine);
+
+      const events = payload.events as Array<{ kind: string; cmd?: string; name?: string; backupPath?: string }>;
+      const backupIndex = events.findIndex((e) => e.kind === "backup");
+      const deleteIndex = events.findIndex((e) => e.kind === "run" && (e.cmd || "").includes("sandbox delete"));
+      const restoreIndex = events.findIndex((e) => e.kind === "restore");
+
+      assert.ok(backupIndex >= 0, "should call backupSandboxState before delete");
+      assert.ok(deleteIndex > backupIndex, "backup must happen before sandbox delete");
+      assert.ok(restoreIndex > deleteIndex, "restore must happen after sandbox recreate");
+      const backupEvent = events[backupIndex];
+      assert.equal(backupEvent?.name, "my-assistant", "backup target must match sandbox name");
+      const restoreEvent = events[restoreIndex];
+      assert.equal(restoreEvent?.backupPath, "/tmp/fake-backup-path", "restore must use backup path");
+    },
+  );
+
+  it(
+    "recreate-sandbox with NEMOCLAW_RECREATE_WITHOUT_BACKUP=1 skips backup",
+    { timeout: 60_000 },
+    async () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-recreate-skip-backup-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "recreate-skip-backup.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+      const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
+      const sandboxStatePath = JSON.stringify(
+        path.join(repoRoot, "dist", "lib", "state", "sandbox.js"),
+      );
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
+
+      const script = String.raw`
+const runner = require(${runnerPath});
+const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
+const registry = require(${registryPath});
+const sandboxState = require(${sandboxStatePath});
+const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+
+const events = [];
+runner.run = (command) => {
+  events.push({ kind: "run", cmd: _n(command) });
+  return { status: 0 };
+};
+runner.runCapture = (command) => {
+  const cmd = _n(command);
+  if (cmd.includes("sandbox get my-assistant")) return "my-assistant";
+  if (cmd.includes("sandbox list")) return "my-assistant Ready";
+  if (cmd.includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
+  {
+    const sandboxExecCurl = require(${onboardScriptMocksPath}).mockSandboxExecCurl(command, {
+      defaultCurlOutput: "ok",
+    });
+    if (sandboxExecCurl !== null) return sandboxExecCurl;
+  }
+  return "";
+};
+registry.getSandbox = () => ({ name: "my-assistant", gpuEnabled: false });
+registry.registerSandbox = () => true;
+registry.updateSandbox = () => true;
+registry.setDefault = () => true;
+registry.removeSandbox = () => true;
+
+sandboxState.backupSandboxState = () => {
+  events.push({ kind: "backup" });
+  return { success: true, backedUpDirs: [], failedDirs: [], backedUpFiles: [], failedFiles: [] };
+};
+sandboxState.restoreSandboxState = () => {
+  events.push({ kind: "restore" });
+  return { success: true, restoredDirs: [], failedDirs: [], restoredFiles: [], failedFiles: [] };
+};
+
+const preflight = require(${JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard", "preflight.js"))});
+preflight.checkPortAvailable = async () => ({ ok: true });
+
+childProcess.spawn = (...args) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.unref = () => {};
+  child.pid = 4244;
+  events.push({ kind: "spawn", cmd: _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]) });
+  process.nextTick(() => {
+    child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.emit("close", 0);
+  });
+  return child;
+};
+
+const { createSandbox } = require(${onboardPath});
+
+(async () => {
+  process.env.OPENSHELL_GATEWAY = "nemoclaw";
+  process.env.NEMOCLAW_RECREATE_SANDBOX = "1";
+  process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "1";
+  const sandboxName = await createSandbox(null, "gpt-5.4", "nvidia-prod", null, "my-assistant");
+  console.log(JSON.stringify({ sandboxName, events }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const payloadLine = result.stdout
+        .trim()
+        .split("\n")
+        .slice()
+        .reverse()
+        .find((line) => line.startsWith("{") && line.endsWith("}"));
+      assert.ok(payloadLine, `expected JSON payload in stdout:\n${result.stdout}`);
+      const payload = JSON.parse(payloadLine);
+      const events = payload.events as Array<{ kind: string }>;
+      assert.ok(
+        !events.some((e) => e.kind === "backup"),
+        "should not call backupSandboxState when NEMOCLAW_RECREATE_WITHOUT_BACKUP=1",
+      );
+      assert.ok(
+        !events.some((e) => e.kind === "restore"),
+        "should not call restoreSandboxState when no backup occurred",
       );
     },
   );
@@ -2995,6 +3264,7 @@ const { createSandbox } = require(${onboardPath});
 (async () => {
   process.env.OPENSHELL_GATEWAY = "nemoclaw";
   process.env.NEMOCLAW_RECREATE_SANDBOX = "1";
+  process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP = "1";
   await createSandbox(null, "gpt-5.4", "nvidia-prod", null, "my-assistant");
   const session = onboardSession.loadSession();
   console.log(JSON.stringify({ policyPresets: session && session.policyPresets }));
@@ -3276,6 +3546,7 @@ const { createSandbox } = require(${onboardPath});
         ...process.env,
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_RECREATE_WITHOUT_BACKUP: "1",
       };
       delete env["NEMOCLAW_NON_INTERACTIVE"];
       delete env["NEMOCLAW_RECREATE_SANDBOX"];


### PR DESCRIPTION
## Summary
`NEMOCLAW_RECREATE_SANDBOX=1` (the only path the installer permits when a sandbox already exists during a cross-version upgrade) previously deleted the existing sandbox without preserving workspace state. Files under `/sandbox/.openclaw/workspace/` were dropped silently — registration, model/provider, and policy presets all carried forward, but `workspace`, `skills`, `extensions`, etc. did not. This PR backs up workspace state before deletion in every onboard recreate branch that finds the sandbox registered in the gateway — ready or not-ready — sets `pendingStateRestore`, and restores the workspace into the freshly created sandbox, matching the behaviour of `nemoclaw <name> rebuild --force`. If the backup cannot complete in full (partial, empty, or throwing), onboarding aborts with an actionable message; `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` opts out and recreates with a fresh workspace.

## Related Issue
Fixes #4179

## Changes
- `src/lib/onboard/sandbox-backup-on-recreate.ts` (new) — `backupSandboxBeforeRecreate` runs `sandboxState.backupSandboxState` and returns an `ok` flag with the resulting `BackupResult`. Strict mode: `ok: true` only when `backup.success && manifest?.backupPath`; partial backups return `ok: false` with `failureKind: "partial"` so failed entries are not silently dropped on delete. `shouldSkipPreRecreateBackup` reads `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1`.
- `src/lib/onboard.ts` — credential-rotation backup block now delegates to the helper (drops ~30 lines of duplicated error-handling) and no longer persists `providerCredentialHashes` on the abort path so a failed rebuild leaves rotation detectable on the next onboard. New generic pre-delete backup runs right before `sandbox delete` whenever the sandbox is registered in the gateway, no prior backup was taken, and the opt-out flag is unset — covering both ready and not-ready paths so the issue repro (`exists but is not ready`) hits the backup. On `ok: false`, onboarding exits with a clear pointer to the opt-out flag so user data is preserved by default. Net-negative diff on `onboard.ts` to keep `onboard-entrypoint-budget` green.
- Restore message updated to cover the new "pre-recreate backup" case (previously only mentioned credential rotation or pre-upgrade backups).
- Tests — `src/lib/onboard/sandbox-backup-on-recreate.test.ts` covers full-success, partial-failure (now `ok: false`), missing-`manifest.backupPath`, empty-failure, throw-on-backup, and the env opt-out predicate (returns `BackupResult`, not `unknown`, so `typecheck:cli` is clean). Three branch tests in `test/onboard.test.ts` drive `NEMOCLAW_RECREATE_SANDBOX=1` through `createSandbox`: ready-path backup → delete → create → restore ordering with backup-path round-trip into `restoreSandboxState`; the same flow against a not-ready sandbox (the issue repro); and `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` skips both backup and restore. Pre-existing recreate-path tests set the opt-out flag where they were not designed to exercise the backup phase.
- `docs/reference/commands.mdx` — describes the default pre-recreate backup (ready or not-ready), the abort-on-partial-failure behaviour, and the new `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` opt-out.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] \`make docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented workspace backup/restore during sandbox recreation, skip-backup option (NEMOCLAW_RECREATE_WITHOUT_BACKUP=1), and abort behavior when backups fail.

* **New Features / UX**
  * Onboarding now performs a pre-recreate backup (including credential-rotation flows) and shows clearer "pre-upgrade" vs "pre-recreate" restore messages.

* **Tests**
  * Added coverage for pre-recreate backup, partial/failed/skip-backup outcomes, and restore sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->