### PR TITLE
ci(skills): align catalog refresh with repo gh-CLI PR pattern

### DIFF
--- a/.github/pr-bodies/catalog-skills-refresh.md
+++ b/.github/pr-bodies/catalog-skills-refresh.md
@@ -1,0 +1,11 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+## Summary
+- Regenerates `skills/nemoclaw/` from `.agents/catalog-skills.yaml` and `.agents/skills/`.
+- Keeps the NVIDIA Verified Skills catalog export deterministic and reviewable.
+
+## Validation
+- `python3 scripts/export-catalog-skills.py --check`
+
+After maintainer review, request signing by commenting `/nvskills-ci` on this PR if the workflow did not do so automatically.

--- a/.github/pr-bodies/catalog-skills-refresh.md
+++ b/.github/pr-bodies/catalog-skills-refresh.md
@@ -1,11 +1,15 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+# Catalog Skills Refresh
+
 ## Summary
+
 - Regenerates `skills/nemoclaw/` from `.agents/catalog-skills.yaml` and `.agents/skills/`.
 - Keeps the NVIDIA Verified Skills catalog export deterministic and reviewable.
 
 ## Validation
+
 - `python3 scripts/export-catalog-skills.py --check`
 
 After maintainer review, request signing by commenting `/nvskills-ci` on this PR if the workflow did not do so automatically.

--- a/.github/workflows/catalog-skills-refresh.yaml
+++ b/.github/workflows/catalog-skills-refresh.yaml
@@ -37,12 +37,37 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: true
+          # Keep the write-capable token out of git config while repository
+          # code (exporter, etc.) runs. Push credentials are configured
+          # narrowly inside the create/update step via `gh auth setup-git`.
+          persist-credentials: false
 
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Preserve signer artifacts from existing refresh branch
+        env:
+          BRANCH: automation/catalog-skills-refresh
+        run: |
+          set -euo pipefail
+          # If NVSkills CI has already pushed signing artifacts (skill.oms.sig,
+          # skill-card.md) to the refresh branch, overlay that branch's
+          # skills/nemoclaw into the working tree before regenerating. The
+          # exporter (scripts/export-catalog-skills.py) auto-preserves those
+          # files when an existing export tree is present, so this overlay is
+          # what keeps signer artifacts from being dropped on force-push.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Existing $BRANCH found; overlaying skills/nemoclaw to preserve NVSkills artifacts"
+            git fetch --depth 1 origin "$BRANCH":"refs/remotes/origin/$BRANCH"
+            if git ls-tree -d "origin/$BRANCH" -- skills/nemoclaw >/dev/null 2>&1; then
+              rm -rf skills/nemoclaw
+              git checkout "origin/$BRANCH" -- skills/nemoclaw
+            fi
+          else
+            echo "No existing $BRANCH; running fresh export from main"
+          fi
 
       - name: Regenerate catalog skills export
         run: python3 scripts/export-catalog-skills.py
@@ -75,6 +100,12 @@ jobs:
           BRANCH: automation/catalog-skills-refresh
         run: |
           set -euo pipefail
+          # Install the GITHUB_TOKEN as a git credential helper at push time
+          # only. Combined with persist-credentials: false on checkout, this
+          # keeps the write-capable token out of git config while exporter
+          # code runs.
+          gh auth setup-git
+
           git checkout -B "$BRANCH"
           git add .agents/catalog-skills.yaml skills/nemoclaw
           git commit -m "chore(skills): refresh catalog export"

--- a/.github/workflows/catalog-skills-refresh.yaml
+++ b/.github/workflows/catalog-skills-refresh.yaml
@@ -61,7 +61,11 @@ jobs:
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             echo "Existing $BRANCH found; overlaying skills/nemoclaw to preserve NVSkills artifacts"
             git fetch --depth 1 origin "$BRANCH":"refs/remotes/origin/$BRANCH"
-            if git ls-tree -d "origin/$BRANCH" -- skills/nemoclaw >/dev/null 2>&1; then
+            # Use `git cat-file -e` instead of `git ls-tree -d`: the latter can
+            # exit 0 with empty output when the tree exists but the path does
+            # not, which would otherwise wipe skills/nemoclaw and then fail at
+            # checkout. cat-file -e fails when the object is absent.
+            if git cat-file -e "origin/$BRANCH:skills/nemoclaw" 2>/dev/null; then
               rm -rf skills/nemoclaw
               git checkout "origin/$BRANCH" -- skills/nemoclaw
             fi

--- a/.github/workflows/catalog-skills-refresh.yaml
+++ b/.github/workflows/catalog-skills-refresh.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Configure git author
         run: |
@@ -70,33 +70,33 @@ jobs:
       - name: Create or update refresh pull request
         id: cpr
         if: ${{ steps.diff.outputs.changed == 'true' && (github.event_name == 'schedule' || !inputs.dry_run) }}
-        uses: peter-evans/create-pull-request@8ce3b843f60ac63fbde403f79364ff7d80b5fbb1 # v7.0.8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: automation/catalog-skills-refresh
-          delete-branch: true
-          commit-message: "chore(skills): refresh catalog export"
-          title: "chore(skills): refresh catalog export"
-          body: |
-            ## Summary
-            - Regenerates `skills/nemoclaw/` from `.agents/catalog-skills.yaml` and `.agents/skills/`.
-            - Keeps the NVIDIA Verified Skills catalog export deterministic and reviewable.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: automation/catalog-skills-refresh
+        run: |
+          set -euo pipefail
+          git checkout -B "$BRANCH"
+          git add .agents/catalog-skills.yaml skills/nemoclaw
+          git commit -m "chore(skills): refresh catalog export"
+          git push --force-with-lease origin "$BRANCH"
 
-            ## Validation
-            - `python3 scripts/export-catalog-skills.py --check`
-
-            After maintainer review, request signing by commenting `/nvskills-ci` on this PR if the workflow did not do so automatically.
-          labels: |
-            documentation
-            CI/CD
-          add-paths: |
-            .agents/catalog-skills.yaml
-            skills/nemoclaw
+          PR_NUMBER="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [[ -z "$PR_NUMBER" ]]; then
+            PR_URL="$(gh pr create \
+              --head "$BRANCH" \
+              --base main \
+              --title "chore(skills): refresh catalog export" \
+              --body-file .github/pr-bodies/catalog-skills-refresh.md \
+              --label documentation \
+              --label CI/CD)"
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+          echo "pull-request-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Request NVSkills signing
         if: ${{ steps.cpr.outputs.pull-request-number != '' && github.event_name == 'workflow_dispatch' && inputs.request_nvskills_ci && !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           gh pr comment "$PR_NUMBER" --body "/nvskills-ci"


### PR DESCRIPTION
## Summary

The Skills / Catalog Refresh workflow (merged via #4284 for issue #4282) fails immediately on every dispatch:

```
Unable to resolve action `peter-evans/create-pull-request@8ce3b843f60ac63fbde403f79364ff7d80b5fbb1`,
unable to find version `8ce3b843f60ac63fbde403f79364ff7d80b5fbb1`
```

That SHA does not exist in the upstream `peter-evans/create-pull-request` repo, so GitHub fails at "Prepare all required actions" before any job step runs. Failing run: [26518855615](https://github.com/NVIDIA/NemoClaw/actions/runs/26518855615).

## Fix

Replace the third-party action with an inline `gh`-CLI script. This is the pattern every other NemoClaw workflow uses for GitHub mutations:

| Workflow | Pattern |
|---|---|
| `assign-linked-issue-author.yaml` | `gh issue edit … --add-assignee`, `gh pr view`, `gh pr list` |
| `pr-limit.yaml` | `gh pr list`, `gh pr comment`, `gh pr close` |
| `e2e-advisor.yaml` / `pr-review-advisor.yaml` | `gh api`, `gh pr comment` |
| `catalog-skills-refresh.yaml` (already, for `/nvskills-ci`) | `gh pr comment` |

`peter-evans/create-pull-request` was the **only** third-party mutation action in the repo, and the only place we had to maintain a SHA pin against an external action's release cadence.

## Changes

- `.github/workflows/catalog-skills-refresh.yaml`
  - Removed the broken `peter-evans/create-pull-request@<bad-sha>` step.
  - Replaced it with an inline `git checkout -B` / `git push --force-with-lease` / `gh pr create` script, idempotent against an existing open PR via `gh pr list --head`.
  - Flipped `persist-credentials: false` → `true` on the checkout so `git push` has a token.
  - Switched the `/nvskills-ci` step from `secrets.GITHUB_TOKEN` to `github.token` for consistency with the rest of the workflow and the repo.
- `.github/pr-bodies/catalog-skills-refresh.md` (new)
  - Moved the long PR body out of the YAML to keep the workflow readable.

## Validation

- `actionlint` clean (no new warnings).
- Idempotency: re-dispatch reuses the existing open PR via `gh pr list --head` instead of creating a duplicate.
- Dry-run path is unchanged — the new step is gated by the same `if:` condition as before.

## Notes

- We could re-pin `peter-evans/create-pull-request` to the real `v7.0.8` SHA (`271a8d0340265f705b14b6d32b9829c1cb33d45e`) instead. Choosing the inline script because it's the existing repo convention and removes the supply-chain pin entirely.

Refs #4282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation for catalog refreshes with safer credential handling, preservation of existing signing artifacts during refreshes, and a more robust inline process for creating/updating refresh branches and PRs.
  * Refined token usage for the signing request step.

* **Documentation**
  * Added a PR body template detailing regeneration, validation checks, and how to request signing when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->