### PR TITLE
fix(inference): redirect bare `inference set` to openshell

### DIFF
--- a/src/commands/inference/set.ts
+++ b/src/commands/inference/set.ts
@@ -3,7 +3,7 @@
 
 import { Flags } from "@oclif/core";
 
-function requiredNonEmptyFlag(description: string) {
+function nonEmptyFlag(description: string) {
   return Flags.string({
     description,
     parse: async (input: string) => {
@@ -11,7 +11,6 @@ function requiredNonEmptyFlag(description: string) {
       if (!trimmed) throw new Error(`${description} cannot be empty`);
       return trimmed;
     },
-    required: true,
   });
 }
 
@@ -19,6 +18,7 @@ import {
   InferenceSetError,
   runInferenceSet,
 } from "../../lib/actions/inference-set";
+import { CLI_NAME } from "../../lib/cli/branding";
 import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 
 export default class InferenceSetCommand extends NemoClawCommand {
@@ -35,8 +35,8 @@ export default class InferenceSetCommand extends NemoClawCommand {
     "<%= config.bin %> inference set --provider openai-api --model gpt-5.4 --sandbox my-assistant",
   ];
   static flags = {
-    provider: requiredNonEmptyFlag("OpenShell inference provider name"),
-    model: requiredNonEmptyFlag("Model id to route through the selected provider"),
+    provider: nonEmptyFlag("OpenShell inference provider name"),
+    model: nonEmptyFlag("Model id to route through the selected provider"),
     sandbox: Flags.string({
       description:
         "Registered sandbox to sync; defaults to the NemoClaw default sandbox or the unambiguous Hermes sandbox under nemohermes",
@@ -48,6 +48,10 @@ export default class InferenceSetCommand extends NemoClawCommand {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(InferenceSetCommand);
+    if (!flags.provider || !flags.model) {
+      this.printOpenShellRedirect();
+      return;
+    }
     try {
       await runInferenceSet({
         provider: flags.provider,
@@ -62,5 +66,20 @@ export default class InferenceSetCommand extends NemoClawCommand {
       }
       throw error;
     }
+  }
+
+  private printOpenShellRedirect(): void {
+    this.failWithLines(
+      [
+        `  Unknown ${CLI_NAME} command: inference set`,
+        "",
+        "  This operation belongs to OpenShell.",
+        "  Run: openshell inference set -g nemoclaw --model <model> --provider <provider>",
+        `  To also sync the running sandbox config, pass --provider and --model to ${CLI_NAME} inference set.`,
+        "",
+        `  Run '${CLI_NAME} help' for NemoClaw commands.`,
+      ],
+      1,
+    );
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -472,17 +472,23 @@ describe("CLI dispatch", () => {
     expect(gateway.out).not.toContain("Try: nemoclaw <sandbox-name> connect");
   });
 
-  it("redirects bare `inference set` to openshell instead of leaking oclif validation errors (#4544)", () => {
-    const r = run("inference set 2>&1");
-    expect(r.code).toBe(1);
-    expect(r.out).toContain("Unknown nemoclaw command: inference set");
-    expect(r.out).toContain("This operation belongs to OpenShell.");
-    expect(r.out).toContain(
-      "Run: openshell inference set -g nemoclaw --model <model> --provider <provider>",
-    );
-    expect(r.out).not.toContain("Missing required flag");
-    expect(r.out).not.toContain("FailedFlagValidationError");
-    expect(r.out).not.toContain("node_modules/@oclif/core");
+  it("redirects `inference set` to openshell when provider or model is missing", () => {
+    for (const argv of [
+      "inference set 2>&1",
+      "inference set --provider nvidia-prod 2>&1",
+      "inference set --model nvidia/model 2>&1",
+    ]) {
+      const r = run(argv);
+      expect(r.code, `nemoclaw ${argv}`).toBe(1);
+      expect(r.out, `nemoclaw ${argv}`).toContain("Unknown nemoclaw command: inference set");
+      expect(r.out, `nemoclaw ${argv}`).toContain("This operation belongs to OpenShell.");
+      expect(r.out, `nemoclaw ${argv}`).toContain(
+        "Run: openshell inference set -g nemoclaw --model <model> --provider <provider>",
+      );
+      expect(r.out, `nemoclaw ${argv}`).not.toContain("Missing required flag");
+      expect(r.out, `nemoclaw ${argv}`).not.toContain("FailedFlagValidationError");
+      expect(r.out, `nemoclaw ${argv}`).not.toContain("node_modules/@oclif/core");
+    }
 
     let hermesOut = "";
     let hermesCode = 0;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -472,11 +472,15 @@ describe("CLI dispatch", () => {
     expect(gateway.out).not.toContain("Try: nemoclaw <sandbox-name> connect");
   });
 
-  it("prints oclif validation failures without stack traces", () => {
+  it("redirects bare `inference set` to openshell instead of leaking oclif validation errors (#4544)", () => {
     const r = run("inference set 2>&1");
-    expect(r.code).toBe(2);
-    expect(r.out).toContain("Missing required flag model");
-    expect(r.out).toContain("Missing required flag provider");
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Unknown nemoclaw command: inference set");
+    expect(r.out).toContain("This operation belongs to OpenShell.");
+    expect(r.out).toContain(
+      "Run: openshell inference set -g nemoclaw --model <model> --provider <provider>",
+    );
+    expect(r.out).not.toContain("Missing required flag");
     expect(r.out).not.toContain("FailedFlagValidationError");
     expect(r.out).not.toContain("node_modules/@oclif/core");
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -483,6 +483,35 @@ describe("CLI dispatch", () => {
     expect(r.out).not.toContain("Missing required flag");
     expect(r.out).not.toContain("FailedFlagValidationError");
     expect(r.out).not.toContain("node_modules/@oclif/core");
+
+    let hermesOut = "";
+    let hermesCode = 0;
+    try {
+      hermesOut = execSync(`node "${HERMES_CLI}" inference set 2>&1`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+        timeout: execTimeout(),
+        env: { ...process.env, HOME: `/tmp/nemoclaw-cli-test-${Date.now()}` },
+      });
+    } catch (err) {
+      const result = readCliErrorOutput(
+        isCliErrorCandidate(err)
+          ? {
+              status: typeof err.status === "number" ? err.status : undefined,
+              stdout: readBufferOrStringProperty(err, "stdout"),
+              stderr: readBufferOrStringProperty(err, "stderr"),
+            }
+          : String(err),
+      );
+      hermesOut = result.out;
+      hermesCode = result.code;
+    }
+    expect(hermesCode).toBe(1);
+    expect(hermesOut).toContain("Unknown nemohermes command: inference set");
+    expect(hermesOut).toContain("This operation belongs to OpenShell.");
+    expect(hermesOut).toContain(
+      "Run: openshell inference set -g nemoclaw --model <model> --provider <provider>",
+    );
   });
 
   it("suggests list for a mistyped list command", () => {


### PR DESCRIPTION
## Summary
Bare `nemoclaw inference set` now redirects users to `openshell inference set` instead of emitting an oclif "Missing required flag" error, matching the existing UX contract used by `term`, `policy set`, and `gateway stop`. Passing both `--provider` and `--model` still drives the existing NemoClaw sandbox-sync orchestration.

## Related Issue
Fixes #4544.

## Changes
- `src/commands/inference/set.ts`: drop `required: true` from `--provider`/`--model`. When either is absent, short-circuit with the standard OpenShell-redirect message (exit 1) and mention that supplying both flags additionally runs NemoClaw's sandbox-sync step.
- `test/cli.test.ts`: rewrite the previous "oclif validation failures without stack traces" assertion to verify the new redirect surface; preserve the no-stack-trace / no-oclif-internals guard.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhanced Command Guidance**
  * The `inference set` command now fails gracefully when required parameters are missing, showing a clear multi-line message directing users to run the equivalent OpenShell command and how to sync sandbox config.

* **Improved Validation**
  * Provider and model inputs are validated to reject empty values (trimming applied).

* **Tests**
  * CLI tests updated to expect the new redirect message and exit behavior instead of prior flag-validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NemoClaw/pull/4566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

