### PR TITLE
fix(onboard): honor Ollama no-tools override during validation

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4219,7 +4219,9 @@ async function selectAndValidateOllamaModel(
       null,
       {
         skipResponsesProbe: true,
-        requireChatCompletionsToolCalling: true,
+        // Mirror the first-gate escape hatch in proxy.ts checkOllamaModelToolSupport.
+        requireChatCompletionsToolCalling:
+          process.env.NEMOCLAW_OLLAMA_REQUIRE_TOOLS !== "0",
         allowHostDockerInternal:
           localInference.getResolvedOllamaHost() === OLLAMA_HOST_DOCKER_INTERNAL,
       },

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4219,9 +4219,7 @@ async function selectAndValidateOllamaModel(
       null,
       {
         skipResponsesProbe: true,
-        // Mirror the first-gate escape hatch in proxy.ts checkOllamaModelToolSupport.
-        requireChatCompletionsToolCalling:
-          process.env.NEMOCLAW_OLLAMA_REQUIRE_TOOLS !== "0",
+        requireChatCompletionsToolCalling: process.env.NEMOCLAW_OLLAMA_REQUIRE_TOOLS !== "0",
         allowHostDockerInternal:
           localInference.getResolvedOllamaHost() === OLLAMA_HOST_DOCKER_INTERNAL,
       },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Honors `NEMOCLAW_OLLAMA_REQUIRE_TOOLS=0` during Local Ollama endpoint validation. This lets users who explicitly accept tools-incapable Ollama models continue onboarding instead of failing later on the strict tool-calling validation probe.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #4234

## Changes
<!-- Bullet list of key changes. -->
- Keeps Local Ollama tool-calling validation enabled by default.
- Disables the strict Chat Completions tool-calling probe when `NEMOCLAW_OLLAMA_REQUIRE_TOOLS=0` is set.
- Aligns endpoint validation with the earlier Ollama model capability gate.

## Type of Change

- [√ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [√ ] `npx prek run --all-files` passes
- [√] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [√] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: rluo8 <ruluo@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ollama model tool-calling validation is now configurable via an environment variable. Users can opt out of strict tool-calling checks during local model selection and provider setup, improving compatibility with varied Ollama installations and workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->