### PR TITLE
fix(status): preserve registry on missing live sandbox

### DIFF
--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -14,7 +14,6 @@ import {
 import * as agentRuntime from "../../agent/runtime";
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
 import { D, G, R, RD, YW } from "../../cli/terminal-style";
-import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import { parseGatewayInference } from "../../inference/config";
 import {
   type ProviderHealthProbeOptions,
@@ -25,8 +24,6 @@ import * as nim from "../../inference/nim";
 import * as sandboxVersion from "../../sandbox/version";
 import * as shields from "../../shields";
 import { parseSandboxPhase } from "../../state/gateway";
-import type { Session } from "../../state/onboard-session";
-import * as onboardSession from "../../state/onboard-session";
 import * as registry from "../../state/registry";
 import {
   createSystemDeps as createSessionDeps,
@@ -239,6 +236,29 @@ async function printGatewayFailureLayerHeader(sandboxName: string): Promise<void
   console.log(`  ${getLayerHeader(failure.layer)}`);
 }
 
+function printMissingLiveSandboxStatusGuidance(
+  sandboxName: string,
+  lookup: SandboxGatewayState,
+): void {
+  console.log("");
+  console.log(
+    `  Sandbox '${sandboxName}' is registered locally, but is not present in the live OpenShell gateway.`,
+  );
+  if (lookup.recoveredGateway) {
+    const via = lookup.recoveryVia ? ` via ${lookup.recoveryVia}` : "";
+    console.log(
+      `  The ${CLI_DISPLAY_NAME} gateway was just recovered${via}; it may still be reconciling post-restart sandbox state.`,
+    );
+  }
+  console.log("  No local registry entry was removed by this status check.");
+  console.log(
+    `  Retry \`${CLI_NAME} ${sandboxName} status\` after the gateway finishes reconnecting.`,
+  );
+  console.log(
+    `  If the sandbox was intentionally deleted, run \`${CLI_NAME} list\` to inspect the remaining sandboxes or \`${CLI_NAME} onboard\` to create a new one.`,
+  );
+}
+
 // eslint-disable-next-line complexity
 export async function showSandboxStatus(sandboxName: string): Promise<void> {
   // #2666: never let an unexpected throw from the gateway probe (e.g. openshell
@@ -360,31 +380,7 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
     console.log(lookup.output);
     process.exit(1);
   } else if (lookup.state === "missing") {
-    // Belt-and-suspenders: only destroy registry state if the nemoclaw gateway
-    // is demonstrably the healthy active gateway. Guards against regressions
-    // in the reconciler.
-    const guard = getNamedGatewayLifecycleState();
-    if (guard.state !== "healthy_named") {
-      console.log("");
-      if (guard.state === "connected_other") {
-        printWrongGatewayActiveGuidance(sandboxName, guard.activeGateway, console.log);
-      } else {
-        await printGatewayFailureLayerHeader(sandboxName);
-        printGatewayLifecycleHint(guard.status || "", sandboxName, console.log);
-      }
-    } else {
-      registry.removeSandbox(sandboxName);
-      const session = onboardSession.loadSession();
-      if (session && session.sandboxName === sandboxName) {
-        onboardSession.updateSession((s: Session) => {
-          s.sandboxName = null;
-          return s;
-        });
-      }
-      console.log("");
-      console.log(`  Sandbox '${sandboxName}' is not present in the live OpenShell gateway.`);
-      console.log("  Removed stale local registry entry.");
-    }
+    printMissingLiveSandboxStatusGuidance(sandboxName, lookup);
     process.exit(1);
   } else if (lookup.state === "identity_drift") {
     console.log("");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -6063,7 +6063,7 @@ describe("CLI dispatch", () => {
     testTimeout(10_000),
   );
 
-  it("auto-cleans an orphan registry entry on status when the named gateway is healthy", () => {
+  it("preserves an orphan registry entry on passive status when the named gateway is healthy", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-status-orphan-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -6117,12 +6117,15 @@ describe("CLI dispatch", () => {
 
     expect(statusResult.code).toBe(1);
     expect(statusResult.out).not.toContain("Inference: healthy");
-    expect(statusResult.out).toContain("is not present in the live OpenShell gateway");
-    expect(statusResult.out).toContain("Removed stale local registry entry");
+    expect(statusResult.out).toContain(
+      "registered locally, but is not present in the live OpenShell gateway",
+    );
+    expect(statusResult.out).toContain("No local registry entry was removed");
+    expect(statusResult.out).not.toContain("Removed stale local registry entry");
 
     const saved = JSON.parse(fs.readFileSync(path.join(registryDir, "sandboxes.json"), "utf8"));
-    expect(saved.sandboxes.alpha).toBeUndefined();
-    expect(saved.defaultSandbox).toBeNull();
+    expect(saved.sandboxes.alpha).toBeDefined();
+    expect(saved.defaultSandbox).toBe("alpha");
   });
 });
 

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -315,10 +315,10 @@ describe("Scenario 1: connect — healthy nemoclaw active + sandbox NotFound tru
   });
 });
 
-// ─── Scenario 2 ─── destructive path preserved for `status` ────────────────
+// ─── Scenario 2 ─── passive `status` must preserve registry state ─────────
 describe("Scenario 2: status — healthy nemoclaw active + sandbox NotFound truly gone", () => {
   it(
-    "removes the registry entry, clears session, and logs removal (no exit 1)",
+    "reports the missing live sandbox without removing local registry state",
     { timeout: TIMEOUT_MS },
     () => {
       writeStubOpenshell({
@@ -331,18 +331,16 @@ describe("Scenario 2: status — healthy nemoclaw active + sandbox NotFound trul
 
       const r = runCli("status");
 
-      // status doesn't exit non-zero on a missing sandbox — it just logs.
+      assert.equal(r.status, 1, `expected exit 1, got ${r.status}`);
       assert.equal(
         registrySandboxPresent(r),
-        false,
-        `expected registry entry removed, got: ${JSON.stringify(r.registry)}`,
-      );
-      assert.equal(
-        r.sessionSandboxName === null || r.sessionSandboxName === undefined,
         true,
-        `expected session sandboxName cleared, got: ${r.sessionSandboxName}`,
+        `expected registry entry preserved, got: ${JSON.stringify(r.registry)}`,
       );
-      assert.match(r.stdout, /Removed stale local registry entry/);
+      assert.equal(r.sessionSandboxName, SANDBOX_NAME, "expected session sandboxName preserved");
+      assert.match(r.stdout, /registered locally, but is not present/);
+      assert.match(r.stdout, /No local registry entry was removed/);
+      assert.doesNotMatch(r.stdout, /Removed stale local registry entry/);
     },
   );
 });


### PR DESCRIPTION
## Summary
Addresses the destructive passive-status side effect from #4423. `nemoclaw <name> status` is now non-destructive when a sandbox is registered locally but missing from the live OpenShell gateway, preventing the first post-reboot status check on DGX Spark from deleting registry state before gateway reconciliation catches up.

This is the v0.0.56 safety mitigation only: it preserves local registry/onboard-session state and makes the failure explicit. The broader #4423 recovery goals remain open on the issue, including DGX Spark gateway auto-start after reboot and full post-reboot sandbox reconciliation/recovery.

## Related Issue
Partially addresses #4423.

## Changes
- Preserve registry and onboard-session state in the status-only missing-live-sandbox path.
- Print explicit guidance that status did not remove the entry and should be retried after gateway reconnection.
- Keep destructive stale-entry cleanup in active-use paths like `connect`, and update regression tests to lock that split.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Validation run:
- `npm run build:cli`
- `npx vitest run test/gateway-state-reconcile-2276.test.ts test/cli.test.ts` - 182 passed, 1 skipped
- `npx vitest run test/cli.test.ts -t "preserves an orphan registry entry"` - 1 passed
- `npx vitest run test/gateway-state-reconcile-2276.test.ts -t "reports the missing live sandbox"` - 1 passed

Advisor-selected E2E:
- Required `sandbox-operations-e2e` auto-dispatched by the E2E advisor against PR head `93dd87a67c876358d42ef399a083d86baf3dc5a0`: https://github.com/NVIDIA/NemoClaw/actions/runs/26715565554
- Required scenario E2E `ubuntu-repo-cloud-openclaw` dispatched against this branch: https://github.com/NVIDIA/NemoClaw/actions/runs/26715713730
- Optional adjacent `gateway-drift-preflight-e2e` regression dispatched against this branch: https://github.com/NVIDIA/NemoClaw/actions/runs/26715713787

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `status` command now preserves local sandbox registry entries when registered locally but missing from the gateway. Clear guidance is provided for recovery steps instead of automatic removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->