### PR TITLE
fix(onboard): bound chat tool-call validation output

### DIFF
--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -656,7 +656,7 @@ exit 0
         );
         expect(retryPayload).toMatchObject({
           tool_choice: "required",
-          max_tokens: 64,
+          max_tokens: 256,
           stream: false,
         });
       } finally {

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -651,9 +651,14 @@ exit 0
         expect(result).toMatchObject({ ok: false });
         expect(result.message).toContain("did not return a tool call");
         expect(fs.readFileSync(counter, "utf8").trim()).toBe("2");
-        expect(fs.readFileSync(path.join(tmpDir, "request-2.json"), "utf8")).toContain(
-          '"tool_choice":"required"',
+        const retryPayload = JSON.parse(
+          fs.readFileSync(path.join(tmpDir, "request-2.json"), "utf8"),
         );
+        expect(retryPayload).toMatchObject({
+          tool_choice: "required",
+          max_tokens: 64,
+          stream: false,
+        });
       } finally {
         process.env.PATH = originalPath;
         fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -427,7 +427,7 @@ function probeChatCompletionsToolCalling(endpointUrl, model, apiKey, options = {
       temperature: 0,
       // Bound strict tool-call probes so a slow local model cannot keep
       // generating until the host-side curl process timeout kills validation.
-      max_tokens: 64,
+      max_tokens: 256,
       stream: false,
     }),
     url,

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -425,6 +425,10 @@ function probeChatCompletionsToolCalling(endpointUrl, model, apiKey, options = {
       ],
       tool_choice: "required",
       temperature: 0,
+      // Bound strict tool-call probes so a slow local model cannot keep
+      // generating until the host-side curl process timeout kills validation.
+      max_tokens: 64,
+      stream: false,
     }),
     url,
   ];


### PR DESCRIPTION
## Summary
Bounds strict chat-completions tool-call validation requests by setting `max_tokens` and `stream: false`. This keeps slow local inference models from continuing generation until the host-side curl process timeout kills onboarding validation.

## Related Issue
Refs #4501

## Changes
- Add `max_tokens: 64` and `stream: false` to the strict chat-completions tool-call probe payload in `src/lib/inference/onboard-probes.ts`.
- Update the strict retry probe test to assert the bounded validation payload.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Constrained probe validation requests to limit output and disable streaming, improving stability of onboarding checks.

* **Tests**
  * Updated tests to assert specific request payload fields (required tool choice, max tokens, non-streaming) for stricter validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->