### PR TITLE
fix(e2e): unset OPENCLAW_GATEWAY_PORT and TOKEN in devices approve guard

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1870,7 +1870,8 @@ openclaw() {
   # NemoClaw#4462: keep user-initiated device approval usable from an
   # interactive sandbox shell until upstream OpenClaw can approve scope
   # upgrades through the gateway without requesting the upgraded scopes for
-  # the approval command itself. Other commands keep OPENCLAW_GATEWAY_URL.
+  # the approval command itself. Approval calls temporarily drop the gateway
+  # URL/port/token; other commands keep the full gateway environment.
   if [ "${1:-}" = "devices" ] && [ "${2:-}" = "approve" ]; then
     ( unset OPENCLAW_GATEWAY_URL OPENCLAW_GATEWAY_PORT OPENCLAW_GATEWAY_TOKEN; command openclaw "$@" )
     return $?

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1869,7 +1869,7 @@ openclaw() {
   # upgrades through the gateway without requesting the upgraded scopes for
   # the approval command itself. Other commands keep OPENCLAW_GATEWAY_URL.
   if [ "${1:-}" = "devices" ] && [ "${2:-}" = "approve" ]; then
-    ( unset OPENCLAW_GATEWAY_URL; command openclaw "$@" )
+    ( unset OPENCLAW_GATEWAY_URL OPENCLAW_GATEWAY_PORT OPENCLAW_GATEWAY_TOKEN; command openclaw "$@" )
     return $?
   fi
   case "$1" in

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1536,18 +1536,21 @@ RUN_TIMEOUT_SECS = _env_seconds('NEMOCLAW_AUTO_PAIR_RUN_TIMEOUT_SECS', 10)
 # `openclaw devices approve <scope-upgrade>` can request the upgraded scopes
 # for its own connection and return the same pending-scope error it is trying
 # to resolve. List calls must stay gateway-pinned so we inspect the live
-# gateway, but approval calls temporarily remove OPENCLAW_GATEWAY_URL to use
-# OpenClaw's local pairing fallback. Remove this when OpenClaw approve can
-# complete scope upgrades through the gateway using only operator.pairing.
-def run(*args, strip_gateway_url=False):
+# gateway, but approval calls temporarily remove OPENCLAW_GATEWAY_URL,
+# OPENCLAW_GATEWAY_PORT, and OPENCLAW_GATEWAY_TOKEN to use OpenClaw's local
+# pairing fallback. Remove this when OpenClaw approve can complete scope
+# upgrades through the gateway using only operator.pairing.
+def run(*args, strip_gateway_env=False):
     # Bound every openclaw CLI invocation so a wedged child cannot pin
     # the watcher beyond DEADLINE (CodeRabbit #4292): subprocess.run with
     # no timeout would hold a hung `openclaw devices list/approve` past
     # the fast→slow transition and the 8h deadline check.
     env = None
-    if strip_gateway_url:
+    if strip_gateway_env:
         env = os.environ.copy()
         env.pop('OPENCLAW_GATEWAY_URL', None)
+        env.pop('OPENCLAW_GATEWAY_PORT', None)
+        env.pop('OPENCLAW_GATEWAY_TOKEN', None)
     try:
         proc = subprocess.run(
             args, capture_output=True, text=True, timeout=RUN_TIMEOUT_SECS, env=env,
@@ -1600,7 +1603,7 @@ while time.time() < DEADLINE:
                 print(f'[auto-pair] rejected unknown client={client_id} mode={client_mode}')
                 continue
             arc, aout, aerr = run(
-                OPENCLAW, 'devices', 'approve', request_id, '--json', strip_gateway_url=True,
+                OPENCLAW, 'devices', 'approve', request_id, '--json', strip_gateway_env=True,
             )
             # rc=124 is the timeout sentinel from run() — do NOT add the
             # request to HANDLED on a transient timeout, so the next poll

--- a/test/e2e/test-issue-4462-scope-upgrade-approval.sh
+++ b/test/e2e/test-issue-4462-scope-upgrade-approval.sh
@@ -742,7 +742,7 @@ fi
 . /tmp/nemoclaw-proxy-env.sh
 printf "OPENCLAW_GATEWAY_URL=%s\n" "${OPENCLAW_GATEWAY_URL-unset}"
 type openclaw 2>/dev/null | sed -n "1,12p"
-grep -F "unset OPENCLAW_GATEWAY_URL; command openclaw" /tmp/nemoclaw-proxy-env.sh >/dev/null \
+grep -F "unset OPENCLAW_GATEWAY_URL OPENCLAW_GATEWAY_PORT OPENCLAW_GATEWAY_TOKEN; command openclaw" /tmp/nemoclaw-proxy-env.sh >/dev/null \
   && echo "APPROVE_GUARD_PRESENT"
 ' 2>&1)
 guard_rc=$?

--- a/test/e2e/test-issue-4462-scope-upgrade-approval.sh
+++ b/test/e2e/test-issue-4462-scope-upgrade-approval.sh
@@ -374,26 +374,53 @@ approve_request() {
   local request_id="$1"
   local label="$2"
   local allow_already_approved="${3:-0}"
-  local output rc approve_json approved_id before_url after_url state_after_approve approved_after_approve pending_after_approve
+  local output rc approve_json approved_id before_url before_port before_token after_url after_port after_token approve_env state_after_approve approved_after_approve pending_after_approve
   output=$(sandbox_exec_sh_script 90 '
-set -u
-request_id="$1"
-if [ ! -r /tmp/nemoclaw-proxy-env.sh ]; then
-  echo "missing /tmp/nemoclaw-proxy-env.sh" >&2
-  exit 2
-fi
-# shellcheck source=/dev/null
-. /tmp/nemoclaw-proxy-env.sh
-printf "__URL_BEFORE__=%s\n" "${OPENCLAW_GATEWAY_URL-unset}"
-set +e
-approve_output="$(openclaw devices approve "$request_id" --json 2>&1)"
-approve_rc=$?
-set -e
-printf "__APPROVE_RC__=%s\n" "$approve_rc"
-printf "__APPROVE_OUTPUT_BEGIN__\n%s\n__APPROVE_OUTPUT_END__\n" "$approve_output"
-printf "__URL_AFTER__=%s\n" "${OPENCLAW_GATEWAY_URL-unset}"
-exit "$approve_rc"
-' "$request_id" 2>&1)
+	set -u
+	request_id="$1"
+	real_openclaw="$(command -v openclaw || true)"
+	if [ -z "$real_openclaw" ]; then
+	  echo "missing real openclaw binary" >&2
+	  exit 2
+	fi
+	if [ ! -r /tmp/nemoclaw-proxy-env.sh ]; then
+	  echo "missing /tmp/nemoclaw-proxy-env.sh" >&2
+	  exit 2
+	fi
+	# shellcheck source=/dev/null
+	. /tmp/nemoclaw-proxy-env.sh
+	probe_dir="$(mktemp -d /tmp/nemoclaw-approve-env.XXXXXX)"
+	probe_log="$probe_dir/env.log"
+	cat >"$probe_dir/openclaw" <<'"'"'PROBESH'"'"'
+#!/bin/sh
+token_state="$([ "${OPENCLAW_GATEWAY_TOKEN+x}" = x ] && printf set || printf unset)"
+printf "__APPROVE_SUBPROCESS_ENV__=%s:%s:%s\n" "${OPENCLAW_GATEWAY_URL-unset}" "${OPENCLAW_GATEWAY_PORT-unset}" "$token_state" >>"$NEMOCLAW_4462_APPROVE_ENV_LOG"
+exec "$NEMOCLAW_4462_REAL_OPENCLAW" "$@"
+PROBESH
+	chmod +x "$probe_dir/openclaw"
+	export NEMOCLAW_4462_REAL_OPENCLAW="$real_openclaw"
+	export NEMOCLAW_4462_APPROVE_ENV_LOG="$probe_log"
+	PATH="$probe_dir:$PATH"
+	printf "__URL_BEFORE__=%s\n" "${OPENCLAW_GATEWAY_URL-unset}"
+	printf "__PORT_BEFORE__=%s\n" "${OPENCLAW_GATEWAY_PORT-unset}"
+	printf "__TOKEN_BEFORE__=%s\n" "$([ "${OPENCLAW_GATEWAY_TOKEN+x}" = x ] && printf set || printf unset)"
+	set +e
+	approve_output="$(openclaw devices approve "$request_id" --json 2>&1)"
+	approve_rc=$?
+	set -e
+	printf "__APPROVE_RC__=%s\n" "$approve_rc"
+	printf "__APPROVE_OUTPUT_BEGIN__\n%s\n__APPROVE_OUTPUT_END__\n" "$approve_output"
+	if [ -r "$probe_log" ]; then
+	  cat "$probe_log"
+	else
+	  printf "__APPROVE_SUBPROCESS_ENV__=missing:missing:missing\n"
+	fi
+	printf "__URL_AFTER__=%s\n" "${OPENCLAW_GATEWAY_URL-unset}"
+	printf "__PORT_AFTER__=%s\n" "${OPENCLAW_GATEWAY_PORT-unset}"
+	printf "__TOKEN_AFTER__=%s\n" "$([ "${OPENCLAW_GATEWAY_TOKEN+x}" = x ] && printf set || printf unset)"
+	rm -rf "$probe_dir"
+	exit "$approve_rc"
+	' "$request_id" 2>&1)
   rc=$?
   {
     printf '=== approve %s request=%s rc=%s ===\n' "$label" "$request_id" "$rc"
@@ -416,13 +443,30 @@ exit "$approve_rc"
     return 1
   fi
   before_url=$(sed -n 's/^__URL_BEFORE__=//p' <<<"$output" | tail -1)
+  before_port=$(sed -n 's/^__PORT_BEFORE__=//p' <<<"$output" | tail -1)
+  before_token=$(sed -n 's/^__TOKEN_BEFORE__=//p' <<<"$output" | tail -1)
   after_url=$(sed -n 's/^__URL_AFTER__=//p' <<<"$output" | tail -1)
+  after_port=$(sed -n 's/^__PORT_AFTER__=//p' <<<"$output" | tail -1)
+  after_token=$(sed -n 's/^__TOKEN_AFTER__=//p' <<<"$output" | tail -1)
+  approve_env=$(sed -n 's/^__APPROVE_SUBPROCESS_ENV__=//p' <<<"$output" | tail -1)
   if [[ "$before_url" != ws://127.0.0.1:* ]] && [[ "$before_url" != ws://localhost:* ]]; then
     fail "${label}: proxy env did not expose a loopback OPENCLAW_GATEWAY_URL before approve (${before_url:-empty})"
     return 1
   fi
+  if [ -z "$before_port" ] || [ "$before_port" = "unset" ] || [ "$before_token" != "set" ]; then
+    fail "${label}: proxy env did not expose OPENCLAW_GATEWAY_PORT/TOKEN before approve (port=${before_port:-empty} token_state=${before_token:-empty})"
+    return 1
+  fi
   if [ "$after_url" != "$before_url" ]; then
     fail "${label}: devices approve leaked OPENCLAW_GATEWAY_URL mutation into caller shell (${before_url} -> ${after_url})"
+    return 1
+  fi
+  if [ "$after_port" != "$before_port" ] || [ "$after_token" != "$before_token" ]; then
+    fail "${label}: devices approve leaked gateway port/token mutation into caller shell (port ${before_port} -> ${after_port}; token changed=$([ "$after_token" != "$before_token" ] && printf yes || printf no))"
+    return 1
+  fi
+  if [ "$approve_env" != "unset:unset:unset" ]; then
+    fail "${label}: devices approve subprocess retained gateway env (${approve_env:-empty})"
     return 1
   fi
   approve_json=$(sed -n '/^__APPROVE_OUTPUT_BEGIN__$/,/^__APPROVE_OUTPUT_END__$/p' <<<"$output" | sed '1d;$d' | extract_json_doc 2>/dev/null) || approve_json=""

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -1469,7 +1469,7 @@ describe("nemoclaw-start auto-pair client whitelisting (#117)", () => {
       `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
-  printf 'list:%s\n' "\${OPENCLAW_GATEWAY_URL-unset}" >> ${JSON.stringify(envLog)}
+  printf 'list:%s:%s:%s\n' "\${OPENCLAW_GATEWAY_URL-unset}" "\${OPENCLAW_GATEWAY_PORT-unset}" "\${OPENCLAW_GATEWAY_TOKEN-unset}" >> ${JSON.stringify(envLog)}
   count="$(cat ${JSON.stringify(stateFile)} 2>/dev/null || echo 0)"
   count=$((count + 1))
   echo "$count" > ${JSON.stringify(stateFile)}
@@ -1481,7 +1481,7 @@ if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "list" ]; then
   exit 0
 fi
 if [ "\${1:-}" = "devices" ] && [ "\${2:-}" = "approve" ]; then
-  printf 'approve:%s:%s\n' "$3" "\${OPENCLAW_GATEWAY_URL-unset}" >> ${JSON.stringify(envLog)}
+  printf 'approve:%s:%s:%s:%s\n' "$3" "\${OPENCLAW_GATEWAY_URL-unset}" "\${OPENCLAW_GATEWAY_PORT-unset}" "\${OPENCLAW_GATEWAY_TOKEN-unset}" >> ${JSON.stringify(envLog)}
   echo "$3" >> ${JSON.stringify(approveLog)}
   printf '{}\n'
   exit 0
@@ -1504,6 +1504,8 @@ exit 2
           ...process.env,
           OPENCLAW_BIN: fakeOpenclaw,
           OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_GATEWAY_TOKEN: "test-gateway-token",
           // Cap the slow-mode keepalive (NemoClaw#4263) so the test
           // terminates without waiting out the default 8h deadline.
           NEMOCLAW_AUTO_PAIR_DEADLINE_SECS: "5",
@@ -1525,9 +1527,9 @@ exit 2
         "ok-webchat",
       ]);
       const envLogLines = fs.readFileSync(envLog, "utf-8").trim().split("\n");
-      expect(envLogLines).toContain("list:ws://127.0.0.1:18789");
-      expect(envLogLines).toContain("approve:ok-browser:unset");
-      expect(envLogLines).toContain("approve:ok-webchat:unset");
+      expect(envLogLines).toContain("list:ws://127.0.0.1:18789:18789:test-gateway-token");
+      expect(envLogLines).toContain("approve:ok-browser:unset:unset:unset");
+      expect(envLogLines).toContain("approve:ok-webchat:unset:unset:unset");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -805,7 +805,7 @@ describe("nemoclaw-start configure guard behavior", () => {
     fs.mkdirSync(fakeBin);
     fs.writeFileSync(
       path.join(fakeBin, "openclaw"),
-      `#!/usr/bin/env bash\nprintf 'ARGS=%s URL=%s\\n' "$*" "\${OPENCLAW_GATEWAY_URL-unset}" >> ${JSON.stringify(commandLog)}\nexit 0\n`,
+      `#!/usr/bin/env bash\nprintf 'ARGS=%s URL=%s PORT=%s TOKEN=%s\\n' "$*" "\${OPENCLAW_GATEWAY_URL-unset}" "\${OPENCLAW_GATEWAY_PORT-unset}" "\${OPENCLAW_GATEWAY_TOKEN-unset}" >> ${JSON.stringify(commandLog)}\nexit 0\n`,
       { mode: 0o755 },
     );
     const runtimeBlock = `${runtimeShellEnvBlock(src)}\nwrite_runtime_shell_env`.replaceAll(
@@ -827,6 +827,8 @@ describe("nemoclaw-start configure guard behavior", () => {
       '_CIAO_GUARD_SCRIPT="/tmp/ciao-guard.js"',
       '_SLACK_GUARD_SCRIPT="/nonexistent/slack-guard.js"',
       'export OPENCLAW_GATEWAY_URL="ws://127.0.0.1:18789"',
+      'export OPENCLAW_GATEWAY_PORT="18789"',
+      'export OPENCLAW_GATEWAY_TOKEN="test-gateway-token"',
       "_TOOL_REDIRECTS=()",
       "set +u",
       runtimeBlock,
@@ -904,7 +906,7 @@ describe("nemoclaw-start configure guard behavior", () => {
     }
   });
 
-  it("#4462: unsets OPENCLAW_GATEWAY_URL only for devices approve", () => {
+  it("#4462: unsets OPENCLAW_GATEWAY_URL, PORT, and TOKEN for devices approve", () => {
     const setup = writeProxyEnvWithGuard();
     try {
       const result = runGuardedShell(setup, [
@@ -916,10 +918,10 @@ describe("nemoclaw-start configure guard behavior", () => {
 
       expect(result.status).toBe(0);
       expect(fs.readFileSync(setup.commandLog, "utf-8").trim().split("\n")).toEqual([
-        "ARGS=devices list --json URL=ws://127.0.0.1:18789",
-        "ARGS=devices approve request-1 --json URL=unset",
+        "ARGS=devices list --json URL=ws://127.0.0.1:18789 PORT=18789 TOKEN=test-gateway-token",
+        "ARGS=devices approve request-1 --json URL=unset PORT=unset TOKEN=unset",
         "SHELL_URL=ws://127.0.0.1:18789",
-        "ARGS=agent --agent main -m hello URL=ws://127.0.0.1:18789",
+        "ARGS=agent --agent main -m hello URL=ws://127.0.0.1:18789 PORT=18789 TOKEN=test-gateway-token",
       ]);
     } finally {
       fs.rmSync(setup.tmpDir, { recursive: true, force: true });

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -790,7 +790,7 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("TOKEN=unset");
     expect(result.stderr).not.toContain("#token=");
-    expect(envFile).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(envFile).not.toMatch(/^export OPENCLAW_GATEWAY_TOKEN=/m);
   });
 });
 


### PR DESCRIPTION
## Summary

**[Agent-generated issue]**

The `issue-4462-scope-upgrade-approval-e2e / run` job in nightly run [#26698759656](https://github.com/NVIDIA/NemoClaw/actions/runs/26698759656) failed because the `openclaw devices approve` guard function in the sandbox proxy env only unset `OPENCLAW_GATEWAY_URL`, leaving `OPENCLAW_GATEWAY_PORT` and `OPENCLAW_GATEWAY_TOKEN` in the environment. The OpenClaw CLI falls back to the port-based gateway URL, causing the approval to route through the gateway and fail with `GatewayClientRequestError: scope upgrade pending approval`.

### Changes

- **`scripts/nemoclaw-start.sh`**: Unset all three gateway env vars (`OPENCLAW_GATEWAY_URL`, `OPENCLAW_GATEWAY_PORT`, `OPENCLAW_GATEWAY_TOKEN`) in the `devices approve` guard subshell.
- **`test/nemoclaw-start.test.ts`**: Update the fake `openclaw` stub to log PORT and TOKEN alongside URL; add `OPENCLAW_GATEWAY_PORT` and `OPENCLAW_GATEWAY_TOKEN` to the test env; update assertions to verify all three are `unset` for `devices approve` while remaining set for other commands.

### Root Cause

The #4462 guard (line 1872 of `nemoclaw-start.sh`) runs `openclaw devices approve` in a subshell that unsets only `OPENCLAW_GATEWAY_URL`. The sandbox proxy env also exports `OPENCLAW_GATEWAY_PORT` (line 264) and `OPENCLAW_GATEWAY_TOKEN` (line 1351). When the OpenClaw CLI resolves the gateway URL, it can fall back to `OPENCLAW_GATEWAY_PORT`, reconnecting to the gateway and hitting the scope-upgrade Catch-22: the approve command itself requires the upgraded scope.

### Validation

The `GITHUB_TOKEN` used by this CI run does not include the `workflow` scope, so the `-custom-e2e` validation branch could not be pushed. To validate manually:

```bash
gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw \
  --ref fix/nightly-e2e-gateway-env-approve-guard-a25b393 \
  -f jobs=issue-4462-scope-upgrade-approval-e2e
```

- Original failing run: [#26698759656](https://github.com/NVIDIA/NemoClaw/actions/runs/26698759656) on `a25b3931`

Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the devices approval flow fully clears gateway URL, port, and token in both the auto-pair watcher and the interactive shell wrapper before delegating to the real command.

* **Tests**
  * Tightened and expanded end-to-end and unit tests to assert gateway URL/port/token are present for listing/agent calls but are unset during approval, and to validate the approval subprocess observes the expected unset state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->