### PR TITLE
docs: update onboarding quickstarts

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -20,6 +20,10 @@ Interfaces, defaults, and supported features may change without notice, and it i
 </Warning>
 
 Review the [Prerequisites](/get-started/prerequisites) before starting.
+Docker must be installed, running, and reachable from the current shell before Hermes onboarding can build the sandbox image.
+On Linux, the installer can install Docker, start the service, and add your user to the `docker` group.
+If it changes group membership, run the printed `newgrp docker` recovery command before rerunning the installer.
+On macOS, start Docker Desktop or Colima before you run the installer.
 The first Hermes build can take several minutes because NemoClaw builds the Hermes sandbox base image if it is not already cached.
 
 ## Install and Onboard
@@ -32,6 +36,20 @@ $ export NEMOCLAW_AGENT=hermes
 $ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
+If a headless host needs to expose the Hermes API through a remote URL or tunnel, set `CHAT_UI_URL` before onboarding.
+Use the externally reachable origin for port `8642`, without the `/v1` path.
+NemoClaw derives the forwarded port from this value, binds the forward for remote access when the origin is non-loopback, and prints the final OpenAI-compatible base URL with `/v1` in the ready summary.
+
+```console
+$ export NEMOCLAW_AGENT=hermes
+$ export CHAT_UI_URL="https://hermes.example.com:8642"
+$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+For SSH local port forwarding to `127.0.0.1:8642`, leave `CHAT_UI_URL` unset.
+Do not append an OpenClaw `#token=` fragment to the Hermes URL.
+Hermes API clients authenticate with the bearer token from the generated Hermes environment instead of an OpenClaw dashboard URL token.
+
 If NemoClaw is already installed, start Hermes onboarding directly.
 
 ```console
@@ -40,7 +58,8 @@ $ nemohermes onboard
 
 ## Respond to the Wizard
 
-The onboard wizard asks for a sandbox name, inference provider, model, credentials, and network policy preset.
+The onboard wizard asks for an inference provider, model, any required credential, and sandbox name before it prints the review summary.
+After you confirm, NemoClaw registers inference, prompts for supported messaging channels, builds and starts the sandbox, sets up Hermes, then applies the selected network policy tier and presets.
 At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
 
 The default Hermes sandbox name is `hermes`.
@@ -56,7 +75,7 @@ The provider options and credential environment variables are the same as the st
 For provider-specific prompts, refer to the [Respond to the Onboard Wizard](/get-started/quickstart#respond-to-the-onboard-wizard) section and the [Inference Options](/inference/inference-options) page.
 The Hermes wizard does not ask for Brave Web Search because Hermes does not use NemoClaw's OpenClaw web-search configuration.
 
-After provider and policy selection, review the summary and confirm the build.
+After provider and model selection, review the summary and confirm the build.
 NemoClaw writes Hermes configuration into `/sandbox/.hermes`, routes model traffic through `inference.local`, and starts the Hermes gateway inside the sandbox.
 The Hermes image includes runtime dependencies for the supported NemoClaw messaging integrations, API service, and health endpoint.
 The base image does not include unsupported Hermes integrations.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -30,12 +30,28 @@ NemoClaw creates a fresh OpenClaw instance inside the sandbox during the onboard
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
-The piped installer prompts through your terminal. In headless scripts or CI,
-pass explicit acceptance to the `bash` side of the pipe:
+The third-party software notice runs before Node.js or the NemoClaw CLI is installed.
+The piped installer can prompt through your terminal when a TTY is available.
+In non-TTY contexts, such as CI, an SSH command with piped stdin, or a shell script, pass explicit acceptance to the `bash` side of the pipe:
 
-```console
-$ curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
 ```
+
+or pass the installer flag through `bash -s`:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --yes-i-accept-third-party-software
+```
+
+To run both installation and onboarding without prompts, also set non-interactive mode and the provider variables your chosen inference path requires:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
+```
+
+Do not place `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` before `curl`.
+In `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 curl ... | bash`, the variable applies only to `curl`, so the installer process cannot see the acceptance.
 
 If you use nvm or fnm to manage Node.js, the installer might not update your current shell's PATH.
 If `nemoclaw` is not found after install, run `source ~/.bashrc` (or `source ~/.zshrc` for zsh) or open a new terminal.
@@ -69,7 +85,9 @@ If you export `NEMOCLAW_DISABLE_DEVICE_AUTH` after onboarding finishes, it has n
 
 ### Respond to the Onboard Wizard
 
-After the installer launches `nemoclaw onboard`, the wizard runs preflight checks, starts or reuses the OpenShell gateway, and asks for an inference provider, sandbox name, optional web search, optional messaging channels, and network policy presets.
+After the installer launches `nemoclaw onboard`, the wizard runs preflight checks, starts or reuses the OpenShell gateway, asks for an inference provider and model, collects any required credential, then asks for the sandbox name.
+It prints a review summary before it registers the provider with OpenShell.
+After you confirm, NemoClaw registers inference, prompts for optional web search and messaging channels, builds and starts the sandbox, sets up OpenClaw, then applies the selected network policy tier and presets.
 At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
 If existing sandbox sessions are running, the installer warns before onboarding because the setup can rebuild or upgrade sandboxes after the new sandbox launches.
 
@@ -253,8 +271,9 @@ For example, if you picked an OpenAI-compatible endpoint, the summary looks like
   ──────────────────────────────────────────────────
   Provider:      compatible-endpoint
   Model:         openai/openai/gpt-5.5
-  API key:       COMPATIBLE_API_KEY (staged for OpenShell gateway registration)
+  API key:       configured for OpenShell gateway registration
   Web search:    disabled
+  Managed tools: none
   Messaging:     none
   Sandbox name:  my-gpt-claw
   Note:          Sandbox build typically takes 5–15 minutes on this host.
@@ -283,6 +302,7 @@ Review [Messaging Channels](/manage-sandboxes/messaging-channels) before enablin
 ### Choose Network Policy Presets
 
 After the sandbox image builds and OpenClaw starts inside the sandbox, NemoClaw asks which network policy tier to apply.
+Web search and messaging selections happen before this point so the sandbox image and the policy suggestions stay aligned.
 The default **Balanced** tier includes common development presets such as npm, PyPI, Hugging Face, Homebrew, and Brave Search when the selected agent supports web search.
 Use the arrow keys or `j` and `k` to move, Space to select, and Enter to confirm.
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -66,6 +66,17 @@ Use this command for new installs and for recreating a sandbox after changes to 
 $ nemoclaw onboard [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--sandbox-gpu | --no-sandbox-gpu] [--sandbox-gpu-device <device>] [--agent <name>] [--control-ui-port <N>] [--yes | -y] [--no-ollama-autostart] [--yes-i-accept-third-party-software]
 ```
 
+#### `--resume` and `--fresh`
+
+NemoClaw records onboarding progress so interrupted runs can continue.
+Use `--resume` to continue a resumable onboarding session with the provider, model, sandbox name, agent, and custom Dockerfile path recorded by the original run.
+If the recorded session conflicts with flags you pass on the recovery run, NemoClaw exits and tells you to either rerun with the original settings or start over.
+
+Use `--fresh` to discard the saved onboarding session and start the wizard from the beginning.
+This clears stale or failed session state before NemoClaw creates a new session record.
+The installer also accepts `--fresh` and forwards it to `nemoclaw onboard`, which skips automatic resume detection.
+`--resume` and `--fresh` are mutually exclusive.
+
 <Warning>
 For NemoClaw-managed environments, use `nemoclaw onboard` when you need to create or recreate the OpenShell gateway or sandbox.
 Avoid `openshell self-update`, `npm update -g openshell`, `openshell gateway start --recreate`, or `openshell sandbox create` directly unless you intend to manage OpenShell separately and then rerun `nemoclaw onboard`.
@@ -88,7 +99,8 @@ Supported non-experimental choices include NVIDIA Endpoints, OpenAI, Anthropic, 
 Credentials are registered with the OpenShell gateway and never persisted to host disk. See [Credential Storage](/security/credential-storage) for details on inspection, rotation, and migration from earlier releases.
 The legacy `nemoclaw setup` command is deprecated; use `nemoclaw onboard` instead.
 
-After provider selection, the wizard prompts for a **policy tier** that controls the default set of network policy presets applied to the sandbox.
+After provider selection, the wizard reviews the provider, model, credential state, and sandbox name before registering inference.
+It then prompts for optional web search and messaging channels, builds and starts the sandbox, and asks for a **policy tier** that controls the default set of network policy presets applied to the sandbox.
 Three tiers are available:
 
 | Tier | Description |


### PR DESCRIPTION
## Summary
Update the onboarding docs for the current v0.0.53 flow so users see the correct installer, quickstart, and Hermes setup guidance.

## Related Issue
Fixes #4418
Fixes #4417
Fixes #4413
Fixes #4412

## Changes
- Added `nemoclaw onboard --resume` and `--fresh` guidance to the command reference.
- Updated the OpenClaw quickstart for non-TTY installer acceptance and the current review, web search, messaging, sandbox, and policy ordering.
- Added Hermes Docker prerequisite notes and headless `CHAT_UI_URL` guidance for exposing the Hermes API on port `8642`.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes:
- Commit and push hooks passed for the staged doc changes.
- `npm run docs` completed with 0 errors and 1 existing Fern theme contrast warning.
- `npx prek run --all-files` failed in unrelated existing CLI/e2e tests: two test timeouts and one sandbox connect assertion.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Hermes quickstart with Docker prerequisites, including Linux and macOS setup steps
  * Added headless/remote access guidance for exposing the Hermes API externally
  * Clarified third-party software acceptance process for piped installer in TTY and non-TTY environments
  * Documented `--resume` and `--fresh` flags for resumable and fresh onboarding runs
  * Updated onboarding wizard flow descriptions for improved clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->