### PR TITLE
fix(sandbox): stop false Docker unhealthy and add paused-container hint (#4503, #4495)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -837,7 +837,7 @@ RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]; then \
 # can detect and restart unhealthy containers in standalone deployments.
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/1430
 #
-# Two-stage probe so Docker health does not contradict the NemoClaw delivery
+# Layered probe so Docker health does not contradict the NemoClaw delivery
 # chain on runtimes where the dashboard port lives in a different network
 # namespace (e.g. DGX Spark / aarch64 with OpenShell-managed forwarding).
 # The reporter saw `nemoclaw status` Ready + the host forward succeed while
@@ -846,27 +846,31 @@ RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]; then \
 #
 #   1. Direct in-container probe (HTTP 200) — definitive when it works,
 #      preserves the original Compose/standalone health signal.
-#   2. ONLY on curl exit 7 ("Couldn't connect"), fall back to verifying
-#      ALL of:
-#        - the OpenClaw gateway process started by nemoclaw-start is
-#          still alive (via pgrep --ignore-ancestors), AND
-#        - the gateway log file exists and is non-empty (proves the
-#          process started and emitted its banner; rules out cases
-#          where the gateway never came up).
-#      Exit 7 means the in-container TCP connect was refused by the
-#      kernel because nothing is bound to the dashboard port inside
-#      this network namespace — the namespace-mismatch shape reported
-#      in #3975. A connect timeout (curl exit 28) is treated as a real
-#      failure: a listener exists but is not responding (wedged HTTP
-#      server), and we want Docker to restart in that case.
-#
-# Tradeoff: this fallback also fires in a standalone deployment where the
-# gateway process is alive but the configured dashboard port is wrong or
-# the listener never came up. We accept that residual risk because it
-# requires a misconfiguration the start-period (45s) already gives the
-# wizard a chance to fix, and the existing host-side delivery chain
-# probes (verify-deployment.ts, host port forward, sandbox status) still
-# catch it from outside.
+#   2. A connect timeout (curl exit 28) or HTTP 4xx/5xx (curl exit 22) is a
+#      real bad signal: a listener exists but is wedged or answered with a
+#      failure inside this container, so Docker should restart it.
+#   3. ONLY on curl exit 7 ("Couldn't connect" — the kernel refused the
+#      in-container TCP connect because nothing is bound to the dashboard
+#      port in THIS network namespace) the meaning depends on whether this
+#      container is the one running the OpenClaw gateway:
+#        a. If nemoclaw-start launched the gateway in this container it
+#           drops the /tmp/nemoclaw-gateway-local marker (see
+#           scripts/nemoclaw-start.sh). The gateway is local but its port
+#           may be forwarded out of this namespace (#3975), so confirm the
+#           gateway came up: the process is still alive (pgrep
+#           --ignore-ancestors) AND the gateway log is non-empty. A
+#           standalone deployment whose gateway never started fails here so
+#           Docker restarts it (#1430).
+#        b. If the marker is ABSENT the OpenClaw gateway is delivered
+#           outside this container (OpenShell docker-driver deployments run
+#           it on the host / in a host-side process chain — #4503). An
+#           in-container curl/pgrep cannot observe an out-of-namespace
+#           gateway, so a process-name fallback here produced false
+#           "unhealthy" while `nemoclaw status` and OpenShell reported the
+#           sandbox Ready. We must not drive Docker health off a signal we
+#           cannot prove: report healthy and defer to NemoClaw/OpenShell's
+#           host-side delivery-chain monitoring (verify-deployment.ts, host
+#           port forward, sandbox status).
 #
 # The process pattern matches both `openclaw gateway run` (the launcher
 # command nemoclaw-start runs) and `openclaw-gateway` (the re-execed
@@ -879,9 +883,6 @@ RUN if [ "$NEMOCLAW_DARWIN_VM_COMPAT" = "1" ]; then \
 # without --ignore-ancestors `pgrep -f` would happily report it as the
 # live gateway even after the real process exited (procps 4.0+ supports
 # this flag; the base image pins procps to 2:4.0.4-9).
-#
-# We deliberately do not fall back on HTTP 4xx/5xx — those mean the gateway
-# answered with a failure inside this container, which is a real bad signal.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
     CMD port="${NEMOCLAW_DASHBOARD_PORT:-${OPENCLAW_GATEWAY_PORT:-}}"; \
         if [ -z "$port" ]; then \
@@ -891,6 +892,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
         curl -sf --max-time 3 "http://127.0.0.1:${port}/health" > /dev/null 2>&1 || rc=$?; \
         if [ "$rc" = 0 ]; then exit 0; fi; \
         if [ "$rc" != 7 ]; then exit 1; fi; \
+        [ -f /tmp/nemoclaw-gateway-local ] || exit 0; \
         pgrep --ignore-ancestors -f 'openclaw[ -]gateway' > /dev/null 2>&1 || exit 1; \
         [ -s /tmp/gateway.log ]
 

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -194,6 +194,29 @@ case "${1:-}" in
 esac
 NEMOCLAW_CMD=("$@")
 
+# Drop the marker the Docker HEALTHCHECK reads to decide whether an
+# in-container gateway liveness check is meaningful. We write it as early as
+# possible on the gateway-serving path — before the long startup work below —
+# so a slow or hung boot is governed by the strict local liveness check
+# (pgrep + gateway log) instead of being masked as healthy. Its presence means
+# this container runs the OpenClaw gateway (standalone deployments and the
+# #3975 forwarded-port shape). Its absence means the gateway is delivered out
+# of this container's namespace (OpenShell docker-driver sandboxes run it on
+# the host — #4503); an in-container probe cannot observe it, so the HEALTHCHECK
+# reports healthy and defers to NemoClaw/OpenShell host-side delivery-chain
+# monitoring. See the HEALTHCHECK block in the Dockerfile.
+# Best-effort: a write failure must never block startup.
+mark_in_container_gateway() {
+  : >/tmp/nemoclaw-gateway-local 2>/dev/null || true
+}
+# A non-empty NEMOCLAW_CMD means this container only runs a one-shot command
+# (e.g. `openclaw agent ...`) and never serves the gateway, so leave the marker
+# absent. Both the root and non-root entrypoint paths gate gateway startup on
+# the same emptiness check further below.
+if [ ${#NEMOCLAW_CMD[@]} -eq 0 ]; then
+  mark_in_container_gateway
+fi
+
 _chat_ui_url_port() {
   [ -n "${CHAT_UI_URL:-}" ] || return 1
   python3 - "$CHAT_UI_URL" <<'PYPORT'

--- a/src/lib/actions/sandbox/docker-health.test.ts
+++ b/src/lib/actions/sandbox/docker-health.test.ts
@@ -3,20 +3,27 @@
 
 import { describe, expect, it } from "vitest";
 
-import { getSandboxDockerHealth } from "../../../../dist/lib/actions/sandbox/docker-health";
+import {
+  getSandboxDockerHealth,
+  getSandboxDockerRuntime,
+} from "../../../../dist/lib/actions/sandbox/docker-health";
 import type { SandboxEntry } from "../../../../dist/lib/state/registry";
 
 function fixture({
   driver = "docker",
   psNames = "openshell-cluster-nemoclaw\nopenshell-my-assistant-12ab\nopenshell-other-aa11",
   healthRaw = "unhealthy\n",
+  pausedRaw = "false\n",
   throwOnInspect = false,
+  throwOnPaused = false,
   knownSandboxes = ["my-assistant"],
 }: {
   driver?: string | null;
   psNames?: string;
   healthRaw?: string;
+  pausedRaw?: string;
   throwOnInspect?: boolean;
+  throwOnPaused?: boolean;
   knownSandboxes?: string[];
 } = {}) {
   const sandbox: Partial<SandboxEntry> = { name: "my-assistant", openshellDriver: driver };
@@ -27,6 +34,10 @@ function fixture({
     dockerInspectHealth: () => {
       if (throwOnInspect) throw new Error("docker inspect crashed");
       return healthRaw;
+    },
+    dockerInspectPaused: () => {
+      if (throwOnPaused) throw new Error("docker inspect paused crashed");
+      return pausedRaw;
     },
   };
 }
@@ -139,5 +150,64 @@ describe("getSandboxDockerHealth", () => {
     const result = getSandboxDockerHealth("my-assistant", deps);
     expect(result.state).toBe("unknown");
     expect(result.containerName).toBe("openshell-my-assistant-12ab");
+  });
+});
+
+describe("getSandboxDockerRuntime (#4495)", () => {
+  it("reports paused=true when the resolved docker-driver container is paused", () => {
+    const deps = fixture({ healthRaw: "healthy\n", pausedRaw: "true\n" });
+    expect(getSandboxDockerRuntime("my-assistant", deps)).toEqual({
+      health: "healthy",
+      paused: true,
+      containerName: "openshell-my-assistant-12ab",
+    });
+  });
+
+  it("reports paused=false for a running container", () => {
+    const deps = fixture({ healthRaw: "healthy\n", pausedRaw: "false\n" });
+    expect(getSandboxDockerRuntime("my-assistant", deps).paused).toBe(false);
+  });
+
+  it("normalizes whitespace and case in the .State.Paused value", () => {
+    const deps = fixture({ pausedRaw: "  True \n" });
+    expect(getSandboxDockerRuntime("my-assistant", deps).paused).toBe(true);
+  });
+
+  it("treats a non-boolean / empty paused value as not paused", () => {
+    const deps = fixture({ pausedRaw: "<no value>\n" });
+    expect(getSandboxDockerRuntime("my-assistant", deps).paused).toBe(false);
+  });
+
+  it("reports paused=false and does not throw when the paused inspect fails", () => {
+    const deps = fixture({ healthRaw: "unhealthy\n", throwOnPaused: true });
+    const result = getSandboxDockerRuntime("my-assistant", deps);
+    expect(result.paused).toBe(false);
+    expect(result.health).toBe("unhealthy");
+    expect(result.containerName).toBe("openshell-my-assistant-12ab");
+  });
+
+  it("returns health 'none', paused false for non-docker-driver sandboxes", () => {
+    const deps = fixture({ driver: "kubernetes" });
+    expect(getSandboxDockerRuntime("my-assistant", deps)).toEqual({
+      health: "none",
+      paused: false,
+      containerName: null,
+    });
+  });
+
+  it("returns health 'none', paused false when no container is found", () => {
+    const deps = fixture({ psNames: "openshell-cluster-nemoclaw\n" });
+    expect(getSandboxDockerRuntime("my-assistant", deps)).toEqual({
+      health: "none",
+      paused: false,
+      containerName: null,
+    });
+  });
+
+  it("reports health 'unknown' but still resolves paused when the health inspect throws", () => {
+    const deps = fixture({ throwOnInspect: true, pausedRaw: "true\n" });
+    const result = getSandboxDockerRuntime("my-assistant", deps);
+    expect(result.health).toBe("unknown");
+    expect(result.paused).toBe(true);
   });
 });

--- a/src/lib/actions/sandbox/docker-health.ts
+++ b/src/lib/actions/sandbox/docker-health.ts
@@ -17,11 +17,25 @@ export interface SandboxDockerHealth {
   containerName: string | null;
 }
 
+/**
+ * Combined Docker runtime view for a docker-driver sandbox container: the
+ * HEALTHCHECK signal plus whether the container is paused (`docker pause`).
+ * A paused container can surface upstream as `Phase: Error` even though the
+ * sandbox is intact, so `status` reads `paused` to print a recovery hint
+ * without rewriting the authoritative phase. See #4495.
+ */
+export interface SandboxDockerRuntime {
+  health: DockerHealthState;
+  paused: boolean;
+  containerName: string | null;
+}
+
 interface ResolveDeps {
   getSandbox: (name: string) => registry.SandboxEntry | null;
   listSandboxNames: () => string[];
   dockerPsNames: () => string;
   dockerInspectHealth: (containerName: string) => string;
+  dockerInspectPaused: (containerName: string) => string;
 }
 
 const defaultDeps: ResolveDeps = {
@@ -32,6 +46,12 @@ const defaultDeps: ResolveDeps = {
   dockerInspectHealth: (containerName) =>
     dockerContainerInspectFormat(
       "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+      containerName,
+      { ignoreError: true },
+    ),
+  dockerInspectPaused: (containerName) =>
+    dockerContainerInspectFormat(
+      "{{if .State}}{{.State.Paused}}{{else}}false{{end}}",
       containerName,
       { ignoreError: true },
     ),
@@ -122,4 +142,40 @@ export function getSandboxDockerHealth(
     return { state: "unknown", containerName };
   }
   return { state: normalizeHealthState(raw), containerName };
+}
+
+function normalizePausedState(raw: string): boolean {
+  // `docker inspect --format {{.State.Paused}}` prints `true`/`false`. Treat
+  // anything else (empty output, inspect failure surfaced as a string, older
+  // engines without the field) as not paused so we never invent a paused hint.
+  return raw.trim().toLowerCase() === "true";
+}
+
+/**
+ * Resolve a docker-driver sandbox container once and read both its HEALTHCHECK
+ * state and `.State.Paused` flag. Returns `health: "none", paused: false` when
+ * the sandbox is not on the docker driver or no container is found — same
+ * resolution contract as {@link getSandboxDockerHealth}. A paused container is
+ * still listed by `docker ps`, so the existing resolver finds it. See #4495.
+ */
+export function getSandboxDockerRuntime(
+  sandboxName: string,
+  depsOverride: Partial<ResolveDeps> = {},
+): SandboxDockerRuntime {
+  const deps: ResolveDeps = { ...defaultDeps, ...depsOverride };
+  const containerName = resolveDockerDriverSandboxContainer(sandboxName, deps);
+  if (!containerName) return { health: "none", paused: false, containerName: null };
+  let health: DockerHealthState;
+  try {
+    health = normalizeHealthState(deps.dockerInspectHealth(containerName));
+  } catch {
+    health = "unknown";
+  }
+  let paused = false;
+  try {
+    paused = normalizePausedState(deps.dockerInspectPaused(containerName));
+  } catch {
+    paused = false;
+  }
+  return { health, paused, containerName };
 }

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -29,7 +29,7 @@ import {
   createSystemDeps as createSessionDeps,
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
-import { getSandboxDockerHealth } from "./docker-health";
+import { getSandboxDockerRuntime } from "./docker-health";
 import {
   classifyGatewayFailure,
   getLayerHeader,
@@ -92,6 +92,13 @@ export interface SandboxStatusReport {
   openshellDriver: string;
   openshellVersion: string;
   policies: string[];
+  /**
+   * Whether the resolved docker-driver sandbox container is paused
+   * (`docker pause`). `false` for non-docker-driver sandboxes or when no
+   * container is found. A paused container can report `Phase: Error`
+   * upstream while the sandbox is intact — see #4495.
+   */
+  dockerPaused: boolean;
 }
 
 interface SandboxStatusSnapshot {
@@ -174,6 +181,8 @@ export async function getSandboxStatusReport(
 ): Promise<SandboxStatusReport> {
   const snapshot = await collectSandboxStatusSnapshot(sandboxName);
   const { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth } = snapshot;
+  const dockerRuntime =
+    lookup.state === "present" ? getSandboxDockerRuntime(sandboxName) : null;
   const phase =
     lookup.state === "present" ? parseSandboxPhase(lookup.output || "") : null;
   const sandboxGpuEnabled = sb
@@ -200,6 +209,7 @@ export async function getSandboxStatusReport(
     openshellDriver: (sb && sb.openshellDriver) || "unknown",
     openshellVersion: (sb && sb.openshellVersion) || "unknown",
     policies,
+    dockerPaused: !!dockerRuntime?.paused,
   };
 }
 
@@ -283,6 +293,10 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
   // synthesized fallback keeps the user-visible contract intact.
   const snapshot = await collectSandboxStatusSnapshot(sandboxName);
   const { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth } = snapshot;
+  // Resolve the docker-driver container once: reused for the paused-container
+  // recovery hint (#4495) and the Docker health line below (#3975).
+  const dockerRuntime =
+    lookup.state === "present" ? getSandboxDockerRuntime(sandboxName) : null;
   maybeEnsureHermesToolGatewayBroker(sb);
   if (rpcIssue) {
     printOpenShellStateRpcIssue(rpcIssue, {
@@ -401,15 +415,35 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
         printDockerRuntimeDownGuidance(sandboxName, { writer: console.log });
         process.exit(1);
       }
-      console.log("");
-      console.log(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
-      console.log(
-        "  This usually happens when a process crash inside the sandbox prevented clean startup.",
-      );
-      console.log("");
-      console.log(
-        `  Run \`${CLI_NAME} ${sandboxName} rebuild --yes\` to recreate the sandbox (--yes skips the confirmation prompt; workspace state will be preserved).`,
-      );
+      // A paused Docker-driver container can surface upstream as `Phase: Error`
+      // (e.g. GPU passthrough on Ubuntu 24.04) even though the sandbox is
+      // otherwise intact. We do not rewrite OpenShell's authoritative phase
+      // (printed verbatim above); we add a paused-container recovery hint so
+      // the failure mode is actionable, and skip the misleading rebuild
+      // suggestion since unpausing — not recreating — is the fix. See #4495.
+      // `Error` is terminal, so the #4428 runtime-down reclassification above
+      // does not intercept this branch.
+      if (phase === "Error" && dockerRuntime?.paused && dockerRuntime.containerName) {
+        console.log("");
+        console.log(
+          `  The Docker-driver container for '${sandboxName}' is paused: ${dockerRuntime.containerName}`,
+        );
+        console.log(
+          "  A paused container can report 'Phase: Error' even though the sandbox is intact.",
+        );
+        console.log("  Resume it to restore the running phase:");
+        console.log(`    ${D}docker unpause ${dockerRuntime.containerName}${R}`);
+      } else {
+        console.log("");
+        console.log(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
+        console.log(
+          "  This usually happens when a process crash inside the sandbox prevented clean startup.",
+        );
+        console.log("");
+        console.log(
+          `  Run \`${CLI_NAME} ${sandboxName} rebuild --yes\` to recreate the sandbox (--yes skips the confirmation prompt; workspace state will be preserved).`,
+        );
+      }
     }
   } else if (lookup.state === "wrong_gateway_active") {
     const activeGateway =
@@ -519,12 +553,12 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
   // automatically: the in-sandbox `isSandboxGatewayRunningForStatus`
   // probe uses the same 127.0.0.1 endpoint Docker checks, so it cannot
   // independently confirm that Docker's reading is stale. (#3975)
-  if (lookup.state === "present") {
-    const dockerHealth = getSandboxDockerHealth(sandboxName);
-    if (dockerHealth.state !== "none" && dockerHealth.state !== "unknown") {
-      if (dockerHealth.state === "healthy") {
+  if (lookup.state === "present" && dockerRuntime) {
+    const dockerHealth = dockerRuntime;
+    if (dockerHealth.health !== "none" && dockerHealth.health !== "unknown") {
+      if (dockerHealth.health === "healthy") {
         console.log(`    Docker health: ${G}healthy${R}`);
-      } else if (dockerHealth.state === "starting") {
+      } else if (dockerHealth.health === "starting") {
         console.log(`    Docker health: ${D}starting${R}`);
       } else {
         console.log(`    Docker health: ${RD}unhealthy${R}`);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1186,6 +1186,101 @@ describe("CLI dispatch", () => {
     expect(parsed).toHaveProperty("gatewayState");
   });
 
+  // #4495: a paused Docker-driver container can surface upstream as
+  // `Phase: Error` even though the sandbox is intact. NemoClaw must keep the
+  // raw OpenShell phase but add an actionable paused-container recovery hint.
+  it("status surfaces a paused Docker-driver container hint without rewriting Phase: Error", testTimeoutOptions(30_000), () => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-cli-status-paused-"),
+    );
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha", {
+      openshellDriver: "docker",
+      openshellVersion: "0.0.44",
+    } as unknown as Partial<SandboxEntry>);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+        "  echo 'Sandbox:'",
+        "  echo",
+        "  echo '  Id: abc'",
+        "  echo '  Name: alpha'",
+        "  echo '  Namespace: openshell'",
+        "  echo '  Phase: Error'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo '  Provider: nvidia-prod'",
+        "  echo '  Model: nvidia/nemotron'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    // Docker reports the resolved sandbox container as paused.
+    fs.writeFileSync(
+      path.join(localBin, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "ps" ]; then echo "openshell-alpha-abc123"; exit 0; fi',
+        'if [ "$1" = "inspect" ]; then',
+        '  for a in "$@"; do',
+        "    case \"$a\" in",
+        '      *Paused*) echo "true"; exit 0 ;;',
+        '      *Health*) echo "none"; exit 0 ;;',
+        "    esac",
+        "  done",
+        '  echo ""; exit 0',
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv(
+      "alpha status",
+      {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      },
+      30000,
+    );
+
+    // Raw OpenShell phase is preserved verbatim — not rewritten to Ready.
+    expect(r.out).toContain("Phase: Error");
+    // Actionable paused-container recovery hint is added.
+    expect(r.out).toContain("paused: openshell-alpha-abc123");
+    expect(r.out).toContain("docker unpause openshell-alpha-abc123");
+    // The misleading rebuild suggestion must not fire for a paused container.
+    expect(r.out).not.toContain("rebuild --yes");
+
+    // The structured report exposes the paused flag for automation consumers.
+    const j = runWithEnv(
+      "alpha status --json",
+      {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      },
+      30000,
+    );
+    const parsed = JSON.parse(j.out);
+    expect(parsed.phase).toBe("Error");
+    expect(parsed.dockerPaused).toBe(true);
+  });
+
   it("sandbox status --json defaults openshell driver/version to 'unknown' strings", () => {
     const home = fs.mkdtempSync(
       path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-json-unknown-"),

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -317,6 +317,48 @@ describe("nemoclaw-start non-root fallback", () => {
     }
   });
 
+  // #4503: the Docker HEALTHCHECK reports healthy on curl-exit-7 only when the
+  // /tmp/nemoclaw-gateway-local marker is ABSENT (gateway delivered out of this
+  // container's namespace). To avoid masking a slow in-container startup, the
+  // entrypoint must drop that marker early on the gateway-serving path — and
+  // must NOT drop it when only running a one-shot command.
+  it("drops the in-container gateway healthcheck marker only on the gateway-serving path (#4503)", () => {
+    const src = fs.readFileSync(START_SCRIPT, "utf-8");
+    const start = src.indexOf('NEMOCLAW_CMD=("$@")');
+    const end = src.indexOf("_chat_ui_url_port()", start);
+    if (start === -1 || end === -1 || end <= start) {
+      throw new Error("Expected NEMOCLAW_CMD assignment and the gateway marker block");
+    }
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gw-marker-"));
+    const markerPath = path.join(tmpDir, "nemoclaw-gateway-local");
+    const snippet = src
+      .slice(start, end)
+      .replaceAll("/tmp/nemoclaw-gateway-local", markerPath);
+
+    function runScenario(setArgs: string) {
+      const script = ["#!/usr/bin/env bash", "set -euo pipefail", setArgs, snippet].join("\n");
+      return spawnSync("bash", ["-c", script], { encoding: "utf-8", timeout: 5000 });
+    }
+
+    try {
+      // Gateway-serving path: no trailing command, so the marker is dropped.
+      fs.rmSync(markerPath, { force: true });
+      const serving = runScenario("set --");
+      expect(serving.status).toBe(0);
+      expect(fs.existsSync(markerPath)).toBe(true);
+
+      // One-shot command path: the marker must stay absent so the out-of-
+      // namespace healthcheck branch never strict-checks a non-gateway
+      // container.
+      fs.rmSync(markerPath, { force: true });
+      const oneShot = runScenario("set -- openclaw agent --agent main");
+      expect(oneShot.status).toBe(0);
+      expect(fs.existsSync(markerPath)).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("executes explicit non-root commands before gateway startup setup", () => {
     const src = fs.readFileSync(START_SCRIPT, "utf-8");
     const script = [

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -296,23 +296,34 @@ describe("sandbox provisioning: image health checks (#1430)", () => {
       curlExit,
       pgrepExit,
       gatewayLog = "gateway log line\n",
+      // The /tmp/nemoclaw-gateway-local marker is dropped by nemoclaw-start
+      // only when this container runs the in-container OpenClaw gateway. Most
+      // probes here exercise that path, so default it to present.
+      gatewayLocalMarker = true,
     }: {
       curlExit: number;
       pgrepExit: number;
       gatewayLog?: string;
+      gatewayLocalMarker?: boolean;
     }) {
       const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-health-fallback-"));
       const logPath = path.join(tmp, "gateway.log");
+      const markerPath = path.join(tmp, "nemoclaw-gateway-local");
       const rawCommand = dockerHealthCommandBetween(
         dockerfile,
         "# Health check: poll the gateway's /health endpoint",
         "# Entrypoint runs as root",
       );
-      const command = rawCommand.replaceAll("/tmp/gateway.log", logPath);
+      const command = rawCommand
+        .replaceAll("/tmp/gateway.log", logPath)
+        .replaceAll("/tmp/nemoclaw-gateway-local", markerPath);
 
       if (gatewayLog !== "") {
         fs.writeFileSync(logPath, gatewayLog);
+      }
+      if (gatewayLocalMarker) {
+        fs.writeFileSync(markerPath, "");
       }
 
       try {
@@ -371,6 +382,49 @@ describe("sandbox provisioning: image health checks (#1430)", () => {
       // a 4xx/5xx means the gateway is reachable and unhappy, not a
       // namespace mismatch — so pgrep should not run.
       expect(probe.calls).not.toContain("pgrep");
+    });
+
+    // #4503: OpenShell docker-driver sandboxes deliver the OpenClaw gateway
+    // outside this container's network namespace (it runs on the host), so
+    // nemoclaw-start never drops the /tmp/nemoclaw-gateway-local marker. The
+    // in-container curl gets connection-refused and the in-container pgrep
+    // finds no gateway process, yet `nemoclaw status`/OpenShell report Ready.
+    // Without the marker the healthcheck must NOT mark the container unhealthy
+    // off a signal it cannot observe.
+    describe("does not falsely fail when the gateway runs outside this container's namespace (#4503)", () => {
+      it("reports healthy on curl exit 7 with no in-container gateway process when the marker is absent", () => {
+        const probe = runProductionHealthProbe({
+          curlExit: 7,
+          pgrepExit: 1,
+          gatewayLog: "gateway log line\n",
+          gatewayLocalMarker: false,
+        });
+        expect(probe.result.status).toBe(0);
+        // The process-name fallback is meaningless out-of-namespace, so the
+        // healthcheck must short-circuit before consulting pgrep.
+        expect(probe.calls).not.toContain("pgrep");
+      });
+
+      it("reports healthy on curl exit 7 even when no gateway log exists and the marker is absent", () => {
+        const probe = runProductionHealthProbe({
+          curlExit: 7,
+          pgrepExit: 1,
+          gatewayLog: "",
+          gatewayLocalMarker: false,
+        });
+        expect(probe.result.status).toBe(0);
+        expect(probe.calls).not.toContain("pgrep");
+      });
+
+      it("still reports unhealthy on a wedged listener (curl exit 28) regardless of the marker", () => {
+        const probe = runProductionHealthProbe({
+          curlExit: 28,
+          pgrepExit: 0,
+          gatewayLocalMarker: false,
+        });
+        expect(probe.result.status).toBe(1);
+        expect(probe.calls).not.toContain("pgrep");
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes two Docker-driver sandbox container-state issues that mislead operators: a HEALTHCHECK that falsely marks functional Docker-driver sandboxes `(unhealthy)`, and a `Phase: Error` for a paused container with no recovery guidance. Both share the Docker-driver container-state / health-signal / status-UX axis.

## Related Issue

Fixes #4503
Fixes #4495

## Changes

**#4503 — stop false Docker `(unhealthy)`**
- `scripts/nemoclaw-start.sh` drops a `/tmp/nemoclaw-gateway-local` marker **early** on the gateway-serving path (before the long startup work), signalling that this container runs the in-container OpenClaw gateway.
- `Dockerfile` HEALTHCHECK keeps the strict local liveness fallback (`pgrep 'openclaw[ -]gateway'` + non-empty gateway log) on curl exit 7 **only when the marker is present** (standalone/Compose #1430 and the #3975 forwarded-port shape). When the marker is **absent**, the gateway is delivered outside this container's namespace (OpenShell docker-driver deployments run it on the host), so an in-container probe cannot prove failure — the check reports healthy and defers to NemoClaw/OpenShell host-side delivery-chain monitoring. Writing the marker early ensures a slow in-container startup is governed by the strict check, not masked as healthy. Genuine bad signals (curl timeout exit 28, HTTP 4xx/5xx exit 22) still report unhealthy.

**#4495 — paused-container recovery hint without rewriting the phase**
- `src/lib/actions/sandbox/docker-health.ts` adds `getSandboxDockerRuntime`, which resolves the docker-driver container once and reads both `.State.Health.Status` and `.State.Paused`.
- `src/lib/actions/sandbox/status.ts` keeps OpenShell's authoritative `Phase: Error` verbatim but, when the resolved container is paused, prints an actionable `docker unpause <container>` recovery hint and skips the misleading rebuild suggestion. `dockerPaused` is exposed in the structured `--json` report. The authoritative phase-mapping fix itself belongs upstream in OpenShell.

**Regression coverage**
- `test/sandbox-provisioning.test.ts`: marker-aware healthcheck cases, including the #4503 out-of-namespace path (curl exit 7 + no in-container gateway + marker absent → healthy) and that wedged/HTTP-error signals still fail.
- `test/nemoclaw-start.test.ts`: the marker is dropped on the gateway-serving path and stays absent for one-shot commands.
- `src/lib/actions/sandbox/docker-health.test.ts`: `getSandboxDockerRuntime` paused parsing and resolution contract.
- `test/cli.test.ts`: status surfaces the paused hint without rewriting `Phase: Error`, plus the `dockerPaused` report field.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes on verification: targeted tests for all changed code pass (docker-health 21, sandbox-provisioning 28, the new start-script marker test, and the paused-status cli test). The Dockerfile HEALTHCHECK fix was reproduced and verified end-to-end with a faithful bash fixture across 8 scenarios (curl exit 0/7/22/28 × marker present/absent × process/log present/absent). The remaining failures in a full `cli`-project run are environmental — load-induced timeouts on CLI-spawning oclif/help tests and one umask-dependent directory mode-bits test in `config-sync.ts` (a file this PR does not touch); all pass when run in isolation. CI runs these on dedicated runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status reports (including JSON) now detect and expose Docker paused state and show a paused-container recovery hint with a `docker unpause <container>` suggestion.

* **Bug Fixes**
  * Healthcheck logic updated to avoid false restarts when the dashboard listener is unreachable due to host/network delivery by honoring a local marker and handling specific probe exit codes.

* **Tests**
  * Added tests covering paused detection, healthcheck marker behavior, and updated status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->