### PR TITLE
chore(ci): install NVSkills CI request listener for /nvskills-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,11 @@
 # ── Agent skills catalog ──
 /.agents/catalog-skills.yaml        @NVIDIA/nemoclaw-maintainer @NVIDIA/nemoclaw-engineer
 /.agents/skills/                    @NVIDIA/nemoclaw-maintainer @NVIDIA/nemoclaw-engineer
-/skills/nemoclaw/                   @NVIDIA/nemoclaw-maintainer @NVIDIA/nemoclaw-engineer
+/skills/                            @NVIDIA/nemoclaw-maintainer @NVIDIA/nemoclaw-engineer
+
+# ── NVSkills CI request listener (must stay CODEOWNERS-protected per
+#    NVIDIA/nvskills-ci team-onboarding step 4) ──
+/.github/workflows/request-nvskills-ci.yml  @NVIDIA/nemoclaw-maintainer
 
 # ── Tests ──
 /test/                              @NVIDIA/nemoclaw-engineer

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -29,6 +29,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@d6c3af084edd278e5524c95e6586fc763835eb62
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Forwards `/nvskills-ci` PR comments and signature push events to the central
+# NVSkills CI service in NVIDIA/nvskills-ci. Mirrors
+# templates/team-request-workflow.yml from NVIDIA/nvskills-ci@main.
+#
+# Onboarding reference: NVIDIA/nvskills-ci/docs/team-onboarding.md
+# This file must remain CODEOWNERS-protected (see .github/CODEOWNERS).
+#
+# Required repository secret: NVSKILLS_CI_DISPATCH_TOKEN
+
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Install the NVSkills CI request listener so `/nvskills-ci` comments on catalog refresh PRs actually trigger NVSkills signing. Without this listener, comments are no-ops and merged refresh PRs ship unsigned (which downstream `NVIDIA/skills` then drops on sync).

## Related Issue

Follow-up to #4282 / #4342. Discovered while running the post-merge signing flow on PR #4344: the `/nvskills-ci` comment posted on that PR produced no workflow run because NemoClaw was missing the team-request listener.

## Changes

- **`.github/workflows/request-nvskills-ci.yml`** (new): copied byte-for-byte from `NVIDIA/nvskills-ci/templates/team-request-workflow.yml@main`, with a NemoClaw SPDX header. Forwards `/nvskills-ci` PR comments (and `nv-skills-ci[bot]` signature pushes) to `NVIDIA/skills/.github/workflows/team-request.yml@main` via `secrets.NVSKILLS_CI_DISPATCH_TOKEN`.
- **`.github/CODEOWNERS`**: add an explicit nemoclaw-maintainer rule for `/.github/workflows/request-nvskills-ci.yml` so onboarding step 4 (CODEOWNERS protection) is visibly enforced; also flatten the now-stale `/skills/nemoclaw/` rule to `/skills/` to match the post-#4342 export layout.

## Onboarding status

Per [`NVIDIA/nvskills-ci/docs/team-onboarding.md`](https://github.com/NVIDIA/nvskills-ci/blob/main/docs/team-onboarding.md):

| Step | What | Status |
|---|---|---|
| 1 | Add NemoClaw to `config/onboarded-repositories.json` | ✅ already done |
| 2 | Install `templates/team-request-workflow.yml` as `.github/workflows/request-nvskills-ci.yml` | ✅ this PR |
| 3 | Set `NVSKILLS_CI_DISPATCH_TOKEN` repo secret | ⚠️ **manual maintainer/admin action required after merge** |
| 4 | CODEOWNERS-protect the new workflow file | ✅ this PR |
| 5 | Test by commenting `/nvskills-ci` on a PR | 🟡 unblocked once step 3 lands |

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- Workflow body verified byte-identical to upstream template:

  ```
  $ diff <(tail -n +13 .github/workflows/request-nvskills-ci.yml) \
         ~/Development/nvskills-ci/templates/team-request-workflow.yml
  (no output — identical)
  ```

- Listener is inert until the `NVSKILLS_CI_DISPATCH_TOKEN` secret is set; until then `/nvskills-ci` comments will fail at the secret-injection boundary, but they will at least produce a visible failed workflow run instead of silently doing nothing.

- [x] No secrets, API keys, or credentials committed
- [x] Tests added or updated for new or changed behavior — N/A (single workflow file mirrored from upstream template; behavior is exercised by the next live `/nvskills-ci` comment)
- [ ] Docs updated for user-facing behavior changes — N/A (CI-internal)
- [ ] `npm run docs` builds without warnings — N/A
- [ ] Doc pages follow the style guide — N/A
- [ ] New doc pages include SPDX header and frontmatter — N/A

---
Signed-off-by: Justin Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership mappings to reorganize responsibility for the skills subtree and simplify maintainer coverage.
  * Added a workflow to request NVSkills validation/signature runs: can be triggered by a specially formatted issue comment or by specific commit pushes from the CI signature actor, and securely forwards the dispatch token to the centralized validation workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->