### PR TITLE
fix(sandbox): keep Homebrew on Linuxbrew prefix

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -245,6 +245,8 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 # but a plain symlink there makes Homebrew infer /usr/local as its prefix. The
 # wrapper must execute the Linuxbrew prefix shim, not the repository script
 # directly, so Homebrew keeps /home/linuxbrew/.linuxbrew as its writable prefix.
+# The wrapper also defaults Homebrew's temp extraction to /tmp, because the
+# sandbox policy permits /tmp writes while /var/tmp stays outside the write set.
 # Installed formulae are added to the sandbox user's login-shell PATH via
 # /etc/profile.d instead of Docker ENV, because /home/linuxbrew is
 # sandbox-writable and must not be inherited by privileged startup code before
@@ -270,6 +272,8 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
         /home/linuxbrew/.linuxbrew/bin/brew \
     && { \
         printf '%s\n' '#!/bin/sh'; \
+        printf '%s\n' "export HOMEBREW_TEMP=\"\${HOMEBREW_TEMP:-/tmp}\""; \
+        printf '%s\n' "export TMPDIR=\"\${TMPDIR:-/tmp}\""; \
         printf '%s\n' 'exec /home/linuxbrew/.linuxbrew/bin/brew "$@"'; \
     } > /usr/local/bin/brew \
     && chmod 755 /usr/local/bin/brew \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -245,9 +245,10 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 # but a plain symlink there makes Homebrew infer /usr/local as its prefix. The
 # wrapper must execute the Linuxbrew prefix shim, not the repository script
 # directly, so Homebrew keeps /home/linuxbrew/.linuxbrew as its writable prefix.
-# Installed formulae are added to login-shell PATH via /etc/profile.d instead
-# of Docker ENV, because /home/linuxbrew is sandbox-writable and must not be
-# inherited by privileged startup code before nemoclaw-start locks PATH down.
+# Installed formulae are added to the sandbox user's login-shell PATH via
+# /etc/profile.d instead of Docker ENV, because /home/linuxbrew is
+# sandbox-writable and must not be inherited by privileged startup code before
+# nemoclaw-start locks PATH down.
 #
 # Companion change: /home/linuxbrew is added to filesystem_policy.read_write
 # in nemoclaw-blueprint/policies/openclaw-sandbox.yaml so brew can write
@@ -274,9 +275,13 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
     && chmod 755 /usr/local/bin/brew \
     && gosu sandbox /usr/local/bin/brew --prefix | grep -qx /home/linuxbrew/.linuxbrew \
     && gosu sandbox /usr/local/bin/brew --version
-RUN printf '%s\n' "export PATH=\"\${PATH}:/home/linuxbrew/.linuxbrew/bin\"" \
-        > /etc/profile.d/nemoclaw-linuxbrew.sh \
+RUN { \
+        printf '%s\n' "if [ \"\$(id -un 2>/dev/null || true)\" = sandbox ]; then"; \
+        printf '%s\n' "  export PATH=\"\${PATH}:/home/linuxbrew/.linuxbrew/bin\""; \
+        printf '%s\n' "fi"; \
+    } > /etc/profile.d/nemoclaw-linuxbrew.sh \
     && chmod 644 /etc/profile.d/nemoclaw-linuxbrew.sh \
+    && bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 1 ;; *) exit 0 ;; esac" \
     && gosu sandbox bash -lc 'command -v brew >/dev/null' \
     && gosu sandbox bash -lc 'command -v brew' | grep -qx /usr/local/bin/brew \
     && gosu sandbox bash -lc 'brew --prefix' | grep -qx /home/linuxbrew/.linuxbrew \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -277,15 +277,24 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
         printf '%s\n' 'exec /home/linuxbrew/.linuxbrew/bin/brew "$@"'; \
     } > /usr/local/bin/brew \
     && chmod 755 /usr/local/bin/brew \
+    && grep -qx 'export HOMEBREW_TEMP=/tmp' /usr/local/bin/brew \
+    && grep -qx 'export TMPDIR=/tmp' /usr/local/bin/brew \
+    && gosu sandbox env HOMEBREW_TEMP=/var/tmp TMPDIR=/var/tmp /usr/local/bin/brew --prefix \
+        | grep -qx /home/linuxbrew/.linuxbrew \
     && gosu sandbox /usr/local/bin/brew --prefix | grep -qx /home/linuxbrew/.linuxbrew \
     && gosu sandbox /usr/local/bin/brew --version
 RUN { \
-        printf '%s\n' "if [ \"\$(id -un 2>/dev/null || true)\" = sandbox ]; then"; \
+        printf '%s\n' "if [ \"\$(/usr/bin/id -un 2>/dev/null || true)\" = sandbox ]; then"; \
         printf '%s\n' "  export PATH=\"\${PATH}:/home/linuxbrew/.linuxbrew/bin\""; \
         printf '%s\n' "fi"; \
     } > /etc/profile.d/nemoclaw-linuxbrew.sh \
     && chmod 644 /etc/profile.d/nemoclaw-linuxbrew.sh \
     && bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 1 ;; *) exit 0 ;; esac" \
+    && mkdir -p /tmp/nemoclaw-hostile-bin \
+    && { printf '%s\n' '#!/bin/sh'; printf '%s\n' 'echo sandbox'; } > /tmp/nemoclaw-hostile-bin/id \
+    && chmod 755 /tmp/nemoclaw-hostile-bin/id \
+    && PATH="/tmp/nemoclaw-hostile-bin:${PATH}" bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 1 ;; *) exit 0 ;; esac" \
+    && rm -rf /tmp/nemoclaw-hostile-bin \
     && gosu sandbox bash -lc 'command -v brew >/dev/null' \
     && gosu sandbox bash -lc 'command -v brew' | grep -qx /usr/local/bin/brew \
     && gosu sandbox bash -lc 'brew --prefix' | grep -qx /home/linuxbrew/.linuxbrew \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -240,11 +240,13 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 # /home/linuxbrew/.linuxbrew/bin/* is then dead code.
 #
 # Image-build runs as root, so we create the prefix, chown it to the
-# sandbox user, clone Homebrew core under it as the sandbox user, and
-# symlink the brew entry point into the Homebrew prefix and /usr/local/bin.
-# /usr/local/bin is already on the locked sandbox PATH, so users can run
-# `brew` without adding the sandbox-writable Homebrew prefix to privileged
-# startup PATH.
+# sandbox user, clone Homebrew core under it as the sandbox user, and expose a
+# /usr/local/bin wrapper. /usr/local/bin is already on the locked sandbox PATH,
+# but a plain symlink there makes Homebrew infer /usr/local as its prefix. The
+# wrapper must execute the Linuxbrew prefix shim, not the repository script
+# directly, so Homebrew keeps /home/linuxbrew/.linuxbrew as its writable prefix.
+# The Linuxbrew bin directory is appended to PATH so installed formulae are
+# runnable while system binaries still win name resolution.
 #
 # Companion change: /home/linuxbrew is added to filesystem_policy.read_write
 # in nemoclaw-blueprint/policies/openclaw-sandbox.yaml so brew can write
@@ -264,6 +266,14 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
         /home/linuxbrew/.linuxbrew/Homebrew \
     && ln -s /home/linuxbrew/.linuxbrew/Homebrew/bin/brew \
         /home/linuxbrew/.linuxbrew/bin/brew \
-    && ln -s /home/linuxbrew/.linuxbrew/Homebrew/bin/brew \
-        /usr/local/bin/brew \
-    && gosu sandbox brew --version
+    && { \
+        printf '%s\n' '#!/bin/sh'; \
+        printf '%s\n' 'exec /home/linuxbrew/.linuxbrew/bin/brew "$@"'; \
+    } > /usr/local/bin/brew \
+    && chmod 755 /usr/local/bin/brew \
+    && gosu sandbox /usr/local/bin/brew --prefix | grep -qx /home/linuxbrew/.linuxbrew \
+    && gosu sandbox /usr/local/bin/brew --version
+ENV PATH="${PATH}:/home/linuxbrew/.linuxbrew/bin"
+RUN printf '%s\n' "export PATH=\"\${PATH}:/home/linuxbrew/.linuxbrew/bin\"" \
+        > /etc/profile.d/nemoclaw-linuxbrew.sh \
+    && chmod 644 /etc/profile.d/nemoclaw-linuxbrew.sh

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -245,8 +245,8 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 # but a plain symlink there makes Homebrew infer /usr/local as its prefix. The
 # wrapper must execute the Linuxbrew prefix shim, not the repository script
 # directly, so Homebrew keeps /home/linuxbrew/.linuxbrew as its writable prefix.
-# The wrapper also defaults Homebrew's temp extraction to /tmp, because the
-# sandbox policy permits /tmp writes while /var/tmp stays outside the write set.
+# The wrapper also pins Homebrew's temp extraction to /tmp, because the sandbox
+# policy permits /tmp writes while /var/tmp stays outside the write set.
 # Installed formulae are added to the sandbox user's login-shell PATH via
 # /etc/profile.d instead of Docker ENV, because /home/linuxbrew is
 # sandbox-writable and must not be inherited by privileged startup code before
@@ -272,8 +272,8 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
         /home/linuxbrew/.linuxbrew/bin/brew \
     && { \
         printf '%s\n' '#!/bin/sh'; \
-        printf '%s\n' "export HOMEBREW_TEMP=\"\${HOMEBREW_TEMP:-/tmp}\""; \
-        printf '%s\n' "export TMPDIR=\"\${TMPDIR:-/tmp}\""; \
+        printf '%s\n' 'export HOMEBREW_TEMP=/tmp'; \
+        printf '%s\n' 'export TMPDIR=/tmp'; \
         printf '%s\n' 'exec /home/linuxbrew/.linuxbrew/bin/brew "$@"'; \
     } > /usr/local/bin/brew \
     && chmod 755 /usr/local/bin/brew \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -245,8 +245,9 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
 # but a plain symlink there makes Homebrew infer /usr/local as its prefix. The
 # wrapper must execute the Linuxbrew prefix shim, not the repository script
 # directly, so Homebrew keeps /home/linuxbrew/.linuxbrew as its writable prefix.
-# The Linuxbrew bin directory is appended to PATH so installed formulae are
-# runnable while system binaries still win name resolution.
+# Installed formulae are added to login-shell PATH via /etc/profile.d instead
+# of Docker ENV, because /home/linuxbrew is sandbox-writable and must not be
+# inherited by privileged startup code before nemoclaw-start locks PATH down.
 #
 # Companion change: /home/linuxbrew is added to filesystem_policy.read_write
 # in nemoclaw-blueprint/policies/openclaw-sandbox.yaml so brew can write
@@ -273,7 +274,10 @@ RUN mkdir -p /home/linuxbrew/.linuxbrew/bin \
     && chmod 755 /usr/local/bin/brew \
     && gosu sandbox /usr/local/bin/brew --prefix | grep -qx /home/linuxbrew/.linuxbrew \
     && gosu sandbox /usr/local/bin/brew --version
-ENV PATH="${PATH}:/home/linuxbrew/.linuxbrew/bin"
 RUN printf '%s\n' "export PATH=\"\${PATH}:/home/linuxbrew/.linuxbrew/bin\"" \
         > /etc/profile.d/nemoclaw-linuxbrew.sh \
-    && chmod 644 /etc/profile.d/nemoclaw-linuxbrew.sh
+    && chmod 644 /etc/profile.d/nemoclaw-linuxbrew.sh \
+    && gosu sandbox bash -lc 'command -v brew >/dev/null' \
+    && gosu sandbox bash -lc 'command -v brew' | grep -qx /usr/local/bin/brew \
+    && gosu sandbox bash -lc 'brew --prefix' | grep -qx /home/linuxbrew/.linuxbrew \
+    && gosu sandbox bash -lc "case \":\${PATH}:\" in *:/home/linuxbrew/.linuxbrew/bin:*) exit 0 ;; *) exit 1 ;; esac"

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -276,7 +276,8 @@ $ nemoclaw my-assistant policy-remove huggingface --yes
 ### Homebrew Specifics
 
 The sandbox base image includes Homebrew (Linuxbrew), so applying the `brew` preset is the only step needed before installing a formula.
-A `/usr/local/bin/brew` symlink puts the entry point on the sandbox `PATH`, so the agent can run `brew install <formula>` directly:
+A `/usr/local/bin/brew` wrapper puts the entry point on the sandbox `PATH` while delegating to the Linuxbrew prefix.
+Installed formula commands are available from the Linuxbrew bin directory:
 
 ```console
 $ nemoclaw my-assistant policy-add brew --yes

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -277,11 +277,12 @@ $ nemoclaw my-assistant policy-remove huggingface --yes
 
 The sandbox base image includes Homebrew (Linuxbrew), so applying the `brew` preset is the only step needed before installing a formula.
 A `/usr/local/bin/brew` wrapper puts the entry point on the sandbox `PATH` while delegating to the Linuxbrew prefix.
-Installed formula commands are available from the Linuxbrew bin directory:
+Installed formula commands are available from the Linuxbrew bin directory in sandbox shell sessions:
 
 ```console
 $ nemoclaw my-assistant policy-add brew --yes
 $ nemoclaw my-assistant exec -- brew install <formula>
+$ nemoclaw my-assistant exec -- bash -lc '<formula-command>'
 ```
 
 You do not need to bootstrap Homebrew, install build dependencies, or source `brew shellenv` inside the sandbox.

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -336,11 +336,12 @@ test_net_11_brew_install_hello() {
 
   log "  Installing hello through the sandbox Homebrew wrapper..."
   local response
-  response=$(sandbox_exec "bash -lc 'set -e; export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1; brew --prefix; brew install --quiet hello; command -v hello; hello'" 2>&1) || true
+  response=$(sandbox_exec "bash -lc 'set -e; export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1; command -v brew; brew --prefix; brew install --quiet hello; command -v hello; hello'" 2>&1) || true
 
   log "  Response: ${response:0:1000}"
 
-  if echo "$response" | grep -q "/home/linuxbrew/.linuxbrew" \
+  if echo "$response" | grep -q "/usr/local/bin/brew" \
+    && echo "$response" | grep -q "/home/linuxbrew/.linuxbrew" \
     && echo "$response" | grep -q "/home/linuxbrew/.linuxbrew/bin/hello" \
     && echo "$response" | grep -q "Hello, world!"; then
     pass "TC-NET-11: brew preset installed hello and ran the formula command"

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -18,6 +18,7 @@
 #   TC-NET-09: SSRF validation (dangerous IPs rejected)
 #   TC-NET-10: OpenClaw web_fetch can reach approved host gateway target,
 #              while OpenShell still denies unapproved host gateway ports
+#   TC-NET-11: Homebrew preset installs and runs a formula end-to-end
 #
 # Prerequisites:
 #   - Docker running
@@ -318,6 +319,33 @@ test_net_02_whitelist_access() {
     pass "TC-NET-02: PyPI reachable via pip (download started)"
   else
     fail "TC-NET-02: Whitelist" "pip could not reach PyPI: ${response:0:200}"
+  fi
+}
+
+# =============================================================================
+# TC-NET-11: Homebrew preset install/use path
+# =============================================================================
+test_net_11_brew_install_hello() {
+  log "=== TC-NET-11: Homebrew Preset Installs and Runs hello ==="
+
+  log "  Adding brew preset for Homebrew formula install test..."
+  if ! apply_preset "brew"; then
+    fail "TC-NET-11: Setup" "Could not apply brew preset"
+    return
+  fi
+
+  log "  Installing hello through the sandbox Homebrew wrapper..."
+  local response
+  response=$(sandbox_exec "bash -lc 'set -e; export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1; brew --prefix; brew install --quiet hello; command -v hello; hello'" 2>&1) || true
+
+  log "  Response: ${response:0:1000}"
+
+  if echo "$response" | grep -q "/home/linuxbrew/.linuxbrew" \
+    && echo "$response" | grep -q "/home/linuxbrew/.linuxbrew/bin/hello" \
+    && echo "$response" | grep -q "Hello, world!"; then
+    pass "TC-NET-11: brew preset installed hello and ran the formula command"
+  else
+    fail "TC-NET-11: Homebrew install" "brew install/use path failed: ${response:0:500}"
   fi
 }
 
@@ -982,6 +1010,7 @@ main() {
   test_net_07_inference_exemption
   test_net_09_ssrf_validation
   test_net_10_openclaw_web_fetch_host_gateway
+  test_net_11_brew_install_hello
   test_net_06_permissive_mode # last — opens all egress, affects subsequent tests
 
   trap - EXIT

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -337,13 +337,80 @@ test_net_11_brew_install_hello() {
     return
   fi
 
-  log "  Installing hello through the sandbox Homebrew wrapper..."
-  local response
-  response=$(sandbox_exec "bash -lc 'set -e; export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1; command -v brew; brew --prefix; brew install --quiet hello; command -v hello; hello'" "$PACKAGE_MANAGER_SANDBOX_TIMEOUT_SECONDS" 2>&1) || true
+  local policy_list
+  if ! policy_list=$(nemoclaw "$SANDBOX_NAME" policy-list 2>&1); then
+    fail "TC-NET-11: policy-list" "policy-list failed after brew preset: ${policy_list:0:500}"
+    return
+  fi
+  log "  policy-list: ${policy_list:0:600}"
+  if printf '%s\n' "$policy_list" | grep -E "^[[:space:]]*●[[:space:]]+brew[[:space:]]" >/dev/null; then
+    pass "TC-NET-11: policy-list shows brew applied"
+  else
+    fail "TC-NET-11: policy-list" "brew preset not marked applied: ${policy_list:0:500}"
+    return
+  fi
+
+  local connect_probe connect_rc=0
+  connect_probe=$(run_with_timeout 60 nemoclaw "$SANDBOX_NAME" connect --probe-only 2>&1) || connect_rc=$?
+  log "  connect --probe-only: ${connect_probe:0:500}"
+  if [[ $connect_rc -eq 0 ]]; then
+    pass "TC-NET-11: nemoclaw connect --probe-only reaches sandbox"
+  else
+    fail "TC-NET-11: connect --probe-only" "connect probe failed: ${connect_probe:0:500}"
+    return
+  fi
+
+  log "  Probing Homebrew policy endpoints and installing hello through the wrapper..."
+  local brew_probe_script brew_probe_b64 response
+  brew_probe_script="$(
+    cat <<'BREW_PROBE'
+set -euo pipefail
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_ENV_HINTS=1
+
+check_status() {
+  local name="$1"
+  local url="$2"
+  local status
+  status=$(curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 30 "$url") || {
+    echo "BREW_ENDPOINT_${name}_CURL_FAILED"
+    return 1
+  }
+  case "$status" in
+    2??|3??|401)
+      echo "BREW_ENDPOINT_${name}_OK_${status}"
+      ;;
+    *)
+      echo "BREW_ENDPOINT_${name}_BAD_${status}"
+      return 1
+      ;;
+  esac
+}
+
+check_status formulae https://formulae.brew.sh
+check_status raw https://raw.githubusercontent.com/Homebrew/brew/HEAD/README.md
+git ls-remote https://github.com/Homebrew/brew.git HEAD >/dev/null
+echo "BREW_ENDPOINT_github_OK"
+check_status ghcr https://ghcr.io/v2/
+
+command -v brew
+brew --prefix
+brew install --quiet hello
+command -v hello
+hello
+BREW_PROBE
+  )"
+  brew_probe_b64="$(printf '%s' "$brew_probe_script" | base64 | tr -d '\n')"
+  response=$(sandbox_exec "printf '%s' '${brew_probe_b64}' | base64 -d > /tmp/nemoclaw-brew-e2e.sh
+bash /tmp/nemoclaw-brew-e2e.sh" "$PACKAGE_MANAGER_SANDBOX_TIMEOUT_SECONDS" 2>&1) || true
 
   log "  Response: ${response:0:1000}"
 
-  if echo "$response" | grep -q "/usr/local/bin/brew" \
+  if echo "$response" | grep -q "BREW_ENDPOINT_formulae_OK_" \
+    && echo "$response" | grep -q "BREW_ENDPOINT_raw_OK_" \
+    && echo "$response" | grep -q "BREW_ENDPOINT_github_OK" \
+    && echo "$response" | grep -q "BREW_ENDPOINT_ghcr_OK_" \
+    && echo "$response" | grep -q "/usr/local/bin/brew" \
     && echo "$response" | grep -q "/home/linuxbrew/.linuxbrew" \
     && echo "$response" | grep -q "/home/linuxbrew/.linuxbrew/bin/hello" \
     && echo "$response" | grep -q "Hello, world!"; then
@@ -1006,6 +1073,7 @@ main() {
   setup_sandbox
 
   test_net_01_deny_default
+  test_net_11_brew_install_hello
   test_net_02_whitelist_access
   test_net_03_live_policy_add
   test_net_04_dry_run
@@ -1014,7 +1082,6 @@ main() {
   test_net_07_inference_exemption
   test_net_09_ssrf_validation
   test_net_10_openclaw_web_fetch_host_gateway
-  test_net_11_brew_install_hello
   test_net_06_permissive_mode # last — opens all egress, affects subsequent tests
 
   trap - EXIT

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -38,6 +38,8 @@ source "${SCRIPT_DIR_TIMEOUT}/lib/install-path-refresh.sh"
 # ── Config ───────────────────────────────────────────────────────────────────
 SANDBOX_NAME="e2e-net-policy"
 LOG_FILE="test-network-policy-$(date +%Y%m%d-%H%M%S).log"
+SANDBOX_EXEC_TIMEOUT_SECONDS=120
+PACKAGE_MANAGER_SANDBOX_TIMEOUT_SECONDS=300
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'
@@ -175,6 +177,7 @@ EOF
 # Execute a command inside the sandbox via SSH.
 sandbox_exec() {
   local cmd="$1"
+  local timeout_seconds="${2:-$SANDBOX_EXEC_TIMEOUT_SECONDS}"
   local ssh_cfg
   ssh_cfg="$(mktemp)"
   if ! openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_cfg" 2>/dev/null; then
@@ -184,7 +187,7 @@ sandbox_exec() {
     return 1
   fi
   local result ssh_exit=0
-  result=$(run_with_timeout 120 ssh -F "$ssh_cfg" \
+  result=$(run_with_timeout "$timeout_seconds" ssh -F "$ssh_cfg" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
     -o ConnectTimeout=10 -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" "$cmd" 2>&1) || ssh_exit=$?
@@ -336,7 +339,7 @@ test_net_11_brew_install_hello() {
 
   log "  Installing hello through the sandbox Homebrew wrapper..."
   local response
-  response=$(sandbox_exec "bash -lc 'set -e; export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1; command -v brew; brew --prefix; brew install --quiet hello; command -v hello; hello'" 2>&1) || true
+  response=$(sandbox_exec "bash -lc 'set -e; export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1; command -v brew; brew --prefix; brew install --quiet hello; command -v hello; hello'" "$PACKAGE_MANAGER_SANDBOX_TIMEOUT_SECONDS" 2>&1) || true
 
   log "  Response: ${response:0:1000}"
 

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1641,7 +1641,7 @@ exit 1
       }
     });
 
-    it("brew preset whitelists the PATH shim and Homebrew-managed entrypoints (#3913)", () => {
+    it("brew preset whitelists the PATH wrapper and Homebrew-managed entrypoints (#3913)", () => {
       const content = requirePresetContent(policies.loadPreset("brew"));
       const parsed = YAML.parse(content);
       const brewPolicy = parsed.network_policies?.brew as


### PR DESCRIPTION
## Summary

Fixes #3757 as a follow-up to #3916. The base image now exposes `brew` on the normal sandbox `PATH` without making Homebrew infer `/usr/local` as its prefix.

## Problem

#3916 correctly baked Homebrew into `/home/linuxbrew/.linuxbrew`, but it exposed the entry point with a plain `/usr/local/bin/brew` symlink. In a fresh sandbox that made Homebrew report `/usr/local` as the prefix, which broke the QA path in two ways:

- `brew install --quiet hello` tried to create locks under root-owned `/usr/local/var/homebrew`.
- On arm64, Homebrew rejected the Intel/default `/usr/local` prefix.

After fixing the prefix, installed formula commands also need to be reachable in sandbox shell sessions without asking users to source `brew shellenv` manually.

## Changes

- Replace the `/usr/local/bin/brew` symlink with a wrapper that execs `/home/linuxbrew/.linuxbrew/bin/brew`, preserving the Linuxbrew prefix.
- Add build-time assertions that `/usr/local/bin/brew --prefix` and sandbox login-shell `brew --prefix` both return `/home/linuxbrew/.linuxbrew`.
- Add `/home/linuxbrew/.linuxbrew/bin` through `/etc/profile.d/nemoclaw-linuxbrew.sh` only for the `sandbox` user, while deliberately avoiding a global Docker `ENV PATH` entry for the sandbox-writable Linuxbrew prefix.
- Add network-policy E2E coverage for the real QA path: apply `brew`, install `hello`, resolve `hello` on PATH, and run it.
- Update the Homebrew docs wording from symlink to wrapper and show shell-session execution for installed formula commands.

## Validation

- `npm run build:cli`
- `npm run typecheck:cli`
- `npx vitest run test/policies.test.ts`
- `npm run source-shape:check`
- `hadolint Dockerfile.base`
- `bash -n test/e2e/test-network-policy.sh`
- `shellcheck test/e2e/test-network-policy.sh`
- `git diff --check`
- Throwaway base-image behavior smoke with this wrapper/profile change applied in-container and no global Linuxbrew `PATH`:
  - root login shell does not include `/home/linuxbrew/.linuxbrew/bin`
  - direct `/usr/local/bin/brew --prefix` -> `/home/linuxbrew/.linuxbrew`
  - sandbox login shell includes `/home/linuxbrew/.linuxbrew/bin`
  - `brew install --quiet hello` succeeds
  - `command -v hello` -> `/home/linuxbrew/.linuxbrew/bin/hello`
  - `hello` -> `Hello, world!`

## Local caveats

- Full `docker build -f Dockerfile.base ...` could not run on this host because Docker has no working buildx/BuildKit component; the legacy builder fails on the existing `RUN --mount` step before reaching this change.
- `npx vitest run test/nemoclaw-start.test.ts test/policies.test.ts` passed the related policy coverage but still hit existing local fixture failures in `test/nemoclaw-start.test.ts` because `nemoclaw/node_modules/json5` is absent in this worktree. `test/policies.test.ts` passes by itself.
- `npx prek run --files Dockerfile.base docs/network-policy/integration-policy-examples.mdx test/policies.test.ts` passed the visible file hooks including hadolint, gitleaks, docs-to-skills, and source-shape, then failed in the full CLI test hook on the same unrelated `test/nemoclaw-start.test.ts` baseline-capture failures plus a coverage temp-file ENOENT.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Homebrew runtime to a wrapper-script approach and conditionally expose the package manager bin on sandbox shell PATH
  * Added runtime validations to ensure wrapper and PATH behave correctly across privileged and sandbox sessions
  * Made sandbox command execution timeouts configurable

* **Documentation**
  * Clarified wrapper behavior and how installed commands are available in sandbox sessions

* **Tests**
  * Updated test wording to reference "PATH wrapper"
  * Added an end-to-end test validating install/use flow and expected runtime behavior (TC-NET-11)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->