### PR TITLE
docs(commands): document hidden internal:* command family (#3782)

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1319,16 +1319,16 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 ## Internal Commands
 
 NemoClaw registers a hidden `internal` command namespace. These commands are
-compatibility entrypoints for repo-owned scripts — the installer, the
-uninstaller, DNS setup, and developer tooling — not part of the supported
-public CLI surface.
+compatibility entrypoints for repo-owned scripts, such as the installer, the
+uninstaller, DNS setup, and developer tooling. They are not part of the
+supported public CLI surface.
 
-They are intentionally omitted from `nemohermes --help` (each command class sets
-`hidden = true`), but they remain registered and routable, which is why they
-are listed here for reference. Treat their names, flags, and output as
-implementation details: they exist to back `install.sh`, `uninstall.sh`, and
-related automation, and they may change or be removed without notice. Most are
-invoked indirectly by those scripts rather than typed by hand.
+Each command class sets `hidden = true`, so the commands stay out of
+`nemohermes --help`. They remain registered and routable, which is why they are
+listed here for reference. Treat their names, flags, and output as
+implementation details. They exist to back `install.sh`, `uninstall.sh`, and
+related automation, and they may change or be removed without notice. Most run
+indirectly through those scripts rather than being typed by hand.
 
 For contributor guidance on how these command files are structured, see
 `src/commands/internal/README.md`.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1316,6 +1316,40 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 | **Robustness** | Requires the npm package to be discoverable so the CLI can find the local script. | Works even if the `nemohermes` CLI is missing, broken, or partially uninstalled. |
 | **Recommended for** | Routine uninstalls. | Recovery when the CLI is unavailable. |
 
+## Internal Commands
+
+NemoClaw registers a hidden `internal` command namespace. These commands are
+compatibility entrypoints for repo-owned scripts — the installer, the
+uninstaller, DNS setup, and developer tooling — not part of the supported
+public CLI surface.
+
+They are intentionally omitted from `nemohermes --help` (each command class sets
+`hidden = true`), but they remain registered and routable, which is why they
+are listed here for reference. Treat their names, flags, and output as
+implementation details: they exist to back `install.sh`, `uninstall.sh`, and
+related automation, and they may change or be removed without notice. Most are
+invoked indirectly by those scripts rather than typed by hand.
+
+For contributor guidance on how these command files are structured, see
+`src/commands/internal/README.md`.
+
+| Command | Owning script context | Purpose |
+|---------|-----------------------|---------|
+| `nemohermes internal installer plan` | `install.sh` | Build a deterministic installer plan from environment and probe inputs without applying it. |
+| `nemohermes internal installer normalize-env` | `install.sh` | Normalize installer ref and provider environment values without applying installation changes. |
+| `nemohermes internal installer resolve-release-tag` | `install.sh` | Resolve the installer ref using the same precedence as `install.sh`. |
+| `nemohermes internal uninstall plan` | `uninstall.sh` / `nemohermes uninstall` | Build a deterministic uninstall plan without applying it. |
+| `nemohermes internal uninstall run-plan` | `uninstall.sh` / `nemohermes uninstall` | Remove host-side NemoClaw resources from a previously built plan. |
+| `nemohermes internal uninstall classify-shim` | `uninstall.sh` / `nemohermes uninstall` | Classify whether a shim path is safe for the uninstaller to remove. |
+| `nemohermes internal dns setup-proxy` | onboarding / sandbox setup | Configure the DNS forwarder bridge inside a sandbox pod. |
+| `nemohermes internal dns fix-coredns` | onboarding / sandbox setup | Patch CoreDNS to use a non-loopback upstream resolver. |
+| `nemohermes internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` (development) | Run `npm link`, falling back to a user-local NemoClaw development shim. |
+
+These commands do not appear in the command-level parity check, which compares
+`nemohermes --help` against the public command headings in this reference; hidden
+commands are excluded from both. The table above is the canonical reference for
+the family.
+
 ## Environment Variables
 
 NemoClaw reads the following environment variables to configure service ports, onboarding behavior, and lifecycle defaults.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1512,6 +1512,40 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 | **Robustness** | Requires the npm package to be discoverable so the CLI can find the local script. | Works even if the `nemoclaw` CLI is missing, broken, or partially uninstalled. |
 | **Recommended for** | Routine uninstalls. | Recovery when the CLI is unavailable. |
 
+## Internal Commands
+
+NemoClaw registers a hidden `internal` command namespace. These commands are
+compatibility entrypoints for repo-owned scripts — the installer, the
+uninstaller, DNS setup, and developer tooling — not part of the supported
+public CLI surface.
+
+They are intentionally omitted from `nemoclaw --help` (each command class sets
+`hidden = true`), but they remain registered and routable, which is why they
+are listed here for reference. Treat their names, flags, and output as
+implementation details: they exist to back `install.sh`, `uninstall.sh`, and
+related automation, and they may change or be removed without notice. Most are
+invoked indirectly by those scripts rather than typed by hand.
+
+For contributor guidance on how these command files are structured, see
+`src/commands/internal/README.md`.
+
+| Command | Owning script context | Purpose |
+|---------|-----------------------|---------|
+| `nemoclaw internal installer plan` | `install.sh` | Build a deterministic installer plan from environment and probe inputs without applying it. |
+| `nemoclaw internal installer normalize-env` | `install.sh` | Normalize installer ref and provider environment values without applying installation changes. |
+| `nemoclaw internal installer resolve-release-tag` | `install.sh` | Resolve the installer ref using the same precedence as `install.sh`. |
+| `nemoclaw internal uninstall plan` | `uninstall.sh` / `nemoclaw uninstall` | Build a deterministic uninstall plan without applying it. |
+| `nemoclaw internal uninstall run-plan` | `uninstall.sh` / `nemoclaw uninstall` | Remove host-side NemoClaw resources from a previously built plan. |
+| `nemoclaw internal uninstall classify-shim` | `uninstall.sh` / `nemoclaw uninstall` | Classify whether a shim path is safe for the uninstaller to remove. |
+| `nemoclaw internal dns setup-proxy` | onboarding / sandbox setup | Configure the DNS forwarder bridge inside a sandbox pod. |
+| `nemoclaw internal dns fix-coredns` | onboarding / sandbox setup | Patch CoreDNS to use a non-loopback upstream resolver. |
+| `nemoclaw internal dev npm-link-or-shim` | `scripts/npm-link-or-shim.sh` (development) | Run `npm link`, falling back to a user-local NemoClaw development shim. |
+
+These commands do not appear in the command-level parity check, which compares
+`nemoclaw --help` against the public command headings in this reference; hidden
+commands are excluded from both. The table above is the canonical reference for
+the family.
+
 ## Environment Variables
 
 NemoClaw reads the following environment variables to configure service ports, onboarding behavior, and lifecycle defaults.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1515,16 +1515,16 @@ Use the hosted `curl … | bash` form only when the CLI is broken or already par
 ## Internal Commands
 
 NemoClaw registers a hidden `internal` command namespace. These commands are
-compatibility entrypoints for repo-owned scripts — the installer, the
-uninstaller, DNS setup, and developer tooling — not part of the supported
-public CLI surface.
+compatibility entrypoints for repo-owned scripts, such as the installer, the
+uninstaller, DNS setup, and developer tooling. They are not part of the
+supported public CLI surface.
 
-They are intentionally omitted from `nemoclaw --help` (each command class sets
-`hidden = true`), but they remain registered and routable, which is why they
-are listed here for reference. Treat their names, flags, and output as
-implementation details: they exist to back `install.sh`, `uninstall.sh`, and
-related automation, and they may change or be removed without notice. Most are
-invoked indirectly by those scripts rather than typed by hand.
+Each command class sets `hidden = true`, so the commands stay out of
+`nemoclaw --help`. They remain registered and routable, which is why they are
+listed here for reference. Treat their names, flags, and output as
+implementation details. They exist to back `install.sh`, `uninstall.sh`, and
+related automation, and they may change or be removed without notice. Most run
+indirectly through those scripts rather than being typed by hand.
 
 For contributor guidance on how these command files are structured, see
 `src/commands/internal/README.md`.

--- a/test/internal-commands-docs.test.ts
+++ b/test/internal-commands-docs.test.ts
@@ -11,10 +11,14 @@
  * trivially reachable": registered, routable, and explained only in the
  * developer-facing src/commands/internal/README.md.
  *
- * This test pins the user-facing reference instead: every registered hidden
+ * This test pins the user-facing references instead: every registered hidden
  * `internal:*` command must be listed in docs/reference/commands.mdx (by its
  * space-form invocation), while staying out of the public `### \`nemoclaw …\``
- * headings so command-level parity keeps treating them as hidden.
+ * headings so command-level parity keeps treating them as hidden. The same
+ * assertions run against the generated NemoHermes reference
+ * (docs/reference/commands-nemohermes.mdx, `nemohermes` binary form) so a
+ * regression in scripts/sync-agent-variant-docs.ts cannot silently drop the
+ * section from the agent variant.
  */
 
 import { readFileSync } from "node:fs";
@@ -24,7 +28,20 @@ import { describe, expect, it } from "vitest";
 import { getRegisteredOclifCommandsMetadata } from "../src/lib/cli/oclif-metadata";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-const commandsMdPath = path.join(repoRoot, "docs/reference/commands.mdx");
+
+/** User-facing command references, one per agent CLI variant. */
+const references = [
+  {
+    name: "commands.mdx",
+    binary: "nemoclaw",
+    text: readFileSync(path.join(repoRoot, "docs/reference/commands.mdx"), "utf8"),
+  },
+  {
+    name: "commands-nemohermes.mdx",
+    binary: "nemohermes",
+    text: readFileSync(path.join(repoRoot, "docs/reference/commands-nemohermes.mdx"), "utf8"),
+  },
+];
 
 /** Hidden `internal:*` command IDs from the generated oclif manifest. */
 function hiddenInternalCommandIds(): string[] {
@@ -34,13 +51,12 @@ function hiddenInternalCommandIds(): string[] {
     .sort();
 }
 
-/** `internal:uninstall:plan` -> `nemoclaw internal uninstall plan`. */
-function spaceFormInvocation(commandId: string): string {
-  return `nemoclaw ${commandId.replace(/:/g, " ")}`;
+/** `internal:uninstall:plan` -> `<binary> internal uninstall plan`. */
+function spaceFormInvocation(binary: string, commandId: string): string {
+  return `${binary} ${commandId.replace(/:/g, " ")}`;
 }
 
 describe("internal command documentation (#3782)", () => {
-  const commandsMd = readFileSync(commandsMdPath, "utf8");
   const internalIds = hiddenInternalCommandIds();
 
   it("registers the hidden internal command family", () => {
@@ -49,21 +65,28 @@ describe("internal command documentation (#3782)", () => {
     expect(internalIds.length).toBeGreaterThanOrEqual(9);
   });
 
-  it("documents every hidden internal command in commands.mdx", () => {
-    const undocumented = internalIds.filter(
-      (id) => !commandsMd.includes(spaceFormInvocation(id)),
-    );
-    expect(undocumented).toEqual([]);
-  });
+  it.each(references)(
+    "documents every hidden internal command in $name",
+    ({ text, binary }) => {
+      const undocumented = internalIds.filter(
+        (id) => !text.includes(spaceFormInvocation(binary, id)),
+      );
+      expect(undocumented).toEqual([]);
+    },
+  );
 
-  it("keeps internal commands out of the public `### \\`nemoclaw …\\`` parity headings", () => {
-    // canonicalUsageList() (and thus check-docs.sh command-level parity) only
-    // sees non-hidden commands, so an `### \`nemoclaw internal …\`` heading
-    // would be flagged as docs-only drift. Internal commands must be listed
-    // in some other form (a table, prose, fenced block) instead.
-    const offendingHeadings = commandsMd
-      .split("\n")
-      .filter((line) => /^### `nemoclaw internal\b/.test(line));
-    expect(offendingHeadings).toEqual([]);
-  });
+  it.each(references)(
+    "keeps internal commands out of the public command headings in $name",
+    ({ text, binary }) => {
+      // canonicalUsageList() (and thus check-docs.sh command-level parity) only
+      // sees non-hidden commands, so an `### \`<binary> internal …\`` heading
+      // would be flagged as docs-only drift. Internal commands must be listed
+      // in some other form (a table, prose, fenced block) instead.
+      const headingPrefix = `### \`${binary} internal`;
+      const offendingHeadings = text
+        .split("\n")
+        .filter((line) => line.startsWith(headingPrefix));
+      expect(offendingHeadings).toEqual([]);
+    },
+  );
 });

--- a/test/internal-commands-docs.test.ts
+++ b/test/internal-commands-docs.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Documentation gate for the hidden `internal:*` command family (#3782).
+ *
+ * The `internal:*` commands are marked `hidden = true` in their oclif command
+ * classes, so they are intentionally omitted from `nemoclaw --help`, from the
+ * canonical `--dump-commands` list, and therefore from the `### \`nemoclaw …\``
+ * parity check in check-docs.sh. That kept them "documented nowhere, but
+ * trivially reachable": registered, routable, and explained only in the
+ * developer-facing src/commands/internal/README.md.
+ *
+ * This test pins the user-facing reference instead: every registered hidden
+ * `internal:*` command must be listed in docs/reference/commands.mdx (by its
+ * space-form invocation), while staying out of the public `### \`nemoclaw …\``
+ * headings so command-level parity keeps treating them as hidden.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getRegisteredOclifCommandsMetadata } from "../src/lib/cli/oclif-metadata";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const commandsMdPath = path.join(repoRoot, "docs/reference/commands.mdx");
+
+/** Hidden `internal:*` command IDs from the generated oclif manifest. */
+function hiddenInternalCommandIds(): string[] {
+  return Object.entries(getRegisteredOclifCommandsMetadata())
+    .filter(([id, meta]) => id.startsWith("internal:") && meta.hidden === true)
+    .map(([id]) => id)
+    .sort();
+}
+
+/** `internal:uninstall:plan` -> `nemoclaw internal uninstall plan`. */
+function spaceFormInvocation(commandId: string): string {
+  return `nemoclaw ${commandId.replace(/:/g, " ")}`;
+}
+
+describe("internal command documentation (#3782)", () => {
+  const commandsMd = readFileSync(commandsMdPath, "utf8");
+  const internalIds = hiddenInternalCommandIds();
+
+  it("registers the hidden internal command family", () => {
+    // Guards against the manifest silently losing the family (which would make
+    // the documentation assertions below vacuously pass).
+    expect(internalIds.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it("documents every hidden internal command in commands.mdx", () => {
+    const undocumented = internalIds.filter(
+      (id) => !commandsMd.includes(spaceFormInvocation(id)),
+    );
+    expect(undocumented).toEqual([]);
+  });
+
+  it("keeps internal commands out of the public `### \\`nemoclaw …\\`` parity headings", () => {
+    // canonicalUsageList() (and thus check-docs.sh command-level parity) only
+    // sees non-hidden commands, so an `### \`nemoclaw internal …\`` heading
+    // would be flagged as docs-only drift. Internal commands must be listed
+    // in some other form (a table, prose, fenced block) instead.
+    const offendingHeadings = commandsMd
+      .split("\n")
+      .filter((line) => /^### `nemoclaw internal\b/.test(line));
+    expect(offendingHeadings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The `internal:*` command family is marked `hidden = true` in oclif but stays registered and routable, so it was "documented nowhere, but trivially reachable" — explained only in the developer-facing `src/commands/internal/README.md`, never in the user-facing CLI reference. This PR documents the nine `internal:*` commands in `docs/reference/commands.mdx` and adds a regression test that keeps them documented.

## Related Issue

Fixes #3782

## Changes

- Add an **Internal Commands** section to `docs/reference/commands.mdx` listing all nine `internal:*` commands, their owning script context (installer, uninstaller, DNS setup, dev tooling), their purpose, and a clear note that they are **not part of the supported public CLI surface** and may change without notice.
- Document them with a table rather than `### \`nemoclaw …\`` headings, so hidden commands stay excluded from the command-level docs parity check (`canonicalUsageList()` / `check-docs.sh --only-cli` only see non-hidden commands).
- Regenerate the NemoHermes variant (`docs/reference/commands-nemohermes.mdx`) via `npm run docs:sync-agent-variants`.
- Add `test/internal-commands-docs.test.ts`: a regression gate asserting every hidden `internal:*` command in the generated oclif manifest appears in `commands.mdx`, and that none uses a public `### \`nemoclaw internal …\`` heading. The test fails on current `main` and passes with this change.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

(Doc change plus a documentation-guardrail test; no runtime/CLI behavior changes.)

## Verification

- [x] `npm test` — focused/relevant: new regression test + `src/lib/cli/oclif-metadata.test.ts` pass; full `cli` vitest project run reviewed (the only failures are pre-existing, environment-specific filesystem-permission/ownership/umask tests in `config-sync` and `nemoclaw-start`, unrelated to this docs change and reproducible on unmodified `main`).
- [x] `test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli` (command + flag parity) passes.
- [x] `npm run docs:check-agent-variants` passes (NemoHermes variant in sync).
- [x] `npm run typecheck:cli` passes.
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Docs updated for user-facing behavior changes.
- [x] Doc pages follow the style guide.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Internal Commands” reference documenting the hidden internal command namespace used for installer/uninstaller/DNS/setup and developer tooling; lists canonical internal subcommands and notes they remain registered but are excluded from standard help/parity headings.

* **Tests**
  * Added automated tests to verify the internal command family is documented, all hidden internal commands appear in docs, and public-facing headings do not expose them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->