### PR TITLE
fix(sandbox): preserve registry entry on stale-sandbox connect recovery (#4497)

### DIFF
--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -7,16 +7,16 @@ import os from "node:os";
 import path from "node:path";
 
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
-import { isTerminalSandboxPhase, parseSandboxPhase } from "../../state/gateway";
 import {
   getNamedGatewayLifecycleState,
   recoverNamedGatewayRuntime,
 } from "../../gateway-runtime-action";
+import { isTerminalSandboxPhase, parseSandboxPhase } from "../../state/gateway";
+
 const { pruneKnownHostsEntries } = require("../../onboard") as {
   pruneKnownHostsEntries: (contents: string) => string;
 };
-import * as onboardSession from "../../state/onboard-session";
-import type { Session } from "../../state/onboard-session";
+
 import { stripAnsi } from "../../adapters/openshell/client";
 import {
   detectOpenShellStateRpcPreflightIssue,
@@ -35,7 +35,6 @@ import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "../../adapters/openshell/timeouts";
-import * as registry from "../../state/registry";
 import {
   isDockerRuntimeDown,
   printDockerRuntimeDownGuidance,
@@ -431,18 +430,23 @@ export async function ensureLiveSandboxOrExit(
       }
       process.exit(1);
     }
-    registry.removeSandbox(sandboxName);
-    const session = onboardSession.loadSession();
-    if (session && session.sandboxName === sandboxName) {
-      onboardSession.updateSession((state: Session) => {
-        state.sandboxName = null;
-        return state;
-      });
-    }
-    console.error(`  Sandbox '${sandboxName}' is not present in the live OpenShell gateway.`);
-    console.error("  Removed stale local registry entry.");
+    // The sandbox is absent from a healthy NemoClaw gateway, but the local
+    // registry entry still holds the metadata that `rebuild` / `onboard
+    // --recreate-sandbox` need to recover it. Removing it here would race with
+    // the recovery guidance `status` prints for a stuck/stale sandbox: a
+    // routine `connect` would delete the very state the recommended
+    // `rebuild --yes` depends on, so the rebuild then fails with "does not
+    // exist" (#4497). Preserve the entry and route intentional purges through
+    // the explicit `destroy` command instead of deleting state automatically.
     console.error(
-      `  Run \`${CLI_NAME} list\` to confirm the remaining sandboxes, or \`${CLI_NAME} onboard\` to create a new one.`,
+      `  Sandbox '${sandboxName}' is registered locally, but is not present in the live OpenShell gateway.`,
+    );
+    console.error("  Your local registry entry has been preserved — nothing was removed.");
+    console.error(
+      `  If the live sandbox is stuck mid-provision, retry \`${CLI_NAME} ${sandboxName} rebuild --yes\` once it reappears to recreate it (workspace state is preserved when the live sandbox still exists).`,
+    );
+    console.error(
+      `  If the sandbox was intentionally deleted, run \`${CLI_NAME} ${sandboxName} destroy\` to remove the stale local entry, or \`${CLI_NAME} onboard\` to create a new one.`,
     );
     process.exit(1);
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5280,7 +5280,7 @@ describe("CLI dispatch", () => {
     expect(calls).not.toContain("should-not-connect");
   });
 
-  it("removes stale registry entries when connect targets a missing live sandbox", () => {
+  it("preserves the registry entry when connect targets a missing live sandbox (#4497)", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-stale-connect-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -5311,8 +5311,9 @@ describe("CLI dispatch", () => {
         "  exit 1",
         "fi",
         // Simulate a healthy, active `nemoclaw` named gateway so the
-        // lifecycle guard confirms healthy_named and the registry removal
-        // path fires. Without this, the guard preserves the entry (#2276).
+        // lifecycle guard confirms healthy_named. Even on this path connect
+        // must now preserve the entry so a follow-up rebuild can recover it
+        // (#4497); it previously removed it here (#2276).
         'if [ "$1" = "status" ]; then',
         "  printf 'Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n'",
         "  exit 0",
@@ -5332,9 +5333,11 @@ describe("CLI dispatch", () => {
     });
 
     expect(r.code).toBe(1);
-    expect(r.out.includes("Removed stale local registry entry")).toBeTruthy();
+    expect(r.out.includes("Removed stale local registry entry")).toBe(false);
+    expect(r.out.includes("registered locally, but is not present")).toBeTruthy();
+    expect(r.out.includes("preserved")).toBeTruthy();
     const saved = JSON.parse(fs.readFileSync(path.join(registryDir, "sandboxes.json"), "utf8"));
-    expect(saved.sandboxes.alpha).toBeUndefined();
+    expect(saved.sandboxes.alpha).toBeDefined();
   });
 
   it("recovers a missing registry entry from the last onboard session during list", () => {

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -729,16 +729,69 @@ else
   fail "Stale sandbox status exited $status_exit (expected 1)"
 fi
 
+# #4497: neither status nor connect may delete the stale local entry — the
+# metadata is what `rebuild` / `onboard --recreate-sandbox` need to recover.
 if grep -q "Removed stale local registry entry" <<<"$status_output"; then
-  pass "Stale registry entry was reconciled during status"
+  fail "status removed the local registry entry (must be preserved, #4497)"
 else
-  fail "Stale registry reconciliation message missing"
+  pass "status preserved the stale registry entry"
 fi
 
 if registry_has "$SANDBOX_A"; then
-  fail "Registry still contains '$SANDBOX_A' after status reconciliation"
+  pass "Registry still contains '$SANDBOX_A' after status"
 else
-  pass "Registry entry for '$SANDBOX_A' removed after status reconciliation"
+  fail "Registry entry for '$SANDBOX_A' was removed by status (must be preserved, #4497)"
+fi
+
+# A routine `connect` against the same stale entry must also preserve it.
+CONNECT_LOG="$(mktemp)"
+NEMOCLAW_NON_INTERACTIVE=1 run_nemoclaw "$SANDBOX_A" connect >"$CONNECT_LOG" 2>&1
+connect_exit=$?
+connect_output="$(cat "$CONNECT_LOG")"
+rm -f "$CONNECT_LOG"
+
+if [ "$connect_exit" -eq 1 ]; then
+  pass "Stale sandbox connect exited 1"
+else
+  fail "Stale sandbox connect exited $connect_exit (expected 1)"
+fi
+
+if grep -q "Removed stale local registry entry" <<<"$connect_output"; then
+  fail "connect removed the local registry entry (must be preserved, #4497)"
+else
+  pass "connect preserved the stale registry entry"
+fi
+
+if registry_has "$SANDBOX_A"; then
+  pass "Registry still contains '$SANDBOX_A' after connect (#4497)"
+else
+  fail "connect removed '$SANDBOX_A' from the registry (must be preserved, #4497)"
+fi
+
+# The preserved entry must still be locatable by the recovery command the
+# status hint recommends: rebuild must get past the dispatcher and into its
+# own flow rather than failing with "does not exist".
+REBUILD_LOG="$(mktemp)"
+NEMOCLAW_NON_INTERACTIVE=1 run_nemoclaw "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || true
+rebuild_output="$(cat "$REBUILD_LOG")"
+rm -f "$REBUILD_LOG"
+
+if grep -q "does not exist" <<<"$rebuild_output"; then
+  fail "rebuild could not locate the preserved sandbox '$SANDBOX_A' (#4497)"
+else
+  pass "rebuild located the preserved sandbox '$SANDBOX_A' (#4497)"
+fi
+
+# #4497: the explicit `destroy` command is the intended way to purge a stale
+# entry now that routine status/connect no longer delete it. Purge it here,
+# while the gateway is still healthy, so the preserved entry does not leak into
+# Phase 7 cleanup (which runs against a stopped gateway and cannot remove it).
+run_nemoclaw "$SANDBOX_A" destroy --yes 2>/dev/null || true
+openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
+if registry_has "$SANDBOX_A"; then
+  fail "destroy did not purge the stale '$SANDBOX_A' registry entry (#4497)"
+else
+  pass "destroy purged the stale '$SANDBOX_A' registry entry (#4497)"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -778,12 +778,18 @@ fi
 # status hint recommends: rebuild must get past the dispatcher and into its
 # own flow rather than failing with "does not exist".
 REBUILD_LOG="$(mktemp)"
+rebuild_exit=0
 run_with_timeout "$RECOVERY_PROBE_TIMEOUT_SECONDS" \
-  env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || true
+  env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || rebuild_exit=$?
 rebuild_output="$(cat "$REBUILD_LOG")"
 rm -f "$REBUILD_LOG"
 
-if grep -q "does not exist" <<<"$rebuild_output"; then
+# A timeout (124 from `timeout`/`gtimeout`) must fail, not silently pass: a
+# killed process produces output without "does not exist", so guard the exit
+# code before the content assertion.
+if [ "$rebuild_exit" -eq 124 ]; then
+  fail "rebuild probe timed out after ${RECOVERY_PROBE_TIMEOUT_SECONDS}s (possible prompt regression, #4497)"
+elif grep -q "does not exist" <<<"$rebuild_output"; then
   fail "rebuild could not locate the preserved sandbox '$SANDBOX_A' (#4497)"
 else
   pass "rebuild located the preserved sandbox '$SANDBOX_A' (#4497)"

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -743,9 +743,15 @@ else
   fail "Registry entry for '$SANDBOX_A' was removed by status (must be preserved, #4497)"
 fi
 
+# Bound every Phase 5 recovery probe so a reintroduced prompt or hang fails the
+# job fast instead of stalling to the phase timeout. Mirrors the probe-only
+# connect in Phase 4.
+RECOVERY_PROBE_TIMEOUT_SECONDS="${NEMOCLAW_E2E_RECOVERY_PROBE_TIMEOUT_SECONDS:-180}"
+
 # A routine `connect` against the same stale entry must also preserve it.
 CONNECT_LOG="$(mktemp)"
-NEMOCLAW_NON_INTERACTIVE=1 run_nemoclaw "$SANDBOX_A" connect >"$CONNECT_LOG" 2>&1
+run_with_timeout "$RECOVERY_PROBE_TIMEOUT_SECONDS" \
+  env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" connect >"$CONNECT_LOG" 2>&1
 connect_exit=$?
 connect_output="$(cat "$CONNECT_LOG")"
 rm -f "$CONNECT_LOG"
@@ -772,7 +778,8 @@ fi
 # status hint recommends: rebuild must get past the dispatcher and into its
 # own flow rather than failing with "does not exist".
 REBUILD_LOG="$(mktemp)"
-NEMOCLAW_NON_INTERACTIVE=1 run_nemoclaw "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || true
+run_with_timeout "$RECOVERY_PROBE_TIMEOUT_SECONDS" \
+  env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || true
 rebuild_output="$(cat "$REBUILD_LOG")"
 rm -f "$REBUILD_LOG"
 
@@ -786,7 +793,8 @@ fi
 # entry now that routine status/connect no longer delete it. Purge it here,
 # while the gateway is still healthy, so the preserved entry does not leak into
 # Phase 7 cleanup (which runs against a stopped gateway and cannot remove it).
-run_nemoclaw "$SANDBOX_A" destroy --yes 2>/dev/null || true
+run_with_timeout "$RECOVERY_PROBE_TIMEOUT_SECONDS" \
+  env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" destroy --yes 2>/dev/null || true
 openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
 if registry_has "$SANDBOX_A"; then
   fail "destroy did not purge the stale '$SANDBOX_A' registry entry (#4497)"

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -7,6 +7,13 @@
 // other OpenShell gateway is currently active. Covers the Architect's §5
 // scenarios 1-12. (Scenario 13 is a shell-level e2e, skipped.)
 //
+// Updated for issue #4497 — a routine `connect` against a healthy gateway must
+// no longer auto-remove the local registry entry even when the live sandbox is
+// truly gone (Scenario 1, formerly destructive). `status` recommends
+// `rebuild --yes` for stuck/stale sandboxes, so deleting the registry entry in
+// `connect` would race that recommendation and leave `rebuild` with nothing to
+// recover. Intentional purges now go through the explicit `destroy` command.
+//
 // Each test spawns `nemoclaw.js` as a child process with a stub `openshell`
 // binary on the $PATH. The stub is configured per-scenario via a JSON
 // "script" file: it records every invocation and returns canned output
@@ -287,32 +294,37 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-// ─── Scenario 1 ─── destructive path preserved for `connect` ───────────────
+// ─── Scenario 1 ─── connect is now non-destructive (#4497) ─────────────────
 describe("Scenario 1: connect — healthy nemoclaw active + sandbox NotFound truly gone", () => {
-  it("removes the registry entry, clears session, and exits 1", { timeout: TIMEOUT_MS }, () => {
-    writeStubOpenshell({
-      sandboxGet: [{ output: SANDBOX_GET_NOT_FOUND, exit: 1 }],
-      status: [{ output: STATUS_CONNECTED_NEMOCLAW, exit: 0 }],
-      gatewayInfo: [{ output: GATEWAY_INFO_NEMOCLAW, exit: 0 }],
-      gatewaySelect: { output: "", exit: 0 },
-      selectFlipsActive: false,
-    });
+  it(
+    "preserves the registry entry and session, points at rebuild/destroy, and exits 1",
+    { timeout: TIMEOUT_MS },
+    () => {
+      writeStubOpenshell({
+        sandboxGet: [{ output: SANDBOX_GET_NOT_FOUND, exit: 1 }],
+        status: [{ output: STATUS_CONNECTED_NEMOCLAW, exit: 0 }],
+        gatewayInfo: [{ output: GATEWAY_INFO_NEMOCLAW, exit: 0 }],
+        gatewaySelect: { output: "", exit: 0 },
+        selectFlipsActive: false,
+      });
 
-    const r = runCli("connect");
+      const r = runCli("connect");
 
-    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stderr}`);
-    assert.equal(
-      registrySandboxPresent(r),
-      false,
-      `expected registry entry removed, got: ${JSON.stringify(r.registry)}`,
-    );
-    assert.equal(
-      r.sessionSandboxName === null || r.sessionSandboxName === undefined,
-      true,
-      `expected session sandboxName cleared, got: ${r.sessionSandboxName}`,
-    );
-    assert.match(r.stderr, /Removed stale local registry entry/);
-  });
+      assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stderr}`);
+      assert.equal(
+        registrySandboxPresent(r),
+        true,
+        `expected registry entry preserved, got: ${JSON.stringify(r.registry)}`,
+      );
+      assert.equal(r.sessionSandboxName, SANDBOX_NAME, "expected session sandboxName preserved");
+      // #4497: no routine command may delete the state `rebuild` needs.
+      assert.doesNotMatch(r.stderr, /Removed stale local registry entry/);
+      assert.match(r.stderr, /registered locally, but is not present/);
+      assert.match(r.stderr, /preserved/);
+      assert.match(r.stderr, new RegExp(`${SANDBOX_NAME} rebuild --yes`));
+      assert.match(r.stderr, new RegExp(`${SANDBOX_NAME} destroy`));
+    },
+  );
 });
 
 // ─── Scenario 2 ─── passive `status` must preserve registry state ─────────
@@ -710,6 +722,88 @@ describe("Scenario 12: skill install — wrong gateway active yields guidance, n
       assert.equal(session.sandboxName, SANDBOX_NAME);
       assert.match(result.stderr, /NOT been removed/);
       assert.match(result.stderr, /openshell gateway select nemoclaw/);
+    },
+  );
+});
+
+// ─── Scenario 14 (#4497) ─── connect preserves enough state for rebuild ─────
+// End-to-end recovery contract: a healthy gateway reports the sandbox as gone,
+// `connect` must NOT delete the registry entry, and a follow-up
+// `rebuild --yes` must still be able to LOCATE the sandbox (it now gets past
+// the dispatcher's "does not exist" guard and into the rebuild flow, where it
+// stops at the credential preflight with the sandbox untouched). Before the
+// fix, `connect` removed the entry and `rebuild` failed with "does not exist".
+describe("Scenario 14 (#4497): connect preserves registry so rebuild can recover", () => {
+  it(
+    "after a non-destructive connect, `rebuild --yes` still finds the sandbox",
+    { timeout: TIMEOUT_MS },
+    () => {
+      writeStubOpenshell({
+        sandboxGet: [{ output: SANDBOX_GET_NOT_FOUND, exit: 1 }],
+        status: [{ output: STATUS_CONNECTED_NEMOCLAW, exit: 0 }],
+        gatewayInfo: [{ output: GATEWAY_INFO_NEMOCLAW, exit: 0 }],
+        gatewaySelect: { output: "", exit: 0 },
+        selectFlipsActive: false,
+      });
+
+      // Step 3: routine connect must preserve the registry entry.
+      const connect = runCli("connect");
+      assert.equal(connect.status, 1, `connect expected exit 1, got ${connect.status}`);
+      assert.equal(
+        registrySandboxPresent(connect),
+        true,
+        `connect must preserve the registry entry, got: ${JSON.stringify(connect.registry)}`,
+      );
+      assert.equal(connect.sessionSandboxName, SANDBOX_NAME, "session must survive connect");
+      assert.doesNotMatch(connect.stderr, /Removed stale local registry entry/);
+
+      // Step 4: the previously-suggested rebuild can still locate the sandbox.
+      // The registry provider is `nvidia-prod`; with NVIDIA_API_KEY unset the
+      // rebuild stops at the credential preflight (before any destructive
+      // backup/delete) — proving it located the entry rather than tripping the
+      // dispatcher's "does not exist" guard.
+      const repoRoot = path.join(import.meta.dirname, "..");
+      const rebuild = spawnSync(
+        process.execPath,
+        [path.join(repoRoot, "bin", "nemoclaw.js"), SANDBOX_NAME, "rebuild", "--yes"],
+        {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          timeout: TIMEOUT_MS,
+          env: {
+            ...process.env,
+            HOME: tmpDir,
+            PATH: `${homeLocalBin}:/usr/bin:/bin`,
+            NO_COLOR: "1",
+            NEMOCLAW_NON_INTERACTIVE: "1",
+            // Force the credential preflight to fail deterministically so the
+            // rebuild halts the moment after it locates the sandbox.
+            NVIDIA_API_KEY: "",
+            NEMOCLAW_PROVIDER_KEY: "",
+          },
+        },
+      );
+      const rebuildOut = `${rebuild.stdout || ""}\n${rebuild.stderr || ""}`;
+
+      assert.doesNotMatch(
+        rebuildOut,
+        /does not exist/,
+        `rebuild must locate the preserved sandbox, got:\n${rebuildOut}`,
+      );
+      assert.match(
+        rebuildOut,
+        new RegExp(`Rebuild sandbox '${SANDBOX_NAME}'`),
+        `rebuild must enter the rebuild flow, got:\n${rebuildOut}`,
+      );
+      // Registry entry still intact after the located-but-halted rebuild.
+      const registryPath = path.join(registryDir, "sandboxes.json");
+      const reg = fs.existsSync(registryPath)
+        ? JSON.parse(fs.readFileSync(registryPath, "utf-8"))
+        : null;
+      assert.ok(
+        reg?.sandboxes?.[SANDBOX_NAME],
+        `registry entry must remain after rebuild preflight, got: ${JSON.stringify(reg)}`,
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary
Stale-sandbox recovery no longer deletes the local registry entry before `rebuild` can use it. When a sandbox is registered locally but absent from a healthy NemoClaw gateway, a routine `connect` used to remove the entry — the very metadata the `rebuild --yes` hint (printed by `status`) depends on — so the follow-up rebuild failed with "does not exist".

## Related Issue
Fixes #4497

## Changes
- `src/lib/actions/sandbox/gateway-state.ts`: make the missing-live branch of `ensureLiveSandboxOrExit` non-destructive. It now preserves the registry entry and onboard session, prints recovery guidance (retry `rebuild --yes` / `onboard`), and routes intentional purges through the explicit `destroy` command instead of deleting state automatically. Drops the now-unused `registry` / `onboard-session` imports.
- `test/gateway-state-reconcile-2276.test.ts`: flip Scenario 1 to the new non-destructive contract and add Scenario 14 (#4497) proving `status`-recommended → `connect` preserves → `rebuild --yes` can still locate the sandbox.
- `test/cli.test.ts`: update the CLI-dispatch connect test to assert the entry is preserved (not removed).
- `test/e2e/test-double-onboard.sh`: Phase 5 now asserts `status` and `connect` preserve the stale entry and that `rebuild` can locate it, then purges it via the explicit `destroy` while the gateway is healthy so cleanup stays reliable.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification
Reproduced end-to-end on a host whose local registry held entries while `openshell sandbox list` reported none (healthy gateway): before the fix `connect` printed "Removed stale local registry entry" and the subsequent `rebuild --yes` failed with "does not exist"; after the fix `connect` preserves the entry and `rebuild --yes` locates the sandbox and proceeds into its own flow.

- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes (pre-existing, load-induced 5000ms timeouts in `test/e2e-scenario/framework-tests` are unrelated — they fail on the clean baseline too and pass when run with a larger timeout)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes (n/a — guidance text only)

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale local sandbox registry entries are now preserved when the live sandbox is missing; CLI output now explains the entry is preserved and points to `rebuild --yes` / `onboard` for recovery and `destroy` for deliberate removal.

* **Tests**
  * Updated unit and end-to-end tests to expect preserved-registry behavior and added a recovery scenario validating `connect` + `rebuild --yes` flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->