### PR TITLE
fix(e2e): unconditionally skip Telegram reachability probe for fake-token tests

### DIFF
--- a/test/e2e/test-channels-stop-start.sh
+++ b/test/e2e/test-channels-stop-start.sh
@@ -369,6 +369,13 @@ assert_policy_preset_active() {
   fi
 }
 
+is_fake_telegram_token() {
+  case "${1:-}" in
+    *fake*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 export_fake_channel_env() {
   local suffix="$1"
   export TELEGRAM_BOT_TOKEN="${ORIG_TELEGRAM_BOT_TOKEN:-test-fake-telegram-token-${suffix}}"
@@ -419,10 +426,12 @@ install_for_active_agent() {
   export NEMOCLAW_RECREATE_SANDBOX=1
   export NEMOCLAW_FRESH=1
 
-  # Always skip the Telegram reachability probe in E2E: fake tokens trigger
-  # HTTP 401/404 which the new probe treats as "skip Telegram", breaking the
-  # test even when api.telegram.org is reachable.
-  export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+  if [ -z "${NEMOCLAW_SKIP_TELEGRAM_REACHABILITY:-}" ] && is_fake_telegram_token "$TELEGRAM_BOT_TOKEN"; then
+    # This E2E normally uses fake tokens to exercise config plumbing, not the
+    # live Telegram API. Remove once onboard has a hermetic fake Telegram API.
+    export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+    info "Skipping onboarding Telegram reachability probe for fake-token E2E"
+  fi
 
   info "Running install.sh --non-interactive for ${ACTIVE_AGENT} (${ACTIVE_SANDBOX})..."
   bash install.sh --non-interactive >"$log" 2>&1 &

--- a/test/e2e/test-channels-stop-start.sh
+++ b/test/e2e/test-channels-stop-start.sh
@@ -419,12 +419,10 @@ install_for_active_agent() {
   export NEMOCLAW_RECREATE_SANDBOX=1
   export NEMOCLAW_FRESH=1
 
-  if [ -z "${NEMOCLAW_SKIP_TELEGRAM_REACHABILITY:-}" ]; then
-    if ! curl -fsS --max-time 10 https://api.telegram.org/ >/dev/null 2>&1; then
-      export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
-      info "api.telegram.org unreachable from host; setting NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1"
-    fi
-  fi
+  # Always skip the Telegram reachability probe in E2E: fake tokens trigger
+  # HTTP 401/404 which the new probe treats as "skip Telegram", breaking the
+  # test even when api.telegram.org is reachable.
+  export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
 
   info "Running install.sh --non-interactive for ${ACTIVE_AGENT} (${ACTIVE_SANDBOX})..."
   bash install.sh --non-interactive >"$log" 2>&1 &

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -671,10 +671,15 @@ if openshell --version >/dev/null 2>&1; then
 fi
 pass "Pre-cleanup complete"
 
-# Always skip the Telegram reachability probe in E2E: these tests use fake
-# tokens that fail the HTTP 401/404 check even when api.telegram.org is
-# reachable, causing onboard to silently drop the Telegram channel.
-export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+if [ -z "${NEMOCLAW_SKIP_TELEGRAM_REACHABILITY:-}" ] \
+  && [ -z "${TELEGRAM_BOT_TOKEN_REAL:-}" ] \
+  && [[ "$TELEGRAM_TOKEN" == *fake* ]]; then
+  # This E2E normally uses fake tokens to exercise config plumbing, not the
+  # live Telegram API. Keep real-token runs on the onboard validation path.
+  # Remove once onboard has a hermetic fake Telegram API.
+  export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+  info "Skipping onboarding Telegram reachability probe for fake-token E2E"
+fi
 
 # Pre-merge Slack policy into the base sandbox policy.
 #

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -564,12 +564,10 @@ if openshell --version >/dev/null 2>&1; then
 fi
 pass "Pre-cleanup complete"
 
-if [ -z "${NEMOCLAW_SKIP_TELEGRAM_REACHABILITY:-}" ]; then
-  if ! curl -fsS --max-time 10 https://api.telegram.org/ >/dev/null 2>&1; then
-    export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
-    info "Host cannot reach api.telegram.org; skipping onboarding Telegram reachability probe for fake-token E2E"
-  fi
-fi
+# Always skip the Telegram reachability probe in E2E: these tests use fake
+# tokens that fail the HTTP 401/404 check even when api.telegram.org is
+# reachable, causing onboard to silently drop the Telegram channel.
+export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
 
 # Pre-merge Slack policy into the base sandbox policy.
 #

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -150,6 +150,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+is_fake_telegram_token() {
+  case "${1:-}" in
+    *fake*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # ── Phase 0: Install NemoClaw with token A ────────────────────────
 
 section "Phase 0: Install NemoClaw and first onboard with token A"
@@ -158,10 +165,13 @@ section "Phase 0: Install NemoClaw and first onboard with token A"
 openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 
-# Always skip the Telegram reachability probe in E2E: fake tokens trigger
-# HTTP 401/404 which the new probe treats as "skip Telegram", breaking the
-# test even when api.telegram.org is reachable.
-export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+if [ -z "${NEMOCLAW_SKIP_TELEGRAM_REACHABILITY:-}" ] \
+  && { is_fake_telegram_token "$TELEGRAM_BOT_TOKEN_A" || is_fake_telegram_token "$TELEGRAM_BOT_TOKEN_B"; }; then
+  # This E2E normally uses fake tokens to exercise rotation plumbing, not the
+  # live Telegram API. Remove once onboard has a hermetic fake Telegram API.
+  export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+  info "Skipping onboarding Telegram reachability probe for fake-token E2E"
+fi
 
 export TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN_A"
 export DISCORD_BOT_TOKEN="$DISCORD_BOT_TOKEN_A"

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -158,6 +158,11 @@ section "Phase 0: Install NemoClaw and first onboard with token A"
 openshell sandbox delete "$SANDBOX_NAME" 2>/dev/null || true
 openshell gateway destroy -g nemoclaw 2>/dev/null || true
 
+# Always skip the Telegram reachability probe in E2E: fake tokens trigger
+# HTTP 401/404 which the new probe treats as "skip Telegram", breaking the
+# test even when api.telegram.org is reachable.
+export NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1
+
 export TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN_A"
 export DISCORD_BOT_TOKEN="$DISCORD_BOT_TOKEN_A"
 export SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN_A"


### PR DESCRIPTION
## Summary

Fixes #4556

Three nightly E2E jobs (`messaging-providers-e2e`, `channels-stop-start-e2e`,
`token-rotation-e2e`) failed in [run 26668952264](https://github.com/NVIDIA/NemoClaw/actions/runs/26668952264)
because commit b13e4f4 introduced `checkTelegramReachability()` which validates
the Telegram bot token via HTTP before onboarding.

The E2E scripts use **fake** tokens. On GitHub Actions runners
`api.telegram.org` is reachable, so the existing conditional guard
(`if ! curl … api.telegram.org`) never fires. The new probe sends the fake
token, receives HTTP 401, and silently drops Telegram from onboard —
breaking every assertion that expects Telegram to be configured.

### Root cause

| File | Issue |
|---|---|
| `src/lib/onboard/telegram-reachability.ts` (line 65-69) | HTTP 401/404 → `{skipped: true}` removes Telegram from `found` channels |
| `src/lib/onboard.ts` (`setupMessagingChannels`) | Filters Telegram out of `found` when `reachability.skipped` is true |
| `test/e2e/test-messaging-providers.sh` (line 567-572) | Guard checks host reachability, not token validity |
| `test/e2e/test-channels-stop-start.sh` (line 422-427) | Same guard pattern |
| `test/e2e/test-token-rotation.sh` | No guard at all |

### Fix

Export `NEMOCLAW_SKIP_TELEGRAM_REACHABILITY=1` unconditionally in all three
test scripts so the probe is always bypassed when running with fake tokens.
This is the correct layer: the workflow YAML already passes fake tokens as
env vars, and the scripts know they are running with fake credentials.

## Changes

- `test/e2e/test-messaging-providers.sh` — replace conditional
  curl-reachability check with unconditional export
- `test/e2e/test-channels-stop-start.sh` — same
- `test/e2e/test-token-rotation.sh` — add unconditional export before
  first token assignment

## Validation

> **Note:** The automation token lacks `actions:write` / `workflows` scope,
> so a validation `workflow_dispatch` could not be triggered automatically.
> A maintainer should trigger:
> ```
> gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw \
>   --ref fix/nightly-e2e-telegram-probe-fake-token-a5e7e63 \
>   -f jobs="messaging-providers-e2e,channels-stop-start-e2e,token-rotation-e2e"
> ```

## Test plan

- [ ] Trigger `nightly-e2e.yaml` on this branch with the three affected jobs
- [ ] Verify `messaging-providers-e2e` passes (Telegram channel configured)
- [ ] Verify `channels-stop-start-e2e` passes (Telegram stop/start works)
- [ ] Verify `token-rotation-e2e` passes (Telegram token rotation detected)
- [ ] Confirm no regressions in unrelated nightly jobs

Signed-off-by: Hung Le <hple@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E test setups now skip the Telegram reachability probe only when configured tokens appear to be fake, avoiding network-dependent failures for fake-token runs.
  * Removed reliance on an external host-reachability check, making test behavior deterministic for fake-token scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->