### PR TITLE
docs: surface README community paths (Fixes #3827)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,25 @@ It provides guided onboarding, a hardened blueprint, routed inference, network p
 - [OpenClaw](https://openclaw.ai) (default)
 - [Hermes](https://get-hermes.ai/)
 
-For capabilities, architecture, security controls, and the full feature list, see the [NemoClaw documentation](https://docs.nvidia.com/nemoclaw/latest/).
+## Get Involved
 
-## Get Started
+NemoClaw is early alpha software, and feedback from users and contributors helps shape the project.
+Use the links below to pick the right channel:
+
+| Need | Where to go |
+|------|-------------|
+| Ask setup or usage questions | [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions) or [Discord](https://discord.gg/XFpfPv9Uvx) |
+| Report a reproducible bug | [GitHub Issues](https://github.com/NVIDIA/NemoClaw/issues) |
+| Propose a feature or larger design change | [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions) first, then open an issue when the scope is clear |
+| Start contributing | [CONTRIBUTING.md](CONTRIBUTING.md), especially issues labeled [`good first issue`](https://github.com/NVIDIA/NemoClaw/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) |
+| Follow current priorities | [Open milestones](https://github.com/NVIDIA/NemoClaw/milestones) and labeled issues |
+| Report a vulnerability | [SECURITY.md](SECURITY.md), not public issues |
+
+Please also review the [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
+## Getting Started
+
+For capabilities, architecture, security controls, and the full feature list, see the [NemoClaw documentation](https://docs.nvidia.com/nemoclaw/latest/).
 
 Review [Prerequisites](https://docs.nvidia.com/nemoclaw/latest/get-started/prerequisites.html) before installing.
 For Hermes, set `NEMOCLAW_AGENT=hermes` before running the installer, or use the `nemohermes` alias after install.
@@ -56,6 +72,9 @@ Refer to the following pages on the official documentation website for more info
 | [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html) | Common issues and resolution steps. |
 
 ## Community
+
+Join the NemoClaw community to ask questions and share feedback.
+For bugs, feature proposals, contribution guidance, roadmap pointers, and security reporting, use the channel matrix in [Get Involved](#get-involved).
 
 - [Discord](https://discord.gg/XFpfPv9Uvx)
 - [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions)

--- a/test/readme-community-links.test.ts
+++ b/test/readme-community-links.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+
+describe("README community front door", () => {
+  it("surfaces contribution, community, roadmap, and security paths near the top", () => {
+    const getInvolvedIndex = readme.indexOf("## Get Involved");
+    const gettingStartedIndex = readme.indexOf("## Getting Started");
+
+    expect(getInvolvedIndex).toBeGreaterThan(0);
+    expect(getInvolvedIndex).toBeLessThan(gettingStartedIndex);
+
+    for (const required of [
+      "[GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions)",
+      "[Discord](https://discord.gg/XFpfPv9Uvx)",
+      "[GitHub Issues](https://github.com/NVIDIA/NemoClaw/issues)",
+      "[CONTRIBUTING.md](CONTRIBUTING.md)",
+      "[`good first issue`](https://github.com/NVIDIA/NemoClaw/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)",
+      "[Open milestones](https://github.com/NVIDIA/NemoClaw/milestones)",
+      "[SECURITY.md](SECURITY.md), not public issues",
+      "[Code of Conduct](CODE_OF_CONDUCT.md)",
+    ]) {
+      expect(readme.slice(getInvolvedIndex, gettingStartedIndex)).toContain(required);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds an early README "Get Involved" block so new users and contributors can quickly find the right channel for questions, bugs, feature proposals, contributing, roadmap context, and security reports.

Fixes #3827.

## Changes

- Added a top-level channel matrix near the beginning of `README.md`.
- Linked contribution guidance, `good first issue`, GitHub Discussions, Discord, Issues, open milestones, `SECURITY.md`, and `CODE_OF_CONDUCT.md`.
- Updated the later Community section to point back to the new front-door matrix.
- Added a README regression test to keep those paths visible near the top.

## Testing

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run docs`
- `npx vitest run test/readme-community-links.test.ts`

## Evidence it works

- Fern docs validation completed with 0 errors.
- The README test confirms the new Get Involved section appears before Getting Started and includes the required community, contribution, roadmap, conduct, and security links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Get Involved" section with a community/help channel matrix for setup/usage questions, bug reports, feature/design proposals, how to start contributing, milestone/priority tracking, and vulnerability reporting.
  * Updated the Community section to point readers to the new guidance and added a Code of Conduct reference.

* **Tests**
  * Added automated tests that verify the README contains the "Get Involved" section before "Getting Started" and includes the required community and security links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->