### PR TITLE
ci: block newly added JavaScript files

### DIFF
--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -20,6 +20,40 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Block newly added JavaScript files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          rows="$(gh api --paginate "/repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | select((.filename | test("\\.(js|cjs|mjs)$")) and (.status == "added" or (.status == "renamed" and ((.previous_filename // "") | test("\\.(js|cjs|mjs)$") | not)))) | [.status, .filename, (.previous_filename // "")] | @tsv')"
+
+          if [ -z "$rows" ]; then
+            echo "PASS: no newly added .js, .cjs, or .mjs files."
+            exit 0
+          fi
+
+          cat <<'EOF'
+          FAIL: this PR adds JavaScript source files.
+
+          NemoClaw is standardizing on TypeScript for new Node.js code. Please
+          use .ts for new source, test, and script files instead of .js, .cjs,
+          or .mjs. Existing JavaScript files may still be modified or deleted.
+
+          Blocked files:
+          EOF
+          while IFS=$'\t' read -r file_status file_path previous_path; do
+            if [ -n "$previous_path" ]; then
+              echo "          - ${file_path} (${file_status} from ${previous_path})"
+            else
+              echo "          - ${file_path} (${file_status})"
+            fi
+          done <<< "$rows"
+          exit 1
+
       - name: Require src/lib/onboard.ts to be net-neutral or smaller
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
Adds a pull_request_target guardrail that blocks PRs from adding new .js, .cjs, or .mjs files. This nudges new Node.js code toward TypeScript while still allowing existing JavaScript files to be modified or deleted.

## Changes
- Adds a `Block newly added JavaScript files` step to `.github/workflows/codebase-growth-guardrails.yaml`.
- Uses GitHub PR file metadata only, without checking out or executing PR code.
- Fails added JavaScript files and non-JS-to-JS renames, while allowing existing JavaScript edits and JS-to-JS renames.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new CI guardrail that blocks pull requests introducing new JavaScript source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->