### PR TITLE
fix(uninstall): kill leftover host openshell-gateway on cleanup (#3516)

### DIFF
--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -189,7 +189,7 @@ Re-run the installer.
 Before it onboards anything, the installer calls [`nemoclaw backup-all`](/reference/commands#nemoclaw-backup-all) automatically, storing a snapshot of each running sandbox in `~/.nemoclaw/rebuild-backups/` as a safety net.
 If your existing gateway is from OpenShell earlier than `0.0.37`, the installer prompts before it runs the new automatic gateway upgrade path.
 The automatic path is offered only when the existing `nemoclaw` CLI supports `backup-all`; older installs must preserve sandbox state manually before retiring the gateway.
-For unattended installs, set `NEMOCLAW_ACCEPT_EXPERIMENTAL_OPENSHELL_UPGRADE=1`, or manually run `nemoclaw backup-all` and `openshell gateway destroy -g nemoclaw || openshell gateway destroy` before rerunning the installer as `curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_OPENSHELL_UPGRADE_PREPARED=1 bash`.
+For unattended installs, set `NEMOCLAW_ACCEPT_EXPERIMENTAL_OPENSHELL_UPGRADE=1`, or manually run `nemoclaw backup-all`, `openshell gateway remove nemoclaw || openshell gateway destroy -g nemoclaw || openshell gateway destroy` (both verbs are tried so the right one runs on either OpenShell release), and `sudo pkill -f openshell-gateway` if a privileged host gateway remains before rerunning the installer as `curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_OPENSHELL_UPGRADE_PREPARED=1 bash`.
 
 ```console
 $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -81,7 +81,7 @@ $ NEMOCLAW_SINGLE_SESSION=1 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 When existing sandboxes were created with OpenShell earlier than `0.0.37`, the installer prompts before running the new automatic gateway upgrade path.
 For scripted installs, set `NEMOCLAW_ACCEPT_EXPERIMENTAL_OPENSHELL_UPGRADE=1` to allow the installer to back up registered sandbox state, retire the old gateway, install the current supported OpenShell release, and restore state during onboarding.
 The automatic path is disabled if the existing `nemoclaw` CLI does not advertise `backup-all`; preserve sandbox state manually before retiring the old gateway in that case.
-To perform those steps manually, run `nemoclaw backup-all`, retire the old gateway with `openshell gateway destroy -g nemoclaw || openshell gateway destroy`, then rerun the installer as `curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_OPENSHELL_UPGRADE_PREPARED=1 bash`.
+To perform those steps manually, run `nemoclaw backup-all`, retire the old gateway registration with `openshell gateway remove nemoclaw || openshell gateway destroy -g nemoclaw || openshell gateway destroy` (both verbs are tried so the right one runs on either OpenShell release), stop any remaining privileged host gateway with `sudo pkill -f openshell-gateway`, then rerun the installer as `curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_OPENSHELL_UPGRADE_PREPARED=1 bash`.
 
 The wizard prompts for a provider first, then collects the provider credential if needed.
 Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, and compatible OpenAI or Anthropic endpoints.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1150,11 +1150,12 @@ Run `fix-coredns.sh` to point CoreDNS at the container gateway IP instead, then 
 ### `k3s` cannot find a freshly built image
 
 After building a new sandbox image, `k3s` inside the gateway container sometimes fails to pull it even though the image exists on the host.
-Destroy and restart the gateway, then re-run setup.
+Remove the gateway registration, stop any leftover host gateway process, then re-run setup.
 
 ```console
-$ openshell gateway destroy
-$ openshell gateway start
+$ openshell gateway remove nemoclaw
+$ sudo pkill -f openshell-gateway
+$ nemoclaw onboard --resume
 ```
 
 ### GPU passthrough on Spark

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1666,7 +1666,8 @@ print_openshell_upgrade_manual_commands() {
   cat <<EOF
   Manual upgrade path:
     ${_CLI_BIN} backup-all
-    openshell gateway destroy -g nemoclaw || openshell gateway destroy
+    openshell gateway remove nemoclaw || openshell gateway destroy -g nemoclaw || openshell gateway destroy
+    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains
     curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_OPENSHELL_UPGRADE_PREPARED=1 bash
     ${_CLI_BIN} upgrade-sandboxes --check
 

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { resolveOpenshell } from "../../adapters/openshell/resolve";
@@ -21,6 +20,7 @@ import {
   shouldStopHostServicesAfterDestroy,
 } from "../../domain/sandbox/destroy";
 import { stopStaleDashboardListeners } from "../../onboard/stale-gateway-cleanup";
+import { stopHostGatewayProcesses } from "../../onboard/host-gateway-process";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
 import { killTimer as defaultKillShieldsTimer } from "../../shields/timer-control";
 import type { Session } from "../../state/onboard-session";
@@ -81,57 +81,6 @@ type RemoveShieldsStateDeps = {
 const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 const DASHBOARD_FORWARD_PORT = String(DASHBOARD_PORT);
 
-function dockerDriverGatewayPidFile(): string {
-  const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR;
-  const stateDir =
-    configured && configured.trim()
-      ? path.resolve(configured.trim())
-      : path.join(
-          os.homedir(),
-          ".local",
-          "state",
-          "nemoclaw",
-          "openshell-docker-gateway",
-        );
-  return path.join(stateDir, "openshell-gateway.pid");
-}
-
-function isDockerDriverGatewayPid(pid: number): boolean {
-  try {
-    const cmdline = fs
-      .readFileSync(`/proc/${pid}/cmdline`, "utf-8")
-      .replace(/\0/g, " ");
-    return cmdline.includes("openshell-gateway") || cmdline.includes("openclaw-gateway");
-  } catch {
-    return false;
-  }
-}
-
-function stopDockerDriverGatewayProcess(): void {
-  const pidFile = dockerDriverGatewayPidFile();
-  let pid: number | null = null;
-  try {
-    pid = Number.parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
-  } catch {
-    return;
-  }
-  if (!Number.isInteger(pid) || pid <= 0) {
-    fs.rmSync(pidFile, { force: true });
-    return;
-  }
-  if (!isDockerDriverGatewayPid(pid)) {
-    fs.rmSync(pidFile, { force: true });
-    return;
-  }
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch {
-    fs.rmSync(pidFile, { force: true });
-    return;
-  }
-  fs.rmSync(pidFile, { force: true });
-}
-
 function cleanupGatewayAfterLastSandbox(): void {
   const { runOpenshell } = require("../../adapters/openshell/runtime") as {
     runOpenshell: (
@@ -156,7 +105,12 @@ function cleanupGatewayAfterLastSandbox(): void {
   // openshell record was lost across upgrades or failed onboards.
   stopStaleDashboardListeners();
   if (process.platform === "linux") {
-    stopDockerDriverGatewayProcess();
+    // Sandbox destroy is conservative: only stop the host gateway whose PID
+    // file we wrote during onboard. Disable the pgrep sweep so a stray
+    // openshell-gateway under another user/project on the same host (rare but
+    // possible on shared hosts) is not torn down by a NemoClaw `destroy`.
+    // The uninstall path keeps the broader sweep on (run-plan.ts).
+    stopHostGatewayProcesses({}, { usePgrepFallback: false });
     const removeResult = runOpenshell(
       ["gateway", "remove", NEMOCLAW_GATEWAY_NAME],
       {

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -637,13 +637,13 @@ describe("uninstall run plan", () => {
         log: (line) => logs.push(line),
         rmSync: vi.fn(),
         run: (command, args) => {
-          const psResult = psStub("99887", {
+          const psResult = psStub("9999887", {
             cmdline: "/home/test/.local/bin/openshell-gateway --port 8080\n",
             exited,
           })(args);
           if (psResult) return psResult;
           if (command === "pgrep" && args[0] === "-f" && String(args[1]).includes("openshell-gateway")) {
-            return { status: 0, stdout: "99887\n", stderr: "" };
+            return { status: 0, stdout: "9999887\n", stderr: "" };
           }
           if (command === "lsof") return ok("");
           if (args[0] === "-c") return ok("/fake/bin/tool\n");
@@ -655,8 +655,8 @@ describe("uninstall run plan", () => {
     );
 
     expect(result.exitCode).toBe(0);
-    expect(killed).toContain(99887);
-    expect(logs).toContain("Stopped host openshell-gateway process 99887");
+    expect(killed).toContain(9999887);
+    expect(logs).toContain("Stopped host openshell-gateway process 9999887");
 
   });
 });

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -621,6 +621,7 @@ describe("uninstall run plan", () => {
   it("kills host openshell-gateway process during uninstall (#3516)", () => {
     const logs: string[] = [];
     const killed: number[] = [];
+    const exited = new Set<number>();
     const result = runUninstallPlan(
       { assumeYes: true, deleteModels: false, keepOpenShell: true },
       {
@@ -630,12 +631,18 @@ describe("uninstall run plan", () => {
         isTty: false,
         kill: (pid) => {
           killed.push(pid);
+          exited.add(pid);
           return true;
         },
         log: (line) => logs.push(line),
         rmSync: vi.fn(),
         run: (command, args) => {
-          if (command === "pgrep" && args.includes("openshell-gateway")) {
+          const psResult = psStub("99887", {
+            cmdline: "/home/test/.local/bin/openshell-gateway --port 8080\n",
+            exited,
+          })(args);
+          if (psResult) return psResult;
+          if (command === "pgrep" && args[0] === "-f" && String(args[1]).includes("openshell-gateway")) {
             return { status: 0, stdout: "99887\n", stderr: "" };
           }
           if (command === "lsof") return ok("");
@@ -649,7 +656,7 @@ describe("uninstall run plan", () => {
 
     expect(result.exitCode).toBe(0);
     expect(killed).toContain(99887);
-    expect(logs).toContain("Stopped host openshell-gateway processes 99887");
+    expect(logs).toContain("Stopped host openshell-gateway process 99887");
 
   });
 });

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -11,6 +11,7 @@ import { getAgentBranding, type AgentBranding } from "../../cli/branding";
 import { sleepMs } from "../../core/wait";
 import { defaultUninstallPaths, NEMOCLAW_OLLAMA_MODELS, NEMOCLAW_PROVIDERS, type UninstallPaths } from "../../domain/uninstall/paths";
 import { buildUninstallPlan, type UninstallPlan } from "../../domain/uninstall/plan";
+import { stopHostGatewayProcesses } from "../../onboard/host-gateway-process";
 import { stopStaleDashboardListeners } from "../../onboard/stale-gateway-cleanup";
 import { classifyShimPath, type FileSystemDeps } from "./plan";
 
@@ -582,7 +583,17 @@ function executePlan(plan: UninstallPlan, paths: UninstallPaths, options: Uninst
         commandExists: runtime.commandExists,
       });
       stopOrphanedOpenShell(runtime);
-      stopMatchingPids("openshell-gateway", runtime, "host openshell-gateway processes");
+      stopHostGatewayProcesses(
+        {
+          run: runtime.run,
+          kill: runtime.kill,
+          env: runtime.env,
+          log: runtime.log,
+          warn: runtime.warn,
+          commandExists: runtime.commandExists,
+        },
+        { logNoProcesses: true },
+      );
       stopOllamaAuthProxy(paths, runtime);
     } else if (step.name === "OpenShell resources") {
       removeOpenShellResources(options, runtime);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -445,6 +445,8 @@ const dockerDriverGatewayEnv: typeof import("./onboard/docker-driver-gateway-env
 const { getDockerDriverGatewayEndpoint } = dockerDriverGatewayEnv;
 const dockerDriverGatewayRuntimeMarker: typeof import("./onboard/docker-driver-gateway-runtime-marker") =
   require("./onboard/docker-driver-gateway-runtime-marker");
+const hostGatewayProcess: typeof import("./onboard/host-gateway-process") =
+  require("./onboard/host-gateway-process");
 const vmDriverProcess: typeof import("./onboard/vm-driver-process") = require("./onboard/vm-driver-process");
 const preflightUtils: typeof import("./onboard/preflight") = require("./onboard/preflight");
 const clusterImagePatch: typeof import("./cluster-image-patch") = require("./cluster-image-patch");
@@ -1078,38 +1080,19 @@ function removeDockerDriverGatewayRegistration(): boolean {
   return destroyResult.status === 0;
 }
 
-function terminateDockerDriverGatewayProcess(pid: number): boolean {
-  if (!isPidAlive(pid)) {
-    return false;
-  }
-
-  try {
-    process.kill(pid, "SIGTERM");
-    for (let i = 0; i < 10; i += 1) {
-      if (!isPidAlive(pid)) break;
-      sleepSeconds(1);
-    }
-    if (isPidAlive(pid)) process.kill(pid, "SIGKILL");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function stopDockerDriverGatewayProcess(): boolean {
-  const pid = getDockerDriverGatewayPid();
-  if (pid === null || !isPidAlive(pid)) {
-    clearDockerDriverGatewayRuntimeFiles();
-    return false;
-  }
-  if (!isDockerDriverGatewayProcess(pid, resolveOpenShellGatewayBinary())) {
-    clearDockerDriverGatewayRuntimeFiles();
-    return false;
-  }
-
-  const stopped = terminateDockerDriverGatewayProcess(pid);
-  clearDockerDriverGatewayRuntimeFiles();
-  return stopped;
+  const result = hostGatewayProcess.stopHostGatewayProcesses(
+    {
+      log: console.log,
+      warn: console.warn,
+    },
+    {
+      gatewayBin: resolveOpenShellGatewayBinary(),
+      pidFile: getDockerDriverGatewayPidFile(),
+      stateDir: getDockerDriverGatewayStateDir(),
+    },
+  );
+  return result.stopped.length > 0;
 }
 
 function stopLegacyGatewayClusterContainer(): boolean {
@@ -1148,8 +1131,18 @@ function retireLegacyGatewayForDockerDriverUpgrade(): void {
 
 function restartDockerDriverGatewayProcessForDrift(pid: number, reason: string): void {
   console.log(`  Existing OpenShell Docker-driver gateway is stale (${reason}); restarting...`);
-  terminateDockerDriverGatewayProcess(pid);
-  clearDockerDriverGatewayRuntimeFiles();
+  hostGatewayProcess.stopHostGatewayProcesses(
+    {
+      log: console.log,
+      warn: console.warn,
+    },
+    {
+      gatewayBin: resolveOpenShellGatewayBinary(),
+      pidFile: getDockerDriverGatewayPidFile(),
+      pids: [pid],
+      stateDir: getDockerDriverGatewayStateDir(),
+    },
+  );
 }
 
 async function refreshDockerDriverGatewayReuseState(
@@ -1274,6 +1267,11 @@ function handleFinalGatewayStartFailure({
   printError(`    openshell gateway remove ${GATEWAY_NAME}`);
   printError(`    # For OpenShell releases that still expose lifecycle commands:`);
   printError(`    openshell gateway destroy -g ${GATEWAY_NAME}`);
+  if (process.platform === "linux") {
+    printError(
+      "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",
+    );
+  }
   printError(
     `    docker volume ls -q --filter "name=openshell-cluster-${GATEWAY_NAME}" | xargs -r docker volume rm`,
   );

--- a/src/lib/onboard/gateway-gpu-passthrough.ts
+++ b/src/lib/onboard/gateway-gpu-passthrough.ts
@@ -118,6 +118,7 @@ function reportUnreadableSandboxRegistryForGpuGatewayReuse(
   error(`    openshell gateway remove ${gatewayName}`);
   error("    # For OpenShell releases that still expose lifecycle commands:");
   error(`    openshell gateway destroy -g ${gatewayName}`);
+  error("    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains");
   error("    nemoclaw onboard --gpu");
   exit(1);
 }

--- a/src/lib/onboard/gpu-recovery.test.ts
+++ b/src/lib/onboard/gpu-recovery.test.ts
@@ -28,9 +28,12 @@ describe("gpuPassthroughRecoveryLines", () => {
     expect(joined).toContain("attempted safe gateway replacement automatically");
     expect(joined).toContain("openshell gateway remove nemoclaw");
     expect(joined).toContain("openshell gateway destroy -g nemoclaw");
+    expect(joined).toContain("sudo pkill -f openshell-gateway");
     expect(joined).toContain("nemoclaw onboard --gpu");
     expect(joined).not.toContain("nemoclaw uninstall");
-    // Must NOT suggest the destroy form — there is nothing to destroy.
+    // Must NOT suggest the per-sandbox `nemoclaw <name> destroy` form — there
+    // is nothing to destroy. (`openshell gateway destroy -g` is fine; it's
+    // the legacy gateway-lifecycle verb, not a sandbox destroy.)
     expect(joined).not.toMatch(/nemoclaw [a-z-]+ destroy/);
   });
 

--- a/src/lib/onboard/gpu-recovery.ts
+++ b/src/lib/onboard/gpu-recovery.ts
@@ -56,6 +56,7 @@ export function gpuPassthroughRecoveryLines(
       "    openshell gateway remove nemoclaw",
       "    # For OpenShell releases that still expose lifecycle commands:",
       "    openshell gateway destroy -g nemoclaw",
+      "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",
       "    nemoclaw onboard --gpu",
     ];
   }

--- a/src/lib/onboard/host-gateway-process.test.ts
+++ b/src/lib/onboard/host-gateway-process.test.ts
@@ -69,8 +69,8 @@ describe("stopHostGatewayProcesses", () => {
   it("uses pgrep fallback when the Docker-driver gateway PID file is missing", () => {
     const exited = new Set<number>();
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
-      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("99887\n")],
-      ...psResponses(99887, { exited }),
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("9999887\n")],
+      ...psResponses(9999887, { exited }),
     ]);
     const { run } = makeRun(responses);
     const kill = vi.fn<HostGatewayProcessDeps["kill"]>((pid, signal) => {
@@ -84,19 +84,19 @@ describe("stopHostGatewayProcesses", () => {
       { stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")) },
     );
 
-    expect(result.stopped).toEqual([99887]);
-    expect(kill).toHaveBeenCalledWith(99887, "SIGTERM");
-    expect(log).toHaveBeenCalledWith("Stopped host openshell-gateway process 99887");
+    expect(result.stopped).toEqual([9999887]);
+    expect(kill).toHaveBeenCalledWith(9999887, "SIGTERM");
+    expect(log).toHaveBeenCalledWith("Stopped host openshell-gateway process 9999887");
   });
 
   it("accepts the docker-compat parent PID whose argv0 is docker", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
     const pidFile = path.join(stateDir, "openshell-gateway.pid");
-    fs.writeFileSync(pidFile, "5151\n");
+    fs.writeFileSync(pidFile, "9999551\n");
     const exited = new Set<number>();
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
       ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", notFound()],
-      ...psResponses(5151, {
+      ...psResponses(9999551, {
         cmdline:
           "/usr/bin/docker run --rm --name nemoclaw-openshell-gateway --network host /opt/nemoclaw/openshell-gateway\n",
         exited,
@@ -113,18 +113,18 @@ describe("stopHostGatewayProcesses", () => {
       { stateDir },
     );
 
-    expect(result.stopped).toEqual([5151]);
-    expect(kill).toHaveBeenCalledWith(5151, "SIGTERM");
+    expect(result.stopped).toEqual([9999551]);
+    expect(kill).toHaveBeenCalledWith(9999551, "SIGTERM");
     expect(fs.existsSync(pidFile)).toBe(false);
   });
 
   it("rejects a PID whose argv0 is not docker even if it touches the mount path", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
     const pidFile = path.join(stateDir, "openshell-gateway.pid");
-    fs.writeFileSync(pidFile, "6262\n");
+    fs.writeFileSync(pidFile, "9999662\n");
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
       ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", notFound()],
-      ...psResponses(6262, {
+      ...psResponses(9999662, {
         cmdline: "/usr/bin/vim /opt/nemoclaw/openshell-gateway\n",
         exited: new Set(),
       }),
@@ -137,7 +137,7 @@ describe("stopHostGatewayProcesses", () => {
       { stateDir },
     );
 
-    expect(result.skippedNonMatchingPids).toEqual([6262]);
+    expect(result.skippedNonMatchingPids).toEqual([9999662]);
     expect(kill).not.toHaveBeenCalled();
   });
 
@@ -170,16 +170,16 @@ describe("stopHostGatewayProcesses", () => {
   it("ignores unrelated command lines that merely mention openshell-gateway", () => {
     const exited = new Set<number>();
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
-      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("111\n222\n")],
-      ...psResponses(111, { exited }),
-      ...psResponses(222, {
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("9999111\n9999222\n")],
+      ...psResponses(9999111, { exited }),
+      ...psResponses(9999222, {
         cmdline: "node /home/test/.npm-global/bin/codex issue text mentions openshell-gateway\n",
         exited,
       }),
     ]);
     const { run } = makeRun(responses);
     const kill = vi.fn<HostGatewayProcessDeps["kill"]>((pid, signal) => {
-      if (pid === 111 && signal === "SIGTERM") exited.add(pid);
+      if (pid === 9999111 && signal === "SIGTERM") exited.add(pid);
       return true;
     });
 
@@ -188,15 +188,15 @@ describe("stopHostGatewayProcesses", () => {
       { stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")) },
     );
 
-    expect(result.stopped).toEqual([111]);
-    expect(result.skippedNonMatchingPids).toEqual([222]);
-    expect(kill).not.toHaveBeenCalledWith(222, expect.anything());
+    expect(result.stopped).toEqual([9999111]);
+    expect(result.skippedNonMatchingPids).toEqual([9999222]);
+    expect(kill).not.toHaveBeenCalledWith(9999222, expect.anything());
   });
 
   it("prints sudo remediation when a privileged host gateway cannot be killed", () => {
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
-      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("42\n")],
-      ...psResponses(42, { exited: new Set(), owner: "root" }),
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("9999042\n")],
+      ...psResponses(9999042, { exited: new Set(), owner: "root" }),
     ]);
     const { run } = makeRun(responses);
     const warn = vi.fn();
@@ -216,18 +216,24 @@ describe("stopHostGatewayProcesses", () => {
       },
     );
 
-    expect(result.failed).toEqual([42]);
-    expect(result.sudoRemediationPids).toEqual([42]);
+    expect(result.failed).toEqual([9999042]);
+    expect(result.sudoRemediationPids).toEqual([9999042]);
     expect(warn).toHaveBeenCalledWith(
-      "Cannot stop root-owned host openshell-gateway process 42. Run: sudo pkill -f openshell-gateway",
+      "Cannot stop root-owned host openshell-gateway process 9999042. Run: sudo pkill -f openshell-gateway",
     );
   });
 
   it("skips pgrep sweep when explicit PIDs are passed (drift restart)", () => {
+    // Use a PID above the Linux kernel pid_max default (4194304) so that the
+    // production code's `/proc/<pid>/cmdline` probe always misses and the
+    // mocked `ps -o args=` response wins. Without this guard a real process
+    // happening to hold the chosen PID on a busy CI runner makes the
+    // cmdline-matcher reject the candidate and the test flakes.
+    const driftPid = 9999777;
     const exited = new Set<number>();
     const pgrepCalls: string[][] = [];
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
-      ...psResponses(7777, { exited }),
+      ...psResponses(driftPid, { exited }),
     ]);
     const { run } = makeRun(responses);
     // Wrap run so we can detect any pgrep invocation: pgrep MUST NOT run when
@@ -244,30 +250,30 @@ describe("stopHostGatewayProcesses", () => {
     const result = stopHostGatewayProcesses(
       { run: tracedRun, kill, env: { USER: "tester" }, commandExists: () => true, log: vi.fn() },
       {
-        pids: [7777],
+        pids: [driftPid],
         stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")),
       },
     );
 
-    expect(result.stopped).toEqual([7777]);
+    expect(result.stopped).toEqual([driftPid]);
     expect(pgrepCalls).toEqual([]);
   });
 
   it("clears stale PID files and still scans for orphaned host gateways", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
     const pidFile = path.join(stateDir, "openshell-gateway.pid");
-    fs.writeFileSync(pidFile, "123\n");
+    fs.writeFileSync(pidFile, "9999123\n");
     const exited = new Set<number>();
     const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
-      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("456\n")],
-      ...psResponses(123, { exited: new Set() }).map(([key, value]) =>
-        key === "ps -p 123 -o pid=" ? [key, notFound()] : [key, value],
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("9999456\n")],
+      ...psResponses(9999123, { exited: new Set() }).map(([key, value]) =>
+        key === "ps -p 9999123 -o pid=" ? [key, notFound()] : [key, value],
       ) as [string, RunResult | ((args: string[]) => RunResult)][],
-      ...psResponses(456, { exited }),
+      ...psResponses(9999456, { exited }),
     ]);
     const { run } = makeRun(responses);
     const kill: HostGatewayProcessDeps["kill"] = (pid, signal) => {
-      if (pid === 456 && signal === "SIGTERM") exited.add(pid);
+      if (pid === 9999456 && signal === "SIGTERM") exited.add(pid);
       return true;
     };
 
@@ -276,8 +282,8 @@ describe("stopHostGatewayProcesses", () => {
       { stateDir },
     );
 
-    expect(result.skippedDeadPids).toEqual([123]);
-    expect(result.stopped).toEqual([456]);
+    expect(result.skippedDeadPids).toEqual([9999123]);
+    expect(result.stopped).toEqual([9999456]);
     expect(fs.existsSync(pidFile)).toBe(false);
   });
 });

--- a/src/lib/onboard/host-gateway-process.test.ts
+++ b/src/lib/onboard/host-gateway-process.test.ts
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  stopHostGatewayProcesses,
+  type HostGatewayProcessDeps,
+  type RunResult,
+} from "./host-gateway-process";
+
+interface RunArgs {
+  args: string[];
+  command: string;
+}
+
+function ok(stdout = ""): RunResult {
+  return { status: 0, stdout, stderr: "" };
+}
+
+function notFound(): RunResult {
+  return { status: 1, stdout: "", stderr: "" };
+}
+
+function makeRun(
+  responses: Map<string, RunResult | ((args: string[]) => RunResult)>,
+): {
+  calls: RunArgs[];
+  run: HostGatewayProcessDeps["run"];
+} {
+  const calls: RunArgs[] = [];
+  const run: HostGatewayProcessDeps["run"] = (command, args) => {
+    calls.push({ command, args });
+    const key = `${command} ${args.join(" ")}`;
+    const exact = responses.get(key);
+    if (exact !== undefined) {
+      return typeof exact === "function" ? exact(args) : exact;
+    }
+    if (command === "pgrep") return notFound();
+    if (command === "ps") return notFound();
+    return ok();
+  };
+  return { calls, run };
+}
+
+function psResponses(
+  pid: number,
+  opts: {
+    cmdline?: string;
+    exited: Set<number>;
+    owner?: string;
+  },
+): [string, RunResult | ((args: string[]) => RunResult)][] {
+  return [
+    [`ps -p ${pid} -o pid=`, () => (opts.exited.has(pid) ? notFound() : ok(`${pid}\n`))],
+    [`ps -p ${pid} -o user=`, ok(`${opts.owner ?? "tester"}\n`)],
+    [
+      `ps -p ${pid} -o args=`,
+      ok(opts.cmdline ?? `/home/test/.local/bin/openshell-gateway --port 8080\n`),
+    ],
+  ];
+}
+
+describe("stopHostGatewayProcesses", () => {
+  it("uses pgrep fallback when the Docker-driver gateway PID file is missing", () => {
+    const exited = new Set<number>();
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("99887\n")],
+      ...psResponses(99887, { exited }),
+    ]);
+    const { run } = makeRun(responses);
+    const kill = vi.fn<HostGatewayProcessDeps["kill"]>((pid, signal) => {
+      if (signal === "SIGTERM") exited.add(pid);
+      return true;
+    });
+    const log = vi.fn();
+
+    const result = stopHostGatewayProcesses(
+      { run, kill, env: { USER: "tester" }, commandExists: () => true, log },
+      { stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")) },
+    );
+
+    expect(result.stopped).toEqual([99887]);
+    expect(kill).toHaveBeenCalledWith(99887, "SIGTERM");
+    expect(log).toHaveBeenCalledWith("Stopped host openshell-gateway process 99887");
+  });
+
+  it("accepts the docker-compat parent PID whose argv0 is docker", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
+    const pidFile = path.join(stateDir, "openshell-gateway.pid");
+    fs.writeFileSync(pidFile, "5151\n");
+    const exited = new Set<number>();
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", notFound()],
+      ...psResponses(5151, {
+        cmdline:
+          "/usr/bin/docker run --rm --name nemoclaw-openshell-gateway --network host /opt/nemoclaw/openshell-gateway\n",
+        exited,
+      }),
+    ]);
+    const { run } = makeRun(responses);
+    const kill = vi.fn<HostGatewayProcessDeps["kill"]>((pid, signal) => {
+      if (signal === "SIGTERM") exited.add(pid);
+      return true;
+    });
+
+    const result = stopHostGatewayProcesses(
+      { run, kill, env: { USER: "tester" }, commandExists: () => true, log: vi.fn() },
+      { stateDir },
+    );
+
+    expect(result.stopped).toEqual([5151]);
+    expect(kill).toHaveBeenCalledWith(5151, "SIGTERM");
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  it("rejects a PID whose argv0 is not docker even if it touches the mount path", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
+    const pidFile = path.join(stateDir, "openshell-gateway.pid");
+    fs.writeFileSync(pidFile, "6262\n");
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", notFound()],
+      ...psResponses(6262, {
+        cmdline: "/usr/bin/vim /opt/nemoclaw/openshell-gateway\n",
+        exited: new Set(),
+      }),
+    ]);
+    const { run } = makeRun(responses);
+    const kill = vi.fn<HostGatewayProcessDeps["kill"]>(() => true);
+
+    const result = stopHostGatewayProcesses(
+      { run, kill, env: { USER: "tester" }, commandExists: () => true, log: vi.fn() },
+      { stateDir },
+    );
+
+    expect(result.skippedNonMatchingPids).toEqual([6262]);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("warns instead of claiming success when pgrep is unavailable", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
+    const { run } = makeRun(new Map());
+    const warn = vi.fn();
+    const log = vi.fn();
+
+    const result = stopHostGatewayProcesses(
+      {
+        run,
+        kill: () => true,
+        env: { USER: "tester" },
+        commandExists: (cmd) => cmd !== "pgrep",
+        warn,
+        log,
+      },
+      { logNoProcesses: true, stateDir },
+    );
+
+    expect(result.stopped).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      "pgrep not found; could not scan for orphan host openshell-gateway processes. " +
+        "If port 8080 is still bound, run: sudo pkill -f openshell-gateway",
+    );
+    expect(log).not.toHaveBeenCalledWith("No host openshell-gateway processes found");
+  });
+
+  it("ignores unrelated command lines that merely mention openshell-gateway", () => {
+    const exited = new Set<number>();
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("111\n222\n")],
+      ...psResponses(111, { exited }),
+      ...psResponses(222, {
+        cmdline: "node /home/test/.npm-global/bin/codex issue text mentions openshell-gateway\n",
+        exited,
+      }),
+    ]);
+    const { run } = makeRun(responses);
+    const kill = vi.fn<HostGatewayProcessDeps["kill"]>((pid, signal) => {
+      if (pid === 111 && signal === "SIGTERM") exited.add(pid);
+      return true;
+    });
+
+    const result = stopHostGatewayProcesses(
+      { run, kill, env: { USER: "tester" }, commandExists: () => true, log: vi.fn() },
+      { stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")) },
+    );
+
+    expect(result.stopped).toEqual([111]);
+    expect(result.skippedNonMatchingPids).toEqual([222]);
+    expect(kill).not.toHaveBeenCalledWith(222, expect.anything());
+  });
+
+  it("prints sudo remediation when a privileged host gateway cannot be killed", () => {
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("42\n")],
+      ...psResponses(42, { exited: new Set(), owner: "root" }),
+    ]);
+    const { run } = makeRun(responses);
+    const warn = vi.fn();
+
+    const result = stopHostGatewayProcesses(
+      {
+        run,
+        kill: () => false,
+        env: { USER: "tester" },
+        commandExists: () => true,
+        warn,
+      },
+      {
+        killWaitMs: 0,
+        stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")),
+        termWaitMs: 0,
+      },
+    );
+
+    expect(result.failed).toEqual([42]);
+    expect(result.sudoRemediationPids).toEqual([42]);
+    expect(warn).toHaveBeenCalledWith(
+      "Cannot stop root-owned host openshell-gateway process 42. Run: sudo pkill -f openshell-gateway",
+    );
+  });
+
+  it("skips pgrep sweep when explicit PIDs are passed (drift restart)", () => {
+    const exited = new Set<number>();
+    const pgrepCalls: string[][] = [];
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ...psResponses(7777, { exited }),
+    ]);
+    const { run } = makeRun(responses);
+    // Wrap run so we can detect any pgrep invocation: pgrep MUST NOT run when
+    // an explicit drift PID is supplied.
+    const tracedRun: HostGatewayProcessDeps["run"] = (command, args) => {
+      if (command === "pgrep") pgrepCalls.push(args);
+      return run(command, args);
+    };
+    const kill = vi.fn<HostGatewayProcessDeps["kill"]>((pid, signal) => {
+      if (signal === "SIGTERM") exited.add(pid);
+      return true;
+    });
+
+    const result = stopHostGatewayProcesses(
+      { run: tracedRun, kill, env: { USER: "tester" }, commandExists: () => true, log: vi.fn() },
+      {
+        pids: [7777],
+        stateDir: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-")),
+      },
+    );
+
+    expect(result.stopped).toEqual([7777]);
+    expect(pgrepCalls).toEqual([]);
+  });
+
+  it("clears stale PID files and still scans for orphaned host gateways", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-gateway-"));
+    const pidFile = path.join(stateDir, "openshell-gateway.pid");
+    fs.writeFileSync(pidFile, "123\n");
+    const exited = new Set<number>();
+    const responses = new Map<string, RunResult | ((args: string[]) => RunResult)>([
+      ["pgrep -f ^(/[^ ]*/)?openshell-gateway( |$)", ok("456\n")],
+      ...psResponses(123, { exited: new Set() }).map(([key, value]) =>
+        key === "ps -p 123 -o pid=" ? [key, notFound()] : [key, value],
+      ) as [string, RunResult | ((args: string[]) => RunResult)][],
+      ...psResponses(456, { exited }),
+    ]);
+    const { run } = makeRun(responses);
+    const kill: HostGatewayProcessDeps["kill"] = (pid, signal) => {
+      if (pid === 456 && signal === "SIGTERM") exited.add(pid);
+      return true;
+    };
+
+    const result = stopHostGatewayProcesses(
+      { run, kill, env: { USER: "tester" }, commandExists: () => true, log: vi.fn() },
+      { stateDir },
+    );
+
+    expect(result.skippedDeadPids).toEqual([123]);
+    expect(result.stopped).toEqual([456]);
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+});

--- a/src/lib/onboard/host-gateway-process.ts
+++ b/src/lib/onboard/host-gateway-process.ts
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { sleepMs } from "../core/wait";
+import { clearDockerDriverGatewayRuntimeMarker } from "./docker-driver-gateway-runtime-marker";
+
+export interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export interface HostGatewayProcessDeps {
+  run: (command: string, args: string[], options?: SpawnSyncOptions) => RunResult;
+  kill: (pid: number, signal?: NodeJS.Signals | number) => boolean;
+  env: NodeJS.ProcessEnv;
+  commandExists?: (command: string) => boolean;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+export interface StopHostGatewayOptions {
+  gatewayBin?: string | null;
+  killWaitMs?: number;
+  logNoProcesses?: boolean;
+  pids?: Iterable<number>;
+  pidFile?: string;
+  pollIntervalMs?: number;
+  stateDir?: string;
+  termWaitMs?: number;
+  usePgrepFallback?: boolean;
+}
+
+export interface StopHostGatewayResult {
+  failed: number[];
+  skippedDeadPids: number[];
+  skippedNonMatchingPids: number[];
+  stopped: number[];
+  sudoRemediationPids: number[];
+}
+
+const HOST_GATEWAY_PROCESS_NAMES = new Set(["openshell-gateway", "openclaw-gateway"]);
+// Container runtimes that can host the compatibility gateway. Limited to the
+// ones `docker-driver-gateway-launch` actually invokes so a random user
+// command (e.g. `vim /opt/nemoclaw/openshell-gateway`) is never mistaken for
+// the parent process of a compat-mode gateway.
+const DOCKER_DRIVER_GATEWAY_CONTAINER_RUNTIME_NAMES = new Set(["docker"]);
+// Mount path used by docker-driver-gateway-launch when glibc compat forces the
+// gateway to run inside a Docker compatibility container. The parent PID we
+// record is the host-side `docker run` process whose argv0 is `docker`, so we
+// also accept cmdlines whose argv0 is a known container runtime AND that
+// include this mount path as a distinct argv token.
+const DOCKER_DRIVER_GATEWAY_MOUNT_PATH = "/opt/nemoclaw/openshell-gateway";
+// pgrep regex anchors on the original openshell-gateway launch shapes. We do
+// not extend it to also match the Docker compat parent because pgrep -f only
+// sees the cmdline string, not argv0; without an argv0 gate the compat mount
+// path could match unrelated commands. The compat parent is rediscovered via
+// the PID file written at launch time.
+const HOST_GATEWAY_PGREP_PATTERN = "^(/[^ ]*/)?openshell-gateway( |$)";
+const DEFAULT_TERM_WAIT_MS = 1000;
+const DEFAULT_KILL_WAIT_MS = 1000;
+const DEFAULT_POLL_INTERVAL_MS = 50;
+
+function toRunResult(result: ReturnType<typeof spawnSync>): RunResult {
+  return {
+    status: result.status,
+    stdout: typeof result.stdout === "string" ? result.stdout : String(result.stdout ?? ""),
+    stderr: typeof result.stderr === "string" ? result.stderr : String(result.stderr ?? ""),
+  };
+}
+
+function defaultRun(
+  command: string,
+  args: string[],
+  options: SpawnSyncOptions = {},
+): RunResult {
+  return toRunResult(spawnSync(command, args, { encoding: "utf-8", ...options }));
+}
+
+function defaultKill(pid: number, signal?: NodeJS.Signals | number): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultCommandExists(command: string, env: NodeJS.ProcessEnv): boolean {
+  return (
+    defaultRun("sh", ["-c", `command -v ${JSON.stringify(command)} >/dev/null 2>&1`], {
+      env,
+    }).status === 0
+  );
+}
+
+export function resolveDockerDriverGatewayStateDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = env.HOME || os.homedir(),
+): string {
+  const configured = env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR;
+  if (configured && configured.trim()) return path.resolve(configured.trim());
+  return path.join(homeDir, ".local", "state", "nemoclaw", "openshell-docker-gateway");
+}
+
+export function resolveDockerDriverGatewayPidFile(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = env.HOME || os.homedir(),
+): string {
+  return path.join(resolveDockerDriverGatewayStateDir(env, homeDir), "openshell-gateway.pid");
+}
+
+function defaultDeps(overrides: Partial<HostGatewayProcessDeps> = {}): HostGatewayProcessDeps {
+  const env = overrides.env ?? process.env;
+  return {
+    run: overrides.run ?? defaultRun,
+    kill: overrides.kill ?? defaultKill,
+    env,
+    commandExists: overrides.commandExists ?? ((cmd) => defaultCommandExists(cmd, env)),
+    log: overrides.log,
+    warn: overrides.warn,
+  };
+}
+
+function parsePidLines(output: string): number[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => Number.parseInt(line.trim(), 10))
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+function readPidFile(pidFile: string): number | null {
+  try {
+    const pid = Number.parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function readProcCmdline(pid: number): string {
+  try {
+    return fs.readFileSync(`/proc/${pid}/cmdline`, "utf-8").replace(/\0/g, " ").trim();
+  } catch {
+    return "";
+  }
+}
+
+function processArgs(pid: number, deps: HostGatewayProcessDeps): string {
+  const procArgs = readProcCmdline(pid);
+  if (procArgs) return procArgs;
+  const result = deps.run("ps", ["-p", String(pid), "-o", "args="], { env: deps.env });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function pidExists(pid: number, deps: HostGatewayProcessDeps): boolean {
+  return deps.run("ps", ["-p", String(pid), "-o", "pid="], { env: deps.env }).status === 0;
+}
+
+function pidOwner(pid: number, deps: HostGatewayProcessDeps): string | null {
+  const result = deps.run("ps", ["-p", String(pid), "-o", "user="], { env: deps.env });
+  if (result.status !== 0) return null;
+  return result.stdout.trim() || null;
+}
+
+function hostGatewayCmdlineMatches(
+  cmdline: string,
+  gatewayBin: string | null | undefined,
+): boolean {
+  const tokens = cmdline.trim().split(/\s+/);
+  const argv0 = tokens[0] ?? "";
+  if (!argv0) return false;
+  const base = path.basename(argv0);
+  if (HOST_GATEWAY_PROCESS_NAMES.has(base)) return true;
+  if (
+    typeof gatewayBin === "string" &&
+    gatewayBin.length > 0 &&
+    path.resolve(argv0) === path.resolve(gatewayBin)
+  ) {
+    return true;
+  }
+  // Docker compatibility mode: argv0 basename must be a known container
+  // runtime AND the mount path appears as a separate argv token. Substring
+  // matching inside random tokens (e.g. a log message or `vim
+  // /opt/nemoclaw/openshell-gateway`) would over-match, so require both.
+  if (
+    DOCKER_DRIVER_GATEWAY_CONTAINER_RUNTIME_NAMES.has(base) &&
+    tokens.includes(DOCKER_DRIVER_GATEWAY_MOUNT_PATH)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function waitForExit(
+  pid: number,
+  deps: HostGatewayProcessDeps,
+  timeoutMs: number,
+  pollIntervalMs: number,
+): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidExists(pid, deps)) return true;
+    sleepMs(pollIntervalMs);
+  }
+  return !pidExists(pid, deps);
+}
+
+function clearRuntimeFiles(pidFile: string, stateDir: string): void {
+  fs.rmSync(pidFile, { force: true });
+  clearDockerDriverGatewayRuntimeMarker(stateDir);
+}
+
+function addPid(candidates: Map<number, Set<string>>, pid: number, source: string): void {
+  const sources = candidates.get(pid) ?? new Set<string>();
+  sources.add(source);
+  candidates.set(pid, sources);
+}
+
+function pgrepHostGatewayPids(deps: HostGatewayProcessDeps): {
+  pids: number[];
+  scanned: boolean;
+} {
+  if (deps.commandExists && !deps.commandExists("pgrep")) {
+    return { pids: [], scanned: false };
+  }
+  const result = deps.run("pgrep", ["-f", HOST_GATEWAY_PGREP_PATTERN], { env: deps.env });
+  if (result.status !== 0 && result.status !== 1) {
+    const warn = deps.warn ?? ((message: string) => console.warn(message));
+    const detail = result.stderr.trim() || `status ${String(result.status)}`;
+    warn(`pgrep failed while scanning host openshell-gateway processes: ${detail}`);
+    return { pids: [], scanned: false };
+  }
+  return { pids: parsePidLines(result.stdout), scanned: true };
+}
+
+function warnSudoRemediation(pid: number, deps: HostGatewayProcessDeps): void {
+  const warn = deps.warn ?? ((message: string) => console.warn(message));
+  const owner = pidOwner(pid, deps);
+  const ownerLabel = owner ? `${owner}-owned` : "privileged";
+  warn(
+    `Cannot stop ${ownerLabel} host openshell-gateway process ${pid}. ` +
+      "Run: sudo pkill -f openshell-gateway",
+  );
+}
+
+function tryStopPid(
+  pid: number,
+  deps: HostGatewayProcessDeps,
+  options: Required<Pick<StopHostGatewayOptions, "killWaitMs" | "pollIntervalMs" | "termWaitMs">>,
+): "stopped" | "failed" {
+  const log = deps.log ?? ((message: string) => console.log(message));
+  deps.kill(pid, "SIGTERM");
+  if (waitForExit(pid, deps, options.termWaitMs, options.pollIntervalMs)) {
+    log(`Stopped host openshell-gateway process ${pid}`);
+    return "stopped";
+  }
+  deps.kill(pid, "SIGKILL");
+  if (waitForExit(pid, deps, options.killWaitMs, options.pollIntervalMs)) {
+    log(`Stopped host openshell-gateway process ${pid} (after SIGKILL)`);
+    return "stopped";
+  }
+  warnSudoRemediation(pid, deps);
+  return "failed";
+}
+
+export function stopHostGatewayProcesses(
+  depsOverrides: Partial<HostGatewayProcessDeps> = {},
+  options: StopHostGatewayOptions = {},
+): StopHostGatewayResult {
+  const deps = defaultDeps(depsOverrides);
+  const stateDir = options.stateDir ?? resolveDockerDriverGatewayStateDir(deps.env);
+  const pidFile = options.pidFile ?? path.join(stateDir, "openshell-gateway.pid");
+  const candidates = new Map<number, Set<string>>();
+  const result: StopHostGatewayResult = {
+    failed: [],
+    skippedDeadPids: [],
+    skippedNonMatchingPids: [],
+    stopped: [],
+    sudoRemediationPids: [],
+  };
+
+  const pidFromFile = readPidFile(pidFile);
+  if (pidFromFile !== null) {
+    addPid(candidates, pidFromFile, "pid-file");
+  } else if (fs.existsSync(pidFile)) {
+    clearRuntimeFiles(pidFile, stateDir);
+  }
+
+  const explicitPids = Array.from(options.pids ?? []).filter(
+    (pid): pid is number => Number.isInteger(pid) && pid > 0,
+  );
+  for (const pid of explicitPids) addPid(candidates, pid, "explicit");
+
+  // When a caller passes explicit PIDs (e.g. drift-restart targeting one
+  // gateway), default to NOT sweeping every matching openshell-gateway on the
+  // host. Otherwise an onboard drift could terminate an unrelated worktree's
+  // gateway. Sweeping callers (uninstall, sandbox destroy of the last sandbox)
+  // omit `pids` and so still get the pgrep fallback by default.
+  const useFallback =
+    options.usePgrepFallback ?? explicitPids.length === 0;
+  let pgrepRan = false;
+  if (useFallback) {
+    const sweep = pgrepHostGatewayPids(deps);
+    pgrepRan = sweep.scanned;
+    for (const pid of sweep.pids) addPid(candidates, pid, "pgrep");
+  }
+
+  const waitOptions = {
+    killWaitMs: options.killWaitMs ?? DEFAULT_KILL_WAIT_MS,
+    pollIntervalMs: options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    termWaitMs: options.termWaitMs ?? DEFAULT_TERM_WAIT_MS,
+  };
+  let clearedRuntimeFiles = false;
+  for (const [pid, sources] of candidates) {
+    if (!pidExists(pid, deps)) {
+      result.skippedDeadPids.push(pid);
+      if (sources.has("pid-file") && !clearedRuntimeFiles) {
+        clearRuntimeFiles(pidFile, stateDir);
+        clearedRuntimeFiles = true;
+      }
+      continue;
+    }
+    if (!hostGatewayCmdlineMatches(processArgs(pid, deps), options.gatewayBin)) {
+      result.skippedNonMatchingPids.push(pid);
+      if (sources.has("pid-file") && !clearedRuntimeFiles) {
+        clearRuntimeFiles(pidFile, stateDir);
+        clearedRuntimeFiles = true;
+      }
+      continue;
+    }
+
+    if (tryStopPid(pid, deps, waitOptions) === "stopped") {
+      result.stopped.push(pid);
+      if (!clearedRuntimeFiles) {
+        clearRuntimeFiles(pidFile, stateDir);
+        clearedRuntimeFiles = true;
+      }
+    } else {
+      result.failed.push(pid);
+      result.sudoRemediationPids.push(pid);
+    }
+  }
+
+  if (options.logNoProcesses && candidates.size === 0) {
+    if (useFallback && !pgrepRan) {
+      // The pid-file branch found nothing and the pgrep fallback could not
+      // run (typically `pgrep` is absent on a minimal image). Surface the
+      // skip so an uninstaller doesn't claim success while an orphan host
+      // gateway is still bound.
+      const warn = deps.warn ?? ((message: string) => console.warn(message));
+      warn(
+        "pgrep not found; could not scan for orphan host openshell-gateway processes. " +
+          "If port 8080 is still bound, run: sudo pkill -f openshell-gateway",
+      );
+    } else {
+      const log = deps.log ?? ((message: string) => console.log(message));
+      log("No host openshell-gateway processes found");
+    }
+  }
+
+  return result;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2699,7 +2699,7 @@ describe("CLI dispatch", () => {
     expect(fs.readFileSync(bashLog, "utf8")).not.toContain("volume ls -q --filter");
   });
 
-  it("tears down the gateway runtime when --cleanup-gateway is passed (#2166)", () => {
+  it("tears down the gateway runtime when --cleanup-gateway is passed (#2166)", testTimeoutOptions(30_000), () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-destroy-last-cleanup-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -2747,13 +2747,19 @@ describe("CLI dispatch", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
+    fs.writeFileSync(path.join(localBin, "pgrep"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    fs.writeFileSync(path.join(localBin, "lsof"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
 
-    const r = runWithEnv("alpha destroy -y --cleanup-gateway", {
-      HOME: home,
-      PATH: `${localBin}:${process.env.PATH || ""}`,
-    });
+    const r = runWithEnv(
+      "alpha destroy -y --cleanup-gateway",
+      {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      },
+      30_000,
+    );
 
-    expect(r.code).toBe(0);
+    expect(r.code, r.out).toBe(0);
     const openshellOutput = fs.readFileSync(openshellLog, "utf8");
     expect(openshellOutput).toContain("sandbox delete alpha");
     expect(openshellOutput).toContain("forward stop 18789");
@@ -2763,7 +2769,7 @@ describe("CLI dispatch", () => {
     expect(fs.readFileSync(bashLog, "utf8")).toContain("volume ls -q --filter");
   });
 
-  it("honours NEMOCLAW_CLEANUP_GATEWAY=1 as the env-driven opt-in (#2166)", () => {
+  it("honours NEMOCLAW_CLEANUP_GATEWAY=1 as the env-driven opt-in (#2166)", testTimeoutOptions(30_000), () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-destroy-last-env-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -2811,14 +2817,20 @@ describe("CLI dispatch", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
+    fs.writeFileSync(path.join(localBin, "pgrep"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    fs.writeFileSync(path.join(localBin, "lsof"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
 
-    const r = runWithEnv("alpha destroy -y", {
-      HOME: home,
-      PATH: `${localBin}:${process.env.PATH || ""}`,
-      NEMOCLAW_CLEANUP_GATEWAY: "1",
-    });
+    const r = runWithEnv(
+      "alpha destroy -y",
+      {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_CLEANUP_GATEWAY: "1",
+      },
+      30_000,
+    );
 
-    expect(r.code).toBe(0);
+    expect(r.code, r.out).toBe(0);
     const openshellOutput = fs.readFileSync(openshellLog, "utf8");
     expect(openshellOutput).toContain("forward stop 18789");
     expect(openshellOutput).toContain(

--- a/test/gateway-final-failure-cleanup.test.ts
+++ b/test/gateway-final-failure-cleanup.test.ts
@@ -66,6 +66,15 @@ describe("final gateway startup failure cleanup", () => {
     expect(errors).toContain("  Cleanup attempted.");
     expect(errors).toContain("    openshell gateway remove nemoclaw");
     expect(errors).toContain("    openshell gateway destroy -g nemoclaw");
+    if (process.platform === "linux") {
+      expect(errors).toContain(
+        "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",
+      );
+    } else {
+      expect(errors).not.toContain(
+        "    sudo pkill -f openshell-gateway  # if a privileged host gateway process remains",
+      );
+    }
     expect(errors).toContain(
       '    docker volume ls -q --filter "name=openshell-cluster-nemoclaw" | xargs -r docker volume rm',
     );


### PR DESCRIPTION
## Summary

Consolidates host-side `openshell-gateway` cleanup into a single shared helper used by uninstall, sandbox destroy, and onboard so direct `openshell gateway destroy` (and the destroy `--cleanup-gateway` flow) can no longer leave `/usr/local/bin/openshell-gateway` running on port 8080 on Linux Docker-driver hosts. Surfaces an actionable `sudo pkill -f openshell-gateway` remediation when a privileged PID survives both lifecycle verbs.

## Related Issue

Closes #3516.

## Changes

- **New `src/lib/onboard/host-gateway-process.ts`** — shared stopper with PID-file primary path, opt-out `pgrep` fallback for orphans, Docker-compat parent recognition (`argv0 == docker` AND mount-path token), bounded SIGTERM/SIGKILL with verified exit via `ps`, sudo remediation log on root-owned survivors, and a warning when `pgrep` is unavailable so an uninstaller never reports clean teardown while an orphan is still bound.
- **`src/lib/actions/uninstall/run-plan.ts`** — invokes the shared helper during the "Stopping services" step (the broader pgrep sweep is intentional for uninstall).
- **`src/lib/actions/sandbox/destroy.ts`** — replaces the local PID-file probe with the shared helper and disables the pgrep sweep so `destroy --cleanup-gateway` cannot terminate an unrelated host's openshell-gateway.
- **`src/lib/onboard.ts`** — routes `stopDockerDriverGatewayProcess` and the drift restart through the shared helper (drift restart targets only the supplied PID); adds the `sudo pkill -f openshell-gateway` line to the final-failure recovery banner on Linux while keeping both lifecycle verbs.
- **Recovery hints** (`gpu-recovery.ts`, `gateway-gpu-passthrough.ts`) and **user-facing docs** (`docs/manage-sandboxes/lifecycle.mdx`, `docs/reference/commands.mdx`, `docs/reference/troubleshooting.mdx`, `scripts/install.sh`) — instruct users to run `openshell gateway remove` first with the legacy `openshell gateway destroy -g` fallback, then `sudo pkill -f openshell-gateway` for stuck privileged processes.

## Type of Change

- [x] Code change with doc updates

## Verification

- [x] Targeted unit tests pass (`vitest run src/lib/onboard/host-gateway-process.test.ts src/lib/actions/uninstall/run-plan.test.ts test/gateway-final-failure-cleanup.test.ts src/lib/onboard/gpu-recovery.test.ts src/lib/onboard/gateway-gpu-passthrough.test.ts test/cli.test.ts` — 42 affected tests pass).
- [x] `npm run typecheck:cli` clean.
- [x] `npm run build:cli` clean.
- [x] Tests added for: PID-file path, pgrep fallback, false-positive rejection (`vim /opt/nemoclaw/openshell-gateway` and node cmdline mentioning openshell-gateway), Docker-compat parent matching, pgrep-skip when explicit PIDs are passed, pgrep-unavailable warning, and the existing uninstall-#3516 path.
- [x] E2E verified by spawning a fake `/tmp/.../openshell-gateway` Python listener on a unique port and confirming both PID-file-only (with pgrep disabled) and pgrep-only branches stop it via the built `dist/lib/onboard/host-gateway-process.js`.
- [x] No secrets committed.
- [x] Docs updated for user-facing behavior changes.

Full `npm test` was attempted but produced environment-induced timeouts (system load 24 on 4 cores from parallel sessions); individual reruns of every test file in the change set pass.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade, onboarding, and troubleshooting guidance with clearer gateway cleanup steps and an added privileged-process remediation suggestion.

* **Improvements**
  * More robust and conservative host gateway shutdown and cleanup behavior with clearer user-facing messages.

* **Tests**
  * Added and adjusted tests to validate gateway shutdown paths and related messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->