### PR TITLE
fix(onboard): drive Brave Search through OpenShell provider rewrite (#3626)

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -120,9 +120,8 @@ NemoClaw filters tier suggestions and resume selections by active agent support,
 | `custom` | Apply exactly `NEMOCLAW_POLICY_PRESETS`. Previously-applied presets not in the list are removed. Alias: `list`. |
 | `skip` | Skip the policy step entirely. Aliases: `none`, `no`. |
 
-If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.
-That means the OpenClaw agent can read the key.
-NemoClaw explores an OpenShell-hosted credential path first, but the current OpenClaw Brave runtime does not consume that path end to end yet.
+If you enable Brave Search during onboarding, NemoClaw registers a Brave Search OpenShell provider and keeps `openclaw.json` on an OpenShell credential placeholder.
+At egress, OpenShell rewrites Brave's `X-Subscription-Token` header with the real `BRAVE_API_KEY`.
 Treat Brave Search as an explicit opt-in and use a dedicated low-privilege Brave key.
 
 For non-interactive onboarding, you must explicitly accept the third-party software notice:

--- a/nemoclaw-blueprint/provider-profiles/brave.yaml
+++ b/nemoclaw-blueprint/provider-profiles/brave.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id: brave
+display_name: Brave Search
+description: Brave Search API access
+category: agent
+credentials:
+  - name: api_key
+    description: Brave Search API key
+    env_vars:
+      - BRAVE_API_KEY
+    required: true
+    auth_style: header
+    header_name: x-subscription-token
+    query_param: ''
+endpoints:
+  - host: api.search.brave.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+binaries:
+  - /usr/local/bin/node
+  - /usr/bin/node
+  - /usr/local/bin/curl
+  - /usr/bin/curl
+inference_capable: false

--- a/scripts/find-source-shape-tests.ts
+++ b/scripts/find-source-shape-tests.ts
@@ -128,6 +128,7 @@ function looksLikeDeclarativeConfigPath(text: string): boolean {
   return (
     /nemoclaw-blueprint\/blueprint\.yaml/.test(normalized) ||
     /nemoclaw-blueprint\/policies\//.test(normalized) ||
+    /nemoclaw-blueprint\/provider-profiles\//.test(normalized) ||
     /nemoclaw-blueprint\/router\/pool-config\.yaml/.test(normalized) ||
     /nemoclaw-blueprint\/model-specific-setup\//.test(normalized) ||
     /agents\/[^/]+\/policy-(?:additions|permissive)\.yaml/.test(normalized)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -547,7 +547,7 @@ usage() {
   printf "    NEMOCLAW_MODEL                Inference model to configure\n"
   printf "    NEMOCLAW_POLICY_MODE          suggested | custom | skip\n"
   printf "    NEMOCLAW_POLICY_PRESETS       Comma-separated policy presets\n"
-  printf "    BRAVE_API_KEY                 Enable Brave Search with this API key (stored in sandbox OpenClaw config)\n"
+  printf "    BRAVE_API_KEY                 Enable Brave Search with this API key (kept behind OpenShell provider rewrite)\n"
   printf "    NEMOCLAW_EXPERIMENTAL=1       Show experimental/local options\n"
   printf "    CHAT_UI_URL                   Chat UI URL to open after setup\n"
   printf "    DISCORD_BOT_TOKEN             Auto-enable Discord policy support\n"

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3105,6 +3105,15 @@ async function createSandbox(
 
   const braveWebSearchEnabled = braveProviderProfile.shouldEnableBraveWebSearch(webSearchConfig);
   const braveApiKey = braveWebSearchEnabled ? getCredential(webSearch.BRAVE_API_KEY_ENV) || normalizeCredentialValue(process.env[webSearch.BRAVE_API_KEY_ENV]) : null;
+  // Fail before any recreate/delete path runs: otherwise a missing key would
+  // destroy the existing sandbox first and only then surface the abort (#3626).
+  if (braveWebSearchEnabled && !braveApiKey) {
+    console.error("  Brave Search is enabled, but BRAVE_API_KEY is not available in this process.");
+    console.error(
+      "  Re-run with BRAVE_API_KEY set, or disable Brave Search before recreating the sandbox.",
+    );
+    process.exit(1);
+  }
   if (braveWebSearchEnabled) {
     messagingTokenDefs.push({ name: `${sandboxName}-brave-search`, envKey: webSearch.BRAVE_API_KEY_ENV, token: braveApiKey, providerType: braveProviderProfile.BRAVE_PROVIDER_PROFILE_ID });
   }
@@ -3535,13 +3544,6 @@ async function createSandbox(
     "openclaw-sandbox.yaml",
   );
   const basePolicyPath = (agent && agentOnboard.getAgentPolicyPath(agent)) || defaultPolicyPath;
-  if (braveWebSearchEnabled && !braveApiKey) {
-    console.error("  Brave Search is enabled, but BRAVE_API_KEY is not available in this process.");
-    console.error(
-      "  Re-run with BRAVE_API_KEY set, or disable Brave Search before recreating the sandbox.",
-    );
-    process.exit(1);
-  }
   const tokensByEnvKey = Object.fromEntries(
     messagingTokenDefs.map(({ envKey, token }) => [envKey, token]),
   );

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3103,14 +3103,10 @@ async function createSandbox(
     .filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey))
     .filter(({ envKey }) => !disabledEnvKeys.has(envKey));
 
+  // Honor process.env fallback so direct createSandbox() callers don't trip the abort.
+  const braveApiKey = webSearchConfig ? getCredential(webSearch.BRAVE_API_KEY_ENV) || normalizeCredentialValue(process.env[webSearch.BRAVE_API_KEY_ENV]) : null;
   if (webSearchConfig) {
-    // `brave` providerType wires X-Subscription-Token rewrite at egress (#3626).
-    messagingTokenDefs.push({
-      name: `${sandboxName}-brave-search`,
-      envKey: webSearch.BRAVE_API_KEY_ENV,
-      token: getCredential(webSearch.BRAVE_API_KEY_ENV),
-      providerType: braveProviderProfile.BRAVE_PROVIDER_PROFILE_ID,
-    });
+    messagingTokenDefs.push({ name: `${sandboxName}-brave-search`, envKey: webSearch.BRAVE_API_KEY_ENV, token: braveApiKey, providerType: braveProviderProfile.BRAVE_PROVIDER_PROFILE_ID });
   }
   const previousProviderCredentialHashes =
     registry.getSandbox(sandboxName)?.providerCredentialHashes ?? {};
@@ -3539,7 +3535,7 @@ async function createSandbox(
     "openclaw-sandbox.yaml",
   );
   const basePolicyPath = (agent && agentOnboard.getAgentPolicyPath(agent)) || defaultPolicyPath;
-  if (webSearchConfig && !getCredential(webSearch.BRAVE_API_KEY_ENV)) {
+  if (webSearchConfig && !braveApiKey) {
     console.error("  Brave Search is enabled, but BRAVE_API_KEY is not available in this process.");
     console.error(
       "  Re-run with BRAVE_API_KEY set, or disable Brave Search before recreating the sandbox.",

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3103,9 +3103,9 @@ async function createSandbox(
     .filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey))
     .filter(({ envKey }) => !disabledEnvKeys.has(envKey));
 
-  // Honor process.env fallback so direct createSandbox() callers don't trip the abort.
-  const braveApiKey = webSearchConfig ? getCredential(webSearch.BRAVE_API_KEY_ENV) || normalizeCredentialValue(process.env[webSearch.BRAVE_API_KEY_ENV]) : null;
-  if (webSearchConfig) {
+  const braveWebSearchEnabled = braveProviderProfile.shouldEnableBraveWebSearch(webSearchConfig);
+  const braveApiKey = braveWebSearchEnabled ? getCredential(webSearch.BRAVE_API_KEY_ENV) || normalizeCredentialValue(process.env[webSearch.BRAVE_API_KEY_ENV]) : null;
+  if (braveWebSearchEnabled) {
     messagingTokenDefs.push({ name: `${sandboxName}-brave-search`, envKey: webSearch.BRAVE_API_KEY_ENV, token: braveApiKey, providerType: braveProviderProfile.BRAVE_PROVIDER_PROFILE_ID });
   }
   const previousProviderCredentialHashes =
@@ -3535,7 +3535,7 @@ async function createSandbox(
     "openclaw-sandbox.yaml",
   );
   const basePolicyPath = (agent && agentOnboard.getAgentPolicyPath(agent)) || defaultPolicyPath;
-  if (webSearchConfig && !braveApiKey) {
+  if (braveWebSearchEnabled && !braveApiKey) {
     console.error("  Brave Search is enabled, but BRAVE_API_KEY is not available in this process.");
     console.error(
       "  Re-run with BRAVE_API_KEY set, or disable Brave Search before recreating the sandbox.",
@@ -7394,7 +7394,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       hermesToolGateways,
       stagedLegacyKeys,
       migratedLegacyKeys,
-      webSearchEnabled: Boolean(webSearchConfig?.fetchEnabled),
+      webSearchEnabled: braveProviderProfile.shouldEnableBraveWebSearch(webSearchConfig),
       deps: {
         ensureAgentDashboardForward,
         verifyWebSearchInsideSandbox,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -122,7 +122,6 @@ const runner: typeof import("./runner") = require("./runner");
 const { ROOT, SCRIPTS, redact, run, runShell, runCapture, runFile, shellQuote, validateName } =
   runner;
 const braveProviderProfile: typeof import("./onboard/brave-provider-profile") = require("./onboard/brave-provider-profile");
-const { ensureBraveProviderProfile: ensureBraveProviderProfileImpl } = braveProviderProfile;
 const nameValidation: typeof import("./name-validation") = require("./name-validation");
 const { NAME_ALLOWED_FORMAT, getNameValidationGuidance } = nameValidation;
 const docker: typeof import("./adapters/docker") = require("./adapters/docker");
@@ -837,12 +836,7 @@ function upsertProvider(
   return result;
 }
 
-type MessagingTokenDef = {
-  name: string;
-  envKey: string;
-  token: string | null;
-  providerType?: string;
-};
+type MessagingTokenDef = { name: string; envKey: string; token: string | null; providerType?: string };
 
 type EndpointValidationResult =
   | { ok: true; api: string | null; retry?: undefined }
@@ -859,7 +853,7 @@ function upsertMessagingProviders(
   tokenDefs: MessagingTokenDef[],
   options: { replaceExisting?: boolean } = {},
 ) {
-  ensureBraveProviderProfileImpl(tokenDefs, { root: ROOT, runOpenshell, redact });
+  braveProviderProfile.ensureBraveProviderProfile(tokenDefs, { root: ROOT, runOpenshell, redact });
   const upserted = onboardProviders.upsertMessagingProviders(
     tokenDefs,
     runOpenshell,
@@ -3110,11 +3104,7 @@ async function createSandbox(
     .filter(({ envKey }) => !disabledEnvKeys.has(envKey));
 
   if (webSearchConfig) {
-    // Tag the provider type as "brave" so the L7 proxy rewrites
-    // X-Subscription-Token via the registered Brave provider profile.
-    // No `replaceExistingProvider` — OpenShell rejects `provider delete` on
-    // providers still attached to a live sandbox, so reuse paths must rely
-    // on `provider update` to refresh the credential in place.
+    // `brave` providerType wires X-Subscription-Token rewrite at egress (#3626).
     messagingTokenDefs.push({
       name: `${sandboxName}-brave-search`,
       envKey: webSearch.BRAVE_API_KEY_ENV,
@@ -3616,16 +3606,10 @@ async function createSandbox(
   ];
 
   appendResourceFlagsForProfile(createArgs, resourceProfile, getOpenshellBinary(), { isNonInteractive, note, prompt, promptOrDefault });
-  // Create OpenShell providers for messaging/search credentials so they flow
-  // through the provider/placeholder system instead of raw env vars. The L7
-  // proxy rewrites provider-auth locations with real secrets at egress.
-  //
-  // `replaceExisting: true` is safe here because any prior sandbox was just
-  // deleted by the recreate path above, detaching its provider(s). For Brave
-  // this also migrates legacy `${sandbox}-brave-search` providers off the
-  // pre-fix `generic` type — `openshell provider update` cannot change the
-  // type, so delete+create is the only path that re-registers the provider
-  // under the `brave` profile that drives the X-Subscription-Token rewrite.
+  // The recreate path above just deleted the previous sandbox, so any
+  // attached providers are detached and safe to delete+create. That's
+  // required for the legacy Brave generic→brave type migration since
+  // `openshell provider update` cannot change `--type` (#3626).
   const messagingProviders = [
     ...new Set([
       ...upsertMessagingProviders(messagingTokenDefs, { replaceExisting: true }),
@@ -7417,8 +7401,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       webSearchEnabled: Boolean(webSearchConfig?.fetchEnabled),
       deps: {
         ensureAgentDashboardForward,
-        verifyWebSearchInsideSandbox: (name, agentRef) =>
-          verifyWebSearchInsideSandbox(name, agentRef),
+        verifyWebSearchInsideSandbox,
         recordPostVerifyStarted,
         recordSessionComplete,
         toSessionUpdates: (updates) => toSessionUpdates(updates as Parameters<typeof toSessionUpdates>[0]),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -121,6 +121,13 @@ const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const runner: typeof import("./runner") = require("./runner");
 const { ROOT, SCRIPTS, redact, run, runShell, runCapture, runFile, shellQuote, validateName } =
   runner;
+const BRAVE_PROVIDER_PROFILE_ID = "brave";
+const BRAVE_PROVIDER_PROFILE_PATH = path.join(
+  ROOT,
+  "nemoclaw-blueprint",
+  "provider-profiles",
+  "brave.yaml",
+);
 const nameValidation: typeof import("./name-validation") = require("./name-validation");
 const { NAME_ALLOWED_FORMAT, getNameValidationGuidance } = nameValidation;
 const docker: typeof import("./adapters/docker") = require("./adapters/docker");
@@ -835,7 +842,12 @@ function upsertProvider(
   return result;
 }
 
-type MessagingTokenDef = { name: string; envKey: string; token: string | null };
+type MessagingTokenDef = {
+  name: string;
+  envKey: string;
+  token: string | null;
+  providerType?: string;
+};
 
 type EndpointValidationResult =
   | { ok: true; api: string | null; retry?: undefined }
@@ -848,8 +860,43 @@ const verifyDirectSandboxGpu = sandboxGpuPreflight.createDirectSandboxGpuVerifie
 });
 
 
-function upsertMessagingProviders(tokenDefs: MessagingTokenDef[]) {
-  const upserted = onboardProviders.upsertMessagingProviders(tokenDefs, runOpenshell);
+function ensureBraveProviderProfile(tokenDefs: MessagingTokenDef[]): void {
+  if (
+    !tokenDefs.some(
+      ({ providerType, token }) => providerType === BRAVE_PROVIDER_PROFILE_ID && Boolean(token),
+    )
+  ) {
+    return;
+  }
+
+  const result = runOpenshell(["provider", "profile", "import", "--file", BRAVE_PROVIDER_PROFILE_PATH], {
+    ignoreError: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status === 0) return;
+
+  // Tolerate "already exists" diagnostics so re-onboard/recreate with a Brave
+  // profile already registered on the gateway keeps working.
+  const rawDiagnostic = `${result.stderr || ""} ${result.stdout || ""}`;
+  if (/already exists/i.test(rawDiagnostic)) return;
+
+  const diagnostic = compactText(redact(rawDiagnostic));
+  console.error("\n  ✗ Failed to register the Brave Search provider profile with OpenShell.");
+  if (diagnostic) console.error(`    ${diagnostic.slice(0, 500)}`);
+  console.error("    Update OpenShell with scripts/install-openshell.sh and re-run onboarding.");
+  process.exit(result.status || 1);
+}
+
+function upsertMessagingProviders(
+  tokenDefs: MessagingTokenDef[],
+  options: { replaceExisting?: boolean } = {},
+) {
+  ensureBraveProviderProfile(tokenDefs);
+  const upserted = onboardProviders.upsertMessagingProviders(
+    tokenDefs,
+    runOpenshell,
+    options,
+  );
   // upsertMessagingProviders process.exits on failure, so reaching this
   // point means every entry in tokenDefs that had a token was registered.
   // Mark migrated only when the registered token equals the staged legacy
@@ -3064,7 +3111,7 @@ async function createSandbox(
     ),
   );
 
-  const messagingTokenDefs = [
+  const messagingTokenDefs: MessagingTokenDef[] = [
     {
       name: `${sandboxName}-discord-bridge`,
       envKey: "DISCORD_BOT_TOKEN",
@@ -3095,10 +3142,16 @@ async function createSandbox(
     .filter(({ envKey }) => !disabledEnvKeys.has(envKey));
 
   if (webSearchConfig) {
+    // Tag the provider type as "brave" so the L7 proxy rewrites
+    // X-Subscription-Token via the registered Brave provider profile.
+    // No `replaceExistingProvider` — OpenShell rejects `provider delete` on
+    // providers still attached to a live sandbox, so reuse paths must rely
+    // on `provider update` to refresh the credential in place.
     messagingTokenDefs.push({
       name: `${sandboxName}-brave-search`,
       envKey: webSearch.BRAVE_API_KEY_ENV,
       token: getCredential(webSearch.BRAVE_API_KEY_ENV),
+      providerType: BRAVE_PROVIDER_PROFILE_ID,
     });
   }
   const previousProviderCredentialHashes =
@@ -3595,12 +3648,21 @@ async function createSandbox(
   ];
 
   appendResourceFlagsForProfile(createArgs, resourceProfile, getOpenshellBinary(), { isNonInteractive, note, prompt, promptOrDefault });
-  // Create OpenShell providers for messaging credentials so they flow through
-  // the provider/placeholder system instead of raw env vars. The L7 proxy
-  // rewrites Authorization headers (Bearer/Bot) and URL-path segments
-  // (/bot{TOKEN}/) with real secrets at egress (OpenShell >= 0.0.20).
+  // Create OpenShell providers for messaging/search credentials so they flow
+  // through the provider/placeholder system instead of raw env vars. The L7
+  // proxy rewrites provider-auth locations with real secrets at egress.
+  //
+  // `replaceExisting: true` is safe here because any prior sandbox was just
+  // deleted by the recreate path above, detaching its provider(s). For Brave
+  // this also migrates legacy `${sandbox}-brave-search` providers off the
+  // pre-fix `generic` type — `openshell provider update` cannot change the
+  // type, so delete+create is the only path that re-registers the provider
+  // under the `brave` profile that drives the X-Subscription-Token rewrite.
   const messagingProviders = [
-    ...new Set([...upsertMessagingProviders(messagingTokenDefs), ...reusableMessagingProviders]),
+    ...new Set([
+      ...upsertMessagingProviders(messagingTokenDefs, { replaceExisting: true }),
+      ...reusableMessagingProviders,
+    ]),
   ];
   for (const p of messagingProviders) {
     createArgs.push("--provider", p);
@@ -3792,13 +3854,6 @@ async function createSandbox(
     // Runtime-only: do not bake the per-sandbox broker token into image layers.
     envArgs.push(formatEnvAssignment("TOOL_GATEWAY_USER_TOKEN", hermesToolBrokerToken));
   }
-  if (webSearchConfig?.fetchEnabled) {
-    const braveKey =
-      getCredential(webSearch.BRAVE_API_KEY_ENV) || process.env[webSearch.BRAVE_API_KEY_ENV];
-    if (braveKey) {
-      envArgs.push(formatEnvAssignment(webSearch.BRAVE_API_KEY_ENV, braveKey));
-    }
-  }
   const sandboxReadyTimeoutSecs = getSandboxReadyTimeoutSecs(effectiveSandboxGpuConfig);
   const sandboxEnv = buildSubprocessEnv();
   // Remove host-infrastructure credentials that the generic allowlist
@@ -3975,15 +4030,6 @@ async function createSandbox(
       );
       throw error;
     }
-  }
-
-  // Verify web search config was actually accepted by the agent runtime.
-  // Hermes silently ignores unknown web.backend values (e.g. "brave" before
-  // upstream support lands), so we exec into the sandbox and check for a
-  // recognizable signal. OpenClaw validates at config-generation time, but
-  // this probe catches drift for all agents.
-  if (webSearchConfig?.fetchEnabled) {
-    verifyWebSearchInsideSandbox(sandboxName, agent);
   }
 
   // Release any stale forward on the dashboard port before claiming it for the new sandbox.
@@ -7400,8 +7446,11 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
       hermesToolGateways,
       stagedLegacyKeys,
       migratedLegacyKeys,
+      webSearchEnabled: Boolean(webSearchConfig?.fetchEnabled),
       deps: {
         ensureAgentDashboardForward,
+        verifyWebSearchInsideSandbox: (name, agentRef) =>
+          verifyWebSearchInsideSandbox(name, agentRef),
         recordPostVerifyStarted,
         recordSessionComplete,
         toSessionUpdates: (updates) => toSessionUpdates(updates as Parameters<typeof toSessionUpdates>[0]),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -121,13 +121,8 @@ const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const runner: typeof import("./runner") = require("./runner");
 const { ROOT, SCRIPTS, redact, run, runShell, runCapture, runFile, shellQuote, validateName } =
   runner;
-const BRAVE_PROVIDER_PROFILE_ID = "brave";
-const BRAVE_PROVIDER_PROFILE_PATH = path.join(
-  ROOT,
-  "nemoclaw-blueprint",
-  "provider-profiles",
-  "brave.yaml",
-);
+const braveProviderProfile: typeof import("./onboard/brave-provider-profile") = require("./onboard/brave-provider-profile");
+const { ensureBraveProviderProfile: ensureBraveProviderProfileImpl } = braveProviderProfile;
 const nameValidation: typeof import("./name-validation") = require("./name-validation");
 const { NAME_ALLOWED_FORMAT, getNameValidationGuidance } = nameValidation;
 const docker: typeof import("./adapters/docker") = require("./adapters/docker");
@@ -860,38 +855,11 @@ const verifyDirectSandboxGpu = sandboxGpuPreflight.createDirectSandboxGpuVerifie
 });
 
 
-function ensureBraveProviderProfile(tokenDefs: MessagingTokenDef[]): void {
-  if (
-    !tokenDefs.some(
-      ({ providerType, token }) => providerType === BRAVE_PROVIDER_PROFILE_ID && Boolean(token),
-    )
-  ) {
-    return;
-  }
-
-  const result = runOpenshell(["provider", "profile", "import", "--file", BRAVE_PROVIDER_PROFILE_PATH], {
-    ignoreError: true,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.status === 0) return;
-
-  // Tolerate "already exists" diagnostics so re-onboard/recreate with a Brave
-  // profile already registered on the gateway keeps working.
-  const rawDiagnostic = `${result.stderr || ""} ${result.stdout || ""}`;
-  if (/already exists/i.test(rawDiagnostic)) return;
-
-  const diagnostic = compactText(redact(rawDiagnostic));
-  console.error("\n  ✗ Failed to register the Brave Search provider profile with OpenShell.");
-  if (diagnostic) console.error(`    ${diagnostic.slice(0, 500)}`);
-  console.error("    Update OpenShell with scripts/install-openshell.sh and re-run onboarding.");
-  process.exit(result.status || 1);
-}
-
 function upsertMessagingProviders(
   tokenDefs: MessagingTokenDef[],
   options: { replaceExisting?: boolean } = {},
 ) {
-  ensureBraveProviderProfile(tokenDefs);
+  ensureBraveProviderProfileImpl(tokenDefs, { root: ROOT, runOpenshell, redact });
   const upserted = onboardProviders.upsertMessagingProviders(
     tokenDefs,
     runOpenshell,
@@ -3151,7 +3119,7 @@ async function createSandbox(
       name: `${sandboxName}-brave-search`,
       envKey: webSearch.BRAVE_API_KEY_ENV,
       token: getCredential(webSearch.BRAVE_API_KEY_ENV),
-      providerType: BRAVE_PROVIDER_PROFILE_ID,
+      providerType: braveProviderProfile.BRAVE_PROVIDER_PROFILE_ID,
     });
   }
   const previousProviderCredentialHashes =

--- a/src/lib/onboard/brave-provider-profile.test.ts
+++ b/src/lib/onboard/brave-provider-profile.test.ts
@@ -7,6 +7,7 @@ import {
   BRAVE_PROVIDER_PROFILE_ID,
   braveProviderProfilePath,
   ensureBraveProviderProfile,
+  shouldEnableBraveWebSearch,
 } from "./brave-provider-profile";
 
 function makeDeps(
@@ -86,5 +87,26 @@ describe("ensureBraveProviderProfile", () => {
       ),
     ).toThrow(/exit:2/);
     expect(deps.exit).toHaveBeenCalledWith(2);
+  });
+});
+
+describe("shouldEnableBraveWebSearch", () => {
+  it("returns false for null/undefined web search config", () => {
+    expect(shouldEnableBraveWebSearch(null)).toBe(false);
+    expect(shouldEnableBraveWebSearch(undefined)).toBe(false);
+  });
+
+  it("returns false when fetchEnabled is missing or falsy", () => {
+    // Regression for #3626: a `{ fetchEnabled: false }` config previously
+    // tripped `if (webSearchConfig)` in createSandbox and pushed a Brave
+    // provider/token plus the BRAVE_API_KEY abort even though the runtime
+    // gate downstream is `fetchEnabled`.
+    expect(shouldEnableBraveWebSearch({})).toBe(false);
+    expect(shouldEnableBraveWebSearch({ fetchEnabled: false })).toBe(false);
+    expect(shouldEnableBraveWebSearch({ fetchEnabled: null })).toBe(false);
+  });
+
+  it("returns true only when fetchEnabled is explicitly true", () => {
+    expect(shouldEnableBraveWebSearch({ fetchEnabled: true })).toBe(true);
   });
 });

--- a/src/lib/onboard/brave-provider-profile.test.ts
+++ b/src/lib/onboard/brave-provider-profile.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  BRAVE_PROVIDER_PROFILE_ID,
+  braveProviderProfilePath,
+  ensureBraveProviderProfile,
+} from "./brave-provider-profile";
+
+function makeDeps(
+  runOpenshell: ReturnType<typeof vi.fn>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    root: "/repo",
+    runOpenshell,
+    redact: (s: string) => s,
+    log: vi.fn(),
+    exit: vi.fn((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }),
+    ...overrides,
+  } as Parameters<typeof ensureBraveProviderProfile>[1];
+}
+
+describe("ensureBraveProviderProfile", () => {
+  it("does nothing when no token def is brave-typed", () => {
+    const runOpenshell = vi.fn();
+    ensureBraveProviderProfile(
+      [{ providerType: "generic", token: "tok" }],
+      makeDeps(runOpenshell),
+    );
+    expect(runOpenshell).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the brave token def has no token", () => {
+    const runOpenshell = vi.fn();
+    ensureBraveProviderProfile(
+      [{ providerType: BRAVE_PROVIDER_PROFILE_ID, token: null }],
+      makeDeps(runOpenshell),
+    );
+    expect(runOpenshell).not.toHaveBeenCalled();
+  });
+
+  it("imports the Brave profile from the blueprint path on first run", () => {
+    const runOpenshell = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
+    ensureBraveProviderProfile(
+      [{ providerType: BRAVE_PROVIDER_PROFILE_ID, token: "brv-test" }],
+      makeDeps(runOpenshell),
+    );
+    expect(runOpenshell).toHaveBeenCalledWith(
+      ["provider", "profile", "import", "--file", braveProviderProfilePath("/repo")],
+      expect.objectContaining({ ignoreError: true }),
+    );
+  });
+
+  it("treats an existing-profile diagnostic as success on re-onboard", () => {
+    const runOpenshell = vi.fn(() => ({
+      status: 1,
+      stderr: "custom provider profile 'brave' already exists",
+      stdout: "",
+    }));
+    const deps = makeDeps(runOpenshell);
+    expect(() =>
+      ensureBraveProviderProfile(
+        [{ providerType: BRAVE_PROVIDER_PROFILE_ID, token: "brv-test" }],
+        deps,
+      ),
+    ).not.toThrow();
+    expect(deps.exit).not.toHaveBeenCalled();
+  });
+
+  it("exits with the OpenShell status when import fails for a non-idempotent reason", () => {
+    const runOpenshell = vi.fn(() => ({
+      status: 2,
+      stderr: "schema validation error: missing endpoints",
+      stdout: "",
+    }));
+    const deps = makeDeps(runOpenshell);
+    expect(() =>
+      ensureBraveProviderProfile(
+        [{ providerType: BRAVE_PROVIDER_PROFILE_ID, token: "brv-test" }],
+        deps,
+      ),
+    ).toThrow(/exit:2/);
+    expect(deps.exit).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/lib/onboard/brave-provider-profile.ts
+++ b/src/lib/onboard/brave-provider-profile.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+import { compactText } from "../core/url-utils";
+
+export const BRAVE_PROVIDER_PROFILE_ID = "brave";
+
+export type BraveProviderProfileDeps = {
+  root: string;
+  runOpenshell: (
+    args: string[],
+    // The runner accepts a wider options shape; we only set ignoreError +
+    // stdio here, so erase the type at the boundary to keep this module
+    // free of the runner.ts internals.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    opts: any,
+  ) => { status: number | null; stderr?: string | Buffer | null; stdout?: string | Buffer | null };
+  redact: (input: string) => string;
+  log?: (message?: string) => void;
+  exit?: (code?: number) => never;
+};
+
+type TokenDefShape = { providerType?: string; token: string | null };
+
+function bufferOrStringToText(value: string | Buffer | null | undefined): string {
+  if (typeof value === "string") return value;
+  if (value && typeof (value as Buffer).toString === "function") return (value as Buffer).toString();
+  return "";
+}
+
+export function braveProviderProfilePath(root: string): string {
+  return path.join(root, "nemoclaw-blueprint", "provider-profiles", "brave.yaml");
+}
+
+/**
+ * Register the Brave Search provider profile with OpenShell so providers
+ * created with `--type brave` drive the L7 proxy's X-Subscription-Token
+ * rewrite. Skipped unless at least one token definition is Brave-typed and
+ * has a usable token. Idempotent: tolerates OpenShell reporting that the
+ * custom profile is already registered.
+ */
+export function ensureBraveProviderProfile(
+  tokenDefs: readonly TokenDefShape[],
+  deps: BraveProviderProfileDeps,
+): void {
+  const needs = tokenDefs.some(
+    ({ providerType, token }) => providerType === BRAVE_PROVIDER_PROFILE_ID && Boolean(token),
+  );
+  if (!needs) return;
+
+  const errorLog = deps.log ?? console.error;
+  const exit = deps.exit ?? ((code?: number) => process.exit(code));
+
+  const result = deps.runOpenshell(
+    ["provider", "profile", "import", "--file", braveProviderProfilePath(deps.root)],
+    { ignoreError: true, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.status === 0) return;
+
+  // OpenShell reports re-imports of an already-registered custom profile as
+  // a non-zero exit. Tolerate that so re-onboard / recreate keeps working.
+  const rawDiagnostic = `${bufferOrStringToText(result.stderr)} ${bufferOrStringToText(result.stdout)}`;
+  if (/already exists/i.test(rawDiagnostic)) return;
+
+  const diagnostic = compactText(deps.redact(rawDiagnostic));
+  errorLog("\n  ✗ Failed to register the Brave Search provider profile with OpenShell.");
+  if (diagnostic) errorLog(`    ${diagnostic.slice(0, 500)}`);
+  errorLog("    Update OpenShell with scripts/install-openshell.sh and re-run onboarding.");
+  exit(result.status || 1);
+}

--- a/src/lib/onboard/brave-provider-profile.ts
+++ b/src/lib/onboard/brave-provider-profile.ts
@@ -7,6 +7,20 @@ import { compactText } from "../core/url-utils";
 
 export const BRAVE_PROVIDER_PROFILE_ID = "brave";
 
+/**
+ * Single source of truth for "the user opted in to Brave Search at runtime."
+ * Returning true on a config whose `fetchEnabled` is false would cause
+ * `createSandbox` to push a Brave provider/token and trip the BRAVE_API_KEY-
+ * required abort even when the feature is off, while the downstream
+ * finalization/verifier paths already gate on `fetchEnabled`. Keep every gate
+ * routed through this helper so they stay aligned.
+ */
+export function shouldEnableBraveWebSearch(
+  webSearchConfig: { fetchEnabled?: boolean | null } | null | undefined,
+): boolean {
+  return Boolean(webSearchConfig?.fetchEnabled);
+}
+
 export type BraveProviderProfileDeps = {
   root: string;
   runOpenshell: (

--- a/src/lib/onboard/machine/handlers/finalization.test.ts
+++ b/src/lib/onboard/machine/handlers/finalization.test.ts
@@ -22,6 +22,7 @@ function createDeps(overrides: Partial<FinalizationStateOptions<Agent, VerifyCha
     buildChain: vi.fn(() => ({ port: 18789 })),
     verify: vi.fn(async () => ({ ok: true })),
     diagnostics: vi.fn(() => ["  ✓ verified"]),
+    verifyWebSearch: vi.fn(),
     dashboard: vi.fn(),
     error: vi.fn(),
     log: vi.fn(),
@@ -40,6 +41,7 @@ function createDeps(overrides: Partial<FinalizationStateOptions<Agent, VerifyCha
       buildVerifyChain: calls.buildChain,
       verifyDeployment: calls.verify,
       formatVerificationDiagnostics: calls.diagnostics,
+      verifyWebSearchInsideSandbox: calls.verifyWebSearch,
       printDashboard: calls.dashboard,
       error: calls.error,
       log: calls.log,
@@ -61,6 +63,7 @@ function baseOptions(
     hermesToolGateways: [],
     stagedLegacyKeys: [],
     migratedLegacyKeys: new Set(),
+    webSearchEnabled: false,
     deps,
   };
 }
@@ -141,5 +144,27 @@ describe("handleFinalizationState", () => {
     expect(calls.removeLegacy).not.toHaveBeenCalled();
     expect(calls.error).toHaveBeenCalledWith(expect.stringContaining("SLACK_BOT_TOKEN"));
     expect(result.unmigratedLegacyKeys).toEqual(["SLACK_BOT_TOKEN"]);
+  });
+
+  it("runs web-search verification only when webSearchEnabled is true", async () => {
+    const { deps: depsOff, calls: callsOff } = createDeps();
+    await handleFinalizationState(baseOptions(depsOff));
+    expect(callsOff.verifyWebSearch).not.toHaveBeenCalled();
+
+    const { deps: depsOn, calls: callsOn } = createDeps();
+    const agent = { name: "openclaw" };
+    await handleFinalizationState({
+      ...baseOptions(depsOn),
+      agent,
+      webSearchEnabled: true,
+    });
+    expect(callsOn.verifyWebSearch).toHaveBeenCalledWith("my-assistant", agent);
+    // Probe runs after sandbox-process recovery so the post-policy state is live.
+    expect(callsOn.verifyWebSearch.mock.invocationCallOrder[0]).toBeGreaterThan(
+      callsOn.recoverProcesses.mock.invocationCallOrder[0],
+    );
+    expect(callsOn.verifyWebSearch.mock.invocationCallOrder[0]).toBeLessThan(
+      callsOn.verify.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/src/lib/onboard/machine/handlers/finalization.ts
+++ b/src/lib/onboard/machine/handlers/finalization.ts
@@ -13,6 +13,7 @@ export interface FinalizationStateOptions<Agent, VerifyChain, VerificationResult
   hermesToolGateways: string[];
   stagedLegacyKeys: readonly string[];
   migratedLegacyKeys: ReadonlySet<string>;
+  webSearchEnabled: boolean;
   deps: {
     ensureAgentDashboardForward(sandboxName: string, agent: NonNullable<Agent>): number;
     recordPostVerifyStarted(): Promise<Session>;
@@ -25,6 +26,13 @@ export interface FinalizationStateOptions<Agent, VerifyChain, VerificationResult
     buildVerifyChain(chatUiUrl: string): VerifyChain;
     verifyDeployment(sandboxName: string, chain: VerifyChain): Promise<VerificationResult>;
     formatVerificationDiagnostics(result: VerificationResult): string[];
+    /**
+     * Best-effort probe that confirms the agent runtime actually accepted the
+     * web-search config and (for Brave) that the L7 proxy rewrites the
+     * `X-Subscription-Token` header at egress. Called after the post-policy
+     * sandbox-process recovery so the final policy/gateway state is live.
+     */
+    verifyWebSearchInsideSandbox(sandboxName: string, agent: Agent): void;
     printDashboard(
       sandboxName: string,
       model: string,
@@ -53,6 +61,7 @@ export async function handleFinalizationState<Agent, VerifyChain, VerificationRe
   hermesToolGateways,
   stagedLegacyKeys,
   migratedLegacyKeys,
+  webSearchEnabled,
   deps,
 }: FinalizationStateOptions<Agent, VerifyChain, VerificationResult>): Promise<FinalizationStateResult> {
   if (agent) deps.ensureAgentDashboardForward(sandboxName, agent as NonNullable<Agent>);
@@ -75,6 +84,13 @@ export async function handleFinalizationState<Agent, VerifyChain, VerificationRe
   deps.cleanupStaleHostFiles();
   // Policy application can restart the sandbox; recover OpenClaw before verification (#3573).
   deps.checkAndRecoverSandboxProcesses(sandboxName, { quiet: true });
+
+  // Probe Brave Search egress through the L7 proxy now that the final
+  // policy and provider state are live — earlier probes would race the
+  // not-yet-applied `brave` preset (#3626). Best-effort; never blocks.
+  if (webSearchEnabled) {
+    deps.verifyWebSearchInsideSandbox(sandboxName, agent);
+  }
 
   await deps.recordPostVerifyStarted();
 

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -7,7 +7,7 @@ type RunResult = { status: number; stdout?: string; stderr?: string };
 type RunOptions = { env?: Record<string, string | undefined> };
 type RunOpenshell = (command: string[], opts?: RunOptions) => RunResult;
 
-const { buildProviderArgs, providerExistsInGateway, upsertProvider } = require(
+const { buildProviderArgs, providerExistsInGateway, upsertProvider, upsertMessagingProviders } = require(
   "../../../dist/lib/onboard/providers",
 ) as {
   buildProviderArgs: (
@@ -25,7 +25,18 @@ const { buildProviderArgs, providerExistsInGateway, upsertProvider } = require(
     baseUrl: string | null,
     env: Record<string, string | undefined>,
     runOpenshell: RunOpenshell,
+    options?: { replaceExisting?: boolean },
   ) => { ok: boolean; status?: number; message?: string };
+  upsertMessagingProviders: (
+    tokenDefs: Array<{
+      name: string;
+      envKey: string;
+      token: string | null;
+      providerType?: string;
+    }>,
+    runOpenshell: RunOpenshell,
+    options?: { replaceExisting?: boolean },
+  ) => string[];
 };
 
 describe("onboard provider helpers", () => {
@@ -164,5 +175,85 @@ describe("onboard provider helpers", () => {
     });
 
     expect(result).toEqual({ ok: false, status: 1, message: "gateway unreachable" });
+  });
+
+  it("creates Brave Search providers with the Brave provider profile", () => {
+    const commands: string[] = [];
+    const providers = upsertMessagingProviders(
+      [
+        {
+          name: "alpha-brave-search",
+          envKey: "BRAVE_API_KEY",
+          token: "brv-test",
+          providerType: "brave",
+        },
+      ],
+      (command) => {
+        commands.push(command.join(" "));
+        if (command.includes("get")) return { status: 1, stdout: "", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    );
+
+    expect(providers).toEqual(["alpha-brave-search"]);
+    expect(commands).toContain("provider get alpha-brave-search");
+    expect(commands).toContain(
+      "provider create --name alpha-brave-search --type brave --credential BRAVE_API_KEY",
+    );
+  });
+
+  it("updates an existing Brave Search provider in place on reuse paths", () => {
+    const commands: string[] = [];
+    const providers = upsertMessagingProviders(
+      [
+        {
+          name: "alpha-brave-search",
+          envKey: "BRAVE_API_KEY",
+          token: "brv-test",
+          providerType: "brave",
+        },
+      ],
+      (command) => {
+        commands.push(command.join(" "));
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    );
+
+    // No `provider delete` — OpenShell rejects deleting providers that are
+    // still attached to a live sandbox, so reuse paths must use `update`.
+    expect(providers).toEqual(["alpha-brave-search"]);
+    expect(commands).toEqual([
+      "provider get alpha-brave-search",
+      "provider update alpha-brave-search --credential BRAVE_API_KEY",
+    ]);
+  });
+
+  it("replaces existing providers when the caller opts in (post-sandbox-delete path)", () => {
+    const commands: string[] = [];
+    // replaceExisting: true is only safe after the sandbox holding the
+    // provider has been deleted. Used to migrate legacy generic-typed
+    // Brave providers to the brave profile on `--recreate-sandbox`.
+    const providers = upsertMessagingProviders(
+      [
+        {
+          name: "alpha-brave-search",
+          envKey: "BRAVE_API_KEY",
+          token: "brv-test",
+          providerType: "brave",
+        },
+      ],
+      (command) => {
+        commands.push(command.join(" "));
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      { replaceExisting: true },
+    );
+
+    expect(providers).toEqual(["alpha-brave-search"]);
+    expect(commands).toEqual([
+      "provider get alpha-brave-search",
+      "provider delete alpha-brave-search",
+      "provider create --name alpha-brave-search --type brave --credential BRAVE_API_KEY",
+    ]);
   });
 });

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -271,18 +271,38 @@ function providerExistsInGateway(name, _runOpenshell) {
  * Create or update an OpenShell provider in the gateway.
  *
  * Checks whether the provider already exists via `openshell provider get`;
- * uses `create` for new providers and `update` for existing ones.
+ * uses `create` for new providers and `update` for existing ones. When
+ * `options.replaceExisting` is true an existing provider is deleted and
+ * recreated instead of updated — required for provider-type changes that
+ * `provider update` cannot apply (e.g. the Brave Search migration from the
+ * legacy `generic` type to the `brave` profile). The caller must guarantee
+ * the provider is detached from any live sandbox before opting in: OpenShell
+ * rejects `provider delete` on attached providers.
  * @param {string} name - Provider name (e.g. "discord-bridge", "inference").
- * @param {string} type - Provider type ("openai", "anthropic", "generic").
+ * @param {string} type - Provider type ("openai", "anthropic", "generic", "brave").
  * @param {string} credentialEnv - Environment variable name for the credential.
  * @param {string|null} baseUrl - Optional base URL for the provider endpoint.
  * @param {Record<string, string>} env - Environment variables for the openshell command.
  * @param {Function} _runOpenshell - Injected runOpenshell from onboard.ts.
+ * @param {{replaceExisting?: boolean}} options - Optional replacement controls.
  * @returns {{ ok: boolean, status?: number, message?: string }}
  */
-function upsertProvider(name, type, credentialEnv, baseUrl, env, _runOpenshell) {
+function upsertProvider(name, type, credentialEnv, baseUrl, env, _runOpenshell, options = {}) {
   const exists = providerExistsInGateway(name, _runOpenshell);
-  const action = exists ? "update" : "create";
+  if (exists && options.replaceExisting) {
+    const deleteResult = _runOpenshell(["provider", "delete", name], {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (deleteResult.status !== 0) {
+      const output =
+        compactText(redact(`${deleteResult.stderr || ""}`)) ||
+        compactText(redact(`${deleteResult.stdout || ""}`)) ||
+        `Failed to replace provider '${name}'.`;
+      return { ok: false, status: deleteResult.status || 1, message: output };
+    }
+  }
+  const action = exists && !options.replaceExisting ? "update" : "create";
   const args = buildProviderArgs(action, name, type, credentialEnv, baseUrl);
   const runOpts = { ignoreError: true, env, stdio: ["ignore", "pipe", "pipe"] };
   const result = _runOpenshell(args, runOpts);
@@ -300,15 +320,29 @@ function upsertProvider(name, type, credentialEnv, baseUrl, env, _runOpenshell) 
  * Upsert all messaging providers that have tokens configured.
  * Returns the list of provider names that were successfully created/updated.
  * Exits the process if any upsert fails.
- * @param {Array<{name: string, envKey: string, token: string|null}>} tokenDefs
+ *
+ * Pass `options.replaceExisting` true only when every entry is guaranteed
+ * detached from any live sandbox (post-sandbox-delete on the recreate path);
+ * reuse paths must omit it because `provider delete` fails for attached
+ * providers.
+ * @param {Array<{name: string, envKey: string, token: string|null, providerType?: string}>} tokenDefs
  * @param {Function} _runOpenshell - Injected runOpenshell from onboard.ts.
+ * @param {{replaceExisting?: boolean}} options - Forwarded to every upsertProvider call.
  * @returns {string[]} Provider names that were upserted.
  */
-function upsertMessagingProviders(tokenDefs, _runOpenshell) {
+function upsertMessagingProviders(tokenDefs, _runOpenshell, options = {}) {
   const upserted = [];
-  for (const { name, envKey, token } of tokenDefs) {
+  for (const { name, envKey, token, providerType } of tokenDefs) {
     if (!token) continue;
-    const result = upsertProvider(name, "generic", envKey, null, { [envKey]: token }, _runOpenshell);
+    const result = upsertProvider(
+      name,
+      providerType || "generic",
+      envKey,
+      null,
+      { [envKey]: token },
+      _runOpenshell,
+      { replaceExisting: Boolean(options.replaceExisting) },
+    );
     if (!result.ok) {
       console.error(`\n  ✗ Failed to create messaging provider '${name}': ${result.message}`);
       process.exit(1);

--- a/src/lib/onboard/web-search-verify.test.ts
+++ b/src/lib/onboard/web-search-verify.test.ts
@@ -96,6 +96,30 @@ describe("verifyWebSearchInsideSandbox", () => {
     );
   });
 
+  it("refuses to probe when the apiKey is a literal secret rather than a placeholder", () => {
+    const d = deps([
+      JSON.stringify({
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "brave",
+              apiKey: "BSA-real-looking-secret-do-not-interpolate",
+            },
+          },
+        },
+      }),
+    ]);
+
+    verifyWebSearchInsideSandbox("alpha", { name: "openclaw" }, d);
+
+    // Only the openclaw.json read happens — no curl probe with the raw key.
+    expect(d.runCaptureOpenshell).toHaveBeenCalledTimes(1);
+    expect(d.warn).toHaveBeenCalledWith(
+      "  ⚠ Brave Search apiKey in openclaw.json is not an OpenShell placeholder; skipping egress probe.",
+    );
+  });
+
   it("warns when OpenClaw config is malformed or disabled", () => {
     const malformed = deps("not-json");
     verifyWebSearchInsideSandbox("alpha", { name: "openclaw" }, malformed);

--- a/src/lib/onboard/web-search-verify.test.ts
+++ b/src/lib/onboard/web-search-verify.test.ts
@@ -5,9 +5,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import { verifyWebSearchInsideSandbox, type WebSearchVerifyDeps } from "./web-search-verify";
 
-function deps(output: string | null) {
+function deps(output: string | null | Array<string | null>) {
+  const outputs = Array.isArray(output) ? [...output] : [output];
   return {
-    runCaptureOpenshell: vi.fn(() => output),
+    runCaptureOpenshell: vi.fn<WebSearchVerifyDeps["runCaptureOpenshell"]>(
+      () => outputs.shift() ?? null,
+    ),
     cliName: vi.fn(() => "nemoclaw"),
     log: vi.fn(),
     warn: vi.fn(),
@@ -35,12 +38,62 @@ describe("verifyWebSearchInsideSandbox", () => {
     expect(d.warn).toHaveBeenCalledWith("    Check: nemoclaw alpha exec hermes dump");
   });
 
-  it("reports active OpenClaw web search config", () => {
-    const d = deps(JSON.stringify({ tools: { web: { search: { enabled: true } } } }));
+  it("verifies OpenClaw Brave Search egress through the subscription-token header", () => {
+    const d = deps([
+      JSON.stringify({
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "brave",
+              apiKey: "openshell:resolve:env:BRAVE_API_KEY",
+            },
+          },
+        },
+      }),
+      JSON.stringify({ web: { results: [{ title: "NVIDIA" }] } }) + "\nHTTP_STATUS:200\n",
+    ]);
 
     verifyWebSearchInsideSandbox("alpha", { name: "openclaw" }, d);
 
-    expect(d.log).toHaveBeenCalledWith("  ✓ Web search is active inside sandbox");
+    expect(d.runCaptureOpenshell).toHaveBeenCalledTimes(2);
+    expect(d.runCaptureOpenshell.mock.calls[1][0]).toEqual([
+      "sandbox",
+      "exec",
+      "-n",
+      "alpha",
+      "--",
+      "sh",
+      "-lc",
+      expect.stringContaining("X-Subscription-Token: openshell:resolve:env:BRAVE_API_KEY"),
+    ]);
+    expect(d.log).toHaveBeenCalledWith("  ✓ Brave Search egress verified inside sandbox");
+  });
+
+  it("warns when OpenClaw Brave Search egress rejects the placeholder", () => {
+    const d = deps([
+      JSON.stringify({
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "brave",
+              apiKey: "openshell:resolve:env:BRAVE_API_KEY",
+            },
+          },
+        },
+      }),
+      '{"message":"Unauthorized"}\nHTTP_STATUS:401\n',
+    ]);
+
+    verifyWebSearchInsideSandbox("alpha", { name: "openclaw" }, d);
+
+    expect(d.warn).toHaveBeenCalledWith(
+      "  ⚠ Brave Search config exists, but egress verification returned HTTP 401.",
+    );
+    expect(d.warn).toHaveBeenCalledWith(
+      "    Re-run onboarding with --recreate-sandbox to migrate the Brave provider to the new profile.",
+    );
   });
 
   it("warns when OpenClaw config is malformed or disabled", () => {

--- a/src/lib/onboard/web-search-verify.ts
+++ b/src/lib/onboard/web-search-verify.ts
@@ -117,6 +117,16 @@ export function verifyWebSearchInsideSandbox(
           warn("  ⚠ Brave Search is enabled but openclaw.json has no API key placeholder.");
           return;
         }
+        // Refuse to interpolate raw secrets into the curl argv. The probe
+        // only proves the L7 proxy rewrites a placeholder, so a literal key
+        // would expose itself in host/sandbox process listings without
+        // testing the thing we care about.
+        if (!/^openshell:resolve:env:[A-Za-z0-9_]+$/.test(search.apiKey.trim())) {
+          warn(
+            "  ⚠ Brave Search apiKey in openclaw.json is not an OpenShell placeholder; skipping egress probe.",
+          );
+          return;
+        }
         const probe = deps.runCaptureOpenshell(
           [
             "sandbox",

--- a/src/lib/onboard/web-search-verify.ts
+++ b/src/lib/onboard/web-search-verify.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { shellQuote } from "../core/shell-quote";
+
 export type WebSearchVerifyAgent = {
   name?: string | null;
 } | null | undefined;
@@ -11,6 +13,37 @@ export type WebSearchVerifyDeps = {
   log?: (message?: string) => void;
   warn?: (message?: string) => void;
 };
+
+function buildBraveEgressProbeCommand(apiKey: string): string {
+  return [
+    "curl",
+    "-sS",
+    "--compressed",
+    "--max-time",
+    "20",
+    "-G",
+    "https://api.search.brave.com/res/v1/web/search",
+    "--data-urlencode",
+    "q=NVIDIA",
+    "--data-urlencode",
+    "count=1",
+    "-H",
+    `X-Subscription-Token: ${apiKey}`,
+    "-w",
+    "\nHTTP_STATUS:%{http_code}\n",
+  ]
+    .map(shellQuote)
+    .join(" ");
+}
+
+function hasBraveResult(body: string): boolean {
+  try {
+    const parsed = JSON.parse(body);
+    return Array.isArray(parsed?.web?.results) && parsed.web.results.length > 0;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Post-creation probe: verify web search is actually functional inside the
@@ -59,7 +92,8 @@ export function verifyWebSearchInsideSandbox(
         log("  ✓ Web search is active inside sandbox");
       }
     } else if (agentName === "openclaw") {
-      // OpenClaw: verify tools.web.search block exists in the baked config.
+      // OpenClaw: verify tools.web.search block exists, then prove the
+      // placeholder works at egress through Brave's X-Subscription-Token header.
       const configCheck = deps.runCaptureOpenshell(
         ["sandbox", "exec", "-n", sandboxName, "--", "cat", "/sandbox/.openclaw/openclaw.json"],
         { ignoreError: true, timeout: 10_000 },
@@ -70,10 +104,53 @@ export function verifyWebSearchInsideSandbox(
       }
       try {
         const parsed = JSON.parse(configCheck);
-        if (parsed?.tools?.web?.search?.enabled) {
-          log("  ✓ Web search is active inside sandbox");
-        } else {
+        const search = parsed?.tools?.web?.search;
+        if (!search?.enabled) {
           warn("  ⚠ Web search was configured but tools.web.search is not enabled in openclaw.json.");
+          return;
+        }
+        if (search.provider !== "brave") {
+          log("  ✓ Web search is active inside sandbox");
+          return;
+        }
+        if (typeof search.apiKey !== "string" || search.apiKey.trim() === "") {
+          warn("  ⚠ Brave Search is enabled but openclaw.json has no API key placeholder.");
+          return;
+        }
+        const probe = deps.runCaptureOpenshell(
+          [
+            "sandbox",
+            "exec",
+            "-n",
+            sandboxName,
+            "--",
+            "sh",
+            "-lc",
+            buildBraveEgressProbeCommand(search.apiKey),
+          ],
+          { ignoreError: true, timeout: 30_000 },
+        );
+        if (!probe) {
+          warn("  ⚠ Brave Search config exists, but the egress verification request failed.");
+          return;
+        }
+        const statusMatch = probe.match(/(?:^|\n)HTTP_STATUS:(\d{3})(?:\n|$)/);
+        const status = statusMatch?.[1] || "unknown";
+        const body = probe.replace(/(?:^|\n)HTTP_STATUS:\d{3}\s*$/m, "").trim();
+        if (status === "200" && hasBraveResult(body)) {
+          log("  ✓ Brave Search egress verified inside sandbox");
+        } else {
+          warn(`  ⚠ Brave Search config exists, but egress verification returned HTTP ${status}.`);
+          if (status === "401" || status === "403") {
+            // A 401/403 with the placeholder in the request typically means
+            // the L7 proxy did not rewrite X-Subscription-Token. The most
+            // common cause is a legacy `${sandbox}-brave-search` provider
+            // still registered with the pre-fix `generic` type — `provider
+            // update` cannot change the type, so a recreate is required.
+            warn(
+              `    Re-run onboarding with --recreate-sandbox to migrate the Brave provider to the new profile.`,
+            );
+          }
         }
       } catch {
         warn("  ⚠ Could not parse openclaw.json to verify web search config.");

--- a/test/e2e/test-brave-search-e2e.sh
+++ b/test/e2e/test-brave-search-e2e.sh
@@ -255,9 +255,13 @@ check_no_real_key_in_sandbox() {
   config_dump=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc \
     'cat /sandbox/.openclaw/openclaw.json 2>/dev/null || true' 2>&1) || true
 
+  # Accept both the canonical placeholder and any revision-scoped form
+  # OpenShell may emit (e.g. `openshell:resolve:env:v11_BRAVE_API_KEY`).
+  local placeholder_pattern='openshell:resolve:env:([A-Za-z0-9_]+_)?BRAVE_API_KEY'
+
   if [ -n "${BRAVE_API_KEY:-}" ] && printf '%s' "$config_dump" | grep -qF "$BRAVE_API_KEY"; then
     fail "B3a: SECURITY — real BRAVE_API_KEY found verbatim in /sandbox/.openclaw/openclaw.json"
-  elif printf '%s' "$config_dump" | grep -q "openshell:resolve:env:BRAVE_API_KEY"; then
+  elif printf '%s' "$config_dump" | grep -qE "$placeholder_pattern"; then
     pass "B3a: openclaw.json contains the placeholder, not the real key"
   else
     fail "B3a: openclaw.json has neither the real key nor the placeholder — web search not configured"
@@ -268,7 +272,7 @@ check_no_real_key_in_sandbox() {
 
   if [ -n "${BRAVE_API_KEY:-}" ] && printf '%s' "$env_value" | grep -qF "$BRAVE_API_KEY"; then
     fail "B3b: SECURITY — real BRAVE_API_KEY visible to sandbox shell via printenv"
-  elif [ -z "$env_value" ] || printf '%s' "$env_value" | grep -q "openshell:resolve:env:BRAVE_API_KEY"; then
+  elif [ -z "$env_value" ] || printf '%s' "$env_value" | grep -qE "$placeholder_pattern"; then
     pass "B3b: sandbox shell env does not expose the real key (placeholder or empty)"
   else
     fail "B3b: unexpected non-empty BRAVE_API_KEY in sandbox env"
@@ -319,17 +323,35 @@ check_real_brave_search_via_agent() {
   fi
 }
 
-# B4b — real Brave search via curl from inside the sandbox (literal reading
-# of "e.g. via curl" in the issue). Pre-req: curl must be in brave.yaml's
-# `binaries:` allowlist.
+# B4b — real Brave search via curl from inside the sandbox. This proves the
+# placeholder is rewritten to the real key at egress for Brave's custom
+# X-Subscription-Token header. The placeholder is read from the running
+# openclaw.json so we exercise whatever shape OpenShell wrote (canonical
+# `openshell:resolve:env:BRAVE_API_KEY` or a revision-scoped variant).
 check_real_brave_search_via_curl() {
-  local response status_code body rc=0
+  local response status_code body rc=0 placeholder
+  placeholder=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc \
+    'python3 -c "
+import json, sys
+try:
+    with open(\"/sandbox/.openclaw/openclaw.json\") as f:
+        cfg = json.load(f)
+    print(cfg.get(\"tools\", {}).get(\"web\", {}).get(\"search\", {}).get(\"apiKey\", \"\") or \"\")
+except Exception:
+    sys.exit(1)
+"' 2>/dev/null) || true
+  placeholder="${placeholder#"${placeholder%%[![:space:]]*}"}"
+  placeholder="${placeholder%"${placeholder##*[![:space:]]}"}"
+  if [ -z "$placeholder" ]; then
+    fail "B4b: could not read tools.web.search.apiKey placeholder from /sandbox/.openclaw/openclaw.json"
+    return
+  fi
 
   response=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc \
     "curl -sS --max-time 20 -G 'https://api.search.brave.com/res/v1/web/search' \
       --data-urlencode 'q=NVIDIA' \
       --data-urlencode 'count=1' \
-      -H 'X-Subscription-Token: openshell:resolve:env:BRAVE_API_KEY' \
+      -H 'X-Subscription-Token: ${placeholder}' \
       -w '\nHTTP_STATUS:%{http_code}\n'" \
     2>&1) || rc=$?
 
@@ -351,7 +373,7 @@ sys.exit(0 if len(results) > 0 else 2)
       fail "B4b: HTTP 200 but response had no web.results[] (body parsed empty)"
     fi
   elif [ "$status_code" = "401" ] || [ "$status_code" = "403" ]; then
-    skip "B4b: HTTP $status_code — proxy did not substitute the placeholder for a generic curl caller. B4a covers the positive path; drop B4b in the PR if so."
+    fail "B4b: HTTP $status_code — proxy did not substitute the Brave placeholder at egress"
   elif [ "$status_code" = "000" ] || [ -z "$status_code" ]; then
     fail "B4b: curl never completed an HTTP transaction — check curl is in brave.yaml binaries allowlist. $(printf '%s' "${response:0:300}" | redact_stream "${BRAVE_API_KEY:-}")"
   else

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -3829,4 +3829,98 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
+  it("aborts createSandbox for missing BRAVE_API_KEY before any sandbox delete (#3626)", () => {
+    // Regression: the Brave credential guard previously sat *after* the
+    // recreate/sandbox-delete branch ran. A user with Brave enabled and no
+    // BRAVE_API_KEY would lose their existing sandbox before seeing the abort.
+    // Move it next to the credential lookup and assert no `sandbox delete`
+    // command escapes before exit.
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-brave-abort-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "brave-abort-check.js");
+    const outputPath = path.join(tmpDir, "outcome.json");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const outputPathLiteral = JSON.stringify(outputPath);
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const fs = require("node:fs");
+const runner = require(${runnerPath});
+
+const openshellCalls = [];
+runner.runOpenshell = (command) => {
+  openshellCalls.push(Array.isArray(command) ? command.join(" ") : String(command));
+  return { status: 0, stdout: "", stderr: "" };
+};
+runner.runCaptureOpenshell = () => "";
+runner.run = (command) => {
+  openshellCalls.push("run: " + (Array.isArray(command) ? command.join(" ") : String(command)));
+  return { status: 0 };
+};
+
+const errors = [];
+const originalError = console.error;
+console.error = (...args) => errors.push(args.join(" "));
+const originalExit = process.exit;
+process.exit = (code) => {
+  fs.writeFileSync(${outputPathLiteral}, JSON.stringify({ exitCode: code, errors, openshellCalls }));
+  originalExit(code);
+};
+
+// Reproduce the bug scenario: Brave enabled, no key anywhere.
+delete process.env.BRAVE_API_KEY;
+
+const { createSandbox } = require(${onboardPath});
+(async () => {
+  await createSandbox(
+    null,           // gpu
+    "gpt-5.4",      // model
+    "nvidia-prod",  // provider
+    null,           // preferredInferenceApi
+    "my-assistant", // sandboxNameOverride
+    { fetchEnabled: true }, // webSearchConfig
+  );
+})().catch(() => {});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_RECREATE_SANDBOX: "1",
+        BRAVE_API_KEY: "",
+      },
+    });
+
+    assert.ok(
+      fs.existsSync(outputPath),
+      `outcome file missing; exit=${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    const payload = JSON.parse(fs.readFileSync(outputPath, "utf-8")) as {
+      exitCode: number;
+      errors: string[];
+      openshellCalls: string[];
+    };
+    expect(payload.exitCode).toBe(1);
+    expect(payload.errors.join("\n")).toMatch(/BRAVE_API_KEY is not available/);
+    // The abort must run before *any* destructive openshell command —
+    // most importantly `sandbox delete`. `forward list` is read-only and
+    // happens earlier; only flag mutating commands here.
+    const destructive = payload.openshellCalls.filter((c) =>
+      /\bsandbox\s+(?:delete|create|rebuild)\b|\bprovider\s+(?:delete|create|update)\b/.test(c),
+    );
+    expect(destructive).toEqual([]);
+  });
+
 });

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -21,6 +21,10 @@ const BASE_POLICY_PATH = new URL(
   "../nemoclaw-blueprint/policies/openclaw-sandbox.yaml",
   import.meta.url,
 );
+const BRAVE_PROVIDER_PROFILE_PATH = new URL(
+  "../nemoclaw-blueprint/provider-profiles/brave.yaml",
+  import.meta.url,
+);
 const PERMISSIVE_POLICY_PATH = new URL(
   "../nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
   import.meta.url,
@@ -84,6 +88,26 @@ type SandboxPolicy = {
 type PolicyPreset = {
   preset?: { name?: string; description?: string };
   network_policies?: Record<string, PolicyEntry>;
+};
+
+type ProviderProfileCredential = {
+  env_vars?: string[];
+  auth_style?: string;
+  header_name?: string;
+};
+
+type ProviderProfileEndpoint = {
+  host?: string;
+  port?: number;
+  protocol?: string;
+  access?: string;
+  enforcement?: string;
+};
+
+type ProviderProfile = {
+  id?: string;
+  credentials?: ProviderProfileCredential[];
+  endpoints?: ProviderProfileEndpoint[];
 };
 
 function loadYaml<T>(path: URL): T {
@@ -420,6 +444,33 @@ describe("base sandbox policy", () => {
     // npm/node being in this list lets the agent bypass 'none' policy preset.
     // Exact allowlist — adding any binary here requires a deliberate review.
     expect(paths).toEqual(["/usr/local/bin/openclaw"]);
+  });
+});
+
+describe("Brave Search provider profile", () => {
+  const profile = loadYaml<ProviderProfile>(BRAVE_PROVIDER_PROFILE_PATH);
+
+  it("routes BRAVE_API_KEY through Brave's subscription-token header", () => {
+    expect(profile.id).toBe("brave");
+    expect(profile.credentials).toEqual([
+      expect.objectContaining({
+        env_vars: ["BRAVE_API_KEY"],
+        auth_style: "header",
+        header_name: "x-subscription-token",
+      }),
+    ]);
+  });
+
+  it("matches the Brave Search API endpoint used by the policy preset", () => {
+    expect(profile.endpoints).toEqual([
+      expect.objectContaining({
+        host: "api.search.brave.com",
+        port: 443,
+        protocol: "rest",
+        access: "read-write",
+        enforcement: "enforce",
+      }),
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Brave Search uses the `X-Subscription-Token` header rather than `Authorization: Bearer`. The existing provider-shaped credential flow left the placeholder in the egress request unchanged and Brave responded 401/403. This PR routes the Brave key through a typed OpenShell provider so the L7 proxy rewrites the custom header at egress and adds a post-policy probe that verifies the rewrite is actually happening.

## Related Issue

Fixes #3626.

## Changes

- New `nemoclaw-blueprint/provider-profiles/brave.yaml` profile registering `BRAVE_API_KEY` against Brave's `X-Subscription-Token` header for `api.search.brave.com`.
- Onboard registers the profile (idempotent — tolerates `already exists`) and creates the sandbox Brave provider with `--type brave`.
- Stop injecting raw `BRAVE_API_KEY` into the sandbox env; the L7 proxy now substitutes the placeholder at egress.
- Move the web-search verifier to after `setupPoliciesWithSelection` and add a Brave-specific curl probe inside the sandbox using the actual `tools.web.search.apiKey` placeholder from `openclaw.json` (revision-scoped variants accepted).
- Pass `replaceExisting: true` only at the post-sandbox-delete call site so legacy `generic`-typed `${sandbox}-brave-search` providers migrate during `--recreate-sandbox`; reuse paths still call `update`. The 401/403 warning now tells operators to re-onboard with `--recreate-sandbox`.
- E2E B3a/B3b accept revision-scoped placeholders; B4b reads the placeholder from `openclaw.json` and fails on 401/403 (instead of skipping) so the rewrite is exercised end-to-end.

## Type of Change

- [x] Code change with doc updates

## Verification

- [x] `npm test` passes for the changed surface (`providers`, `web-search-verify`, `validate-blueprint`, `onboard-brave-validation`, `dockerfile-patch`, `initial-policy`, plus the full `src/lib/onboard` suite — 467 tests)
- [x] `npm run typecheck:cli` clean
- [x] `npm run build:cli` succeeds
- [x] Tests added/updated for new behavior (provider profile validation, Brave egress probe success/failure, migration replace path)
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes (`docs/reference/commands.mdx`, `scripts/install.sh` usage)

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brave Search provider added to onboarding: registers a Brave provider profile, supports replace-vs-reuse provider registration, performs egress verification during finalization, and aborts onboarding early if the Brave API key is required but missing.

* **Documentation**
  * Onboarding docs and installer help clarify Brave API keys are represented by a provider placeholder and rewritten at egress, not stored directly in sandbox config.

* **Tests**
  * New and updated unit and E2E tests covering Brave onboarding, import/replace flows, placeholder handling, and egress verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->