### PR TITLE
fix(e2e): accept non-root WhatsApp QR preload owner

### DIFF
--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { loadE2eWorkflowContract, reusableNightlyJobs } from "./helpers/e2e-workflow-contract";
@@ -108,5 +110,17 @@ describe("E2E reusable workflow contract", () => {
     expect(cloudJob.uses).toBe("./.github/workflows/e2e-script.yaml");
     expect(cloudJob.with?.script).toBe("test/e2e/test-full-e2e.sh");
     expect(cloudJob.with?.ref).toBe("${{ inputs.target_ref || github.ref }}");
+  });
+
+  it("gates WhatsApp sandbox-owned preload acceptance on non-root entrypoint evidence", () => {
+    const script = readFileSync(new URL("./e2e/test-messaging-providers.sh", import.meta.url), "utf8");
+
+    expect(script).toContain(
+      "entrypoint_start_log_stat=$(sandbox_exec \"stat -c '%U:%a' /tmp/nemoclaw-start.log",
+    );
+    expect(script).toContain(
+      "[ \"$whatsapp_qr_preload_stat\" = \"sandbox:444\" ] && [ \"$entrypoint_start_log_stat\" = \"sandbox:600\" ]",
+    );
+    expect(script).toContain("entrypoint start log: ${entrypoint_start_log_stat}");
   });
 });

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -921,19 +921,22 @@ fi
 # `{ small: true }` half-block rendering so the in-sandbox pairing QR fits a
 # phone-camera frame, and the openclaw() guard injects it for the single
 # `channels login --channel whatsapp` invocation. Verify both the preload file
-# (root-owned, read-only) and the guard wiring are present in the sandbox.
+# (root-owned/read-only in root mode; read-only in non-root mode) and the guard
+# wiring are present in the sandbox.
 whatsapp_qr_preload_stat=$(sandbox_exec "stat -c '%U:%a' /tmp/nemoclaw-whatsapp-qr-compact.js 2>/dev/null || echo missing")
+entrypoint_start_log_stat=$(sandbox_exec "stat -c '%U:%a' /tmp/nemoclaw-start.log 2>/dev/null || echo missing")
 if [ "$whatsapp_qr_preload_stat" = "root:444" ]; then
   pass "M-WA6b: WhatsApp compact-QR preload installed root:444 (#4522)"
-elif [ "$whatsapp_qr_preload_stat" = "sandbox:444" ]; then
-  # Non-root sandbox mode: emit_sandbox_sourced_file writes the file as the
-  # sandbox user because chown root:root is intentionally skipped when
-  # id -u != 0. The security-relevant invariant is the read-only 444 mode.
+elif [ "$whatsapp_qr_preload_stat" = "sandbox:444" ] && [ "$entrypoint_start_log_stat" = "sandbox:600" ]; then
+  # /tmp/nemoclaw-start.log is written before sandbox-init.sh is sourced:
+  # root mode creates root:600, while non-root mode creates sandbox:600.
+  # Only accept sandbox-owned sourced files when that independent init-time
+  # signal proves privilege separation was already disabled.
   pass "M-WA6b: WhatsApp compact-QR preload installed sandbox:444 (non-root mode) (#4522)"
 elif [ "$whatsapp_qr_preload_stat" = "missing" ]; then
   fail "M-WA6b: WhatsApp compact-QR preload not installed in sandbox (#4522)"
 else
-  fail "M-WA6b: WhatsApp compact-QR preload has unexpected owner/mode: ${whatsapp_qr_preload_stat} (#4522)"
+  fail "M-WA6b: WhatsApp compact-QR preload has unexpected owner/mode: ${whatsapp_qr_preload_stat} (entrypoint start log: ${entrypoint_start_log_stat}) (#4522)"
 fi
 
 # Assert on the actual NODE_OPTIONS injection line, not just the filename: the

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -925,6 +925,11 @@ fi
 whatsapp_qr_preload_stat=$(sandbox_exec "stat -c '%U:%a' /tmp/nemoclaw-whatsapp-qr-compact.js 2>/dev/null || echo missing")
 if [ "$whatsapp_qr_preload_stat" = "root:444" ]; then
   pass "M-WA6b: WhatsApp compact-QR preload installed root:444 (#4522)"
+elif [ "$whatsapp_qr_preload_stat" = "sandbox:444" ]; then
+  # Non-root sandbox mode: emit_sandbox_sourced_file writes the file as the
+  # sandbox user because chown root:root is intentionally skipped when
+  # id -u != 0. The security-relevant invariant is the read-only 444 mode.
+  pass "M-WA6b: WhatsApp compact-QR preload installed sandbox:444 (non-root mode) (#4522)"
 elif [ "$whatsapp_qr_preload_stat" = "missing" ]; then
   fail "M-WA6b: WhatsApp compact-QR preload not installed in sandbox (#4522)"
 else


### PR DESCRIPTION
## Summary
The messaging providers E2E check now accepts the non-root sandbox owner for the WhatsApp compact QR preload while still requiring read-only mode. This matches `emit_sandbox_sourced_file()` behavior when the sandbox setup runs without UID 0 and avoids failing the nightly messaging-providers job on a harmless owner difference.

## Related Issue
Fixes #4636

## Changes
- Accept `/tmp/nemoclaw-whatsapp-qr-compact.js` as `sandbox:444` in non-root sandbox mode.
- Preserve the existing `root:444`, missing-file, and unexpected-mode branches.
- Document why ownership can differ while the security-relevant read-only mode remains `444`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- `bash -n test/e2e/test-messaging-providers.sh` passes.
- `git diff --check` passes.
- `npx vitest run --project cli test/e2e-script-workflow.test.ts` passes.
- `npx prek run --all-files` ran but failed on an unrelated existing timeout: `test/cli.test.ts > CLI dispatch > channels mutation dry-run paths dispatch through oclif`.
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end tests for WhatsApp compact-QR pairing to accept a sandbox-owned preload when accompanied by a sandbox-owned entrypoint log, in addition to the existing root-owned case.
  * Added a contract-style E2E test that validates the pairing verification script contains the expected sandbox-vs-root checks and logging assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->