### PR TITLE
fix(e2e): align double-onboard stale-registry test with non-destructive status (#4578)

### DIFF
--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -717,6 +717,11 @@ else
   fail "Registry was unexpectedly cleaned before status reconciliation"
 fi
 
+# Since fix(status) #4578, `nemoclaw status` is non-destructive and no
+# longer removes stale registry entries.  First verify the non-destructive
+# status output, then trigger reconciliation via `connect --probe-only`
+# which still calls ensureLiveSandboxOrExit.
+
 STATUS_LOG="$(mktemp)"
 run_nemoclaw "$SANDBOX_A" status >"$STATUS_LOG" 2>&1
 status_exit=$?
@@ -729,16 +734,28 @@ else
   fail "Stale sandbox status exited $status_exit (expected 1)"
 fi
 
-if grep -q "Removed stale local registry entry" <<<"$status_output"; then
-  pass "Stale registry entry was reconciled during status"
+if grep -q "No local registry entry was removed" <<<"$status_output"; then
+  pass "Stale sandbox status preserved registry entry (#4578)"
+else
+  fail "Stale sandbox status did not emit non-destructive guidance (#4578)"
+fi
+
+# Trigger actual stale-entry reconciliation via connect --probe-only
+RECONCILE_LOG="$(mktemp)"
+run_nemoclaw "$SANDBOX_A" connect --probe-only >"$RECONCILE_LOG" 2>&1 || true
+reconcile_output="$(cat "$RECONCILE_LOG")"
+rm -f "$RECONCILE_LOG"
+
+if grep -q "Removed stale local registry entry" <<<"$reconcile_output"; then
+  pass "Stale registry entry was reconciled during connect --probe-only"
 else
   fail "Stale registry reconciliation message missing"
 fi
 
 if registry_has "$SANDBOX_A"; then
-  fail "Registry still contains '$SANDBOX_A' after status reconciliation"
+  fail "Registry still contains '$SANDBOX_A' after reconciliation"
 else
-  pass "Registry entry for '$SANDBOX_A' removed after status reconciliation"
+  pass "Registry entry for '$SANDBOX_A' removed after reconciliation"
 fi
 
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

**✨ [AI-generated PR]**

The `double-onboard-e2e` nightly job failed at Phase 5 (Stale registry reconciliation) because the test expected `nemoclaw status` to reconcile stale registry entries, but commit 4f7ae09 (`fix(status): preserve registry on missing live sandbox (#4578)`) intentionally made `status` non-destructive — it now prints guidance instead of removing entries. This PR aligns the test with the new behavior: it first verifies the non-destructive `status` output, then triggers actual reconciliation via `connect --probe-only` (which still calls `ensureLiveSandboxOrExit`).

## Related Issue

Fixes #4639

## Changes

- **`test/e2e/test-double-onboard.sh`**: Replace the single `nemoclaw status` reconciliation assertion with a two-step sequence:
  1. Verify `status` exits 1 and preserves the registry entry ("No local registry entry was removed")
  2. Trigger reconciliation via `connect --probe-only` and verify "Removed stale local registry entry"

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets, on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`fix/nightly-e2e-status-stale-reconcile-451f26f-custom-e2e`](https://github.com/hunglp6d/NemoClaw/tree/fix/nightly-e2e-status-stale-reconcile-451f26f-custom-e2e) on `hunglp6d/NemoClaw`
- Validation run: [#26792577152](https://github.com/hunglp6d/NemoClaw/actions/runs/26792577152) — **success**
- Targeted jobs: `double-onboard-e2e (#78975727168)`
- Original failing run: [26790528855](https://github.com/NVIDIA/NemoClaw/actions/runs/26790528855) on `451f26f6a9e56d2bdc05cff47985545bb79c77a2`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-run the validation by pushing any commit to the validation branch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code

---

Signed-off-by: Hung Le <hple@nvidia.com>