### PR TITLE
fix(cli): add --json flag to per-sandbox status command

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -378,6 +378,16 @@ $ nemoclaw my-assistant recover
 
 Show sandbox status, health, and inference configuration.
 
+Pass `--json` to emit a structured per-sandbox report instead of the text renderer.
+The JSON output includes `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, and `policies`.
+`openshellDriver` and `openshellVersion` are always strings (falling back to `"unknown"` when the registry has no value), so consumers can rely on `typeof` checks.
+The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, or the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`).
+
+```console
+$ nemoclaw my-assistant status
+$ nemoclaw my-assistant status --json
+```
+
 The command probes every inference provider and reports one of three states on the `Inference` line:
 
 | State | Meaning |

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -379,13 +379,15 @@ $ nemoclaw my-assistant recover
 Show sandbox status, health, and inference configuration.
 
 Pass `--json` to emit a structured per-sandbox report instead of the text renderer.
-The JSON output includes `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, and `policies`.
+The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, and `policies`.
 `openshellDriver` and `openshellVersion` are always strings (falling back to `"unknown"` when the registry has no value), so consumers can rely on `typeof` checks.
 The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, or the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`).
+The alias form `nemoclaw <name> status --json` requires the sandbox to be registered locally; the canonical form `nemoclaw sandbox status <name> --json` is the one to use from automation that may run against an unknown sandbox name, since it still emits a JSON document with `found: false` instead of a text error.
 
 ```console
 $ nemoclaw my-assistant status
 $ nemoclaw my-assistant status --json
+$ nemoclaw sandbox status my-assistant --json
 ```
 
 The command probes every inference provider and reports one of three states on the `Inference` line:

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -27,7 +27,7 @@ export default class SandboxStatusCommand extends NemoClawCommand {
     const { args } = await this.parse(SandboxStatusCommand);
     if (this.jsonEnabled()) {
       const report = await getSandboxStatusReport(args.sandboxName);
-      if (!report.found || report.gatewayState !== "present") {
+      if (!report.found || report.gatewayState !== "present" || report.rpcIssue) {
         process.exitCode = 1;
       }
       return report;

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -3,24 +3,35 @@
 
 import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 
-import { showSandboxStatus } from "../../lib/actions/sandbox/status";
+import { getSandboxStatusReport, showSandboxStatus } from "../../lib/actions/sandbox/status";
 import { sandboxNameArg } from "../../lib/sandbox/command-support";
 
 export default class SandboxStatusCommand extends NemoClawCommand {
   static id = "sandbox:status";
   static strict = true;
+  static enableJsonFlag = true;
   static summary = "Sandbox health and NIM status";
   static description = "Show sandbox health, OpenShell gateway state, and local NIM status.";
-  static usage = ["<name>"];
-  static examples = ["<%= config.bin %> sandbox status alpha"];
+  static usage = ["<name> [--json]"];
+  static examples = [
+    "<%= config.bin %> sandbox status alpha",
+    "<%= config.bin %> sandbox status alpha --json",
+  ];
   static args = {
     sandboxName: sandboxNameArg,
   };
   static flags = {
   };
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(SandboxStatusCommand);
+    if (this.jsonEnabled()) {
+      const report = await getSandboxStatusReport(args.sandboxName);
+      if (!report.found || report.gatewayState !== "present") {
+        process.exitCode = 1;
+      }
+      return report;
+    }
     await showSandboxStatus(args.sandboxName);
   }
 }

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -5,6 +5,7 @@ import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 
 import { getSandboxStatusReport, showSandboxStatus } from "../../lib/actions/sandbox/status";
 import { sandboxNameArg } from "../../lib/sandbox/command-support";
+import { redactForLog } from "../../lib/security/redact";
 
 export default class SandboxStatusCommand extends NemoClawCommand {
   static id = "sandbox:status";
@@ -30,7 +31,11 @@ export default class SandboxStatusCommand extends NemoClawCommand {
       if (!report.found || report.gatewayState !== "present" || report.rpcIssue) {
         process.exitCode = 1;
       }
-      return report;
+      // #4310: route the machine-readable report through the centralized
+      // redactForLog source of truth so health diagnostics (inferenceHealth
+      // endpoint/detail/subprobes) cannot leak token-shaped values into
+      // automation that persists CLI JSON output.
+      return redactForLog(report);
     }
     await showSandboxStatus(args.sandboxName);
   }

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -63,6 +63,85 @@ export function getSandboxStatusInferenceHealth(
   });
 }
 
+export interface SandboxStatusReport {
+  schemaVersion: 1;
+  name: string;
+  found: boolean;
+  model: string;
+  provider: string;
+  phase: string | null;
+  gatewayState: string;
+  inferenceHealth: ProviderHealthStatus | null;
+  hostGpuDetected: boolean;
+  sandboxGpuEnabled: boolean;
+  sandboxGpuMode: string | null;
+  sandboxGpuDevice: string | null;
+  openshellDriver: string;
+  openshellVersion: string;
+  policies: string[];
+}
+
+export async function getSandboxStatusReport(
+  sandboxName: string,
+): Promise<SandboxStatusReport> {
+  const sb = registry.getSandbox(sandboxName);
+  let lookup: SandboxGatewayState;
+  try {
+    lookup = await getReconciledSandboxGatewayState(sandboxName, {
+      getState: getSandboxGatewayStateForStatus,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    lookup = {
+      state: "gateway_error",
+      output: `  Could not probe live gateway state: ${message}`,
+    };
+  }
+  let liveResult: Awaited<ReturnType<typeof captureOpenshellForStatus>> | null = null;
+  if (lookup.state === "present") {
+    try {
+      liveResult = await captureOpenshellForStatus(["inference", "get"]);
+    } catch {
+      liveResult = null;
+    }
+  }
+  const live =
+    liveResult && !isCommandTimeout(liveResult) ? parseGatewayInference(liveResult.output) : null;
+  const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
+  const currentProvider = (live && live.provider) || (sb && sb.provider) || "unknown";
+  const inferenceHealth = getSandboxStatusInferenceHealth(
+    lookup.state === "present",
+    currentProvider,
+    currentModel,
+  );
+  const phase =
+    lookup.state === "present" ? parseSandboxPhase(lookup.output || "") : null;
+  const sandboxGpuEnabled = sb
+    ? (sb.sandboxGpuEnabled ?? (sb.gpuEnabled === true))
+    : false;
+  const policies =
+    sb && Array.isArray(sb.policies)
+      ? sb.policies.filter((policy): policy is string => typeof policy === "string")
+      : [];
+  return {
+    schemaVersion: 1,
+    name: sandboxName,
+    found: !!sb,
+    model: currentModel,
+    provider: currentProvider,
+    phase,
+    gatewayState: lookup.state,
+    inferenceHealth,
+    hostGpuDetected: !!(sb && sb.hostGpuDetected),
+    sandboxGpuEnabled,
+    sandboxGpuMode: (sb && sb.sandboxGpuMode) || null,
+    sandboxGpuDevice: (sb && sb.sandboxGpuDevice) || null,
+    openshellDriver: (sb && sb.openshellDriver) || "unknown",
+    openshellVersion: (sb && sb.openshellVersion) || "unknown",
+    policies,
+  };
+}
+
 /**
  * Render one Inference status line. The main probe and each subprobe go
  * through this helper so multi-hop providers (e.g. ollama-local backend +

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -85,7 +85,6 @@ export interface SandboxStatusReport {
 interface SandboxStatusSnapshot {
   sb: registry.SandboxEntry | null;
   lookup: SandboxGatewayState;
-  liveResult: Awaited<ReturnType<typeof captureOpenshellForStatus>> | null;
   rpcIssue: ReturnType<typeof detectOpenShellStateRpcResultIssue>;
   currentModel: string;
   currentProvider: string;
@@ -117,6 +116,16 @@ async function collectSandboxStatusSnapshot(
     }
   }
   const rpcIssue = liveResult ? detectOpenShellStateRpcResultIssue(liveResult) : null;
+  if (rpcIssue) {
+    return {
+      sb,
+      lookup,
+      rpcIssue,
+      currentModel: "unknown",
+      currentProvider: "unknown",
+      inferenceHealth: null,
+    };
+  }
   const live =
     liveResult && !isCommandTimeout(liveResult) ? parseGatewayInference(liveResult.output) : null;
   const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
@@ -126,8 +135,6 @@ async function collectSandboxStatusSnapshot(
     currentProvider,
     currentModel,
   );
-  // #3265 optional gateway-chain subprobe: from inside the sandbox so a
-  // broken hop the host-side probes can't see still surfaces.
   if (
     inferenceHealth &&
     lookup.state === "present" &&
@@ -147,7 +154,7 @@ async function collectSandboxStatusSnapshot(
       inferenceHealth.subprobes = [...(inferenceHealth.subprobes ?? []), gatewaySubprobe];
     }
   }
-  return { sb, lookup, liveResult, rpcIssue, currentModel, currentProvider, inferenceHealth };
+  return { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth };
 }
 
 export async function getSandboxStatusReport(

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -72,6 +72,7 @@ export interface SandboxStatusReport {
   phase: string | null;
   gatewayState: string;
   inferenceHealth: ProviderHealthStatus | null;
+  rpcIssue: { kind: "image_drift" | "protobuf_mismatch" } | null;
   hostGpuDetected: boolean;
   sandboxGpuEnabled: boolean;
   sandboxGpuMode: string | null;
@@ -81,9 +82,19 @@ export interface SandboxStatusReport {
   policies: string[];
 }
 
-export async function getSandboxStatusReport(
+interface SandboxStatusSnapshot {
+  sb: registry.SandboxEntry | null;
+  lookup: SandboxGatewayState;
+  liveResult: Awaited<ReturnType<typeof captureOpenshellForStatus>> | null;
+  rpcIssue: ReturnType<typeof detectOpenShellStateRpcResultIssue>;
+  currentModel: string;
+  currentProvider: string;
+  inferenceHealth: ProviderHealthStatus | null;
+}
+
+async function collectSandboxStatusSnapshot(
   sandboxName: string,
-): Promise<SandboxStatusReport> {
+): Promise<SandboxStatusSnapshot> {
   const sb = registry.getSandbox(sandboxName);
   let lookup: SandboxGatewayState;
   try {
@@ -105,6 +116,7 @@ export async function getSandboxStatusReport(
       liveResult = null;
     }
   }
+  const rpcIssue = liveResult ? detectOpenShellStateRpcResultIssue(liveResult) : null;
   const live =
     liveResult && !isCommandTimeout(liveResult) ? parseGatewayInference(liveResult.output) : null;
   const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
@@ -114,6 +126,35 @@ export async function getSandboxStatusReport(
     currentProvider,
     currentModel,
   );
+  // #3265 optional gateway-chain subprobe: from inside the sandbox so a
+  // broken hop the host-side probes can't see still surfaces.
+  if (
+    inferenceHealth &&
+    lookup.state === "present" &&
+    (currentProvider === "ollama-local" || currentProvider === "vllm-local")
+  ) {
+    const gatewayChain = await probeSandboxInferenceGatewayHealth(sandboxName);
+    if (gatewayChain) {
+      const gatewaySubprobe: ProviderHealthStatus = {
+        ok: gatewayChain.ok,
+        probed: true,
+        providerLabel: "Inference gateway chain",
+        endpoint: gatewayChain.endpoint,
+        detail: gatewayChain.detail,
+        probeLabel: "gateway",
+        ...(gatewayChain.ok ? {} : { failureLabel: "unreachable" as const }),
+      };
+      inferenceHealth.subprobes = [...(inferenceHealth.subprobes ?? []), gatewaySubprobe];
+    }
+  }
+  return { sb, lookup, liveResult, rpcIssue, currentModel, currentProvider, inferenceHealth };
+}
+
+export async function getSandboxStatusReport(
+  sandboxName: string,
+): Promise<SandboxStatusReport> {
+  const snapshot = await collectSandboxStatusSnapshot(sandboxName);
+  const { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth } = snapshot;
   const phase =
     lookup.state === "present" ? parseSandboxPhase(lookup.output || "") : null;
   const sandboxGpuEnabled = sb
@@ -132,6 +173,7 @@ export async function getSandboxStatusReport(
     phase,
     gatewayState: lookup.state,
     inferenceHealth,
+    rpcIssue: rpcIssue ? { kind: rpcIssue.kind } : null,
     hostGpuDetected: !!(sb && sb.hostGpuDetected),
     sandboxGpuEnabled,
     sandboxGpuMode: (sb && sb.sandboxGpuMode) || null,
@@ -192,73 +234,20 @@ async function printGatewayFailureLayerHeader(sandboxName: string): Promise<void
 
 // eslint-disable-next-line complexity
 export async function showSandboxStatus(sandboxName: string): Promise<void> {
-  const sb = registry.getSandbox(sandboxName);
-  maybeEnsureHermesToolGatewayBroker(sb);
   // #2666: never let an unexpected throw from the gateway probe (e.g. openshell
   // hanging when its container is stopped and the published port is held by a
   // foreign listener) suppress the sandbox header. The downstream switch
   // handles `gateway_error` by printing an actionable block + exit(1), so a
   // synthesized fallback keeps the user-visible contract intact.
-  let lookup: SandboxGatewayState;
-  try {
-    lookup = await getReconciledSandboxGatewayState(sandboxName, {
-      getState: getSandboxGatewayStateForStatus,
+  const snapshot = await collectSandboxStatusSnapshot(sandboxName);
+  const { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth } = snapshot;
+  maybeEnsureHermesToolGatewayBroker(sb);
+  if (rpcIssue) {
+    printOpenShellStateRpcIssue(rpcIssue, {
+      action: `checking inference status for sandbox '${sandboxName}'`,
+      command: `${CLI_NAME} ${sandboxName} status`,
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    lookup = {
-      state: "gateway_error",
-      output: `  Could not probe live gateway state: ${message}`,
-    };
-  }
-  let liveResult: Awaited<ReturnType<typeof captureOpenshellForStatus>> | null = null;
-  if (lookup.state === "present") {
-    try {
-      liveResult = await captureOpenshellForStatus(["inference", "get"]);
-    } catch {
-      liveResult = null;
-    }
-  }
-  if (liveResult) {
-    const inferenceIssue = detectOpenShellStateRpcResultIssue(liveResult);
-    if (inferenceIssue) {
-      printOpenShellStateRpcIssue(inferenceIssue, {
-        action: `checking inference status for sandbox '${sandboxName}'`,
-        command: `${CLI_NAME} ${sandboxName} status`,
-      });
-      process.exit(1);
-    }
-  }
-  const live =
-    liveResult && !isCommandTimeout(liveResult) ? parseGatewayInference(liveResult.output) : null;
-  const currentModel = (live && live.model) || (sb && sb.model) || "unknown";
-  const currentProvider = (live && live.provider) || (sb && sb.provider) || "unknown";
-  const inferenceHealth = getSandboxStatusInferenceHealth(
-    lookup.state === "present",
-    currentProvider,
-    currentModel,
-  );
-  // #3265 optional 3rd line: probe the full inference chain (openclaw gateway
-  // → auth proxy → backend) from inside the sandbox so a broken hop the
-  // host-side probes can't see still surfaces in `status`.
-  if (
-    inferenceHealth &&
-    lookup.state === "present" &&
-    (currentProvider === "ollama-local" || currentProvider === "vllm-local")
-  ) {
-    const gatewayChain = await probeSandboxInferenceGatewayHealth(sandboxName);
-    if (gatewayChain) {
-      const gatewaySubprobe: ProviderHealthStatus = {
-        ok: gatewayChain.ok,
-        probed: true,
-        providerLabel: "Inference gateway chain",
-        endpoint: gatewayChain.endpoint,
-        detail: gatewayChain.detail,
-        probeLabel: "gateway",
-        ...(gatewayChain.ok ? {} : { failureLabel: "unreachable" as const }),
-      };
-      inferenceHealth.subprobes = [...(inferenceHealth.subprobes ?? []), gatewaySubprobe];
-    }
+    process.exit(1);
   }
   if (sb) {
     console.log("");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -992,6 +992,7 @@ describe("CLI dispatch", () => {
       PATH: `${localBin}:${process.env.PATH || ""}`,
     });
 
+    expect(r.code).toBe(0);
     expect(r.out.trim().startsWith("{")).toBe(true);
     expect(r.out.trim().endsWith("}")).toBe(true);
     expect(r.out).not.toContain("Sandbox: ");
@@ -1011,6 +1012,7 @@ describe("CLI dispatch", () => {
       openshellDriver: "docker",
       openshellVersion: "0.0.44",
       policies: ["npm"],
+      rpcIssue: null,
     });
     expect(typeof parsed.openshellDriver).toBe("string");
     expect(typeof parsed.openshellVersion).toBe("string");
@@ -1038,10 +1040,50 @@ describe("CLI dispatch", () => {
     });
 
     const parsed = JSON.parse(r.out);
+    expect(r.code).toBe(0);
     expect(parsed.openshellDriver).toBe("unknown");
     expect(parsed.openshellVersion).toBe("unknown");
     expect(typeof parsed.openshellDriver).toBe("string");
     expect(typeof parsed.openshellVersion).toBe("string");
+  });
+
+  it("sandbox status --json surfaces rpcIssue and exits 1 on protobuf mismatch", () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-json-rpc-"),
+    );
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'protobuf decode: invalid wire type'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("alpha status --json", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    const parsed = JSON.parse(r.out);
+    expect(parsed.rpcIssue).toEqual({ kind: "protobuf_mismatch" });
   });
 
   it("sandbox status --help advertises --json flag", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -943,6 +943,119 @@ describe("CLI dispatch", () => {
     });
   });
 
+  it("sandbox status --json emits structured per-sandbox report", () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-json-"),
+    );
+    const localBin = path.join(home, "bin");
+    const sandboxName = `alpha-${process.pid}-${Date.now()}`;
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, sandboxName, {
+      model: "configured-model",
+      provider: "configured-provider",
+      gpuEnabled: true,
+      policies: ["npm"],
+      hostGpuDetected: true,
+      sandboxGpuEnabled: true,
+      sandboxGpuMode: "passthrough",
+      sandboxGpuDevice: "0",
+      openshellDriver: "docker",
+      openshellVersion: "0.0.44",
+    } as unknown as Partial<SandboxEntry>);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'Gateway inference:'",
+        "  echo",
+        "  echo '  Provider: nvidia-prod'",
+        "  echo '  Model: nvidia/nemotron'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv(`${sandboxName} status --json`, {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.out.trim().startsWith("{")).toBe(true);
+    expect(r.out.trim().endsWith("}")).toBe(true);
+    expect(r.out).not.toContain("Sandbox: ");
+    expect(r.out).not.toContain("Nonexistent flag: --json");
+
+    const parsed = JSON.parse(r.out);
+    expect(parsed).toMatchObject({
+      schemaVersion: 1,
+      name: sandboxName,
+      found: true,
+      model: "nvidia/nemotron",
+      provider: "nvidia-prod",
+      hostGpuDetected: true,
+      sandboxGpuEnabled: true,
+      sandboxGpuMode: "passthrough",
+      sandboxGpuDevice: "0",
+      openshellDriver: "docker",
+      openshellVersion: "0.0.44",
+      policies: ["npm"],
+    });
+    expect(typeof parsed.openshellDriver).toBe("string");
+    expect(typeof parsed.openshellVersion).toBe("string");
+    expect(parsed).toHaveProperty("phase");
+    expect(parsed).toHaveProperty("inferenceHealth");
+    expect(parsed).toHaveProperty("gatewayState");
+  });
+
+  it("sandbox status --json defaults openshell driver/version to 'unknown' strings", () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-json-unknown-"),
+    );
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      ["#!/usr/bin/env bash", "exit 0"].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("alpha status --json", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    const parsed = JSON.parse(r.out);
+    expect(parsed.openshellDriver).toBe("unknown");
+    expect(parsed.openshellVersion).toBe("unknown");
+    expect(typeof parsed.openshellDriver).toBe("string");
+    expect(typeof parsed.openshellVersion).toBe("string");
+  });
+
+  it("sandbox status --help advertises --json flag", () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-help-json-"),
+    );
+    writeSandboxRegistry(home);
+    const r = runWithEnv("sandbox status alpha --help", { HOME: home });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("--json");
+    expect(r.out).toContain("$ nemoclaw sandbox status <name> [--json]");
+    expect(r.out).toContain("$ nemoclaw sandbox status alpha --json");
+  });
+
   it("status rejects unknown flags through current dispatch path", () => {
     const r = run("status --bogus");
     expect(r.code).toBe(2);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1099,6 +1099,10 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("--json");
     expect(r.out).toContain("$ nemoclaw sandbox status <name> [--json]");
     expect(r.out).toContain("$ nemoclaw sandbox status alpha --json");
+
+    const alias = runWithEnv("alpha status --help", { HOME: home });
+    expect(alias.code).toBe(0);
+    expect(alias.out).toContain("--json");
   });
 
   it("status rejects unknown flags through current dispatch path", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1084,6 +1084,9 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(1);
     const parsed = JSON.parse(r.out);
     expect(parsed.rpcIssue).toEqual({ kind: "protobuf_mismatch" });
+    expect(parsed.inferenceHealth).toBeNull();
+    expect(parsed.model).toBe("unknown");
+    expect(parsed.provider).toBe("unknown");
   });
 
   it("sandbox status --help advertises --json flag", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1089,6 +1089,107 @@ describe("CLI dispatch", () => {
     expect(parsed.provider).toBe("unknown");
   });
 
+  it("sandbox status --json reports found:false and exits 1 for unknown sandbox via canonical form", () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-json-notfound-"),
+    );
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    // Registry contains "alpha"; we will query a different name so the
+    // canonical `sandbox status <name> --json` path produces the documented
+    // automation contract: `found: false`, gatewayState != present, exit 1.
+    writeSandboxRegistry(home, "alpha");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ]; then',
+        "  echo 'NotFound: sandbox not found'",
+        "  exit 1",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("sandbox status ghost --json", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    const parsed = JSON.parse(r.out);
+    expect(parsed.name).toBe("ghost");
+    expect(parsed.found).toBe(false);
+    expect(parsed.gatewayState).not.toBe("present");
+    expect(parsed.rpcIssue).toBeNull();
+    expect(parsed.model).toBe("unknown");
+    expect(parsed.provider).toBe("unknown");
+    expect(parsed.openshellDriver).toBe("unknown");
+    expect(parsed.openshellVersion).toBe("unknown");
+  });
+
+  it("sandbox status --json reports gatewayState!=present and exits 1 when sandbox is registered but gateway lookup is missing", () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-json-nonpresent-"),
+    );
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha", {
+      model: "configured-model",
+      provider: "configured-provider",
+    });
+    // openshell `sandbox get alpha` returns NotFound -> gatewayState becomes
+    // "missing" after reconciliation against a healthy named gateway.
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ]; then',
+        "  echo 'NotFound: sandbox not found'",
+        "  exit 1",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("alpha status --json", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    const parsed = JSON.parse(r.out);
+    expect(parsed.name).toBe("alpha");
+    expect(parsed.found).toBe(true);
+    expect(parsed.gatewayState).not.toBe("present");
+    expect(parsed.rpcIssue).toBeNull();
+    // Live inference probe is not attempted when gateway is not present, so
+    // the report falls back to registry model/provider rather than "unknown".
+    expect(parsed.model).toBe("configured-model");
+    expect(parsed.provider).toBe("configured-provider");
+    expect(parsed.inferenceHealth).toBeNull();
+  });
+
   it("sandbox status --help advertises --json flag", () => {
     const home = fs.mkdtempSync(
       path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-help-json-"),


### PR DESCRIPTION
## Summary
`nemoclaw <name> status` now accepts `--json` and emits a structured per-sandbox report, mirroring what the global `nemoclaw status --json` (added in #2790 / #2822) already exposes. Automation can read `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, and `openshellVersion` for a specific sandbox without scraping the text renderer.

## Related Issue
Fixes #4310. Enhances #2790 (resolved by #2822) by extending the JSON renderer to the per-sandbox status variant.

## Changes
- `src/commands/sandbox/status.ts` opts into `static enableJsonFlag = true`, updates the usage/examples to advertise `--json`, and branches on `this.jsonEnabled()` so the existing text path is unchanged.
- New `getSandboxStatusReport(sandboxName)` in `src/lib/actions/sandbox/status.ts` returns a `SandboxStatusReport`: `schemaVersion`, `name`, `found`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `policies`. `openshellDriver` and `openshellVersion` are normalised to the string `"unknown"` when missing so consumers can rely on `typeof` checks.
- The JSON path sets `process.exitCode = 1` when the sandbox is missing locally or the gateway state is not `present`, so scripts can distinguish "ready" from "drift/unreachable" without parsing the body.
- `test/cli.test.ts` covers the populated JSON shape, the `"unknown"` string fallback for `openshellDriver` / `openshellVersion`, the protobuf-mismatch path (asserts exit code `1`, `rpcIssue = { kind: "protobuf_mismatch" }`, `inferenceHealth = null`, and `model` / `provider` = `"unknown"`), and the `--help` advertising `--json`.
- `collectSandboxStatusSnapshot` is shared by `showSandboxStatus` and `getSandboxStatusReport`; it fail-closes on `detectOpenShellStateRpcResultIssue` so the JSON path no longer emits inferred `model` / `provider` / `inferenceHealth` alongside an `rpcIssue`. The host-side gateway-chain subprobe is appended in the collector so both text and JSON paths surface it.
- `docs/reference/commands.mdx` documents the `--json` flag in the per-sandbox status section (fields, fallback, exit-code contract) so the CLI/docs parity check stays green.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [X] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [X] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `sandbox status` gains a `--json` mode that emits a structured per-sandbox JSON report (gateway state, inference health, GPU details, policies, model/provider, OpenShell driver/version).

* **Behavior**
  * `openshellDriver`/`openshellVersion` default to `"unknown"` when unset.
  * `--json` returns structured data and sets non‑zero exit codes for missing sandbox, non‑present gateway, or RPC/schema issues; text output unchanged without `--json`.

* **Tests**
  * Added coverage for JSON output, defaults, RPC issue handling, exit codes, and help text.

* **Documentation**
  * Command docs updated with `--json` behavior, fields, exit conditions, and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->