### PR TITLE
fix(onboard): run OpenClaw setup with explicit shell

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6101,7 +6101,7 @@ function syncNemoClawConfigInSandbox(sandboxName: string, provider: string, mode
   runSandboxConfigSync(sandboxName, {
     getSelectionConfig: () => getProviderSelectionConfig(provider, model),
     runConnectScript: (name, scriptContent) => {
-      run(openshellArgv(["sandbox", "connect", name]), {
+      run(openshellArgv(["sandbox", "connect", name, "--", "bash", "-s"]), {
         stdio: ["pipe", "ignore", "inherit"],
         input: scriptContent,
       });

--- a/src/lib/onboard/openclaw-setup.test.ts
+++ b/src/lib/onboard/openclaw-setup.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createOpenclawSetup } from "./openclaw-setup";
+
+function createDeps() {
+  return {
+    step: vi.fn(),
+    agentProductName: vi.fn(() => "OpenClaw"),
+    getProviderSelectionConfig: vi.fn(() => ({ provider: "nvidia-prod", model: "model" })),
+    buildSandboxConfigSyncScript: vi.fn(() => "echo sync"),
+    writeSandboxConfigSyncFile: vi.fn(() => "/tmp/nemoclaw-sync-test.sh"),
+    run: vi.fn(),
+    openshellArgv: vi.fn((args: string[]) => ["openshell", ...args]),
+    cleanupTempDir: vi.fn(),
+  };
+}
+
+describe("createOpenclawSetup", () => {
+  it("runs the sync script through an explicit bash connect command", async () => {
+    const deps = createDeps();
+    vi.spyOn(fs, "readFileSync").mockReturnValue("echo sync from file");
+
+    await createOpenclawSetup(deps)("demo", "model", "nvidia-prod");
+
+    expect(deps.openshellArgv).toHaveBeenCalledWith([
+      "sandbox",
+      "connect",
+      "demo",
+      "--",
+      "bash",
+      "-s",
+    ]);
+    expect(deps.run).toHaveBeenCalledWith(
+      ["openshell", "sandbox", "connect", "demo", "--", "bash", "-s"],
+      expect.objectContaining({
+        stdio: ["pipe", "ignore", "inherit"],
+        input: "echo sync from file",
+      }),
+    );
+  });
+});

--- a/src/lib/onboard/openclaw-setup.ts
+++ b/src/lib/onboard/openclaw-setup.ts
@@ -32,7 +32,7 @@ export function createOpenclawSetup(deps: OpenclawSetupDeps) {
       const scriptFile = deps.writeSandboxConfigSyncFile(script);
       try {
         const scriptContent = fs.readFileSync(scriptFile, "utf-8");
-        deps.run(deps.openshellArgv(["sandbox", "connect", sandboxName]), {
+        deps.run(deps.openshellArgv(["sandbox", "connect", sandboxName, "--", "bash", "-s"]), {
           stdio: ["pipe", "ignore", "inherit"],
           input: scriptContent,
         });


### PR DESCRIPTION
## Summary
Recent nightly runs show OpenClaw sandboxes reaching Ready and serving the dashboard, then failing during the onboarding OpenClaw setup step at `openshell sandbox connect <name>`. That setup step streams a non-interactive sync script into the default connect session; this PR makes the connect command execute `bash -s` explicitly so the script is interpreted by a known shell instead of relying on OpenShell's default connect-shell behavior.

## Changes
- Run OpenClaw setup sync through `openshell sandbox connect <name> -- bash -s`.
- Use the same explicit shell for the resume config-sync path.
- Add unit coverage proving OpenClaw setup invokes the explicit `bash -s` connect form.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox connection handling to properly execute bash scripts via stdin during setup.

* **Tests**
  * Added test coverage for sandbox setup functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->