### PR TITLE
fix(hermes): repair root entrypoint sandbox layout

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -33,6 +33,9 @@
 #                            agent state, and the same agent type running.
 #   hermes-e2e               Hermes Agent E2E — install → onboard --agent hermes → health
 #                            probe → live inference. Validates the multi-agent architecture.
+#   hermes-root-entrypoint-smoke-e2e
+#                            Builds the real Hermes image and verifies root entrypoint startup,
+#                            gateway-user execution, v0.14 layout repair, and PID migration.
 #   openclaw-onboard-security-posture-e2e
 #                            Full OpenClaw onboard on a non-root host user
 #                            with trusted rc-file and runtime guard assertions.
@@ -91,6 +94,7 @@ on:
           token-rotation-e2e, sandbox-survival-e2e,
           openshell-gateway-upgrade-e2e,
           issue-2478-crash-loop-recovery-e2e, hermes-e2e,
+          hermes-root-entrypoint-smoke-e2e,
           openclaw-onboard-security-posture-e2e,
           hermes-onboard-security-posture-e2e,
           hermes-inference-switch-e2e, hermes-discord-e2e,
@@ -677,6 +681,21 @@ jobs:
       env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_AGENT":"hermes","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-hermes"}'
       nvidia_api_key: true
       github_token: true
+    secrets:
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
+  hermes-root-entrypoint-smoke-e2e:
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'workflow_dispatch' ||
+       inputs.jobs == '' ||
+       contains(format(',{0},', inputs.jobs), ',hermes-root-entrypoint-smoke-e2e,'))
+    uses: ./.github/workflows/e2e-script.yaml
+    with:
+      ref: ${{ inputs.target_ref || github.ref }}
+      script: test/e2e/test-hermes-root-entrypoint-smoke.sh
+      timeout_minutes: 45
+      artifact_name: "hermes-root-entrypoint-smoke-log"
+      artifact_path: "/tmp/nemoclaw-hermes-root-entrypoint-smoke.log"
     secrets:
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
       BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
@@ -1809,6 +1828,7 @@ jobs:
         sandbox-survival-e2e,
         issue-2478-crash-loop-recovery-e2e,
         hermes-e2e,
+        hermes-root-entrypoint-smoke-e2e,
         openclaw-onboard-security-posture-e2e,
         hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
@@ -1911,6 +1931,7 @@ jobs:
         sandbox-survival-e2e,
         issue-2478-crash-loop-recovery-e2e,
         hermes-e2e,
+        hermes-root-entrypoint-smoke-e2e,
         openclaw-onboard-security-posture-e2e,
         hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
@@ -2070,6 +2091,7 @@ jobs:
         sandbox-survival-e2e,
         issue-2478-crash-loop-recovery-e2e,
         hermes-e2e,
+        hermes-root-entrypoint-smoke-e2e,
         openclaw-onboard-security-posture-e2e,
         hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,

--- a/.github/workflows/sandbox-images-and-e2e.yaml
+++ b/.github/workflows/sandbox-images-and-e2e.yaml
@@ -84,6 +84,19 @@ jobs:
           docker run --rm --user sandbox nemoclaw-hermes-production \
             test -x /usr/local/bin/nemoclaw-start
 
+      - name: Run Hermes root entrypoint smoke
+        env:
+          NEMOCLAW_HERMES_TEST_IMAGE: nemoclaw-hermes-production
+        run: bash test/e2e/test-hermes-root-entrypoint-smoke.sh
+
+      - name: Upload Hermes root entrypoint smoke log on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hermes-root-entrypoint-smoke-log
+          path: /tmp/nemoclaw-hermes-root-entrypoint-smoke.log
+          if-no-files-found: ignore
+
   build-sandbox-images-arm64:
     if: inputs.run_arm64
     runs-on: ubuntu-24.04-arm

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -135,10 +135,11 @@ RUN mkdir -p /sandbox/.hermes/memories \
     'file, and web tools. Be concise and helpful.' \
     > /sandbox/.hermes/SOUL.md
 
-# Set mutable-default permissions (640/750 sandbox:sandbox).
+# Set mutable-default permissions (640 files, 3770 config root).
 # The sandbox user can write config; the gateway user can read it via
-# supplementary sandbox-group membership. Shields-up applies 444 root:root +
-# chattr +i.
+# supplementary sandbox-group membership and create Hermes v0.14 runtime dirs
+# without being able to remove sticky-protected config files. Shields-up applies
+# 444 root:root + chattr +i.
 # hadolint ignore=DL3002
 USER root
 # Flatten stale published base images that still contain the old .hermes-data
@@ -215,11 +216,15 @@ RUN set -eu; \
         "$config_dir/plugins" \
         "$config_dir/cron" \
         "$config_dir/logs" \
+        "$config_dir/logs/curator" \
         "$config_dir/skins" \
         "$config_dir/plans" \
         "$config_dir/workspace" \
         "$config_dir/profiles" \
         "$config_dir/cache" \
+        "$config_dir/hooks" \
+        "$config_dir/image_cache" \
+        "$config_dir/audio_cache" \
         "$config_dir/pairing" \
         "$config_dir/platforms" \
         "$config_dir/platforms/whatsapp" \
@@ -251,7 +256,7 @@ RUN set -eu; \
     rm -rf /root/.cache/pip /sandbox/.cache \
     && chown -R sandbox:sandbox /sandbox/.hermes \
     && chown gateway:sandbox /sandbox/.hermes/runtime \
-    && chmod 750 /sandbox/.hermes \
+    && chmod 3770 /sandbox/.hermes \
     && chmod 770 \
         /sandbox/.hermes/memories \
         /sandbox/.hermes/sessions \
@@ -259,11 +264,15 @@ RUN set -eu; \
         /sandbox/.hermes/plugins \
         /sandbox/.hermes/cron \
         /sandbox/.hermes/logs \
+        /sandbox/.hermes/logs/curator \
         /sandbox/.hermes/skins \
         /sandbox/.hermes/plans \
         /sandbox/.hermes/workspace \
         /sandbox/.hermes/profiles \
         /sandbox/.hermes/cache \
+        /sandbox/.hermes/hooks \
+        /sandbox/.hermes/image_cache \
+        /sandbox/.hermes/audio_cache \
         /sandbox/.hermes/pairing \
         /sandbox/.hermes/platforms \
         /sandbox/.hermes/platforms/whatsapp \
@@ -278,7 +287,7 @@ RUN set -eu; \
     && chmod 2770 /sandbox/.hermes/runtime \
     && chmod 640 /sandbox/.hermes/config.yaml \
     && chmod 640 /sandbox/.hermes/.env \
-    && for name in state.db state.db-wal state.db-shm gateway.pid gateway.lock gateway_state.json channel_directory.json; do \
+    && for name in state.db state.db-wal state.db-shm gateway.lock gateway_state.json channel_directory.json; do \
         rm -f "/sandbox/.hermes/${name}"; \
         ln -s "runtime/${name}" "/sandbox/.hermes/${name}"; \
     done

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -75,19 +75,24 @@ RUN groupadd -r sandbox \
     && chown -R sandbox:sandbox /sandbox
 
 # Create .hermes with mutable integration dirs plus a scoped runtime dir.
-# Top-level gateway state names redirect into runtime so the config root can
-# remain non-group-writable without reintroducing the old .hermes-data bridge.
+# Hermes v0.14 writes some top-level state with O_EXCL, so the gateway group can
+# create new entries in .hermes while sticky-bit protection keeps config files
+# from being removed by the gateway user.
 RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/sessions \
         /sandbox/.hermes/skills \
         /sandbox/.hermes/plugins \
         /sandbox/.hermes/cron \
         /sandbox/.hermes/logs \
+        /sandbox/.hermes/logs/curator \
         /sandbox/.hermes/skins \
         /sandbox/.hermes/plans \
         /sandbox/.hermes/workspace \
         /sandbox/.hermes/profiles \
         /sandbox/.hermes/cache \
+        /sandbox/.hermes/hooks \
+        /sandbox/.hermes/image_cache \
+        /sandbox/.hermes/audio_cache \
         /sandbox/.hermes/pairing \
         /sandbox/.hermes/platforms \
         /sandbox/.hermes/platforms/whatsapp \
@@ -95,7 +100,7 @@ RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/runtime \
     && chown -R sandbox:sandbox /sandbox/.hermes \
     && chown gateway:sandbox /sandbox/.hermes/runtime \
-    && chmod 750 /sandbox/.hermes \
+    && chmod 3770 /sandbox/.hermes \
     && chmod 770 \
         /sandbox/.hermes/memories \
         /sandbox/.hermes/sessions \
@@ -103,11 +108,15 @@ RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/plugins \
         /sandbox/.hermes/cron \
         /sandbox/.hermes/logs \
+        /sandbox/.hermes/logs/curator \
         /sandbox/.hermes/skins \
         /sandbox/.hermes/plans \
         /sandbox/.hermes/workspace \
         /sandbox/.hermes/profiles \
         /sandbox/.hermes/cache \
+        /sandbox/.hermes/hooks \
+        /sandbox/.hermes/image_cache \
+        /sandbox/.hermes/audio_cache \
         /sandbox/.hermes/pairing \
         /sandbox/.hermes/platforms \
         /sandbox/.hermes/platforms/whatsapp \
@@ -118,7 +127,7 @@ RUN mkdir -p /sandbox/.hermes/memories \
         /sandbox/.hermes/platforms/whatsapp \
         /sandbox/.hermes/platforms/whatsapp/session \
     && chmod 2770 /sandbox/.hermes/runtime \
-    && for name in state.db state.db-wal state.db-shm gateway.pid gateway.lock gateway_state.json channel_directory.json; do \
+    && for name in state.db state.db-wal state.db-shm gateway.lock gateway_state.json channel_directory.json; do \
         rm -f "/sandbox/.hermes/${name}"; \
         ln -s "runtime/${name}" "/sandbox/.hermes/${name}"; \
     done

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -116,8 +116,9 @@ INTERNAL_PORT=18642
 HERMES="$(command -v hermes)" # Resolve once, use absolute path everywhere
 
 # Hermes resolves config and runtime state relative to HERMES_HOME. The config
-# root is mutable by the sandbox owner and readable by the gateway group, while
-# gateway-created top-level state is redirected to a scoped runtime directory.
+# root is mutable by the sandbox owner and readable by the gateway group. The
+# root directory is group-writable with sticky-bit protection so Hermes v0.14 can
+# create new top-level state while the gateway user cannot remove config files.
 # Immutability is opt-in via `shields up`.
 HERMES_DIR="/sandbox/.hermes"
 HERMES_HASH_FILE="/etc/nemoclaw/hermes.config-hash"
@@ -216,6 +217,53 @@ remove_stale_gateway_file() {
   fi
 }
 
+ensure_hermes_config_root_mode() {
+  if [ -L "$HERMES_DIR" ] || [ ! -d "$HERMES_DIR" ]; then
+    echo "[SECURITY] Refusing Hermes layout repair because ${HERMES_DIR} is not a safe directory" >&2
+    return 1
+  fi
+
+  if [ "$(id -u)" -eq 0 ]; then
+    chown sandbox:sandbox "$HERMES_DIR"
+  fi
+  chmod 3770 "$HERMES_DIR"
+}
+
+ensure_hermes_state_dir() {
+  local dir="$1"
+  local mode="$2"
+
+  if [ -L "$dir" ]; then
+    echo "[SECURITY] Refusing Hermes layout repair because ${dir} is a symlink" >&2
+    return 1
+  fi
+  if [ -e "$dir" ] && [ ! -d "$dir" ]; then
+    echo "[SECURITY] Refusing Hermes layout repair because ${dir} is not a directory" >&2
+    return 1
+  fi
+
+  mkdir -p "$dir"
+
+  if [ -L "$dir" ] || [ ! -d "$dir" ]; then
+    echo "[SECURITY] Refusing Hermes layout repair because ${dir} did not resolve to a safe directory" >&2
+    return 1
+  fi
+
+  if [ "$(id -u)" -eq 0 ]; then
+    chown sandbox:sandbox "$dir"
+  fi
+  chmod "$mode" "$dir"
+}
+
+repair_hermes_startup_layout() {
+  ensure_hermes_config_root_mode
+  ensure_hermes_state_dir "${HERMES_DIR}/logs" 770
+  ensure_hermes_state_dir "${HERMES_DIR}/logs/curator" 770
+  ensure_hermes_state_dir "${HERMES_DIR}/hooks" 770
+  ensure_hermes_state_dir "${HERMES_DIR}/image_cache" 770
+  ensure_hermes_state_dir "${HERMES_DIR}/audio_cache" 770
+}
+
 cleanup_stale_hermes_gateway_runtime() {
   local runtime_dir="${HERMES_DIR}/runtime"
 
@@ -224,12 +272,12 @@ cleanup_stale_hermes_gateway_runtime() {
     return 0
   fi
 
+  repair_hermes_startup_layout
+
   # Hermes can leave gateway.lock behind after Docker GPU recreation kills the
   # old process namespace. Clear it only after confirming no gateway is alive.
-  remove_stale_gateway_file "${runtime_dir}/gateway.pid" "PID file"
-  if [ ! -L "${HERMES_DIR}/gateway.pid" ]; then
-    remove_stale_gateway_file "${HERMES_DIR}/gateway.pid" "legacy PID file"
-  fi
+  remove_stale_gateway_file "${runtime_dir}/gateway.pid" "runtime PID file"
+  remove_stale_gateway_file "${HERMES_DIR}/gateway.pid" "legacy PID file"
   remove_stale_gateway_file "${runtime_dir}/gateway.lock" "lock file"
   cleanup_orphan_socat_forwarders
 }

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -217,10 +217,27 @@ remove_stale_gateway_file() {
   fi
 }
 
+hermes_config_root_is_locked() {
+  local owner mode
+
+  owner="$(stat -c '%U:%G' "$HERMES_DIR" 2>/dev/null || stat -f '%Su:%Sg' "$HERMES_DIR" 2>/dev/null || true)"
+  mode="$(stat -c '%a' "$HERMES_DIR" 2>/dev/null || stat -f '%Lp' "$HERMES_DIR" 2>/dev/null || true)"
+
+  case "${owner} ${mode}" in
+    "root:root 755" | "root:root 0755") return 0 ;;
+  esac
+  return 1
+}
+
 ensure_hermes_config_root_mode() {
   if [ -L "$HERMES_DIR" ] || [ ! -d "$HERMES_DIR" ]; then
     echo "[SECURITY] Refusing Hermes layout repair because ${HERMES_DIR} is not a safe directory" >&2
     return 1
+  fi
+
+  if hermes_config_root_is_locked; then
+    echo "[gateway] Hermes config root is locked; preserving shields-up permissions" >&2
+    return 0
   fi
 
   if [ "$(id -u)" -eq 0 ]; then
@@ -256,6 +273,11 @@ ensure_hermes_state_dir() {
 }
 
 repair_hermes_startup_layout() {
+  if hermes_config_root_is_locked; then
+    echo "[gateway] Hermes layout repair skipped because config root is locked" >&2
+    return 0
+  fi
+
   ensure_hermes_config_root_mode
   ensure_hermes_state_dir "${HERMES_DIR}/logs" 770
   ensure_hermes_state_dir "${HERMES_DIR}/logs/curator" 770

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -518,10 +518,12 @@ function unlockAgentConfig(
   // control-UI mutations (Enable Dreaming, account toggles) EACCES
   // against sandbox:sandbox 600 even after shields-down
   // (#2681 supersedes #2693).
-  // Hermes is unchanged — its sandbox does not run a separate gateway UID,
-  // so the shared-group contract does not apply.
+  // Hermes keeps config files non-group-writable, but its root entrypoint runs
+  // the gateway as a separate UID in the sandbox group. The config root stays
+  // group-writable + sticky so Hermes can create top-level runtime state while
+  // the gateway UID cannot remove sandbox-owned config files.
   const fileMode = target.agentName === "hermes" ? "640" : "660";
-  const dirMode = target.agentName === "hermes" ? "750" : "2770";
+  const dirMode = target.agentName === "hermes" ? "3770" : "2770";
   for (const f of filesToUnlock) {
     try {
       privilegedSandboxExec(sandboxName, ["chattr", "-i", f]);

--- a/test/e2e/test-hermes-root-entrypoint-smoke.sh
+++ b/test/e2e/test-hermes-root-entrypoint-smoke.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Hermes root-entrypoint smoke test:
+#   - builds the real Hermes sandbox image unless NEMOCLAW_HERMES_TEST_IMAGE is set
+#   - starts the container as root via /usr/local/bin/nemoclaw-start
+#   - verifies Hermes health, privilege separation, PID-file layout, and sticky
+#     config protection
+#   - repeats startup from a legacy image/state shape with gateway.pid as a
+#     runtime symlink
+
+set -euo pipefail
+
+LOG_PATH="${NEMOCLAW_HERMES_ROOT_ENTRYPOINT_LOG:-/tmp/nemoclaw-hermes-root-entrypoint-smoke.log}"
+: >"$LOG_PATH"
+exec > >(tee -a "$LOG_PATH") 2>&1
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUN_ID="${GITHUB_RUN_ID:-local}-$$"
+IMAGE="${NEMOCLAW_HERMES_TEST_IMAGE:-nemoclaw-hermes-root-entrypoint-smoke:${RUN_ID}}"
+BASE_IMAGE="nemoclaw-hermes-root-entrypoint-base:${RUN_ID}"
+containers=()
+
+dump_container() {
+  local container="$1"
+  docker inspect "$container" >/dev/null 2>&1 || return 0
+  echo -e "${YELLOW}[DIAG]${NC} --- ${container} diagnostics ---" >&2
+  docker ps -a --filter "name=^/${container}$" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' >&2 || true
+  docker logs "$container" >&2 || true
+  docker exec "$container" sh -lc \
+    'set +e; echo "== identity =="; id; echo "== hermes tree =="; ls -ld /sandbox/.hermes /sandbox/.hermes/runtime /sandbox/.hermes/logs /sandbox/.hermes/logs/curator /sandbox/.hermes/hooks /sandbox/.hermes/image_cache /sandbox/.hermes/audio_cache 2>&1; ls -l /sandbox/.hermes/gateway.pid /sandbox/.hermes/runtime/gateway.pid /sandbox/.hermes/config.yaml 2>&1; echo "== processes =="; ps -eo user=,pid=,args= | grep -E "hermes|socat" | grep -v grep; echo "== start log =="; tail -n 120 /tmp/nemoclaw-start.log 2>&1; echo "== gateway log =="; tail -n 160 /tmp/gateway.log 2>&1' \
+    >&2 || true
+  echo -e "${YELLOW}[DIAG]${NC} --- end ${container} diagnostics ---" >&2
+}
+
+fail() {
+  echo -e "${RED}[FAIL]${NC} $1" >&2
+  for container in "${containers[@]}"; do
+    dump_container "$container"
+  done
+  exit 1
+}
+
+cleanup() {
+  for container in "${containers[@]}"; do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+require_docker() {
+  command -v docker >/dev/null 2>&1 || fail "docker is required"
+  docker info >/dev/null 2>&1 || fail "docker daemon is not available"
+}
+
+build_image_if_needed() {
+  if [ -n "${NEMOCLAW_HERMES_TEST_IMAGE:-}" ]; then
+    info "Using prebuilt Hermes image ${IMAGE}"
+    docker image inspect "$IMAGE" >/dev/null 2>&1 || fail "prebuilt image not found: ${IMAGE}"
+    return 0
+  fi
+
+  info "Building Hermes base image ${BASE_IMAGE}"
+  docker build -f "${REPO_ROOT}/agents/hermes/Dockerfile.base" -t "$BASE_IMAGE" "$REPO_ROOT" \
+    || fail "failed to build Hermes base image"
+
+  info "Building Hermes production image ${IMAGE}"
+  docker build -f "${REPO_ROOT}/agents/hermes/Dockerfile" \
+    --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+    -t "$IMAGE" \
+    "$REPO_ROOT" \
+    || fail "failed to build Hermes production image"
+}
+
+wait_for_health() {
+  local container="$1"
+  local body=""
+  local running=""
+
+  for _attempt in $(seq 1 90); do
+    if body="$(docker exec "$container" sh -lc 'curl -sf --max-time 2 http://127.0.0.1:8642/health' 2>/dev/null)"; then
+      echo "$body"
+      printf '%s\n' "$body" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"' \
+        || fail "${container}: health response did not report status ok: ${body}"
+      printf '%s\n' "$body" | grep -Eq '"platform"[[:space:]]*:[[:space:]]*"hermes-agent"' \
+        || fail "${container}: health response did not report Hermes platform: ${body}"
+      return 0
+    fi
+
+    running="$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || true)"
+    [ "$running" = "true" ] || fail "${container}: container exited before health became ready"
+    sleep 2
+  done
+
+  fail "${container}: Hermes health did not become ready"
+}
+
+assert_container_sh() {
+  local container="$1"
+  local message="$2"
+  local command="$3"
+  docker exec "$container" sh -lc "$command" >/dev/null || fail "${container}: ${message}"
+}
+
+assert_container_sh_fails() {
+  local container="$1"
+  local message="$2"
+  local command="$3"
+  if docker exec "$container" sh -lc "$command" >/dev/null 2>&1; then
+    fail "${container}: ${message}"
+  fi
+}
+
+assert_gateway_log_clean() {
+  local container="$1"
+  assert_container_sh "$container" "gateway log contains PID race failure" \
+    "! grep -F 'PID file race lost' /tmp/gateway.log"
+  assert_container_sh "$container" "gateway log contains config load failure" \
+    "! grep -F 'Could not load config.yaml' /tmp/gateway.log"
+}
+
+assert_runtime_layout() {
+  local container="$1"
+
+  assert_container_sh "$container" "Hermes config root mode is not 3770" \
+    "[ \"\$(stat -c '%a' /sandbox/.hermes)\" = '3770' ]"
+  assert_container_sh "$container" "required Hermes v0.14 directories are missing" \
+    "for dir in hooks image_cache audio_cache logs/curator; do test -d \"/sandbox/.hermes/\$dir\"; done"
+  assert_container_sh "$container" "gateway user cannot write required Hermes v0.14 directories" \
+    "gosu gateway sh -lc 'for dir in hooks image_cache audio_cache logs/curator; do p=\"/sandbox/.hermes/\$dir/.nemoclaw-write-test\"; : >\"\$p\" && rm -f \"\$p\"; done'"
+  assert_container_sh "$container" "gateway.pid is not a regular top-level file" \
+    "test -f /sandbox/.hermes/gateway.pid && test ! -L /sandbox/.hermes/gateway.pid"
+  assert_container_sh_fails "$container" "gateway user was able to remove config.yaml" \
+    "gosu gateway rm /sandbox/.hermes/config.yaml"
+  assert_container_sh "$container" "config.yaml disappeared after gateway remove attempt" \
+    "test -f /sandbox/.hermes/config.yaml"
+}
+
+assert_gateway_process() {
+  local container="$1"
+  assert_container_sh "$container" "Hermes gateway process is not running as gateway user" \
+    "ps -eo user=,args= | awk '\$1 == \"gateway\" && index(\$0, \"hermes gateway run\") { found = 1 } END { exit found ? 0 : 1 }'"
+  assert_container_sh "$container" "start log does not show gateway privilege separation" \
+    "grep -F \"hermes gateway launched as 'gateway' user\" /tmp/nemoclaw-start.log"
+}
+
+run_clean_variant() {
+  local container="nemoclaw-hermes-root-clean-${RUN_ID}"
+  info "Starting clean root-entrypoint container ${container}"
+  docker run -d --name "$container" "$IMAGE" /usr/local/bin/nemoclaw-start >/dev/null \
+    || fail "failed to start clean root-entrypoint container"
+  containers+=("$container")
+
+  wait_for_health "$container" >/dev/null
+  assert_gateway_process "$container"
+  assert_gateway_log_clean "$container"
+  assert_runtime_layout "$container"
+  pass "Clean root-entrypoint startup reached Hermes health"
+}
+
+run_legacy_variant() {
+  local container="nemoclaw-hermes-root-legacy-${RUN_ID}"
+  local legacy_bootstrap
+  legacy_bootstrap='set -euo pipefail
+rm -f /sandbox/.hermes/gateway.pid
+printf "stale pid\n" >/sandbox/.hermes/runtime/gateway.pid
+printf "stale lock\n" >/sandbox/.hermes/runtime/gateway.lock
+ln -s runtime/gateway.pid /sandbox/.hermes/gateway.pid
+chmod 750 /sandbox/.hermes
+rm -rf /sandbox/.hermes/hooks /sandbox/.hermes/image_cache /sandbox/.hermes/audio_cache /sandbox/.hermes/logs/curator
+exec /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start'
+
+  info "Starting legacy-layout root-entrypoint container ${container}"
+  docker run -d --name "$container" --entrypoint /bin/bash "$IMAGE" -lc "$legacy_bootstrap" >/dev/null \
+    || fail "failed to start legacy-layout root-entrypoint container"
+  containers+=("$container")
+
+  wait_for_health "$container" >/dev/null
+  assert_gateway_process "$container"
+  assert_gateway_log_clean "$container"
+  assert_runtime_layout "$container"
+  assert_container_sh "$container" "legacy gateway.pid symlink migration was not logged" \
+    "grep -F 'Removing unsafe stale Hermes legacy PID file symlink' /tmp/nemoclaw-start.log"
+  pass "Legacy gateway.pid symlink/state migrated and booted"
+}
+
+require_docker
+build_image_if_needed
+run_clean_variant
+run_legacy_variant
+
+pass "Hermes root-entrypoint smoke passed"

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -102,6 +102,15 @@ function writeFakeProcCmdline(procRoot: string, pid: number, argv: string[]) {
   fs.writeFileSync(path.join(pidDir, "cmdline"), Buffer.from(`${argv.join("\0")}\0`));
 }
 
+function lstatIfPresent(entry: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(entry);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
 function runHermesGatewayRuntimeCleanup(opts: {
   liveGateway?: boolean;
   orphanSocat?: boolean;
@@ -144,6 +153,9 @@ function runHermesGatewayRuntimeCleanup(opts: {
       extractShellFunctionFromSource(src, "has_live_hermes_gateway"),
       extractShellFunctionFromSource(src, "cleanup_orphan_socat_forwarders"),
       extractShellFunctionFromSource(src, "remove_stale_gateway_file"),
+      extractShellFunctionFromSource(src, "ensure_hermes_config_root_mode"),
+      extractShellFunctionFromSource(src, "ensure_hermes_state_dir"),
+      extractShellFunctionFromSource(src, "repair_hermes_startup_layout"),
       extractShellFunctionFromSource(src, "cleanup_stale_hermes_gateway_runtime"),
       `KILL_LOG=${shellQuote(killLog)}`,
       'kill() { printf "%s\\n" "$*" >>"$KILL_LOG"; return 0; }',
@@ -162,12 +174,27 @@ function runHermesGatewayRuntimeCleanup(opts: {
       timeout: 5000,
       env: process.env,
     });
+    const legacyPidStat = lstatIfPresent(legacyPid);
+    const requiredDirs = Object.fromEntries(
+      ["logs", "logs/curator", "hooks", "image_cache", "audio_cache"].map((entry) => {
+        const entryPath = path.join(hermesHome, entry);
+        return [
+          entry,
+          fs.existsSync(entryPath)
+            ? (fs.statSync(entryPath).mode & 0o777).toString(8)
+            : "missing",
+        ];
+      }),
+    );
     return {
       result,
       killLog: fs.existsSync(killLog) ? fs.readFileSync(killLog, "utf-8") : "",
+      hermesDirMode: (fs.statSync(hermesHome).mode & 0o7777).toString(8),
+      requiredDirs,
       runtimePidExists: fs.existsSync(runtimePid),
       runtimeLockExists: fs.existsSync(runtimeLock),
-      legacyPidIsSymlink: fs.lstatSync(legacyPid).isSymbolicLink(),
+      legacyPidExists: legacyPidStat !== null,
+      legacyPidIsSymlink: legacyPidStat?.isSymbolicLink() ?? false,
     };
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -259,15 +286,31 @@ describe("agents/hermes/start.sh runtime shell env", () => {
 });
 
 describe("agents/hermes/start.sh gateway runtime cleanup", () => {
-  it("removes stale Hermes pid and lock files while preserving the compatibility pid symlink", () => {
+  it("removes stale Hermes pid and lock files plus the legacy compatibility pid symlink", () => {
     const run = runHermesGatewayRuntimeCleanup({});
 
     expect(run.result.status).toBe(0);
     expect(run.runtimePidExists).toBe(false);
     expect(run.runtimeLockExists).toBe(false);
-    expect(run.legacyPidIsSymlink).toBe(true);
-    expect(run.result.stderr).toContain("Removing stale Hermes PID file");
+    expect(run.legacyPidExists).toBe(false);
+    expect(run.legacyPidIsSymlink).toBe(false);
+    expect(run.result.stderr).toContain("Removing stale Hermes runtime PID file");
+    expect(run.result.stderr).toContain("Removing unsafe stale Hermes legacy PID file symlink");
     expect(run.result.stderr).toContain("Removing stale Hermes lock file");
+  });
+
+  it("repairs the Hermes v0.14 writable directory layout before launch", () => {
+    const run = runHermesGatewayRuntimeCleanup({ staleLock: false, stalePid: false });
+
+    expect(run.result.status).toBe(0);
+    expect(run.hermesDirMode).toBe("3770");
+    expect(run.requiredDirs).toEqual({
+      logs: "770",
+      "logs/curator": "770",
+      hooks: "770",
+      image_cache: "770",
+      audio_cache: "770",
+    });
   });
 
   it("kills orphaned socat forwarders when no Hermes gateway is alive", () => {
@@ -284,6 +327,7 @@ describe("agents/hermes/start.sh gateway runtime cleanup", () => {
     expect(run.result.status).toBe(0);
     expect(run.runtimePidExists).toBe(true);
     expect(run.runtimeLockExists).toBe(true);
+    expect(run.legacyPidIsSymlink).toBe(true);
     expect(run.killLog).toBe("");
     expect(run.result.stderr).toContain("Existing Hermes gateway process detected");
   });

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -116,6 +116,7 @@ function runHermesGatewayRuntimeCleanup(opts: {
   orphanSocat?: boolean;
   staleLock?: boolean;
   stalePid?: boolean;
+  lockedConfigRoot?: boolean;
 }) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-runtime-cleanup-"));
   const hermesHome = path.join(tmpDir, ".hermes");
@@ -129,6 +130,9 @@ function runHermesGatewayRuntimeCleanup(opts: {
 
   fs.mkdirSync(runtimeDir, { recursive: true });
   fs.mkdirSync(procRoot, { recursive: true });
+  if (opts.lockedConfigRoot) {
+    fs.chmodSync(hermesHome, 0o755);
+  }
   fs.symlinkSync("runtime/gateway.pid", legacyPid);
   if (opts.stalePid !== false) fs.writeFileSync(runtimePid, "999999\n");
   if (opts.staleLock !== false) fs.writeFileSync(runtimeLock, "stale lock");
@@ -153,6 +157,7 @@ function runHermesGatewayRuntimeCleanup(opts: {
       extractShellFunctionFromSource(src, "has_live_hermes_gateway"),
       extractShellFunctionFromSource(src, "cleanup_orphan_socat_forwarders"),
       extractShellFunctionFromSource(src, "remove_stale_gateway_file"),
+      extractShellFunctionFromSource(src, "hermes_config_root_is_locked"),
       extractShellFunctionFromSource(src, "ensure_hermes_config_root_mode"),
       extractShellFunctionFromSource(src, "ensure_hermes_state_dir"),
       extractShellFunctionFromSource(src, "repair_hermes_startup_layout"),
@@ -161,6 +166,17 @@ function runHermesGatewayRuntimeCleanup(opts: {
       'kill() { printf "%s\\n" "$*" >>"$KILL_LOG"; return 0; }',
       `HERMES_DIR=${shellQuote(hermesHome)}`,
       `NEMOCLAW_PROC_ROOT=${shellQuote(procRoot)}`,
+      opts.lockedConfigRoot
+        ? [
+            'stat() {',
+            '  if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%U:%G" ] && [ "${3:-}" = "$HERMES_DIR" ]; then printf "root:root\\n"; return 0; fi',
+            '  if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%a" ] && [ "${3:-}" = "$HERMES_DIR" ]; then printf "755\\n"; return 0; fi',
+            '  if [ "${1:-}" = "-f" ] && [ "${2:-}" = "%Su:%Sg" ] && [ "${3:-}" = "$HERMES_DIR" ]; then printf "root:root\\n"; return 0; fi',
+            '  if [ "${1:-}" = "-f" ] && [ "${2:-}" = "%Lp" ] && [ "${3:-}" = "$HERMES_DIR" ]; then printf "755\\n"; return 0; fi',
+            '  command stat "$@"',
+            '}',
+          ].join("\n")
+        : "",
       "PUBLIC_PORT=8642",
       "INTERNAL_PORT=18642",
       "cleanup_stale_hermes_gateway_runtime",
@@ -311,6 +327,26 @@ describe("agents/hermes/start.sh gateway runtime cleanup", () => {
       image_cache: "770",
       audio_cache: "770",
     });
+  });
+
+  it("preserves a locked Hermes config root during stale gateway cleanup", () => {
+    const run = runHermesGatewayRuntimeCleanup({ lockedConfigRoot: true });
+
+    expect(run.result.status).toBe(0);
+    expect(run.hermesDirMode).toBe("755");
+    expect(run.requiredDirs).toEqual({
+      logs: "missing",
+      "logs/curator": "missing",
+      hooks: "missing",
+      image_cache: "missing",
+      audio_cache: "missing",
+    });
+    expect(run.runtimePidExists).toBe(false);
+    expect(run.runtimeLockExists).toBe(false);
+    expect(run.legacyPidExists).toBe(false);
+    expect(run.result.stderr).toContain(
+      "Hermes layout repair skipped because config root is locked",
+    );
   });
 
   it("kills orphaned socat forwarders when no Hermes gateway is alive", () => {

--- a/test/repro-2681-group-writable.test.ts
+++ b/test/repro-2681-group-writable.test.ts
@@ -3,13 +3,13 @@
 
 /**
  * Behavioral regression coverage for the group-writable mutable-default
- * contract (#2681).
+ * contract (#2681 and the Hermes root-entrypoint gateway split).
  *
  * These tests execute the entrypoint's permission-normalization function
  * against a temporary OpenClaw config tree instead of asserting on production
- * source text. The contract is what matters: when shields are down, OpenClaw's
- * config tree is group-writable and setgid; when shields are up (root-owned),
- * startup must not weaken the lock.
+ * source text. The contract is what matters: when shields are down, mutable
+ * config roots have the write modes needed by their gateway model; when
+ * shields are up (root-owned), startup must not weaken the lock.
  */
 
 import fs from "node:fs";
@@ -57,9 +57,13 @@ function withMockedDockerExecFileSync<T>(calls: string[][], run: () => T): T {
     const command = separator >= 0 ? args.slice(separator + 1) : [...args];
     calls.push(command);
     if (command[0] === "stat" && command[1] === "-c") {
-      return command.at(-1) === "/sandbox/.openclaw"
-        ? "2770 sandbox:sandbox\n"
-        : "660 sandbox:sandbox\n";
+      const target = command.at(-1);
+      if (target === "/sandbox/.openclaw") return "2770 sandbox:sandbox\n";
+      if (target === "/sandbox/.hermes") return "3770 sandbox:sandbox\n";
+      if (typeof target === "string" && target.startsWith("/sandbox/.hermes/")) {
+        return "640 sandbox:sandbox\n";
+      }
+      return "660 sandbox:sandbox\n";
     }
     if (command[0] === "lsattr") {
       return `---------------------- ${command.at(-1)}\n`;
@@ -88,7 +92,7 @@ function mkdtempOnPosixFs(prefix: string): string {
   throw lastError;
 }
 
-describe("Issue #2681 — mutable OpenClaw config permissions", () => {
+describe("mutable agent config permissions", () => {
   it("restores group-write and setgid on mutable config trees during non-root startup", () => {
     const tmpDir = mkdtempOnPosixFs("nemoclaw-2681-perms-");
     const configDir = path.join(tmpDir, ".openclaw");
@@ -164,6 +168,35 @@ describe("Issue #2681 — mutable OpenClaw config permissions", () => {
     expect(commands.find((command) => command[0] === "sh" && command[1] === "-c")).toEqual(
       expect.arrayContaining(["/sandbox/.openclaw", "sandbox:sandbox", "g+rwX,o-rwx", "2770"]),
     );
+  });
+
+  it("shields-down restores Hermes sticky group-writable config root without group-writable config files", () => {
+    const commands: string[][] = [];
+    withMockedDockerExecFileSync(commands, () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { unlockAgentConfig } = require("../dist/lib/shields/index.js") as {
+        unlockAgentConfig: (
+          sandboxName: string,
+          target: {
+            agentName?: string;
+            configPath: string;
+            configDir: string;
+            sensitiveFiles?: string[];
+          },
+        ) => void;
+      };
+
+      unlockAgentConfig("sandbox-pod", {
+        agentName: "hermes",
+        configPath: "/sandbox/.hermes/config.yaml",
+        configDir: "/sandbox/.hermes",
+        sensitiveFiles: ["/sandbox/.hermes/.env"],
+      });
+    });
+
+    expect(commands).toContainEqual(["chmod", "640", "/sandbox/.hermes/config.yaml"]);
+    expect(commands).toContainEqual(["chmod", "640", "/sandbox/.hermes/.env"]);
+    expect(commands).toContainEqual(["chmod", "3770", "/sandbox/.hermes"]);
   });
 
   it("shields-up strips setgid from the OpenClaw config root before verifying lock", () => {

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -905,8 +905,16 @@ describe("Hermes sandbox provisioning", () => {
       for (const run of runs) {
         expect(run.result.status).toBe(0);
         const hermesDir = path.join(run.sandboxRoot, ".hermes");
-        expect((fs.statSync(hermesDir).mode & 0o777).toString(8)).toBe("750");
-        for (const dir of ["logs", "cache", "platforms"]) {
+        expect((fs.statSync(hermesDir).mode & 0o7777).toString(8)).toBe("3770");
+        for (const dir of [
+          "logs",
+          "logs/curator",
+          "cache",
+          "hooks",
+          "image_cache",
+          "audio_cache",
+          "platforms",
+        ]) {
           expect((fs.statSync(path.join(hermesDir, dir)).mode & 0o777).toString(8)).toBe("770");
         }
         expect((fs.statSync(path.join(hermesDir, "platforms")).mode & 0o7777).toString(8)).toBe(
@@ -920,6 +928,7 @@ describe("Hermes sandbox provisioning", () => {
         expect(fs.readlinkSync(path.join(hermesDir, "gateway_state.json"))).toBe(
           "runtime/gateway_state.json",
         );
+        expect(() => fs.lstatSync(path.join(hermesDir, "gateway.pid"))).toThrow();
         expect(run.calls).toContain(`chown gateway:sandbox ${path.join(hermesDir, "runtime")}`);
       }
     } finally {


### PR DESCRIPTION
## Summary
- precreate Hermes v0.14 runtime directories: `hooks`, `image_cache`, `audio_cache`, and `logs/curator`
- make `/sandbox/.hermes` sticky group-writable (`3770`) so the `gateway` user can create Hermes top-level runtime state without being able to remove sandbox-owned config files
- stop precreating `/sandbox/.hermes/gateway.pid` as a symlink, since Hermes v0.14 writes it with `O_CREAT | O_EXCL`
- repair legacy startup state by removing old `gateway.pid -> runtime/gateway.pid` symlinks, clearing stale PID/lock state, and restoring required dirs before launch
- add unit, provisioning, shields-down, CI image, nightly, and Docker smoke coverage

## Cause / QA Context
This fixes a Hermes startup failure that presents as the familiar Step `[7/8]` gateway timeout, but the runtime fingerprint is different from the older rc-file rewrite bug.

The older closed issue path failed before gateway launch with:

```text
mktemp: failed to create file via template '/sandbox/..bashrc.tmp.XXXXXX': Permission denied
```

Current v0.0.51-era source no longer uses that `/sandbox/.bashrc` / `/sandbox/.profile` rewrite path. The failure addressed here happens later, when the real Hermes v0.14 image starts through the root NemoClaw entrypoint and then drops into the separate `gateway` UID. In that posture Hermes needs to create new top-level state under `HERMES_HOME` (`hooks`, `image_cache`, `audio_cache`, and `logs/curator`), but NemoClaw kept `/sandbox/.hermes` too closed for the `gateway` user to create those entries. At the same time NemoClaw precreated `/sandbox/.hermes/gateway.pid` as a symlink into `runtime/`, while Hermes v0.14 creates `gateway.pid` with `O_CREAT | O_EXCL`; the pre-existing symlink is interpreted as a PID race.

The observable fingerprint for this condition is:

```text
[gateway] hermes gateway launched as 'gateway' user
Could not load config.yaml
PID file race lost to another gateway instance. Exiting.
```

That distinction matters for the Brev/Ubuntu 22 reports: multiple Hermes regressions collapse into the same product symptom (`Hermes Agent gateway did not respond within 90s`, then supervisor fallback/sleep), so QA can reasonably see a closed Hermes startup bug as still open even when the old `mktemp /sandbox/..bashrc.tmp` root cause is gone. This PR targets the newer root-entrypoint / gateway-UID / Hermes-v0.14 layout failure and adds a deterministic smoke that reproduces that exact startup posture without needing Brev or live messaging credentials.

## Validation
- [x] `bash -n agents/hermes/start.sh test/e2e/test-hermes-root-entrypoint-smoke.sh`
- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] `npx vitest run test/hermes-start.test.ts test/sandbox-provisioning.test.ts test/repro-2681-group-writable.test.ts test/validate-e2e-coverage.test.ts`
- [x] `npx vitest run test/e2e-script-workflow.test.ts test/e2e/scenario-framework-tests/e2e-convention-lint.test.ts test/validate-e2e-coverage.test.ts`
- [x] `bash test/e2e/test-hermes-root-entrypoint-smoke.sh`
- [ ] Full `nightly-e2e.yaml` on `fb073a308641230d8a63aa855f46feccf624b1d3`: https://github.com/NVIDIA/NemoClaw/actions/runs/26479245694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes startup reliability with automatic filesystem layout repair and safer legacy PID handling.

* **Chores**
  * Hardened Hermes runtime/config directory permissions and privilege separation.
  * Added CI smoke tests and a nightly E2E job to validate Hermes root entrypoint.

* **Tests**
  * Expanded test coverage for permission normalization, sandbox provisioning, and legacy-startup scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
