### PR TITLE
docs: remove alpha software references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 NVIDIA NemoClaw is an open-source reference stack for running [OpenClaw](https://openclaw.ai) always-on assistants inside [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandboxes more safely. It provides CLI tooling, a blueprint for sandbox orchestration, and security hardening.
 
-**Status:** Active development. Interfaces may change without notice.
+Status: Active development. Interfaces may change without notice.
 
 ## Agent Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Project Overview
 
-NVIDIA NemoClaw is an open-source reference stack for running [OpenClaw](https://openclaw.ai) always-on assistants inside [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandboxes more safely. It provides CLI tooling, a blueprint for sandbox orchestration, and security hardening.
+NVIDIA NemoClaw is an open-source reference stack for running always-on AI agents such as [OpenClaw](https://openclaw.ai) and [Hermes](https://get-hermes.ai/) inside [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandboxes more safely. It provides CLI tooling, a blueprint for sandbox orchestration, and security hardening.
 
 Status: Active development. Interfaces may change without notice.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 NVIDIA NemoClaw is an open-source reference stack for running [OpenClaw](https://openclaw.ai) always-on assistants inside [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandboxes more safely. It provides CLI tooling, a blueprint for sandbox orchestration, and security hardening.
 
-**Status:** Alpha (March 2026+). Interfaces may change without notice.
+**Status:** Active development. Interfaces may change without notice.
 
 ## Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,10 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue)](https://github.com/NVIDIA/NemoClaw/blob/main/LICENSE)
 [![Security Policy](https://img.shields.io/badge/Security-Report%20a%20Vulnerability-red)](https://github.com/NVIDIA/NemoClaw/blob/main/SECURITY.md)
-[![Project Status](https://img.shields.io/badge/status-alpha-orange)](https://docs.nvidia.com/nemoclaw/latest/about/release-notes.html)
 [![Discord](https://img.shields.io/badge/Discord-Join-7289da)](https://discord.gg/XFpfPv9Uvx)
 
 NVIDIA NemoClaw is an open source reference stack for running always-on AI agents more safely inside [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) sandboxes.
 It provides guided onboarding, a hardened blueprint, routed inference, network policy, and lifecycle management through a single CLI.
-
-> [!NOTE]
-> NemoClaw is **alpha software**.
-> This software is not production-ready.
-> Interfaces, APIs, and behavior may change without notice.
-> See [Release Notes](https://docs.nvidia.com/nemoclaw/latest/about/release-notes.html) for the current version.
 
 **Supported agents:**
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -24,11 +24,6 @@ import { CommandTerminal } from "./_components/CommandTerminal";
       alt: "Security Policy",
     },
     {
-      href: "https://github.com/NVIDIA/NemoClaw/blob/main/docs/about/release-notes.mdx",
-      src: "https://img.shields.io/badge/status-alpha-orange",
-      alt: "Project Status",
-    },
-    {
       href: "https://discord.gg/XFpfPv9Uvx",
       src: "https://img.shields.io/badge/Discord-Join-7289da",
       alt: "Discord",

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -12,9 +12,6 @@ title: NVIDIA NemoClaw
 
 global-theme: nvidia
 
-announcement:
-  message: "🔔 NVIDIA NemoClaw is <strong>alpha software</strong>. APIs and behavior may change without notice. Do not use in production."
-
 layout:
   searchbar-placement: header
   page-width: 1376px


### PR DESCRIPTION
## Summary
- remove the alpha software note and status-alpha badge from the README
- remove the alpha software announcement from the Fern docs config
- remove the status-alpha badge from the docs landing page
- update AGENTS.md status wording from Alpha to Active development

## Validation
- git diff --check
- npm run docs:strict
- FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" check --warnings

Fern check reports 0 errors. The 2 warnings are the pre-existing unauthenticated redirects check and light-mode accent contrast warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Project status updated from “Alpha” to “Active development” across documentation.
  * Removed alpha warning banners and site announcement messaging.
  * Updated repository badges and introductory header to include a Discord join badge alongside existing badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->