### PR TITLE
fix(sandbox): block snapshot create while shields are up

### DIFF
--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -12,6 +12,7 @@ import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
 import * as policies from "../../policy";
 import { ROOT, run, shellQuote, validateName } from "../../runner";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
+import { isShieldsDown } from "../../shields";
 import { isGatewayHealthy } from "../../state/gateway";
 import type { SandboxEntry } from "../../state/registry";
 import * as registry from "../../state/registry";
@@ -329,6 +330,11 @@ export async function runSandboxSnapshot(
       const liveNames = parseLiveSandboxNames(isLive.output || "");
       if (!liveNames.has(sandboxName)) {
         console.error(`  Sandbox '${sandboxName}' is not running. Cannot create snapshot.`);
+        snapshotExit(1);
+      }
+      if (!isShieldsDown(sandboxName)) {
+        console.error("  Cannot create snapshot while shields are up.");
+        console.error(`  Run \`${CLI_NAME} ${sandboxName} shields down\` first, then retry.`);
         snapshotExit(1);
       }
       const label = request.name ? ` (--name ${request.name})` : "";

--- a/test/snapshot-shields-guard.test.ts
+++ b/test/snapshot-shields-guard.test.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression tests for issue #4493: `snapshot create` while shields are up must
+// surface a shields/audit/lock keyword and a recovery command (spec T5999692),
+// not the generic "Snapshot failed. Failed directories: ..." wording.
+
+import { describe, it, expect } from "vitest";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { execTimeout } from "./helpers/timeouts";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+
+type CliRunResult = { code: number; out: string };
+
+function runCli(args: string, env: Record<string, string | undefined> = {}): CliRunResult {
+  try {
+    const out = execSync(`node "${CLI}" ${args}`, {
+      encoding: "utf-8",
+      timeout: execTimeout(),
+      env: {
+        ...process.env,
+        NEMOCLAW_HEALTH_POLL_COUNT: "1",
+        NEMOCLAW_HEALTH_POLL_INTERVAL: "0",
+        ...env,
+      },
+    });
+    return { code: 0, out };
+  } catch (err: unknown) {
+    if (typeof err === "object" && err !== null && "status" in err) {
+      const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+      const out = [e.stdout, e.stderr]
+        .map((b) => (typeof b === "string" ? b : b ? b.toString("utf-8") : ""))
+        .join("");
+      return { code: typeof e.status === "number" ? e.status : 1, out };
+    }
+    return { code: 1, out: String(err) };
+  }
+}
+
+function writeExecutable(filePath: string, lines: string[]): void {
+  fs.writeFileSync(filePath, ["#!/bin/sh", ...lines].join("\n"), { mode: 0o755 });
+}
+
+function writeSandboxRegistry(home: string, sandboxName: string): void {
+  const registryDir = path.join(home, ".nemoclaw");
+  fs.mkdirSync(registryDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(registryDir, "sandboxes.json"),
+    JSON.stringify({
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          model: "test-model",
+          provider: "nvidia-prod",
+          gpuEnabled: false,
+          policies: [],
+        },
+      },
+      defaultSandbox: sandboxName,
+    }),
+    { mode: 0o600 },
+  );
+}
+
+/**
+ * shieldsDown: false + an updatedAt timestamp + an existing state file is the
+ * "locked" mode per deriveShieldsMode in src/lib/shields/index.ts.
+ */
+function writeShieldsLocked(home: string, sandboxName: string): void {
+  const stateDir = path.join(home, ".nemoclaw", "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, `shields-${sandboxName}.json`),
+    JSON.stringify({
+      shieldsDown: false,
+      shieldsDownAt: null,
+      shieldsDownTimeout: null,
+      updatedAt: new Date().toISOString(),
+    }),
+    { mode: 0o600 },
+  );
+}
+
+/**
+ * Healthy-gateway env: openshell `sandbox list` reports alpha as Ready, docker
+ * `inspect` reports the gateway container as Running. The shields state file
+ * is left unset so the caller can opt into "locked" via writeShieldsLocked.
+ */
+function makeHealthyGatewayEnv(prefix: string): { home: string; env: Record<string, string> } {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const localBin = path.join(home, "bin");
+  fs.mkdirSync(localBin, { recursive: true });
+  writeSandboxRegistry(home, "alpha");
+
+  writeExecutable(path.join(localBin, "openshell"), [
+    'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+    '  printf "NAME STATUS\\nalpha Ready\\n"',
+    "  exit 0",
+    "fi",
+    "exit 0",
+  ]);
+  writeExecutable(path.join(localBin, "docker"), [
+    'if [ "$1" = "inspect" ]; then echo "true"; exit 0; fi',
+    "exit 0",
+  ]);
+
+  return {
+    home,
+    env: {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH ?? ""}`,
+    },
+  };
+}
+
+describe("snapshot create — shields-up guard (#4493)", () => {
+  it("rejects snapshot create when shields are up with a shields-aware error", () => {
+    const { home, env } = makeHealthyGatewayEnv("nemoclaw-snap-shields-up-");
+    writeShieldsLocked(home, "alpha");
+
+    const r = runCli("alpha snapshot create", env);
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("shields are up");
+    expect(r.out).toContain("shields down");
+    expect(r.out).not.toContain("Failed directories:");
+  });
+
+  it("does not block snapshot create when shields are not configured (mutable default)", () => {
+    const { env } = makeHealthyGatewayEnv("nemoclaw-snap-shields-default-");
+
+    const r = runCli("alpha snapshot create", env);
+
+    expect(r.out).not.toContain("shields are up");
+  });
+});

--- a/test/snapshot-shields-guard.test.ts
+++ b/test/snapshot-shields-guard.test.ts
@@ -6,7 +6,7 @@
 // not the generic "Snapshot failed. Failed directories: ..." wording.
 
 import { describe, it, expect } from "vitest";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -17,9 +17,9 @@ const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
 
 type CliRunResult = { code: number; out: string };
 
-function runCli(args: string, env: Record<string, string | undefined> = {}): CliRunResult {
+function runCli(args: string[], env: Record<string, string | undefined> = {}): CliRunResult {
   try {
-    const out = execSync(`node "${CLI}" ${args}`, {
+    const out = execFileSync("node", [CLI, ...args], {
       encoding: "utf-8",
       timeout: execTimeout(),
       env: {
@@ -123,7 +123,7 @@ describe("snapshot create — shields-up guard (#4493)", () => {
     const { home, env } = makeHealthyGatewayEnv("nemoclaw-snap-shields-up-");
     writeShieldsLocked(home, "alpha");
 
-    const r = runCli("alpha snapshot create", env);
+    const r = runCli(["alpha", "snapshot", "create"], env);
 
     expect(r.code).toBe(1);
     expect(r.out).toContain("shields are up");
@@ -134,7 +134,7 @@ describe("snapshot create — shields-up guard (#4493)", () => {
   it("does not block snapshot create when shields are not configured (mutable default)", () => {
     const { env } = makeHealthyGatewayEnv("nemoclaw-snap-shields-default-");
 
-    const r = runCli("alpha snapshot create", env);
+    const r = runCli(["alpha", "snapshot", "create"], env);
 
     expect(r.out).not.toContain("shields are up");
   });


### PR DESCRIPTION
## Summary
`nemoclaw <name> snapshot create` while shields are up previously exited 1 with the generic wording `Snapshot failed. Failed directories: ...`, violating spec T5999692 which requires the error to contain `shields` / `audit` / `lock` so the operator knows to run `shields down`. This PR front-checks shields state in the create case and emits the spec's "Preferred future" wording (`Cannot create snapshot while shields are up. Run \`nemoclaw <name> shields down\` first, then retry.`) before `backupSandboxState` ever runs.

## Related Issue
Fixes #4493
Fixes #4496

## Changes
- `src/lib/actions/sandbox/snapshot.ts`: import `isShieldsDown` from `../../shields`; in `case "create"` after the gateway/liveness checks and before the "Creating snapshot…" log, exit early with the shields-aware error when shields are up.
- `test/snapshot-shields-guard.test.ts` (new): two CLI-level integration tests modeled on the existing `test/snapshot-gateway-guard.test.ts` pattern — (1) shields up → exit 1, output contains `shields are up` + `shields down`, does NOT contain the old generic `Failed directories:` wording; (2) shields not configured → guard does NOT fire (no `shields are up` in output).

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Verification details (what actually ran locally)
- `npx vitest run --project cli test/snapshot-shields-guard.test.ts` — 2/2 pass; the locked-shields case prints exactly `Cannot create snapshot while shields are up.` + `Run \`nemoclaw alpha shields down\` first, then retry.` and the assertion that the old `Failed directories:` wording is absent holds.
- `npx vitest run --project cli test/snapshot.test.ts test/snapshot-gateway-guard.test.ts test/snapshot-restore-existing-dest.test.ts` — 53/53 pass (regression check on adjacent snapshot suites).
- `npm run typecheck:cli` — clean.
- `npx prek run --all-files` — fails to bootstrap on this Ubuntu 20.04 host (Python 3.8 vs hook requirement ≥3.9; with Python 3.12 on PATH the Go toolchain download fails through the corp proxy). Same as prior PRs (#4295) — relying on CI.

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot creation now refuses to run when a sandbox is protected by shields, displaying an instructional error telling users to disable shields first before retrying.

* **Tests**
  * Added regression tests covering snapshot creation with shields up and with shields absent, ensuring correct exit behavior and user-facing messages in both scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->