### PR TITLE
docs: document WeChat channel and mark WeChat/WhatsApp experimental

### DIFF
--- a/ci/env-var-doc-allowlist.json
+++ b/ci/env-var-doc-allowlist.json
@@ -32,10 +32,6 @@
     "reason": "Internal installer sentinel exported only during OpenShell gateway replacement so onboard restores the pre-upgrade sandbox backup. Not user-facing."
   },
   {
-    "name": "NEMOCLAW_WECHAT_QUIET",
-    "reason": "Internal diagnostic quiet flag for the unreleased WeChat channel path. WeChat docs are intentionally suppressed until the feature is ready for public documentation."
-  },
-  {
     "name": "NEMOCLAW_TEST_NO_SLEEP",
     "reason": "Test sentinel that bypasses real-time sleep() calls in onboard inference probes. Set to '1' only by Vitest tests; never user-set."
   },

--- a/docs/.docs-skip
+++ b/docs/.docs-skip
@@ -38,8 +38,6 @@ skip-features:
   - "test/e2e/test-shields-config.sh"    # shields/config E2E, experimental
   - "shields-status"                     # plugin shields-status command, experimental
   - "config-show"                        # plugin config-show command, experimental
-  - "wechat"                             # WeChat channel docs are not public yet
-  - "WeChat"                             # WeChat channel docs are not public yet
 
 skip-terms:
   - "permissive mode"                    # do not reference this concept in docs
@@ -48,6 +46,3 @@ skip-terms:
   - "shields status"                     # experimental shields command, not advertised
   - "config rotate-token"                # experimental config command, not advertised
   - "rotate-token"                       # experimental config command, not advertised
-  - "wechat"                             # WeChat channel docs are not public yet
-  - "WeChat"                             # WeChat channel docs are not public yet
-  - "WECHAT"                             # WeChat channel docs are not public yet

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -13,25 +13,26 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use this 
 
 ## v0.0.51
 
-NemoClaw v0.0.51 improves messaging controls, local inference setup, policy validation, and onboarding recovery:
+NemoClaw v0.0.51 improves messaging controls, local inference setup, sandbox diagnostics, policy validation, and onboarding recovery:
 
 - Slack setup now supports channel allowlisting. During onboarding, `channels add slack`, and non-interactive rebuilds, set `SLACK_ALLOWED_CHANNELS` to restrict channel `@mention` handling to selected Slack channel IDs. Combine it with `SLACK_ALLOWED_USERS` when you want both channel and member checks.
 - Local Ollama setup now detects host installations that are below the minimum supported version and offers an explicit upgrade path. On macOS, NemoClaw uses Homebrew. On Linux, NemoClaw uses the system installer for upgrades and refuses non-interactive upgrade paths that would require a hidden sudo prompt.
+- Non-interactive Linux Ollama setup can use a sudo-free user-local install path when passwordless sudo is unavailable. The docs now describe `NEMOCLAW_OLLAMA_INSTALL_MODE`, the user-local install trade-offs, and the manual `zstd` requirement.
 - Managed Ollama model selection now uses a memory-aware registry for starter models. If a known bootstrap model does not fit currently available GPU memory, NemoClaw warns and falls back to the largest known model that does fit instead of starting a model that is likely to fail.
+- `nemoclaw onboard` restores the managed vLLM menu entry for DGX Spark and DGX Station hosts, which had been hidden after a previous onboard refactor dropped the `gpu.platform` value the vLLM menu builder relies on.
 - `nemoclaw resources` and `NEMOCLAW_RESOURCE_PROFILE` expose sandbox CPU and memory profiles. Profiles can be selected during onboarding, and `NEMOCLAW_CPU` or `NEMOCLAW_RAM` can override the selected profile for scripted runs.
 - Cloudflare named tunnels are supported through `CLOUDFLARE_TUNNEL_TOKEN`. `nemoclaw tunnel start` passes the token through the environment and expects the named tunnel route to already point at the dashboard port.
 - Jira policy validation guidance now matches the maintained preset. Use a Node HTTPS status probe for Atlassian API access and an explicit status-only curl probe for `auth.atlassian.com` when validating approved requests manually.
+- Sandbox logs merge OpenClaw gateway output and OpenShell audit events into one stream, and `--tail` applies once to the merged result so policy denials appear beside gateway logs.
 - Onboarding recovers more cleanly across host and runtime edge cases, including root-owned config sync directories, stale dashboard port allocation, unreachable Docker daemons, stale dashboard forwards, default NVIDIA CDI spec directories, and Linux Docker-driver health checks.
 
 ## v0.0.50
 
 NemoClaw v0.0.50 focused on onboarding reliability, local inference hardening, messaging diagnostics, and sandbox lifecycle cleanup:
 
-- `nemoclaw onboard` handles DGX Spark and DGX Station managed vLLM setup more consistently, including restored vLLM menu entries and CPU-fallback detection on Spark hosts.
-- Non-interactive Linux Ollama setup can use a sudo-free user-local install path when passwordless sudo is unavailable. The docs now describe `NEMOCLAW_OLLAMA_INSTALL_MODE`, the user-local install trade-offs, and the manual `zstd` requirement.
+- `nemoclaw onboard` detects DGX Spark hosts where managed Ollama falls back to CPU execution. Local inference setup fails the Ollama validation step with a tailored diagnostic, adds a Spark `OLLAMA_LLM_LIBRARY=cuda_v13` systemd override when that backend is installed, and enables the managed Linux Ollama service so local inference survives reboot.
 - Compatible endpoint setup rejects `host.docker.internal` inference URLs because OpenShell sandboxes do not have a portable host-service route through that name. Use Local Ollama's authenticated proxy path or a policy-managed host service instead.
 - Telegram setup now surfaces BotFather group privacy guidance. Disable privacy mode, then remove and re-add the bot to each group before testing group delivery.
-- Sandbox logs merge OpenClaw gateway output and OpenShell audit events into one stream, and `--tail` applies once to the merged result so policy denials appear beside gateway logs.
 - Maintenance commands recover the OpenShell gateway before retrying sandbox-list operations, which makes rebuild, recover, upgrade, and backup flows more resilient after gateway drift.
 - NemoClaw no longer writes proxy hooks into sandbox shell startup files. Local proxy configuration stays on supported OpenShell and NemoClaw paths rather than mutating user shell rc files.
 - Windows bootstrap installs Ubuntu 24.04 when WSL is present but no Ubuntu distribution is registered.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -273,10 +273,11 @@ After you confirm the summary, NemoClaw registers the selected provider with the
 The wizard then asks whether to enable Brave Web Search.
 If you enable it, enter a Brave Search API key when prompted.
 
-The wizard also offers messaging channels such as Telegram, Discord, Slack, and WhatsApp.
+The wizard also offers messaging channels such as Telegram, Discord, Slack, WeChat, and WhatsApp.
 Press a channel number to toggle it, then press Enter to continue.
 If you select a channel, NemoClaw validates the token format before it bakes the channel configuration into the sandbox.
 For example, Slack bot tokens must start with `xoxb-`.
+WeChat and WhatsApp are experimental; review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
 
 ### Choose Network Policy Presets
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -277,7 +277,8 @@ The wizard also offers messaging channels such as Telegram, Discord, Slack, WeCh
 Press a channel number to toggle it, then press Enter to continue.
 If you select a channel, NemoClaw validates the token format before it bakes the channel configuration into the sandbox.
 For example, Slack bot tokens must start with `xoxb-`.
-WeChat and WhatsApp are experimental; review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
+WeChat and WhatsApp are experimental.
+Review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
 
 ### Choose Network Policy Presets
 

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -3,17 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Messaging Channels"
 sidebar-title: "Set Up Messaging Channels"
-description: "Connect Telegram, Discord, Slack, or WhatsApp to your sandboxed OpenClaw or Hermes agent using OpenShell-managed channel messaging."
-description-agent: "Explains how Telegram, Discord, Slack, and WhatsApp reach sandboxed OpenClaw and Hermes agents through OpenShell-managed processes and NemoClaw channel commands. Use when setting up messaging channels, chat interfaces, or integrations without relying on nemoclaw tunnel start for bridges."
-keywords: ["nemoclaw messaging channels", "nemoclaw telegram", "nemoclaw discord", "nemoclaw slack", "nemoclaw whatsapp", "openshell channel messaging"]
+description: "Connect Telegram, Discord, Slack, WeChat, or WhatsApp to your sandboxed OpenClaw or Hermes agent using OpenShell-managed channel messaging."
+description-agent: "Explains how Telegram, Discord, Slack, WeChat, and WhatsApp reach sandboxed OpenClaw and Hermes agents through OpenShell-managed processes and NemoClaw channel commands. Use when setting up messaging channels, chat interfaces, or integrations without relying on nemoclaw tunnel start for bridges."
+keywords: ["nemoclaw messaging channels", "nemoclaw telegram", "nemoclaw discord", "nemoclaw slack", "nemoclaw wechat", "nemoclaw whatsapp", "openshell channel messaging"]
 content:
   type: "how_to"
 skill:
   priority: 30
 ---
-Telegram, Discord, Slack, and WhatsApp reach your OpenClaw or Hermes agent through OpenShell-managed processes and gateway constructs.
-For token-based channels, NemoClaw registers credentials with OpenShell providers; WhatsApp pairs inside the sandbox via QR scan and intentionally stores mutable session state there.
+Telegram, Discord, Slack, WeChat, and WhatsApp reach your OpenClaw or Hermes agent through OpenShell-managed processes and gateway constructs.
+For token-based channels, NemoClaw registers credentials with OpenShell providers; WeChat captures a token through a host-side QR scan during onboarding; WhatsApp pairs inside the sandbox via QR scan and intentionally stores mutable session state there.
 NemoClaw bakes the selected channel configuration into the sandbox image and keeps runtime delivery under OpenShell control.
+
+<Warning title="Experimental Channels">
+WeChat and WhatsApp are experimental.
+Both rely on QR-based pairing flows that are more fragile than token-based bots, and the upstream client libraries can change behavior without notice.
+Interfaces, defaults, and supported features may change, and these channels are not recommended for production use.
+</Warning>
 
 You can enable channels during `nemoclaw onboard` or add them later with host-side `nemoclaw <sandbox> channels` commands.
 Do not run agent-specific channel mutation commands such as `openclaw channels add` or `openclaw channels remove` inside the sandbox because NemoClaw generates `/sandbox/.openclaw/openclaw.json` for OpenClaw and `/sandbox/.hermes/.env` for Hermes at image build time, and changes inside the running container do not persist across rebuilds.
@@ -25,7 +31,7 @@ For details, refer to [Commands](/reference/commands).
 ## Prerequisites
 
 - A machine where you can run `nemoclaw onboard` (local or remote host that runs the gateway and sandbox).
-- A token for each token-based messaging platform you want to enable, or a phone you can use to scan the QR code for WhatsApp pairing.
+- A token for each token-based messaging platform you want to enable, a personal WeChat account on your phone for the host-side QR scan during onboarding, or a phone you can use to scan the QR code for WhatsApp pairing.
 - A network policy preset for each enabled channel, or equivalent custom egress rules.
 
 ## Channel Requirements
@@ -35,7 +41,8 @@ For details, refer to [Commands](/reference/commands).
 | Telegram | `TELEGRAM_BOT_TOKEN` | `TELEGRAM_ALLOWED_IDS` for DM allowlisting, `TELEGRAM_REQUIRE_MENTION` for group-chat replies |
 | Discord | `DISCORD_BOT_TOKEN` | `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION` |
 | Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `SLACK_ALLOWED_USERS` for DM and channel `@mention` user allowlisting, `SLACK_ALLOWED_CHANNELS` for channel ID allowlisting |
-| WhatsApp | None. Pair via QR after rebuild | None |
+| WeChat (experimental) | None. Captured via host-side QR scan during `nemoclaw onboard` | `WECHAT_ALLOWED_IDS` for DM allowlisting |
+| WhatsApp (experimental) | None. Pair via QR after rebuild | None |
 
 Telegram uses a bot token from [BotFather](https://t.me/BotFather).
 Open Telegram, send `/newbot` to [@BotFather](https://t.me/BotFather), follow the prompts, and copy the token.
@@ -59,7 +66,23 @@ Set `SLACK_ALLOWED_CHANNELS` to comma-separated Slack channel IDs to restrict ch
 When both Slack allowlists are set, NemoClaw requires the mention to come from one of the allowed channels and one of the allowed members.
 Channel messages still require an explicit bot mention.
 
-WhatsApp Web does not use a host-side token or OpenShell credential provider.
+WeChat (experimental) delivers messages over Tencent's iLink gateway via the upstream `@tencent-weixin/openclaw-weixin` plugin baked into the sandbox base image and the built-in Hermes iLink WeChat adapter.
+The supported mode in this release is **personal WeChat** (`bot_type=3`).
+WeChat Official Account and WeCom/Enterprise WeChat are not wired up.
+
+Because the bot token only exists after a successful iLink QR handshake, NemoClaw runs the QR login on the host during `nemoclaw onboard`.
+You scan the QR with WeChat on your phone (Discover → Scan), confirm the login, and NemoClaw captures the token, `accountId`, `baseUrl`, and `userId` from the iLink response.
+NemoClaw registers the token as the `<sandbox>-wechat-bridge` OpenShell provider and substitutes the `openshell:resolve:env:WECHAT_BOT_TOKEN` placeholder for it inside the sandbox, so the token never lands in the image or on disk inside the running container.
+The non-secret per-account metadata (`WECHAT_ACCOUNT_ID`, `WECHAT_BASE_URL`, `WECHAT_USER_ID`) is baked into the sandbox image so the in-sandbox bridge can pre-seed the per-account context tokens without re-running the QR handshake.
+
+WeChat is DM-only (`allowIdsMode: "dm"`).
+NemoClaw adds the operator who scanned the QR to `WECHAT_ALLOWED_IDS` automatically, and you can append more comma-separated WeChat user IDs through the same env var.
+You can silence the host-side `[wechat]` diagnostic lines (poll status, IDC redirects, swallowed gateway errors) by exporting `NEMOCLAW_WECHAT_QUIET=1` once the flow is stable in your environment.
+
+Tencent's iLink gateway is a third-party service.
+Review your organization's terms-of-service, compliance, and data-residency constraints before enabling WeChat.
+
+WhatsApp (experimental) Web does not use a host-side token or OpenShell credential provider.
 NemoClaw advertises WhatsApp for both OpenClaw and Hermes sandboxes, and each agent completes pairing with its own in-sandbox command.
 Pairing happens inside the sandbox after the rebuild completes and creates mutable session credentials there.
 Run `openshell term` and then use the agent-specific pairing command to render the QR code in the terminal:
@@ -76,10 +99,16 @@ Pair only one sandbox per WhatsApp account at a time.
 
 ## Enable Channels During Onboarding
 
-When the wizard reaches **Messaging channels**, it lists Telegram, Discord, Slack, and WhatsApp.
+When the wizard reaches **Messaging channels**, it lists Telegram, Discord, Slack, WeChat, and WhatsApp.
 Press a channel number to toggle it on or off, then press **Enter** when done.
 If a token-based channel token is not already in the environment or credential store, the wizard prompts for it and saves it.
-WhatsApp uses QR pairing instead of a host-side token, so the wizard does not prompt.
+
+If you enable WeChat (experimental), the wizard does not prompt for a paste token.
+Instead, it renders a QR code in your terminal, polls Tencent's iLink gateway, and captures the bot token after you scan the QR with WeChat on your phone.
+The login has an eight-minute deadline, refreshes the QR up to three times on expiry, and follows iLink's IDC redirects automatically.
+Keep the terminal in the foreground until you see `✓ WeChat login confirmed`.
+
+WhatsApp (experimental) uses QR pairing instead of a host-side token, so the wizard does not prompt.
 It prints pairing instructions and you complete the pairing inside the sandbox after rebuild.
 NemoClaw also selects the matching network policy preset during policy setup so the channel can reach its provider API.
 
@@ -96,13 +125,16 @@ $ export SLACK_ALLOWED_USERS=<your-slack-member-id>
 $ export SLACK_ALLOWED_CHANNELS=<your-slack-channel-id>
 ```
 
+This release does not support non-interactive WeChat configuration because the iLink QR handshake requires a human to scan the QR on a paired phone.
+Run `nemoclaw onboard` interactively when you want to enable WeChat.
+
 Then run onboarding:
 
 ```console
 $ nemoclaw onboard
 ```
 
-Complete the rest of the wizard so the blueprint can create OpenShell providers where needed (for example `<sandbox>-telegram-bridge`), bake channel configuration into the image (`NEMOCLAW_MESSAGING_CHANNELS_B64`), and start the sandbox.
+Complete the rest of the wizard so the blueprint can create OpenShell providers where needed (for example `<sandbox>-telegram-bridge` or `<sandbox>-wechat-bridge`), bake channel configuration into the image (`NEMOCLAW_MESSAGING_CHANNELS_B64`), and start the sandbox.
 
 ## Add Channels After Onboarding
 
@@ -119,10 +151,11 @@ Add the channel you want:
 $ nemoclaw my-assistant channels add telegram
 $ nemoclaw my-assistant channels add discord
 $ nemoclaw my-assistant channels add slack
+$ nemoclaw my-assistant channels add wechat
 $ nemoclaw my-assistant channels add whatsapp
 ```
 
-`channels add` collects whatever each channel needs (token prompts for Telegram, Discord, and Slack; nothing for WhatsApp because pairing happens in-sandbox after rebuild), registers bridge providers with the OpenShell gateway when tokens were captured, records the channel in the sandbox registry, and asks whether to rebuild immediately.
+`channels add` collects whatever each channel needs (token prompts for Telegram, Discord, and Slack; an interactive host-side QR scan for WeChat; nothing for WhatsApp because pairing happens in-sandbox after rebuild), registers bridge providers with the OpenShell gateway when tokens were captured, records the channel in the sandbox registry, and asks whether to rebuild immediately.
 The command accepts mixed-case input such as `Telegram`, then stores and prints the canonical lowercase channel name.
 If a matching built-in network policy preset exists, `channels add` applies it to the sandbox automatically before the rebuild so the bridge has egress to its upstream API; if applying the preset fails, NemoClaw warns and tells you to re-apply manually with `nemoclaw <sandbox> policy-add <channel>` after the rebuild.
 Choose the rebuild so the running sandbox image picks up the new channel.
@@ -151,18 +184,41 @@ $ DISCORD_BOT_TOKEN=<your-discord-bot-token> \
   nemoclaw my-assistant channels add discord
 ```
 
+### `channels add wechat`
+
+`channels add wechat` (experimental) follows the same shape as the other channels with two differences driven by the iLink QR handshake.
+
+First, the command does not prompt for a paste token.
+Instead, it renders a QR code in your terminal, polls Tencent's iLink gateway, and captures both the bot token and the per-account metadata (`accountId`, `baseUrl`, `userId`) once you scan the QR with WeChat on your phone (Discover → Scan).
+The login has an eight-minute deadline and refreshes the QR up to three times on expiry; keep the terminal in the foreground until you see `✓ WeChat login confirmed`.
+
+Second, the command requires an interactive terminal.
+Non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`) fails fast with a clear error because the QR handshake needs a paired phone.
+
+```console
+$ nemoclaw my-assistant channels add wechat
+```
+
+If `WECHAT_BOT_TOKEN` is already cached for this sandbox (the operator onboarded with WeChat earlier), `channels add wechat` reuses the cached token and skips the QR scan to keep the upstream plugin's existing iLink session intact.
+Re-running QR would invalidate that session; use `channels remove wechat` first if you intend to acquire a fresh account.
+
 ## Rotate or Remove Credentials
 
 Running `channels add` for a channel that is already configured overwrites the stored tokens and registers the updated bridge provider.
+For WeChat the cached-token short-circuit applies; see [`channels add wechat`](#channels-add-wechat) for how to acquire a fresh account.
 Rebuild the sandbox after the update so the image reflects the current channel set.
 
 To remove a channel and clear its stored credentials, run:
 
 ```console
 $ nemoclaw my-assistant channels remove telegram
+$ nemoclaw my-assistant channels remove wechat
 ```
 
-For QR-paired channels (today: WhatsApp), `channels remove` destructively clears the in-sandbox session directory before the rebuild so the next rebuild does not restore stale auth files and reconnect the channel.
+`channels remove wechat` clears the bot token, deletes the `<sandbox>-wechat-bridge` OpenShell provider, and drops `wechat` from the sandbox's enabled-channel set.
+The next rebuild produces an image without the WeChat channel block in `openclaw.json` and without the per-account state files under `/sandbox/.openclaw/openclaw-weixin/`.
+
+For in-sandbox QR-paired channels (today: WhatsApp), `channels remove` destructively clears the in-sandbox session directory before the rebuild so the next rebuild does not restore stale auth files and reconnect the channel.
 The cleanup targets `/sandbox/.openclaw/<channel>/` for OpenClaw and `/sandbox/.hermes/platforms/<channel>/` for Hermes.
 The cleanup tries `openshell sandbox exec` and falls back to SSH if that does not produce the success sentinel.
 If neither transport can reach a running sandbox for a QR-paired channel, the command exits non-zero and asks you to start the sandbox and re-run.
@@ -177,11 +233,19 @@ Use `channels stop` when you want to pause a bridge without deleting credentials
 ```console
 $ nemoclaw my-assistant channels stop telegram
 $ nemoclaw my-assistant channels start telegram
+
+$ nemoclaw my-assistant channels stop wechat
+$ nemoclaw my-assistant channels start wechat
 ```
 
-Telegram, Discord, and Slack each allow only one active consumer per channel credential.
-Multiple sandboxes can use the same channel type at the same time when each sandbox uses a distinct bot/app token.
+For WeChat specifically, `channels stop wechat` followed by a rebuild keeps the per-account state files under `/sandbox/.openclaw/openclaw-weixin/accounts/` intact even though the bridge is no longer wired up in `openclaw.json`.
+A subsequent `channels start wechat` plus rebuild revives the bridge against the same iLink account without a fresh QR scan.
+The bot token is held by the OpenShell provider across the stop/start cycle.
+
+Telegram, Discord, Slack, and WeChat each allow only one active consumer per channel credential.
+Multiple sandboxes can use the same channel type at the same time when each sandbox uses a distinct bot/app token (or a distinct WeChat iLink bot account).
 For example, two Telegram sandboxes can DM the same `TELEGRAM_ALLOWED_IDS` account as long as they use different `TELEGRAM_BOT_TOKEN` values.
+For WeChat, each sandbox must own a distinct iLink `accountId` (bot identity); running two sandboxes against the same WeChat account causes one of them to lose messages.
 If you enable a messaging channel and another sandbox already uses the same token, onboarding prompts you to confirm before continuing in interactive mode and exits non-zero in non-interactive mode.
 If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning; re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
 `nemoclaw status` reports cross-sandbox overlaps so you can resolve duplicates before messages start dropping.
@@ -190,13 +254,13 @@ If NemoClaw only has legacy channel metadata and cannot compare credential hashe
 
 Use `channels stop` when you want to pause one bridge and keep the sandbox running.
 Use `nemoclaw tunnel stop` or its deprecated alias `nemoclaw stop` when you want to stop host auxiliary services and also ask NemoClaw to stop the OpenClaw gateway inside the selected sandbox.
-Stopping the in-sandbox gateway stops Telegram, Discord, Slack, and WhatsApp polling for that sandbox until you restart the sandbox or gateway.
+Stopping the in-sandbox gateway stops Telegram, Discord, Slack, WeChat, and WhatsApp polling for that sandbox until you restart the sandbox or gateway.
 
 ## Confirm Delivery
 
 After the sandbox is running, send a message to the configured bot or app.
 If delivery fails, use `openshell term` on the host, check gateway logs, and verify network policy allows the channel API.
-Use the matching policy preset (`telegram`, `discord`, `slack`, or `whatsapp`) or review [Common Integration Policy Examples](/network-policy/integration-policy-examples).
+Use the matching policy preset (`telegram`, `discord`, `slack`, `wechat`, or `whatsapp`) or review [Common Integration Policy Examples](/network-policy/integration-policy-examples).
 
 ## Tunnel Command
 

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -12,7 +12,9 @@ skill:
   priority: 30
 ---
 Telegram, Discord, Slack, WeChat, and WhatsApp reach your OpenClaw or Hermes agent through OpenShell-managed processes and gateway constructs.
-For token-based channels, NemoClaw registers credentials with OpenShell providers; WeChat captures a token through a host-side QR scan during onboarding; WhatsApp pairs inside the sandbox via QR scan and intentionally stores mutable session state there.
+For token-based channels, NemoClaw registers credentials with OpenShell providers.
+WeChat captures a token through a host-side QR scan during onboarding.
+WhatsApp pairs inside the sandbox via QR scan and intentionally stores mutable session state there.
 NemoClaw bakes the selected channel configuration into the sandbox image and keeps runtime delivery under OpenShell control.
 
 <Warning title="Experimental Channels">
@@ -155,9 +157,12 @@ $ nemoclaw my-assistant channels add wechat
 $ nemoclaw my-assistant channels add whatsapp
 ```
 
-`channels add` collects whatever each channel needs (token prompts for Telegram, Discord, and Slack; an interactive host-side QR scan for WeChat; nothing for WhatsApp because pairing happens in-sandbox after rebuild), registers bridge providers with the OpenShell gateway when tokens were captured, records the channel in the sandbox registry, and asks whether to rebuild immediately.
+`channels add` collects whatever each channel needs.
+It prompts for Telegram, Discord, and Slack tokens, runs an interactive host-side QR scan for WeChat, and collects nothing for WhatsApp because pairing happens in-sandbox after rebuild.
+It registers bridge providers with the OpenShell gateway when tokens were captured, records the channel in the sandbox registry, and asks whether to rebuild immediately.
 The command accepts mixed-case input such as `Telegram`, then stores and prints the canonical lowercase channel name.
-If a matching built-in network policy preset exists, `channels add` applies it to the sandbox automatically before the rebuild so the bridge has egress to its upstream API; if applying the preset fails, NemoClaw warns and tells you to re-apply manually with `nemoclaw <sandbox> policy-add <channel>` after the rebuild.
+If a matching built-in network policy preset exists, `channels add` applies it to the sandbox automatically before the rebuild so the bridge has egress to its upstream API.
+If applying the preset fails, NemoClaw warns and tells you to re-apply manually with `nemoclaw <sandbox> policy-add <channel>` after the rebuild.
 Choose the rebuild so the running sandbox image picks up the new channel.
 If you need optional channel settings such as `TELEGRAM_ALLOWED_IDS`, `TELEGRAM_REQUIRE_MENTION`, `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION`, `SLACK_ALLOWED_USERS`, or `SLACK_ALLOWED_CHANNELS`, export them before the rebuild starts.
 If you defer the rebuild, apply the change later:
@@ -190,7 +195,8 @@ $ DISCORD_BOT_TOKEN=<your-discord-bot-token> \
 
 First, the command does not prompt for a paste token.
 Instead, it renders a QR code in your terminal, polls Tencent's iLink gateway, and captures both the bot token and the per-account metadata (`accountId`, `baseUrl`, `userId`) once you scan the QR with WeChat on your phone (Discover → Scan).
-The login has an eight-minute deadline and refreshes the QR up to three times on expiry; keep the terminal in the foreground until you see `✓ WeChat login confirmed`.
+The login has an eight-minute deadline and refreshes the QR up to three times on expiry.
+Keep the terminal in the foreground until you see `✓ WeChat login confirmed`.
 
 Second, the command requires an interactive terminal.
 Non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`) fails fast with a clear error because the QR handshake needs a paired phone.
@@ -200,12 +206,14 @@ $ nemoclaw my-assistant channels add wechat
 ```
 
 If `WECHAT_BOT_TOKEN` is already cached for this sandbox (the operator onboarded with WeChat earlier), `channels add wechat` reuses the cached token and skips the QR scan to keep the upstream plugin's existing iLink session intact.
-Re-running QR would invalidate that session; use `channels remove wechat` first if you intend to acquire a fresh account.
+Re-running QR would invalidate that session.
+Use `channels remove wechat` first if you intend to acquire a fresh account.
 
 ## Rotate or Remove Credentials
 
 Running `channels add` for a channel that is already configured overwrites the stored tokens and registers the updated bridge provider.
-For WeChat the cached-token short-circuit applies; see [`channels add wechat`](#channels-add-wechat) for how to acquire a fresh account.
+For WeChat the cached-token short-circuit applies.
+See [`channels add wechat`](#channels-add-wechat) for how to acquire a fresh account.
 Rebuild the sandbox after the update so the image reflects the current channel set.
 
 To remove a channel and clear its stored credentials, run:
@@ -245,9 +253,11 @@ The bot token is held by the OpenShell provider across the stop/start cycle.
 Telegram, Discord, Slack, and WeChat each allow only one active consumer per channel credential.
 Multiple sandboxes can use the same channel type at the same time when each sandbox uses a distinct bot/app token (or a distinct WeChat iLink bot account).
 For example, two Telegram sandboxes can DM the same `TELEGRAM_ALLOWED_IDS` account as long as they use different `TELEGRAM_BOT_TOKEN` values.
-For WeChat, each sandbox must own a distinct iLink `accountId` (bot identity); running two sandboxes against the same WeChat account causes one of them to lose messages.
+For WeChat, each sandbox must own a distinct iLink `accountId` (bot identity).
+Running two sandboxes against the same WeChat account causes one of them to lose messages.
 If you enable a messaging channel and another sandbox already uses the same token, onboarding prompts you to confirm before continuing in interactive mode and exits non-zero in non-interactive mode.
-If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning; re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
+If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning.
+Re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
 `nemoclaw status` reports cross-sandbox overlaps so you can resolve duplicates before messages start dropping.
 
 ## Stop Messaging Delivery

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -183,7 +183,8 @@ Available presets:
 | `pypi` | Python Package Index |
 | `slack` | Slack API and webhooks |
 | `telegram` | Telegram Bot API |
-| `whatsapp` | WhatsApp Web messaging |
+| `wechat` | WeChat (personal) iLink Bot API (experimental) |
+| `whatsapp` | WhatsApp Web messaging (experimental) |
 
 To apply a preset to a running sandbox:
 

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -65,7 +65,8 @@ NemoClaw ships maintained policy presets for common services in `nemoclaw-bluepr
 | Python Package Index | `pypi` |
 | Slack messaging | `slack` |
 | Telegram Bot API | `telegram` |
-| WhatsApp Web messaging | `whatsapp` |
+| WeChat (personal) iLink Bot API (experimental) | `wechat` |
+| WhatsApp Web messaging (experimental) | `whatsapp` |
 
 Preview the endpoints before applying:
 
@@ -125,7 +126,7 @@ If delivery fails, open the TUI and send a test message to the bot:
 $ openshell term
 ```
 
-The matching preset for each supported messaging channel is the channel name (`telegram`, `discord`, `slack`, or `whatsapp`).
+The matching preset for each supported messaging channel is the channel name (`telegram`, `discord`, `slack`, `wechat`, or `whatsapp`).
 
 ## Slack or Discord Messaging
 
@@ -157,6 +158,37 @@ If you enabled Slack or Discord during onboarding, apply only the matching prese
 ```console
 $ nemoclaw my-assistant policy-add slack --yes
 $ nemoclaw my-assistant policy-add discord --yes
+```
+
+## WeChat or WhatsApp Messaging (Experimental)
+
+WeChat and WhatsApp are experimental.
+Both rely on QR-based pairing flows that are more fragile than token-based bots, and the upstream client libraries can change behavior without notice.
+
+WeChat uses Tencent's iLink Bot API for personal accounts.
+The bot token is captured by a host-side QR scan during onboarding rather than pasted from a developer portal.
+Add the channel and apply the preset:
+
+```console
+$ NEMOCLAW_NON_INTERACTIVE=1 nemoclaw my-assistant channels add wechat
+$ nemoclaw my-assistant rebuild
+$ nemoclaw my-assistant policy-add wechat --yes
+```
+
+WhatsApp Web pairs entirely inside the sandbox via QR scan, so `channels add` does not collect a host-side token.
+Apply the preset and complete the in-sandbox pairing after the rebuild:
+
+```console
+$ NEMOCLAW_NON_INTERACTIVE=1 nemoclaw my-assistant channels add whatsapp
+$ nemoclaw my-assistant rebuild
+$ nemoclaw my-assistant policy-add whatsapp --yes
+```
+
+If you enabled WeChat or WhatsApp during onboarding, apply only the matching preset:
+
+```console
+$ nemoclaw my-assistant policy-add wechat --yes
+$ nemoclaw my-assistant policy-add whatsapp --yes
 ```
 
 ## GitHub and Jira
@@ -297,5 +329,5 @@ Use `nemoclaw my-assistant policy-add` for maintained NemoClaw presets.
 
 - [Approve or Deny Agent Network Requests](/network-policy/approve-network-requests) for the interactive OpenShell TUI flow.
 - [Customize the Sandbox Network Policy](/network-policy/customize-network-policy) for static policy edits and raw OpenShell policy files.
-- [Messaging Channels](/manage-sandboxes/messaging-channels) for Telegram, Discord, Slack, and WhatsApp channel configuration.
+- [Messaging Channels](/manage-sandboxes/messaging-channels) for Telegram, Discord, Slack, WeChat, and WhatsApp channel configuration.
 - [Commands](/reference/commands) for the full `policy-add`, `policy-list`, `policy-remove`, and `channels` command reference.

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -167,10 +167,10 @@ Both rely on QR-based pairing flows that are more fragile than token-based bots,
 
 WeChat uses Tencent's iLink Bot API for personal accounts.
 The bot token is captured by a host-side QR scan during onboarding rather than pasted from a developer portal.
-Add the channel and apply the preset:
+Add the channel interactively and apply the preset:
 
 ```console
-$ NEMOCLAW_NON_INTERACTIVE=1 nemoclaw my-assistant channels add wechat
+$ nemoclaw my-assistant channels add wechat
 $ nemoclaw my-assistant rebuild
 $ nemoclaw my-assistant policy-add wechat --yes
 ```

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -652,8 +652,9 @@ $ nemoclaw my-assistant hosts-remove searxng.local
 
 ### `nemoclaw <name> channels list`
 
-List the messaging channels NemoClaw knows about (`telegram`, `discord`, `slack`, `whatsapp`) with a short description.
+List the messaging channels NemoClaw knows about (`telegram`, `discord`, `slack`, `wechat`, `whatsapp`) with a short description.
 The command is a static reference; it does not consult credentials or the running sandbox.
+WeChat and WhatsApp are experimental.
 
 ```console
 $ nemoclaw my-assistant channels list
@@ -665,7 +666,11 @@ Register a messaging channel with the sandbox and rebuild so the image picks up 
 Channels fall into three login modes:
 
 - **Token paste** (`telegram`, `discord`, `slack`): the command prompts for any missing token and registers it with the OpenShell gateway.
-- **In-sandbox QR** (`whatsapp`): the command records the channel without a host-side token or OpenShell credential provider.
+- **Host-side QR** (`wechat`, experimental): the command renders an iLink QR code on the host and you scan it from WeChat on your phone.
+  On confirm, NemoClaw captures the bot token, registers it with the OpenShell gateway, and stores non-secret per-account metadata (`WECHAT_ACCOUNT_ID`, `WECHAT_BASE_URL`, `WECHAT_USER_ID`) for the in-sandbox bridge.
+  The scanning operator's WeChat user ID is added to `WECHAT_ALLOWED_IDS` automatically; supply additional comma-separated IDs to authorize more DM senders.
+  NemoClaw advertises WeChat for both OpenClaw (the `@tencent-weixin/openclaw-weixin` plugin) and Hermes (the built-in iLink WeChat adapter).
+- **In-sandbox QR** (`whatsapp`, experimental): the command records the channel without a host-side token or OpenShell credential provider.
   NemoClaw advertises WhatsApp for OpenClaw and Hermes sandboxes; after rebuild, run `openclaw channels login --channel whatsapp` for OpenClaw or `hermes whatsapp` for Hermes.
   This intentionally leaves QR-created mutable session state in the sandbox until you unpair it or clear the durable agent state.
 
@@ -692,7 +697,7 @@ If you omit the required `<channel>` argument, the CLI prints the `channels add 
 Clear the stored credentials for a messaging channel and rebuild the sandbox so the image drops the channel.
 Running `remove` for a channel that was never configured is a no-op against the credentials file and still triggers the rebuild prompt.
 When the bridge provider is attached to a live sandbox, NemoClaw detaches it before deleting the provider from the OpenShell gateway.
-If the matching built-in policy preset is applied, such as `telegram`, `discord`, `slack`, or `whatsapp`, NemoClaw also removes that preset so the upstream API is no longer allow-listed after the channel is gone.
+If the matching built-in policy preset is applied, such as `telegram`, `discord`, `slack`, `wechat`, or `whatsapp`, NemoClaw also removes that preset so the upstream API is no longer allow-listed after the channel is gone.
 NemoClaw also strips the channel from `session.policyPresets` so a subsequent `onboard --resume` does not re-apply the preset on the next rebuild.
 
 For QR-paired channels (today: WhatsApp), NemoClaw destructively clears the in-sandbox session directory before the rebuild so the `state_dirs` backup does not restore the auth blob and let the channel reconnect:
@@ -717,7 +722,7 @@ Host-side removal is the supported path because agent channel config is baked in
 
 ### `nemoclaw <name> channels stop <channel>`
 
-Pause a single messaging bridge (`telegram`, `discord`, `slack`, or `whatsapp`) without clearing its credentials.
+Pause a single messaging bridge (`telegram`, `discord`, `slack`, `wechat`, or `whatsapp`) without clearing its credentials.
 The channel is marked disabled in the per-sandbox registry, and the sandbox is rebuilt so the onboard step skips registering the bridge with the gateway.
 The provider stays registered with the OpenShell gateway, so a later `channels start` brings the bridge back without re-entering tokens.
 
@@ -1305,6 +1310,7 @@ These flags toggle optional behaviors during onboarding; set them before running
 | `NEMOCLAW_OPENSHELL_GATEWAY_BIN` | path | Advanced override for the `openshell-gateway` binary used by the Linux Docker-driver gateway. Defaults to the binary next to `openshell`, then common install paths. |
 | `NEMOCLAW_OPENSHELL_SANDBOX_BIN` | path | Advanced override for the `openshell-sandbox` binary passed to the Linux Docker-driver gateway supervisor. Defaults to the binary next to `openshell`, then common install paths. |
 | `NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR` | path | Advanced override for the Linux Docker-driver gateway pid file and SQLite state directory. Defaults to `~/.local/state/nemoclaw/openshell-docker-gateway`. |
+| `NEMOCLAW_WECHAT_QUIET` | `1` to enable | Silences the `[wechat]` diagnostic lines printed during the host-side WeChat QR login (poll status, IDC redirects, swallowed gateway errors). Visible by default while the experimental WeChat path stabilizes; set `1` once the flow is reliable in your environment. |
 
 ### Probe Timeouts
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -668,7 +668,7 @@ Channels fall into three login modes:
 - **Token paste** (`telegram`, `discord`, `slack`): the command prompts for any missing token and registers it with the OpenShell gateway.
 - **Host-side QR** (`wechat`, experimental): the command renders an iLink QR code on the host and you scan it from WeChat on your phone.
   On confirm, NemoClaw captures the bot token, registers it with the OpenShell gateway, and stores non-secret per-account metadata (`WECHAT_ACCOUNT_ID`, `WECHAT_BASE_URL`, `WECHAT_USER_ID`) for the in-sandbox bridge.
-  The scanning operator's WeChat user ID is added to `WECHAT_ALLOWED_IDS` automatically.
+  NemoClaw automatically adds the scanning operator's WeChat user ID to `WECHAT_ALLOWED_IDS`.
   Supply additional comma-separated IDs to authorize more DM senders.
   NemoClaw advertises WeChat for both OpenClaw (the `@tencent-weixin/openclaw-weixin` plugin) and Hermes (the built-in iLink WeChat adapter).
 - **In-sandbox QR** (`whatsapp`, experimental): the command records the channel without a host-side token or OpenShell credential provider.
@@ -1311,7 +1311,7 @@ These flags toggle optional behaviors during onboarding; set them before running
 | `NEMOCLAW_OPENSHELL_GATEWAY_BIN` | path | Advanced override for the `openshell-gateway` binary used by the Linux Docker-driver gateway. Defaults to the binary next to `openshell`, then common install paths. |
 | `NEMOCLAW_OPENSHELL_SANDBOX_BIN` | path | Advanced override for the `openshell-sandbox` binary passed to the Linux Docker-driver gateway supervisor. Defaults to the binary next to `openshell`, then common install paths. |
 | `NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR` | path | Advanced override for the Linux Docker-driver gateway pid file and SQLite state directory. Defaults to `~/.local/state/nemoclaw/openshell-docker-gateway`. |
-| `NEMOCLAW_WECHAT_QUIET` | `1` to enable | Silences the `[wechat]` diagnostic lines printed during the host-side WeChat QR login (poll status, IDC redirects, swallowed gateway errors). Visible by default while the experimental WeChat path stabilizes, so set `1` once the flow is reliable in your environment. |
+| `NEMOCLAW_WECHAT_QUIET` | `1` to enable | Silences the `[wechat]` diagnostic lines printed during the host-side WeChat QR login (poll status, IDC redirects, swallowed gateway errors), which are visible by default while the experimental WeChat path stabilizes; set `1` once the flow is reliable in your environment. |
 
 ### Probe Timeouts
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -668,7 +668,8 @@ Channels fall into three login modes:
 - **Token paste** (`telegram`, `discord`, `slack`): the command prompts for any missing token and registers it with the OpenShell gateway.
 - **Host-side QR** (`wechat`, experimental): the command renders an iLink QR code on the host and you scan it from WeChat on your phone.
   On confirm, NemoClaw captures the bot token, registers it with the OpenShell gateway, and stores non-secret per-account metadata (`WECHAT_ACCOUNT_ID`, `WECHAT_BASE_URL`, `WECHAT_USER_ID`) for the in-sandbox bridge.
-  The scanning operator's WeChat user ID is added to `WECHAT_ALLOWED_IDS` automatically; supply additional comma-separated IDs to authorize more DM senders.
+  The scanning operator's WeChat user ID is added to `WECHAT_ALLOWED_IDS` automatically.
+  Supply additional comma-separated IDs to authorize more DM senders.
   NemoClaw advertises WeChat for both OpenClaw (the `@tencent-weixin/openclaw-weixin` plugin) and Hermes (the built-in iLink WeChat adapter).
 - **In-sandbox QR** (`whatsapp`, experimental): the command records the channel without a host-side token or OpenShell credential provider.
   NemoClaw advertises WhatsApp for OpenClaw and Hermes sandboxes; after rebuild, run `openclaw channels login --channel whatsapp` for OpenClaw or `hermes whatsapp` for Hermes.
@@ -1310,7 +1311,7 @@ These flags toggle optional behaviors during onboarding; set them before running
 | `NEMOCLAW_OPENSHELL_GATEWAY_BIN` | path | Advanced override for the `openshell-gateway` binary used by the Linux Docker-driver gateway. Defaults to the binary next to `openshell`, then common install paths. |
 | `NEMOCLAW_OPENSHELL_SANDBOX_BIN` | path | Advanced override for the `openshell-sandbox` binary passed to the Linux Docker-driver gateway supervisor. Defaults to the binary next to `openshell`, then common install paths. |
 | `NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR` | path | Advanced override for the Linux Docker-driver gateway pid file and SQLite state directory. Defaults to `~/.local/state/nemoclaw/openshell-docker-gateway`. |
-| `NEMOCLAW_WECHAT_QUIET` | `1` to enable | Silences the `[wechat]` diagnostic lines printed during the host-side WeChat QR login (poll status, IDC redirects, swallowed gateway errors). Visible by default while the experimental WeChat path stabilizes; set `1` once the flow is reliable in your environment. |
+| `NEMOCLAW_WECHAT_QUIET` | `1` to enable | Silences the `[wechat]` diagnostic lines printed during the host-side WeChat QR login (poll status, IDC redirects, swallowed gateway errors). Visible by default while the experimental WeChat path stabilizes, so set `1` once the flow is reliable in your environment. |
 
 ### Probe Timeouts
 

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -50,8 +50,9 @@ GitHub access (`github.com`, `api.github.com`) is not included in the baseline p
 Apply the `github` preset during onboarding if your agent needs GitHub access.
 See [Customize the Network Policy](/network-policy/customize-network-policy).
 
-The baseline policy does not include messaging endpoints for Telegram, Discord, Slack, and WhatsApp.
+The baseline policy does not include messaging endpoints for Telegram, Discord, Slack, WeChat, or WhatsApp.
 Enable the channel during onboarding or apply the matching messaging preset so the sandbox can reach that platform.
+WeChat and WhatsApp are experimental; review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
 </Note>
 
 <a id="policy-tiers"></a>
@@ -64,7 +65,7 @@ The baseline policy is always applied regardless of the selected tier.
 |------|------------------|-------------|
 | Restricted | None | Base sandbox only. No third-party network access beyond inference and core agent tooling. |
 | Balanced (default) | `npm`, `pypi`, `huggingface`, `brew`, `brave when supported` | Full dev tooling and web search for agents that support web search. No messaging platform access. |
-| Open | `npm`, `pypi`, `huggingface`, `brew`, `brave when supported`, `slack`, `discord`, `telegram`, `whatsapp`, `jira`, `outlook` | Broad access across third-party services including messaging and productivity. |
+| Open | `npm`, `pypi`, `huggingface`, `brew`, `brave when supported`, `slack`, `discord`, `telegram`, `wechat` (experimental), `whatsapp` (experimental), `jira`, `outlook` | Broad access across third-party services including messaging and productivity. |
 
 After selecting a tier, a combined preset and access-mode screen lets you include or exclude individual presets and toggle each between read (GET only) and read-write (GET + POST/PUT/PATCH) access.
 Tier-default presets are pre-selected; additional presets can be added from the full list.

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -52,7 +52,8 @@ See [Customize the Network Policy](/network-policy/customize-network-policy).
 
 The baseline policy does not include messaging endpoints for Telegram, Discord, Slack, WeChat, or WhatsApp.
 Enable the channel during onboarding or apply the matching messaging preset so the sandbox can reach that platform.
-WeChat and WhatsApp are experimental; review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
+WeChat and WhatsApp are experimental.
+Review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
 </Note>
 
 <a id="policy-tiers"></a>

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -559,7 +559,8 @@ Follow these steps to reconnect.
    $ nemoclaw tunnel start
    ```
 
-   OpenShell-managed channel messaging handles Telegram, Discord, Slack, and WhatsApp at onboarding, not through a separate bridge process from `nemoclaw tunnel start`.
+   OpenShell-managed channel messaging handles Telegram, Discord, Slack, WeChat, and WhatsApp at onboarding, not through a separate bridge process from `nemoclaw tunnel start`.
+   WeChat and WhatsApp are experimental.
    To pause a single bridge without destroying the sandbox, use `nemoclaw <name> channels stop <channel>`.
 
 <Warning title="If the sandbox does not recover">
@@ -769,12 +770,15 @@ Run the equivalent host-side command instead:
 
 ```console
 $ nemoclaw <sandbox> channels list
-$ nemoclaw <sandbox> channels add <telegram|discord|slack|whatsapp>
-$ nemoclaw <sandbox> channels remove <telegram|discord|slack|whatsapp>
+$ nemoclaw <sandbox> channels add <telegram|discord|slack|wechat|whatsapp>
+$ nemoclaw <sandbox> channels remove <telegram|discord|slack|wechat|whatsapp>
 ```
 
 `channels add` registers credentials with the OpenShell gateway and `channels remove` clears them; both offer to rebuild the sandbox so the image reflects the new channel set.
 In non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`), the commands stage the change and leave the rebuild to a follow-up `nemoclaw <sandbox> rebuild`.
+WeChat and WhatsApp are experimental; review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
+
+WeChat captures its bot token through a host-side QR scan during `nemoclaw onboard` or `channels add wechat`; you scan the iLink QR from WeChat on your phone and NemoClaw registers the captured token with the OpenShell gateway.
 
 WhatsApp pairs entirely inside the sandbox.
 NemoClaw advertises WhatsApp for OpenClaw and Hermes sandboxes after you add the channel on the host.
@@ -1333,7 +1337,7 @@ Skills that require macOS-only binaries cannot be enabled on Brev.
 Skills that require additional CLI binaries require a custom sandbox image rebuild.
 
 For credentials, use the supported host-side setup flow.
-Re-run onboarding for inference or Brave Search credentials, or use `nemoclaw <name> channels add <telegram|discord|slack|whatsapp>` for messaging channels.
+Re-run onboarding for inference or Brave Search credentials, or use `nemoclaw <name> channels add <telegram|discord|slack|wechat|whatsapp>` for messaging channels.
 To add a binary to the sandbox image, update the sandbox `Dockerfile.base` to install the required package, then rebuild:
 
 ```console

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -774,11 +774,14 @@ $ nemoclaw <sandbox> channels add <telegram|discord|slack|wechat|whatsapp>
 $ nemoclaw <sandbox> channels remove <telegram|discord|slack|wechat|whatsapp>
 ```
 
-`channels add` registers credentials with the OpenShell gateway and `channels remove` clears them; both offer to rebuild the sandbox so the image reflects the new channel set.
+`channels add` registers credentials with the OpenShell gateway and `channels remove` clears them.
+Both offer to rebuild the sandbox so the image reflects the new channel set.
 In non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`), the commands stage the change and leave the rebuild to a follow-up `nemoclaw <sandbox> rebuild`.
-WeChat and WhatsApp are experimental; review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
+WeChat and WhatsApp are experimental.
+Review [Messaging Channels](/manage-sandboxes/messaging-channels) before enabling them.
 
-WeChat captures its bot token through a host-side QR scan during `nemoclaw onboard` or `channels add wechat`; you scan the iLink QR from WeChat on your phone and NemoClaw registers the captured token with the OpenShell gateway.
+WeChat captures its bot token through a host-side QR scan during `nemoclaw onboard` or `channels add wechat`.
+You scan the iLink QR from WeChat on your phone and NemoClaw registers the captured token with the OpenShell gateway.
 
 WhatsApp pairs entirely inside the sandbox.
 NemoClaw advertises WhatsApp for OpenClaw and Hermes sandboxes after you add the channel on the host.


### PR DESCRIPTION
## Summary
Restore the WeChat channel docs that had been removed via the `docs/.docs-skip` list, mark both WeChat and WhatsApp as experimental wherever they are user-visible, and re-document the host-side WeChat QR onboarding flow plus the `NEMOCLAW_WECHAT_QUIET` diagnostic env var. Also tighten the v0.0.50/v0.0.51 release-notes entries so each bullet lands in the version that actually shipped it.

## Changes
- `docs/.docs-skip`: drop `wechat` / `WeChat` / `WECHAT` from `skip-features` and `skip-terms` so the docs-to-skills gate stops suppressing WeChat content.
- `docs/manage-sandboxes/messaging-channels.mdx`: add an experimental warning for WeChat and WhatsApp; document Tencent's iLink Bot API personal-WeChat (`bot_type=3`) integration, the host-side QR handshake, the `<sandbox>-wechat-bridge` OpenShell provider, the `WECHAT_ACCOUNT_ID` / `WECHAT_BASE_URL` / `WECHAT_USER_ID` / `WECHAT_ALLOWED_IDS` metadata, the cached-token short-circuit on `channels add wechat`, and the `channels remove/stop/start wechat` lifecycle.
- `docs/network-policy/integration-policy-examples.mdx`, `docs/network-policy/customize-network-policy.mdx`, `docs/reference/network-policies.mdx`: list the `wechat` preset and Open-tier coverage, with explicit experimental tags on `wechat` and `whatsapp`.
- `docs/reference/commands.mdx`: extend `channels add` / `channels remove` / `channels stop` to cover `wechat`, document the host-side QR login mode, mark WhatsApp's QR mode as experimental, and add `NEMOCLAW_WECHAT_QUIET` to the Onboarding Behavior Flags table.
- `docs/reference/troubleshooting.mdx`, `docs/get-started/quickstart.mdx`: include `wechat` in command syntax and the wizard channel list, calling out experimental status.
- `ci/env-var-doc-allowlist.json`: remove `NEMOCLAW_WECHAT_QUIET` now that it is publicly documented in `docs/reference/commands.mdx`.
- `docs/about/release-notes.mdx`: move bullets that actually shipped in v0.0.51 (managed vLLM menu restoration on DGX Spark/Station, sudo-free user-local Linux Ollama install path, merged sandbox logs) into the v0.0.51 entry; rewrite the v0.0.50 DGX Spark bullet to focus on the CPU-fallback diagnostic and `OLLAMA_LLM_LIBRARY=cuda_v13` systemd override.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes:
- Pre-existing failing CLI unit test `src/lib/inference/local.test.ts > resolveNonInteractiveOllamaModel respects unknown tags and downgrades known oversize ones` (asserts `qwen3.6:35b` but resolver now returns `nemotron-3-nano:30b`) is unrelated to this doc-only change. The corresponding pre-commit `Test (CLI)` hook is skipped because no `src/`/`test/`/`bin/` files are touched.
- `docs-to-skills.py --dry-run`, `npx tsx scripts/check-env-var-docs.ts`, and `npm run docs` were all run during preparation and reported no errors or skip-term violations.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental WeChat and WhatsApp messaging channels with host-side WeChat QR login and token pairing.

* **Documentation**
  * Extensive updates across quickstart, messaging channels, network policies, commands reference, troubleshooting, and release notes to document flows, prerequisites, onboarding, management, and experimental warnings.

* **Chores**
  * Updated docs-skip lists and config allowlists to reflect messaging channel changes (removed one obsolete env-var entry).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->