### PR TITLE
fix(onboard): guard config-sync chmod with ownership check

### DIFF
--- a/src/lib/onboard/config-sync.ts
+++ b/src/lib/onboard/config-sync.ts
@@ -35,14 +35,30 @@ export function buildSandboxConfigSyncScript(selectionConfig: ProviderSelectionC
   // the sandbox. We write the NemoClaw selection config and normalize the
   // mutable-default OpenClaw config permissions after the gateway has had a
   // chance to perform its own startup initialization.
+  // Guard chmod with an ownership check: on the host, ~/.nemoclaw is
+  // user-owned and the chmod hardens it. Inside OpenClaw sandbox containers
+  // the directory is root-owned (Dockerfile line 733 sets root:root 1755 for
+  // DAC protection of blueprints/) and the sandbox user cannot chmod it.
+  // Hermes containers are unaffected (their Dockerfile.base chowns to
+  // sandbox:sandbox). Without the guard, `set -euo pipefail` turns the
+  // EPERM into exit 1, crashing every OpenClaw E2E job at step 7/8.
+  // See: NemoClaw#4054 (added the chmod), NemoClaw#4009 (original hardening
+  // request).
   return `
 set -euo pipefail
 mkdir -p -m 700 ~/.nemoclaw
-chmod 700 ~/.nemoclaw
+# Only chmod if the current user owns the directory (host installs).
+# Inside the sandbox the dir may be root-owned; prepare_filesystem handles it.
+if [ "$(stat -c '%u' ~/.nemoclaw 2>/dev/null)" = "$(id -u)" ]; then
+  chmod 700 ~/.nemoclaw
+fi
 cat > ~/.nemoclaw/config.json <<'EOF_NEMOCLAW_CFG'
 ${JSON.stringify(selectionConfig, null, 2)}
 EOF_NEMOCLAW_CFG
-chmod 600 ~/.nemoclaw/config.json
+# Only chmod config.json if the current user owns it.
+if [ "$(stat -c '%u' ~/.nemoclaw/config.json 2>/dev/null)" = "$(id -u)" ]; then
+  chmod 600 ~/.nemoclaw/config.json
+fi
 config_dir=/sandbox/.openclaw
 if [ -d "$config_dir" ]; then
   config_dir_owner="$(stat -c '%U' "$config_dir" 2>/dev/null || echo unknown)"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Guard `chmod 700 ~/.nemoclaw` and `chmod 600 ~/.nemoclaw/config.json` in the sandbox config-sync script with an ownership check so the commands only run when the current user owns the target. This prevents EPERM crashes inside OpenClaw sandbox containers where `/sandbox/.nemoclaw` is root-owned (Dockerfile L733: `root:root 1755`), fixing all 39 failed OpenClaw E2E jobs in the May 26 nightly run.

## Related Issue

Fixes #4207

## Changes

- Wrap `chmod 700 ~/.nemoclaw` with `if [ "$(stat -c '%u' ~/.nemoclaw)" = "$(id -u)" ]` so it only runs when the sandbox user owns the directory (host installs). Inside root-owned containers, `prepare_filesystem` already handles permissions.
- Wrap `chmod 600 ~/.nemoclaw/config.json` with the same ownership guard.
- Existing tests in `config-sync.test.ts` continue to pass (3/3) since the `chmod 700` and `chmod 600` strings are still present inside the if-blocks.

## Root Cause

PR #4054 (commit `f1044ad`) added unconditional `chmod 700 ~/.nemoclaw` and `chmod 600 ~/.nemoclaw/config.json` to `buildSandboxConfigSyncScript()` in `src/lib/onboard/config-sync.ts`. The script runs as the `sandbox` user inside OpenClaw containers where `/sandbox/.nemoclaw` is `root:root 1755` (Dockerfile L733). Under `set -euo pipefail`, the EPERM from the failed chmod becomes exit 1, piped through `openshell sandbox connect`, crashing every OpenClaw E2E job at onboard step 7/8.

Hermes containers are unaffected because `Dockerfile.base` L74-75 chowns `/sandbox` to `sandbox:sandbox`.

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets, on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`ci/nightly-e2e-self-hosted`](https://github.com/hunglp6d/NemoClaw/tree/ci/nightly-e2e-self-hosted) on `hunglp6d/NemoClaw`
- Validation run: [#26426343022](https://github.com/hunglp6d/NemoClaw/actions/runs/26426343022) — **success** ✅
- Targeted jobs: `cloud-e2e` (covers the OpenClaw onboard path that crashes)
- Original failing run: [26425202514](https://github.com/NVIDIA/NemoClaw/actions/runs/26425202514) on `4f9b749`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-run the validation by pushing any commit to the validation branch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Hung Le <hple@nvidia.com>