### PR TITLE
fix(hosts): gate host aliases on docker/vm drivers (#4516)

### DIFF
--- a/src/lib/actions/sandbox/host-aliases.ts
+++ b/src/lib/actions/sandbox/host-aliases.ts
@@ -80,12 +80,7 @@ function normalizeDriver(driver: unknown): string | null {
 // without pretending a one-time /etc/hosts edit inside the direct container
 // would survive a sandbox restart or rebuild.
 function assertLegacyGatewayHostAliasSupport(sandboxName: string): void {
-  let driver: string | null = null;
-  try {
-    driver = normalizeDriver(registry.getSandbox(sandboxName)?.openshellDriver);
-  } catch {
-    driver = null;
-  }
+  const driver = normalizeDriver(registry.getSandbox(sandboxName)?.openshellDriver);
   if (driver && DIRECT_CONTAINER_DRIVERS.has(driver)) {
     hostAliasesFail([
       `  Host aliases are not supported on the '${driver}' driver sandbox '${sandboxName}'.`,

--- a/src/lib/actions/sandbox/host-aliases.ts
+++ b/src/lib/actions/sandbox/host-aliases.ts
@@ -5,9 +5,17 @@ import { isIP } from "node:net";
 
 import { dockerExecFileSync } from "../../adapters/docker";
 import { CLI_NAME } from "../../cli/branding";
+import * as registry from "../../state/registry";
 
 const K3S_CONTAINER = "openshell-cluster-nemoclaw";
 const HOST_ALIAS_KUBECTL_TIMEOUT_MS = 10_000;
+
+// Drivers that run a per-sandbox direct container (openshell-<sandbox>...)
+// instead of the legacy k3s gateway. They have no openshell-cluster-nemoclaw
+// container and no Kubernetes `Sandbox` custom resource, so the kubectl-based
+// host-alias backend below cannot target them. See src/lib/sandbox/privileged-exec.ts
+// for the direct-container resolution these drivers use elsewhere.
+const DIRECT_CONTAINER_DRIVERS = new Set(["docker", "vm"]);
 
 type HostAlias = {
   ip: string;
@@ -55,6 +63,38 @@ export class HostAliasesCommandError extends Error {
 
 function hostAliasesFail(lines: string | readonly string[], exitCode = 1): never {
   throw new HostAliasesCommandError(lines, exitCode);
+}
+
+function normalizeDriver(driver: unknown): string | null {
+  return typeof driver === "string" && driver.trim()
+    ? driver.trim().toLowerCase()
+    : null;
+}
+
+// Host aliases are persisted on the legacy Kubernetes gateway `Sandbox`
+// custom resource and applied by `docker exec openshell-cluster-nemoclaw
+// kubectl ...`. The docker and vm drivers run per-sandbox direct containers
+// with no gateway cluster container and no `Sandbox` CR, so this k3s
+// control-plane path cannot work for them. Fail fast with an actionable
+// message instead of targeting a container that does not exist (#4516) — and
+// without pretending a one-time /etc/hosts edit inside the direct container
+// would survive a sandbox restart or rebuild.
+function assertLegacyGatewayHostAliasSupport(sandboxName: string): void {
+  let driver: string | null = null;
+  try {
+    driver = normalizeDriver(registry.getSandbox(sandboxName)?.openshellDriver);
+  } catch {
+    driver = null;
+  }
+  if (driver && DIRECT_CONTAINER_DRIVERS.has(driver)) {
+    hostAliasesFail([
+      `  Host aliases are not supported on the '${driver}' driver sandbox '${sandboxName}'.`,
+      "  This command edits aliases on the legacy Kubernetes gateway sandbox resource,",
+      `  which the ${driver} driver does not run (there is no openshell-cluster-nemoclaw container).`,
+      "  OpenShell does not yet expose a persistent host-alias API for this driver, and a",
+      "  one-time /etc/hosts edit would not survive a sandbox restart or rebuild.",
+    ]);
+  }
 }
 
 function validateHostAliasHostname(hostname: string): boolean {
@@ -186,6 +226,7 @@ function patchHostAliasesWithRetry(
 }
 
 export function listSandboxHostAliases(sandboxName: string): void {
+  assertLegacyGatewayHostAliasSupport(sandboxName);
   const aliases = getHostAliases(getSandboxResource(sandboxName));
   if (aliases.length === 0) {
     console.log(`  No host aliases configured for '${sandboxName}'.`);
@@ -207,6 +248,7 @@ export function addSandboxHostAlias(
   sandboxName: string,
   options: AddSandboxHostAliasOptions = {},
 ): void {
+  assertLegacyGatewayHostAliasSupport(sandboxName);
   const dryRun = Boolean(options.dryRun);
   const { hostname: rawHostname, ip } = options;
   if (!rawHostname || !ip) {
@@ -249,6 +291,7 @@ export function removeSandboxHostAlias(
   sandboxName: string,
   options: RemoveSandboxHostAliasOptions = {},
 ): void {
+  assertLegacyGatewayHostAliasSupport(sandboxName);
   const dryRun = Boolean(options.dryRun);
   const { hostname: rawHostname } = options;
   if (!rawHostname) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -120,6 +120,7 @@ type SandboxEntry = {
   gpuEnabled: boolean;
   policies: string[];
   agent?: string;
+  openshellDriver?: string | null;
 };
 
 function writeRecordingCommand(
@@ -2560,6 +2561,47 @@ describe("CLI dispatch", () => {
       value: "124",
     });
   });
+
+  for (const driver of ["docker", "vm"] as const) {
+    it(`gates host alias commands on the ${driver} driver without targeting the legacy gateway container`, testTimeoutOptions(30_000), () => {
+      const home = fs.mkdtempSync(
+        path.join(os.tmpdir(), `nemoclaw-cli-hosts-${driver}-`),
+      );
+      const localBin = path.join(home, "bin");
+      const dockerLog = path.join(home, "docker.log");
+      fs.mkdirSync(localBin, { recursive: true });
+      // Record any docker invocation so we can prove the gate fires before
+      // the legacy `docker exec openshell-cluster-nemoclaw kubectl` path.
+      writeHostAliasDockerStub(localBin, dockerLog, [
+        { ip: "10.0.0.5", hostnames: ["old.local"] },
+      ]);
+      writeSandboxRegistry(home, "alpha", { openshellDriver: driver });
+
+      const env = { HOME: home, PATH: `${localBin}:${process.env.PATH || ""}` };
+      const list = runWithEnv("alpha hosts-list", env);
+      const add = runWithEnv("alpha hosts-add searxng.local 192.168.1.105", env);
+      const remove = runWithEnv("alpha hosts-remove searxng.local", env);
+
+      for (const result of [list, add, remove]) {
+        expect(result.code).toBe(1);
+        expect(result.out).toContain(
+          `Host aliases are not supported on the '${driver}' driver sandbox 'alpha'.`,
+        );
+      }
+
+      // Even the dry-run preview must not reach the legacy resource read.
+      const dryRun = runWithEnv(
+        "alpha hosts-add searxng.local 192.168.1.105 --dry-run",
+        env,
+      );
+      expect(dryRun.code).toBe(1);
+      expect(dryRun.out).not.toContain("/spec/podTemplate/spec/hostAliases");
+
+      // The gate runs before any docker exec, so the legacy gateway container
+      // is never targeted.
+      expect(fs.existsSync(dockerLog)).toBe(false);
+    });
+  }
 
   it("supports oclif-native sandbox command forms", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-native-sandbox-"));


### PR DESCRIPTION
## Summary

Host-alias commands (`hosts-list` / `hosts-add` / `hosts-remove`) still assumed the legacy k3s gateway container `openshell-cluster-nemoclaw` and the Kubernetes `Sandbox` custom resource. Docker- and vm-driver sandboxes run per-sandbox direct containers with no gateway cluster container and no `Sandbox` CR, so the commands failed before reading aliases with `No such container: openshell-cluster-nemoclaw`. This gates those commands on direct-container drivers with an actionable message instead of targeting a container that does not exist.

## Related Issue

Fixes #4516

## Changes

- `src/lib/actions/sandbox/host-aliases.ts`: read the sandbox `openshellDriver` from the registry and fail fast with an actionable unsupported-runtime message for the `docker` and `vm` direct-container drivers, before any `docker exec ... kubectl` call. Legacy k3s behavior (`kubernetes` / unrecorded driver) is preserved unchanged. The message is explicit that OpenShell exposes no persistent host-alias API for these drivers and that a one-time `/etc/hosts` edit would not survive a restart/rebuild — so we do not pretend durability.
- `test/cli.test.ts`: added a parameterized regression test (docker + vm) proving the commands exit non-zero with the unsupported message and never invoke the legacy gateway container, including the `--dry-run` preview path. Extended the test `SandboxEntry` type with `openshellDriver`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Ran locally: `npm run typecheck:cli` (pass), the full `test/cli.test.ts` CLI project — 172/172 passing (single-worker run; the shared host could not sustain the fully parallel `npm test`, but the affected `cli` project is green), the plugin pre-commit Vitest hook (pass on commit), `codex review` (no actionable findings), plus a manual reproduction through the built CLI confirming docker/vm drivers are gated and the legacy k3s path still patches the `Sandbox` resource for unrecorded drivers. Full `npm test` and `prek` will run in CI.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host-alias commands now validate OpenShell driver compatibility and return clear, actionable errors when used with unsupported drivers (docker, vm). Commands fail fast and do not attempt legacy gateway edits or produce misleading previews.
  * `--dry-run` correctly fails on incompatible driver configurations and does not emit a host-alias JSON preview.

* **Tests**
  * Added tests covering host-alias commands and `--dry-run` to verify immediate failure and absence of legacy gateway operations for unsupported drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->