### PR TITLE
fix(hermes): guard ui-tui and web npm ci steps for older Hermes versions

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -176,10 +176,14 @@ RUN set -eu; \
     done; \
     uv sync --frozen --no-dev "$@" --no-cache \
     && npm ci --prefer-offline --no-audit --no-fund \
-    && npm ci --prefix ui-tui --prefer-offline --no-audit --no-fund \
-    && npm run build --prefix ui-tui \
-    && npm ci --prefix web --prefer-offline --no-audit --no-fund \
-    && npm run build --prefix web \
+    && if [ -f ui-tui/package-lock.json ]; then \
+           npm ci --prefix ui-tui --prefer-offline --no-audit --no-fund \
+           && npm run build --prefix ui-tui; \
+       fi \
+    && if [ -f web/package-lock.json ]; then \
+           npm ci --prefix web --prefer-offline --no-audit --no-fund \
+           && npm run build --prefix web; \
+       fi \
     && rm -rf /tmp/camoufox-* \
     && ln -sf /opt/hermes/.venv/bin/hermes /usr/local/bin/hermes \
     && ln -sf /opt/hermes/.venv/bin/hermes-agent /usr/local/bin/hermes-agent \


### PR DESCRIPTION
## Summary

Guard the `ui-tui` and `web` `npm ci` / build steps in `agents/hermes/Dockerfile.base` with `[ -f <dir>/package-lock.json ]` existence checks so the Dockerfile stays compatible with older Hermes releases (v2026.4.13) that lack these subdirectories.

Commit 40ea247 (#4442 "feat(hermes): expose optional web dashboard") added unconditional `npm ci --prefix ui-tui` and `npm ci --prefix web` steps. The rebuild-hermes E2E tests build Dockerfile.base with `HERMES_VERSION=v2026.4.13`, which predates the `ui-tui/` and `web/` directories — causing `npm ci` to fail with `EUSAGE` ("no existing package-lock.json").

## Related Issue

_Linked after issue creation below._

## Changes

- Wrap `npm ci --prefix ui-tui` + `npm run build --prefix ui-tui` in `if [ -f ui-tui/package-lock.json ]`
- Wrap `npm ci --prefix web` + `npm run build --prefix web` in `if [ -f web/package-lock.json ]`
- No functional change for current Hermes (v2026.5.16) which has both lockfiles
- Restores backward compatibility for the rebuild-hermes E2E test matrix

## Validation

> **Note:** The `custom-e2e` validation branch could not be created because the GitHub token lacks the `workflows` permission needed to push files under `.github/workflows/`. The fix is a mechanical conditional guard on a Docker RUN step and has been verified by code inspection against the build logs.

- Original failing run: [26610274905](https://github.com/NVIDIA/NemoClaw/actions/runs/26610274905) on `d3e0f3ba27969847591c00af08a6c79681ba24e8`
- Targeted jobs: `rebuild-hermes-e2e / run (#78414410806)`, `rebuild-hermes-stale-base-e2e / run (#78414410803)`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>
