### PR TITLE
fix(ci): remove unsupported Brev nightly inputs

### DIFF
--- a/.github/workflows/brev-nightly-e2e.yaml
+++ b/.github/workflows/brev-nightly-e2e.yaml
@@ -20,10 +20,6 @@ on:
         description: "Branch to test (default: ref used for this dispatch; schedule always tests main)"
         required: false
         default: ""
-      launchable_id:
-        description: "Published launchable ID override (empty = workflow/test default)"
-        required: false
-        default: ""
       keep_alive:
         description: "Keep Brev instances alive after tests (for SSH debugging)"
         required: false
@@ -49,8 +45,6 @@ jobs:
       branch: ${{ github.event_name == 'schedule' && 'main' || inputs.branch || github.ref_name }}
       test_suite: ${{ matrix.test_suite }}
       use_launchable: true
-      use_published_launchable: true
-      launchable_id: ${{ github.event_name == 'workflow_dispatch' && inputs.launchable_id || '' }}
       keep_alive: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_alive || false }}
     secrets:
       BREV_API_KEY: ${{ secrets.BREV_API_KEY }}

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { readYaml } from "./helpers/e2e-workflow-contract";
+
+type ReusableCallerJob = {
+  uses?: string;
+  with?: Record<string, unknown>;
+  secrets?: Record<string, unknown>;
+};
+
+type Workflow = {
+  on?: {
+    workflow_call?: {
+      inputs?: Record<string, unknown>;
+      secrets?: Record<string, unknown>;
+    };
+    workflow_dispatch?: {
+      inputs?: Record<string, unknown>;
+    };
+  };
+  jobs?: Record<string, ReusableCallerJob>;
+};
+
+describe("Brev nightly workflow contract", () => {
+  const nightly = readYaml<Workflow>(".github/workflows/brev-nightly-e2e.yaml");
+  const branchValidation = readYaml<Workflow>(".github/workflows/e2e-branch-validation.yaml");
+
+  it("passes only declared inputs and secrets to branch validation", () => {
+    const declaredInputs = new Set(Object.keys(branchValidation.on?.workflow_call?.inputs ?? {}));
+    const declaredSecrets = new Set(Object.keys(branchValidation.on?.workflow_call?.secrets ?? {}));
+    const callerJobs = Object.entries(nightly.jobs ?? {}).filter(
+      ([, job]) => job.uses === "./.github/workflows/e2e-branch-validation.yaml",
+    );
+
+    expect(callerJobs.length).toBeGreaterThan(0);
+    for (const [jobName, job] of callerJobs) {
+      const unknownInputs = Object.keys(job.with ?? {}).filter((name) => !declaredInputs.has(name));
+      const unknownSecrets = Object.keys(job.secrets ?? {}).filter((name) => !declaredSecrets.has(name));
+
+      expect(unknownInputs, `${jobName} passes unsupported reusable workflow inputs`).toEqual([]);
+      expect(unknownSecrets, `${jobName} passes unsupported reusable workflow secrets`).toEqual([]);
+    }
+  });
+
+  it("does not expose stale published-launchable controls", () => {
+    const dispatchInputs = Object.keys(nightly.on?.workflow_dispatch?.inputs ?? {});
+    const callerInputs = Object.values(nightly.jobs ?? {}).flatMap((job) => Object.keys(job.with ?? {}));
+
+    expect(dispatchInputs).not.toContain("launchable_id");
+    expect(callerInputs).not.toContain("launchable_id");
+    expect(callerInputs).not.toContain("use_published_launchable");
+  });
+});


### PR DESCRIPTION
## Summary
Remove stale published-launchable inputs from the Brev nightly reusable workflow call so scheduled runs can start successfully. Add a workflow contract test that ensures the Brev nightly only passes inputs and secrets declared by `e2e-branch-validation.yaml`.

## Changes
- Removed unsupported `use_published_launchable` and `launchable_id` inputs from `.github/workflows/brev-nightly-e2e.yaml`.
- Removed the stale manual `launchable_id` dispatch input.
- Added `test/brev-nightly-workflow.test.ts` to catch undeclared reusable workflow inputs/secrets.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation tests for nightly end-to-end workflow configuration compliance

* **Chores**
  * Updated nightly end-to-end testing workflow with new SSH debugging capability and refined configuration parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->