### PR TITLE
fix(inference): validate Ollama /api/tags response body in health probes

### DIFF
--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -306,7 +306,7 @@ describe("inference health", () => {
           ok: true,
           httpStatus: 200,
           curlStatus: 0,
-          body: "{}",
+          body: '{"models":[]}',
           stderr: "",
           message: "HTTP 200",
         }),

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -330,7 +330,7 @@ describe("local inference helpers", () => {
         ok: true,
         httpStatus: 200,
         curlStatus: 0,
-        body: "{}",
+        body: '{"models":[]}',
         stderr: "",
         message: "HTTP 200",
       }),
@@ -379,7 +379,7 @@ describe("local inference helpers", () => {
           ok: true,
           httpStatus: 200,
           curlStatus: 0,
-          body: "{}",
+          body: '{"models":[]}',
           stderr: "",
           message: "HTTP 200",
         };
@@ -409,7 +409,7 @@ describe("local inference helpers", () => {
           ok: !isProxy,
           httpStatus: isProxy ? 401 : 200,
           curlStatus: 0,
-          body: "",
+          body: isProxy ? "" : '{"models":[]}',
           stderr: "",
           message: isProxy ? "HTTP 401" : "HTTP 200",
         };
@@ -443,7 +443,7 @@ describe("local inference helpers", () => {
               ok: true,
               httpStatus: 200,
               curlStatus: 0,
-              body: "{}",
+              body: '{"models":[]}',
               stderr: "",
               message: "HTTP 200",
             };
@@ -455,6 +455,76 @@ describe("local inference helpers", () => {
     expect(proxy?.failureLabel).toBe("unreachable");
     expect(proxy?.detail).toContain("unreachable");
     expect(proxy?.detail).toContain("11435");
+  });
+
+  // Scenario A (#4275): backend is down, auth proxy is still up. The backend's
+  // /api/tags should not register as healthy when the response body is not the
+  // Ollama wire format — a captive HTTP_PROXY or stale listener can otherwise
+  // answer with arbitrary 2xx that the curl-status-only check accepts.
+  it("rejects a backend 200 whose body is not the Ollama /api/tags JSON shape", () => {
+    const result = probeLocalProviderHealth("ollama-local", {
+      loadOllamaProxyTokenImpl: () => null,
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        // E.g. a corporate HTTP proxy that intercepts loopback and serves an
+        // HTML landing page on every URL, or a stale unrelated listener.
+        body: "<html><body>Privoxy</body></html>",
+        stderr: "",
+        message: "HTTP 200",
+      }),
+    });
+    expect(result?.ok).toBe(false);
+    expect(result?.failureLabel).toBe("unhealthy");
+    expect(result?.detail).toContain("not a valid /api/tags response");
+    expect(result?.detail).toContain("HTTP_PROXY");
+  });
+
+  it("rejects an auth-proxy 200 whose body is not the Ollama /api/tags JSON shape", () => {
+    const result = probeLocalProviderHealth("ollama-local", {
+      loadOllamaProxyTokenImpl: () => "token",
+      runCurlProbeImpl: (argv: string[]) => {
+        const isProxy = argv.some(
+          (a) => typeof a === "string" && a.includes("11435"),
+        );
+        return {
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          // Proxy is up but its upstream Ollama backend is gone; the proxy
+          // returns a stub 200 with no models array.
+          body: isProxy ? '{"error":"backend unreachable"}' : '{"models":[]}',
+          stderr: "",
+          message: "HTTP 200",
+        };
+      },
+    });
+    expect(result?.ok).toBe(true);
+    const proxy = result?.subprobes?.[0];
+    expect(proxy?.ok).toBe(false);
+    expect(proxy?.failureLabel).toBe("unhealthy");
+    expect(proxy?.detail).toContain("not a valid /api/tags response");
+    expect(proxy?.detail).toContain("upstream Ollama");
+  });
+
+  // Regression-lock for #4275 fix: an empty models array is still a valid
+  // /api/tags response (host just has no models pulled yet) and must remain
+  // healthy.
+  it("treats an empty Ollama /api/tags models array as healthy", () => {
+    const result = probeLocalProviderHealth("ollama-local", {
+      loadOllamaProxyTokenImpl: () => null,
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        body: '{"models":[]}',
+        stderr: "",
+        message: "HTTP 200",
+      }),
+    });
+    expect(result?.ok).toBe(true);
+    expect(result?.detail).toContain("reachable");
   });
 
   it("returns null when provider health probing is not supported", () => {

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -229,6 +229,23 @@ function runLocalCurlProbe(argv: string[]): CurlProbeResult {
   return runCurlProbe(argv, { env: buildSubprocessEnv(), replaceEnv: true });
 }
 
+// A 200 response on `/api/tags` alone is not enough to call Ollama healthy —
+// a captive HTTP_PROXY, a stale listener, or a stub on the loopback port can
+// all answer with arbitrary 2xx bodies that look healthy at the curl-status
+// level. The authoritative signal is the Ollama wire format itself:
+// `{ "models": [...] }`. An empty array is fine — that just means no models
+// pulled yet — but a body that doesn't parse as JSON-with-array-`models` did
+// not come from Ollama and the probe should not call it healthy. (#4275)
+function isValidOllamaTagsResponseBody(body: string): boolean {
+  if (!body) return false;
+  try {
+    const parsed = JSON.parse(body);
+    return parsed !== null && typeof parsed === "object" && Array.isArray(parsed.models);
+  } catch {
+    return false;
+  }
+}
+
 export function validateOllamaPortConfiguration(): ValidationResult {
   if (!isWsl() && OLLAMA_PORT === OLLAMA_PROXY_PORT) {
     return {
@@ -376,6 +393,21 @@ export function probeOllamaAuthProxyHealth(
     probeLabel: "auth proxy",
   };
   if (result.ok) {
+    // A 200 from the proxy alone is not a healthy signal — the proxy may be
+    // serving a captive HTTP_PROXY page, or its upstream Ollama backend may
+    // be down but the proxy returned a stub. Confirm with the wire format. (#4275)
+    if (!isValidOllamaTagsResponseBody(result.body)) {
+      return {
+        ...base,
+        ok: false,
+        failureLabel: "unhealthy",
+        detail:
+          `Ollama auth proxy returned HTTP ${result.httpStatus} on ${endpoint} but the body ` +
+          `is not a valid /api/tags response. The proxy is reachable but its upstream Ollama ` +
+          `backend is not, or an HTTP proxy is intercepting the loopback. ` +
+          `Restart \`ollama serve\` and check HTTP_PROXY/NO_PROXY.`,
+      };
+    }
     return { ...base, ok: true, detail: `Ollama auth proxy is reachable on ${endpoint}.` };
   }
   if (result.httpStatus === 401) {
@@ -436,6 +468,25 @@ export function probeLocalProviderHealth(
   const attachProbeLabel = probeLabel ? { probeLabel } : {};
 
   if (result.ok) {
+    // For ollama-local, a 200 is necessary but not sufficient: a captive
+    // HTTP_PROXY, a stale listener on 11434, or any other HTTP responder
+    // can return 200 with an arbitrary body. Treat the probe as healthy
+    // only when the response is the Ollama /api/tags JSON shape. (#4275)
+    if (provider === "ollama-local" && !isValidOllamaTagsResponseBody(result.body)) {
+      return {
+        ok: false,
+        providerLabel,
+        endpoint,
+        failureLabel: "unhealthy",
+        detail:
+          `${providerLabel} responded on ${endpoint} with HTTP ${result.httpStatus} but the ` +
+          `body is not a valid /api/tags response. The listener may not be Ollama (e.g. a ` +
+          `stale process or an HTTP proxy intercepting the loopback). Restart \`ollama serve\` ` +
+          `and verify HTTP_PROXY/NO_PROXY.`,
+        ...attachProbeLabel,
+        ...attachSubprobes,
+      };
+    }
     return {
       ok: true,
       providerLabel,


### PR DESCRIPTION
## Summary
Fix #4275 where `nemoclaw status` reports `Inference (ollama backend)` and `Inference (auth proxy)` as `healthy` after `ollama serve` is stopped, on hosts where an HTTP proxy (or any other listener) is bound to `127.0.0.1:11434` / `127.0.0.1:11435` and answers `/api/tags` with HTTP 200 + an arbitrary body. The local-provider probe accepted any 200 as healthy regardless of body, so a corp `HTTP_PROXY` intercepting loopback or a stale unrelated listener silently hid the backend-down condition.

## Related Issue
Fixes #4275

## Changes
- `src/lib/inference/local.ts`: HTTP 200 on `/api/tags` is now necessary but not sufficient. Treat the response as healthy only when the body parses as Ollama's `{"models":[...]}` wire format (empty array is still valid — host has no models pulled yet). Apply the same body-shape check to `probeOllamaAuthProxyHealth` so a proxy serving a stub when its upstream Ollama backend is unreachable no longer hides the failure.
- `src/lib/inference/local.test.ts`: three new tests — Scenario A (backend returns HTML 200 stub, the #4275 failure mode), the proxy-stub variant (proxy reachable but returns non-Ollama body), and a regression-lock for `{"models":[]}` still being healthy.
- `src/lib/inference/health.test.ts`: one test-fixture update to use the real wire-format body.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Verification details (what actually ran locally)
- `npx vitest run --project cli src/lib/inference/local.test.ts` — 64/64 pass
- `npx vitest run --project cli src/lib/inference/health.test.ts` — 28/28 pass
- `npx vitest run --project cli test/sandbox-connect-inference.test.ts` — 15/15 pass (regression check on a timing-sensitive nearby suite)
- `npm run typecheck:cli` — clean
- `npx @biomejs/biome lint src/lib/inference/local.ts src/lib/inference/local.test.ts` — clean
- `npx prek run --all-files` — could not bootstrap on this host (Python 3.8 vs hook requirement ≥3.9); will run in CI
- `npm test` not run end-to-end. Two pre-existing failures in `test/generate-openclaw-config.test.ts` (Python int-string digit limit) reproduce on `main` and are unrelated to this change

### End-to-end repro
Reproduced #4275 with out-of-process HTTP listeners on `127.0.0.1:11434` and `127.0.0.1:11435` returning 200 with non-Ollama bodies (HTML and a JSON stub respectively):

- **Pre-fix** (`HEAD~1` dist): both probes report `ok=true` / "reachable" — the exact #4275 symptom.
- **Post-fix**: both probes report `ok=false` / `unhealthy` with detail pointing the user at `ollama serve` and `HTTP_PROXY`/`NO_PROXY`.
- **Regression-lock**: a valid `{"models":[...]}` response (with or without entries) still resolves as `ok=true` / "reachable".

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks for local Ollama providers now validate that probe responses are valid JSON with the expected models list; non-JSON or incorrect bodies are treated as unhealthy and failure messages are clearer.
* **Tests**
  * Updated and added tests to cover valid/invalid probe bodies and a regression case ensuring an empty models array is still considered healthy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->