### PR TITLE
test(cli): stub docker in follow log tests

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2992,6 +2992,7 @@ describe("CLI dispatch", () => {
     const markerFile = path.join(home, "logs-follow-source-exit-args");
     fs.mkdirSync(localBin, { recursive: true });
     fs.mkdirSync(registryDir, { recursive: true });
+    writeHealthyDockerStub(localBin);
     fs.writeFileSync(
       path.join(registryDir, "sandboxes.json"),
       JSON.stringify({
@@ -3071,6 +3072,7 @@ describe("CLI dispatch", () => {
     const releaseFile = path.join(home, "release-log-children");
     fs.mkdirSync(localBin, { recursive: true });
     writeSandboxRegistry(home);
+    writeHealthyDockerStub(localBin);
     fs.writeFileSync(
       path.join(localBin, "openshell"),
       [


### PR DESCRIPTION
## Summary
Stubs a healthy Docker daemon in the two long-running `logs --follow` CLI tests. This keeps the tests on the intended streaming/signal path instead of depending on the host runner's Docker daemon state.

## Changes
- Added `writeHealthyDockerStub(localBin)` to the `logs --follow` source-exit test setup.
- Added the same Docker stub to the SIGTERM child-drain follow-mode test setup.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification run:

```bash
npm test -- --run test/cli.test.ts -t "keeps logs --follow running when one log source exits|waits for logs --follow children to stop after SIGTERM"
npx prek run --files test/cli.test.ts
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI test reliability for the logs follow feature by enhancing Docker daemon verification in test environments.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->