### PR TITLE
fix(maintenance): surface gateway schema preflight on host-process gateway drift

### DIFF
--- a/src/lib/actions/gateway-drift-preflight.test.ts
+++ b/src/lib/actions/gateway-drift-preflight.test.ts
@@ -23,6 +23,15 @@ const driftIssue: OpenShellStateRpcIssue = {
   },
 };
 
+const hostProcessDriftIssue: OpenShellStateRpcIssue = {
+  kind: "host_process_drift",
+  drift: {
+    gatewayBin: "/home/u/.local/bin/openshell-gateway",
+    currentVersion: "0.0.43",
+    expectedVersion: "0.0.44",
+  },
+};
+
 function mockExit() {
   return vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
     throw new Error(`process.exit(${code ?? 0})`);
@@ -125,6 +134,34 @@ describe("gateway drift preflight for maintenance actions", () => {
     );
     expect(captureOpenshellSpy).not.toHaveBeenCalled();
     expect(backupSandboxStateSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+  });
+
+  it("backup-all fails before sandbox list on host-process gateway binary drift", async () => {
+    detectPreflightIssueSpy.mockReturnValue(hostProcessDriftIssue);
+
+    await expect(backupAll()).rejects.toThrow("process.exit(1)");
+
+    expect(printIssueSpy).toHaveBeenCalledWith(
+      hostProcessDriftIssue,
+      expect.objectContaining({ command: "nemoclaw backup-all" }),
+    );
+    expect(captureOpenshellSpy).not.toHaveBeenCalled();
+    expect(backupSandboxStateSpy).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
+  });
+
+  it("upgrade-sandboxes fails before sandbox list on host-process gateway binary drift", async () => {
+    detectPreflightIssueSpy.mockReturnValue(hostProcessDriftIssue);
+
+    await expect(upgradeSandboxes({ check: true })).rejects.toThrow("process.exit(1)");
+
+    expect(printIssueSpy).toHaveBeenCalledWith(
+      hostProcessDriftIssue,
+      expect.objectContaining({ command: "nemoclaw upgrade-sandboxes" }),
+    );
+    expect(captureOpenshellSpy).not.toHaveBeenCalled();
+    expect(classifyUpgradeableSandboxesSpy).not.toHaveBeenCalled();
     expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
   });
 

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -72,7 +72,7 @@ export interface SandboxStatusReport {
   phase: string | null;
   gatewayState: string;
   inferenceHealth: ProviderHealthStatus | null;
-  rpcIssue: { kind: "image_drift" | "protobuf_mismatch" } | null;
+  rpcIssue: { kind: "image_drift" | "host_process_drift" | "protobuf_mismatch" } | null;
   hostGpuDetected: boolean;
   sandboxGpuEnabled: boolean;
   sandboxGpuMode: string | null;

--- a/src/lib/adapters/openshell/gateway-drift.test.ts
+++ b/src/lib/adapters/openshell/gateway-drift.test.ts
@@ -394,7 +394,7 @@ describe("OpenShell gateway drift preflight", () => {
     );
   });
 
-  it("formats runtime protobuf mismatches with gateway-specific recovery guidance", () => {
+  it("formats runtime protobuf mismatches with gateway-neutral recovery guidance when drift is unknown", () => {
     const lines = formatOpenShellStateRpcIssue(
       {
         kind: "protobuf_mismatch",
@@ -402,14 +402,18 @@ describe("OpenShell gateway drift preflight", () => {
       },
       {
         action: "querying live sandboxes",
-        gatewayName: "custom-gw",
       },
     );
 
+    const joined = lines.join("\n");
     expect(lines).toContain(
       "  OpenShell gateway/schema mismatch was detected while querying live sandboxes.",
     );
-    expect(lines.join("\n")).toContain("openshell-cluster-custom-gw");
-    expect(lines.join("\n")).not.toContain("schema preflight failed before");
+    expect(joined).toContain("preserve sandbox state first");
+    expect(joined).toContain("No sandbox data was changed.");
+    // Driver is unknown when no drift was resolved: do not name a cluster container.
+    expect(joined).not.toContain("openshell-cluster");
+    expect(joined).not.toContain("Docker volumes");
+    expect(joined).not.toContain("schema preflight failed before");
   });
 });

--- a/src/lib/adapters/openshell/gateway-drift.test.ts
+++ b/src/lib/adapters/openshell/gateway-drift.test.ts
@@ -10,6 +10,7 @@ import {
   detectOpenShellStateRpcResultIssue,
   formatOpenShellStateRpcIssue,
   getGatewayClusterImageDrift,
+  getGatewayHostProcessDrift,
   parseGatewayClusterImageVersion,
 } from "../../../../dist/lib/adapters/openshell/gateway-drift";
 
@@ -52,6 +53,10 @@ describe("OpenShell gateway drift preflight", () => {
         deps: {
           getInstalledOpenshellVersion: () => "0.0.37",
           getGatewayClusterImageRef: () => "ghcr.io/nvidia/openshell/cluster:0.0.37",
+          // An active cluster gateway at the installed version: no drift of
+          // either kind. isGatewayClusterActive keeps the host-process probe
+          // from falling through to real system state in this unit test.
+          isGatewayClusterActive: () => true,
         },
       }),
     ).toBeNull();
@@ -186,6 +191,154 @@ describe("OpenShell gateway drift preflight", () => {
     expect(getGatewayClusterImageDrift()).toBeNull();
   });
 
+  it("detects host-process gateway binary drift when no cluster container exists", () => {
+    const drift = getGatewayHostProcessDrift({
+      deps: {
+        getInstalledOpenshellVersion: () => "0.0.44",
+        getGatewayClusterImageRef: () => null,
+        getHostProcessGatewayRuntime: () => ({
+          gatewayBin: "/home/u/.local/bin/openshell-gateway",
+          runningVersion: "0.0.43",
+        }),
+      },
+    });
+
+    expect(drift).toEqual({
+      gatewayBin: "/home/u/.local/bin/openshell-gateway",
+      currentVersion: "0.0.43",
+      expectedVersion: "0.0.44",
+    });
+  });
+
+  it("does not flag a matching host-process gateway binary", () => {
+    expect(
+      getGatewayHostProcessDrift({
+        deps: {
+          getInstalledOpenshellVersion: () => "0.0.44",
+          getGatewayClusterImageRef: () => null,
+          getHostProcessGatewayRuntime: () => ({
+            gatewayBin: "/home/u/.local/bin/openshell-gateway",
+            runningVersion: "0.0.44",
+          }),
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not probe host-process drift while an active cluster gateway is present", () => {
+    let runtimeProbed = false;
+    expect(
+      getGatewayHostProcessDrift({
+        deps: {
+          getInstalledOpenshellVersion: () => "0.0.44",
+          getGatewayClusterImageRef: () => "ghcr.io/nvidia/openshell/cluster:0.0.44",
+          isGatewayClusterActive: () => true,
+          getHostProcessGatewayRuntime: () => {
+            runtimeProbed = true;
+            return { gatewayBin: "/x", runningVersion: "0.0.43" };
+          },
+        },
+      }),
+    ).toBeNull();
+    expect(runtimeProbed).toBe(false);
+  });
+
+  it("detects host-process drift when a leftover cluster container exists but is not active", () => {
+    const drift = getGatewayHostProcessDrift({
+      deps: {
+        getInstalledOpenshellVersion: () => "0.0.44",
+        // A stopped/leftover cluster container still returns an image ref...
+        getGatewayClusterImageRef: () => "ghcr.io/nvidia/openshell/cluster:0.0.36",
+        // ...but it is not the active gateway, so it must not mask host drift.
+        isGatewayClusterActive: () => false,
+        getHostProcessGatewayRuntime: () => ({
+          gatewayBin: "/home/u/.local/bin/openshell-gateway",
+          runningVersion: "0.0.43",
+        }),
+      },
+    });
+
+    expect(drift).toMatchObject({ currentVersion: "0.0.43", expectedVersion: "0.0.44" });
+  });
+
+  it("returns null when the host-process gateway version cannot be probed", () => {
+    expect(
+      getGatewayHostProcessDrift({
+        deps: {
+          getInstalledOpenshellVersion: () => "0.0.44",
+          getGatewayClusterImageRef: () => null,
+          getHostProcessGatewayRuntime: () => ({
+            gatewayBin: "/home/u/.local/bin/openshell-gateway",
+            runningVersion: null,
+          }),
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("surfaces host-process drift as a preflight issue when cluster image drift is absent", () => {
+    const issue = detectOpenShellStateRpcPreflightIssue({
+      deps: {
+        getInstalledOpenshellVersion: () => "0.0.44",
+        getGatewayClusterImageRef: () => null,
+        getHostProcessGatewayRuntime: () => ({
+          gatewayBin: "/home/u/.local/bin/openshell-gateway",
+          runningVersion: "0.0.43",
+        }),
+      },
+    });
+
+    expect(issue).toMatchObject({
+      kind: "host_process_drift",
+      drift: { currentVersion: "0.0.43", expectedVersion: "0.0.44" },
+    });
+  });
+
+  it("formats host-process drift with a running gateway binary line and preflight phase", () => {
+    const lines = formatOpenShellStateRpcIssue(
+      {
+        kind: "host_process_drift",
+        drift: {
+          gatewayBin: "/home/u/.local/bin/openshell-gateway",
+          currentVersion: "0.0.43",
+          expectedVersion: "0.0.44",
+        },
+      },
+      { action: "backing up registered sandboxes", command: "nemoclaw backup-all" },
+    );
+
+    const joined = lines.join("\n");
+    expect(joined).toContain(
+      "OpenShell gateway schema preflight failed before backing up registered sandboxes.",
+    );
+    expect(joined).toContain("Installed OpenShell: 0.0.44");
+    expect(joined).toContain(
+      "Running gateway binary: /home/u/.local/bin/openshell-gateway (0.0.43)",
+    );
+    expect(joined).toContain("No sandbox data was changed.");
+    expect(joined).toContain("nemoclaw backup-all");
+    // Host-process gateways have no cluster container; do not reference its volumes.
+    expect(joined).not.toContain("openshell-cluster-nemoclaw");
+    expect(joined).not.toContain("Running gateway image");
+  });
+
+  it("ignores host-process gateway drift when the Vitest sentinel is set", () => {
+    expect(process.env.VITEST).toBe("true");
+    expect(process.env.NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT).toBe("1");
+
+    // Injected deps opt back into detection; the bare call stays disabled.
+    expect(
+      getGatewayHostProcessDrift({
+        deps: {
+          getInstalledOpenshellVersion: () => "0.0.44",
+          getGatewayClusterImageRef: () => null,
+          getHostProcessGatewayRuntime: () => ({ gatewayBin: "/x", runningVersion: "0.0.43" }),
+        },
+      }),
+    ).not.toBeNull();
+    expect(getGatewayHostProcessDrift()).toBeNull();
+  });
+
   it("classifies protobuf invalid-wire output as an unsafe OpenShell state result", () => {
     const issue = detectOpenShellStateRpcResultIssue(
       {
@@ -207,6 +360,37 @@ describe("OpenShell gateway drift preflight", () => {
         "  No sandbox data was changed.",
         expect.stringContaining("nemoclaw backup-all"),
       ]),
+    );
+  });
+
+  it("attaches host-process drift to a protobuf mismatch when there is no cluster container", () => {
+    const issue = detectOpenShellStateRpcResultIssue(
+      {
+        status: 1,
+        output:
+          'Error: status: Internal, message: "Sandbox.metadata: SandboxResponse.sandbox: invalid wire type value: 6"',
+      },
+      {
+        deps: {
+          getInstalledOpenshellVersion: () => "0.0.44",
+          getGatewayClusterImageRef: () => null,
+          getHostProcessGatewayRuntime: () => ({
+            gatewayBin: "/home/u/.local/bin/openshell-gateway",
+            runningVersion: "0.0.43",
+          }),
+        },
+      },
+    );
+
+    expect(issue?.kind).toBe("protobuf_mismatch");
+    expect(issue?.drift).toMatchObject({
+      gatewayBin: "/home/u/.local/bin/openshell-gateway",
+      currentVersion: "0.0.43",
+      expectedVersion: "0.0.44",
+    });
+    const joined = formatOpenShellStateRpcIssue(issue!).join("\n");
+    expect(joined).toContain(
+      "Running gateway binary: /home/u/.local/bin/openshell-gateway (0.0.43)",
     );
   });
 

--- a/src/lib/adapters/openshell/gateway-drift.ts
+++ b/src/lib/adapters/openshell/gateway-drift.ts
@@ -469,11 +469,7 @@ function compactOutput(output: string): string {
 
 export function formatOpenShellStateRpcIssue(
   issue: OpenShellStateRpcIssue,
-  {
-    action = "querying OpenShell sandbox state",
-    command,
-    gatewayName = DEFAULT_GATEWAY_NAME,
-  }: FormatIssueOptions = {},
+  { action = "querying OpenShell sandbox state", command }: FormatIssueOptions = {},
 ): string[] {
   const phaseLine =
     issue.kind === "protobuf_mismatch"
@@ -522,11 +518,16 @@ export function formatOpenShellStateRpcIssue(
     lines.push(
       `  If gateway recreation is required, preserve sandbox state first; do not delete sandbox volumes or backups until \`openshell status\` reports a healthy ${CLI_DISPLAY_NAME} gateway on the installed OpenShell version.`,
     );
-  } else {
-    const gatewayContainerName =
-      drift?.containerName ?? getGatewayClusterContainerName(gatewayName);
+  } else if (drift) {
     lines.push(
-      `  If gateway recreation is required, preserve sandbox state first; do not remove \`${gatewayContainerName}\` Docker volumes unless you have a backup and explicitly accept state loss.`,
+      `  If gateway recreation is required, preserve sandbox state first; do not remove \`${drift.containerName}\` Docker volumes unless you have a backup and explicitly accept state loss.`,
+    );
+  } else {
+    // protobuf_mismatch with no resolved drift: the gateway driver is unknown
+    // here (could be host-process), so stay gateway-neutral rather than naming a
+    // cluster container that may not exist.
+    lines.push(
+      `  If gateway recreation is required, preserve sandbox state first; do not delete sandbox state, backups, or gateway data until \`openshell status\` reports a healthy ${CLI_DISPLAY_NAME} gateway.`,
     );
   }
 

--- a/src/lib/adapters/openshell/gateway-drift.ts
+++ b/src/lib/adapters/openshell/gateway-drift.ts
@@ -1,11 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
+import {
+  getDockerDriverGatewayRuntimeMarkerPath,
+  readDockerDriverGatewayRuntimeMarker,
+} from "../../onboard/docker-driver-gateway-runtime-marker";
+import {
+  hostGatewayCmdlineMatches,
+  resolveDockerDriverGatewayStateDir,
+} from "../../onboard/host-gateway-process";
 import { isOpenShellProtobufSchemaMismatch } from "../../runtime-recovery";
 import { isGatewayHealthy } from "../../state/gateway";
 import { dockerContainerInspectFormat } from "../docker";
-import { stripAnsi } from "./client";
+import { parseVersionFromText, stripAnsi } from "./client";
+import { resolveOpenshell } from "./resolve";
 import { captureOpenshell, getInstalledOpenshellVersionOrNull } from "./runtime";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "./timeouts";
 
@@ -18,6 +32,19 @@ export type GatewayClusterImageDrift = {
   expectedVersion: string;
 };
 
+export type GatewayHostProcessDrift = {
+  gatewayBin: string | null;
+  currentVersion: string;
+  expectedVersion: string;
+};
+
+export type GatewayDrift = GatewayClusterImageDrift | GatewayHostProcessDrift;
+
+export type HostProcessGatewayRuntime = {
+  gatewayBin: string | null;
+  runningVersion: string | null;
+};
+
 export type OpenShellStateRpcIssue =
   | {
       kind: "image_drift";
@@ -25,8 +52,13 @@ export type OpenShellStateRpcIssue =
       output?: string;
     }
   | {
+      kind: "host_process_drift";
+      drift: GatewayHostProcessDrift;
+      output?: string;
+    }
+  | {
       kind: "protobuf_mismatch";
-      drift?: GatewayClusterImageDrift | null;
+      drift?: GatewayDrift | null;
       output: string;
     };
 
@@ -34,7 +66,14 @@ type GatewayDriftDeps = {
   getInstalledOpenshellVersion?: () => string | null;
   getGatewayClusterImageRef?: (gatewayName: string) => string | null;
   isGatewayClusterActive?: (gatewayName: string) => boolean;
+  getHostProcessGatewayRuntime?: () => HostProcessGatewayRuntime | null;
 };
+
+export function isHostProcessGatewayDrift(
+  drift: GatewayDrift | null | undefined,
+): drift is GatewayHostProcessDrift {
+  return !!drift && "gatewayBin" in drift;
+}
 
 type GatewayDriftOptions = {
   gatewayName?: string;
@@ -57,7 +96,8 @@ function hasInjectedGatewayDriftDeps(deps: GatewayDriftDeps): boolean {
   return (
     typeof deps.getInstalledOpenshellVersion === "function" ||
     typeof deps.getGatewayClusterImageRef === "function" ||
-    typeof deps.isGatewayClusterActive === "function"
+    typeof deps.isGatewayClusterActive === "function" ||
+    typeof deps.getHostProcessGatewayRuntime === "function"
   );
 }
 
@@ -225,13 +265,184 @@ export function getGatewayClusterImageDrift({
   };
 }
 
+function probeGatewayBinaryVersion(gatewayBin: string, timeoutMs: number): string | null {
+  try {
+    const result = spawnSync(gatewayBin, ["--version"], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.error) return null;
+    return parseVersionFromText(`${result.stdout || ""}${result.stderr || ""}`);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether `pid` is a live host-process gateway. Uses `process.kill(pid, 0)` for
+ * liveness, then confirms identity via {@link hostGatewayCmdlineMatches}, which
+ * gates on argv0 (the executable) rather than any cmdline token — so a recycled
+ * PID belonging to an unrelated process that merely mentions the binary path
+ * (e.g. `vim /opt/.../openshell-gateway`) cannot make a stale marker look live.
+ */
+function isLiveGatewayProcess(pid: number | null | undefined, gatewayBin: string | null): boolean {
+  if (!Number.isInteger(pid as number) || (pid as number) <= 0) return false;
+  try {
+    process.kill(pid as number, 0);
+  } catch (err) {
+    // ESRCH → no such process (dead). EPERM → exists but not ours (alive).
+    if ((err as NodeJS.ErrnoException).code !== "EPERM") return false;
+  }
+  let cmdline = "";
+  try {
+    cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, "utf-8").replace(/\0/g, " ").trim();
+  } catch {
+    try {
+      const ps = spawnSync("ps", ["-p", String(pid), "-o", "args="], {
+        encoding: "utf-8",
+        timeout: 2000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      cmdline = ps.status === 0 ? String(ps.stdout || "").trim() : "";
+    } catch {
+      cmdline = "";
+    }
+  }
+  return cmdline ? hostGatewayCmdlineMatches(cmdline, gatewayBin) : false;
+}
+
+/**
+ * Resolve the host-process gateway binary path. Prefers the binary of a *live*
+ * marker gateway process (what is actually serving RPCs). A stale marker — dead
+ * PID, e.g. after OpenShell was reinstalled elsewhere or
+ * `NEMOCLAW_OPENSHELL_GATEWAY_BIN` changed — must not be trusted, or we would
+ * flag drift against a binary that is no longer the gateway and wrongly block
+ * recovery. When the marker is stale or absent, mirror
+ * `onboard.ts:resolveOpenShellGatewayBinary` (env override → sibling of the
+ * resolved `openshell` binary → standard install paths): the binary
+ * `startDockerDriverGateway()` would actually launch next.
+ */
+function resolveHostProcessGatewayBin(
+  marker: { gatewayBin: string | null; pid?: number } | null,
+): string | null {
+  if (marker?.gatewayBin && isLiveGatewayProcess(marker.pid, marker.gatewayBin)) {
+    return marker.gatewayBin;
+  }
+  const configuredBin = process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN?.trim();
+  if (configuredBin) return path.resolve(configuredBin);
+  const openshellBin = resolveOpenshell();
+  const candidates = [
+    ...(openshellBin ? [path.join(path.dirname(openshellBin), "openshell-gateway")] : []),
+    path.join(os.homedir(), ".local", "bin", "openshell-gateway"),
+    "/usr/local/bin/openshell-gateway",
+    "/usr/bin/openshell-gateway",
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Resolve the host-process (Docker-driver) gateway binary and its on-disk
+ * version.
+ *
+ * We re-probe `<bin> --version` rather than trusting the marker's stored
+ * `openshellVersion`. That recorded value is the *CLI* version captured at
+ * launch, not the gateway binary's version, so it (a) misses the primary
+ * #4430 repro — a gateway binary swapped to a version *older* than the CLI,
+ * where the marker still records the newer CLI version — and (b) false-positives
+ * on a stale marker whose recorded process is long dead (the marker is only
+ * rewritten on the next NemoClaw-managed gateway start). The on-disk binary is
+ * the version that the gateway is currently serving or would next be launched
+ * from.
+ *
+ * The narrow remaining gap — an in-place OpenShell upgrade that leaves the old
+ * gateway *process* running while the on-disk binary is already new — cannot be
+ * resolved from local state (no reliable served-version probe exists), but it is
+ * still fail-closed: querying that stale process yields a protobuf/schema
+ * mismatch that {@link detectOpenShellStateRpcResultIssue} catches and surfaces
+ * with the same structured "no sandbox data was changed" guidance.
+ */
+export function getHostProcessGatewayRuntimeOrNull({
+  timeoutMs = OPENSHELL_PROBE_TIMEOUT_MS,
+}: { timeoutMs?: number } = {}): HostProcessGatewayRuntime | null {
+  const marker = readDockerDriverGatewayRuntimeMarker(
+    getDockerDriverGatewayRuntimeMarkerPath(resolveDockerDriverGatewayStateDir()),
+  );
+  const gatewayBin = resolveHostProcessGatewayBin(marker);
+  if (!gatewayBin) {
+    return null;
+  }
+  return { gatewayBin, runningVersion: probeGatewayBinaryVersion(gatewayBin, timeoutMs) };
+}
+
+/**
+ * Detect drift between the installed OpenShell CLI and a host-process /
+ * Docker-driver gateway binary. Only applies when there is no legacy
+ * `openshell-cluster-*` container to inspect; cluster-image drift is handled
+ * by {@link getGatewayClusterImageDrift}.
+ */
+export function getGatewayHostProcessDrift({
+  gatewayName = DEFAULT_GATEWAY_NAME,
+  deps = {},
+  timeoutMs = OPENSHELL_PROBE_TIMEOUT_MS,
+}: GatewayDriftOptions = {}): GatewayHostProcessDrift | null {
+  if (isGatewayDriftPreflightDisabled(deps)) {
+    return null;
+  }
+  // Host-process drift only applies when the active gateway is not a legacy
+  // cluster container. A cluster image ref alone is not enough: `docker inspect`
+  // still returns `.Config.Image` for a *stopped* leftover container, which must
+  // not mask a real host-process gateway. Only suppress host-process detection
+  // when that container is actually the active gateway (mirrors the cluster
+  // detector's own active gate). The active probe runs solely when a cluster
+  // container exists, so the common marker-less host-process path stays cheap.
+  const clusterImage =
+    deps.getGatewayClusterImageRef?.(gatewayName) ??
+    getGatewayClusterImageRef(gatewayName, { timeoutMs });
+  if (clusterImage) {
+    const clusterActive =
+      deps.isGatewayClusterActive?.(gatewayName) ??
+      isGatewayClusterActiveForGateway(gatewayName, { timeoutMs });
+    if (clusterActive) {
+      return null;
+    }
+  }
+  const expectedVersion =
+    deps.getInstalledOpenshellVersion?.() ??
+    getInstalledOpenshellVersionOrNull({ timeout: timeoutMs });
+  if (!expectedVersion) {
+    return null;
+  }
+  const runtime =
+    deps.getHostProcessGatewayRuntime?.() ??
+    getHostProcessGatewayRuntimeOrNull({ timeoutMs });
+  if (!runtime || !runtime.runningVersion || runtime.runningVersion === expectedVersion) {
+    return null;
+  }
+  return {
+    gatewayBin: runtime.gatewayBin,
+    currentVersion: runtime.runningVersion,
+    expectedVersion,
+  };
+}
+
 export function detectOpenShellStateRpcPreflightIssue({
   gatewayName = DEFAULT_GATEWAY_NAME,
   deps = {},
   timeoutMs = OPENSHELL_PROBE_TIMEOUT_MS,
 }: GatewayDriftOptions = {}): OpenShellStateRpcIssue | null {
-  const drift = getGatewayClusterImageDrift({ gatewayName, deps, timeoutMs });
-  return drift ? { kind: "image_drift", drift } : null;
+  const imageDrift = getGatewayClusterImageDrift({ gatewayName, deps, timeoutMs });
+  if (imageDrift) {
+    return { kind: "image_drift", drift: imageDrift };
+  }
+  const hostDrift = getGatewayHostProcessDrift({ gatewayName, deps, timeoutMs });
+  if (hostDrift) {
+    return { kind: "host_process_drift", drift: hostDrift };
+  }
+  return null;
 }
 
 export function detectOpenShellStateRpcResultIssue(
@@ -246,7 +457,8 @@ export function detectOpenShellStateRpcResultIssue(
     kind: "protobuf_mismatch",
     drift: isGatewayDriftPreflightDisabled(deps)
       ? null
-      : getGatewayClusterImageDrift({ gatewayName, deps, timeoutMs }),
+      : (getGatewayClusterImageDrift({ gatewayName, deps, timeoutMs }) ??
+        getGatewayHostProcessDrift({ gatewayName, deps, timeoutMs })),
     output,
   };
 }
@@ -264,22 +476,24 @@ export function formatOpenShellStateRpcIssue(
   }: FormatIssueOptions = {},
 ): string[] {
   const phaseLine =
-    issue.kind === "image_drift"
-      ? `  OpenShell gateway schema preflight failed before ${action}.`
-      : `  OpenShell gateway/schema mismatch was detected while ${action}.`;
+    issue.kind === "protobuf_mismatch"
+      ? `  OpenShell gateway/schema mismatch was detected while ${action}.`
+      : `  OpenShell gateway schema preflight failed before ${action}.`;
   const lines = [
     "",
     phaseLine,
   ];
 
-  const drift = issue.kind === "image_drift" ? issue.drift : issue.drift || null;
-  const gatewayContainerName =
-    drift?.containerName ?? getGatewayClusterContainerName(gatewayName);
+  const drift = issue.kind === "protobuf_mismatch" ? issue.drift ?? null : issue.drift;
   if (drift) {
-    lines.push(
-      `  Installed OpenShell: ${drift.expectedVersion}`,
-      `  Running gateway image: ${drift.currentImage} (${drift.currentVersion})`,
-    );
+    lines.push(`  Installed OpenShell: ${drift.expectedVersion}`);
+    if (isHostProcessGatewayDrift(drift)) {
+      lines.push(
+        `  Running gateway binary: ${drift.gatewayBin ?? "host-process gateway"} (${drift.currentVersion})`,
+      );
+    } else {
+      lines.push(`  Running gateway image: ${drift.currentImage} (${drift.currentVersion})`);
+    }
   } else {
     lines.push(
       `  ${CLI_DISPLAY_NAME} saw protobuf/schema mismatch output from OpenShell.`,
@@ -299,11 +513,22 @@ export function formatOpenShellStateRpcIssue(
     "  No sandbox data was changed.",
     "",
     "  Recovery:",
-    `    1. Run \`${CLI_NAME} onboard --resume\` to repair or recreate the ${CLI_DISPLAY_NAME} gateway with the installed OpenShell image.`,
+    `    1. Run \`${CLI_NAME} onboard --resume\` to repair or recreate the ${CLI_DISPLAY_NAME} gateway with the installed OpenShell version.`,
     `    2. Rerun${command ? ` \`${command}\`` : " the command"} after \`openshell status\` reports a healthy ${CLI_DISPLAY_NAME} gateway.`,
     "",
-    `  If gateway recreation is required, preserve sandbox state first; do not remove \`${gatewayContainerName}\` Docker volumes unless you have a backup and explicitly accept state loss.`,
   );
+
+  if (isHostProcessGatewayDrift(drift)) {
+    lines.push(
+      `  If gateway recreation is required, preserve sandbox state first; do not delete sandbox volumes or backups until \`openshell status\` reports a healthy ${CLI_DISPLAY_NAME} gateway on the installed OpenShell version.`,
+    );
+  } else {
+    const gatewayContainerName =
+      drift?.containerName ?? getGatewayClusterContainerName(gatewayName);
+    lines.push(
+      `  If gateway recreation is required, preserve sandbox state first; do not remove \`${gatewayContainerName}\` Docker volumes unless you have a backup and explicitly accept state loss.`,
+    );
+  }
 
   return lines;
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2540,10 +2540,10 @@ async function startDockerDriverGateway({ exitOnFailure = true, skipSandboxBridg
       ignoreError: true,
     });
     const currentInfo = runCaptureOpenshell(["gateway", "info"], { ignoreError: true });
-    if (
-      isGatewayHealthy(status, namedInfo, currentInfo) &&
-      (await isGatewayTcpReady())
-    ) {
+    // #4430: the status/gateway-info/TCP probes above take real wall-clock time; re-confirm
+    // childExit/isPidAlive *after* them so a gateway that drifts on schema and aborts during
+    // migration after accepting briefly can never print the misleading healthy line below.
+    if (isGatewayHealthy(status, namedInfo, currentInfo) && (await isGatewayTcpReady()) && !childExit.exited && isPidAlive(childPid)) {
       await verifySandboxBridgeGatewayReachableOrExit(exitOnFailure, { skip: skipSandboxBridgeReachability }); console.log("  ✓ Docker-driver gateway is healthy");
       return;
     }

--- a/src/lib/onboard/host-gateway-process.ts
+++ b/src/lib/onboard/host-gateway-process.ts
@@ -168,7 +168,7 @@ function pidOwner(pid: number, deps: HostGatewayProcessDeps): string | null {
   return result.stdout.trim() || null;
 }
 
-function hostGatewayCmdlineMatches(
+export function hostGatewayCmdlineMatches(
   cmdline: string,
   gatewayBin: string | null | undefined,
 ): boolean {

--- a/test/e2e/test-gateway-drift-preflight.sh
+++ b/test/e2e/test-gateway-drift-preflight.sh
@@ -24,8 +24,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 WORK_ROOT="$(mktemp -d -t nemoclaw-gateway-drift-preflight.XXXXXX)"
 export NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT=0
+LIVE_GATEWAY_PID=""
 
 cleanup() {
+  if [ -n "$LIVE_GATEWAY_PID" ]; then
+    kill "$LIVE_GATEWAY_PID" 2>/dev/null || true
+  fi
   rm -rf "$WORK_ROOT"
 }
 trap cleanup EXIT
@@ -170,6 +174,105 @@ run_backup_case() {
   return $?
 }
 
+# Host-process / Docker-driver gateway: there is no openshell-cluster-* container,
+# so docker inspect always fails. The gateway version comes from probing the
+# gateway binary recorded in the runtime marker.
+write_fake_docker_no_cluster() {
+  local bin_dir="$1"
+  cat >"$bin_dir/docker" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "$NEMOCLAW_FAKE_CASE_DIR/docker-calls.log"
+if [ "${1:-}" = "inspect" ] || { [ "${1:-}" = "container" ] && [ "${2:-}" = "inspect" ]; }; then
+  printf 'Error: No such object\n' >&2
+  exit 1
+fi
+exit 0
+SH
+  chmod +x "$bin_dir/docker"
+}
+
+write_fake_gateway_binary() {
+  local bin_dir="$1"
+  local version="${2:-0.0.43}"
+  # --version prints the (drifted) version; any other invocation sleeps so the
+  # script can run it as a long-lived process whose PID seeds a live marker.
+  cat >"$bin_dir/openshell-gateway" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in --version|-V) printf 'openshell-gateway %s\n' '$version'; exit 0 ;; esac
+# Stay alive as a long-lived process whose argv0 is this binary path, so the
+# drift detector's argv0-based liveness/identity check recognizes it the same
+# way it recognizes a real openshell-gateway process.
+exec -a "\$0" sleep 600
+SH
+  chmod +x "$bin_dir/openshell-gateway"
+}
+
+write_host_process_marker() {
+  local home="$1"
+  local gateway_bin="$2"
+  local pid="${3:-999999}"
+  local state_dir="$home/.local/state/nemoclaw/openshell-docker-gateway"
+  mkdir -p "$state_dir"
+  cat >"$state_dir/runtime.json" <<JSON
+{
+  "version": 1,
+  "pid": $pid,
+  "driver": "docker",
+  "platform": "linux",
+  "arch": "$(node -e 'process.stdout.write(process.arch)')",
+  "endpoint": "http://127.0.0.1:8080",
+  "desiredEnvHash": "deadbeef",
+  "gatewayBin": "$gateway_bin",
+  "openshellVersion": "0.0.44",
+  "dockerHost": "unix:///run/docker.sock",
+  "createdAt": "2026-05-25T10:27:03.702Z"
+}
+JSON
+  chmod 600 "$state_dir/runtime.json"
+}
+
+run_host_process_case() {
+  local name="$1"
+  shift
+  CASE_DIR="$WORK_ROOT/$name"
+  local home="$CASE_DIR/home"
+  local bin_dir="$CASE_DIR/bin"
+  mkdir -p "$home" "$bin_dir"
+  export TMPDIR="$CASE_DIR"
+  : >"$CASE_DIR/openshell-calls.log"
+  : >"$CASE_DIR/docker-calls.log"
+  write_registry "$home"
+  write_fake_openshell "$bin_dir"
+  write_fake_docker_no_cluster "$bin_dir"
+  write_fake_gateway_binary "$bin_dir" "${NEMOCLAW_FAKE_GATEWAY_BIN_VERSION:-0.0.43}"
+  if [ "${NEMOCLAW_E2E_SKIP_MARKER:-0}" = "1" ]; then
+    # No marker: exercise the marker-less fallback resolver (sibling of the
+    # resolved openshell binary on PATH).
+    :
+  elif [ "${NEMOCLAW_E2E_LIVE_MARKER:-0}" = "1" ]; then
+    # Live marker: start the gateway as a long-lived process and seed the marker
+    # with its PID, so the detector trusts marker.gatewayBin via the liveness
+    # check rather than the fallback resolver.
+    "$bin_dir/openshell-gateway" serve &
+    LIVE_GATEWAY_PID=$!
+    write_host_process_marker "$home" "$bin_dir/openshell-gateway" "$LIVE_GATEWAY_PID"
+  else
+    # Stale marker (dead PID): the detector must ignore marker.gatewayBin and
+    # fall back to live resolution.
+    write_host_process_marker "$home" "$bin_dir/openshell-gateway"
+  fi
+
+  local output="$CASE_DIR/command.out"
+  HOME="$home" \
+    PATH="$bin_dir:$PATH" \
+    NEMOCLAW_FAKE_CASE_DIR="$CASE_DIR" \
+    TMPDIR="$CASE_DIR" \
+    NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT="${NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT:-0}" \
+    "$@" >"$output" 2>&1
+  return $?
+}
+
 assert_contains() {
   local file="$1" pattern="$2" description="$3"
   if grep -qiE "$pattern" "$file"; then
@@ -230,6 +333,91 @@ if grep -qx 'sandbox list' "$CASE_DIR/openshell-calls.log"; then
   fail "sandbox list was called despite preflight image drift"
 fi
 pass "preflight image drift blocks sandbox list"
+
+section "Host-process gateway binary drift fails before sandbox list (backup-all, live marker)"
+set +e
+NEMOCLAW_E2E_LIVE_MARKER=1 \
+  run_host_process_case host-process-backup \
+  node "$REPO_ROOT/bin/nemoclaw.js" backup-all
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "backup-all unexpectedly succeeded with host-process gateway binary drift"
+pass "backup-all exits non-zero on host-process gateway binary drift"
+assert_contains "$CASE_DIR/command.out" 'schema preflight failed|gateway schema preflight failed|Running gateway binary' "host-process gateway drift preflight is surfaced"
+assert_contains "$CASE_DIR/command.out" '0\.0\.37' "installed OpenShell version is reported"
+assert_contains "$CASE_DIR/command.out" 'Running gateway binary.*0\.0\.43' "running host-process gateway binary/version is reported"
+assert_contains "$CASE_DIR/command.out" 'No sandbox data was changed|Refusing to trust OpenShell sandbox state' "fail-closed no-mutation guidance is printed"
+assert_not_contains "$CASE_DIR/command.out" 'Running gateway image' "host-process drift does not claim a cluster image"
+if grep -qx 'sandbox list' "$CASE_DIR/openshell-calls.log"; then
+  fail "sandbox list was called despite host-process preflight drift"
+fi
+pass "preflight host-process drift blocks sandbox list"
+
+section "Host-process gateway binary drift fails before sandbox list (upgrade-sandboxes)"
+set +e
+run_host_process_case host-process-upgrade \
+  node "$REPO_ROOT/bin/nemoclaw.js" upgrade-sandboxes --check
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "upgrade-sandboxes unexpectedly succeeded with host-process gateway binary drift"
+pass "upgrade-sandboxes exits non-zero on host-process gateway binary drift"
+assert_contains "$CASE_DIR/command.out" 'schema preflight failed|gateway schema preflight failed|Running gateway binary' "host-process gateway drift preflight is surfaced for upgrade-sandboxes"
+assert_contains "$CASE_DIR/command.out" 'Running gateway binary.*0\.0\.43' "running host-process gateway binary/version is reported for upgrade-sandboxes"
+if grep -qx 'sandbox list' "$CASE_DIR/openshell-calls.log"; then
+  fail "sandbox list was called despite host-process preflight drift (upgrade-sandboxes)"
+fi
+pass "preflight host-process drift blocks sandbox list for upgrade-sandboxes"
+
+section "Host-process gateway binary drift detected via fallback resolver (no runtime marker)"
+set +e
+NEMOCLAW_E2E_SKIP_MARKER=1 \
+  run_host_process_case host-process-no-marker \
+  node "$REPO_ROOT/bin/nemoclaw.js" backup-all
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "backup-all unexpectedly succeeded with host-process drift and no runtime marker"
+pass "backup-all exits non-zero on host-process gateway binary drift without a runtime marker"
+assert_contains "$CASE_DIR/command.out" 'schema preflight failed|gateway schema preflight failed|Running gateway binary' "host-process gateway drift preflight is surfaced without a marker"
+assert_contains "$CASE_DIR/command.out" 'Running gateway binary.*0\.0\.43' "fallback-resolved gateway binary/version is reported"
+if grep -qx 'sandbox list' "$CASE_DIR/openshell-calls.log"; then
+  fail "sandbox list was called despite host-process preflight drift (no marker)"
+fi
+pass "preflight host-process drift (fallback resolver) blocks sandbox list"
+
+section "Stale runtime marker does not false-positive when the live gateway matches the CLI"
+# A dead-PID marker points at a separate old binary, but the gateway that
+# recovery would actually launch (sibling of openshell on PATH) matches the
+# installed CLI. The preflight must NOT flag host-process drift; it should pass
+# and let the (reactive) sandbox-list path run.
+CASE_DIR="$WORK_ROOT/host-process-stale-marker"
+stale_home="$CASE_DIR/home"
+stale_bin="$CASE_DIR/bin"
+stale_old="$CASE_DIR/old-install"
+mkdir -p "$stale_home" "$stale_bin" "$stale_old"
+: >"$CASE_DIR/openshell-calls.log"
+: >"$CASE_DIR/docker-calls.log"
+write_registry "$stale_home"
+write_fake_openshell "$stale_bin"
+write_fake_docker_no_cluster "$stale_bin"
+# Sibling gateway on PATH matches the fake CLI version (0.0.37): no real drift.
+write_fake_gateway_binary "$stale_bin" "0.0.37"
+# Separate stale binary (0.0.43) referenced by a dead-PID marker.
+write_fake_gateway_binary "$stale_old" "0.0.43"
+write_host_process_marker "$stale_home" "$stale_old/openshell-gateway" 999999
+set +e
+HOME="$stale_home" \
+  PATH="$stale_bin:$PATH" \
+  NEMOCLAW_FAKE_CASE_DIR="$CASE_DIR" \
+  TMPDIR="$CASE_DIR" \
+  NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT=0 \
+  node "$REPO_ROOT/bin/nemoclaw.js" backup-all >"$CASE_DIR/command.out" 2>&1
+set -e
+assert_not_contains "$CASE_DIR/command.out" 'Running gateway binary.*0\.0\.43' "stale marker binary is not used to fabricate drift"
+if grep -qx 'sandbox list' "$CASE_DIR/openshell-calls.log"; then
+  pass "preflight passes (no false positive) and proceeds to sandbox list"
+else
+  fail "preflight blocked sandbox list on a stale marker even though the live gateway matches the CLI"
+fi
 
 section "Summary"
 pass "Gateway drift preflight regression guard completed"


### PR DESCRIPTION
## Summary

`backup-all` and `upgrade-sandboxes` only ran the structured OpenShell gateway *schema preflight* for legacy cluster-container image drift. On a host-process / Docker-driver gateway there is no `openshell-cluster-*` container to inspect, so the preflight returned `null` and a drifted/older gateway binary fell through to the generic `Failed to query running sandboxes` recovery message instead of the structured "schema preflight failed" guidance. This extends drift detection to host-process gateways while preserving the existing fail-closed (no-mutation) behavior.

## Related Issue

Fixes #4430 — https://github.com/NVIDIA/NemoClaw/issues/4430

## Changes

- **Host-process gateway drift detection** (`src/lib/adapters/openshell/gateway-drift.ts`): compare the installed OpenShell CLI version against the running/launchable gateway binary's `--version`. The binary is resolved from a *live* runtime marker, else `NEMOCLAW_OPENSHELL_GATEWAY_BIN` → sibling of the resolved `openshell` binary → standard install paths (mirrors `resolveOpenShellGatewayBinary`). A stale marker (dead or recycled PID — verified via argv0 using the shared `hostGatewayCmdlineMatches`) is ignored so a reinstall elsewhere cannot fabricate drift.
- Host-process detection is suppressed only when an **active** cluster gateway exists, so a stopped leftover `openshell-cluster-*` container no longer masks host-process drift.
- New `host_process_drift` issue kind formats a `Running gateway binary: <bin> (<ver>)` line plus host-process-appropriate recovery guidance; cluster-container output is unchanged. Host-process drift detail is also attached to the reactive protobuf-mismatch path.
- **Startup readiness tightening** (`src/lib/onboard.ts`, net-neutral): re-confirm process liveness *after* the status/gateway-info/TCP probes so a gateway that crashes during migration can no longer print a misleading `✓ Docker-driver gateway is healthy` line.
- Tests: unit coverage in `gateway-drift.test.ts` and `gateway-drift-preflight.test.ts`; host-process e2e variants (live marker, marker-less fallback, stale-marker false-positive guard) in `test/e2e/test-gateway-drift-preflight.sh`.

Fail-closed behavior is preserved: both commands still exit 1 before trusting live sandbox state or mutating backup/rebuild state. The narrow remaining gap — an in-place OpenShell upgrade that leaves an old gateway *process* running while the on-disk binary is already new — has no reliable local served-version signal, but stays fail-closed: querying that process yields a protobuf/schema mismatch that `detectOpenShellStateRpcResultIssue` surfaces with the same structured guidance.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] Targeted Vitest suites pass (`gateway-drift`, `gateway-drift-preflight`, `sandbox/status`, `host-gateway-process`, `docker-driver-gateway-runtime-marker`, and adjacent gateway-state/rebuild tests)
- [x] `test/e2e/test-gateway-drift-preflight.sh` passes (cluster image drift, protobuf mismatch, host-process live-marker / marker-less / stale-marker cases)
- [x] `npm run typecheck:cli`, `biome lint`, and the layer-import-boundary check pass
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] `npm test` (full suite) — targeted + e2e suites run green; the full run has pre-existing environmental failures on this host (umask-dependent `config-sync`, oclif-usage, ollama/inference-route, and `tsx`-subprocess timeout tests) that reproduce on `main` without this change
- [ ] Docs updated — not required; this changes diagnostic CLI output only, no new user-facing flags or pages
- `codex review --uncommitted` reports no actionable findings

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect host-process gateway binary drift and surface clear, gateway-specific diagnostics and recovery guidance.

* **Bug Fixes**
  * Tighter gateway health checks to avoid reporting a gateway as healthy if its process exits during probing.

* **Tests**
  * Added unit and end-to-end tests covering host-process drift detection and early termination behavior for backup/upgrade preflight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->