### PR TITLE
fix(onboard): record Docker driver for macOS docker-driver sandboxes (#3728)

### DIFF
--- a/src/lib/onboard/sandbox-registry-metadata.test.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it } from "vitest";
+// Import the compiled module: sandbox-registry-metadata.ts pulls in state/registry,
+// which transitively requires the JS-only `./platform` helper that vitest cannot
+// resolve from TS source. Same pattern as `vm-dns-monkeypatch.test.ts`.
+import { createSandboxRegistryMetadataHelpers } from "../../../dist/lib/onboard/sandbox-registry-metadata";
+import type { SandboxGpuConfig } from "./sandbox-gpu-mode";
+
+const ORIGINAL_PLATFORM = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+function restorePlatform(): void {
+  if (ORIGINAL_PLATFORM) {
+    Object.defineProperty(process, "platform", ORIGINAL_PLATFORM);
+  }
+}
+
+function makeHelpers(opts: { dockerDriverEnabled: boolean }) {
+  return createSandboxRegistryMetadataHelpers({
+    isLinuxDockerDriverGatewayEnabled: () => opts.dockerDriverEnabled,
+    getInstalledOpenshellVersion: () => "0.0.42",
+    runCaptureOpenshell: () => null,
+  });
+}
+
+const GPU_OFF: SandboxGpuConfig = {
+  hostGpuDetected: false,
+  hostGpuPlatform: null,
+  sandboxGpuEnabled: false,
+  mode: "auto",
+  sandboxGpuDevice: null,
+  errors: [],
+};
+
+describe("getSandboxRuntimeRegistryFields openshellDriver", () => {
+  afterEach(restorePlatform);
+
+  it("records Docker for macOS sandboxes on the Docker-driver gateway path", () => {
+    setPlatform("darwin");
+    const helpers = makeHelpers({ dockerDriverEnabled: true });
+
+    const fields = helpers.getSandboxRuntimeRegistryFields(GPU_OFF);
+
+    expect(fields.openshellDriver).toBe("docker");
+  });
+
+  it("records Docker for Linux sandboxes on the Docker-driver gateway path", () => {
+    setPlatform("linux");
+    const helpers = makeHelpers({ dockerDriverEnabled: true });
+
+    const fields = helpers.getSandboxRuntimeRegistryFields(GPU_OFF);
+
+    expect(fields.openshellDriver).toBe("docker");
+  });
+
+  it("records Kubernetes for legacy Linux sandboxes when the Docker-driver gateway is disabled", () => {
+    setPlatform("linux");
+    const helpers = makeHelpers({ dockerDriverEnabled: false });
+
+    const fields = helpers.getSandboxRuntimeRegistryFields(GPU_OFF);
+
+    expect(fields.openshellDriver).toBe("kubernetes");
+  });
+});

--- a/src/lib/onboard/sandbox-registry-metadata.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.ts
@@ -49,17 +49,17 @@ export function createSandboxRegistryMetadataHelpers(
     | "openshellDriver"
     | "openshellVersion"
   > {
+    // OpenShell's Docker-driver gateway always starts with OPENSHELL_DRIVERS=docker,
+    // including on macOS arm64 (#3454). Recording "vm" for darwin here makes later
+    // setup misclassify the sandbox and run VM-only DNS monkeypatch / warning paths
+    // (#3728).
     return {
       gpuEnabled: config.sandboxGpuEnabled,
       hostGpuDetected: config.hostGpuDetected,
       sandboxGpuEnabled: config.sandboxGpuEnabled,
       sandboxGpuMode: config.mode,
       sandboxGpuDevice: config.sandboxGpuDevice,
-      openshellDriver: deps.isLinuxDockerDriverGatewayEnabled()
-        ? process.platform === "darwin"
-          ? "vm"
-          : "docker"
-        : "kubernetes",
+      openshellDriver: deps.isLinuxDockerDriverGatewayEnabled() ? "docker" : "kubernetes",
       openshellVersion: deps.getInstalledOpenshellVersion(
         deps.runCaptureOpenshell(["--version"], { ignoreError: true }),
       ),

--- a/src/lib/onboard/vm-dns-monkeypatch.test.ts
+++ b/src/lib/onboard/vm-dns-monkeypatch.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { applyOpenShellVmDnsMonkeypatch } from "../../../dist/lib/actions/sandbox/vm-dns-monkeypatch";
 import { applyOnboardVmDnsMonkeypatch } from "../../../dist/lib/onboard/vm-dns-monkeypatch";
 
 describe("applyOnboardVmDnsMonkeypatch", () => {
@@ -92,5 +93,32 @@ describe("applyOnboardVmDnsMonkeypatch", () => {
     expect(warnings).toEqual([
       "  Warning: OpenShell VM DNS monkeypatch did not apply: VM rootfs not found",
     ]);
+  });
+
+  // Regression: #3728. macOS Docker-driver sandboxes were misclassified as VM
+  // and ran the VM-only DNS monkeypatch path, which printed misleading warnings.
+  // The Docker runtime path should be silent — no "skipped", no "Warning".
+  it("emits no output for macOS Docker-driver sandboxes", () => {
+    const logs: string[] = [];
+    const warns: string[] = [];
+
+    applyOnboardVmDnsMonkeypatch(
+      "mac-docker",
+      { openshellDriver: "docker" },
+      {
+        apply: (sandboxName, entry) =>
+          applyOpenShellVmDnsMonkeypatch(sandboxName, entry, {
+            capture: () => ({ status: 0, output: "" }),
+            env: {},
+            platform: "darwin",
+            stateDir: "/tmp/nemoclaw-test-state-3728",
+          }),
+        log: (message) => logs.push(message),
+        warn: (message) => warns.push(message),
+      },
+    );
+
+    expect(logs).toEqual([]);
+    expect(warns).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3728. On macOS arm64 (and any other host where the Docker-driver
gateway path is enabled), `getSandboxRuntimeRegistryFields` recorded
`openshellDriver: "vm"` based purely on `process.platform === "darwin"`.
That mismatched the runtime — OpenShell's Docker-driver gateway always
starts with `OPENSHELL_DRIVERS=docker` (#3454) — and downstream code keyed
off `openshellDriver === "vm"` to run the VM-only DNS monkeypatch and emit
the misleading VM-driver warnings reported in the issue.

This change records `"docker"` on every Docker-driver host. The VM-only
log/warning paths are gated on `openshellDriver === "vm"`, so they now
stay silent for macOS Docker-driver sandboxes. Legacy/opt-in sandboxes
that were already written to disk with `openshellDriver: "vm"` still
trigger the existing VM-only compatibility shim.

## Changes

- `src/lib/onboard/sandbox-registry-metadata.ts` — drop the
  `process.platform === "darwin" ? "vm" : "docker"` branch; record
  `"docker"` whenever `isLinuxDockerDriverGatewayEnabled()` is true.
- `src/lib/onboard/sandbox-registry-metadata.test.ts` (new) — unit tests
  asserting macOS Docker-driver → `"docker"`, Linux Docker-driver →
  `"docker"`, and legacy Linux → `"kubernetes"`.
- `src/lib/onboard/vm-dns-monkeypatch.test.ts` — regression test that
  exercises the real `applyOpenShellVmDnsMonkeypatch` with
  `openshellDriver: "docker"` on a mocked darwin platform and verifies
  the onboard wrapper emits no logs or warnings.

## Test plan

- [x] `npm run typecheck:cli`
- [x] `npm run build:cli`
- [x] `npx vitest run src/lib/onboard/sandbox-registry-metadata.test.ts src/lib/onboard/vm-dns-monkeypatch.test.ts src/lib/actions/sandbox/vm-dns-monkeypatch.test.ts` — 18/18 pass
- [x] `cd nemoclaw && npm run build && npm test` — 457/457 pass
- [x] `npx @biomejs/biome check` clean on touched files
- [x] Linux host can't reproduce the macOS-specific behavior directly, so
      the regression is covered by mocking `process.platform` (allowed
      by the issue brief).

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker and Kubernetes driver selection for sandbox runtime configuration.
  * Fixed DNS monkeypatch handling on macOS Docker-driver sandboxes.
  * Corrected platform-specific driver assignment logic for Linux and macOS environments.

* **Tests**
  * Added comprehensive test coverage for driver selection across different platforms and configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->