### PR TITLE
test(e2e): skip TC-SBX-09 lifecycle drive when sandbox blocks tmux fork

### DIFF
--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -481,14 +481,14 @@ test_sbx_09_tmux_session_flow() {
 
   if echo "$flow_out" | grep -q "TMUX_FLOW_OK" && echo "$flow_out" | grep -q "${sess}"; then
     pass "TC-SBX-09: tmux new/list/kill session lifecycle works"
-  elif echo "$flow_out" | grep -qE "fork failed: (Permission denied|Resource temporarily unavailable)"; then
-    # OpenShell sandbox hardening (seccomp + no-new-privileges + nproc=512)
-    # blocks tmux's fork-to-spawn child window under the e2e SSH session
-    # account. The binary-presence assertion above already covers issue
-    # #4513; the lifecycle drive depends on sandbox runtime capabilities
-    # that are environment-dependent and not in scope of this case.
+  elif echo "$flow_out" | grep -qE "fork failed: (Permission denied|Resource temporarily unavailable|Operation not permitted)"; then
+    # Sandbox hardening (seccomp + no-new-privileges + nproc cap) can refuse
+    # tmux's fork-to-spawn child window under the e2e SSH session account.
+    # The binary-presence assertion above already covers the install surface;
+    # the lifecycle drive depends on runtime capabilities that are
+    # environment-dependent and not in scope of this case.
     sandbox_exec "TMUX_TMPDIR=/tmp tmux kill-session -t '${sess}' 2>/dev/null || true" >/dev/null 2>&1 || true
-    skip "TC-SBX-09 — tmux lifecycle drive blocked by sandbox fork policy: $(echo "$flow_out" | head -3)"
+    skip "TC-SBX-09" "tmux lifecycle drive blocked by sandbox fork policy: $(echo "$flow_out" | head -3)"
   else
     # Best-effort cleanup in case kill-session never ran.
     sandbox_exec "TMUX_TMPDIR=/tmp tmux kill-session -t '${sess}' 2>/dev/null || true" >/dev/null 2>&1 || true

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -481,6 +481,14 @@ test_sbx_09_tmux_session_flow() {
 
   if echo "$flow_out" | grep -q "TMUX_FLOW_OK" && echo "$flow_out" | grep -q "${sess}"; then
     pass "TC-SBX-09: tmux new/list/kill session lifecycle works"
+  elif echo "$flow_out" | grep -qE "fork failed: (Permission denied|Resource temporarily unavailable)"; then
+    # OpenShell sandbox hardening (seccomp + no-new-privileges + nproc=512)
+    # blocks tmux's fork-to-spawn child window under the e2e SSH session
+    # account. The binary-presence assertion above already covers issue
+    # #4513; the lifecycle drive depends on sandbox runtime capabilities
+    # that are environment-dependent and not in scope of this case.
+    sandbox_exec "TMUX_TMPDIR=/tmp tmux kill-session -t '${sess}' 2>/dev/null || true" >/dev/null 2>&1 || true
+    skip "TC-SBX-09 — tmux lifecycle drive blocked by sandbox fork policy: $(echo "$flow_out" | head -3)"
   else
     # Best-effort cleanup in case kill-session never ran.
     sandbox_exec "TMUX_TMPDIR=/tmp tmux kill-session -t '${sess}' 2>/dev/null || true" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

`TC-SBX-09: Tmux Session Flow` has been failing on every scheduled nightly E2E run since #4606 merged. The first assertion (tmux binary present) still passes; the second assertion — drive a full detached `new-session` → `list-sessions` → `kill-session` cycle inside the sandbox — consistently fails with `create window failed: fork failed: Permission denied`.

Root cause: OpenShell sandbox hardening (seccomp, `no-new-privileges`, `nproc=512` ulimit) blocks tmux's fork-to-spawn child window when invoked under the e2e SSH session account. The binary-presence assertion already covers the surface of issue #4513; the lifecycle drive depends on sandbox runtime capabilities that are environment-dependent and out of scope for this case. Degrade that branch to `skip` with the observed `fork failed` output so the suite reports the limitation without failing the nightly.

Latest failing scheduled nightly: [run 26790528855](https://github.com/NVIDIA/NemoClaw/actions/runs/26790528855). Same failure also blocks PR review on [#4388](https://github.com/NVIDIA/NemoClaw/pull/4388) via inherited advisor reruns [run 26790735708](https://github.com/NVIDIA/NemoClaw/actions/runs/26790735708) and [run 26791599457](https://github.com/NVIDIA/NemoClaw/actions/runs/26791599457).

## Related Issue

Follow-up to #4606 (which added TC-SBX-09 alongside the sandbox-image tmux pin). The PR body of #4606 noted *"A full image-build + live-sandbox E2E was not run in this environment"* — the lifecycle drive added by that PR turned out to be incompatible with the live OpenShell sandbox seccomp + capability profile, so every scheduled `E2E / Nightly` run since the merge has reported `sandbox-operations-e2e` as failing on this single assertion. This PR keeps the binary-presence guard from #4606 intact (the actual surface of #4513) while making the lifecycle drive a soft skip when the sandbox refuses to fork, so the nightly pipeline can go green again without masking real regressions (a non-`fork failed` error still hits the `fail` branch).

## Changes

- `test/e2e/test-sandbox-operations.sh`: in `test_sbx_09_tmux_session_flow`, add a `skip` branch matching `fork failed: (Permission denied|Resource temporarily unavailable)` between the existing `pass`/`fail` branches; keeps best-effort `kill-session` cleanup before recording the skip.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved tmux sandbox operations test to better detect and handle fork failures with enhanced error recovery and clearer skip messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->