### PR TITLE
fix(skills): address NVSkills validator findings on user skills (stacked on #4438)

### DIFF
--- a/.agents/skills/nemoclaw-user-agent-skills/SKILL.md
+++ b/.agents/skills/nemoclaw-user-agent-skills/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: "nemoclaw-user-agent-skills"
-description: "Describes the agent skills shipped with NemoClaw and how to access them by cloning the repository. Use when users ask about AI agent support, coding assistant integration, or the .agents/skills/ directory. Trigger keywords - nemoclaw agent skills, ai coding assistant, cursor, claude code, copilot."
+description: "Helps users obtain and load NemoClaw's bundled agent skills into Claude Code, Cursor, Copilot, or another skills-aware AI coding assistant by cloning the NemoClaw repository and pointing the assistant at the .agents/skills/ directory. Use when the user wants to install, copy, mount, or activate NemoClaw skills inside their assistant — not for general discovery of which skills exist (use nemoclaw-skills-guide for catalog browsing). Trigger keywords - install nemoclaw agent skills, clone nemoclaw skills, load .agents/skills, point cursor at nemoclaw skills, claude code nemoclaw skills, copy nemoclaw skills into assistant."
 license: "Apache-2.0"
+metadata:
+  author: "Miyoung Choi <miyoungc@nvidia.com>"
+  tags:
+    - nemoclaw
+    - agent-skills
+    - installation
+    - claude-code
+    - cursor
+    - copilot
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -9,6 +18,27 @@ license: "Apache-2.0"
 
 # NemoClaw Agent Skills for Your AI Coding Assistant
 
+## Instructions
+
+Use this skill only when the user wants to **install or load** NemoClaw's agent skills into their AI coding assistant. If the user is asking *which* skills exist or *what they do*, hand off to `nemoclaw-skills-guide` instead.
+
+Follow this fixed sequence. Do not exceed the listed tool budget.
+
+1. **Confirm intent.** In one sentence, restate what the user wants (e.g., "You want to load NemoClaw's bundled skills into Claude Code on macOS"). Do not call any tools yet.
+2. **Read the reference once.** Load `references/agent-skills.md` exactly one time. Do not re-read it on the same request.
+3. **Answer with the install steps** scoped to the assistant the user named (Claude Code, Cursor, Copilot, generic). Use the clone command and the assistant-specific skills directory pattern from the reference.
+4. **Verify and stop.** Tell the user how to confirm the assistant sees the skills (typically `ls` of the target directory or the assistant's skill listing command). Do not run additional tool calls after the verification instruction.
+
+Tool budget per invocation: at most **one** Read of `references/agent-skills.md` and at most **one** shell or filesystem call if the user asks for a verification command. If the user's request expands beyond install/load, return the answer and suggest the appropriate sibling skill rather than chaining more tool calls.
+
+## Examples
+
+**Example 1 — Claude Code on macOS.** User says "I want to use NemoClaw's skills in Claude Code." Restate intent, read `references/agent-skills.md`, then provide: `git clone https://github.com/NVIDIA/NemoClaw && ln -s "$(pwd)/NemoClaw/.agents/skills" ~/.claude/skills/nemoclaw`, followed by the verification command.
+
+**Example 2 — Cursor.** User says "How do I get NemoClaw skills into Cursor?" Same flow, but point the assistant at Cursor's skills location instead of `~/.claude/skills/`. Do not list every NemoClaw skill — that's the job of `nemoclaw-skills-guide`.
+
+**Example 3 — Out-of-scope handoff.** User says "What can NemoClaw skills do for me?" Do **not** load this skill's reference. Recommend `nemoclaw-skills-guide` and stop.
+
 ## References
 
-- **Load [references/agent-skills.md](references/agent-skills.md)** when users ask about AI agent support, coding assistant integration, or the .agents/skills/ directory. Describes the agent skills shipped with NemoClaw and how to access them by cloning the repository.
+- **Load [references/agent-skills.md](references/agent-skills.md)** once per request when the user wants to install or load NemoClaw's agent skills into their AI coding assistant. Describes the clone-and-link workflow for accessing the bundled `.agents/skills/` directory.

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -2,6 +2,16 @@
 name: "nemoclaw-user-get-started"
 description: "Installs NemoClaw, launches a sandbox, and runs the first agent prompt. Use when onboarding, installing, or launching a NemoClaw sandbox for the first time. Trigger keywords - nemoclaw quickstart, install nemoclaw openclaw sandbox, nemohermes quickstart, hermes agent nemoclaw, run hermes openshell sandbox, nemoclaw prerequisites, nemoclaw supported platforms, nemoclaw hardware software, nemoclaw windows wsl2 setup, nemoclaw install windows docker desktop."
 license: "Apache-2.0"
+metadata:
+  author: "Miyoung Choi <miyoungc@nvidia.com>"
+  tags:
+    - nemoclaw
+    - quickstart
+    - installation
+    - onboarding
+    - openclaw
+    - hermes
+    - wsl
 ---
 
 <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
@@ -14,6 +24,37 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 **Note:**
 
 Make sure you have completed reviewing the [Prerequisites](references/prerequisites.md) before following this guide.
+
+## Instructions
+
+Use this skill only for **first-time install and first-prompt** flows. Hand off to a sibling skill for ongoing operations.
+
+Follow this fixed sequence. Do not exceed the listed tool budget.
+
+1. **Identify the platform** in one question or by inspection: macOS, Linux, Windows + WSL 2, or remote GPU (Brev / DGX). Do not call any tools yet.
+2. **Load at most one reference.** Choose the single reference that matches the user's situation:
+   - Verifying hardware/OS support → `references/prerequisites.md`.
+   - Windows-specific setup → `references/windows-preparation.md`.
+   - Hermes-instead-of-OpenClaw → `references/quickstart-hermes.md`.
+   - Detailed wizard walkthrough → `references/quickstart-details.md`.
+   - Otherwise → use the inline steps below; do not load any reference.
+3. **Walk the user through three phases**, in order, scoped to their platform:
+   - **Install** with the installer one-liner from the inline steps.
+   - **Onboard** by responding to the wizard (provider, sandbox name, policy tier).
+   - **First prompt** via the dashboard URL or `nemoclaw <name> connect` then `openclaw tui`.
+4. **Verify and stop.** Point the user at `nemoclaw <name> status` to confirm the sandbox is healthy. For ongoing tasks (rebuild, channels, monitoring) recommend `nemoclaw-user-manage-sandboxes` or `nemoclaw-user-monitor-sandbox` and stop.
+
+Tool budget per invocation: at most **one** Read of a single `references/*.md` file. Do not chain into other references in the same response. If the user's question expands into policy editing, inference switching, or multi-sandbox operations, return the quickstart answer and suggest the appropriate sibling skill rather than calling more tools.
+
+## Examples
+
+**Example 1 — Fresh macOS install.** User says "I just got a new MacBook, how do I try NemoClaw?" Identify platform = macOS. Skip references (inline steps cover this). Provide the `curl ... | bash` installer, walk them through the wizard summary screen, and end with `http://127.0.0.1:18789/` plus `nemoclaw my-sandbox status`.
+
+**Example 2 — Windows user.** User says "Can I run NemoClaw on Windows 11?" Identify platform = Windows. Load `references/windows-preparation.md` exactly once. Cover WSL 2 + Ubuntu + Docker Desktop prep, then return them to the standard install one-liner inside WSL.
+
+**Example 3 — Hermes path.** User says "I want to run Hermes, not OpenClaw, in the sandbox." Identify intent = Hermes. Load `references/quickstart-hermes.md` exactly once. Provide Hermes-specific install + onboard + first-prompt steps. Do not load `quickstart-details.md` in the same turn.
+
+**Example 4 — Out-of-scope handoff.** User says "My sandbox is running but messaging isn't working." Do not load any reference here. Recommend `nemoclaw-user-manage-sandboxes` and stop.
 
 ## Install NemoClaw and Onboard OpenClaw Agent
 


### PR DESCRIPTION
## Summary

Stacked on top of #4438. Applies the NVSkills validator's verbatim fix recommendations from the most recent failed validation runs on `export-nemoclaw-user-agent-skills` (GitLab pipeline [52953267](https://gitlab-master.nvidia.com/nvcarps/ci-group/nvcarps-ci/-/pipelines/52953267), job 328478588).

This PR edits **source skills only** (`.agents/skills/<name>/SKILL.md`). A follow-up commit will mirror the changes into `skills/<name>/` per the publishing flow introduced in #4448.

## What this addresses

Per the failure report, the validator flagged 5 [MEDIUM] static lints and 5 HIGH agent-eval regressions across the two user skills. This PR targets the structural items the validator can verify deterministically:

| Validator finding | Fix in this PR |
|---|---|
| `metadata.author` missing (MEDIUM × both) | Added `Miyoung Choi <miyoungc@nvidia.com>` |
| `metadata.tags` missing (MEDIUM × both) | Added scoped tag lists |
| "Author not specified in metadata" (MEDIUM) | Resolved by metadata.author |
| Missing `## Instructions` (MEDIUM × both) | Added with explicit step sequence |
| Missing `## Examples` (MEDIUM × both) | Added with 3–4 grounded examples |
| Discoverability HIGH on `nemoclaw-user-agent-skills` — "codex conflates with nemoclaw-skills-guide" | Rewrote `description:` to scope to install/load and redirect discovery queries to nemoclaw-skills-guide |
| "Cap or sequence tool invocations so skill_efficiency stops collapsing to 0.0" | Both `## Instructions` sections now cap to one Read of one reference, no chaining |

## Out of scope (follow-up commit)

- Mirror edits into `skills/nemoclaw-user-agent-skills/SKILL.md` and `skills/nemoclaw-user-get-started/SKILL.md` so NVSkills CI sees them when signing.
- `evals/evals.json` rubric tuning.

## Test plan

After mirror commit lands, comment `/nvskills-ci` on #4438 and confirm:
1. Static QUALITY/SCHEMA findings drop from 5 → 0.
2. Discoverability score on `nemoclaw-user-agent-skills` rises from 0.50 toward the 0.70 threshold.
3. `skill_efficiency` no longer collapses to 0.0 on case 003 trials.