### PR TITLE
fix(e2e): install workflow target ref in public onboard tests

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -193,6 +193,12 @@ jobs:
         with:
           ref: ${{ inputs.target_ref || github.ref }}
 
+      - name: Resolve public install ref
+        id: public_install_ref
+        shell: bash
+        run: |
+          printf 'ref=%s\n' "$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run cloud onboard E2E test
         env:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -203,7 +209,7 @@ jobs:
           NEMOCLAW_POLICY_MODE: "custom"
           NEMOCLAW_POLICY_PRESETS: "npm,pypi"
           NEMOCLAW_SANDBOX_NAME: "e2e-cloud-onboard"
-          NEMOCLAW_PUBLIC_INSTALL_REF: ${{ inputs.target_ref || github.sha }}
+          NEMOCLAW_PUBLIC_INSTALL_REF: ${{ steps.public_install_ref.outputs.ref }}
         run: bash test/e2e/test-cloud-onboard-e2e.sh
 
       - name: Upload install log on failure
@@ -414,6 +420,12 @@ jobs:
         with:
           ref: ${{ inputs.target_ref || github.ref }}
 
+      - name: Resolve public install ref
+        id: public_install_ref
+        shell: bash
+        run: |
+          printf 'ref=%s\n' "$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -429,7 +441,7 @@ jobs:
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
           NEMOCLAW_RECREATE_SANDBOX: "1"
           NEMOCLAW_SANDBOX_NAME: "e2e-openclaw-tui-correlation"
-          NEMOCLAW_PUBLIC_INSTALL_REF: ${{ inputs.target_ref || github.sha }}
+          NEMOCLAW_PUBLIC_INSTALL_REF: ${{ steps.public_install_ref.outputs.ref }}
           GITHUB_TOKEN: ${{ github.token }}
         run: bash test/e2e/test-openclaw-tui-chat-correlation.sh
 

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -203,7 +203,7 @@ jobs:
           NEMOCLAW_POLICY_MODE: "custom"
           NEMOCLAW_POLICY_PRESETS: "npm,pypi"
           NEMOCLAW_SANDBOX_NAME: "e2e-cloud-onboard"
-          NEMOCLAW_INSTALL_REF: ${{ github.ref_name }}
+          NEMOCLAW_PUBLIC_INSTALL_REF: ${{ inputs.target_ref || github.sha }}
         run: bash test/e2e/test-cloud-onboard-e2e.sh
 
       - name: Upload install log on failure
@@ -429,6 +429,7 @@ jobs:
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
           NEMOCLAW_RECREATE_SANDBOX: "1"
           NEMOCLAW_SANDBOX_NAME: "e2e-openclaw-tui-correlation"
+          NEMOCLAW_PUBLIC_INSTALL_REF: ${{ inputs.target_ref || github.sha }}
           GITHUB_TOKEN: ${{ github.token }}
         run: bash test/e2e/test-openclaw-tui-chat-correlation.sh
 

--- a/test/e2e/test-cloud-onboard-e2e.sh
+++ b/test/e2e/test-cloud-onboard-e2e.sh
@@ -25,6 +25,7 @@
 #   NEMOCLAW_POLICY_PRESETS=npm,pypi                   — policy presets
 #   RUN_E2E_CLOUD_ONBOARD_INTERACTIVE_INSTALL=0        — set 0 for non-interactive (default), 1 for expect
 #   NEMOCLAW_INSTALL_SCRIPT_URL                        — override public installer URL
+#   NEMOCLAW_PUBLIC_INSTALL_REF                        — Git ref used for the public install script and clone
 #   NEMOCLAW_INSTALL_REF                               — Git ref cloned by public installer
 #   NEMOCLAW_PUBLIC_INSTALL_CWD                        — override temp cwd for public install
 #   E2E_CLOUD_ONBOARD_INSTALL_LOG                      — install log path

--- a/test/validate-e2e-coverage.test.ts
+++ b/test/validate-e2e-coverage.test.ts
@@ -61,6 +61,24 @@ function getJobIf(job: unknown): string | undefined {
   return undefined;
 }
 
+function getJobStep(job: unknown, stepName: string): Record<string, unknown> | undefined {
+  if (typeof job !== "object" || job === null) return undefined;
+  const steps = (job as Record<string, unknown>).steps;
+  if (!Array.isArray(steps)) return undefined;
+  return steps.find(
+    (step): step is Record<string, unknown> =>
+      typeof step === "object" &&
+      step !== null &&
+      (step as Record<string, unknown>).name === stepName,
+  );
+}
+
+function getStepEnv(job: unknown, stepName: string): Record<string, unknown> | undefined {
+  const step = getJobStep(job, stepName);
+  if (!step || typeof step.env !== "object" || step.env === null) return undefined;
+  return step.env as Record<string, unknown>;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("nightly E2E workflow validation", () => {
@@ -124,6 +142,39 @@ describe("nightly E2E workflow validation", () => {
       `Nightly E2E aggregate jobs missing real E2E jobs in needs: ` +
         `${missing.join(", ")}. Update notify-on-failure, report-to-pr, ` +
         `and scorecard so their needs lists include every nightly E2E job.`,
+    ).toEqual([]);
+  });
+
+  it("public installer E2Es install the workflow target ref", () => {
+    const jobs = workflow.jobs as Record<string, unknown>;
+    const expectedRef = "${{ inputs.target_ref || github.sha }}";
+    const publicInstallerJobs: Array<[string, string]> = [
+      ["cloud-onboard-e2e", "Run cloud onboard E2E test"],
+      ["openclaw-tui-chat-correlation-e2e", "Run OpenClaw TUI chat correlation E2E test"],
+    ];
+    const invalid: string[] = [];
+
+    for (const [jobName, stepName] of publicInstallerJobs) {
+      const env = getStepEnv(jobs[jobName], stepName);
+      if (!env) {
+        invalid.push(`${jobName} (${stepName} missing env)`);
+        continue;
+      }
+      if (env.NEMOCLAW_PUBLIC_INSTALL_REF !== expectedRef) {
+        invalid.push(
+          `${jobName} NEMOCLAW_PUBLIC_INSTALL_REF=${String(env.NEMOCLAW_PUBLIC_INSTALL_REF)}`,
+        );
+      }
+      if (env.NEMOCLAW_INSTALL_REF === "${{ github.ref_name }}") {
+        invalid.push(`${jobName} still pins public install to github.ref_name`);
+      }
+    }
+
+    expect(
+      invalid,
+      `Public installer E2Es must pass inputs.target_ref through to the curl-install path; ` +
+        `otherwise trusted main dispatch checks out the PR head but installs main. ` +
+        `Invalid jobs: ${invalid.join(", ")}`,
     ).toEqual([]);
   });
 });

--- a/test/validate-e2e-coverage.test.ts
+++ b/test/validate-e2e-coverage.test.ts
@@ -79,6 +79,17 @@ function getStepEnv(job: unknown, stepName: string): Record<string, unknown> | u
   return step.env as Record<string, unknown>;
 }
 
+function getCheckoutStep(job: unknown): Record<string, unknown> | undefined {
+  if (typeof job !== "object" || job === null) return undefined;
+  const steps = (job as Record<string, unknown>).steps;
+  if (!Array.isArray(steps)) return undefined;
+  return steps.find((step): step is Record<string, unknown> => {
+    if (typeof step !== "object" || step === null) return false;
+    const uses = (step as Record<string, unknown>).uses;
+    return typeof uses === "string" && uses.startsWith("actions/checkout");
+  });
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("nightly E2E workflow validation", () => {
@@ -145,9 +156,10 @@ describe("nightly E2E workflow validation", () => {
     ).toEqual([]);
   });
 
-  it("public installer E2Es install the workflow target ref", () => {
+  it("public installer E2Es install the resolved checkout ref", () => {
     const jobs = workflow.jobs as Record<string, unknown>;
-    const expectedRef = "${{ inputs.target_ref || github.sha }}";
+    const expectedCheckoutRef = "${{ inputs.target_ref || github.ref }}";
+    const expectedInstallRef = "${{ steps.public_install_ref.outputs.ref }}";
     const publicInstallerJobs: Array<[string, string]> = [
       ["cloud-onboard-e2e", "Run cloud onboard E2E test"],
       ["openclaw-tui-chat-correlation-e2e", "Run OpenClaw TUI chat correlation E2E test"],
@@ -155,12 +167,31 @@ describe("nightly E2E workflow validation", () => {
     const invalid: string[] = [];
 
     for (const [jobName, stepName] of publicInstallerJobs) {
+      const checkoutWith = getCheckoutStep(jobs[jobName])?.with as
+        | Record<string, unknown>
+        | undefined;
+      if (checkoutWith?.ref !== expectedCheckoutRef) {
+        invalid.push(`${jobName} checkout.ref=${String(checkoutWith?.ref)}`);
+      }
+
+      const resolver = getJobStep(jobs[jobName], "Resolve public install ref");
+      if (!resolver) {
+        invalid.push(`${jobName} missing resolved-ref step`);
+      } else {
+        if (resolver.id !== "public_install_ref") {
+          invalid.push(`${jobName} resolved-ref id=${String(resolver.id)}`);
+        }
+        if (typeof resolver.run !== "string" || !resolver.run.includes("git rev-parse HEAD")) {
+          invalid.push(`${jobName} resolved-ref step does not use git rev-parse HEAD`);
+        }
+      }
+
       const env = getStepEnv(jobs[jobName], stepName);
       if (!env) {
         invalid.push(`${jobName} (${stepName} missing env)`);
         continue;
       }
-      if (env.NEMOCLAW_PUBLIC_INSTALL_REF !== expectedRef) {
+      if (env.NEMOCLAW_PUBLIC_INSTALL_REF !== expectedInstallRef) {
         invalid.push(
           `${jobName} NEMOCLAW_PUBLIC_INSTALL_REF=${String(env.NEMOCLAW_PUBLIC_INSTALL_REF)}`,
         );
@@ -172,8 +203,9 @@ describe("nightly E2E workflow validation", () => {
 
     expect(
       invalid,
-      `Public installer E2Es must pass inputs.target_ref through to the curl-install path; ` +
-        `otherwise trusted main dispatch checks out the PR head but installs main. ` +
+      `Public installer E2Es must resolve the checked-out ref once and pass that SHA ` +
+        `through to the curl-install path; otherwise trusted dispatch can check out one ` +
+        `commit but install another. ` +
         `Invalid jobs: ${invalid.join(", ")}`,
     ).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- pass `inputs.target_ref || github.sha` through to the public installer path for `cloud-onboard-e2e`
- pass the same ref through the TUI correlation wrapper, which reuses cloud onboard setup
- add workflow validation so public-installer E2Es cannot silently check out a target ref but install `main`

## Validation
- `npx vitest run test/validate-e2e-coverage.test.ts --reporter=verbose`
- `bash -n test/e2e/test-cloud-onboard-e2e.sh test/e2e/test-openclaw-tui-chat-correlation.sh`
- `git diff --check`
- `npm run typecheck:cli`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation tests to ensure public installer refs are resolved consistently across E2E workflows.
  * Added helper utilities to inspect workflow steps and environment settings for test coverage.

* **Chores**
  * Updated E2E workflow configuration to set and propagate a resolved public install reference used by tests and jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->