### PR TITLE
test(e2e): add scenario aliases for layered plans

### DIFF
--- a/test/e2e-scenario/framework-tests/e2e-scenario-resolver.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-resolver.test.ts
@@ -10,6 +10,7 @@ import yaml from "js-yaml";
 
 import { resolveScenario, type ResolverInput } from "../runtime/resolver/plan.ts";
 import { loadMetadataFromDir, loadMetadataFromObjects } from "../runtime/resolver/load.ts";
+import { listScenarios } from "../scenarios/registry.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const E2E_DIR = path.join(REPO_ROOT, "test/e2e-scenario");
@@ -64,6 +65,20 @@ describe("E2E scenario resolver", () => {
       exit_code: 1,
       no_stack_trace: true,
     });
+  });
+
+  it("should_resolve_every_typed_scenario_id_through_yaml_setup_scenarios", () => {
+    const meta = realMetadata();
+    const failures = listScenarios().flatMap((scenario) => {
+      try {
+        resolveScenario(scenario.id, meta);
+        return [];
+      } catch (error) {
+        return [`${scenario.id}: ${(error as Error).message}`];
+      }
+    });
+
+    expect(failures, failures.join("\n")).toEqual([]);
   });
 
   it("should_fail_for_unknown_scenario", () => {

--- a/test/e2e-scenario/nemoclaw_scenarios/scenarios.yaml
+++ b/test/e2e-scenario/nemoclaw_scenarios/scenarios.yaml
@@ -213,6 +213,132 @@ setup_scenarios:
     - credentials
     - onboarding-state
     - baseline-onboarding
+  ubuntu-repo-openai-compatible-openclaw:
+    alias_for_plan: ubuntu-repo-docker__openai-compatible-openclaw
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: openai-compatible-openclaw
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+  ubuntu-repo-cloud-openclaw-brave:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-brave
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-brave
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+  ubuntu-repo-cloud-openclaw-telegram:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-telegram
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-telegram
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+    - messaging-telegram
+  ubuntu-repo-cloud-openclaw-discord:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-discord
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-discord
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+    - messaging-discord
+  ubuntu-repo-cloud-openclaw-slack:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-slack
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-slack
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+    - messaging-slack
+  ubuntu-repo-cloud-hermes-discord:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-hermes-discord
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-hermes-discord
+    expected_state: cloud-hermes-ready
+    suites:
+    - smoke
+    - messaging-discord
+  ubuntu-repo-cloud-hermes-slack:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-hermes-slack
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-hermes-slack
+    expected_state: cloud-hermes-ready
+    suites:
+    - smoke
+    - messaging-slack
+  ubuntu-repo-cloud-openclaw-resume:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-resume-after-interrupt
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-resume-after-interrupt
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+  ubuntu-repo-cloud-openclaw-repair:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-repair-existing-config
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-repair-existing-config
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+  ubuntu-repo-cloud-openclaw-double-same-provider:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-double-same-provider
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-double-same-provider
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+  ubuntu-repo-cloud-openclaw-double-provider-switch:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-double-provider-switch
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-double-provider-switch
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+  ubuntu-repo-cloud-openclaw-token-rotation:
+    alias_for_plan: ubuntu-repo-docker__cloud-nvidia-openclaw-token-rotation
+    dimensions:
+      platform: ubuntu-local
+      install: repo-current
+      runtime: docker-running
+      onboarding: cloud-nvidia-openclaw-token-rotation
+    expected_state: cloud-openclaw-ready
+    suites:
+    - smoke
+    - messaging-token-rotation
   ubuntu-invalid-nvidia-key-negative:
     dimensions:
       platform: ubuntu-local


### PR DESCRIPTION
## Summary
Add friendly setup-scenario aliases for the layered E2E onboarding test plans so the YAML shell resolver can run every canonical typed scenario ID. This closes the drift where workflow/advisor scenario IDs resolved through the typed registry but failed through `runtime/run-scenario.sh`.

## Related Issue
Fixes #4378.

## Changes
- Add 12 missing `setup_scenarios` aliases in `test/e2e-scenario/nemoclaw_scenarios/scenarios.yaml` for messaging, Hermes messaging, lifecycle, token-rotation, Brave, and OpenAI-compatible plans.
- Preserve dimensions, expected-state, and suite metadata on each alias so coverage reports stay populated.
- Add a resolver regression test that every typed canonical scenario ID resolves through YAML setup scenarios.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:
- `bash test/e2e-scenario/runtime/run-scenario.sh <new-friendly-id> --plan-only` passed for all 12 added aliases.
- `npx vitest run --project e2e-scenario-framework --silent=false --reporter=default` passes.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test to validate scenario resolution across all registered scenarios.

* **Chores**
  * Expanded end-to-end testing scenarios to cover additional OpenCLAW onboarding variants, cloud deployment options (Brave, Telegram, Discord, Slack), and lifecycle scenarios (resume-after-interrupt, repair-existing-config, token-rotation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->