### PR TITLE
fix(cli): surface copy-paste recovery hints in onboard error paths

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -157,7 +157,7 @@ After fixing the key, re-enable web search with `nemoclaw config web-search`.
 
 The wizard prompts for a sandbox name.
 Names must be 1 to 63 characters, lowercase, start with a letter, contain only letters, numbers, and internal hyphens, and end with a letter or number.
-Uppercase letters are automatically lowercased.
+Names that do not match these rules are rejected; the CLI prints a `Try: <suggested-slug>` recovery line whenever it can derive a valid lowercase, hyphen-separated form from the input (for example, `MyAssistant` produces `Try: myassistant`).
 Names that match global CLI commands (`status`, `list`, `debug`, etc.) are rejected to avoid routing conflicts.
 Use `--agent <name>` to target a specific installed agent profile during onboarding.
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -157,7 +157,8 @@ After fixing the key, re-enable web search with `nemoclaw config web-search`.
 
 The wizard prompts for a sandbox name.
 Names must be 1 to 63 characters, lowercase, start with a letter, contain only letters, numbers, and internal hyphens, and end with a letter or number.
-Names that do not match these rules are rejected; the CLI prints a `Try: <suggested-slug>` recovery line whenever it can derive a valid lowercase, hyphen-separated form from the input (for example, `MyAssistant` produces `Try: myassistant`).
+The CLI rejects names that do not match these rules.
+It also prints a `Try: <suggested-slug>` recovery line whenever it can derive a valid lowercase, hyphen-separated form from the input, so passing `--name MyAssistant` reports `Try: myassistant`.
 Names that match global CLI commands (`status`, `list`, `debug`, etc.) are rejected to avoid routing conflicts.
 Use `--agent <name>` to target a specific installed agent profile during onboarding.
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -367,7 +367,8 @@ Run `nemoclaw status` for a broader gateway health report.
 ### Invalid sandbox name
 
 Sandbox names must be lowercase, start with a letter, contain only letters, numbers, and internal hyphens, and end with a letter or number.
-Uppercase letters are automatically lowercased.
+Names that do not match these rules are rejected; the wizard prints a `Try: <suggested-slug>` recovery line whenever it can derive a valid lowercase, hyphen-separated form from the input.
+For example, passing `--name MyAssistant` rejects the upper-cased input and prints `Try: myassistant` so you can rerun with the suggested slug.
 
 Names that collide with global CLI commands are also rejected.
 Reserved names include `onboard`, `list`, `deploy`, `setup`, `start`, `stop`, `status`, `debug`, `uninstall`, `credentials`, and `help`.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -367,8 +367,8 @@ Run `nemoclaw status` for a broader gateway health report.
 ### Invalid sandbox name
 
 Sandbox names must be lowercase, start with a letter, contain only letters, numbers, and internal hyphens, and end with a letter or number.
-Names that do not match these rules are rejected; the wizard prints a `Try: <suggested-slug>` recovery line whenever it can derive a valid lowercase, hyphen-separated form from the input.
-For example, passing `--name MyAssistant` rejects the upper-cased input and prints `Try: myassistant` so you can rerun with the suggested slug.
+The CLI rejects names that do not match these rules.
+It prints a `Try: <suggested-slug>` recovery line whenever it can derive a valid lowercase, hyphen-separated form from the input, so passing `--name MyAssistant` reports `Try: myassistant` and you can rerun with the suggested slug.
 
 Names that collide with global CLI commands are also rejected.
 Reserved names include `onboard`, `list`, `deploy`, `setup`, `start`, `stop`, `status`, `debug`, `uninstall`, `credentials`, and `help`.

--- a/src/lib/name-validation.ts
+++ b/src/lib/name-validation.ts
@@ -17,13 +17,15 @@ function validationSubject(label: string): string {
 }
 
 // Derive a copy-paste-ready RFC 1123 label from arbitrary user input. Returns
-// null when no recoverable slug exists (empty, all-symbol input, or the input
-// is already valid). The transform mirrors what a user would do by hand:
-// lowercase, replace illegal chars with `-`, collapse runs of `-`, trim
-// terminal `-`, prefix a leading non-letter with `s-`, and truncate to the
-// max length without leaving a dangling hyphen.
+// null when no recoverable slug exists (empty, all-symbol input) or when the
+// input is already a valid name (no canonicalisation is performed against
+// inputs the validator would accept). The transform mirrors what a user would
+// do by hand: lowercase, replace illegal chars with `-`, collapse runs of `-`,
+// trim terminal `-`, prefix a leading non-letter with `s-`, and truncate to
+// the max length without leaving a dangling hyphen.
 export function suggestNameSlug(value: string): string | null {
   if (typeof value !== "string") return null;
+  if (value.length <= NAME_MAX_LENGTH && NAME_VALID_PATTERN.test(value)) return null;
   let slug = value.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-");
   slug = slug.replace(/^-+|-+$/g, "");
   if (!slug) return null;

--- a/src/lib/name-validation.ts
+++ b/src/lib/name-validation.ts
@@ -6,12 +6,37 @@ export const NAME_ALLOWED_FORMAT =
   `1-${NAME_MAX_LENGTH} characters, lowercase, starts with a letter, ` +
   "letters/numbers/internal hyphens only, ends with letter/number";
 
+const NAME_VALID_PATTERN = /^[a-z]([a-z0-9-]*[a-z0-9])?$/;
+
 function validationSubject(label: string): string {
   const normalized = label.trim().toLowerCase();
   if (normalized === "sandbox name") return "Sandbox names";
   if (normalized === "instance name") return "Instance names";
   if (normalized === "target sandbox name") return "Target sandbox names";
   return "Names";
+}
+
+// Derive a copy-paste-ready RFC 1123 label from arbitrary user input. Returns
+// null when no recoverable slug exists (empty, all-symbol input, or the input
+// is already valid). The transform mirrors what a user would do by hand:
+// lowercase, replace illegal chars with `-`, collapse runs of `-`, trim
+// terminal `-`, prefix a leading non-letter with `s-`, and truncate to the
+// max length without leaving a dangling hyphen.
+export function suggestNameSlug(value: string): string | null {
+  if (typeof value !== "string") return null;
+  let slug = value.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-");
+  slug = slug.replace(/^-+|-+$/g, "");
+  if (!slug) return null;
+  if (!/^[a-z]/.test(slug)) {
+    slug = `s-${slug}`;
+  }
+  if (slug.length > NAME_MAX_LENGTH) {
+    slug = slug.slice(0, NAME_MAX_LENGTH);
+  }
+  slug = slug.replace(/[^a-z0-9]+$/g, "");
+  if (!slug || !NAME_VALID_PATTERN.test(slug)) return null;
+  if (slug === value) return null;
+  return slug;
 }
 
 export function getNameValidationGuidance(
@@ -28,6 +53,10 @@ export function getNameValidationGuidance(
   }
   if (opts.includeAllowedFormat !== false) {
     lines.push(`Allowed format: ${NAME_ALLOWED_FORMAT}.`);
+  }
+  const suggestion = suggestNameSlug(value);
+  if (suggestion) {
+    lines.push(`Try: ${suggestion}`);
   }
   return lines;
 }

--- a/src/lib/name-validation.ts
+++ b/src/lib/name-validation.ts
@@ -6,7 +6,7 @@ export const NAME_ALLOWED_FORMAT =
   `1-${NAME_MAX_LENGTH} characters, lowercase, starts with a letter, ` +
   "letters/numbers/internal hyphens only, ends with letter/number";
 
-const NAME_VALID_PATTERN = /^[a-z]([a-z0-9-]*[a-z0-9])?$/;
+export const NAME_VALID_PATTERN = /^[a-z]([a-z0-9-]*[a-z0-9])?$/;
 
 function validationSubject(label: string): string {
   const normalized = label.trim().toLowerCase();

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -153,6 +153,7 @@ const {
 const errnoUtils: typeof import("./core/errno") = require("./core/errno");
 const { isErrnoException } = errnoUtils;
 const { requireValue }: typeof import("./core/require-value") = require("./core/require-value");
+const { logMissingNvidiaApiKeyHelp }: typeof import("./onboard/missing-credential-hints") = require("./onboard/missing-credential-hints");
 
 type RunnerOptions = {
   env?: NodeJS.ProcessEnv;
@@ -4434,11 +4435,7 @@ async function setupNim(
           if (isNonInteractive()) {
             const resolvedNvidiaKey = resolveProviderCredential("NVIDIA_API_KEY");
             if (!resolvedNvidiaKey) {
-              console.error(
-                "  NVIDIA_API_KEY (or NEMOCLAW_PROVIDER_KEY) is required for NVIDIA Endpoints in non-interactive mode.",
-              );
-              console.error("  Set with: export NVIDIA_API_KEY=nvapi-...");
-              console.error(`  Get a key from ${REMOTE_PROVIDER_CONFIG.build.helpUrl}`);
+              logMissingNvidiaApiKeyHelp(REMOTE_PROVIDER_CONFIG.build.helpUrl);
               process.exit(1);
             }
             const keyError = validateNvidiaApiKeyValue(resolvedNvidiaKey);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4437,6 +4437,8 @@ async function setupNim(
               console.error(
                 "  NVIDIA_API_KEY (or NEMOCLAW_PROVIDER_KEY) is required for NVIDIA Endpoints in non-interactive mode.",
               );
+              console.error("  Set with: export NVIDIA_API_KEY=nvapi-...");
+              console.error(`  Get a key from ${REMOTE_PROVIDER_CONFIG.build.helpUrl}`);
               process.exit(1);
             }
             const keyError = validateNvidiaApiKeyValue(resolvedNvidiaKey);

--- a/src/lib/onboard/missing-credential-hints.ts
+++ b/src/lib/onboard/missing-credential-hints.ts
@@ -5,7 +5,8 @@ export function logMissingNvidiaApiKeyHelp(helpUrl: string | null | undefined): 
   console.error(
     "  NVIDIA_API_KEY (or NEMOCLAW_PROVIDER_KEY) is required for NVIDIA Endpoints in non-interactive mode.",
   );
-  console.error("  Set with: export NVIDIA_API_KEY=nvapi-...");
+  console.error("  Set with:");
+  console.error("  export NVIDIA_API_KEY=nvapi-...");
   if (helpUrl) {
     console.error(`  Get a key from ${helpUrl}`);
   }

--- a/src/lib/onboard/missing-credential-hints.ts
+++ b/src/lib/onboard/missing-credential-hints.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function logMissingNvidiaApiKeyHelp(helpUrl: string | null | undefined): void {
+  console.error(
+    "  NVIDIA_API_KEY (or NEMOCLAW_PROVIDER_KEY) is required for NVIDIA Endpoints in non-interactive mode.",
+  );
+  console.error("  Set with: export NVIDIA_API_KEY=nvapi-...");
+  if (helpUrl) {
+    console.error(`  Get a key from ${helpUrl}`);
+  }
+}

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -6,7 +6,7 @@ import type {
   SpawnSyncOptionsWithStringEncoding,
   SpawnSyncReturns,
 } from "node:child_process";
-import { NAME_ALLOWED_FORMAT, NAME_MAX_LENGTH } from "./name-validation";
+import { NAME_ALLOWED_FORMAT, NAME_MAX_LENGTH, NAME_VALID_PATTERN } from "./name-validation";
 
 const { spawnSync } = require("child_process");
 const path = require("path");
@@ -322,7 +322,7 @@ function validateName(name: string, label = "name"): string {
       `${label} too long (max ${NAME_MAX_LENGTH} chars): '${name.slice(0, 20)}...'. Allowed format: ${NAME_ALLOWED_FORMAT}.`,
     );
   }
-  if (!/^[a-z]([a-z0-9-]*[a-z0-9])?$/.test(name)) {
+  if (!NAME_VALID_PATTERN.test(name)) {
     throw new Error(
       `Invalid ${label}: '${name}'. Allowed format: ${NAME_ALLOWED_FORMAT}.`,
     );

--- a/test/onboard-sandbox-name.test.ts
+++ b/test/onboard-sandbox-name.test.ts
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { loadAgent } from "../dist/lib/agent/defs.js";
@@ -106,7 +112,10 @@ describe("onboard sandbox naming helpers", () => {
     it("collapses runs of hyphens and trims terminal hyphens", () => {
       expect(suggestNameSlug("--legacy--")).toBe("legacy");
       expect(suggestNameSlug("foo  bar")).toBe("foo-bar");
-      expect(suggestNameSlug("a---b")).toBe("a-b");
+    });
+
+    it("returns null for inputs that are already valid even with internal hyphen runs", () => {
+      expect(suggestNameSlug("a---b")).toBeNull();
     });
 
     it("prefixes 's-' when the slug would otherwise start with a digit", () => {
@@ -131,4 +140,65 @@ describe("onboard sandbox naming helpers", () => {
       expect(suggestNameSlug("!!!")).toBeNull();
     });
   });
+
+  it(
+    "rejects --name MyAssistant at the onboard boundary and prints Try: myassistant",
+    () => {
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-bad-name-"));
+      const scriptPath = path.join(tmpDir, "onboard-bad-name.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+
+      const script = String.raw`
+const onboardModule = require(${onboardPath});
+
+(async () => {
+  const lines = [];
+  const originalError = console.error;
+  const originalExit = process.exit;
+  console.error = (...args) => lines.push(args.join(" "));
+  process.exit = (code) => {
+    const error = new Error("process.exit:" + code);
+    error.exitCode = code;
+    throw error;
+  };
+  let exitCode = null;
+  try {
+    await onboardModule.onboard({ sandboxName: "MyAssistant", nonInteractive: true });
+    process.stdout.write(JSON.stringify({ completed: true, exitCode, lines }));
+  } catch (error) {
+    exitCode = error.exitCode ?? null;
+    process.stdout.write(
+      JSON.stringify({ completed: false, exitCode, lines, message: error.message }),
+    );
+  } finally {
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+})().catch((error) => {
+  process.stderr.write(error.stack || String(error));
+  process.exit(2);
+});
+`;
+      fs.writeFileSync(scriptPath, script);
+
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: { ...process.env, HOME: tmpDir },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(result.stdout.trim());
+      assert.equal(payload.completed, false);
+      assert.equal(payload.exitCode, 1);
+      assert.ok(
+        payload.lines.some((line: string) => line.includes("Invalid sandbox name: 'MyAssistant'.")),
+        `expected 'Invalid sandbox name' line, got ${JSON.stringify(payload.lines)}`,
+      );
+      assert.ok(
+        payload.lines.some((line: string) => line.trim() === "Try: myassistant"),
+        `expected standalone 'Try: myassistant' line, got ${JSON.stringify(payload.lines)}`,
+      );
+    },
+  );
 });

--- a/test/onboard-sandbox-name.test.ts
+++ b/test/onboard-sandbox-name.test.ts
@@ -93,7 +93,7 @@ describe("onboard sandbox naming helpers", () => {
   });
 
   describe("suggestNameSlug", () => {
-    it("lowercases mixed-case input (T5987921 spec: 'MyAssistant' -> 'myassistant')", () => {
+    it("lowercases mixed-case input", () => {
       expect(suggestNameSlug("MyAssistant")).toBe("myassistant");
     });
 

--- a/test/onboard-sandbox-name.test.ts
+++ b/test/onboard-sandbox-name.test.ts
@@ -4,7 +4,11 @@
 import { describe, expect, it } from "vitest";
 
 import { loadAgent } from "../dist/lib/agent/defs.js";
-import { getNameValidationGuidance, NAME_ALLOWED_FORMAT } from "../dist/lib/name-validation.js";
+import {
+  getNameValidationGuidance,
+  NAME_ALLOWED_FORMAT,
+  suggestNameSlug,
+} from "../dist/lib/name-validation.js";
 
 const {
   getDefaultSandboxNameForAgent,
@@ -82,8 +86,49 @@ describe("onboard sandbox naming helpers", () => {
     expect(getNameValidationGuidance("sandbox name", "a".repeat(64))).toEqual([
       "Sandbox names must be 63 characters or fewer.",
       `Allowed format: ${NAME_ALLOWED_FORMAT}.`,
+      `Try: ${"a".repeat(63)}`,
     ]);
     expect(getNameValidationGuidance("sandbox name", "bad name", { includeAllowedFormat: false }))
-      .toEqual(["Sandbox names cannot contain spaces."]);
+      .toEqual(["Sandbox names cannot contain spaces.", "Try: bad-name"]);
+  });
+
+  describe("suggestNameSlug", () => {
+    it("lowercases mixed-case input (T5987921 spec: 'MyAssistant' -> 'myassistant')", () => {
+      expect(suggestNameSlug("MyAssistant")).toBe("myassistant");
+    });
+
+    it("replaces spaces and other illegal characters with hyphens", () => {
+      expect(suggestNameSlug("bad name")).toBe("bad-name");
+      expect(suggestNameSlug("My Project Sandbox")).toBe("my-project-sandbox");
+      expect(suggestNameSlug("agent_007")).toBe("agent-007");
+    });
+
+    it("collapses runs of hyphens and trims terminal hyphens", () => {
+      expect(suggestNameSlug("--legacy--")).toBe("legacy");
+      expect(suggestNameSlug("foo  bar")).toBe("foo-bar");
+      expect(suggestNameSlug("a---b")).toBe("a-b");
+    });
+
+    it("prefixes 's-' when the slug would otherwise start with a digit", () => {
+      expect(suggestNameSlug("123-leading")).toBe("s-123-leading");
+      expect(suggestNameSlug("9lives")).toBe("s-9lives");
+    });
+
+    it("truncates over-length inputs to the max name length", () => {
+      const slug = suggestNameSlug("a".repeat(80));
+      expect(slug).toBe("a".repeat(63));
+      expect(slug!.length).toBe(63);
+    });
+
+    it("returns null when the input is already a valid name", () => {
+      expect(suggestNameSlug("my-assistant")).toBeNull();
+      expect(suggestNameSlug("openclaw")).toBeNull();
+    });
+
+    it("returns null when no recoverable slug can be derived", () => {
+      expect(suggestNameSlug("")).toBeNull();
+      expect(suggestNameSlug("---")).toBeNull();
+      expect(suggestNameSlug("!!!")).toBeNull();
+    });
   });
 });

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -4745,10 +4745,14 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
         ),
       ),
     );
-    assert.ok(
-      payload.lines.some((line: string) =>
-        line.includes("Set with: export NVIDIA_API_KEY=nvapi-..."),
-      ),
+    const setWithIndex = payload.lines.findIndex(
+      (line: string) => line.trim() === "Set with:",
+    );
+    assert.ok(setWithIndex >= 0, "expected a standalone 'Set with:' line");
+    assert.equal(
+      payload.lines[setWithIndex + 1].trim(),
+      "export NVIDIA_API_KEY=nvapi-...",
+      "expected the export command on its own line so it can be copy-pasted",
     );
     assert.ok(
       payload.lines.some((line: string) =>

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -4643,6 +4643,120 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
     );
   });
 
+  it("fails early in non-interactive mode with copy-paste recovery hints when no NVIDIA_API_KEY is set", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-build-missingkey-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "build-missingkey-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "credentials", "store.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+
+    const script = String.raw`
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+
+const prompts = [];
+credentials.prompt = async (message) => {
+  prompts.push(message);
+  throw new Error("unexpected prompt");
+};
+credentials.ensureApiKey = async () => {
+  throw new Error("unexpected ensureApiKey");
+};
+runner.runCapture = () => "";
+
+const onboardFile = ${onboardPath};
+const source = fs.readFileSync(onboardFile, "utf-8");
+const injected = source + "\nmodule.exports.__setNonInteractive = (value) => { NON_INTERACTIVE = value; };";
+const onboardModule = new Module(onboardFile, module);
+onboardModule.filename = onboardFile;
+onboardModule.paths = Module._nodeModulePaths(path.dirname(onboardFile));
+onboardModule._compile(injected, onboardFile);
+
+const { setupNim, __setNonInteractive } = onboardModule.exports;
+
+(async () => {
+  delete process.env.NVIDIA_API_KEY;
+  delete process.env.NEMOCLAW_PROVIDER_KEY;
+  __setNonInteractive(true);
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  process.exit = (code) => {
+    const error = new Error("process.exit:" + code);
+    error.exitCode = code;
+    throw error;
+  };
+  try {
+    await setupNim(null);
+    originalLog(JSON.stringify({ completed: true, prompts, lines }));
+  } catch (error) {
+    originalLog(
+      JSON.stringify({
+        completed: false,
+        prompts,
+        lines,
+        message: error.message,
+        exitCode: error.exitCode ?? null,
+      }),
+    );
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NVIDIA_API_KEY: "",
+        NEMOCLAW_PROVIDER_KEY: "",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.completed, false);
+    assert.equal(payload.exitCode, 1);
+    assert.equal(payload.prompts.length, 0);
+    assert.ok(
+      payload.lines.some((line: string) =>
+        line.includes(
+          "NVIDIA_API_KEY (or NEMOCLAW_PROVIDER_KEY) is required for NVIDIA Endpoints in non-interactive mode.",
+        ),
+      ),
+    );
+    assert.ok(
+      payload.lines.some((line: string) =>
+        line.includes("Set with: export NVIDIA_API_KEY=nvapi-..."),
+      ),
+    );
+    assert.ok(
+      payload.lines.some((line: string) =>
+        line.includes("Get a key from https://build.nvidia.com/settings/api-keys"),
+      ),
+    );
+  });
+
   it("lets users re-enter an NVIDIA API key after authorization failure without restarting selection", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-build-auth-retry-"));


### PR DESCRIPTION
## Summary
Two `nemoclaw onboard` error paths named the root cause and exited non-zero, but neither emitted the copy-paste-ready recovery command the T5987921 spec requires. Sandbox-name validation now appends a `Try: <derived-slug>` line whenever a recoverable slug differs from the rejected input, and the non-interactive `NVIDIA_API_KEY` requirement now prints the concrete `export NVIDIA_API_KEY=nvapi-...` line plus the existing build-provider help URL.

## Related Issue
Fixes #4425.

## Changes
- `src/lib/name-validation.ts`: add and export `suggestNameSlug(value)` which derives a copy-paste-ready RFC 1123 label from arbitrary user input (lowercase, replace illegal characters with `-`, collapse runs of `-`, trim terminal `-`, prefix a leading non-letter with `s-`, truncate to `NAME_MAX_LENGTH`) and returns `null` when no recoverable slug exists or the input is already valid. `getNameValidationGuidance(label, value, opts)` now appends a `Try: <slug>` line whenever `suggestNameSlug(value)` yields a non-null suggestion, so every CLI surface that already prints guidance (`onboard`, `sandbox-agent`, `deploy`) picks it up automatically.
- `src/lib/onboard/missing-credential-hints.ts`: new helper module exposing `logMissingNvidiaApiKeyHelp(helpUrl)`. The helper emits a three-line recovery block before the caller exits non-zero — first the requirement line (`NVIDIA_API_KEY (or NEMOCLAW_PROVIDER_KEY) is required for NVIDIA Endpoints in non-interactive mode.`), then the `Set with:` label on its own line followed by the standalone `export NVIDIA_API_KEY=nvapi-...` command so the user can copy-paste it directly, and finally the existing `Get a key from <helpUrl>` line when a help URL is configured.
- `src/lib/onboard.ts`: the non-interactive `NVIDIA_API_KEY` "is required" branch in the build-provider configuration step delegates to `logMissingNvidiaApiKeyHelp` and then exits non-zero, replacing the previous inline `console.error` block. This keeps the top-level entrypoint net-smaller and satisfies the `codebase-growth-guardrails` policy.
- `src/lib/runner.ts` and `src/lib/name-validation.ts`: the RFC 1123 label regex now lives once in `name-validation.ts` as the exported `NAME_VALID_PATTERN`, and `runner.ts:validateName()` imports it instead of duplicating the literal — so the slug helper and the hard validator cannot drift.
- `test/onboard-sandbox-name.test.ts`: update the existing equality assertions for `getNameValidationGuidance` to expect the new `Try: <slug>` line where the input is recoverable, and add a dedicated `suggestNameSlug` describe block covering: mixed-case (`MyAssistant` → `myassistant`), illegal characters mapped to hyphen (`bad name`, `My Project Sandbox`, `agent_007`), collapsed and trimmed hyphen runs that produce a different slug (`--legacy--`, `foo  bar`), digit-leading inputs that gain the `s-` prefix (`123-leading`, `9lives`), length truncation (`a × 80` → `a × 63`), the already-valid no-op cases including internal hyphen runs (`my-assistant`, `openclaw`, `a---b`), and the unrecoverable cases that return `null` (empty string, `---`, `!!!`). A subprocess test drives the onboard entrypoint with `{ sandboxName: "MyAssistant", nonInteractive: true }` and asserts exit code 1, the `Invalid sandbox name: 'MyAssistant'.` error line, and the standalone `Try: myassistant` recovery line so the CLI wiring cannot regress while the helper-level tests pass.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [X] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [X] `npx prek run --all-files` passes
- [X] `npm test` passes
- [X] Tests added or updated for new or changed behavior
- [X] No secrets, API keys, or credentials committed
- [X] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shows a "Try: <suggestion>" sandbox-name hint when input is invalid, offering a compliant lowercase, hyphen-separated slug when possible.
  * Non-interactive onboarding now exits early with clear copy-paste recovery instructions ("Set with:" and example) and an optional help URL when required provider credentials are missing.

* **Documentation**
  * Updated onboarding and troubleshooting docs to reflect stricter name validation and the new "Try:" suggestion behavior.

* **Tests**
  * Added/updated tests covering slug suggestions and non-interactive credential failure behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->