### PR TITLE
fix(inference): narrow Hermes Provider host smoke skip

### DIFF
--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
 const {
   getChatCompletionsProbeCurlArgs,
@@ -17,9 +17,15 @@ const {
   isSandboxInternalUrl,
   probeOpenAiLikeEndpoint,
   RETRIABLE_HTTP_PROBE_STATUSES,
+  shouldSmokeOpenAiLikeOnboardRoute,
 } = require("../../../dist/lib/inference/onboard-probes");
 
 describe("OpenAI-compatible inference probe response parsing", () => {
+  it("does not host-smoke Hermes Provider with the ambient OPENAI_API_KEY", () => {
+    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider")).toBe(false);
+    expect(shouldSmokeOpenAiLikeOnboardRoute("openai-api")).toBe(true);
+  });
+
   it("detects tool-calling responses payloads conservatively", () => {
     expect(
       hasResponsesToolCall(

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -5,7 +5,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { runVerifyOnboardSmokeHarness } from "../../../test/helpers/onboard-smoke-verifier-harness";
 
 const {
   getChatCompletionsProbeCurlArgs,
@@ -18,42 +17,9 @@ const {
   isSandboxInternalUrl,
   probeOpenAiLikeEndpoint,
   RETRIABLE_HTTP_PROBE_STATUSES,
-  shouldSmokeOpenAiLikeOnboardRoute,
 } = require("../../../dist/lib/inference/onboard-probes");
 
 describe("OpenAI-compatible inference probe response parsing", () => {
-  it("does not host-smoke Hermes Provider with the ambient OPENAI_API_KEY", () => {
-    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "OPENAI_API_KEY")).toBe(false);
-    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "NOUS_API_KEY")).toBe(true);
-    expect(shouldSmokeOpenAiLikeOnboardRoute("openai-api")).toBe(true);
-  });
-
-  it("skips only the Hermes OAuth smoke path in the runtime verifier", () => {
-    const calls = runVerifyOnboardSmokeHarness([
-      { credentialEnv: "OPENAI_API_KEY" },
-      { credentialEnv: "NOUS_API_KEY" },
-      { credentialEnv: "OPENAI_API_KEY", forceOpenAiLike: true },
-    ]);
-    expect(
-      calls.filter((call) =>
-        ["resolveProviderCredential", "getCredential", "runCurlProbe"].includes(call[0]),
-      ),
-    ).toEqual([
-      ["resolveProviderCredential", "NOUS_API_KEY"],
-      [
-        "runCurlProbe",
-        "https://api.example.com/v1/chat/completions",
-        "Authorization: Bearer resolved-NOUS_API_KEY",
-      ],
-      ["resolveProviderCredential", "OPENAI_API_KEY"],
-      [
-        "runCurlProbe",
-        "https://api.example.com/v1/chat/completions",
-        "Authorization: Bearer resolved-OPENAI_API_KEY",
-      ],
-    ]);
-  });
-
   it("detects tool-calling responses payloads conservatively", () => {
     expect(
       hasResponsesToolCall(

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { runVerifyOnboardSmokeHarness } from "../../../test/helpers/onboard-smoke-verifier-harness";
 
 const {
   getChatCompletionsProbeCurlArgs,
@@ -29,89 +29,11 @@ describe("OpenAI-compatible inference probe response parsing", () => {
   });
 
   it("skips only the Hermes OAuth smoke path in the runtime verifier", () => {
-    const harness = String.raw`
-const Module = require("node:module");
-const originalLoad = Module._load;
-const calls = [];
-
-process.env.VITEST = "false";
-
-Module._load = function patchedLoad(request, parent, isMain) {
-  if (request === "../credentials/store") {
-    return {
-      getCredential(name) {
-        calls.push(["getCredential", name]);
-        return "stored-" + name;
-      },
-      normalizeCredentialValue(value) {
-        calls.push(["normalizeCredentialValue", value]);
-        return value;
-      },
-      resolveProviderCredential(name) {
-        calls.push(["resolveProviderCredential", name]);
-        return "resolved-" + name;
-      },
-    };
-  }
-  if (request === "../adapters/http/probe") {
-    return {
-      getCurlTimingArgs() {
-        return [];
-      },
-      runChatCompletionsStreamingProbe() {
-        throw new Error("unexpected streaming probe");
-      },
-      runCurlProbe(args) {
-        const authHeader =
-          args.find((arg) => String(arg).startsWith("Authorization: Bearer ")) || "no-auth";
-        calls.push(["runCurlProbe", args[args.length - 1], authHeader]);
-        return {
-          ok: true,
-          httpStatus: 200,
-          curlStatus: 0,
-          message: "OK",
-          body: '{"choices":[{"message":{"content":"OK"}}]}',
-        };
-      },
-      runStreamingEventProbe() {
-        throw new Error("unexpected streaming event probe");
-      },
-    };
-  }
-  return originalLoad.apply(this, arguments);
-};
-
-const { verifyOnboardInferenceSmoke } = require(process.env.PROBES_MODULE);
-console.log = (...args) => calls.push(["log", args.join(" ")]);
-
-const baseOptions = {
-  endpointUrl: "https://api.example.com/v1",
-  model: "nous/test-model",
-  provider: "hermes-provider",
-};
-
-verifyOnboardInferenceSmoke({ ...baseOptions, credentialEnv: "OPENAI_API_KEY" });
-verifyOnboardInferenceSmoke({ ...baseOptions, credentialEnv: "NOUS_API_KEY" });
-verifyOnboardInferenceSmoke({
-  ...baseOptions,
-  credentialEnv: "OPENAI_API_KEY",
-  forceOpenAiLike: true,
-});
-
-process.stdout.write(JSON.stringify(calls));
-`;
-    const result = spawnSync(process.execPath, ["-e", harness], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        PROBES_MODULE: path.join(process.cwd(), "dist/lib/inference/onboard-probes.js"),
-        VITEST: "false",
-      },
-    });
-
-    expect(result.status, result.stderr).toBe(0);
-    const calls = JSON.parse(result.stdout) as [string, ...unknown[]][];
+    const calls = runVerifyOnboardSmokeHarness([
+      { credentialEnv: "OPENAI_API_KEY" },
+      { credentialEnv: "NOUS_API_KEY" },
+      { credentialEnv: "OPENAI_API_KEY", forceOpenAiLike: true },
+    ]);
     expect(
       calls.filter((call) =>
         ["resolveProviderCredential", "getCredential", "runCurlProbe"].includes(call[0]),

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -25,6 +26,110 @@ describe("OpenAI-compatible inference probe response parsing", () => {
     expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "OPENAI_API_KEY")).toBe(false);
     expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "NOUS_API_KEY")).toBe(true);
     expect(shouldSmokeOpenAiLikeOnboardRoute("openai-api")).toBe(true);
+  });
+
+  it("skips only the Hermes OAuth smoke path in the runtime verifier", () => {
+    const harness = String.raw`
+const Module = require("node:module");
+const originalLoad = Module._load;
+const calls = [];
+
+process.env.VITEST = "false";
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "../credentials/store") {
+    return {
+      getCredential(name) {
+        calls.push(["getCredential", name]);
+        return "stored-" + name;
+      },
+      normalizeCredentialValue(value) {
+        calls.push(["normalizeCredentialValue", value]);
+        return value;
+      },
+      resolveProviderCredential(name) {
+        calls.push(["resolveProviderCredential", name]);
+        return "resolved-" + name;
+      },
+    };
+  }
+  if (request === "../adapters/http/probe") {
+    return {
+      getCurlTimingArgs() {
+        return [];
+      },
+      runChatCompletionsStreamingProbe() {
+        throw new Error("unexpected streaming probe");
+      },
+      runCurlProbe(args) {
+        const authHeader =
+          args.find((arg) => String(arg).startsWith("Authorization: Bearer ")) || "no-auth";
+        calls.push(["runCurlProbe", args[args.length - 1], authHeader]);
+        return {
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          message: "OK",
+          body: '{"choices":[{"message":{"content":"OK"}}]}',
+        };
+      },
+      runStreamingEventProbe() {
+        throw new Error("unexpected streaming event probe");
+      },
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+const { verifyOnboardInferenceSmoke } = require(process.env.PROBES_MODULE);
+console.log = (...args) => calls.push(["log", args.join(" ")]);
+
+const baseOptions = {
+  endpointUrl: "https://api.example.com/v1",
+  model: "nous/test-model",
+  provider: "hermes-provider",
+};
+
+verifyOnboardInferenceSmoke({ ...baseOptions, credentialEnv: "OPENAI_API_KEY" });
+verifyOnboardInferenceSmoke({ ...baseOptions, credentialEnv: "NOUS_API_KEY" });
+verifyOnboardInferenceSmoke({
+  ...baseOptions,
+  credentialEnv: "OPENAI_API_KEY",
+  forceOpenAiLike: true,
+});
+
+process.stdout.write(JSON.stringify(calls));
+`;
+    const result = spawnSync(process.execPath, ["-e", harness], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PROBES_MODULE: path.join(process.cwd(), "dist/lib/inference/onboard-probes.js"),
+        VITEST: "false",
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const calls = JSON.parse(result.stdout) as [string, ...unknown[]][];
+    expect(
+      calls.filter((call) =>
+        ["resolveProviderCredential", "getCredential", "runCurlProbe"].includes(call[0]),
+      ),
+    ).toEqual([
+      ["resolveProviderCredential", "NOUS_API_KEY"],
+      [
+        "runCurlProbe",
+        "https://api.example.com/v1/chat/completions",
+        "Authorization: Bearer resolved-NOUS_API_KEY",
+      ],
+      ["resolveProviderCredential", "OPENAI_API_KEY"],
+      [
+        "runCurlProbe",
+        "https://api.example.com/v1/chat/completions",
+        "Authorization: Bearer resolved-OPENAI_API_KEY",
+      ],
+    ]);
   });
 
   it("detects tool-calling responses payloads conservatively", () => {

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -22,7 +22,8 @@ const {
 
 describe("OpenAI-compatible inference probe response parsing", () => {
   it("does not host-smoke Hermes Provider with the ambient OPENAI_API_KEY", () => {
-    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider")).toBe(false);
+    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "OPENAI_API_KEY")).toBe(false);
+    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "NOUS_API_KEY")).toBe(true);
     expect(shouldSmokeOpenAiLikeOnboardRoute("openai-api")).toBe(true);
   });
 

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -835,6 +835,11 @@ module.exports = {
 };
 
 function shouldSmokeOpenAiLikeOnboardRoute(provider) {
+  // Hermes Provider OAuth mints a short-lived agent key and stores it with
+  // OpenShell provider storage. A host-side direct probe would resolve the
+  // ambient OPENAI_API_KEY instead, which can falsely fail after successful
+  // OAuth if the user's shell has a different OpenAI key staged.
+  if (provider === "hermes-provider") return false;
   const { REMOTE_PROVIDER_CONFIG } = require("../onboard/providers");
   if (provider === "nvidia-nim" || provider === "nvidia-router") return true;
   return Object.values(REMOTE_PROVIDER_CONFIG).some(

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -834,12 +834,13 @@ module.exports = {
   RETRIABLE_HTTP_PROBE_STATUSES,
 };
 
-function shouldSmokeOpenAiLikeOnboardRoute(provider) {
+function shouldSmokeOpenAiLikeOnboardRoute(provider, credentialEnv = null) {
   // Hermes Provider OAuth mints a short-lived agent key and stores it with
   // OpenShell provider storage. A host-side direct probe would resolve the
   // ambient OPENAI_API_KEY instead, which can falsely fail after successful
-  // OAuth if the user's shell has a different OpenAI key staged.
-  if (provider === "hermes-provider") return false;
+  // OAuth if the user's shell has a different OpenAI key staged. The Nous API
+  // key path still has a host credential and should keep the direct smoke.
+  if (provider === "hermes-provider" && credentialEnv === "OPENAI_API_KEY") return false;
   const { REMOTE_PROVIDER_CONFIG } = require("../onboard/providers");
   if (provider === "nvidia-nim" || provider === "nvidia-router") return true;
   return Object.values(REMOTE_PROVIDER_CONFIG).some(
@@ -848,7 +849,12 @@ function shouldSmokeOpenAiLikeOnboardRoute(provider) {
 }
 
 function verifyOnboardInferenceSmoke(options) {
-  if (!options.forceOpenAiLike && !shouldSmokeOpenAiLikeOnboardRoute(options.provider)) return;
+  if (
+    !options.forceOpenAiLike &&
+    !shouldSmokeOpenAiLikeOnboardRoute(options.provider, options.credentialEnv)
+  ) {
+    return;
+  }
   if (process.env.VITEST === "true") return;
 
   const endpointUrl = options.endpointUrl || require("./config").INFERENCE_ROUTE_URL;

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -834,7 +834,7 @@ module.exports = {
   RETRIABLE_HTTP_PROBE_STATUSES,
 };
 
-function shouldSmokeOpenAiLikeOnboardRoute(provider, credentialEnv = null) {
+export function shouldSmokeOpenAiLikeOnboardRoute(provider: string, credentialEnv: string | null = null) {
   const {
     HERMES_INFERENCE_CREDENTIAL_ENV,
     HERMES_PROVIDER_NAME,
@@ -856,7 +856,7 @@ function shouldSmokeOpenAiLikeOnboardRoute(provider, credentialEnv = null) {
   );
 }
 
-function verifyOnboardInferenceSmoke(options) {
+export function verifyOnboardInferenceSmoke(options: any) {
   if (
     !options.forceOpenAiLike &&
     !shouldSmokeOpenAiLikeOnboardRoute(options.provider, options.credentialEnv)

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -835,12 +835,20 @@ module.exports = {
 };
 
 function shouldSmokeOpenAiLikeOnboardRoute(provider, credentialEnv = null) {
+  const {
+    HERMES_INFERENCE_CREDENTIAL_ENV,
+    HERMES_PROVIDER_NAME,
+  } = require("../hermes-provider-auth");
   // Hermes Provider OAuth mints a short-lived agent key and stores it with
   // OpenShell provider storage. A host-side direct probe would resolve the
   // ambient OPENAI_API_KEY instead, which can falsely fail after successful
   // OAuth if the user's shell has a different OpenAI key staged. The Nous API
   // key path still has a host credential and should keep the direct smoke.
-  if (provider === "hermes-provider" && credentialEnv === "OPENAI_API_KEY") return false;
+  // Remove this exception once the host smoke can resolve the actual Hermes
+  // OAuth agent key from OpenShell provider storage.
+  if (provider === HERMES_PROVIDER_NAME && credentialEnv === HERMES_INFERENCE_CREDENTIAL_ENV) {
+    return false;
+  }
   const { REMOTE_PROVIDER_CONFIG } = require("../onboard/providers");
   if (provider === "nvidia-nim" || provider === "nvidia-router") return true;
   return Object.values(REMOTE_PROVIDER_CONFIG).some(

--- a/test/helpers/onboard-smoke-verifier-harness.ts
+++ b/test/helpers/onboard-smoke-verifier-harness.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+export type SmokeVerifierHarnessCall = [string, ...unknown[]];
+
+type VerifyOnboardSmokeInvocation = {
+  credentialEnv?: string;
+  endpointUrl?: string;
+  forceOpenAiLike?: boolean;
+  model?: string;
+  provider?: string;
+};
+
+export function runVerifyOnboardSmokeHarness(
+  invocations: VerifyOnboardSmokeInvocation[],
+): SmokeVerifierHarnessCall[] {
+  const harness = String.raw`
+const Module = require("node:module");
+const originalLoad = Module._load;
+const calls = [];
+
+process.env.VITEST = "false";
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "../credentials/store") {
+    return {
+      getCredential(name) {
+        calls.push(["getCredential", name]);
+        return "stored-" + name;
+      },
+      normalizeCredentialValue(value) {
+        calls.push(["normalizeCredentialValue", value]);
+        return value;
+      },
+      resolveProviderCredential(name) {
+        calls.push(["resolveProviderCredential", name]);
+        return "resolved-" + name;
+      },
+    };
+  }
+  if (request === "../hermes-provider-auth") {
+    return {
+      HERMES_PROVIDER_NAME: "hermes-provider",
+      HERMES_INFERENCE_CREDENTIAL_ENV: "OPENAI_API_KEY",
+      HERMES_NOUS_API_KEY_CREDENTIAL_ENV: "NOUS_API_KEY",
+    };
+  }
+  if (request === "../adapters/http/probe") {
+    return {
+      getCurlTimingArgs() {
+        return [];
+      },
+      runChatCompletionsStreamingProbe() {
+        throw new Error("unexpected streaming probe");
+      },
+      runCurlProbe(args) {
+        const authHeader =
+          args.find((arg) => String(arg).startsWith("Authorization: Bearer ")) || "no-auth";
+        calls.push(["runCurlProbe", args[args.length - 1], authHeader]);
+        return {
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          message: "OK",
+          body: '{"choices":[{"message":{"content":"OK"}}]}',
+        };
+      },
+      runStreamingEventProbe() {
+        throw new Error("unexpected streaming event probe");
+      },
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+const { verifyOnboardInferenceSmoke } = require(process.env.PROBES_MODULE);
+const invocations = JSON.parse(process.env.SMOKE_INVOCATIONS || "[]");
+console.log = (...args) => calls.push(["log", args.join(" ")]);
+
+for (const invocation of invocations) {
+  verifyOnboardInferenceSmoke({
+    endpointUrl: "https://api.example.com/v1",
+    model: "nous/test-model",
+    provider: "hermes-provider",
+    ...invocation,
+  });
+}
+
+process.stdout.write(JSON.stringify(calls));
+`;
+  const result = spawnSync(process.execPath, ["-e", harness], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PROBES_MODULE: path.join(process.cwd(), "dist/lib/inference/onboard-probes.js"),
+      SMOKE_INVOCATIONS: JSON.stringify(invocations),
+      VITEST: "false",
+    },
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || "smoke verifier harness failed");
+  }
+  return JSON.parse(result.stdout) as SmokeVerifierHarnessCall[];
+}

--- a/test/helpers/onboard-smoke-verifier-harness.ts
+++ b/test/helpers/onboard-smoke-verifier-harness.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 
@@ -21,7 +24,7 @@ const calls = [];
 
 process.env.VITEST = "false";
 
-Module._load = function patchedLoad(request, parent, isMain) {
+Module._load = function patchedLoad(request, _parent, _isMain) {
   if (request === "../credentials/store") {
     return {
       getCredential(name) {

--- a/test/onboard-smoke-verifier.test.ts
+++ b/test/onboard-smoke-verifier.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { runVerifyOnboardSmokeHarness } from "./helpers/onboard-smoke-verifier-harness";
+
+const { shouldSmokeOpenAiLikeOnboardRoute } = require("../dist/lib/inference/onboard-probes");
+
+describe("Hermes onboard smoke verification", () => {
+  it("does not host-smoke Hermes Provider with the ambient OPENAI_API_KEY", () => {
+    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "OPENAI_API_KEY")).toBe(false);
+    expect(shouldSmokeOpenAiLikeOnboardRoute("hermes-provider", "NOUS_API_KEY")).toBe(true);
+    expect(shouldSmokeOpenAiLikeOnboardRoute("openai-api")).toBe(true);
+  });
+
+  it("skips only the Hermes OAuth smoke path in the runtime verifier", () => {
+    const calls = runVerifyOnboardSmokeHarness([
+      { credentialEnv: "OPENAI_API_KEY" },
+      { credentialEnv: "NOUS_API_KEY" },
+      { credentialEnv: "OPENAI_API_KEY", forceOpenAiLike: true },
+    ]);
+    expect(
+      calls.filter((call) =>
+        ["resolveProviderCredential", "getCredential", "runCurlProbe"].includes(call[0]),
+      ),
+    ).toEqual([
+      ["resolveProviderCredential", "NOUS_API_KEY"],
+      [
+        "runCurlProbe",
+        "https://api.example.com/v1/chat/completions",
+        "Authorization: Bearer resolved-NOUS_API_KEY",
+      ],
+      ["resolveProviderCredential", "OPENAI_API_KEY"],
+      [
+        "runCurlProbe",
+        "https://api.example.com/v1/chat/completions",
+        "Authorization: Bearer resolved-OPENAI_API_KEY",
+      ],
+    ]);
+  });
+});

--- a/test/onboard-smoke-verifier.test.ts
+++ b/test/onboard-smoke-verifier.test.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
+import { shouldSmokeOpenAiLikeOnboardRoute } from "../dist/lib/inference/onboard-probes";
 import { runVerifyOnboardSmokeHarness } from "./helpers/onboard-smoke-verifier-harness";
-
-const { shouldSmokeOpenAiLikeOnboardRoute } = require("../dist/lib/inference/onboard-probes");
 
 describe("Hermes onboard smoke verification", () => {
   it("does not host-smoke Hermes Provider with the ambient OPENAI_API_KEY", () => {


### PR DESCRIPTION
## Summary
Replay the Hermes Provider host-smoke fix from #4385 on a maintainer branch, then narrow it so only OAuth-backed Hermes Provider onboarding skips the host-side OpenAI-compatible smoke probe. Nous API key onboarding still has a host credential, so it keeps direct validation for bad keys, base URLs, or models.

## Original Contribution
- Based on #4385 from @shannonsands / NousResearch.
- The replay commit preserves contributor credit with a `Co-authored-by` trailer.

## Changes
- Skip the host-side smoke probe for `hermes-provider` only when the onboarding credential env is `OPENAI_API_KEY`, which is the OAuth agent-key storage path.
- Keep host-side smoke validation for `hermes-provider` with `NOUS_API_KEY`.
- Add regression coverage for both Hermes OAuth and Nous API key behavior.

## Verification
- `npm run build:cli` passes
- `npm run typecheck:cli` passes
- `npx vitest run src/lib/inference/onboard-probes.test.ts` passes
- `npx @biomejs/biome check src/lib/inference/onboard-probes.ts src/lib/inference/onboard-probes.test.ts` passes
- `git diff --check` passes

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding verification now skips the Hermes OAuth smoke check when a Hermes-specific credential environment is present, preventing false setup failures.

* **Tests**
  * Added tests covering onboarding decisions across different credential environments.
  * Added a runtime harness to simulate verifier flows and capture probe invocations for end-to-end verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->