### PR TITLE
fix(sandbox): classify Docker daemon outage instead of stuck-phase/connect timeout (#4428)

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -28,6 +28,11 @@ import { LOCAL_INFERENCE_TIMEOUT_SECS } from "../../onboard/env";
 import { isWsl } from "../../platform";
 import { ROOT } from "../../runner";
 import * as sandboxVersion from "../../sandbox/version";
+import {
+  isTerminalSandboxPhase,
+  parseSandboxPhase,
+  TERMINAL_SANDBOX_PHASES,
+} from "../../state/gateway";
 import type { SandboxEntry } from "../../state/registry";
 import * as registry from "../../state/registry";
 import {
@@ -36,6 +41,10 @@ import {
 } from "../../state/sandbox-session";
 import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import { runSetupDnsProxy } from "../dns";
+import {
+  isDockerRuntimeDown,
+  printDockerRuntimeDownGuidance,
+} from "./gateway-failure-classifier";
 import { ensureLiveSandboxOrExit, printGatewayLifecycleHint } from "./gateway-state";
 import { checkAndRecoverSandboxProcesses } from "./process-recovery";
 import {
@@ -206,6 +215,15 @@ function failConnectReadinessGatewayUnavailable(
 
 function outputShowsGatewayUnavailable(output = ""): boolean {
   return GATEWAY_UNAVAILABLE_RE.test(output);
+}
+
+// Fail fast with Docker-outage guidance instead of polling to the readiness
+// timeout. Only fires for Docker-driver sandboxes whose `docker info` is
+// failing (#4428).
+function failConnectReadinessDockerRuntimeDown(sandboxName: string): never {
+  console.error("");
+  printDockerRuntimeDownGuidance(sandboxName, { writer: console.error, retryCommand: "connect" });
+  process.exit(1);
 }
 
 function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {
@@ -762,7 +780,25 @@ export async function connectSandbox(
 ): Promise<void> {
   preflightVllmModelEnvOrExit();
   const { isSandboxReady, parseSandboxStatus } = require("../../onboard");
-  await ensureLiveSandboxOrExit(sandboxName, { allowNonReadyPhase: true });
+  const live = await ensureLiveSandboxOrExit(sandboxName, { allowNonReadyPhase: true });
+
+  // Fast-fail on a Docker daemon outage before the probe-only health check and
+  // the session/recovery probes below (each can spawn 15s `openshell sandbox
+  // exec`/`ssh-config` calls) and before the readiness wait loop. When Docker
+  // is down and the sandbox is not yet ready, connect cannot make progress;
+  // surface the outage immediately so the user is not left waiting tens of
+  // seconds (or killed by an external `timeout`). Terminal phases keep their
+  // normal handling below (#4428).
+  const livePhase = parseSandboxPhase(live.output || "");
+  if (
+    livePhase &&
+    livePhase !== "Ready" &&
+    livePhase !== "Running" &&
+    !isTerminalSandboxPhase(livePhase) &&
+    isDockerRuntimeDown(sandboxName)
+  ) {
+    failConnectReadinessDockerRuntimeDown(sandboxName);
+  }
 
   if (probeOnly) {
     return runSandboxConnectProbe(sandboxName);
@@ -840,20 +876,20 @@ export async function connectSandbox(
     if (!listCommandFailed && status && /^unknown$/i.test(status)) {
       failIfGatewayBlocksConnectReadiness(sandboxName);
     }
-    const TERMINAL = new Set([
-      "Failed",
-      "Error",
-      "CrashLoopBackOff",
-      "ImagePullBackOff",
-      "Unknown",
-      "Evicted",
-    ]);
-    if (status && TERMINAL.has(status)) {
+    if (status && TERMINAL_SANDBOX_PHASES.has(status)) {
       console.error("");
       console.error(`  Sandbox '${sandboxName}' is in '${status}' state.`);
       console.error(`  Run:  ${CLI_NAME} ${sandboxName} logs --follow`);
       console.error(`  Run:  ${CLI_NAME} ${sandboxName} status`);
       process.exit(1);
+    }
+
+    // Probe-disagreement safety net: `sandbox get` may have reported Ready/no
+    // phase (so the early guard was skipped) while `sandbox list` shows a
+    // non-terminal status. Status is non-terminal here, so re-check Docker and
+    // fail fast rather than entering the readiness loop (#4428).
+    if (isDockerRuntimeDown(sandboxName)) {
+      failConnectReadinessDockerRuntimeDown(sandboxName);
     }
 
     console.log(`  Waiting for sandbox '${sandboxName}' to be ready...`);
@@ -882,12 +918,17 @@ export async function connectSandbox(
         failIfGatewayBlocksConnectReadiness(sandboxName);
       }
       if (cur !== "unknown") everSeen = true;
-      if (TERMINAL.has(cur)) {
+      if (TERMINAL_SANDBOX_PHASES.has(cur)) {
         console.error("");
         console.error(`  Sandbox '${sandboxName}' entered '${cur}' state.`);
         console.error(`  Run:  ${CLI_NAME} ${sandboxName} logs --follow`);
         console.error(`  Run:  ${CLI_NAME} ${sandboxName} status`);
         process.exit(1);
+      }
+      // Catch a Docker daemon that dies mid-wait so we stop polling instead of
+      // running out the full readiness timeout (#4428).
+      if (isDockerRuntimeDown(sandboxName)) {
+        failConnectReadinessDockerRuntimeDown(sandboxName);
       }
       if (!everSeen && elapsed >= 30) {
         console.error("");

--- a/src/lib/actions/sandbox/gateway-failure-classifier.ts
+++ b/src/lib/actions/sandbox/gateway-failure-classifier.ts
@@ -5,7 +5,9 @@ import net from "node:net";
 
 import { dockerInfo } from "../../adapters/docker/info";
 import { dockerCapture } from "../../adapters/docker/run";
+import { CLI_NAME } from "../../cli/branding";
 import { GATEWAY_PORT } from "../../core/ports";
+import * as registry from "../../state/registry";
 
 const DEFAULT_CONTAINER = "openshell-cluster-nemoclaw";
 const DOCKER_TIMEOUT_MS = 3000;
@@ -131,4 +133,85 @@ const LAYER_HEADERS: Record<GatewayFailureLayer, string> = {
 
 export function getLayerHeader(layer: GatewayFailureLayer): string {
   return LAYER_HEADERS[layer];
+}
+
+type SandboxDriverLookup = (
+  name: string,
+) => { openshellDriver?: string | null } | null | undefined;
+
+// Drivers whose sandbox runtime does NOT live in the local Docker daemon. Only
+// `vm` qualifies: the NemoClaw gateway always runs as the local Docker
+// container `openshell-cluster-nemoclaw` (see classifyGatewayFailure), so the
+// `docker` driver and the `kubernetes`/k3s driver (k3s-in-Docker, or Docker
+// Desktop's Kubernetes — selected by `isLinuxDockerDriverGatewayEnabled()` for
+// non-Linux/non-arm64 hosts) both depend on a reachable local Docker daemon. A
+// `vm` sandbox runs in a real VM with no local Docker daemon, so a failing
+// `docker info` is normal and must not trigger the outage preflight.
+const NON_DOCKER_DRIVERS = new Set(["vm"]);
+
+/**
+ * Whether a sandbox's runtime depends on the local Docker daemon. Only the
+ * explicit `vm` driver is excluded. The `docker` and `kubernetes` drivers are
+ * Docker-backed, and legacy/recovered registry entries that predate
+ * `openshellDriver` metadata (field omitted/null) are also treated as
+ * Docker-backed so the outage guard still protects the Linux/Docker sandboxes
+ * #4428 targets — the historical default driver was Docker. The narrow cost is
+ * that a recovered `vm` entry that lost its driver metadata could see Docker
+ * guidance on a Docker-less host; that is preferable to silently regressing
+ * every legacy Docker sandbox. (#4428)
+ */
+function isDockerBackedSandbox(sandboxName: string, getSandbox: SandboxDriverLookup): boolean {
+  const driver = getSandbox(sandboxName)?.openshellDriver;
+  return !(typeof driver === "string" && NON_DOCKER_DRIVERS.has(driver.toLowerCase()));
+}
+
+/**
+ * Synchronous Docker daemon reachability check for a specific sandbox (the
+ * `docker_unreachable` layer of {@link classifyGatewayFailure}). Sandbox
+ * commands use this as a fast preflight so a transient Docker daemon outage is
+ * classified as a host runtime problem rather than a stuck sandbox phase or a
+ * connect timeout (#4428). Returns `false` for non-Docker drivers so VM/
+ * Kubernetes sandboxes are never misclassified. `docker info` is a `spawnSync`
+ * call, so this stays synchronous and can run from non-async call sites such
+ * as `logs` and `policy-list`.
+ */
+export function isDockerRuntimeDown(
+  sandboxName: string,
+  opts?: {
+    runners?: Pick<GatewayFailureRunners, "dockerInfo">;
+    getSandbox?: SandboxDriverLookup;
+  },
+): boolean {
+  const getSandbox = opts?.getSandbox ?? registry.getSandbox;
+  if (!isDockerBackedSandbox(sandboxName, getSandbox)) return false;
+  const probe = opts?.runners?.dockerInfo ?? defaultRunners.dockerInfo;
+  return !probe();
+}
+
+/**
+ * Print actionable recovery guidance for a Docker daemon outage. Deliberately
+ * never recommends rebuild/destroy/onboard: when Docker is down the sandbox
+ * itself is fine and recreating it cannot succeed until the daemon is back
+ * (#4428). Shared by status, connect, logs, and policy-list so the outage is
+ * named consistently as a host runtime problem.
+ */
+export function printDockerRuntimeDownGuidance(
+  sandboxName: string,
+  opts: { writer?: (message: string) => void; retryCommand?: string } = {},
+): void {
+  const writer = opts.writer ?? console.error;
+  const retryCommand = opts.retryCommand ?? "status";
+  writer(`  ${getLayerHeader("docker_unreachable")}`);
+  writer(
+    `  The Docker daemon is not reachable, so sandbox '${sandboxName}' cannot be verified or started.`,
+  );
+  writer(
+    "  This is a Docker runtime outage on the host, not a sandbox failure — do not rebuild, destroy, or re-onboard the sandbox.",
+  );
+  writer("  Recovery:");
+  writer(
+    "    1. Start the Docker daemon (e.g. `sudo systemctl start docker`, or start Docker Desktop).",
+  );
+  writer("    2. Confirm it is back with `docker info`.");
+  writer(`    3. Retry: ${CLI_NAME} ${sandboxName} ${retryCommand}`);
 }

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
-import { parseSandboxPhase } from "../../state/gateway";
+import { isTerminalSandboxPhase, parseSandboxPhase } from "../../state/gateway";
 import {
   getNamedGatewayLifecycleState,
   recoverNamedGatewayRuntime,
@@ -36,6 +36,10 @@ import {
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "../../adapters/openshell/timeouts";
 import * as registry from "../../state/registry";
+import {
+  isDockerRuntimeDown,
+  printDockerRuntimeDownGuidance,
+} from "./gateway-failure-classifier";
 
 export type SandboxGatewayState = {
   state: string;
@@ -393,6 +397,14 @@ export async function ensureLiveSandboxOrExit(
   if (lookup.state === "present") {
     const phase = parseSandboxPhase(lookup.output || "");
     if (!allowNonReadyPhase && phase && phase !== "Ready" && phase !== "Running") {
+      // Don't steer toward rebuild when the host Docker daemon is down: the
+      // sandbox is fine and recreating it cannot succeed until Docker is back
+      // (#4428). Terminal phases (Failed/Error/...) are settled failures and
+      // keep the rebuild guidance so a genuine failure is never masked.
+      if (!isTerminalSandboxPhase(phase) && isDockerRuntimeDown(sandboxName)) {
+        printDockerRuntimeDownGuidance(sandboxName);
+        process.exit(1);
+      }
       console.error(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
       console.error(
         "  This usually happens when a process crash inside the sandbox prevented clean startup.",

--- a/src/lib/actions/sandbox/logs.ts
+++ b/src/lib/actions/sandbox/logs.ts
@@ -16,6 +16,10 @@ import {
   normalizeSandboxLogsOptions,
 } from "../../domain/sandbox/logs";
 import { ROOT } from "../../runner";
+import {
+  isDockerRuntimeDown,
+  printDockerRuntimeDownGuidance,
+} from "./gateway-failure-classifier";
 
 function exitWithSpawnResult(result: LogProbeResult) {
   if (result.status !== null) {
@@ -174,7 +178,18 @@ function warnSandboxAuditLogsUnavailable(
 }
 
 export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions | boolean) {
+  // Normalize/validate options before any host I/O so malformed flags still
+  // surface their own error rather than a Docker-outage message.
   const logsOptions = normalizeSandboxLogsOptions(options);
+
+  // Preflight the Docker daemon so a host runtime outage is named as such
+  // instead of surfacing as opaque "log source unavailable" failures from the
+  // underlying OpenShell commands (#4428).
+  if (isDockerRuntimeDown(sandboxName)) {
+    printDockerRuntimeDownGuidance(sandboxName, { retryCommand: "logs" });
+    process.exit(1);
+  }
+
   if (logsOptions.follow) {
     streamSandboxFollowLogs(sandboxName, logsOptions);
     return;

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -26,6 +26,10 @@ import {
 import * as registry from "../../state/registry";
 import { runOpenshell } from "../../adapters/openshell/runtime";
 import { shellQuote } from "../../runner";
+import {
+  isDockerRuntimeDown,
+  printDockerRuntimeDownGuidance,
+} from "./gateway-failure-classifier";
 import { executeSandboxCommand, executeSandboxExecCommand } from "./process-recovery";
 import { rebuildSandbox } from "./rebuild";
 import { printTelegramDirectMessageAllowlistWarning } from "./telegram-channel-bridge-verification";
@@ -267,7 +271,18 @@ export function listSandboxPolicies(sandboxName: string) {
 
   if (gatewayPresets === null) {
     console.log("");
-    console.log("  ⚠ Could not query gateway — showing local state only.");
+    // A null gateway result can be a transient Docker daemon outage rather
+    // than a gateway-only problem. Name the runtime outage so the user
+    // restarts Docker instead of assuming their local policy state drifted
+    // (#4428).
+    if (isDockerRuntimeDown(sandboxName)) {
+      printDockerRuntimeDownGuidance(sandboxName, {
+        writer: console.log,
+        retryCommand: "policy-list",
+      });
+    } else {
+      console.log("  ⚠ Could not query gateway — showing local state only.");
+    }
   }
   console.log("");
 }

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -24,7 +24,7 @@ import {
 import * as nim from "../../inference/nim";
 import * as sandboxVersion from "../../sandbox/version";
 import * as shields from "../../shields";
-import { parseSandboxPhase } from "../../state/gateway";
+import { isTerminalSandboxPhase, parseSandboxPhase } from "../../state/gateway";
 import type { Session } from "../../state/onboard-session";
 import * as onboardSession from "../../state/onboard-session";
 import * as registry from "../../state/registry";
@@ -33,7 +33,12 @@ import {
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
 import { getSandboxDockerHealth } from "./docker-health";
-import { classifyGatewayFailure, getLayerHeader } from "./gateway-failure-classifier";
+import {
+  classifyGatewayFailure,
+  getLayerHeader,
+  isDockerRuntimeDown,
+  printDockerRuntimeDownGuidance,
+} from "./gateway-failure-classifier";
 import type { SandboxGatewayState } from "./gateway-state";
 import {
   getReconciledSandboxGatewayState,
@@ -338,6 +343,19 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
     console.log(lookup.output);
     const phase = parseSandboxPhase(lookup.output || "");
     if (phase && phase !== "Ready") {
+      // A non-ready, non-terminal phase can mean two very different things. If
+      // the Docker daemon is down, OpenShell can still return a present-but-
+      // Provisioning sandbox (cached/transitional state); steering the user
+      // toward rebuild is wrong because the sandbox is fine and rebuild cannot
+      // succeed until Docker is back. Reclassify as a runtime outage first
+      // (#4428). Terminal phases (Failed/Error/...) are settled sandbox
+      // failures and keep the existing rebuild guidance even when Docker is
+      // down, so a genuine failure is never masked.
+      if (!isTerminalSandboxPhase(phase) && isDockerRuntimeDown(sandboxName)) {
+        console.log("");
+        printDockerRuntimeDownGuidance(sandboxName, { writer: console.log });
+        process.exit(1);
+      }
       console.log("");
       console.log(`  Sandbox '${sandboxName}' is stuck in '${phase}' phase.`);
       console.log(

--- a/src/lib/state/gateway.ts
+++ b/src/lib/state/gateway.ts
@@ -168,6 +168,24 @@ export function parseSandboxPhase(getOutput: string): string | null {
   return match ? match[1] : null;
 }
 
+// Phases that represent a settled, non-transitional failure rather than a
+// sandbox still coming up. OpenShell only reports these when it has real
+// state, so a Docker-outage reclassification must NOT hide them — the user
+// needs the genuine failure/rebuild guidance even during a daemon blip
+// (#4428). Mirrors the terminal set used by the connect readiness loop.
+export const TERMINAL_SANDBOX_PHASES = new Set<string>([
+  "Failed",
+  "Error",
+  "CrashLoopBackOff",
+  "ImagePullBackOff",
+  "Unknown",
+  "Evicted",
+]);
+
+export function isTerminalSandboxPhase(phase: string | null | undefined): boolean {
+  return !!phase && TERMINAL_SANDBOX_PHASES.has(phase);
+}
+
 export function getSandboxStateFromOutputs(
   sandboxName: string,
   getOutput = "",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -169,6 +169,21 @@ function writeSandboxRegistry(
   );
 }
 
+// Several sandbox commands (status, connect, logs, policy-list) now preflight
+// `docker info` to classify a Docker daemon outage (#4428). Tests that should
+// exercise the normal (Docker-up) path must stub a healthy `docker info` so
+// they stay hermetic regardless of whether the host/CI runner has a running
+// Docker daemon.
+function writeHealthyDockerStub(localBin: string): void {
+  fs.writeFileSync(
+    path.join(localBin, "docker"),
+    ["#!/usr/bin/env bash", 'if [ "$1" = "info" ]; then echo "24.0.0"; exit 0; fi', "exit 0"].join(
+      "\n",
+    ),
+    { mode: 0o755 },
+  );
+}
+
 const FAKE_OPENCLAW_LOG_LINE = "openclaw gateway log: policy checker ready";
 const FAKE_OPENSHELL_LOG_LINE = "openshell audit log: DENIED example.com:443";
 
@@ -200,6 +215,8 @@ function createLogsTestSetup(prefix: string, openshellLines: string[] = []) {
     ].join("\n"),
     { mode: 0o755 },
   );
+  // `logs` now preflights the Docker daemon (#4428); stub a healthy daemon.
+  writeHealthyDockerStub(localBin);
 
   return {
     home,
@@ -3706,6 +3723,7 @@ describe("CLI dispatch", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
+    writeHealthyDockerStub(localBin);
 
     const r = runWithEnv("alpha logs", {
       HOME: home,
@@ -4380,6 +4398,9 @@ describe("CLI dispatch", () => {
     fs.writeFileSync(path.join(localBin, "sleep"), ["#!/usr/bin/env bash", "exit 0"].join("\n"), {
       mode: 0o755,
     });
+    // Healthy Docker so the connect readiness wait is not short-circuited by
+    // the #4428 docker-down fast-fail.
+    writeHealthyDockerStub(localBin);
 
     const r = runWithEnv(
       "alpha connect",
@@ -5203,6 +5224,9 @@ describe("CLI dispatch", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
+    // Healthy Docker so the #4428 logs preflight does not short-circuit before
+    // the SIGINT path under test.
+    writeHealthyDockerStub(localBin);
 
     const result = spawnSync(process.execPath, [CLI, "alpha", "logs", "--follow"], {
       cwd: path.join(import.meta.dirname, ".."),
@@ -6123,6 +6147,212 @@ describe("CLI dispatch", () => {
     const saved = JSON.parse(fs.readFileSync(path.join(registryDir, "sandboxes.json"), "utf8"));
     expect(saved.sandboxes.alpha).toBeUndefined();
     expect(saved.defaultSandbox).toBeNull();
+  });
+});
+
+describe("Docker daemon outage classification (#4428)", () => {
+  // Build a fake runtime where OpenShell still reports a present sandbox in a
+  // non-ready phase (the reporter's case: cached/transitional state) while the
+  // Docker daemon is down. `dockerInfoOk` flips between the outage repro and
+  // the genuine-startup-failure control case.
+  function setupDockerOutageEnv(
+    prefix: string,
+    {
+      dockerInfoOk,
+      phase = "Provisioning",
+      driver = "docker",
+    }: { dockerInfoOk: boolean; phase?: string; driver?: string },
+  ): { home: string; localBin: string; env: Record<string, string> } {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    // The Docker-outage reclassification only applies to Docker-driver
+    // sandboxes (#4428); record the driver so the gate matches.
+    writeSandboxRegistry(home, "v053-baseline", {
+      policies: ["npm"],
+      openshellDriver: driver,
+    } as unknown as Partial<SandboxEntry>);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ]; then',
+        `  printf "Name: v053-baseline\\nPhase: ${phase}\\nPolicy:\\n"`,
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+        `  printf "NAME             STATUS\\nv053-baseline    ${phase}\\n"`,
+        "  exit 0",
+        "fi",
+        // policy get fails so getGatewayPresets() returns null (gateway not
+        // queryable), exercising the policy-list reclassification branch.
+        'if [ "$1" = "policy" ] && [ "$2" = "get" ]; then exit 1; fi',
+        'if [ "$1" = "status" ]; then printf "Gateway: nemoclaw\\nStatus: Connected\\n"; exit 0; fi',
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then echo "Gateway: nemoclaw"; exit 0; fi',
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then exit 1; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const dockerInfoBody = dockerInfoOk
+      ? 'echo "24.0.0"; exit 0'
+      : 'echo "Cannot connect to the Docker daemon" >&2; exit 1';
+    fs.writeFileSync(
+      path.join(localBin, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        `if [ "$1" = "info" ]; then ${dockerInfoBody}; fi`,
+        // ps lists nothing so the classifier never claims a running container.
+        'if [ "$1" = "ps" ]; then exit 0; fi',
+        dockerInfoOk ? "exit 0" : "exit 1",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(path.join(localBin, "sleep"), ["#!/usr/bin/env bash", "exit 0"].join("\n"), {
+      mode: 0o755,
+    });
+    return {
+      home,
+      localBin,
+      env: { HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` },
+    };
+  }
+
+  const DOCKER_DOWN_HEADER = "docker_unreachable";
+  const DOCKER_DOWN_HINT = "Start the Docker daemon";
+
+  it("status names the Docker outage instead of stuck-phase rebuild guidance", () => {
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-status-down-", {
+      dockerInfoOk: false,
+    });
+    try {
+      const r = runWithEnv("v053-baseline status", env);
+      expect(r.code).toBe(1);
+      expect(r.out).toContain(DOCKER_DOWN_HEADER);
+      expect(r.out).toContain("Docker daemon is not reachable");
+      expect(r.out).toContain(DOCKER_DOWN_HINT);
+      // Must NOT steer the user toward rebuild for a transient daemon outage.
+      expect(r.out).not.toContain("is stuck in 'Provisioning' phase");
+      expect(r.out).not.toMatch(/rebuild --yes/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("status keeps stuck-phase rebuild guidance when Docker is reachable", () => {
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-status-up-", {
+      dockerInfoOk: true,
+    });
+    try {
+      const r = runWithEnv("v053-baseline status", env);
+      // Genuine startup failure: Docker is fine, sandbox is wedged Provisioning.
+      expect(r.out).toContain("is stuck in 'Provisioning' phase");
+      expect(r.out).toContain("rebuild --yes");
+      expect(r.out).not.toContain(DOCKER_DOWN_HEADER);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("status keeps a terminal phase failure visible even when Docker is down", () => {
+    // A settled Failed phase is a real sandbox failure; the Docker-outage
+    // reclassification must not mask it (#4428 review).
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-status-failed-down-", {
+      dockerInfoOk: false,
+      phase: "Failed",
+    });
+    try {
+      const r = runWithEnv("v053-baseline status", env);
+      expect(r.out).toContain("is stuck in 'Failed' phase");
+      expect(r.out).toContain("rebuild --yes");
+      expect(r.out).not.toContain(DOCKER_DOWN_HEADER);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    "connect fails fast with Docker outage guidance instead of waiting out the readiness timeout",
+    () => {
+      const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-connect-down-", {
+        dockerInfoOk: false,
+      });
+      try {
+        const startedAt = Date.now();
+        // A large connect timeout would be burned entirely pre-fix; the fast
+        // path must return well before it.
+        const r = runWithEnv("v053-baseline connect", { ...env, NEMOCLAW_CONNECT_TIMEOUT: "120" });
+        const elapsedMs = Date.now() - startedAt;
+        expect(r.code).toBe(1);
+        expect(r.out).toContain(DOCKER_DOWN_HEADER);
+        expect(r.out).toContain(DOCKER_DOWN_HINT);
+        expect(r.out).not.toContain("Waiting for sandbox");
+        expect(r.out).not.toContain("Timed out after");
+        expect(elapsedMs).toBeLessThan(30_000);
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    },
+    testTimeout(40_000),
+  );
+
+  it("connect --probe-only also surfaces the Docker outage instead of an opaque probe failure", () => {
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-probe-down-", {
+      dockerInfoOk: false,
+    });
+    try {
+      const r = runWithEnv("v053-baseline connect --probe-only", env);
+      expect(r.code).toBe(1);
+      expect(r.out).toContain(DOCKER_DOWN_HEADER);
+      expect(r.out).toContain(DOCKER_DOWN_HINT);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("logs names the Docker outage as the unavailable runtime layer", () => {
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-logs-down-", {
+      dockerInfoOk: false,
+    });
+    try {
+      const r = runWithEnv("v053-baseline logs", env);
+      expect(r.code).toBe(1);
+      expect(r.out).toContain(DOCKER_DOWN_HEADER);
+      expect(r.out).toContain(DOCKER_DOWN_HINT);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("policy-list reports the Docker outage instead of a local-state-only warning", () => {
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-policy-down-", {
+      dockerInfoOk: false,
+    });
+    try {
+      const r = runWithEnv("v053-baseline policy-list", env);
+      expect(r.out).toContain(DOCKER_DOWN_HEADER);
+      expect(r.out).toContain(DOCKER_DOWN_HINT);
+      expect(r.out).not.toContain("Could not query gateway — showing local state only");
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not misclassify a non-Docker (vm) driver sandbox as a Docker outage", () => {
+    // A failing local `docker info` is normal for vm/kubernetes drivers; status
+    // must fall through to the existing stuck-phase guidance, not the
+    // Docker-outage block (#4428 review).
+    const { home, env } = setupDockerOutageEnv("nemoclaw-cli-4428-vm-down-", {
+      dockerInfoOk: false,
+      driver: "vm",
+    });
+    try {
+      const r = runWithEnv("v053-baseline status", env);
+      expect(r.out).not.toContain(DOCKER_DOWN_HEADER);
+      expect(r.out).toContain("is stuck in 'Provisioning' phase");
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/gateway-failure-classifier.test.ts
+++ b/test/gateway-failure-classifier.test.ts
@@ -7,6 +7,8 @@ import {
   classifyGatewayFailure,
   getLayerHeader,
   type GatewayFailureRunners,
+  isDockerRuntimeDown,
+  printDockerRuntimeDownGuidance,
 } from "../dist/lib/actions/sandbox/gateway-failure-classifier.js";
 
 function makeRunners(overrides: Partial<GatewayFailureRunners> = {}): GatewayFailureRunners {
@@ -116,6 +118,103 @@ describe("classifyGatewayFailure", () => {
       }),
     });
     expect(portProbeCalled).toBe(false);
+  });
+});
+
+describe("isDockerRuntimeDown", () => {
+  const dockerSandbox = () => ({ openshellDriver: "docker" });
+
+  it("returns true when docker info fails for a Docker-driver sandbox", () => {
+    expect(
+      isDockerRuntimeDown("alpha", {
+        runners: { dockerInfo: () => false },
+        getSandbox: dockerSandbox,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when docker info succeeds", () => {
+    expect(
+      isDockerRuntimeDown("alpha", {
+        runners: { dockerInfo: () => true },
+        getSandbox: dockerSandbox,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for the vm driver even when docker info fails", () => {
+    // A vm sandbox runs in a real VM with no local Docker daemon, so a failing
+    // `docker info` must not be misclassified as a runtime outage.
+    let probed = false;
+    const result = isDockerRuntimeDown("alpha", {
+      runners: {
+        dockerInfo: () => {
+          probed = true;
+          return false;
+        },
+      },
+      getSandbox: () => ({ openshellDriver: "vm" }),
+    });
+    expect(result).toBe(false);
+    // The docker probe should be short-circuited by the driver gate.
+    expect(probed).toBe(false);
+  });
+
+  it("treats the kubernetes driver as Docker-backed (gateway runs in local Docker)", () => {
+    // The k3s/Docker-Desktop gateway still lives in the local Docker daemon, so
+    // a Docker outage must be classified for kubernetes-driver sandboxes too.
+    expect(
+      isDockerRuntimeDown("alpha", {
+        runners: { dockerInfo: () => false },
+        getSandbox: () => ({ openshellDriver: "kubernetes" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats legacy/recovered entries without driver metadata as Docker-backed", () => {
+    // Sandboxes registered before `openshellDriver` existed (or recovered from
+    // gateway state) omit the field; they must still get the outage guard
+    // rather than falling back to the broken Provisioning/rebuild path (#4428).
+    for (const entry of [{}, { openshellDriver: null }, () => null] as const) {
+      const getSandbox = typeof entry === "function" ? entry : () => entry;
+      expect(
+        isDockerRuntimeDown("alpha", {
+          runners: { dockerInfo: () => false },
+          getSandbox,
+        }),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("printDockerRuntimeDownGuidance", () => {
+  function capture(fn: (writer: (m: string) => void) => void): string {
+    const lines: string[] = [];
+    fn((m) => lines.push(m));
+    return lines.join("\n");
+  }
+
+  it("names the docker_unreachable layer and steers away from rebuild/destroy/onboard", () => {
+    const out = capture((writer) => printDockerRuntimeDownGuidance("my-sandbox", { writer }));
+    expect(out).toContain("docker_unreachable");
+    expect(out).toContain("Docker daemon is not reachable");
+    expect(out).toContain("docker info");
+    // The only mention of rebuild/destroy/onboard must be the explicit advice
+    // NOT to do them — never a `rebuild --yes`-style call to action (#4428).
+    expect(out).toContain("do not rebuild, destroy, or re-onboard");
+    expect(out).not.toMatch(/rebuild --yes|Run `[^`]*rebuild/i);
+  });
+
+  it("uses the supplied retry command in the retry hint", () => {
+    const out = capture((writer) =>
+      printDockerRuntimeDownGuidance("my-sandbox", { writer, retryCommand: "connect" }),
+    );
+    expect(out).toContain("my-sandbox connect");
+  });
+
+  it("defaults the retry hint to status", () => {
+    const out = capture((writer) => printDockerRuntimeDownGuidance("my-sandbox", { writer }));
+    expect(out).toContain("my-sandbox status");
   });
 });
 

--- a/test/repro-2010.test.ts
+++ b/test/repro-2010.test.ts
@@ -235,11 +235,23 @@ require(${JSON.stringify(CLI_PATH)});
 `;
       const scriptPath = path.join(tmpDir, "repro.js");
       fs.writeFileSync(scriptPath, script);
+      // policy-list now preflights `docker info` to classify a Docker daemon
+      // outage (#4428); stub a healthy daemon so the gateway-unreachable
+      // fallback path stays hermetic on Dockerless/Docker-stopped runners.
+      const binDir = path.join(tmpDir, "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(binDir, "docker"),
+        ["#!/usr/bin/env bash", 'if [ "$1" = "info" ]; then echo "24.0.0"; exit 0; fi', "exit 0"].join(
+          "\n",
+        ),
+        { mode: 0o755 },
+      );
       try {
         const result = spawnSync(process.execPath, [scriptPath], {
           cwd: REPO_ROOT,
           encoding: "utf-8",
-          env: { ...process.env, HOME: tmpDir },
+          env: { ...process.env, HOME: tmpDir, PATH: `${binDir}:${process.env.PATH || ""}` },
         });
         return (result.stdout || "") + (result.stderr || "");
       } finally {

--- a/test/sandbox-stuck-recovery.test.ts
+++ b/test/sandbox-stuck-recovery.test.ts
@@ -95,7 +95,20 @@ process.exit(0);
     { mode: 0o755 },
   );
 
-  return { tmpDir, sandboxName };
+  // Healthy `docker info` stub so these stuck-phase tests exercise the genuine
+  // "Docker up, sandbox wedged" path rather than the #4428 Docker-outage
+  // reclassification (which fires when `docker info` fails). Lives next to the
+  // fake openshell; runCli puts this dir on PATH.
+  fs.writeFileSync(
+    path.join(homeLocalBin, "docker"),
+    `#!${process.execPath}
+if (process.argv[2] === "info") { process.stdout.write("24.0.0\\n"); process.exit(0); }
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+
+  return { tmpDir, sandboxName, homeLocalBin };
 }
 
 function runCli(
@@ -105,6 +118,9 @@ function runCli(
   extraEnv: Record<string, string> = {},
 ) {
   const repoRoot = path.join(import.meta.dirname, "..");
+  // Put the fixture bin (with the healthy docker stub) first so the #4428
+  // Docker preflight sees a reachable daemon regardless of the host runner.
+  const homeLocalBin = path.join(tmpDir, ".local", "bin");
   return spawnSync(
     process.execPath,
     [path.join(repoRoot, "bin", "nemoclaw.js"), sandboxName, subcommand],
@@ -114,7 +130,7 @@ function runCli(
       env: {
         ...process.env,
         HOME: tmpDir,
-        PATH: "/usr/bin:/bin",
+        PATH: `${homeLocalBin}:/usr/bin:/bin`,
         NEMOCLAW_NO_CONNECT_HINT: "1",
         ...extraEnv,
       },


### PR DESCRIPTION
## Summary

When the Docker daemon is unreachable but OpenShell still returns a present sandbox in a non-ready phase (e.g. `Provisioning`), NemoClaw misclassified a transient Docker outage as a sandbox startup problem — `status` told users to `rebuild --yes` and `connect` waited out the full `NEMOCLAW_CONNECT_TIMEOUT`. This adds a shared Docker-runtime-down preflight so `status`/`connect`/`logs`/`policy-list` name the outage and tell the user to restart Docker, without steering them toward rebuild/destroy/onboard.

## Related Issue

Closes #4428 — https://github.com/NVIDIA/NemoClaw/issues/4428

## Changes

- Add `isDockerRuntimeDown(sandboxName)` and `printDockerRuntimeDownGuidance()` to `gateway-failure-classifier.ts`. The preflight is gated to Docker-backed sandboxes (the `docker`/`kubernetes` drivers, whose gateway runs in the local `openshell-cluster-nemoclaw` container, plus legacy entries with no driver metadata) and skipped for the `vm` driver.
- `status`: for a non-ready, **non-terminal** phase, emit Docker-outage guidance and exit instead of the generic stuck-phase/rebuild block when Docker is down.
- `connect`: fast-fail with Docker-outage guidance before the session/recovery probes and the readiness wait loop (covers normal connect, `--probe-only`, and a Docker daemon that dies mid-wait), so it no longer burns the connect timeout.
- `logs`: preflight Docker (after option validation) so an outage is named instead of opaque "log source unavailable" errors.
- `policy-list`: report the Docker outage instead of the generic "Could not query gateway — showing local state only" warning.
- `ensureLiveSandboxOrExit`: avoid rebuild guidance for a non-terminal phase during a Docker outage.
- Add a shared `TERMINAL_SANDBOX_PHASES`/`isTerminalSandboxPhase` helper in `state/gateway.ts` so terminal phases (`Failed`/`Error`/...) always keep their failure guidance even when Docker is down, and dedupe the connect readiness loop's terminal set.

Genuine startup failures stay distinct: when Docker is reachable and the sandbox stays `Provisioning`, the existing stuck-phase/rebuild guidance remains.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes (pre-existing, change-unrelated environmental flakes only: `e2e-scenario` dry-run 5s-timeout tests and `onboard/config-sync` ownership test, both failing identically on the clean tree)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] CLI type-check (`npm run typecheck:cli`) and Biome lint pass; local `codex review` clean

Reproduced end-to-end through `./bin/nemoclaw.js` with fake `docker`/`openshell` on PATH (`docker info` failing, `openshell sandbox get/list` reporting `Phase: Provisioning`): before the fix `status` printed `rebuild --yes` and `connect` waited out the timeout; after the fix all four commands emit Docker-runtime-down guidance and `connect` fails fast (~1.5s). The Docker-reachable `Provisioning` case still gets the existing stuck-phase guidance.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker daemon outage detection with actionable recovery instructions
  * Fast-fail behavior in connect and probe flows to avoid unnecessary waiting

* **Bug Fixes**
  * Replaced misleading rebuild guidance when Docker is the root cause
  * Clearer outage-specific messages in logs, status, and policy-list commands

* **Tests**
  * Added hermetic Docker-health stubs and tests covering outage detection and guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->