### PR TITLE
feat(skills): add release notes maintainer workflow

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
@@ -152,10 +152,17 @@ Create a Markdown draft and an HTML preview. By default, place these outside the
 
 The Markdown body is the source that will be posted to GitHub Discussions. The HTML file is just a browser preview for review.
 
-After writing the files, open the HTML preview:
+After writing the files, open the HTML preview with the platform's default file opener:
 
-```bash
+```text
+macOS:
 open ../nemoclaw-<current-version>-release-note-draft.html
+
+Linux:
+xdg-open ../nemoclaw-<current-version>-release-note-draft.html
+
+Windows (PowerShell):
+Start-Process ../nemoclaw-<current-version>-release-note-draft.html
 ```
 
 Stop here unless the user approves posting.

--- a/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: nemoclaw-maintainer-release-notes
+description: Draft and publish NemoClaw release notes from live GitHub tag and compare data. Produces the repo's narrative release-note style with three lead paragraphs, categorized shipped changes, why-it-matters bullets, and external-only contributor thanks. Use after cutting a release tag or when asked to write/post a release announcement. Trigger keywords - release note, release notes, announcement, discussion post, changelog, v0.0.x is out, Carl Sagan.
+user_invocable: true
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# NemoClaw Maintainer Release Notes
+
+Draft and publish NemoClaw release notes from live release data. The house style is:
+
+- three narrative lead paragraphs,
+- a categorized list of shipped changes,
+- one "what changed and why it matters / why we did it" bullet for every included shipped change,
+- external-only contributor thanks,
+- visible `#NNNN` GitHub links.
+
+Default to a local draft and HTML preview first. Do not create or update a GitHub Discussion until the user explicitly approves posting.
+
+## Prerequisites
+
+- You must be in the NemoClaw git repository.
+- `gh` must be authenticated for `NVIDIA/NemoClaw`.
+- The release tag should already exist. If the user is still cutting the tag, use `nemoclaw-maintainer-cut-release-tag` first.
+- Use live GitHub and remote tag state, not memory or a stale local branch.
+
+## Step 1: Verify the Release Range
+
+Identify the current release tag and previous release tag. If the user gives only the current version, derive the previous semver tag from remote tags.
+
+```bash
+git ls-remote https://github.com/NVIDIA/NemoClaw.git \
+  refs/heads/main \
+  refs/tags/<previous-version> 'refs/tags/<previous-version>^{}' \
+  refs/tags/<current-version> 'refs/tags/<current-version>^{}' \
+  refs/tags/latest 'refs/tags/latest^{}'
+```
+
+Confirm:
+
+- `<current-version>^{}` peels to the intended release commit.
+- `latest` points to the same peeled commit unless the user explicitly says otherwise.
+- The compare range is `<previous-version>...<current-version>`.
+
+## Step 2: Collect the Shipped Surface
+
+Use the compare API as the first source of truth:
+
+```bash
+gh api repos/NVIDIA/NemoClaw/compare/<previous-version>...<current-version> \
+  --jq '{status,ahead_by,total_commits,commits:[.commits[] | {sha:.sha, headline:(.commit.message|split("\n")[0]), author:.commit.author.name}], files:[.files[] | {filename,status,changes}]}'
+```
+
+For each PR number in commit headlines, collect live PR metadata:
+
+```bash
+gh pr view <number> --repo NVIDIA/NemoClaw \
+  --json number,title,author,headRepositoryOwner,url,mergeCommit,labels,body,mergedAt
+```
+
+Also inspect any shipped commit that does not have a PR number in the headline. Include it only if it is a real shipped change worth announcing.
+
+## Step 3: Decide What to Include
+
+Include the shipped product, docs, release-surface, and CI confidence changes that a reader should know about.
+
+For each included item, write:
+
+- what changed,
+- why it matters or why we did it,
+- a visible PR link like `[#4474](https://github.com/NVIDIA/NemoClaw/pull/4474)`.
+
+Be careful with sensitive internal cleanup:
+
+- Do not count testing reverts or guardrail reversions as release value unless the user explicitly asks for a full raw changelog.
+- If a revert-like commit must be mentioned, use neutral language and do not frame it as someone else's mistake.
+- Avoid public wording that could embarrass a teammate.
+
+## Step 4: Categorize the Changes
+
+Use categories that match the release surface. Prefer 4-6 sections. Common categories:
+
+- OpenClaw, Sandbox, and Network Stability
+- Windows, WSL, and Onboarding Recovery
+- Messaging and OpenClaw Runtime Activation
+- Hermes and Inference
+- Skills, Docs, and Release Surface
+- CI and Release Confidence
+
+Every included shipped change should appear in exactly one category unless the user asks for a shorter note.
+
+## Step 5: Handle Contributor Credit
+
+By default, thank external contributors only. Do not thank NVIDIA/internal contributors by GitHub ID unless the user explicitly asks.
+
+Determine external contributors from live GitHub state:
+
+```bash
+for login in <github-logins>; do
+  code=$(gh api -i orgs/NVIDIA/members/$login 2>/dev/null \
+    | sed -n '1s/.* \([0-9][0-9][0-9]\).*/\1/p' || true)
+  printf '%s %s\n' "$login" "${code:-unknown}"
+done
+```
+
+Interpretation:
+
+- `204` means the account is a visible member of `NVIDIA`.
+- `404` means the account is not a visible member and should be treated as external for release-note thanks.
+
+Replay PRs need special care:
+
+- If a maintainer replayed an external PR, inspect the replay PR body and the original PR.
+- Credit the original external GitHub username in the issue-level bullet for the shipped replay.
+- Also thank that username in the final thanks section.
+- Do not mention affiliations, organizations, domains, or companies unless the user explicitly asks. Use the GitHub username only.
+
+Example:
+
+```markdown
+- [#4474](https://github.com/NVIDIA/NemoClaw/pull/4474) replays and narrows the Hermes Provider host-smoke fix originally contributed by @shannonsands in [#4385](https://github.com/NVIDIA/NemoClaw/pull/4385). ...
+
+## Thank you
+
+Thank you to external contributor @shannonsands for the original Hermes Provider smoke-check contribution in [#4385](https://github.com/NVIDIA/NemoClaw/pull/4385), which was replayed and narrowed into [#4474](https://github.com/NVIDIA/NemoClaw/pull/4474) for this release.
+```
+
+## Step 6: Draft the Narrative
+
+Write the top section as exactly three paragraphs unless the user asks otherwise.
+
+If the user requests a theme, let it shape the paragraphs. If the user asks for the voice of Carl Sagan, keep it subtle: cosmic scale, humility, clarity, and wonder, but no parody, no quotes, and no overdone imitation.
+
+Suggested structure:
+
+1. Stability theme and infrastructure/security boundary changes.
+2. User-facing workflow stability: messaging, Hermes, inference, onboarding.
+3. Maintenance stability: skills, docs, checks, and release confidence.
+
+Keep the prose warm and polished, but concrete. Tie the narrative to actual PRs in the release range.
+
+## Step 7: Write Local Drafts First
+
+Create a Markdown draft and an HTML preview. By default, place these outside the checkout root so the repo stays clean, for example:
+
+```bash
+../nemoclaw-<current-version>-release-note-draft.md
+../nemoclaw-<current-version>-release-note-draft.html
+```
+
+The Markdown body is the source that will be posted to GitHub Discussions. The HTML file is just a browser preview for review.
+
+After writing the files, open the HTML preview:
+
+```bash
+open ../nemoclaw-<current-version>-release-note-draft.html
+```
+
+Stop here unless the user approves posting.
+
+## Step 8: Publish to GitHub Discussions After Approval
+
+When the user says to post the release note, publish the reviewed Markdown body as a Discussion in `Announcements`.
+
+Resolve repository and category IDs live:
+
+```bash
+gh api graphql -f owner=NVIDIA -f name=NemoClaw -f query='
+query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    id
+    discussionCategories(first:20){ nodes{ id name slug } }
+  }
+}'
+```
+
+Check for an existing discussion for the same version before creating a new one:
+
+```bash
+gh api graphql -f owner=NVIDIA -f name=NemoClaw -f query='
+query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    discussions(first:20, orderBy:{field:CREATED_AT,direction:DESC}){
+      nodes{ number title url createdAt category{ name } }
+    }
+  }
+}' --jq '.data.repository.discussions.nodes | map(select(.title|test("<current-version>"; "i")))'
+```
+
+Create the discussion:
+
+```bash
+gh api graphql \
+  -f repositoryId='<repo-id>' \
+  -f categoryId='<announcements-category-id>' \
+  -f title='NemoClaw <current-version> is out' \
+  -F body=@../nemoclaw-<current-version>-release-note-draft.md \
+  -f query='mutation($repositoryId:ID!,$categoryId:ID!,$title:String!,$body:String!){
+    createDiscussion(input:{repositoryId:$repositoryId,categoryId:$categoryId,title:$title,body:$body}){
+      discussion{ number title url category{ name } body }
+    }
+  }'
+```
+
+Verify the live result:
+
+```bash
+gh api graphql -F number=<discussion-number> -f owner=NVIDIA -f name=NemoClaw -f query='
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    discussion(number:$number){ number title url category{ name } body createdAt }
+  }
+}'
+```
+
+Confirm:
+
+- category is `Announcements`,
+- title is `NemoClaw <current-version> is out`,
+- body starts with the reviewed draft,
+- external thanks are present if expected,
+- no affiliation text appears unless the user requested it.
+
+## Output
+
+For a draft-only run, return:
+
+- Markdown draft path,
+- HTML preview path,
+- a short note about the compare range and any excluded revert/test-cleanup items.
+
+For a posted run, return:
+
+- Discussion URL,
+- discussion number,
+- verification summary.
+
+## Hard Rules
+
+- Never publish a Discussion before the user approves the local draft.
+- Never draft from memory alone; use live `gh api compare` and PR metadata.
+- Never mention contributor affiliation unless the user explicitly asks.
+- Never thank internal contributors by default; keep thanks external-only.
+- Never include testing reverts as release-value bullets unless explicitly asked for a raw changelog.
+- Never create duplicate release Discussions.

--- a/.agents/skills/nemoclaw-skills-guide/SKILL.md
+++ b/.agents/skills/nemoclaw-skills-guide/SKILL.md
@@ -17,15 +17,15 @@ Load the specific skill you need after identifying it here.
 Skills are grouped into three buckets by audience.
 The prefix in each skill name indicates who it is for.
 
-### `nemoclaw-user-*` (9 skills)
+### `nemoclaw-user-*` (10 skills)
 
 For end users operating a NemoClaw sandbox.
 Covers installation, inference configuration, network policy management, monitoring, remote deployment, security configuration, workspace management, and reference material.
 
-### `nemoclaw-maintainer-*` (8 skills)
+### `nemoclaw-maintainer-*` (12 skills)
 
 For project maintainers.
-Covers the daily maintainer cadence (morning standup, daytime loop, evening handoff), cutting releases, finding PRs to review, normalizing issue and PR title tags, performing security code reviews, and verifying whether stale bug reports still reproduce on the latest release.
+Covers the daily maintainer cadence (morning standup, daytime loop, evening handoff), cutting releases, drafting release notes, finding PRs to review, comparing PRs, cross-issue sweeps, triage, normalizing issue and PR title tags, performing security code reviews, and verifying whether stale bug reports still reproduce on the latest release.
 
 ### `nemoclaw-contributor-*` (2 skills)
 
@@ -48,6 +48,7 @@ Covers creating pull requests that follow the project template and drafting docu
 | `nemoclaw-user-configure-security` | Review the risk framework for every configurable security control, understand credential storage, and assess posture trade-offs. |
 | `nemoclaw-user-manage-sandboxes` | Manage day-two sandbox operations, including status, logs, diagnostics, rebuilds, upgrades, messaging channels, workspace files, backup, and restore. |
 | `nemoclaw-user-reference` | CLI command reference, plugin and blueprint architecture, baseline network policies, and troubleshooting guide. |
+| `nemoclaw-user-agent-skills` | Describes the agent skills shipped with NemoClaw and how to access them by cloning the repository. |
 <!-- user-skills-table:end -->
 
 ### Maintainer Skills
@@ -55,10 +56,14 @@ Covers creating pull requests that follow the project template and drafting docu
 | Skill | Summary |
 |-------|---------|
 | `nemoclaw-maintainer-morning` | Morning standup: triage the backlog, determine the day's target version, label selected items, surface stragglers, and output the daily plan. |
+| `nemoclaw-maintainer-triage` | Suggest and optionally apply labels for issues and PRs using the live NemoClaw triage instructions. |
+| `nemoclaw-maintainer-cross-issue-sweep` | Scan open issues for adjacent fixes or contradiction risks when reviewing a PR. |
 | `nemoclaw-maintainer-day` | Daytime loop: pick the highest-value version-targeted item and execute the right workflow (merge gate, salvage, security sweep, test gaps, hotspot cooling, or sequencing). Designed for `/loop`. |
 | `nemoclaw-maintainer-evening` | End-of-day handoff: check version progress, bump stragglers to the next patch, generate a QA handoff summary, and cut the release tag. |
 | `nemoclaw-maintainer-cut-release-tag` | Cut an annotated semver tag on main, move the `latest` floating tag, and push both to origin. |
+| `nemoclaw-maintainer-release-notes` | Draft and publish release notes from live tag/compare data, with the three-paragraph narrative, categorized change list, and external-only contributor thanks. |
 | `nemoclaw-maintainer-find-review-pr` | Find open PRs labeled security + priority-high, link each to its issue, detect duplicates, and present a review summary. |
+| `nemoclaw-maintainer-pr-comparator` | Compare competing PRs for the same issue and recommend which one to merge. |
 | `nemoclaw-maintainer-normalize-title-tags` | Preview and remove bracketed `NemoClaw` title tags from issues and PRs case-insensitively, even when the tag appears later in the title. |
 | `nemoclaw-maintainer-security-code-review` | Perform a 9-category security review of a PR or issue, producing per-category PASS/WARNING/FAIL verdicts. |
 | `nemoclaw-maintainer-verify-stale` | Verify whether old bug reports still reproduce on latest. Reuses or provisions a Brev box (CPU or GPU), runs the extracted reproducer, scores confidence, and posts an evidence-backed comment with `fixed-on-latest` or `verify-inconclusive`. Tag-only — never auto-closes. |
@@ -82,8 +87,8 @@ Skills are cumulative. Each role includes the skills from the roles above it:
 
 | Role | Skills included | Count | Start with |
 |------|----------------|-------|------------|
-| User | `nemoclaw-user-*` | 9 | `nemoclaw-user-get-started` |
-| Contributor | `nemoclaw-user-*` + `nemoclaw-contributor-*` | 11 | `nemoclaw-user-overview` |
-| Maintainer | All skills | 19 | `nemoclaw-maintainer-morning` |
+| User | `nemoclaw-user-*` | 10 | `nemoclaw-user-get-started` |
+| Contributor | `nemoclaw-user-*` + `nemoclaw-contributor-*` | 12 | `nemoclaw-user-overview` |
+| Maintainer | All skills | 24 | `nemoclaw-maintainer-morning` |
 
 After identifying the role, present the applicable skills from the Skill Catalog above and recommend the starting skill.


### PR DESCRIPTION
## Summary
- Add `nemoclaw-maintainer-release-notes`, a maintainer skill for drafting and posting NemoClaw release notes from live tag/compare data.
- Capture the release-note workflow used for v0.0.54: three-paragraph narrative, categorized shipped-change bullets, local HTML preview before posting, external-only GitHub username thanks, replay attribution, and no affiliation text.
- Update the skills guide so the new maintainer skill is discoverable and fix the guide counts to match the current skill directories.

## Validation
- `npx markdownlint-cli2 .agents/skills/nemoclaw-maintainer-release-notes/SKILL.md .agents/skills/nemoclaw-skills-guide/SKILL.md`
- `git diff --check`

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-invocable maintainer skill to draft and publish NemoClaw release notes with strict house style, categorized shipped changes, contributor credit rules, preview/draft-by-default behavior, and safeguards against premature posting.

* **Documentation**
  * Updated maintainer skills guide and skill catalog to reflect an expanded maintainer skill set and revised role skill counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->