### PR TITLE
fix(e2e): recognize scenario advisor paths

### DIFF
--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -50,6 +50,62 @@ describe("E2E scenario advisor", () => {
     );
   });
 
+  it("recognizes migrated test/e2e-scenario validation suite paths", () => {
+    const result = analyze([
+      "test/e2e-scenario/validation_suites/messaging/telegram/00-telegram-injection-safety.sh",
+    ]);
+
+    expect(result.relevantChangedFiles).toEqual([
+      "test/e2e-scenario/validation_suites/messaging/telegram/00-telegram-injection-safety.sh",
+    ]);
+    expect(result.required).toContainEqual(
+      expect.objectContaining({
+        id: "ubuntu-repo-docker__cloud-nvidia-openclaw-telegram:messaging-telegram",
+        workflow: "e2e-scenarios.yaml",
+        scenario: "ubuntu-repo-docker__cloud-nvidia-openclaw-telegram",
+        suiteFilter: "messaging-telegram",
+      }),
+    );
+  });
+
+  it("requires all known scenarios when typed scenario internals change", () => {
+    const result = analyze(["test/e2e-scenario/scenarios/run.ts"]);
+
+    expect(result.required).toContainEqual(
+      expect.objectContaining({ id: "e2e-scenarios-all" }),
+    );
+    expect(result.required).toContainEqual(
+      expect.objectContaining({
+        scenario: "ubuntu-repo-docker__cloud-nvidia-openclaw",
+      }),
+    );
+    expect(result.required).toContainEqual(
+      expect.objectContaining({
+        scenario: "ubuntu-repo-docker__cloud-nvidia-openclaw-telegram",
+      }),
+    );
+    expect(result.required.length).toBeGreaterThan(7);
+    expect(result.noScenarioE2eReason).toBeNull();
+  });
+
+  it("requires all known scenarios when migrated manifests change", () => {
+    const result = analyze([
+      "test/e2e-scenario/manifests/openclaw-nvidia.yaml",
+    ]);
+
+    expect(result.relevantChangedFiles).toEqual([
+      "test/e2e-scenario/manifests/openclaw-nvidia.yaml",
+    ]);
+    expect(result.required).toContainEqual(
+      expect.objectContaining({ id: "e2e-scenarios-all" }),
+    );
+    expect(result.required).toContainEqual(
+      expect.objectContaining({
+        scenario: "ubuntu-repo-docker__cloud-nvidia-openclaw",
+      }),
+    );
+  });
+
   it("requires all scenario E2E and targeted follow-up when suite metadata changes", () => {
     const result = analyze([
       "test/e2e/validation_suites/suites.yaml",

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -11,6 +11,7 @@ import { parseArgs, writeJson } from "../advisors/io.mts";
 const SCENARIO_WORKFLOW = "e2e-scenarios.yaml";
 const SCENARIO_ALL_WORKFLOW = "e2e-scenarios-all.yaml";
 const DEFAULT_BASELINE_SCENARIO = "ubuntu-repo-cloud-openclaw";
+const SCENARIO_ROOTS = ["test/e2e-scenario", "test/e2e"];
 const CORE_SCENARIO_IDS = [
   "ubuntu-repo-cloud-openclaw",
   "ubuntu-repo-cloud-hermes",
@@ -104,33 +105,47 @@ export function analyzeScenarioRecommendations({
   const reasons = new Set<string>();
   const relevantChangedFiles = changedFiles.filter(isScenarioRelevantFile);
   let allScenariosRequired = false;
+  let allKnownScenariosRequired = false;
+  const scenarioWorkflowInputs = detectScenarioWorkflowInputs(root);
 
   for (const file of changedFiles) {
+    const scenarioPath = parseScenarioPath(file);
     if (file === ".github/workflows/e2e-scenarios-all.yaml") {
       allScenariosRequired = true;
       reasons.add("the all-scenarios fan-out workflow changed");
     } else if (file === ".github/workflows/e2e-scenarios.yaml") {
       allScenariosRequired = true;
       reasons.add("the reusable single-scenario workflow changed");
-    } else if (file === "test/e2e/nemoclaw_scenarios/scenarios.yaml") {
+    } else if (scenarioPath?.kind === "scenario-catalog") {
       allScenariosRequired = true;
+      allKnownScenariosRequired = true;
       reasons.add("scenario catalog metadata changed");
-    } else if (file === "test/e2e/nemoclaw_scenarios/expected-states.yaml") {
+    } else if (scenarioPath?.kind === "expected-states") {
       allScenariosRequired = true;
+      allKnownScenariosRequired = true;
       reasons.add("expected-state metadata changed");
-    } else if (file === "test/e2e/validation_suites/suites.yaml") {
+    } else if (scenarioPath?.kind === "suite-catalog") {
       allScenariosRequired = true;
+      allKnownScenariosRequired = true;
       reasons.add("suite catalog metadata changed");
-    } else if (
-      file.startsWith("test/e2e/runtime/") ||
-      file.startsWith("test/e2e/nemoclaw_scenarios/helpers/")
-    ) {
+    } else if (scenarioPath?.kind === "shared-runtime") {
       allScenariosRequired = true;
+      allKnownScenariosRequired = true;
       reasons.add("shared scenario runner/runtime code changed");
-    } else if (
-      file.startsWith("test/e2e/nemoclaw_scenarios/onboard/") ||
-      file.startsWith("test/e2e/nemoclaw_scenarios/install/")
-    ) {
+    } else if (scenarioPath?.kind === "typed-scenario-code") {
+      allScenariosRequired = true;
+      allKnownScenariosRequired = true;
+      reasons.add("typed scenario builder/assertion/compiler code changed");
+    } else if (scenarioPath?.kind === "manifest") {
+      allScenariosRequired = true;
+      allKnownScenariosRequired = true;
+      reasons.add("scenario onboarding manifest changed");
+    } else if (scenarioPath?.kind === "onboarding-assertion") {
+      allScenariosRequired = true;
+      allKnownScenariosRequired = true;
+      reasons.add("onboarding assertion changed");
+    } else if (scenarioPath?.kind === "install-onboard-helper") {
+      allScenariosRequired = true;
       directScenarioIds.add(DEFAULT_BASELINE_SCENARIO);
       reasons.add("scenario install/onboard helper code changed");
     }
@@ -148,6 +163,11 @@ export function analyzeScenarioRecommendations({
   for (const suiteId of changedSuiteIds) {
     const matchingScenarios = suiteToScenarios.get(suiteId) || [];
     for (const scenario of matchingScenarios) directScenarioIds.add(scenario);
+  }
+
+  if (allKnownScenariosRequired) {
+    for (const scenario of Object.keys(scenarios))
+      directScenarioIds.add(scenario);
   }
 
   const required: ScenarioRecommendation[] = [];
@@ -176,6 +196,7 @@ export function analyzeScenarioRecommendations({
         scenario,
         suiteFilter,
         reasonForScenario(scenario, changedSuiteIds, reasons),
+        scenarioWorkflowInputs,
       ),
     );
   }
@@ -196,6 +217,7 @@ export function analyzeScenarioRecommendations({
           scenario,
           suiteFilter,
           `Targeted follow-up for changed suite(s): ${suiteFilter || [...changedSuiteIds].sort().join(",")}`,
+          scenarioWorkflowInputs,
           false,
         ),
       );
@@ -216,6 +238,7 @@ export function analyzeScenarioRecommendations({
           specialScenario,
           suiteFilterForScenario(specialScenario, changedSuiteIds, scenarios),
           "Special-runner scenario covers a changed suite but may require scarce hardware/secrets.",
+          scenarioWorkflowInputs,
           false,
         ),
       );
@@ -279,11 +302,11 @@ export function renderScenarioSummary(result: ScenarioAdvisorResult): string {
 }
 
 function loadScenarios(root: string): Record<string, ScenarioEntry> {
-  const filePath = path.join(
+  const filePath = firstExistingScenarioPath(
     root,
-    "test/e2e/nemoclaw_scenarios/scenarios.yaml",
+    "nemoclaw_scenarios/scenarios.yaml",
   );
-  if (!fs.existsSync(filePath)) return {};
+  if (!filePath) return {};
   const text = fs.readFileSync(filePath, "utf8");
   return {
     ...parseScenarioSection(text, "test_plans"),
@@ -292,9 +315,23 @@ function loadScenarios(root: string): Record<string, ScenarioEntry> {
 }
 
 function loadSuiteScriptMap(root: string): Record<string, string[]> {
-  const filePath = path.join(root, "test/e2e/validation_suites/suites.yaml");
-  if (!fs.existsSync(filePath)) return {};
+  const filePath = firstExistingScenarioPath(
+    root,
+    "validation_suites/suites.yaml",
+  );
+  if (!filePath) return {};
   return parseSuiteScripts(fs.readFileSync(filePath, "utf8"));
+}
+
+function firstExistingScenarioPath(
+  root: string,
+  relative: string,
+): string | undefined {
+  for (const scenarioRoot of SCENARIO_ROOTS) {
+    const filePath = path.join(root, scenarioRoot, relative);
+    if (fs.existsSync(filePath)) return filePath;
+  }
+  return undefined;
 }
 
 function parseScenarioSection(
@@ -413,10 +450,65 @@ function isScenarioRelevantFile(file: string): boolean {
   return (
     file === ".github/workflows/e2e-scenarios.yaml" ||
     file === ".github/workflows/e2e-scenarios-all.yaml" ||
-    file.startsWith("test/e2e/runtime/") ||
-    file.startsWith("test/e2e/nemoclaw_scenarios/") ||
-    file.startsWith("test/e2e/validation_suites/")
+    parseScenarioPath(file) !== undefined
   );
+}
+
+type ScenarioPathKind =
+  | "scenario-catalog"
+  | "expected-states"
+  | "suite-catalog"
+  | "validation-suite"
+  | "shared-runtime"
+  | "install-onboard-helper"
+  | "typed-scenario-code"
+  | "manifest"
+  | "onboarding-assertion"
+  | "scenario-docs-or-tests";
+
+function parseScenarioPath(
+  file: string,
+): { root: string; relative: string; kind: ScenarioPathKind } | undefined {
+  const scenarioRoot = SCENARIO_ROOTS.find((candidate) =>
+    file.startsWith(`${candidate}/`),
+  );
+  if (!scenarioRoot) return undefined;
+  const relative = file.slice(scenarioRoot.length + 1);
+
+  if (relative === "nemoclaw_scenarios/scenarios.yaml")
+    return { root: scenarioRoot, relative, kind: "scenario-catalog" };
+  if (relative === "nemoclaw_scenarios/expected-states.yaml")
+    return { root: scenarioRoot, relative, kind: "expected-states" };
+  if (relative === "validation_suites/suites.yaml")
+    return { root: scenarioRoot, relative, kind: "suite-catalog" };
+  if (
+    relative.startsWith("runtime/") ||
+    relative.startsWith("nemoclaw_scenarios/helpers/")
+  ) {
+    return { root: scenarioRoot, relative, kind: "shared-runtime" };
+  }
+  if (
+    relative.startsWith("nemoclaw_scenarios/onboard/") ||
+    relative.startsWith("nemoclaw_scenarios/install/")
+  ) {
+    return { root: scenarioRoot, relative, kind: "install-onboard-helper" };
+  }
+  if (relative.startsWith("validation_suites/"))
+    return { root: scenarioRoot, relative, kind: "validation-suite" };
+  if (relative.startsWith("scenarios/"))
+    return { root: scenarioRoot, relative, kind: "typed-scenario-code" };
+  if (relative.startsWith("manifests/"))
+    return { root: scenarioRoot, relative, kind: "manifest" };
+  if (relative.startsWith("onboarding_assertions/"))
+    return { root: scenarioRoot, relative, kind: "onboarding-assertion" };
+  if (
+    relative.startsWith("framework-tests/") ||
+    relative.startsWith("scenario-framework-tests/") ||
+    relative.startsWith("docs/")
+  ) {
+    return { root: scenarioRoot, relative, kind: "scenario-docs-or-tests" };
+  }
+  return undefined;
 }
 
 function inferSuiteIdsFromPath(
@@ -424,12 +516,9 @@ function inferSuiteIdsFromPath(
   suiteIds: Set<string>,
   suiteScriptMap: Record<string, string[]>,
 ): string[] {
-  if (
-    !file.startsWith("test/e2e/validation_suites/") ||
-    file.endsWith("/suites.yaml")
-  )
-    return [];
-  const relative = file.slice("test/e2e/validation_suites/".length);
+  const scenarioPath = parseScenarioPath(file);
+  if (scenarioPath?.kind !== "validation-suite") return [];
+  const relative = scenarioPath.relative.slice("validation_suites/".length);
   const segments = relative.split("/");
   const candidates = new Set<string>();
   for (let size = Math.min(segments.length, 3); size >= 1; size -= 1) {
@@ -507,15 +596,35 @@ function reasonForScenario(
   return `Scenario \`${scenario}\` exercises the changed scenario E2E surface.${suiteText} ${[...reasons].join("; ")}`.trim();
 }
 
+type ScenarioWorkflowInputs = {
+  scenarioField: "scenario" | "scenarios";
+  supportsSuiteFilter: boolean;
+};
+
+function detectScenarioWorkflowInputs(root: string): ScenarioWorkflowInputs {
+  const workflowPath = path.join(root, ".github/workflows/e2e-scenarios.yaml");
+  const text = fs.existsSync(workflowPath)
+    ? fs.readFileSync(workflowPath, "utf8")
+    : "";
+  return {
+    scenarioField: /^\s{6}scenarios:\s*$/m.test(text)
+      ? "scenarios"
+      : "scenario",
+    supportsSuiteFilter: /^\s{6}suite_filter:\s*$/m.test(text),
+  };
+}
+
 function buildSingleScenarioRecommendation(
   scenario: string,
   suiteFilter: string | undefined,
   reason: string,
+  workflowInputs: ScenarioWorkflowInputs,
   required = true,
 ): ScenarioRecommendation {
-  const suitePart = suiteFilter
-    ? ` --field suite_filter=${shellQuote(suiteFilter)}`
-    : "";
+  const suitePart =
+    suiteFilter && workflowInputs.supportsSuiteFilter
+      ? ` --field suite_filter=${shellQuote(suiteFilter)}`
+      : "";
   return {
     id: suiteFilter ? `${scenario}:${suiteFilter}` : scenario,
     workflow: SCENARIO_WORKFLOW,
@@ -523,7 +632,7 @@ function buildSingleScenarioRecommendation(
     suiteFilter,
     required,
     reason,
-    dispatchCommand: `gh workflow run e2e-scenarios.yaml --ref <pr-head-ref> --field scenario=${shellQuote(scenario)}${suitePart}`,
+    dispatchCommand: `gh workflow run e2e-scenarios.yaml --ref <pr-head-ref> --field ${workflowInputs.scenarioField}=${shellQuote(scenario)}${suitePart}`,
   };
 }
 


### PR DESCRIPTION
## Summary
The deterministic E2E scenario advisor now recognizes the migrated `test/e2e-scenario/**` tree in addition to the legacy `test/e2e/**` scenario paths. It recommends all known scenario coverage when core typed scenario internals, manifests, expected-state metadata, runtime helpers, or onboarding assertions change, instead of only noticing workflow/suite changes.

## Related Issue
Refs #4283

## Changes
- Add scenario-root detection for both `test/e2e-scenario` and legacy `test/e2e` paths in `tools/e2e-advisor/scenarios.mts`.
- Classify migrated scenario files by role: catalogs, expected states, suite catalogs, validation suites, runtime helpers, install/onboard helpers, typed scenario code, manifests, onboarding assertions, docs, and framework tests.
- Recommend `e2e-scenarios-all` plus all known scenario IDs for broad-impact scenario internals such as typed builders, manifests, runtime helpers, expected states, and onboarding assertions.
- Keep targeted suite recommendations for individual validation-suite changes.
- Detect whether `.github/workflows/e2e-scenarios.yaml` uses `scenario` or `scenarios` inputs so rendered dispatch commands stay aligned with the active workflow contract.
- Add regression coverage for migrated suite paths, typed scenario internals, and migrated manifest changes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification run locally:
- `npx vitest run test/e2e-scenario-advisor.test.ts test/e2e-advisor-dispatch.test.ts` (31 tests passed)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended E2E scenario advisor test coverage with three new validation test cases covering scenario path migration, internal changes, and manifest updates.

* **Chores**
  * Enhanced scenario detection infrastructure to support multiple scenario roots and improved workflow input handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->