### PR TITLE
ci(e2e): opt functional jobs into residual caps on CI

### DIFF
--- a/.github/workflows/e2e-script.yaml
+++ b/.github/workflows/e2e-script.yaml
@@ -66,6 +66,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # GitHub-hosted Linux runners retain dangerous bounding-set capabilities but
+  # do not grant CAP_SETPCAP to the sandbox entrypoint. Functional E2E runs opt
+  # in explicitly so #4264's fail-closed guard remains covered by the dedicated
+  # gateway-isolation security regression instead of breaking every sandbox use.
+  NEMOCLAW_ALLOW_RESIDUAL_CAPS: "1"
+
 jobs:
   run:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -137,6 +137,14 @@ on:
 permissions:
   contents: read
 
+env:
+  # GitHub-hosted Linux runners retain dangerous bounding-set capabilities but
+  # do not grant CAP_SETPCAP to the sandbox entrypoint. Nightly functional E2E
+  # jobs opt in explicitly so #4264's fail-closed guard remains covered by the
+  # dedicated gateway-isolation security regression instead of breaking every
+  # sandbox use on these CI hosts.
+  NEMOCLAW_ALLOW_RESIDUAL_CAPS: "1"
+
 concurrency:
   group: nightly-e2e-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.ref, inputs.pr_number || 'manual') || 'schedule' }}
   cancel-in-progress: true

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -8,6 +8,11 @@ import { loadE2eWorkflowContract, reusableNightlyJobs } from "./helpers/e2e-work
 describe("E2E reusable workflow contract", () => {
   const { runnerWorkflow, nightlyWorkflow, action } = loadE2eWorkflowContract();
 
+  it("opts functional E2E workflows into residual-cap execution on CI hosts", () => {
+    expect(runnerWorkflow.env?.NEMOCLAW_ALLOW_RESIDUAL_CAPS).toBe("1");
+    expect(nightlyWorkflow.env?.NEMOCLAW_ALLOW_RESIDUAL_CAPS).toBe("1");
+  });
+
   it("does not persist checkout credentials in the reusable runner", () => {
     const checkoutSteps = runnerWorkflow.jobs.run.steps.filter((step) =>
       String(step.uses ?? "").startsWith("actions/checkout@"),

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -23,10 +23,12 @@ export type WorkflowStep = {
 };
 
 export type NightlyWorkflow = {
+  env?: Record<string, string>;
   jobs: Record<string, WorkflowJob>;
 };
 
 export type RunnerWorkflow = {
+  env?: Record<string, string>;
   jobs: {
     run: {
       steps: WorkflowStep[];


### PR DESCRIPTION
## Summary
Functional E2E jobs now explicitly set `NEMOCLAW_ALLOW_RESIDUAL_CAPS=1` on GitHub-hosted CI runners where CAP_SETPCAP is unavailable. This keeps #4264's fail-closed sandbox behavior intact while allowing the non-security functional E2E suite to run on the known weaker CI posture.

## Changes
- Set `NEMOCLAW_ALLOW_RESIDUAL_CAPS=1` at the reusable E2E script workflow level for converted functional jobs.
- Set the same opt-in at the nightly workflow level for direct nightly E2E jobs.
- Added workflow contract coverage to assert both functional E2E workflow entry points keep the explicit residual-cap CI opt-in.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E workflow contract test to validate environment variable configuration.

* **Chores**
  * Updated CI/CD workflows with environment variable configuration.
  * Extended workflow contract types to support environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->