### PR TITLE
fix(sandbox): propagate no-gpu intent into rebuild recreate

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -786,7 +786,9 @@ Upgrade a sandbox to the current agent version while preserving workspace state.
 The command backs up workspace state, destroys the old sandbox (including its host-side Docker image), recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
 Credentials are stripped from backups before storage.
 Policy presets applied to the old sandbox are reapplied to the new one so your egress rules survive the rebuild.
-The recorded sandbox GPU mode is preserved across rebuild: a sandbox onboarded with an explicit GPU opt-out (stored as `sandboxGpuMode: "0"`, plus legacy registry entries that only record `gpuEnabled: false`) is recreated with the same opt-out so the inner `onboard --resume` skips the Docker CDI GPU preflight on hosts without an NVIDIA GPU; auto-mode sandboxes remain auto.
+The recorded sandbox GPU mode is preserved across rebuild.
+A sandbox onboarded with an explicit GPU opt-out (stored as `sandboxGpuMode: "0"`, plus legacy registry entries that only record `gpuEnabled: false`) is recreated with the same opt-out, so the inner `onboard --resume` skips the Docker CDI GPU preflight on hosts without an NVIDIA GPU.
+Auto-mode sandboxes remain auto.
 
 ```console
 $ nemoclaw my-assistant rebuild [--yes|-y|--force] [--verbose|-v]

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -786,6 +786,7 @@ Upgrade a sandbox to the current agent version while preserving workspace state.
 The command backs up workspace state, destroys the old sandbox (including its host-side Docker image), recreates it with the current image via `onboard --resume`, and restores workspace state into the new sandbox.
 Credentials are stripped from backups before storage.
 Policy presets applied to the old sandbox are reapplied to the new one so your egress rules survive the rebuild.
+The recorded sandbox GPU mode is preserved across rebuild: a sandbox onboarded with an explicit GPU opt-out (stored as `sandboxGpuMode: "0"`, plus legacy registry entries that only record `gpuEnabled: false`) is recreated with the same opt-out so the inner `onboard --resume` skips the Docker CDI GPU preflight on hosts without an NVIDIA GPU; auto-mode sandboxes remain auto.
 
 ```console
 $ nemoclaw my-assistant rebuild [--yes|-y|--force] [--verbose|-v]

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { rebuildShouldOptOutGpu } from "../../../../dist/lib/actions/sandbox/rebuild";
+
+describe("rebuildShouldOptOutGpu", () => {
+  it("returns false when the registry entry is null", () => {
+    expect(rebuildShouldOptOutGpu(null)).toBe(false);
+    expect(rebuildShouldOptOutGpu(undefined)).toBe(false);
+  });
+
+  it("returns true when sandboxGpuEnabled is explicitly false", () => {
+    expect(rebuildShouldOptOutGpu({ sandboxGpuEnabled: false })).toBe(true);
+    expect(
+      rebuildShouldOptOutGpu({ sandboxGpuEnabled: false, gpuEnabled: true }),
+    ).toBe(true);
+  });
+
+  it("returns true when sandboxGpuEnabled is missing and gpuEnabled is false (legacy entries)", () => {
+    expect(rebuildShouldOptOutGpu({ gpuEnabled: false })).toBe(true);
+  });
+
+  it("returns false when sandboxGpuEnabled is true regardless of gpuEnabled", () => {
+    expect(
+      rebuildShouldOptOutGpu({ sandboxGpuEnabled: true, gpuEnabled: false }),
+    ).toBe(false);
+    expect(rebuildShouldOptOutGpu({ sandboxGpuEnabled: true })).toBe(false);
+  });
+
+  it("returns false when both flags are unset (no recorded intent)", () => {
+    expect(rebuildShouldOptOutGpu({})).toBe(false);
+  });
+
+  it("returns false when sandboxGpuEnabled is missing and gpuEnabled is true", () => {
+    expect(rebuildShouldOptOutGpu({ gpuEnabled: true })).toBe(false);
+  });
+});

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
@@ -60,7 +60,7 @@ describe("rebuildShouldOptOutGpu", () => {
     expect(rebuildShouldOptOutGpu({ gpuEnabled: true })).toBe(false);
   });
 
-  it("treats unrecognized sandboxGpuMode values as no explicit intent", () => {
+  it("falls through to the legacy gpuEnabled check when sandboxGpuMode is not 0/1/auto", () => {
     expect(
       rebuildShouldOptOutGpu({
         sandboxGpuMode: "bogus" as unknown as string,
@@ -71,6 +71,31 @@ describe("rebuildShouldOptOutGpu", () => {
       rebuildShouldOptOutGpu({
         sandboxGpuMode: "bogus" as unknown as string,
         sandboxGpuEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("normalises mixed-case mode 'AUTO' and aliases like 'off' through normalizeSandboxGpuMode", () => {
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "AUTO" as unknown as string,
+        sandboxGpuEnabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "off" as unknown as string,
+      }),
+    ).toBe(true);
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "false" as unknown as string,
+      }),
+    ).toBe(true);
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "TRUE" as unknown as string,
+        sandboxGpuEnabled: false,
       }),
     ).toBe(false);
   });

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
@@ -11,29 +11,67 @@ describe("rebuildShouldOptOutGpu", () => {
     expect(rebuildShouldOptOutGpu(undefined)).toBe(false);
   });
 
-  it("returns true when sandboxGpuEnabled is explicitly false", () => {
-    expect(rebuildShouldOptOutGpu({ sandboxGpuEnabled: false })).toBe(true);
+  it("returns true when sandboxGpuMode is the explicit opt-out '0'", () => {
     expect(
-      rebuildShouldOptOutGpu({ sandboxGpuEnabled: false, gpuEnabled: true }),
+      rebuildShouldOptOutGpu({ sandboxGpuMode: "0", sandboxGpuEnabled: false }),
     ).toBe(true);
+    expect(rebuildShouldOptOutGpu({ sandboxGpuMode: "0" })).toBe(true);
   });
 
-  it("returns true when sandboxGpuEnabled is missing and gpuEnabled is false (legacy entries)", () => {
+  it("returns false when sandboxGpuMode is 'auto' (CPU fallback is not explicit opt-out)", () => {
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "auto",
+        sandboxGpuEnabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "auto",
+        sandboxGpuEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when sandboxGpuMode is '1' regardless of sandboxGpuEnabled", () => {
+    expect(
+      rebuildShouldOptOutGpu({ sandboxGpuMode: "1", sandboxGpuEnabled: true }),
+    ).toBe(false);
+    expect(
+      rebuildShouldOptOutGpu({ sandboxGpuMode: "1", sandboxGpuEnabled: false }),
+    ).toBe(false);
+  });
+
+  it("falls back to gpuEnabled=false for legacy entries with no sandboxGpuMode", () => {
     expect(rebuildShouldOptOutGpu({ gpuEnabled: false })).toBe(true);
   });
 
-  it("returns false when sandboxGpuEnabled is true regardless of gpuEnabled", () => {
+  it("ignores legacy gpuEnabled=false when sandboxGpuEnabled=true is recorded", () => {
     expect(
       rebuildShouldOptOutGpu({ sandboxGpuEnabled: true, gpuEnabled: false }),
     ).toBe(false);
-    expect(rebuildShouldOptOutGpu({ sandboxGpuEnabled: true })).toBe(false);
   });
 
-  it("returns false when both flags are unset (no recorded intent)", () => {
+  it("returns false when no GPU metadata is recorded", () => {
     expect(rebuildShouldOptOutGpu({})).toBe(false);
   });
 
-  it("returns false when sandboxGpuEnabled is missing and gpuEnabled is true", () => {
+  it("returns false when only gpuEnabled=true is recorded", () => {
     expect(rebuildShouldOptOutGpu({ gpuEnabled: true })).toBe(false);
+  });
+
+  it("treats unrecognized sandboxGpuMode values as no explicit intent", () => {
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "bogus" as unknown as string,
+        gpuEnabled: false,
+      }),
+    ).toBe(true);
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "bogus" as unknown as string,
+        sandboxGpuEnabled: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
@@ -63,19 +63,28 @@ describe("rebuildShouldOptOutGpu", () => {
     expect(rebuildShouldOptOutGpu({ gpuEnabled: true })).toBe(false);
   });
 
-  it("falls through to the legacy gpuEnabled check when sandboxGpuMode is not 0/1/auto", () => {
+  it("does NOT route malformed sandboxGpuMode values through the legacy gpuEnabled fallback", () => {
     expect(
       rebuildShouldOptOutGpu({
         sandboxGpuMode: "bogus" as unknown as string,
         gpuEnabled: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       rebuildShouldOptOutGpu({
         sandboxGpuMode: "bogus" as unknown as string,
         sandboxGpuEnabled: true,
       }),
     ).toBe(false);
+  });
+
+  it("falls back to legacy gpuEnabled when sandboxGpuMode is an empty string", () => {
+    expect(
+      rebuildShouldOptOutGpu({
+        sandboxGpuMode: "" as unknown as string,
+        gpuEnabled: false,
+      }),
+    ).toBe(true);
   });
 
   it("normalises mixed-case mode 'AUTO' and aliases like 'off' through normalizeSandboxGpuMode", () => {

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { rebuildShouldOptOutGpu } from "../../../../dist/lib/actions/sandbox/rebuild-gpu-opt-out";
+import {
+  buildRebuildRecreateOnboardOpts,
+  rebuildShouldOptOutGpu,
+} from "../../../../dist/lib/actions/sandbox/rebuild-gpu-opt-out";
 
 describe("rebuildShouldOptOutGpu", () => {
   it("returns false when the registry entry is null", () => {
@@ -98,5 +101,71 @@ describe("rebuildShouldOptOutGpu", () => {
         sandboxGpuEnabled: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("buildRebuildRecreateOnboardOpts", () => {
+  const baseArgs = {
+    rebuildAgent: "openclaw",
+    storedFromDockerfile: null,
+    autoYes: true,
+  };
+
+  it("forwards noGpu:true when the recorded sandboxGpuMode is the explicit opt-out '0'", () => {
+    const opts = buildRebuildRecreateOnboardOpts({
+      ...baseArgs,
+      sb: { sandboxGpuMode: "0", sandboxGpuEnabled: false },
+    });
+    expect(opts.noGpu).toBe(true);
+    expect(opts).toMatchObject({
+      resume: true,
+      nonInteractive: true,
+      recreateSandbox: true,
+      agent: "openclaw",
+      fromDockerfile: null,
+      autoYes: true,
+    });
+  });
+
+  it("forwards noGpu:true for legacy entries with gpuEnabled:false and no sandboxGpuMode", () => {
+    const opts = buildRebuildRecreateOnboardOpts({
+      ...baseArgs,
+      sb: { gpuEnabled: false },
+    });
+    expect(opts.noGpu).toBe(true);
+  });
+
+  it("omits noGpu for auto-mode CPU fallback so resume stays auto", () => {
+    const opts = buildRebuildRecreateOnboardOpts({
+      ...baseArgs,
+      sb: { sandboxGpuMode: "auto", sandboxGpuEnabled: false },
+    });
+    expect(opts).not.toHaveProperty("noGpu");
+  });
+
+  it("omits noGpu when sandboxGpuMode is '1'", () => {
+    const opts = buildRebuildRecreateOnboardOpts({
+      ...baseArgs,
+      sb: { sandboxGpuMode: "1", sandboxGpuEnabled: true },
+    });
+    expect(opts).not.toHaveProperty("noGpu");
+  });
+
+  it("omits noGpu when no sandbox entry is captured", () => {
+    const opts = buildRebuildRecreateOnboardOpts({ ...baseArgs, sb: null });
+    expect(opts).not.toHaveProperty("noGpu");
+  });
+
+  it("preserves storedFromDockerfile and autoYes regardless of GPU opt-out", () => {
+    const opts = buildRebuildRecreateOnboardOpts({
+      sb: { sandboxGpuMode: "0" },
+      rebuildAgent: "hermes",
+      storedFromDockerfile: "/sandbox/.openclaw/Dockerfile.custom",
+      autoYes: false,
+    });
+    expect(opts.agent).toBe("hermes");
+    expect(opts.fromDockerfile).toBe("/sandbox/.openclaw/Dockerfile.custom");
+    expect(opts.autoYes).toBe(false);
+    expect(opts.noGpu).toBe(true);
   });
 });

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { rebuildShouldOptOutGpu } from "../../../../dist/lib/actions/sandbox/rebuild";
+import { rebuildShouldOptOutGpu } from "../../../../dist/lib/actions/sandbox/rebuild-gpu-opt-out";
 
 describe("rebuildShouldOptOutGpu", () => {
   it("returns false when the registry entry is null", () => {

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
@@ -10,9 +10,11 @@ export type RebuildGpuOptOutEntry = {
 };
 
 // Modern source of truth is the persisted `sandboxGpuMode` string ("0" / "1" /
-// "auto"); the legacy `gpuEnabled` fallback only fires when no mode field is
-// present so older registry entries written before `sandboxGpuMode` landed
-// are still honoured.
+// "auto"). The legacy `gpuEnabled` fallback fires when `normalizeSandboxGpuMode`
+// returns null — that covers older registry entries written before
+// `sandboxGpuMode` landed and tolerates malformed mode values (treating them
+// as "no recorded intent") rather than locking the rebuild into the wrong
+// branch on corrupted state.
 export function rebuildShouldOptOutGpu(
   sb: RebuildGpuOptOutEntry | null | undefined,
 ): boolean {

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
@@ -3,15 +3,18 @@
 
 import { normalizeSandboxGpuMode } from "../../onboard/sandbox-gpu-mode";
 
+export type RebuildGpuOptOutEntry = {
+  sandboxGpuMode?: string | null;
+  sandboxGpuEnabled?: boolean;
+  gpuEnabled?: boolean;
+};
+
+// Modern source of truth is the persisted `sandboxGpuMode` string ("0" / "1" /
+// "auto"); the legacy `gpuEnabled` fallback only fires when no mode field is
+// present so older registry entries written before `sandboxGpuMode` landed
+// are still honoured.
 export function rebuildShouldOptOutGpu(
-  sb:
-    | {
-        sandboxGpuMode?: string | null;
-        sandboxGpuEnabled?: boolean;
-        gpuEnabled?: boolean;
-      }
-    | null
-    | undefined,
+  sb: RebuildGpuOptOutEntry | null | undefined,
 ): boolean {
   if (!sb) return false;
   const mode = normalizeSandboxGpuMode(sb.sandboxGpuMode);
@@ -19,4 +22,31 @@ export function rebuildShouldOptOutGpu(
   if (mode === "1" || mode === "auto") return false;
   if (sb.sandboxGpuEnabled === true) return false;
   return sb.gpuEnabled === false;
+}
+
+export type RebuildRecreateOnboardOpts = {
+  resume: true;
+  nonInteractive: true;
+  recreateSandbox: true;
+  agent: string | null | undefined;
+  fromDockerfile: string | null;
+  autoYes: boolean;
+  noGpu?: true;
+};
+
+export function buildRebuildRecreateOnboardOpts(args: {
+  sb: RebuildGpuOptOutEntry | null | undefined;
+  rebuildAgent: string | null | undefined;
+  storedFromDockerfile: string | null;
+  autoYes: boolean;
+}): RebuildRecreateOnboardOpts {
+  return {
+    resume: true,
+    nonInteractive: true,
+    recreateSandbox: true,
+    agent: args.rebuildAgent,
+    fromDockerfile: args.storedFromDockerfile,
+    autoYes: args.autoYes,
+    ...(rebuildShouldOptOutGpu(args.sb) ? { noGpu: true as const } : {}),
+  };
 }

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
@@ -10,11 +10,14 @@ export type RebuildGpuOptOutEntry = {
 };
 
 // Modern source of truth is the persisted `sandboxGpuMode` string ("0" / "1" /
-// "auto"). The legacy `gpuEnabled` fallback fires when `normalizeSandboxGpuMode`
-// returns null — that covers older registry entries written before
-// `sandboxGpuMode` landed and tolerates malformed mode values (treating them
-// as "no recorded intent") rather than locking the rebuild into the wrong
-// branch on corrupted state.
+// "auto"). The legacy `gpuEnabled` fallback only runs for older entries with
+// no recorded mode field — a malformed but present `sandboxGpuMode` value is
+// treated as "do nothing" rather than silently routed through the legacy
+// path, so corrupted state cannot flip a sandbox into a permanent opt-out.
+function hasRecordedGpuMode(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 export function rebuildShouldOptOutGpu(
   sb: RebuildGpuOptOutEntry | null | undefined,
 ): boolean {
@@ -22,6 +25,7 @@ export function rebuildShouldOptOutGpu(
   const mode = normalizeSandboxGpuMode(sb.sandboxGpuMode);
   if (mode === "0") return true;
   if (mode === "1" || mode === "auto") return false;
+  if (hasRecordedGpuMode(sb.sandboxGpuMode)) return false;
   if (sb.sandboxGpuEnabled === true) return false;
   return sb.gpuEnabled === false;
 }

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { normalizeSandboxGpuMode } from "../../onboard/sandbox-gpu-mode";
+
+export function rebuildShouldOptOutGpu(
+  sb:
+    | {
+        sandboxGpuMode?: string | null;
+        sandboxGpuEnabled?: boolean;
+        gpuEnabled?: boolean;
+      }
+    | null
+    | undefined,
+): boolean {
+  if (!sb) return false;
+  const mode = normalizeSandboxGpuMode(sb.sandboxGpuMode);
+  if (mode === "0") return true;
+  if (mode === "1" || mode === "auto") return false;
+  if (sb.sandboxGpuEnabled === true) return false;
+  return sb.gpuEnabled === false;
+}

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -65,6 +65,15 @@ import { openRebuildShieldsWindow, printRebuildShieldsRecovery, relockRebuildShi
 /**
  * Emit timestamped rebuild diagnostics when verbose rebuild logging is enabled.
  */
+export function rebuildShouldOptOutGpu(
+  sb: { sandboxGpuEnabled?: boolean; gpuEnabled?: boolean } | null | undefined,
+): boolean {
+  if (!sb) return false;
+  if (sb.sandboxGpuEnabled === false) return true;
+  if (sb.sandboxGpuEnabled === undefined && sb.gpuEnabled === false) return true;
+  return false;
+}
+
 function _rebuildLog(msg: string) {
   console.error(`  ${D}[rebuild ${new Date().toISOString()}] ${redact(msg)}${R}`);
 }
@@ -676,6 +685,14 @@ export async function rebuildSandbox(
     throw err;
   }) as typeof process.exit;
 
+  // Propagate the original sandbox's no-GPU intent into the recreate path so
+  // the inner `onboard --resume` does not enforce a Docker CDI GPU preflight
+  // on hosts without an NVIDIA GPU. Without this, a `--no-gpu` sandbox on a
+  // non-NVIDIA host (e.g. Snapdragon ARM WSL2) is destroyed and the recreate
+  // fails at preflight because the registry entry has already been removed
+  // and the cached session's gpuPassthrough is not enough to bypass the CDI
+  // check on every code path.
+  const sbHadNoGpu = rebuildShouldOptOutGpu(sb);
   try {
     await onboard({
       resume: true,
@@ -689,6 +706,7 @@ export async function rebuildSandbox(
       // non-interactive onboard does not abort after the old sandbox has
       // been deleted (#2639 follow-up).
       autoYes: skipConfirm || rebuildConfirmed,
+      ...(sbHadNoGpu ? { noGpu: true } : {}),
     });
     log("onboard() returned successfully");
   } catch (err) {

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -66,12 +66,25 @@ import { openRebuildShieldsWindow, printRebuildShieldsRecovery, relockRebuildShi
  * Emit timestamped rebuild diagnostics when verbose rebuild logging is enabled.
  */
 export function rebuildShouldOptOutGpu(
-  sb: { sandboxGpuEnabled?: boolean; gpuEnabled?: boolean } | null | undefined,
+  sb:
+    | {
+        sandboxGpuMode?: string | null;
+        sandboxGpuEnabled?: boolean;
+        gpuEnabled?: boolean;
+      }
+    | null
+    | undefined,
 ): boolean {
   if (!sb) return false;
-  if (sb.sandboxGpuEnabled === false) return true;
-  if (sb.sandboxGpuEnabled === undefined && sb.gpuEnabled === false) return true;
-  return false;
+  const mode = sb.sandboxGpuMode;
+  if (mode === "0") return true;
+  if (mode === "1" || mode === "auto") return false;
+  // Legacy entries without sandboxGpuMode fall back to gpuEnabled. Treat the
+  // missing mode field as "no explicit intent recorded" and only opt out
+  // when the explicit-opt-out signal (`gpuEnabled === false`) is set with no
+  // counter-signal from `sandboxGpuEnabled`.
+  if (sb.sandboxGpuEnabled === true) return false;
+  return sb.gpuEnabled === false;
 }
 
 function _rebuildLog(msg: string) {

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -61,10 +61,8 @@ import {
 import { removeSandboxRegistryEntry } from "./destroy";
 import { executeSandboxCommand } from "./process-recovery";
 import { openRebuildShieldsWindow, printRebuildShieldsRecovery, relockRebuildShieldsWindow } from "./rebuild-shields";
+import { normalizeSandboxGpuMode } from "../../onboard/sandbox-gpu-mode";
 
-/**
- * Emit timestamped rebuild diagnostics when verbose rebuild logging is enabled.
- */
 export function rebuildShouldOptOutGpu(
   sb:
     | {
@@ -76,17 +74,16 @@ export function rebuildShouldOptOutGpu(
     | undefined,
 ): boolean {
   if (!sb) return false;
-  const mode = sb.sandboxGpuMode;
+  const mode = normalizeSandboxGpuMode(sb.sandboxGpuMode);
   if (mode === "0") return true;
   if (mode === "1" || mode === "auto") return false;
-  // Legacy entries without sandboxGpuMode fall back to gpuEnabled. Treat the
-  // missing mode field as "no explicit intent recorded" and only opt out
-  // when the explicit-opt-out signal (`gpuEnabled === false`) is set with no
-  // counter-signal from `sandboxGpuEnabled`.
   if (sb.sandboxGpuEnabled === true) return false;
   return sb.gpuEnabled === false;
 }
 
+/**
+ * Emit timestamped rebuild diagnostics when verbose rebuild logging is enabled.
+ */
 function _rebuildLog(msg: string) {
   console.error(`  ${D}[rebuild ${new Date().toISOString()}] ${redact(msg)}${R}`);
 }
@@ -700,11 +697,7 @@ export async function rebuildSandbox(
 
   // Propagate the original sandbox's no-GPU intent into the recreate path so
   // the inner `onboard --resume` does not enforce a Docker CDI GPU preflight
-  // on hosts without an NVIDIA GPU. Without this, a `--no-gpu` sandbox on a
-  // non-NVIDIA host (e.g. Snapdragon ARM WSL2) is destroyed and the recreate
-  // fails at preflight because the registry entry has already been removed
-  // and the cached session's gpuPassthrough is not enough to bypass the CDI
-  // check on every code path.
+  // on hosts without an NVIDIA GPU.
   const sbHadNoGpu = rebuildShouldOptOutGpu(sb);
   try {
     await onboard({

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -681,10 +681,9 @@ export async function rebuildSandbox(
   // rebuild (either via --yes/--force or by answering "y" at the prompt).
   // Propagate that consent so the size-confirm gate inside the
   // non-interactive onboard does not abort after the old sandbox has
-  // been deleted (#2639 follow-up). The recreate path also inherits the
-  // original sandbox's no-GPU intent so the inner `onboard --resume` does
-  // not enforce the Docker CDI GPU preflight on hosts without an NVIDIA
-  // GPU.
+  // been deleted. The recreate path also inherits the original sandbox's
+  // no-GPU intent so the inner `onboard --resume` does not enforce the
+  // Docker CDI GPU preflight on hosts without an NVIDIA GPU.
   const recreateOpts = buildRebuildRecreateOnboardOpts({
     sb,
     rebuildAgent,

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -61,7 +61,7 @@ import {
 import { removeSandboxRegistryEntry } from "./destroy";
 import { executeSandboxCommand } from "./process-recovery";
 import { openRebuildShieldsWindow, printRebuildShieldsRecovery, relockRebuildShieldsWindow } from "./rebuild-shields";
-import { rebuildShouldOptOutGpu } from "./rebuild-gpu-opt-out";
+import { buildRebuildRecreateOnboardOpts } from "./rebuild-gpu-opt-out";
 
 /**
  * Emit timestamped rebuild diagnostics when verbose rebuild logging is enabled.
@@ -677,25 +677,22 @@ export async function rebuildSandbox(
     throw err;
   }) as typeof process.exit;
 
-  // Propagate the original sandbox's no-GPU intent into the recreate path so
-  // the inner `onboard --resume` does not enforce a Docker CDI GPU preflight
-  // on hosts without an NVIDIA GPU.
-  const sbHadNoGpu = rebuildShouldOptOutGpu(sb);
+  // Reaching here means the user already consented to the destructive
+  // rebuild (either via --yes/--force or by answering "y" at the prompt).
+  // Propagate that consent so the size-confirm gate inside the
+  // non-interactive onboard does not abort after the old sandbox has
+  // been deleted (#2639 follow-up). The recreate path also inherits the
+  // original sandbox's no-GPU intent so the inner `onboard --resume` does
+  // not enforce the Docker CDI GPU preflight on hosts without an NVIDIA
+  // GPU.
+  const recreateOpts = buildRebuildRecreateOnboardOpts({
+    sb,
+    rebuildAgent,
+    storedFromDockerfile,
+    autoYes: skipConfirm || rebuildConfirmed,
+  });
   try {
-    await onboard({
-      resume: true,
-      nonInteractive: true,
-      recreateSandbox: true,
-      agent: rebuildAgent,
-      fromDockerfile: storedFromDockerfile,
-      // Reaching here means the user already consented to the destructive
-      // rebuild (either via --yes/--force or by answering "y" at the prompt).
-      // Propagate that consent so the size-confirm gate inside the
-      // non-interactive onboard does not abort after the old sandbox has
-      // been deleted (#2639 follow-up).
-      autoYes: skipConfirm || rebuildConfirmed,
-      ...(sbHadNoGpu ? { noGpu: true } : {}),
-    });
+    await onboard(recreateOpts);
     log("onboard() returned successfully");
   } catch (err) {
     onboardFailed = true;

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -61,25 +61,7 @@ import {
 import { removeSandboxRegistryEntry } from "./destroy";
 import { executeSandboxCommand } from "./process-recovery";
 import { openRebuildShieldsWindow, printRebuildShieldsRecovery, relockRebuildShieldsWindow } from "./rebuild-shields";
-import { normalizeSandboxGpuMode } from "../../onboard/sandbox-gpu-mode";
-
-export function rebuildShouldOptOutGpu(
-  sb:
-    | {
-        sandboxGpuMode?: string | null;
-        sandboxGpuEnabled?: boolean;
-        gpuEnabled?: boolean;
-      }
-    | null
-    | undefined,
-): boolean {
-  if (!sb) return false;
-  const mode = normalizeSandboxGpuMode(sb.sandboxGpuMode);
-  if (mode === "0") return true;
-  if (mode === "1" || mode === "auto") return false;
-  if (sb.sandboxGpuEnabled === true) return false;
-  return sb.gpuEnabled === false;
-}
+import { rebuildShouldOptOutGpu } from "./rebuild-gpu-opt-out";
 
 /**
  * Emit timestamped rebuild diagnostics when verbose rebuild logging is enabled.


### PR DESCRIPTION
## Summary
`nemoclaw <name> rebuild --yes` on a sandbox onboarded with an explicit `--no-gpu` (recorded as `sandboxGpuMode: "0"`) now propagates that recorded intent into the inner `onboard --resume` so the Docker CDI GPU preflight is skipped on hosts without an NVIDIA GPU (e.g. Snapdragon ARM WSL2). Without this, rebuild deletes the old sandbox, then the recreate's preflight fails on CDI and leaves the user with only a `rebuild-backups/` archive and a stub registry entry. Auto-mode sandboxes (`sandboxGpuMode: "auto"`) remain auto across rebuild, including the CPU-fallback case where `sandboxGpuEnabled` ends up `false` because the host has no NVIDIA GPU.

## Related Issue
Fixes #3985.

## Changes
- New module `src/lib/actions/sandbox/rebuild-gpu-opt-out.ts`. Exports `rebuildShouldOptOutGpu(sb)`: the source of truth is `sandboxGpuMode` (routed through `normalizeSandboxGpuMode` so `"AUTO"` / `"off"` / `"false"` map consistently). `"0"` → opt out, `"1"` / `"auto"` → keep current behaviour. Legacy entries without `sandboxGpuMode` fall back to `gpuEnabled === false` only when no `sandboxGpuEnabled: true` counter-signal is set, so a modern auto-mode CPU-fallback record (`sandboxGpuMode: "auto"`, `sandboxGpuEnabled: false`) is not silently converted into a permanent explicit opt-out on rebuild. Also exports `buildRebuildRecreateOnboardOpts({ sb, rebuildAgent, storedFromDockerfile, autoYes })`, which returns the options object passed to the inner `onboard()` and conditionally spreads `{ noGpu: true }` only when `rebuildShouldOptOutGpu(sb)` is true.
- `src/lib/actions/sandbox/rebuild.ts` replaces the inline option literal with a call to `buildRebuildRecreateOnboardOpts(...)` so the wiring is testable from the helper module without driving the full rebuild flow.
- `src/lib/actions/sandbox/rebuild-gpu-opt-out.test.ts` covers both helpers. For `rebuildShouldOptOutGpu`: null/undefined entry, `sandboxGpuMode: "0"` (with and without `sandboxGpuEnabled`), `sandboxGpuMode: "auto"` (CPU-fallback `sandboxGpuEnabled: false` returns false, matching the established `getResumeSandboxGpuOverrides` semantic), `sandboxGpuMode: "1"`, the legacy `gpuEnabled: false` fallback when no `sandboxGpuMode` is recorded, the counter-signal case where `sandboxGpuEnabled: true` overrides legacy `gpuEnabled: false`, no-intent (`{}` and `gpuEnabled: true`), unrecognised `sandboxGpuMode` values that are NOT routed through the legacy `gpuEnabled` fallback (corrupted state cannot flip a sandbox into a permanent opt-out), empty-string `sandboxGpuMode` treated as no recorded mode and so still falling back to legacy `gpuEnabled: false`, and case-insensitive aliases (`"AUTO"`, `"off"`, `"false"`, `"TRUE"`). For `buildRebuildRecreateOnboardOpts`: `noGpu: true` is forwarded for `sandboxGpuMode: "0"` and legacy `gpuEnabled: false`; omitted for `sandboxGpuMode: "auto"` / `"1"` and for the no-sandbox-entry case; `agent` / `storedFromDockerfile` / `autoYes` are preserved regardless of GPU opt-out.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [X] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [X] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebuild now preserves a sandbox's GPU opt-out intent so resumed onboarding skips GPU preflight on non‑NVIDIA hosts when appropriate, while preserving other onboarding options.

* **Tests**
  * Added comprehensive tests covering explicit modes, legacy metadata precedence, malformed/empty values, normalization, and generated recreate/resume options.

* **Documentation**
  * Documented that recorded sandbox GPU mode is preserved across rebuilds and affects onboard resume behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
