### PR TITLE
fix(debug): validate sandbox name and clean partial tarballs

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1144,6 +1144,9 @@ $ nemoclaw debug [--quick|-q] [--sandbox NAME] [--output PATH|-o PATH]
 | `--output PATH`, `-o PATH` | Write diagnostics tarball to the given path |
 
 If `--output` is set and the tarball cannot be written (for example, the destination directory is missing or read-only), the command exits non-zero so scripts can detect the failure.
+The tarball is written to a temporary sibling and renamed on success, so a pre-existing file at `--output` is preserved when `tar` fails.
+
+When `--sandbox` is supplied explicitly (via flag or one of `NEMOCLAW_SANDBOX_NAME`, `NEMOCLAW_SANDBOX`, `SANDBOX_NAME` — flag wins, then the env vars in that order), the name must match a registered sandbox; if `openshell sandbox list` succeeds it must also appear in the live gateway. An unknown or stale name exits non-zero with an actionable error that names the sandbox and reports the source env var when applicable, and no tarball is written. Without an explicit name, `nemoclaw debug` falls back to the registry's default sandbox (and warns if that default is stale).
 
 ### `nemoclaw credentials list`
 

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -59,8 +59,17 @@ function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return defaultSandbox;
   };
 
+  const isSandboxKnown = (name: string): boolean => {
+    const { sandboxes } = registry.listSandboxes();
+    if (sandboxes.find((sandbox) => sandbox.name === name)) return true;
+    const liveList = captureOpenshell(rootDir, ["sandbox", "list"]);
+    if (liveList.status === 0 && parseLiveSandboxNames(liveList.output).has(name)) return true;
+    return false;
+  };
+
   return {
     getDefaultSandbox,
+    isSandboxKnown,
     runDebug,
   };
 }

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -61,10 +61,12 @@ function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
 
   const isSandboxKnown = (name: string): boolean => {
     const { sandboxes } = registry.listSandboxes();
-    if (sandboxes.find((sandbox) => sandbox.name === name)) return true;
+    if (!sandboxes.find((sandbox) => sandbox.name === name)) return false;
     const liveList = captureOpenshell(rootDir, ["sandbox", "list"]);
-    if (liveList.status === 0 && parseLiveSandboxNames(liveList.output).has(name)) return true;
-    return false;
+    if (liveList.status === 0 && !parseLiveSandboxNames(liveList.output).has(name)) {
+      return false;
+    }
+    return true;
   };
 
   return {

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -12,6 +12,7 @@ describe("debug command", () => {
       { quick: true, output: "/tmp/out.tgz" },
       {
         getDefaultSandbox: () => "alpha",
+        isSandboxKnown: () => true,
         runDebug,
       },
     );
@@ -20,5 +21,102 @@ describe("debug command", () => {
       output: "/tmp/out.tgz",
       sandboxName: "alpha",
     });
+  });
+
+  it("accepts an explicit --sandbox name that is registered", () => {
+    const runDebug = vi.fn();
+    const isSandboxKnown = vi.fn().mockReturnValue(true);
+    runDebugCommandWithOptions(
+      { sandboxName: "alpha" },
+      {
+        getDefaultSandbox: () => undefined,
+        isSandboxKnown,
+        runDebug,
+      },
+    );
+    expect(isSandboxKnown).toHaveBeenCalledWith("alpha");
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
+  });
+
+  it("rejects an explicit --sandbox name that is not registered, exits non-zero, skips runDebug", () => {
+    const runDebug = vi.fn();
+    const errorLines: string[] = [];
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    }) as unknown as (code: number) => never;
+    expect(() =>
+      runDebugCommandWithOptions(
+        { sandboxName: "does-not-exist", output: "/tmp/out.tgz" },
+        {
+          getDefaultSandbox: () => "alpha",
+          isSandboxKnown: () => false,
+          runDebug,
+          errorLine: (msg) => errorLines.push(msg),
+          exit,
+        },
+      ),
+    ).toThrow("exit");
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(runDebug).not.toHaveBeenCalled();
+    expect(errorLines[0]).toContain("does-not-exist");
+    expect(errorLines[0]).toContain("not registered");
+    expect(errorLines.join("\n")).toContain("nemoclaw list");
+  });
+
+  it("validates an env-sourced sandbox name and reports the env source on failure", () => {
+    const runDebug = vi.fn();
+    const errorLines: string[] = [];
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    }) as unknown as (code: number) => never;
+    expect(() =>
+      runDebugCommandWithOptions(
+        {},
+        {
+          env: { NEMOCLAW_SANDBOX: "ghost" } as NodeJS.ProcessEnv,
+          getDefaultSandbox: () => "alpha",
+          isSandboxKnown: () => false,
+          runDebug,
+          errorLine: (msg) => errorLines.push(msg),
+          exit,
+        },
+      ),
+    ).toThrow("exit");
+    expect(runDebug).not.toHaveBeenCalled();
+    expect(errorLines[0]).toContain("ghost");
+    expect(errorLines[0]).toContain("NEMOCLAW_SANDBOX");
+  });
+
+  it("flag overrides env vars when both are present", () => {
+    const runDebug = vi.fn();
+    const isSandboxKnown = vi.fn().mockReturnValue(true);
+    runDebugCommandWithOptions(
+      { sandboxName: "alpha" },
+      {
+        env: { NEMOCLAW_SANDBOX: "beta" } as NodeJS.ProcessEnv,
+        getDefaultSandbox: () => undefined,
+        isSandboxKnown,
+        runDebug,
+      },
+    );
+    expect(isSandboxKnown).toHaveBeenCalledWith("alpha");
+    expect(isSandboxKnown).not.toHaveBeenCalledWith("beta");
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
+  });
+
+  it("falls back to getDefaultSandbox when neither flag nor env is set", () => {
+    const runDebug = vi.fn();
+    const isSandboxKnown = vi.fn();
+    runDebugCommandWithOptions(
+      {},
+      {
+        env: {} as NodeJS.ProcessEnv,
+        getDefaultSandbox: () => "alpha",
+        isSandboxKnown,
+        runDebug,
+      },
+    );
+    expect(isSandboxKnown).not.toHaveBeenCalled();
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 });

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -73,7 +73,7 @@ describe("debug command", () => {
       runDebugCommandWithOptions(
         {},
         {
-          env: { NEMOCLAW_SANDBOX: "ghost" } as NodeJS.ProcessEnv,
+          env: { NEMOCLAW_SANDBOX_NAME: "ghost" } as NodeJS.ProcessEnv,
           getDefaultSandbox: () => "alpha",
           isSandboxKnown: () => false,
           runDebug,
@@ -84,7 +84,27 @@ describe("debug command", () => {
     ).toThrow("exit");
     expect(runDebug).not.toHaveBeenCalled();
     expect(errorLines[0]).toContain("ghost");
-    expect(errorLines[0]).toContain("NEMOCLAW_SANDBOX");
+    expect(errorLines[0]).toContain("NEMOCLAW_SANDBOX_NAME");
+  });
+
+  it("prefers NEMOCLAW_SANDBOX_NAME over NEMOCLAW_SANDBOX and SANDBOX_NAME", () => {
+    const runDebug = vi.fn();
+    const isSandboxKnown = vi.fn().mockReturnValue(true);
+    runDebugCommandWithOptions(
+      {},
+      {
+        env: {
+          NEMOCLAW_SANDBOX_NAME: "primary",
+          NEMOCLAW_SANDBOX: "secondary",
+          SANDBOX_NAME: "tertiary",
+        } as NodeJS.ProcessEnv,
+        getDefaultSandbox: () => undefined,
+        isSandboxKnown,
+        runDebug,
+      },
+    );
+    expect(isSandboxKnown).toHaveBeenCalledWith("primary");
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "primary" });
   });
 
   it("flag overrides env vars when both are present", () => {

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -82,6 +82,7 @@ describe("debug command", () => {
         },
       ),
     ).toThrow("exit");
+    expect(exit).toHaveBeenCalledWith(1);
     expect(runDebug).not.toHaveBeenCalled();
     expect(errorLines[0]).toContain("ghost");
     expect(errorLines[0]).toContain("NEMOCLAW_SANDBOX_NAME");

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -12,14 +12,18 @@ export interface RunDebugCommandDeps {
   exit?: (code: number) => never;
 }
 
+const SANDBOX_NAME_ENV_VARS = ["NEMOCLAW_SANDBOX_NAME", "NEMOCLAW_SANDBOX", "SANDBOX_NAME"] as const;
+
 function resolveExplicitName(
   options: DebugOptions,
   env: NodeJS.ProcessEnv,
-): { name: string; source: "flag" | "env" } | null {
+): { name: string; source: "flag" | "env"; envVar?: string } | null {
   const flagName = options.sandboxName?.trim();
   if (flagName) return { name: flagName, source: "flag" };
-  const envName = (env.NEMOCLAW_SANDBOX ?? env.SANDBOX_NAME ?? "").trim();
-  if (envName) return { name: envName, source: "env" };
+  for (const envVar of SANDBOX_NAME_ENV_VARS) {
+    const value = env[envVar]?.trim();
+    if (value) return { name: value, source: "env", envVar };
+  }
   return null;
 }
 
@@ -37,7 +41,7 @@ export function runDebugCommandWithOptions(options: DebugOptions, deps: RunDebug
   if (explicit) {
     if (!deps.isSandboxKnown(explicit.name)) {
       const sourceLabel =
-        explicit.source === "env" ? " (from NEMOCLAW_SANDBOX/SANDBOX_NAME)" : "";
+        explicit.source === "env" && explicit.envVar ? ` (from ${explicit.envVar})` : "";
       errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
       errorLine("  Run `nemoclaw list` to see available sandboxes.");
       exit(1);

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -5,13 +5,48 @@ import type { DebugOptions } from "./debug";
 
 export interface RunDebugCommandDeps {
   getDefaultSandbox: () => string | undefined;
+  isSandboxKnown: (name: string) => boolean;
   runDebug: (options: DebugOptions) => void;
+  env?: NodeJS.ProcessEnv;
+  errorLine?: (message: string) => void;
+  exit?: (code: number) => never;
+}
+
+function resolveExplicitName(
+  options: DebugOptions,
+  env: NodeJS.ProcessEnv,
+): { name: string; source: "flag" | "env" } | null {
+  const flagName = options.sandboxName?.trim();
+  if (flagName) return { name: flagName, source: "flag" };
+  const envName = (env.NEMOCLAW_SANDBOX ?? env.SANDBOX_NAME ?? "").trim();
+  if (envName) return { name: envName, source: "env" };
+  return null;
 }
 
 export function runDebugCommandWithOptions(options: DebugOptions, deps: RunDebugCommandDeps): void {
   const opts = { ...options };
-  if (!opts.sandboxName) {
+  const env = deps.env ?? process.env;
+  const errorLine = deps.errorLine ?? ((msg: string) => console.error(msg));
+  const exit =
+    deps.exit ??
+    ((code: number) => {
+      process.exit(code);
+    });
+
+  const explicit = resolveExplicitName(opts, env);
+  if (explicit) {
+    if (!deps.isSandboxKnown(explicit.name)) {
+      const sourceLabel =
+        explicit.source === "env" ? " (from NEMOCLAW_SANDBOX/SANDBOX_NAME)" : "";
+      errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
+      errorLine("  Run `nemoclaw list` to see available sandboxes.");
+      exit(1);
+      return;
+    }
+    opts.sandboxName = explicit.name;
+  } else {
     opts.sandboxName = deps.getDefaultSandbox();
   }
+
   deps.runDebug(opts);
 }

--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -84,13 +84,13 @@ describe("createTarball", () => {
 
   it("removes any partial tarball when tar fails", () => {
     tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
-    writeFileSync(join(tempDir, "dummy.txt"), "test data");
+    writeFileSync(join(tempDir, "payload.txt"), "test data");
     outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
     const output = join(outputDir, "partial.tar.gz");
     // Pre-create a stub file so createTarball can prove it removed a partial.
     writeFileSync(output, "stub partial tarball");
-    // Force tar failure by removing the source directory before tar starts
-    // would race; instead point tar at a missing source via the same trick.
+    // Removing the source dir forces tar to fail without racing in-progress
+    // collection.
     rmSync(tempDir, { recursive: true, force: true });
     const ok = createTarball(tempDir, output);
     expect(ok).toBe(false);

--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -82,6 +82,22 @@ describe("createTarball", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("removes any partial tarball when tar fails", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
+    writeFileSync(join(tempDir, "dummy.txt"), "test data");
+    outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    const output = join(outputDir, "partial.tar.gz");
+    // Pre-create a stub file so createTarball can prove it removed a partial.
+    writeFileSync(output, "stub partial tarball");
+    // Force tar failure by removing the source directory before tar starts
+    // would race; instead point tar at a missing source via the same trick.
+    rmSync(tempDir, { recursive: true, force: true });
+    const ok = createTarball(tempDir, output);
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(output)).toBe(false);
+  });
+
   it("creates tarball successfully and returns true for valid output path", () => {
     tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
     writeFileSync(join(tempDir, "dummy.txt"), "test data");

--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -82,20 +82,27 @@ describe("createTarball", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("removes any partial tarball when tar fails", () => {
+  it("leaves pre-existing user output untouched and removes the temp sibling when tar fails", () => {
     tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
     writeFileSync(join(tempDir, "payload.txt"), "test data");
     outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
     const output = join(outputDir, "partial.tar.gz");
-    // Pre-create a stub file so createTarball can prove it removed a partial.
-    writeFileSync(output, "stub partial tarball");
+    // Pre-existing user file must NOT be clobbered when tar fails.
+    const previous = "pre-existing user content";
+    writeFileSync(output, previous);
     // Removing the source dir forces tar to fail without racing in-progress
     // collection.
     rmSync(tempDir, { recursive: true, force: true });
     const ok = createTarball(tempDir, output);
     expect(ok).toBe(false);
     expect(process.exitCode).toBe(1);
-    expect(existsSync(output)).toBe(false);
+    expect(existsSync(output)).toBe(true);
+    expect(readFileSync(output, "utf-8")).toBe(previous);
+    // No .partial sibling should remain after cleanup.
+    const partials = readdirSync(outputDir).filter(
+      (name) => name.endsWith(".partial") || name.includes(".partial."),
+    );
+    expect(partials).toEqual([]);
   });
 
   it("creates tarball successfully and returns true for valid output path", () => {

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -517,6 +517,11 @@ export function createTarball(collectDir: string, output: string): boolean {
       ? `killed by signal ${result.signal}`
       : `exited with code ${result.status ?? "unknown"}`;
     error(`Failed to create tarball at ${output} (tar ${reason})`);
+    try {
+      rmSync(output, { force: true });
+    } catch {
+      /* best-effort cleanup of partial tarball */
+    }
     process.exitCode = 1;
     return false;
   }

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -563,9 +563,15 @@ export function runDebug(opts: DebugOptions = {}): void {
   // Compiled location: dist/lib/diagnostics/debug.js → repo root is 3 levels up
   const repoDir = join(__dirname, "..", "..", "..");
 
-  // Resolve sandbox name
+  // Resolve sandbox name. Precedence matches the documented services + debug
+  // contract in docs/reference/commands.mdx: explicit option > NEMOCLAW_SANDBOX_NAME
+  // > NEMOCLAW_SANDBOX > SANDBOX_NAME.
   let sandboxName =
-    opts.sandboxName ?? process.env.NEMOCLAW_SANDBOX ?? process.env.SANDBOX_NAME ?? "";
+    opts.sandboxName ??
+    process.env.NEMOCLAW_SANDBOX_NAME ??
+    process.env.NEMOCLAW_SANDBOX ??
+    process.env.SANDBOX_NAME ??
+    "";
   if (!sandboxName) {
     sandboxName = detectSandboxName();
   }

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -508,19 +508,40 @@ function collectKernelMessages(collectDir: string): void {
  * guidance that goes with the generated file.
  */
 export function createTarball(collectDir: string, output: string): boolean {
-  const result = spawnSync("tar", ["czf", output, "-C", dirname(collectDir), basename(collectDir)], {
-    stdio: "inherit",
-    timeout: 60_000,
-  });
+  // Write to a sibling temp path so a tar failure cannot clobber a
+  // pre-existing user file at `output`. Rename atomically on success.
+  const partial = `${output}.partial.${process.pid}`;
+  const result = spawnSync(
+    "tar",
+    ["czf", partial, "-C", dirname(collectDir), basename(collectDir)],
+    {
+      stdio: "inherit",
+      timeout: 60_000,
+    },
+  );
   if (result.status !== 0 || result.signal) {
     const reason = result.signal
       ? `killed by signal ${result.signal}`
       : `exited with code ${result.status ?? "unknown"}`;
     error(`Failed to create tarball at ${output} (tar ${reason})`);
     try {
-      rmSync(output, { force: true });
+      rmSync(partial, { force: true });
     } catch {
       /* best-effort cleanup of partial tarball */
+    }
+    process.exitCode = 1;
+    return false;
+  }
+  try {
+    renameSync(partial, output);
+  } catch (err) {
+    error(
+      `Failed to move tarball into place at ${output}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    try {
+      rmSync(partial, { force: true });
+    } catch {
+      /* best-effort */
     }
     process.exitCode = 1;
     return false;

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { join } from "node:path";
 
 import { dockerExecFileSync } from "../adapters/docker/exec";
 import { DASHBOARD_PORT } from "../core/ports";
 import { listSandboxes } from "../state/registry";
+import { createTarball as createDiagnosticsTarball } from "./tarball";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -503,55 +504,8 @@ function collectKernelMessages(collectDir: string): void {
 // Tarball
 // ---------------------------------------------------------------------------
 
-/**
- * Archive the collected diagnostics into a tarball and print the sharing
- * guidance that goes with the generated file.
- */
 export function createTarball(collectDir: string, output: string): boolean {
-  // Write to a sibling temp path so a tar failure cannot clobber a
-  // pre-existing user file at `output`. Rename atomically on success.
-  const partial = `${output}.partial.${process.pid}`;
-  const result = spawnSync(
-    "tar",
-    ["czf", partial, "-C", dirname(collectDir), basename(collectDir)],
-    {
-      stdio: "inherit",
-      timeout: 60_000,
-    },
-  );
-  if (result.status !== 0 || result.signal) {
-    const reason = result.signal
-      ? `killed by signal ${result.signal}`
-      : `exited with code ${result.status ?? "unknown"}`;
-    error(`Failed to create tarball at ${output} (tar ${reason})`);
-    try {
-      rmSync(partial, { force: true });
-    } catch {
-      /* best-effort cleanup of partial tarball */
-    }
-    process.exitCode = 1;
-    return false;
-  }
-  try {
-    renameSync(partial, output);
-  } catch (err) {
-    error(
-      `Failed to move tarball into place at ${output}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    try {
-      rmSync(partial, { force: true });
-    } catch {
-      /* best-effort */
-    }
-    process.exitCode = 1;
-    return false;
-  }
-  info(`Tarball written to ${output}`);
-  warn(
-    "Known secrets are auto-redacted, but please review for any remaining sensitive data before sharing.",
-  );
-  info("Attach this file to your GitHub issue.");
-  return true;
+  return createDiagnosticsTarball(collectDir, output, { info, warn, error });
 }
 
 /**
@@ -584,15 +538,12 @@ export function runDebug(opts: DebugOptions = {}): void {
   // Compiled location: dist/lib/diagnostics/debug.js → repo root is 3 levels up
   const repoDir = join(__dirname, "..", "..", "..");
 
-  // Resolve sandbox name. Precedence matches the documented services + debug
-  // contract in docs/reference/commands.mdx: explicit option > NEMOCLAW_SANDBOX_NAME
-  // > NEMOCLAW_SANDBOX > SANDBOX_NAME.
-  let sandboxName =
-    opts.sandboxName ??
-    process.env.NEMOCLAW_SANDBOX_NAME ??
-    process.env.NEMOCLAW_SANDBOX ??
-    process.env.SANDBOX_NAME ??
-    "";
+  // Resolve sandbox name. The CLI wrapper (runDebugCommandWithOptions) is the
+  // sole supported caller; it already trims, validates, and applies the
+  // documented precedence (--sandbox > NEMOCLAW_SANDBOX_NAME > NEMOCLAW_SANDBOX
+  // > SANDBOX_NAME) before calling here. Reading env again would let
+  // whitespace-only values bypass validation, so only trim the option.
+  let sandboxName = opts.sandboxName?.trim() ?? "";
   if (!sandboxName) {
     sandboxName = detectSandboxName();
   }

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { renameSync, rmSync } from "node:fs";
+import { basename, dirname } from "node:path";
+
+export interface CreateTarballOptions {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  /** Timeout for the underlying `tar` invocation. Defaults to 60 seconds. */
+  timeoutMs?: number;
+}
+
+/**
+ * Archive `collectDir` into a tarball at `output`. Writes to a sibling
+ * `.partial.<pid>` path and renames atomically on success so a pre-existing
+ * file at `output` is preserved when `tar` fails. Sets `process.exitCode = 1`
+ * on failure so callers do not have to remember.
+ */
+export function createTarball(
+  collectDir: string,
+  output: string,
+  options: CreateTarballOptions,
+): boolean {
+  const { info, warn, error, timeoutMs = 60_000 } = options;
+  const partial = `${output}.partial.${process.pid}`;
+  const result = spawnSync(
+    "tar",
+    ["czf", partial, "-C", dirname(collectDir), basename(collectDir)],
+    {
+      stdio: "inherit",
+      timeout: timeoutMs,
+    },
+  );
+  if (result.status !== 0 || result.signal) {
+    const reason = result.signal
+      ? `killed by signal ${result.signal}`
+      : `exited with code ${result.status ?? "unknown"}`;
+    error(`Failed to create tarball at ${output} (tar ${reason})`);
+    try {
+      rmSync(partial, { force: true });
+    } catch {
+      /* best-effort cleanup of partial tarball */
+    }
+    process.exitCode = 1;
+    return false;
+  }
+  try {
+    renameSync(partial, output);
+  } catch (err) {
+    error(
+      `Failed to move tarball into place at ${output}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    try {
+      rmSync(partial, { force: true });
+    } catch {
+      /* best-effort */
+    }
+    process.exitCode = 1;
+    return false;
+  }
+  info(`Tarball written to ${output}`);
+  warn(
+    "Known secrets are auto-redacted, but please review for any remaining sensitive data before sharing.",
+  );
+  info("Attach this file to your GitHub issue.");
+  return true;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1616,7 +1616,28 @@ describe("CLI dispatch", () => {
       }),
       { mode: 0o600 },
     );
-    const r = runWithEnv("debug --quick --sandbox mybox 2>&1", { HOME: home }, 30000);
+    // Fake openshell so the live-list check sees `mybox`. Without this the
+    // host's real openshell (or absence thereof) decides the assertion.
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+        "  echo 'NAME'",
+        "  echo 'mybox      Ready'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const r = runWithEnv(
+      "debug --quick --sandbox mybox 2>&1",
+      { HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
+      30000,
+    );
     expect(r.code).toBe(0);
     expect(r.out).not.toContain("default sandbox 'ghost'");
     expect(r.out).not.toContain("--sandbox NAME");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -288,7 +288,7 @@ function createDebugCommandTestEnv(
   const sandboxName = `${prefix}${process.pid.toString(36)}-${Date.now().toString(36)}`;
   fs.mkdirSync(localBin, { recursive: true });
   // Register the env-sourced sandbox plus any extra names supplied via the
-  // --sandbox flag so the validation gate added for #4494 accepts them.
+  // --sandbox flag so the validation gate accepts them.
   writeSandboxRegistry(home, sandboxName);
   if (options.extraSandboxNames && options.extraSandboxNames.length > 0) {
     const registryPath = path.join(home, ".nemoclaw", "sandboxes.json");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -307,12 +307,14 @@ function createDebugCommandTestEnv(
     }
     fs.writeFileSync(registryPath, JSON.stringify(current), { mode: 0o600 });
   }
+  const registeredNames = [sandboxName, ...(options.extraSandboxNames ?? [])];
+  const listLines = ["NAME", ...registeredNames.map((name) => `${name}      Ready`)];
   fs.writeFileSync(
     path.join(localBin, "openshell"),
     [
       "#!/bin/sh",
       'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
-      "  echo 'NAME'",
+      ...listLines.map((line) => `  echo ${JSON.stringify(line)}`),
       "  exit 0",
       "fi",
       "echo 'openshell ok'",
@@ -1533,6 +1535,46 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("not registered");
     expect(fs.existsSync(tarball)).toBe(false);
   });
+
+  it(
+    "debug --sandbox NAME rejects a stale registry entry missing from the live gateway",
+    testTimeoutOptions(30_000),
+    () => {
+      // Same fixture pattern as createDebugCommandTestEnv but with an openshell
+      // stub whose live list intentionally omits the registry name, mirroring
+      // the bug where the local registry kept a name the gateway no longer
+      // serves.
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-debug-stale-"));
+      const localBin = path.join(home, "bin");
+      fs.mkdirSync(localBin, { recursive: true });
+      writeSandboxRegistry(home, "stale-box");
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          "  echo 'NAME'",
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      const tarball = path.join(home, "out.tar.gz");
+      const r = runWithEnv(
+        `debug --sandbox stale-box --output ${tarball} 2>&1`,
+        {
+          HOME: home,
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+        },
+        30000,
+      );
+      expect(r.code).not.toBe(0);
+      expect(r.out).toContain("stale-box");
+      expect(r.out).toContain("not registered");
+      expect(fs.existsSync(tarball)).toBe(false);
+    },
+  );
 
   it("debug --sandbox without a name exits 1", () => {
     const r = run("debug --sandbox");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -279,11 +279,34 @@ function createCloudflaredServiceDir(prefix: string): { sandboxName: string; ser
   return { sandboxName, serviceDir };
 }
 
-function createDebugCommandTestEnv(prefix: string): Record<string, string> {
+function createDebugCommandTestEnv(
+  prefix: string,
+  options: { extraSandboxNames?: string[] } = {},
+): Record<string, string> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   const localBin = path.join(home, "bin");
   const sandboxName = `${prefix}${process.pid.toString(36)}-${Date.now().toString(36)}`;
   fs.mkdirSync(localBin, { recursive: true });
+  // Register the env-sourced sandbox plus any extra names supplied via the
+  // --sandbox flag so the validation gate added for #4494 accepts them.
+  writeSandboxRegistry(home, sandboxName);
+  if (options.extraSandboxNames && options.extraSandboxNames.length > 0) {
+    const registryPath = path.join(home, ".nemoclaw", "sandboxes.json");
+    const current = JSON.parse(fs.readFileSync(registryPath, "utf-8")) as {
+      sandboxes: Record<string, unknown>;
+      defaultSandbox?: string | null;
+    };
+    for (const extra of options.extraSandboxNames) {
+      current.sandboxes[extra] = {
+        name: extra,
+        model: "test-model",
+        provider: "nvidia-prod",
+        gpuEnabled: false,
+        policies: [],
+      };
+    }
+    fs.writeFileSync(registryPath, JSON.stringify(current), { mode: 0o600 });
+  }
   fs.writeFileSync(
     path.join(localBin, "openshell"),
     [
@@ -1489,11 +1512,26 @@ describe("CLI dispatch", () => {
   it("debug --sandbox NAME targets the specified sandbox", testTimeoutOptions(30_000), () => {
     const r = runWithEnv(
       "debug --quick --sandbox mybox",
-      createDebugCommandTestEnv("nemoclaw-cli-debug-sandbox-"),
+      createDebugCommandTestEnv("nemoclaw-cli-debug-sandbox-", { extraSandboxNames: ["mybox"] }),
       30000,
     );
     expect(r.code).toBe(0);
     expect(r.out).toContain("Collecting diagnostics for sandbox 'mybox'");
+  });
+
+  it("debug --sandbox NAME rejects an unregistered name and exits non-zero", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-debug-unknown-"));
+    writeSandboxRegistry(home);
+    const tarball = path.join(home, "out.tar.gz");
+    const r = runWithEnv(
+      `debug --sandbox does-not-exist --output ${tarball} 2>&1`,
+      { HOME: home },
+      30000,
+    );
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("does-not-exist");
+    expect(r.out).toContain("not registered");
+    expect(fs.existsSync(tarball)).toBe(false);
   });
 
   it("debug --sandbox without a name exits 1", () => {
@@ -1522,7 +1560,18 @@ describe("CLI dispatch", () => {
     fs.mkdirSync(path.join(home, ".nemoclaw"), { recursive: true });
     fs.writeFileSync(
       path.join(home, ".nemoclaw", "sandboxes.json"),
-      JSON.stringify({ sandboxes: {}, defaultSandbox: "ghost" }),
+      JSON.stringify({
+        sandboxes: {
+          mybox: {
+            name: "mybox",
+            model: "test-model",
+            provider: "nvidia-prod",
+            gpuEnabled: false,
+            policies: [],
+          },
+        },
+        defaultSandbox: "ghost",
+      }),
       { mode: 0o600 },
     );
     const r = runWithEnv("debug --quick --sandbox mybox 2>&1", { HOME: home }, 30000);

--- a/test/e2e/test-diagnostics.sh
+++ b/test/e2e/test-diagnostics.sh
@@ -10,6 +10,7 @@
 #   TC-DIAG-04: nemoclaw --version (semver output, exit 0)
 #   TC-DIAG-02: nemoclaw debug --quick (fast, non-empty archive)
 #   TC-DIAG-01: nemoclaw debug --output (tarball, no credentials in archive)
+#   TC-DIAG-06: nemoclaw debug --sandbox <unknown> rejected; registered name accepted
 #   TC-DIAG-05: /nemoclaw status inside sandbox (model + provider)
 #   TC-DIAG-03: credentials list (no values) + credentials reset
 #
@@ -293,6 +294,62 @@ test_diag_01_debug_tarball() {
 }
 
 # =============================================================================
+# TC-DIAG-06: debug --sandbox NAME validation
+# Registered names succeed; unknown names exit non-zero, name the sandbox,
+# and leave no partial tarball.
+# =============================================================================
+test_diag_06_debug_sandbox_validation() {
+  log "=== TC-DIAG-06: debug --sandbox NAME validation ==="
+
+  local debug_dir
+  debug_dir=$(mktemp -d)
+
+  local good_output="${debug_dir}/known.tar.gz"
+  local good_rc=0 good_log=""
+  good_log=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 30} nemoclaw debug --quick --sandbox "$SANDBOX_NAME" --output "$good_output" 2>&1) || good_rc=$?
+  log "  Registered name exit=$good_rc"
+  if [[ $good_rc -eq 0 ]] && [[ -s "$good_output" ]]; then
+    pass "TC-DIAG-06: Registered --sandbox produced non-empty archive"
+  else
+    fail "TC-DIAG-06: Registered name" "exit=$good_rc, output=${good_log:0:300}"
+  fi
+
+  local bad_name="nemoclaw-e2e-does-not-exist"
+  local bad_output="${debug_dir}/unknown.tar.gz"
+  local bad_rc=0 bad_log=""
+  bad_log=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 30} nemoclaw debug --quick --sandbox "$bad_name" --output "$bad_output" 2>&1) || bad_rc=$?
+  log "  Unknown name exit=$bad_rc"
+
+  if [[ $bad_rc -ne 0 ]]; then
+    pass "TC-DIAG-06: Unknown --sandbox exits non-zero"
+  else
+    fail "TC-DIAG-06: Unknown name exit code" "expected non-zero, got 0"
+  fi
+
+  if echo "$bad_log" | grep -q "$bad_name"; then
+    pass "TC-DIAG-06: Error message names the unknown sandbox"
+  else
+    fail "TC-DIAG-06: Error message" "did not mention '$bad_name'"
+  fi
+
+  if echo "$bad_log" | grep -qi "not registered"; then
+    pass "TC-DIAG-06: Error message reports 'not registered'"
+  else
+    fail "TC-DIAG-06: Error message" "missing 'not registered' guidance"
+  fi
+
+  if [[ ! -e "$bad_output" ]]; then
+    pass "TC-DIAG-06: No partial tarball written for unknown sandbox"
+  else
+    local size
+    size=$(stat -c '%s' "$bad_output" 2>/dev/null || stat -f '%z' "$bad_output" 2>/dev/null || echo "?")
+    fail "TC-DIAG-06: Tarball cleanup" "partial tarball persisted at $bad_output (${size} bytes)"
+  fi
+
+  rm -rf "$debug_dir"
+}
+
+# =============================================================================
 # TC-DIAG-05: Sandbox inference config visible inside sandbox
 # =============================================================================
 test_diag_05_sandbox_config() {
@@ -440,6 +497,7 @@ main() {
   fi
 
   test_diag_01_debug_tarball
+  test_diag_06_debug_sandbox_validation
   test_diag_05_sandbox_config
   test_diag_03_credentials # modifies state — runs last
 

--- a/test/e2e/test-diagnostics.sh
+++ b/test/e2e/test-diagnostics.sh
@@ -314,7 +314,10 @@ test_diag_06_debug_sandbox_validation() {
     fail "TC-DIAG-06: Registered name" "exit=$good_rc, output=${good_log:0:300}"
   fi
 
-  local bad_name="nemoclaw-e2e-does-not-exist"
+  # Unique per-run name avoids collisions when another e2e job leaves a
+  # sandbox with a shared "does-not-exist" placeholder behind.
+  local bad_name
+  bad_name="nemoclaw-e2e-missing-$$-$(date +%s)-${RANDOM}"
   local bad_output="${debug_dir}/unknown.tar.gz"
   local bad_rc=0 bad_log=""
   bad_log=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 30} nemoclaw debug --quick --sandbox "$bad_name" --output "$bad_output" 2>&1) || bad_rc=$?


### PR DESCRIPTION
## Summary

`nemoclaw debug --sandbox <unknown> --output FILE` silently collected host diagnostics for a non-existent sandbox and wrote a non-empty (~8 KB) tarball with exit 0. Validation in `runDebugCommandWithOptions` only ran when `--sandbox` was omitted, so explicit names from `--sandbox`, `NEMOCLAW_SANDBOX_NAME`, `NEMOCLAW_SANDBOX`, and `SANDBOX_NAME` bypassed both registry and live-gateway checks. Per T6029556 the command must exit non-zero, name the unknown sandbox, and leave no partial tarball.

## Related Issue

Fixes #4494.

## Changes

- `src/commands/debug.ts`: new `isSandboxKnown(name)` mirroring `getDefaultSandbox` — requires the name to live in the local registry, and when `openshell sandbox list` succeeds it must also appear in the live gateway (rejects stale registry entries)
- `src/lib/diagnostics/debug-command.ts`: validate any explicit name (flag or env var) before collection; documented precedence is `--sandbox` > `NEMOCLAW_SANDBOX_NAME` > `NEMOCLAW_SANDBOX` > `SANDBOX_NAME`; on miss, print an actionable error that names the sandbox and the source env var, then exit 1
- `src/lib/diagnostics/debug.ts`: drop the redundant env-var re-read in `runDebug` so whitespace-only env values cannot bypass the wrapper's trim/validate, and trim the option name
- `src/lib/diagnostics/tarball.ts` (new): atomic tarball — write to `output.partial.<pid>`, rename on success, and `rmSync` the partial (not the user's `--output`) on `tar` failure so a pre-existing file is preserved
- `docs/reference/commands.mdx`: document the explicit-name precedence, the registry + live-gateway validation contract, the unknown/stale exit-non-zero behaviour, and the atomic tarball semantics
- Unit tests: explicit-name validation (flag + env), source labelling, `NEMOCLAW_SANDBOX_NAME` precedence, flag-over-env, default fallback, exit(1) assertion on env failure, atomic tarball preservation of pre-existing files, partial cleanup on failure
- `test/cli.test.ts`: `createDebugCommandTestEnv` registers its env-sourced sandbox plus any `extraSandboxNames`, and the fake `openshell sandbox list` now emits those names so the live check passes; new CLI cases cover unknown explicit name (exits non-zero, no tarball) and stale registry entry (registry-known but missing from the live list → rejected)
- `test/e2e/test-diagnostics.sh`: `TC-DIAG-06` confirms a registered `--sandbox` succeeds and an unknown name (per-run unique to avoid shared-env collisions) exits non-zero, names the sandbox, says "not registered", and leaves no archive

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug command: explicit sandbox can come from flag or env (clear precedence); names are validated against both the local registry and live gateway, errors cite the env key or name and exit non-zero.

* **Bug Fixes**
  * Tarball creation is atomic (PID-suffixed partial then rename), preserves pre-existing files, cleans partials on failure, sets non-zero exit state, and logs warnings (auto-redaction, attach-to-issue guidance).

* **Tests**
  * Expanded unit and E2E coverage for sandbox resolution/validation, error messaging, and tarball cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
