### PR TITLE
fix(sandbox): rotate OpenClaw gateway token on rebuild

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1165,15 +1165,42 @@ install_telegram_diagnostics() {
 }
 
 _read_gateway_token() {
-  python3 - <<'PYTOKEN'
-import json
-try:
-    with open('/sandbox/.openclaw/openclaw.json') as f:
-        cfg = json.load(f)
-    print(cfg.get('gateway', {}).get('auth', {}).get('token', ''))
-except Exception:
-    print('')
-PYTOKEN
+  node - <<'NODETOKEN'
+const fs = require("fs");
+
+const configPath = "/sandbox/.openclaw/openclaw.json";
+
+function loadJson5() {
+  try {
+    const JSON5 = require("/opt/nemoclaw/node_modules/json5");
+    if (JSON5 && typeof JSON5.parse === "function") {
+      return JSON5;
+    }
+  } catch {
+    // Fall through to the caller's empty-token behavior.
+  }
+  return undefined;
+}
+
+function parseConfig(text) {
+  try {
+    return JSON.parse(text);
+  } catch (jsonError) {
+    const JSON5 = loadJson5();
+    if (!JSON5) {
+      throw jsonError;
+    }
+    return JSON5.parse(text);
+  }
+}
+
+try {
+  const cfg = parseConfig(fs.readFileSync(configPath, "utf8"));
+  console.log(cfg?.gateway?.auth?.token || "");
+} catch {
+  console.log("");
+}
+NODETOKEN
 }
 
 ensure_gateway_token() {
@@ -1192,52 +1219,106 @@ ensure_gateway_token() {
   fi
 
   local _write_rc=0
-  python3 - "$config_file" <<'PYTOKEN' || _write_rc=$?
-import json
-import os
-import secrets
-import sys
-import tempfile
+  node - "$config_file" <<'NODETOKEN' || _write_rc=$?
+const crypto = require("crypto");
+const fs = require("fs");
+const pathModule = require("path");
 
-path = sys.argv[1]
-try:
-    with open(path) as f:
-        cfg = json.load(f)
-    auth = cfg.setdefault('gateway', {}).setdefault('auth', {})
-    auth['token'] = secrets.token_urlsafe(32)
-    dir_path = os.path.dirname(path)
-    fd, tmp_path = tempfile.mkstemp(prefix='.openclaw.', suffix='.tmp', dir=dir_path, text=True)
-    try:
-        os.fchmod(fd, 0o600)
-        with os.fdopen(fd, 'w') as f:
-            fd = None
-            json.dump(cfg, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, path)
-        dir_flags = os.O_RDONLY
-        if hasattr(os, 'O_DIRECTORY'):
-            dir_flags |= os.O_DIRECTORY
-        dir_fd = os.open(dir_path, dir_flags)
-        try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
-    except Exception:
-        if fd is not None:
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
-except Exception as exc:
-    print(f'[SECURITY] Failed to ensure OpenClaw gateway token: {exc}', file=sys.stderr)
-    sys.exit(1)
-PYTOKEN
+const path = process.argv[2];
+
+function loadJson5() {
+  const candidate = "/opt/nemoclaw/node_modules/json5";
+  const JSON5 = require(candidate);
+  if (!JSON5 || typeof JSON5.parse !== "function") {
+    throw new Error(`JSON5 parser at ${candidate} is missing parse()`);
+  }
+  return JSON5;
+}
+
+function parseConfig(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return loadJson5().parse(text);
+  }
+}
+
+function tokenUrlSafe(bytes) {
+  return crypto
+    .randomBytes(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function makeTempPath(dirPath) {
+  for (let i = 0; i < 16; i += 1) {
+    const suffix = crypto.randomBytes(12).toString("hex");
+    const tmpPath = pathModule.join(dirPath, `.openclaw.${process.pid}.${suffix}.tmp`);
+    try {
+      const fd = fs.openSync(tmpPath, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY, 0o600);
+      return { fd, tmpPath };
+    } catch (error) {
+      if (error && error.code === "EEXIST") {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("unable to allocate temporary OpenClaw config path");
+}
+
+try {
+  const cfg = parseConfig(fs.readFileSync(path, "utf8"));
+  const gateway = cfg.gateway && typeof cfg.gateway === "object" ? cfg.gateway : (cfg.gateway = {});
+  const auth = gateway.auth && typeof gateway.auth === "object" ? gateway.auth : (gateway.auth = {});
+  auth.token = tokenUrlSafe(32);
+
+  const dirPath = pathModule.dirname(path);
+  let fd;
+  let tmpPath;
+  try {
+    ({ fd, tmpPath } = makeTempPath(dirPath));
+    fs.fchmodSync(fd, 0o600);
+    fs.writeFileSync(fd, JSON.stringify(cfg, null, 2));
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(tmpPath, path);
+
+    let dirFlags = fs.constants.O_RDONLY;
+    if (fs.constants.O_DIRECTORY) {
+      dirFlags |= fs.constants.O_DIRECTORY;
+    }
+    const dirFd = fs.openSync(dirPath, dirFlags);
+    try {
+      fs.fsyncSync(dirFd);
+    } finally {
+      fs.closeSync(dirFd);
+    }
+  } catch (error) {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Ignore cleanup failure and report the original error below.
+      }
+    }
+    if (tmpPath) {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        // Ignore cleanup failure and report the original error below.
+      }
+    }
+    throw error;
+  }
+} catch (error) {
+  console.error(`[SECURITY] Failed to ensure OpenClaw gateway token: ${error.message || error}`);
+  process.exit(1);
+}
+NODETOKEN
 
   if [ "$_write_rc" -eq 0 ] && [ -f "$hash_file" ]; then
     (cd "$(dirname "$config_file")" && sha256sum "$(basename "$config_file")" >"$hash_file") || _write_rc=$?
@@ -1249,6 +1330,14 @@ PYTOKEN
 
   [ "$_write_rc" -eq 0 ] || return "$_write_rc"
   printf '[token] Gateway auth token refreshed for startup\n' >&2
+}
+
+ensure_gateway_token_if_missing() {
+  if [ -n "$(_read_gateway_token)" ]; then
+    return 0
+  fi
+
+  ensure_gateway_token
 }
 
 export_gateway_token() {
@@ -1274,6 +1363,17 @@ needs_gateway_token_for_current_command() {
     openclaw) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+prepare_gateway_token_for_current_command() {
+  if [ ${#NEMOCLAW_CMD[@]} -eq 0 ]; then
+    ensure_gateway_token
+    return $?
+  fi
+
+  if needs_gateway_token_for_current_command; then
+    ensure_gateway_token_if_missing
+  fi
 }
 
 # Write an auth profile JSON for the NVIDIA API key so the gateway can authenticate.
@@ -2448,9 +2548,7 @@ if [ "$(id -u)" -ne 0 ]; then
   apply_cors_override
   refresh_openclaw_provider_placeholders
   ensure_mutable_openclaw_config_hash
-  if needs_gateway_token_for_current_command; then
-    ensure_gateway_token
-  fi
+  prepare_gateway_token_for_current_command
   # Capture baseline for next start's recovery — only after overrides and
   # placeholder refresh have produced the post-startup config the user
   # actually runs with.
@@ -2591,9 +2689,7 @@ apply_cors_override
 configure_messaging_channels
 refresh_openclaw_provider_placeholders
 ensure_mutable_openclaw_config_hash
-if needs_gateway_token_for_current_command; then
-  ensure_gateway_token
-fi
+prepare_gateway_token_for_current_command
 # Capture baseline for next start's recovery — only after overrides and
 # placeholder refresh have produced the post-startup config the user
 # actually runs with.

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1187,10 +1187,6 @@ ensure_gateway_token() {
     return 1
   fi
 
-  if [ -n "$(_read_gateway_token)" ]; then
-    return 0
-  fi
-
   if [ "$(id -u)" -eq 0 ]; then
     prepare_openclaw_config_for_write "$config_file" "$hash_file"
   fi
@@ -1208,37 +1204,36 @@ try:
     with open(path) as f:
         cfg = json.load(f)
     auth = cfg.setdefault('gateway', {}).setdefault('auth', {})
-    if not auth.get('token'):
-        auth['token'] = secrets.token_urlsafe(32)
-        dir_path = os.path.dirname(path)
-        fd, tmp_path = tempfile.mkstemp(prefix='.openclaw.', suffix='.tmp', dir=dir_path, text=True)
+    auth['token'] = secrets.token_urlsafe(32)
+    dir_path = os.path.dirname(path)
+    fd, tmp_path = tempfile.mkstemp(prefix='.openclaw.', suffix='.tmp', dir=dir_path, text=True)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, 'w') as f:
+            fd = None
+            json.dump(cfg, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        dir_flags = os.O_RDONLY
+        if hasattr(os, 'O_DIRECTORY'):
+            dir_flags |= os.O_DIRECTORY
+        dir_fd = os.open(dir_path, dir_flags)
         try:
-            os.fchmod(fd, 0o600)
-            with os.fdopen(fd, 'w') as f:
-                fd = None
-                json.dump(cfg, f, indent=2)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, path)
-            dir_flags = os.O_RDONLY
-            if hasattr(os, 'O_DIRECTORY'):
-                dir_flags |= os.O_DIRECTORY
-            dir_fd = os.open(dir_path, dir_flags)
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except Exception:
+        if fd is not None:
             try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        except Exception:
-            if fd is not None:
-                try:
-                    os.close(fd)
-                except OSError:
-                    pass
-            try:
-                os.unlink(tmp_path)
+                os.close(fd)
             except OSError:
                 pass
-            raise
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 except Exception as exc:
     print(f'[SECURITY] Failed to ensure OpenClaw gateway token: {exc}', file=sys.stderr)
     sys.exit(1)
@@ -1253,6 +1248,7 @@ PYTOKEN
   fi
 
   [ "$_write_rc" -eq 0 ] || return "$_write_rc"
+  printf '[token] Gateway auth token refreshed for startup\n' >&2
 }
 
 export_gateway_token() {

--- a/test/e2e/test-rebuild-openclaw.sh
+++ b/test/e2e/test-rebuild-openclaw.sh
@@ -13,8 +13,9 @@
 #   6. Run `nemoclaw <name> rebuild --yes`
 #   7. Verify marker files survived the rebuild
 #   8. Verify the sandbox now reports the CURRENT version
-#   9. Verify no credentials leaked into the local backup
-#   10. Verify policy presets survived the rebuild (#1952)
+#   9. Verify the OpenClaw gateway auth token rotated (#4517)
+#   10. Verify no credentials leaked into the local backup
+#   11. Verify policy presets survived the rebuild (#1952)
 #
 # Prerequisites:
 #   - Docker running
@@ -36,6 +37,7 @@ register_sandbox_for_teardown "$SANDBOX_NAME"
 OLD_OPENCLAW_VERSION="2026.3.11"
 MARKER_FILE="/sandbox/.openclaw/workspace/rebuild-marker.txt"
 MARKER_CONTENT="REBUILD_OC_E2E_$(date +%s)"
+PRE_REBUILD_GATEWAY_TOKEN="nemoclaw-e2e-old-gateway-token-${MARKER_CONTENT}"
 REGISTRY_FILE="$HOME/.nemoclaw/sandboxes.json"
 SESSION_FILE="$HOME/.nemoclaw/onboard-session.json"
 
@@ -58,6 +60,27 @@ fail() {
 }
 info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
 diag() { echo -e "${YELLOW}[DIAG]${NC} $1"; }
+
+read_sandbox_gateway_token() {
+  openshell sandbox exec --name "${SANDBOX_NAME}" -- python3 -c '
+import json
+with open("/sandbox/.openclaw/openclaw.json") as f:
+    cfg = json.load(f)
+print(cfg.get("gateway", {}).get("auth", {}).get("token", ""), end="")
+'
+}
+
+read_sandbox_runtime_gateway_token() {
+  # shellcheck disable=SC2016 # OPENCLAW_GATEWAY_TOKEN must expand inside the sandbox.
+  openshell sandbox exec --name "${SANDBOX_NAME}" -- bash -lc '
+. /tmp/nemoclaw-proxy-env.sh >/dev/null 2>&1 || exit 1
+printf "%s" "${OPENCLAW_GATEWAY_TOKEN:-}"
+'
+}
+
+read_sandbox_config_hash() {
+  openshell sandbox exec --name "${SANDBOX_NAME}" -- cat /sandbox/.openclaw/.config-hash
+}
 
 # Enable verbose logging in rebuild command
 export NEMOCLAW_REBUILD_VERBOSE=1
@@ -170,6 +193,36 @@ info "Phase 4: Writing markers and registering sandbox..."
 openshell sandbox exec --name "${SANDBOX_NAME}" -- \
   sh -c "mkdir -p /sandbox/.openclaw/workspace && echo '${MARKER_CONTENT}' > ${MARKER_FILE}" \
   || fail "Failed to write marker file"
+
+# Seed an existing gateway token so the rebuild path must rotate it.
+openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+  env "PRE_REBUILD_GATEWAY_TOKEN=${PRE_REBUILD_GATEWAY_TOKEN}" python3 -c '
+import json
+import os
+
+path = "/sandbox/.openclaw/openclaw.json"
+with open(path) as f:
+    cfg = json.load(f)
+cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = os.environ["PRE_REBUILD_GATEWAY_TOKEN"]
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+' || fail "Failed to seed old gateway token"
+openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+  sh -c "cd /sandbox/.openclaw && sha256sum openclaw.json > .config-hash" \
+  || fail "Failed to write pre-rebuild config hash"
+PRE_REBUILD_CONFIG_HASH="$(read_sandbox_config_hash 2>/dev/null || true)"
+SEEDED_GATEWAY_TOKEN="$(read_sandbox_gateway_token 2>/dev/null || true)"
+if [ "${SEEDED_GATEWAY_TOKEN}" = "${PRE_REBUILD_GATEWAY_TOKEN}" ]; then
+  pass "Old gateway token seeded before rebuild"
+else
+  fail "Failed to verify seeded gateway token before rebuild"
+fi
+if [ -n "${PRE_REBUILD_CONFIG_HASH}" ] && echo "${PRE_REBUILD_CONFIG_HASH}" | grep -q "openclaw.json"; then
+  pass "Pre-rebuild config hash recorded"
+else
+  fail "Pre-rebuild config hash missing openclaw.json"
+fi
 
 # Verify
 VERIFY=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${MARKER_FILE}" 2>/dev/null || true)
@@ -358,6 +411,44 @@ else
   fail "Registry agentVersion not updated: got '${REGISTRY_VERSION}', expected != '${OLD_OPENCLAW_VERSION}'"
 fi
 
+# Gateway token rotated and runtime env matches (#4517)
+POST_REBUILD_GATEWAY_TOKEN="$(read_sandbox_gateway_token 2>/dev/null || true)"
+if [ -n "${POST_REBUILD_GATEWAY_TOKEN}" ]; then
+  pass "Gateway auth token present after rebuild"
+else
+  fail "Gateway auth token missing after rebuild — issue #4517"
+fi
+if [ "${POST_REBUILD_GATEWAY_TOKEN}" != "${PRE_REBUILD_GATEWAY_TOKEN}" ]; then
+  pass "Gateway auth token rotated after rebuild"
+else
+  fail "Gateway auth token did not rotate after rebuild — issue #4517"
+fi
+RUNTIME_GATEWAY_TOKEN="$(read_sandbox_runtime_gateway_token 2>/dev/null || true)"
+if [ "${RUNTIME_GATEWAY_TOKEN}" = "${POST_REBUILD_GATEWAY_TOKEN}" ]; then
+  pass "Runtime proxy env exports the rotated gateway token"
+elif [ "${RUNTIME_GATEWAY_TOKEN}" = "${PRE_REBUILD_GATEWAY_TOKEN}" ]; then
+  fail "Runtime proxy env still exports the old gateway token — issue #4517"
+else
+  fail "Runtime proxy env gateway token does not match openclaw.json — issue #4517"
+fi
+POST_REBUILD_CONFIG_HASH="$(read_sandbox_config_hash 2>/dev/null || true)"
+if [ -n "${POST_REBUILD_CONFIG_HASH}" ] && echo "${POST_REBUILD_CONFIG_HASH}" | grep -q "openclaw.json"; then
+  pass "Post-rebuild config hash references openclaw.json"
+else
+  fail "Post-rebuild config hash missing openclaw.json — issue #4517"
+fi
+if [ "${POST_REBUILD_CONFIG_HASH}" != "${PRE_REBUILD_CONFIG_HASH}" ]; then
+  pass "Config hash changed after gateway token rotation"
+else
+  fail "Config hash did not change after gateway token rotation — issue #4517"
+fi
+if openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+  sh -c "cd /sandbox/.openclaw && sha256sum -c .config-hash --status" 2>/dev/null; then
+  pass "Config hash validates after gateway token rotation"
+else
+  fail "Config hash does not validate after gateway token rotation — issue #4517"
+fi
+
 # Inference works after rebuild (proves credential chain is intact)
 info "Verifying inference after rebuild..."
 INFERENCE_RESPONSE=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- \
@@ -385,6 +476,13 @@ if [ -d "$BACKUP_DIR" ]; then
     pass "No credentials in backup"
   else
     fail "Credentials found: $CRED_LEAKS"
+  fi
+  GATEWAY_TOKEN_LEAKS=$(find "$BACKUP_DIR" -type f \
+    -exec grep -F -l "${PRE_REBUILD_GATEWAY_TOKEN}" {} \; 2>/dev/null || true)
+  if [ -z "${GATEWAY_TOKEN_LEAKS}" ]; then
+    pass "Old gateway token absent from backup"
+  else
+    fail "Old gateway token found in backup: ${GATEWAY_TOKEN_LEAKS}"
   fi
 else
   fail "Backup directory missing: $BACKUP_DIR"

--- a/test/e2e/test-rebuild-openclaw.sh
+++ b/test/e2e/test-rebuild-openclaw.sh
@@ -62,20 +62,14 @@ info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
 diag() { echo -e "${YELLOW}[DIAG]${NC} $1"; }
 
 read_sandbox_gateway_token() {
-  openshell sandbox exec --name "${SANDBOX_NAME}" -- python3 -c '
-import json
-with open("/sandbox/.openclaw/openclaw.json") as f:
-    cfg = json.load(f)
-print(cfg.get("gateway", {}).get("auth", {}).get("token", ""), end="")
-'
+  openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+    python3 -c 'import json; cfg = json.load(open("/sandbox/.openclaw/openclaw.json")); print(cfg.get("gateway", {}).get("auth", {}).get("token", ""), end="")'
 }
 
 read_sandbox_runtime_gateway_token() {
   # shellcheck disable=SC2016 # OPENCLAW_GATEWAY_TOKEN must expand inside the sandbox.
-  openshell sandbox exec --name "${SANDBOX_NAME}" -- bash -lc '
-. /tmp/nemoclaw-proxy-env.sh >/dev/null 2>&1 || exit 1
-printf "%s" "${OPENCLAW_GATEWAY_TOKEN:-}"
-'
+  openshell sandbox exec --name "${SANDBOX_NAME}" -- \
+    bash -lc '. /tmp/nemoclaw-proxy-env.sh >/dev/null 2>&1 || exit 1; printf "%s" "${OPENCLAW_GATEWAY_TOKEN:-}"'
 }
 
 read_sandbox_config_hash() {
@@ -196,18 +190,9 @@ openshell sandbox exec --name "${SANDBOX_NAME}" -- \
 
 # Seed an existing gateway token so the rebuild path must rotate it.
 openshell sandbox exec --name "${SANDBOX_NAME}" -- \
-  env "PRE_REBUILD_GATEWAY_TOKEN=${PRE_REBUILD_GATEWAY_TOKEN}" python3 -c '
-import json
-import os
-
-path = "/sandbox/.openclaw/openclaw.json"
-with open(path) as f:
-    cfg = json.load(f)
-cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = os.environ["PRE_REBUILD_GATEWAY_TOKEN"]
-with open(path, "w") as f:
-    json.dump(cfg, f, indent=2)
-    f.write("\n")
-' || fail "Failed to seed old gateway token"
+  env "PRE_REBUILD_GATEWAY_TOKEN=${PRE_REBUILD_GATEWAY_TOKEN}" \
+  python3 -c 'import json, os; path = "/sandbox/.openclaw/openclaw.json"; cfg = json.load(open(path)); cfg.setdefault("gateway", {}).setdefault("auth", {})["token"] = os.environ["PRE_REBUILD_GATEWAY_TOKEN"]; f = open(path, "w"); json.dump(cfg, f, indent=2); f.write("\n"); f.close()' \
+  || fail "Failed to seed old gateway token"
 openshell sandbox exec --name "${SANDBOX_NAME}" -- \
   sh -c "cd /sandbox/.openclaw && sha256sum openclaw.json > .config-hash" \
   || fail "Failed to write pre-rebuild config hash"

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -60,11 +60,34 @@ function startScriptHeredoc(src: string, marker: string): string {
 }
 
 function extractShellFunctionFromSource(src: string, name: string): string {
-  const match = src.match(new RegExp(`${name}\\(\\) \\{([\\s\\S]*?)^\\}`, "m"));
-  if (!match) {
+  const header = `${name}() {`;
+  const start = src.indexOf(header);
+  if (start === -1) {
     throw new Error(`Expected ${name} in scripts/nemoclaw-start.sh`);
   }
-  return `${name}() {${match[1]}\n}`;
+  const bodyStart = start + header.length;
+  const lines = src.slice(bodyStart).split(/(?<=\n)/);
+  let offset = 0;
+  let heredocEnd: string | undefined;
+  for (const line of lines) {
+    const bareLine = line.replace(/\r?\n$/, "");
+    if (heredocEnd) {
+      offset += line.length;
+      if (bareLine === heredocEnd) {
+        heredocEnd = undefined;
+      }
+      continue;
+    }
+    const heredoc = line.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/);
+    if (heredoc) {
+      heredocEnd = heredoc[1];
+    }
+    if (bareLine === "}") {
+      return `${name}() {${src.slice(bodyStart, bodyStart + offset)}\n}`;
+    }
+    offset += line.length;
+  }
+  throw new Error(`Expected closing brace for ${name} in scripts/nemoclaw-start.sh`);
 }
 
 function runEmbeddedPreload(
@@ -308,7 +331,9 @@ describe("nemoclaw-start non-root fallback", () => {
       'refresh_openclaw_provider_placeholders() { :; }',
       'ensure_mutable_openclaw_config_hash() { :; }',
       extractShellFunctionFromSource(src, "needs_gateway_token_for_current_command"),
+      extractShellFunctionFromSource(src, "prepare_gateway_token_for_current_command"),
       'ensure_gateway_token() { echo "SHOULD_NOT_ENSURE"; exit 75; }',
+      'ensure_gateway_token_if_missing() { echo "SHOULD_NOT_ENSURE"; exit 76; }',
       'write_openclaw_config_baseline() { :; }',
       'export_gateway_token() { :; }',
       'write_runtime_shell_env() { :; }',
@@ -353,6 +378,28 @@ describe("nemoclaw-start non-root fallback", () => {
     expect(result.stdout).toContain("yes:/usr/local/bin/openclaw");
     expect(result.stdout).toContain("no:true");
     expect(result.stdout).toContain("no:bash");
+  });
+
+  it("#4517: refreshes startup tokens but only ensures direct OpenClaw command tokens", () => {
+    const src = fs.readFileSync(START_SCRIPT, "utf-8");
+    const script = [
+      "set -euo pipefail",
+      extractShellFunctionFromSource(src, "needs_gateway_token_for_current_command"),
+      extractShellFunctionFromSource(src, "prepare_gateway_token_for_current_command"),
+      'ensure_gateway_token() { printf "rotate:%s\\n" "${NEMOCLAW_CMD[*]:-<none>}"; }',
+      'ensure_gateway_token_if_missing() { printf "ensure-missing:%s\\n" "${NEMOCLAW_CMD[*]}"; }',
+      'check() { NEMOCLAW_CMD=("$@"); prepare_gateway_token_for_current_command; }',
+      "check",
+      "check openclaw agent --agent main",
+      "check true",
+    ].join("\n");
+
+    const result = spawnSync("bash", ["-c", script], { encoding: "utf-8", timeout: 5000 });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("rotate:<none>");
+    expect(result.stdout).toContain("ensure-missing:openclaw agent --agent main");
+    expect(result.stdout).not.toContain("true");
   });
 
   it("repairs writable OpenClaw state directories in non-root mode", () => {
@@ -462,6 +509,7 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
   ) {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-token-"));
     const openclawDir = path.join(tmpDir, ".openclaw");
+    const optNemoclaw = path.join(tmpDir, "opt", "nemoclaw");
     const configPath = path.join(openclawDir, "openclaw.json");
     const hashPath = path.join(openclawDir, ".config-hash");
     const proxyEnv = path.join(tmpDir, "proxy-env.sh");
@@ -469,6 +517,10 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     const predictableTmpPath = `${configPath}.tmp`;
     const tmpSymlinkVictim = path.join(tmpDir, "predictable-tmp-victim");
     fs.mkdirSync(openclawDir, { recursive: true });
+    fs.mkdirSync(path.join(optNemoclaw, "node_modules"), { recursive: true });
+    fs.cpSync(JSON5_MODULE, path.join(optNemoclaw, "node_modules", "json5"), {
+      recursive: true,
+    });
     fs.writeFileSync(configPath, configJson);
     fs.writeFileSync(hashPath, "initial-hash\n");
     if (preseedPredictableTmpSymlink) {
@@ -479,10 +531,11 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     const readToken = extractShellFunctionFromSource(src, "_read_gateway_token").replaceAll(
       "/sandbox/.openclaw/openclaw.json",
       configPath,
-    );
+    ).replaceAll("/opt/nemoclaw", optNemoclaw);
     const ensureGatewayToken = extractShellFunctionFromSource(src, "ensure_gateway_token")
       .replaceAll("/sandbox/.openclaw/openclaw.json", configPath)
-      .replaceAll("/sandbox/.openclaw/.config-hash", hashPath);
+      .replaceAll("/sandbox/.openclaw/.config-hash", hashPath)
+      .replaceAll("/opt/nemoclaw", optNemoclaw);
     const configWriteHelperStubs = [
       "prepare_openclaw_config_for_write() { :; }",
       "restore_openclaw_config_after_write() { :; }",
@@ -634,6 +687,33 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     expect(configAfter.gateway.auth.token).toEqual(expect.any(String));
     expect(configAfter.gateway.auth.token).not.toBe("");
     expect(configAfter.gateway.auth.token).not.toBe(oldToken);
+    expect(envFile).toContain(`export OPENCLAW_GATEWAY_TOKEN='${configAfter.gateway.auth.token}'`);
+    expect(envFile).not.toContain(oldToken);
+    expect(envFile).not.toContain("stale-token");
+    expect(hashAfter).not.toBe("initial-hash\n");
+    expect(hashAfter).toMatch(/ openclaw\.json\n$/);
+  });
+
+  it("#4517: rotates an existing gateway token from JSON5 config", () => {
+    const oldToken = "old-json5-token-before-rebuild";
+    const { result, envFile, configAfter, hashAfter } = runGatewayTokenHarness(
+      [
+        "{",
+        "  // OpenClaw config accepts JSON5.",
+        "  gateway: { auth: { token: 'old-json5-token-before-rebuild', }, },",
+        "  model: 'nvidia/nemotron-3-super-120b-a12b',",
+        "}",
+      ].join("\n"),
+      "stale-token",
+      "18790",
+      true,
+    );
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(configAfter.gateway.auth.token).toEqual(expect.any(String));
+    expect(configAfter.gateway.auth.token).not.toBe("");
+    expect(configAfter.gateway.auth.token).not.toBe(oldToken);
+    expect(configAfter.model).toBe("nvidia/nemotron-3-super-120b-a12b");
     expect(envFile).toContain(`export OPENCLAW_GATEWAY_TOKEN='${configAfter.gateway.auth.token}'`);
     expect(envFile).not.toContain(oldToken);
     expect(envFile).not.toContain("stale-token");
@@ -2834,7 +2914,9 @@ describe("Telegram diagnostics (#2766)", () => {
         'refresh_openclaw_provider_placeholders() { :; }',
         'ensure_mutable_openclaw_config_hash() { :; }',
         'needs_gateway_token_for_current_command() { :; }',
+        extractShellFunctionFromSource(src, "prepare_gateway_token_for_current_command"),
         'ensure_gateway_token() { :; }',
+        'ensure_gateway_token_if_missing() { :; }',
         'write_openclaw_config_baseline() { :; }',
         'export_gateway_token() { :; }',
         'write_runtime_shell_env() { :; }',

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -621,6 +621,26 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     expect(hashAfter).toMatch(/ openclaw\.json\n$/);
   });
 
+  it("#4517: rotates an existing gateway token before writing the runtime shell env", () => {
+    const oldToken = "old-token-before-rebuild";
+    const { result, envFile, configAfter, hashAfter } = runGatewayTokenHarness(
+      JSON.stringify({ gateway: { auth: { token: oldToken } } }),
+      "stale-token",
+      "18790",
+      true,
+    );
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(configAfter.gateway.auth.token).toEqual(expect.any(String));
+    expect(configAfter.gateway.auth.token).not.toBe("");
+    expect(configAfter.gateway.auth.token).not.toBe(oldToken);
+    expect(envFile).toContain(`export OPENCLAW_GATEWAY_TOKEN='${configAfter.gateway.auth.token}'`);
+    expect(envFile).not.toContain(oldToken);
+    expect(envFile).not.toContain("stale-token");
+    expect(hashAfter).not.toBe("initial-hash\n");
+    expect(hashAfter).toMatch(/ openclaw\.json\n$/);
+  });
+
   it("does not write gateway tokens through a preseeded predictable temp symlink", () => {
     const {
       result,


### PR DESCRIPTION
## Summary
- refresh the OpenClaw gateway auth token every time the startup path calls `ensure_gateway_token`
- keep the existing symlink checks, atomic config rewrite, `.config-hash` recompute, and runtime env export path intact
- add regression coverage for rotating a pre-existing persisted token during rebuild/startup

Fixes #4517

## Tests
- `npm run build:cli`
- `npx vitest run test/nemoclaw-start.test.ts`

## Optional live validation
```bash
nemoclaw onboard --name token-test
CNAME=$(docker ps --format "{{.Names}}" | grep openshell-token-test | head -1)
T_A=$(docker exec -u sandbox $CNAME bash -c '. /tmp/nemoclaw-proxy-env.sh; echo $OPENCLAW_GATEWAY_TOKEN')
echo "T_A=${T_A}"

nemoclaw token-test sandbox rebuild --yes

CNAME=$(docker ps --format "{{.Names}}" | grep openshell-token-test | head -1)
T_B=$(docker exec -u sandbox $CNAME bash -c '. /tmp/nemoclaw-proxy-env.sh; echo $OPENCLAW_GATEWAY_TOKEN')
echo "T_B=${T_B}"

[ "$T_A" = "$T_B" ] && echo SAME || echo ROTATED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now always refreshes the gateway auth token; other commands only generate tokens when needed. Token generation uses durable, atomic writes with secure permissions and ensures rename persistence. Startup logs token refresh and backups/runtime will not contain stale tokens. JSON5 configs are supported.

* **Tests**
  * Expanded unit and e2e tests covering token rotation, JSON5 handling, config-hash updates, runtime env contents, and prevention of credential leaks into backups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->