### PR TITLE
fix(channels): normalize Slack runtime env placeholders before OpenClaw start (#4274)

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1081,6 +1081,40 @@ if isinstance(channels, dict):
                     f"[channels] {label} placeholder does not match the OpenShell runtime placeholder for {env_key}"
                 )
 
+# Slack stores Bolt-compatible aliases (xoxb-/xapp-OPENSHELL-RESOLVE-ENV-*) on
+# disk rather than the canonical "openshell:resolve:env:*" placeholder, so the
+# loop above (which keys on the canonical prefix) never inspects it. Diagnose
+# the alias-vs-runtime-env consistency separately. The aliases themselves are
+# never rewritten on disk — the L7 egress proxy resolves them at request time —
+# so we only warn, never mutate. Ref: NVIDIA/NemoClaw#4274.
+slack_aliases = {
+    "botToken": ("SLACK_BOT_TOKEN", "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN", "xoxb-"),
+    "appToken": ("SLACK_APP_TOKEN", "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN", "xapp-"),
+    }
+if isinstance(channels, dict):
+    slack_cfg = channels.get("slack", {})
+    slack_accounts = slack_cfg.get("accounts", {}) if isinstance(slack_cfg, dict) else {}
+    if isinstance(slack_accounts, dict):
+        for account_id, account in slack_accounts.items():
+            if not isinstance(account, dict):
+                continue
+            for field, (env_key, alias, token_scheme) in slack_aliases.items():
+                if account.get(field) != alias:
+                    continue
+                label = f"slack.{account_id}.{field}"
+                env_value = os.environ.get(env_key, "")
+                if not env_value:
+                    warnings.append(
+                        f"[channels] {label} expects the {env_key} provider placeholder but it is missing from the runtime environment"
+                    )
+                elif not env_value.startswith(prefix) and not env_value.startswith(token_scheme):
+                    # A genuine xoxb-/xapp- token (token_scheme) is accepted by
+                    # Bolt, so only warn when the runtime value is neither an
+                    # OpenShell placeholder nor a plausibly-real Slack token.
+                    warnings.append(
+                        f"[channels] {label} runtime {env_key} is neither an OpenShell placeholder nor a {token_scheme} Slack token; Slack Bolt may reject it"
+                    )
+
 if updated != config:
     with open(config_file, "w", encoding="utf-8") as f:
         json.dump(updated, f, indent=2)
@@ -1110,6 +1144,48 @@ PYPLACEHOLDERS
 
   restore_openclaw_config_after_write "$config_file" "$hash_file"
   [ "$_write_rc" -eq 0 ] || return "$_write_rc"
+}
+
+# ── Slack runtime env normalization (Bolt-compatible placeholder) ──
+# OpenShell injects messaging-provider credentials into the sandbox process
+# environment as canonical resolve placeholders, e.g.
+#   SLACK_BOT_TOKEN=openshell:resolve:env:v51_SLACK_BOT_TOKEN
+# Unlike the canonical OpenClaw config values (handled by
+# refresh_openclaw_provider_placeholders), Slack Bolt validates token *shape*
+# at startup and rejects anything that does not begin with xoxb-/xapp-. After a
+# messaging-provider rebuild the gateway therefore inherits a placeholder it
+# cannot parse and Slack auth fails even though the provider attached
+# successfully (NVIDIA/NemoClaw#4274). The L7 egress proxy rewrites the
+# Bolt-aliased form (xoxb-/xapp-OPENSHELL-RESOLVE-ENV-*) at request time — the
+# same alias the config generator bakes into openclaw.json — so normalize the
+# runtime env to that alias before launching OpenClaw.
+#
+# This runs in the *main* shell (never a subshell / command substitution) so
+# the exported values are inherited by the gateway and any one-shot
+# "${NEMOCLAW_CMD[@]}" child. Real xoxb-/xapp- tokens and already-aliased values
+# are left untouched, so it is safe to call unconditionally and is idempotent.
+#
+# OpenShell injects self-referential placeholders (the SLACK_BOT_TOKEN env var
+# resolves to "openshell:resolve:env:<rev>_SLACK_BOT_TOKEN"), so the match
+# requires the trailing key name as well as the prefix — a placeholder that
+# resolves some *other* key is left alone rather than silently rebound to the
+# Slack secret.
+normalize_slack_runtime_env() {
+  local prefix="openshell:resolve:env:"
+
+  case "${SLACK_BOT_TOKEN-}" in
+    "$prefix"*SLACK_BOT_TOKEN)
+      export SLACK_BOT_TOKEN="xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN"
+      printf '[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias\n' >&2
+      ;;
+  esac
+
+  case "${SLACK_APP_TOKEN-}" in
+    "$prefix"*SLACK_APP_TOKEN)
+      export SLACK_APP_TOKEN="xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN"
+      printf '[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias\n' >&2
+      ;;
+  esac
 }
 
 # ── Slack secrets-on-disk tripwire ────────────────────────────────
@@ -2664,6 +2740,9 @@ if [ "$(id -u)" -ne 0 ]; then
   write_runtime_shell_env
   ensure_runtime_shell_env_shim
   lock_rc_files "$_SANDBOX_HOME" || true
+  # Normalize Slack provider placeholders before any child inherits the env —
+  # covers both the one-shot "${NEMOCLAW_CMD[@]}" exec and the gateway launch.
+  normalize_slack_runtime_env
 
   if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
     exec "${NEMOCLAW_CMD[@]}"
@@ -2806,6 +2885,10 @@ export_gateway_token
 write_runtime_shell_env
 ensure_runtime_shell_env_shim
 lock_rc_files "$_SANDBOX_HOME"
+# Normalize Slack provider placeholders before any child (the one-shot
+# "${NEMOCLAW_CMD[@]}" exec or the stepped-down gateway) inherits the env.
+# gosu/setpriv preserve the environment, so the export reaches the gateway user.
+normalize_slack_runtime_env
 
 # Messaging channel config was announced before placeholder refresh so the
 # baseline captures the same provider placeholders the gateway will use.

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1013,6 +1013,7 @@ refresh_openclaw_provider_placeholders() {
       python3 - "$config_file" <<'PYPLACEHOLDERS'
 import json
 import os
+import re
 import sys
 
 config_file = sys.argv[1]
@@ -1103,16 +1104,21 @@ if isinstance(channels, dict):
                     continue
                 label = f"slack.{account_id}.{field}"
                 env_value = os.environ.get(env_key, "")
+                # A valid runtime placeholder is the canonical self-referential
+                # form or its revision-scoped variant for *this* key; a
+                # placeholder for a different key (or a suffix collision) is not
+                # accepted and must be surfaced. A genuine xoxb-/xapp- token is
+                # accepted by Bolt as-is.
+                placeholder_re = re.compile(
+                    rf"^{re.escape(prefix)}(v[0-9]+_)?{re.escape(env_key)}$"
+                )
                 if not env_value:
                     warnings.append(
                         f"[channels] {label} expects the {env_key} provider placeholder but it is missing from the runtime environment"
                     )
-                elif not env_value.startswith(prefix) and not env_value.startswith(token_scheme):
-                    # A genuine xoxb-/xapp- token (token_scheme) is accepted by
-                    # Bolt, so only warn when the runtime value is neither an
-                    # OpenShell placeholder nor a plausibly-real Slack token.
+                elif not placeholder_re.match(env_value) and not env_value.startswith(token_scheme):
                     warnings.append(
-                        f"[channels] {label} runtime {env_key} is neither an OpenShell placeholder nor a {token_scheme} Slack token; Slack Bolt may reject it"
+                        f"[channels] {label} runtime {env_key} is neither the {env_key} OpenShell placeholder nor a {token_scheme} Slack token; Slack Bolt may reject it"
                     )
 
 if updated != config:
@@ -1166,26 +1172,24 @@ PYPLACEHOLDERS
 # are left untouched, so it is safe to call unconditionally and is idempotent.
 #
 # OpenShell injects self-referential placeholders (the SLACK_BOT_TOKEN env var
-# resolves to "openshell:resolve:env:<rev>_SLACK_BOT_TOKEN"), so the match
-# requires the trailing key name as well as the prefix — a placeholder that
-# resolves some *other* key is left alone rather than silently rebound to the
-# Slack secret.
+# resolves to "openshell:resolve:env:SLACK_BOT_TOKEN" or its revision-scoped
+# form "openshell:resolve:env:v<rev>_SLACK_BOT_TOKEN"). The match is anchored to
+# exactly those two shapes so a placeholder that resolves some *other* key
+# (including a suffix collision like ...v1_NOT_SLACK_BOT_TOKEN) is left alone
+# rather than silently rebound to the Slack secret.
 normalize_slack_runtime_env() {
-  local prefix="openshell:resolve:env:"
+  local bot_re='^openshell:resolve:env:(v[0-9]+_)?SLACK_BOT_TOKEN$'
+  local app_re='^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$'
 
-  case "${SLACK_BOT_TOKEN-}" in
-    "$prefix"*SLACK_BOT_TOKEN)
-      export SLACK_BOT_TOKEN="xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN"
-      printf '[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias\n' >&2
-      ;;
-  esac
+  if [[ "${SLACK_BOT_TOKEN-}" =~ $bot_re ]]; then
+    export SLACK_BOT_TOKEN="xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN"
+    printf '[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias\n' >&2
+  fi
 
-  case "${SLACK_APP_TOKEN-}" in
-    "$prefix"*SLACK_APP_TOKEN)
-      export SLACK_APP_TOKEN="xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN"
-      printf '[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias\n' >&2
-      ;;
-  esac
+  if [[ "${SLACK_APP_TOKEN-}" =~ $app_re ]]; then
+    export SLACK_APP_TOKEN="xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN"
+    printf '[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias\n' >&2
+  fi
 }
 
 # ── Slack secrets-on-disk tripwire ────────────────────────────────

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -2985,7 +2985,31 @@ describe("provider placeholder refresh (#4251)", () => {
 
     expect(run.result.status, run.result.stderr).toBe(0);
     expect(run.result.stderr).toContain(
-      "slack.default.botToken runtime SLACK_BOT_TOKEN is neither an OpenShell placeholder nor a xoxb- Slack token",
+      "slack.default.botToken runtime SLACK_BOT_TOKEN is neither the SLACK_BOT_TOKEN OpenShell placeholder nor a xoxb- Slack token",
+    );
+  });
+
+  it("warns when the Slack runtime env resolves a different key than expected", () => {
+    // A placeholder for the wrong key must not look healthy — Bolt would still
+    // inherit a non-Slack placeholder and fail at startup.
+    const run = runRefresh(
+      {
+        channels: {
+          slack: {
+            accounts: {
+              default: {
+                botToken: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+              },
+            },
+          },
+        },
+      },
+      { SLACK_BOT_TOKEN: "openshell:resolve:env:v51_OTHER_KEY" },
+    );
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.result.stderr).toContain(
+      "slack.default.botToken runtime SLACK_BOT_TOKEN is neither the SLACK_BOT_TOKEN OpenShell placeholder nor a xoxb- Slack token",
     );
   });
 });
@@ -3109,6 +3133,19 @@ describe("Slack runtime env normalization (#4274)", () => {
     expect(run.result.status, run.result.stderr).toBe(0);
     expect(run.bot).toBe("openshell:resolve:env:v51_SOME_OTHER_KEY");
     expect(run.app).toBe("openshell:resolve:env:v51_SOME_OTHER_KEY");
+  });
+
+  it("leaves a suffix-collision key (…_NOT_SLACK_BOT_TOKEN) untouched", () => {
+    // The match is anchored: only the canonical key or its v<rev>_ form is
+    // rebound, never a key that merely ends with the same suffix.
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "openshell:resolve:env:v51_NOT_SLACK_BOT_TOKEN",
+      SLACK_APP_TOKEN: "openshell:resolve:env:MY_SLACK_APP_TOKEN",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("openshell:resolve:env:v51_NOT_SLACK_BOT_TOKEN");
+    expect(run.app).toBe("openshell:resolve:env:MY_SLACK_APP_TOKEN");
   });
 });
 

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -381,6 +381,7 @@ describe("nemoclaw-start non-root fallback", () => {
       'write_runtime_shell_env() { :; }',
       'ensure_runtime_shell_env_shim() { :; }',
       'lock_rc_files() { :; }',
+      'normalize_slack_runtime_env() { :; }',
       'configure_messaging_channels() { echo "SHOULD_NOT_CONFIGURE"; exit 70; }',
       'install_telegram_diagnostics() { echo "SHOULD_NOT_INSTALL"; exit 71; }',
       'install_slack_channel_guard() { echo "SHOULD_NOT_INSTALL"; exit 73; }',
@@ -2885,6 +2886,230 @@ describe("provider placeholder refresh (#4251)", () => {
       "telegram.default.botToken is an OpenShell placeholder but TELEGRAM_BOT_TOKEN is missing",
     );
   });
+
+  it("warns when the Slack config alias is present but SLACK_BOT_TOKEN is missing", () => {
+    const run = runRefresh({
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              botToken: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+              appToken: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+            },
+          },
+        },
+      },
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.result.stderr).toContain(
+      "slack.default.botToken expects the SLACK_BOT_TOKEN provider placeholder but it is missing",
+    );
+    expect(run.result.stderr).toContain(
+      "slack.default.appToken expects the SLACK_APP_TOKEN provider placeholder but it is missing",
+    );
+  });
+
+  it("does not warn when the Slack config alias matches an OpenShell runtime placeholder", () => {
+    const run = runRefresh(
+      {
+        channels: {
+          slack: {
+            accounts: {
+              default: {
+                botToken: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+                appToken: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+              },
+            },
+          },
+        },
+      },
+      {
+        SLACK_BOT_TOKEN: "openshell:resolve:env:v42_SLACK_BOT_TOKEN",
+        SLACK_APP_TOKEN: "openshell:resolve:env:v42_SLACK_APP_TOKEN",
+      },
+    );
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.result.stderr).not.toContain("slack.default");
+    // The Bolt-compatible alias is never rewritten on disk; it does not match
+    // the canonical "openshell:resolve:env:SLACK_BOT_TOKEN" placeholder key.
+    expect(run.config.channels.slack.accounts.default.botToken).toBe(
+      "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+    );
+    expect(run.config.channels.slack.accounts.default.appToken).toBe(
+      "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+    );
+  });
+
+  it("does not warn when the Slack runtime env holds a genuine xoxb-/xapp- token", () => {
+    const run = runRefresh(
+      {
+        channels: {
+          slack: {
+            accounts: {
+              default: {
+                botToken: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+                appToken: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+              },
+            },
+          },
+        },
+      },
+      {
+        SLACK_BOT_TOKEN: "xoxb-1-real-bot-token",
+        SLACK_APP_TOKEN: "xapp-1-real-app-token",
+      },
+    );
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.result.stderr).not.toContain("slack.default");
+    expect(JSON.stringify(run.config)).not.toContain("xoxb-1-real-bot-token");
+  });
+
+  it("warns when the Slack runtime env holds neither a placeholder nor a Slack token", () => {
+    const run = runRefresh(
+      {
+        channels: {
+          slack: {
+            accounts: {
+              default: {
+                botToken: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+              },
+            },
+          },
+        },
+      },
+      { SLACK_BOT_TOKEN: "garbage-not-a-token" },
+    );
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.result.stderr).toContain(
+      "slack.default.botToken runtime SLACK_BOT_TOKEN is neither an OpenShell placeholder nor a xoxb- Slack token",
+    );
+  });
+});
+
+describe("Slack runtime env normalization (#4274)", () => {
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+
+  // Exercises normalize_slack_runtime_env() through the real shell function so
+  // we prove the *exported* process-env values the OpenClaw child inherits are
+  // Bolt-compatible, not the canonical "openshell:resolve:env:*" placeholder.
+  function runNormalize(env: Record<string, string | undefined> = {}): {
+    bot: string;
+    app: string;
+    result: ReturnType<typeof spawnSync>;
+  } {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-runtime-env-"));
+    const scriptPath = path.join(tmpDir, "run.sh");
+    const fn = extractShellFunctionFromSource(src, "normalize_slack_runtime_env");
+    fs.writeFileSync(
+      scriptPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        fn,
+        "normalize_slack_runtime_env",
+        'printf "BOT=%s\\n" "${SLACK_BOT_TOKEN-__UNSET__}"',
+        'printf "APP=%s\\n" "${SLACK_APP_TOKEN-__UNSET__}"',
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    // A clean env so an inherited SLACK_* from the host can't mask an "unset" case.
+    const childEnv: Record<string, string> = { PATH: process.env.PATH || "" };
+    for (const [key, value] of Object.entries(env)) {
+      if (value !== undefined) childEnv[key] = value;
+    }
+    const result = spawnSync("bash", [scriptPath], {
+      encoding: "utf-8",
+      env: childEnv,
+      timeout: 5000,
+    });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    const bot = (result.stdout.match(/^BOT=(.*)$/m)?.[1] ?? "").trimEnd();
+    const app = (result.stdout.match(/^APP=(.*)$/m)?.[1] ?? "").trimEnd();
+    return { bot, app, result };
+  }
+
+  it("normalizes revision-scoped Slack placeholders to Bolt-compatible aliases", () => {
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "openshell:resolve:env:v51_SLACK_BOT_TOKEN",
+      SLACK_APP_TOKEN: "openshell:resolve:env:v51_SLACK_APP_TOKEN",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN");
+    expect(run.app).toBe("xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN");
+  });
+
+  it("does not leak the revision suffix into the normalized env or logs", () => {
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "openshell:resolve:env:v51_SLACK_BOT_TOKEN",
+      SLACK_APP_TOKEN: "openshell:resolve:env:v51_SLACK_APP_TOKEN",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).not.toContain("v51_");
+    expect(run.app).not.toContain("v51_");
+    expect(run.result.stderr).not.toContain("v51_");
+    expect(run.bot).not.toContain("openshell:resolve:env:");
+    expect(run.app).not.toContain("openshell:resolve:env:");
+  });
+
+  it("normalizes the canonical (non-revision) placeholder too", () => {
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "openshell:resolve:env:SLACK_BOT_TOKEN",
+      SLACK_APP_TOKEN: "openshell:resolve:env:SLACK_APP_TOKEN",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN");
+    expect(run.app).toBe("xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN");
+  });
+
+  it("leaves already-aliased Slack tokens unchanged (idempotent)", () => {
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+      SLACK_APP_TOKEN: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN");
+    expect(run.app).toBe("xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN");
+  });
+
+  it("leaves real Slack tokens untouched", () => {
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "xoxb-123-real-bot-token",
+      SLACK_APP_TOKEN: "xapp-1-real-app-token",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("xoxb-123-real-bot-token");
+    expect(run.app).toBe("xapp-1-real-app-token");
+  });
+
+  it("does not create Slack env vars that were never set", () => {
+    const run = runNormalize();
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("__UNSET__");
+    expect(run.app).toBe("__UNSET__");
+  });
+
+  it("leaves a placeholder that resolves a different key untouched", () => {
+    // OpenShell injects self-referential placeholders. A placeholder resolving
+    // some other secret must not be silently rebound to the Slack alias.
+    const run = runNormalize({
+      SLACK_BOT_TOKEN: "openshell:resolve:env:v51_SOME_OTHER_KEY",
+      SLACK_APP_TOKEN: "openshell:resolve:env:v51_SOME_OTHER_KEY",
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.bot).toBe("openshell:resolve:env:v51_SOME_OTHER_KEY");
+    expect(run.app).toBe("openshell:resolve:env:v51_SOME_OTHER_KEY");
+  });
 });
 
 describe("Telegram diagnostics (#2766)", () => {
@@ -2968,6 +3193,7 @@ describe("Telegram diagnostics (#2766)", () => {
         'write_runtime_shell_env() { :; }',
         'ensure_runtime_shell_env_shim() { :; }',
         'lock_rc_files() { :; }',
+        'normalize_slack_runtime_env() { :; }',
         'configure_messaging_channels() { echo "ORDER:configure"; }',
         'install_slack_channel_guard() { :; }',
         'verify_no_slack_secrets_on_disk() { :; }',


### PR DESCRIPTION
## Summary

After a messaging-provider rebuild, OpenShell injects Slack credentials into the sandbox process environment as canonical resolve placeholders (e.g. `SLACK_BOT_TOKEN=openshell:resolve:env:v51_SLACK_BOT_TOKEN`). Slack Bolt validates token *shape* at startup and rejects anything that does not begin with `xoxb-`/`xapp-`, so the gateway inherits a value it cannot parse and Slack auth fails even though the provider attached successfully. This normalizes those runtime env placeholders to the Bolt-compatible alias before OpenClaw starts.

## Related Issue

Fixes #4274

## Changes

- Add `normalize_slack_runtime_env()` to `scripts/nemoclaw-start.sh` and call it in **both** the non-root and root launch paths, before any child (the one-shot `"${NEMOCLAW_CMD[@]}"` exec or the stepped-down gateway) inherits the environment.
  - Rewrites self-referential `openshell:resolve:env:*SLACK_BOT_TOKEN` / `*SLACK_APP_TOKEN` placeholders to `xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN` / `xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN` — the same alias the config generator already bakes into `openclaw.json`, which the L7 egress proxy resolves at request time.
  - The match requires the trailing key name as well as the prefix, so a placeholder resolving some *other* key is left alone rather than silently rebound to the Slack secret.
  - Real `xoxb-`/`xapp-` tokens and already-aliased values are left untouched, so the export is idempotent and safe to call unconditionally. `gosu`/`setpriv` preserve the environment, so the export reaches the gateway user; no raw token is written to disk.
- Extend `refresh_openclaw_provider_placeholders` diagnostics so Slack warns when a config alias is present but the runtime env is missing, or holds a value that is neither an OpenShell placeholder nor a plausibly-real Slack token.
- Add focused regression tests in `test/nemoclaw-start.test.ts` that drive the real shell functions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification notes:
- `vitest run test/nemoclaw-start.test.ts` — **111 passed** (includes the new `Slack runtime env normalization (#4274)` suite and the extended `provider placeholder refresh` suite, all exercising the real shell functions). Regression reproduced before the fix (failing) and confirmed green after.
- Related suites green: `generate-openclaw-config.test.ts`, `messaging/channels/manifests.test.ts`, `onboard/slack-validation.test.ts` (131 passed) — confirms the alias strings match the config generator and manifest.
- Lint on the touched shell script: `shfmt -i 2 -ci -bn -d` clean; `shellcheck -x` reports only a pre-existing unrelated `SC2015` note outside this diff.
- Full `npm test` was not run end-to-end here (the `cli` Vitest project's broad integration suite exceeds the local time budget); the focused and adjacent suites above cover the changed code paths. No live Slack credentials or Brev/Docker sandbox were available, so the E2E pairing path could not be exercised locally; fake placeholder values were used for all unit/regression tests.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects missing or mismatched Slack tokens and emits targeted warnings during startup.
  * Normalizes Slack runtime placeholders into Bolt-compatible alias forms before child processes inherit the environment.

* **Tests**
  * Added end-to-end tests covering Slack runtime normalization, warning conditions, idempotency, and startup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->