### PR TITLE
fix(onboard): preserve root-owned config sync dirs

### DIFF
--- a/src/lib/onboard/config-sync.test.ts
+++ b/src/lib/onboard/config-sync.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,33 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { buildSandboxConfigSyncScript, writeSandboxConfigSyncFile } from "./config-sync";
+
+const itUnix = process.platform === "win32" ? it.skip : it;
+
+function writeFakeCommand(binDir: string, name: string, stdout: string): void {
+  const file = path.join(binDir, name);
+  fs.writeFileSync(file, `#!/bin/sh\nprintf '%s\\n' '${stdout}'\n`, { mode: 0o755 });
+}
+
+function runConfigSyncScript(script: string, homeDir: string, fakeUid: string): void {
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sync-bin-"));
+  try {
+    writeFakeCommand(fakeBin, "id", fakeUid);
+    writeFakeCommand(fakeBin, "stat", fakeUid);
+    const result = spawnSync("bash", ["-c", script], {
+      cwd: homeDir,
+      env: { ...process.env, HOME: homeDir, PATH: `${fakeBin}:${process.env.PATH || ""}` },
+      encoding: "utf8",
+    });
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  } finally {
+    fs.rmSync(fakeBin, { recursive: true, force: true });
+  }
+}
+
+function modeBits(file: string): number {
+  return fs.statSync(file).mode & 0o777;
+}
 
 describe("sandbox config sync helpers", () => {
   it("builds a sandbox sync script that records provider selection without rewriting OpenClaw config", () => {
@@ -22,10 +50,17 @@ describe("sandbox config sync helpers", () => {
       providerLabel: "Other OpenAI-compatible endpoint",
     });
 
-    expect(script).toMatch(/mkdir -p -m 700 ~\/\.nemoclaw/);
-    expect(script).toMatch(/chmod 700 ~\/\.nemoclaw/);
-    expect(script).toMatch(/cat > ~\/\.nemoclaw\/config\.json/);
-    expect(script).toMatch(/chmod 600 ~\/\.nemoclaw\/config\.json/);
+    expect(script).toMatch(/nemoclaw_dir="\$\{HOME:-\/sandbox\}\/\.nemoclaw"/);
+    expect(script).toMatch(/mkdir -p -m 700 "\$nemoclaw_dir"/);
+    expect(script).toMatch(/nemoclaw_dir_uid="\$\(stat -c '%u' "\$nemoclaw_dir"/);
+    expect(script).toMatch(/current_uid="\$\(id -u/);
+    expect(script).toMatch(
+      /if \[ -n "\$nemoclaw_dir_uid" \] && \[ "\$nemoclaw_dir_uid" = "\$current_uid" \]; then/,
+    );
+    expect(script).toMatch(/chmod 700 "\$nemoclaw_dir"/);
+    expect(script).toMatch(/cat > "\$nemoclaw_config"/);
+    expect(script).toMatch(/chmod 600 "\$nemoclaw_config"/);
+    expect(script).not.toMatch(/^chmod 700 ~\/\.nemoclaw$/m);
     expect(script).toContain('"model": "nemotron-3-nano:30b"');
     expect(script).toContain('"credentialEnv": "OPENAI_API_KEY"');
     expect(script).not.toMatch(/cat > ~\/\.openclaw\/openclaw\.json/);
@@ -60,6 +95,65 @@ describe("sandbox config sync helpers", () => {
     expect(script).not.toContain("adapter-token");
     expect(script).not.toContain("bedrock-bearer");
     expect(script).not.toContain("bedrock-runtime.us-east-1.amazonaws.com");
+  });
+
+  itUnix("tightens user-owned NemoClaw config dirs and files", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sync-home-"));
+    try {
+      const nemoclawDir = path.join(homeDir, ".nemoclaw");
+      fs.mkdirSync(nemoclawDir, { mode: 0o755 });
+      const script = buildSandboxConfigSyncScript({
+        endpointType: "custom",
+        endpointUrl: "https://inference.local/v1",
+        ncpPartner: null,
+        model: "nemotron-3-nano:30b",
+        profile: "inference-local",
+        credentialEnv: "OPENAI_API_KEY",
+        provider: "compatible-endpoint",
+        providerLabel: "Other OpenAI-compatible endpoint",
+      });
+
+      runConfigSyncScript(script, homeDir, "1234");
+
+      expect(modeBits(nemoclawDir)).toBe(0o700);
+      expect(modeBits(path.join(nemoclawDir, "config.json"))).toBe(0o600);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  itUnix("does not chmod a NemoClaw config dir owned by another user", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sync-home-"));
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sync-bin-"));
+    try {
+      const nemoclawDir = path.join(homeDir, ".nemoclaw");
+      fs.mkdirSync(nemoclawDir, { mode: 0o755 });
+      writeFakeCommand(fakeBin, "id", "1234");
+      writeFakeCommand(fakeBin, "stat", "0");
+      const script = buildSandboxConfigSyncScript({
+        endpointType: "custom",
+        endpointUrl: "https://inference.local/v1",
+        ncpPartner: null,
+        model: "nemotron-3-nano:30b",
+        profile: "inference-local",
+        credentialEnv: "OPENAI_API_KEY",
+        provider: "compatible-endpoint",
+        providerLabel: "Other OpenAI-compatible endpoint",
+      });
+
+      const result = spawnSync("bash", ["-c", script], {
+        cwd: homeDir,
+        env: { ...process.env, HOME: homeDir, PATH: `${fakeBin}:${process.env.PATH || ""}` },
+        encoding: "utf8",
+      });
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(modeBits(nemoclawDir)).toBe(0o755);
+      expect(modeBits(path.join(nemoclawDir, "config.json"))).toBe(0o600);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
   });
 
   it("writes sandbox sync scripts to a mkdtemp-backed temp file", () => {

--- a/src/lib/onboard/config-sync.ts
+++ b/src/lib/onboard/config-sync.ts
@@ -37,12 +37,18 @@ export function buildSandboxConfigSyncScript(selectionConfig: ProviderSelectionC
   // chance to perform its own startup initialization.
   return `
 set -euo pipefail
-mkdir -p -m 700 ~/.nemoclaw
-chmod 700 ~/.nemoclaw
-cat > ~/.nemoclaw/config.json <<'EOF_NEMOCLAW_CFG'
+nemoclaw_dir="\${HOME:-/sandbox}/.nemoclaw"
+nemoclaw_config="$nemoclaw_dir/config.json"
+mkdir -p -m 700 "$nemoclaw_dir"
+nemoclaw_dir_uid="$(stat -c '%u' "$nemoclaw_dir" 2>/dev/null || echo '')"
+current_uid="$(id -u 2>/dev/null || echo '')"
+if [ -n "$nemoclaw_dir_uid" ] && [ "$nemoclaw_dir_uid" = "$current_uid" ]; then
+  chmod 700 "$nemoclaw_dir"
+fi
+cat > "$nemoclaw_config" <<'EOF_NEMOCLAW_CFG'
 ${JSON.stringify(selectionConfig, null, 2)}
 EOF_NEMOCLAW_CFG
-chmod 600 ~/.nemoclaw/config.json
+chmod 600 "$nemoclaw_config"
 config_dir=/sandbox/.openclaw
 if [ -d "$config_dir" ]; then
   config_dir_owner="$(stat -c '%U' "$config_dir" 2>/dev/null || echo unknown)"


### PR DESCRIPTION
## Summary

- keep `~/.nemoclaw` directory hardening for user-owned config dirs
- skip directory `chmod` when the config dir is owned by another UID, which preserves OpenClaw's root-owned `/sandbox/.nemoclaw` layout
- keep `config.json` restricted to `0600`
- add shell-level regression coverage for owned and non-owned config directories

## Root Cause

PR #4054 changed the step-7 sandbox config sync script from writing `~/.nemoclaw/config.json` to unconditionally running `chmod 700 ~/.nemoclaw` first. In the OpenClaw sandbox image, `/sandbox/.nemoclaw` is intentionally root-owned with mode `1755`, while `/sandbox/.nemoclaw/config.json` is sandbox-owned and writable. The directory chmod fails under `set -euo pipefail`, so `openshell sandbox connect <sandbox>` exits 1 during:

`[7/8] Setting up OpenClaw inside sandbox`

This restores compatibility with that image contract without reverting the file-permission hardening from #4054.

## Evidence

- Last known good public install: run `26413471038`, installed ref `8ed9a2c04c80627deed519a7c5ffe8f95ebb5ddd`, `cloud-onboard-e2e` reached `✓ OpenClaw gateway launched inside sandbox`.
- First observed failing public install: run `26414889786`, installed ref `94fefa6fd08e33d48eede651e33770a0712da854`, `cloud-onboard-e2e` failed at `openshell sandbox connect e2e-cloud-onboard`.
- The commit window contains #4054, #3980, and #3675; #4054 is the only PR that changed the config-sync script executed at the failing boundary.

## Validation

- `npm ci --include=dev --ignore-scripts`
- `npx vitest run src/lib/onboard/config-sync.test.ts --reporter=verbose`
- `npx @biomejs/biome check src/lib/onboard/config-sync.ts src/lib/onboard/config-sync.test.ts`
- `git diff --check`
- `npm run build:cli`
- `npm run typecheck:cli`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved NemoClaw configuration directory permission handling to be more robust in different user ownership scenarios.
  * Enhanced sandbox configuration script to conditionally apply permissions based on directory ownership.

* **Tests**
  * Added comprehensive integration tests for configuration directory permission management and ownership verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->