### PR TITLE
fix(onboard): stream OpenShell upgrade progress instead of a silent wait (#4431)

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -337,12 +337,21 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 download_with_curl() {
   local name
+  local -a curl_progress
+  # Show a live progress bar on a terminal so the (often slow) release download
+  # is not a silent gap; stay quiet (errors only) when non-interactive. (#4431)
+  if [ -t 1 ] || [ -t 2 ]; then
+    curl_progress=(--progress-bar)
+  else
+    curl_progress=(-sS)
+  fi
   for name in "${ASSETS[@]}" "${CHECKSUM_FILES[@]}"; do
-    curl -fsSL "https://github.com/NVIDIA/OpenShell/releases/download/${RELEASE_TAG}/$name" \
+    curl -fL "${curl_progress[@]}" "https://github.com/NVIDIA/OpenShell/releases/download/${RELEASE_TAG}/$name" \
       -o "$tmpdir/$name"
   done
 }
 
+info "Downloading OpenShell release assets (this may take a minute)..."
 if command -v gh >/dev/null 2>&1; then
   gh_ok=1
   for name in "${ASSETS[@]}" "${CHECKSUM_FILES[@]}"; do

--- a/src/lib/onboard/openshell-pin.ts
+++ b/src/lib/onboard/openshell-pin.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+import { type SpawnSyncOptionsWithStringEncoding, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -206,16 +206,18 @@ export type RunOpenshellInstallDeps = OpenshellInstallPinDeps & {
 export function runOpenshellInstall(deps: RunOpenshellInstallDeps): OpenShellInstallResult {
   const { env } = computeOpenshellInstallEnv(process.env, deps);
   if (env === null) return { installed: false, localBin: null, futureShellPathHint: null };
+  // Stream install-openshell.sh output live (info() progress + curl progress bar)
+  // so the in-onboard OpenShell upgrade shows progress instead of sitting silent
+  // for the whole download/verify (#4431). `inherit` keeps this call synchronous
+  // (no async ripple into the onboard entrypoint) while the child writes straight
+  // to the terminal in real time.
   const result = spawnSync("bash", [path.join(deps.scriptsDir, "install-openshell.sh")], {
     cwd: deps.cwd,
     env,
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf-8",
+    stdio: ["ignore", "inherit", "inherit"],
     timeout: 300_000,
   });
   if (result.status !== 0) {
-    const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
-    if (output) console.error(output);
     return { installed: false, localBin: null, futureShellPathHint: null };
   }
   const localBin = process.env.XDG_BIN_HOME || path.join(process.env.HOME || "", ".local", "bin");

--- a/test/onboard-openshell-install-stream.test.ts
+++ b/test/onboard-openshell-install-stream.test.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({ spawnSync: spawnSyncMock }));
+
+import {
+  runOpenshellInstall,
+  type RunOpenshellInstallDeps,
+} from "../src/lib/onboard/openshell-pin";
+
+function makeDeps(
+  overrides: Partial<RunOpenshellInstallDeps> = {},
+): RunOpenshellInstallDeps {
+  return {
+    getBlueprintMaxOpenshellVersion: () => null,
+    versionGte: () => true,
+    scriptsDir: "/fake/scripts",
+    cwd: "/fake/cwd",
+    resolveOpenshell: () => null,
+    getFutureShellPathHint: () => null,
+    setOpenshellBin: () => {},
+    ...overrides,
+  };
+}
+
+describe("runOpenshellInstall progress streaming (#4431)", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it("inherits stdio so install-openshell.sh output streams live", () => {
+    spawnSyncMock.mockReturnValue({ status: 0 });
+    runOpenshellInstall(makeDeps());
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const options = spawnSyncMock.mock.calls[0][2];
+    expect(options.stdio).toEqual(["ignore", "inherit", "inherit"]);
+  });
+
+  it("does not pipe/buffer the child output anymore", () => {
+    spawnSyncMock.mockReturnValue({ status: 0 });
+    runOpenshellInstall(makeDeps());
+    const options = spawnSyncMock.mock.calls[0][2];
+    expect(options.stdio).not.toContain("pipe");
+  });
+
+  it("returns a not-installed result without throwing on non-zero exit", () => {
+    spawnSyncMock.mockReturnValue({ status: 1 });
+    const result = runOpenshellInstall(makeDeps());
+    expect(result.installed).toBe(false);
+    expect(result.localBin).toBeNull();
+    expect(result.futureShellPathHint).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
`runOpenshellInstall` now streams `scripts/install-openshell.sh` output live during the in-onboard OpenShell upgrade, so the upgrade reports progress instead of going quiet between the `Upgrading...` line and completion. Reported by NV QA.

## Related Issue
Closes #4431

## Problem
When `nemoclaw onboard` finds an installed OpenShell below the blueprint minimum, it runs `scripts/install-openshell.sh` to upgrade. `runOpenshellInstall` (`src/lib/onboard/openshell-pin.ts`) spawned that script with `stdio: ["ignore", "pipe", "pipe"]`, which buffers stdout/stderr and only prints the buffer when the script exits non-zero. On a successful upgrade the buffer is discarded, so after `openshell X.Y.Z is below minimum required version. Upgrading...` no further output reaches the terminal for the entire download and checksum step (about 145s in the report). `download_with_curl` compounds it: `curl -fsSL` suppresses the progress meter via `-s`, so the release download is silent even once the script's stream is surfaced.

## Changes
- `src/lib/onboard/openshell-pin.ts`: spawn `install-openshell.sh` with `stdio: ["ignore", "inherit", "inherit"]` so its `info()` progress lines reach the terminal as they are emitted. The call stays synchronous, so no async change propagates into the onboard entry point, and the failure path no longer needs to re-print a captured buffer because the output has already streamed.
- `scripts/install-openshell.sh`: print a `Downloading OpenShell release assets...` line before the download dispatch so the `gh release download` path is not silent either.
- `download_with_curl` now passes `--progress-bar` when stdout or stderr is a terminal, falling back to `-sS` (errors only) when non-interactive so CI logs stay clean.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Ran: new `test/onboard-openshell-install-stream.test.ts` confirms `runOpenshellInstall` spawns with inherited stdio, no longer pipes or buffers, and returns a not-installed result without throwing on a non-zero exit; existing OpenShell suites pass (`onboard-openshell-version`, `install-openshell-version-check`, `install-openshell-upgrade-prompt`, `resolve-openshell`), 54/54; script behavior verified with a stubbed `curl`, where a non-interactive run issues `curl -fL -sS ...` and a pty-backed run issues `curl -fL --progress-bar ...`; `bash -n scripts/install-openshell.sh`, `npx biome check`, and `npm run typecheck:cli` clean.

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>