### PR TITLE
fix(destroy): release macOS gateway after final sandbox

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -561,8 +561,8 @@ If you want to upgrade the sandbox while preserving state, use `nemohermes <name
 
 If another terminal has an active SSH session to the sandbox, `destroy` prints an active-session warning and requires a second confirmation before it proceeds.
 Pass `--yes`, `-y`, or `--force` to skip the prompt in scripted workflows.
-By default, `destroy` preserves the shared NemoClaw gateway.
-Pass `--cleanup-gateway` to remove the shared gateway when destroying the last sandbox, or `--no-cleanup-gateway` to force preservation when environment defaults request cleanup.
+By default, `destroy` preserves the shared NemoClaw gateway on Linux and cleans it up for unattended final-sandbox destroys on macOS so port 8080 is released.
+Pass `--cleanup-gateway` to remove the shared gateway when destroying the last sandbox, or `--no-cleanup-gateway` to force preservation when platform or environment defaults request cleanup.
 
 ```bash
 nemohermes my-assistant destroy [--yes|-y|--force] [--cleanup-gateway|--no-cleanup-gateway]
@@ -1492,7 +1492,7 @@ These flags change defaults for commands that manage existing sandboxes.
 
 | Variable | Format | Effect |
 |----------|--------|--------|
-| `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemohermes <name> destroy` removes the shared gateway when destroying the last sandbox. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
+| `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemohermes <name> destroy` removes the shared gateway when destroying the last sandbox, overriding the platform default. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `nemohermes <name> connect` and `nemohermes <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 | `NEMOCLAW_SHIELDS_ACCEPT_LEGACY_BASELINE` | `1` to opt in | Allows advanced immutable-config verification to trust the current on-disk bytes for older or partial content baselines. Use only after you have rebuilt or manually inspected the sandbox state and accepted that the baseline is operator-approved. |
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -712,8 +712,8 @@ If you want to upgrade the sandbox while preserving state, use `nemoclaw <name> 
 
 If another terminal has an active SSH session to the sandbox, `destroy` prints an active-session warning and requires a second confirmation before it proceeds.
 Pass `--yes`, `-y`, or `--force` to skip the prompt in scripted workflows.
-By default, `destroy` preserves the shared NemoClaw gateway.
-Pass `--cleanup-gateway` to remove the shared gateway when destroying the last sandbox, or `--no-cleanup-gateway` to force preservation when environment defaults request cleanup.
+By default, `destroy` preserves the shared NemoClaw gateway on Linux and cleans it up for unattended final-sandbox destroys on macOS so port 8080 is released.
+Pass `--cleanup-gateway` to remove the shared gateway when destroying the last sandbox, or `--no-cleanup-gateway` to force preservation when platform or environment defaults request cleanup.
 
 ```bash
 nemoclaw my-assistant destroy [--yes|-y|--force] [--cleanup-gateway|--no-cleanup-gateway]
@@ -1720,7 +1720,7 @@ These flags change defaults for commands that manage existing sandboxes.
 
 | Variable | Format | Effect |
 |----------|--------|--------|
-| `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemoclaw <name> destroy` removes the shared gateway when destroying the last sandbox. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
+| `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemoclaw <name> destroy` removes the shared gateway when destroying the last sandbox, overriding the platform default. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `nemoclaw <name> connect` and `nemoclaw <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 | `NEMOCLAW_SHIELDS_ACCEPT_LEGACY_BASELINE` | `1` to opt in | Allows advanced immutable-config verification to trust the current on-disk bytes for older or partial content baselines. Use only after you have rebuilt or manually inspected the sandbox state and accepted that the baseline is operator-approved. |
 

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -13,6 +13,7 @@ import { prompt as askPrompt } from "../../credentials/store";
 import {
   type DestroySandboxOptions,
   normalizeDestroySandboxOptions,
+  shouldCleanupGatewayByDefaultAfterLastSandbox,
 } from "../../domain/lifecycle/options";
 import {
   getSandboxDeleteOutcome,
@@ -144,13 +145,15 @@ function isNonInteractive(): boolean {
 
 /**
  * Decide whether to tear down the shared NemoClaw gateway after destroying
- * the last sandbox. Default is to preserve it (#2166); explicit opt-in via
- * `cleanupGateway: true` (which `normalizeDestroySandboxOptions` also reads
- * from `--cleanup-gateway` / `NEMOCLAW_CLEANUP_GATEWAY`).
+ * the last sandbox. Default preserves it on Linux (#2166) but cleans it up for
+ * unattended macOS destroys so port 8080 is released (#4662). Explicit
+ * `cleanupGateway` options always win (including `--cleanup-gateway`,
+ * `--no-cleanup-gateway`, and `NEMOCLAW_CLEANUP_GATEWAY`).
  *
  * Prompt rules:
  *   - explicit `cleanupGateway` set         → honour it without prompting
- *   - non-interactive or `--yes` / `--force` → preserve gateway (safe default)
+ *   - macOS + non-interactive or `--yes` / `--force` → destroy gateway
+ *   - other non-interactive or `--yes` / `--force` → preserve gateway
  *   - interactive without `--yes`           → prompt the user
  */
 async function resolveCleanupGatewayDecision(
@@ -158,6 +161,16 @@ async function resolveCleanupGatewayDecision(
 ): Promise<boolean> {
   if (options.cleanupGateway === true) return true;
   if (options.cleanupGateway === false) return false;
+  if (
+    shouldCleanupGatewayByDefaultAfterLastSandbox({
+      platform: process.platform,
+      yes: options.yes,
+      force: options.force,
+      nonInteractive: isNonInteractive(),
+    })
+  ) {
+    return true;
+  }
   if (options.yes === true || options.force === true) return false;
   if (isNonInteractive()) return false;
   console.log(`  ${YW}This was the last sandbox.${R}`);

--- a/src/lib/domain/lifecycle/options.test.ts
+++ b/src/lib/domain/lifecycle/options.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeGarbageCollectImagesOptions,
   normalizeRebuildSandboxOptions,
   normalizeUpgradeSandboxesOptions,
+  shouldCleanupGatewayByDefaultAfterLastSandbox,
 } from "./options";
 
 describe("lifecycle option normalization", () => {
@@ -114,6 +115,25 @@ describe("lifecycle option normalization", () => {
         process.env[ENV_KEY] = noise;
         expect(normalizeDestroySandboxOptions({}).cleanupGateway).toBeUndefined();
       }
+    });
+
+    it("defaults final-sandbox gateway cleanup on macOS but preserves the #2166 Linux default", () => {
+      expect(
+        shouldCleanupGatewayByDefaultAfterLastSandbox({
+          platform: "darwin",
+          yes: true,
+          force: false,
+          nonInteractive: true,
+        }),
+      ).toBe(true);
+      expect(
+        shouldCleanupGatewayByDefaultAfterLastSandbox({
+          platform: "linux",
+          yes: true,
+          force: false,
+          nonInteractive: true,
+        }),
+      ).toBe(false);
     });
   });
 

--- a/src/lib/domain/lifecycle/options.ts
+++ b/src/lib/domain/lifecycle/options.ts
@@ -7,8 +7,10 @@ export interface DestroySandboxOptions {
   /**
    * When the sandbox being destroyed is the last one, also tear down the
    * shared NemoClaw gateway (port forward, gateway pod, cluster volumes).
-   * Default `false` — gateway is preserved so the next `nemoclaw onboard`
-   * can reuse it without a full re-bootstrap. See #2166.
+   * Default is platform-aware: preserve on Linux so the next
+   * `nemoclaw onboard` can reuse the gateway without a full re-bootstrap
+   * (#2166), but clean up unattended final-sandbox destroys on macOS so
+   * port 8080 is released for automation (#4662).
    *
    * Resolution order during normalization: explicit option, then
    * `--cleanup-gateway` argv flag, then `NEMOCLAW_CLEANUP_GATEWAY=1` env
@@ -64,6 +66,18 @@ export function normalizeDestroySandboxOptions(
       ? { cleanupGateway: envCleanupGateway }
       : {}),
   };
+}
+
+export function shouldCleanupGatewayByDefaultAfterLastSandbox(input: {
+  platform: NodeJS.Platform;
+  yes?: boolean;
+  force?: boolean;
+  nonInteractive?: boolean;
+}): boolean {
+  return (
+    input.platform === "darwin" &&
+    (input.yes === true || input.force === true || input.nonInteractive === true)
+  );
 }
 
 export function normalizeRebuildSandboxOptions(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3858,7 +3858,7 @@ describe("CLI dispatch", () => {
     expect(log).not.toContain("sandbox exec alpha sh -c");
   });
 
-  it("preserves the gateway runtime by default when the last sandbox is destroyed (#2166)", () => {
+  it("uses the platform default when the last sandbox is destroyed (#2166, #4662)", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-destroy-last-"));
     const localBin = path.join(home, "bin");
     const registryDir = path.join(home, ".nemoclaw");
@@ -3906,6 +3906,8 @@ describe("CLI dispatch", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
+    fs.writeFileSync(path.join(localBin, "pgrep"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    fs.writeFileSync(path.join(localBin, "lsof"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
 
     const r = runWithEnv("alpha destroy -y", {
       HOME: home,
@@ -3916,13 +3918,18 @@ describe("CLI dispatch", () => {
     const openshellOutput = fs.readFileSync(openshellLog, "utf8");
     expect(openshellOutput).toContain("sandbox delete alpha");
     expect(openshellOutput).toContain("NAME STATUS");
-    // Gateway preservation is now the default. `--yes` confirms only the
-    // sandbox; the shared NemoClaw gateway must stay up so the next
-    // `nemoclaw onboard` reuses it.
-    expect(openshellOutput).not.toContain("forward stop 18789");
-    expect(openshellOutput).not.toContain("gateway destroy -g nemoclaw");
-    expect(openshellOutput).not.toContain("gateway remove nemoclaw");
-    expect(fs.readFileSync(bashLog, "utf8")).not.toContain("volume ls -q --filter");
+    if (process.platform === "darwin") {
+      expect(openshellOutput).toContain("forward stop 18789");
+      expect(openshellOutput).toContain("gateway destroy -g nemoclaw");
+      expect(fs.readFileSync(bashLog, "utf8")).toContain("volume ls -q --filter");
+    } else {
+      // Keep the #2166 default on Linux/Jetson: `--yes` confirms only the
+      // sandbox; the shared gateway stays up so the next onboard can reuse it.
+      expect(openshellOutput).not.toContain("forward stop 18789");
+      expect(openshellOutput).not.toContain("gateway destroy -g nemoclaw");
+      expect(openshellOutput).not.toContain("gateway remove nemoclaw");
+      expect(fs.readFileSync(bashLog, "utf8")).not.toContain("volume ls -q --filter");
+    }
   });
 
   it("tears down the gateway runtime when --cleanup-gateway is passed (#2166)", testTimeoutOptions(30_000), () => {


### PR DESCRIPTION
## Summary
Fixes macOS final-sandbox cleanup so unattended `destroy` releases the shared OpenShell gateway and port 8080. Keeps the #2166 Linux/Jetson default that preserves the gateway unless cleanup is explicitly requested.

## Related Issue
Fixes #4662

## Changes
- Add a platform-aware final-sandbox gateway cleanup default: macOS unattended destroy cleans up, Linux preserves by default.
- Keep explicit `--cleanup-gateway`, `--no-cleanup-gateway`, and `NEMOCLAW_CLEANUP_GATEWAY` precedence unchanged.
- Update CLI/unit coverage and command reference docs for `nemoclaw` and `nemohermes`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused checks run:
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4662-npm-cache npm run build:cli`
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4662-npm-cache npx vitest run src/lib/domain/lifecycle/options.test.ts --project cli`
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4662-npm-cache npx vitest run test/cli.test.ts --project cli -t "last sandbox is destroyed|cleanup-gateway|NEMOCLAW_CLEANUP_GATEWAY"`
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4662-npm-cache npm run typecheck:cli`
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-4662-npm-cache npm run docs:check-agent-variants`
- `git diff --check`

---
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified platform-specific default behavior for the `destroy` command's shared gateway cleanup: Linux preserves it by default; macOS cleans it up to release port 8080
  * Documented `--cleanup-gateway` and `--no-cleanup-gateway` flags for explicit control over gateway cleanup
  * Updated environment variable documentation for gateway cleanup behavior overrides

* **Tests**
  * Updated tests to verify platform-specific destroy behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->