### PR TITLE
docs: promote skills and refresh release docs

### DIFF
--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -78,6 +78,7 @@ When Ollama reports a loaded-model context length, NemoClaw uses that value for 
 If the selected model declares that it does not support tool calling, onboarding stops with guidance to choose a model whose `ollama show <model>` capabilities include `tools`.
 The validation also requires structured chat-completions tool calls.
 If the model leaks tool-call JSON as plain message text, onboarding stops so you can choose a model that returns tool calls in the expected response field.
+If a host-side validation probe times out, NemoClaw retries the Ollama tool-call validation with a larger timeout before failing the setup.
 On WSL, if you choose the Windows-host Ollama path, NemoClaw uses `host.docker.internal:11434` and pulls missing models through the Ollama HTTP API instead of requiring the `ollama` CLI inside WSL.
 
 ### WSL with Windows-Host Ollama
@@ -108,53 +109,35 @@ JSON such as `{"name":"memory_search","arguments":{...}}` instead of running a
 tool, switch to vLLM with `--enable-auto-tool-choice` and the correct
 `--tool-call-parser`. See [Tool-Calling Reliability](references/tool-calling-reliability.md).
 
-### Authenticated Reverse Proxy
+### GPU Memory Cleanup
 
-On non-WSL hosts, NemoClaw keeps Ollama bound to `127.0.0.1:11434` and starts a token-gated reverse proxy on `0.0.0.0:11435`.
-The native install/start paths also reset NemoClaw-managed systemd launches to the loopback binding.
-Containers and other hosts on the local network reach Ollama only through the
-proxy, which validates a Bearer token before forwarding requests.
-On that native path, NemoClaw never exposes Ollama without authentication.
+When you switch away from Ollama, stop host services, or destroy an Ollama-backed sandbox, NemoClaw asks Ollama to unload currently loaded models from GPU memory.
+The cleanup sends `keep_alive: 0` for each model reported by Ollama and runs on a best-effort basis, so shutdown continues if Ollama is already stopped.
+This does not delete downloaded model files.
 
-WSL Ollama paths do not use this proxy.
-Windows-host Ollama uses the Windows daemon through `host.docker.internal`.
-
-For non-WSL Ollama setups, the onboard wizard manages the proxy automatically:
-
-- Generates a random 24-byte token on first run and stores it in
-  `~/.nemoclaw/ollama-proxy-token` with `0600` permissions.
-- Starts the proxy after Ollama and verifies it before continuing.
-- Cleans up stale proxy processes from previous runs.
-- Probes the sandbox Docker network path to the proxy before committing the inference route.
-- Stops matching proxy processes during uninstall before deleting NemoClaw state.
-- Reuses the persisted token after a host reboot so you do not need to re-run
-  onboard.
-
-On native Linux hosts, a firewall can allow the host proxy health check while still blocking sandbox containers on the OpenShell Docker bridge.
-When the sandbox-side proxy probe fails with a TCP error, onboarding exits before it saves the inference route and prints a command like:
+### Non-Interactive Setup
 
 ```console
-$ sudo ufw allow from <openshell-docker-subnet> to any port 11435 proto tcp
-$ nemoclaw onboard
+$ NEMOCLAW_PROVIDER=ollama \
+  NEMOCLAW_MODEL=qwen2.5:14b \
+  nemoclaw onboard --non-interactive --yes
 ```
 
-If the probe cannot run, for example because Docker Desktop or WSL uses a different host routing model, onboarding continues and relies on the regular proxy health check.
+If `NEMOCLAW_MODEL` is not set, NemoClaw selects a default model based on available memory.
+If `NEMOCLAW_MODEL` names a known bootstrap model (for example `qwen3.6:35b`) that does not fit the host's currently available GPU memory, NemoClaw warns and falls back to the largest known model that does fit.
+Unknown or custom tags (any value the bootstrap registry has not seen) are still passed through; the Ollama runner validates the choice itself.
 
-The sandbox provider is configured to use proxy port `11435` with the generated
-token as its `OPENAI_API_KEY` credential.
-OpenShell's L7 proxy injects the token at egress, so the agent inside the
-sandbox never sees the token directly.
+`--yes` (or `NEMOCLAW_YES=1`) authorises the Ollama model download without an interactive confirmation prompt.
+Under `--non-interactive`, `--yes` (or `NEMOCLAW_YES=1`) is required to authorise the download — onboard exits otherwise, since it cannot prompt.
+Run onboard without `--non-interactive` to get the interactive `[y/N]` prompt that shows the model size before downloading.
 
-All proxy endpoints require the Bearer token, including `GET /api/tags`.
-Internal health and reachability checks run via the proxy treat any HTTP
-response (including `401`) as proof the proxy is alive — they only fail
-when nothing answers at all.
+| Variable | Purpose |
+|---|---|
+| `NEMOCLAW_PROVIDER` | Set to `ollama`. |
+| `NEMOCLAW_MODEL` | Ollama model tag to use. Optional. |
+| `NEMOCLAW_YES` | Set to `1` to auto-accept the model-download confirmation prompt. Optional. |
 
-If Ollama is already running on a non-loopback address when you start onboard,
-the wizard restarts it on `127.0.0.1:11434` so the proxy is the only network
-path to the model server.
-
-Load [references/use-local-inference-details.md](references/use-local-inference-details.md) for detailed steps on GPU Memory Cleanup, Non-Interactive Setup.
+Load [references/use-local-inference-details.md](references/use-local-inference-details.md) for detailed steps on Authenticated Reverse Proxy.
 
 ## OpenAI-Compatible Server
 
@@ -273,7 +256,7 @@ Load [references/use-local-inference-details.md](references/use-local-inference-
 - **Load [references/set-up-sub-agent.md](references/set-up-sub-agent.md)** when users ask how to add a second model, configure a sub-agent model, use Omni for vision tasks, configure agents.list, or use sessions_spawn in NemoClaw. Shows the NemoClaw-specific file paths and update flow for adding an auxiliary OpenClaw sub-agent model.
 - **[references/tool-calling-reliability.md](references/tool-calling-reliability.md)** — Explains Ollama tool-call leak symptoms, when vLLM with a tool-call parser is recommended, and how to repoint NemoClaw to a parser-aware local endpoint.
 - **Load [references/inference-options.md](references/inference-options.md)** when explaining which providers are available, what the onboard wizard presents, or how inference routing works. Lists all inference providers offered during NemoClaw onboarding.
-- **Load [references/use-local-inference-details.md](references/use-local-inference-details.md)** when you need detailed steps for GPU Memory Cleanup, Non-Interactive Setup, Selecting the API Path, and related details.
+- **Load [references/use-local-inference-details.md](references/use-local-inference-details.md)** when you need detailed steps for Authenticated Reverse Proxy, Non-Interactive Setup, Selecting the API Path, and related details.
 
 ## Related Skills
 

--- a/.agents/skills/nemoclaw-user-configure-inference/references/use-local-inference-details.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/use-local-inference-details.md
@@ -2,33 +2,70 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # Use a Local Inference Server: Details
 
-## GPU Memory Cleanup
+## Authenticated Reverse Proxy
 
-When you switch away from Ollama, stop host services, or destroy an Ollama-backed sandbox, NemoClaw asks Ollama to unload currently loaded models from GPU memory.
-The cleanup sends `keep_alive: 0` for each model reported by Ollama and runs on a best-effort basis, so shutdown continues if Ollama is already stopped.
-This does not delete downloaded model files.
+On non-WSL hosts, NemoClaw keeps Ollama bound to `127.0.0.1:11434` and starts a token-gated reverse proxy on `0.0.0.0:11435`.
+The native install/start paths also reset NemoClaw-managed systemd launches to the loopback binding.
+Containers and other hosts on the local network reach Ollama only through the
+proxy, which validates a Bearer token before forwarding requests.
+On that native path, NemoClaw never exposes Ollama without authentication.
+
+WSL Ollama paths do not use this proxy.
+Windows-host Ollama uses the Windows daemon through `host.docker.internal`.
+
+For non-WSL Ollama setups, the onboard wizard manages the proxy automatically:
+
+- Generates a random 24-byte token on first run and stores it in
+  `~/.nemoclaw/ollama-proxy-token` with `0600` permissions.
+- Starts the proxy after Ollama and verifies it before continuing.
+- Cleans up stale proxy processes from previous runs.
+- Probes the sandbox Docker network path to the proxy before committing the inference route.
+- Stops matching proxy processes during uninstall before deleting NemoClaw state.
+- Reuses the persisted token after a host reboot so you do not need to re-run
+  onboard.
+
+On native Linux hosts, a firewall can allow the host proxy health check while still blocking sandbox containers on the OpenShell Docker bridge.
+When the sandbox-side proxy probe fails with a TCP error, onboarding exits before it saves the inference route and prints a command like:
+
+```console
+$ sudo ufw allow from <openshell-docker-subnet> to any port 11435 proto tcp
+$ nemoclaw onboard
+```
+
+If the probe cannot run, for example because Docker Desktop or WSL uses a different host routing model, onboarding continues and relies on the regular proxy health check.
+
+The sandbox provider is configured to use proxy port `11435` with the generated
+token as its `OPENAI_API_KEY` credential.
+OpenShell's L7 proxy injects the token at egress, so the agent inside the
+sandbox never sees the token directly.
+
+All proxy endpoints require the Bearer token, including `GET /api/tags`.
+Internal health and reachability checks run via the proxy treat any HTTP
+response (including `401`) as proof the proxy is alive — they only fail
+when nothing answers at all.
+
+If Ollama is already running on a non-loopback address when you start onboard,
+the wizard restarts it on `127.0.0.1:11434` so the proxy is the only network
+path to the model server.
 
 ### Non-Interactive Setup
 
+Set the following environment variables for scripted or CI/CD deployments.
+
 ```console
-$ NEMOCLAW_PROVIDER=ollama \
-  NEMOCLAW_MODEL=qwen2.5:14b \
-  nemoclaw onboard --non-interactive --yes
+$ NEMOCLAW_PROVIDER=custom \
+  NEMOCLAW_ENDPOINT_URL=http://localhost:8000/v1 \
+  NEMOCLAW_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+  COMPATIBLE_API_KEY=dummy \
+  nemoclaw onboard --non-interactive
 ```
-
-If `NEMOCLAW_MODEL` is not set, NemoClaw selects a default model based on available memory.
-If `NEMOCLAW_MODEL` names a known bootstrap model (for example `qwen3.6:35b`) that does not fit the host's currently available GPU memory, NemoClaw warns and falls back to the largest known model that does fit.
-Unknown or custom tags (any value the bootstrap registry has not seen) are still passed through; the Ollama runner validates the choice itself.
-
-`--yes` (or `NEMOCLAW_YES=1`) authorises the Ollama model download without an interactive confirmation prompt.
-Under `--non-interactive`, `--yes` (or `NEMOCLAW_YES=1`) is required to authorise the download — onboard exits otherwise, since it cannot prompt.
-Run onboard without `--non-interactive` to get the interactive `[y/N]` prompt that shows the model size before downloading.
 
 | Variable | Purpose |
 |---|---|
-| `NEMOCLAW_PROVIDER` | Set to `ollama`. |
-| `NEMOCLAW_MODEL` | Ollama model tag to use. Optional. |
-| `NEMOCLAW_YES` | Set to `1` to auto-accept the model-download confirmation prompt. Optional. |
+| `NEMOCLAW_PROVIDER` | Set to `custom` for an OpenAI-compatible endpoint. |
+| `NEMOCLAW_ENDPOINT_URL` | Base URL of the local server. |
+| `NEMOCLAW_MODEL` | Model ID as reported by the server. |
+| `COMPATIBLE_API_KEY` | API key for the endpoint. Use any non-empty value if authentication is not required. |
 
 ### Selecting the API Path
 
@@ -75,6 +112,26 @@ $ NEMOCLAW_PROVIDER=anthropicCompatible \
   nemoclaw onboard --non-interactive
 ```
 
+### Non-Interactive Setup
+
+Use an already-running vLLM server:
+
+```console
+$ NEMOCLAW_PROVIDER=vllm \
+  nemoclaw onboard --non-interactive
+```
+
+Install or start managed vLLM when a supported profile is detected.
+On DGX Spark and DGX Station, `NEMOCLAW_PROVIDER=install-vllm` is enough for non-interactive runs; add `NEMOCLAW_EXPERIMENTAL=1` on generic Linux NVIDIA GPU hosts.
+
+```console
+$ NEMOCLAW_PROVIDER=install-vllm \
+  nemoclaw onboard --non-interactive
+```
+
+NemoClaw records the model returned by vLLM's `/v1/models` endpoint.
+Start vLLM with the model you want before onboarding if you manage the server yourself.
+
 ### Override the Managed-vLLM Model
 
 Managed vLLM serves the profile default unless you select a different registry entry.
@@ -120,6 +177,8 @@ This setting is baked into the sandbox at build time.
 Changing it after onboarding requires re-running `nemoclaw onboard`.
 
 `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` only governs the inference-server validation probe.
+During local Ollama setup, NemoClaw treats host-side curl process timeouts as retryable probe failures and retries with a larger timeout before it reports a validation failure.
+NemoClaw also retries Docker runtime detection with a longer `docker info` timeout before it chooses the local inference route.
 The post-create readiness wait (image build, gateway upload, in-sandbox boot) has its own budget, `NEMOCLAW_SANDBOX_READY_TIMEOUT`, also defaulting to 180 seconds.
 On hosts where the sandbox image takes minutes to build or upload — large quantised models, DGX Station first runs, or remote VMs over a slow link — raise both together:
 

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -400,7 +400,7 @@ The scanner intercepts Write, Edit, and similar tool calls targeting memory and 
 | Aspect | Detail |
 |---|---|
 | Default | Enabled. The plugin registers a `before_tool_call` hook that scans for 14 high-confidence secret patterns. |
-| What it covers | Examples include `.openclaw/memory/`, `.openclaw/workspace/`, `.openclaw/agents/`, `.openclaw/skills/`, `.openclaw/hooks/`, `.openclaw/credentials/`, `.openclaw/openclaw.json`, `.nemoclaw/`, and `MEMORY.md`; the exact coverage is defined by `MEMORY_PATH_SEGMENTS` and enforced through `isMemoryPath()`. |
+| What it covers | Three classifiers, all enforced through `isMemoryPath()`: (1) absolute `MEMORY_PATH_SEGMENTS` such as `/.openclaw/memory/`, `/.openclaw/workspace/`, `/.openclaw/agents/`, `/.openclaw/skills/`, `/.openclaw/hooks/`, `/.openclaw/credentials/`, `/.openclaw/openclaw.json`, `/.nemoclaw/`; (2) canonical workspace basenames in `MEMORY_BASENAMES` (`IDENTITY.md`, `MEMORY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`) matched regardless of the surrounding path; and (3) lexically-normalized workspace-relative writes matching `MEMORY_RELATIVE_PREFIXES` (`.openclaw/`, `.nemoclaw/`, `memory/`) or named workspace daily memory paths, for embedded-fallback mode where the host's path resolver is unavailable. |
 | What you can change | This is not a user-facing knob. The plugin enforces it automatically. |
 | Risk if relaxed | Without scanning, the agent could persist API keys or tokens in memory files that survive across sessions and backups. |
 | Recommendation | No action needed. If a write is blocked, the agent receives an actionable error listing the detected patterns. |

--- a/.agents/skills/nemoclaw-user-get-started/SKILL.md
+++ b/.agents/skills/nemoclaw-user-get-started/SKILL.md
@@ -15,6 +15,12 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 
 Make sure you have completed reviewing the [Prerequisites](references/prerequisites.md) before following this guide.
 
+**Use Agent Skills:**
+
+NemoClaw ships user skills for AI coding assistants.
+Load them when you want your assistant to walk through installation, inference choices, policy approvals, monitoring, or troubleshooting with NemoClaw-specific guidance.
+Refer to Agent Skills (use the `nemoclaw-user-agent-skills` skill).
+
 ## Install NemoClaw and Onboard OpenClaw Agent
 
 Download and run the installer script.
@@ -115,6 +121,7 @@ If you enable it, enter a Brave Search API key when prompted.
 
 The wizard also offers messaging channels such as Telegram, Discord, Slack, WeChat, and WhatsApp.
 Press a channel number to toggle it, then press Enter to continue.
+If you leave all channels unselected, pressing Enter skips messaging setup.
 If you select a channel, NemoClaw validates the token format before it bakes the channel configuration into the sandbox.
 For example, Slack bot tokens must start with `xoxb-`.
 WeChat and WhatsApp are experimental.
@@ -212,3 +219,4 @@ openclaw tui
 ## Related Skills
 
 - `nemoclaw-user-overview` — NemoClaw Overview (use the `nemoclaw-user-overview` skill) to learn what NemoClaw is and its capabilities
+- `nemoclaw-user-agent-skills` — Agent Skills (use the `nemoclaw-user-agent-skills` skill) to load NemoClaw guidance into an AI coding assistant

--- a/.agents/skills/nemoclaw-user-get-started/references/prerequisites.md
+++ b/.agents/skills/nemoclaw-user-get-started/references/prerequisites.md
@@ -67,3 +67,4 @@ The table is generated from [`ci/platform-matrix.json`](https://github.com/NVIDI
 
 - [Prepare Windows for NemoClaw](windows-preparation.md) if you are using Windows.
 - [Quickstart](../SKILL.md) to install NemoClaw and launch your first sandbox.
+- Agent Skills (use the `nemoclaw-user-agent-skills` skill) to load NemoClaw guidance into an AI coding assistant before setup.

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/messaging-channels.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/messaging-channels.md
@@ -94,6 +94,7 @@ Pair only one sandbox per WhatsApp account at a time.
 
 When the wizard reaches **Messaging channels**, it lists Telegram, Discord, Slack, WeChat, and WhatsApp.
 Press a channel number to toggle it on or off, then press **Enter** when done.
+If no channels are selected, pressing **Enter** skips messaging setup.
 If a token-based channel token is not already in the environment or credential store, the wizard prompts for it and saves it.
 
 If you enable WeChat (experimental), the wizard does not prompt for a paste token.

--- a/.agents/skills/nemoclaw-user-overview/references/overview.md
+++ b/.agents/skills/nemoclaw-user-overview/references/overview.md
@@ -23,6 +23,7 @@ NemoClaw provides the following product capabilities.
 | Feature | Description |
 |---------|-------------|
 | Guided onboarding | Validates credentials, selects providers, and creates a working sandbox in one command. |
+| Agent skills | Packages NemoClaw documentation as user skills so AI coding assistants can guide setup, inference configuration, policy management, monitoring, deployment, security review, and troubleshooting. |
 | Hardened blueprint | A security-first Dockerfile with capability drops, least-privilege network rules, and declarative policy. |
 | State management | Safe migration of agent state across machines with credential stripping and integrity verification. |
 | Messaging channels | OpenShell-managed processes connect Telegram, Discord, Slack, and similar platforms to the sandboxed agent. NemoClaw configures channels during onboarding; OpenShell supplies the native constructs, credential flow, and runtime supervision. |
@@ -60,4 +61,5 @@ Navigate to the following topics to learn more about NemoClaw and how to install
 - [Architecture Overview](how-it-works.md) to understand how NemoClaw works.
 - [Ecosystem](ecosystem.md) to understand how OpenClaw, OpenShell, and NemoClaw relate in the wider stack, and when to use NemoClaw versus OpenShell.
 - Quickstart (use the `nemoclaw-user-get-started` skill) to install NemoClaw and run your first sandboxed agent.
+- Agent Skills (use the `nemoclaw-user-agent-skills` skill) to load NemoClaw guidance into an AI coding assistant.
 - Inference Options (use the `nemoclaw-user-configure-inference` skill) to check the inference providers that NemoClaw supports and how inference routing works.

--- a/.agents/skills/nemoclaw-user-overview/references/release-notes.md
+++ b/.agents/skills/nemoclaw-user-overview/references/release-notes.md
@@ -4,6 +4,14 @@
 
 NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use this page to track changes.
 
+## v0.0.55
+
+NemoClaw v0.0.55 improves local Ollama onboarding reliability, plugin secret-scanner resilience, and messaging-channel prompt clarity:
+
+- Local Ollama validation retries host-side curl process timeouts with a larger timeout before failing, and Docker runtime detection retries `docker info` before choosing the local inference route. For more information, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill).
+- The NemoClaw OpenClaw plugin keeps the memory secret scanner active when OpenClaw runs in embedded fallback mode without a usable path resolver. The scanner falls back to literal memory and workspace-relative paths instead of crashing before the first write-tool call. For more information, refer to Security Best Practices (use the `nemoclaw-user-configure-security` skill).
+- The onboarding messaging-channel picker now states that pressing Enter with no channels selected skips messaging setup. For more information, refer to Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill).
+
 ## v0.0.54
 
 NemoClaw v0.0.54 updates messaging activation, Windows WSL onboarding, NemoHermes dashboard access, and sandbox repair paths:

--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -30,6 +30,7 @@ NemoClaw provides the following product capabilities.
 | Feature | Description |
 |---------|-------------|
 | Guided onboarding | Validates credentials, selects providers, and creates a working sandbox in one command. |
+| Agent skills | Packages NemoClaw documentation as user skills so AI coding assistants can guide setup, inference configuration, policy management, monitoring, deployment, security review, and troubleshooting. |
 | Hardened blueprint | A security-first Dockerfile with capability drops, least-privilege network rules, and declarative policy. |
 | State management | Safe migration of agent state across machines with credential stripping and integrity verification. |
 | Messaging channels | OpenShell-managed processes connect Telegram, Discord, Slack, and similar platforms to the sandboxed agent. NemoClaw configures channels during onboarding; OpenShell supplies the native constructs, credential flow, and runtime supervision. |
@@ -67,4 +68,5 @@ Navigate to the following topics to learn more about NemoClaw and how to install
 - [Architecture Overview](/about/how-it-works) to understand how NemoClaw works.
 - [Ecosystem](/about/ecosystem) to understand how OpenClaw, OpenShell, and NemoClaw relate in the wider stack, and when to use NemoClaw versus OpenShell.
 - [Quickstart](/get-started/quickstart) to install NemoClaw and run your first sandboxed agent.
+- [Agent Skills](/resources/agent-skills) to load NemoClaw guidance into an AI coding assistant.
 - [Inference Options](/inference/inference-options) to check the inference providers that NemoClaw supports and how inference routing works.

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -11,6 +11,14 @@ content:
 ---
 NVIDIA NemoClaw is available in early preview starting March 16, 2026. Use this page to track changes.
 
+## v0.0.55
+
+NemoClaw v0.0.55 improves local Ollama onboarding reliability, plugin secret-scanner resilience, and messaging-channel prompt clarity:
+
+- Local Ollama validation retries host-side curl process timeouts with a larger timeout before failing, and Docker runtime detection retries `docker info` before choosing the local inference route. For more information, refer to [Use a Local Inference Server](/inference/use-local-inference).
+- The NemoClaw OpenClaw plugin keeps the memory secret scanner active when OpenClaw runs in embedded fallback mode without a usable path resolver. The scanner falls back to literal memory and workspace-relative paths instead of crashing before the first write-tool call. For more information, refer to [Security Best Practices](/security/best-practices).
+- The onboarding messaging-channel picker now states that pressing Enter with no channels selected skips messaging setup. For more information, refer to [Messaging Channels](/manage-sandboxes/messaging-channels).
+
 ## v0.0.54
 
 NemoClaw v0.0.54 updates messaging activation, Windows WSL onboarding, NemoHermes dashboard access, and sandbox repair paths:

--- a/docs/get-started/prerequisites.mdx
+++ b/docs/get-started/prerequisites.mdx
@@ -74,3 +74,4 @@ The table is generated from [`ci/platform-matrix.json`](https://github.com/NVIDI
 
 - [Prepare Windows for NemoClaw](/get-started/windows-preparation) if you are using Windows.
 - [Quickstart](/get-started/quickstart) to install NemoClaw and launch your first sandbox.
+- [Agent Skills](/resources/agent-skills) to load NemoClaw guidance into an AI coding assistant before setup.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -17,6 +17,12 @@ Follow these steps to get started with NemoClaw and your first sandboxed OpenCla
 Make sure you have completed reviewing the [Prerequisites](/get-started/prerequisites) before following this guide.
 </Note>
 
+<Tip title="Use Agent Skills">
+NemoClaw ships user skills for AI coding assistants.
+Load them when you want your assistant to walk through installation, inference choices, policy approvals, monitoring, or troubleshooting with NemoClaw-specific guidance.
+Refer to [Agent Skills](/resources/agent-skills).
+</Tip>
+
 ## Install NemoClaw and Onboard OpenClaw Agent
 
 Download and run the installer script.
@@ -386,6 +392,7 @@ Navigate to the following topics to learn more about NemoClaw.
 - [NemoClaw Overview](/about/overview) to learn what NemoClaw is and its capabilities.
 - [Architecture Overview](/about/how-it-works) to understand how NemoClaw works.
 - [Ecosystem](/about/ecosystem) to understand how OpenClaw, OpenShell, and NemoClaw relate in the wider stack, and when to use NemoClaw versus OpenShell.
+- [Agent Skills](/resources/agent-skills) to load NemoClaw guidance into an AI coding assistant.
 
 Use the following topics to learn how to use NemoClaw.
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -300,6 +300,7 @@ If you enable it, enter a Brave Search API key when prompted.
 
 The wizard also offers messaging channels such as Telegram, Discord, Slack, WeChat, and WhatsApp.
 Press a channel number to toggle it, then press Enter to continue.
+If you leave all channels unselected, pressing Enter skips messaging setup.
 If you select a channel, NemoClaw validates the token format before it bakes the channel configuration into the sandbox.
 For example, Slack bot tokens must start with `xoxb-`.
 WeChat and WhatsApp are experimental.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "NVIDIA NemoClaw"
 sidebar-title: "NVIDIA NemoClaw Developer Guide"
-description: "NemoClaw is an open-source reference stack that simplifies running OpenClaw always-on assistants more safely, with a single command."
-keywords: "NemoClaw, OpenClaw, OpenShell, AI agents, sandboxing, inference routing"
+description: "NemoClaw is an open-source reference stack that simplifies running OpenClaw always-on assistants more safely, with a single command and packaged agent skills."
+keywords: "NemoClaw, OpenClaw, OpenShell, AI agents, agent skills, sandboxing, inference routing"
 position: 1
 ---
 
@@ -39,6 +39,7 @@ import { CommandTerminal } from "./_components/CommandTerminal";
 NVIDIA NemoClaw is an open-source reference stack that simplifies running [OpenClaw](https://openclaw.ai) always-on assistants more safely.
 NemoClaw provides onboarding, lifecycle management, and OpenClaw operations within OpenShell containers.
 It installs the [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) runtime, part of NVIDIA Agent Toolkit, setting up an environment designed for executing agents with additional security and inference routing capabilities.
+NemoClaw also ships user skills for AI coding assistants, so tools such as Cursor and Claude Code can guide you through setup, inference, policy management, monitoring, deployment, security, and troubleshooting from the same documentation.
 
 ## Get Started
 
@@ -59,6 +60,22 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 </llms-only>
 
 For more detailed guidance on getting started, refer to [Quickstart](/get-started/quickstart).
+
+## Use NemoClaw User Skills
+
+If you work from an AI coding assistant, load NemoClaw's user skills before you install or operate a sandbox.
+The skills turn these docs into task-focused guidance that your assistant can apply to your local environment.
+
+<Cards>
+
+<Card title="Set Up Agent Skills" href="/resources/agent-skills">
+
+Clone the skills or add them to your assistant so NemoClaw guidance is available directly in chat.
+
+<Badge intent="tip" minimal outlined>Resource</Badge>
+</Card>
+
+</Cards>
 
 ---
 
@@ -100,6 +117,13 @@ Track NemoClaw release changes and component version policy.
 Install NemoClaw, verify prerequisites, and run your first sandboxed agent.
 
 <Badge intent="tip" minimal outlined>Guide</Badge>
+</Card>
+
+<Card title="Agent Skills" href="/resources/agent-skills">
+
+Use NemoClaw's packaged agent skills to guide coding assistants through common workflows.
+
+<Badge intent="tip" minimal outlined>Resource</Badge>
 </Card>
 
 <Card title="Inference" href="/inference/inference-options">
@@ -156,13 +180,6 @@ Look up architecture details, CLI commands, policies, and troubleshooting guidan
 Learn about the NemoClaw architecture, plugin structure, and blueprint design in detail.
 
 <Badge intent="tip" minimal outlined>Reference</Badge>
-</Card>
-
-<Card title="Agent Skills" href="/resources/agent-skills">
-
-Use NemoClaw's packaged agent skills to guide coding assistants through common workflows.
-
-<Badge intent="tip" minimal outlined>Resource</Badge>
 </Card>
 
 </Cards>

--- a/docs/inference/use-local-inference.mdx
+++ b/docs/inference/use-local-inference.mdx
@@ -77,6 +77,7 @@ When Ollama reports a loaded-model context length, NemoClaw uses that value for 
 If the selected model declares that it does not support tool calling, onboarding stops with guidance to choose a model whose `ollama show <model>` capabilities include `tools`.
 The validation also requires structured chat-completions tool calls.
 If the model leaks tool-call JSON as plain message text, onboarding stops so you can choose a model that returns tool calls in the expected response field.
+If a host-side validation probe times out, NemoClaw retries the Ollama tool-call validation with a larger timeout before failing the setup.
 On WSL, if you choose the Windows-host Ollama path, NemoClaw uses `host.docker.internal:11434` and pulls missing models through the Ollama HTTP API instead of requiring the `ollama` CLI inside WSL.
 
 ### WSL with Windows-Host Ollama
@@ -409,6 +410,8 @@ This setting is baked into the sandbox at build time.
 Changing it after onboarding requires re-running `nemoclaw onboard`.
 
 `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` only governs the inference-server validation probe.
+During local Ollama setup, NemoClaw treats host-side curl process timeouts as retryable probe failures and retries with a larger timeout before it reports a validation failure.
+NemoClaw also retries Docker runtime detection with a longer `docker info` timeout before it chooses the local inference route.
 The post-create readiness wait (image build, gateway upload, in-sandbox boot) has its own budget, `NEMOCLAW_SANDBOX_READY_TIMEOUT`, also defaulting to 180 seconds.
 On hosts where the sandbox image takes minutes to build or upload — large quantised models, DGX Station first runs, or remote VMs over a slow link — raise both together:
 

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -103,6 +103,7 @@ Pair only one sandbox per WhatsApp account at a time.
 
 When the wizard reaches **Messaging channels**, it lists Telegram, Discord, Slack, WeChat, and WhatsApp.
 Press a channel number to toggle it on or off, then press **Enter** when done.
+If no channels are selected, pressing **Enter** skips messaging setup.
 If a token-based channel token is not already in the environment or credential store, the wizard prompts for it and saves it.
 
 If you enable WeChat (experimental), the wizard does not prompt for a paste token.


### PR DESCRIPTION
## Summary
Promotes NemoClaw user skills in the most visible docs entry points and refreshes the docs for v0.0.55.
This keeps the public docs and generated user skills aligned with the latest release tag.

## Related Issue
None.

## Changes
- Adds homepage, overview, prerequisites, and quickstart links that make NemoClaw user skills easier to discover.
- #4540 -> `docs/inference/use-local-inference.mdx` and `docs/about/release-notes.mdx`: Documents local Ollama validation retries and Docker runtime detection retries.
- #4519 -> `docs/about/release-notes.mdx`: Notes the plugin secret-scanner fallback behavior for embedded fallback mode.
- #4526 -> `docs/get-started/quickstart.mdx`, `docs/manage-sandboxes/messaging-channels.mdx`, and `docs/about/release-notes.mdx`: Documents that pressing Enter with no messaging channels selected skips setup.
- Refreshes generated `nemoclaw-user-*` skills from the updated Fern docs.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details:
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx` passed.
- `npm run docs` passed with 0 errors and the existing Fern light-mode contrast warning.
- Commit hooks passed for the docs commits.
- Full all-files/pre-push checks were attempted but hit unrelated CLI test timeouts, so the all-files checkbox is left unchecked.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agent Skills guidance and links across overview, getting started, quickstart, and homepage to load NemoClaw user skills into AI coding assistants.
  * Clarified local inference onboarding reliability (retry/timeout behavior and Docker detection) for Ollama/vLLM.
  * Clarified messaging-channel onboarding to skip setup when no channels are selected and Enter is pressed.
  * Improved secret-scanner behavior descriptions and added v0.0.55 release notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->