### PR TITLE
fix(policy): add openclaw-pricing preset and auto-suggest for OpenClaw

### DIFF
--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -178,8 +178,8 @@ Available presets:
 | `huggingface` | Hugging Face Hub (download-only) and inference router |
 | `jira` | Atlassian Jira API |
 | `local-inference` | Local Ollama and vLLM through the host gateway |
-| `model-pricing` | OpenClaw model-pricing reference fetch (LiteLLM and OpenRouter) |
 | `npm` | npm and Yarn registries |
+| `openclaw-pricing` | OpenClaw model-pricing reference fetch (LiteLLM and OpenRouter) |
 | `outlook` | Microsoft 365 and Outlook |
 | `pypi` | Python Package Index |
 | `slack` | Slack API and webhooks |

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -178,6 +178,7 @@ Available presets:
 | `huggingface` | Hugging Face Hub (download-only) and inference router |
 | `jira` | Atlassian Jira API |
 | `local-inference` | Local Ollama and vLLM through the host gateway |
+| `model-pricing` | OpenClaw model-pricing reference fetch (LiteLLM and OpenRouter) |
 | `npm` | npm and Yarn registries |
 | `outlook` | Microsoft 365 and Outlook |
 | `pypi` | Python Package Index |

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -60,7 +60,7 @@ NemoClaw ships maintained policy presets for common services in `nemoclaw-bluepr
 | Hugging Face Hub and Inference API | `huggingface` |
 | Jira and Atlassian Cloud | `jira` |
 | Local Ollama or vLLM through the host gateway | `local-inference` |
-| OpenClaw model-pricing reference fetch | `model-pricing` |
+| OpenClaw model-pricing reference fetch | `openclaw-pricing` |
 | npm and Yarn packages | `npm` |
 | Microsoft 365, Outlook, and Graph API | `outlook` |
 | Python Package Index | `pypi` |
@@ -260,12 +260,12 @@ The default-strict egress policy denies both hosts.
 The fetch fails closed, the gateway logs `[gateway/model-pricing] LiteLLM pricing fetch failed: TypeError: fetch failed` (and the matching OpenRouter line) on every startup, and every session record records `usage.cost = 0` even though the input and output token counts populate correctly.
 Tools that read the session log to display per-turn cost (audit dashboards, compliance review surfaces) cannot distinguish a real free run from this silent failure.
 
-Apply the `model-pricing` preset to allow both pricing endpoints.
+Apply the `openclaw-pricing` preset to allow both pricing endpoints.
 The preset pins each host to a single read-only path so it does not widen egress beyond the pricing fetch:
 
 ```console
-$ nemoclaw my-assistant policy-add model-pricing --dry-run
-$ nemoclaw my-assistant policy-add model-pricing --yes
+$ nemoclaw my-assistant policy-add openclaw-pricing --dry-run
+$ nemoclaw my-assistant policy-add openclaw-pricing --yes
 ```
 
 After the next gateway restart the WARN entries stop and `usage.cost` populates from the fetched pricing tables.

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -60,6 +60,7 @@ NemoClaw ships maintained policy presets for common services in `nemoclaw-bluepr
 | Hugging Face Hub and Inference API | `huggingface` |
 | Jira and Atlassian Cloud | `jira` |
 | Local Ollama or vLLM through the host gateway | `local-inference` |
+| OpenClaw model-pricing reference fetch | `model-pricing` |
 | npm and Yarn packages | `npm` |
 | Microsoft 365, Outlook, and Graph API | `outlook` |
 | Python Package Index | `pypi` |
@@ -251,6 +252,23 @@ $ nemoclaw my-assistant exec -- brew install <formula>
 ```
 
 You do not need to bootstrap Homebrew, install build dependencies, or source `brew shellenv` inside the sandbox.
+
+## Model Pricing
+
+OpenClaw's gateway fetches reference pricing from LiteLLM and OpenRouter on every start so it can populate `usage.cost` in session JSONL records.
+The default-strict egress policy denies both hosts.
+The fetch fails closed, the gateway logs `[gateway/model-pricing] LiteLLM pricing fetch failed: TypeError: fetch failed` (and the matching OpenRouter line) on every startup, and every session record records `usage.cost = 0` even though the input and output token counts populate correctly.
+Tools that read the session log to display per-turn cost (audit dashboards, compliance review surfaces) cannot distinguish a real free run from this silent failure.
+
+Apply the `model-pricing` preset to allow both pricing endpoints.
+The preset pins each host to a single read-only path so it does not widen egress beyond the pricing fetch:
+
+```console
+$ nemoclaw my-assistant policy-add model-pricing --dry-run
+$ nemoclaw my-assistant policy-add model-pricing --yes
+```
+
+After the next gateway restart the WARN entries stop and `usage.cost` populates from the fetched pricing tables.
 
 ## Local Inference
 

--- a/nemoclaw-blueprint/policies/presets/model-pricing.yaml
+++ b/nemoclaw-blueprint/policies/presets/model-pricing.yaml
@@ -9,7 +9,6 @@
 # compliance review surfaces) cannot distinguish a real free run from
 # the silent failure mode. Enabling this preset whitelists the two
 # specific pricing endpoints, pinned to GET-only on a single path each.
-# See https://github.com/NVIDIA/NemoClaw/issues/4211.
 preset:
   name: model-pricing
   description: "OpenClaw model-pricing reference fetch (LiteLLM + OpenRouter)"

--- a/nemoclaw-blueprint/policies/presets/model-pricing.yaml
+++ b/nemoclaw-blueprint/policies/presets/model-pricing.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# OpenClaw's gateway/model-pricing subsystem fetches reference pricing from
+# LiteLLM and OpenRouter on every gateway start. With default-strict egress
+# both fetches fail closed with `TypeError: fetch failed`, the gateway
+# emits a WARN every startup, and every session JSONL row records
+# `usage.cost = 0` even though token counts populate correctly. Tools
+# reading the session log to display per-turn cost (audit dashboards,
+# compliance review surfaces) cannot distinguish a real free run from
+# the silent failure mode. Enabling this preset whitelists the two
+# specific pricing endpoints, pinned to GET-only on a single path each.
+# See https://github.com/NVIDIA/NemoClaw/issues/4211.
+preset:
+  name: model-pricing
+  description: "OpenClaw model-pricing reference fetch (LiteLLM + OpenRouter)"
+network_policies:
+  model-pricing:
+    name: model-pricing
+    endpoints:
+      # LiteLLM publishes the upstream pricing table on raw.githubusercontent.com.
+      # Path is pinned to the single JSON file the fetch reads, GET only.
+      - host: raw.githubusercontent.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow:
+              method: GET
+              path: "/BerriAI/litellm/main/model_prices_and_context_window.json"
+      # OpenRouter exposes its model catalogue (with cost fields) under
+      # /api/v1/models. The fetch is read-only, so POST is not allowed.
+      - host: openrouter.ai
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/api/v1/models" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }

--- a/nemoclaw-blueprint/policies/presets/openclaw-pricing.yaml
+++ b/nemoclaw-blueprint/policies/presets/openclaw-pricing.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# OpenClaw's gateway/model-pricing subsystem fetches reference pricing from
+# OpenClaw's gateway/openclaw-pricing subsystem fetches reference pricing from
 # LiteLLM and OpenRouter on every gateway start. With default-strict egress
 # both fetches fail closed with `TypeError: fetch failed`, the gateway
 # emits a WARN every startup, and every session JSONL row records
@@ -10,11 +10,11 @@
 # the silent failure mode. Enabling this preset whitelists the two
 # specific pricing endpoints, pinned to GET-only on a single path each.
 preset:
-  name: model-pricing
-  description: "OpenClaw model-pricing reference fetch (LiteLLM + OpenRouter)"
+  name: openclaw-pricing
+  description: "OpenClaw openclaw-pricing reference fetch (LiteLLM + OpenRouter)"
 network_policies:
-  model-pricing:
-    name: model-pricing
+  openclaw-pricing:
+    name: openclaw-pricing
     endpoints:
       # LiteLLM publishes the upstream pricing table on raw.githubusercontent.com.
       # Path is pinned to the single JSON file the fetch reads, GET only.

--- a/nemoclaw-blueprint/policies/presets/openclaw-pricing.yaml
+++ b/nemoclaw-blueprint/policies/presets/openclaw-pricing.yaml
@@ -1,17 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# OpenClaw's gateway/openclaw-pricing subsystem fetches reference pricing from
+# OpenClaw's gateway/model-pricing subsystem fetches reference pricing from
 # LiteLLM and OpenRouter on every gateway start. With default-strict egress
 # both fetches fail closed with `TypeError: fetch failed`, the gateway
 # emits a WARN every startup, and every session JSONL row records
 # `usage.cost = 0` even though token counts populate correctly. Tools
 # reading the session log to display per-turn cost (audit dashboards,
 # compliance review surfaces) cannot distinguish a real free run from
-# the silent failure mode. Enabling this preset whitelists the two
+# the silent failure mode. Enabling this preset allowlists the two
 # specific pricing endpoints, pinned to GET-only on a single path each.
 preset:
   name: openclaw-pricing
-  description: "OpenClaw openclaw-pricing reference fetch (LiteLLM + OpenRouter)"
+  description: "OpenClaw model-pricing reference fetch (LiteLLM + OpenRouter)"
 network_policies:
   openclaw-pricing:
     name: openclaw-pricing

--- a/src/lib/onboard/machine/handlers/policies.test.ts
+++ b/src/lib/onboard/machine/handlers/policies.test.ts
@@ -200,4 +200,26 @@ describe("handlePoliciesState", () => {
       expect.objectContaining({ selectedPresets: ["npm", "github"] }),
     );
   });
+
+  it("forwards 'openclaw' to setupPoliciesWithSelection when agent is null (default OpenClaw)", async () => {
+    const { deps, calls } = createDeps();
+
+    await handlePoliciesState({ ...baseOptions(deps), agent: null });
+
+    expect(calls.setupPolicies).toHaveBeenCalledWith(
+      "my-assistant",
+      expect.objectContaining({ agent: "openclaw" }),
+    );
+  });
+
+  it("forwards 'hermes' to setupPoliciesWithSelection when agent.name is hermes", async () => {
+    const { deps, calls } = createDeps();
+
+    await handlePoliciesState({ ...baseOptions(deps), agent: { name: "hermes" } });
+
+    expect(calls.setupPolicies).toHaveBeenCalledWith(
+      "my-assistant",
+      expect.objectContaining({ agent: "hermes" }),
+    );
+  });
 });

--- a/src/lib/onboard/machine/handlers/policies.test.ts
+++ b/src/lib/onboard/machine/handlers/policies.test.ts
@@ -222,4 +222,15 @@ describe("handlePoliciesState", () => {
       expect.objectContaining({ agent: "hermes" }),
     );
   });
+
+  it("treats whitespace-only agent.name as default OpenClaw", async () => {
+    const { deps, calls } = createDeps();
+
+    await handlePoliciesState({ ...baseOptions(deps), agent: { name: "   " } });
+
+    expect(calls.setupPolicies).toHaveBeenCalledWith(
+      "my-assistant",
+      expect.objectContaining({ agent: "openclaw" }),
+    );
+  });
 });

--- a/src/lib/onboard/machine/handlers/policies.ts
+++ b/src/lib/onboard/machine/handlers/policies.ts
@@ -75,6 +75,7 @@ export interface PoliciesStateOptions<Agent, WebSearchConfig> {
         disabledChannels?: string[] | null;
         webSearchConfig: WebSearchConfig | null;
         provider: string;
+        agent?: string | null;
         webSearchSupported: boolean;
         hermesToolGateways: string[];
         onSelection: (policyPresets: string[]) => void;
@@ -177,6 +178,7 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
       disabledChannels: activeSandbox?.disabledChannels,
       webSearchConfig,
       provider,
+      agent: (agent as { name?: string } | null)?.name ?? null,
       webSearchSupported,
       hermesToolGateways,
       onSelection: (policyPresets) => {

--- a/src/lib/onboard/machine/handlers/policies.ts
+++ b/src/lib/onboard/machine/handlers/policies.ts
@@ -178,7 +178,11 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
       disabledChannels: activeSandbox?.disabledChannels,
       webSearchConfig,
       provider,
-      agent: (agent as { name?: string } | null)?.name ?? null,
+      // selectOnboardAgent returns null for the default OpenClaw path (no
+      // --agent flag, no recorded agent). Normalise that to "openclaw" so
+      // openclaw-pricing auto-suggestion still fires; explicit Hermes runs
+      // keep their own name and are left alone.
+      agent: (agent as { name?: string } | null)?.name ?? "openclaw",
       webSearchSupported,
       hermesToolGateways,
       onSelection: (policyPresets) => {

--- a/src/lib/onboard/machine/handlers/policies.ts
+++ b/src/lib/onboard/machine/handlers/policies.ts
@@ -3,6 +3,14 @@
 
 import type { Session, SessionUpdates } from "../../../state/onboard-session";
 
+// Inlined to avoid pulling sandbox-agent's transitive runner.ts deps into
+// the generic state handler. Matches normalizeSandboxAgentName: trim,
+// default null/blank/"openclaw" to "openclaw".
+function normalizeAgentName(name: string | null | undefined): string {
+  const trimmed = typeof name === "string" ? name.trim() : "";
+  return trimmed && trimmed !== "openclaw" ? trimmed : "openclaw";
+}
+
 export interface PolicyPresetEntry {
   name: string;
   [key: string]: unknown;
@@ -179,10 +187,10 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
       webSearchConfig,
       provider,
       // selectOnboardAgent returns null for the default OpenClaw path (no
-      // --agent flag, no recorded agent). Normalise that to "openclaw" so
-      // openclaw-pricing auto-suggestion still fires; explicit Hermes runs
-      // keep their own name and are left alone.
-      agent: (agent as { name?: string } | null)?.name ?? "openclaw",
+      // --agent flag, no recorded agent). Normalise null/blank/whitespace
+      // to "openclaw" so the auto-suggest gate still fires; explicit
+      // Hermes runs keep their own name.
+      agent: normalizeAgentName((agent as { name?: string } | null)?.name),
       webSearchSupported,
       hermesToolGateways,
       onSelection: (policyPresets) => {

--- a/src/lib/onboard/policy-presets.ts
+++ b/src/lib/onboard/policy-presets.ts
@@ -12,6 +12,7 @@ export interface SuggestedPolicyPresetOptions {
   enabledChannels?: string[] | null;
   webSearchConfig?: WebSearchConfig | null;
   provider?: string | null;
+  agent?: string | null;
   isNonInteractive?: () => boolean;
 }
 
@@ -19,12 +20,16 @@ export function getSuggestedPolicyPresets({
   enabledChannels = null,
   webSearchConfig = null,
   provider = null,
+  agent = null,
   isNonInteractive,
 }: SuggestedPolicyPresetOptions = {}): string[] {
   const suggestions = ["pypi", "npm"];
 
   if (provider && LOCAL_INFERENCE_PROVIDERS.includes(provider)) {
     suggestions.push("local-inference");
+  }
+  if (agent === "openclaw") {
+    suggestions.push("openclaw-pricing");
   }
   const usesExplicitMessagingSelection = Array.isArray(enabledChannels);
   const nonInteractive =

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -37,6 +37,7 @@ export type SetupPresetSuggestionOptions = {
   enabledChannels?: string[] | null;
   webSearchConfig?: WebSearchConfig | null;
   provider?: string | null;
+  agent?: string | null;
   knownPresetNames?: string[] | null;
   webSearchSupported?: boolean | null;
   hermesToolGateways?: string[] | null;
@@ -48,6 +49,7 @@ export type SetupPolicySelectionOptions = {
   webSearchConfig?: WebSearchConfig | null;
   enabledChannels?: string[] | null;
   provider?: string | null;
+  agent?: string | null;
   knownPresetNames?: string[];
   webSearchSupported?: boolean | null;
   hermesToolGateways?: string[] | null;
@@ -127,7 +129,12 @@ export function computeSetupPresetSuggestions(
   tierName: string,
   options: SetupPresetSuggestionOptions = {},
 ): string[] {
-  const { enabledChannels = null, webSearchConfig = null, provider = null } = options;
+  const {
+    enabledChannels = null,
+    webSearchConfig = null,
+    provider = null,
+    agent = null,
+  } = options;
   const known = Array.isArray(options.knownPresetNames) ? new Set(options.knownPresetNames) : null;
   const supportOptions = { webSearchSupported: options.webSearchSupported };
   const suggestions = deps.tiers
@@ -144,6 +151,7 @@ export function computeSetupPresetSuggestions(
   };
   if (webSearchConfig) add("brave");
   if (provider && deps.localInferenceProviders.includes(provider)) add("local-inference");
+  if (agent === "openclaw") add("openclaw-pricing");
   if (Array.isArray(enabledChannels)) {
     for (const channel of enabledChannels) add(channel);
     for (const preset of requiredMessagingChannelPolicyPresets(enabledChannels)) add(preset);
@@ -237,6 +245,7 @@ export async function setupPoliciesWithSelection(
   const webSearchConfig = options.webSearchConfig || null;
   const enabledChannels = Array.isArray(options.enabledChannels) ? options.enabledChannels : null;
   const provider = options.provider || null;
+  const agent = options.agent || null;
   const hermesToolGateways = Array.isArray(options.hermesToolGateways)
     ? options.hermesToolGateways
     : null;
@@ -315,6 +324,7 @@ export async function setupPoliciesWithSelection(
       enabledChannels,
       webSearchConfig,
       provider,
+      agent,
       knownPresetNames: allPresets.map((preset) => preset.name),
       webSearchSupported: options.webSearchSupported,
       hermesToolGateways,

--- a/test/onboard-policy-suggestions.test.ts
+++ b/test/onboard-policy-suggestions.test.ts
@@ -14,6 +14,7 @@ const {
       enabledChannels?: string[] | null;
       knownPresetNames: string[];
       provider?: string | null;
+      agent?: string | null;
       webSearchConfig?: { fetchEnabled?: boolean; provider?: string | null } | null;
       webSearchSupported?: boolean | null;
     },
@@ -25,6 +26,7 @@ const {
   getSuggestedPolicyPresets: (options?: {
     enabledChannels?: string[] | null;
     provider?: string | null;
+    agent?: string | null;
   }) => string[];
 };
 
@@ -101,6 +103,30 @@ describe("onboard policy preset suggestions", () => {
     expect(getSuggestedPolicyPresets({ provider: "openai-api" })).not.toContain("local-inference");
     expect(getSuggestedPolicyPresets({ provider: null })).not.toContain("local-inference");
     expect(getSuggestedPolicyPresets({})).not.toContain("local-inference");
+  });
+
+  it("suggests openclaw-pricing preset only for the openclaw agent", () => {
+    expect(getSuggestedPolicyPresets({ agent: "openclaw" })).toContain("openclaw-pricing");
+    expect(getSuggestedPolicyPresets({ agent: "hermes" })).not.toContain("openclaw-pricing");
+    expect(getSuggestedPolicyPresets({ agent: null })).not.toContain("openclaw-pricing");
+    expect(getSuggestedPolicyPresets({})).not.toContain("openclaw-pricing");
+  });
+
+  it("adds openclaw-pricing to tier suggestions when agent is openclaw", () => {
+    const knownWithPricing = [...known, "openclaw-pricing"];
+    const openclawSuggestions = computeSetupPresetSuggestions("balanced", {
+      enabledChannels: [],
+      knownPresetNames: knownWithPricing,
+      agent: "openclaw",
+    });
+    expect(openclawSuggestions).toContain("openclaw-pricing");
+
+    const hermesSuggestions = computeSetupPresetSuggestions("balanced", {
+      enabledChannels: [],
+      knownPresetNames: knownWithPricing,
+      agent: "hermes",
+    });
+    expect(hermesSuggestions).not.toContain("openclaw-pricing");
   });
 
   it("returns balanced tier defaults without messaging presets when no channels enabled", () => {

--- a/test/onboard-policy-suggestions.test.ts
+++ b/test/onboard-policy-suggestions.test.ts
@@ -127,6 +127,23 @@ describe("onboard policy preset suggestions", () => {
       agent: "hermes",
     });
     expect(hermesSuggestions).not.toContain("openclaw-pricing");
+
+    // Defence-in-depth: the suggestion gate must not fire for raw null
+    // or omitted-agent cases either. The handler normalises null to
+    // "openclaw" upstream, but anything that bypasses that normalisation
+    // (third-party callers, tests) should default to safe-no-add.
+    const nullAgentSuggestions = computeSetupPresetSuggestions("balanced", {
+      enabledChannels: [],
+      knownPresetNames: knownWithPricing,
+      agent: null,
+    });
+    expect(nullAgentSuggestions).not.toContain("openclaw-pricing");
+
+    const omittedAgentSuggestions = computeSetupPresetSuggestions("balanced", {
+      enabledChannels: [],
+      knownPresetNames: knownWithPricing,
+    });
+    expect(omittedAgentSuggestions).not.toContain("openclaw-pricing");
   });
 
   it("returns balanced tier defaults without messaging presets when no channels enabled", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -142,9 +142,9 @@ selectFromList(items, options)
 
 describe("policies", () => {
   describe("listPresets", () => {
-    it("returns all 19 presets", () => {
+    it("returns all 20 presets", () => {
       const presets = policies.listPresets();
-      expect(presets.length).toBe(19);
+      expect(presets.length).toBe(20);
     });
 
     it("each preset has name and description", () => {
@@ -167,6 +167,7 @@ describe("policies", () => {
         "huggingface",
         "jira",
         "local-inference",
+        "model-pricing",
         "nous-audio",
         "nous-browser",
         "nous-code",

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -167,13 +167,13 @@ describe("policies", () => {
         "huggingface",
         "jira",
         "local-inference",
-        "model-pricing",
         "nous-audio",
         "nous-browser",
         "nous-code",
         "nous-image",
         "nous-web",
         "npm",
+        "openclaw-pricing",
         "outlook",
         "pypi",
         "slack",
@@ -314,16 +314,16 @@ describe("policies", () => {
       }
     });
 
-    it("model-pricing preset pins LiteLLM and OpenRouter reference fetches to GET-only paths", () => {
+    it("openclaw-pricing preset pins LiteLLM and OpenRouter reference fetches to GET-only paths", () => {
       // OpenClaw's gateway/model-pricing subsystem fetches the LiteLLM
       // pricing table and the OpenRouter model catalogue on every start.
       // Both endpoints are read-only metadata fetches, so the preset must
       // expose exactly one GET rule per host on the specific path each
       // fetch reads, with no wildcards that could widen into a general
       // raw.githubusercontent.com or openrouter.ai escape hatch.
-      const parsed = parsePresetYaml("model-pricing");
+      const parsed = parsePresetYaml("openclaw-pricing");
       const endpoints: Array<Record<string, unknown>> =
-        parsed?.network_policies?.["model-pricing"]?.endpoints ?? [];
+        parsed?.network_policies?.["openclaw-pricing"]?.endpoints ?? [];
 
       const litellm = endpoints.find((item) => item.host === "raw.githubusercontent.com");
       if (!litellm) throw new Error("expected raw.githubusercontent.com endpoint");
@@ -347,7 +347,7 @@ describe("policies", () => {
       expect(openrouter.rules).toEqual([{ allow: { method: "GET", path: "/api/v1/models" } }]);
 
       const binaries: Array<{ path: string }> =
-        parsed?.network_policies?.["model-pricing"]?.binaries ?? [];
+        parsed?.network_policies?.["openclaw-pricing"]?.binaries ?? [];
       const binaryPaths = binaries.map((entry) => entry.path).sort();
       expect(binaryPaths).toEqual(["/usr/bin/node", "/usr/local/bin/node"]);
     });

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -314,6 +314,44 @@ describe("policies", () => {
       }
     });
 
+    it("model-pricing preset pins LiteLLM and OpenRouter reference fetches to GET-only paths", () => {
+      // OpenClaw's gateway/model-pricing subsystem fetches the LiteLLM
+      // pricing table and the OpenRouter model catalogue on every start.
+      // Both endpoints are read-only metadata fetches, so the preset must
+      // expose exactly one GET rule per host on the specific path each
+      // fetch reads, with no wildcards that could widen into a general
+      // raw.githubusercontent.com or openrouter.ai escape hatch.
+      const parsed = parsePresetYaml("model-pricing");
+      const endpoints: Array<Record<string, unknown>> =
+        parsed?.network_policies?.["model-pricing"]?.endpoints ?? [];
+
+      const litellm = endpoints.find((item) => item.host === "raw.githubusercontent.com");
+      if (!litellm) throw new Error("expected raw.githubusercontent.com endpoint");
+      expect(litellm.port).toBe(443);
+      expect(litellm.protocol).toBe("rest");
+      expect(litellm.enforcement).toBe("enforce");
+      expect(litellm.rules).toEqual([
+        {
+          allow: {
+            method: "GET",
+            path: "/BerriAI/litellm/main/model_prices_and_context_window.json",
+          },
+        },
+      ]);
+
+      const openrouter = endpoints.find((item) => item.host === "openrouter.ai");
+      if (!openrouter) throw new Error("expected openrouter.ai endpoint");
+      expect(openrouter.port).toBe(443);
+      expect(openrouter.protocol).toBe("rest");
+      expect(openrouter.enforcement).toBe("enforce");
+      expect(openrouter.rules).toEqual([{ allow: { method: "GET", path: "/api/v1/models" } }]);
+
+      const binaries: Array<{ path: string }> =
+        parsed?.network_policies?.["model-pricing"]?.binaries ?? [];
+      const binaryPaths = binaries.map((entry) => entry.path).sort();
+      expect(binaryPaths).toEqual(["/usr/bin/node", "/usr/local/bin/node"]);
+    });
+
     it("local-inference preset includes openclaw and common tool binaries", () => {
       const content = requirePresetContent(policies.loadPreset("local-inference"));
       expect(content).toContain("/usr/local/bin/openclaw");

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -324,6 +324,7 @@ describe("policies", () => {
       const parsed = parsePresetYaml("openclaw-pricing");
       const endpoints: Array<Record<string, unknown>> =
         parsed?.network_policies?.["openclaw-pricing"]?.endpoints ?? [];
+      expect(endpoints).toHaveLength(2);
 
       const litellm = endpoints.find((item) => item.host === "raw.githubusercontent.com");
       if (!litellm) throw new Error("expected raw.githubusercontent.com endpoint");


### PR DESCRIPTION
## Summary
OpenClaw's gateway fetches reference pricing from LiteLLM (`raw.githubusercontent.com/BerriAI/litellm/.../model_prices_and_context_window.json`) and OpenRouter (`openrouter.ai/api/v1/models`) on every start to populate `usage.cost` in session JSONL records. The default-strict NemoClaw egress denies both, so every gateway start logs `[gateway/model-pricing] LiteLLM pricing fetch failed: TypeError: fetch failed` (and the matching OpenRouter line) at WARN, and every session record ends up with `usage.cost = 0` even though `usage.input` / `usage.output` token counts populate correctly. Tools that read the session log to display per-turn cost cannot distinguish a real free run from this silent failure. This PR adds an `openclaw-pricing` preset that allowlists exactly the two endpoints (each pinned to a single GET-only path) and wires it into `getSuggestedPolicyPresets` / `computeSetupPresetSuggestions` so onboarding auto-suggests it when the agent is OpenClaw and leaves Hermes-only setups untouched.

## Related Issue
Fixes #4211

## Changes
- `nemoclaw-blueprint/policies/presets/openclaw-pricing.yaml` (new) — preset bundle. `raw.githubusercontent.com` is pinned to `GET /BerriAI/litellm/main/model_prices_and_context_window.json`. `openrouter.ai` is pinned to `GET /api/v1/models`. Binaries are limited to `node` (the gateway fetches via node). Named `openclaw-pricing` because the fetch is driven by OpenClaw's `gateway/model-pricing` subsystem; the file name attributes the egress widening to the agent that needs it, leaving room for agent-scoped policies elsewhere.
- `src/lib/onboard/policy-presets.ts`, `src/lib/onboard/policy-selection.ts`, `src/lib/onboard/machine/handlers/policies.ts` — new optional `agent` field on `SuggestedPolicyPresetOptions` / `SetupPresetSuggestionOptions` / `SetupPolicySelectionOptions`. The handler now normalises `agent?.name` (trim, default null/blank/whitespace/"openclaw" → "openclaw") so the default OpenClaw onboard path — where `selectOnboardAgent` returns `null` when no `--agent` flag and no recorded session agent is present — still hits the auto-suggest gate. Explicit Hermes runs keep their own name. `getSuggestedPolicyPresets` and `computeSetupPresetSuggestions` add `openclaw-pricing` only when `agent === "openclaw"` so Hermes-only flows do not pick up the widened egress they would never hit.
- `test/policies.test.ts` — preset count 19 → 20, the sorted-names list, and the existing contract test for the preset are updated to the new name. Contract test asserts exactly two endpoints, with host/port/protocol/enforcement, GET-only rules pinned to the precise paths, and node-only binaries.
- `test/onboard-policy-suggestions.test.ts` — new cases verifying `openclaw-pricing` is suggested only for `agent: "openclaw"` (and explicitly not for `"hermes"`, `null`, or unset) and that the tier-suggestion path picks it up only on the OpenClaw branch. Defence-in-depth assertions cover both raw `agent: null` and omitted-agent shapes so the gate cannot be tripped by a third-party caller that bypasses the handler-side normalisation.
- `src/lib/onboard/machine/handlers/policies.test.ts` — regression tests confirming the handler forwards `agent: "openclaw"` for `agent: null`, `agent: "hermes"` for `agent: { name: "hermes" }`, and that whitespace-only `agent.name` resolves back to `"openclaw"`.
- `docs/network-policy/customize-network-policy.mdx` — preset added to the available-presets table.
- `docs/network-policy/integration-policy-examples.mdx` — preset row added to the supported-presets table; the existing "Model Pricing" section now describes the WARN + `usage.cost = 0` symptom and the `policy-add openclaw-pricing` commands to fix it.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behaviour
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behaviour changes
- [ ] \`make docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an openclaw-pricing preset to allow model-pricing fetches from LiteLLM and OpenRouter; now suggested automatically when an OpenClaw agent is detected during onboarding

* **Documentation**
  * Documented the new preset, a failure mode under strict egress, and the commands to apply the preset so pricing is populated

* **Tests**
  * Added and updated tests to cover the new preset and onboarding suggestion behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->