### PR TITLE
docs: refresh v0.0.53 notes and skill links

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -73,6 +73,7 @@ NemoClaw lists installed models or offers starter models if none are installed.
 On hosts where the larger starter models fit the currently available GPU memory, the starter list includes `qwen3.6:35b` and selects it by default.
 When another GPU workload is using most of the memory at onboard time, NemoClaw downgrades the menu to the largest model that still fits.
 It pulls the selected model, loads it into memory, and validates it before continuing.
+When Ollama reports a loaded-model context length, NemoClaw uses that value for the `contextWindow` baked into `openclaw.json` unless you set `NEMOCLAW_CONTEXT_WINDOW` yourself.
 If the selected model declares that it does not support tool calling, onboarding stops with guidance to choose a model whose `ollama show <model>` capabilities include `tools`.
 The validation also requires structured chat-completions tool calls.
 If the model leaks tool-call JSON as plain message text, onboarding stops so you can choose a model that returns tool calls in the expected response field.

--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -101,7 +101,7 @@ Ollama is convenient for local chat, but some model/template combinations can
 return tool calls as plain text under realistic agent load. If the TUI shows raw
 JSON such as `{"name":"memory_search","arguments":{...}}` instead of running a
 tool, switch to vLLM with `--enable-auto-tool-choice` and the correct
-`--tool-call-parser`. See Tool-Calling Reliability (use the `nemoclaw-user-configure-inference` skill).
+`--tool-call-parser`. See [Tool-Calling Reliability](references/tool-calling-reliability.md).
 
 ### Authenticated Reverse Proxy
 
@@ -253,7 +253,7 @@ You can use this variable in both interactive and non-interactive mode.
 If you already onboarded and the sandbox is failing at runtime, re-run
 `nemoclaw onboard` to re-probe the endpoint and bake the correct API path
 into the image.
-Refer to Switch Inference Models (use the `nemoclaw-user-configure-inference` skill) for details.
+Refer to [Switch Inference Models](references/switch-inference-providers.md) for details.
 
 ## Anthropic-Compatible Server
 
@@ -431,7 +431,7 @@ If `Inference` is healthy but `Inference (auth proxy)` is not, rerun onboarding 
 ## Switch Models at Runtime
 
 You can change the model without re-running onboard.
-Refer to Switch Inference Models (use the `nemoclaw-user-configure-inference` skill) for the full procedure.
+Refer to [Switch Inference Models](references/switch-inference-providers.md) for the full procedure.
 
 For compatible endpoints, the command is:
 
@@ -450,4 +450,7 @@ If the provider itself needs to change (for example, switching from vLLM to a cl
 
 ## Related Skills
 
+- [Inference Options](references/inference-options.md) for the full list of providers available during onboarding.
+- [Tool-Calling Reliability](references/tool-calling-reliability.md) for diagnosing raw JSON tool-call output with local models.
+- [Switch Inference Models](references/switch-inference-providers.md) for runtime model switching.
 - `nemoclaw-user-get-started` — Quickstart (use the `nemoclaw-user-get-started` skill) for first-time installation

--- a/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
@@ -50,7 +50,7 @@ The managed install/start vLLM entry appears by default on DGX Spark and DGX Sta
 | Other Anthropic-compatible endpoint | Routes to any server that implements the Anthropic Messages API (`/v1/messages`). The wizard prompts for a base URL and model name. Set `COMPATIBLE_ANTHROPIC_API_KEY`. | You provide the model name. |
 | Google Gemini | Routes to Google's OpenAI-compatible chat-completions endpoint. NemoClaw skips the Responses-API probe because Gemini does not support `/v1/responses`. Set `GEMINI_API_KEY`. | `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | Hermes Provider | Routes Hermes Agent through the host OpenShell provider registered by NemoClaw when onboarding Hermes Agent. | Curated Hermes Provider models such as `moonshotai/kimi-k2.6`, `openai/gpt-5.4-mini`, and `z-ai/glm-5.1`. |
-| Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill). |
+| Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to [Use a Local Inference Server](../SKILL.md). |
 | Model Router | Starts a host-side router on port `4000`, registers it as an OpenAI-compatible provider, and keeps the sandbox pointed at `inference.local`. Set `NEMOCLAW_PROVIDER=routed` for non-interactive setup. | The router pool defines the model names. |
 
 ## Choosing the Right Option for Nemotron
@@ -114,7 +114,7 @@ An already-running vLLM server appears directly in the onboarding selection list
 | Local NVIDIA NIM | NIM-capable GPU detected | Pulls and manages a NIM container. |
 | Local vLLM | vLLM running on `localhost:8000`, or a supported DGX Spark, DGX Station, or Linux NVIDIA GPU profile | Auto-detects the loaded model when vLLM is already running. Can install or start a managed vLLM container by default on DGX Spark/Station and after opt-in on generic Linux NVIDIA GPU hosts. |
 
-For setup instructions, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill).
+For setup instructions, refer to [Use a Local Inference Server](../SKILL.md).
 
 ## Validation
 
@@ -137,6 +137,6 @@ Other provider credentials, such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMI
 
 ## Next Steps
 
-- Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill) for Ollama, vLLM, NIM, and compatible-endpoint setup details.
-- Tool-Calling Reliability (use the `nemoclaw-user-configure-inference` skill) for deciding when Ollama is enough and when vLLM with a parser is safer.
-- Switch Inference Models (use the `nemoclaw-user-configure-inference` skill) for changing the model at runtime without re-onboarding.
+- [Use a Local Inference Server](../SKILL.md) for Ollama, vLLM, NIM, and compatible-endpoint setup details.
+- [Tool-Calling Reliability](tool-calling-reliability.md) for deciding when Ollama is enough and when vLLM with a parser is safer.
+- [Switch Inference Models](switch-inference-providers.md) for changing the model at runtime without re-onboarding.

--- a/.agents/skills/nemoclaw-user-configure-inference/references/set-up-sub-agent.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/set-up-sub-agent.md
@@ -116,5 +116,5 @@ Use the [`vlm-demo`](https://github.com/brevdev/nemoclaw-demos/tree/main/vlm-dem
 Use the following resources for more information:
 
 - Refer to [OpenClaw Sub-Agents](https://docs.openclaw.ai/tools/subagents) for `sessions_spawn`, `agents.list`, nesting, tool policy, and auth behavior.
-- Refer to Switch Inference Providers (use the `nemoclaw-user-configure-inference` skill) to change the primary orchestration model instead of adding a sub-agent model.
+- Refer to [Switch Inference Providers](switch-inference-providers.md) to change the primary orchestration model instead of adding a sub-agent model.
 - Refer to Workspace Files (use the `nemoclaw-user-manage-sandboxes` skill) to understand per-agent workspace directories.

--- a/.agents/skills/nemoclaw-user-configure-inference/references/switch-inference-providers.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/switch-inference-providers.md
@@ -123,6 +123,7 @@ To change these values, set the corresponding environment variables before runni
 | `NEMOCLAW_AGENT_HEARTBEAT_EVERY` | Go-style duration (`30m`, `1h`, `0m` to disable) | `unset` (OpenClaw default) |
 
 Invalid values are ignored, and the default bakes into the image.
+For Local Ollama, onboarding loads the selected model first and uses Ollama's reported runtime context length when `NEMOCLAW_CONTEXT_WINDOW` is unset.
 Use `NEMOCLAW_INFERENCE_INPUTS=text,image` only for a model that accepts image input through the selected provider.
 
 ```console

--- a/.agents/skills/nemoclaw-user-configure-inference/references/switch-inference-providers.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/switch-inference-providers.md
@@ -204,4 +204,4 @@ The status output includes the active provider, model, and endpoint with the res
 
 ## Related Topics
 
-- Inference Options (use the `nemoclaw-user-configure-inference` skill) for the full list of providers available during onboarding.
+- [Inference Options](inference-options.md) for the full list of providers available during onboarding.

--- a/.agents/skills/nemoclaw-user-configure-inference/references/tool-calling-reliability.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/tool-calling-reliability.md
@@ -159,6 +159,6 @@ model.
 
 ## Next Steps
 
-- Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill)
-- Inference Options (use the `nemoclaw-user-configure-inference` skill)
-- Switch Inference Models (use the `nemoclaw-user-configure-inference` skill)
+- [Use a Local Inference Server](../SKILL.md)
+- [Inference Options](inference-options.md)
+- [Switch Inference Models](switch-inference-providers.md)

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -182,13 +182,13 @@ Writable agent state such as plugins, skills, hooks, and workspace metadata live
 By default, this directory starts writable so the agent can manage its own config, install skills, and write to standard home-directory paths natively.
 For sensitive workloads, use a reviewed host-side immutability workflow after initial setup so config and writable state entry points cannot be changed by the sandbox user.
 
-- **DAC permissions (default).** The sandbox user owns `/sandbox/.openclaw` with mode `700` and `openclaw.json` with mode `600`, so the agent can read and write config directly.
+- **DAC permissions (default).** The sandbox user owns `/sandbox/.openclaw` with mode `2770` (setgid `sandbox:sandbox`) and `openclaw.json` with mode `660`, so the agent and its group can read and write config directly. A reviewed host-side immutability workflow should compare the intended ownership and mode with the live sandbox filesystem before treating the config tree as locked.
 - **Config integrity hash.** The image includes a SHA256 hash of `openclaw.json`. In the default mutable state, `.config-hash` is sandbox-owned and is not a tamper-proof trust anchor, so startup does not fail closed on that hash. When the hash is root-owned and read-only, startup enforces it and refuses to start if the hash does not match.
 - **Gateway token environment.** The gateway exports `OPENCLAW_GATEWAY_TOKEN` and writes it to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions. Keep this in mind when deciding whether a workload should run with mutable config or an immutable config posture.
 
 | Aspect | Detail |
 |---|---|
-| Default | The sandbox keeps `/sandbox/.openclaw` writable (`700 sandbox:sandbox`), sets `openclaw.json` to `600 sandbox:sandbox`, lets the agent manage state directly, and has the gateway place `OPENCLAW_GATEWAY_TOKEN` in `/tmp/nemoclaw-proxy-env.sh` for interactive shells. |
+| Default | The sandbox keeps `/sandbox/.openclaw` writable (`2770 sandbox:sandbox`), sets `openclaw.json` to `660 sandbox:sandbox`, lets the agent manage state directly, and has the gateway place `OPENCLAW_GATEWAY_TOKEN` in `/tmp/nemoclaw-proxy-env.sh` for interactive shells. |
 | What you can change | Apply a reviewed host-side immutability workflow to lock config and state directories with DAC permissions and the immutable flag where available. |
 | Risk of default | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. |
 | Recommendation | For always-on assistants handling sensitive workloads, lock config after initial setup. For development workflows, the writable default is appropriate. |

--- a/.agents/skills/nemoclaw-user-configure-security/references/credential-storage.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/credential-storage.md
@@ -107,4 +107,4 @@ On the next run NemoClaw prompts again unless the credential is supplied through
 
 ## Related Files
 
-For the broader sandbox security model and operational trade-offs, see Security Best Practices (use the `nemoclaw-user-configure-security` skill) and Architecture (use the `nemoclaw-user-reference` skill).
+For the broader sandbox security model and operational trade-offs, see [Security Best Practices](best-practices.md) and Architecture (use the `nemoclaw-user-reference` skill).

--- a/.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/openclaw-controls.md
@@ -117,5 +117,5 @@ The implementation detects unsafe nested quantifiers, bounds input length, and c
 
 ## Next Steps
 
-- Security Best Practices (use the `nemoclaw-user-configure-security` skill) for NemoClaw's own security controls and risk framework.
-- Credential Storage (use the `nemoclaw-user-configure-security` skill) for how NemoClaw stores and protects provider credentials.
+- [Security Best Practices](best-practices.md) for NemoClaw's own security controls and risk framework.
+- [Credential Storage](credential-storage.md) for how NemoClaw stores and protects provider credentials.

--- a/.agents/skills/nemoclaw-user-deploy-remote/references/brev-web-ui.md
+++ b/.agents/skills/nemoclaw-user-deploy-remote/references/brev-web-ui.md
@@ -8,7 +8,7 @@ This flow provisions a remote VM, configures inference, starts OpenClaw inside a
 **Note:**
 
 Use this guide when you want to try NemoClaw without installing the CLI or using a local GPU.
-If you want to manage the remote host from a terminal, see Deploy to a Remote GPU Instance (use the `nemoclaw-user-deploy-remote` skill).
+If you want to manage the remote host from a terminal, see [Deploy to a Remote GPU Instance](../SKILL.md).
 
 ## What This Flow Creates
 
@@ -151,5 +151,5 @@ After your agent is running, explore these related tasks:
 - Set Up Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill) to learn how to connect Telegram, Slack, or Discord.
 - Switch Inference Providers (use the `nemoclaw-user-configure-inference` skill) to learn how to change the model provider after setup.
 - Monitor Sandbox Activity (use the `nemoclaw-user-monitor-sandbox` skill) to learn how to inspect sandbox health and logs.
-- Deploy to a Remote GPU Instance (use the `nemoclaw-user-deploy-remote` skill) to learn how to deploy NemoClaw to a remote GPU instance using the CLI.
+- [Deploy to a Remote GPU Instance](../SKILL.md) to learn how to deploy NemoClaw to a remote GPU instance using the CLI.
 - Troubleshooting (use the `nemoclaw-user-reference` skill) to learn how to fix common setup and runtime issues.

--- a/.agents/skills/nemoclaw-user-deploy-remote/references/install-openclaw-plugins.md
+++ b/.agents/skills/nemoclaw-user-deploy-remote/references/install-openclaw-plugins.md
@@ -85,7 +85,7 @@ other NemoClaw extension paths.
 
 ## Next Steps
 
-- Review Sandbox Hardening (use the `nemoclaw-user-deploy-remote` skill) before adding plugin code to a
+- Review [Sandbox Hardening](sandbox-hardening.md) before adding plugin code to a
   shared or long-lived sandbox.
 - Review Network Policies (use the `nemoclaw-user-reference` skill) to plan plugin
   egress rules.

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -12,7 +12,7 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 
 **Note:**
 
-Make sure you have completed reviewing the Prerequisites (use the `nemoclaw-user-get-started` skill) before following this guide.
+Make sure you have completed reviewing the [Prerequisites](references/prerequisites.md) before following this guide.
 
 ## Install NemoClaw and Onboard OpenClaw Agent
 

--- a/.agents/skills/nemoclaw-user-get-started/references/prerequisites.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/prerequisites.md
@@ -65,5 +65,5 @@ The table is generated from [`ci/platform-matrix.json`](https://github.com/NVIDI
 
 ## Next Steps
 
-- Prepare Windows for NemoClaw (use the `nemoclaw-user-get-started` skill) if you are using Windows.
-- Quickstart (use the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox.
+- [Prepare Windows for NemoClaw](windows-preparation.md) if you are using Windows.
+- [Quickstart](../SKILL.md) to install NemoClaw and launch your first sandbox.

--- a/.agents/skills/nemoclaw-user-get-started/references/quickstart-hermes.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/quickstart-hermes.md
@@ -10,7 +10,7 @@ The `nemohermes` command is an alias for `nemoclaw` with the Hermes agent pre-se
 The Hermes agent option is experimental.
 Interfaces, defaults, and supported features may change without notice, and it is not recommended for production use.
 
-Review the Prerequisites (use the `nemoclaw-user-get-started` skill) before starting.
+Review the [Prerequisites](prerequisites.md) before starting.
 The first Hermes build can take several minutes because NemoClaw builds the Hermes sandbox base image if it is not already cached.
 
 ## Install and Onboard
@@ -44,7 +44,7 @@ Sandbox name [hermes]: my-hermes
 
 Choose the inference provider that matches where you want Hermes model traffic to go.
 The provider options and credential environment variables are the same as the standard NemoClaw quickstart.
-For provider-specific prompts, refer to the Respond to the Onboard Wizard (use the `nemoclaw-user-get-started` skill) section and the Inference Options (use the `nemoclaw-user-configure-inference` skill) page.
+For provider-specific prompts, refer to the [Respond to the Onboard Wizard](../SKILL.md#respond-to-the-onboard-wizard) section and the Inference Options (use the `nemoclaw-user-configure-inference` skill) page.
 The Hermes wizard does not ask for Brave Web Search because Hermes does not use NemoClaw's OpenClaw web-search configuration.
 
 After provider and policy selection, review the summary and confirm the build.

--- a/.agents/skills/nemoclaw-user-get-started/references/windows-preparation.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/windows-preparation.md
@@ -3,7 +3,7 @@
 # Prepare Windows for NemoClaw
 
 You can run NemoClaw inside Windows Subsystem for Linux (WSL 2) on Windows.
-Complete these steps before following the Quickstart (use the `nemoclaw-user-get-started` skill).
+Complete these steps before following the [Quickstart](../SKILL.md).
 Linux and macOS users do not need this page and can go directly to the Quickstart.
 
 **Note:**
@@ -15,7 +15,7 @@ This guide has been tested on x86-64.
 Verify the following before you begin:
 
 - Windows 10 (build 19041 or later) or Windows 11.
-- Hardware requirements are the same as the Quickstart (use the `nemoclaw-user-get-started` skill).
+- Hardware requirements are the same as the [Quickstart](../SKILL.md).
 
 ## Option: Use the Bootstrap Script
 
@@ -137,7 +137,7 @@ Use one instance, or move one of them to a different port before running `nemocl
 
 Your Windows environment is ready.
 If you used the bootstrap script, follow the installer command it printed inside Ubuntu.
-If you prepared Windows manually, open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the Quickstart (use the `nemoclaw-user-get-started` skill) to install NemoClaw and launch your first sandbox.
+If you prepared Windows manually, open a WSL terminal (type `wsl` in PowerShell, or open Ubuntu from Windows Terminal) and continue with the [Quickstart](../SKILL.md) to install NemoClaw and launch your first sandbox.
 
 All NemoClaw commands run inside WSL, not in PowerShell.
 

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -158,7 +158,7 @@ This is useful when you want to test a destination before deciding whether it be
 
 NemoClaw ships preset policy files for common integrations in `nemoclaw-blueprint/policies/presets/`.
 Apply a preset as-is or use it as a starting template for a custom policy.
-For guided post-install examples, see Common Integration Policy Examples (use the `nemoclaw-user-manage-policy` skill).
+For guided post-install examples, see [Common Integration Policy Examples](references/integration-policy-examples.md).
 
 During onboarding, the policy tier (use the `nemoclaw-user-reference` skill) you select determines which presets are enabled by default.
 You can add or remove individual presets in the interactive preset screen that follows tier selection.
@@ -295,6 +295,8 @@ $ nemoclaw my-assistant policy-remove my-internal-api --yes
 
 ## Related Skills
 
+- [Approve or Deny Agent Network Requests](references/approve-network-requests.md) for real-time operator approval.
+- [Common Integration Policy Examples](references/integration-policy-examples.md) for maintained preset examples such as Outlook, messaging, GitHub, Jira, Brave Search, package managers, Hugging Face, and local inference.
 - `nemoclaw-user-reference` — Network Policies (use the `nemoclaw-user-reference` skill) for the full baseline policy reference
 - OpenShell [Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) for the full YAML policy schema reference.
 - OpenShell [Sandbox Policies](https://docs.nvidia.com/openshell/latest/sandboxes/policies.html) for applying, iterating, and debugging policies at the OpenShell layer.

--- a/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/SKILL.md
@@ -175,6 +175,7 @@ Available presets:
 | `jira` | Atlassian Jira API |
 | `local-inference` | Local Ollama and vLLM through the host gateway |
 | `npm` | npm and Yarn registries |
+| `openclaw-pricing` | OpenClaw model-pricing reference fetch (LiteLLM and OpenRouter) |
 | `outlook` | Microsoft 365 and Outlook |
 | `pypi` | Python Package Index |
 | `slack` | Slack API and webhooks |

--- a/.agents/skills/nemoclaw-user-manage-policy/references/approve-network-requests.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/references/approve-network-requests.md
@@ -44,7 +44,7 @@ The TUI presents an approval prompt for each blocked request.
 
 Approved endpoints remain in the running policy until the sandbox stops.
 They are not persisted to the baseline policy file.
-To keep an endpoint allowed after a restart, update the policy YAML or apply a preset as described in Customize the Sandbox Network Policy (use the `nemoclaw-user-manage-policy` skill).
+To keep an endpoint allowed after a restart, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](../SKILL.md).
 
 ## Run the Walkthrough
 
@@ -59,6 +59,6 @@ The walkthrough requires tmux and the `NVIDIA_API_KEY` environment variable, and
 
 ## Related Topics
 
-- Customize the Sandbox Network Policy (use the `nemoclaw-user-manage-policy` skill) to add endpoints permanently.
+- [Customize the Sandbox Network Policy](../SKILL.md) to add endpoints permanently.
 - Network Policies (use the `nemoclaw-user-reference` skill) for the full baseline policy reference.
 - Monitor Sandbox Activity (use the `nemoclaw-user-monitor-sandbox` skill) for general sandbox monitoring.

--- a/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
@@ -330,7 +330,7 @@ Use `nemoclaw my-assistant policy-add` for maintained NemoClaw presets.
 
 ## Next Steps
 
-- Approve or Deny Agent Network Requests (use the `nemoclaw-user-manage-policy` skill) for the interactive OpenShell TUI flow.
-- Customize the Sandbox Network Policy (use the `nemoclaw-user-manage-policy` skill) for static policy edits and raw OpenShell policy files.
+- [Approve or Deny Agent Network Requests](approve-network-requests.md) for the interactive OpenShell TUI flow.
+- [Customize the Sandbox Network Policy](../SKILL.md) for static policy edits and raw OpenShell policy files.
 - Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill) for Telegram, Discord, Slack, WeChat, and WhatsApp channel configuration.
 - Commands (use the `nemoclaw-user-reference` skill) for the full `policy-add`, `policy-list`, `policy-remove`, and `channels` command reference.

--- a/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
+++ b/.agents/skills/nemoclaw-user-manage-policy/references/integration-policy-examples.md
@@ -45,6 +45,7 @@ NemoClaw ships maintained policy presets for common services in `nemoclaw-bluepr
 | Hugging Face Hub and Inference API | `huggingface` |
 | Jira and Atlassian Cloud | `jira` |
 | Local Ollama or vLLM through the host gateway | `local-inference` |
+| OpenClaw model-pricing reference fetch | `openclaw-pricing` |
 | npm and Yarn packages | `npm` |
 | Microsoft 365, Outlook, and Graph API | `outlook` |
 | Python Package Index | `pypi` |
@@ -268,6 +269,23 @@ $ nemoclaw my-assistant exec -- brew install <formula>
 ```
 
 You do not need to bootstrap Homebrew, install build dependencies, or source `brew shellenv` inside the sandbox.
+
+## Model Pricing
+
+OpenClaw's gateway fetches reference pricing from LiteLLM and OpenRouter on every start so it can populate `usage.cost` in session JSONL records.
+The default-strict egress policy denies both hosts.
+The fetch fails closed, the gateway logs `[gateway/model-pricing] LiteLLM pricing fetch failed: TypeError: fetch failed` (and the matching OpenRouter line) on every startup, and every session record records `usage.cost = 0` even though the input and output token counts populate correctly.
+Tools that read the session log to display per-turn cost (audit dashboards, compliance review surfaces) cannot distinguish a real free run from this silent failure.
+
+Apply the `openclaw-pricing` preset to allow both pricing endpoints.
+The preset pins each host to a single read-only path so it does not widen egress beyond the pricing fetch:
+
+```console
+$ nemoclaw my-assistant policy-add openclaw-pricing --dry-run
+$ nemoclaw my-assistant policy-add openclaw-pricing --yes
+```
+
+After the next gateway restart the WARN entries stop and `usage.cost` populates from the fetched pricing tables.
 
 ## Local Inference
 

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/SKILL.md
@@ -229,7 +229,7 @@ Aborts before the destroy step are non-destructive.
 The flow refuses to proceed past preflight if a credential is missing or past backup if required manifest-defined state cannot be copied, so a failed run leaves the original sandbox intact and ready to retry.
 When a backup command reports partial archive output, NemoClaw keeps the usable entries and reports only the manifest-defined paths that could not be archived.
 
-See Backup and Restore (use the `nemoclaw-user-manage-sandboxes` skill) for the full list of state-preservation guarantees, snapshot retention, and instructions for manual backups when the auto-flow is not enough.
+See [Backup and Restore](references/backup-restore.md) for the full list of state-preservation guarantees, snapshot retention, and instructions for manual backups when the auto-flow is not enough.
 
 **If the rebuild aborts with `Missing credential: <KEY>`:**
 
@@ -279,4 +279,7 @@ For a full comparison of the two forms, including what they fetch, what they tru
 
 ## Related Skills
 
+- [Set Up Messaging Channels](references/messaging-channels.md) to connect Telegram, Discord, or Slack.
+- [Workspace Files](references/workspace-files.md) for persistent OpenClaw files inside the sandbox.
+- [Backup and Restore](references/backup-restore.md) for snapshot and restore workflows.
 - `nemoclaw-user-monitor-sandbox` — Monitor Sandbox Activity (use the `nemoclaw-user-monitor-sandbox` skill) for observability tools

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/backup-restore.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/backup-restore.md
@@ -140,7 +140,7 @@ memory/
 
 When OpenClaw is configured with multiple named agents, each agent has its own
 workspace directory (`workspace-main/`, `workspace-support/`, `workspace-ops/`,
-and so on — see Multi-Agent Deployments (use the `nemoclaw-user-manage-sandboxes` skill)).
+and so on — see [Multi-Agent Deployments](workspace-files.md#multi-agent-deployments)).
 
 `nemoclaw <name> snapshot create` automatically discovers every `workspace-*/`
 directory under the sandbox state tree and includes it in the snapshot bundle
@@ -162,5 +162,5 @@ editing, or maintain a host-side sync layer. Tracking shared-file tooling
 
 ## Next Steps
 
-- Workspace Files overview (use the `nemoclaw-user-manage-sandboxes` skill) to learn what each file does
+- [Workspace Files overview](workspace-files.md) to learn what each file does
 - Commands reference (use the `nemoclaw-user-reference` skill)

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/runtime-controls.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/runtime-controls.md
@@ -33,7 +33,7 @@ If a row above conflicts with what you observe, the runtime source of truth insi
 
 The mutability table above is a consolidated index of information that lives in more detail on per-topic pages:
 
-- Manage Sandbox Lifecycle (use the `nemoclaw-user-manage-sandboxes` skill) — full rebuild / re-onboard / upgrade workflow.
+- [Manage Sandbox Lifecycle](../SKILL.md) — full rebuild / re-onboard / upgrade workflow.
 - Switch Inference Providers (use the `nemoclaw-user-configure-inference` skill) — the rebuild path for provider and model changes.
 - Customize Network Policy (use the `nemoclaw-user-manage-policy` skill) and Approve Network Requests (use the `nemoclaw-user-manage-policy` skill) — runtime policy editing and operator approval flow.
 - Security Best Practices (use the `nemoclaw-user-configure-security` skill) — the per-attack-surface posture table that this page complements.

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/workspace-files.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/workspace-files.md
@@ -88,7 +88,7 @@ Workspace files are removed from the sandbox unless you created a snapshot or ba
 **Warning:**
 
 Back up your workspace files before running `nemoclaw <name> destroy`.
-See Backup and Restore (use the `nemoclaw-user-manage-sandboxes` skill) for instructions.
+See [Backup and Restore](backup-restore.md) for instructions.
 
 ## Editing Workspace Files
 
@@ -101,5 +101,5 @@ You can edit them in two ways:
 ## Next Steps
 
 - Set Up Task-Specific Sub-Agents (use the `nemoclaw-user-configure-inference` skill)
-- Backup and Restore workspace files (use the `nemoclaw-user-manage-sandboxes` skill)
+- [Backup and Restore workspace files](backup-restore.md)
 - Commands reference (use the `nemoclaw-user-reference` skill)

--- a/.agents/skills/nemoclaw-user-overview/references/ecosystem.md
+++ b/.agents/skills/nemoclaw-user-overview/references/ecosystem.md
@@ -89,6 +89,6 @@ Use the following table to decide when to use NemoClaw versus OpenShell.
 
 ## Related topics
 
-- Overview (use the `nemoclaw-user-overview` skill) contains what NemoClaw is, capabilities, benefits, and use cases.
-- How It Works (use the `nemoclaw-user-overview` skill) describes how NemoClaw runs, plugin, blueprint, sandbox creation, routing, protection layers.
+- [Overview](overview.md) contains what NemoClaw is, capabilities, benefits, and use cases.
+- [How It Works](how-it-works.md) describes how NemoClaw runs, plugin, blueprint, sandbox creation, routing, protection layers.
 - Architecture (use the `nemoclaw-user-reference` skill) shows the repository structure and technical diagrams.

--- a/.agents/skills/nemoclaw-user-overview/references/how-it-works.md
+++ b/.agents/skills/nemoclaw-user-overview/references/how-it-works.md
@@ -98,7 +98,7 @@ For details on the baseline rules, refer to Network Policies (use the `nemoclaw-
 
 ## Next Steps
 
-- Read Ecosystem (use the `nemoclaw-user-overview` skill) for stack-level relationships and NemoClaw versus OpenShell-only paths.
+- Read [Ecosystem](ecosystem.md) for stack-level relationships and NemoClaw versus OpenShell-only paths.
 - Follow the Quickstart (use the `nemoclaw-user-get-started` skill) to launch your first sandbox.
 - Refer to the Architecture (use the `nemoclaw-user-reference` skill) for the full technical structure, including file layouts and the blueprint lifecycle.
 - Refer to Inference Options (use the `nemoclaw-user-configure-inference` skill) for detailed provider configuration.

--- a/.agents/skills/nemoclaw-user-overview/references/overview.md
+++ b/.agents/skills/nemoclaw-user-overview/references/overview.md
@@ -57,7 +57,7 @@ You can use NemoClaw for various use cases including the following.
 
 Navigate to the following topics to learn more about NemoClaw and how to install and use it.
 
-- Architecture Overview (use the `nemoclaw-user-overview` skill) to understand how NemoClaw works.
-- Ecosystem (use the `nemoclaw-user-overview` skill) to understand how OpenClaw, OpenShell, and NemoClaw relate in the wider stack, and when to use NemoClaw versus OpenShell.
+- [Architecture Overview](how-it-works.md) to understand how NemoClaw works.
+- [Ecosystem](ecosystem.md) to understand how OpenClaw, OpenShell, and NemoClaw relate in the wider stack, and when to use NemoClaw versus OpenShell.
 - Quickstart (use the `nemoclaw-user-get-started` skill) to install NemoClaw and run your first sandboxed agent.
 - Inference Options (use the `nemoclaw-user-configure-inference` skill) to check the inference providers that NemoClaw supports and how inference routing works.

--- a/.agents/skills/nemoclaw-user-overview/references/release-notes.md
+++ b/.agents/skills/nemoclaw-user-overview/references/release-notes.md
@@ -4,6 +4,19 @@
 
 NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use this page to track changes.
 
+## v0.0.53
+
+NemoClaw v0.0.53 focuses on safer sandbox recreation, stricter onboarding preflight defaults, local inference reliability, policy coverage, and day-two repair workflows:
+
+- `nemoclaw onboard` backs up workspace state before deleting an existing sandbox during recreation, including sandboxes that are registered but not ready. If the backup is partial or fails, onboarding aborts before delete so workspace, skills, extensions, identity, memory, messaging state, and credentials are not silently dropped. Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` only when you intentionally want a fresh workspace.
+- Under-provisioned container-runtime warnings now default to abort in interactive onboarding. Pressing Enter at the warning stops the run so you can resize Docker Desktop or Colima before the sandbox build stalls. Non-interactive runs continue with a warning, and `NEMOCLAW_IGNORE_RUNTIME_RESOURCES=1` still suppresses the check when you have already accepted the resource trade-off.
+- OpenClaw sandboxes can use the new `openclaw-pricing` policy preset for model-pricing reference fetches from LiteLLM and OpenRouter. NemoClaw suggests this preset during OpenClaw onboarding so session JSONL records can populate `usage.cost` without widening egress beyond the two read-only pricing endpoints.
+- Local Ollama onboarding is more accurate. NemoClaw validates the `/api/tags` response body through the authenticated proxy, honors accepted no-tools overrides through validation and proxy setup, and uses Ollama's reported runtime context length for `contextWindow` unless you set `NEMOCLAW_CONTEXT_WINDOW`.
+- Onboarding and gateway reuse recover from more host-runtime drift. NemoClaw recovers stopped gateways before preserving PVC-backed state, verifies gateway containers before reusing port-conflict state, defers Docker-driver gateway teardown until step `[2/8]`, records Docker-driver sandboxes on macOS, and uses Docker `--gpus` rather than CDI repair on WSL Docker Desktop.
+- The sandbox and integration paths handle more common failures cleanly, including Brave Search credential rewrite through OpenShell providers, Telegram placeholder repair, host-gateway `web_fetch` routing, read-only host targets for `share mount`, live gateway drift in `list`, host-alias Kubernetes invocations, Jetson bridge DNS preflight failures, and non-ready sandboxes during maintenance backups.
+- Hermes startup no longer treats a fresh root-entrypoint layout as locked state, which avoids false locked-layout detection during sandbox boot.
+- Maintainer tooling can export a signed skills catalog, detect untracked files during skills refresh diffs, and run the stale-issue verification workflow added for maintainers.
+
 ## v0.0.52
 
 NemoClaw v0.0.52 upgrades the bundled OpenClaw runtime, repairs Hermes sandbox startup, restores onboarding ready output, and hardens Slack onboarding, Windows bootstrap, and private-network handling:

--- a/.agents/skills/nemoclaw-user-reference/references/cli-selection-guide.md
+++ b/.agents/skills/nemoclaw-user-reference/references/cli-selection-guide.md
@@ -198,7 +198,7 @@ Use `openshell sandbox upload` and `openshell sandbox download` for manual file 
 
 ## Related Topics
 
-- Commands (use the `nemoclaw-user-reference` skill) for the full NemoClaw command reference.
+- [Commands](commands.md) for the full NemoClaw command reference.
 - Manage Sandbox Lifecycle (use the `nemoclaw-user-manage-sandboxes` skill) for day-two operations.
 - Switch Inference Models (use the `nemoclaw-user-configure-inference` skill) for inference route examples.
 - Customize the Network Policy (use the `nemoclaw-user-manage-policy` skill) for persistent network access changes.

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -113,9 +113,8 @@ NemoClaw filters tier suggestions and resume selections by active agent support,
 | `custom` | Apply exactly `NEMOCLAW_POLICY_PRESETS`. Previously-applied presets not in the list are removed. Alias: `list`. |
 | `skip` | Skip the policy step entirely. Aliases: `none`, `no`. |
 
-If you enable Brave Search during onboarding, NemoClaw currently stores the Brave API key in the sandbox's OpenClaw configuration.
-That means the OpenClaw agent can read the key.
-NemoClaw explores an OpenShell-hosted credential path first, but the current OpenClaw Brave runtime does not consume that path end to end yet.
+If you enable Brave Search during onboarding, NemoClaw registers a Brave Search OpenShell provider and keeps `openclaw.json` on an OpenShell credential placeholder.
+At egress, OpenShell rewrites Brave's `X-Subscription-Token` header with the real `BRAVE_API_KEY`.
 Treat Brave Search as an explicit opt-in and use a dedicated low-privilege Brave key.
 
 For non-interactive onboarding, you must explicitly accept the third-party software notice:
@@ -178,6 +177,13 @@ In interactive mode, the wizard asks for confirmation before delete and recreate
 In non-interactive mode, NemoClaw recreates automatically when the stored selection is readable and differs; if NemoClaw cannot read the stored selection, NemoClaw reuses by default.
 Set `NEMOCLAW_RECREATE_SANDBOX=1` to force recreation even when no drift is detected.
 
+Before deleting an existing sandbox during recreation, NemoClaw backs up the workspace state (agents, extensions, workspace, skills, hooks, identity, devices, canvas, cron, memory, telegram, wechat, credentials) and restores it into the new sandbox once it is live.
+This applies whether the existing sandbox is ready or marked not-ready, so cross-version upgrades that pass `NEMOCLAW_RECREATE_SANDBOX=1` no longer drop user files under `/sandbox/.openclaw/workspace/`.
+The behaviour matches `nemoclaw <name> rebuild --force`.
+NemoClaw aborts the recreate when the backup cannot complete in full — including when individual state directories or files fail mid-backup — so failed entries are not silently dropped on delete.
+Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` to skip the pre-recreate backup.
+The destination sandbox starts with a fresh workspace.
+
 Before creating the gateway, the wizard runs preflight checks.
 It verifies that Docker is reachable, warns on untested runtimes such as Podman, and prints host remediation guidance when prerequisites are missing.
 The preflight also enforces the OpenShell version range declared in the blueprint (`min_openshell_version` and `max_openshell_version`).
@@ -187,6 +193,9 @@ If release metadata is unavailable, the installer uses its bundled fallback pin 
 
 When NemoClaw finds an existing gateway to reuse, it probes the host gateway HTTP endpoint before declaring the gateway reusable.
 If the container is running but the upstream is still warming up (for example, immediately after a Docker daemon restart), NemoClaw rebuilds the gateway instead of trusting stale metadata.
+On the Docker-driver gateway path, preflight stays read-only when it detects a stale gateway (for example, a Docker-driver runtime env hash drift).
+It prints a `⚠ Gateway will be recreated when sandbox creation starts` notice and defers the actual teardown to step `[2/8] Starting OpenShell gateway`.
+This means pressing `Ctrl+C` between preflight and step `[2/8]` leaves the running gateway and existing sandbox containers untouched, so `nemoclaw onboard` is safe to run just to check preflight output.
 For Linux Docker-driver gateways, onboarding also checks that a helper container on the OpenShell Docker network can reach `host.openshell.internal:<gateway-port>`.
 If a host firewall blocks that sandbox path, onboarding exits with a `sudo ufw allow from <subnet> to any port <gateway-port> proto tcp` command before it reports the gateway healthy.
 Tune the wait via `NEMOCLAW_REUSE_HEALTH_POLL_COUNT` (default `6`) and `NEMOCLAW_REUSE_HEALTH_POLL_INTERVAL` (default `5` seconds).

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -4,7 +4,7 @@
 
 The `nemoclaw` CLI is the primary interface for managing NemoClaw sandboxes.
 It is installed automatically by the installer (`curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash`).
-For guidance on when to use `nemoclaw` versus the underlying `openshell` CLI, see CLI Selection Guide (use the `nemoclaw-user-reference` skill).
+For guidance on when to use `nemoclaw` versus the underlying `openshell` CLI, see [CLI Selection Guide](cli-selection-guide.md).
 
 ## `/nemoclaw` Slash Command
 
@@ -91,7 +91,7 @@ Three tiers are available:
 | Open | Broad access across third-party services including messaging and productivity. Agent-specific unsupported presets are filtered out. |
 
 After selecting a tier, the wizard shows a combined preset and access-mode screen where you can include or exclude individual presets and toggle each between read and read-write access.
-For details on tiers and the presets each includes, see Network Policies (use the `nemoclaw-user-reference` skill).
+For details on tiers and the presets each includes, see [Network Policies](network-policies.md#policy-tiers).
 
 In non-interactive mode, set the tier with `NEMOCLAW_POLICY_TIER` (default: `balanced`):
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -211,7 +211,7 @@ $ NEMOCLAW_GATEWAY_BIND_ADDRESS=0.0.0.0 NEMOCLAW_GATEWAY_PORT=8990 nemoclaw onbo
 Use `NEMOCLAW_GATEWAY_BIND_ADDRESS=0.0.0.0` only when other hosts on the
 network should be able to reach the gateway.
 
-See Environment Variables (use the `nemoclaw-user-reference` skill) for the full list of port overrides.
+See [Environment Variables](commands.md#environment-variables) for the full list of port overrides.
 
 ### Running multiple sandboxes simultaneously
 
@@ -1383,7 +1383,7 @@ If you see this error, use the host-side config command instead:
 $ nemoclaw <name> config set --key <dotpath> --value '<json-or-string>' --restart
 ```
 
-Refer to Commands (use the `nemoclaw-user-reference` skill) for the full list of supported configuration keys.
+Refer to [Commands](commands.md) for the full list of supported configuration keys.
 
 ### OpenClaw dashboard is unreachable after extended uptime on Brev
 

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -397,6 +397,9 @@ Default Colima ships with 2 vCPU and 2 GiB of memory, which is not enough headro
 On macOS Apple Silicon, the build can stall part-way through with no progress and no error, leaving the wizard waiting indefinitely.
 
 Preflight inspects `docker info` for `NCPU` and `MemTotal` and prints a warning when the runtime falls below 4 vCPU or 8 GiB.
+In interactive onboarding, the warning prompt defaults to abort, so pressing Enter stops the run before the sandbox build reaches the likely stall point.
+Type `y` only when you intentionally want to continue on the smaller runtime.
+Non-interactive onboarding prints the warning and continues.
 On Colima, raise the resources before re-running onboard:
 
 ```console
@@ -773,6 +776,23 @@ You scan the iLink QR from WeChat on your phone and NemoClaw registers the captu
 WhatsApp pairs entirely inside the sandbox.
 NemoClaw advertises WhatsApp for OpenClaw and Hermes sandboxes after you add the channel on the host.
 Run `openclaw channels login --channel whatsapp` inside OpenClaw sandboxes, or run `hermes whatsapp` inside Hermes sandboxes.
+
+### `scripts/rcf_patch.py` is missing from the blueprint
+
+`scripts/rcf_patch.py` is intentionally absent from current NemoClaw blueprints.
+Older QA plans used that helper for a Dockerfile "Patch-4" test that corrupted the build-time `replaceConfigFile` monkey-patch and expected `ERROR: Patch 4 (replaceConfigFile EACCES) not applied`.
+The old Patch-4 fail-closed test no longer applies because NemoClaw no longer patches OpenClaw's compiled `replaceConfigFile` source at image build time.
+
+Current sandboxes use a mutable-default config model instead.
+Before a reviewed host-side lockdown, `/sandbox/.openclaw/openclaw.json` is group-writable by the sandbox and gateway users, so OpenClaw config mutations should write normally rather than requiring an EACCES swallow.
+After lockdown, runtime config mutations should fail cleanly or route users to the supported host-side NemoClaw command.
+
+To validate this area now, use the config lifecycle tests instead of looking for `rcf_patch.py`:
+
+```console
+$ npm run build:cli
+$ npm test -- test/repro-2681-group-writable.test.ts
+```
 
 ### `openclaw config set` or `unset` is blocked inside the sandbox
 
@@ -1167,7 +1187,10 @@ Recent NVIDIA Container Toolkit installs configure the Docker daemon for Contain
 If no `nvidia.com/gpu` CDI spec has been generated on the host yet, gateway start fails with `Docker responded with status code 500: CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all`.
 The standard NemoClaw installer detects this gap before onboarding, first tries to enable the NVIDIA CDI refresh systemd units, and falls back to generating the spec directly with `nvidia-ctk`.
 If you run `nemoclaw onboard` directly, preflight prints the manual remediation instead.
-The underlying fix is the same on any Docker host whose `docker info` advertises a non-empty `CDISpecDirs`.
+The native Linux fix is the same on Docker hosts whose `docker info` advertises a non-empty `CDISpecDirs`.
+On WSL with Docker Desktop, Docker may advertise CDI directories even though `--device nvidia.com/gpu=all` is not usable from the WSL distro.
+For that runtime, NemoClaw skips Linux CDI repair and uses Docker's `--gpus` compatibility path for sandbox GPU access.
+This compatibility path can be retired once Docker Desktop exposes usable `nvidia.com/gpu` CDI specs inside WSL, or once OpenShell no longer requires host-visible CDI specs for Docker Desktop WSL GPU passthrough.
 
 Enable the refresh units, verify they list `nvidia.com/gpu` entries, then rerun onboarding:
 
@@ -1183,6 +1206,12 @@ If the refresh units are unavailable or do not generate CDI devices, generate th
 $ sudo mkdir -p /etc/cdi
 $ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 $ nvidia-ctk cdi list
+```
+
+On WSL with Docker Desktop, confirm Docker Desktop WSL integration is enabled for your distro and verify Docker GPU access from WSL:
+
+```console
+$ docker run --rm --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark
 ```
 
 If GPU passthrough is not required on this host, rerun onboarding with `--no-gpu` instead.

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -11,6 +11,19 @@ content:
 ---
 NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use this page to track changes.
 
+## v0.0.53
+
+NemoClaw v0.0.53 focuses on safer sandbox recreation, stricter onboarding preflight defaults, local inference reliability, policy coverage, and day-two repair workflows:
+
+- `nemoclaw onboard` backs up workspace state before deleting an existing sandbox during recreation, including sandboxes that are registered but not ready. If the backup is partial or fails, onboarding aborts before delete so workspace, skills, extensions, identity, memory, messaging state, and credentials are not silently dropped. Set `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1` only when you intentionally want a fresh workspace.
+- Under-provisioned container-runtime warnings now default to abort in interactive onboarding. Pressing Enter at the warning stops the run so you can resize Docker Desktop or Colima before the sandbox build stalls. Non-interactive runs continue with a warning, and `NEMOCLAW_IGNORE_RUNTIME_RESOURCES=1` still suppresses the check when you have already accepted the resource trade-off.
+- OpenClaw sandboxes can use the new `openclaw-pricing` policy preset for model-pricing reference fetches from LiteLLM and OpenRouter. NemoClaw suggests this preset during OpenClaw onboarding so session JSONL records can populate `usage.cost` without widening egress beyond the two read-only pricing endpoints.
+- Local Ollama onboarding is more accurate. NemoClaw validates the `/api/tags` response body through the authenticated proxy, honors accepted no-tools overrides through validation and proxy setup, and uses Ollama's reported runtime context length for `contextWindow` unless you set `NEMOCLAW_CONTEXT_WINDOW`.
+- Onboarding and gateway reuse recover from more host-runtime drift. NemoClaw recovers stopped gateways before preserving PVC-backed state, verifies gateway containers before reusing port-conflict state, defers Docker-driver gateway teardown until step `[2/8]`, records Docker-driver sandboxes on macOS, and uses Docker `--gpus` rather than CDI repair on WSL Docker Desktop.
+- The sandbox and integration paths handle more common failures cleanly, including Brave Search credential rewrite through OpenShell providers, Telegram placeholder repair, host-gateway `web_fetch` routing, read-only host targets for `share mount`, live gateway drift in `list`, host-alias Kubernetes invocations, Jetson bridge DNS preflight failures, and non-ready sandboxes during maintenance backups.
+- Hermes startup no longer treats a fresh root-entrypoint layout as locked state, which avoids false locked-layout detection during sandbox boot.
+- Maintainer tooling can export a signed skills catalog, detect untracked files during skills refresh diffs, and run the stale-issue verification workflow added for maintainers.
+
 ## v0.0.52
 
 NemoClaw v0.0.52 upgrades the bundled OpenClaw runtime, repairs Hermes sandbox startup, restores onboarding ready output, and hardens Slack onboarding, Windows bootstrap, and private-network handling:

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -409,6 +409,9 @@ Default Colima ships with 2 vCPU and 2 GiB of memory, which is not enough headro
 On macOS Apple Silicon, the build can stall part-way through with no progress and no error, leaving the wizard waiting indefinitely.
 
 Preflight inspects `docker info` for `NCPU` and `MemTotal` and prints a warning when the runtime falls below 4 vCPU or 8 GiB.
+In interactive onboarding, the warning prompt defaults to abort, so pressing Enter stops the run before the sandbox build reaches the likely stall point.
+Type `y` only when you intentionally want to continue on the smaller runtime.
+Non-interactive onboarding prints the warning and continues.
 On Colima, raise the resources before re-running onboard:
 
 ```console
@@ -794,15 +797,14 @@ Older QA plans used that helper for a Dockerfile "Patch-4" test that corrupted t
 The old Patch-4 fail-closed test no longer applies because NemoClaw no longer patches OpenClaw's compiled `replaceConfigFile` source at image build time.
 
 Current sandboxes use a mutable-default config model instead.
-Before lockdown, `/sandbox/.openclaw/openclaw.json` is group-writable by the sandbox and gateway users, so OpenClaw config mutations should write normally rather than requiring an EACCES swallow.
-After lockdown, `nemoclaw <sandbox> shields up` intentionally locks the config tree as root-owned read-only state; runtime config mutations should fail cleanly or route users to the supported host-side NemoClaw command.
+Before a reviewed host-side lockdown, `/sandbox/.openclaw/openclaw.json` is group-writable by the sandbox and gateway users, so OpenClaw config mutations should write normally rather than requiring an EACCES swallow.
+After lockdown, runtime config mutations should fail cleanly or route users to the supported host-side NemoClaw command.
 
-To validate this area now, use the shields/config lifecycle tests instead of looking for `rcf_patch.py`:
+To validate this area now, use the config lifecycle tests instead of looking for `rcf_patch.py`:
 
 ```console
 $ npm run build:cli
 $ npm test -- test/repro-2681-group-writable.test.ts
-$ bash test/e2e/test-shields-config.sh
 ```
 
 ### `openclaw config set` or `unset` is blocked inside the sandbox

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -202,7 +202,7 @@ Writable agent state such as plugins, skills, hooks, and workspace metadata live
 By default, this directory starts writable so the agent can manage its own config, install skills, and write to standard home-directory paths natively.
 For sensitive workloads, use a reviewed host-side immutability workflow after initial setup so config and writable state entry points cannot be changed by the sandbox user.
 
-- **DAC permissions (default).** The sandbox user owns `/sandbox/.openclaw` with mode `2770` (setgid `sandbox:sandbox`) and `openclaw.json` with mode `660`, so the agent and its group can read and write config directly. `shields status` cross-checks the locked posture against the sandbox filesystem and reports drift when a host-root tamper reverts these perms.
+- **DAC permissions (default).** The sandbox user owns `/sandbox/.openclaw` with mode `2770` (setgid `sandbox:sandbox`) and `openclaw.json` with mode `660`, so the agent and its group can read and write config directly. A reviewed host-side immutability workflow should compare the intended ownership and mode with the live sandbox filesystem before treating the config tree as locked.
 - **Config integrity hash.** The image includes a SHA256 hash of `openclaw.json`. In the default mutable state, `.config-hash` is sandbox-owned and is not a tamper-proof trust anchor, so startup does not fail closed on that hash. When the hash is root-owned and read-only, startup enforces it and refuses to start if the hash does not match.
 - **Gateway token environment.** The gateway exports `OPENCLAW_GATEWAY_TOKEN` and writes it to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions. Keep this in mind when deciding whether a workload should run with mutable config or an immutable config posture.
 

--- a/scripts/docs-to-skills.py
+++ b/scripts/docs-to-skills.py
@@ -746,6 +746,7 @@ def rewrite_doc_paths(
     source_page: DocPage,
     docs_dir: Path,
     doc_to_skill: dict[str, str],
+    local_doc_links: dict[str, str] | None = None,
     html_baseurl: str | None = None,
     doc_platform: str = "myst-md",
 ) -> tuple[str, list[tuple[Path, str]]]:
@@ -762,12 +763,14 @@ def rewrite_doc_paths(
        record a copy task and rewrite the link to ``images/<basename>``.
        The caller is responsible for copying the recorded files into the
        skill output directory after writing the markdown body.
-    3. If the target resolves to a doc that has a generated skill,
+    3. If the target resolves to a doc emitted in the current skill
+       directory, rewrite the link to that local file.
+    4. If the target resolves to a doc that has a generated skill,
        replace the whole link with ``text (use the `<skill>` skill)``.
-    4. If the target is a page inside ``docs/``, emit
+    5. If the target is a page inside ``docs/``, emit
        ``[text](<html_baseurl><page>.html)`` using the base URL read
        from ``conf.py``.
-    5. Otherwise (target outside ``docs/``, or no base URL available),
+    6. Otherwise (target outside ``docs/``, or no base URL available),
        strip the hyperlink and keep the link text. Self-containment wins
        over navigability in the fallback.
 
@@ -861,6 +864,16 @@ def rewrite_doc_paths(
             if not resolved.is_file():
                 continue
             return f"[{link_text}]({_record_image_copy(resolved)})"
+
+        # Prefer same-skill reference files over self-referential skill hints.
+        for resolved in candidates:
+            try:
+                rel_to_repo = resolved.relative_to(repo_root)
+            except ValueError:
+                continue
+            rel_str = rel_to_repo.as_posix()
+            if local_doc_links and rel_str in local_doc_links:
+                return f"[{link_text}]({local_doc_links[rel_str]}{frag})"
 
         # Check if target doc maps to a generated skill
         for resolved in candidates:
@@ -1502,7 +1515,12 @@ def generate_skill(
     skill_md_images: list[tuple[Path, str]] = []
     ref_images: dict[str, list[tuple[Path, str]]] = {}
 
-    def _clean(text: str, source: DocPage, image_acc: list[tuple[Path, str]]) -> str:
+    def _clean(
+        text: str,
+        source: DocPage,
+        image_acc: list[tuple[Path, str]],
+        local_doc_links: dict[str, str] | None = None,
+    ) -> str:
         """Apply directive cleanup and path rewriting for a source page."""
         if doc_platform == "fern-mdx":
             result = clean_fern_mdx(text)
@@ -1514,6 +1532,7 @@ def generate_skill(
                 source,
                 docs_dir,
                 doc_to_skill,
+                local_doc_links=local_doc_links,
                 html_baseurl=html_baseurl,
                 doc_platform=doc_platform,
             )
@@ -1523,6 +1542,30 @@ def generate_skill(
     procedures, deferred_procedures, context_pages, reference_pages = (
         partition_skill_pages(pages)
     )
+    ref_section_pages = deferred_procedures + context_pages + reference_pages
+
+    def _page_rel(page: DocPage) -> str | None:
+        if docs_dir is None:
+            return None
+        try:
+            return page.path.resolve().relative_to(docs_dir.parent).as_posix()
+        except ValueError:
+            return None
+
+    skill_md_local_links: dict[str, str] = {}
+    reference_local_links: dict[str, str] = {}
+    for page in ref_section_pages:
+        rel = _page_rel(page)
+        if rel is None:
+            continue
+        ref_name = page.path.stem + ".md"
+        skill_md_local_links[rel] = f"references/{ref_name}"
+        reference_local_links[rel] = ref_name
+    for page in procedures:
+        rel = _page_rel(page)
+        if rel is not None:
+            reference_local_links[rel] = "../SKILL.md"
+
     description_pages = (
         procedures + deferred_procedures + context_pages + reference_pages
         if procedures
@@ -1571,7 +1614,9 @@ def generate_skill(
     for pp in procedures:
         for heading, content in pp.sections:
             if heading.lower() in ("prerequisites", "before you begin"):
-                cleaned = _clean(content, pp, skill_md_images)
+                cleaned = _clean(
+                    content, pp, skill_md_images, skill_md_local_links
+                )
                 for item_line in cleaned.split("\n"):
                     stripped = item_line.strip()
                     if stripped.startswith("- "):
@@ -1605,17 +1650,21 @@ def generate_skill(
             if heading.lower() in skip_sections:
                 continue
             if heading.lower() in related_sections:
-                collected_related.append(_clean(content, pp, skill_md_images))
+                collected_related.append(
+                    _clean(content, pp, skill_md_images, skill_md_local_links)
+                )
                 continue
             if not heading:
-                cleaned = _clean(content, pp, skill_md_images)
+                cleaned = _clean(content, pp, skill_md_images, skill_md_local_links)
                 cleaned = re.sub(r"^#\s+.+\n+", "", cleaned)
                 if cleaned.strip():
                     lines.append(cleaned)
                     lines.append("")
                 continue
 
-            cleaned_content = _clean(content, pp, skill_md_images)
+            cleaned_content = _clean(
+                content, pp, skill_md_images, skill_md_local_links
+            )
             lines.append(f"## {heading}")
             lines.append("")
             lines.append(cleaned_content)
@@ -1649,7 +1698,6 @@ def generate_skill(
     # trigger from description.agent (the "Use when ..." clause) so the
     # agent can decide on-sight whether to load the file, which is how
     # progressive disclosure is supposed to work.
-    ref_section_pages = deferred_procedures + context_pages + reference_pages
     if ref_section_pages:
         lines.append("")
         lines.append("## References")
@@ -1683,7 +1731,7 @@ def generate_skill(
     for rp in deferred_procedures + reference_pages + context_pages:
         ref_name = rp.path.stem + ".md"
         ref_image_acc: list[tuple[Path, str]] = []
-        body = _clean(rp.body, rp, ref_image_acc)
+        body = _clean(rp.body, rp, ref_image_acc, reference_local_links)
         if doc_platform == "myst-md" and rp.title:
             body = canonicalize_leading_h1(body, rp.title)
         elif doc_platform == "fern-mdx" and rp.title and not body.startswith("# "):


### PR DESCRIPTION
## Summary
- Add the v0.0.53 release notes with the user-facing onboarding, inference, policy, runtime, Hermes, and maintainer-tooling changes from the release range.
- Refresh generated `nemoclaw-user-*` skills from the current Fern docs, including already-merged policy, inference, troubleshooting, and command-reference updates.
- Fix `scripts/docs-to-skills.py` so links to pages emitted inside the same skill resolve to local `references/*.md` files or back to `../SKILL.md` instead of telling agents to load the same skill again.
- Remove skipped experimental shield wording from generated-doc source so the release-prep skip-term gate stays clean.

## Source summary
- #4197 -> `docs/about/release-notes.mdx`, `docs/reference/commands.mdx`: Document pre-recreate workspace backup, abort-on-partial-backup behavior, and `NEMOCLAW_RECREATE_WITHOUT_BACKUP`.
- #4273 -> `docs/about/release-notes.mdx`, `docs/reference/troubleshooting.mdx`: Document the under-provisioned runtime prompt defaulting to abort in interactive onboarding.
- #4220 -> `docs/about/release-notes.mdx`, `docs/network-policy/customize-network-policy.mdx`, `docs/network-policy/integration-policy-examples.mdx`: Include the `openclaw-pricing` preset and generated skill refresh.
- #4253 -> `docs/about/release-notes.mdx`, `docs/inference/use-local-inference.mdx`, `docs/inference/switch-inference-providers.mdx`: Carry the Ollama runtime context-window docs into generated skills.
- #4298 -> `docs/about/release-notes.mdx`, `docs/reference/troubleshooting.mdx`: Carry WSL Docker Desktop GPU guidance into generated skills and release notes.
- #4297, #4210, #4221, #4225, #4288, #4306, #4311, #4319, #4342, #4284, #3327 -> `docs/about/release-notes.mdx`: Summarize release-range fixes and maintainer tooling changes that did not need new standalone docs pages.
- Same-skill link rewrite fix -> `scripts/docs-to-skills.py`, `.agents/skills/nemoclaw-user-*`: Regenerate skill links such as `[Prerequisites](references/prerequisites.md)` and sibling reference links instead of self-referential skill hints.

## Verification
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx`
- `python3 -m py_compile scripts/docs-to-skills.py`
- Generated self-reference scan found no `use the same skill` matches in generated user skills.
- `npx vitest run test/skills-frontmatter.test.ts`
- `npx prek run docs-to-skills-dry-run --all-files`
- `rg "permissive mode|shields down|shields up|shields status|config rotate-token|rotate-token" docs .agents/skills` returned no matches outside `docs/.docs-skip`.
- `npm run docs` passes with full network access. Fern reports 0 errors and one existing light-mode accent contrast warning.
- `FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && (cd fern && npx --yes "fern-api@${FERN_VERSION}" check --warnings)` reports 0 errors and the same contrast warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v0.0.53 release notes and new openclaw-pricing preset for model pricing.

* **Documentation**
  * Clarified Ollama/local model context-window behavior and onboarding validation.
  * Standardized links/navigation across many guides (direct topic links instead of skill-name references).
  * Expanded sandbox recreation/backup-restore and troubleshooting (interactive onboarding defaults, GPU/WSL guidance).

* **Bug Fixes**
  * Improved gateway reuse/recovery and fixed Hermes startup lock detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->