### PR TITLE
fix(installer): retry npm registry installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,19 @@ ENV NPM_CONFIG_AUDIT=false \
     NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
     NPM_CONFIG_FETCH_TIMEOUT=300000
+COPY scripts/npm-retry.sh /usr/local/bin/nemoclaw-npm-retry
+RUN chmod 755 /usr/local/bin/nemoclaw-npm-retry
 COPY nemoclaw/package.json nemoclaw/package-lock.json nemoclaw/tsconfig.json /opt/nemoclaw/
 COPY nemoclaw/src/ /opt/nemoclaw/src/
 WORKDIR /opt/nemoclaw
-RUN npm ci && npm run build
+RUN nemoclaw-npm-retry npm ci && npm run build
 
 # Stage 2: Runtime image — pull cached base from GHCR
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 ARG OPENCLAW_VERSION=2026.5.22
 ARG OPENCLAW_2026_5_22_INTEGRITY=sha512-m+zgBELGbCHjWB1IWF5WSWNPr480cMKOMff2OF72c8A0AMD4hC/9+qwYtzjYmGkETcffnB711JymlVsQnh2Tow==
+COPY --from=builder /usr/local/bin/nemoclaw-npm-retry /usr/local/bin/nemoclaw-npm-retry
 
 # Harden: remove unnecessary build tools and network probes from base image (#830)
 # Protect runtime tools before autoremove — the GHCR base may predate the
@@ -84,7 +87,7 @@ ENV NPM_CONFIG_AUDIT=false \
     NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000 \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
     NPM_CONFIG_FETCH_TIMEOUT=300000
-RUN npm ci --omit=dev
+RUN nemoclaw-npm-retry npm ci --omit=dev
 COPY scripts/patch-openclaw-tool-catalog.js /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js
 COPY scripts/patch-openclaw-chat-send.js /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js
 RUN chmod 755 /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js \
@@ -112,7 +115,7 @@ RUN set -eu; \
     EXPECTED_INTEGRITY=""; \
     if [ "$OPENCLAW_VERSION" = "2026.5.22" ]; then EXPECTED_INTEGRITY="$OPENCLAW_2026_5_22_INTEGRITY"; fi; \
     if [ -n "$EXPECTED_INTEGRITY" ]; then \
-        REGISTRY_INTEGRITY=$(npm view "openclaw@${OPENCLAW_VERSION}" dist.integrity); \
+        REGISTRY_INTEGRITY=$(nemoclaw-npm-retry npm view "openclaw@${OPENCLAW_VERSION}" dist.integrity); \
         if [ "$REGISTRY_INTEGRITY" != "$EXPECTED_INTEGRITY" ]; then \
             echo "ERROR: OpenClaw ${OPENCLAW_VERSION} npm integrity mismatch" >&2; \
             echo "Expected: ${EXPECTED_INTEGRITY}" >&2; \
@@ -130,7 +133,7 @@ RUN set -eu; \
         # at the shell level first gives npm a clean slate and avoids the
         # rmdir failure inside npm's own install path.
         rm -rf /usr/local/lib/node_modules/openclaw /usr/local/bin/openclaw; \
-        npm install -g --no-audit --no-fund --no-progress "openclaw@${OPENCLAW_VERSION}"; \
+        nemoclaw-npm-retry npm install -g --no-audit --no-fund --no-progress "openclaw@${OPENCLAW_VERSION}"; \
     fi; \
     # Pre-install the codex-acp package so the embedded ACPx runtime can
     # call the local binary instead of `npx @zed-industries/codex-acp`.
@@ -139,7 +142,7 @@ RUN set -eu; \
     # versioned npx package specs even when the package is globally installed.
     # Installing the binary at build time and configuring ACPx to use it
     # directly keeps TC-SBX-02 off the runtime npm path.
-    npm install -g --no-audit --no-fund --no-progress \
+    nemoclaw-npm-retry npm install -g --no-audit --no-fund --no-progress \
         '@zed-industries/codex-acp@0.11.1'; \
     command -v codex-acp >/dev/null
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -795,6 +795,42 @@ spin() {
 
 command_exists() { command -v "$1" &>/dev/null; }
 
+npm_with_retry() {
+  local attempts="${NEMOCLAW_NPM_RETRY_ATTEMPTS:-3}"
+  local delay="${NEMOCLAW_NPM_RETRY_DELAY_SECONDS:-5}"
+  local max_delay="${NEMOCLAW_NPM_RETRY_MAX_DELAY_SECONDS:-30}"
+  local attempt status
+
+  [[ "$attempts" =~ ^[0-9]+$ ]] || attempts=3
+  [[ "$delay" =~ ^[0-9]+$ ]] || delay=5
+  [[ "$max_delay" =~ ^[0-9]+$ ]] || max_delay=30
+  ((attempts < 1)) && attempts=1
+  ((max_delay < 1)) && max_delay=1
+
+  export NPM_CONFIG_FETCH_RETRIES="${NPM_CONFIG_FETCH_RETRIES:-5}"
+  export NPM_CONFIG_FETCH_RETRY_MINTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MINTIMEOUT:-20000}"
+  export NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT:-120000}"
+  export NPM_CONFIG_FETCH_TIMEOUT="${NPM_CONFIG_FETCH_TIMEOUT:-300000}"
+
+  attempt=1
+  while true; do
+    if npm "$@"; then
+      return 0
+    else
+      status=$?
+    fi
+    if ((attempt >= attempts)); then
+      return "$status"
+    fi
+    printf '[npm-retry] command failed with exit %s; retrying in %ss (%s/%s): npm %s\n' \
+      "$status" "$delay" "$attempt" "$attempts" "$*" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+    ((delay > max_delay)) && delay="$max_delay"
+  done
+}
+
 MIN_NODE_VERSION="22.16.0"
 MIN_NPM_MAJOR=10
 
@@ -1394,9 +1430,9 @@ install_nemoclaw() {
       spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$NEMOCLAW_SOURCE_ROOT" \
         || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     fi
-    spin "Installing ${_CLI_DISPLAY} dependencies" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm install --ignore-scripts"
+    spin "Installing ${_CLI_DISPLAY} dependencies" bash -c "$(declare -f npm_with_retry); cd \"\$1\" && npm_with_retry install --ignore-scripts" _ "$NEMOCLAW_SOURCE_ROOT"
     spin "Building ${_CLI_DISPLAY} CLI modules" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm run --if-present build:cli"
-    spin "Building ${_CLI_DISPLAY} plugin" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\"/nemoclaw && npm install --ignore-scripts && npm run build"
+    spin "Building ${_CLI_DISPLAY} plugin" bash -c "$(declare -f npm_with_retry); cd \"\$1\" && npm_with_retry install --ignore-scripts && npm run build" _ "$NEMOCLAW_SOURCE_ROOT/nemoclaw"
     spin "Linking ${_CLI_DISPLAY} CLI" bash -c "cd \"$NEMOCLAW_SOURCE_ROOT\" && npm link"
 
     # Bootstrap OpenShell when the source checkout is being used as a fresh
@@ -1437,9 +1473,9 @@ install_nemoclaw() {
       spin "Preparing OpenClaw package" bash -c "$(declare -f info warn resolve_openclaw_version pre_extract_openclaw); pre_extract_openclaw \"\$1\"" _ "$nemoclaw_src" \
         || warn "Pre-extraction failed — npm install may fail if openclaw tarball is broken"
     fi
-    spin "Installing ${_CLI_DISPLAY} dependencies" bash -c "cd \"$nemoclaw_src\" && npm install --ignore-scripts"
+    spin "Installing ${_CLI_DISPLAY} dependencies" bash -c "$(declare -f npm_with_retry); cd \"\$1\" && npm_with_retry install --ignore-scripts" _ "$nemoclaw_src"
     spin "Building ${_CLI_DISPLAY} CLI modules" bash -c "cd \"$nemoclaw_src\" && npm run --if-present build:cli"
-    spin "Building ${_CLI_DISPLAY} plugin" bash -c "cd \"$nemoclaw_src\"/nemoclaw && npm install --ignore-scripts && npm run build"
+    spin "Building ${_CLI_DISPLAY} plugin" bash -c "$(declare -f npm_with_retry); cd \"\$1\" && npm_with_retry install --ignore-scripts && npm run build" _ "$nemoclaw_src/nemoclaw"
     spin "Linking ${_CLI_DISPLAY} CLI" bash -c "cd \"$nemoclaw_src\" && npm link"
 
     # Install/upgrade the OpenShell CLI on the GitHub-clone path (curl|bash).

--- a/scripts/npm-retry.sh
+++ b/scripts/npm-retry.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+attempts="${NEMOCLAW_NPM_RETRY_ATTEMPTS:-3}"
+delay="${NEMOCLAW_NPM_RETRY_DELAY_SECONDS:-5}"
+max_delay="${NEMOCLAW_NPM_RETRY_MAX_DELAY_SECONDS:-30}"
+
+case "$attempts" in
+  "" | *[!0-9]*) attempts=3 ;;
+esac
+case "$delay" in
+  "" | *[!0-9]*) delay=5 ;;
+esac
+case "$max_delay" in
+  "" | *[!0-9]*) max_delay=30 ;;
+esac
+
+[ "$attempts" -lt 1 ] && attempts=1
+[ "$max_delay" -lt 1 ] && max_delay=1
+
+export NPM_CONFIG_FETCH_RETRIES="${NPM_CONFIG_FETCH_RETRIES:-5}"
+export NPM_CONFIG_FETCH_RETRY_MINTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MINTIMEOUT:-20000}"
+export NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT:-120000}"
+export NPM_CONFIG_FETCH_TIMEOUT="${NPM_CONFIG_FETCH_TIMEOUT:-300000}"
+
+attempt=1
+while :; do
+  if "$@"; then
+    exit 0
+  else
+    status=$?
+  fi
+  if [ "$attempt" -ge "$attempts" ]; then
+    exit "$status"
+  fi
+  printf '[npm-retry] command failed with exit %s; retrying in %ss (%s/%s): %s\n' \
+    "$status" "$delay" "$attempt" "$attempts" "$*" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+  delay=$((delay * 2))
+  [ "$delay" -gt "$max_delay" ] && delay="$max_delay"
+done

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -189,6 +189,7 @@ function runOpenClawUpgradeBlock(currentVersion: string) {
     `OPENCLAW_VERSION=${JSON.stringify(openclawVersion)}`,
     `OPENCLAW_2026_5_22_INTEGRITY=${JSON.stringify(openclawIntegrity)}`,
     `openclaw() { if [ "\${1:-}" = "--version" ]; then printf 'openclaw ${currentVersion}\\n'; else return 127; fi; }`,
+    'nemoclaw-npm-retry() { "$@"; }',
     "npm() {",
     '  printf "npm %s\\n" "$*" >> "$call_log";',
     '  if [ "${1:-}" = "view" ] && [ "${2:-}" = "openclaw@${OPENCLAW_VERSION}" ] && [ "${3:-}" = "dist.integrity" ]; then',

--- a/test/install-npm-resolution.test.ts
+++ b/test/install-npm-resolution.test.ts
@@ -71,6 +71,82 @@ function isLinuxRoot(): boolean {
 }
 
 describe("installer npm resolution", () => {
+  it("retries npm commands after a transient failure", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-npm-retry-"));
+    const fakeBin = path.join(tmp, "bin");
+    const npmLog = path.join(tmp, "npm.log");
+    const npmCount = path.join(tmp, "npm-count");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [ -f "$NPM_COUNT_PATH" ]; then count="$(cat "$NPM_COUNT_PATH")"; fi
+count=$((count + 1))
+printf '%s' "$count" > "$NPM_COUNT_PATH"
+printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
+if [ "$count" -eq 1 ]; then exit 152; fi
+exit 0
+`,
+    );
+    writeExecutable(
+      path.join(fakeBin, "sleep"),
+      `#!/usr/bin/env bash
+printf 'sleep %s\\n' "$*" >> "$NPM_LOG_PATH"
+exit 0
+`,
+    );
+
+    const result = runInstallerFunction("npm_with_retry install --ignore-scripts", fakeBin, {
+      HOME: tmp,
+      NEMOCLAW_NPM_RETRY_ATTEMPTS: "2",
+      NEMOCLAW_NPM_RETRY_DELAY_SECONDS: "0",
+      NPM_COUNT_PATH: npmCount,
+      NPM_LOG_PATH: npmLog,
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.readFileSync(npmLog, "utf-8")).toBe(
+      ["install --ignore-scripts", "sleep 0", "install --ignore-scripts", ""].join("\n"),
+    );
+  });
+
+  it("returns the final npm status when retries are exhausted", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-npm-retry-exhausted-"));
+    const fakeBin = path.join(tmp, "bin");
+    const npmLog = path.join(tmp, "npm.log");
+    fs.mkdirSync(fakeBin);
+
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$NPM_LOG_PATH"
+exit 152
+`,
+    );
+    writeExecutable(
+      path.join(fakeBin, "sleep"),
+      `#!/usr/bin/env bash
+printf 'sleep %s\\n' "$*" >> "$NPM_LOG_PATH"
+exit 0
+`,
+    );
+
+    const result = runInstallerFunction("npm_with_retry install --ignore-scripts", fakeBin, {
+      HOME: tmp,
+      NEMOCLAW_NPM_RETRY_ATTEMPTS: "2",
+      NEMOCLAW_NPM_RETRY_DELAY_SECONDS: "0",
+      NPM_LOG_PATH: npmLog,
+    });
+
+    expect(result.status).toBe(152);
+    expect(fs.readFileSync(npmLog, "utf-8")).toBe(
+      ["install --ignore-scripts", "sleep 0", "install --ignore-scripts", ""].join("\n"),
+    );
+  });
+
   it("prefers the active npm on PATH over a hostile nvm environment", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-path-npm-"));
     const fakeBin = path.join(tmp, "bin");


### PR DESCRIPTION
## Summary
Add npm retry wrappers to the installer and sandbox image build so transient registry resets do not fail E2E setup before the actual scenario starts. The failing run showed `npm error network read ECONNRESET` during shared Install NemoClaw setup and again during sandbox image `npm ci`, not a double-onboard assertion failure.

## Related Issue
None.

## Changes
- Add `scripts/npm-retry.sh`, a small executable retry wrapper that preserves npm fetch timeout/retry defaults and returns the final npm exit status when retries are exhausted.
- Use the retry wrapper for sandbox Dockerfile npm operations: plugin build `npm ci`, runtime `npm ci --omit=dev`, OpenClaw integrity lookup/install, and codex-acp install.
- Add `npm_with_retry` to `scripts/install.sh` and use it for source-checkout/root and plugin dependency installs.
- Add installer retry tests for transient success and exhausted-retry exit status; update the Dockerfile upgrade fixture to account for the wrapper.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification run locally:
- `npx vitest run --project cli test/install-npm-resolution.test.ts test/fetch-guard-patch-regression.test.ts` passes.
- `npx prek run shellcheck --files scripts/install.sh scripts/npm-retry.sh` passes.
- `npx prek run hadolint --files Dockerfile` passes.
- `git diff --check` passes.

Full local hook note: `npx prek run --files ...` / commit hooks reached the full CLI suite and failed on unrelated local macOS issues: `test/install-docker-group-reexec.test.ts` expects `sg`, and one `test/cli.test.ts` dispatch case timed out at 5s. The touched focused tests and shell/Dockerfile checks pass.

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * npm operations during installation and builds now automatically retry on transient failures with exponential backoff timing.
  * Added configurable environment variables to control retry attempts and delay durations.

* **Tests**
  * Added integration tests to verify retry behavior under transient and persistent failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->