### PR TITLE
test(e2e): retry empty TUI chat event captures

### DIFF
--- a/test/openclaw-tui-chat-correlation.test.ts
+++ b/test/openclaw-tui-chat-correlation.test.ts
@@ -540,6 +540,15 @@ function looksLikeEventCaptureFailure(repro: LiveIssue2603Trace): boolean {
   );
 }
 
+// The zero-chat-events failure is an observability race at the live repro boundary:
+// OpenClaw accepts the chat.send requests, but this websocket client captures no
+// chat stream events before assertions. The source boundary is the pinned
+// OpenClaw 2026.5.x gateway/websocket runtime inside the sandbox, so this
+// NemoClaw-side E2E can only keep the #2603/#3145 correlation assertions stable
+// while preserving signal for real empty-final, duplicate-turn, and
+// uncorrelated-reply regressions. Remove this retry when OpenClaw exposes a
+// deterministic chat subscription/readiness acknowledgement or the 10x nightly
+// sweep no longer shows the zero-event capture signature without this guard.
 function runLiveIssue2603ReproWithEventCaptureRetry(sandboxName: string): LiveIssue2603Run {
   const attempts: LiveIssue2603Trace[] = [];
   let repro = runLiveIssue2603Repro(sandboxName);

--- a/test/openclaw-tui-chat-correlation.test.ts
+++ b/test/openclaw-tui-chat-correlation.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import type { ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -81,6 +82,11 @@ type Issue2603Analysis = {
 };
 
 type LiveIssue2603Trace = Issue2603Trace & { error?: string };
+
+type LiveIssue2603Run = {
+  repro: LiveIssue2603Trace;
+  attempts: LiveIssue2603Trace[];
+};
 
 type ExecStringOptions = Omit<ExecFileSyncOptionsWithStringEncoding, "encoding" | "stdio">;
 
@@ -190,10 +196,47 @@ function analyzeIssue2603Trace({ sentRuns, events, historyMessages }: Issue2603T
   };
 }
 
-function buildFailureSummary(analysis: Issue2603Analysis): string {
+function compactHistoryMessages(messages: ChatMessage[]): { role?: string; text: string }[] {
+  return messages.map((message) => ({
+    role: message.role,
+    text: textFromMessage(message),
+  }));
+}
+
+function summarizeLiveAttempt(attempt: LiveIssue2603Trace, index: number) {
+  if (attempt.error) {
+    return {
+      attempt: index + 1,
+      error: attempt.error,
+      eventCount: attempt.events?.length ?? 0,
+    };
+  }
+
+  const analysis = analyzeIssue2603Trace(attempt);
+  return {
+    attempt: index + 1,
+    sentRunCount: attempt.sentRuns.length,
+    eventCount: attempt.events.length,
+    chatEventCount: analysis.chatEvents.length,
+    missingReplies: analysis.missingReplies,
+    emptyFinalsForSubmittedRuns: analysis.emptyFinalsForSubmittedRuns,
+    missingUserTurns: analysis.missingUserTurns,
+    duplicateUserTurns: analysis.duplicateUserTurns,
+  };
+}
+
+function buildFailureSummary(
+  analysis: Issue2603Analysis,
+  trace?: Issue2603Trace,
+  attempts?: LiveIssue2603Trace[],
+): string {
   return JSON.stringify(
     {
       expectations: ISSUE_2603_FIX_EXPECTATIONS,
+      sentRuns: trace?.sentRuns,
+      eventCount: trace?.events.length,
+      historyMessages: trace ? compactHistoryMessages(trace.historyMessages) : undefined,
+      attempts: attempts?.map(summarizeLiveAttempt),
       emptyFinalsForSubmittedRuns: analysis.emptyFinalsForSubmittedRuns,
       missingReplies: analysis.missingReplies,
       duplicateReplies: analysis.duplicateReplies,
@@ -470,7 +513,7 @@ function runLiveIssue2603Repro(sandboxName: string): LiveIssue2603Trace {
 
   execOpenShell(["sandbox", "upload", sandboxName, localScript, remoteScript], { timeout: 30_000 });
 
-  const sessionKey = `issue2603-${Date.now()}`;
+  const sessionKey = `issue2603-${Date.now()}-${randomUUID()}`;
   const tokenExpression =
     "JSON.parse(require('fs').readFileSync('/sandbox/.openclaw/openclaw.json','utf8')).gateway?.auth?.token||''";
   const output = execInSandbox(
@@ -481,6 +524,36 @@ function runLiveIssue2603Repro(sandboxName: string): LiveIssue2603Trace {
   const resultLine = output.split(/\r?\n/).find((line) => line.startsWith("ISSUE2603_RESULT "));
   if (!resultLine) throw new Error(`live repro did not emit ISSUE2603_RESULT. Output:\n${output}`);
   return JSON.parse(resultLine.slice("ISSUE2603_RESULT ".length)) as LiveIssue2603Trace;
+}
+
+function looksLikeEventCaptureFailure(repro: LiveIssue2603Trace): boolean {
+  if (repro.error || !Array.isArray(repro.sentRuns) || !Array.isArray(repro.events)) return false;
+
+  const analysis = analyzeIssue2603Trace(repro);
+  return (
+    repro.sentRuns.length === 3 &&
+    analysis.chatEvents.length === 0 &&
+    analysis.emptyFinalsForSubmittedRuns.length === 0 &&
+    analysis.duplicateReplies.length === 0 &&
+    analysis.uncorrelatedReplies.length === 0 &&
+    analysis.missingReplies.length === repro.sentRuns.length
+  );
+}
+
+function runLiveIssue2603ReproWithEventCaptureRetry(sandboxName: string): LiveIssue2603Run {
+  const attempts: LiveIssue2603Trace[] = [];
+  let repro = runLiveIssue2603Repro(sandboxName);
+  attempts.push(repro);
+
+  if (looksLikeEventCaptureFailure(repro)) {
+    console.warn(
+      "ISSUE2603_RETRY captured zero chat events after accepted sends; retrying with a fresh session",
+    );
+    repro = runLiveIssue2603Repro(sandboxName);
+    attempts.push(repro);
+  }
+
+  return { repro, attempts };
 }
 
 describe("OpenClaw TUI chat correlation regression (#2603)", () => {
@@ -565,15 +638,41 @@ describe("OpenClaw TUI chat correlation regression (#2603)", () => {
     expect(analysis.uncorrelatedReplies).toEqual([]);
   });
 
+  it("only retries the live repro when no chat events were captured", () => {
+    expect(
+      looksLikeEventCaptureFailure({
+        sentRuns: capturedIssue2603Trace.sentRuns,
+        events: [],
+        historyMessages: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      looksLikeEventCaptureFailure({
+        sentRuns: capturedIssue2603Trace.sentRuns,
+        events: [
+          {
+            event: "chat",
+            payload: {
+              runId: "18f73be1-3410-46cb-8098-e881bf92c510",
+              state: "final",
+            },
+          },
+        ],
+        historyMessages: [],
+      }),
+    ).toBe(false);
+  });
+
   it.runIf(process.env[LIVE_REPRO_ENV] === "1")(
     "keeps rapid live TUI/webchat sends correlated on a real OpenClaw sandbox",
     () => {
       const sandboxName = process.env[LIVE_SANDBOX_ENV] || "hclaw";
-      const repro = runLiveIssue2603Repro(sandboxName);
+      const { repro, attempts } = runLiveIssue2603ReproWithEventCaptureRetry(sandboxName);
       if (repro.error) throw new Error(`live repro failed before assertions: ${repro.error}`);
 
       const analysis = analyzeIssue2603Trace(repro);
-      const failureSummary = buildFailureSummary(analysis);
+      const failureSummary = buildFailureSummary(analysis, repro, attempts);
       expect(analysis.emptyFinalsForSubmittedRuns, failureSummary).toEqual([]);
       expect(analysis.missingReplies, failureSummary).toEqual([]);
       expect(analysis.duplicateReplies, failureSummary).toEqual([]);
@@ -581,6 +680,6 @@ describe("OpenClaw TUI chat correlation regression (#2603)", () => {
       expect(analysis.missingUserTurns, failureSummary).toEqual([]);
       expect(analysis.duplicateUserTurns, failureSummary).toEqual([]);
     },
-    190_000,
+    370_000,
   );
 });


### PR DESCRIPTION
## Summary
Retries the OpenClaw TUI chat correlation live repro only when an accepted-send attempt captures zero chat events, which matches the dominant harness flake. The strict correlation assertions remain unchanged for empty finals, duplicate turns, missing replies with observed events, and uncorrelated replies.

## Changes
- Add a one-time retry path for zero-event live TUI/webchat correlation captures with a fresh session key.
- Add per-attempt diagnostics to the failure summary, including sent runs, event counts, and compact history messages.
- Add a unit regression check that the retry predicate applies only to the zero-chat-events case and does not mask empty final events.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with per-run unique session identifiers.
  * Added detection for a specific event-capture failure mode and a retry wrapper to rerun repros when that condition occurs.
  * Enhanced failure reporting to include richer diagnostic context and aggregated attempt data.
  * Increased live-test timeout and added a unit test validating the event-capture failure classifier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->