### PR TITLE
fix(onboard): preserve PVC across host stop/start by recovering stopped gateway (#4187)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2082,6 +2082,7 @@ async function preflight(
   // Docker container, so the live CLI health check is the source of truth.
   if (gatewayReuseState === "healthy" && gatewayCliSupportsLifecycleCommands(runCaptureOpenshell)) {
     const containerState = verifyGatewayContainerRunning(GATEWAY_NAME);
+    let checkImageDrift = false;
     if (containerState === "missing") {
       console.log("  Gateway metadata is stale (container not running). Cleaning up...");
       runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
@@ -2090,6 +2091,33 @@ async function preflight(
         "  ✓ Stale gateway metadata cleaned up",
         "  ! Stale gateway metadata cleanup failed; leaving registry state intact.",
       );
+    } else if (containerState === "stopped") {
+      // #4187: a stopped legacy `openshell-cluster-*` container after a host
+      // VM stop/start still holds the k3s local-path PVC volume. Attempt
+      // non-destructive recovery (openshell gateway start) before any
+      // destructive cleanup path so we never delete the PVC backing data
+      // and silently provision a fresh, empty workspace.
+      console.log(
+        "  Gateway container is stopped (likely host or Docker restart). Attempting non-destructive recovery...",
+      );
+      const recovered = await recoverGatewayRuntime();
+      if (recovered) {
+        console.log(
+          "  ✓ Gateway recovered without removing volumes; existing sandbox PVC preserved.",
+        );
+        checkImageDrift = true;
+      } else {
+        console.error(
+          `  Could not start the stopped NemoClaw gateway and ${getGatewayLocalEndpoint()}/ is not responding.`,
+        );
+        console.error(
+          "  Refusing to delete openshell-cluster-* volumes — they may hold the existing PVC/workspace data.",
+        );
+        console.error(
+          "  Restart Docker, free the gateway port if held by another process, and re-run `nemoclaw onboard`. See #4187.",
+        );
+        process.exit(1);
+      }
     } else if (containerState === "unknown") {
       // Docker probe failed but cached metadata says healthy. Try the host-level
       // HTTP probe — it doesn't depend on Docker, so it can confirm the gateway
@@ -2125,6 +2153,10 @@ async function preflight(
         "  ! Stale gateway cleanup failed; leaving registry state intact.",
       );
     } else {
+      checkImageDrift = true;
+    }
+
+    if (checkImageDrift) {
       const imageDrift = getGatewayClusterImageDrift();
       if (imageDrift) {
         console.log(
@@ -7134,6 +7166,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         gatewayCliSupportsLifecycleCommands: () => gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
         verifyGatewayContainerRunning,
         waitForGatewayHttpReady,
+        recoverGatewayRuntime,
         getGatewayLocalEndpoint,
         stopDashboardForward: () => bestEffortForwardStop(runOpenshell, DASHBOARD_PORT),
         destroyGateway,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -428,6 +428,8 @@ const { destroyGatewayWithVolumeCleanup } =
 const {
   gatewayCliSupportsLifecycleCommands,
 } = require("./onboard/gateway-lifecycle") as typeof import("./onboard/gateway-lifecycle");
+const { reconcilePreflightGatewayReuseState } =
+  require("./onboard/preflight-gateway-reuse") as typeof import("./onboard/preflight-gateway-reuse");
 const {
   getGatewayReuseHealthWaitConfig,
   isDockerDriverGatewayHttpReady,
@@ -2080,97 +2082,22 @@ async function preflight(
   // metadata can be stale after a manual `docker rm`. See #2020. Newer
   // package-managed OpenShell gateways do not have an openshell-cluster-*
   // Docker container, so the live CLI health check is the source of truth.
-  if (gatewayReuseState === "healthy" && gatewayCliSupportsLifecycleCommands(runCaptureOpenshell)) {
-    const containerState = verifyGatewayContainerRunning(GATEWAY_NAME);
-    let checkImageDrift = false;
-    if (containerState === "missing") {
-      console.log("  Gateway metadata is stale (container not running). Cleaning up...");
-      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
-      gatewayReuseState = destroyGatewayForReuse(
-        destroyGateway,
-        "  ✓ Stale gateway metadata cleaned up",
-        "  ! Stale gateway metadata cleanup failed; leaving registry state intact.",
-      );
-    } else if (containerState === "stopped") {
-      // #4187: a stopped legacy `openshell-cluster-*` container after a host
-      // VM stop/start still holds the k3s local-path PVC volume. Attempt
-      // non-destructive recovery (openshell gateway start) before any
-      // destructive cleanup path so we never delete the PVC backing data
-      // and silently provision a fresh, empty workspace.
-      console.log(
-        "  Gateway container is stopped (likely host or Docker restart). Attempting non-destructive recovery...",
-      );
-      const recovered = await recoverGatewayRuntime();
-      if (recovered) {
-        console.log(
-          "  ✓ Gateway recovered without removing volumes; existing sandbox PVC preserved.",
-        );
-        checkImageDrift = true;
-      } else {
-        console.error(
-          `  Could not start the stopped NemoClaw gateway and ${getGatewayLocalEndpoint()}/ is not responding.`,
-        );
-        console.error(
-          "  Refusing to delete openshell-cluster-* volumes — they may hold the existing PVC/workspace data.",
-        );
-        console.error(
-          "  Restart Docker, free the gateway port if held by another process, and re-run `nemoclaw onboard`. See #4187.",
-        );
-        process.exit(1);
-      }
-    } else if (containerState === "unknown") {
-      // Docker probe failed but cached metadata says healthy. Try the host-level
-      // HTTP probe — it doesn't depend on Docker, so it can confirm the gateway
-      // is genuinely serving even when the daemon is flaky.
-      //
-      // Per #2020 the "unknown" state must stay non-destructive end-to-end:
-      // do not downgrade to "missing" in preflight even when HTTP probe fails.
-      // Doing so would feed the orphan-cleanup block below, and a transient
-      // `docker inspect` failure plus an HTTP warm-up miss would delete a
-      // live gateway. The main onboard "unknown" branch makes the abort/reuse
-      // decision once preflight has surfaced the warning to the user.
-      if (await waitForGatewayHttpReady()) {
-        console.log(
-          "  Warning: could not verify gateway container state (Docker may be unavailable), but the gateway is responding on HTTP. Proceeding with reuse.",
-        );
-      } else {
-        console.log(
-          "  Warning: could not verify gateway container state and the gateway is not responding on HTTP. Onboard will abort before reuse if this persists; restart Docker and re-run.",
-        );
-      }
-    } else if (!(await waitForGatewayHttpReady())) {
-      // Container is running but the gateway HTTP endpoint is not responding.
-      // Common immediately after a Docker daemon restart — the container comes
-      // back before the OpenShell gateway upstream finishes warming up. Safe to
-      // recreate because Docker is functional. See #3258.
-      console.log(
-        `  Gateway container is running but ${getGatewayLocalEndpoint()}/ is not responding. Recreating...`,
-      );
-      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true });
-      gatewayReuseState = destroyGatewayForReuse(
-        destroyGateway,
-        "  ✓ Stale gateway cleaned up",
-        "  ! Stale gateway cleanup failed; leaving registry state intact.",
-      );
-    } else {
-      checkImageDrift = true;
-    }
-
-    if (checkImageDrift) {
-      const imageDrift = getGatewayClusterImageDrift();
-      if (imageDrift) {
-        console.log(
-          `  Gateway image ${imageDrift.currentVersion} does not match openshell ${imageDrift.expectedVersion}. Recreating...`,
-        );
-        stopAllDashboardForwards();
-        gatewayReuseState = destroyGatewayForReuse(
-          destroyGateway,
-          "  ✓ Previous gateway cleaned up",
-          "  ! Previous gateway cleanup failed; leaving registry state intact.",
-        );
-      }
-    }
-  }
+  gatewayReuseState = await reconcilePreflightGatewayReuseState({
+    gatewayReuseState,
+    supportsLifecycleCommands: gatewayCliSupportsLifecycleCommands(runCaptureOpenshell),
+    gatewayName: GATEWAY_NAME,
+    verifyGatewayContainerRunning,
+    recoverGatewayRuntime,
+    waitForGatewayHttpReady,
+    getGatewayLocalEndpoint,
+    stopDashboardForward: () =>
+      runOpenshell(["forward", "stop", String(DASHBOARD_PORT)], { ignoreError: true }),
+    stopAllDashboardForwards,
+    destroyGateway,
+    destroyGatewayForReuse,
+    getGatewayClusterImageDrift,
+    exitProcess: (code) => process.exit(code),
+  });
 
   if (gatewayReuseState === "stale" || gatewayReuseState === "active-unnamed") {
     console.log(`  Cleaning up previous ${cliDisplayName()} session...`);

--- a/src/lib/onboard/gateway-container-running.test.ts
+++ b/src/lib/onboard/gateway-container-running.test.ts
@@ -20,10 +20,10 @@ describe("verifyGatewayContainerRunning", () => {
     );
   });
 
-  it("returns missing for existing but stopped containers", () => {
+  it("returns stopped for existing but stopped containers (#4187)", () => {
     const dockerInspect = vi.fn(() => dockerInspectResult(0, "false\n"));
 
-    expect(verifyGatewayContainerRunning("nemoclaw", { dockerInspect })).toBe("missing");
+    expect(verifyGatewayContainerRunning("nemoclaw", { dockerInspect })).toBe("stopped");
   });
 
   it("returns missing when Docker reports the gateway container is absent", () => {

--- a/src/lib/onboard/gateway-container-running.ts
+++ b/src/lib/onboard/gateway-container-running.ts
@@ -1,13 +1,21 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type GatewayContainerState = "running" | "missing" | "unknown";
+export type GatewayContainerState = "running" | "stopped" | "missing" | "unknown";
 
 type DockerInspect = (
   args: string[],
   opts: { ignoreError: true; suppressOutput: true },
 ) => { status: number | null; stdout?: unknown; stderr?: unknown };
 
+// Distinguishes a stopped-but-existing legacy gateway container from a truly
+// absent one. Conflating the two caused #4187: after a host VM stop/start the
+// k3s-in-Docker `openshell-cluster-${gatewayName}` container is stopped but
+// still holds the PVC volume. Treating that as "missing" routed onboarding
+// through the destructive cleanup branch (`destroyGatewayWithVolumeCleanup`)
+// which removes `openshell-cluster-${gatewayName}*` Docker volumes — i.e. the
+// PVC backing store — before sandbox recreation, so the next `createSandbox`
+// provisioned a fresh, empty workspace.
 export function verifyGatewayContainerRunning(
   gatewayName: string,
   deps: { dockerInspect?: DockerInspect } = {},
@@ -26,7 +34,7 @@ export function verifyGatewayContainerRunning(
   }
 
   if (result.status === 0) {
-    return "missing";
+    return "stopped";
   }
 
   const stderr = (result.stderr || "").toString();

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -16,6 +16,7 @@ function createDeps(overrides: Partial<GatewayStateOptions<Gpu>["deps"]> = {}) {
     lifecycle: vi.fn(() => false),
     verifyContainer: vi.fn((_gatewayName: string): GatewayContainerState => "running"),
     waitHttp: vi.fn(async () => true),
+    recoverGateway: vi.fn(async () => true),
     stopDashboardForward: vi.fn(),
     destroy: vi.fn(() => true),
     destroyForReuse: vi.fn(() => "missing" as GatewayReuseState),
@@ -42,6 +43,7 @@ function createDeps(overrides: Partial<GatewayStateOptions<Gpu>["deps"]> = {}) {
       gatewayCliSupportsLifecycleCommands: calls.lifecycle,
       verifyGatewayContainerRunning: calls.verifyContainer,
       waitForGatewayHttpReady: calls.waitHttp,
+      recoverGatewayRuntime: calls.recoverGateway,
       getGatewayLocalEndpoint: () => "http://127.0.0.1:31818",
       stopDashboardForward: calls.stopDashboardForward,
       destroyGateway: calls.destroy,
@@ -157,6 +159,65 @@ describe("handleGatewayState", () => {
       "  ! Stale gateway metadata cleanup failed; leaving registry state intact.",
     );
     expect(calls.startGateway).toHaveBeenCalled();
+  });
+
+  it("recovers a stopped lifecycle gateway without destroying volumes (#4187)", async () => {
+    const recoverGateway = vi.fn(async () => true);
+    const { deps, calls } = createDeps({
+      gatewayCliSupportsLifecycleCommands: vi.fn(() => true),
+      verifyGatewayContainerRunning: vi.fn(() => "stopped" as GatewayContainerState),
+      recoverGatewayRuntime: recoverGateway,
+    });
+
+    await handleGatewayState(baseOptions(deps, "healthy"));
+
+    expect(recoverGateway).toHaveBeenCalledOnce();
+    expect(calls.stopDashboardForward).not.toHaveBeenCalled();
+    expect(calls.destroyForReuse).not.toHaveBeenCalled();
+    expect(calls.exit).not.toHaveBeenCalled();
+    expect(calls.startGateway).not.toHaveBeenCalled();
+    expect(calls.skipped).toHaveBeenCalledWith("gateway", "running", "reuse");
+    expect(calls.complete).toHaveBeenCalledWith("gateway");
+  });
+
+  it("refuses to destroy volumes when stopped-container recovery fails (#4187)", async () => {
+    const recoverGateway = vi.fn(async () => false);
+    const { deps, calls } = createDeps({
+      gatewayCliSupportsLifecycleCommands: vi.fn(() => true),
+      verifyGatewayContainerRunning: vi.fn(() => "stopped" as GatewayContainerState),
+      recoverGatewayRuntime: recoverGateway,
+    });
+
+    await expect(handleGatewayState(baseOptions(deps, "healthy"))).rejects.toThrow("exit 1");
+
+    expect(recoverGateway).toHaveBeenCalledOnce();
+    expect(calls.exit).toHaveBeenCalledWith(1);
+    expect(calls.destroyForReuse).not.toHaveBeenCalled();
+    expect(calls.stopDashboardForward).not.toHaveBeenCalled();
+  });
+
+  it("still recreates a recovered stopped gateway when image drift is detected (#4187)", async () => {
+    const recoverGateway = vi.fn(async () => true);
+    const { deps, calls } = createDeps({
+      gatewayCliSupportsLifecycleCommands: vi.fn(() => true),
+      verifyGatewayContainerRunning: vi.fn(() => "stopped" as GatewayContainerState),
+      recoverGatewayRuntime: recoverGateway,
+      getGatewayClusterImageDrift: vi.fn(() => ({
+        currentVersion: "0.0.38",
+        expectedVersion: "0.0.39",
+      })),
+      destroyGatewayForReuse: vi.fn(() => "missing" as GatewayReuseState),
+    });
+
+    await handleGatewayState(baseOptions(deps, "healthy"));
+
+    expect(recoverGateway).toHaveBeenCalledOnce();
+    expect(calls.stopForwards).toHaveBeenCalledOnce();
+    expect(deps.destroyGatewayForReuse).toHaveBeenCalledWith(
+      deps.destroyGateway,
+      "  ✓ Previous gateway cleaned up",
+      "  ! Previous gateway cleanup failed; leaving registry state intact.",
+    );
   });
 
   it("refuses to destroy an unknown container state when HTTP is also unavailable", async () => {

--- a/src/lib/onboard/machine/handlers/gateway.ts
+++ b/src/lib/onboard/machine/handlers/gateway.ts
@@ -21,6 +21,7 @@ export interface GatewayStateOptions<Gpu> {
     gatewayCliSupportsLifecycleCommands(): boolean;
     verifyGatewayContainerRunning(gatewayName: string): GatewayContainerState;
     waitForGatewayHttpReady(): Promise<boolean>;
+    recoverGatewayRuntime(): Promise<boolean>;
     getGatewayLocalEndpoint(): string;
     stopDashboardForward(): void;
     destroyGateway(
@@ -85,6 +86,7 @@ export async function handleGatewayState<Gpu>({
 
   if (gatewayReuseState === "healthy" && supportsLifecycleCommands) {
     const containerState = deps.verifyGatewayContainerRunning(gatewayName);
+    let checkImageDrift = false;
     if (containerState === "missing") {
       console.log("  Gateway metadata is stale (container not running). Cleaning up...");
       deps.stopDashboardForward();
@@ -93,6 +95,30 @@ export async function handleGatewayState<Gpu>({
         "  ✓ Stale gateway metadata cleaned up",
         "  ! Stale gateway metadata cleanup failed; leaving registry state intact.",
       );
+    } else if (containerState === "stopped") {
+      // #4187: a stopped legacy `openshell-cluster-*` container after a host
+      // VM stop/start still holds the PVC volume. Attempt non-destructive
+      // recovery (openshell gateway start) before any destructive path so we
+      // never delete the k3s local-path PVC backing data.
+      console.log(
+        "  Gateway container is stopped (likely host or Docker restart). Attempting non-destructive recovery...",
+      );
+      const recovered = await deps.recoverGatewayRuntime();
+      if (recovered) {
+        console.log("  ✓ Gateway recovered without removing volumes; existing sandbox PVC preserved.");
+        checkImageDrift = true;
+      } else {
+        console.log(
+          `  Could not start the stopped NemoClaw gateway and ${deps.getGatewayLocalEndpoint()}/ is not responding.`,
+        );
+        console.log(
+          "  Refusing to delete openshell-cluster-* volumes — they may hold the existing PVC/workspace data.",
+        );
+        console.log(
+          "  Restart Docker, free the gateway port if held by another process, and re-run `nemoclaw onboard`. See #4187.",
+        );
+        deps.exitProcess(1);
+      }
     } else if (containerState === "unknown") {
       if (await deps.waitForGatewayHttpReady()) {
         console.log(
@@ -118,6 +144,10 @@ export async function handleGatewayState<Gpu>({
         "  ! Stale gateway cleanup failed; leaving registry state intact.",
       );
     } else {
+      checkImageDrift = true;
+    }
+
+    if (checkImageDrift) {
       const imageDrift = deps.getGatewayClusterImageDrift();
       if (imageDrift) {
         console.log(

--- a/src/lib/onboard/preflight-gateway-reuse.test.ts
+++ b/src/lib/onboard/preflight-gateway-reuse.test.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { GatewayContainerState } from "./gateway-container-running";
+import type { GatewayReuseState } from "../state/gateway";
+import {
+  reconcilePreflightGatewayReuseState,
+  type PreflightGatewayReuseDeps,
+} from "./preflight-gateway-reuse";
+
+function makeDeps(
+  overrides: Partial<PreflightGatewayReuseDeps> = {},
+): PreflightGatewayReuseDeps {
+  return {
+    gatewayReuseState: "healthy",
+    supportsLifecycleCommands: true,
+    gatewayName: "nemoclaw",
+    verifyGatewayContainerRunning: vi.fn(() => "running" as GatewayContainerState),
+    recoverGatewayRuntime: vi.fn(async () => true),
+    waitForGatewayHttpReady: vi.fn(async () => true),
+    getGatewayLocalEndpoint: () => "http://127.0.0.1:31818",
+    stopDashboardForward: vi.fn(),
+    stopAllDashboardForwards: vi.fn(),
+    destroyGateway: vi.fn(() => true),
+    destroyGatewayForReuse: vi.fn(() => "missing" as GatewayReuseState),
+    getGatewayClusterImageDrift: vi.fn(() => null),
+    exitProcess: vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }),
+    ...overrides,
+  };
+}
+
+describe("reconcilePreflightGatewayReuseState", () => {
+  it("short-circuits when reuse state is not healthy", async () => {
+    const verify = vi.fn(() => "running" as GatewayContainerState);
+    const deps = makeDeps({ gatewayReuseState: "missing", verifyGatewayContainerRunning: verify });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("missing");
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits when lifecycle commands are not supported", async () => {
+    const verify = vi.fn(() => "running" as GatewayContainerState);
+    const deps = makeDeps({ supportsLifecycleCommands: false, verifyGatewayContainerRunning: verify });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("healthy");
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("recovers a stopped container without removing volumes (#4187)", async () => {
+    const recover = vi.fn(async () => true);
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "stopped" as GatewayContainerState),
+      recoverGatewayRuntime: recover,
+      destroyGatewayForReuse: destroyForReuse,
+    });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("healthy");
+    expect(recover).toHaveBeenCalledOnce();
+    expect(destroyForReuse).not.toHaveBeenCalled();
+    expect(deps.exitProcess).not.toHaveBeenCalled();
+  });
+
+  it("exits without destroying volumes when stopped-container recovery fails (#4187)", async () => {
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    });
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "stopped" as GatewayContainerState),
+      recoverGatewayRuntime: vi.fn(async () => false),
+      destroyGatewayForReuse: destroyForReuse,
+      exitProcess: exit,
+    });
+
+    await expect(reconcilePreflightGatewayReuseState(deps)).rejects.toThrow("exit 1");
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(destroyForReuse).not.toHaveBeenCalled();
+  });
+
+  it("cleans stale metadata when the container is missing", async () => {
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "missing" as GatewayContainerState),
+      destroyGatewayForReuse: destroyForReuse,
+    });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("missing");
+    expect(deps.stopDashboardForward).toHaveBeenCalledOnce();
+    expect(destroyForReuse).toHaveBeenCalledWith(
+      deps.destroyGateway,
+      "  ✓ Stale gateway metadata cleaned up",
+      "  ! Stale gateway metadata cleanup failed; leaving registry state intact.",
+    );
+  });
+
+  it("recreates a running gateway when HTTP is unhealthy", async () => {
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "running" as GatewayContainerState),
+      waitForGatewayHttpReady: vi.fn(async () => false),
+      destroyGatewayForReuse: destroyForReuse,
+    });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("missing");
+    expect(deps.stopDashboardForward).toHaveBeenCalledOnce();
+    expect(destroyForReuse).toHaveBeenCalledWith(
+      deps.destroyGateway,
+      "  ✓ Stale gateway cleaned up",
+      "  ! Stale gateway cleanup failed; leaving registry state intact.",
+    );
+  });
+
+  it("recreates on image drift after stopping dashboard forwards", async () => {
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "running" as GatewayContainerState),
+      getGatewayClusterImageDrift: vi.fn(() => ({ currentVersion: "0.0.38", expectedVersion: "0.0.39" })),
+      destroyGatewayForReuse: destroyForReuse,
+    });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("missing");
+    expect(deps.stopAllDashboardForwards).toHaveBeenCalledOnce();
+    expect(destroyForReuse).toHaveBeenCalledWith(
+      deps.destroyGateway,
+      "  ✓ Previous gateway cleaned up",
+      "  ! Previous gateway cleanup failed; leaving registry state intact.",
+    );
+  });
+
+  it("does not destroy on unknown container state when HTTP is responding", async () => {
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "unknown" as GatewayContainerState),
+      waitForGatewayHttpReady: vi.fn(async () => true),
+      destroyGatewayForReuse: destroyForReuse,
+    });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("healthy");
+    expect(destroyForReuse).not.toHaveBeenCalled();
+    expect(deps.exitProcess).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/preflight-gateway-reuse.test.ts
+++ b/src/lib/onboard/preflight-gateway-reuse.test.ts
@@ -159,4 +159,22 @@ describe("reconcilePreflightGatewayReuseState", () => {
     expect(destroyForReuse).not.toHaveBeenCalled();
     expect(deps.exitProcess).not.toHaveBeenCalled();
   });
+
+  // #2020 safety case: a transient docker inspect failure plus an HTTP warm-up
+  // miss must NOT downgrade reuse state into destructive cleanup. Locks the
+  // behavior described in the implementation comment so it can't regress.
+  it("does not destroy on unknown container state when HTTP is not responding", async () => {
+    const destroyForReuse = vi.fn(() => "missing" as GatewayReuseState);
+    const deps = makeDeps({
+      verifyGatewayContainerRunning: vi.fn(() => "unknown" as GatewayContainerState),
+      waitForGatewayHttpReady: vi.fn(async () => false),
+      destroyGatewayForReuse: destroyForReuse,
+    });
+
+    const result = await reconcilePreflightGatewayReuseState(deps);
+
+    expect(result).toBe("healthy");
+    expect(destroyForReuse).not.toHaveBeenCalled();
+    expect(deps.exitProcess).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/onboard/preflight-gateway-reuse.ts
+++ b/src/lib/onboard/preflight-gateway-reuse.ts
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { GatewayContainerState } from "./gateway-container-running";
+import type { GatewayReuseState } from "../state/gateway";
+
+export interface PreflightGatewayReuseDeps {
+  gatewayReuseState: GatewayReuseState;
+  supportsLifecycleCommands: boolean;
+  gatewayName: string;
+  verifyGatewayContainerRunning(name: string): GatewayContainerState;
+  recoverGatewayRuntime(): Promise<boolean>;
+  waitForGatewayHttpReady(): Promise<boolean>;
+  getGatewayLocalEndpoint(): string;
+  stopDashboardForward(): void;
+  stopAllDashboardForwards(): void;
+  destroyGateway(): boolean;
+  destroyGatewayForReuse(
+    destroyGateway: () => boolean,
+    successMessage: string,
+    failureMessage: string,
+  ): GatewayReuseState;
+  getGatewayClusterImageDrift(): { currentVersion: string; expectedVersion: string } | null;
+  exitProcess(code: number): never;
+}
+
+/**
+ * Preflight reconciliation for the legacy lifecycle-CLI gateway. Verifies the
+ * `openshell-cluster-${gatewayName}` Docker container against cached gateway
+ * metadata and decides whether to reuse, recover, or recreate. See #2020 for
+ * the original stale-metadata handling and #4187 for the stop/start recovery
+ * branch that preserves the k3s local-path PVC volumes.
+ *
+ * Returns the (possibly downgraded) `GatewayReuseState`. Caller drives the
+ * destructive cleanup and final start using the same hooks the original
+ * inline block did.
+ */
+export async function reconcilePreflightGatewayReuseState(
+  deps: PreflightGatewayReuseDeps,
+): Promise<GatewayReuseState> {
+  let gatewayReuseState = deps.gatewayReuseState;
+  if (gatewayReuseState !== "healthy" || !deps.supportsLifecycleCommands) {
+    return gatewayReuseState;
+  }
+
+  const containerState = deps.verifyGatewayContainerRunning(deps.gatewayName);
+  let checkImageDrift = false;
+  if (containerState === "missing") {
+    console.log("  Gateway metadata is stale (container not running). Cleaning up...");
+    deps.stopDashboardForward();
+    gatewayReuseState = deps.destroyGatewayForReuse(
+      deps.destroyGateway,
+      "  ✓ Stale gateway metadata cleaned up",
+      "  ! Stale gateway metadata cleanup failed; leaving registry state intact.",
+    );
+  } else if (containerState === "stopped") {
+    // #4187: a stopped legacy `openshell-cluster-*` container after a host VM
+    // stop/start still holds the k3s local-path PVC volume. Attempt
+    // non-destructive recovery (openshell gateway start) before any
+    // destructive cleanup path so we never delete the PVC backing data and
+    // silently provision a fresh, empty workspace.
+    console.log(
+      "  Gateway container is stopped (likely host or Docker restart). Attempting non-destructive recovery...",
+    );
+    const recovered = await deps.recoverGatewayRuntime();
+    if (recovered) {
+      console.log(
+        "  ✓ Gateway recovered without removing volumes; existing sandbox PVC preserved.",
+      );
+      checkImageDrift = true;
+    } else {
+      console.error(
+        `  Could not start the stopped NemoClaw gateway and ${deps.getGatewayLocalEndpoint()}/ is not responding.`,
+      );
+      console.error(
+        "  Refusing to delete openshell-cluster-* volumes — they may hold the existing PVC/workspace data.",
+      );
+      console.error(
+        "  Restart Docker, free the gateway port if held by another process, and re-run `nemoclaw onboard`. See #4187.",
+      );
+      deps.exitProcess(1);
+    }
+  } else if (containerState === "unknown") {
+    // Docker probe failed but cached metadata says healthy. Try the host-level
+    // HTTP probe — it doesn't depend on Docker, so it can confirm the gateway
+    // is genuinely serving even when the daemon is flaky.
+    //
+    // Per #2020 the "unknown" state must stay non-destructive end-to-end: do
+    // not downgrade to "missing" in preflight even when HTTP probe fails.
+    // Doing so would feed the orphan-cleanup block below, and a transient
+    // `docker inspect` failure plus an HTTP warm-up miss would delete a live
+    // gateway. The main onboard "unknown" branch makes the abort/reuse
+    // decision once preflight has surfaced the warning to the user.
+    if (await deps.waitForGatewayHttpReady()) {
+      console.log(
+        "  Warning: could not verify gateway container state (Docker may be unavailable), but the gateway is responding on HTTP. Proceeding with reuse.",
+      );
+    } else {
+      console.log(
+        "  Warning: could not verify gateway container state and the gateway is not responding on HTTP. Onboard will abort before reuse if this persists; restart Docker and re-run.",
+      );
+    }
+  } else if (!(await deps.waitForGatewayHttpReady())) {
+    // Container is running but the gateway HTTP endpoint is not responding.
+    // Common immediately after a Docker daemon restart — the container comes
+    // back before the OpenShell gateway upstream finishes warming up. Safe to
+    // recreate because Docker is functional. See #3258.
+    console.log(
+      `  Gateway container is running but ${deps.getGatewayLocalEndpoint()}/ is not responding. Recreating...`,
+    );
+    deps.stopDashboardForward();
+    gatewayReuseState = deps.destroyGatewayForReuse(
+      deps.destroyGateway,
+      "  ✓ Stale gateway cleaned up",
+      "  ! Stale gateway cleanup failed; leaving registry state intact.",
+    );
+  } else {
+    checkImageDrift = true;
+  }
+
+  if (checkImageDrift) {
+    const imageDrift = deps.getGatewayClusterImageDrift();
+    if (imageDrift) {
+      console.log(
+        `  Gateway image ${imageDrift.currentVersion} does not match openshell ${imageDrift.expectedVersion}. Recreating...`,
+      );
+      deps.stopAllDashboardForwards();
+      gatewayReuseState = deps.destroyGatewayForReuse(
+        deps.destroyGateway,
+        "  ✓ Previous gateway cleaned up",
+        "  ! Previous gateway cleanup failed; leaving registry state intact.",
+      );
+    }
+  }
+
+  return gatewayReuseState;
+}


### PR DESCRIPTION
## Summary

After a host VM stop/start, NemoClaw was deleting the existing `openshell-cluster-*` Docker volumes (which hold the legacy k3s local-path PVC backing data) before recreating the sandbox, so the user came back to an empty workspace. Split gateway container state to distinguish a stopped existing container from a missing one and attempt non-destructive recovery before any destructive cleanup.

## Related Issue

Fixes #4187

## Changes

- `src/lib/onboard/gateway-container-running.ts`: split `GatewayContainerState` into `running`/`stopped`/`missing`/`unknown`. A Docker inspect that succeeds with `{{.State.Running}} == false` now returns `stopped` (was collapsed into `missing`).
- `src/lib/onboard/machine/handlers/gateway.ts`: add a `stopped` branch that calls a new `recoverGatewayRuntime` dep (existing `openshell gateway start` recovery path) before any destructive cleanup. On success, continue with reuse (image-drift check still applies). On failure, exit with guidance instead of silently deleting volumes.
- `src/lib/onboard.ts` preflight: mirror the same `stopped` recovery flow for the early-preflight gateway sanity check. Wire `recoverGatewayRuntime` into the handler deps.
- Truly missing containers, unhealthy HTTP after restart, image drift, and unknown Docker state keep their existing semantics — only the stopped-but-recoverable case changes.
- Tests: new coverage for `stopped` detection and three handler scenarios (recovery succeeds, recovery fails + refuse-to-destroy, recovery succeeds with image drift still triggering recreate).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` passes (2 pre-existing failures in `src/lib/inference/local.test.ts` on upstream/main, unrelated to this change)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes — N/A: bugfix preserves intended semantics
- [x] `npm run typecheck:cli` passes
- [x] Codex review clean

### E2E note

Full hosted-VM stop/start reproduction was not possible from this workspace because the installed `openshell 0.0.39` CLI does not expose `gateway start`/`destroy` (no lifecycle commands), so the buggy code path is gated off on this host. The affected population is hosts running an older OpenShell with the legacy k3s-in-Docker gateway. Coverage:

- Unit tests in `gateway.test.ts` exercise the full handler flow with the new `stopped` state.
- Live Docker smoke confirmed `verifyGatewayContainerRunning` returns `stopped` for an actually stopped `openshell-cluster-*` container (previously returned `missing`).

---

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight now reconciles legacy gateway reuse state and can attempt non-destructive runtime recovery for stopped gateway containers.
  * Image-drift checks can be triggered after a successful recovery; reconciliation handles HTTP-readiness and transient daemon cases safely.

* **Bug Fixes**
  * Distinguishes “stopped” vs “missing” containers to avoid unnecessary destructive cleanup.
  * Refuses destructive volume removal when recovery fails and surfaces guidance.

* **Tests**
  * Added tests for stopped-container recovery, failure paths, HTTP readiness, unknown state safety, and image-drift scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->