### PR TITLE
fix(whatsapp): render compact pairing QR and split gateway diagnostics

### DIFF
--- a/nemoclaw-blueprint/scripts/whatsapp-qr-compact.js
+++ b/nemoclaw-blueprint/scripts/whatsapp-qr-compact.js
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// whatsapp-qr-compact.js — force compact, scan-friendly QR rendering during
+// in-sandbox WhatsApp pairing.
+//
+// The upstream @openclaw/whatsapp plugin renders the Linked-Devices pairing QR
+// through the `qrcode-terminal` package at full size. Full-size rendering uses
+// two terminal cells per QR module, so a WhatsApp Web QR fills 50–80+ rows and
+// hundreds of columns — on a DGX Spark terminal it overflows the screen and is
+// impossible to capture in a single phone-camera frame (NemoClaw#4522).
+//
+// NemoClaw owns the user-facing pairing workflow, so this preload forces the
+// same `{ small: true }` half-block rendering the host-side WeChat QR path
+// already uses (src/ext/wechat/login.ts). Half-block mode packs two QR rows
+// into one terminal row and one module per column, roughly quartering the
+// rendered area without changing the QR payload, so it still scans.
+//
+// The patch hooks Module._load rather than require('qrcode-terminal') directly
+// because the package is resolved from the plugin's nested node_modules, which
+// this preload (loaded from /tmp via NODE_OPTIONS) cannot resolve on its own.
+// It only rewrites the `small` option; any caller that already opts into small
+// rendering is unaffected, and the QR text/error-correction level is untouched.
+//
+// Removal criterion: drop this preload (and its wiring in nemoclaw-start.sh)
+// once the bundled @openclaw/whatsapp renders a scan-friendly QR by default or
+// exposes a documented compact-rendering flag NemoClaw can set through
+// openclaw.json. Verify by pairing on a DGX Spark terminal and confirming the
+// QR fits without this preload.
+//
+// Ref: https://github.com/NVIDIA/NemoClaw/issues/4522
+
+(function () {
+  'use strict';
+
+  if (process.__nemoclawWhatsappQrCompactInstalled) return;
+  try {
+    Object.defineProperty(process, '__nemoclawWhatsappQrCompactInstalled', { value: true });
+  } catch (_e) {
+    process.__nemoclawWhatsappQrCompactInstalled = true;
+  }
+
+  var Module = require('module');
+  var origLoad = Module._load;
+
+  function patchQrcodeTerminal(mod) {
+    if (!mod || mod.__nemoclawCompactPatched) return mod;
+    if (typeof mod.generate !== 'function') return mod;
+
+    var origGenerate = mod.generate;
+    mod.generate = function (text, opts, cb) {
+      // Support both generate(text, cb) and generate(text, opts, cb).
+      if (typeof opts === 'function') {
+        cb = opts;
+        opts = undefined;
+      }
+      var merged = {};
+      if (opts && typeof opts === 'object') {
+        for (var key in opts) {
+          if (Object.prototype.hasOwnProperty.call(opts, key)) merged[key] = opts[key];
+        }
+      }
+      merged.small = true;
+      return origGenerate.call(this, text, merged, cb);
+    };
+
+    try {
+      Object.defineProperty(mod, '__nemoclawCompactPatched', { value: true });
+    } catch (_e) {
+      mod.__nemoclawCompactPatched = true;
+    }
+    return mod;
+  }
+
+  Module._load = function (request, _parent, _isMain) {
+    var loaded = origLoad.apply(this, arguments);
+    if (request === 'qrcode-terminal') {
+      try {
+        return patchQrcodeTerminal(loaded);
+      } catch (_e) {
+        return loaded;
+      }
+    }
+    return loaded;
+  };
+})();

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1164,6 +1164,34 @@ install_telegram_diagnostics() {
   printf '[channels] Telegram diagnostics installed (NODE_OPTIONS updated)\n' >&2
 }
 
+# ── WhatsApp compact-QR preload (scan-friendly in-sandbox pairing) ───
+# The upstream @openclaw/whatsapp QR renders at full size and overflows DGX
+# Spark terminals (NemoClaw#4522). This preload forces qrcode-terminal into
+# the same `{ small: true }` half-block mode the host-side WeChat path uses.
+# Unlike the diagnostics/guard preloads it is NOT added to the global
+# NODE_OPTIONS — the gateway never renders the pairing QR. The openclaw()
+# guard injects it for the single `channels login --channel whatsapp`
+# invocation, so we only need the file present in the sandbox.
+_WHATSAPP_QR_COMPACT_SCRIPT="/tmp/nemoclaw-whatsapp-qr-compact.js"
+_WHATSAPP_QR_COMPACT_SOURCE="/usr/local/lib/nemoclaw/preloads/whatsapp-qr-compact.js"
+
+install_whatsapp_qr_compact() {
+  local config_file="/sandbox/.openclaw/openclaw.json"
+
+  # Only install when WhatsApp is configured in the baked OpenClaw config.
+  if ! grep -q '"whatsapp"' "$config_file" 2>/dev/null; then
+    return 0
+  fi
+
+  # Source file is absent on older base images; skip rather than fail the boot.
+  if [ ! -f "$_WHATSAPP_QR_COMPACT_SOURCE" ]; then
+    return 0
+  fi
+
+  printf '[channels] Installing WhatsApp compact-QR renderer (scan-friendly pairing)\n' >&2
+  emit_sandbox_sourced_file "$_WHATSAPP_QR_COMPACT_SCRIPT" <"$_WHATSAPP_QR_COMPACT_SOURCE"
+}
+
 _read_gateway_token() {
   node - <<'NODETOKEN'
 const fs = require("fs");
@@ -1955,6 +1983,42 @@ openclaw() {
             echo "'channels add wechat' flow — no in-sandbox login step." >&2
             return 1
           fi
+          # NemoClaw-supported WhatsApp pairing (NemoClaw#4522): validate the
+          # gateway environment up front so a gateway close (e.g. the reported
+          # "1008 abnormal closure") is diagnosed separately from QR rendering,
+          # and force compact QR output so the code fits on the screen.
+          if [ "$_login_help" != "1" ] && [ "$_login_channel" = "whatsapp" ]; then
+            if [ -z "${OPENCLAW_GATEWAY_URL:-}" ]; then
+              echo "Error: WhatsApp pairing cannot start — OPENCLAW_GATEWAY_URL is not set in this shell." >&2
+              echo "Pairing talks to the OpenClaw gateway; without the gateway URL the login will" >&2
+              echo "close immediately (this is a gateway/env problem, not a QR problem)." >&2
+              echo "" >&2
+              echo "Reconnect with 'openshell sandbox connect <sandbox>' and retry. If it persists," >&2
+              echo "exit the sandbox and rebuild with 'nemoclaw <sandbox> rebuild'." >&2
+              return 1
+            fi
+            echo "[whatsapp] Pairing via gateway ${OPENCLAW_GATEWAY_URL}." >&2
+            echo "[whatsapp] On your phone: WhatsApp > Linked devices > Link a device, then scan the QR below." >&2
+            # Literal path: this guard body is emitted inside a single-quoted
+            # heredoc, so shell variables are intentionally not expanded here.
+            # Keep in sync with _WHATSAPP_QR_COMPACT_SCRIPT above.
+            _whatsapp_qr_compact="/tmp/nemoclaw-whatsapp-qr-compact.js"
+            if [ -f "$_whatsapp_qr_compact" ]; then
+              NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--require $_whatsapp_qr_compact" command openclaw "$@"
+            else
+              command openclaw "$@"
+            fi
+            _whatsapp_login_exit=$?
+            if [ "$_whatsapp_login_exit" -ne 0 ]; then
+              echo "" >&2
+              echo "[whatsapp] Pairing exited with code ${_whatsapp_login_exit} before it completed." >&2
+              echo "[whatsapp] A gateway close (e.g. '1008 abnormal closure') is a gateway/session" >&2
+              echo "issue, not a QR-size issue — the QR above rendered independently of the gateway." >&2
+              echo "[whatsapp] Re-run 'openclaw channels login --channel whatsapp' to retry. If it keeps" >&2
+              echo "closing, exit the sandbox and run 'nemoclaw <sandbox> channels status --channel whatsapp'." >&2
+            fi
+            return $_whatsapp_login_exit
+          fi
           ;;
         *)
           echo "Error: 'openclaw channels $2' cannot modify channels inside the sandbox." >&2
@@ -2572,6 +2636,7 @@ if [ "$(id -u)" -ne 0 ]; then
   write_openclaw_config_baseline
   install_telegram_diagnostics
   install_slack_channel_guard
+  install_whatsapp_qr_compact
   verify_no_slack_secrets_on_disk
 
   # Ensure writable state directories exist and are owned by the current user.
@@ -2614,7 +2679,7 @@ if [ "$(id -u)" -ne 0 ]; then
   # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
   # (both are trust-boundary files; tampering would let the sandbox user
   # inject code into any Node process via NODE_OPTIONS).
-  validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_TELEGRAM_DIAGNOSTICS_SCRIPT" "$_SLACK_GUARD_SCRIPT"
+  validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_TELEGRAM_DIAGNOSTICS_SCRIPT" "$_SLACK_GUARD_SCRIPT" "$_WHATSAPP_QR_COMPACT_SCRIPT"
 
   # Start gateway in background, auto-pair, then wait
   nohup "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" >/tmp/gateway.log 2>&1 &
@@ -2708,6 +2773,7 @@ lock_rc_files "$_SANDBOX_HOME"
 # Install channel-specific preloads before starting OpenClaw.
 install_telegram_diagnostics
 install_slack_channel_guard
+install_whatsapp_qr_compact
 verify_no_slack_secrets_on_disk
 
 # Write auth profile as sandbox user and recursively re-tighten any
@@ -2822,7 +2888,7 @@ seed_default_workspace_templates_as_sandbox
 # Pass the HTTP proxy-fix path so it is validated alongside proxy-env.sh
 # (both are trust-boundary files; tampering would let the sandbox user
 # inject code into any Node process via NODE_OPTIONS).
-validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_TELEGRAM_DIAGNOSTICS_SCRIPT" "$_SLACK_GUARD_SCRIPT"
+validate_tmp_permissions "$_SANDBOX_SAFETY_NET" "$_PROXY_FIX_SCRIPT" "$_NEMOTRON_FIX_SCRIPT" "$_WS_FIX_SCRIPT" "$_SECCOMP_GUARD_SCRIPT" "$_CIAO_GUARD_SCRIPT" "$_TELEGRAM_DIAGNOSTICS_SCRIPT" "$_SLACK_GUARD_SCRIPT" "$_WHATSAPP_QR_COMPACT_SCRIPT"
 
 # Start the gateway as the 'gateway' user.
 # SECURITY: The sandbox user cannot kill this process because it runs

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1997,6 +1997,22 @@ openclaw() {
               echo "exit the sandbox and rebuild with 'nemoclaw <sandbox> rebuild'." >&2
               return 1
             fi
+            # The OpenClaw gateway is a WebSocket endpoint (set to
+            # ws://127.0.0.1:<port> at boot). Reject a malformed scheme up front
+            # so a typo'd/clobbered URL is reported as a gateway/env problem
+            # rather than failing inside the login as an ambiguous close.
+            case "${OPENCLAW_GATEWAY_URL}" in
+              ws://*|wss://*) ;;
+              *)
+                echo "Error: WhatsApp pairing cannot start — OPENCLAW_GATEWAY_URL='${OPENCLAW_GATEWAY_URL}' is not a ws:// gateway URL." >&2
+                echo "The OpenClaw gateway is a WebSocket endpoint (e.g. ws://127.0.0.1:<port>); a malformed value" >&2
+                echo "would fail the login in a way that looks like a QR/pairing problem (this is a gateway/env problem)." >&2
+                echo "" >&2
+                echo "Reconnect with 'openshell sandbox connect <sandbox>' and retry. If it persists," >&2
+                echo "exit the sandbox and rebuild with 'nemoclaw <sandbox> rebuild'." >&2
+                return 1
+                ;;
+            esac
             echo "[whatsapp] Pairing via gateway ${OPENCLAW_GATEWAY_URL}." >&2
             echo "[whatsapp] On your phone: WhatsApp > Linked devices > Link a device, then scan the QR below." >&2
             # Literal path: this guard body is emitted inside a single-quoted

--- a/src/lib/sandbox/channels.ts
+++ b/src/lib/sandbox/channels.ts
@@ -128,7 +128,7 @@ export const KNOWN_CHANNELS: Record<string, ChannelDef> = {
   },
   whatsapp: {
     description: "WhatsApp Web messaging (QR pairing)",
-    help: "WhatsApp Web pairs via QR code scanned with your phone — no host-side token. After the sandbox is running, run `openshell term` and then use `openclaw channels login --channel whatsapp` for OpenClaw or `hermes whatsapp` for Hermes to display the QR.",
+    help: "WhatsApp Web pairs via QR code scanned with your phone — no host-side token. After the sandbox is running, connect to it (e.g. `openshell sandbox connect <sandbox>`) and run `openclaw channels login --channel whatsapp` for OpenClaw or `hermes whatsapp` for Hermes. NemoClaw renders the OpenClaw QR in compact (scan-friendly) form and validates the gateway before pairing, so a gateway close (e.g. `1008`) is reported separately from the QR (issue #4522).",
     label: "WhatsApp",
     loginMethod: "in-sandbox-qr",
     setupNotes: [

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -916,11 +916,17 @@ else
   fail "M-WA6b: WhatsApp compact-QR preload has unexpected owner/mode: ${whatsapp_qr_preload_stat} (#4522)"
 fi
 
-whatsapp_qr_guard_wiring=$(sandbox_exec "grep -c -- 'nemoclaw-whatsapp-qr-compact.js' /tmp/nemoclaw-proxy-env.sh 2>/dev/null || echo 0")
+# Assert on the actual NODE_OPTIONS injection line, not just the filename: the
+# filename also appears in the install banner and the literal path assignment,
+# so a filename-only grep would still pass if the `--require` wiring regressed.
+# The guard body is emitted inside a single-quoted heredoc, so the proxy-env
+# file contains the literal token `--require $_whatsapp_qr_compact`. Escape `$`
+# so the host shell does not expand it before sandbox_exec ships the command.
+whatsapp_qr_guard_wiring=$(sandbox_exec "grep -cF -- '--require \$_whatsapp_qr_compact' /tmp/nemoclaw-proxy-env.sh 2>/dev/null || echo 0")
 if [ "${whatsapp_qr_guard_wiring:-0}" -ge 1 ] 2>/dev/null; then
-  pass "M-WA6c: openclaw() guard references compact-QR preload for WhatsApp login (#4522)"
+  pass "M-WA6c: openclaw() guard injects compact-QR preload via NODE_OPTIONS for WhatsApp login (#4522)"
 else
-  fail "M-WA6c: openclaw() guard missing compact-QR preload wiring for WhatsApp login (#4522)"
+  fail "M-WA6c: openclaw() guard missing compact-QR preload --require injection for WhatsApp login (#4522)"
 fi
 
 # M1: Verify Telegram provider exists in gateway

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -901,6 +901,28 @@ else
   exit 1
 fi
 
+# M-WA6b: WhatsApp compact-QR pairing wiring (NemoClaw#4522). The entrypoint
+# installs a NemoClaw-owned preload that forces qrcode-terminal into
+# `{ small: true }` half-block rendering so the in-sandbox pairing QR fits a
+# phone-camera frame, and the openclaw() guard injects it for the single
+# `channels login --channel whatsapp` invocation. Verify both the preload file
+# (root-owned, read-only) and the guard wiring are present in the sandbox.
+whatsapp_qr_preload_stat=$(sandbox_exec "stat -c '%U:%a' /tmp/nemoclaw-whatsapp-qr-compact.js 2>/dev/null || echo missing")
+if [ "$whatsapp_qr_preload_stat" = "root:444" ]; then
+  pass "M-WA6b: WhatsApp compact-QR preload installed root:444 (#4522)"
+elif [ "$whatsapp_qr_preload_stat" = "missing" ]; then
+  fail "M-WA6b: WhatsApp compact-QR preload not installed in sandbox (#4522)"
+else
+  fail "M-WA6b: WhatsApp compact-QR preload has unexpected owner/mode: ${whatsapp_qr_preload_stat} (#4522)"
+fi
+
+whatsapp_qr_guard_wiring=$(sandbox_exec "grep -c -- 'nemoclaw-whatsapp-qr-compact.js' /tmp/nemoclaw-proxy-env.sh 2>/dev/null || echo 0")
+if [ "${whatsapp_qr_guard_wiring:-0}" -ge 1 ] 2>/dev/null; then
+  pass "M-WA6c: openclaw() guard references compact-QR preload for WhatsApp login (#4522)"
+else
+  fail "M-WA6c: openclaw() guard missing compact-QR preload wiring for WhatsApp login (#4522)"
+fi
+
 # M1: Verify Telegram provider exists in gateway
 if openshell provider get "${SANDBOX_NAME}-telegram-bridge" >/dev/null 2>&1; then
   pass "M1: Provider '${SANDBOX_NAME}-telegram-bridge' exists in gateway"

--- a/test/whatsapp-qr-compact.test.ts
+++ b/test/whatsapp-qr-compact.test.ts
@@ -1,0 +1,240 @@
+// @ts-nocheck
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, it, expect } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const START_SCRIPT = path.join(REPO_ROOT, "scripts", "nemoclaw-start.sh");
+const PRELOAD_SOURCE = path.join(
+  REPO_ROOT,
+  "nemoclaw-blueprint",
+  "scripts",
+  "whatsapp-qr-compact.js",
+);
+
+// A WhatsApp Web pairing ref is a long, dense payload. Use a deterministic one
+// so the rendered dimensions are stable across runs.
+const WHATSAPP_QR_PAYLOAD =
+  "2@" +
+  Buffer.from("ref-token-".repeat(8)).toString("base64") +
+  "," +
+  Buffer.from("noise-key-".repeat(4)).toString("base64") +
+  "," +
+  Buffer.from("identity-key").toString("base64") +
+  ",abcdEFGH1234";
+
+// Render the QR via the cb form (so the rendered string is captured rather
+// than written to stdout) and report its dimensions for several option shapes.
+const PROBE_PROGRAM = `
+const qr = require("qrcode-terminal");
+const payload = ${JSON.stringify(WHATSAPP_QR_PAYLOAD)};
+function dims(call) {
+  let out = "";
+  call((s) => { out = s; });
+  const lines = out.split("\\n");
+  return { lines: lines.length, cols: Math.max(...lines.map((l) => [...l].length)) };
+}
+const result = {
+  // generate(text, cb) — no opts at all.
+  noOpts: dims((cb) => qr.generate(payload, cb)),
+  // generate(text, { small: false }, cb) — caller explicitly asks for big.
+  explicitBig: dims((cb) => qr.generate(payload, { small: false }, cb)),
+  // generate(text, { small: true }, cb) — caller already compact.
+  explicitSmall: dims((cb) => qr.generate(payload, { small: true }, cb)),
+};
+process.stdout.write(JSON.stringify(result));
+`;
+
+function runProbe(withPreload: boolean): {
+  noOpts: { lines: number; cols: number };
+  explicitBig: { lines: number; cols: number };
+  explicitSmall: { lines: number; cols: number };
+} {
+  const args = withPreload ? ["--require", PRELOAD_SOURCE, "-e", PROBE_PROGRAM] : ["-e", PROBE_PROGRAM];
+  const r = spawnSync(process.execPath, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    timeout: 10000,
+  });
+  if (r.status !== 0) {
+    throw new Error(`probe failed (status=${r.status}): ${r.stderr}`);
+  }
+  return JSON.parse(r.stdout.trim());
+}
+
+describe("WhatsApp compact-QR preload", () => {
+  const baseline = runProbe(false);
+  const patched = runProbe(true);
+
+  it("baseline qrcode-terminal renders large QR without options", () => {
+    // Sanity check the fixture: the default (non-small) rendering is the
+    // oversized output the issue is about, and small mode is meaningfully
+    // shorter and narrower.
+    expect(baseline.noOpts.lines).toBeGreaterThan(baseline.explicitSmall.lines);
+    expect(baseline.noOpts.cols).toBeGreaterThan(baseline.explicitSmall.cols);
+  });
+
+  it("forces compact rendering when the caller passes no options", () => {
+    // With the preload, generate(text, cb) must match an explicit small render
+    // and be strictly smaller than the unpatched default.
+    expect(patched.noOpts).toEqual(baseline.explicitSmall);
+    expect(patched.noOpts.lines).toBeLessThan(baseline.noOpts.lines);
+  });
+
+  it("overrides an explicit small:false back to compact rendering", () => {
+    expect(patched.explicitBig).toEqual(baseline.explicitSmall);
+  });
+
+  it("leaves an already-compact caller unchanged", () => {
+    expect(patched.explicitSmall).toEqual(baseline.explicitSmall);
+  });
+
+  it("keeps the rendered QR within a scan-friendly bound (<= 40 lines)", () => {
+    // The reporter saw 80+ lines. Compact rendering must stay well under a
+    // single phone-camera frame. 40 lines is a generous ceiling for a
+    // half-block WhatsApp QR.
+    expect(patched.noOpts.lines).toBeLessThanOrEqual(40);
+  });
+
+  it("is idempotent when loaded twice", () => {
+    const r = spawnSync(
+      process.execPath,
+      ["--require", PRELOAD_SOURCE, "--require", PRELOAD_SOURCE, "-e", PROBE_PROGRAM],
+      { cwd: REPO_ROOT, encoding: "utf-8", timeout: 10000 },
+    );
+    expect(r.status).toBe(0);
+    const twice = JSON.parse(r.stdout.trim());
+    expect(twice.noOpts).toEqual(baseline.explicitSmall);
+  });
+});
+
+// Extract the sandbox-side `openclaw()` guard function from the single-quoted
+// heredoc so we can exercise the WhatsApp login branch without a live sandbox.
+function extractGuardFunction(src: string): string {
+  const begin = src.indexOf("# nemoclaw-configure-guard begin");
+  const end = src.indexOf("# nemoclaw-configure-guard end");
+  if (begin === -1 || end === -1 || end <= begin) {
+    throw new Error("Expected nemoclaw-configure-guard markers in scripts/nemoclaw-start.sh");
+  }
+  return src.slice(begin, end);
+}
+
+describe("WhatsApp pairing guard (channels login --channel whatsapp)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+  const guard = extractGuardFunction(src);
+
+  function runGuard(
+    args: string[],
+    opts: { gatewayUrl?: string; preloadPresent?: boolean; fakeExit?: number },
+  ): { status: number; stdout: string; stderr: string; preloadPath: string } {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wa-guard-"));
+    try {
+      // Fake `openclaw` binary on PATH so `command openclaw` resolves to it.
+      const binDir = path.join(tempDir, "bin");
+      fs.mkdirSync(binDir);
+      const fakeOpenclaw = path.join(binDir, "openclaw");
+      fs.writeFileSync(
+        fakeOpenclaw,
+        [
+          "#!/usr/bin/env bash",
+          'echo "FAKE_OPENCLAW_ARGS=$*"',
+          'echo "FAKE_OPENCLAW_NODE_OPTIONS=${NODE_OPTIONS:-}"',
+          `exit ${opts.fakeExit ?? 0}`,
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+
+      const preloadPath = path.join(tempDir, "nemoclaw-whatsapp-qr-compact.js");
+      if (opts.preloadPresent) fs.writeFileSync(preloadPath, "// stub preload\n");
+
+      // The guard body hardcodes the literal /tmp path (single-quoted heredoc);
+      // redirect it to the temp file for the test.
+      const guardBody = guard.replaceAll("/tmp/nemoclaw-whatsapp-qr-compact.js", preloadPath);
+
+      const wrapperLines = [
+        "#!/usr/bin/env bash",
+        `export PATH=${JSON.stringify(binDir)}:\"$PATH\"`,
+      ];
+      if (opts.gatewayUrl !== undefined) {
+        wrapperLines.push(`export OPENCLAW_GATEWAY_URL=${JSON.stringify(opts.gatewayUrl)}`);
+      } else {
+        wrapperLines.push("unset OPENCLAW_GATEWAY_URL");
+      }
+      wrapperLines.push(
+        guardBody,
+        `openclaw ${args.map((a) => JSON.stringify(a)).join(" ")}`,
+        'echo "GUARD_EXIT=$?"',
+      );
+      const wrapperPath = path.join(tempDir, "run.sh");
+      fs.writeFileSync(wrapperPath, wrapperLines.join("\n"), { mode: 0o700 });
+
+      const r = spawnSync("bash", [wrapperPath], { encoding: "utf-8", timeout: 10000 });
+      return {
+        status: r.status ?? -1,
+        stdout: r.stdout ?? "",
+        stderr: r.stderr ?? "",
+        preloadPath,
+      };
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  it("blocks login for non-WhatsApp channels", () => {
+    const r = runGuard(["channels", "login", "--channel", "telegram"], {
+      gatewayUrl: "ws://127.0.0.1:8080",
+    });
+    expect(r.stderr).toContain("only supported inside the sandbox for WhatsApp");
+    expect(r.stdout).toContain("GUARD_EXIT=1");
+    expect(r.stdout).not.toContain("FAKE_OPENCLAW_ARGS");
+  });
+
+  it("refuses to pair when OPENCLAW_GATEWAY_URL is missing", () => {
+    const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
+      preloadPresent: true,
+    });
+    expect(r.stderr).toContain("OPENCLAW_GATEWAY_URL is not set");
+    expect(r.stdout).toContain("GUARD_EXIT=1");
+    // Must not attempt the login when the gateway env is missing.
+    expect(r.stdout).not.toContain("FAKE_OPENCLAW_ARGS");
+  });
+
+  it("injects the compact-QR preload into NODE_OPTIONS for the login", () => {
+    const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
+      gatewayUrl: "ws://127.0.0.1:8080",
+      preloadPresent: true,
+    });
+    expect(r.stdout).toContain("FAKE_OPENCLAW_ARGS=channels login --channel whatsapp");
+    expect(r.stdout).toContain(`--require ${r.preloadPath}`);
+    expect(r.stdout).toContain("GUARD_EXIT=0");
+    // Clean exit: no gateway-close diagnostics.
+    expect(r.stderr).not.toContain("abnormal closure");
+  });
+
+  it("runs login even if the preload file is absent (older base image)", () => {
+    const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
+      gatewayUrl: "ws://127.0.0.1:8080",
+      preloadPresent: false,
+    });
+    expect(r.stdout).toContain("FAKE_OPENCLAW_ARGS=channels login --channel whatsapp");
+    expect(r.stdout).not.toContain("--require");
+    expect(r.stdout).toContain("GUARD_EXIT=0");
+  });
+
+  it("surfaces gateway-close diagnostics separately from the QR on non-zero exit", () => {
+    const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
+      gatewayUrl: "ws://127.0.0.1:8080",
+      preloadPresent: true,
+      fakeExit: 7,
+    });
+    expect(r.stderr).toContain("1008 abnormal closure");
+    expect(r.stderr).toContain("not a QR-size issue");
+    // Guard preserves the underlying exit code.
+    expect(r.stdout).toContain("GUARD_EXIT=7");
+  });
+});

--- a/test/whatsapp-qr-compact.test.ts
+++ b/test/whatsapp-qr-compact.test.ts
@@ -204,6 +204,31 @@ describe("WhatsApp pairing guard (channels login --channel whatsapp)", () => {
     expect(r.stdout).not.toContain("FAKE_OPENCLAW_ARGS");
   });
 
+  it.each(["foo", "http://127.0.0.1:18789", "127.0.0.1:18789"])(
+    "refuses to pair when OPENCLAW_GATEWAY_URL is not a ws:// URL (%s)",
+    (badUrl) => {
+      const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
+        gatewayUrl: badUrl,
+        preloadPresent: true,
+      });
+      expect(r.stderr).toContain("is not a ws:// gateway URL");
+      expect(r.stdout).toContain("GUARD_EXIT=1");
+      expect(r.stdout).not.toContain("FAKE_OPENCLAW_ARGS");
+    },
+  );
+
+  it.each(["ws://127.0.0.1:18789", "wss://gateway.internal:443"])(
+    "accepts ws:// and wss:// gateway URLs (%s)",
+    (goodUrl) => {
+      const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
+        gatewayUrl: goodUrl,
+        preloadPresent: true,
+      });
+      expect(r.stdout).toContain("FAKE_OPENCLAW_ARGS=channels login --channel whatsapp");
+      expect(r.stdout).toContain("GUARD_EXIT=0");
+    },
+  );
+
   it("injects the compact-QR preload into NODE_OPTIONS for the login", () => {
     const r = runGuard(["channels", "login", "--channel", "whatsapp"], {
       gatewayUrl: "ws://127.0.0.1:8080",


### PR DESCRIPTION
## Summary

NemoClaw delegated in-sandbox WhatsApp QR pairing to the upstream `@openclaw/whatsapp` plugin, which renders the Linked-Devices QR at full size — on DGX Spark terminals it filled 50–80+ rows and hundreds of columns and could not be scanned in one phone-camera frame, and the reported `1008 abnormal closure` surfaced as raw gateway text with no separation from the QR problem. This PR makes the NemoClaw-supported pairing path render a compact QR and diagnose gateway close/error conditions separately from QR rendering.

## Related Issue

Fixes #4522

## Changes

- Add a NemoClaw-owned Node preload (`nemoclaw-blueprint/scripts/whatsapp-qr-compact.js`) that forces `qrcode-terminal` into the same `{ small: true }` half-block mode the host-side WeChat QR path already uses (`src/ext/wechat/login.ts`), roughly quartering the rendered area without changing the QR payload. It hooks `Module._load` so the plugin's nested copy is patched and is idempotent.
- Install the preload only when WhatsApp is configured, and inject it for the single `openclaw channels login --channel whatsapp` invocation via the sandbox `openclaw()` guard — the gateway never renders the pairing QR, so it stays off global `NODE_OPTIONS`. The preload is validated under `validate_tmp_permissions` (root:444) so the sandbox user cannot tamper with a `NODE_OPTIONS`-injected file.
- Validate `OPENCLAW_GATEWAY_URL` before pairing, and on a non-zero login exit print retry/diagnostic guidance that distinguishes a gateway close (e.g. `1008`) from a QR-size issue.
- Update the WhatsApp channel help text to describe the compact, gateway-validated pairing path.
- Add unit tests for the renderer (forces small, bounds rendered lines, idempotent) and the guard branch (gateway preflight, preload injection, close diagnostics), plus a live e2e check (`M-WA6b`/`M-WA6c`) that the preload + guard wiring land in the sandbox.
- The preload carries a documented removal criterion for when upstream renders a scan-friendly QR by default.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` passes (cli + plugin projects; the only failures were pre-existing 5000ms timeouts in `test/e2e-scenario/framework-tests/*` that spawn real bash and flake under parallel load — they pass in isolation and are unrelated to this change)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Targeted: `test/whatsapp-qr-compact.test.ts`, `src/lib/sandbox/channels.test.ts`, `src/lib/sandbox/whatsapp-diagnostics.test.ts`, `test/nemoclaw-start.test.ts`, `npm run typecheck:cli` — all green

Live note: no live WhatsApp sandbox/account was available, so the compact-QR rendering and gateway diagnostics are validated by hermetic tests around the renderer and the sandbox guard; the live `channels login --channel whatsapp` scan was not exercised end-to-end. The compact renderer assumes the bundled plugin uses `qrcode-terminal` (the dominant renderer, same lib as the WeChat path); the gateway validation/diagnostics apply regardless.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp pairing now displays compact, scan‑friendly QR codes; startup tooling can install a sandbox preload to enforce compact rendering during login and validates the gateway before pairing.

* **Documentation**
  * Updated WhatsApp channel help text with revised login instructions and pairing flow guidance.

* **Tests**
  * Added e2e and unit tests covering compact‑QR rendering, preload installation/wiring, and the WhatsApp login guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->