### PR TITLE
fix(onboard): gate host-network GPU local inference reachability (#4509)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3748,17 +3748,17 @@ async function createSandbox(
   });
 
   if (effectiveSandboxGpuConfig.sandboxGpuEnabled) {
-    try {
-      verifyDirectSandboxGpu(sandboxName);
-    } catch (error) {
-      dockerGpuPatch.printDockerGpuProofFailure(
-        sandboxName,
-        error,
-        dockerGpuCreatePatch.selectedMode(),
-        { runCaptureOpenshell },
-      );
-      throw error;
-    }
+    // Runs the GPU proof, then (when the Docker GPU patch recreated the
+    // container) gates on host-network local inference reachability (#4509).
+    dockerGpuLocalInference.verifyGpuSandboxAfterReady(effectiveSandboxGpuConfig, provider, {
+      sandboxName,
+      dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(),
+      useDockerGpuPatch,
+      verifyDirectSandboxGpu,
+      selectedMode: dockerGpuCreatePatch.selectedMode,
+      runCaptureOpenshell,
+      log: console.log,
+    });
   }
 
   // Release any stale forward on the dashboard port before claiming it for the new sandbox.

--- a/src/lib/onboard/docker-gpu-local-inference.test.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.test.ts
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  printDockerGpuHostNetworkInferenceVerificationFailure,
+  shouldUseDockerGpuPatchHostNetwork,
+  verifyDockerGpuHostNetworkLocalInference,
+  verifyGpuSandboxAfterReady,
+} from "../../../dist/lib/onboard/docker-gpu-local-inference";
+
+const HOST_NETWORK_ENV = { NEMOCLAW_DOCKER_GPU_PATCH_NETWORK: "host" } as NodeJS.ProcessEnv;
+const GPU_CONFIG = { sandboxGpuEnabled: true };
+
+function hostNetworkOptions(extra: Record<string, unknown> = {}) {
+  return {
+    sandboxName: "alpha",
+    dockerDriverGateway: true,
+    platform: "linux" as NodeJS.Platform,
+    env: HOST_NETWORK_ENV,
+    ...extra,
+  };
+}
+
+function inspectWithNetworkMode(mode: string): string {
+  return JSON.stringify([{ HostConfig: { NetworkMode: mode } }]);
+}
+
+const CURL_CHECK_PROBE = "command -v curl >/dev/null 2>&1";
+
+// Build a dockerRun mock that reports curl as present and returns `probeResult`
+// for the actual reachability probe (curl -sf ...).
+function dockerRunWithCurl(probeResult: { status: number; stderr?: string }) {
+  return vi.fn((args: readonly string[]) => {
+    if (args.includes(CURL_CHECK_PROBE)) return { status: 0 };
+    return probeResult;
+  });
+}
+
+describe("shouldUseDockerGpuPatchHostNetwork", () => {
+  it("is true only on the Linux Docker-driver host-network path", () => {
+    expect(
+      shouldUseDockerGpuPatchHostNetwork(GPU_CONFIG, {
+        dockerDriverGateway: true,
+        platform: "linux",
+        env: HOST_NETWORK_ENV,
+      }),
+    ).toBe(true);
+    // Not host network mode.
+    expect(
+      shouldUseDockerGpuPatchHostNetwork(GPU_CONFIG, {
+        dockerDriverGateway: true,
+        platform: "linux",
+        env: {},
+      }),
+    ).toBe(false);
+    // Not linux.
+    expect(
+      shouldUseDockerGpuPatchHostNetwork(GPU_CONFIG, {
+        dockerDriverGateway: true,
+        platform: "darwin",
+        env: HOST_NETWORK_ENV,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("verifyDockerGpuHostNetworkLocalInference", () => {
+  it("skips when the host-network GPU patch is not active", () => {
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      hostNetworkOptions({ env: {} }),
+    );
+    expect(result.status).toBe("skipped");
+  });
+
+  it("skips for non-local providers", () => {
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "build",
+      hostNetworkOptions(),
+    );
+    expect(result).toEqual({ status: "skipped", reason: "not-local-provider" });
+  });
+
+  it("skips when the Docker GPU patch is explicitly disabled", () => {
+    const dockerRun = vi.fn();
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      hostNetworkOptions({
+        env: { ...HOST_NETWORK_ENV, NEMOCLAW_DOCKER_GPU_PATCH: "0" },
+        deps: {
+          findContainerIds: () => [],
+          dockerCapture: vi.fn(),
+          dockerRun,
+          sleep: vi.fn(),
+        },
+      }),
+    );
+    expect(result.status).toBe("skipped");
+    // No container lookup or probe is attempted when the patch is opted out.
+    expect(dockerRun).not.toHaveBeenCalled();
+  });
+
+  it("passes when the container is on host network and the probe succeeds", () => {
+    const dockerCapture = vi.fn(() => inspectWithNetworkMode("host"));
+    const dockerRun = dockerRunWithCurl({ status: 0 });
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "vllm-local",
+      hostNetworkOptions({
+        deps: {
+          findContainerIds: () => ["container-abc"],
+          dockerCapture,
+          dockerRun,
+          sleep: vi.fn(),
+        },
+      }),
+    );
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.containerId).toBe("container-abc");
+      expect(result.networkMode).toBe("host");
+      expect(result.endpoint).toContain("/v1/models");
+    }
+    // Probe runs curl inside the recreated container against the direct URL.
+    expect(dockerRun).toHaveBeenCalledWith(
+      expect.arrayContaining(["exec", "container-abc", "curl", "-sf"]),
+      expect.objectContaining({ ignoreError: true }),
+    );
+  });
+
+  it("fails when no recreated container is found", () => {
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      hostNetworkOptions({
+        deps: {
+          findContainerIds: () => [],
+          dockerCapture: vi.fn(),
+          dockerRun: vi.fn(),
+          sleep: vi.fn(),
+        },
+      }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("container-not-found");
+      expect(result.recovery.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("fails when the recreated container is not on host network", () => {
+    const dockerRun = vi.fn(() => ({ status: 0 }));
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      hostNetworkOptions({
+        deps: {
+          findContainerIds: () => ["container-xyz"],
+          dockerCapture: vi.fn(() => inspectWithNetworkMode("openshell-docker")),
+          dockerRun,
+          sleep: vi.fn(),
+        },
+      }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("network-mode");
+      expect(result.networkMode).toBe("openshell-docker");
+    }
+    // Do not probe when the network mode is already wrong.
+    expect(dockerRun).not.toHaveBeenCalled();
+  });
+
+  it("fails and retries when the direct endpoint probe never succeeds", () => {
+    const dockerRun = dockerRunWithCurl({ status: 7, stderr: "Connection refused" });
+    const sleep = vi.fn();
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      hostNetworkOptions({
+        deps: {
+          findContainerIds: () => ["container-xyz"],
+          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
+          dockerRun,
+          sleep,
+        },
+      }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("probe");
+      expect(result.detail).toContain("Connection refused");
+      expect(result.endpoint).toContain("/api/tags");
+    }
+    // 1 curl-availability check + 3 probe attempts.
+    expect(dockerRun).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("soft-skips with a warning when the container image lacks curl", () => {
+    // dockerRun reports curl missing (non-zero for the curl-availability check).
+    const dockerRun = vi.fn(() => ({ status: 1 }));
+    const log = vi.fn();
+    const result = verifyDockerGpuHostNetworkLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      hostNetworkOptions({
+        log,
+        deps: {
+          findContainerIds: () => ["container-xyz"],
+          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
+          dockerRun,
+          sleep: vi.fn(),
+        },
+      }),
+    );
+    expect(result).toEqual({ status: "skipped", reason: "probe-tool-unavailable" });
+    // Only the curl-availability check runs; no curl probe is attempted.
+    expect(dockerRun).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("curl is not available"));
+  });
+});
+
+describe("verifyGpuSandboxAfterReady", () => {
+  function baseOptions(extra: Record<string, unknown> = {}) {
+    return {
+      sandboxName: "alpha",
+      dockerDriverGateway: true,
+      platform: "linux" as NodeJS.Platform,
+      env: HOST_NETWORK_ENV,
+      useDockerGpuPatch: true,
+      verifyDirectSandboxGpu: vi.fn(),
+      selectedMode: () => null,
+      runCaptureOpenshell: vi.fn(() => ""),
+      log: vi.fn(),
+      ...extra,
+    };
+  }
+
+  it("runs the GPU proof and the host-network inference gate when the patch is active", () => {
+    const log = vi.fn();
+    const verifyDirectSandboxGpu = vi.fn();
+    verifyGpuSandboxAfterReady(
+      GPU_CONFIG,
+      "vllm-local",
+      baseOptions({
+        verifyDirectSandboxGpu,
+        log,
+        deps: {
+          findContainerIds: () => ["container-abc"],
+          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
+          dockerRun: dockerRunWithCurl({ status: 0 }),
+          sleep: vi.fn(),
+        },
+      }),
+    );
+    expect(verifyDirectSandboxGpu).toHaveBeenCalledWith("alpha");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("reachable from sandbox"));
+  });
+
+  it("routes failure diagnostics through the provided error sink and exits", () => {
+    const logError = vi.fn();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    try {
+      expect(() =>
+        verifyGpuSandboxAfterReady(
+          GPU_CONFIG,
+          "ollama-local",
+          baseOptions({
+            logError,
+            deps: {
+              findContainerIds: () => ["container-xyz"],
+              dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
+              dockerRun: dockerRunWithCurl({ status: 7, stderr: "Connection refused" }),
+              sleep: vi.fn(),
+            },
+          }),
+        ),
+      ).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(logError).toHaveBeenCalledWith(
+        expect.stringContaining("Local inference reachability check failed"),
+      );
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("skips the inference gate when the Docker GPU patch did not recreate the container", () => {
+    const findContainerIds = vi.fn(() => ["container-abc"]);
+    const verifyDirectSandboxGpu = vi.fn();
+    verifyGpuSandboxAfterReady(
+      GPU_CONFIG,
+      "ollama-local",
+      baseOptions({
+        useDockerGpuPatch: false,
+        verifyDirectSandboxGpu,
+        deps: { findContainerIds, dockerCapture: vi.fn(), dockerRun: vi.fn(), sleep: vi.fn() },
+      }),
+    );
+    expect(verifyDirectSandboxGpu).toHaveBeenCalledWith("alpha");
+    // No container resolution happens when the patch is not in play.
+    expect(findContainerIds).not.toHaveBeenCalled();
+  });
+});
+
+describe("printDockerGpuHostNetworkInferenceVerificationFailure", () => {
+  it("surfaces endpoint, network mode, container id, and recovery hints", () => {
+    const lines: string[] = [];
+    printDockerGpuHostNetworkInferenceVerificationFailure(
+      {
+        status: "failed",
+        kind: "probe",
+        provider: "ollama-local",
+        message: "unreachable",
+        containerId: "container-xyz",
+        networkMode: "host",
+        endpoint: "http://127.0.0.1:11434/api/tags",
+        detail: "Connection refused",
+        recovery: ["do the thing"],
+      },
+      (line) => lines.push(line),
+    );
+    const text = lines.join("\n");
+    expect(text).toContain("container=container-xyz");
+    expect(text).toContain("network_mode=host");
+    expect(text).toContain("endpoint=http://127.0.0.1:11434/api/tags");
+    expect(text).toContain("Local Ollama");
+    expect(text).toContain("do the thing");
+  });
+});

--- a/src/lib/onboard/docker-gpu-local-inference.test.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.test.ts
@@ -224,6 +224,29 @@ describe("verifyDockerGpuHostNetworkLocalInference", () => {
     expect(dockerRun).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(expect.stringContaining("curl is not available"));
   });
+
+  it("surfaces the curl-missing skip warning even without a logger", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const result = verifyDockerGpuHostNetworkLocalInference(
+        GPU_CONFIG,
+        "ollama-local",
+        hostNetworkOptions({
+          // No log provided — the warning must still reach the operator.
+          deps: {
+            findContainerIds: () => ["container-xyz"],
+            dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
+            dockerRun: vi.fn(() => ({ status: 1 })),
+            sleep: vi.fn(),
+          },
+        }),
+      );
+      expect(result).toEqual({ status: "skipped", reason: "probe-tool-unavailable" });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("curl is not available"));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe("verifyGpuSandboxAfterReady", () => {

--- a/src/lib/onboard/docker-gpu-local-inference.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.ts
@@ -1,15 +1,32 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { dockerCapture, dockerRun } from "../adapters/docker";
 import {
+  getLocalProviderHealthEndpoint,
+  getLocalProviderLabel,
   getLocalProviderValidationBaseUrl,
   LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV,
 } from "../inference/local";
-import { getDockerGpuPatchNetworkMode, shouldApplyDockerGpuPatch } from "./docker-gpu-patch";
+import {
+  DOCKER_GPU_PATCH_NETWORK_ENV,
+  type DockerGpuPatchMode,
+  findOpenShellDockerSandboxContainerIds,
+  getDockerGpuPatchNetworkMode,
+  parseDockerInspectJson,
+  printDockerGpuProofFailure,
+  shouldApplyDockerGpuPatch,
+} from "./docker-gpu-patch";
 
 const {
   LOCAL_INFERENCE_PROVIDERS,
 }: { LOCAL_INFERENCE_PROVIDERS: string[] } = require("./providers");
+
+const DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS = 30_000;
+const DOCKER_GPU_INFERENCE_PROBE_CONNECT_TIMEOUT_SECS = 5;
+const DOCKER_GPU_INFERENCE_PROBE_MAX_TIME_SECS = 10;
+const DOCKER_GPU_INFERENCE_PROBE_MAX_ATTEMPTS = 3;
+const DOCKER_GPU_INFERENCE_PROBE_RETRY_DELAY_SECS = 2;
 
 type DockerGpuLocalInferenceConfig = {
   sandboxGpuEnabled: boolean;
@@ -19,6 +36,7 @@ type DockerGpuLocalInferenceConfig = {
 type DockerGpuLocalInferenceOptions = {
   dockerDriverGateway: boolean;
   env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
   log?: (message: string) => void;
 };
 
@@ -27,8 +45,11 @@ export function shouldUseDockerGpuPatchHostNetwork(
   options: DockerGpuLocalInferenceOptions,
 ): boolean {
   return (
-    shouldApplyDockerGpuPatch(config, { dockerDriverGateway: options.dockerDriverGateway }) &&
-    getDockerGpuPatchNetworkMode(options.env ?? process.env) === "host"
+    shouldApplyDockerGpuPatch(config, {
+      dockerDriverGateway: options.dockerDriverGateway,
+      env: options.env,
+      platform: options.platform,
+    }) && getDockerGpuPatchNetworkMode(options.env ?? process.env) === "host"
   );
 }
 
@@ -64,4 +85,318 @@ export function dockerGpuPatchHostNetworkInferenceBaseUrl(
     );
   }
   return baseUrl;
+}
+
+type DockerRunResult = {
+  status?: number | null;
+  stdout?: string | Buffer | null;
+  stderr?: string | Buffer | null;
+};
+
+export type DockerGpuHostNetworkInferenceVerifyDeps = {
+  findContainerIds?: (sandboxName: string) => string[];
+  dockerCapture?: (args: readonly string[], opts?: Record<string, unknown>) => string;
+  dockerRun?: (args: readonly string[], opts?: Record<string, unknown>) => DockerRunResult;
+  sleep?: (seconds: number) => void;
+};
+
+export type DockerGpuHostNetworkInferenceVerification =
+  | { status: "skipped"; reason: string }
+  | { status: "ok"; provider: string; containerId: string; networkMode: string; endpoint: string }
+  | {
+      status: "failed";
+      kind: "container-not-found" | "network-mode" | "probe";
+      provider: string;
+      message: string;
+      containerId: string | null;
+      networkMode: string | null;
+      endpoint: string | null;
+      detail: string | null;
+      recovery: string[];
+    };
+
+function resultText(result: DockerRunResult | null | undefined): string {
+  if (!result) return "";
+  return `${String(result.stderr || "")} ${String(result.stdout || "")}`.trim();
+}
+
+function inspectContainerNetworkMode(
+  containerId: string,
+  dockerCaptureFn: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerCapture"]>,
+): string | null {
+  try {
+    const output = dockerCaptureFn(["inspect", "--type", "container", containerId], {
+      ignoreError: true,
+      timeout: DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS,
+    });
+    if (!output || !output.trim()) return null;
+    const inspect = parseDockerInspectJson(output);
+    const mode = String(inspect.HostConfig?.NetworkMode || "").trim();
+    return mode || null;
+  } catch {
+    return null;
+  }
+}
+
+function containerHasCurl(
+  containerId: string,
+  dockerRunFn: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerRun"]>,
+): boolean {
+  try {
+    const result = dockerRunFn(
+      ["exec", containerId, "sh", "-lc", "command -v curl >/dev/null 2>&1"],
+      {
+        ignoreError: true,
+        suppressOutput: true,
+        timeout: DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS,
+      },
+    );
+    return Number(result?.status ?? 1) === 0;
+  } catch {
+    return false;
+  }
+}
+
+function probeContainerInferenceEndpoint(
+  containerId: string,
+  endpoint: string,
+  deps: {
+    dockerRun: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerRun"]>;
+    sleep: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["sleep"]>;
+  },
+): { ok: boolean; detail: string | null } {
+  let detail: string | null = null;
+  for (let attempt = 1; attempt <= DOCKER_GPU_INFERENCE_PROBE_MAX_ATTEMPTS; attempt++) {
+    try {
+      // Run curl from inside the recreated host-network container so the probe
+      // exercises the exact loopback path OpenClaw will use (127.0.0.1 ->
+      // host loopback under --network host). Inherit the container's own proxy
+      // env so NO_PROXY/loopback handling matches the agent runtime.
+      const result = deps.dockerRun(
+        [
+          "exec",
+          containerId,
+          "curl",
+          "-sf",
+          "--connect-timeout",
+          String(DOCKER_GPU_INFERENCE_PROBE_CONNECT_TIMEOUT_SECS),
+          "--max-time",
+          String(DOCKER_GPU_INFERENCE_PROBE_MAX_TIME_SECS),
+          "-o",
+          "/dev/null",
+          endpoint,
+        ],
+        {
+          ignoreError: true,
+          suppressOutput: true,
+          timeout: DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS,
+        },
+      );
+      if (Number(result?.status ?? 1) === 0) return { ok: true, detail: null };
+      detail = resultText(result) || "docker exec curl exited non-zero";
+    } catch (error) {
+      detail = error instanceof Error ? error.message : String(error);
+    }
+    if (attempt < DOCKER_GPU_INFERENCE_PROBE_MAX_ATTEMPTS) {
+      deps.sleep(DOCKER_GPU_INFERENCE_PROBE_RETRY_DELAY_SECS);
+    }
+  }
+  return { ok: false, detail };
+}
+
+/**
+ * Post-recreate reachability gate for Docker-driver GPU host-network local
+ * inference (#4509). After the GPU patch recreates the sandbox container with
+ * `--network host` and OpenClaw is wired to the direct `127.0.0.1` provider
+ * URL, prove the real container can actually reach that endpoint before
+ * onboarding declares success — otherwise the failure only surfaces later as
+ * an opaque `ECONNREFUSED` during an agent prompt.
+ *
+ * Self-gates: returns `skipped` unless the host-network GPU patch is active
+ * for a local inference provider.
+ */
+export function verifyDockerGpuHostNetworkLocalInference(
+  config: DockerGpuLocalInferenceConfig,
+  provider: string | null | undefined,
+  options: DockerGpuLocalInferenceOptions & {
+    sandboxName: string;
+    deps?: DockerGpuHostNetworkInferenceVerifyDeps;
+  },
+): DockerGpuHostNetworkInferenceVerification {
+  if (!shouldUseDockerGpuPatchHostNetwork(config, options)) {
+    return { status: "skipped", reason: "not-host-network-gpu" };
+  }
+  if (!provider || !LOCAL_INFERENCE_PROVIDERS.includes(provider)) {
+    return { status: "skipped", reason: "not-local-provider" };
+  }
+  const endpoint = getLocalProviderHealthEndpoint(provider);
+  if (!endpoint) {
+    return { status: "skipped", reason: "no-health-endpoint" };
+  }
+
+  const deps = options.deps ?? {};
+  const findContainerIds =
+    deps.findContainerIds ?? ((name: string) => findOpenShellDockerSandboxContainerIds(name));
+  const dockerCaptureFn = deps.dockerCapture ?? dockerCapture;
+  const dockerRunFn = deps.dockerRun ?? dockerRun;
+  const sleep =
+    deps.sleep ??
+    ((seconds: number) => {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, seconds) * 1000);
+    });
+
+  const containerId = findContainerIds(options.sandboxName)[0];
+  if (!containerId) {
+    return {
+      status: "failed",
+      kind: "container-not-found",
+      provider,
+      message: `Could not find the recreated OpenShell Docker container for sandbox '${options.sandboxName}'.`,
+      containerId: null,
+      networkMode: null,
+      endpoint,
+      detail: null,
+      recovery: [
+        "Confirm the sandbox container is running:  openshell sandbox list",
+        "Re-run onboarding; the Docker GPU container recreate may not have completed.",
+      ],
+    };
+  }
+
+  const networkMode = inspectContainerNetworkMode(containerId, dockerCaptureFn);
+  if (networkMode !== "host") {
+    return {
+      status: "failed",
+      kind: "network-mode",
+      provider,
+      message:
+        `Docker-driver GPU host networking was requested (${DOCKER_GPU_PATCH_NETWORK_ENV}=host) but the ` +
+        `recreated sandbox container is on network mode '${networkMode ?? "unknown"}'. OpenClaw is wired ` +
+        `to ${endpoint}, which is only reachable under --network host.`,
+      containerId,
+      networkMode: networkMode ?? null,
+      endpoint,
+      detail: null,
+      recovery: [
+        "The GPU patch only switches to --network host when it can rewrite OPENSHELL_ENDPOINT",
+        "  from host.openshell.internal to 127.0.0.1; check the recreate logs above.",
+        `Re-run with ${DOCKER_GPU_PATCH_NETWORK_ENV}=host, or omit it to use the proxy inference path.`,
+      ],
+    };
+  }
+
+  // Minimal/custom images (e.g. some --from-dockerfile bases) may not ship
+  // curl. A missing probe tool must not be reported as an unreachable
+  // endpoint — that would turn a tooling gap into a false onboarding failure.
+  // Soft-skip with a visible warning instead, preserving prior behavior where
+  // there was no gate at all (#4509 review follow-up).
+  if (!containerHasCurl(containerId, dockerRunFn)) {
+    options.log?.(
+      `  ⚠ Skipping host-network local inference reachability check: curl is not available in ${containerId}.`,
+    );
+    return { status: "skipped", reason: "probe-tool-unavailable" };
+  }
+
+  const probe = probeContainerInferenceEndpoint(containerId, endpoint, {
+    dockerRun: dockerRunFn,
+    sleep,
+  });
+  if (!probe.ok) {
+    return {
+      status: "failed",
+      kind: "probe",
+      provider,
+      message: `The recreated host-network sandbox container could not reach the local inference endpoint ${endpoint}.`,
+      containerId,
+      networkMode,
+      endpoint,
+      detail: probe.detail,
+      recovery: [
+        `Confirm the provider is listening on the host loopback:  curl ${endpoint}`,
+        "Ensure Ollama/vLLM binds 127.0.0.1 directly (not only a container bridge address).",
+        "Check that HTTP_PROXY/NO_PROXY inside the sandbox do not intercept the loopback request.",
+        "Set NEMOCLAW_DOCKER_GPU_PATCH=0 to skip the GPU container recreate and use the proxy path.",
+      ],
+    };
+  }
+
+  return { status: "ok", provider, containerId, networkMode, endpoint };
+}
+
+export function printDockerGpuHostNetworkInferenceVerificationFailure(
+  verification: Extract<DockerGpuHostNetworkInferenceVerification, { status: "failed" }>,
+  log: (message: string) => void = (message) => console.error(message),
+): void {
+  const providerLabel = getLocalProviderLabel(verification.provider) ?? verification.provider;
+  log("");
+  log("  Local inference reachability check failed for the GPU host-network sandbox.");
+  log(`  ${verification.message}`);
+  log(`  provider=${providerLabel}`);
+  if (verification.containerId) log(`  container=${verification.containerId}`);
+  if (verification.networkMode) log(`  network_mode=${verification.networkMode}`);
+  if (verification.endpoint) log(`  endpoint=${verification.endpoint}`);
+  if (verification.detail) log(`  detail=${verification.detail.slice(0, 300)}`);
+  log("  Recovery:");
+  for (const line of verification.recovery) log(`    ${line}`);
+}
+
+export type GpuSandboxAfterReadyOptions = {
+  sandboxName: string;
+  dockerDriverGateway: boolean;
+  useDockerGpuPatch: boolean;
+  verifyDirectSandboxGpu: (sandboxName: string) => void;
+  selectedMode: () => DockerGpuPatchMode | null;
+  runCaptureOpenshell: (args: string[], opts?: Record<string, unknown>) => string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  log?: (message: string) => void;
+  logError?: (message: string) => void;
+  deps?: DockerGpuHostNetworkInferenceVerifyDeps;
+};
+
+/**
+ * Post-readiness GPU sandbox verification orchestrator (kept out of the
+ * ~12k-line onboard.ts entrypoint per the codebase-growth guardrail). Runs the
+ * direct GPU proof, then — only when the Docker GPU patch recreated the
+ * container — gates on host-network local inference reachability (#4509). Exits
+ * the process with actionable output if either proof fails.
+ */
+export function verifyGpuSandboxAfterReady(
+  config: DockerGpuLocalInferenceConfig,
+  provider: string | null | undefined,
+  options: GpuSandboxAfterReadyOptions,
+): void {
+  try {
+    options.verifyDirectSandboxGpu(options.sandboxName);
+  } catch (error) {
+    printDockerGpuProofFailure(options.sandboxName, error, options.selectedMode(), {
+      runCaptureOpenshell: options.runCaptureOpenshell,
+    });
+    throw error;
+  }
+
+  // When NEMOCLAW_DOCKER_GPU_PATCH=0, useDockerGpuPatch is false and there is no
+  // recreated container to probe, so skip the host-network inference gate.
+  if (!options.useDockerGpuPatch) return;
+  const verification = verifyDockerGpuHostNetworkLocalInference(config, provider, {
+    sandboxName: options.sandboxName,
+    dockerDriverGateway: options.dockerDriverGateway,
+    env: options.env,
+    platform: options.platform,
+    log: options.log,
+    deps: options.deps,
+  });
+  const log = options.log ?? console.log;
+  if (verification.status === "ok") {
+    log(`  ✓ GPU host-network local inference reachable from sandbox: ${verification.endpoint}`);
+  } else if (verification.status === "failed") {
+    // Route failure diagnostics through the caller-provided error sink so
+    // wrappers / structured log collectors still see them; defaults to
+    // console.error (onboard's stderr error channel).
+    printDockerGpuHostNetworkInferenceVerificationFailure(
+      verification,
+      options.logError ?? ((message) => console.error(message)),
+    );
+    process.exit(1);
+  }
 }

--- a/src/lib/onboard/docker-gpu-local-inference.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.ts
@@ -40,6 +40,11 @@ type DockerGpuLocalInferenceOptions = {
   log?: (message: string) => void;
 };
 
+/**
+ * True only on the Linux Docker-driver GPU patch path with
+ * `NEMOCLAW_DOCKER_GPU_PATCH_NETWORK=host`, i.e. when the recreated sandbox
+ * uses host networking and local inference is wired to the direct loopback URL.
+ */
 export function shouldUseDockerGpuPatchHostNetwork(
   config: DockerGpuLocalInferenceConfig,
   options: DockerGpuLocalInferenceOptions,
@@ -115,11 +120,16 @@ export type DockerGpuHostNetworkInferenceVerification =
       recovery: string[];
     };
 
+/** Flatten a docker run result's stderr/stdout into a single trimmed string. */
 function resultText(result: DockerRunResult | null | undefined): string {
   if (!result) return "";
   return `${String(result.stderr || "")} ${String(result.stdout || "")}`.trim();
 }
 
+/**
+ * Inspect a container and return its `HostConfig.NetworkMode`, or `null` when
+ * the inspect output is empty or unparseable.
+ */
 function inspectContainerNetworkMode(
   containerId: string,
   dockerCaptureFn: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerCapture"]>,
@@ -138,6 +148,7 @@ function inspectContainerNetworkMode(
   }
 }
 
+/** Returns true when `curl` is on PATH inside the container (probe tooling). */
 function containerHasCurl(
   containerId: string,
   dockerRunFn: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerRun"]>,
@@ -157,6 +168,11 @@ function containerHasCurl(
   }
 }
 
+/**
+ * Probe the direct loopback inference endpoint from inside the container with
+ * bounded retries. Returns `{ ok: true }` on the first 2xx, otherwise `ok:
+ * false` with the last failure detail.
+ */
 function probeContainerInferenceEndpoint(
   containerId: string,
   endpoint: string,
@@ -291,7 +307,11 @@ export function verifyDockerGpuHostNetworkLocalInference(
   // Soft-skip with a visible warning instead, preserving prior behavior where
   // there was no gate at all (#4509 review follow-up).
   if (!containerHasCurl(containerId, dockerRunFn)) {
-    options.log?.(
+    // Always surface this skip: it is the operator's only explanation for why
+    // the reachability proof did not run. Fall back to console.warn when no
+    // logger is wired so the warning is never silently dropped.
+    const warn = options.log ?? ((message: string) => console.warn(message));
+    warn(
       `  ⚠ Skipping host-network local inference reachability check: curl is not available in ${containerId}.`,
     );
     return { status: "skipped", reason: "probe-tool-unavailable" };
@@ -323,6 +343,11 @@ export function verifyDockerGpuHostNetworkLocalInference(
   return { status: "ok", provider, containerId, networkMode, endpoint };
 }
 
+/**
+ * Print a failed host-network inference verification result as actionable
+ * operator output: the message, provider, container, network mode, endpoint,
+ * truncated detail, and recovery hints. Defaults to `console.error`.
+ */
 export function printDockerGpuHostNetworkInferenceVerificationFailure(
   verification: Extract<DockerGpuHostNetworkInferenceVerification, { status: "failed" }>,
   log: (message: string) => void = (message) => console.error(message),

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -310,6 +310,21 @@ else
   fail "Onboard GPU proof missing: cuInit(0)"
 fi
 
+# 4d.1: Host-network local inference reachability gate (#4509). When the GPU
+# patch wires OpenClaw to the direct 127.0.0.1 sandbox URL, onboard must prove
+# the recreated host-network container can actually reach that endpoint before
+# declaring success — instead of leaving an unreachable loopback to surface as
+# an opaque ECONNREFUSED during the first agent prompt.
+if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG"; then
+  if grep -Fq "GPU host-network local inference reachable from sandbox" "$INSTALL_LOG"; then
+    pass "Onboard proved host-network local inference reachable before success"
+  else
+    fail "Onboard did not prove host-network local inference reachability (#4509 gate missing)"
+  fi
+else
+  skip "Host-network direct sandbox URL not active; inference reachability gate not exercised"
+fi
+
 # 4e: Inference provider is ollama-local
 if inf_check=$(openshell inference get 2>&1); then
   if echo "$inf_check" | grep -qi "ollama"; then


### PR DESCRIPTION
## Summary

The Docker-driver GPU host-network path recreates the sandbox with `--network host` and wires OpenClaw to the direct `127.0.0.1` Ollama/vLLM URL, but onboarding declared success without proving the recreated container could actually reach that endpoint. A failed host-network recreate, an unexpected non-host network mode, or a host provider binding/state problem only surfaced later as an opaque `ECONNREFUSED` during the first agent prompt. This adds a post-recreate reachability gate so onboarding fails early with actionable output.

## Related Issue

Fixes #4509

## Changes

- Add `verifyDockerGpuHostNetworkLocalInference` in `src/lib/onboard/docker-gpu-local-inference.ts`: on the Docker-driver GPU host-network local-inference path it resolves the recreated OpenShell-managed container, asserts `HostConfig.NetworkMode` is `host`, and runs a bounded `docker exec curl` probe against the direct loopback health endpoint (`/api/tags` for Ollama, `/v1/models` for vLLM).
- On failure, surface the selected endpoint, network mode, container id, and short recovery hints, then fail onboarding (no silent continue). The gate self-skips when the patch is opted out (`NEMOCLAW_DOCKER_GPU_PATCH=0`), when the network mode is not host, or — to avoid false negatives — when a minimal/custom image lacks `curl` (soft-skip with a warning).
- Orchestrate via `verifyGpuSandboxAfterReady` so `src/lib/onboard.ts` stays net-neutral per the codebase-growth guardrail (logic lives under `src/lib/onboard/`).
- Extend `test/e2e/test-gpu-e2e.sh` to assert the reachability proof when the direct sandbox URL is active, instead of only discovering failure during the agent prompt.
- Add focused unit tests for the container-inspection / probe decision logic and the orchestrator.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npm test` passes (unrelated `e2e-scenario` framework tests flaked on the shared host's default 5s timeout under concurrent load; they pass green at a 30s timeout in isolation)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] `npm run build:cli` and `npm run typecheck:cli` clean; `biome check` clean

### Hardware-gated E2E gap

The full host-network proof requires an Ubuntu 24.04 + NVIDIA GPU + native Docker environment, which the triage host does not have. The container-inspection and probe decision logic is covered by unit tests with mocked Docker/OpenShell adapters; the live GPU host-network proof is exercised by `test/e2e/test-gpu-e2e.sh` on GPU hardware.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU sandbox verification now runs an additional host-network reachability gate when applicable, with retries and clear, actionable failure diagnostics; onboarding may stop if this gate fails.

* **Tests**
  * Added comprehensive unit tests for host-network GPU local inference scenarios.
  * Enhanced GPU end-to-end tests to validate host-network reachability when the direct sandbox URL path is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->