### PR TITLE
fix(gateway): keep auto-pair watcher alive for late OpenClaw CLI scope upgrades (#4263)

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1393,9 +1393,24 @@ HANDLED = set()  # Track rejected/approved requestIds to avoid reprocessing
 ALLOWED_CLIENTS = {'openclaw-control-ui'}
 ALLOWED_MODES = {'webchat', 'cli'}
 
+RUN_TIMEOUT_SECS = _env_seconds('NEMOCLAW_AUTO_PAIR_RUN_TIMEOUT_SECS', 10)
+
 def run(*args):
-    proc = subprocess.run(args, capture_output=True, text=True)
-    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    # Bound every openclaw CLI invocation so a wedged child cannot pin
+    # the watcher beyond DEADLINE (CodeRabbit #4292): subprocess.run with
+    # no timeout would hold a hung `openclaw devices list/approve` past
+    # the fast→slow transition and the 8h deadline check.
+    try:
+        proc = subprocess.run(
+            args, capture_output=True, text=True, timeout=RUN_TIMEOUT_SECS,
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except subprocess.TimeoutExpired as exc:
+        # 124 matches GNU `timeout` exit status so log scrapers can spot it.
+        out = (exc.stdout or '') if isinstance(exc.stdout, str) else ''
+        err = (exc.stderr or '') if isinstance(exc.stderr, str) else ''
+        print(f'[auto-pair] timeout calling {args[1] if len(args) > 1 else "openclaw"} {args[2] if len(args) > 2 else ""}'.rstrip())
+        return 124, out.strip(), err.strip()
 
 while time.time() < DEADLINE:
     rc, out, err = run(OPENCLAW, 'devices', 'list', '--json')

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1360,9 +1360,31 @@ import subprocess
 import time
 
 OPENCLAW = os.environ.get('OPENCLAW_BIN', 'openclaw')
-DEADLINE = time.time() + 600
+
+
+def _env_seconds(name, default):
+    raw = os.environ.get(name, '').strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+# Total runtime cap. After convergence the watcher polls at a slow cadence,
+# so it can stay alive for the typical sandbox session without saturating
+# the gateway. Late `openclaw agent` runs (NemoClaw#4263) request additional
+# scopes that the gateway holds as pending until something approves them; an
+# exited watcher leaves those upgrades stuck and the agent falls back to
+# embedded mode. Defaults: 8h total, 30s slow-mode cadence.
+FAST_DEADLINE = time.time() + _env_seconds('NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS', 600)
+DEADLINE = time.time() + _env_seconds('NEMOCLAW_AUTO_PAIR_DEADLINE_SECS', 28800)
+SLOW_INTERVAL = _env_seconds('NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS', 30)
 QUIET_POLLS = 0
 APPROVED = 0
+SLOW_MODE = False
 HANDLED = set()  # Track rejected/approved requestIds to avoid reprocessing
 # SECURITY NOTE: clientId/clientMode are client-supplied and spoofable
 # (the gateway stores connectParams.client.id verbatim). This allowlist
@@ -1378,17 +1400,27 @@ def run(*args):
 while time.time() < DEADLINE:
     rc, out, err = run(OPENCLAW, 'devices', 'list', '--json')
     if rc != 0 or not out:
-        time.sleep(1)
+        time.sleep(SLOW_INTERVAL if SLOW_MODE else 1)
         continue
     try:
         data = json.loads(out)
     except Exception:
-        time.sleep(1)
+        time.sleep(SLOW_INTERVAL if SLOW_MODE else 1)
         continue
 
     pending = data.get('pending') or []
     paired = data.get('paired') or []
     has_browser = any((d.get('clientId') == 'openclaw-control-ui') or (d.get('clientMode') == 'webchat') for d in paired if isinstance(d, dict))
+
+    # Fast-deadline transition is checked here, BEFORE the pending-branch
+    # `continue`, so that a sticky pending request (rejected unknown client
+    # added to HANDLED, or a permanent approve failure) cannot hold the
+    # watcher in 1s polling for the full DEADLINE window — that would
+    # re-create the NemoClaw#2484 connect-handler pile-up on a much longer
+    # timeline.
+    if not SLOW_MODE and time.time() >= FAST_DEADLINE:
+        SLOW_MODE = True
+        print(f'[auto-pair] fast-mode deadline reached; switching to slow-mode approvals={APPROVED}')
 
     if pending:
         QUIET_POLLS = 0
@@ -1408,42 +1440,51 @@ while time.time() < DEADLINE:
             HANDLED.add(request_id)
             if arc == 0:
                 APPROVED += 1
-                print(f'[auto-pair] approved request={request_id} client={client_id}')
+                print(f'[auto-pair] approved request={request_id} client={client_id} mode={client_mode}')
             elif aout or aerr:
                 print(f'[auto-pair] approve failed request={request_id}: {(aerr or aout)[:400]}')
-        time.sleep(1)
+        time.sleep(SLOW_INTERVAL if SLOW_MODE else 1)
         continue
 
     QUIET_POLLS += 1
-    # Exit-on-quiet conditions, checked in order of strength:
+    # Convergence conditions, checked in order of strength:
     #   1. Browser device paired — original control-UI workflow
     #   2. Any paired device — covers dangerouslyDisableDeviceAuth setups
     #      where the gateway auto-pairs CLI clients directly without the
     #      watcher running `openclaw devices approve` (so APPROVED stays
     #      0 forever in those configurations)
     #   3. We approved at least one device explicitly
-    # Without these, the watcher polled `openclaw devices list --json`
-    # every 1 second for 10 minutes whenever no browser device joined,
-    # saturating the gateway connect handler and starving concurrent
-    # `openclaw agent` connects (NemoClaw#2484: WS handshake-timeout).
-    if QUIET_POLLS >= 4:
+    # On convergence the watcher used to exit. That left late CLI scope
+    # upgrades pending forever (NemoClaw#4263). Now we transition to a slow
+    # polling cadence (default 30s) so late allowlisted scope upgrades for
+    # already-paired clients still get approved without saturating the
+    # gateway connect handler (NemoClaw#2484: WS handshake-timeout). The
+    # fast-deadline transition is now evaluated above (before the pending
+    # branch) so a stuck pending request cannot defer it.
+    if not SLOW_MODE and QUIET_POLLS >= 4:
         if has_browser:
-            print(f'[auto-pair] browser pairing converged approvals={APPROVED}')
-            break
-        if paired:
-            print(f'[auto-pair] devices paired ({len(paired)}); exiting approvals={APPROVED}')
-            break
-        if APPROVED > 0:
-            print(f'[auto-pair] non-browser pairing converged approvals={APPROVED}')
-            break
+            SLOW_MODE = True
+            print(f'[auto-pair] browser pairing converged; entering slow-mode approvals={APPROVED}')
+        elif paired:
+            SLOW_MODE = True
+            print(f'[auto-pair] devices paired ({len(paired)}); entering slow-mode approvals={APPROVED}')
+        elif APPROVED > 0:
+            SLOW_MODE = True
+            print(f'[auto-pair] non-browser pairing converged; entering slow-mode approvals={APPROVED}')
 
-    # Back off polling once anything is paired or approved: 1s when
-    # actively processing pending requests / waiting for first pairing,
-    # 5s thereafter. The 5s cadence avoids connect-handler pile-up under
-    # high gateway connect latency.
-    time.sleep(5 if (APPROVED > 0 or paired) else 1)
+    # Back off polling: 1s in fast mode while waiting for first pairing,
+    # 5s in fast mode once anything is paired/approved, and SLOW_INTERVAL
+    # (default 30s) after convergence. Slow-mode keepalive lets late CLI
+    # scope upgrades get approved through the rest of DEADLINE without
+    # hammering the gateway.
+    if SLOW_MODE:
+        time.sleep(SLOW_INTERVAL)
+    elif APPROVED > 0 or paired:
+        time.sleep(5)
+    else:
+        time.sleep(1)
 else:
-    print(f'[auto-pair] watcher timed out approvals={APPROVED}')
+    print(f'[auto-pair] watcher deadline reached approvals={APPROVED}')
 PYAUTOPAIR
   AUTO_PAIR_PID=$!
   echo "[gateway] auto-pair watcher launched (pid $AUTO_PAIR_PID)" >&2

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1452,6 +1452,13 @@ while time.time() < DEADLINE:
                 print(f'[auto-pair] rejected unknown client={client_id} mode={client_mode}')
                 continue
             arc, aout, aerr = run(OPENCLAW, 'devices', 'approve', request_id, '--json')
+            # rc=124 is the timeout sentinel from run() — do NOT add the
+            # request to HANDLED on a transient timeout, so the next poll
+            # can retry (CodeRabbit #4292). Permanent failures (other
+            # non-zero rc) still get HANDLED so we don't spin on a stuck
+            # bad request.
+            if arc == 124:
+                continue
             HANDLED.add(request_id)
             if arc == 0:
                 APPROVED += 1

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -605,6 +605,105 @@ function ensureSandboxInferenceRouteOrExit(
   return result.sandbox;
 }
 
+// One-shot, defense-in-depth approval pass for late OpenClaw CLI/webchat
+// scope upgrades (NemoClaw#4263). The in-sandbox auto-pair watcher keeps
+// approving allowlisted requests in slow-mode for hours after startup; this
+// pass covers the case where the watcher has exited or is otherwise stuck
+// when the user runs `nemoclaw <sandbox> connect`. The script sources
+// `/tmp/nemoclaw-proxy-env.sh` (written by `nemoclaw-start.sh`) so the
+// in-sandbox `openclaw devices list/approve` invocations target the
+// running gateway with its token, and applies the same allowlist as the
+// startup watcher — `openclaw-control-ui` clients plus `webchat`/`cli`
+// modes. Unknown clients are ignored, not approved.
+//
+// Failure modes (timeout, sandbox-exec errors, missing openclaw, gateway
+// unreachable) are swallowed: the connect flow must not be blocked by a
+// best-effort approval. Internal timeouts (2s list + 1s × MAX_APPROVALS)
+// fit within the outer spawnSync cap, so a partial-completion mid-loop
+// kill cannot strand allowlisted requests within a normal batch.
+const CONNECT_AUTO_PAIR_MAX_APPROVALS = 8;
+const CONNECT_AUTO_PAIR_TIMEOUT_MS = 12_000;
+
+function runConnectAutoPairApprovalPass(sandboxName: string): void {
+  const script = `
+PROXY_ENV=/tmp/nemoclaw-proxy-env.sh
+[ -r "$PROXY_ENV" ] && . "$PROXY_ENV"
+command -v openclaw >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+OPENCLAW_BIN="$(command -v openclaw)" python3 - <<'PYAPPROVE'
+import json
+import os
+import subprocess
+import sys
+
+OPENCLAW = os.environ.get('OPENCLAW_BIN', 'openclaw')
+ALLOWED_CLIENTS = {'openclaw-control-ui'}
+ALLOWED_MODES = {'webchat', 'cli'}
+MAX_APPROVALS = ${CONNECT_AUTO_PAIR_MAX_APPROVALS}
+
+try:
+    proc = subprocess.run(
+        [OPENCLAW, 'devices', 'list', '--json'],
+        capture_output=True, text=True, timeout=2,
+    )
+except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+    sys.exit(0)
+if proc.returncode != 0 or not proc.stdout.strip():
+    sys.exit(0)
+try:
+    data = json.loads(proc.stdout)
+except ValueError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+pending = data.get('pending')
+if not isinstance(pending, list):
+    sys.exit(0)
+approved_count = 0
+seen_request_ids = set()
+for device in pending:
+    if approved_count >= MAX_APPROVALS:
+        break
+    if not isinstance(device, dict):
+        continue
+    request_id = device.get('requestId')
+    if not request_id or request_id in seen_request_ids:
+        continue
+    client_id = device.get('clientId', '')
+    client_mode = device.get('clientMode', '')
+    if client_id not in ALLOWED_CLIENTS and client_mode not in ALLOWED_MODES:
+        continue
+    seen_request_ids.add(request_id)
+    try:
+        subprocess.run(
+            [OPENCLAW, 'devices', 'approve', request_id, '--json'],
+            capture_output=True, text=True, timeout=1,
+        )
+        approved_count += 1
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        continue
+PYAPPROVE
+exit 0
+`;
+  try {
+    // Best-effort: discard stdout/stderr. Outer cap is sized to cover the
+    // internal budget (2s list + 1s × MAX_APPROVALS plus shell/python
+    // startup slack) so a wedged sandbox can never block the connect flow.
+    spawnSync(
+      getOpenshellBinary(),
+      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", script],
+      {
+        cwd: ROOT,
+        env: process.env,
+        stdio: ["ignore", "ignore", "ignore"],
+        timeout: CONNECT_AUTO_PAIR_TIMEOUT_MS,
+      },
+    );
+  } catch {
+    /* defense-in-depth — never throw from the connect path */
+  }
+}
+
 function maybeEnsureHermesToolGatewayBroker(sb: SandboxEntry | null): void {
   if (
     !sb ||
@@ -795,6 +894,14 @@ export async function connectSandbox(
   // After the sandbox is Ready, verify and recover the route before SSH.
   sb = ensureSandboxInferenceRouteOrExit(sandboxName);
   maybeEnsureHermesToolGatewayBroker(sb);
+
+  // ── Auto-pair late scope-upgrade approval (#4263) ───────────────
+  // Defense in depth: even with the in-sandbox watcher running in
+  // slow-mode keepalive, a brief approval pass before opening SSH
+  // catches any pending allowlisted CLI/webchat scope upgrades that
+  // piled up between startup and now (e.g., watcher crashed, watcher
+  // deadline exhausted, multi-sandbox gateway contention).
+  runConnectAutoPairApprovalPass(sandboxName);
 
   // Print a one-shot hint before dropping the user into the sandbox
   // shell so a fresh user knows the first thing to type. Without this,

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -1766,6 +1766,98 @@ exit 0
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
+
+  it("retries a transient approve timeout instead of permanently handling the requestId", () => {
+    // Regression for CodeRabbit feedback on PR #4292: a transient
+    // timeout from `openclaw devices approve` used to mark the
+    // requestId HANDLED unconditionally, so the late scope upgrade was
+    // never retried — defeating the watcher's whole purpose. The fix
+    // detects the rc=124 timeout sentinel and skips HANDLED, so the
+    // next poll retries the same request.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-aretry-"));
+    const fakeOpenclaw = path.join(tmpDir, "openclaw");
+    const stateFile = path.join(tmpDir, "approve-count");
+    const approveLog = path.join(tmpDir, "approvals.log");
+    const pendingResponse = JSON.stringify({
+      pending: [
+        { requestId: "flaky-cli", clientId: "openclaw-cli", clientMode: "cli" },
+      ],
+      paired: [],
+    });
+    const allPaired = JSON.stringify({
+      pending: [],
+      paired: [{ clientId: "openclaw-cli", clientMode: "cli" }],
+    });
+
+    // The fake openclaw counts how many `devices approve flaky-cli`
+    // calls have been made; the first one hangs past the timeout, the
+    // second one succeeds. `devices list` returns the pending request
+    // until the approve succeeds, then returns paired.
+    fs.writeFileSync(
+      fakeOpenclaw,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
+  if [ -f ${JSON.stringify(approveLog)} ]; then
+    printf '%s\n' ${JSON.stringify(allPaired)}
+  else
+    printf '%s\n' ${JSON.stringify(pendingResponse)}
+  fi
+  exit 0
+fi
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "approve" ]; then
+  count="$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)"
+  count=$((count + 1))
+  echo "$count" > ${JSON.stringify(stateFile)}
+  if [ "$count" = "1" ]; then
+    # First call: hang past the per-call timeout to force rc=124.
+    sleep 5
+    exit 0
+  fi
+  # Second call: succeed and record the approval.
+  echo "$3" >> ${JSON.stringify(approveLog)}
+  printf '{}\n'
+  exit 0
+fi
+echo "unexpected: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const watcherSrc = startScriptHeredoc(
+        fs.readFileSync(START_SCRIPT, "utf-8"),
+        "PYAUTOPAIR",
+      );
+      const run = spawnSync("python3", ["-c", watcherSrc], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS: "600",
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "8",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+          NEMOCLAW_AUTO_PAIR_RUN_TIMEOUT_SECS: "1",
+        },
+        timeout: 30_000,
+      });
+      expect(run.status).toBe(0);
+      // Timeout was logged for the first attempt.
+      expect(run.stdout).toContain("[auto-pair] timeout calling devices approve");
+      // Retry succeeded on the second attempt.
+      expect(run.stdout).toContain(
+        "[auto-pair] approved request=flaky-cli client=openclaw-cli mode=cli",
+      );
+      // The approve log records exactly one successful approval (the
+      // retry, not the hung first attempt).
+      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
+        "flaky-cli",
+      ]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 40_000);
 });
 
 describe("nemoclaw-start gateway launch signal handling", () => {

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -1704,6 +1704,68 @@ exit 2
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
+
+  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", () => {
+    // Regression for CodeRabbit feedback on PR #4292: the watcher's
+    // `run()` helper used to call `subprocess.run` with no timeout, so a
+    // hung `openclaw devices list` could hold the watcher past DEADLINE
+    // and past the fast→slow transition. The fix adds a per-invocation
+    // timeout (default 10s, overridable via env). This test uses a fake
+    // openclaw that sleeps longer than the per-invocation timeout but
+    // shorter than the watcher deadline, and verifies the watcher does
+    // not block on it.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-runto-"));
+    const fakeOpenclaw = path.join(tmpDir, "openclaw");
+
+    fs.writeFileSync(
+      fakeOpenclaw,
+      `#!/usr/bin/env bash
+# Sleep longer than the per-invocation timeout to simulate a wedged CLI.
+sleep 5
+echo '{"pending":[],"paired":[]}'
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      // Do NOT monkey-patch time.sleep here: we want real wall-clock
+      // semantics so subprocess.run(..., timeout=...) actually fires.
+      const watcherSrc = startScriptHeredoc(
+        fs.readFileSync(START_SCRIPT, "utf-8"),
+        "PYAUTOPAIR",
+      );
+      const start = Date.now();
+      const run = spawnSync("python3", ["-c", watcherSrc], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS: "600",
+          // Watcher must finish well before the test timeout. Per-call
+          // timeout 1s × ~3 polls + slow sleep = ~6s; the deadline
+          // bounds the whole loop at 4s.
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "4",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+          NEMOCLAW_AUTO_PAIR_RUN_TIMEOUT_SECS: "1",
+        },
+        timeout: 20_000,
+      });
+      const elapsedMs = Date.now() - start;
+      expect(run.status).toBe(0);
+      // The watcher exited via DEADLINE, not via a wedged subprocess.
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      // Timeout log was emitted for at least one stuck `devices list`.
+      expect(run.stdout).toContain("[auto-pair] timeout calling devices list");
+      // Sanity: with timeout=1s and deadline=4s the watcher must finish
+      // in well under the 20s test cap. If the timeout didn't fire, the
+      // first `sleep 5` would already exceed 4s on its own and the
+      // watcher could still run for many seconds; cap at 12s.
+      expect(elapsedMs).toBeLessThan(12_000);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30_000);
 });
 
 describe("nemoclaw-start gateway launch signal handling", () => {

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -1364,7 +1364,14 @@ exit 2
     try {
       const run = spawnSync("python3", ["-c", autoPairScript], {
         encoding: "utf-8",
-        env: { ...process.env, OPENCLAW_BIN: fakeOpenclaw },
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          // Cap the slow-mode keepalive (NemoClaw#4263) so the test
+          // terminates without waiting out the default 8h deadline.
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "5",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+        },
         timeout: 30_000,
       });
       expect(run.status).toBe(0);
@@ -1373,7 +1380,9 @@ exit 2
       );
       expect(run.stdout).toContain("[auto-pair] approved request=ok-webchat client=other-client");
       expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
-      expect(run.stdout).toContain("browser pairing converged approvals=2");
+      expect(run.stdout).toContain(
+        "[auto-pair] browser pairing converged; entering slow-mode approvals=2",
+      );
       expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
         "ok-browser",
         "ok-webchat",
@@ -1382,6 +1391,319 @@ exit 2
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 40_000);
+});
+
+describe("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  function buildAutoPairScript(): string {
+    return startScriptHeredoc(src, "PYAUTOPAIR").replace(
+      "import time",
+      "import time\ntime.sleep = lambda _seconds: None",
+    );
+  }
+
+  it("approves late CLI scope upgrades after browser pairing converges", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-"));
+    const fakeOpenclaw = path.join(tmpDir, "openclaw");
+    const stateFile = path.join(tmpDir, "list-count");
+    const approveLog = path.join(tmpDir, "approvals.log");
+
+    // Poll timeline:
+    //   1-2: first-time browser pairing request pending.
+    //   3-6: browser paired, nothing pending (watcher converges to slow mode).
+    //   7-10: late CLI scope upgrade arrives — must still get approved.
+    //   11+: cli paired alongside browser.
+    const initialPending = JSON.stringify({
+      pending: [
+        {
+          requestId: "browser-pair",
+          clientId: "openclaw-control-ui",
+          clientMode: "webchat",
+        },
+      ],
+      paired: [],
+    });
+    const browserPaired = JSON.stringify({
+      pending: [],
+      paired: [{ clientId: "openclaw-control-ui", clientMode: "webchat" }],
+    });
+    const lateCli = JSON.stringify({
+      pending: [
+        { requestId: "late-cli", clientId: "openclaw-cli", clientMode: "cli" },
+      ],
+      paired: [{ clientId: "openclaw-control-ui", clientMode: "webchat" }],
+    });
+    const allPaired = JSON.stringify({
+      pending: [],
+      paired: [
+        { clientId: "openclaw-control-ui", clientMode: "webchat" },
+        { clientId: "openclaw-cli", clientMode: "cli" },
+      ],
+    });
+
+    fs.writeFileSync(
+      fakeOpenclaw,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
+  count="$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)"
+  count=$((count + 1))
+  echo "$count" > ${JSON.stringify(stateFile)}
+  if [ "$count" -le 2 ]; then
+    printf '%s\n' ${JSON.stringify(initialPending)}
+  elif [ "$count" -le 6 ]; then
+    printf '%s\n' ${JSON.stringify(browserPaired)}
+  elif [ "$count" -le 10 ]; then
+    printf '%s\n' ${JSON.stringify(lateCli)}
+  else
+    printf '%s\n' ${JSON.stringify(allPaired)}
+  fi
+  exit 0
+fi
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "approve" ]; then
+  echo "$3" >> ${JSON.stringify(approveLog)}
+  printf '{}\n'
+  exit 0
+fi
+echo "unexpected: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          // Short deadline so the test terminates promptly. time.sleep is
+          // monkey-patched out, so wall-clock matters only for the DEADLINE
+          // check; 5s gives the loop ~tens of iterations through every
+          // branch before exiting.
+          NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS: "600",
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "5",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+        },
+        timeout: 30_000,
+      });
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain(
+        "[auto-pair] approved request=browser-pair client=openclaw-control-ui mode=webchat",
+      );
+      expect(run.stdout).toContain(
+        "[auto-pair] browser pairing converged; entering slow-mode approvals=1",
+      );
+      // Critical: the late CLI scope upgrade is approved AFTER convergence.
+      expect(run.stdout).toContain(
+        "[auto-pair] approved request=late-cli client=openclaw-cli mode=cli",
+      );
+      // Deadline-based exit message (instead of an early convergence break).
+      expect(run.stdout).toContain("watcher deadline reached approvals=2");
+      // The watcher MUST NOT print the old early-exit messages.
+      expect(run.stdout).not.toContain("browser pairing converged approvals=");
+      expect(run.stdout).not.toContain("devices paired (");
+      expect(run.stdout).not.toContain("non-browser pairing converged approvals=");
+      // Both allowlisted approvals should have been recorded.
+      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
+        "browser-pair",
+        "late-cli",
+      ]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 40_000);
+
+  it("rejects unknown clients in slow-mode keepalive", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-evil-"));
+    const fakeOpenclaw = path.join(tmpDir, "openclaw");
+    const stateFile = path.join(tmpDir, "list-count");
+    const approveLog = path.join(tmpDir, "approvals.log");
+
+    // Non-browser paired entry — exercises the `devices paired` slow-mode
+    // transition (not the browser-specific one) so we can prove the
+    // allowlist still rejects rogue clients in either convergence path.
+    const initialPaired = JSON.stringify({
+      pending: [],
+      paired: [{ clientId: "paired-cli", clientMode: "cli" }],
+    });
+    const evilLate = JSON.stringify({
+      pending: [
+        { requestId: "evil-late", clientId: "evil-client", clientMode: "unknown" },
+      ],
+      paired: [{ clientId: "paired-cli", clientMode: "cli" }],
+    });
+
+    fs.writeFileSync(
+      fakeOpenclaw,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
+  count="$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)"
+  count=$((count + 1))
+  echo "$count" > ${JSON.stringify(stateFile)}
+  if [ "$count" -le 5 ]; then
+    printf '%s\n' ${JSON.stringify(initialPaired)}
+  else
+    printf '%s\n' ${JSON.stringify(evilLate)}
+  fi
+  exit 0
+fi
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "approve" ]; then
+  echo "$3" >> ${JSON.stringify(approveLog)}
+  printf '{}\n'
+  exit 0
+fi
+echo "unexpected: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS: "600",
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "5",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+        },
+        timeout: 30_000,
+      });
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain(
+        "[auto-pair] devices paired (1); entering slow-mode approvals=0",
+      );
+      expect(run.stdout).toContain(
+        "[auto-pair] rejected unknown client=evil-client mode=unknown",
+      );
+      // Critical: never approved.
+      expect(fs.existsSync(approveLog)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 40_000);
+
+  it("falls back to fast-deadline transition when no convergence signal arrives", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-fastdl-"));
+    const fakeOpenclaw = path.join(tmpDir, "openclaw");
+    const approveLog = path.join(tmpDir, "approvals.log");
+    const emptyResponse = JSON.stringify({ pending: [], paired: [] });
+
+    fs.writeFileSync(
+      fakeOpenclaw,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
+  printf '%s\n' ${JSON.stringify(emptyResponse)}
+  exit 0
+fi
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "approve" ]; then
+  echo "$3" >> ${JSON.stringify(approveLog)}
+  printf '{}\n'
+  exit 0
+fi
+echo "unexpected: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          // Fast deadline is already past at startup, so the watcher
+          // immediately enters slow mode without needing convergence.
+          NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS: "0.0001",
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "2",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+        },
+        timeout: 20_000,
+      });
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain(
+        "[auto-pair] fast-mode deadline reached; switching to slow-mode approvals=0",
+      );
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      expect(fs.existsSync(approveLog)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("fast-deadline transitions to slow-mode even while pending requests are sticky", () => {
+    // Regression for the Codex review finding: a permanently-pending
+    // request (rejected unknown client added to HANDLED, or approve
+    // failure that never clears) used to hold the watcher in the
+    // 1s-polling pending branch for the full DEADLINE, recreating the
+    // NemoClaw#2484 connect-handler pile-up on an 8h timeline. The
+    // fast-deadline transition must apply even when `pending` stays
+    // non-empty.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-sticky-"));
+    const fakeOpenclaw = path.join(tmpDir, "openclaw");
+    const approveLog = path.join(tmpDir, "approvals.log");
+    const stickyEvilResponse = JSON.stringify({
+      pending: [
+        { requestId: "evil-stuck", clientId: "evil-client", clientMode: "unknown" },
+      ],
+      paired: [],
+    });
+
+    fs.writeFileSync(
+      fakeOpenclaw,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
+  printf '%s\n' ${JSON.stringify(stickyEvilResponse)}
+  exit 0
+fi
+if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "approve" ]; then
+  echo "$3" >> ${JSON.stringify(approveLog)}
+  printf '{}\n'
+  exit 0
+fi
+echo "unexpected: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+
+    try {
+      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          OPENCLAW_BIN: fakeOpenclaw,
+          // Fast deadline already past — slow-mode transition must fire
+          // on the very next poll even though pending is non-empty.
+          NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS: "0.0001",
+          NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "2",
+          NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS: "1",
+        },
+        timeout: 20_000,
+      });
+      expect(run.status).toBe(0);
+      // First poll: rejects the evil client, then evaluates fast-deadline
+      // before the pending-branch continue, and transitions to slow mode.
+      expect(run.stdout).toContain(
+        "[auto-pair] fast-mode deadline reached; switching to slow-mode approvals=0",
+      );
+      expect(run.stdout).toContain(
+        "[auto-pair] rejected unknown client=evil-client mode=unknown",
+      );
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      // Unknown client was never approved.
+      expect(fs.existsSync(approveLog)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30_000);
 });
 
 describe("nemoclaw-start gateway launch signal handling", () => {

--- a/test/sandbox-connect-inference.test.ts
+++ b/test/sandbox-connect-inference.test.ts
@@ -151,6 +151,19 @@ if (args[0] === "sandbox" && args[1] === "exec") {
   const command = args.join(" ");
   if (!command.includes("inference.local/v1/models")) {
     fs.writeFileSync(stateFile, JSON.stringify(state));
+    // Test hook (#4263 / CodeRabbit): when the connect-time auto-pair
+    // approval pass is specifically targeted, simulate the failure
+    // path the production code must tolerate. The approval-pass script
+    // is identifiable by its embedded \`openclaw devices approve\` call.
+    if (
+      process.env.NEMOCLAW_TEST_FAIL_APPROVAL_PASS === "1" &&
+      command.includes("openclaw") &&
+      command.includes("devices") &&
+      command.includes("approve")
+    ) {
+      process.stderr.write("simulated sandbox exec failure\\n");
+      process.exit(7);
+    }
     process.stdout.write("__NEMOCLAW_SANDBOX_EXEC_STARTED__\\nRUNNING\\n");
     process.exit(0);
   }
@@ -1216,13 +1229,26 @@ describe("sandbox connect auto-pair approval pass (#4263)", () => {
         "claude-sonnet-4-20250514",
       );
 
-      // The fake openshell records sandbox-exec and returns 0 immediately;
-      // this test guards against a regression that lets a failure inside
-      // the best-effort approval pass surface into the connect path.
-      const result = runConnect(tmpDir, sandboxName);
+      // Force the approval-pass sandbox-exec to fail with exit status 7
+      // (simulated via the NEMOCLAW_TEST_FAIL_APPROVAL_PASS hook in the
+      // fake openshell). The connect flow must still reach SSH handoff —
+      // the approval pass is best-effort and must not surface failures.
+      const result = runConnect(tmpDir, sandboxName, {
+        NEMOCLAW_TEST_FAIL_APPROVAL_PASS: "1",
+      });
       expect(result.status).toBe(0);
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
-      // SSH handoff still happens.
+      // Approval-pass exec was attempted (and the fake openshell exited
+      // non-zero for it, per the hook above).
+      const approvalExec = (state.sandboxExecCalls as string[][]).find(
+        (call) =>
+          call.includes("--") &&
+          call.some((segment) => segment.includes("openclaw")) &&
+          call.some((segment) => segment.includes("devices")) &&
+          call.some((segment) => segment.includes("approve")),
+      );
+      expect(approvalExec).toBeDefined();
+      // Despite the approval-pass failure, SSH handoff still happens.
       expect(state.sandboxConnectCalls).toContainEqual([
         "sandbox",
         "connect",

--- a/test/sandbox-connect-inference.test.ts
+++ b/test/sandbox-connect-inference.test.ts
@@ -1146,3 +1146,88 @@ describe("sandbox connect inference route swap (#1248)", () => {
     },
   );
 });
+
+describe("sandbox connect auto-pair approval pass (#4263)", () => {
+  it(
+    "runs a bounded openclaw devices approval pass before opening SSH",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "approval-pass-sandbox",
+          model: "claude-sonnet-4-20250514",
+          provider: "anthropic-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "anthropic-prod",
+        "claude-sonnet-4-20250514",
+      );
+
+      const result = runConnect(tmpDir, sandboxName);
+      expect(result.status).toBe(0);
+
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      // Look for the approval-pass sandbox-exec invocation specifically.
+      const approvalExec = (state.sandboxExecCalls as string[][]).find(
+        (call) =>
+          call.includes("--") &&
+          call.some((segment) => segment.includes("openclaw")) &&
+          call.some((segment) => segment.includes("devices")) &&
+          call.some((segment) => segment.includes("approve")),
+      );
+      expect(approvalExec).toBeDefined();
+      // The exec must target the requested sandbox and use `sh -c <script>`.
+      expect(approvalExec).toContain("sandbox");
+      expect(approvalExec).toContain("exec");
+      expect(approvalExec).toContain("--name");
+      expect(approvalExec).toContain(sandboxName);
+      const script = approvalExec?.[approvalExec.length - 1] || "";
+      // Hardened script content: sources the proxy env, allowlists only
+      // openclaw-control-ui plus webchat/cli, and short-circuits when the
+      // tools aren't present.
+      expect(script).toContain("/tmp/nemoclaw-proxy-env.sh");
+      expect(script).toContain("command -v openclaw");
+      expect(script).toContain("command -v python3");
+      expect(script).toContain("devices");
+      expect(script).toContain("list");
+      expect(script).toContain("approve");
+      expect(script).toContain("openclaw-control-ui");
+      expect(script).toContain("webchat");
+      expect(script).toContain("cli");
+      // Allowlist must NOT silently approve arbitrary clients.
+      expect(script).not.toContain("evil-client");
+    },
+  );
+
+  it(
+    "does not block connect when the in-sandbox approval pass cannot run",
+    testTimeoutOptions(20_000),
+    () => {
+      const { tmpDir, stateFile, sandboxName } = setupFixture(
+        {
+          name: "approval-pass-tolerant",
+          model: "claude-sonnet-4-20250514",
+          provider: "anthropic-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+        "anthropic-prod",
+        "claude-sonnet-4-20250514",
+      );
+
+      // The fake openshell records sandbox-exec and returns 0 immediately;
+      // this test guards against a regression that lets a failure inside
+      // the best-effort approval pass surface into the connect path.
+      const result = runConnect(tmpDir, sandboxName);
+      expect(result.status).toBe(0);
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      // SSH handoff still happens.
+      expect(state.sandboxConnectCalls).toContainEqual([
+        "sandbox",
+        "connect",
+        sandboxName,
+      ]);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes NemoClaw#4263. The in-sandbox auto-pair watcher used to exit as soon as browser or any device pairing converged (originally added in NemoClaw#2484 to avoid gateway connect-handler saturation). When an OpenClaw CLI agent later requested an additional scope, the gateway held the upgrade as pending approval forever and the agent fell back to embedded mode. On the shared multi-sandbox gateway both sandboxes hit this consistently after the watcher quiet-exit.

## Related Issue

Fixes #4263.

## Changes

- `scripts/nemoclaw-start.sh` auto-pair watcher: replaces convergence-break with a slow-mode keepalive. After convergence (or after `NEMOCLAW_AUTO_PAIR_FAST_DEADLINE_SECS`, default 600s), the watcher transitions to slow polling at `NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS` (default 30s) up to `NEMOCLAW_AUTO_PAIR_DEADLINE_SECS` (default 8h) and keeps approving allowlisted `openclaw-control-ui` / `webchat` / `cli` scope upgrades. The fast-deadline transition is evaluated *before* the pending-branch `continue`, so a sticky pending request (rejected unknown client, permanent approve failure) cannot hold the watcher at 1s polling for the full deadline — avoiding a regression of the NemoClaw#2484 connect-handler pile-up on a longer timeline.
- `src/lib/actions/sandbox/connect.ts` adds a one-shot defense-in-depth approval pass before the SSH handoff. It sources `/tmp/nemoclaw-proxy-env.sh`, applies the same allowlist, caps at `MAX_APPROVALS = 8` with an outer `12s` timeout (sized to cover `2s list + 1s × MAX_APPROVALS` plus shell/python startup slack), and swallows every failure so it never blocks connect. This catches the case where the watcher crashed or exhausted its deadline between sandbox start and the user's first connect.
- Tests cover: slow-mode keepalive approval of late scope upgrades, rejection of unknown clients in slow mode, the fast-deadline fallback with no convergence signal, the new sticky-pending regression (codex-review surfaced), and the connect-time approval pass (happy path + tolerance to failure).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` for the touched test files passes (`test/nemoclaw-start.test.ts`, `test/sandbox-connect-inference.test.ts`: 103/103)
- [x] `npm run typecheck:cli` passes
- [x] Tests added for slow-mode keepalive, fast-deadline transition, sticky-pending regression, and connect-time approval pass
- [x] No secrets, API keys, or credentials committed
- [ ] Docs: not user-facing; behavior is the in-sandbox watcher and connect-time approval pass.

## Test plan

- [x] `npx vitest run test/nemoclaw-start.test.ts -t "auto-pair"` — 5 tests pass
- [x] `npx vitest run test/sandbox-connect-inference.test.ts -t "#4263"` — 2 tests pass
- [x] `npx vitest run test/nemoclaw-start.test.ts test/sandbox-connect-inference.test.ts` — 103 tests pass
- [x] `npm run typecheck:cli` — clean
- [ ] Live multi-sandbox repro on a Brev/OpenShell host (not attempted from triage workspace; the targeted tests cover the watcher state machine and connect-time exec path)

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic device pairing for allowlisted clients during sandbox connect; approvals capped and continued in slow-mode after convergence

* **Bug Fixes**
  * Approval pass is best-effort and won’t block sandbox connect if it fails
  * Per-call pairing operations are time-bounded to avoid hanging the watcher
  * Watcher timing, cadence and final log updated to reflect deadline-driven exit behavior

* **Tests**
  * Added tests for slow-mode keepalive, approval-pass behavior, timeouts, retries, and regressions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->