### PR TITLE
fix(host-aliases): prepend docker exec subcommand for kubectl invocation

### DIFF
--- a/src/lib/actions/sandbox/host-aliases.ts
+++ b/src/lib/actions/sandbox/host-aliases.ts
@@ -69,10 +69,13 @@ function normalizeHostAliasHostname(hostname: string): string {
 }
 
 function runKubectlInClusterRaw(args: string[]): string {
-  return dockerExecFileSync([K3S_CONTAINER, "kubectl", "-n", "openshell", ...args], {
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: HOST_ALIAS_KUBECTL_TIMEOUT_MS,
-  });
+  return dockerExecFileSync(
+    ["exec", K3S_CONTAINER, "kubectl", "-n", "openshell", ...args],
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: HOST_ALIAS_KUBECTL_TIMEOUT_MS,
+    },
+  );
 }
 
 function throwKubectlError(action: string, error: unknown): never {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1841,9 +1841,9 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("Added host alias searxng.local -> 192.168.1.105");
     const log = fs.readFileSync(dockerLog, "utf8").trim().split(/\n/);
-    // Regression for #4317: docker invocation must start with the `exec`
-    // subcommand. Without it, docker parses kubectl's `-n` as a docker flag
-    // and exits 125 ("unknown shorthand flag: 'n' in -n").
+    // The docker invocation must start with the `exec` subcommand. Without
+    // it, docker parses kubectl's `-n` as a docker flag and exits 125
+    // ("unknown shorthand flag: 'n' in -n").
     expect(log[0]).toBe("exec");
     expect(log).toContain("patch");
     expect(log).toContain("--type=json");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1841,6 +1841,10 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("Added host alias searxng.local -> 192.168.1.105");
     const log = fs.readFileSync(dockerLog, "utf8").trim().split(/\n/);
+    // Regression for #4317: docker invocation must start with the `exec`
+    // subcommand. Without it, docker parses kubectl's `-n` as a docker flag
+    // and exits 125 ("unknown shorthand flag: 'n' in -n").
+    expect(log[0]).toBe("exec");
     expect(log).toContain("patch");
     expect(log).toContain("--type=json");
     const patch = JSON.parse(log[log.indexOf("-p") + 1]);
@@ -1862,12 +1866,15 @@ describe("CLI dispatch", () => {
   it("lists host aliases from the sandbox resource", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-hosts-list-"));
     const localBin = path.join(home, "bin");
+    const dockerLog = path.join(home, "docker.log");
     fs.mkdirSync(localBin, { recursive: true });
     writeSandboxRegistry(home);
     fs.writeFileSync(
       path.join(localBin, "docker"),
       [
         "#!/usr/bin/env bash",
+        `log_file=${JSON.stringify(dockerLog)}`,
+        'printf "%s\\n" "$@" >> "$log_file"',
         'printf "%s\\n" \'{"metadata":{"resourceVersion":"123"},"spec":{"podTemplate":{"spec":{"hostAliases":[{"ip":"192.168.1.105","hostnames":["searxng.local","search.lan"]}]}}}}\'',
       ].join("\n"),
       { mode: 0o755 },
@@ -1881,6 +1888,10 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("Host aliases for 'alpha'");
     expect(r.out).toContain("192.168.1.105  searxng.local, search.lan");
+    const log = fs.readFileSync(dockerLog, "utf8").trim().split(/\n/);
+    expect(log[0]).toBe("exec");
+    expect(log).toContain("kubectl");
+    expect(log).toContain("get");
   });
 
   it("removes host aliases with a sandbox json patch", () => {
@@ -1902,6 +1913,7 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("Removed host alias searxng.local");
     const log = fs.readFileSync(dockerLog, "utf8").trim().split(/\n/);
+    expect(log[0]).toBe("exec");
     expect(log).toContain("patch");
     const patch = JSON.parse(log[log.lastIndexOf("-p") + 1]);
     expect(patch[0]).toEqual({


### PR DESCRIPTION
## Summary
`nemoclaw <sandbox> hosts-list` / `hosts-add` / `hosts-remove` failed with `Failed to read host aliases. unknown shorthand flag: 'n' in -n` and exit 125 on real Docker engines because `runKubectlInClusterRaw` invoked `dockerExecFileSync` without the `exec` subcommand. Docker then parsed `kubectl`'s `-n openshell` as a Docker flag and bailed before any kubectl call could run. This patch prepends `"exec"` to the argv so the helper actually runs `docker exec <k3s-container> kubectl -n openshell ...`.

## Related Issue
Fixes #4317.

## Changes
- `src/lib/actions/sandbox/host-aliases.ts`: `runKubectlInClusterRaw` now passes `["exec", K3S_CONTAINER, "kubectl", "-n", "openshell", ...args]` to `dockerExecFileSync`, restoring the intended `docker exec ... kubectl ...` invocation.
- `test/cli.test.ts`: hardened the three host-alias integration tests (`hosts-add`, `hosts-list`, `hosts-remove`). Each test now captures the docker stub argv and asserts `log[0] === "exec"`, so the original PATH-shim fixture (which only `printf`-ed `"$@"` to a log) catches the missing subcommand instead of silently absorbing it.

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed host-alias listing and removal so CLI invocations now run correctly (ensures Docker command includes the expected exec/kubectl sequence).

* **Tests**
  * Strengthened tests to validate the exact command invocation format and logged docker calls for host-alias operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->