### PR TITLE
fix(cli): sandbox status JSON, openshell resolve, policy descriptions, and tunnel command

### DIFF
--- a/src/commands/sandbox/oclif-command-adapters.test.ts
+++ b/src/commands/sandbox/oclif-command-adapters.test.ts
@@ -28,6 +28,13 @@ const mocks = vi.hoisted(() => {
     shieldsStatus: vi.fn(),
     shieldsUp: vi.fn(),
     showSandboxStatus: vi.fn().mockResolvedValue(undefined),
+    buildStatusCommandDeps: vi.fn(() => ({ statusDeps: true })),
+    getSandboxStatusReport: vi.fn(() => ({
+      schemaVersion: 1,
+      sandbox: { name: "alpha" },
+      gatewayHealth: { healthy: true, state: "healthy_named" },
+      services: [],
+    })),
     SandboxConfigError,
   };
 });
@@ -46,6 +53,14 @@ vi.mock("../../lib/actions/sandbox/rebuild", () => ({
 
 vi.mock("../../lib/actions/sandbox/status", () => ({
   showSandboxStatus: mocks.showSandboxStatus,
+}));
+
+vi.mock("../../lib/inventory", () => ({
+  getSandboxStatusReport: mocks.getSandboxStatusReport,
+}));
+
+vi.mock("../../lib/status-command-deps", () => ({
+  buildStatusCommandDeps: mocks.buildStatusCommandDeps,
 }));
 
 vi.mock("../../lib/actions/sandbox/policy-channel", () => ({
@@ -147,6 +162,25 @@ describe("sandbox oclif command adapters", () => {
     expect(mocks.listSandboxPolicies).toHaveBeenCalledWith("alpha");
     expect(mocks.listSandboxChannels).toHaveBeenCalledWith("alpha");
     expect(mocks.configGet).toHaveBeenCalledWith("alpha", { key: "model", format: "yaml" });
+  });
+
+  it("maps sandbox status --json to a structured sandbox report", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await SandboxStatusCommand.run(["alpha", "--json"], rootDir);
+
+      expect(mocks.buildStatusCommandDeps).toHaveBeenCalledWith(rootDir);
+      expect(mocks.getSandboxStatusReport).toHaveBeenCalledWith({ statusDeps: true }, "alpha");
+      expect(mocks.showSandboxStatus).not.toHaveBeenCalled();
+      expect(JSON.parse(String(log.mock.calls.at(-1)?.[0]))).toEqual({
+        schemaVersion: 1,
+        sandbox: { name: "alpha" },
+        gatewayHealth: { healthy: true, state: "healthy_named" },
+        services: [],
+      });
+    } finally {
+      log.mockRestore();
+    }
   });
 
   it("maps config action failures to oclif exit codes", async () => {

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -8,6 +8,9 @@ import { getSandboxStatusReport } from "../../lib/inventory";
 import { sandboxNameArg } from "../../lib/sandbox/command-support";
 import { buildStatusCommandDeps } from "../../lib/status-command-deps";
 
+/**
+ * CLI command to query and show the detailed health and status of a sandbox.
+ */
 export default class SandboxStatusCommand extends NemoClawCommand {
   static id = "sandbox:status";
   static strict = true;
@@ -22,6 +25,9 @@ export default class SandboxStatusCommand extends NemoClawCommand {
   static flags = {
   };
 
+  /**
+   * Run the sandbox status command. Supports standard printed output or JSON format.
+   */
   public async run(): Promise<unknown> {
     const { args } = await this.parse(SandboxStatusCommand);
     if (this.jsonEnabled()) {

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -4,23 +4,33 @@
 import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 
 import { showSandboxStatus } from "../../lib/actions/sandbox/status";
+import { getSandboxStatusReport } from "../../lib/inventory";
 import { sandboxNameArg } from "../../lib/sandbox/command-support";
+import { buildStatusCommandDeps } from "../../lib/status-command-deps";
 
 export default class SandboxStatusCommand extends NemoClawCommand {
   static id = "sandbox:status";
   static strict = true;
+  static enableJsonFlag = true;
   static summary = "Sandbox health and NIM status";
   static description = "Show sandbox health, OpenShell gateway state, and local NIM status.";
-  static usage = ["<name>"];
-  static examples = ["<%= config.bin %> sandbox status alpha"];
+  static usage = ["<name> [--json]"];
+  static examples = ["<%= config.bin %> sandbox status alpha", "<%= config.bin %> sandbox status alpha --json"];
   static args = {
     sandboxName: sandboxNameArg,
   };
   static flags = {
   };
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(SandboxStatusCommand);
+    if (this.jsonEnabled()) {
+      const report = getSandboxStatusReport(buildStatusCommandDeps(this.config.root), args.sandboxName);
+      if (!report.sandbox || (report.gatewayHealth && !report.gatewayHealth.healthy)) {
+        process.exitCode = 1;
+      }
+      return report;
+    }
     await showSandboxStatus(args.sandboxName);
   }
 }

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -41,6 +41,7 @@ const mocks = vi.hoisted(() => {
     runStartCommand: vi.fn().mockResolvedValue(undefined),
     runStopCommand: vi.fn(),
     runUninstallCommand: vi.fn(),
+    showTunnelStatus: vi.fn(),
     showRootHelp: vi.fn(),
     showVersion: vi.fn(),
     spawnSync: vi.fn(),
@@ -72,8 +73,13 @@ vi.mock("../lib/actions/global", () => ({
 vi.mock("../lib/adapters/openshell/client", () => ({ captureOpenshellCommand: mocks.captureOpenshellCommand }));
 vi.mock("../lib/state/registry", () => ({ listSandboxes: mocks.listSandboxes }));
 vi.mock("../lib/adapters/openshell/resolve", () => ({ resolveOpenshell: mocks.resolveOpenshell }));
-vi.mock("../lib/tunnel/services", () => ({ startAll: mocks.startAll, stopAll: mocks.stopAll }));
+vi.mock("../lib/tunnel/services", () => ({
+  showStatus: mocks.showTunnelStatus,
+  startAll: mocks.startAll,
+  stopAll: mocks.stopAll,
+}));
 vi.mock("../lib/tunnel/service-command", () => ({
+  resolveDefaultSandboxName: vi.fn(() => undefined),
   runStartCommand: mocks.runStartCommand,
   runStopCommand: mocks.runStopCommand,
 }));
@@ -92,6 +98,7 @@ import DeprecatedStopCommand from "./stop";
 import RootHelpCommand from "./root/help";
 import VersionCommand from "./root/version";
 import TunnelStartCommand from "./tunnel/start";
+import TunnelStatusCommand from "./tunnel/status";
 import TunnelStopCommand from "./tunnel/stop";
 import UninstallCliCommand from "./uninstall";
 
@@ -216,11 +223,13 @@ describe("simple global oclif adapters", () => {
 
   it("maps tunnel and deprecated service commands to service actions", async () => {
     await TunnelStartCommand.run([], rootDir);
+    await TunnelStatusCommand.run([], rootDir);
     await TunnelStopCommand.run([], rootDir);
     await DeprecatedStartCommand.run([], rootDir);
     await DeprecatedStopCommand.run([], rootDir);
 
     expect(mocks.runStartCommand).toHaveBeenCalledTimes(2);
+    expect(mocks.showTunnelStatus).toHaveBeenCalledWith({ sandboxName: undefined });
     expect(mocks.runStopCommand).toHaveBeenCalledTimes(2);
     expect(mocks.runStartCommand).toHaveBeenCalledWith(
       expect.objectContaining({ listSandboxes: expect.any(Function), startAll: mocks.startAll }),

--- a/src/commands/tunnel.ts
+++ b/src/commands/tunnel.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
+import { CLI_NAME } from "../lib/cli/branding";
+
+export default class TunnelCommand extends NemoClawCommand {
+  static id = "tunnel";
+  static strict = true;
+  static summary = "Manage the cloudflared public-URL tunnel";
+  static description = "Start, inspect, or stop the cloudflared public-URL tunnel.";
+  static usage = ["tunnel <start|status|stop>"];
+  static examples = [
+    "<%= config.bin %> tunnel start",
+    "<%= config.bin %> tunnel status",
+    "<%= config.bin %> tunnel stop",
+  ];
+  static flags = {
+  };
+
+  public async run(): Promise<void> {
+    await this.parse(TunnelCommand);
+    this.log("");
+    this.log(`  Usage: ${CLI_NAME} tunnel <subcommand>`);
+    this.log("");
+    this.log("  Subcommands:");
+    this.log("    start    Start the cloudflared public-URL tunnel");
+    this.log("    status   Show cloudflared tunnel process and public URL status");
+    this.log("    stop     Stop the cloudflared public-URL tunnel");
+    this.log("");
+  }
+}

--- a/src/commands/tunnel.ts
+++ b/src/commands/tunnel.ts
@@ -4,6 +4,9 @@
 import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
 import { CLI_NAME } from "../lib/cli/branding";
 
+/**
+ * Root CLI command for cloudflared public-URL tunnel management.
+ */
 export default class TunnelCommand extends NemoClawCommand {
   static id = "tunnel";
   static strict = true;
@@ -18,6 +21,9 @@ export default class TunnelCommand extends NemoClawCommand {
   static flags = {
   };
 
+  /**
+   * Run the root tunnel command to display help text and list subcommands.
+   */
   public async run(): Promise<void> {
     await this.parse(TunnelCommand);
     this.log("");

--- a/src/commands/tunnel/status.ts
+++ b/src/commands/tunnel/status.ts
@@ -7,6 +7,9 @@ import { showStatus } from "../../lib/tunnel/services";
 import { resolveDefaultSandboxName } from "../../lib/tunnel/service-command";
 import { serviceDeps } from "../../lib/tunnel/command-support";
 
+/**
+ * CLI command to show the status of the cloudflared public-URL tunnel.
+ */
 export default class TunnelStatusCommand extends NemoClawCommand {
   static id = "tunnel:status";
   static strict = true;
@@ -17,6 +20,9 @@ export default class TunnelStatusCommand extends NemoClawCommand {
   static flags = {
   };
 
+  /**
+   * Run the tunnel status command to display tunnel and public URL health.
+   */
   public async run(): Promise<void> {
     await this.parse(TunnelStatusCommand);
     const deps = serviceDeps();

--- a/src/commands/tunnel/status.ts
+++ b/src/commands/tunnel/status.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+
+import { showStatus } from "../../lib/tunnel/services";
+import { resolveDefaultSandboxName } from "../../lib/tunnel/service-command";
+import { serviceDeps } from "../../lib/tunnel/command-support";
+
+export default class TunnelStatusCommand extends NemoClawCommand {
+  static id = "tunnel:status";
+  static strict = true;
+  static summary = "Show cloudflared tunnel status";
+  static description = "Show cloudflared tunnel process and public URL status.";
+  static usage = ["tunnel status"];
+  static examples = ["<%= config.bin %> tunnel status"];
+  static flags = {
+  };
+
+  public async run(): Promise<void> {
+    await this.parse(TunnelStatusCommand);
+    const deps = serviceDeps();
+    showStatus({ sandboxName: resolveDefaultSandboxName(deps.listSandboxes) });
+  }
+}

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -32,6 +32,7 @@ import {
   createSystemDeps as createSessionDeps,
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
+import { dockerInfo } from "../../adapters/docker/info";
 import { getSandboxDockerHealth } from "./docker-health";
 import { classifyGatewayFailure, getLayerHeader } from "./gateway-failure-classifier";
 import type { SandboxGatewayState } from "./gateway-state";
@@ -253,6 +254,12 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
   }
 
   if (lookup.state === "present") {
+    if (dockerInfo({ ignoreError: true, timeout: 3000 }).length === 0) {
+      console.log("");
+      await printGatewayFailureLayerHeader(sandboxName);
+      process.exitCode = 1;
+      return;
+    }
     console.log("");
     if ("recoveredGateway" in lookup && lookup.recoveredGateway) {
       console.log(

--- a/src/lib/adapters/openshell/resolve.ts
+++ b/src/lib/adapters/openshell/resolve.ts
@@ -14,12 +14,19 @@ export interface ResolveOpenshellOptions {
   home?: string;
 }
 
+/**
+ * Check if the given value is an absolute path.
+ * Supports both Windows-style absolute paths (with drive letters) and POSIX-style paths (starting with '/').
+ */
 function isAbsolutePath(value: string): boolean {
   return path.isAbsolute(value) || value.startsWith("/");
 }
 
+/**
+ * Return the expected local openshell executable path located under the user's home directory.
+ */
 function homeLocalOpenshell(home: string): string {
-  return home.startsWith("/") ? `${home}/.local/bin/openshell` : path.join(home, ".local", "bin", "openshell");
+  return path.join(home, ".local", "bin", "openshell");
 }
 
 /**
@@ -53,11 +60,11 @@ export function resolveOpenshell(opts: ResolveOpenshellOptions = {}): string | n
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "ignore"],
       }).trim();
-      if (found.startsWith("/")) return found;
+      if (isAbsolutePath(found)) return found;
     } catch {
       /* ignored */
     }
-  } else if (opts.commandVResult?.startsWith("/")) {
+  } else if (opts.commandVResult && isAbsolutePath(opts.commandVResult)) {
     return opts.commandVResult;
   }
 

--- a/src/lib/adapters/openshell/resolve.ts
+++ b/src/lib/adapters/openshell/resolve.ts
@@ -3,6 +3,7 @@
 
 import { execSync } from "node:child_process";
 import { accessSync, constants } from "node:fs";
+import path from "node:path";
 
 export interface ResolveOpenshellOptions {
   /** Mock result for `command -v` (undefined = run real command). */
@@ -11,6 +12,14 @@ export interface ResolveOpenshellOptions {
   checkExecutable?: (path: string) => boolean;
   /** HOME directory override. */
   home?: string;
+}
+
+function isAbsolutePath(value: string): boolean {
+  return path.isAbsolute(value) || value.startsWith("/");
+}
+
+function homeLocalOpenshell(home: string): string {
+  return home.startsWith("/") ? `${home}/.local/bin/openshell` : path.join(home, ".local", "bin", "openshell");
 }
 
 /**
@@ -33,14 +42,17 @@ export function resolveOpenshell(opts: ResolveOpenshellOptions = {}): string | n
     });
 
   const override = process.env.NEMOCLAW_OPENSHELL_BIN;
-  if (override?.startsWith("/") && checkExecutable(override)) {
+  if (override && isAbsolutePath(override) && checkExecutable(override)) {
     return override;
   }
 
   // Step 1: command -v
   if (opts.commandVResult === undefined) {
     try {
-      const found = execSync("command -v openshell", { encoding: "utf-8" }).trim();
+      const found = execSync("command -v openshell", {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
       if (found.startsWith("/")) return found;
     } catch {
       /* ignored */
@@ -51,7 +63,7 @@ export function resolveOpenshell(opts: ResolveOpenshellOptions = {}): string | n
 
   // Step 2: fallback candidates
   const candidates = [
-    ...(home?.startsWith("/") ? [`${home}/.local/bin/openshell`] : []),
+    ...(home && isAbsolutePath(home) ? [homeLocalOpenshell(home)] : []),
     "/usr/local/bin/openshell",
     "/usr/bin/openshell",
   ];

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -428,6 +428,12 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       "order": 32
     }
   ],
+  "tunnel:status": [
+    {
+      "group": "Services",
+      "order": 32.5
+    }
+  ],
   "tunnel:stop": [
     {
       "group": "Services",

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -158,6 +158,13 @@ export interface StatusReport {
   services: StatusServiceRow[];
 }
 
+export interface SandboxStatusReport {
+  schemaVersion: 1;
+  sandbox: StatusSandboxRow | null;
+  gatewayHealth: GatewayHealth | null;
+  services: StatusServiceRow[];
+}
+
 function safeStatusString(value: string | null | undefined): string | null {
   if (typeof value !== "string" || value.length === 0) return null;
   return redactFull(value);
@@ -384,6 +391,28 @@ export function getStatusReport(deps: ShowStatusCommandDeps): StatusReport {
     sandboxes: sandboxes.map((sandbox) =>
       buildStatusSandboxRow(sandbox, resolvedDefault, liveInference),
     ),
+    services,
+  };
+}
+
+export function getSandboxStatusReport(
+  deps: ShowStatusCommandDeps,
+  sandboxName: string,
+): SandboxStatusReport {
+  const { sandboxes, defaultSandbox } = deps.listSandboxes();
+  const resolvedDefault = defaultSandbox || null;
+  const target = sandboxes.find((sandbox) => sandbox.name === sandboxName) ?? null;
+  const liveInference =
+    target && target.name === resolvedDefault && sandboxes.length > 0 ? deps.getLiveInference() : null;
+  const gatewayHealth =
+    deps.getGatewayHealth && target ? deps.getGatewayHealth() : null;
+  const services =
+    deps.getServiceStatuses?.({ sandboxName }).map(normalizeServiceStatus) ?? [];
+
+  return {
+    schemaVersion: 1,
+    sandbox: target ? buildStatusSandboxRow(target, resolvedDefault, liveInference) : null,
+    gatewayHealth: normalizeGatewayHealth(gatewayHealth),
     services,
   };
 }

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -44,14 +44,27 @@ type SetupPolicyPresetSupportOptions = {
   webSearchSupported?: boolean | null;
 };
 
+/**
+ * Check if the given value is a policy document object.
+ */
 function isPolicyDocument(value: PolicyValue): value is PolicyDocument {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Check if the given value is a plain policy object.
+ */
+function isPolicyObject(value: PolicyValue): value is PolicyObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Read the name and description metadata from a preset YAML file.
+ */
 function readPresetInfo(content: string, fallbackName: string): { name: string; description: string } {
   try {
     const parsed = YAML.parse(content);
-    const preset = isPolicyDocument(parsed) && isPolicyDocument(parsed.preset) ? parsed.preset : null;
+    const preset = isPolicyDocument(parsed) && isPolicyObject(parsed.preset) ? parsed.preset : null;
     const name = typeof preset?.name === "string" ? preset.name.trim() : fallbackName;
     const description = typeof preset?.description === "string" ? preset.description.trim() : "";
     return {
@@ -100,10 +113,6 @@ function loadPreset(name: string): string | null {
     return null;
   }
   return fs.readFileSync(file, "utf-8");
-}
-
-function isPolicyObject(value: PolicyValue): value is PolicyObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseNetworkPolicies(content: string | null | undefined): PolicyObject | null {

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -48,6 +48,21 @@ function isPolicyDocument(value: PolicyValue): value is PolicyDocument {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function readPresetInfo(content: string, fallbackName: string): { name: string; description: string } {
+  try {
+    const parsed = YAML.parse(content);
+    const preset = isPolicyDocument(parsed) && isPolicyDocument(parsed.preset) ? parsed.preset : null;
+    const name = typeof preset?.name === "string" ? preset.name.trim() : fallbackName;
+    const description = typeof preset?.description === "string" ? preset.description.trim() : "";
+    return {
+      name: name || fallbackName,
+      description,
+    };
+  } catch {
+    return { name: fallbackName, description: "" };
+  }
+}
+
 /**
  * Enumerate every preset YAML under `nemoclaw-blueprint/policies/presets/`
  * and return `{ file, name, description }` triples parsed from the file's
@@ -60,12 +75,12 @@ function listPresets(): PresetInfo[] {
     .filter((f: string) => f.endsWith(".yaml"))
     .map((f: string) => {
       const content = fs.readFileSync(path.join(PRESETS_DIR, f), "utf-8");
-      const nameMatch = content.match(/^\s*name:\s*(.+)$/m);
-      const descMatch = content.match(/^\s*description:\s*"?([^"]*)"?$/m);
+      const fallbackName = f.replace(".yaml", "");
+      const info = readPresetInfo(content, fallbackName);
       return {
         file: f,
-        name: nameMatch ? nameMatch[1].trim() : f.replace(".yaml", ""),
-        description: descMatch ? descMatch[1].trim() : "",
+        name: info.name,
+        description: info.description,
       };
     });
 }
@@ -295,7 +310,7 @@ function clampSetupPolicyPresetNames(
  */
 function extractPresetEntries(presetContent: string | null | undefined): string | null {
   if (!presetContent) return null;
-  const npMatch = presetContent.match(/^network_policies:\n([\s\S]*)$/m);
+  const npMatch = presetContent.match(/^network_policies:\r?\n([\s\S]*)$/m);
   if (!npMatch) return null;
   return npMatch[1].trimEnd();
 }
@@ -362,7 +377,13 @@ function assertOpenshellResolvable(): void {
       ? `PATH=${currentPath} (via \`command -v openshell\`)`
       : "PATH=<unset> (via `command -v openshell`)",
   );
-  if (home?.startsWith("/")) checked.push(`${home}/.local/bin/openshell`);
+  if (home && path.isAbsolute(home)) {
+    checked.push(path.join(home, ".local", "bin", "openshell"));
+    const posixStyleHomeCandidate = `${home}/.local/bin/openshell`;
+    if (posixStyleHomeCandidate !== checked[checked.length - 1]) {
+      checked.push(posixStyleHomeCandidate);
+    }
+  }
   checked.push("/usr/local/bin/openshell", "/usr/bin/openshell");
 
   console.error("  openshell binary not found. Checked:");

--- a/src/lib/share-command.ts
+++ b/src/lib/share-command.ts
@@ -123,7 +123,28 @@ export function checkLocalMountWritable(localMount: string): { writable: boolean
   try {
     fs.mkdirSync(localMount, { recursive: true });
   } catch (err: unknown) {
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    let code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      let current = localMount;
+      while (current && current !== path.dirname(current)) {
+        if (fs.existsSync(current)) {
+          break;
+        }
+        current = path.dirname(current);
+      }
+      if (current && fs.existsSync(current)) {
+        try {
+          const tempPath = path.join(current, `.nemoclaw-ro-probe-${Math.random().toString(36).slice(2)}`);
+          fs.mkdirSync(tempPath);
+          fs.rmdirSync(tempPath);
+        } catch (probeErr: unknown) {
+          const probeCode = (probeErr as NodeJS.ErrnoException | undefined)?.code;
+          if (probeCode === "EROFS") {
+            code = "EROFS";
+          }
+        }
+      }
+    }
     if (code === "EROFS") return { writable: false, reason: "parent filesystem is read-only" };
     if (code === "EACCES") return { writable: false, reason: "permission denied creating the directory" };
     return { writable: false, reason: err instanceof Error ? err.message : String(err) };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -403,6 +403,9 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Configure inference endpoint and credentials");
     expect(r.out).toContain("nemoclaw onboard --from");
     expect(r.out).toContain("Use a custom Dockerfile for the sandbox image");
+    expect(r.out).toContain("nemoclaw tunnel start");
+    expect(r.out).toContain("nemoclaw tunnel status");
+    expect(r.out).toContain("nemoclaw tunnel stop");
   });
 
   it("--help exits 0", () => {
@@ -960,6 +963,40 @@ describe("CLI dispatch", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("tunnel start");
     expect(r.out).toContain("Start the cloudflared public-URL tunnel");
+  });
+
+  it("tunnel help exits 0 and shows tunnel subcommands", () => {
+    const r = run("tunnel --help");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("tunnel <start|status|stop>");
+    expect(r.out).toContain("Manage the cloudflared public-URL tunnel");
+  });
+
+  it("tunnel status --help exits 0 and shows tunnel status usage", () => {
+    const r = run("tunnel status --help");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("tunnel status");
+    expect(r.out).toContain("Show cloudflared tunnel status");
+  });
+
+  it("tunnel status exits 0 and reports stopped cloudflared state", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-tunnel-status-"));
+    const sandboxName = `tunnel-${process.pid}-${Date.now()}`;
+    const serviceDir = path.join("/tmp", `nemoclaw-services-${sandboxName}`);
+    fs.rmSync(serviceDir, { recursive: true, force: true });
+    try {
+      const r = runWithEnv("tunnel status", {
+        HOME: home,
+        NEMOCLAW_SANDBOX_NAME: sandboxName,
+      });
+      expect(r.code).toBe(0);
+      expect(r.out).toContain("cloudflared");
+      expect(r.out).toContain("(stopped)");
+      expect(r.out).toContain("nemoclaw tunnel start");
+    } finally {
+      fs.rmSync(serviceDir, { recursive: true, force: true });
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it("deprecated start --help exits 0 and shows alias usage", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -157,6 +157,16 @@ describe("policies", () => {
       }
     });
 
+    it("parses unquoted preset descriptions without absorbing the YAML body", () => {
+      const whatsapp = policies
+        .listPresets()
+        .find((preset: { name: string }) => preset.name === "whatsapp");
+
+      expect(whatsapp?.description).toBe("WhatsApp Web WebSocket and media access");
+      expect(whatsapp?.description).not.toContain("network_policies");
+      expect(whatsapp?.description).not.toContain("endpoints");
+    });
+
     it("returns expected preset names", () => {
       const names = policies
         .listPresets()

--- a/test/share-command-writable.test.ts
+++ b/test/share-command-writable.test.ts
@@ -35,6 +35,30 @@ describe("checkLocalMountWritable (#3192)", () => {
     });
   });
 
+  it("reports a read-only filesystem when mkdirSync raises ENOENT but parent is read-only (Node 22 EROFS masking)", () => {
+    const err = new Error("ENOENT: no such file or directory, mkdir '/ro/mount/nested'") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    vi.spyOn(fs, "mkdirSync").mockImplementation((path, options) => {
+      if (path === "/ro/mount/nested") {
+        throw err;
+      }
+      if (path.toString().includes(".nemoclaw-ro-probe-")) {
+        const erofsErr = new Error("EROFS: read-only file system, mkdir") as NodeJS.ErrnoException;
+        erofsErr.code = "EROFS";
+        throw erofsErr;
+      }
+      return undefined;
+    });
+    vi.spyOn(fs, "existsSync").mockImplementation((path) => {
+      return path === "/ro/mount";
+    });
+
+    expect(checkLocalMountWritable("/ro/mount/nested")).toEqual({
+      writable: false,
+      reason: "parent filesystem is read-only",
+    });
+  });
+
   it("reports permission denied when mkdirSync raises EACCES", () => {
     const err = new Error("EACCES: permission denied, mkdir '/restricted'") as NodeJS.ErrnoException;
     err.code = "EACCES";


### PR DESCRIPTION
This PR packages a set of CLI improvements and fixes for NemoClaw:

1. **Egress Policy Preset Description Fix**: Parses unquoted descriptions in preset YAML files safely without absorbing the trailing YAML nodes or policy blocks.
2. **OpenShell Binary Resolution Fix**: Supports absolute paths in Windows and non-POSIX home environments, and suppresses stderr from \command -v openshell\ fallback checks.
3. **Sandbox Status JSON Support**: Implements support for the \--json\ output format for the \sandbox status\ command to output a structured JSON health and service status report.
4. **Tunnel Subcommands**: Adds the \	unnel\ and \	unnel status\ CLI subcommands to start, stop, and inspect the cloudflared public-URL tunnels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox status can emit structured JSON via a new --json option; non-JSON output unchanged
  * New top-level tunnel command with start, status, and stop subcommands; tunnel status reports tunnel process and public URL
  * Tunnel status added to public CLI help/layout

* **Bug Fixes**
  * Improved openshell path detection and validation
  * More robust preset YAML parsing (handles CRLF)
  * Better detection/reporting of read-only mount errors and gateway start failures

* **Tests**
  * Added/updated tests for JSON status, tunnel status wiring, presets, and mount writability edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->