### PR TITLE
test(ci): stabilize platform vitest on main

### DIFF
--- a/src/lib/onboard/sandbox-gpu-preflight.test.ts
+++ b/src/lib/onboard/sandbox-gpu-preflight.test.ts
@@ -83,6 +83,7 @@ describe("sandbox GPU preflight", () => {
     expect(() =>
       validateSandboxGpuPreflight(sandboxGpuConfig(), {
         platform: "linux",
+        env: {},
         dockerInfoFormat: dockerInfo,
         getDockerCdiSpecDirs,
         findReadableNvidiaCdiSpecFiles,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5152,6 +5152,7 @@ describe("CLI dispatch", () => {
         }),
         { mode: 0o600 },
       );
+      writeHealthyDockerStub(localBin);
       fs.writeFileSync(
         path.join(localBin, "openshell"),
         [

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -48,7 +48,9 @@ function runEnsureDocker(env: Record<string, string>, installerArgs: string[]): 
     #   - systemctl exits cleanly so the daemon-start branch is a no-op
     #   - user is non-root, not in docker group via NSS, not in active group list
     #   - sudo is a no-op so usermod doesn't actually run
-    #   - is_wsl_host returns 1 so we don't bail out early
+    #   - uname reports Linux and is_wsl_host returns 1 so platform guards
+    #     don't bail out early when the test suite runs on macOS
+    uname() { printf 'Linux\n'; }
     docker() { return 1; }
     systemctl() { return 0; }
     sudo() { return 0; }

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -682,6 +682,7 @@ describe("sandbox provisioning: base runtime tools", () => {
     const log = path.join(tmp, "calls.log");
     const marker = path.join(tmp, "ps-installed");
     const chattrMarker = path.join(tmp, "chattr-installed");
+    const tmuxMarker = path.join(tmp, "tmux-installed");
     const lists = path.join(tmp, "apt-lists");
     fs.mkdirSync(lists);
     const command = dockerRunCommandBetween(
@@ -695,9 +696,10 @@ describe("sandbox provisioning: base runtime tools", () => {
       `call_log=${JSON.stringify(log)}`,
       `ps_marker=${JSON.stringify(marker)}`,
       `chattr_marker=${JSON.stringify(chattrMarker)}`,
+      `tmux_marker=${JSON.stringify(tmuxMarker)}`,
       'apt-mark() { printf "apt-mark %s\\n" "$*" >> "$call_log"; }',
-      'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; if [[ "$*" == *"install"* && "$*" == *"procps=2:4.0.4-9"* ]]; then touch "$ps_marker"; fi; if [[ "$*" == *"install"* && "$*" == *"e2fsprogs=1.47.2-3+b11"* ]]; then touch "$chattr_marker"; fi; }',
-      'command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "ps" ]; then [ -f "$ps_marker" ]; elif [ "${1:-}" = "-v" ] && [ "${2:-}" = "chattr" ]; then [ -f "$chattr_marker" ]; else builtin command "$@"; fi; }',
+      'apt-get() { printf "apt-get %s\\n" "$*" >> "$call_log"; if [[ "$*" == *"install"* && "$*" == *"procps=2:4.0.4-9"* ]]; then touch "$ps_marker"; fi; if [[ "$*" == *"install"* && "$*" == *"e2fsprogs=1.47.2-3+b11"* ]]; then touch "$chattr_marker"; fi; if [[ "$*" == *"install"* && "$*" == *"tmux=3.5a-3"* ]]; then touch "$tmux_marker"; fi; }',
+      'command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "ps" ]; then [ -f "$ps_marker" ]; elif [ "${1:-}" = "-v" ] && [ "${2:-}" = "chattr" ]; then [ -f "$chattr_marker" ]; elif [ "${1:-}" = "-v" ] && [ "${2:-}" = "tmux" ]; then [ -f "$tmux_marker" ]; else builtin command "$@"; fi; }',
       'ps() { [ -f "$ps_marker" ] || return 127; printf "procps test version\\n"; }',
       command,
     ].join("\n");


### PR DESCRIPTION
## Summary
Stabilizes the platform Vitest failures from the main push run by making the affected tests hermetic across macOS and WSL. The changes keep CI-only environment differences from steering tests into the wrong platform branches.

## Changes
- Stub healthy Docker for the connect-readiness gateway recovery test so it exercises the disconnected OpenShell gateway path instead of host Docker availability.
- Clear inherited WSL environment for the generic Linux sandbox GPU preflight test so it stays on the CDI path.
- Force the installer Docker group re-exec test to run its Linux branch even when the suite runs on macOS.
- Update the Dockerfile runtime-tools snippet test to mock the newly required `tmux` runtime tool.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for GPU preflight validation, Docker daemon health checks, installer platform detection, and package installation verification to improve test reliability and prevent false failures on different runner environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->