### PR TITLE
fix(skills): flatten catalog export and detect untracked files in refresh diff

### DIFF
--- a/.agents/catalog-skills.yaml
+++ b/.agents/catalog-skills.yaml
@@ -6,7 +6,7 @@
 # The export is regenerated with: python3 scripts/export-catalog-skills.py
 version: 1
 source: .agents/skills
-export: skills/nemoclaw
+export: skills
 include:
   - skill: nemoclaw-skills-guide
     rationale: Public index for user-facing NemoClaw skills.

--- a/.github/catalog-skills-signing-flow.md
+++ b/.github/catalog-skills-signing-flow.md
@@ -3,7 +3,7 @@
 
 # NemoClaw catalog skills signing flow
 
-This diagram shows the required sequence for publishing NemoClaw user-facing skills into the NVIDIA Verified Skills catalog through the generated `skills/nemoclaw/` export.
+This diagram shows the required sequence for publishing NemoClaw user-facing skills into the NVIDIA Verified Skills catalog through the generated `skills/` export.
 
 ```mermaid
 sequenceDiagram
@@ -11,7 +11,7 @@ sequenceDiagram
     actor Maintainer as Human maintainer
     participant Source as NemoClaw source<br/>.agents/skills + .agents/catalog-skills.yaml
     participant Exporter as scripts/export-catalog-skills.py
-    participant Export as Generated export<br/>skills/nemoclaw
+    participant Export as Generated export<br/>skills
     participant PRCI as PR workflow<br/>CI / Pull Request
     participant Refresh as Skills / Catalog Refresh workflow
     participant PR as Same-repo refresh PR
@@ -25,7 +25,7 @@ sequenceDiagram
     Exporter->>Export: Copy allowlisted skills as real files<br/>write catalog-metadata.json<br/>preserve skill.oms.sig + skill-card.md if present
     Maintainer->>PRCI: Open implementation or content PR
     PRCI->>Exporter: python3 scripts/export-catalog-skills.py --check --allow-missing
-    Exporter-->>PRCI: Pass before first export exists;<br/>after refresh PR, fail if skills/nemoclaw is stale or hand-edited
+    Exporter-->>PRCI: Pass before first export exists;<br/>after refresh PR, fail if skills is stale or hand-edited
     Maintainer->>Main: Merge reviewed PR after checks pass
 
     Note over Refresh,PR: Post-merge refresh automation added by this PR
@@ -56,7 +56,7 @@ sequenceDiagram
 These are the manual review and approval points in the catalog signing flow.
 
 - Curate `.agents/catalog-skills.yaml` when public skill scope changes.
-- Review the generated `skills/nemoclaw/` diff in the same PR as the allowlist/source update.
+- Review the generated `skills/` diff in the same PR as the allowlist/source update.
 - Manually comment `/nvskills-ci` if the workflow bot cannot request signing.
 - Review and merge the signer-updated PR before expecting `NVIDIA/skills` to sync the signed skills.
 
@@ -75,5 +75,5 @@ These checks and workflow steps automate export freshness while keeping signing 
 
 - Review the exporter implementation in [`scripts/export-catalog-skills.py`](../scripts/export-catalog-skills.py).
 - Update the catalog allowlist in [`.agents/catalog-skills.yaml`](../.agents/catalog-skills.yaml) when public skill scope changes.
-- Review generated export diffs under `skills/nemoclaw/` in the refresh PR before requesting or accepting signing artifacts.
+- Review generated export diffs under `skills/` in the refresh PR before requesting or accepting signing artifacts.
 - Check the workflow definitions in [`.github/workflows/pr.yaml`](workflows/pr.yaml) and [`.github/workflows/catalog-skills-refresh.yaml`](workflows/catalog-skills-refresh.yaml).

--- a/.github/pr-bodies/catalog-skills-refresh.md
+++ b/.github/pr-bodies/catalog-skills-refresh.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- Regenerates `skills/nemoclaw/` from `.agents/catalog-skills.yaml` and `.agents/skills/`.
+- Regenerates `skills/` from `.agents/catalog-skills.yaml` and `.agents/skills/`.
 - Keeps the NVIDIA Verified Skills catalog export deterministic and reviewable.
 
 ## Validation

--- a/.github/workflows/catalog-skills-refresh.yaml
+++ b/.github/workflows/catalog-skills-refresh.yaml
@@ -54,20 +54,20 @@ jobs:
           set -euo pipefail
           # If NVSkills CI has already pushed signing artifacts (skill.oms.sig,
           # skill-card.md) to the refresh branch, overlay that branch's
-          # skills/nemoclaw into the working tree before regenerating. The
+          # skills/ into the working tree before regenerating. The
           # exporter (scripts/export-catalog-skills.py) auto-preserves those
           # files when an existing export tree is present, so this overlay is
           # what keeps signer artifacts from being dropped on force-push.
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Existing $BRANCH found; overlaying skills/nemoclaw to preserve NVSkills artifacts"
+            echo "Existing $BRANCH found; overlaying skills/ to preserve NVSkills artifacts"
             git fetch --depth 1 origin "$BRANCH":"refs/remotes/origin/$BRANCH"
             # Use `git cat-file -e` instead of `git ls-tree -d`: the latter can
             # exit 0 with empty output when the tree exists but the path does
-            # not, which would otherwise wipe skills/nemoclaw and then fail at
+            # not, which would otherwise wipe skills/ and then fail at
             # checkout. cat-file -e fails when the object is absent.
-            if git cat-file -e "origin/$BRANCH:skills/nemoclaw" 2>/dev/null; then
-              rm -rf skills/nemoclaw
-              git checkout "origin/$BRANCH" -- skills/nemoclaw
+            if git cat-file -e "origin/$BRANCH:skills" 2>/dev/null; then
+              rm -rf skills
+              git checkout "origin/$BRANCH" -- skills
             fi
           else
             echo "No existing $BRANCH; running fresh export from main"
@@ -80,16 +80,16 @@ jobs:
         id: diff
         run: |
           # Mark any new files under the export paths as intent-to-add so
-          # `git diff` reports them. Without this, an empty `skills/nemoclaw`
+          # `git diff` reports them. Without this, an empty `skills/`
           # tree on main causes a freshly-exported catalog to look unchanged
           # and the workflow short-circuits without opening a PR.
-          git add --intent-to-add -- .agents/catalog-skills.yaml skills/nemoclaw
-          if git diff --quiet -- .agents/catalog-skills.yaml skills/nemoclaw; then
+          git add --intent-to-add -- .agents/catalog-skills.yaml skills
+          if git diff --quiet -- .agents/catalog-skills.yaml skills; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No catalog skill export changes detected."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff --stat -- .agents/catalog-skills.yaml skills/nemoclaw
+            git diff --stat -- .agents/catalog-skills.yaml skills
           fi
 
       - name: Stop after dry run
@@ -116,7 +116,7 @@ jobs:
           gh auth setup-git
 
           git checkout -B "$BRANCH"
-          git add .agents/catalog-skills.yaml skills/nemoclaw
+          git add .agents/catalog-skills.yaml skills
           git commit -m "chore(skills): refresh catalog export"
           git push --force-with-lease origin "$BRANCH"
 

--- a/.github/workflows/catalog-skills-refresh.yaml
+++ b/.github/workflows/catalog-skills-refresh.yaml
@@ -79,6 +79,11 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
+          # Mark any new files under the export paths as intent-to-add so
+          # `git diff` reports them. Without this, an empty `skills/nemoclaw`
+          # tree on main causes a freshly-exported catalog to look unchanged
+          # and the workflow short-circuits without opening a PR.
+          git add --intent-to-add -- .agents/catalog-skills.yaml skills/nemoclaw
           if git diff --quiet -- .agents/catalog-skills.yaml skills/nemoclaw; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No catalog skill export changes detected."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,7 +161,7 @@ repos:
         name: Verify catalog skills export
         entry: python3 scripts/export-catalog-skills.py --check --allow-missing
         language: system
-        files: ^(\.agents/catalog-skills\.yaml|\.agents/skills/.*|skills/nemoclaw/.*|scripts/export-catalog-skills\.py)$
+        files: ^(\.agents/catalog-skills\.yaml|\.agents/skills/.*|skills/.*|scripts/export-catalog-skills\.py)$
         pass_filenames: false
         priority: 10
 

--- a/scripts/export-catalog-skills.py
+++ b/scripts/export-catalog-skills.py
@@ -4,7 +4,7 @@
 """Export catalog-safe NemoClaw skills to the NVSkills watched directory.
 
 The repository source of truth remains `.agents/skills/`. This script copies the
-checked-in allowlist from `.agents/catalog-skills.yaml` into `skills/nemoclaw/`
+checked-in allowlist from `.agents/catalog-skills.yaml` into `skills/`
 using deterministic ordering and metadata so CI can detect stale or hand-edited
 catalog exports.
 """
@@ -133,7 +133,7 @@ def load_config(path: Path) -> CatalogConfig:
         raise ValueError(f"{repo_path(path)} version must be 1")
 
     source = Path(str(raw.get("source", ".agents/skills")))
-    export = Path(str(raw.get("export", "skills/nemoclaw")))
+    export = Path(str(raw.get("export", "skills")))
     for label, candidate in (("source", source), ("export", export)):
         if candidate.is_absolute() or ".." in candidate.parts:
             raise ValueError(f"{repo_path(path)} {label} must be a safe relative path")

--- a/test/catalog-skills-export.test.ts
+++ b/test/catalog-skills-export.test.ts
@@ -74,7 +74,7 @@ describe("catalog skills export", () => {
     try {
       const tempAgents = path.join(tempDir, ".agents");
       const tempScripts = path.join(tempDir, "scripts");
-      const tempSkills = path.join(tempDir, "skills", "nemoclaw");
+      const tempSkills = path.join(tempDir, "skills");
       fs.mkdirSync(tempAgents, { recursive: true });
       fs.mkdirSync(tempScripts, { recursive: true });
       fs.cpSync(sourceRoot, path.join(tempAgents, "skills"), {
@@ -143,7 +143,7 @@ describe("catalog skills export", () => {
         [
           "version: 1",
           "source: ../outside",
-          "export: skills/nemoclaw",
+          "export: skills",
           "include:",
           "  - skill: ../escape",
           "",
@@ -171,7 +171,7 @@ describe("catalog skills export", () => {
     try {
       const tempAgents = path.join(tempDir, ".agents");
       const tempScripts = path.join(tempDir, "scripts");
-      const tempSkills = path.join(tempDir, "skills", "nemoclaw");
+      const tempSkills = path.join(tempDir, "skills");
       fs.mkdirSync(tempAgents, { recursive: true });
       fs.mkdirSync(tempScripts, { recursive: true });
       fs.cpSync(sourceRoot, path.join(tempAgents, "skills"), {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Two related fixes to the NemoClaw catalog skills export so the `Skills / Catalog Refresh` workflow actually opens a refresh PR on `main`:

1. **Detect untracked files in the change-detection diff.** The workflow ran `git diff --quiet` which only inspects tracked paths, so a freshly-exported catalog against an empty tracked tree looked unchanged and the workflow short-circuited via "Catalog skill export is already current." without ever pushing the 43 generated files.
2. **Flatten the export from `skills/nemoclaw/` to `skills/`.** Every other onboarded NVSkills product repo (`cuopt`, `nurec-skills`, `digital-health-skills`, `aiq`) — and `nvskills-ci` itself, with `skills/ci-smoke-test/SKILL.md` — uses `skills/<skill-name>/SKILL.md`. The per-product namespace layer in NemoClaw was redundant and didn't match anyone else's layout.

## Related Issue

Follow-up to #4282 / #4284 / #4334. Observed on post-merge runs [26526695773](https://github.com/NVIDIA/NemoClaw/actions/runs/26526695773) and [26526772139](https://github.com/NVIDIA/NemoClaw/actions/runs/26526772139): both completed `success` after exporting 11 skills, then exited via `Stop after dry run` without producing a PR because no diff was detected against the empty `skills/` tree on `main`.

## Changes

**Diff fix (commit 1):**
- `.github/workflows/catalog-skills-refresh.yaml`: run `git add --intent-to-add` against the export paths before `git diff --quiet` so untracked files surface as additions.

**Layout flattening (commit 2):**
- `.agents/catalog-skills.yaml`: `export: skills/nemoclaw` → `export: skills`
- `scripts/export-catalog-skills.py`: default target updated
- `.github/workflows/catalog-skills-refresh.yaml`: every `skills/nemoclaw` reference (preserve-overlay, change-detection, commit-add) updated to `skills`
- `.pre-commit-config.yaml`: hook regex now anchors to `skills/.*`
- `.github/catalog-skills-signing-flow.md`, `.github/pr-bodies/catalog-skills-refresh.md`: prose updated
- `test/catalog-skills-export.test.ts`: temp-fixture paths updated

## Why dropping the `nemoclaw/` subdir is safe

Verified directly against `NVIDIA/nvskills-ci` (cloned locally):

- `scripts/validate_request.py:21-26` — `WATCHED_PATH_PREFIXES = (".agents/skills/", "skills/", "team-skills/", "rules/team-rules/", "plugins/")` and `is_watched_path = path.startswith(WATCHED_PATH_PREFIXES)`. **Plain prefix match — no namespacing requirement.**
- `.github/workflows/team-request.yml:114` mirrors the same `startswith("skills/")` filter.
- `docs/team-onboarding.md:27` — *"Store NVSkills content under `skills/`, `team-skills/`, ..."* — no per-product subdir mentioned.
- `nvskills-ci`'s own example skill is at `skills/ci-smoke-test/SKILL.md`.
- Every other product repo follows the same pattern (verified via GitHub API on `cuopt`, `nurec-skills`, `digital-health-skills`, `aiq`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

Reproduced and validated locally on a clean `main` checkout:

```
$ python3 scripts/export-catalog-skills.py
Exported 11 catalog skill(s) to skills

$ ls skills/
catalog-metadata.json
nemoclaw-skills-guide
nemoclaw-user-agent-skills
nemoclaw-user-configure-inference
... (11 skills, flat layout)

# Old change-detection (broken — misses untracked tree):
$ git diff --quiet -- .agents/catalog-skills.yaml skills && echo changed=false || echo changed=true
changed=false

# Fixed change-detection:
$ git add --intent-to-add -- .agents/catalog-skills.yaml skills
$ git diff --quiet -- .agents/catalog-skills.yaml skills && echo changed=false || echo changed=true
changed=true
$ git diff --stat -- .agents/catalog-skills.yaml skills | tail -1
 44 files changed, 8907 insertions(+), 1 deletion(-)
```

Vitest:

```
$ npx vitest run test/catalog-skills-export.test.ts --project cli
 ✓ |cli| test/catalog-skills-export.test.ts (4 tests) 1201ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes for the affected test file (4/4)
- [x] Tests updated for changed export path
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes — N/A (CI-internal)
- [ ] `npm run docs` builds without warnings — N/A
- [ ] Doc pages follow the style guide — N/A
- [ ] New doc pages include SPDX header and frontmatter — N/A

---
Signed-off-by: Justin Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refresh process updated to regenerate and preserve exports under the top-level skills/ directory, improving detection and staging of newly created files and signer artifacts.
  * Pre-commit checks widened to run against the broader skills/ export tree.
* **Documentation**
  * Updated signing-flow and PR guidance to reference the skills/ export location.
* **Tests**
  * Test fixtures aligned to the new skills/ export layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->