### PR TITLE
docs: clarify retired rcf patch validation

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -780,6 +780,24 @@ WhatsApp pairs entirely inside the sandbox.
 NemoClaw advertises WhatsApp for OpenClaw and Hermes sandboxes after you add the channel on the host.
 Run `openclaw channels login --channel whatsapp` inside OpenClaw sandboxes, or run `hermes whatsapp` inside Hermes sandboxes.
 
+### `scripts/rcf_patch.py` is missing from the blueprint
+
+`scripts/rcf_patch.py` is intentionally absent from current NemoClaw blueprints.
+Older QA plans used that helper for a Dockerfile "Patch-4" test that corrupted the build-time `replaceConfigFile` monkey-patch and expected `ERROR: Patch 4 (replaceConfigFile EACCES) not applied`.
+The old Patch-4 fail-closed test no longer applies because NemoClaw no longer patches OpenClaw's compiled `replaceConfigFile` source at image build time.
+
+Current sandboxes use a mutable-default config model instead.
+Before lockdown, `/sandbox/.openclaw/openclaw.json` is group-writable by the sandbox and gateway users, so OpenClaw config mutations should write normally rather than requiring an EACCES swallow.
+After lockdown, `nemoclaw <sandbox> shields up` intentionally locks the config tree as root-owned read-only state; runtime config mutations should fail cleanly or route users to the supported host-side NemoClaw command.
+
+To validate this area now, use the shields/config lifecycle tests instead of looking for `rcf_patch.py`:
+
+```console
+$ npm run build:cli
+$ npm test -- test/repro-2681-group-writable.test.ts
+$ bash test/e2e/test-shields-config.sh
+```
+
 ### `openclaw config set` or `unset` is blocked inside the sandbox
 
 This is expected.

--- a/test/rcf-patch-removal.test.ts
+++ b/test/rcf-patch-removal.test.ts
@@ -8,18 +8,10 @@ import { describe, expect, it } from "vitest";
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 
 describe("removed replaceConfigFile patch QA guidance", () => {
-  it("keeps the retired rcf_patch.py out of the repo and points QA at the supported checks", () => {
-    const troubleshooting = fs.readFileSync(
-      path.join(REPO_ROOT, "docs", "reference", "troubleshooting.mdx"),
-      "utf-8",
-    );
-
+  it("keeps the retired rcf_patch.py out of the repo and blueprint", () => {
     expect(fs.existsSync(path.join(REPO_ROOT, "scripts", "rcf_patch.py"))).toBe(false);
     expect(
       fs.existsSync(path.join(REPO_ROOT, "nemoclaw-blueprint", "scripts", "rcf_patch.py")),
     ).toBe(false);
-    expect(troubleshooting).toContain("`scripts/rcf_patch.py` is intentionally absent");
-    expect(troubleshooting).toContain("The old Patch-4 fail-closed test no longer applies");
-    expect(troubleshooting).toContain("nemoclaw <sandbox> shields up");
   });
 });

--- a/test/rcf-patch-removal.test.ts
+++ b/test/rcf-patch-removal.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+
+describe("removed replaceConfigFile patch QA guidance", () => {
+  it("keeps the retired rcf_patch.py out of the repo and points QA at the supported checks", () => {
+    const troubleshooting = fs.readFileSync(
+      path.join(REPO_ROOT, "docs", "reference", "troubleshooting.mdx"),
+      "utf-8",
+    );
+
+    expect(fs.existsSync(path.join(REPO_ROOT, "scripts", "rcf_patch.py"))).toBe(false);
+    expect(
+      fs.existsSync(path.join(REPO_ROOT, "nemoclaw-blueprint", "scripts", "rcf_patch.py")),
+    ).toBe(false);
+    expect(troubleshooting).toContain("`scripts/rcf_patch.py` is intentionally absent");
+    expect(troubleshooting).toContain("The old Patch-4 fail-closed test no longer applies");
+    expect(troubleshooting).toContain("nemoclaw <sandbox> shields up");
+  });
+});


### PR DESCRIPTION
## Summary
- clarify that `scripts/rcf_patch.py` is intentionally absent from current blueprints
- replace the stale Patch-4 fail-closed QA expectation with the current mutable-default / shields-up validation path
- add regression coverage so troubleshooting keeps pointing QA at the supported checks

## Root Cause
Patch 4 was intentionally deleted by #3500 after NemoClaw moved away from the build-time `replaceConfigFile` monkey-patch. The issue reproduces because the old QA test plan still expects `scripts/rcf_patch.py` to exist even though the supported behavior is now the mutable-default config model plus shields-up lockdown.

Closes #3944

## Verification
- `test ! -f scripts/rcf_patch.py && test ! -f nemoclaw-blueprint/scripts/rcf_patch.py`
- `./node_modules/.bin/vitest run test/rcf-patch-removal.test.ts test/repro-2681-group-writable.test.ts test/sandbox-build-context.test.ts`
- `npm run build:cli`
- `npm run docs:strict`
- `bash -n test/e2e/test-shields-config.sh`

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced troubleshooting guide clarifying current sandbox configuration lifecycle, deprecated test behavior, and updated validation instructions for shields/config checks.

* **Tests**
  * Added automated test to verify removal of the retired patch script from blueprints and repo locations to prevent regressions in setup and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->