### PR TITLE
test(e2e): update cloudflared tunnel pin

### DIFF
--- a/test/e2e/test-tunnel-lifecycle.sh
+++ b/test/e2e/test-tunnel-lifecycle.sh
@@ -116,17 +116,48 @@ preflight() {
   if ! command -v cloudflared >/dev/null 2>&1; then
     # Install via Cloudflare's GPG-signed APT repo — trust anchor for secret-bearing
     # CI; APT verifies GPG-signed Release → package SHA256 (no per-version SHA pin).
-    local cf_version="${CLOUDFLARED_VERSION:-2026.5.2}"
-    log "Installing cloudflared ${cf_version} via Cloudflare APT repo..."
     sudo mkdir -p --mode=0755 /usr/share/keyrings
     curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
       | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
     echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" \
       | sudo tee /etc/apt/sources.list.d/cloudflared.list >/dev/null
     sudo apt-get update -qq
-    sudo apt-get install -y "cloudflared=${cf_version}*" \
+
+    local available_versions
+    available_versions="$(apt-cache madison cloudflared | awk '{print $3}' | sort -Vu)"
+    if [[ -z "$available_versions" ]]; then
+      log "ERROR: no cloudflared versions available in Cloudflare APT repo"
+      exit 1
+    fi
+
+    local cf_version
+    if [[ -n "${CLOUDFLARED_VERSION:-}" ]]; then
+      cf_version="$CLOUDFLARED_VERSION"
+      log "Using explicit cloudflared version override: ${cf_version}"
+    else
+      local cf_min_version="${CLOUDFLARED_MIN_VERSION:-2026.5.1}"
+      cf_version="$(
+        while IFS= read -r version; do
+          if dpkg --compare-versions "$version" ge "$cf_min_version"; then
+            printf '%s\n' "$version"
+          fi
+        done <<<"$available_versions" | sort -V | tail -n 1
+      )"
+      if [[ -z "$cf_version" ]]; then
+        log "ERROR: no cloudflared version in Cloudflare APT repo meets minimum ${cf_min_version}"
+        log "Available versions:"
+        log "$available_versions"
+        exit 1
+      fi
+      log "Resolved cloudflared ${cf_version} from Cloudflare APT repo (minimum ${cf_min_version})"
+    fi
+
+    log "Installing cloudflared ${cf_version} via Cloudflare APT repo..."
+    sudo apt-get install -y "cloudflared=${cf_version}" \
       || {
         log "ERROR: cloudflared ${cf_version} not available in Cloudflare APT repo"
+        log "Available versions:"
+        log "$available_versions"
         exit 1
       }
     log "cloudflared ${cf_version} installed (GPG verified via Cloudflare APT repo)"

--- a/test/e2e/test-tunnel-lifecycle.sh
+++ b/test/e2e/test-tunnel-lifecycle.sh
@@ -116,7 +116,7 @@ preflight() {
   if ! command -v cloudflared >/dev/null 2>&1; then
     # Install via Cloudflare's GPG-signed APT repo — trust anchor for secret-bearing
     # CI; APT verifies GPG-signed Release → package SHA256 (no per-version SHA pin).
-    local cf_version="${CLOUDFLARED_VERSION:-2026.5.1}"
+    local cf_version="${CLOUDFLARED_VERSION:-2026.5.2}"
     log "Installing cloudflared ${cf_version} via Cloudflare APT repo..."
     sudo mkdir -p --mode=0755 /usr/share/keyrings
     curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \


### PR DESCRIPTION
## Summary
- keep installing cloudflared from Cloudflare's GPG-signed APT repo
- allow an exact emergency override with CLOUDFLARED_VERSION
- for default CI, resolve the highest signed APT cloudflared version at or above CLOUDFLARED_MIN_VERSION (default 2026.5.1) and install that exact resolved version
- fail with available APT versions when no version is available or none meets the configured floor

## Context
Full nightly run 26516866067 / job 78096438061 failed at checked-out SHA b8a3413c with:

```
E: Version '2026.5.1*' for 'cloudflared' was not found\n```\n\nCloudflare APT rotated from 2026.5.1 to a newer patch version on the GitHub ubuntu-24.04 runner. This keeps the signed APT trust path while making the default CI install resilient to patch-version rotation.\n\n## Validation\n- bash -n test/e2e/test-tunnel-lifecycle.sh\n- shellcheck test/e2e/test-tunnel-lifecycle.sh\n- git diff --check\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for tunnel lifecycle validation with enhanced version selection and error reporting capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->