### PR TITLE
fix(policy): report custom presets that cannot be recorded locally

### DIFF
--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -833,6 +833,20 @@ function applyPresetContent(
       }
       registry.updateSandbox(sandboxName, { policies: pols });
     }
+  } else if (options.custom) {
+    // The preset reached the gateway, but sandbox `sandboxName` has no local
+    // registry entry, so it cannot be recorded under `customPolicies`. Custom
+    // presets are surfaced only from the registry (both `listCustomPresets`
+    // and `getGatewayPresets` read `registry.getCustomPolicies`), so an
+    // unrecorded custom preset never appears in `policy-list` or `status`.
+    // Report the gap instead of exiting 0 as if the preset were fully applied. (#4510)
+    console.error(
+      `  Warning: '${presetName}' was applied to the gateway but could not be ` +
+        `recorded locally because sandbox '${sandboxName}' is not in the ` +
+        `registry, so it will not appear in policy-list or status. Recover or ` +
+        `re-onboard the sandbox, then re-apply.`,
+    );
+    return false;
   }
 
   return true;

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1033,6 +1033,105 @@ exit 1
     });
   });
 
+  describe("issue 4510: policy-add --from-file false success when the sandbox is absent from the registry", () => {
+    const registryModule = requireForTest(
+      path.join(REPO_ROOT, "dist", "lib", "state", "registry.js"),
+    ) as Record<string, any>;
+    const CUSTOM_CONTENT = "network_policies:\n  slack-files-upload:\n    host: files.slack.com\n";
+    const SOURCE_PATH = "/tmp/slack-files-upload-case.yaml";
+
+    let tmpHome: string;
+    let fakeOpenshell: string;
+    let origHome: string | undefined;
+    let resolveSpy: ReturnType<typeof vi.spyOn>;
+    let savedGetSandbox: any;
+    let savedAddCustomPolicy: any;
+
+    beforeEach(() => {
+      tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-issue4510-"));
+      const localBin = path.join(tmpHome, ".local", "bin");
+      fs.mkdirSync(localBin, { recursive: true });
+      fakeOpenshell = path.join(localBin, "openshell");
+      fs.writeFileSync(fakeOpenshell, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      origHome = process.env.HOME;
+      process.env.HOME = tmpHome;
+      resolveSpy = vi
+        .spyOn(resolveOpenshellModule, "resolveOpenshell")
+        .mockReturnValue(fakeOpenshell);
+      savedGetSandbox = registryModule.getSandbox;
+      savedAddCustomPolicy = registryModule.addCustomPolicy;
+    });
+
+    afterEach(() => {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      resolveSpy.mockRestore();
+      registryModule.getSandbox = savedGetSandbox;
+      registryModule.addCustomPolicy = savedAddCustomPolicy;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    it("returns false and warns when a custom preset cannot be recorded locally", () => {
+      // Sandbox is Ready on the gateway but missing from the local registry
+      // (e.g. after stale-registry pruning), so addCustomPolicy cannot persist.
+      registryModule.getSandbox = () => null;
+      const addSpy = vi.fn(() => false);
+      registryModule.addCustomPolicy = addSpy;
+      const errors: string[] = [];
+      const errSpy = vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+        errors.push(a.map((x) => String(x)).join(" "));
+      });
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      try {
+        const result = policies.applyPresetContent(
+          "my-assistant",
+          "slack-files-upload",
+          CUSTOM_CONTENT,
+          { custom: { sourcePath: SOURCE_PATH } },
+        );
+        // Pre-fix this returned true (silent exit 0) while policy-list/status
+        // never showed the preset. The command must not claim success.
+        expect(result).toBe(false);
+        expect(addSpy).not.toHaveBeenCalled();
+        const combined = errors.join("\n");
+        expect(combined).toContain("my-assistant");
+        expect(combined).toMatch(/could not be\s+recorded locally/);
+        expect(combined).toMatch(/policy-list or status/);
+      } finally {
+        errSpy.mockRestore();
+        logSpy.mockRestore();
+      }
+    });
+
+    it("records the custom preset and returns true when the sandbox is registered", () => {
+      registryModule.getSandbox = (name: string) => ({ name });
+      const addSpy = vi.fn(() => true);
+      registryModule.addCustomPolicy = addSpy;
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        const result = policies.applyPresetContent(
+          "my-assistant",
+          "slack-files-upload",
+          CUSTOM_CONTENT,
+          { custom: { sourcePath: SOURCE_PATH } },
+        );
+        expect(result).toBe(true);
+        expect(addSpy).toHaveBeenCalledWith(
+          "my-assistant",
+          expect.objectContaining({
+            name: "slack-files-upload",
+            content: CUSTOM_CONTENT,
+            sourcePath: SOURCE_PATH,
+          }),
+        );
+      } finally {
+        logSpy.mockRestore();
+        errSpy.mockRestore();
+      }
+    });
+  });
+
   describe("extractPresetEntries", () => {
     it("returns null for null input", () => {
       expect(policies.extractPresetEntries(null)).toBe(null);


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> policy-add --from-file <preset>` applies a custom preset to the gateway and exits 0, but the preset never appears in `policy-list` or `status`. `applyPresetContent` records a custom preset under the sandbox's `customPolicies` only when the sandbox has a local registry entry, yet it returns `true` regardless, so a sandbox that is missing from the registry produces a silent success with nothing recorded.

## Related Issue

Fixes #4510

## Changes

- `applyPresetContent` (`src/lib/policy/index.ts`) now returns `false` and warns when a custom preset reaches the gateway but cannot be recorded locally because the sandbox has no registry entry. `policy-add --from-file` already exits non-zero on a `false` result, so the command no longer reports success for a preset that `policy-list` and `status` cannot display.
- The built-in preset path is unchanged: built-in presets are matched against the live gateway by name (`getGatewayPresets` iterates `listPresets()`), so they stay visible without a registry entry; only custom presets depend on the registry record (`listCustomPresets` and `getGatewayPresets` read `registry.getCustomPolicies`).
- Added regression coverage in `test/policies.test.ts` for the unrecorded case (returns `false`, warns) and the registered-sandbox case (records the preset, returns `true`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

Ran `npm run build:cli`, `npm run typecheck:cli`, `npx @biomejs/biome lint`, and the `policies` and `sandbox/policy` vitest suites (157 passing, including the new regression tests, which fail before the change and pass after).

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for custom preset application: now correctly detects and warns when a preset is applied to the gateway but cannot be recorded locally, with guidance for users to verify their policies.

* **Tests**
  * Added regression tests for custom preset recording when target sandbox is missing from the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->