### PR TITLE
fix(onboard): non-fatal inference set for local Ollama and vLLM (#4257)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -334,6 +334,9 @@ const { createWebSearchFlowHelpers }: typeof import("./onboard/web-search-flow")
 const {
   createValidationRecoveryPromptHelpers,
 }: typeof import("./onboard/validation-recovery-prompt") = require("./onboard/validation-recovery-prompt");
+const {
+  createLocalInferenceRouteApplier,
+}: typeof import("./onboard/local-inference-route") = require("./onboard/local-inference-route");
 const { createOpenshellCliHelpers }: typeof import("./onboard/openshell-cli") = require("./onboard/openshell-cli");
 const sandboxGpuPreflight: typeof import("./onboard/sandbox-gpu-preflight") = require("./onboard/sandbox-gpu-preflight");
 const {
@@ -729,6 +732,16 @@ const { promptValidationRecovery } = createValidationRecoveryPromptHelpers({
     validateNvidiaApiKeyValue(key, credentialEnv ?? undefined),
   getTransportRecoveryMessage: (failure: any) => getTransportRecoveryMessage(failure),
   exitOnboardFromPrompt,
+});
+
+const applyLocalInferenceRoute = createLocalInferenceRouteApplier({
+  runOpenshell,
+  isNonInteractive,
+  promptValidationRecovery,
+  classifyApplyFailure,
+  compactText,
+  redact,
+  localInferenceTimeoutSecs: LOCAL_INFERENCE_TIMEOUT_SECS,
 });
 
 // Provider CRUD — thin wrappers that inject runOpenshell to avoid circular deps.
@@ -5434,63 +5447,6 @@ async function setupNim(
 
 // ── Step 4: Inference provider ───────────────────────────────────
 
-// Wraps `openshell inference set` for local providers (ollama-local, vllm-local)
-// with the same retry/recovery surface as the remote-provider path. Without this,
-// a nonzero exit from `openshell inference set` propagates through runOpenshell
-// and calls process.exit() directly, which terminates onboarding mid-step with no
-// context — onboarding appears to stop silently after the [4/8] warning. See #4257.
-async function applyLocalInferenceRoute({
-  provider,
-  model,
-  label,
-}: {
-  provider: string;
-  model: string;
-  label: string;
-}): Promise<{ ok: true; retry?: undefined } | { retry: "selection" }> {
-  const args = [
-    "inference",
-    "set",
-    "--no-verify",
-    "--provider",
-    provider,
-    "--model",
-    model,
-    "--timeout",
-    String(LOCAL_INFERENCE_TIMEOUT_SECS),
-  ];
-  while (true) {
-    const applyResult = runOpenshell(args, { ignoreError: true });
-    if (applyResult.status === 0) {
-      return { ok: true };
-    }
-    const detail =
-      compactText(redact(`${applyResult.stderr || ""} ${applyResult.stdout || ""}`)) ||
-      `Failed to configure inference provider '${provider}'.`;
-    console.error(`  ${detail}`);
-    if (isNonInteractive()) {
-      // Only surface the resume guidance when we are actually about to exit —
-      // printing it on every interactive retry is misleading because the user
-      // is still inside an active onboard run.
-      console.error(
-        "  No sandbox was created. Fix the inference route and re-run " +
-          "`nemoclaw onboard --resume` to continue, or choose a different provider/model.",
-      );
-      process.exit(applyResult.status || 1);
-    }
-    const retry = await promptValidationRecovery(
-      label,
-      classifyApplyFailure(detail),
-      null,
-      null,
-    );
-    if (retry === "credential" || retry === "retry") {
-      continue;
-    }
-    return { retry: "selection" };
-  }
-}
-
 async function setupInference(
   sandboxName: string | null,
   model: string,
@@ -5728,12 +5684,7 @@ async function setupInference(
       console.error(`  ${providerResult.message}`);
       process.exit(providerResult.status || 1);
     }
-    const vllmSetResult = await applyLocalInferenceRoute({
-      provider: "vllm-local",
-      model,
-      label: "Local vLLM",
-    });
-    if (vllmSetResult.retry === "selection") return { retry: "selection" };
+    if (await applyLocalInferenceRoute("vllm-local", model)) return { retry: "selection" };
     // Do not mutate ~/.nemoclaw/credentials.json here: local vLLM now uses
     // VLLM_LOCAL_CREDENTIAL_ENV, so any saved OPENAI_API_KEY remains available
     // to unrelated OpenAI-backed sandboxes.
@@ -5805,12 +5756,7 @@ async function setupInference(
       console.error(`  ${providerResult.message}`);
       process.exit(providerResult.status || 1);
     }
-    const ollamaSetResult = await applyLocalInferenceRoute({
-      provider: "ollama-local",
-      model,
-      label: "Local Ollama",
-    });
-    if (ollamaSetResult.retry === "selection") return { retry: "selection" };
+    if (await applyLocalInferenceRoute("ollama-local", model)) return { retry: "selection" };
     console.log(`  Priming Ollama model: ${model}`);
     run(getOllamaWarmupCommand(model), { ignoreError: true });
     const probe = validateOllamaModel(model);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -5434,6 +5434,63 @@ async function setupNim(
 
 // ── Step 4: Inference provider ───────────────────────────────────
 
+// Wraps `openshell inference set` for local providers (ollama-local, vllm-local)
+// with the same retry/recovery surface as the remote-provider path. Without this,
+// a nonzero exit from `openshell inference set` propagates through runOpenshell
+// and calls process.exit() directly, which terminates onboarding mid-step with no
+// context — onboarding appears to stop silently after the [4/8] warning. See #4257.
+async function applyLocalInferenceRoute({
+  provider,
+  model,
+  label,
+}: {
+  provider: string;
+  model: string;
+  label: string;
+}): Promise<{ ok: true; retry?: undefined } | { retry: "selection" }> {
+  const args = [
+    "inference",
+    "set",
+    "--no-verify",
+    "--provider",
+    provider,
+    "--model",
+    model,
+    "--timeout",
+    String(LOCAL_INFERENCE_TIMEOUT_SECS),
+  ];
+  while (true) {
+    const applyResult = runOpenshell(args, { ignoreError: true });
+    if (applyResult.status === 0) {
+      return { ok: true };
+    }
+    const detail =
+      compactText(redact(`${applyResult.stderr || ""} ${applyResult.stdout || ""}`)) ||
+      `Failed to configure inference provider '${provider}'.`;
+    console.error(`  ${detail}`);
+    if (isNonInteractive()) {
+      // Only surface the resume guidance when we are actually about to exit —
+      // printing it on every interactive retry is misleading because the user
+      // is still inside an active onboard run.
+      console.error(
+        "  No sandbox was created. Fix the inference route and re-run " +
+          "`nemoclaw onboard --resume` to continue, or choose a different provider/model.",
+      );
+      process.exit(applyResult.status || 1);
+    }
+    const retry = await promptValidationRecovery(
+      label,
+      classifyApplyFailure(detail),
+      null,
+      null,
+    );
+    if (retry === "credential" || retry === "retry") {
+      continue;
+    }
+    return { retry: "selection" };
+  }
+}
+
 async function setupInference(
   sandboxName: string | null,
   model: string,
@@ -5671,17 +5728,12 @@ async function setupInference(
       console.error(`  ${providerResult.message}`);
       process.exit(providerResult.status || 1);
     }
-    runOpenshell([
-      "inference",
-      "set",
-      "--no-verify",
-      "--provider",
-      "vllm-local",
-      "--model",
+    const vllmSetResult = await applyLocalInferenceRoute({
+      provider: "vllm-local",
       model,
-      "--timeout",
-      String(LOCAL_INFERENCE_TIMEOUT_SECS),
-    ]);
+      label: "Local vLLM",
+    });
+    if (vllmSetResult.retry === "selection") return { retry: "selection" };
     // Do not mutate ~/.nemoclaw/credentials.json here: local vLLM now uses
     // VLLM_LOCAL_CREDENTIAL_ENV, so any saved OPENAI_API_KEY remains available
     // to unrelated OpenAI-backed sandboxes.
@@ -5753,17 +5805,12 @@ async function setupInference(
       console.error(`  ${providerResult.message}`);
       process.exit(providerResult.status || 1);
     }
-    runOpenshell([
-      "inference",
-      "set",
-      "--no-verify",
-      "--provider",
-      "ollama-local",
-      "--model",
+    const ollamaSetResult = await applyLocalInferenceRoute({
+      provider: "ollama-local",
       model,
-      "--timeout",
-      String(LOCAL_INFERENCE_TIMEOUT_SECS),
-    ]);
+      label: "Local Ollama",
+    });
+    if (ollamaSetResult.retry === "selection") return { retry: "selection" };
     console.log(`  Priming Ollama model: ${model}`);
     run(getOllamaWarmupCommand(model), { ignoreError: true });
     const probe = validateOllamaModel(model);

--- a/src/lib/onboard/local-inference-route.ts
+++ b/src/lib/onboard/local-inference-route.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { getProbeRecovery } from "../validation-recovery";
+
+export interface LocalInferenceRouteDeps {
+  runOpenshell(
+    args: string[],
+    options: { ignoreError: true },
+  ): { status: number | null; stdout?: string | Buffer | null; stderr?: string | Buffer | null };
+  isNonInteractive(): boolean;
+  promptValidationRecovery(
+    label: string,
+    recovery: ReturnType<typeof getProbeRecovery>,
+    credentialEnv?: string | null,
+    helpUrl?: string | null,
+  ): Promise<"credential" | "selection" | "retry" | "model">;
+  classifyApplyFailure(message: string): ReturnType<typeof getProbeRecovery>;
+  compactText(value: string): string;
+  redact(value: string): string;
+  localInferenceTimeoutSecs: number;
+}
+
+const LOCAL_PROVIDER_LABELS: Record<string, string> = {
+  "vllm-local": "Local vLLM",
+  "ollama-local": "Local Ollama",
+};
+
+// Wraps `openshell inference set` for local providers (ollama-local, vllm-local)
+// with the same retry/recovery surface as the remote-provider path. Without this,
+// a nonzero exit from `openshell inference set` propagates through runOpenshell
+// and calls process.exit() directly, which terminates onboarding mid-step with no
+// context — onboarding appears to stop silently after the [4/8] warning. See #4257.
+// Returns true if the user chose to back out to provider selection; false on success.
+export function createLocalInferenceRouteApplier(deps: LocalInferenceRouteDeps) {
+  return async function applyLocalInferenceRoute(
+    provider: string,
+    model: string,
+  ): Promise<boolean> {
+    const label = LOCAL_PROVIDER_LABELS[provider] || provider;
+    const args = [
+      "inference",
+      "set",
+      "--no-verify",
+      "--provider",
+      provider,
+      "--model",
+      model,
+      "--timeout",
+      String(deps.localInferenceTimeoutSecs),
+    ];
+    while (true) {
+      const applyResult = deps.runOpenshell(args, { ignoreError: true });
+      if (applyResult.status === 0) {
+        return false;
+      }
+      const detail =
+        deps.compactText(deps.redact(`${applyResult.stderr || ""} ${applyResult.stdout || ""}`)) ||
+        `Failed to configure inference provider '${provider}'.`;
+      console.error(`  ${detail}`);
+      if (deps.isNonInteractive()) {
+        // Only surface the resume guidance when we are actually about to exit —
+        // printing it on every interactive retry is misleading because the user
+        // is still inside an active onboard run.
+        console.error(
+          "  No sandbox was created. Fix the inference route and re-run " +
+            "`nemoclaw onboard --resume` to continue, or choose a different provider/model.",
+        );
+        process.exit(applyResult.status || 1);
+      }
+      const retry = await deps.promptValidationRecovery(
+        label,
+        deps.classifyApplyFailure(detail),
+        null,
+        null,
+      );
+      if (retry === "credential" || retry === "retry") {
+        continue;
+      }
+      return true;
+    }
+  };
+}

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1360,6 +1360,257 @@ const { setupInference } = require(${onboardPath});
     );
   });
 
+  it("surfaces a contextual error and exits when ollama-local inference set fails after the proxy-ready warning (#4257)", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-ollama-set-fail-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "ollama-set-fail.cjs");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
+    const platformPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "platform.js"));
+    const localInferencePath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "inference", "local.js"),
+    );
+    const proxyPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "inference", "ollama", "proxy.js"),
+    );
+    const topologyPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "onboard", "local-inference-topology.js"),
+    );
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const platform = require(${platformPath});
+const localInference = require(${localInferencePath});
+const proxy = require(${proxyPath});
+const topology = require(${topologyPath});
+const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
+
+let exitCode = null;
+const realExit = process.exit;
+process.exit = (code) => {
+  if (exitCode === null) exitCode = code;
+  const err = new Error("EXIT_CALLED:" + code);
+  err.__exit = true;
+  throw err;
+};
+
+const errLog = [];
+const origErr = console.error;
+console.error = (...args) => {
+  errLog.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  origErr.apply(console, args);
+};
+
+const commands = [];
+runner.run = (command, opts = {}) => {
+  const cmd = _n(command);
+  commands.push({ command: cmd, ignoreError: !!opts.ignoreError });
+  if (cmd.includes("provider get")) return { status: 1, stdout: "", stderr: "" };
+  if (cmd.includes("inference set") && cmd.includes("ollama-local")) {
+    return { status: 7, stdout: "", stderr: "openshell: route apply failed" };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};
+runner.runCapture = (command) => {
+  const cmd = _n(command);
+  if (cmd.includes("inference") && cmd.includes("get")) {
+    return [
+      "Gateway inference:",
+      "",
+      "  Route: inference.local",
+      "  Provider: ollama-local",
+      "  Model: qwen2.5:7b",
+      "  Version: 1",
+    ].join("\\n");
+  }
+  return "";
+};
+registry.updateSandbox = () => true;
+platform.isWsl = () => true;
+topology.shouldFrontOllamaWithProxy = () => true;
+localInference.validateLocalProvider = () => ({
+  ok: false,
+  message: "container cannot reach Ollama",
+  diagnostic: "simulated WSL native Docker reachability failure",
+});
+localInference.getLocalProviderBaseUrl = () => "http://host.openshell.internal:11435/v1";
+localInference.getOllamaWarmupCommand = () => ["true"];
+localInference.validateOllamaModel = () => ({ ok: true });
+proxy.ensureOllamaAuthProxy = () => {};
+proxy.isProxyHealthy = () => true;
+proxy.getOllamaProxyToken = () => "proxy-token";
+proxy.persistAndProbeOllamaProxy = async () => {};
+
+const { setupInference } = require(${onboardPath});
+
+(async () => {
+  try {
+    await setupInference("test-box", "qwen2.5:7b", "ollama-local");
+  } catch (err) {
+    if (!err || !err.__exit) {
+      origErr("[TEST] outer error:", err && err.message);
+      process.stdout.write(JSON.stringify({ commands, errLog, exitCode, error: String(err && err.message) }) + "\n");
+      realExit.call(process, 99);
+    }
+  }
+  process.stdout.write(JSON.stringify({ commands, errLog, exitCode }) + "\n");
+  realExit.call(process, 0);
+})();
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        // Force the non-interactive branch so the bug surfaces as a hard exit
+        // rather than a recovery prompt that would hang in CI.
+        NEMOCLAW_NON_INTERACTIVE: "1",
+      },
+    });
+
+    // Exit 0 because we override process.exit and end with realExit(0) after
+    // catching the simulated exit. Test asserts on the captured payload instead.
+    expect(result.status).toBe(0);
+    const payload = parseStdoutJson<{
+      commands: { command: string; ignoreError: boolean }[];
+      errLog: string[];
+      exitCode: number | null;
+    }>(result.stdout);
+
+    // Pre-fix, runOpenshell was called without ignoreError, so the runtime
+    // wrapper exited before we could attach context. Post-fix, the local
+    // path must use ignoreError + a contextual error message.
+    const setCmd = payload.commands.find((entry) =>
+      entry.command.includes("inference set --no-verify --provider ollama-local"),
+    );
+    assert.ok(setCmd, "expected ollama-local inference set command to be issued");
+    assert.equal(setCmd.ignoreError, true, "ollama-local inference set must use ignoreError so onboard can recover");
+
+    // The user must see the no-sandbox / resume-onboard guidance, not a silent stop.
+    const combinedErr = payload.errLog.join("\n");
+    assert.match(combinedErr, /No sandbox was created/);
+    assert.match(combinedErr, /nemoclaw onboard --resume/);
+
+    // And the process should still propagate the nonzero status from openshell,
+    // not exit 0.
+    assert.equal(payload.exitCode, 7, "non-interactive onboard must exit with the openshell status");
+  });
+
+  it("surfaces a contextual error and exits when vllm-local inference set fails (#4257)", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-vllm-set-fail-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "vllm-set-fail.cjs");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
+    const localInferencePath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "inference", "local.js"),
+    );
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+
+    const script = String.raw`
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const localInference = require(${localInferencePath});
+const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
+
+let exitCode = null;
+const realExit = process.exit;
+process.exit = (code) => {
+  if (exitCode === null) exitCode = code;
+  const err = new Error("EXIT_CALLED:" + code);
+  err.__exit = true;
+  throw err;
+};
+
+const errLog = [];
+const origErr = console.error;
+console.error = (...args) => {
+  errLog.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  origErr.apply(console, args);
+};
+
+const commands = [];
+runner.run = (command, opts = {}) => {
+  const cmd = _n(command);
+  commands.push({ command: cmd, ignoreError: !!opts.ignoreError });
+  if (cmd.includes("provider get")) return { status: 1, stdout: "", stderr: "" };
+  if (cmd.includes("inference set") && cmd.includes("vllm-local")) {
+    return { status: 13, stdout: "", stderr: "openshell: vllm route apply failed" };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};
+runner.runCapture = () => "";
+registry.updateSandbox = () => true;
+localInference.validateLocalProvider = () => ({ ok: true });
+localInference.getLocalProviderBaseUrl = () => "http://host.openshell.internal:8000/v1";
+
+const { setupInference } = require(${onboardPath});
+
+(async () => {
+  try {
+    await setupInference("test-box", "meta-llama", "vllm-local");
+  } catch (err) {
+    if (!err || !err.__exit) {
+      origErr("[TEST] outer error:", err && err.message);
+      process.stdout.write(JSON.stringify({ commands, errLog, exitCode, error: String(err && err.message) }) + "\n");
+      realExit.call(process, 99);
+    }
+  }
+  process.stdout.write(JSON.stringify({ commands, errLog, exitCode }) + "\n");
+  realExit.call(process, 0);
+})();
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_NON_INTERACTIVE: "1",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const payload = parseStdoutJson<{
+      commands: { command: string; ignoreError: boolean }[];
+      errLog: string[];
+      exitCode: number | null;
+    }>(result.stdout);
+
+    const setCmd = payload.commands.find((entry) =>
+      entry.command.includes("inference set --no-verify --provider vllm-local"),
+    );
+    assert.ok(setCmd, "expected vllm-local inference set command to be issued");
+    assert.equal(setCmd.ignoreError, true, "vllm-local inference set must use ignoreError so onboard can recover");
+
+    const combinedErr = payload.errLog.join("\n");
+    assert.match(combinedErr, /No sandbox was created/);
+    assert.match(combinedErr, /nemoclaw onboard --resume/);
+
+    assert.equal(payload.exitCode, 13, "non-interactive onboard must exit with the openshell status");
+  });
+
   it("detects when the live inference route already matches the requested provider and model", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-inference-ready-"));


### PR DESCRIPTION
## Summary

Local Ollama and vLLM onboarding called `openshell inference set` through `runOpenshell([...])` without `{ ignoreError: true }`, so a nonzero exit propagated through the wrapper's `process.exit(...)` and terminated onboarding mid-step with no context — the same step where the proxy-ready warning fires on WSL2 with Windows-host Ollama. The remote-provider branch already captured the failure and offered recovery; the local branches did not.

## Related Issue

Fixes #4257.

## Changes

- `src/lib/onboard.ts`: extract `applyLocalInferenceRoute` helper that wraps the `openshell inference set` call for `ollama-local` and `vllm-local` with `{ ignoreError: true }`. On failure:
  - prints the redacted openshell stderr/stdout detail every iteration,
  - in non-interactive mode, surfaces the contextual "no sandbox / re-run `nemoclaw onboard --resume`" guidance and exits with the openshell status code,
  - in interactive mode, reuses the existing `promptValidationRecovery` flow so the user can retry, back out to provider selection, or exit intentionally.
- `test/onboard.test.ts`: two new `#4257` tests for `ollama-local` (continuing past the proxy-ready warning) and `vllm-local` that assert the `inference set` call uses `ignoreError`, the user sees the resume guidance, and non-interactive onboard exits with the openshell status (7 and 13 respectively).

The new helper mirrors the pattern already used by the remote-provider branch (`onboard.ts:~5660`). The routed-provider branch (`isRoutedInferenceProvider`, e.g. nvidia-router) still calls `runOpenshell` without `ignoreError` and has the same bug class, but it's outside this issue's scope and structurally distinct (no proxy-ready warning path); leaving for follow-up.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` — targeted: `npx vitest run --project cli test/onboard.test.ts` → 51/51 pass, including the two new `#4257` tests.
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — N/A
- [ ] Doc pages follow the style guide — N/A
- [ ] New doc pages include SPDX header and frontmatter — N/A

I did not run a live WSL2/Windows-host Ollama reproduction from this workspace; the tests simulate the failing `inference set` and assert the recovery contract.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of local inference setup failures with clearer, redacted failure messages and actionable resume guidance.
  * Onboarding now respects interactive vs non-interactive modes: non-interactive runs provide clear exit behavior and instructions; interactive runs offer targeted recovery options or a graceful return to provider selection.

* **Tests**
  * Added tests covering onboarding failure paths for local inference providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->