### PR TITLE
fix(e2e): accept non-root sandbox ownership for WhatsApp QR preload (#4522)

### DIFF
--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -925,6 +925,12 @@ fi
 whatsapp_qr_preload_stat=$(sandbox_exec "stat -c '%U:%a' /tmp/nemoclaw-whatsapp-qr-compact.js 2>/dev/null || echo missing")
 if [ "$whatsapp_qr_preload_stat" = "root:444" ]; then
   pass "M-WA6b: WhatsApp compact-QR preload installed root:444 (#4522)"
+elif [ "$whatsapp_qr_preload_stat" = "sandbox:444" ]; then
+  # Non-root sandbox mode: emit_sandbox_sourced_file produces sandbox:444
+  # because chown root:root is skipped when id -u != 0.  The file is still
+  # read-only (mode 444) which is the security-relevant property; ownership
+  # differs only in privilege-separation posture (see sandbox-init.sh).
+  pass "M-WA6b: WhatsApp compact-QR preload installed sandbox:444 (non-root mode) (#4522)"
 elif [ "$whatsapp_qr_preload_stat" = "missing" ]; then
   fail "M-WA6b: WhatsApp compact-QR preload not installed in sandbox (#4522)"
 else


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The `messaging-providers-e2e` nightly job failed because `test-messaging-providers.sh` assertion `M-WA6b` expected the WhatsApp compact-QR preload file to be owned `root:444`, but the sandbox runs in non-root mode where `emit_sandbox_sourced_file()` (in `scripts/lib/sandbox-init.sh`) produces `sandbox:444` instead. The file permissions (mode 444 = read-only) are the security-relevant property; ownership differs only by privilege-separation posture. This PR widens the assertion to accept both ownership variants.

## Related Issue

Fixes #4636

## Changes

- **`test/e2e/test-messaging-providers.sh`**: Add an `elif` branch to the `M-WA6b` assertion that accepts `sandbox:444` alongside `root:444`, with a comment explaining why non-root mode produces a different owner.

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets, on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`fix/nightly-e2e-whatsapp-qr-preload-owner-451f26f-custom-e2e`](https://github.com/hunglp6d/NemoClaw/tree/fix/nightly-e2e-whatsapp-qr-preload-owner-451f26f-custom-e2e) on `hunglp6d/NemoClaw`
- Validation run: [#26792502483](https://github.com/hunglp6d/NemoClaw/actions/runs/26792502483) — **success**
- Targeted jobs: `messaging-providers-e2e (#78975726764)`
- Original failing run: [26790528855](https://github.com/NVIDIA/NemoClaw/actions/runs/26790528855) on `451f26f6a9e56d2bdc05cff47985545bb79c77a2`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-run the validation by pushing any commit to the validation branch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---

Signed-off-by: Hung Le <hple@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end messaging provider tests to enhance WhatsApp compact-QR preload verification. Now correctly recognizes sandbox file ownership configurations as valid installation cases in addition to existing root ownership scenarios and failure detection.

* **Bug Fixes**
  * Fixed test case handling to properly validate alternative file ownership modes during messaging provider setup verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->