### PR TITLE
fix(hermes): tolerate missing optional ui packages

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -176,10 +176,14 @@ RUN set -eu; \
     done; \
     uv sync --frozen --no-dev "$@" --no-cache \
     && npm ci --prefer-offline --no-audit --no-fund \
-    && npm ci --prefix ui-tui --prefer-offline --no-audit --no-fund \
-    && npm run build --prefix ui-tui \
-    && npm ci --prefix web --prefer-offline --no-audit --no-fund \
-    && npm run build --prefix web \
+    && for ui_dir in ui-tui web; do \
+        if [ -f "${ui_dir}/package-lock.json" ]; then \
+            npm ci --prefix "${ui_dir}" --prefer-offline --no-audit --no-fund; \
+            npm run build --prefix "${ui_dir}"; \
+        else \
+            echo "Skipping optional Hermes UI package ${ui_dir}: package-lock.json not found"; \
+        fi; \
+    done \
     && rm -rf /tmp/camoufox-* \
     && ln -sf /opt/hermes/.venv/bin/hermes /usr/local/bin/hermes \
     && ln -sf /opt/hermes/.venv/bin/hermes-agent /usr/local/bin/hermes-agent \

--- a/test/hermes-share-mount-deps.test.ts
+++ b/test/hermes-share-mount-deps.test.ts
@@ -18,6 +18,14 @@ function extractAptInstallCommand(dockerfile: string): string {
   return match![0].replace(/^RUN\s+/, "").replace(/\\\n/g, " ");
 }
 
+function extractHermesInstallCommand(dockerfile: string): string {
+  const match = dockerfile.match(
+    /RUN\s+set -eu;[\s\S]*?ln -sf \/opt\/hermes\/\.venv\/bin\/hermes-acp \/usr\/local\/bin\/hermes-acp/m,
+  );
+  expect(match).not.toBeNull();
+  return match![0].replace(/^RUN\s+/, "").replace(/\\\n/g, " ");
+}
+
 function runLoggedShell(command: string, tmp: string) {
   const logPath = path.join(tmp, "calls.log");
   const scriptPath = path.join(tmp, "run-hermes-apt-layer.sh");
@@ -26,6 +34,49 @@ function runLoggedShell(command: string, tmp: string) {
     "set -euo pipefail",
     `call_log=${JSON.stringify(logPath)}`,
     'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; }',
+    command,
+  ].join("\n");
+  fs.writeFileSync(scriptPath, script, { mode: 0o700 });
+  const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", timeout: 5000 });
+  const calls = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf-8") : "";
+  return { result, calls };
+}
+
+function runHermesInstallLayer(command: string, tmp: string) {
+  const fixture = path.join(tmp, "hermes");
+  const logPath = path.join(tmp, "calls.log");
+  const scriptPath = path.join(tmp, "run-hermes-install-layer.sh");
+  fs.mkdirSync(path.join(fixture, "web"), { recursive: true });
+  fs.writeFileSync(path.join(fixture, "package-lock.json"), "{}\n");
+  fs.writeFileSync(path.join(fixture, "web", "package-lock.json"), "{}\n");
+
+  const script = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `cd ${JSON.stringify(fixture)}`,
+    `call_log=${JSON.stringify(logPath)}`,
+    'uv() { printf "uv %s\\n" "$*" >> "$call_log"; }',
+    "npm() {",
+    '  printf "npm %s\\n" "$*" >> "$call_log"',
+    '  if [ "${1:-}" = "ci" ]; then',
+    "    shift",
+    '    prefix="."',
+    '    while [ "$#" -gt 0 ]; do',
+    '      if [ "$1" = "--prefix" ]; then',
+    "        shift",
+    '        prefix="$1"',
+    "      fi",
+    "      shift || true",
+    "    done",
+    '    [ -f "${prefix}/package-lock.json" ] || {',
+    '      echo "missing lockfile for ${prefix}" >&2',
+    "      return 42",
+    "    }",
+    "  fi",
+    "}",
+    'rm() { printf "rm %s\\n" "$*" >> "$call_log"; }',
+    'ln() { printf "ln %s\\n" "$*" >> "$call_log"; }',
+    'export HERMES_UV_EXTRAS="messaging"',
     command,
   ].join("\n");
   fs.writeFileSync(scriptPath, script, { mode: 0o700 });
@@ -54,6 +105,24 @@ describe("Hermes share mount package parity (#2947)", () => {
       expect(calls).toContain("procps=2:4.0.4-9");
       expect(calls).toContain("e2fsprogs=1.47.2-3+b11");
       expect(calls).toContain("openssh-sftp-server=1:10.0p1-7+deb13u4");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips optional Hermes UI packages when old rebuild fixtures do not ship them", () => {
+    const dockerfile = fs.readFileSync(HERMES_DOCKERFILE_BASE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-ui-layer-"));
+
+    try {
+      const command = extractHermesInstallCommand(dockerfile);
+      const { result, calls } = runHermesInstallLayer(command, tmp);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(calls).toContain("npm ci --prefer-offline --no-audit --no-fund");
+      expect(calls).not.toContain("--prefix ui-tui");
+      expect(calls).toContain("npm ci --prefix web --prefer-offline --no-audit --no-fund");
+      expect(calls).toContain("npm run build --prefix web");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Make `agents/hermes/Dockerfile.base` skip optional Hermes UI package builds when a selected Hermes release tarball does not include that package lockfile.
- Preserve current behavior for modern Hermes releases that ship `ui-tui/package-lock.json` and `web/package-lock.json`.
- Add a focused regression test that simulates the old Hermes rebuild fixture layout with root/web lockfiles but no `ui-tui` lockfile.

## Why
The `main` nightly run https://github.com/NVIDIA/NemoClaw/actions/runs/26613436661 fails both Hermes rebuild jobs before the rebuild scenario starts:

- `rebuild-hermes-e2e / run`
- `rebuild-hermes-stale-base-e2e / run`

Both fail while `test/e2e/test-rebuild-hermes.sh` builds the intentionally old Hermes fixture image for `v2026.4.13`. That old tarball has a root `package-lock.json` and `web/package-lock.json`, but no `ui-tui/package-lock.json`, so the current unconditional `npm ci --prefix ui-tui` exits with `npm error code EUSAGE`.

## Validation
- `npm ci --ignore-scripts`
- `npx vitest run --project cli test/hermes-share-mount-deps.test.ts`
- `npm run build:cli`
- `npm run typecheck:cli`
- `git diff --check`

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Hermes build process to conditionally install and build UI packages only when dependencies are present.
  * Expanded test coverage for Hermes installation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->