### PR TITLE
fix(onboard): bind gateway name, state dir, and marker per gateway port (#4422)

### DIFF
--- a/src/lib/adapters/openshell/gateway-drift.ts
+++ b/src/lib/adapters/openshell/gateway-drift.ts
@@ -203,7 +203,7 @@ export function isGatewayClusterActiveForGateway(
     ignoreError: true,
     timeout: timeoutMs,
   });
-  if (!isGatewayHealthy(status.output, gatewayInfo.output, activeGatewayInfo.output)) {
+  if (!isGatewayHealthy(status.output, gatewayInfo.output, activeGatewayInfo.output, gatewayName)) {
     return false;
   }
 

--- a/src/lib/core/ports.ts
+++ b/src/lib/core/ports.ts
@@ -116,8 +116,10 @@ export function parseGatewayPort(
   return port;
 }
 
+/** Default OpenShell gateway port when NEMOCLAW_GATEWAY_PORT is unset. */
+export const DEFAULT_GATEWAY_PORT = 8080;
 /** OpenShell gateway port (default 8080, override via NEMOCLAW_GATEWAY_PORT). */
-export const GATEWAY_PORT = parseGatewayPort("NEMOCLAW_GATEWAY_PORT", 8080, {
+export const GATEWAY_PORT = parseGatewayPort("NEMOCLAW_GATEWAY_PORT", DEFAULT_GATEWAY_PORT, {
   dashboardPort: DASHBOARD_PORT,
   dashboardRangeStart: DASHBOARD_PORT_RANGE_START,
   dashboardRangeEnd: DASHBOARD_PORT_RANGE_END,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -470,6 +470,7 @@ const dockerDriverGatewayEnv: typeof import("./onboard/docker-driver-gateway-env
 const { getDockerDriverGatewayEndpoint } = dockerDriverGatewayEnv;
 const dockerDriverGatewayRuntimeMarker: typeof import("./onboard/docker-driver-gateway-runtime-marker") =
   require("./onboard/docker-driver-gateway-runtime-marker");
+const gatewayBinding: typeof import("./onboard/gateway-binding") = require("./onboard/gateway-binding");
 const hostGatewayProcess: typeof import("./onboard/host-gateway-process") =
   require("./onboard/host-gateway-process");
 const vmDriverProcess: typeof import("./onboard/vm-driver-process") = require("./onboard/vm-driver-process");
@@ -572,7 +573,7 @@ const USE_COLOR = !process.env.NO_COLOR && !!process.stdout.isTTY;
 const DIM = USE_COLOR ? "\x1b[2m" : "";
 const RESET = USE_COLOR ? "\x1b[0m" : "";
 let OPENSHELL_BIN: string | null = null;
-const GATEWAY_NAME = "nemoclaw";
+const GATEWAY_NAME = gatewayBinding.resolveGatewayName(GATEWAY_PORT);
 const OPENCLAW_LAUNCH_AGENT_PLIST = "~/Library/LaunchAgents/ai.openclaw.gateway.plist";
 
 const BRAVE_SEARCH_HELP_URL = "https://brave.com/search/api/";
@@ -661,15 +662,9 @@ const {
 });
 
 // Gateway state functions — delegated to src/lib/state/gateway.ts
-const {
-  isSandboxReady,
-  parseSandboxStatus,
-  hasStaleGateway,
-  isSelectedGateway,
-  isGatewayHealthy,
-  getGatewayReuseState,
-  getSandboxStateFromOutputs,
-} = gatewayState;
+const { isSandboxReady, parseSandboxStatus, getSandboxStateFromOutputs } = gatewayState;
+const { hasStaleGateway, isSelectedGateway, isGatewayHealthy, getGatewayReuseState } =
+  gatewayBinding.createGatewayNameBoundClassifiers(gatewayState, GATEWAY_NAME);
 
 const { getGatewayReuseSnapshot, selectNamedGatewayForReuseIfNeeded } =
   gatewayReuse.createGatewayReuseHelpers({
@@ -1203,7 +1198,7 @@ async function refreshDockerDriverGatewayReuseState(
   const baseDesiredEnv = getDockerDriverGatewayEnv(
     runCaptureOpenshell(["--version"], { ignoreError: true }),
   );
-  const runtimeIdentity = gatewayBin ? dockerDriverGatewayLaunch.buildDockerDriverGatewayRuntimeIdentity({ gatewayBin, gatewayEnv: baseDesiredEnv, stateDir: getDockerDriverGatewayStateDir(), sandboxBin: resolveOpenShellSandboxBinary() }) : null;
+  const runtimeIdentity = gatewayBin ? dockerDriverGatewayLaunch.buildDockerDriverGatewayRuntimeIdentity({ gatewayBin, gatewayEnv: baseDesiredEnv, stateDir: getDockerDriverGatewayStateDir(), sandboxBin: resolveOpenShellSandboxBinary(), compatContainerName: gatewayBinding.resolveGatewayCompatContainerName(GATEWAY_PORT) }) : null;
   const desiredEnv = runtimeIdentity?.desiredEnv ?? baseDesiredEnv;
   const driftBin = dockerDriverGatewayLaunch.resolveDriftGatewayBin(runtimeIdentity, gatewayBin);
   const identityBin = runtimeIdentity?.identityGatewayBin ?? gatewayBin;
@@ -1395,7 +1390,8 @@ const {
 function getDockerDriverGatewayStateDir(): string {
   const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR;
   if (configured && configured.trim()) return path.resolve(configured.trim());
-  return path.join(os.homedir(), ".local", "state", "nemoclaw", "openshell-docker-gateway");
+  const dir = gatewayBinding.resolveGatewayStateDirName(GATEWAY_PORT);
+  return path.join(os.homedir(), ".local", "state", "nemoclaw", dir);
 }
 
 function getDockerDriverGatewayPidFile(): string {
@@ -2418,7 +2414,7 @@ async function startDockerDriverGateway({ exitOnFailure = true, skipSandboxBridg
   });
   const gatewayEnv = getDockerDriverGatewayEnv(openshellVersionOutput);
   const stateDir = getDockerDriverGatewayStateDir();
-  const runtimeIdentity = gatewayBin ? dockerDriverGatewayLaunch.buildDockerDriverGatewayRuntimeIdentity({ gatewayBin, gatewayEnv, stateDir, sandboxBin: resolveOpenShellSandboxBinary() }) : null;
+  const runtimeIdentity = gatewayBin ? dockerDriverGatewayLaunch.buildDockerDriverGatewayRuntimeIdentity({ gatewayBin, gatewayEnv, stateDir, sandboxBin: resolveOpenShellSandboxBinary(), compatContainerName: gatewayBinding.resolveGatewayCompatContainerName(GATEWAY_PORT) }) : null;
   const gatewayLaunch = runtimeIdentity?.launch ?? null;
   const driftGatewayBin = dockerDriverGatewayLaunch.resolveDriftGatewayBin(runtimeIdentity, gatewayBin);
   const driftGatewayEnv = runtimeIdentity?.desiredEnv ?? gatewayEnv;
@@ -3134,10 +3130,11 @@ async function createSandbox(
               !selectionDrift.unknown,
               effectiveSandboxGpuConfig,
             );
-            registry.updateSandbox(
-              sandboxName,
-              onboardHermesDashboard.getHermesDashboardRegistryFields(reusedHermesDashboardState),
-            );
+            registry.updateSandbox(sandboxName, {
+              ...onboardHermesDashboard.getHermesDashboardRegistryFields(reusedHermesDashboardState),
+              gatewayName: GATEWAY_NAME,
+              gatewayPort: GATEWAY_PORT,
+            });
             return sandboxName;
           }
         } else {
@@ -3179,10 +3176,11 @@ async function createSandbox(
               !selectionDrift.unknown,
               effectiveSandboxGpuConfig,
             );
-            registry.updateSandbox(
-              sandboxName,
-              onboardHermesDashboard.getHermesDashboardRegistryFields(reusedHermesDashboardState2),
-            );
+            registry.updateSandbox(sandboxName, {
+              ...onboardHermesDashboard.getHermesDashboardRegistryFields(reusedHermesDashboardState2),
+              gatewayName: GATEWAY_NAME,
+              gatewayPort: GATEWAY_PORT,
+            });
             return sandboxName;
           }
         }
@@ -3817,6 +3815,8 @@ async function createSandbox(
     hermesToolGateways: hermesToolGateways.length > 0 ? [...hermesToolGateways] : undefined,
     ...onboardHermesDashboard.getHermesDashboardRegistryFields(finalHermesDashboardState),
     dashboardPort: actualDashboardPort,
+    gatewayName: GATEWAY_NAME,
+    gatewayPort: GATEWAY_PORT,
   });
   registry.setDefault(sandboxName);
 

--- a/src/lib/onboard/docker-driver-gateway-launch.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.ts
@@ -73,6 +73,11 @@ type BuildGatewayLaunchOptions = {
   env?: NodeJS.ProcessEnv;
   hostGlibcVersion?: string | null;
   requiredGlibcVersions?: string[];
+  // Default compatibility container name when NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_CONTAINER_NAME
+  // is unset. Callers pass a per-gateway-port name so a second sandbox's compat
+  // container (and its pre-launch `docker rm`) cannot tear down the first
+  // sandbox's gateway container (#4422).
+  compatContainerName?: string;
 };
 
 export function compareDottedVersions(a: string, b: string): number {
@@ -287,9 +292,13 @@ export function buildDockerDriverGatewayLaunch(
   env.OPENSHELL_GATEWAY_CONFIG = configPath;
 
   const image = safeDockerImage(env.NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_IMAGE, DEFAULT_COMPAT_IMAGE);
+  // The per-port compatContainerName wins so a process-wide
+  // NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_CONTAINER_NAME cannot collapse two sandboxes
+  // back onto one compat container (and its pre-launch `docker rm`) (#4422). The
+  // env override still applies when no per-port name is supplied.
   const containerName = safeDockerName(
-    env.NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_CONTAINER_NAME,
-    DEFAULT_COMPAT_CONTAINER_NAME,
+    options.compatContainerName,
+    safeDockerName(env.NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_CONTAINER_NAME, DEFAULT_COMPAT_CONTAINER_NAME),
   );
   const dockerHost = safeDockerHost(env.DOCKER_HOST);
   if (dockerHost) {

--- a/src/lib/onboard/gateway-binding.test.ts
+++ b/src/lib/onboard/gateway-binding.test.ts
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { DEFAULT_GATEWAY_PORT } from "../../../dist/lib/core/ports";
+import { buildDockerDriverGatewayLaunch } from "../../../dist/lib/onboard/docker-driver-gateway-launch";
+import {
+  getDockerDriverGatewayRuntimeMarkerDriftForStateDir,
+  getDockerDriverGatewayRuntimeMarkerPath,
+  readDockerDriverGatewayRuntimeMarker,
+  writeDockerDriverGatewayRuntimeMarkerForStateDir,
+} from "../../../dist/lib/onboard/docker-driver-gateway-runtime-marker";
+import {
+  BASE_GATEWAY_COMPAT_CONTAINER_NAME,
+  BASE_GATEWAY_NAME,
+  BASE_GATEWAY_STATE_DIR_NAME,
+  resolveGatewayCompatContainerName,
+  resolveGatewayName,
+  resolveGatewayStateDirName,
+} from "../../../dist/lib/onboard/gateway-binding";
+
+describe("gateway-binding resolver (#4422)", () => {
+  it("keeps the bare nemoclaw names for the default gateway port", () => {
+    expect(resolveGatewayName(DEFAULT_GATEWAY_PORT)).toBe(BASE_GATEWAY_NAME);
+    expect(resolveGatewayStateDirName(DEFAULT_GATEWAY_PORT)).toBe(BASE_GATEWAY_STATE_DIR_NAME);
+    expect(resolveGatewayCompatContainerName(DEFAULT_GATEWAY_PORT)).toBe(
+      BASE_GATEWAY_COMPAT_CONTAINER_NAME,
+    );
+  });
+
+  it("suffixes the name, state dir, and compat container for a non-default port", () => {
+    expect(resolveGatewayName(8081)).toBe("nemoclaw-8081");
+    expect(resolveGatewayStateDirName(8081)).toBe("openshell-docker-gateway-8081");
+    expect(resolveGatewayCompatContainerName(8081)).toBe("nemoclaw-openshell-gateway-8081");
+  });
+
+  it("derives distinct bindings for two different gateway ports", () => {
+    const a = 8080;
+    const b = 8081;
+    expect(resolveGatewayName(a)).not.toBe(resolveGatewayName(b));
+    expect(resolveGatewayStateDirName(a)).not.toBe(resolveGatewayStateDirName(b));
+    expect(resolveGatewayCompatContainerName(a)).not.toBe(resolveGatewayCompatContainerName(b));
+  });
+});
+
+describe("docker-driver compat container is gateway-port scoped (#4422)", () => {
+  function withTempState<T>(fn: (paths: { gatewayBin: string; sandboxBin: string; stateDir: string }) => T): T {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-binding-"));
+    const gatewayBin = path.join(dir, "openshell-gateway");
+    const sandboxBin = path.join(dir, "openshell-sandbox");
+    const stateDir = path.join(dir, "state");
+    try {
+      fs.writeFileSync(gatewayBin, "GLIBC_2.39\n", { mode: 0o755 });
+      fs.writeFileSync(sandboxBin, "#!/bin/sh\n", { mode: 0o755 });
+      fs.mkdirSync(stateDir);
+      return fn({ gatewayBin, sandboxBin, stateDir });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("names the compat container per gateway port so a second sandbox does not target the first container", () => {
+    withTempState(({ gatewayBin, sandboxBin, stateDir }) => {
+      const launch = buildDockerDriverGatewayLaunch({
+        gatewayBin,
+        sandboxBin,
+        stateDir,
+        platform: "linux",
+        env: { NEMOCLAW_OPENSHELL_GATEWAY_CONTAINER_PATCH: "1" },
+        gatewayEnv: { OPENSHELL_DRIVERS: "docker" },
+        compatContainerName: resolveGatewayCompatContainerName(8081),
+      });
+
+      expect(launch.mode).toBe("container");
+      expect(launch.containerName).toBe("nemoclaw-openshell-gateway-8081");
+      const nameIdx = launch.args.indexOf("--name");
+      expect(nameIdx).toBeGreaterThanOrEqual(0);
+      expect(launch.args[nameIdx + 1]).toBe("nemoclaw-openshell-gateway-8081");
+    });
+  });
+
+  it("lets the per-port name win over a process-wide env override", () => {
+    withTempState(({ gatewayBin, sandboxBin, stateDir }) => {
+      const launch = buildDockerDriverGatewayLaunch({
+        gatewayBin,
+        sandboxBin,
+        stateDir,
+        platform: "linux",
+        env: {
+          NEMOCLAW_OPENSHELL_GATEWAY_CONTAINER_PATCH: "1",
+          NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_CONTAINER_NAME: "custom-gw",
+        },
+        gatewayEnv: { OPENSHELL_DRIVERS: "docker" },
+        compatContainerName: resolveGatewayCompatContainerName(8081),
+      });
+
+      // The per-port name must win so the env var cannot collapse isolation (#4422).
+      expect(launch.containerName).toBe("nemoclaw-openshell-gateway-8081");
+    });
+  });
+
+  it("honors the env container name override when no per-port name is supplied", () => {
+    withTempState(({ gatewayBin, sandboxBin, stateDir }) => {
+      const launch = buildDockerDriverGatewayLaunch({
+        gatewayBin,
+        sandboxBin,
+        stateDir,
+        platform: "linux",
+        env: {
+          NEMOCLAW_OPENSHELL_GATEWAY_CONTAINER_PATCH: "1",
+          NEMOCLAW_OPENSHELL_GATEWAY_COMPAT_CONTAINER_NAME: "custom-gw",
+        },
+        gatewayEnv: { OPENSHELL_DRIVERS: "docker" },
+      });
+
+      expect(launch.containerName).toBe("custom-gw");
+    });
+  });
+});
+
+describe("per-port gateway runtime markers stay isolated (#4422)", () => {
+  // Regression for the singleton state dir teardown: two sandboxes onboarded
+  // on distinct NEMOCLAW_GATEWAY_PORT values resolve to distinct state dirs, so
+  // creating the second neither overwrites nor invalidates the first sandbox's
+  // runtime marker.
+  function markerInput(port: number, pid: number) {
+    return {
+      pid,
+      desiredEnv: { OPENSHELL_GATEWAY_PORT: String(port) },
+      endpoint: `http://127.0.0.1:${port}`,
+      gatewayBin: "/usr/bin/openshell-gateway",
+      openshellVersion: "0.0.44",
+      dockerHost: null,
+    };
+  }
+
+  it("preserves the first sandbox gateway marker when a second sandbox onboards on another port", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-marker-"));
+    try {
+      const firstPort = 8080;
+      const secondPort = 8081;
+      const firstDir = path.join(root, resolveGatewayStateDirName(firstPort));
+      const secondDir = path.join(root, resolveGatewayStateDirName(secondPort));
+
+      // First sandbox writes its gateway marker (port 8080, pid 1111).
+      writeDockerDriverGatewayRuntimeMarkerForStateDir(firstDir, markerInput(firstPort, 1111));
+
+      // Second sandbox onboards on port 8081 — it writes to its own state dir.
+      writeDockerDriverGatewayRuntimeMarkerForStateDir(secondDir, markerInput(secondPort, 2222));
+
+      // The two markers live in distinct files.
+      expect(getDockerDriverGatewayRuntimeMarkerPath(firstDir)).not.toBe(
+        getDockerDriverGatewayRuntimeMarkerPath(secondDir),
+      );
+
+      // The first sandbox's marker is untouched: still port 8080, pid 1111.
+      const firstMarker = readDockerDriverGatewayRuntimeMarker(
+        getDockerDriverGatewayRuntimeMarkerPath(firstDir),
+      );
+      expect(firstMarker?.endpoint).toBe("http://127.0.0.1:8080");
+      expect(firstMarker?.pid).toBe(1111);
+
+      // And it still validates against what the first sandbox expects — no drift,
+      // i.e. the second onboard did not tear down or retarget the first gateway.
+      expect(
+        getDockerDriverGatewayRuntimeMarkerDriftForStateDir(firstDir, markerInput(firstPort, 1111)),
+      ).toBeNull();
+
+      // The second sandbox's marker reflects its own port/pid independently.
+      const secondMarker = readDockerDriverGatewayRuntimeMarker(
+        getDockerDriverGatewayRuntimeMarkerPath(secondDir),
+      );
+      expect(secondMarker?.endpoint).toBe("http://127.0.0.1:8081");
+      expect(secondMarker?.pid).toBe(2222);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/onboard/gateway-binding.ts
+++ b/src/lib/onboard/gateway-binding.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-gateway-port binding resolver.
+ *
+ * Historically NemoClaw treated the OpenShell gateway as a process-global
+ * singleton named `nemoclaw`, with a single Docker-driver state directory and
+ * a single compatibility container. A second onboard that requested a
+ * different `NEMOCLAW_GATEWAY_PORT` therefore reused the same named gateway,
+ * the same runtime-marker state dir, and the same compat container — so
+ * creating the second sandbox recreated/killed the first sandbox's gateway and
+ * overwrote its runtime marker (#4422).
+ *
+ * These pure resolvers derive a stable per-port binding. The default port
+ * keeps the original `nemoclaw` names verbatim so existing single-sandbox
+ * deployments and on-disk state are untouched; any non-default port gets a
+ * `-<port>` suffixed name/dir/container so two sandboxes on distinct gateway
+ * ports never collide.
+ */
+
+import { DEFAULT_GATEWAY_PORT } from "../core/ports";
+import type { GatewayReuseState } from "../state/gateway";
+
+/** Gateway registration name used for the default gateway port. */
+export const BASE_GATEWAY_NAME = "nemoclaw";
+/** Docker-driver gateway state directory leaf name for the default port. */
+export const BASE_GATEWAY_STATE_DIR_NAME = "openshell-docker-gateway";
+/** Docker-driver gateway compatibility container name for the default port. */
+export const BASE_GATEWAY_COMPAT_CONTAINER_NAME = "nemoclaw-openshell-gateway";
+
+function isDefaultGatewayPort(port: number): boolean {
+  return port === DEFAULT_GATEWAY_PORT;
+}
+
+/**
+ * Resolve the OpenShell gateway registration name for a gateway port. The
+ * default port keeps the bare `nemoclaw` name for backward compatibility; any
+ * other port gets a `nemoclaw-<port>` name so its lifecycle commands
+ * (add/select/remove/start/destroy) never target another sandbox's gateway.
+ */
+export function resolveGatewayName(port: number): string {
+  return isDefaultGatewayPort(port) ? BASE_GATEWAY_NAME : `${BASE_GATEWAY_NAME}-${port}`;
+}
+
+/**
+ * Resolve the Docker-driver gateway state directory leaf name for a gateway
+ * port. The state dir holds the gateway pid file and runtime marker, so a
+ * per-port leaf keeps each sandbox's marker isolated — a second onboard cannot
+ * overwrite the first sandbox's marker or clobber its pid file.
+ */
+export function resolveGatewayStateDirName(port: number): string {
+  return isDefaultGatewayPort(port)
+    ? BASE_GATEWAY_STATE_DIR_NAME
+    : `${BASE_GATEWAY_STATE_DIR_NAME}-${port}`;
+}
+
+/**
+ * Resolve the Docker-driver gateway compatibility container name for a gateway
+ * port. A per-port container name prevents the second onboard's
+ * `docker run --name ...` (and the pre-launch `docker rm`) from tearing down
+ * the first sandbox's compat gateway container.
+ */
+export function resolveGatewayCompatContainerName(port: number): string {
+  return isDefaultGatewayPort(port)
+    ? BASE_GATEWAY_COMPAT_CONTAINER_NAME
+    : `${BASE_GATEWAY_COMPAT_CONTAINER_NAME}-${port}`;
+}
+
+/** Gateway state classifiers from `state/gateway`, each bound to a gateway name. */
+export interface GatewayNameBoundClassifiers {
+  hasStaleGateway(gwInfoOutput?: string): boolean;
+  isSelectedGateway(statusOutput?: string): boolean;
+  isGatewayHealthy(statusOutput?: string, gwInfoOutput?: string, activeGatewayInfoOutput?: string): boolean;
+  getGatewayReuseState(
+    statusOutput?: string,
+    gwInfoOutput?: string,
+    activeGatewayInfoOutput?: string,
+  ): GatewayReuseState;
+}
+
+/**
+ * Bind the gateway-name-aware health/reuse classifiers to a resolved gateway
+ * name so a non-default NEMOCLAW_GATEWAY_PORT (gateway `nemoclaw-<port>`) is
+ * recognized as its own gateway rather than matched against the `nemoclaw`
+ * singleton (#4422). Kept out of onboard.ts to avoid growing that file.
+ */
+export function createGatewayNameBoundClassifiers(
+  state: typeof import("../state/gateway"),
+  gatewayName: string,
+): GatewayNameBoundClassifiers {
+  return {
+    hasStaleGateway: (gwInfoOutput = "") => state.hasStaleGateway(gwInfoOutput, gatewayName),
+    isSelectedGateway: (statusOutput = "") => state.isSelectedGateway(statusOutput, gatewayName),
+    isGatewayHealthy: (statusOutput = "", gwInfoOutput = "", activeGatewayInfoOutput = "") =>
+      state.isGatewayHealthy(statusOutput, gwInfoOutput, activeGatewayInfoOutput, gatewayName),
+    getGatewayReuseState: (statusOutput = "", gwInfoOutput = "", activeGatewayInfoOutput = "") =>
+      state.getGatewayReuseState(statusOutput, gwInfoOutput, activeGatewayInfoOutput, gatewayName),
+  };
+}

--- a/src/lib/onboard/gateway-reuse.ts
+++ b/src/lib/onboard/gateway-reuse.ts
@@ -36,7 +36,12 @@ export function createGatewayReuseHelpers(deps: GatewayReuseDeps): GatewayReuseH
       gatewayStatus,
       gwInfo,
       activeGatewayInfo,
-      gatewayReuseState: getGatewayReuseState(gatewayStatus, gwInfo, activeGatewayInfo),
+      gatewayReuseState: getGatewayReuseState(
+        gatewayStatus,
+        gwInfo,
+        activeGatewayInfo,
+        deps.gatewayName,
+      ),
     };
   }
 
@@ -46,6 +51,7 @@ export function createGatewayReuseHelpers(deps: GatewayReuseDeps): GatewayReuseH
         snapshot.gatewayStatus,
         snapshot.gwInfo,
         snapshot.activeGatewayInfo,
+        deps.gatewayName,
       )
     ) {
       return snapshot;

--- a/src/lib/state/gateway.ts
+++ b/src/lib/state/gateway.ts
@@ -85,11 +85,11 @@ export function getSandboxFailurePhase(output: string, sandboxName: string): str
  * Determine whether stale NemoClaw gateway output indicates a previous
  * session that should be cleaned up before the port preflight check.
  */
-export function hasStaleGateway(gwInfoOutput: string): boolean {
+export function hasStaleGateway(gwInfoOutput: string, gatewayName = GATEWAY_NAME): boolean {
   const clean = typeof gwInfoOutput === "string" ? stripAnsi(gwInfoOutput) : "";
   return (
     clean.length > 0 &&
-    clean.includes(`Gateway: ${GATEWAY_NAME}`) &&
+    getReportedGatewayName(clean) === gatewayName &&
     !clean.includes("No gateway metadata found")
   );
 }
@@ -129,20 +129,21 @@ export function isGatewayHealthy(
   statusOutput = "",
   gwInfoOutput = "",
   activeGatewayInfoOutput = "",
+  gatewayName = GATEWAY_NAME,
 ): boolean {
-  const namedGatewayKnown = hasStaleGateway(gwInfoOutput);
+  const namedGatewayKnown = hasStaleGateway(gwInfoOutput, gatewayName);
   const activeGatewayName =
     getReportedGatewayName(statusOutput) || getReportedGatewayName(activeGatewayInfoOutput);
   const connected = isGatewayConnected(statusOutput);
   const activeInfo = hasActiveGatewayInfo(activeGatewayInfoOutput);
 
   // Primary path: status reports connected and gateway name matches
-  if (connected && activeGatewayName === GATEWAY_NAME) return true;
+  if (connected && activeGatewayName === gatewayName) return true;
 
   // Fallback: status is empty (ARM64/non-TTY) but gateway info confirms
   // the named gateway exists and has an active endpoint
   const statusEmpty = typeof statusOutput === 'string' && stripAnsi(statusOutput).trim().length === 0;
-  if (statusEmpty && namedGatewayKnown && activeInfo && activeGatewayName === GATEWAY_NAME) return true;
+  if (statusEmpty && namedGatewayKnown && activeInfo && activeGatewayName === gatewayName) return true;
 
   return false;
 }
@@ -151,21 +152,22 @@ export function getGatewayReuseState(
   statusOutput = "",
   gwInfoOutput = "",
   activeGatewayInfoOutput = "",
+  gatewayName = GATEWAY_NAME,
 ): GatewayReuseState {
-  if (isGatewayHealthy(statusOutput, gwInfoOutput, activeGatewayInfoOutput)) {
+  if (isGatewayHealthy(statusOutput, gwInfoOutput, activeGatewayInfoOutput, gatewayName)) {
     return "healthy";
   }
   const connected = isGatewayConnected(statusOutput);
   const activeGatewayName =
     getReportedGatewayName(statusOutput) || getReportedGatewayName(activeGatewayInfoOutput);
   const activeInfo = hasActiveGatewayInfo(activeGatewayInfoOutput);
-  if (connected && activeGatewayName === GATEWAY_NAME) {
+  if (connected && activeGatewayName === gatewayName) {
     return "active-unnamed";
   }
-  if ((connected || activeInfo) && activeGatewayName && activeGatewayName !== GATEWAY_NAME) {
+  if ((connected || activeInfo) && activeGatewayName && activeGatewayName !== gatewayName) {
     return "foreign-active";
   }
-  if (hasStaleGateway(gwInfoOutput)) {
+  if (hasStaleGateway(gwInfoOutput, gatewayName)) {
     return "stale";
   }
   if (activeInfo) {
@@ -178,10 +180,11 @@ export function shouldSelectNamedGatewayForReuse(
   statusOutput = "",
   gwInfoOutput = "",
   activeGatewayInfoOutput = "",
+  gatewayName = GATEWAY_NAME,
 ): boolean {
   return (
-    getGatewayReuseState(statusOutput, gwInfoOutput, activeGatewayInfoOutput) === "foreign-active" &&
-    hasStaleGateway(gwInfoOutput)
+    getGatewayReuseState(statusOutput, gwInfoOutput, activeGatewayInfoOutput, gatewayName) ===
+      "foreign-active" && hasStaleGateway(gwInfoOutput, gatewayName)
   );
 }
 

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -44,6 +44,12 @@ export interface SandboxEntry {
   hermesDashboardTui?: boolean;
   disabledChannels?: string[];
   dashboardPort?: number | null;
+  // OpenShell gateway registration name and host port bound to this sandbox.
+  // Persisted so later lifecycle commands operate on the sandbox's own gateway
+  // instead of the process-global `nemoclaw` singleton — a second sandbox on a
+  // different NEMOCLAW_GATEWAY_PORT no longer recreates/kills the first (#4422).
+  gatewayName?: string | null;
+  gatewayPort?: number | null;
 }
 
 export interface SandboxRegistry {
@@ -232,6 +238,8 @@ export function registerSandbox(entry: SandboxEntry): void {
           ? [...entry.disabledChannels]
           : undefined,
       dashboardPort: entry.dashboardPort ?? undefined,
+      gatewayName: entry.gatewayName ?? undefined,
+      gatewayPort: entry.gatewayPort ?? undefined,
     };
     if (!data.defaultSandbox) {
       data.defaultSandbox = entry.name;

--- a/test/gateway-state.test.ts
+++ b/test/gateway-state.test.ts
@@ -222,6 +222,27 @@ describe("isGatewayHealthy", () => {
     const ansiOnly = "\x1b[0m\x1b[32m";
     expect(isGatewayHealthy(ansiOnly, GW_INFO_NAMED, GW_INFO_ACTIVE)).toBe(true);
   });
+
+  // Per-port gateway (#4422): a second sandbox onboarded on a non-default
+  // NEMOCLAW_GATEWAY_PORT runs gateway `nemoclaw-<port>`. Health/reuse
+  // classification must match against that resolved name, not the `nemoclaw`
+  // singleton, so the second sandbox recognizes its own gateway.
+  it("recognizes a non-default-port gateway under its resolved name", () => {
+    const status = STATUS_CONNECTED.replace("nemoclaw", "nemoclaw-8081");
+    const info = GW_INFO_NAMED.replace("nemoclaw", "nemoclaw-8081");
+    expect(isGatewayHealthy(status, info, info, "nemoclaw-8081")).toBe(true);
+    expect(hasStaleGateway(info, "nemoclaw-8081")).toBe(true);
+    expect(getGatewayReuseState(status, info, info, "nemoclaw-8081")).toBe("healthy");
+  });
+
+  it("does not match a non-default-port gateway against the nemoclaw singleton", () => {
+    const status = STATUS_CONNECTED.replace("nemoclaw", "nemoclaw-8081");
+    const info = GW_INFO_NAMED.replace("nemoclaw", "nemoclaw-8081");
+    // The default-named classifier sees a foreign gateway, not its own.
+    expect(isGatewayHealthy(status, info, info)).toBe(false);
+    expect(hasStaleGateway(info)).toBe(false);
+    expect(getGatewayReuseState(status, info, info)).toBe("foreign-active");
+  });
 });
 
 describe("parseSandboxPhase", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -49,6 +49,29 @@ describe("registry", () => {
     expect(data.sandboxes.alpha.provider).toBe("nvidia-prod");
   });
 
+  it("persists distinct gateway bindings for two sandboxes on different ports (#4422)", () => {
+    registry.registerSandbox({
+      name: "first",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      dashboardPort: 18789,
+    });
+    registry.registerSandbox({
+      name: "second",
+      gatewayName: "nemoclaw-8081",
+      gatewayPort: 8081,
+      dashboardPort: 18790,
+    });
+    const data = JSON.parse(fs.readFileSync(regFile, "utf-8"));
+    expect(data.sandboxes.first.gatewayName).toBe("nemoclaw");
+    expect(data.sandboxes.first.gatewayPort).toBe(8080);
+    expect(data.sandboxes.second.gatewayName).toBe("nemoclaw-8081");
+    expect(data.sandboxes.second.gatewayPort).toBe(8081);
+    // The second registration must not retarget the first sandbox's binding.
+    expect(registry.getSandbox("first").gatewayName).toBe("nemoclaw");
+    expect(registry.getSandbox("first").gatewayPort).toBe(8080);
+  });
+
   it("first registered becomes default", () => {
     registry.registerSandbox({ name: "first" });
     registry.registerSandbox({ name: "second" });


### PR DESCRIPTION
## Summary

A second sandbox onboarded with `NEMOCLAW_GATEWAY_PORT` recreated the process-global `nemoclaw` gateway and reused the singleton Docker-driver state directory, so creating it tore down the first sandbox's gateway and overwrote its runtime marker. This binds the gateway name, Docker-driver state dir (pid file + runtime marker), and compatibility container per gateway port so the second onboard no longer disrupts the first.

## Related Issue

Fixes #4422.

Supersedes the runtime behavior left as a no-op in the groundwork PR #4598 (its resolver still returned the singleton name for every port).

## Changes

- Add `src/lib/onboard/gateway-binding.ts` — a per-port resolver. The default gateway port keeps the bare `nemoclaw` name, `openshell-docker-gateway` state dir, and `nemoclaw-openshell-gateway` compat container verbatim (backward compatible); a non-default port yields `nemoclaw-<port>`, `openshell-docker-gateway-<port>`, and `nemoclaw-openshell-gateway-<port>`.
- `onboard.ts`: resolve `GATEWAY_NAME`, the Docker-driver state dir, and the compat container name from `GATEWAY_PORT`; bind the gateway health/reuse classifiers to the resolved name.
- `state/gateway.ts`: `hasStaleGateway` / `isGatewayHealthy` / `getGatewayReuseState` / `shouldSelectNamedGatewayForReuse` accept an optional gateway name (default preserves the singleton). `hasStaleGateway` now matches the reported gateway name exactly instead of by substring.
- `gateway-reuse.ts` and the `gateway-drift.ts` cluster-active probe forward the resolved gateway name to the classifiers.
- `state/registry.ts`: persist `gatewayName` / `gatewayPort` per sandbox.
- Tests: distinct runtime markers for two gateway ports (second onboard does not overwrite/invalidate the first), per-port compat container naming, port-aware health classification, and registry persistence for two ports.

### Follow-up (out of scope here)

Threading the persisted `gatewayName` into every post-create read path (status/connect/destroy/doctor/snapshot) and anchoring the legacy `openshell-cluster-*` volume-prefix cleanup remain for a follow-up; they affect the second sandbox's own later lifecycle under the legacy cluster driver, not the create-time teardown this PR fixes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes (targeted gateway/registry/reuse/drift suites green; full-suite failures on this host are environmental — unbuilt plugin dist, real-process timeouts under load, and a pre-existing chmod-ownership test that also fails on `main`)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] `npm run typecheck:cli` passes

Reproduced end-to-end with the worktree build: a second onboard on port 8081 overwrote the first sandbox's Docker-driver runtime marker (endpoint→8081, pid changed → first gateway drifts) before the fix; after the fix the two markers live in distinct per-port state dirs and the first sandbox's marker is preserved with no drift.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-port gateway support so isolated gateways can run concurrently on different ports.
  * Sandbox metadata now records gateway name and port.
  * Default gateway port standardized to 8080.

* **Bug Fixes**
  * Docker compatibility container naming and runtime state isolated per gateway port to prevent cross-sandbox conflicts.
  * Health and reuse logic now evaluates gateway identity per port.

* **Tests**
  * Added tests for per-port gateway behavior and state isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->