### PR TITLE
fix(onboard): use Docker --gpus instead of CDI repair on WSL Docker Desktop

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1173,7 +1173,8 @@ If no `nvidia.com/gpu` CDI spec has been generated on the host yet, gateway star
 The standard NemoClaw installer detects this gap before onboarding, first tries to enable the NVIDIA CDI refresh systemd units, and falls back to generating the spec directly with `nvidia-ctk`.
 If you run `nemoclaw onboard` directly, preflight prints the manual remediation instead.
 The native Linux fix is the same on Docker hosts whose `docker info` advertises a non-empty `CDISpecDirs`.
-On WSL with Docker Desktop, repair Docker Desktop GPU support from the Windows/Docker Desktop side instead of installing Linux host toolkit packages inside the WSL distro.
+On WSL with Docker Desktop, Docker may advertise CDI directories even though `--device nvidia.com/gpu=all` is not usable from the WSL distro.
+For that runtime, NemoClaw skips Linux CDI repair and uses Docker's `--gpus` compatibility path for sandbox GPU access.
 
 Enable the refresh units, verify they list `nvidia.com/gpu` entries, then rerun onboarding:
 
@@ -1191,13 +1192,13 @@ $ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 $ nvidia-ctk cdi list
 ```
 
-If GPU passthrough is not required on this host, rerun onboarding with `--no-gpu` instead.
-
-On WSL with Docker Desktop, confirm Docker Desktop WSL integration is enabled for your distro, restart Docker Desktop, and verify GPU access from WSL:
+On WSL with Docker Desktop, confirm Docker Desktop WSL integration is enabled for your distro and verify Docker GPU access from WSL:
 
 ```console
 $ docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark
 ```
+
+If GPU passthrough is not required on this host, rerun onboarding with `--no-gpu` instead.
 
 ### Docker GPU patch failed during sandbox create
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1172,7 +1172,8 @@ Recent NVIDIA Container Toolkit installs configure the Docker daemon for Contain
 If no `nvidia.com/gpu` CDI spec has been generated on the host yet, gateway start fails with `Docker responded with status code 500: CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all`.
 The standard NemoClaw installer detects this gap before onboarding, first tries to enable the NVIDIA CDI refresh systemd units, and falls back to generating the spec directly with `nvidia-ctk`.
 If you run `nemoclaw onboard` directly, preflight prints the manual remediation instead.
-The underlying fix is the same on any Docker host whose `docker info` advertises a non-empty `CDISpecDirs`.
+The native Linux fix is the same on Docker hosts whose `docker info` advertises a non-empty `CDISpecDirs`.
+On WSL with Docker Desktop, repair Docker Desktop GPU support from the Windows/Docker Desktop side instead of installing Linux host toolkit packages inside the WSL distro.
 
 Enable the refresh units, verify they list `nvidia.com/gpu` entries, then rerun onboarding:
 
@@ -1191,6 +1192,12 @@ $ nvidia-ctk cdi list
 ```
 
 If GPU passthrough is not required on this host, rerun onboarding with `--no-gpu` instead.
+
+On WSL with Docker Desktop, confirm Docker Desktop WSL integration is enabled for your distro, restart Docker Desktop, and verify GPU access from WSL:
+
+```console
+$ docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark
+```
 
 ### Docker GPU patch failed during sandbox create
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1175,6 +1175,7 @@ If you run `nemoclaw onboard` directly, preflight prints the manual remediation 
 The native Linux fix is the same on Docker hosts whose `docker info` advertises a non-empty `CDISpecDirs`.
 On WSL with Docker Desktop, Docker may advertise CDI directories even though `--device nvidia.com/gpu=all` is not usable from the WSL distro.
 For that runtime, NemoClaw skips Linux CDI repair and uses Docker's `--gpus` compatibility path for sandbox GPU access.
+This compatibility path can be retired once Docker Desktop exposes usable `nvidia.com/gpu` CDI specs inside WSL, or once OpenShell no longer requires host-visible CDI specs for Docker Desktop WSL GPU passthrough.
 
 Enable the refresh units, verify they list `nvidia.com/gpu` entries, then rerun onboarding:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1823,9 +1823,13 @@ repair_installer_nvidia_cdi_spec() {
     node -e '
       const preflightPath = process.argv[1];
       try {
-        const { assessHost, getNvidiaCdiSpecPath } = require(preflightPath);
+        const { assessHost, getNvidiaCdiSpecPath, isWslDockerDesktopRuntime } = require(preflightPath);
         const host = assessHost();
-        if (host && host.cdiNvidiaGpuSpecMissing) {
+        if (
+          host &&
+          host.cdiNvidiaGpuSpecMissing &&
+          !isWslDockerDesktopRuntime(host)
+        ) {
           process.stdout.write(getNvidiaCdiSpecPath(host));
         }
       } catch {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1787,8 +1787,7 @@ function assertCdiNvidiaGpuSpecPresent(
   optedOutGpuPassthrough: boolean,
   hostGpuPlatform: string | null | undefined = null,
 ): void {
-  if (hostGpuPlatform === "jetson") return;
-  if (preflightUtils.isWslDockerDesktopRuntime(host)) return;
+  if (hostGpuPlatform === "jetson" || preflightUtils.isWslDockerDesktopRuntime(host)) return;
   if (!host.cdiNvidiaGpuSpecMissing || optedOutGpuPassthrough) return;
   console.error(
     "  Docker is configured for CDI device injection (CDISpecDirs is set), but no",

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1788,6 +1788,7 @@ function assertCdiNvidiaGpuSpecPresent(
   hostGpuPlatform: string | null | undefined = null,
 ): void {
   if (hostGpuPlatform === "jetson") return;
+  if (preflightUtils.isWslDockerDesktopRuntime(host)) return;
   if (!host.cdiNvidiaGpuSpecMissing || optedOutGpuPassthrough) return;
   console.error(
     "  Docker is configured for CDI device injection (CDISpecDirs is set), but no",

--- a/src/lib/onboard/preflight.test.ts
+++ b/src/lib/onboard/preflight.test.ts
@@ -13,6 +13,7 @@ import {
   getNvidiaCdiSpecPath,
   ensureSwap,
   isDockerUnderProvisioned,
+  isWslDockerDesktopRuntime,
   MIN_RECOMMENDED_DOCKER_CPUS,
   MIN_RECOMMENDED_DOCKER_MEM_GIB,
   parseDockerCdiSpecDirs,
@@ -839,6 +840,14 @@ describe("getNvidiaCdiSpecPath", () => {
   });
 });
 
+describe("isWslDockerDesktopRuntime", () => {
+  it("only matches Docker Desktop-backed WSL hosts", () => {
+    expect(isWslDockerDesktopRuntime({ isWsl: true, runtime: "docker-desktop" })).toBe(true);
+    expect(isWslDockerDesktopRuntime({ isWsl: true, runtime: "docker" })).toBe(false);
+    expect(isWslDockerDesktopRuntime({ isWsl: false, runtime: "docker-desktop" })).toBe(false);
+  });
+});
+
 describe("planHostRemediation", () => {
   it("recommends starting docker when installed but unreachable and service inactive", () => {
     const actions = planHostRemediation({
@@ -1103,6 +1112,77 @@ describe("planHostRemediation", () => {
       -1;
     expect(ctkInstallIndex).toBeGreaterThanOrEqual(0);
     expect(ctkGenerateIndex).toBeGreaterThan(ctkInstallIndex);
+  });
+
+  it("uses Docker Desktop remediation instead of Linux toolkit commands on WSL Docker Desktop", () => {
+    const actions = planHostRemediation({
+      platform: "linux",
+      isWsl: true,
+      runtime: "docker-desktop",
+      packageManager: "apt",
+      systemctlAvailable: true,
+      dockerServiceActive: null,
+      dockerServiceEnabled: null,
+      dockerInstalled: true,
+      dockerRunning: true,
+      dockerReachable: true,
+      nodeInstalled: true,
+      openshellInstalled: true,
+      dockerCgroupVersion: "v2",
+      dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
+      hasNestedOverlayConflict: false,
+      requiresHostCgroupnsFix: false,
+      isUnsupportedRuntime: false,
+      isHeadlessLikely: false,
+      hasNvidiaGpu: true,
+      dockerCdiSpecDirs: ["/etc/cdi", "/var/run/cdi"],
+      cdiNvidiaGpuSpecMissing: true,
+      nvidiaContainerToolkitInstalled: false,
+      notes: ["Running under WSL"],
+    });
+
+    expect(actions.find((entry) => entry.id === "install_nvidia_container_toolkit")).toBeUndefined();
+    const action = actions.find((entry) => entry.id === "repair_wsl_docker_desktop_gpu_cdi");
+    expect(action).toBeTruthy();
+    expect(action?.kind).toBe("manual");
+    expect(action?.blocking).toBe(true);
+    expect(action?.title).toContain("Docker Desktop");
+    expect(action?.commands.join("\n")).toContain("Docker Desktop Settings");
+    expect(action?.commands.join("\n")).not.toContain("nvidia-ctk");
+    expect(action?.commands.join("\n")).not.toContain("nvidia-container-toolkit");
+  });
+
+  it("keeps NVIDIA Container Toolkit remediation for native Docker Engine inside WSL", () => {
+    const actions = planHostRemediation({
+      platform: "linux",
+      isWsl: true,
+      runtime: "docker",
+      packageManager: "apt",
+      systemctlAvailable: true,
+      dockerServiceActive: true,
+      dockerServiceEnabled: true,
+      dockerInstalled: true,
+      dockerRunning: true,
+      dockerReachable: true,
+      nodeInstalled: true,
+      openshellInstalled: true,
+      dockerCgroupVersion: "v2",
+      dockerDefaultCgroupnsMode: "unknown",
+      isContainerRuntimeUnderProvisioned: false,
+      hasNestedOverlayConflict: false,
+      requiresHostCgroupnsFix: false,
+      isUnsupportedRuntime: false,
+      isHeadlessLikely: false,
+      hasNvidiaGpu: true,
+      dockerCdiSpecDirs: ["/etc/cdi", "/var/run/cdi"],
+      cdiNvidiaGpuSpecMissing: true,
+      nvidiaContainerToolkitInstalled: false,
+      notes: ["Running under WSL"],
+    });
+
+    expect(actions.find((entry) => entry.id === "repair_wsl_docker_desktop_gpu_cdi")).toBeUndefined();
+    expect(actions.find((entry) => entry.id === "install_nvidia_container_toolkit")).toBeTruthy();
   });
 
   it("emits an install_nvidia_container_toolkit action with a docs pointer when nvidia-ctk is missing on unknown package managers", () => {

--- a/src/lib/onboard/preflight.test.ts
+++ b/src/lib/onboard/preflight.test.ts
@@ -1114,7 +1114,7 @@ describe("planHostRemediation", () => {
     expect(ctkGenerateIndex).toBeGreaterThan(ctkInstallIndex);
   });
 
-  it("uses Docker Desktop remediation instead of Linux toolkit commands on WSL Docker Desktop", () => {
+  it("uses non-blocking Docker Desktop GPU compatibility guidance on WSL Docker Desktop", () => {
     const actions = planHostRemediation({
       platform: "linux",
       isWsl: true,
@@ -1143,12 +1143,12 @@ describe("planHostRemediation", () => {
     });
 
     expect(actions.find((entry) => entry.id === "install_nvidia_container_toolkit")).toBeUndefined();
-    const action = actions.find((entry) => entry.id === "repair_wsl_docker_desktop_gpu_cdi");
+    const action = actions.find((entry) => entry.id === "wsl_docker_desktop_gpu_compatibility");
     expect(action).toBeTruthy();
-    expect(action?.kind).toBe("manual");
-    expect(action?.blocking).toBe(true);
+    expect(action?.kind).toBe("info");
+    expect(action?.blocking).toBe(false);
     expect(action?.title).toContain("Docker Desktop");
-    expect(action?.commands.join("\n")).toContain("Docker Desktop Settings");
+    expect(action?.reason).toContain("--gpus");
     expect(action?.commands.join("\n")).not.toContain("nvidia-ctk");
     expect(action?.commands.join("\n")).not.toContain("nvidia-container-toolkit");
   });
@@ -1181,7 +1181,7 @@ describe("planHostRemediation", () => {
       notes: ["Running under WSL"],
     });
 
-    expect(actions.find((entry) => entry.id === "repair_wsl_docker_desktop_gpu_cdi")).toBeUndefined();
+    expect(actions.find((entry) => entry.id === "wsl_docker_desktop_gpu_compatibility")).toBeUndefined();
     expect(actions.find((entry) => entry.id === "install_nvidia_container_toolkit")).toBeTruthy();
   });
 

--- a/src/lib/onboard/preflight.test.ts
+++ b/src/lib/onboard/preflight.test.ts
@@ -13,7 +13,6 @@ import {
   getNvidiaCdiSpecPath,
   ensureSwap,
   isDockerUnderProvisioned,
-  isWslDockerDesktopRuntime,
   MIN_RECOMMENDED_DOCKER_CPUS,
   MIN_RECOMMENDED_DOCKER_MEM_GIB,
   parseDockerCdiSpecDirs,
@@ -840,14 +839,6 @@ describe("getNvidiaCdiSpecPath", () => {
   });
 });
 
-describe("isWslDockerDesktopRuntime", () => {
-  it("only matches Docker Desktop-backed WSL hosts", () => {
-    expect(isWslDockerDesktopRuntime({ isWsl: true, runtime: "docker-desktop" })).toBe(true);
-    expect(isWslDockerDesktopRuntime({ isWsl: true, runtime: "docker" })).toBe(false);
-    expect(isWslDockerDesktopRuntime({ isWsl: false, runtime: "docker-desktop" })).toBe(false);
-  });
-});
-
 describe("planHostRemediation", () => {
   it("recommends starting docker when installed but unreachable and service inactive", () => {
     const actions = planHostRemediation({
@@ -1112,77 +1103,6 @@ describe("planHostRemediation", () => {
       -1;
     expect(ctkInstallIndex).toBeGreaterThanOrEqual(0);
     expect(ctkGenerateIndex).toBeGreaterThan(ctkInstallIndex);
-  });
-
-  it("uses non-blocking Docker Desktop GPU compatibility guidance on WSL Docker Desktop", () => {
-    const actions = planHostRemediation({
-      platform: "linux",
-      isWsl: true,
-      runtime: "docker-desktop",
-      packageManager: "apt",
-      systemctlAvailable: true,
-      dockerServiceActive: null,
-      dockerServiceEnabled: null,
-      dockerInstalled: true,
-      dockerRunning: true,
-      dockerReachable: true,
-      nodeInstalled: true,
-      openshellInstalled: true,
-      dockerCgroupVersion: "v2",
-      dockerDefaultCgroupnsMode: "unknown",
-      isContainerRuntimeUnderProvisioned: false,
-      hasNestedOverlayConflict: false,
-      requiresHostCgroupnsFix: false,
-      isUnsupportedRuntime: false,
-      isHeadlessLikely: false,
-      hasNvidiaGpu: true,
-      dockerCdiSpecDirs: ["/etc/cdi", "/var/run/cdi"],
-      cdiNvidiaGpuSpecMissing: true,
-      nvidiaContainerToolkitInstalled: false,
-      notes: ["Running under WSL"],
-    });
-
-    expect(actions.find((entry) => entry.id === "install_nvidia_container_toolkit")).toBeUndefined();
-    const action = actions.find((entry) => entry.id === "wsl_docker_desktop_gpu_compatibility");
-    expect(action).toBeTruthy();
-    expect(action?.kind).toBe("info");
-    expect(action?.blocking).toBe(false);
-    expect(action?.title).toContain("Docker Desktop");
-    expect(action?.reason).toContain("--gpus");
-    expect(action?.commands.join("\n")).not.toContain("nvidia-ctk");
-    expect(action?.commands.join("\n")).not.toContain("nvidia-container-toolkit");
-  });
-
-  it("keeps NVIDIA Container Toolkit remediation for native Docker Engine inside WSL", () => {
-    const actions = planHostRemediation({
-      platform: "linux",
-      isWsl: true,
-      runtime: "docker",
-      packageManager: "apt",
-      systemctlAvailable: true,
-      dockerServiceActive: true,
-      dockerServiceEnabled: true,
-      dockerInstalled: true,
-      dockerRunning: true,
-      dockerReachable: true,
-      nodeInstalled: true,
-      openshellInstalled: true,
-      dockerCgroupVersion: "v2",
-      dockerDefaultCgroupnsMode: "unknown",
-      isContainerRuntimeUnderProvisioned: false,
-      hasNestedOverlayConflict: false,
-      requiresHostCgroupnsFix: false,
-      isUnsupportedRuntime: false,
-      isHeadlessLikely: false,
-      hasNvidiaGpu: true,
-      dockerCdiSpecDirs: ["/etc/cdi", "/var/run/cdi"],
-      cdiNvidiaGpuSpecMissing: true,
-      nvidiaContainerToolkitInstalled: false,
-      notes: ["Running under WSL"],
-    });
-
-    expect(actions.find((entry) => entry.id === "wsl_docker_desktop_gpu_compatibility")).toBeUndefined();
-    expect(actions.find((entry) => entry.id === "install_nvidia_container_toolkit")).toBeTruthy();
   });
 
   it("emits an install_nvidia_container_toolkit action with a docs pointer when nvidia-ctk is missing on unknown package managers", () => {

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -817,21 +817,19 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
     ];
     if (isWslDockerDesktopRuntime(assessment)) {
       actions.push({
-        id: "repair_wsl_docker_desktop_gpu_cdi",
-        title: "Repair Docker Desktop WSL GPU support",
-        kind: "manual",
+        id: "wsl_docker_desktop_gpu_compatibility",
+        title: "Use Docker Desktop WSL GPU compatibility path",
+        kind: "info",
         reason:
           "Docker Desktop is configured for CDI device injection (CDISpecDirs is set) but no " +
-          "nvidia.com/gpu CDI spec is visible from WSL. Installing or running Linux host " +
-          "NVIDIA Container Toolkit commands inside the WSL distro may not repair Docker " +
-          "Desktop's managed Docker daemon. OpenShell's `gateway start --gpu` will fail with " +
-          "`unresolvable CDI devices nvidia.com/gpu=all` until Docker Desktop GPU support is repaired.",
+          "nvidia.com/gpu CDI spec is visible from WSL. On Docker Desktop-backed WSL, NemoClaw " +
+          "uses Docker's `--gpus` compatibility path instead of trying to repair Linux host CDI " +
+          "from inside the WSL distro.",
         commands: [
-          "Open Docker Desktop Settings > Resources > WSL integration and confirm this distro is enabled.",
-          "Restart Docker Desktop, then verify GPU support from WSL with `docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark`.",
-          "Rerun `nemoclaw onboard`, or rerun with `--no-gpu` to skip GPU passthrough.",
+          "If sandbox GPU setup later fails, verify Docker Desktop GPU support from WSL with `docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark`.",
+          "Rerun with `--no-gpu` to skip GPU passthrough.",
         ],
-        blocking: true,
+        blocking: false,
       });
     } else if (assessment.nvidiaContainerToolkitInstalled) {
       actions.push({

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -301,6 +301,12 @@ export function getNvidiaCdiSpecPath(
   return path.join(normalizeCdiSpecDir(assessment.dockerCdiSpecDirs[0]), "nvidia.yaml");
 }
 
+export function isWslDockerDesktopRuntime(
+  assessment: Pick<HostAssessment, "isWsl" | "runtime">,
+): boolean {
+  return assessment.isWsl && assessment.runtime === "docker-desktop";
+}
+
 // True when at least one CDI spec under the configured directories declares
 // `kind: nvidia.com/gpu` (the device class OpenShell injects with `--gpu`).
 // Specs are typically YAML, but the JSON shape is also accepted because
@@ -809,7 +815,25 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
       "nvidia-ctk cdi list   # verify nvidia.com/gpu entries appear",
       "nemoclaw onboard      # or rerun with --no-gpu to skip GPU passthrough",
     ];
-    if (assessment.nvidiaContainerToolkitInstalled) {
+    if (isWslDockerDesktopRuntime(assessment)) {
+      actions.push({
+        id: "repair_wsl_docker_desktop_gpu_cdi",
+        title: "Repair Docker Desktop WSL GPU support",
+        kind: "manual",
+        reason:
+          "Docker Desktop is configured for CDI device injection (CDISpecDirs is set) but no " +
+          "nvidia.com/gpu CDI spec is visible from WSL. Installing or running Linux host " +
+          "NVIDIA Container Toolkit commands inside the WSL distro may not repair Docker " +
+          "Desktop's managed Docker daemon. OpenShell's `gateway start --gpu` will fail with " +
+          "`unresolvable CDI devices nvidia.com/gpu=all` until Docker Desktop GPU support is repaired.",
+        commands: [
+          "Open Docker Desktop Settings > Resources > WSL integration and confirm this distro is enabled.",
+          "Restart Docker Desktop, then verify GPU support from WSL with `docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark`.",
+          "Rerun `nemoclaw onboard`, or rerun with `--no-gpu` to skip GPU passthrough.",
+        ],
+        blocking: true,
+      });
+    } else if (assessment.nvidiaContainerToolkitInstalled) {
       actions.push({
         id: "generate_nvidia_cdi_spec",
         title: "Generate NVIDIA CDI device specs",

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -16,6 +16,11 @@ import os from "node:os";
 import path from "node:path";
 
 import { DASHBOARD_PORT } from "../core/ports";
+import {
+  isWslDockerDesktopRuntime,
+  wslDockerDesktopGpuCompatibilityAction,
+} from "./wsl-docker-desktop-gpu";
+export { isWslDockerDesktopRuntime } from "./wsl-docker-desktop-gpu";
 
 // runner.ts still uses CommonJS-style exports — use require here.
 const { runCapture } = require("../runner");
@@ -299,12 +304,6 @@ export function getNvidiaCdiSpecPath(
   assessment: Pick<HostAssessment, "dockerCdiSpecDirs">,
 ): string {
   return path.join(normalizeCdiSpecDir(assessment.dockerCdiSpecDirs[0]), "nvidia.yaml");
-}
-
-export function isWslDockerDesktopRuntime(
-  assessment: Pick<HostAssessment, "isWsl" | "runtime">,
-): boolean {
-  return assessment.isWsl && assessment.runtime === "docker-desktop";
 }
 
 // True when at least one CDI spec under the configured directories declares
@@ -816,21 +815,7 @@ export function planHostRemediation(assessment: HostAssessment): RemediationActi
       "nemoclaw onboard      # or rerun with --no-gpu to skip GPU passthrough",
     ];
     if (isWslDockerDesktopRuntime(assessment)) {
-      actions.push({
-        id: "wsl_docker_desktop_gpu_compatibility",
-        title: "Use Docker Desktop WSL GPU compatibility path",
-        kind: "info",
-        reason:
-          "Docker Desktop is configured for CDI device injection (CDISpecDirs is set) but no " +
-          "nvidia.com/gpu CDI spec is visible from WSL. On Docker Desktop-backed WSL, NemoClaw " +
-          "uses Docker's `--gpus` compatibility path instead of trying to repair Linux host CDI " +
-          "from inside the WSL distro.",
-        commands: [
-          "If sandbox GPU setup later fails, verify Docker Desktop GPU support from WSL with `docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark`.",
-          "Rerun with `--no-gpu` to skip GPU passthrough.",
-        ],
-        blocking: false,
-      });
+      actions.push(wslDockerDesktopGpuCompatibilityAction());
     } else if (assessment.nvidiaContainerToolkitInstalled) {
       actions.push({
         id: "generate_nvidia_cdi_spec",

--- a/src/lib/onboard/sandbox-gpu-preflight.test.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.test.ts
@@ -93,11 +93,10 @@ describe("sandbox GPU preflight", () => {
     expect(dockerInfo).not.toHaveBeenCalled();
   });
 
-  it("prints Docker Desktop WSL remediation when CDI support is missing there", () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
-      throw new Error(`exit:${code}`);
-    }) as never);
+  it("skips CDI spec validation on Docker Desktop WSL so Docker --gpus can be used", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const getDockerCdiSpecDirs = vi.fn(() => ["/etc/cdi"]);
+    const findReadableNvidiaCdiSpecFiles = vi.fn(() => []);
 
     try {
       expect(() =>
@@ -105,18 +104,17 @@ describe("sandbox GPU preflight", () => {
           platform: "linux",
           env: { WSL_DISTRO_NAME: "Ubuntu" },
           dockerInfoFormat: vi.fn(() => '"Docker Desktop"'),
-          getDockerCdiSpecDirs: vi.fn(() => ["/etc/cdi"]),
-          findReadableNvidiaCdiSpecFiles: vi.fn(() => []),
+          getDockerCdiSpecDirs,
+          findReadableNvidiaCdiSpecFiles,
         }),
-      ).toThrow("exit:1");
-      const message = errorSpy.mock.calls.map((call) => call[0]).join("\n");
-      expect(message).toContain("Docker Desktop WSL GPU support was not detected");
-      expect(message).toContain("Docker Desktop Settings");
-      expect(message).not.toContain("sudo nvidia-ctk");
-      expect(message).not.toContain("sudo systemctl restart docker");
+      ).not.toThrow();
+      expect(getDockerCdiSpecDirs).not.toHaveBeenCalled();
+      expect(findReadableNvidiaCdiSpecFiles).not.toHaveBeenCalled();
+      expect(logSpy.mock.calls.map((call) => call[0]).join("\n")).toContain(
+        "Docker --gpus compatibility path",
+      );
     } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
+      logSpy.mockRestore();
     }
   });
 

--- a/src/lib/onboard/sandbox-gpu-preflight.test.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.test.ts
@@ -13,6 +13,7 @@ import {
   dockerNvidiaRuntimeAvailable,
   formatSandboxGpuPassthroughNote,
   parseDockerRuntimeNames,
+  sandboxGpuRemediationLines,
   validateSandboxGpuPreflight,
 } from "./sandbox-gpu-preflight";
 
@@ -90,6 +91,70 @@ describe("sandbox GPU preflight", () => {
     expect(getDockerCdiSpecDirs).toHaveBeenCalled();
     expect(findReadableNvidiaCdiSpecFiles).toHaveBeenCalledWith(["/etc/cdi"]);
     expect(dockerInfo).not.toHaveBeenCalled();
+  });
+
+  it("prints Docker Desktop WSL remediation when CDI support is missing there", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    try {
+      expect(() =>
+        validateSandboxGpuPreflight(sandboxGpuConfig(), {
+          platform: "linux",
+          env: { WSL_DISTRO_NAME: "Ubuntu" },
+          dockerInfoFormat: vi.fn(() => '"Docker Desktop"'),
+          getDockerCdiSpecDirs: vi.fn(() => ["/etc/cdi"]),
+          findReadableNvidiaCdiSpecFiles: vi.fn(() => []),
+        }),
+      ).toThrow("exit:1");
+      const message = errorSpy.mock.calls.map((call) => call[0]).join("\n");
+      expect(message).toContain("Docker Desktop WSL GPU support was not detected");
+      expect(message).toContain("Docker Desktop Settings");
+      expect(message).not.toContain("sudo nvidia-ctk");
+      expect(message).not.toContain("sudo systemctl restart docker");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("prints neutral WSL remediation when Docker runtime cannot be determined", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    try {
+      expect(() =>
+        validateSandboxGpuPreflight(sandboxGpuConfig(), {
+          platform: "linux",
+          env: { WSL_DISTRO_NAME: "Ubuntu" },
+          dockerInfoFormat: vi.fn(() => ""),
+          getDockerCdiSpecDirs: vi.fn(() => ["/etc/cdi"]),
+          findReadableNvidiaCdiSpecFiles: vi.fn(() => []),
+        }),
+      ).toThrow("exit:1");
+      const message = errorSpy.mock.calls.map((call) => call[0]).join("\n");
+      expect(message).toContain("could not determine whether Docker is Docker Desktop");
+      expect(message).toContain("If using Docker Desktop");
+      expect(message).toContain("If using native Docker Engine inside WSL");
+      expect(message).not.toContain("sudo systemctl restart docker");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("keeps generic Linux CDI remediation outside Docker Desktop WSL", () => {
+    expect(sandboxGpuRemediationLines().join("\n")).toContain("sudo nvidia-ctk");
+    expect(sandboxGpuRemediationLines({ wslDockerDesktop: true }).join("\n")).toContain(
+      "Docker Desktop WSL",
+    );
+    expect(sandboxGpuRemediationLines({ wslDockerDesktopStatus: "unknown" }).join("\n")).toContain(
+      "could not determine",
+    );
   });
 
   it("treats optional direct sandbox GPU proof failures as non-fatal", () => {

--- a/src/lib/onboard/sandbox-gpu-preflight.test.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.test.ts
@@ -184,6 +184,31 @@ describe("sandbox GPU preflight", () => {
     expect(() => verifier("demo")).toThrow("GPU proof failed: fatal proof");
   });
 
+  it("uses Docker Desktop WSL guidance when direct sandbox GPU proof fails there", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const verifier = createDirectSandboxGpuVerifier({
+      platform: "linux",
+      env: { WSL_DISTRO_NAME: "Ubuntu" },
+      dockerInfoFormat: vi.fn(() => '"Docker Desktop"'),
+      runOpenshell: vi.fn(() => ({ status: 1, stdout: "", stderr: "required proof failed" })),
+      buildDirectSandboxGpuProofCommands: vi.fn(() => [
+        { args: ["sandbox", "exec", "demo", "--", "false"], label: "fatal proof" },
+      ]),
+      compactText: (value) => value.trim(),
+      redact: (value) => String(value),
+    });
+
+    try {
+      expect(() => verifier("demo")).toThrow("GPU proof failed: fatal proof");
+      const message = errorSpy.mock.calls.map((call) => call[0]).join("\n");
+      expect(message).toContain("Docker Desktop WSL");
+      expect(message).toContain("--gpus");
+      expect(message).not.toContain("sudo nvidia-ctk");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it("exits with an explicit Jetson NVIDIA runtime message when runtime support is missing", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {

--- a/src/lib/onboard/sandbox-gpu-preflight.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.ts
@@ -106,9 +106,8 @@ export function sandboxGpuRemediationLines(
     (options.wslDockerDesktop ? "docker-desktop" : "not-docker-desktop");
   if (status === "docker-desktop") {
     return [
-      "Docker Desktop WSL GPU support was not detected.",
-      "Open Docker Desktop Settings > Resources > WSL integration and confirm this distro is enabled.",
-      "Restart Docker Desktop, then verify from WSL:",
+      "Docker Desktop WSL detected; NemoClaw uses Docker --gpus compatibility instead of CDI spec validation.",
+      "If sandbox GPU setup later fails, verify from WSL:",
       "  docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark",
       "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
     ];
@@ -264,6 +263,14 @@ export function validateSandboxGpuPreflight(
     return;
   }
 
+  const wslDockerDesktopStatus = detectWslDockerDesktopStatus(deps);
+  if (wslDockerDesktopStatus === "docker-desktop") {
+    console.log(
+      "  Docker Desktop WSL detected; using Docker --gpus compatibility path instead of CDI spec validation.",
+    );
+    return;
+  }
+
   const cdiSpecDirs = (deps.getDockerCdiSpecDirs ?? getDockerCdiSpecDirs)();
   const cdiSpecFiles = (deps.findReadableNvidiaCdiSpecFiles ?? findReadableNvidiaCdiSpecFiles)(
     cdiSpecDirs,
@@ -272,7 +279,7 @@ export function validateSandboxGpuPreflight(
     console.error("");
     console.error("  ✗ Docker CDI GPU support was not detected.");
     for (const line of sandboxGpuRemediationLines({
-      wslDockerDesktopStatus: detectWslDockerDesktopStatus(deps),
+      wslDockerDesktopStatus,
     })) {
       console.error(`    ${line}`);
     }

--- a/src/lib/onboard/sandbox-gpu-preflight.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.ts
@@ -1,14 +1,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+
 import { dockerInfoFormat } from "../adapters/docker";
 import { findReadableNvidiaCdiSpecFiles, getDockerCdiSpecDirs } from "./docker-cdi";
 import type { SandboxGpuConfig, SandboxGpuFlag } from "./sandbox-gpu-mode";
 
 const SANDBOX_GPU_PREFLIGHT_TIMEOUT_MS = 30_000;
 
+type WslDockerDesktopStatus = "docker-desktop" | "not-docker-desktop" | "unknown";
+
 export type SandboxGpuPreflightDeps = {
   platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  release?: string;
+  procVersion?: string;
+  readFileImpl?: (filePath: string, encoding: BufferEncoding) => string;
   dockerInfoFormat?: (format: string, opts?: Record<string, unknown>) => string;
   getDockerCdiSpecDirs?: () => string[];
   findReadableNvidiaCdiSpecFiles?: (dirs: string[]) => string[];
@@ -41,7 +50,78 @@ export function resolveSandboxGpuFlagFromOptions(opts: SandboxGpuFlagOptions): S
   return null;
 }
 
-export function sandboxGpuRemediationLines(): string[] {
+function detectWsl(
+  deps: Pick<
+    SandboxGpuPreflightDeps,
+    "env" | "platform" | "procVersion" | "readFileImpl" | "release"
+  >,
+): boolean {
+  const platform = deps.platform ?? process.platform;
+  if (platform !== "linux") return false;
+  const env = deps.env ?? process.env;
+  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) return true;
+  const release = deps.release ?? os.release();
+  if (/microsoft/i.test(release)) return true;
+  const procVersion =
+    deps.procVersion ??
+    (() => {
+      try {
+        const readFileImpl =
+          deps.readFileImpl ??
+          ((filePath: string, encoding: BufferEncoding) => fs.readFileSync(filePath, encoding));
+        return readFileImpl("/proc/version", "utf-8");
+      } catch {
+        return "";
+      }
+    })();
+  return /microsoft/i.test(procVersion);
+}
+
+function detectDockerDesktopRuntime(deps: SandboxGpuPreflightDeps): WslDockerDesktopStatus {
+  const dockerInfo = deps.dockerInfoFormat ?? dockerInfoFormat;
+  try {
+    const output = String(
+      dockerInfo("{{json .OperatingSystem}}", {
+        ignoreError: true,
+        timeout: SANDBOX_GPU_PREFLIGHT_TIMEOUT_MS,
+      }),
+    ).trim();
+    if (!output || output === "<no value>") return "unknown";
+    return /^"?docker desktop\b/i.test(output) ? "docker-desktop" : "not-docker-desktop";
+  } catch {
+    return "unknown";
+  }
+}
+
+function detectWslDockerDesktopStatus(deps: SandboxGpuPreflightDeps): WslDockerDesktopStatus {
+  if (!detectWsl(deps)) return "not-docker-desktop";
+  return detectDockerDesktopRuntime(deps);
+}
+
+export function sandboxGpuRemediationLines(
+  options: { wslDockerDesktop?: boolean; wslDockerDesktopStatus?: WslDockerDesktopStatus } = {},
+): string[] {
+  const status =
+    options.wslDockerDesktopStatus ??
+    (options.wslDockerDesktop ? "docker-desktop" : "not-docker-desktop");
+  if (status === "docker-desktop") {
+    return [
+      "Docker Desktop WSL GPU support was not detected.",
+      "Open Docker Desktop Settings > Resources > WSL integration and confirm this distro is enabled.",
+      "Restart Docker Desktop, then verify from WSL:",
+      "  docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark",
+      "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
+    ];
+  }
+  if (status === "unknown") {
+    return [
+      "WSL detected, but NemoClaw could not determine whether Docker is Docker Desktop or native Docker Engine.",
+      "If using Docker Desktop, confirm Settings > Resources > WSL integration is enabled for this distro, restart Docker Desktop, and verify:",
+      "  docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark",
+      "If using native Docker Engine inside WSL, install/configure NVIDIA Container Toolkit CDI, then restart Docker.",
+      "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
+    ];
+  }
   return [
     "Install/configure NVIDIA Container Toolkit CDI, then restart Docker:",
     "  sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml",
@@ -191,7 +271,11 @@ export function validateSandboxGpuPreflight(
   if (cdiSpecFiles.length === 0) {
     console.error("");
     console.error("  ✗ Docker CDI GPU support was not detected.");
-    for (const line of sandboxGpuRemediationLines()) console.error(`    ${line}`);
+    for (const line of sandboxGpuRemediationLines({
+      wslDockerDesktopStatus: detectWslDockerDesktopStatus(deps),
+    })) {
+      console.error(`    ${line}`);
+    }
     process.exit(1);
   }
   console.log(`  ✓ Docker CDI GPU support detected (${cdiSpecFiles.join(", ")})`);

--- a/src/lib/onboard/sandbox-gpu-preflight.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.ts
@@ -1,24 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
-import os from "node:os";
-
 import { dockerInfoFormat } from "../adapters/docker";
 import { findReadableNvidiaCdiSpecFiles, getDockerCdiSpecDirs } from "./docker-cdi";
 import type { SandboxGpuConfig, SandboxGpuFlag } from "./sandbox-gpu-mode";
+import {
+  detectWslDockerDesktopStatus,
+  type WslDockerDesktopDetectionDeps,
+  type WslDockerDesktopStatus,
+  wslDockerDesktopGpuCompatibilityRemediationLines,
+} from "./wsl-docker-desktop-gpu";
 
 const SANDBOX_GPU_PREFLIGHT_TIMEOUT_MS = 30_000;
 
-type WslDockerDesktopStatus = "docker-desktop" | "not-docker-desktop" | "unknown";
-
-export type SandboxGpuPreflightDeps = {
-  platform?: NodeJS.Platform;
-  env?: NodeJS.ProcessEnv;
-  release?: string;
-  procVersion?: string;
-  readFileImpl?: (filePath: string, encoding: BufferEncoding) => string;
-  dockerInfoFormat?: (format: string, opts?: Record<string, unknown>) => string;
+export type SandboxGpuPreflightDeps = WslDockerDesktopDetectionDeps & {
   getDockerCdiSpecDirs?: () => string[];
   findReadableNvidiaCdiSpecFiles?: (dirs: string[]) => string[];
 };
@@ -50,77 +45,14 @@ export function resolveSandboxGpuFlagFromOptions(opts: SandboxGpuFlagOptions): S
   return null;
 }
 
-function detectWsl(
-  deps: Pick<
-    SandboxGpuPreflightDeps,
-    "env" | "platform" | "procVersion" | "readFileImpl" | "release"
-  >,
-): boolean {
-  const platform = deps.platform ?? process.platform;
-  if (platform !== "linux") return false;
-  const env = deps.env ?? process.env;
-  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) return true;
-  const release = deps.release ?? os.release();
-  if (/microsoft/i.test(release)) return true;
-  const procVersion =
-    deps.procVersion ??
-    (() => {
-      try {
-        const readFileImpl =
-          deps.readFileImpl ??
-          ((filePath: string, encoding: BufferEncoding) => fs.readFileSync(filePath, encoding));
-        return readFileImpl("/proc/version", "utf-8");
-      } catch {
-        return "";
-      }
-    })();
-  return /microsoft/i.test(procVersion);
-}
-
-function detectDockerDesktopRuntime(deps: SandboxGpuPreflightDeps): WslDockerDesktopStatus {
-  const dockerInfo = deps.dockerInfoFormat ?? dockerInfoFormat;
-  try {
-    const output = String(
-      dockerInfo("{{json .OperatingSystem}}", {
-        ignoreError: true,
-        timeout: SANDBOX_GPU_PREFLIGHT_TIMEOUT_MS,
-      }),
-    ).trim();
-    if (!output || output === "<no value>") return "unknown";
-    return /^"?docker desktop\b/i.test(output) ? "docker-desktop" : "not-docker-desktop";
-  } catch {
-    return "unknown";
-  }
-}
-
-function detectWslDockerDesktopStatus(deps: SandboxGpuPreflightDeps): WslDockerDesktopStatus {
-  if (!detectWsl(deps)) return "not-docker-desktop";
-  return detectDockerDesktopRuntime(deps);
-}
-
 export function sandboxGpuRemediationLines(
   options: { wslDockerDesktop?: boolean; wslDockerDesktopStatus?: WslDockerDesktopStatus } = {},
 ): string[] {
   const status =
     options.wslDockerDesktopStatus ??
     (options.wslDockerDesktop ? "docker-desktop" : "not-docker-desktop");
-  if (status === "docker-desktop") {
-    return [
-      "Docker Desktop WSL detected; NemoClaw uses Docker --gpus compatibility instead of CDI spec validation.",
-      "If sandbox GPU setup later fails, verify from WSL:",
-      "  docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark",
-      "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
-    ];
-  }
-  if (status === "unknown") {
-    return [
-      "WSL detected, but NemoClaw could not determine whether Docker is Docker Desktop or native Docker Engine.",
-      "If using Docker Desktop, confirm Settings > Resources > WSL integration is enabled for this distro, restart Docker Desktop, and verify:",
-      "  docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark",
-      "If using native Docker Engine inside WSL, install/configure NVIDIA Container Toolkit CDI, then restart Docker.",
-      "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
-    ];
-  }
+  const wslRemediationLines = wslDockerDesktopGpuCompatibilityRemediationLines(status);
+  if (wslRemediationLines) return wslRemediationLines;
   return [
     "Install/configure NVIDIA Container Toolkit CDI, then restart Docker:",
     "  sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml",
@@ -205,7 +137,7 @@ function validateJetsonSandboxGpuPreflight(deps: SandboxGpuPreflightDeps): void 
   console.log("  ✓ Docker NVIDIA runtime detected for Jetson/Tegra sandbox GPU");
 }
 
-export interface DirectSandboxGpuVerifierDeps {
+export interface DirectSandboxGpuVerifierDeps extends WslDockerDesktopDetectionDeps {
   runOpenshell(
     args: string[],
     opts?: Record<string, unknown>,
@@ -239,7 +171,9 @@ export function createDirectSandboxGpuVerifier(deps: DirectSandboxGpuVerifierDep
       const diagnostic = deps.compactText(deps.redact(`${result.stderr || ""} ${result.stdout || ""}`));
       console.error(`  ✗ GPU proof failed: ${proof.label}`);
       if (diagnostic) console.error(`    ${diagnostic.slice(0, 300)}`);
-      for (const line of sandboxGpuRemediationLines()) {
+      for (const line of sandboxGpuRemediationLines({
+        wslDockerDesktopStatus: detectWslDockerDesktopStatus(deps),
+      })) {
         console.error(`    ${line}`);
       }
       const statusText = String(result.status || 1);

--- a/src/lib/onboard/wsl-docker-desktop-gpu.test.ts
+++ b/src/lib/onboard/wsl-docker-desktop-gpu.test.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../adapters/docker", () => ({
+  dockerInfoFormat: vi.fn(),
+}));
+
+import {
+  detectWslDockerDesktopStatus,
+  isWslDockerDesktopRuntime,
+  WSL_DOCKER_DESKTOP_GPU_COMPATIBILITY_REMOVAL_CONDITION,
+  wslDockerDesktopGpuCompatibilityAction,
+  wslDockerDesktopGpuCompatibilityRemediationLines,
+} from "./wsl-docker-desktop-gpu";
+
+describe("WSL Docker Desktop GPU compatibility helpers", () => {
+  it("only matches Docker Desktop-backed WSL host assessments", () => {
+    expect(isWslDockerDesktopRuntime({ isWsl: true, runtime: "docker-desktop" })).toBe(true);
+    expect(isWslDockerDesktopRuntime({ isWsl: true, runtime: "docker" })).toBe(false);
+    expect(isWslDockerDesktopRuntime({ isWsl: false, runtime: "docker-desktop" })).toBe(false);
+  });
+
+  it("detects Docker Desktop status only after WSL detection succeeds", () => {
+    const dockerInfoFormat = vi.fn(() => '"Docker Desktop"');
+    expect(
+      detectWslDockerDesktopStatus({
+        platform: "linux",
+        env: { WSL_DISTRO_NAME: "Ubuntu" },
+        dockerInfoFormat,
+      }),
+    ).toBe("docker-desktop");
+    expect(dockerInfoFormat).toHaveBeenCalledWith(
+      "{{json .OperatingSystem}}",
+      expect.objectContaining({ ignoreError: true }),
+    );
+
+    expect(
+      detectWslDockerDesktopStatus({
+        platform: "linux",
+        env: {},
+        release: "6.8.0-generic",
+        procVersion: "Linux version 6.8.0-generic",
+        dockerInfoFormat: vi.fn(() => '"Docker Desktop"'),
+      }),
+    ).toBe("not-docker-desktop");
+  });
+
+  it("centralizes non-blocking Docker --gpus remediation and its removal condition", () => {
+    const action = wslDockerDesktopGpuCompatibilityAction();
+    expect(action.kind).toBe("info");
+    expect(action.blocking).toBe(false);
+    expect(action.reason).toContain("--gpus");
+    expect(action.commands.join("\n")).not.toContain("nvidia-ctk");
+
+    expect(wslDockerDesktopGpuCompatibilityRemediationLines("docker-desktop")?.join("\n")).toContain(
+      "Docker --gpus compatibility",
+    );
+    expect(wslDockerDesktopGpuCompatibilityRemediationLines("unknown")?.join("\n")).toContain(
+      "could not determine whether Docker is Docker Desktop",
+    );
+    expect(wslDockerDesktopGpuCompatibilityRemediationLines("not-docker-desktop")).toBeNull();
+    expect(WSL_DOCKER_DESKTOP_GPU_COMPATIBILITY_REMOVAL_CONDITION).toContain("Remove");
+  });
+});

--- a/src/lib/onboard/wsl-docker-desktop-gpu.ts
+++ b/src/lib/onboard/wsl-docker-desktop-gpu.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+
+import { dockerInfoFormat as defaultDockerInfoFormat } from "../adapters/docker";
+
+const WSL_DOCKER_DESKTOP_DETECTION_TIMEOUT_MS = 30_000;
+export const WSL_DOCKER_DESKTOP_GPU_PROOF_COMMAND =
+  "docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark";
+
+// Source-of-truth for this compatibility branch: Docker Desktop-backed WSL can
+// advertise Docker CDI directories while the WSL distro cannot see a usable
+// nvidia.com/gpu CDI spec. Retire this workaround only after Docker Desktop
+// exposes usable nvidia.com/gpu CDI specs into WSL, or after OpenShell owns a
+// Docker Desktop WSL GPU path that no longer relies on host-visible CDI specs.
+export const WSL_DOCKER_DESKTOP_GPU_COMPATIBILITY_REMOVAL_CONDITION =
+  "Remove this compatibility path when Docker Desktop exposes usable nvidia.com/gpu CDI specs into WSL, or OpenShell no longer requires host-visible CDI specs for Docker Desktop WSL GPU passthrough.";
+
+export type WslDockerDesktopStatus = "docker-desktop" | "not-docker-desktop" | "unknown";
+
+export type WslDockerDesktopHost = {
+  isWsl: boolean;
+  runtime?: string | null;
+};
+
+export type WslDockerDesktopDetectionDeps = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  release?: string;
+  procVersion?: string;
+  readFileImpl?: (filePath: string, encoding: BufferEncoding) => string;
+  dockerInfoFormat?: (format: string, opts?: Record<string, unknown>) => string;
+};
+
+export type WslDockerDesktopGpuCompatibilityAction = {
+  id: "wsl_docker_desktop_gpu_compatibility";
+  title: string;
+  kind: "info";
+  reason: string;
+  commands: string[];
+  blocking: false;
+};
+
+export function isWslDockerDesktopRuntime(host: WslDockerDesktopHost): boolean {
+  return host.isWsl && host.runtime === "docker-desktop";
+}
+
+function detectWsl(deps: WslDockerDesktopDetectionDeps): boolean {
+  const platform = deps.platform ?? process.platform;
+  if (platform !== "linux") return false;
+  const env = deps.env ?? process.env;
+  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) return true;
+  const release = deps.release ?? os.release();
+  if (/microsoft/i.test(release)) return true;
+  const procVersion =
+    deps.procVersion ??
+    (() => {
+      try {
+        const readFileImpl =
+          deps.readFileImpl ??
+          ((filePath: string, encoding: BufferEncoding) => fs.readFileSync(filePath, encoding));
+        return readFileImpl("/proc/version", "utf-8");
+      } catch {
+        return "";
+      }
+    })();
+  return /microsoft/i.test(procVersion);
+}
+
+function detectDockerDesktopRuntime(deps: WslDockerDesktopDetectionDeps): WslDockerDesktopStatus {
+  const dockerInfo = deps.dockerInfoFormat ?? defaultDockerInfoFormat;
+  try {
+    const output = String(
+      dockerInfo("{{json .OperatingSystem}}", {
+        ignoreError: true,
+        timeout: WSL_DOCKER_DESKTOP_DETECTION_TIMEOUT_MS,
+      }),
+    ).trim();
+    if (!output || output === "<no value>") return "unknown";
+    return /^"?docker desktop\b/i.test(output) ? "docker-desktop" : "not-docker-desktop";
+  } catch {
+    return "unknown";
+  }
+}
+
+export function detectWslDockerDesktopStatus(
+  deps: WslDockerDesktopDetectionDeps = {},
+): WslDockerDesktopStatus {
+  if (!detectWsl(deps)) return "not-docker-desktop";
+  return detectDockerDesktopRuntime(deps);
+}
+
+export function wslDockerDesktopGpuCompatibilityRemediationLines(
+  status: WslDockerDesktopStatus,
+): string[] | null {
+  if (status === "docker-desktop") {
+    return [
+      "Docker Desktop WSL detected; NemoClaw uses Docker --gpus compatibility instead of CDI spec validation.",
+      "If sandbox GPU setup later fails, verify from WSL:",
+      `  ${WSL_DOCKER_DESKTOP_GPU_PROOF_COMMAND}`,
+      "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
+    ];
+  }
+  if (status === "unknown") {
+    return [
+      "WSL detected, but NemoClaw could not determine whether Docker is Docker Desktop or native Docker Engine.",
+      "If using Docker Desktop, confirm Settings > Resources > WSL integration is enabled for this distro, restart Docker Desktop, and verify:",
+      `  ${WSL_DOCKER_DESKTOP_GPU_PROOF_COMMAND}`,
+      "If using native Docker Engine inside WSL, install/configure NVIDIA Container Toolkit CDI, then restart Docker.",
+      "Or force CPU sandbox behavior with NEMOCLAW_SANDBOX_GPU=0.",
+    ];
+  }
+  return null;
+}
+
+export function wslDockerDesktopGpuCompatibilityAction(): WslDockerDesktopGpuCompatibilityAction {
+  return {
+    id: "wsl_docker_desktop_gpu_compatibility",
+    title: "Use Docker Desktop WSL GPU compatibility path",
+    kind: "info",
+    reason:
+      "Docker Desktop is configured for CDI device injection (CDISpecDirs is set) but no " +
+      "nvidia.com/gpu CDI spec is visible from WSL. On Docker Desktop-backed WSL, NemoClaw " +
+      "uses Docker's `--gpus` compatibility path instead of trying to repair Linux host CDI " +
+      "from inside the WSL distro.",
+    commands: [
+      `If sandbox GPU setup later fails, verify Docker Desktop GPU support from WSL with \`${WSL_DOCKER_DESKTOP_GPU_PROOF_COMMAND}\`.`,
+      "Rerun with `--no-gpu` to skip GPU passthrough.",
+    ],
+    blocking: false,
+  };
+}

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1254,12 +1254,19 @@ exports.isWslDockerDesktopRuntime = (host) =>
   Boolean(host && host.isWsl && host.runtime === "docker-desktop");
 exports.planHostRemediation = (host) =>
   host.cdiNvidiaGpuSpecMissing
-    ? [{
-        title: "Generate NVIDIA CDI device specs",
-        reason: "missing nvidia.com/gpu",
-        commands: ["sudo nvidia-ctk cdi generate --output=" + exports.getNvidiaCdiSpecPath(host)],
-        blocking: true,
-      }]
+    ? host.isWsl && host.runtime === "docker-desktop"
+      ? [{
+          title: "Use Docker Desktop WSL GPU compatibility path",
+          reason: "missing nvidia.com/gpu CDI; using Docker --gpus",
+          commands: ["verify Docker --gpus support from WSL"],
+          blocking: false,
+        }]
+      : [{
+          title: "Generate NVIDIA CDI device specs",
+          reason: "missing nvidia.com/gpu",
+          commands: ["sudo nvidia-ctk cdi generate --output=" + exports.getNvidiaCdiSpecPath(host)],
+          blocking: true,
+        }]
     : [];
 `,
     );
@@ -1415,9 +1422,10 @@ exit 0
 `,
       });
 
-    expect(result.status, output).toBe(1);
+    expect(result.status, output).toBe(0);
     expect(cdiStateExists).toBe(false);
-    expect(output).toMatch(/Host preflight found issues/);
+    expect(output).toMatch(/Host preflight found warnings/);
+    expect(output).toMatch(/Use Docker Desktop WSL GPU compatibility path/);
     expect(output).not.toMatch(/Trying NVIDIA CDI refresh service/);
     expect(output).not.toMatch(/Generated NVIDIA CDI device spec/);
     expect(systemctlLog).toBe("");

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -1220,8 +1220,12 @@ fi`,
 
   function runNvidiaCdiInstallerRepairTest({
     systemctlScript,
+    isWsl = false,
+    runtime = "docker",
   }: {
     systemctlScript: string;
+    isWsl?: boolean;
+    runtime?: string;
   }) {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-cdi-repair-"));
     const fakeBin = path.join(tmp, "bin");
@@ -1238,13 +1242,16 @@ fi`,
       `
 const fs = require("fs");
 exports.assessHost = () => ({
-  runtime: "docker",
+  runtime: ${JSON.stringify(runtime)},
+  isWsl: ${isWsl ? "true" : "false"},
   notes: [],
   dockerCdiSpecDirs: [process.env.CDI_DIR],
   cdiNvidiaGpuSpecMissing: !fs.existsSync(process.env.CDI_STATE),
 });
 exports.getNvidiaCdiSpecPath = (host) =>
   String(host.dockerCdiSpecDirs[0]).replace(/\\/+$/, "") + "/nvidia.yaml";
+exports.isWslDockerDesktopRuntime = (host) =>
+  Boolean(host && host.isWsl && host.runtime === "docker-desktop");
 exports.planHostRemediation = (host) =>
   host.cdiNvidiaGpuSpecMissing
     ? [{
@@ -1330,6 +1337,7 @@ run_installer_host_preflight
       cdiDir,
       output: `${result.stdout}${result.stderr}`,
       result,
+      cdiStateExists: fs.existsSync(cdiState),
       sudoLog: fs.existsSync(sudoLog) ? fs.readFileSync(sudoLog, "utf-8") : "",
       systemctlLog: fs.existsSync(systemctlLog) ? fs.readFileSync(systemctlLog, "utf-8") : "",
     };
@@ -1392,6 +1400,28 @@ exit 1
     );
     expect(sudoLog).toMatch(/^-v$/m);
     expect(sudoLog).toContain(`nvidia-ctk cdi generate --output=${cdiDir}/nvidia.yaml`);
+  });
+
+  it("skips Linux NVIDIA CDI auto-repair on WSL Docker Desktop", () => {
+    const { cdiStateExists, output, result, sudoLog, systemctlLog } =
+      runNvidiaCdiInstallerRepairTest({
+        isWsl: true,
+        runtime: "docker-desktop",
+        systemctlScript: `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$SYSTEMCTL_LOG"
+touch "$CDI_STATE"
+exit 0
+`,
+      });
+
+    expect(result.status, output).toBe(1);
+    expect(cdiStateExists).toBe(false);
+    expect(output).toMatch(/Host preflight found issues/);
+    expect(output).not.toMatch(/Trying NVIDIA CDI refresh service/);
+    expect(output).not.toMatch(/Generated NVIDIA CDI device spec/);
+    expect(systemctlLog).toBe("");
+    expect(sudoLog).toBe("");
   });
 
   it("warns on Podman but still runs onboarding", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Make WSL Docker Desktop GPU onboarding use NemoClaw's Docker `--gpus` compatibility path instead of treating missing CDI specs as a blocking Linux host repair. Docker Desktop manages the daemon outside the WSL distro, and in that setup Docker GPU access can work through `--gpus all` even when CDI `--device nvidia.com/gpu=all` is not resolvable from WSL. This avoids suggesting or requiring Linux `nvidia-ctk` CDI remediation inside a Docker Desktop-backed WSL distro.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #3973

## Changes
- Skip the blocking CDI spec guard for WSL Docker Desktop hosts.
- Let sandbox GPU preflight proceed on WSL Docker Desktop so the existing Docker GPU patch can try `--gpus all`.
- Keep native Linux and native Docker Engine inside WSL on the CDI remediation path.
- Update tests and troubleshooting docs for the WSL Docker Desktop behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU passthrough handling for WSL with Docker Desktop, now using Docker's `--gpus` compatibility path instead of attempting NVIDIA CDI spec generation.

* **Documentation**
  * Enhanced troubleshooting guidance for GPU passthrough on WSL, including steps to verify Docker Desktop integration and GPU access from within WSL containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->