### PR TITLE
docs: add macOS preparation guide (Fixes #3232)

### DIFF
--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "nemoclaw-user-get-started"
-description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time. Trigger keywords - nemoclaw quickstart, install nemoclaw openclaw sandbox, nemohermes quickstart, hermes agent nemoclaw, run hermes openshell sandbox, nemoclaw prerequisites, nemoclaw supported platforms, nemoclaw hardware software, nemoclaw windows wsl2 setup, nemoclaw install windows docker desktop."
+description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time. Trigger keywords - nemoclaw quickstart, install nemoclaw openclaw sandbox, nemohermes quickstart, hermes agent nemoclaw, run hermes openshell sandbox, nemoclaw macos setup, nemoclaw apple silicon docker desktop colima, nemoclaw install mac xcode homebrew ollama, nemoclaw prerequisites, nemoclaw supported platforms, nemoclaw hardware software, nemoclaw windows wsl2 setup, nemoclaw install windows docker desktop."
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -348,6 +348,7 @@ openclaw tui
 ## References
 
 - **Load [references/quickstart-hermes.md](references/quickstart-hermes.md)** when users ask for Hermes setup, NemoHermes onboarding, or running Hermes inside OpenShell. Installs NemoClaw, selects the Hermes agent, and launches a sandboxed Hermes API endpoint.
+- **Load [references/macos-preparation.md](references/macos-preparation.md)** when preparing an Apple Silicon or Intel Mac for NemoClaw, choosing Docker Desktop or Colima, installing Xcode Command Line Tools, installing Node.js, configuring Ollama, or troubleshooting a macOS-specific install error. Covers macOS-only preparation steps required before the Quickstart.
 - **Load [references/prerequisites.md](references/prerequisites.md)** when verifying prerequisites before installation. Lists the hardware, software, and container runtime requirements for running NemoClaw.
 - **Load [references/windows-preparation.md](references/windows-preparation.md)** when preparing a Windows machine for NemoClaw, enabling WSL 2, configuring Docker Desktop for Windows, or troubleshooting a Windows-specific install error. Covers Windows-only preparation steps required before the Quickstart.
 

--- a/.agents/skills/nemoclaw-user-get-started/references/macos-preparation.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/macos-preparation.md
@@ -1,0 +1,139 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Prepare macOS for NemoClaw
+
+Use this page when you are preparing a Mac for the first time.
+Complete these steps before following the Quickstart (use the `nemoclaw-user-get-started` skill).
+Linux users can go directly to the Quickstart.
+Windows users should use the Windows preparation guide (use the `nemoclaw-user-get-started` skill).
+
+**Note:**
+
+NemoClaw supports both Apple Silicon and Intel Macs through the Docker-driver OpenShell gateway path.
+Apple Silicon is the most commonly tested macOS path.
+
+## Prerequisites
+
+Verify the following before you begin:
+
+- macOS on Apple Silicon or Intel.
+- Hardware requirements are the same as the Quickstart (use the `nemoclaw-user-get-started` skill).
+- Administrator access for installing developer tools and a container runtime.
+- A running container runtime: Docker Desktop or Colima.
+
+## Install Xcode Command Line Tools
+
+Install Apple's command line developer tools:
+
+```bash
+xcode-select --install
+```
+
+The installer and Node.js toolchain rely on these tools.
+If the command reports that tools are already installed, continue to the next step.
+
+## Choose a Container Runtime
+
+NemoClaw needs Docker-compatible container access.
+Use one of the tested options below.
+
+### Option 1: Docker Desktop
+
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and start the application.
+Wait until Docker reports that it is running, then verify it from a terminal:
+
+```bash
+docker info
+```
+
+Docker Desktop is the simplest macOS path for most first-time users.
+If `docker info` cannot connect, open Docker Desktop and wait for startup to finish before retrying.
+
+### Option 2: Colima
+
+Install Colima and Docker CLI with Homebrew:
+
+```bash
+brew install colima docker
+```
+
+Start Colima with enough resources for the sandbox image build:
+
+```bash
+colima start --cpu 4 --memory 8 --disk 40
+```
+
+Then verify Docker access:
+
+```bash
+docker info
+```
+
+**Tip:**
+
+Default Colima resources are often too small for the sandbox image build.
+If onboarding stalls or the build is killed, increase CPU, memory, and disk before retrying.
+
+NemoClaw checks the common Colima socket locations automatically.
+If Colima is running but Docker is still unreachable, see the Colima socket troubleshooting entry (use the `nemoclaw-user-reference` skill).
+
+## Install Node.js
+
+NemoClaw requires Node.js 22.16 or later and npm 10 or later.
+You can install Node.js with Homebrew:
+
+```bash
+brew install node@22
+```
+
+If Homebrew does not put Node.js on your `PATH`, add its shell environment output to your shell profile as directed by `brew`.
+You can also use `nvm`, `fnm`, or another Node.js version manager as long as `node --version` and `npm --version` resolve in the terminal where you run the installer.
+
+Verify the versions:
+
+```bash
+node --version
+npm --version
+```
+
+## Set Up Local Inference with Ollama (Optional)
+
+If you plan to select Ollama during onboarding, install it before running the NemoClaw installer:
+
+```bash
+brew install ollama
+```
+
+Start Ollama:
+
+```bash
+ollama serve
+```
+
+Keep the Ollama process running in another terminal, or configure it as a background service with your preferred macOS service manager.
+During onboarding, NemoClaw can also guide you through Ollama install or upgrade prompts when it detects a missing or unsupported host installation.
+
+Do not run multiple Ollama daemons on port `11434`.
+If another local model runtime already uses that port, stop it or move one of the services before running `nemoclaw onboard`.
+
+## Next Step
+
+Your macOS environment is ready.
+Continue with the Quickstart (use the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+Run the command from the terminal where `node`, `npm`, and `docker` are available.
+
+## Troubleshooting
+
+For macOS-specific troubleshooting, refer to the macOS first-run failures (use the `nemoclaw-user-reference` skill) and Colima socket (use the `nemoclaw-user-reference` skill) sections in the Troubleshooting guide.
+
+Common checks:
+
+- Open Docker Desktop or start Colima before running the installer.
+- Re-run `xcode-select --install` if developer tools are missing or broken after a macOS upgrade.
+- Use `docker info` from the same terminal where you run the installer.
+- Increase Colima resources if the sandbox image build stalls or exits unexpectedly.

--- a/.agents/skills/nemoclaw-user-get-started/references/prerequisites.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/prerequisites.md
@@ -65,5 +65,6 @@ The table is generated from [`ci/platform-matrix.json`](https://github.com/NVIDI
 
 ## Next Steps
 
+- Prepare macOS for NemoClaw (use the `nemoclaw-user-get-started` skill) if you are using macOS.
 - Prepare Windows for NemoClaw (use the `nemoclaw-user-get-started` skill) if you are using Windows.
 - Quickstart (use the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox.

--- a/.agents/skills/nemoclaw-user-get-started/references/windows-preparation.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/windows-preparation.md
@@ -4,7 +4,8 @@
 
 You can run NemoClaw inside Windows Subsystem for Linux (WSL 2) on Windows.
 Complete these steps before following the Quickstart (use the `nemoclaw-user-get-started` skill).
-Linux and macOS users do not need this page and can go directly to the Quickstart.
+Linux users do not need this page and can go directly to the Quickstart.
+macOS users should use the macOS preparation guide (use the `nemoclaw-user-get-started` skill).
 
 **Note:**
 

--- a/docs/get-started/macos-preparation.mdx
+++ b/docs/get-started/macos-preparation.mdx
@@ -1,0 +1,146 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Prepare macOS for NemoClaw"
+sidebar-title: "(macOS Only) macOS Prerequisites"
+description: "Prepare a macOS machine for NemoClaw before running the Quickstart: install developer tools, choose a container runtime, and optionally set up local inference."
+description-agent: "Covers macOS-only preparation steps required before the Quickstart. Use when preparing an Apple Silicon or Intel Mac for NemoClaw, choosing Docker Desktop or Colima, installing Xcode Command Line Tools, installing Node.js, configuring Ollama, or troubleshooting a macOS-specific install error."
+keywords: ["nemoclaw macos setup", "nemoclaw apple silicon docker desktop colima", "nemoclaw install mac xcode homebrew ollama"]
+content:
+  type: "reference"
+---
+Use this page when you are preparing a Mac for the first time.
+Complete these steps before following the [Quickstart](/get-started/quickstart).
+Linux users can go directly to the Quickstart.
+Windows users should use the [Windows preparation guide](/get-started/windows-preparation).
+
+<Note>
+NemoClaw supports both Apple Silicon and Intel Macs through the Docker-driver OpenShell gateway path.
+Apple Silicon is the most commonly tested macOS path.
+</Note>
+
+## Prerequisites
+
+Verify the following before you begin:
+
+- macOS on Apple Silicon or Intel.
+- Hardware requirements are the same as the [Quickstart](/get-started/quickstart).
+- Administrator access for installing developer tools and a container runtime.
+- A running container runtime: Docker Desktop or Colima.
+
+## Install Xcode Command Line Tools
+
+Install Apple's command line developer tools:
+
+```bash
+xcode-select --install
+```
+
+The installer and Node.js toolchain rely on these tools.
+If the command reports that tools are already installed, continue to the next step.
+
+## Choose a Container Runtime
+
+NemoClaw needs Docker-compatible container access.
+Use one of the tested options below.
+
+### Option 1: Docker Desktop
+
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and start the application.
+Wait until Docker reports that it is running, then verify it from a terminal:
+
+```bash
+docker info
+```
+
+Docker Desktop is the simplest macOS path for most first-time users.
+If `docker info` cannot connect, open Docker Desktop and wait for startup to finish before retrying.
+
+### Option 2: Colima
+
+Install Colima and Docker CLI with Homebrew:
+
+```bash
+brew install colima docker
+```
+
+Start Colima with enough resources for the sandbox image build:
+
+```bash
+colima start --cpu 4 --memory 8 --disk 40
+```
+
+Then verify Docker access:
+
+```bash
+docker info
+```
+
+<Tip>
+Default Colima resources are often too small for the sandbox image build.
+If onboarding stalls or the build is killed, increase CPU, memory, and disk before retrying.
+</Tip>
+
+NemoClaw checks the common Colima socket locations automatically.
+If Colima is running but Docker is still unreachable, see the [Colima socket troubleshooting entry](/reference/troubleshooting#colima-socket-not-detected-macos).
+
+## Install Node.js
+
+NemoClaw requires Node.js 22.16 or later and npm 10 or later.
+You can install Node.js with Homebrew:
+
+```bash
+brew install node@22
+```
+
+If Homebrew does not put Node.js on your `PATH`, add its shell environment output to your shell profile as directed by `brew`.
+You can also use `nvm`, `fnm`, or another Node.js version manager as long as `node --version` and `npm --version` resolve in the terminal where you run the installer.
+
+Verify the versions:
+
+```bash
+node --version
+npm --version
+```
+
+## Set Up Local Inference with Ollama (Optional)
+
+If you plan to select Ollama during onboarding, install it before running the NemoClaw installer:
+
+```bash
+brew install ollama
+```
+
+Start Ollama:
+
+```bash
+ollama serve
+```
+
+Keep the Ollama process running in another terminal, or configure it as a background service with your preferred macOS service manager.
+During onboarding, NemoClaw can also guide you through Ollama install or upgrade prompts when it detects a missing or unsupported host installation.
+
+Do not run multiple Ollama daemons on port `11434`.
+If another local model runtime already uses that port, stop it or move one of the services before running `nemoclaw onboard`.
+
+## Next Step
+
+Your macOS environment is ready.
+Continue with the [Quickstart](/get-started/quickstart) to install NemoClaw and launch your first sandbox:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+Run the command from the terminal where `node`, `npm`, and `docker` are available.
+
+## Troubleshooting
+
+For macOS-specific troubleshooting, refer to the [macOS first-run failures](/reference/troubleshooting#macos-first-run-failures) and [Colima socket](/reference/troubleshooting#colima-socket-not-detected-macos) sections in the Troubleshooting guide.
+
+Common checks:
+
+- Open Docker Desktop or start Colima before running the installer.
+- Re-run `xcode-select --install` if developer tools are missing or broken after a macOS upgrade.
+- Use `docker info` from the same terminal where you run the installer.
+- Increase Colima resources if the sandbox image build stalls or exits unexpectedly.

--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -72,5 +72,6 @@ The table is generated from [`ci/platform-matrix.json`](https://github.com/NVIDI
 
 ## Next Steps
 
+- [Prepare macOS for NemoClaw](/get-started/macos-preparation) if you are using macOS.
 - [Prepare Windows for NemoClaw](/get-started/windows-preparation) if you are using Windows.
 - [Quickstart](/get-started/quickstart) to install NemoClaw and launch your first sandbox.

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -11,7 +11,8 @@ content:
 ---
 You can run NemoClaw inside Windows Subsystem for Linux (WSL 2) on Windows.
 Complete these steps before following the [Quickstart](/get-started/quickstart).
-Linux and macOS users do not need this page and can go directly to the Quickstart.
+Linux users do not need this page and can go directly to the Quickstart.
+macOS users should use the [macOS preparation guide](/get-started/macos-preparation).
 
 <Note>
 This guide has been tested on x86-64.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -28,6 +28,9 @@ navigation:
         path: get-started/prerequisites.mdx
         slug: prerequisites
         contents:
+          - page: "(macOS Only) macOS Prerequisites"
+            path: get-started/macos-preparation.mdx
+            slug: macos-preparation
           - page: "(Windows Only) Windows Prerequisites"
             path: get-started/windows-preparation.mdx
             slug: windows-preparation

--- a/test/windows-preparation-doc-copy.test.ts
+++ b/test/windows-preparation-doc-copy.test.ts
@@ -10,6 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const windowsPreparationDoc = path.join(repoRoot, "docs", "get-started", "windows-preparation.mdx");
+const macosPreparationDoc = path.join(repoRoot, "docs", "get-started", "macos-preparation.mdx");
 const contributingDoc = path.join(repoRoot, "docs", "CONTRIBUTING.md");
 const codeRabbitConfig = path.join(repoRoot, ".coderabbit.yaml");
 const contributorUpdateDocsSkill = path.join(
@@ -91,5 +92,25 @@ describe("Windows preparation docs copyable commands", () => {
         ).not.toMatch(pattern);
       }
     }
+  });
+});
+
+describe("macOS preparation docs copyable commands", () => {
+  it("uses bash command blocks without prompt prefixes", () => {
+    const markdown = fs.readFileSync(macosPreparationDoc, "utf8");
+    const blocks = collectFencedBlocks(markdown);
+    const promptLines = blocks.flatMap((block) =>
+      block.lines
+        .map((line, offset) => ({ line, lineNumber: block.line + offset + 1 }))
+        .filter(({ line }) => /^\s*\$ /.test(line))
+        .map(
+          ({ line, lineNumber }) =>
+            `${path.relative(repoRoot, macosPreparationDoc)}:${lineNumber}: ${line}`,
+        ),
+    );
+    const languages = new Set(blocks.map((block) => block.language));
+
+    expect(promptLines).toEqual([]);
+    expect(languages.has("bash")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds a dedicated macOS preparation page so first-time Mac users do not have to piece together setup guidance from the quickstart, prerequisites, local inference, and troubleshooting pages.

Fixes #3232.

## Changes

- Added `docs/get-started/macos-preparation.mdx` with Xcode Command Line Tools, Docker Desktop vs Colima, Node.js, optional Ollama, next-step, and troubleshooting guidance.
- Linked the new page from prerequisites and the Windows preparation page.
- Added the new page to the docs navigation.
- Regenerated the generated get-started user skill reference for the new docs page.
- Extended docs copy-paste safety tests to cover macOS preparation commands.

## Testing

- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx`
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run docs`
- `npx vitest run test/windows-preparation-doc-copy.test.ts`

## Evidence it works

- Fern docs validation completed with 0 errors.
- The generated `nemoclaw-user-get-started` skill now includes the macOS preparation reference.
- The new macOS docs test confirms command examples use copyable shell blocks without prompt prefixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive macOS preparation guide covering prerequisites, development tools, container runtime setup, Node.js installation, and Ollama configuration
  * Updated onboarding documentation with platform-specific routing for macOS, Windows, and Linux users

* **Tests**
  * Added validation tests for documentation code block formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->