### PR TITLE
fix(whatsapp): force version-pinned OpenClaw messaging plugin installs

### DIFF
--- a/scripts/openclaw-build-messaging-plugins.py
+++ b/scripts/openclaw-build-messaging-plugins.py
@@ -6,7 +6,8 @@
 OpenClaw's doctor repair uses the official catalog's unversioned plugin specs.
 That can drift to a newer external messaging plugin than the host OpenClaw
 runtime. NemoClaw pins the runtime with OPENCLAW_VERSION, so build-time channel
-activation must pin external messaging plugins to that same version.
+activation must force explicit npm installs for external messaging plugins and
+pin them to that same version.
 """
 
 from __future__ import annotations
@@ -90,7 +91,7 @@ def plugin_specs(channels: Iterable[str], openclaw_version: str) -> list[str]:
     for channel in channels:
         package_name = EXTERNAL_CHANNEL_PACKAGES.get(channel)
         if package_name:
-            specs.append(f"{package_name}@{openclaw_version}")
+            specs.append(f"npm:{package_name}@{openclaw_version}")
     return specs
 
 
@@ -137,7 +138,7 @@ def main(argv: list[str]) -> int:
         return 0
 
     for spec in specs:
-        run_command(["openclaw", "plugins", "install", spec])
+        run_command(["openclaw", "plugins", "install", spec, "--pin"])
 
     doctor_env = os.environ.copy()
     doctor_env.update(env_overrides)

--- a/test/openclaw-build-messaging-plugins.test.ts
+++ b/test/openclaw-build-messaging-plugins.test.ts
@@ -74,9 +74,9 @@ describe("openclaw-build-messaging-plugins.py", () => {
     });
 
     expect(payload.installSpecs).toEqual([
-      "@openclaw/discord@2026.5.22",
-      "@openclaw/slack@2026.5.22",
-      "@openclaw/whatsapp@2026.5.22",
+      "npm:@openclaw/discord@2026.5.22",
+      "npm:@openclaw/slack@2026.5.22",
+      "npm:@openclaw/whatsapp@2026.5.22",
     ]);
     expect(payload.doctorEnv).toEqual({
       DISCORD_BOT_TOKEN: "openshell:resolve:env:DISCORD_BOT_TOKEN",
@@ -93,7 +93,7 @@ describe("openclaw-build-messaging-plugins.py", () => {
     });
 
     expect(payload.channels).toEqual(["discord"]);
-    expect(payload.installSpecs).toEqual(["@openclaw/discord@2026.5.22"]);
+    expect(payload.installSpecs).toEqual(["npm:@openclaw/discord@2026.5.22"]);
     expect(payload.doctorEnv).toEqual({
       DISCORD_BOT_TOKEN: "openshell:resolve:env:DISCORD_BOT_TOKEN",
     });
@@ -108,6 +108,15 @@ describe("openclaw-build-messaging-plugins.py", () => {
     expect(payload.doctorEnv).toEqual({
       TELEGRAM_BOT_TOKEN: "openshell:resolve:env:TELEGRAM_BOT_TOKEN",
     });
+  });
+
+  it("forces WhatsApp to the OpenClaw runtime version on 2026.5.18 sandboxes", () => {
+    const payload = parseDryRun({
+      OPENCLAW_VERSION: "2026.5.18",
+      NEMOCLAW_MESSAGING_CHANNELS_B64: channelsB64(["whatsapp"]),
+    });
+
+    expect(payload.installSpecs).toEqual(["npm:@openclaw/whatsapp@2026.5.18"]);
   });
 
   it("fails fast on malformed channel payloads", () => {
@@ -155,9 +164,9 @@ describe("openclaw-build-messaging-plugins.py", () => {
 
       expect(result.status, result.stderr).toBe(0);
       expect(fs.readFileSync(tracePath, "utf-8").trim().split("\n")).toEqual([
-        "plugins|install|@openclaw/discord@2026.5.22||||",
-        "plugins|install|@openclaw/slack@2026.5.22||||",
-        "plugins|install|@openclaw/whatsapp@2026.5.22||||",
+        "plugins|install|npm:@openclaw/discord@2026.5.22|--pin|||",
+        "plugins|install|npm:@openclaw/slack@2026.5.22|--pin|||",
+        "plugins|install|npm:@openclaw/whatsapp@2026.5.22|--pin|||",
         [
           "doctor",
           "--fix",
@@ -186,7 +195,8 @@ describe("openclaw-build-messaging-plugins.py", () => {
         "const args = process.argv.slice(2);",
         'fs.appendFileSync(process.env.OPENCLAW_TRACE, `${args.join("|")}|${process.env.DISCORD_BOT_TOKEN || ""}\\n`);',
         'if (args[0] === "plugins" && args[1] === "install") {',
-        '  if (args[2] !== "@openclaw/discord@2026.5.22") process.exit(41);',
+        '  if (args[2] !== "npm:@openclaw/discord@2026.5.22") process.exit(41);',
+        '  if (args[3] !== "--pin") process.exit(47);',
         "  process.exit(0);",
         "}",
         'if (args[0] === "doctor" && args[1] === "--fix" && args[2] === "--non-interactive") {',
@@ -233,7 +243,7 @@ describe("openclaw-build-messaging-plugins.py", () => {
 
       expect(pluginResult.status, pluginResult.stderr).toBe(0);
       expect(fs.readFileSync(tracePath, "utf-8").trim().split("\n")).toEqual([
-        "plugins|install|@openclaw/discord@2026.5.22|",
+        "plugins|install|npm:@openclaw/discord@2026.5.22|--pin|",
         "doctor|--fix|--non-interactive|openshell:resolve:env:DISCORD_BOT_TOKEN",
       ]);
     } finally {


### PR DESCRIPTION
## Summary

NemoClaw already derives external messaging plugin versions from `OPENCLAW_VERSION`, but it passed bare `@openclaw/*@<version>` specs to `openclaw plugins install`. On OpenClaw's official plugin install path that can still resolve through the official/ClawHub/default supply chain and drift to the current plugin release.

This change forces build-time messaging plugin activation through exact npm specs and pins the install record:

- install `npm:@openclaw/<plugin>@${OPENCLAW_VERSION}` instead of a bare `@openclaw/<plugin>@${OPENCLAW_VERSION}` spec
- pass `--pin` so the managed install remains tied to the runtime version
- add a regression check for `OPENCLAW_VERSION=2026.5.18` so WhatsApp resolves to `npm:@openclaw/whatsapp@2026.5.18`, not latest

## Version evidence

Live npm metadata currently shows:

- `openclaw@latest`: `2026.5.28`
- `@openclaw/whatsapp@latest`: `2026.5.28`
- `@openclaw/whatsapp@2026.5.28` peers on `openclaw >=2026.5.28`
- `@openclaw/whatsapp@2026.5.18` peers on `openclaw >=2026.5.18`

So any unpinned/default WhatsApp install into an OpenClaw `2026.5.18` sandbox can pick a plugin that is too new for the runtime.

## Verification

- `npm ci --include=dev --ignore-scripts`
- `python3 -m py_compile scripts/openclaw-build-messaging-plugins.py`
- `npx vitest run test/openclaw-build-messaging-plugins.test.ts`
- `git diff --check`

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced messaging plugin installation reliability by enforcing strict version pinning, ensuring consistent plugin versions across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->