### PR TITLE
fix(onboard): cancel onboarding when `exit` is typed at numbered menus

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -339,6 +339,7 @@ const {
   exitOnboardFromPrompt,
   getNavigationChoice,
   isAffirmativeAnswer,
+  selectFromNumberedMenu,
   step,
   ...onboardPromptHelpers
 }: typeof import("./onboard/prompt-helpers") = require("./onboard/prompt-helpers");
@@ -4265,8 +4266,7 @@ async function setupNim(
         const defaultIdx =
           (envProviderIdx >= 0 ? envProviderIdx : options.findIndex((o) => o.key === "build")) + 1;
         const choice = await prompt(`  Choose [${defaultIdx}]: `);
-        const idx = parseInt(choice || String(defaultIdx), 10) - 1;
-        selected = options[idx] || options[defaultIdx - 1];
+        selected = selectFromNumberedMenu(choice, defaultIdx, options);
       }
 
       if (!selected) {
@@ -4742,8 +4742,7 @@ async function setupNim(
             console.log("");
 
             const modelChoice = await prompt(`  Choose model [1]: `);
-            const midx = parseInt(modelChoice || "1", 10) - 1;
-            sel = models[midx] || models[0];
+            sel = selectFromNumberedMenu(modelChoice, 1, models);
           }
           model = sel.name;
 
@@ -5818,9 +5817,7 @@ async function selectPolicyTier(): Promise<string> {
     const answer = await prompt(
       `  Select tier [1-${allTiers.length}] (default: ${allTiers.indexOf(defaultTier) + 1} ${defaultTier.name}): `,
     );
-    const idx =
-      answer.trim() === "" ? allTiers.indexOf(defaultTier) : parseInt(answer.trim(), 10) - 1;
-    const chosen = allTiers[idx] || defaultTier;
+    const chosen = selectFromNumberedMenu(answer, allTiers.indexOf(defaultTier) + 1, allTiers);
     console.log(`  Tier: ${chosen.label}`);
     return chosen.name;
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -339,7 +339,7 @@ const {
   exitOnboardFromPrompt,
   getNavigationChoice,
   isAffirmativeAnswer,
-  selectFromNumberedMenu,
+  selectFromNumberedMenuOrExit,
   step,
   ...onboardPromptHelpers
 }: typeof import("./onboard/prompt-helpers") = require("./onboard/prompt-helpers");
@@ -4266,7 +4266,7 @@ async function setupNim(
         const defaultIdx =
           (envProviderIdx >= 0 ? envProviderIdx : options.findIndex((o) => o.key === "build")) + 1;
         const choice = await prompt(`  Choose [${defaultIdx}]: `);
-        selected = selectFromNumberedMenu(choice, defaultIdx, options);
+        selected = selectFromNumberedMenuOrExit(choice, defaultIdx, options);
       }
 
       if (!selected) {
@@ -4742,7 +4742,7 @@ async function setupNim(
             console.log("");
 
             const modelChoice = await prompt(`  Choose model [1]: `);
-            sel = selectFromNumberedMenu(modelChoice, 1, models);
+            sel = selectFromNumberedMenuOrExit(modelChoice, 1, models);
           }
           model = sel.name;
 
@@ -5817,7 +5817,7 @@ async function selectPolicyTier(): Promise<string> {
     const answer = await prompt(
       `  Select tier [1-${allTiers.length}] (default: ${allTiers.indexOf(defaultTier) + 1} ${defaultTier.name}): `,
     );
-    const chosen = selectFromNumberedMenu(answer, allTiers.indexOf(defaultTier) + 1, allTiers);
+    const chosen = selectFromNumberedMenuOrExit(answer, allTiers.indexOf(defaultTier) + 1, allTiers);
     console.log(`  Tier: ${chosen.label}`);
     return chosen.name;
   }

--- a/src/lib/onboard/prompt-helpers.test.ts
+++ b/src/lib/onboard/prompt-helpers.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
 import {
   promptOrDefault,
-  selectFromNumberedMenu,
+  selectFromNumberedMenuOrExit,
 } from "../../../dist/lib/onboard/prompt-helpers";
 
 function makeDeps(promptReply: string) {
@@ -33,7 +33,7 @@ describe("promptOrDefault interactive default fallback (#4387)", () => {
   });
 });
 
-describe("selectFromNumberedMenu (#4514)", () => {
+describe("selectFromNumberedMenuOrExit (#4514)", () => {
   const options = [
     { key: "build", label: "NVIDIA Endpoints" },
     { key: "openai", label: "OpenAI" },
@@ -41,15 +41,15 @@ describe("selectFromNumberedMenu (#4514)", () => {
   ];
 
   it("returns the default option on bare Enter", () => {
-    expect(selectFromNumberedMenu("", 1, options)).toBe(options[0]);
+    expect(selectFromNumberedMenuOrExit("", 1, options)).toBe(options[0]);
   });
 
   it("returns the chosen option for a valid number", () => {
-    expect(selectFromNumberedMenu("2", 1, options)).toBe(options[1]);
+    expect(selectFromNumberedMenuOrExit("2", 1, options)).toBe(options[1]);
   });
 
   it("falls back to the default for an out-of-range number", () => {
-    expect(selectFromNumberedMenu("99", 1, options)).toBe(options[0]);
+    expect(selectFromNumberedMenuOrExit("99", 1, options)).toBe(options[0]);
   });
 
   it.each(["exit", "EXIT", "quit", "Quit", "  exit  "])(
@@ -60,7 +60,7 @@ describe("selectFromNumberedMenu (#4514)", () => {
       }) as never);
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
       try {
-        expect(() => selectFromNumberedMenu(reply, 1, options)).toThrow("process.exit(1)");
+        expect(() => selectFromNumberedMenuOrExit(reply, 1, options)).toThrow("process.exit(1)");
         expect(logSpy).toHaveBeenCalledWith("  Exiting onboarding.");
       } finally {
         exitSpy.mockRestore();
@@ -70,6 +70,21 @@ describe("selectFromNumberedMenu (#4514)", () => {
   );
 
   it("does not treat non-navigation words as exit", () => {
-    expect(selectFromNumberedMenu("3", 1, options)).toBe(options[2]);
+    expect(selectFromNumberedMenuOrExit("3", 1, options)).toBe(options[2]);
+  });
+
+  it("returns a valid falsy option instead of silently swapping to the default", () => {
+    const numericOptions = [0, 1, 2];
+    expect(selectFromNumberedMenuOrExit("1", 2, numericOptions)).toBe(0);
+  });
+
+  it("falls back to the default when the chosen index points to an undefined slot", () => {
+    const sparse: Array<string | undefined> = ["a", undefined, "c"];
+    expect(selectFromNumberedMenuOrExit("2", 1, sparse)).toBe(undefined);
+    expect(selectFromNumberedMenuOrExit("4", 1, sparse)).toBe("a");
+  });
+
+  it("treats `back` as non-navigation and falls back to the bracketed default", () => {
+    expect(selectFromNumberedMenuOrExit("back", 1, options)).toBe(options[0]);
   });
 });

--- a/src/lib/onboard/prompt-helpers.test.ts
+++ b/src/lib/onboard/prompt-helpers.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
-import { promptOrDefault } from "../../../dist/lib/onboard/prompt-helpers";
+import {
+  promptOrDefault,
+  selectFromNumberedMenu,
+} from "../../../dist/lib/onboard/prompt-helpers";
 
 function makeDeps(promptReply: string) {
   return {
@@ -27,5 +30,46 @@ describe("promptOrDefault interactive default fallback (#4387)", () => {
   it("returns the user's reply verbatim when non-empty", async () => {
     const deps = makeDeps("3");
     expect(await promptOrDefault(deps, "  Choose [6]: ", null, "6")).toBe("3");
+  });
+});
+
+describe("selectFromNumberedMenu (#4514)", () => {
+  const options = [
+    { key: "build", label: "NVIDIA Endpoints" },
+    { key: "openai", label: "OpenAI" },
+    { key: "custom", label: "Other OpenAI-compatible endpoint" },
+  ];
+
+  it("returns the default option on bare Enter", () => {
+    expect(selectFromNumberedMenu("", 1, options)).toBe(options[0]);
+  });
+
+  it("returns the chosen option for a valid number", () => {
+    expect(selectFromNumberedMenu("2", 1, options)).toBe(options[1]);
+  });
+
+  it("falls back to the default for an out-of-range number", () => {
+    expect(selectFromNumberedMenu("99", 1, options)).toBe(options[0]);
+  });
+
+  it.each(["exit", "EXIT", "quit", "Quit", "  exit  "])(
+    "cancels onboarding when the reply is %j",
+    (reply) => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${code})`);
+      }) as never);
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      try {
+        expect(() => selectFromNumberedMenu(reply, 1, options)).toThrow("process.exit(1)");
+        expect(logSpy).toHaveBeenCalledWith("  Exiting onboarding.");
+      } finally {
+        exitSpy.mockRestore();
+        logSpy.mockRestore();
+      }
+    },
+  );
+
+  it("does not treat non-navigation words as exit", () => {
+    expect(selectFromNumberedMenu("3", 1, options)).toBe(options[2]);
   });
 });

--- a/src/lib/onboard/prompt-helpers.ts
+++ b/src/lib/onboard/prompt-helpers.ts
@@ -29,7 +29,12 @@ export function isAffirmativeAnswer(value: string | null | undefined): boolean {
   );
 }
 
-export function selectFromNumberedMenu<T>(
+// Resolves a `Choose [N]:`-style menu reply for a one-based default index.
+// The exit / quit navigation tokens cancel onboarding here; other tokens
+// (including `back`) are not interpreted as navigation and fall back to the
+// bracketed default when the parsed index is out of range. Per-site `back`
+// semantics belong with the caller, not the helper.
+export function selectFromNumberedMenuOrExit<T>(
   rawChoice: string,
   defaultIdx: number,
   options: T[],
@@ -38,7 +43,8 @@ export function selectFromNumberedMenu<T>(
     exitOnboardFromPrompt();
   }
   const idx = Number.parseInt(rawChoice || String(defaultIdx), 10) - 1;
-  return options[idx] || options[defaultIdx - 1];
+  const fallback = options[defaultIdx - 1];
+  return idx >= 0 && idx < options.length ? options[idx] : fallback;
 }
 
 export interface PromptHelperDeps {

--- a/src/lib/onboard/prompt-helpers.ts
+++ b/src/lib/onboard/prompt-helpers.ts
@@ -29,6 +29,18 @@ export function isAffirmativeAnswer(value: string | null | undefined): boolean {
   );
 }
 
+export function selectFromNumberedMenu<T>(
+  rawChoice: string,
+  defaultIdx: number,
+  options: T[],
+): T {
+  if (getNavigationChoice(rawChoice) === "exit") {
+    exitOnboardFromPrompt();
+  }
+  const idx = Number.parseInt(rawChoice || String(defaultIdx), 10) - 1;
+  return options[idx] || options[defaultIdx - 1];
+}
+
 export interface PromptHelperDeps {
   isNonInteractive(): boolean;
   note(message: string): void;


### PR DESCRIPTION
## Summary

The inference provider menu, NIM model menu, and non-TTY policy tier menu all dispatched the reply through `parseInt(rawChoice || String(default), 10) - 1` with no navigation check first. Typing `exit` at any of them parses to `NaN`, falls through to the bracketed default, and the wizard silently advances as if the operator had pressed Enter. Other prompts in the same flow honour the documented `exit` / `quit` cancellation contract via `getNavigationChoice` + `exitOnboardFromPrompt`.

This PR extracts a single `selectFromNumberedMenu` helper in `src/lib/onboard/prompt-helpers.ts` that wraps the navigation check around the `parseInt`-with-default selection, and routes the three menu sites through it. `onboard.ts` shrinks by three lines on net.

## Related Issue

Fixes #4514.

## Changes

- `src/lib/onboard/prompt-helpers.ts`: add `selectFromNumberedMenu<T>(rawChoice, defaultIdx, options)` — runs `getNavigationChoice` → `exitOnboardFromPrompt()` on `exit` / `quit`, otherwise returns the parsed-index option (falling back to the bracketed default).
- `src/lib/onboard.ts`: replace the inline `parseInt` selection at the inference provider menu, the NIM model menu, and the non-TTY policy tier menu with `selectFromNumberedMenu`. The provider menu now honours the `exit` / `quit` contract advertised by the wizard.
- `src/lib/onboard/prompt-helpers.test.ts`: nine new cases pinning bare-Enter → default, valid number → option, out-of-range → default, every casing / whitespace variant of `exit` / `quit` / `EXIT` / `Quit` / `"  exit  "` → `process.exit(1)` with the `Exiting onboarding.` banner, and non-navigation words → numeric path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm run typecheck:cli` passes
- [x] `npm run build:cli` passes
- [x] `npx vitest run --project cli src/lib/onboard/prompt-helpers.test.ts test/onboard-selection.test.ts` — 87 / 87 pass
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized numbered-menu selection across onboarding flows by consolidating parsing and "exit" handling into a shared prompt helper for consistent behavior.

* **Tests**
  * Added thorough tests covering default selection, numeric choices, out-of-range fallback, exit/cancellation handling, and edge cases (falsy options, sparse arrays, and non-navigation inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->