### PR TITLE
feat(e2e): generate scenario fan-out matrix from typed registry

### DIFF
--- a/.github/workflows/e2e-scenarios-all.yaml
+++ b/.github/workflows/e2e-scenarios-all.yaml
@@ -1,15 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Scenario-based E2E fan-out. Runs every setup scenario from the current
-# migration catalog by calling the single-scenario runner workflow.
+# Scenario-based E2E fan-out. Generates the job matrix from the typed
+# scenario registry (`test/e2e-scenario/scenarios/registry.ts`) so that
+# adding a scenario in `baseline.ts` automatically produces a tile here on
+# the next run -- no workflow edits required.
 #
-# Each child job passes its scenario id through the called workflow's
-# `scenarios` input (comma-separated; one id here per child). The legacy
-# per-call `suite_filter` input was retired when the runner moved to a
-# typed scenario contract, so this fan-out no longer accepts a fan-out-wide
-# suite filter; if per-suite scoping is needed in the future, route it
-# through `e2e-scenarios.yaml` directly with a custom scenario list.
+# The single-scenario runner workflow `e2e-scenarios.yaml` remains the
+# authoritative execution path; this file just fans out one call per
+# scenario id with the runner label resolved by `--emit-matrix`.
 
 name: E2E / Scenario Runner / All
 
@@ -24,51 +23,63 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ubuntu-repo-cloud-openclaw:
-    uses: ./.github/workflows/e2e-scenarios.yaml
-    with:
-      scenarios: ubuntu-repo-cloud-openclaw
-    secrets:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.emit.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-  ubuntu-repo-cloud-hermes:
-    uses: ./.github/workflows/e2e-scenarios.yaml
-    with:
-      scenarios: ubuntu-repo-cloud-hermes
-    secrets:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
 
-  gpu-repo-local-ollama-openclaw:
-    uses: ./.github/workflows/e2e-scenarios.yaml
-    with:
-      scenarios: gpu-repo-local-ollama-openclaw
-    secrets:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
 
-  macos-repo-cloud-openclaw:
-    uses: ./.github/workflows/e2e-scenarios.yaml
-    with:
-      scenarios: macos-repo-cloud-openclaw
-    secrets:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      - id: emit
+        name: Emit scenario matrix from typed registry
+        run: |
+          set -euo pipefail
+          matrix="$(npx tsx test/e2e-scenario/scenarios/run.ts --emit-matrix)"
+          # Sanity-check that the output is non-empty JSON before handing it
+          # to GHA, so a registry error fails this job loudly instead of
+          # producing zero matrix tiles.
+          if [ -z "${matrix}" ] || [ "${matrix}" = "[]" ]; then
+            echo "::error::scenario matrix is empty; check typed registry" >&2
+            exit 1
+          fi
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
-  wsl-repo-cloud-openclaw:
-    uses: ./.github/workflows/e2e-scenarios.yaml
-    with:
-      scenarios: wsl-repo-cloud-openclaw
-    secrets:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      - name: Render matrix summary
+        env:
+          MATRIX_JSON: ${{ steps.emit.outputs.matrix }}
+        run: |
+          {
+            echo '## E2E scenario matrix'
+            echo ''
+            echo '| Scenario | Runner | Label |'
+            echo '| --- | --- | --- |'
+            python3 - <<'PY'
+          import json, os
+          for e in json.loads(os.environ["MATRIX_JSON"]):
+              print(f"| `{e['id']}` | {e['runner']} | {e['label']} |")
+          PY
+          } >> "$GITHUB_STEP_SUMMARY"
 
-  brev-launchable-cloud-openclaw:
+  run-scenario:
+    needs: generate-matrix
+    name: ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/e2e-scenarios.yaml
     with:
-      scenarios: brev-launchable-cloud-openclaw
-    secrets:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-
-  ubuntu-no-docker-preflight-negative:
-    uses: ./.github/workflows/e2e-scenarios.yaml
-    with:
-      scenarios: ubuntu-no-docker-preflight-negative
+      scenarios: ${{ matrix.id }}
     secrets:
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}

--- a/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { buildScenarioMatrix } from "../scenarios/run.ts";
+import { listScenarios } from "../scenarios/registry.ts";
+import { resolveRunnerForScenario } from "../scenarios/runner-routing.ts";
+import { scenario } from "../scenarios/builder.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const RUN_SCENARIOS = path.join(REPO_ROOT, "test/e2e-scenario/scenarios/run.ts");
+const TSX = path.join(REPO_ROOT, "node_modules/.bin/tsx");
+
+function runEmitMatrix() {
+  return spawnSync(TSX, [RUN_SCENARIOS, "--emit-matrix"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    timeout: Number(process.env.E2E_SPAWN_TIMEOUT_MS ?? 60_000),
+  });
+}
+
+describe("typed scenario matrix", () => {
+  it("emits one matrix entry per registered scenario", () => {
+    const matrix = buildScenarioMatrix();
+    const ids = listScenarios().map((s) => s.id);
+    expect(matrix.map((entry) => entry.id).sort()).toEqual([...ids].sort());
+  });
+
+  it("resolves a runner label for every scenario", () => {
+    const matrix = buildScenarioMatrix();
+    expect(matrix.length).toBeGreaterThan(0);
+    for (const entry of matrix) {
+      expect(entry.runner, `runner missing for ${entry.id}`).toMatch(/[A-Za-z0-9-]/);
+      expect(entry.label, `label missing for ${entry.id}`).toContain(entry.id);
+    }
+  });
+
+  it("routes platforms to their canonical runners", () => {
+    const byId = new Map(buildScenarioMatrix().map((entry) => [entry.id, entry]));
+    expect(byId.get("ubuntu-repo-cloud-openclaw")?.runner).toBe("ubuntu-latest");
+    expect(byId.get("macos-repo-cloud-openclaw")?.runner).toBe("macos-26");
+    expect(byId.get("wsl-repo-cloud-openclaw")?.runner).toBe("windows-latest");
+    expect(byId.get("gpu-repo-local-ollama-openclaw")?.runner).toBe(
+      "linux-amd64-gpu-rtxpro6000-latest-1",
+    );
+  });
+
+  it("honors an explicit runs-on:<label> requirement override", () => {
+    const custom = scenario("test-runs-on-override")
+      .description("test fixture")
+      .manifest("test/e2e-scenario/manifests/openclaw-nvidia.yaml")
+      .environment({
+        platform: "ubuntu-local",
+        install: "repo-current",
+        runtime: "docker-running",
+        onboarding: "cloud-openclaw",
+      })
+      .expectedState("cloud-openclaw-ready")
+      .onboardingAssertions(["base-installed"])
+      .suites(["smoke"])
+      .runnerRequirements(["runs-on:custom-self-hosted"])
+      .build();
+    expect(resolveRunnerForScenario(custom).runner).toBe("custom-self-hosted");
+  });
+
+  it("fails loudly when a platform has no default runner mapping", () => {
+    const broken = scenario("test-unknown-platform")
+      .description("test fixture")
+      .manifest("test/e2e-scenario/manifests/openclaw-nvidia.yaml")
+      .environment({
+        platform: "made-up-platform",
+        install: "repo-current",
+        runtime: "docker-running",
+        onboarding: "cloud-openclaw",
+      })
+      .expectedState("cloud-openclaw-ready")
+      .onboardingAssertions(["base-installed"])
+      .suites(["smoke"])
+      .build();
+    expect(() => resolveRunnerForScenario(broken)).toThrow(/no default for platform/);
+  });
+
+  it("--emit-matrix prints a single-line JSON array compatible with $GITHUB_OUTPUT", () => {
+    const result = runEmitMatrix();
+    expect(result.status, result.stderr).toBe(0);
+    const lines = result.stdout.trim().split("\n");
+    expect(lines.length, "matrix output must be a single line").toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBe(listScenarios().length);
+    for (const entry of parsed) {
+      expect(entry).toMatchObject({
+        id: expect.any(String),
+        runner: expect.any(String),
+        label: expect.any(String),
+        platform: expect.any(String),
+        suites: expect.any(Array),
+      });
+    }
+  });
+});

--- a/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
@@ -67,6 +67,24 @@ describe("typed scenario matrix", () => {
     expect(resolveRunnerForScenario(custom).runner).toBe("custom-self-hosted");
   });
 
+  it("rejects empty runs-on requirement overrides", () => {
+    const broken = scenario("test-empty-runs-on-override")
+      .description("test fixture")
+      .manifest("test/e2e-scenario/manifests/openclaw-nvidia.yaml")
+      .environment({
+        platform: "ubuntu-local",
+        install: "repo-current",
+        runtime: "docker-running",
+        onboarding: "cloud-openclaw",
+      })
+      .expectedState("cloud-openclaw-ready")
+      .onboardingAssertions(["base-installed"])
+      .suites(["smoke"])
+      .runnerRequirements(["runs-on:   "])
+      .build();
+    expect(() => resolveRunnerForScenario(broken)).toThrow(/empty runs-on override/);
+  });
+
   it("fails loudly when a platform has no default runner mapping", () => {
     const broken = scenario("test-unknown-platform")
       .description("test fixture")

--- a/test/e2e-scenario/scenarios/run.ts
+++ b/test/e2e-scenario/scenarios/run.ts
@@ -1,24 +1,55 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { compileRunPlans, renderPlanText, writePlanArtifacts } from "./compiler.ts";
 import { ScenarioRunner } from "./orchestrators/runner.ts";
 import { listScenarios } from "./registry.ts";
+import { resolveRunnerForScenario } from "./runner-routing.ts";
+import type { ScenarioDefinition } from "./types.ts";
 
 interface Args {
   list: boolean;
   planOnly: boolean;
   dryRun: boolean;
   validateOnly: boolean;
+  emitMatrix: boolean;
   scenarios: string[];
 }
 
+/**
+ * Shape of a single GitHub Actions matrix `include` entry emitted by
+ * `--emit-matrix`. The fields are kept short and JSON-stable so the consuming
+ * workflow can reference them as `${{ matrix.id }}`, `${{ matrix.runner }}`,
+ * etc. without further parsing.
+ */
+export interface ScenarioMatrixEntry {
+  id: string;
+  runner: string;
+  label: string;
+  platform: string;
+  suites: string[];
+}
+
 function parseArgs(argv: string[]): Args {
-  const args: Args = { list: false, planOnly: false, dryRun: false, validateOnly: false, scenarios: [] };
+  const args: Args = {
+    list: false,
+    planOnly: false,
+    dryRun: false,
+    validateOnly: false,
+    emitMatrix: false,
+    scenarios: [],
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--list") {
       args.list = true;
+      continue;
+    }
+    if (arg === "--emit-matrix") {
+      args.emitMatrix = true;
       continue;
     }
     if (arg === "--plan-only") {
@@ -54,10 +85,54 @@ function printList() {
   }
 }
 
+function buildLabel(scenario: ScenarioDefinition): string {
+  const platform = scenario.environment?.platform ?? "unknown-platform";
+  const suites = scenario.suiteIds ?? [];
+  if (scenario.expectedFailure) {
+    const cls = scenario.expectedFailure.errorClass ?? "expected-failure";
+    return `${platform} \u00b7 ${scenario.id} \u00b7 expect-fail:${cls}`;
+  }
+  if (suites.length === 0) {
+    return `${platform} \u00b7 ${scenario.id}`;
+  }
+  if (suites.length <= 3) {
+    return `${platform} \u00b7 ${scenario.id} \u00b7 ${suites.join("+")}`;
+  }
+  return `${platform} \u00b7 ${scenario.id} \u00b7 ${suites.length} suites`;
+}
+
+/**
+ * Build the GitHub Actions matrix for every scenario in the typed registry.
+ * Sorted by id so workflow runs are deterministic and diffable.
+ */
+export function buildScenarioMatrix(): ScenarioMatrixEntry[] {
+  return listScenarios().map((scenario): ScenarioMatrixEntry => {
+    const { runner } = resolveRunnerForScenario(scenario);
+    return {
+      id: scenario.id,
+      runner,
+      label: buildLabel(scenario),
+      platform: scenario.environment?.platform ?? "unknown",
+      suites: scenario.suiteIds ?? [],
+    };
+  });
+}
+
+function emitMatrix() {
+  // Single line so GHA's `$GITHUB_OUTPUT` can consume it via
+  //   echo "matrix=$(npx tsx ... --emit-matrix)" >> "$GITHUB_OUTPUT"
+  // without needing heredoc multi-line output handling.
+  process.stdout.write(`${JSON.stringify(buildScenarioMatrix())}\n`);
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.list) {
     printList();
+    return;
+  }
+  if (args.emitMatrix) {
+    emitMatrix();
     return;
   }
 
@@ -86,9 +161,25 @@ async function main() {
   }
 }
 
-try {
-  await main();
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
+// Only execute when invoked directly as a script. Importing this module from
+// tests (e.g. `buildScenarioMatrix`) must not trigger the CLI side-effects.
+// Compare via realpath so symlinked paths (e.g. `/tmp` -> `/private/tmp` on
+// macOS) still resolve as equal.
+function isInvokedDirectly(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isInvokedDirectly()) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }

--- a/test/e2e-scenario/scenarios/runner-routing.ts
+++ b/test/e2e-scenario/scenarios/runner-routing.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Maps a typed scenario definition to the GitHub Actions runner label it
+// should execute on. The mapping is derived from the typed
+// `ScenarioEnvironment.platform` and `ScenarioDefinition.runnerRequirements`
+// fields so that adding a scenario to the registry automatically resolves a
+// runner without editing workflow YAML.
+
+import type { ScenarioDefinition } from "./types.ts";
+
+export interface ResolvedRunner {
+  /** GitHub Actions `runs-on` label. */
+  runner: string;
+  /** Reason the runner was selected, surfaced in matrix entries for debugging. */
+  reason: string;
+}
+
+const PLATFORM_DEFAULT_RUNNER: Record<string, string> = {
+  "ubuntu-local": "ubuntu-latest",
+  "gpu-runner": "linux-amd64-gpu-rtxpro6000-latest-1",
+  "macos-local": "macos-26",
+  "wsl-local": "windows-latest",
+  "brev-launchable": "ubuntu-latest",
+};
+
+/**
+ * Resolve the GitHub Actions runner label for a typed scenario.
+ *
+ * Routing precedence:
+ *   1. An explicit `runs-on:<label>` entry in `runnerRequirements`.
+ *   2. The default runner mapped from `environment.platform`.
+ *
+ * Throws when neither path yields a runner so missing platform mappings fail
+ * loudly during matrix generation rather than silently falling back to
+ * `ubuntu-latest` (which used to mask routing bugs in the legacy bash map).
+ */
+export function resolveRunnerForScenario(scenario: ScenarioDefinition): ResolvedRunner {
+  const explicit = (scenario.runnerRequirements ?? []).find((req) => req.startsWith("runs-on:"));
+  if (explicit) {
+    return { runner: explicit.slice("runs-on:".length), reason: "runnerRequirements override" };
+  }
+
+  const platform = scenario.environment?.platform;
+  if (platform && PLATFORM_DEFAULT_RUNNER[platform]) {
+    return { runner: PLATFORM_DEFAULT_RUNNER[platform], reason: `platform:${platform}` };
+  }
+
+  throw new Error(
+    `Cannot resolve runner for scenario '${scenario.id}': no runs-on override and no default for platform '${platform ?? "<missing>"}'.`,
+  );
+}

--- a/test/e2e-scenario/scenarios/runner-routing.ts
+++ b/test/e2e-scenario/scenarios/runner-routing.ts
@@ -38,7 +38,13 @@ const PLATFORM_DEFAULT_RUNNER: Record<string, string> = {
 export function resolveRunnerForScenario(scenario: ScenarioDefinition): ResolvedRunner {
   const explicit = (scenario.runnerRequirements ?? []).find((req) => req.startsWith("runs-on:"));
   if (explicit) {
-    return { runner: explicit.slice("runs-on:".length), reason: "runnerRequirements override" };
+    const runner = explicit.slice("runs-on:".length).trim();
+    if (!runner) {
+      throw new Error(
+        `Cannot resolve runner for scenario '${scenario.id}': empty runs-on override.`,
+      );
+    }
+    return { runner, reason: "runnerRequirements override" };
   }
 
   const platform = scenario.environment?.platform;


### PR DESCRIPTION
## Why

The `e2e-scenarios-all.yaml` fan-out has 8 hand-wired jobs, but the typed scenario registry in `baseline.ts` already defines **22 scenarios**. The other 14 are defined-but-not-dispatched, and every new scenario today requires a YAML edit that's easy to forget. The hand-wired job names also no longer reflect what each scenario actually tests (manifest, suites, expectedState).

This PR makes the fan-out **generated from the existing typed registry** so the workflow can never drift from `baseline.ts` again.

## What changed

### `--emit-matrix` flag on `run.ts`
Walks `listScenarios()` (the existing registry — no new registry created) and prints a single-line JSON array of GHA matrix `include` entries:

```json
[
  { "id": "ubuntu-repo-cloud-openclaw",
    "runner": "ubuntu-latest",
    "label": "ubuntu-local · ubuntu-repo-cloud-openclaw · smoke+inference+credentials",
    "platform": "ubuntu-local",
    "suites": ["smoke", "inference", "credentials"] },
  ...
]
```

### `runner-routing.ts` helper
Derives the `runs-on` label from `ScenarioEnvironment.platform`, with a `runs-on:<label>` override path via `runnerRequirements`. Throws on unknown platforms so missing mappings fail loudly during matrix generation rather than silently falling back to `ubuntu-latest` (which used to mask routing bugs in the legacy bash `ROUTES` map).

### `e2e-scenarios-all.yaml` refactor
Two-job shape:

1. `generate-matrix` — checks out, installs deps, runs `--emit-matrix`, and writes the JSON to `$GITHUB_OUTPUT`. Also renders a Markdown table of all matrix entries in the step summary so you can see the full plan at a glance.
2. `run-scenario` — uses `strategy.matrix.include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}` and calls the existing `e2e-scenarios.yaml` reusable workflow per scenario. Tile names use `${{ matrix.label }}` so the sidebar reflects what's actually being tested.

### Adding a scenario from now on
1. Add the entry to `canonicalScenarioInputs` in `baseline.ts`.
2. That's it. Next workflow run automatically picks it up as a new tile.

## What didn't change

- `e2e-scenarios.yaml` (the single-scenario reusable workflow) is **untouched**. Its `resolve-runner` job continues to be the authoritative runner-selection path during execution; the `runner` field in the matrix is informational and used for the sidebar label.
- The bash `ROUTES` map in `e2e-scenarios.yaml` is left in place for now to keep this PR focused. It becomes effectively dead code once this lands and can be removed in a follow-up.
- No new registry. Everything reads from `test/e2e-scenario/scenarios/registry.ts`.

## Verification

Unit tests in `e2e-scenario-matrix.test.ts` cover:
- matrix entry per registered scenario
- runner resolves for every scenario
- platform-default routing (ubuntu/macos/wsl/gpu)
- explicit `runs-on:<label>` override
- loud failure on unknown platform
- single-line JSON output suitable for `$GITHUB_OUTPUT`

Local run:
```
✓ test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts (6 tests)
✓ test/e2e-scenario/framework-tests/e2e-scenario-registry.test.ts (6 tests)
✓ test/e2e-scenario/framework-tests/e2e-scenarios-workflow.test.ts (2 tests)
✓ test/e2e-scenario/framework-tests/e2e-plan-compiler.test.ts
✓ test/e2e-scenario/framework-tests/e2e-scenario-resolver.test.ts
58 tests passed
```

Manual smoke:
```
$ npx tsx test/e2e-scenario/scenarios/run.ts --emit-matrix | jq 'length'
22
$ npx tsx test/e2e-scenario/scenarios/run.ts --emit-matrix | jq -r '.[].runner' | sort -u
linux-amd64-gpu-rtxpro6000-latest-1
macos-26
ubuntu-latest
windows-latest
```

## Test depth

Unit tests are sufficient — this is a build/CI plumbing change, not a behavioral change to the test runner or scenarios themselves. The actual scenario execution path (`e2e-scenarios.yaml`) is unchanged. After merge, the next manual `workflow_dispatch` of `E2E / Scenario Runner / All` will validate the matrix end-to-end.

## Follow-ups (separate PRs)

- Delete the now-dead `ROUTES` bash map in `e2e-scenarios.yaml` and have its `resolve-runner` job consume `runner-routing.ts` too.
- Consider sharding `e2e-scenarios-all.yaml` by platform once we cross ~80 scenarios (currently at 22, plenty of headroom against the 256-job GHA ceiling).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating scenario matrix generation, runner selection, and error cases for invalid or missing platform/override values.

* **Chores**
  * CI now builds a dynamic test matrix at runtime and runs one job per scenario; fails early if the matrix is empty.
  * Scenario runner can emit a deterministic matrix JSON for the workflow and produces human-readable job labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->