### PR TITLE
ci: allow Brev launchable bridge access

### DIFF
--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -24,18 +24,11 @@
 #   Writes /var/run/nemoclaw-launchable-ready when complete.
 #   Also writes "=== Ready ===" to /tmp/launch-plugin.log for backward compat.
 #
-# Usage (Brev launchable startup script — one-liner that curls this):
-#   curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/<ref>/scripts/brev-launchable-ci-cpu.sh | bash
-#
 # Environment overrides:
 #   OPENSHELL_VERSION     — OpenShell CLI release tag (default: v0.0.44)
 #   NEMOCLAW_REF          — NemoClaw git ref to clone (default: main)
 #   NEMOCLAW_CLONE_DIR    — Where to clone NemoClaw (default: ~/NemoClaw)
 #   SKIP_DOCKER_PULL      — Set to 1 to skip Docker image pre-pulls
-#
-# Related:
-#   - Epic: https://github.com/NVIDIA/NemoClaw/issues/1326
-#   - Issue: https://github.com/NVIDIA/NemoClaw/issues/1327
 
 set -euo pipefail
 
@@ -52,8 +45,6 @@ OLLAMA_AUTH_PROXY_PORT="11435"
 LAUNCH_LOG="${LAUNCH_LOG:-/tmp/launch-plugin.log}"
 SENTINEL="/var/run/nemoclaw-launchable-ready"
 
-# Docker images to pre-pull. These are the expensive layers that cause
-# timeouts when pulled during CI runs.
 DOCKER_IMAGES=(
   "ghcr.io/nvidia/nemoclaw/sandbox-base:latest"
   "node:22-trixie-slim"
@@ -95,29 +86,22 @@ retry() {
   done
 }
 
-allow_docker_bridge_host_port() {
-  local port="$1"
-  local label="$2"
-
+allow_bridge_port() {
+  local port="$1" label="$2"
   if ! command -v ufw >/dev/null 2>&1; then
-    warn "ufw not installed — skipping Docker bridge allow rule for $label"
+    warn "ufw missing; skip $label"
     return
   fi
-
   if sudo -n ufw allow from "$DOCKER_BRIDGE_POOL_CIDR" to any port "$port" proto tcp >/dev/null 2>&1; then
-    info "Allowed Docker bridge traffic to $label on port $port"
+    info "Allowed Docker bridge to $label:$port"
   else
-    warn "Could not add UFW allow rule for $label on port $port"
+    warn "Could not add UFW rule for $label:$port"
   fi
 }
 
 configure_openshell_bridge_firewall() {
-  # The openshell-docker network is created later, so this setup cannot know the
-  # exact future bridge subnet. Brev CI launchable VMs are single-use hosts; allow
-  # Docker's default local bridge pool to the host services sandbox containers
-  # must reach during onboarding.
-  allow_docker_bridge_host_port "$OPENSHELL_GATEWAY_PORT" "OpenShell gateway"
-  allow_docker_bridge_host_port "$OLLAMA_AUTH_PROXY_PORT" "Ollama auth proxy"
+  allow_bridge_port "$OPENSHELL_GATEWAY_PORT" gateway
+  allow_bridge_port "$OLLAMA_AUTH_PROXY_PORT" auth-proxy
 }
 
 # ── Wait for apt locks ───────────────────────────────────────────────
@@ -167,9 +151,7 @@ else
 fi
 sudo systemctl enable --now docker
 sudo usermod -aG docker "$TARGET_USER" 2>/dev/null || true
-# Make the socket world-accessible so SSH sessions (which don't pick up the
-# new docker group until re-login) can use Docker immediately.  This is a
-# short-lived CI VM — socket security is not a concern.
+# Short-lived CI VM: make Docker usable before a fresh login picks up the group.
 sudo chmod 666 /var/run/docker.sock
 info "Docker enabled ($(docker --version 2>/dev/null | head -c 40))"
 configure_openshell_bridge_firewall

--- a/scripts/brev-launchable-ci-cpu.sh
+++ b/scripts/brev-launchable-ci-cpu.sh
@@ -45,6 +45,9 @@ NEMOCLAW_REF="${NEMOCLAW_REF:-main}"
 TARGET_USER="${SUDO_USER:-$(id -un)}"
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 NEMOCLAW_CLONE_DIR="${NEMOCLAW_CLONE_DIR:-${TARGET_HOME}/NemoClaw}"
+DOCKER_BRIDGE_POOL_CIDR="172.16.0.0/12"
+OPENSHELL_GATEWAY_PORT="8080"
+OLLAMA_AUTH_PROXY_PORT="11435"
 
 LAUNCH_LOG="${LAUNCH_LOG:-/tmp/launch-plugin.log}"
 SENTINEL="/var/run/nemoclaw-launchable-ready"
@@ -90,6 +93,31 @@ retry() {
     sleep "$sleep_sec"
     ((attempt++))
   done
+}
+
+allow_docker_bridge_host_port() {
+  local port="$1"
+  local label="$2"
+
+  if ! command -v ufw >/dev/null 2>&1; then
+    warn "ufw not installed — skipping Docker bridge allow rule for $label"
+    return
+  fi
+
+  if sudo -n ufw allow from "$DOCKER_BRIDGE_POOL_CIDR" to any port "$port" proto tcp >/dev/null 2>&1; then
+    info "Allowed Docker bridge traffic to $label on port $port"
+  else
+    warn "Could not add UFW allow rule for $label on port $port"
+  fi
+}
+
+configure_openshell_bridge_firewall() {
+  # The openshell-docker network is created later, so this setup cannot know the
+  # exact future bridge subnet. Brev CI launchable VMs are single-use hosts; allow
+  # Docker's default local bridge pool to the host services sandbox containers
+  # must reach during onboarding.
+  allow_docker_bridge_host_port "$OPENSHELL_GATEWAY_PORT" "OpenShell gateway"
+  allow_docker_bridge_host_port "$OLLAMA_AUTH_PROXY_PORT" "Ollama auth proxy"
 }
 
 # ── Wait for apt locks ───────────────────────────────────────────────
@@ -144,6 +172,7 @@ sudo usermod -aG docker "$TARGET_USER" 2>/dev/null || true
 # short-lived CI VM — socket security is not a concern.
 sudo chmod 666 /var/run/docker.sock
 info "Docker enabled ($(docker --version 2>/dev/null | head -c 40))"
+configure_openshell_bridge_firewall
 
 # ══════════════════════════════════════════════════════════════════════
 # 3. Node.js 22

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -62,11 +62,7 @@ describe("Brev nightly workflow contract", () => {
     expect(script).toContain(
       'sudo -n ufw allow from "$DOCKER_BRIDGE_POOL_CIDR" to any port "$port" proto tcp',
     );
-    expect(script).toContain(
-      'allow_docker_bridge_host_port "$OPENSHELL_GATEWAY_PORT" "OpenShell gateway"',
-    );
-    expect(script).toContain(
-      'allow_docker_bridge_host_port "$OLLAMA_AUTH_PROXY_PORT" "Ollama auth proxy"',
-    );
+    expect(script).toContain('allow_bridge_port "$OPENSHELL_GATEWAY_PORT" gateway');
+    expect(script).toContain('allow_bridge_port "$OLLAMA_AUTH_PROXY_PORT" auth-proxy');
   });
 });

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
 
 import { readYaml } from "./helpers/e2e-workflow-contract";
 
@@ -55,14 +58,85 @@ describe("Brev nightly workflow contract", () => {
     expect(callerInputs).not.toContain("use_published_launchable");
   });
 
-  it("keeps the CI launchable Docker bridge firewall rules", () => {
-    const script = readFileSync("scripts/brev-launchable-ci-cpu.sh", "utf8");
+  it("configures Docker bridge firewall rules in the CI launchable", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "nemoclaw-brev-firewall-"));
 
-    expect(script).toContain('DOCKER_BRIDGE_POOL_CIDR="172.16.0.0/12"');
-    expect(script).toContain(
-      'sudo -n ufw allow from "$DOCKER_BRIDGE_POOL_CIDR" to any port "$port" proto tcp',
-    );
-    expect(script).toContain('allow_bridge_port "$OPENSHELL_GATEWAY_PORT" gateway');
-    expect(script).toContain('allow_bridge_port "$OLLAMA_AUTH_PROXY_PORT" auth-proxy');
+    try {
+      const sudoLog = join(tmp, "sudo.log");
+      const ufwLog = join(tmp, "ufw.log");
+      const launchLog = join(tmp, "launch.log");
+
+      writeExecutable(
+        join(tmp, "sudo"),
+        `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$NEMOCLAW_FAKE_SUDO_LOG"
+if [ "\${1:-}" = "-n" ]; then
+  shift
+fi
+exec "$@"
+`,
+      );
+      writeExecutable(
+        join(tmp, "ufw"),
+        `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$NEMOCLAW_FAKE_UFW_LOG"
+`,
+      );
+      writeExecutable(
+        join(tmp, "getent"),
+        `#!/usr/bin/env bash
+if [ "\${1:-}" = "passwd" ]; then
+  printf '%s:x:1000:1000::%s:/bin/bash\\n' "\${2:-ci}" "$HOME"
+fi
+`,
+      );
+
+      const result = spawnSync(
+        "bash",
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          `
+set -euo pipefail
+source <(awk '/Wait for apt locks/{exit} {print}' scripts/brev-launchable-ci-cpu.sh)
+configure_openshell_bridge_firewall
+`,
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            LAUNCH_LOG: launchLog,
+            NEMOCLAW_FAKE_SUDO_LOG: sudoLog,
+            NEMOCLAW_FAKE_UFW_LOG: ufwLog,
+            PATH: `${tmp}:${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      expect(readFileSync(sudoLog, "utf-8").trim().split("\n")).toEqual([
+        "-n ufw allow from 172.16.0.0/12 to any port 8080 proto tcp",
+        "-n ufw allow from 172.16.0.0/12 to any port 11435 proto tcp",
+      ]);
+      expect(readFileSync(ufwLog, "utf-8").trim().split("\n")).toEqual([
+        "allow from 172.16.0.0/12 to any port 8080 proto tcp",
+        "allow from 172.16.0.0/12 to any port 11435 proto tcp",
+      ]);
+      expect(readFileSync(launchLog, "utf-8")).toMatch(/Allowed Docker bridge to gateway:8080/);
+      expect(readFileSync(launchLog, "utf-8")).toMatch(
+        /Allowed Docker bridge to auth-proxy:11435/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
+
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}

--- a/test/brev-nightly-workflow.test.ts
+++ b/test/brev-nightly-workflow.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 
 import { readYaml } from "./helpers/e2e-workflow-contract";
 
@@ -52,5 +53,20 @@ describe("Brev nightly workflow contract", () => {
     expect(dispatchInputs).not.toContain("launchable_id");
     expect(callerInputs).not.toContain("launchable_id");
     expect(callerInputs).not.toContain("use_published_launchable");
+  });
+
+  it("keeps the CI launchable Docker bridge firewall rules", () => {
+    const script = readFileSync("scripts/brev-launchable-ci-cpu.sh", "utf8");
+
+    expect(script).toContain('DOCKER_BRIDGE_POOL_CIDR="172.16.0.0/12"');
+    expect(script).toContain(
+      'sudo -n ufw allow from "$DOCKER_BRIDGE_POOL_CIDR" to any port "$port" proto tcp',
+    );
+    expect(script).toContain(
+      'allow_docker_bridge_host_port "$OPENSHELL_GATEWAY_PORT" "OpenShell gateway"',
+    );
+    expect(script).toContain(
+      'allow_docker_bridge_host_port "$OLLAMA_AUTH_PROXY_PORT" "Ollama auth proxy"',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add Docker bridge UFW allow rules to the CI Brev launchable startup script for OpenShell gateway (`8080`) and auth proxy (`11435`)
- add a static workflow contract test so the bridge rules stay wired into the launchable path

## Why
This mirrors the firewall fix proposed in `brevdev/nemoclaw-image` so we can validate the same Brev host-network shape from NemoClaw's trusted Brev E2E runner. The failure we are chasing is sandbox containers being unable to reach `host.openshell.internal:8080` from the Docker bridge.

## Validation
- `bash -n scripts/brev-launchable-ci-cpu.sh`
- `shellcheck scripts/brev-launchable-ci-cpu.sh`
- `npx vitest run --project cli test/brev-nightly-workflow.test.ts`
- `git diff --check`
- `npx @biomejs/biome check test/brev-nightly-workflow.test.ts` (ignored by repo config; no files processed)

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI firewall configuration to expose the service gateway and auth proxy via the Docker bridge, applying network rules early during VM provisioning.

* **Tests**
  * Added test coverage to verify the CI launch workflow establishes the intended Docker-bridge firewall rules and records the corresponding launch log messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->