### PR TITLE
fix(policy): keep preset descriptions line-scoped (Fixes #4312)

### DIFF
--- a/nemoclaw-blueprint/policies/presets/whatsapp.yaml
+++ b/nemoclaw-blueprint/policies/presets/whatsapp.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 preset:
   name: whatsapp
-  description: WhatsApp Web WebSocket and media access
+  description: "WhatsApp Web WebSocket and media access"
 network_policies:
   whatsapp:
     name: whatsapp

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -61,7 +61,7 @@ function listPresets(): PresetInfo[] {
     .map((f: string) => {
       const content = fs.readFileSync(path.join(PRESETS_DIR, f), "utf-8");
       const nameMatch = content.match(/^\s*name:\s*(.+)$/m);
-      const descMatch = content.match(/^\s*description:\s*"?([^"]*)"?$/m);
+      const descMatch = content.match(/^\s*description:\s*"?([^\n"]*)"?$/m);
       return {
         file: f,
         name: nameMatch ? nameMatch[1].trim() : f.replace(".yaml", ""),

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -157,6 +157,12 @@ describe("policies", () => {
       }
     });
 
+    it("does not include the WhatsApp preset YAML body in the description", () => {
+      const whatsapp = policies.listPresets().find((p) => p.name === "whatsapp");
+      expect(whatsapp?.description).toBe("WhatsApp Web WebSocket and media access");
+      expect(whatsapp?.description).not.toContain("network_policies:");
+    });
+
     it("returns expected preset names", () => {
       const names = policies
         .listPresets()


### PR DESCRIPTION
## Summary

Fixes #4312.

`policy-list` was reading preset descriptions with a regex that could keep matching into the rest of the YAML body. The WhatsApp preset then showed part of `network_policies` as if it were description text.

## Changes

- Keep preset description parsing scoped to a single line in `src/lib/policy/index.ts`.
- Quote the WhatsApp preset description in `nemoclaw-blueprint/policies/presets/whatsapp.yaml`.
- Add a regression test that checks the WhatsApp description is exact and does not include the YAML body.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npx vitest run test/policies.test.ts`
- `npm test -- test/policies.test.ts`

The focused policy suite passes with 152/152 tests.

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preset descriptions now render exactly as intended; stray YAML markers no longer appear.
  * WhatsApp preset description normalized for consistent display and robust parsing to prevent spillover into the YAML body.

* **Tests**
  * Added tests to validate preset description parsing and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->