### PR TITLE
fix(security): bind HTTPS endpoint validation to connection IP

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -768,11 +768,14 @@ jobs:
         # classification/cleanup without spending live provider quota; real
         # NVIDIA credential isolation and third-party provider smokes stay
         # skipped unless their secrets are explicitly supplied by a future
-        # workflow.
+        # workflow. The HTTPS pin-proxy regression guard (#4684) stays here
+        # because it covers the same custom endpoint/provider-config boundary
+        # without requiring a real provider or Docker sandbox.
         run: |
           set -euo pipefail
           npx vitest run --project e2e-live \
             test/e2e/live/inference-routing.test.ts \
+            test/e2e/live/https-pin-proxy.test.ts \
             --silent=false --reporter=default
 
       - name: Upload inference routing artifacts

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1029,7 +1029,11 @@ For advanced live edits, use the host-side config command instead of running `op
 $$nemoclaw <sandbox> config set --key <dotpath> --value '<json-or-string>' --restart
 ```
 
-Host-side `config set` validates any HTTP or HTTPS URLs in the new value, including URLs nested inside JSON objects or arrays. NemoClaw rejects loopback, private, reserved, and internal hosts; DNS names must resolve successfully and must not resolve to private/internal addresses. HTTP URLs are written with the validated IP address pinned to reduce DNS-rebinding risk. Avoid putting credentials in config values; rotate provider credentials with the credential-management commands instead.
+Host-side `config set` validates any HTTP or HTTPS URLs in the new value, including URLs nested inside JSON objects or arrays.
+NemoClaw rejects loopback, private, reserved, and internal hosts; DNS names must resolve successfully and must not resolve to private/internal addresses.
+HTTP URLs are written with the validated IP address pinned to reduce DNS-rebinding risk.
+Generic config persistence rejects DNS-backed HTTPS URLs because it cannot attach connection-IP pinning while preserving TLS SNI and the Host header; use an IP literal or a local proxy that pins DNS safely.
+Avoid putting credentials in config values; rotate provider credentials with the credential-management commands instead.
 
 ### `openclaw doctor --fix` cannot repair Discord channel config inside the sandbox
 

--- a/nemoclaw/src/blueprint/https-pin-proxy.integration.test.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.integration.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TLSSocket } from "node:tls";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+// The proxy module computes its state directory from os.homedir() at import
+// time, so point HOME at a throwaway temp dir before importing it.
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "nemoclaw-pin-integ-home-"));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => FAKE_HOME };
+});
+
+// This test drives a real TLS connection to a loopback fixture, so the
+// private-range guard is relaxed. The SSRF private-IP rejection itself is
+// covered by the unit tests in https-pin-proxy.test.ts.
+vi.mock("./private-networks.js", () => ({
+  isPrivateIp: () => false,
+  isPrivateHostname: () => false,
+}));
+
+const proxy = await import("./https-pin-proxy.js");
+
+const STATE_DIR = join(FAKE_HOME, ".nemoclaw", "state", "https-pin-proxy");
+const ROUTES_PATH = join(STATE_DIR, "routes.json");
+const ROUTE_PREFIX = "/.nemoclaw/https-pin/";
+// A non-resolvable .test hostname: connecting via DNS instead of the pinned IP
+// would fail with ENOTFOUND, so a successful request proves IP pinning.
+const UPSTREAM_HOSTNAME = "api.pin.test";
+
+// Generate a throwaway self-signed cert at module load (before it.skipIf is
+// evaluated). The key never leaves this temp dir and is removed in afterAll.
+const certDir = mkdtempSync(join(tmpdir(), "nemoclaw-pin-integ-cert-"));
+let opensslAvailable = false;
+let key = "";
+let cert = "";
+try {
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      join(certDir, "key.pem"),
+      "-out",
+      join(certDir, "cert.pem"),
+      "-days",
+      "3650",
+      "-subj",
+      `/CN=${UPSTREAM_HOSTNAME}`,
+      "-addext",
+      `subjectAltName=DNS:${UPSTREAM_HOSTNAME}`,
+    ],
+    { stdio: "ignore" },
+  );
+  key = readFileSync(join(certDir, "key.pem"), "utf8");
+  cert = readFileSync(join(certDir, "cert.pem"), "utf8");
+  opensslAvailable = true;
+} catch {
+  opensslAvailable = false;
+}
+
+afterAll(() => {
+  rmSync(certDir, { recursive: true, force: true });
+  rmSync(FAKE_HOME, { recursive: true, force: true });
+});
+
+interface Observed {
+  servername?: string;
+  host?: string;
+  remoteAddress?: string;
+  path?: string;
+}
+
+function listen(server: http.Server | https.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
+function closeServer(server: http.Server | https.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function getThroughProxy(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path, method: "GET" }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("https pin proxy (real TLS integration)", () => {
+  it.skipIf(!opensslAvailable)(
+    "connects to the validated IP while preserving original SNI and Host with real TLS",
+    async () => {
+      const observed: Observed = {};
+      const upstream = https.createServer({ key, cert }, (req, res) => {
+        const socket = req.socket as TLSSocket;
+        observed.servername = typeof socket.servername === "string" ? socket.servername : undefined;
+        observed.host = req.headers.host;
+        observed.remoteAddress = socket.remoteAddress ?? undefined;
+        observed.path = req.url;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end('{"ok":true}');
+      });
+      const upstreamPort = await listen(upstream);
+
+      // The proxy uses the default https agent, so configure the agent CA to
+      // trust the fixture cert, then restore it afterward.
+      const previousCa = https.globalAgent.options.ca;
+      https.globalAgent.options.ca = cert;
+
+      const route = {
+        id: "a1b2c3d4e5f6a1b2c3d4e5f6",
+        hostname: UPSTREAM_HOSTNAME,
+        port: upstreamPort,
+        basePath: "/v1",
+        baseSearch: "",
+        resolvedAddress: "127.0.0.1",
+        resolvedFamily: 4,
+        updatedAt: new Date().toISOString(),
+      };
+      mkdirSync(STATE_DIR, { recursive: true });
+      writeFileSync(ROUTES_PATH, JSON.stringify({ [route.id]: route }));
+
+      const proxyServer = proxy.createHttpsPinProxyServer();
+      const proxyPort = await listen(proxyServer);
+
+      try {
+        const res = await getThroughProxy(proxyPort, `${ROUTE_PREFIX}${route.id}/v1/models`);
+
+        // The request to a non-resolvable hostname succeeded, so the proxy
+        // connected to the pinned IP rather than re-resolving DNS.
+        expect(res.status).toBe(200);
+        expect(res.body).toBe('{"ok":true}');
+        expect(observed.remoteAddress).toMatch(/127\.0\.0\.1$/);
+        // Original hostname was preserved as TLS SNI and in the HTTP Host header
+        // (the non-default upstream port is appended to Host, never the IP).
+        expect(observed.servername).toBe(UPSTREAM_HOSTNAME);
+        expect(observed.host).toBe(`${UPSTREAM_HOSTNAME}:${upstreamPort}`);
+        expect(observed.path).toBe("/v1/models");
+      } finally {
+        https.globalAgent.options.ca = previousCa;
+        await closeServer(proxyServer);
+        await closeServer(upstream);
+      }
+    },
+  );
+});

--- a/nemoclaw/src/blueprint/https-pin-proxy.test.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.test.ts
@@ -52,13 +52,7 @@ vi.mock("node:https", async (importOriginal) => {
       return req;
     };
     setImmediate(() => {
-      if (upstreamState.behavior === "error") {
-        req.emit("error", new Error("ECONNREFUSED"));
-      } else if (upstreamState.behavior === "timeout") {
-        req._onTimeout?.();
-      } else if (upstreamState.behavior === "hang") {
-        // Intentionally never responds.
-      } else {
+      const emitSuccess = () => {
         const res = new PassThrough() as PassThrough & {
           statusCode?: number;
           headers?: Record<string, string>;
@@ -71,7 +65,17 @@ vi.mock("node:https", async (importOriginal) => {
         };
         cb?.(res);
         res.end('{"ok":true}');
-      }
+      };
+      // Dispatch table keeps the mock branch-free so the test stays linear.
+      const behaviors: Record<typeof upstreamState.behavior, () => void> = {
+        error: () => req.emit("error", new Error("ECONNREFUSED")),
+        timeout: () => req._onTimeout?.(),
+        hang: () => {
+          // Intentionally never responds.
+        },
+        success: emitSuccess,
+      };
+      behaviors[upstreamState.behavior]();
     });
     return req;
   };

--- a/nemoclaw/src/blueprint/https-pin-proxy.test.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.test.ts
@@ -1,0 +1,497 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { PeerCertificate } from "node:tls";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HttpsPinProxyRoute } from "./https-pin-proxy.js";
+import type { ValidatedEndpoint } from "./ssrf.js";
+
+// The proxy module computes its state directory from os.homedir() at import
+// time, so point HOME at a throwaway temp dir before importing it.
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "nemoclaw-pin-proxy-test-"));
+const PROXY_PORT = 21437;
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => FAKE_HOME };
+});
+
+// Controllable stub for the upstream HTTPS leg so the proxy's request
+// forwarding can be exercised without a real TLS server.
+const upstreamState = vi.hoisted(() => ({
+  behavior: "success" as "success" | "error" | "timeout" | "hang",
+  lastOptions: undefined as unknown,
+}));
+
+vi.mock("node:https", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:https")>();
+  const { PassThrough } = await import("node:stream");
+  const request = (options: unknown, cb?: (res: unknown) => void): unknown => {
+    upstreamState.lastOptions = options;
+    const req = new PassThrough() as PassThrough & {
+      setTimeout?: (ms: number, onTimeout: () => void) => unknown;
+      _onTimeout?: () => void;
+    };
+    req.setTimeout = (_ms: number, onTimeout: () => void) => {
+      req._onTimeout = onTimeout;
+      return req;
+    };
+    setImmediate(() => {
+      if (upstreamState.behavior === "error") {
+        req.emit("error", new Error("ECONNREFUSED"));
+      } else if (upstreamState.behavior === "timeout") {
+        req._onTimeout?.();
+      } else if (upstreamState.behavior === "hang") {
+        // Intentionally never responds.
+      } else {
+        const res = new PassThrough() as PassThrough & {
+          statusCode?: number;
+          headers?: Record<string, string>;
+        };
+        res.statusCode = 200;
+        res.headers = {
+          "content-type": "application/json",
+          connection: "keep-alive",
+          "transfer-encoding": "chunked",
+        };
+        cb?.(res);
+        res.end('{"ok":true}');
+      }
+    });
+    return req;
+  };
+  const actualDefault = (actual as { default?: Record<string, unknown> }).default ?? {};
+  return { ...actual, default: { ...actualDefault, request }, request };
+});
+
+// Avoid launching a real detached proxy process.
+const spawnMock = vi.hoisted(() => vi.fn(() => ({ unref: () => {}, pid: 12345 })));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+process.env.NEMOCLAW_HTTPS_PIN_PROXY_PORT = String(PROXY_PORT);
+const proxy = await import("./https-pin-proxy.js");
+// The module captured the port at import time; clear the env so it cannot leak
+// into other test files that assert on the default port.
+delete process.env.NEMOCLAW_HTTPS_PIN_PROXY_PORT;
+
+const STATE_DIR = join(FAKE_HOME, ".nemoclaw", "state", "https-pin-proxy");
+const ROUTES_PATH = join(STATE_DIR, "routes.json");
+const TOKEN_PATH = join(STATE_DIR, "proxy-token");
+const ROUTE_PREFIX = "/.nemoclaw/https-pin/";
+const HEALTH_PATH = "/.nemoclaw/https-pin/health";
+const HEALTH_TOKEN_HEADER = "x-nemoclaw-https-pin-proxy-token";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const openServers: http.Server[] = [];
+
+function track(server: http.Server): http.Server {
+  openServers.push(server);
+  return server;
+}
+
+async function closeAll(): Promise<void> {
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+}
+
+async function startServer(): Promise<{ server: http.Server; port: number }> {
+  const server = track(proxy.createHttpsPinProxyServer());
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  return { server, port: (server.address() as AddressInfo).port };
+}
+
+interface ClientResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+function request(
+  port: number,
+  path: string,
+  options: { method?: string; headers?: Record<string, string> } = {},
+): Promise<ClientResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, path, method: options.method ?? "GET", headers: options.headers },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, body });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function writeToken(token = "a".repeat(64)): string {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(TOKEN_PATH, `${token}\n`);
+  return token;
+}
+
+function writeRoute(route: HttpsPinProxyRoute): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(
+    ROUTES_PATH,
+    JSON.stringify({ [route.id]: { ...route, updatedAt: new Date().toISOString() } }),
+  );
+}
+
+const dnsRoute: HttpsPinProxyRoute = {
+  id: "abcdef0123456789abcdef01",
+  hostname: "api.example.com",
+  port: 443,
+  basePath: "/v1",
+  baseSearch: "",
+  resolvedAddress: "93.184.216.34",
+  resolvedFamily: 4,
+};
+
+function validatedEndpoint(overrides: Partial<ValidatedEndpoint>): ValidatedEndpoint {
+  return {
+    url: "https://api.example.com/v1",
+    pinnedUrl: "https://93.184.216.34/v1",
+    protocol: "https:",
+    hostname: "api.example.com",
+    resolvedAddress: "93.184.216.34",
+    resolvedFamily: 4,
+    dnsResolved: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  rmSync(STATE_DIR, { recursive: true, force: true });
+  upstreamState.behavior = "success";
+  upstreamState.lastOptions = undefined;
+  spawnMock.mockClear();
+});
+
+afterEach(async () => {
+  await closeAll();
+});
+
+// ── Endpoint mapping & request options ──────────────────────────
+
+describe("endpointForValidatedEndpoint", () => {
+  it("returns pinned HTTP endpoints without a proxy route", () => {
+    const result = proxy.endpointForValidatedEndpoint(
+      validatedEndpoint({
+        url: "http://api.example.com/v1",
+        pinnedUrl: "http://93.184.216.34/v1",
+        protocol: "http:",
+      }),
+    );
+    expect(result).toEqual({ endpoint: "http://93.184.216.34/v1" });
+  });
+
+  it("returns IP-literal HTTPS endpoints without a proxy route", () => {
+    const result = proxy.endpointForValidatedEndpoint(
+      validatedEndpoint({
+        url: "https://93.184.216.34/v1",
+        pinnedUrl: "https://93.184.216.34/v1",
+        hostname: "93.184.216.34",
+        resolvedAddress: undefined,
+        resolvedFamily: undefined,
+        dnsResolved: false,
+      }),
+    );
+    expect(result).toEqual({ endpoint: "https://93.184.216.34/v1" });
+  });
+
+  it("routes DNS-backed HTTPS endpoints through a local pinned proxy", () => {
+    const result = proxy.endpointForValidatedEndpoint(
+      validatedEndpoint({
+        url: "https://api.example.com:9443/v1?api-version=1",
+        pinnedUrl: "https://93.184.216.34:9443/v1?api-version=1",
+      }),
+    );
+    expect(result.endpoint).toMatch(
+      new RegExp(`^http://127\\.0\\.0\\.1:${PROXY_PORT}/\\.nemoclaw/https-pin/[a-f0-9]{24}/v1$`),
+    );
+    expect(result.httpsPinRoute).toMatchObject({
+      hostname: "api.example.com",
+      port: 9443,
+      basePath: "/v1",
+      baseSearch: "?api-version=1",
+      resolvedAddress: "93.184.216.34",
+      resolvedFamily: 4,
+    });
+  });
+
+  it("throws when a DNS-backed HTTPS endpoint lacks a resolved address", () => {
+    expect(() =>
+      proxy.endpointForValidatedEndpoint(
+        validatedEndpoint({ resolvedAddress: undefined, resolvedFamily: undefined }),
+      ),
+    ).toThrow(/DNS-backed HTTPS endpoint/);
+  });
+});
+
+describe("buildPinnedHttpsRequestOptions", () => {
+  it("connects to the validated IP while preserving Host and TLS SNI identity", () => {
+    const options = proxy.buildPinnedHttpsRequestOptions({
+      route: { ...dnsRoute, port: 443 },
+      method: "POST",
+      path: "/v1/chat/completions",
+      headers: { authorization: "Bearer token", connection: "close", host: "127.0.0.1:21437" },
+    });
+    expect(options.hostname).toBe("93.184.216.34");
+    expect(options.host).toBe("93.184.216.34");
+    expect(options.servername).toBe("api.example.com");
+    expect(options.family).toBe(4);
+    expect(options.method).toBe("POST");
+    expect(options.path).toBe("/v1/chat/completions");
+    expect(options.headers).toMatchObject({
+      authorization: "Bearer token",
+      host: "api.example.com",
+    });
+    expect(options.headers).not.toHaveProperty("connection");
+  });
+});
+
+describe("sanitizeResponseHeaders", () => {
+  it("strips hop-by-hop response headers before forwarding upstream responses", () => {
+    expect(
+      proxy.sanitizeResponseHeaders({
+        connection: "keep-alive",
+        "content-type": "application/json",
+        "keep-alive": "timeout=5",
+        "transfer-encoding": "chunked",
+        upgrade: "websocket",
+      }),
+    ).toEqual({ "content-type": "application/json" });
+  });
+});
+
+// ── Proxy server request handling ───────────────────────────────
+
+describe("proxy server", () => {
+  it("answers the health check only with the correct token", async () => {
+    const token = writeToken();
+    const { port } = await startServer();
+
+    const ok = await request(port, HEALTH_PATH, { headers: { [HEALTH_TOKEN_HEADER]: token } });
+    expect(ok.status).toBe(200);
+    expect(ok.body).toBe(`ok:${createHash("sha256").update(token).digest("hex")}\n`);
+
+    const wrong = await request(port, HEALTH_PATH, { headers: { [HEALTH_TOKEN_HEADER]: "nope" } });
+    expect(wrong.status).toBe(404);
+  });
+
+  it("returns 404 for the health check when no token has been provisioned", async () => {
+    const { port } = await startServer();
+    const res = await request(port, HEALTH_PATH, {
+      headers: { [HEALTH_TOKEN_HEADER]: "x".repeat(64) },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for paths outside the route prefix", async () => {
+    const { port } = await startServer();
+    const res = await request(port, "/not-a-route");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when no route id is present", async () => {
+    const { port } = await startServer();
+    const res = await request(port, ROUTE_PREFIX);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an unregistered route id", async () => {
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}deadbeefdeadbeefdeadbeef/v1`);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects routes that resolve to a private address", async () => {
+    writeRoute({ ...dnsRoute, resolvedAddress: "10.0.0.5" });
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1/models`);
+    expect(res.status).toBe(502);
+    expect(res.body).toMatch(/private\/internal/);
+  });
+
+  it("forwards to the validated IP and strips hop-by-hop response headers", async () => {
+    writeRoute(dnsRoute);
+    const { port } = await startServer();
+
+    const res = await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1/chat/completions`, {
+      method: "POST",
+      headers: { authorization: "Bearer secret" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('{"ok":true}');
+    expect(res.headers["content-type"]).toBe("application/json");
+
+    const options = upstreamState.lastOptions as {
+      hostname: string;
+      servername: string;
+      path: string;
+      headers: Record<string, string>;
+    };
+    expect(options.hostname).toBe("93.184.216.34");
+    expect(options.servername).toBe("api.example.com");
+    expect(options.path).toBe("/v1/chat/completions");
+    expect(options.headers.host).toBe("api.example.com");
+  });
+
+  it("returns 502 when the upstream request errors", async () => {
+    upstreamState.behavior = "error";
+    writeRoute(dnsRoute);
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1`);
+    expect(res.status).toBe(502);
+    expect(res.body).toMatch(/upstream request failed/);
+  });
+
+  it("aborts the upstream request when it times out", async () => {
+    upstreamState.behavior = "timeout";
+    writeRoute(dnsRoute);
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1`);
+    expect(res.status).toBe(502);
+    expect(res.body).toMatch(/timed out/);
+  });
+});
+
+// ── Route registration & proxy lifecycle ────────────────────────
+
+describe("ensureHttpsPinProxyRoutes", () => {
+  it("is a no-op when there are no routes", async () => {
+    await proxy.ensureHttpsPinProxyRoutes([]);
+    expect(existsSync(ROUTES_PATH)).toBe(false);
+  });
+
+  it("registers routes when the proxy is already healthy", async () => {
+    const server = track(await proxy.serveHttpsPinProxy(PROXY_PORT));
+    expect(server.listening).toBe(true);
+
+    await proxy.ensureHttpsPinProxyRoutes([dnsRoute]);
+
+    const persisted = JSON.parse(readFileSync(ROUTES_PATH, "utf8")) as Record<
+      string,
+      HttpsPinProxyRoute
+    >;
+    expect(persisted[dnsRoute.id]).toMatchObject({
+      hostname: "api.example.com",
+      resolvedAddress: "93.184.216.34",
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("spawns a proxy and fails closed when it never becomes ready", async () => {
+    await expect(proxy.ensureHttpsPinProxyRoutes([dnsRoute])).rejects.toThrow(
+      /did not become ready/,
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Additional edge-path coverage ───────────────────────────────
+
+describe("proxy edge paths", () => {
+  it("defaults the upstream port to 443 for portless DNS endpoints", () => {
+    const result = proxy.endpointForValidatedEndpoint(validatedEndpoint({}));
+    expect(result.httpsPinRoute?.port).toBe(443);
+  });
+
+  it("includes the port in the Host header for non-default upstream ports", () => {
+    const options = proxy.buildPinnedHttpsRequestOptions({
+      route: { ...dnsRoute, port: 9443 },
+      path: "/v1",
+    });
+    expect(options.headers?.host).toBe("api.example.com:9443");
+  });
+
+  it("verifies the upstream certificate against the original hostname", () => {
+    const options = proxy.buildPinnedHttpsRequestOptions({ route: dnsRoute, path: "/v1" });
+    const result = options.checkServerIdentity?.("93.184.216.34", {
+      subject: { CN: "evil.example" },
+      subjectaltname: "DNS:evil.example",
+    } as unknown as PeerCertificate);
+    expect(result).toBeInstanceOf(Error);
+  });
+
+  it("merges the route base query with the incoming request query", async () => {
+    writeRoute({ ...dnsRoute, baseSearch: "?api-version=2" });
+    const { port } = await startServer();
+    await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1/models?model=x`);
+    const options = upstreamState.lastOptions as { path: string };
+    expect(options.path).toBe("/v1/models?api-version=2&model=x");
+  });
+
+  it("uses the route base query when the request has none", async () => {
+    writeRoute({ ...dnsRoute, baseSearch: "?api-version=2" });
+    const { port } = await startServer();
+    await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1/models`);
+    const options = upstreamState.lastOptions as { path: string };
+    expect(options.path).toBe("/v1/models?api-version=2");
+  });
+
+  it("tears down the upstream when the client aborts", async () => {
+    upstreamState.behavior = "hang";
+    writeRoute(dnsRoute);
+    const { port } = await startServer();
+    await new Promise<void>((resolve) => {
+      const req = http.request({
+        host: "127.0.0.1",
+        port,
+        path: `${ROUTE_PREFIX}${dnsRoute.id}/v1`,
+      });
+      req.on("error", () => resolve());
+      req.end();
+      setTimeout(() => req.destroy(), 50);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(upstreamState.lastOptions).toBeDefined();
+  });
+
+  it("recovers from a stale routes lock during registration", async () => {
+    track(await proxy.serveHttpsPinProxy(PROXY_PORT));
+    mkdirSync(STATE_DIR, { recursive: true });
+    const lockPath = join(STATE_DIR, "routes.lock");
+    writeFileSync(lockPath, "99999\n");
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, stale, stale);
+
+    await proxy.ensureHttpsPinProxyRoutes([dnsRoute]);
+
+    const persisted = JSON.parse(readFileSync(ROUTES_PATH, "utf8")) as Record<string, unknown>;
+    expect(persisted[dnsRoute.id]).toBeDefined();
+  });
+});

--- a/nemoclaw/src/blueprint/https-pin-proxy.test.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.test.ts
@@ -169,6 +169,13 @@ function writeRoute(route: HttpsPinProxyRoute): void {
   );
 }
 
+// Persist arbitrary (possibly malformed) route state to exercise the strict
+// validation in loadRoute/isPersistedRoute.
+function writeRawRoutes(routes: Record<string, unknown>): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(ROUTES_PATH, JSON.stringify(routes));
+}
+
 const dnsRoute: HttpsPinProxyRoute = {
   id: "abcdef0123456789abcdef01",
   hostname: "api.example.com",
@@ -389,6 +396,49 @@ describe("proxy server", () => {
   });
 });
 
+describe("persisted route validation", () => {
+  const base: Record<string, unknown> = {
+    ...dnsRoute,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  const tamperedCases: Array<[string, Record<string, unknown>]> = [
+    ["a non-IP resolvedAddress", { ...base, resolvedAddress: "api.example.com" }],
+    ["a zero port", { ...base, port: 0 }],
+    ["an out-of-range port", { ...base, port: 70000 }],
+    ["a non-integer port", { ...base, port: 443.5 }],
+    ["an invalid resolvedFamily", { ...base, resolvedFamily: 7 }],
+    ["a basePath without a leading slash", { ...base, basePath: "v1" }],
+    ["a baseSearch without a leading question mark", { ...base, baseSearch: "api-version=2" }],
+    ["a route id that does not match the lookup key", { ...base, id: "ffffffffffffffffffffffff" }],
+  ];
+
+  it.each(tamperedCases)("returns 404 without calling upstream for %s", async (_label, route) => {
+    writeRawRoutes({ [dnsRoute.id]: route });
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1/models`);
+    expect(res.status).toBe(404);
+    expect(upstreamState.lastOptions).toBeUndefined();
+  });
+
+  it("returns 404 without calling upstream for a malformed route id key", async () => {
+    writeRawRoutes({ "not-hex": { ...base, id: "not-hex" } });
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}not-hex/v1`);
+    expect(res.status).toBe(404);
+    expect(upstreamState.lastOptions).toBeUndefined();
+  });
+
+  it("fails closed when routes.json is corrupt", async () => {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(ROUTES_PATH, "{ this is not valid json");
+    const { port } = await startServer();
+    const res = await request(port, `${ROUTE_PREFIX}${dnsRoute.id}/v1`);
+    expect(res.status).toBe(404);
+    expect(upstreamState.lastOptions).toBeUndefined();
+  });
+});
+
 // ── Route registration & proxy lifecycle ────────────────────────
 
 describe("ensureHttpsPinProxyRoutes", () => {
@@ -419,6 +469,40 @@ describe("ensureHttpsPinProxyRoutes", () => {
       /did not become ready/,
     );
     expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("spawns the detached proxy with an allowlisted env that excludes parent secrets", async () => {
+    const secrets = {
+      GITHUB_TOKEN: "ghp_must_not_leak",
+      AWS_ACCESS_KEY_ID: "AKIA_MUST_NOT_LEAK",
+      NVIDIA_API_KEY: "nvapi-must-not-leak",
+      OPENAI_API_KEY: "sk-must-not-leak",
+    };
+    Object.assign(process.env, secrets);
+    try {
+      await expect(proxy.ensureHttpsPinProxyRoutes([dnsRoute])).rejects.toThrow(
+        /did not become ready/,
+      );
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      const [, , options] = spawnMock.mock.calls[0] as unknown as [
+        string,
+        string[],
+        { env: Record<string, string> },
+      ];
+      const spawnEnv = options.env;
+      // Parent-process secrets must not reach the detached proxy.
+      for (const key of Object.keys(secrets)) {
+        expect(spawnEnv).not.toHaveProperty(key);
+      }
+      // The proxy still receives the values it legitimately needs.
+      expect(spawnEnv.NEMOCLAW_HTTPS_PIN_PROXY_PORT).toBe(String(PROXY_PORT));
+      expect(spawnEnv.PATH).toBeDefined();
+    } finally {
+      for (const key of Object.keys(secrets)) {
+        delete process.env[key];
+      }
+    }
   });
 });
 

--- a/nemoclaw/src/blueprint/https-pin-proxy.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.ts
@@ -23,12 +23,14 @@ import http, {
   type ServerResponse,
 } from "node:http";
 import https, { type RequestOptions } from "node:https";
+import { isIP } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import tls, { type PeerCertificate } from "node:tls";
 import { fileURLToPath } from "node:url";
 
 import { HTTPS_PIN_PROXY_PORT } from "../lib/ports.js";
+import { buildSubprocessEnv } from "../lib/subprocess-env.js";
 import type { ValidatedEndpoint } from "./ssrf.js";
 import { isPrivateIp } from "./private-networks.js";
 
@@ -162,6 +164,8 @@ function readRoutes(): RouteMap {
       ? (parsed as RouteMap)
       : {};
   } catch {
+    // Unreadable or non-JSON state fails closed: with no routes, every request
+    // is treated as unregistered (404) and never reaches https.request.
     return {};
   }
 }
@@ -269,22 +273,67 @@ async function registerHttpsPinProxyRoute(route: HttpsPinProxyRoute): Promise<vo
   });
 }
 
+// Persisted routes are the source of truth for an SSRF defense, so every field
+// is revalidated before use. A corrupt or tampered routes.json must fail closed
+// (be treated as unregistered) rather than reach https.request with a non-IP
+// address that would be re-resolved through DNS, a malformed Host/SNI value, or
+// an out-of-range port.
+const ROUTE_ID_PATTERN = /^[a-f0-9]{24}$/;
+const SNI_HOSTNAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function isValidRouteId(value: unknown): value is string {
+  return typeof value === "string" && ROUTE_ID_PATTERN.test(value);
+}
+
+function isSafeSniHostname(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 253 &&
+    SNI_HOSTNAME_PATTERN.test(value)
+  );
+}
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+function isIpLiteral(value: unknown): value is string {
+  return typeof value === "string" && isIP(value) !== 0;
+}
+
+function isValidResolvedFamily(value: unknown): boolean {
+  return value === undefined || value === 4 || value === 6;
+}
+
+function isValidBasePath(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("/");
+}
+
+function isValidBaseSearch(value: unknown): value is string {
+  return typeof value === "string" && (value === "" || value.startsWith("?"));
+}
+
 function isPersistedRoute(value: unknown): value is PersistedRoute {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const route = value as Partial<PersistedRoute>;
+  // `resolvedAddress` must stay an IP literal so the connection cannot fall back
+  // to DNS resolution; the private-range recheck stays in handleProxyRequest.
   return (
-    typeof route.id === "string" &&
-    typeof route.hostname === "string" &&
-    typeof route.port === "number" &&
-    typeof route.basePath === "string" &&
-    typeof route.baseSearch === "string" &&
-    typeof route.resolvedAddress === "string"
+    isValidRouteId(route.id) &&
+    isSafeSniHostname(route.hostname) &&
+    isValidPort(route.port) &&
+    isValidBasePath(route.basePath) &&
+    isValidBaseSearch(route.baseSearch) &&
+    isIpLiteral(route.resolvedAddress) &&
+    isValidResolvedFamily(route.resolvedFamily)
   );
 }
 
 function loadRoute(routeId: string): PersistedRoute | null {
   const route = readRoutes()[routeId];
-  return isPersistedRoute(route) ? route : null;
+  if (!isPersistedRoute(route) || route.id !== routeId) return null;
+  return route;
 }
 
 function requestPathForRoute(route: PersistedRoute, requestUrl: URL): string {
@@ -481,10 +530,13 @@ function spawnProxyProcess(port = HTTPS_PIN_PROXY_PORT): void {
   try {
     const child = spawn(process.execPath, [modulePath, "serve"], {
       detached: true,
-      env: {
-        ...process.env,
+      // Do not inherit the full parent environment. The runner holds provider
+      // API keys and cloud/GitHub tokens that this detached, long-lived proxy
+      // never needs; spreading process.env would carry them into an unrelated
+      // helper. Forward only the allowlisted env plus the proxy port.
+      env: buildSubprocessEnv({
         NEMOCLAW_HTTPS_PIN_PROXY_PORT: String(port),
-      },
+      }),
       stdio: ["ignore", logFd, logFd],
     });
     child.unref();

--- a/nemoclaw/src/blueprint/https-pin-proxy.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.ts
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import http, {
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+  type OutgoingHttpHeaders,
+  type ServerResponse,
+} from "node:http";
+import https, { type RequestOptions } from "node:https";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import tls, { type PeerCertificate } from "node:tls";
+import { fileURLToPath } from "node:url";
+
+import { HTTPS_PIN_PROXY_PORT } from "../lib/ports.js";
+import type { ValidatedEndpoint } from "./ssrf.js";
+import { isPrivateIp } from "./private-networks.js";
+
+const ROUTE_PREFIX = "/.nemoclaw/https-pin/";
+const HEALTH_PATH = "/.nemoclaw/https-pin/health";
+const STATE_DIR = join(homedir(), ".nemoclaw", "state", "https-pin-proxy");
+const ROUTES_PATH = join(STATE_DIR, "routes.json");
+const ROUTES_LOCK_PATH = join(STATE_DIR, "routes.lock");
+const TOKEN_PATH = join(STATE_DIR, "proxy-token");
+const PID_PATH = join(STATE_DIR, "proxy.pid");
+const LOG_PATH = join(STATE_DIR, "proxy.log");
+const LOOPBACK_HOST = "127.0.0.1";
+const LISTEN_HOST = "127.0.0.1";
+const HEALTH_TOKEN_HEADER = "x-nemoclaw-https-pin-proxy-token";
+const ROUTES_LOCK_TIMEOUT_MS = 2_000;
+const ROUTES_LOCK_STALE_MS = 30_000;
+const UPSTREAM_REQUEST_TIMEOUT_MS = 30_000;
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export interface HttpsPinProxyRoute {
+  id: string;
+  hostname: string;
+  port: number;
+  basePath: string;
+  baseSearch: string;
+  resolvedAddress: string;
+  resolvedFamily?: number;
+}
+
+interface PersistedRoute extends HttpsPinProxyRoute {
+  updatedAt: string;
+}
+
+type RouteMap = Record<string, PersistedRoute>;
+
+function ensureStateDir(): void {
+  if (!existsSync(STATE_DIR)) {
+    mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+  }
+  chmodSync(STATE_DIR, 0o700);
+}
+
+function writeFileAtomically(path: string, contents: string): void {
+  ensureStateDir();
+  const tmpPath = join(STATE_DIR, `.${Date.now()}.${String(process.pid)}.tmp`);
+  let fd: number | null = null;
+  try {
+    fd = openSync(tmpPath, "wx", 0o600);
+    writeFileSync(fd, contents);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    renameSync(tmpPath, path);
+    chmodSync(path, 0o600);
+  } catch (err) {
+    if (fd !== null) {
+      closeSync(fd);
+    }
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Best effort cleanup; the write failure is the meaningful error.
+    }
+    throw err;
+  }
+}
+
+function removeStaleRoutesLock(): void {
+  try {
+    if (Date.now() - statSync(ROUTES_LOCK_PATH).mtimeMs > ROUTES_LOCK_STALE_MS) {
+      unlinkSync(ROUTES_LOCK_PATH);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireRoutesLock(): Promise<number> {
+  ensureStateDir();
+  const deadline = Date.now() + ROUTES_LOCK_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const fd = openSync(ROUTES_LOCK_PATH, "wx", 0o600);
+      writeFileSync(fd, `${String(process.pid)}\n`);
+      return fd;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+      removeStaleRoutesLock();
+      await sleep(25);
+    }
+  }
+  throw new Error("Timed out waiting for HTTPS pin proxy route lock.");
+}
+
+async function withRoutesLock<T>(fn: () => T): Promise<T> {
+  const fd = await acquireRoutesLock();
+  try {
+    return fn();
+  } finally {
+    closeSync(fd);
+    try {
+      unlinkSync(ROUTES_LOCK_PATH);
+    } catch {
+      // The lock may have been removed as stale by another process after timeout.
+    }
+  }
+}
+
+function readRoutes(): RouteMap {
+  try {
+    const parsed = JSON.parse(readFileSync(ROUTES_PATH, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as RouteMap)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeRoutes(routes: RouteMap): void {
+  writeFileAtomically(ROUTES_PATH, `${JSON.stringify(routes, null, 2)}\n`);
+}
+
+function routeIdFor(validated: ValidatedEndpoint): string {
+  return createHash("sha256")
+    .update(`${validated.url}\0${validated.pinnedUrl}`)
+    .digest("hex")
+    .slice(0, 24);
+}
+
+function normalizeBasePath(pathname: string): string {
+  return pathname.startsWith("/") ? pathname : `/${pathname}`;
+}
+
+function localBaseUrlFor(routeId: string, basePath: string, port: number): string {
+  return `http://${LOOPBACK_HOST}:${String(port)}${ROUTE_PREFIX}${routeId}${basePath}`;
+}
+
+function targetPort(parsed: URL): number {
+  if (parsed.port) return Number(parsed.port);
+  return 443;
+}
+
+function hostHeaderValue(hostname: string, port: number): string {
+  const host = hostname.includes(":") && !hostname.startsWith("[") ? `[${hostname}]` : hostname;
+  return port === 443 ? host : `${host}:${String(port)}`;
+}
+
+function mergeSearch(baseSearch: string, requestSearch: string): string {
+  if (!baseSearch) return requestSearch;
+  if (!requestSearch) return baseSearch;
+  return `${baseSearch}&${requestSearch.slice(1)}`;
+}
+
+export function sanitizeResponseHeaders(headers: IncomingHttpHeaders): OutgoingHttpHeaders {
+  const sanitized: OutgoingHttpHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+function sanitizeRequestHeaders(headers: IncomingHttpHeaders, host: string): OutgoingHttpHeaders {
+  const sanitized = sanitizeResponseHeaders(headers);
+  sanitized.host = host;
+  return sanitized;
+}
+
+function routeFromValidatedEndpoint(
+  validated: ValidatedEndpoint,
+  port = HTTPS_PIN_PROXY_PORT,
+): HttpsPinProxyRoute {
+  if (validated.protocol !== "https:" || !validated.dnsResolved || !validated.resolvedAddress) {
+    throw new Error("HTTPS pin proxy routes require a DNS-backed HTTPS endpoint.");
+  }
+
+  const parsed = new URL(validated.url);
+  const id = routeIdFor(validated);
+  const basePath = normalizeBasePath(parsed.pathname || "/");
+  return {
+    id,
+    hostname: validated.hostname,
+    port: targetPort(parsed),
+    basePath,
+    baseSearch: parsed.search,
+    resolvedAddress: validated.resolvedAddress,
+    resolvedFamily: validated.resolvedFamily,
+  };
+}
+
+export function endpointForValidatedEndpoint(validated: ValidatedEndpoint): {
+  endpoint: string;
+  httpsPinRoute?: HttpsPinProxyRoute;
+} {
+  if (validated.protocol === "http:") {
+    return { endpoint: validated.pinnedUrl };
+  }
+
+  if (!validated.dnsResolved) {
+    return { endpoint: validated.url };
+  }
+
+  const httpsPinRoute = routeFromValidatedEndpoint(validated);
+  return {
+    endpoint: localBaseUrlFor(httpsPinRoute.id, httpsPinRoute.basePath, HTTPS_PIN_PROXY_PORT),
+    httpsPinRoute,
+  };
+}
+
+async function registerHttpsPinProxyRoute(route: HttpsPinProxyRoute): Promise<void> {
+  await withRoutesLock(() => {
+    const routes = readRoutes();
+    routes[route.id] = {
+      ...route,
+      updatedAt: new Date().toISOString(),
+    };
+    writeRoutes(routes);
+  });
+}
+
+function isPersistedRoute(value: unknown): value is PersistedRoute {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const route = value as Partial<PersistedRoute>;
+  return (
+    typeof route.id === "string" &&
+    typeof route.hostname === "string" &&
+    typeof route.port === "number" &&
+    typeof route.basePath === "string" &&
+    typeof route.baseSearch === "string" &&
+    typeof route.resolvedAddress === "string"
+  );
+}
+
+function loadRoute(routeId: string): PersistedRoute | null {
+  const route = readRoutes()[routeId];
+  return isPersistedRoute(route) ? route : null;
+}
+
+function requestPathForRoute(route: PersistedRoute, requestUrl: URL): string {
+  const pathAfterRoute = requestUrl.pathname.slice(`${ROUTE_PREFIX}${route.id}`.length) || "/";
+  return `${pathAfterRoute}${mergeSearch(route.baseSearch, requestUrl.search)}`;
+}
+
+export function buildPinnedHttpsRequestOptions(args: {
+  route: HttpsPinProxyRoute;
+  method?: string;
+  headers?: IncomingMessage["headers"];
+  path: string;
+}): RequestOptions {
+  const host = hostHeaderValue(args.route.hostname, args.route.port);
+  return {
+    protocol: "https:",
+    hostname: args.route.resolvedAddress,
+    host: args.route.resolvedAddress,
+    family: args.route.resolvedFamily,
+    port: args.route.port,
+    method: args.method,
+    path: args.path,
+    headers: sanitizeRequestHeaders(args.headers ?? {}, host),
+    servername: args.route.hostname,
+    checkServerIdentity: (_servername: string, cert: PeerCertificate) =>
+      tls.checkServerIdentity(args.route.hostname, cert),
+  };
+}
+
+function sendError(res: ServerResponse, statusCode: number, message: string): void {
+  res.writeHead(statusCode, { "content-type": "text/plain; charset=utf-8" });
+  res.end(message);
+}
+
+function readProxyToken(): string | null {
+  try {
+    const token = readFileSync(TOKEN_PATH, "utf8").trim();
+    return /^[a-f0-9]{64}$/.test(token) ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+function loadOrCreateProxyToken(): string {
+  const existing = readProxyToken();
+  if (existing) return existing;
+  const token = randomBytes(32).toString("hex");
+  writeFileAtomically(TOKEN_PATH, `${token}\n`);
+  return token;
+}
+
+function healthResponseBody(token: string): string {
+  return `ok:${createHash("sha256").update(token).digest("hex")}\n`;
+}
+
+function headerValue(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const value = headers[name];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function handleProxyRequest(req: IncomingMessage, res: ServerResponse): void {
+  if (req.url === HEALTH_PATH) {
+    const token = readProxyToken();
+    if (!token || headerValue(req.headers, HEALTH_TOKEN_HEADER) !== token) {
+      sendError(res, 404, "Unknown HTTPS pin proxy route.\n");
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+    res.end(healthResponseBody(token));
+    return;
+  }
+
+  const requestUrl = new URL(req.url ?? "/", `http://${LOOPBACK_HOST}`);
+  if (!requestUrl.pathname.startsWith(ROUTE_PREFIX)) {
+    sendError(res, 404, "Unknown HTTPS pin proxy route.\n");
+    return;
+  }
+
+  const rest = requestUrl.pathname.slice(ROUTE_PREFIX.length);
+  const routeId = rest.split("/")[0];
+  if (!routeId) {
+    sendError(res, 404, "Missing HTTPS pin proxy route.\n");
+    return;
+  }
+
+  const route = loadRoute(routeId);
+  if (!route) {
+    sendError(res, 404, "HTTPS pin proxy route is not registered.\n");
+    return;
+  }
+  if (isPrivateIp(route.resolvedAddress)) {
+    sendError(res, 502, "HTTPS pin proxy route points to a private/internal address.\n");
+    return;
+  }
+
+  const upstreamPath = requestPathForRoute(route, requestUrl);
+  const upstream = https.request(
+    buildPinnedHttpsRequestOptions({
+      route,
+      method: req.method,
+      headers: req.headers,
+      path: upstreamPath,
+    }),
+    (upstreamRes) => {
+      res.writeHead(upstreamRes.statusCode ?? 502, sanitizeResponseHeaders(upstreamRes.headers));
+      upstreamRes.pipe(res);
+    },
+  );
+
+  const destroyUpstream = (message: string) => {
+    if (!upstream.destroyed) {
+      upstream.destroy(new Error(message));
+    }
+  };
+  const onRequestAborted = () => destroyUpstream("HTTPS pin proxy client request aborted");
+  const onResponseClose = () => {
+    if (!res.writableEnded) {
+      destroyUpstream("HTTPS pin proxy client response closed");
+    }
+  };
+
+  req.on("aborted", onRequestAborted);
+  res.on("close", onResponseClose);
+  upstream.setTimeout(UPSTREAM_REQUEST_TIMEOUT_MS, () => {
+    destroyUpstream("HTTPS pin proxy upstream request timed out");
+  });
+  upstream.on("close", () => {
+    req.off("aborted", onRequestAborted);
+    res.off("close", onResponseClose);
+  });
+  upstream.on("error", (err) => {
+    if (!res.headersSent) {
+      sendError(res, 502, `HTTPS pin proxy upstream request failed: ${err.message}\n`);
+    } else {
+      res.destroy(err);
+    }
+  });
+  req.pipe(upstream);
+}
+
+async function waitForProxyHealth(port: number, token: string): Promise<boolean> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (await isProxyHealthy(port, token)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+function isProxyHealthy(port: number, token: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const expectedBody = healthResponseBody(token);
+    const req = http.request(
+      {
+        host: LOOPBACK_HOST,
+        port,
+        path: HEALTH_PATH,
+        method: "GET",
+        headers: {
+          [HEALTH_TOKEN_HEADER]: token,
+        },
+        timeout: 500,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+          if (body.length > expectedBody.length) {
+            req.destroy();
+          }
+        });
+        res.on("end", () => {
+          resolve(res.statusCode === 200 && body === expectedBody);
+        });
+      },
+    );
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
+function spawnProxyProcess(port = HTTPS_PIN_PROXY_PORT): void {
+  ensureStateDir();
+  const modulePath = fileURLToPath(import.meta.url);
+  const logFd = openSync(LOG_PATH, "a", 0o600);
+  try {
+    const child = spawn(process.execPath, [modulePath, "serve"], {
+      detached: true,
+      env: {
+        ...process.env,
+        NEMOCLAW_HTTPS_PIN_PROXY_PORT: String(port),
+      },
+      stdio: ["ignore", logFd, logFd],
+    });
+    child.unref();
+    if (child.pid) {
+      writeFileSync(PID_PATH, `${String(child.pid)}\n`, { mode: 0o600 });
+      chmodSync(PID_PATH, 0o600);
+    }
+  } finally {
+    closeSync(logFd);
+  }
+}
+
+export async function ensureHttpsPinProxyRoutes(routes: HttpsPinProxyRoute[]): Promise<void> {
+  if (routes.length === 0) return;
+  const proxyToken = loadOrCreateProxyToken();
+  if (!(await isProxyHealthy(HTTPS_PIN_PROXY_PORT, proxyToken))) {
+    spawnProxyProcess();
+  }
+  if (!(await waitForProxyHealth(HTTPS_PIN_PROXY_PORT, proxyToken))) {
+    throw new Error(
+      `HTTPS endpoint pinning proxy did not become ready on ${LOOPBACK_HOST}:${String(
+        HTTPS_PIN_PROXY_PORT,
+      )}. Check ${LOG_PATH}.`,
+    );
+  }
+  for (const route of routes) {
+    await registerHttpsPinProxyRoute(route);
+  }
+}
+
+export function createHttpsPinProxyServer(): http.Server {
+  return http.createServer(handleProxyRequest);
+}
+
+export async function serveHttpsPinProxy(port = HTTPS_PIN_PROXY_PORT): Promise<http.Server> {
+  const server = createHttpsPinProxyServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, LISTEN_HOST, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+if (process.argv[2] === "serve") {
+  serveHttpsPinProxy().catch((err) => {
+    process.stderr.write(
+      `HTTPS pin proxy failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/nemoclaw/src/blueprint/https-pin-proxy.ts
+++ b/nemoclaw/src/blueprint/https-pin-proxy.ts
@@ -382,6 +382,8 @@ function handleProxyRequest(req: IncomingMessage, res: ServerResponse): void {
   }
 
   const upstreamPath = requestPathForRoute(route, requestUrl);
+  // lgtm[js/file-access-to-http] Routes are persisted under a 0700 state dir and
+  // revalidated as public IPs before use; TLS identity remains bound to hostname.
   const upstream = https.request(
     buildPinnedHttpsRequestOptions({
       route,

--- a/nemoclaw/src/blueprint/runner-test-harness.ts
+++ b/nemoclaw/src/blueprint/runner-test-harness.ts
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared in-memory filesystem and fixtures for the runner test suites.
+// Kept out of the *.test.ts namespace so each spec can stay focused.
+
+import type fs from "node:fs";
+import { vi } from "vitest";
+import YAML from "yaml";
+
+export const FAKE_HOME = "/fakehome";
+
+interface FsEntry {
+  type: "file" | "dir";
+  content?: string;
+}
+
+export const store = new Map<string, FsEntry>();
+
+export function addFile(p: string, content: string): void {
+  store.set(p, { type: "file", content });
+}
+
+export function addDir(p: string): void {
+  store.set(p, { type: "dir" });
+}
+
+/** Returns a node:fs mock backed by the in-memory `store`. */
+export function fsMock(original: typeof fs): typeof fs {
+  return {
+    ...original,
+    mkdirSync: vi.fn((p: string) => {
+      addDir(p);
+    }),
+    readFileSync: (p: string) => {
+      const entry = store.get(p);
+      if (entry?.type !== "file") throw new Error(`ENOENT: ${p}`);
+      return entry.content ?? "";
+    },
+    writeFileSync: vi.fn((p: string, data: string) => {
+      store.set(p, { type: "file", content: data });
+    }),
+    readdirSync: (p: string) => {
+      const prefix = p.endsWith("/") ? p : `${p}/`;
+      const entries = new Set<string>();
+      for (const k of store.keys()) {
+        if (k.startsWith(prefix)) {
+          const first = k.slice(prefix.length).split("/")[0];
+          if (first) entries.add(first);
+        }
+      }
+      if (entries.size === 0 && !store.has(p)) throw new Error(`ENOENT: ${p}`);
+      return [...entries].sort();
+    },
+  } as unknown as typeof fs;
+}
+
+export const mockExeca = vi.fn();
+export const mockEnsureHttpsPinProxyRoutes = vi.fn(async () => {});
+
+export function makeValidatedEndpoint(url: string, pinnedUrl = url) {
+  const parsed = new URL(url);
+  const pinned = new URL(pinnedUrl);
+  const dnsResolved = parsed.hostname !== pinned.hostname;
+  const pinnedHostname =
+    pinned.hostname.startsWith("[") && pinned.hostname.endsWith("]")
+      ? pinned.hostname.slice(1, -1)
+      : pinned.hostname;
+  return {
+    url,
+    pinnedUrl,
+    protocol: parsed.protocol as "http:" | "https:",
+    hostname: parsed.hostname,
+    resolvedAddress: dnsResolved ? pinnedHostname : undefined,
+    resolvedFamily: dnsResolved ? (pinnedHostname.includes(":") ? 6 : 4) : undefined,
+    dnsResolved,
+  };
+}
+
+export const stdoutChunks: string[] = [];
+
+export function captureStdout(): void {
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+    stdoutChunks.push(String(chunk));
+    return true;
+  });
+}
+
+export function stdoutText(): string {
+  return stdoutChunks.join("");
+}
+
+export function capturedJsonOutput<T = unknown>(): T {
+  const json = stdoutText()
+    .split("\n")
+    .filter((line) => line && !line.startsWith("RUN_ID:") && !line.startsWith("PROGRESS:"))
+    .join("\n");
+  return JSON.parse(json) as T;
+}
+
+export function minimalBlueprint(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    version: "1.0",
+    components: {
+      inference: {
+        profiles: {
+          default: {
+            provider_type: "openai",
+            provider_name: "my-provider",
+            endpoint: "https://api.example.com/v1",
+            model: "gpt-4",
+            credential_env: "MY_API_KEY",
+          },
+        },
+      },
+      sandbox: { image: "openclaw", name: "test-sandbox", forward_ports: [18789] },
+      policy: { additions: {} },
+    },
+    ...overrides,
+  };
+}
+
+export function routedBlueprint(): Record<string, unknown> {
+  return {
+    version: "1.0",
+    components: {
+      inference: {
+        profiles: {
+          routed: {
+            provider_type: "openai",
+            provider_name: "nvidia-router",
+            endpoint: "http://localhost:4000/v1",
+            model: "routed",
+            credential_env: "NVIDIA_INFERENCE_API_KEY",
+            credential_default: "router-local",
+            timeout_secs: 180,
+          },
+        },
+      },
+      sandbox: { image: "openclaw", name: "test-sandbox", forward_ports: [18789] },
+      router: { enabled: true, port: 4000, pool_config_path: "router/pool-config.yaml" },
+      policy: { additions: {} },
+    },
+  };
+}
+
+export function seedBlueprintFile(bp?: Record<string, unknown>): void {
+  addFile("blueprint.yaml", YAML.stringify(bp ?? minimalBlueprint()));
+}
+
+export function blueprintWithPolicyAdditions(
+  additions: Record<string, unknown>,
+): Record<string, unknown> {
+  const bp = minimalBlueprint();
+  return {
+    ...bp,
+    components: { ...(bp.components as Record<string, unknown>), policy: { additions } },
+  };
+}
+
+export function mockCurrentPolicy(stdout: string): void {
+  mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
+    if (
+      args[0] === "policy" &&
+      args[1] === "get" &&
+      args[2] === "--full" &&
+      args[3] === "test-sandbox"
+    ) {
+      return { exitCode: 0, stdout, stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  });
+}

--- a/nemoclaw/src/blueprint/runner.test.ts
+++ b/nemoclaw/src/blueprint/runner.test.ts
@@ -1,196 +1,64 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 
-// ── In-memory filesystem ────────────────────────────────────────
+import {
+  addDir,
+  addFile,
+  blueprintWithPolicyAdditions,
+  capturedJsonOutput,
+  captureStdout,
+  FAKE_HOME,
+  makeValidatedEndpoint,
+  minimalBlueprint,
+  mockCurrentPolicy,
+  mockEnsureHttpsPinProxyRoutes,
+  mockExeca,
+  routedBlueprint,
+  seedBlueprintFile,
+  stdoutChunks,
+  stdoutText,
+  store,
+} from "./runner-test-harness.js";
 
-interface FsEntry {
-  type: "file" | "dir";
-  content?: string;
-}
+vi.mock("node:os", () => ({ homedir: () => "/fakehome" }));
 
-const store = new Map<string, FsEntry>();
-
-function addFile(p: string, content: string): void {
-  store.set(p, { type: "file", content });
-}
-
-function addDir(p: string): void {
-  store.set(p, { type: "dir" });
-}
-
-const FAKE_HOME = "/fakehome";
-
-vi.mock("node:os", () => ({
-  homedir: () => FAKE_HOME,
-}));
-
-vi.mock("node:crypto", () => ({
+vi.mock("node:crypto", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:crypto")>()),
   randomUUID: () => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
-  const original = await importOriginal<typeof fs>();
-  return {
-    ...original,
-    existsSync: (p: string) => store.has(p),
-    mkdirSync: vi.fn((p: string) => {
-      addDir(p);
-    }),
-    readFileSync: (p: string) => {
-      const entry = store.get(p);
-      if (entry?.type !== "file") throw new Error(`ENOENT: ${p}`);
-      return entry.content ?? "";
-    },
-    writeFileSync: vi.fn((p: string, data: string) => {
-      store.set(p, { type: "file", content: data });
-    }),
-    readdirSync: (p: string) => {
-      const prefix = p.endsWith("/") ? p : p + "/";
-      const entries = new Set<string>();
-      for (const k of store.keys()) {
-        if (k.startsWith(prefix)) {
-          const rest = k.slice(prefix.length);
-          const first = rest.split("/")[0];
-          if (first) entries.add(first);
-        }
-      }
-      if (entries.size === 0 && !store.has(p)) {
-        throw new Error(`ENOENT: ${p}`);
-      }
-      return [...entries].sort();
-    },
-  };
+  const { fsMock } = await import("./runner-test-harness.js");
+  return fsMock(await importOriginal<typeof import("node:fs")>());
 });
 
-const mockExeca = vi.fn();
 vi.mock("execa", () => ({
-  execa: (...args: unknown[]) => mockExeca(...args),
+  execa: async (...args: unknown[]) =>
+    (await import("./runner-test-harness.js")).mockExeca(...args),
 }));
 
 vi.mock("./ssrf.js", () => ({
-  validateEndpointUrl: vi.fn(async (url: string) => ({ url, pinnedUrl: url })),
+  validateEndpointUrl: vi.fn(async (url: string) =>
+    (await import("./runner-test-harness.js")).makeValidatedEndpoint(url),
+  ),
 }));
+
+vi.mock("./https-pin-proxy.js", async (importOriginal) => {
+  const { mockEnsureHttpsPinProxyRoutes: mock } = await import("./runner-test-harness.js");
+  return {
+    ...(await importOriginal<typeof import("./https-pin-proxy.js")>()),
+    ensureHttpsPinProxyRoutes: mock,
+  };
+});
 
 const { validateEndpointUrl } = await import("./ssrf.js");
 const mockedValidateEndpoint = vi.mocked(validateEndpointUrl);
 
 const { emitRunId, loadBlueprint, actionPlan, actionApply, actionStatus, actionRollback, main } =
   await import("./runner.js");
-
-// ── Helpers ─────────────────────────────────────────────────────
-
-const stdoutChunks: string[] = [];
-
-function captureStdout(): void {
-  vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
-    stdoutChunks.push(String(chunk));
-    return true;
-  });
-}
-
-function stdoutText(): string {
-  return stdoutChunks.join("");
-}
-
-function capturedJsonOutput<T = unknown>(): T {
-  const json = stdoutText()
-    .split("\n")
-    .filter((line) => line && !line.startsWith("RUN_ID:") && !line.startsWith("PROGRESS:"))
-    .join("\n");
-  return JSON.parse(json) as T;
-}
-
-function minimalBlueprint(overrides?: Record<string, unknown>): Record<string, unknown> {
-  return {
-    version: "1.0",
-    components: {
-      inference: {
-        profiles: {
-          default: {
-            provider_type: "openai",
-            provider_name: "my-provider",
-            endpoint: "https://api.example.com/v1",
-            model: "gpt-4",
-            credential_env: "MY_API_KEY",
-          },
-        },
-      },
-      sandbox: {
-        image: "openclaw",
-        name: "test-sandbox",
-        forward_ports: [18789],
-      },
-      policy: { additions: {} },
-    },
-    ...overrides,
-  };
-}
-
-function routedBlueprint(): Record<string, unknown> {
-  return {
-    version: "1.0",
-    components: {
-      inference: {
-        profiles: {
-          routed: {
-            provider_type: "openai",
-            provider_name: "nvidia-router",
-            endpoint: "http://localhost:4000/v1",
-            model: "routed",
-            credential_env: "NVIDIA_INFERENCE_API_KEY",
-            credential_default: "router-local",
-            timeout_secs: 180,
-          },
-        },
-      },
-      sandbox: {
-        image: "openclaw",
-        name: "test-sandbox",
-        forward_ports: [18789],
-      },
-      router: {
-        enabled: true,
-        port: 4000,
-        pool_config_path: "router/pool-config.yaml",
-      },
-      policy: { additions: {} },
-    },
-  };
-}
-
-function seedBlueprintFile(bp?: Record<string, unknown>): void {
-  addFile("blueprint.yaml", YAML.stringify(bp ?? minimalBlueprint()));
-}
-
-function blueprintWithPolicyAdditions(additions: Record<string, unknown>): Record<string, unknown> {
-  const bp = minimalBlueprint();
-  const components = bp.components as Record<string, unknown>;
-  return {
-    ...bp,
-    components: {
-      ...components,
-      policy: { additions },
-    },
-  };
-}
-
-function mockCurrentPolicy(stdout: string): void {
-  mockExeca.mockImplementation(async (_cmd: string, args: string[]) => {
-    if (
-      args[0] === "policy" &&
-      args[1] === "get" &&
-      args[2] === "--full" &&
-      args[3] === "test-sandbox"
-    ) {
-      return { exitCode: 0, stdout, stderr: "" };
-    }
-    return { exitCode: 0, stdout: "", stderr: "" };
-  });
-}
 
 // ── Tests ───────────────────────────────────────────────────────
 
@@ -558,10 +426,70 @@ describe("runner", () => {
       mockExeca.mockResolvedValue({ exitCode: 0 });
 
       const plan = await actionPlan("default", minimalBlueprint(), {
+        endpointUrl: "https://93.184.216.34/v1",
+      });
+      expect(plan.inference.endpoint).toBe("https://93.184.216.34/v1");
+      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://93.184.216.34/v1");
+    });
+
+    it("pins HTTP endpoint URL overrides to the validated IP", async () => {
+      captureStdout();
+      mockExeca.mockResolvedValue({ exitCode: 0 });
+      mockedValidateEndpoint.mockResolvedValueOnce(
+        makeValidatedEndpoint("http://override.example.com/v1", "http://93.184.216.34/v1"),
+      );
+
+      const plan = await actionPlan("default", minimalBlueprint(), {
+        endpointUrl: "http://override.example.com/v1",
+      });
+
+      expect(plan.inference.endpoint).toBe("http://93.184.216.34/v1");
+    });
+
+    it("routes DNS-backed HTTPS endpoint URL overrides through the pinning proxy", async () => {
+      captureStdout();
+      mockExeca.mockResolvedValue({ exitCode: 0 });
+      mockedValidateEndpoint.mockResolvedValueOnce(
+        makeValidatedEndpoint("https://override.example.com/v1", "https://93.184.216.34/v1"),
+      );
+
+      const plan = await actionPlan("default", minimalBlueprint(), {
         endpointUrl: "https://override.example.com/v1",
       });
-      expect(plan.inference.endpoint).toBe("https://override.example.com/v1");
-      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://override.example.com/v1");
+
+      expect(plan.inference.endpoint).toMatch(
+        /^http:\/\/127\.0\.0\.1:11437\/\.nemoclaw\/https-pin\/[a-f0-9]{24}\/v1$/,
+      );
+      expect(plan.inference.endpoint).not.toContain("override.example.com");
+      expect(mockEnsureHttpsPinProxyRoutes).not.toHaveBeenCalled();
+    });
+
+    it("routes provider DNS-backed HTTPS blueprint endpoints through the pinning proxy", async () => {
+      captureStdout();
+      mockExeca.mockResolvedValue({ exitCode: 0 });
+      mockedValidateEndpoint.mockResolvedValueOnce(
+        makeValidatedEndpoint("https://integrate.api.nvidia.com/v1", "https://93.184.216.34/v1"),
+      );
+
+      const bp = minimalBlueprint({
+        components: {
+          inference: {
+            profiles: {
+              trusted: {
+                provider_type: "nvidia",
+                endpoint: "https://integrate.api.nvidia.com/v1",
+                model: "nvidia/nemotron",
+              },
+            },
+          },
+          sandbox: { name: "sb" },
+        },
+      });
+
+      const plan = await actionPlan("trusted", bp);
+      expect(plan.inference.endpoint).toMatch(
+        /^http:\/\/127\.0\.0\.1:11437\/\.nemoclaw\/https-pin\/[a-f0-9]{24}\/v1$/,
+      );
     });
 
     it("SSRF-validates the blueprint-defined endpoint even without --endpoint-url override", async () => {
@@ -1081,9 +1009,38 @@ describe("runner", () => {
 
     it("validates and applies endpoint URL override", async () => {
       await actionApply("default", minimalBlueprint(), {
+        endpointUrl: "https://93.184.216.34/v1",
+      });
+      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://93.184.216.34/v1");
+    });
+
+    it("starts the HTTPS pinning proxy for DNS-backed endpoint URL overrides", async () => {
+      mockedValidateEndpoint.mockResolvedValueOnce(
+        makeValidatedEndpoint("https://override.example.com/v1", "https://93.184.216.34/v1"),
+      );
+
+      await actionApply("default", minimalBlueprint(), {
         endpointUrl: "https://override.example.com/v1",
       });
-      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://override.example.com/v1");
+
+      expect(mockEnsureHttpsPinProxyRoutes).toHaveBeenCalledTimes(1);
+      const routes = mockEnsureHttpsPinProxyRoutes.mock.calls[0][0];
+      expect(routes).toHaveLength(1);
+      expect(routes[0]).toMatchObject({
+        hostname: "override.example.com",
+        resolvedAddress: "93.184.216.34",
+      });
+
+      const providerCall = mockExeca.mock.calls.find(
+        (c) => Array.isArray(c[1]) && c[1].includes("provider"),
+      );
+      if (!providerCall) throw new Error("provider create call not found");
+      const configArg = (providerCall[1] as string[]).find((a: string) =>
+        a.startsWith("OPENAI_BASE_URL="),
+      );
+      expect(configArg).toMatch(
+        /^OPENAI_BASE_URL=http:\/\/127\.0\.0\.1:11437\/\.nemoclaw\/https-pin\/[a-f0-9]{24}\/v1$/,
+      );
     });
 
     it("passes --timeout when timeout_secs is set in profile", async () => {
@@ -1445,8 +1402,8 @@ describe("runner", () => {
     });
 
     it("parses apply with --profile and --endpoint-url", async () => {
-      await main(["apply", "--profile", "default", "--endpoint-url", "https://override.test/v1"]);
-      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://override.test/v1");
+      await main(["apply", "--profile", "default", "--endpoint-url", "https://93.184.216.34/v1"]);
+      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://93.184.216.34/v1");
       expect(stdoutText()).toContain("PROGRESS:100:Apply complete");
     });
 
@@ -1463,12 +1420,12 @@ describe("runner", () => {
         "default",
         "--dry-run",
         "--endpoint-url",
-        "https://ep.test",
+        "https://93.184.216.34/v1",
       ]);
       const out = stdoutText();
       expect(out).toContain('"dry_run": true');
-      expect(out).toContain('"endpoint": "https://ep.test"');
-      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://ep.test");
+      expect(out).toContain('"endpoint": "https://93.184.216.34/v1"');
+      expect(mockedValidateEndpoint).toHaveBeenCalledWith("https://93.184.216.34/v1");
     });
   });
 });

--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -13,16 +13,20 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
 
 import { execa } from "execa";
 import YAML from "yaml";
-
-import { validateEndpointUrl } from "./ssrf.js";
-import { buildSubprocessEnv } from "../lib/subprocess-env.js";
 import { DASHBOARD_PORT } from "../lib/ports.js";
+import { buildSubprocessEnv } from "../lib/subprocess-env.js";
+import {
+  endpointForValidatedEndpoint,
+  ensureHttpsPinProxyRoutes,
+  type HttpsPinProxyRoute,
+} from "./https-pin-proxy.js";
+import { validateEndpointUrl } from "./ssrf.js";
 
 type Action = "plan" | "apply" | "status" | "rollback";
 
@@ -422,6 +426,7 @@ async function resolveRunConfig(
   inferenceCfg: InferenceProfile;
   sandboxCfg: SandboxConfig;
   routerCfg: RouterConfig;
+  httpsPinProxyRoutes: HttpsPinProxyRoute[];
 }> {
   const inferenceProfiles = blueprint.components?.inference?.profiles ?? {};
   if (!(profile in inferenceProfiles)) {
@@ -430,25 +435,20 @@ async function resolveRunConfig(
   }
 
   let inferenceCfg = { ...inferenceProfiles[profile] };
-  if (endpointUrl) {
-    const validated = await validateEndpointUrl(endpointUrl);
-    // Use DNS-pinned URL for HTTP (full SSRF/rebinding protection). For HTTPS,
-    // keep the original hostname — TLS certificate validation prevents rebinding
-    // since the attacker cannot present a valid cert for the target.
-    const safe = endpointUrl.startsWith("https:") ? validated.url : validated.pinnedUrl;
-    inferenceCfg = { ...inferenceCfg, endpoint: safe };
-  }
-
-  // Validate the final endpoint (whether from CLI override or blueprint profile)
-  if (inferenceCfg.endpoint) {
-    const validated = await validateEndpointUrl(inferenceCfg.endpoint);
-    const safe = inferenceCfg.endpoint.startsWith("https:") ? validated.url : validated.pinnedUrl;
-    inferenceCfg = { ...inferenceCfg, endpoint: safe };
+  const httpsPinProxyRoutes: HttpsPinProxyRoute[] = [];
+  const rawEndpoint = endpointUrl ?? inferenceCfg.endpoint;
+  if (rawEndpoint) {
+    const validated = await validateEndpointUrl(rawEndpoint);
+    const safe = endpointForValidatedEndpoint(validated);
+    if (safe.httpsPinRoute) {
+      httpsPinProxyRoutes.push(safe.httpsPinRoute);
+    }
+    inferenceCfg = { ...inferenceCfg, endpoint: safe.endpoint };
   }
 
   const sandboxCfg = blueprint.components?.sandbox ?? {};
   const routerCfg = blueprint.components?.router ?? {};
-  return { inferenceProfiles, inferenceCfg, sandboxCfg, routerCfg };
+  return { inferenceProfiles, inferenceCfg, sandboxCfg, routerCfg, httpsPinProxyRoutes };
 }
 
 // ── Actions ─────────────────────────────────────────────────────
@@ -700,7 +700,7 @@ export async function actionApply(
 
   const rid = emitRunId();
 
-  const { inferenceCfg, sandboxCfg } = await resolveRunConfig(
+  const { inferenceCfg, sandboxCfg, httpsPinProxyRoutes } = await resolveRunConfig(
     profile,
     blueprint,
     options?.endpointUrl,
@@ -737,6 +737,7 @@ export async function actionApply(
   }
 
   progress(50, "Configuring inference provider");
+  await ensureHttpsPinProxyRoutes(httpsPinProxyRoutes);
   const providerName = inferenceCfg.provider_name ?? "default";
   const providerType = inferenceCfg.provider_type ?? "openai";
   const endpoint = inferenceCfg.endpoint ?? "";

--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -3,7 +3,7 @@
 
 // Tests for SSRF validation (PSIRT bug 6002763).
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 type LookupResult = Array<{ address: string; family: number }>;
 const mockLookup = vi.fn<(hostname: string, options: { all: true }) => Promise<LookupResult>>();
@@ -98,6 +98,13 @@ describe("validateEndpointUrl", () => {
     const result = await validateEndpointUrl("https://api.nvidia.com/v1");
     expect(result.url).toBe("https://api.nvidia.com/v1");
     expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
+    expect(result).toMatchObject({
+      protocol: "https:",
+      hostname: "api.nvidia.com",
+      resolvedAddress: "93.184.216.34",
+      resolvedFamily: 4,
+      dnsResolved: true,
+    });
   });
 
   it("allows http", async () => {
@@ -113,6 +120,11 @@ describe("validateEndpointUrl", () => {
     const result = await validateEndpointUrl("https://93.184.216.34/v1");
     expect(result.url).toBe("https://93.184.216.34/v1");
     expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
+    expect(result).toMatchObject({
+      protocol: "https:",
+      hostname: "93.184.216.34",
+      dnsResolved: false,
+    });
     expect(mockLookup).not.toHaveBeenCalled();
   });
 
@@ -122,6 +134,7 @@ describe("validateEndpointUrl", () => {
     const result = await validateEndpointUrl("https://[2606:4700:4700::1111]/v1");
     expect(result.url).toBe("https://[2606:4700:4700::1111]/v1");
     expect(result.pinnedUrl).toBe("https://[2606:4700:4700::1111]/v1");
+    expect(result.dnsResolved).toBe(false);
     expect(mockLookup).not.toHaveBeenCalled();
   });
 
@@ -344,6 +357,8 @@ describe("validateEndpointUrl – DNS pinning", () => {
     mockPublicDns();
     const result = await validateEndpointUrl("https://api.example.com/v1");
     expect(result.pinnedUrl).toBe("https://93.184.216.34/v1");
+    expect(result.dnsResolved).toBe(true);
+    expect(result.resolvedAddress).toBe("93.184.216.34");
   });
 
   it("pins IPv6 address with brackets", async () => {

--- a/nemoclaw/src/blueprint/ssrf.ts
+++ b/nemoclaw/src/blueprint/ssrf.ts
@@ -4,11 +4,11 @@
 import { promises as dnsPromises } from "node:dns";
 import { isIP } from "node:net";
 
-import { isPrivateIp, isPrivateHostname } from "./private-networks.js";
+import { isPrivateHostname, isPrivateIp } from "./private-networks.js";
 
 // Re-export so consumers can pick the narrower IP-only check (for
 // post-DNS addresses) or the broader name-aware check (for user input).
-export { isPrivateIp, isPrivateHostname };
+export { isPrivateHostname, isPrivateIp };
 
 const ALLOWED_SCHEMES = new Set(["https:", "http:"]);
 
@@ -24,13 +24,19 @@ function hostnameForDnsLookup(hostname: string): string {
  * DNS rebinding TOCTOU attacks where an attacker returns a public IP at
  * validation time and a private IP at connection time.
  *
- * Callers should use `pinnedUrl` for HTTP endpoints (full protection) and `url`
- * for HTTPS endpoints (TLS certificate validation prevents rebinding since the
- * attacker cannot present a valid cert for the rebinding target).
+ * Callers must use `pinnedUrl` unless their transport can pin the connection IP
+ * while still sending the original hostname as TLS SNI and the HTTP Host header.
+ * Reusing `url` for DNS-backed HTTPS endpoints reopens the validation-to-connect
+ * rebinding window.
  */
 export interface ValidatedEndpoint {
   url: string;
   pinnedUrl: string;
+  protocol: "http:" | "https:";
+  hostname: string;
+  resolvedAddress?: string;
+  resolvedFamily?: number;
+  dnsResolved: boolean;
 }
 
 export async function validateEndpointUrl(url: string): Promise<ValidatedEndpoint> {
@@ -61,7 +67,13 @@ export async function validateEndpointUrl(url: string): Promise<ValidatedEndpoin
 
   const lookupHostname = hostnameForDnsLookup(hostname);
   if (isIP(lookupHostname)) {
-    return { url, pinnedUrl: url };
+    return {
+      url,
+      pinnedUrl: url,
+      protocol: parsed.protocol as "http:" | "https:",
+      hostname,
+      dnsResolved: false,
+    };
   }
 
   let addresses: Array<{ address: string; family: number }>;
@@ -89,5 +101,13 @@ export async function validateEndpointUrl(url: string): Promise<ValidatedEndpoin
   const first = addresses[0];
   pinned.hostname = first.family === 6 ? `[${first.address}]` : first.address;
 
-  return { url, pinnedUrl: pinned.toString() };
+  return {
+    url,
+    pinnedUrl: pinned.toString(),
+    protocol: parsed.protocol as "http:" | "https:",
+    hostname,
+    resolvedAddress: first.address,
+    resolvedFamily: first.family,
+    dnsResolved: true,
+  };
 }

--- a/nemoclaw/src/lib/ports.ts
+++ b/nemoclaw/src/lib/ports.ts
@@ -4,7 +4,7 @@
 /**
  * Dashboard port parsing for the NemoClaw plugin.
  * Mirrors the parsePort() logic from src/lib/ports.ts in the CLI.
- * Only DASHBOARD_PORT is needed by the plugin (runner.ts).
+ * Keep this small and explicit for the plugin-side runner.
  */
 
 export function parsePort(envVar: string, fallback: number): number {
@@ -22,3 +22,4 @@ export function parsePort(envVar: string, fallback: number): number {
 }
 
 export const DASHBOARD_PORT = parsePort("NEMOCLAW_DASHBOARD_PORT", 18789);
+export const HTTPS_PIN_PROXY_PORT = parsePort("NEMOCLAW_HTTPS_PIN_PROXY_PORT", 11437);

--- a/src/lib/actions/inference-set-endpoint-security.test.ts
+++ b/src/lib/actions/inference-set-endpoint-security.test.ts
@@ -48,13 +48,13 @@ describe("custom inference endpoint DNS pinning", () => {
     expect(lookup).toHaveBeenCalledWith("public-endpoint.example", { all: true });
   });
 
-  it("preserves a validated HTTPS hostname for certificate verification", async () => {
+  it("rejects a DNS-backed HTTPS endpoint that cannot be transport-pinned", async () => {
     const lookup = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]);
 
     await expect(
       normalizeCustomEndpointUrl("https://public-endpoint.example/v1/", (value) =>
         rewriteConfigUrlsWithDnsPinning(value, lookup),
       ),
-    ).resolves.toBe("https://public-endpoint.example/v1");
+    ).rejects.toThrow(/cannot safely persist.*connection-IP pinning/i);
   });
 });

--- a/src/lib/sandbox/config.ts
+++ b/src/lib/sandbox/config.ts
@@ -83,6 +83,9 @@ interface DnsValidatedUrl {
   protocol: "http:" | "https:";
   originalUrl: string;
   pinnedUrl: string;
+  hostname: string;
+  resolvedAddress?: string;
+  dnsResolved: boolean;
 }
 
 type ManagedGatewayRestart = (sandboxName: string) => { ok: boolean };
@@ -668,7 +671,13 @@ async function validateUrlValueWithDnsResult(
   assertPublicHost(hostname);
   const lookupHostname = hostnameForDnsLookup(hostname);
   if (isIP(lookupHostname)) {
-    return { protocol: parsed.protocol as "http:" | "https:", originalUrl, pinnedUrl: originalUrl };
+    return {
+      protocol: parsed.protocol as "http:" | "https:",
+      originalUrl,
+      pinnedUrl: originalUrl,
+      hostname,
+      dnsResolved: false,
+    };
   }
 
   let addresses: Array<{ address: string; family?: number }>;
@@ -701,6 +710,9 @@ async function validateUrlValueWithDnsResult(
     protocol: parsed.protocol as "http:" | "https:",
     originalUrl,
     pinnedUrl: pinned.toString(),
+    hostname,
+    resolvedAddress: first.address,
+    dnsResolved: true,
   };
 }
 
@@ -747,6 +759,23 @@ function formatConfigValueForLogs(value: ConfigValue | undefined): string {
   return JSON.stringify(redactConfigValueForPreview(value));
 }
 
+function rewriteValidatedConfigUrl(validated: DnsValidatedUrl): string {
+  if (validated.protocol === "http:") {
+    return validated.pinnedUrl;
+  }
+
+  if (!validated.dnsResolved) {
+    return validated.originalUrl;
+  }
+
+  const resolved = validated.resolvedAddress ? ` (validated IP: ${validated.resolvedAddress})` : "";
+  throw new Error(
+    `HTTPS URL host "${validated.hostname}" resolves through DNS${resolved}. ` +
+      "NemoClaw cannot safely persist it without connection-IP pinning and TLS SNI/Host " +
+      "preservation. Use an IP-literal URL or a local proxy that pins DNS safely.",
+  );
+}
+
 async function rewriteConfigUrlsWithDnsPinning(
   value: ConfigValue,
   lookup: LookupFn = dnsPromises.lookup as LookupFn,
@@ -759,11 +788,7 @@ async function rewriteConfigUrlsWithDnsPinning(
     try {
       const validated = await validateUrlValueWithDnsResult(trimmed, lookup);
       if (!validated) return value;
-      // HTTP has no TLS hostname binding, so persist the DNS-pinned URL to avoid
-      // a config-time/public → runtime/private DNS-rebinding window. For HTTPS,
-      // preserve the original hostname so normal certificate validation still
-      // protects the connection.
-      return validated.protocol === "http:" ? validated.pinnedUrl : validated.originalUrl;
+      return rewriteValidatedConfigUrl(validated);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       throw new ConfigUrlValidationError(trimmed, message);
@@ -972,9 +997,9 @@ async function configSet(sandboxName: string, opts: ConfigSetOpts = {}): Promise
     }
   }
 
-  // Validate URLs for SSRF (supports nested object/array values). HTTP URLs
-  // are persisted with DNS-pinned hosts so later use cannot re-resolve the same
-  // hostname to private/internal space after config-time validation succeeds.
+  // Validate URLs for SSRF (supports nested object/array values). HTTP URLs are
+  // persisted with DNS-pinned hosts. DNS-backed HTTPS URLs need SNI/Host-aware
+  // pinning, which generic config persistence cannot attach.
   let safeValue: ConfigValue;
   try {
     safeValue = await rewriteConfigUrlsWithDnsPinning(parsedValue);

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -515,9 +515,9 @@ describe("config set helpers", () => {
 
     it("rejects DNS-backed HTTPS URLs that cannot be transport-pinned", async () => {
       const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
-      await expect(rewriteConfigUrlsWithDnsPinning("https://example.com/v1", lookup)).rejects.toThrow(
-        /cannot safely persist/i,
-      );
+      await expect(
+        rewriteConfigUrlsWithDnsPinning("https://example.com/v1", lookup),
+      ).rejects.toThrow(/cannot safely persist/i);
     });
 
     it("recursively rewrites nested HTTP URLs and leaves non-URLs unchanged", async () => {

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -513,10 +513,10 @@ describe("config set helpers", () => {
       );
     });
 
-    it("preserves HTTPS hostnames after DNS validation", async () => {
+    it("rejects DNS-backed HTTPS URLs that cannot be transport-pinned", async () => {
       const lookup = async () => [{ address: "93.184.216.34", family: 4 }];
-      await expect(rewriteConfigUrlsWithDnsPinning("https://example.com/v1", lookup)).resolves.toBe(
-        "https://example.com/v1",
+      await expect(rewriteConfigUrlsWithDnsPinning("https://example.com/v1", lookup)).rejects.toThrow(
+        /cannot safely persist/i,
       );
     });
 
@@ -526,7 +526,7 @@ describe("config set helpers", () => {
         rewriteConfigUrlsWithDnsPinning(
           {
             primary: "http://api.example.com/v1",
-            secure: "https://secure.example.com/v1",
+            secure: "https://93.184.216.35/v1",
             label: "production",
             fallbacks: ["http://backup.example.com/v2"],
           },
@@ -534,7 +534,7 @@ describe("config set helpers", () => {
         ),
       ).resolves.toEqual({
         primary: "http://93.184.216.34/v1",
-        secure: "https://secure.example.com/v1",
+        secure: "https://93.184.216.35/v1",
         label: "production",
         fallbacks: ["http://93.184.216.34/v2"],
       });

--- a/test/e2e/live/https-pin-proxy.test.ts
+++ b/test/e2e/live/https-pin-proxy.test.ts
@@ -104,13 +104,12 @@ function writeBlueprint(workdir: string, sandboxName: string): void {
 function ensureFakeExecaModule(cleanup: { add: (name: string, fn: () => void) => void }): void {
   const execaDir = path.join(REPO_ROOT, "nemoclaw", "node_modules", "execa");
   const packageJson = path.join(execaDir, "package.json");
-  if (fs.existsSync(packageJson)) return;
-
-  fs.mkdirSync(execaDir, { recursive: true });
-  fs.writeFileSync(packageJson, JSON.stringify({ type: "module", exports: "./index.js" }));
-  fs.writeFileSync(
-    path.join(execaDir, "index.js"),
-    `import { spawn } from "node:child_process";
+  const createFakeModule = (): void => {
+    fs.mkdirSync(execaDir, { recursive: true });
+    fs.writeFileSync(packageJson, JSON.stringify({ type: "module", exports: "./index.js" }));
+    fs.writeFileSync(
+      path.join(execaDir, "index.js"),
+      `import { spawn } from "node:child_process";
 export function execa(command, args = [], options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -136,10 +135,13 @@ export function execa(command, args = [], options = {}) {
   });
 }
 `,
-  );
-  cleanup.add("remove temporary fake execa module", () => {
-    fs.rmSync(execaDir, { recursive: true, force: true });
-  });
+    );
+    cleanup.add("remove temporary fake execa module", () => {
+      fs.rmSync(execaDir, { recursive: true, force: true });
+    });
+  };
+
+  fs.existsSync(packageJson) ? undefined : createFakeModule();
 }
 
 function writeFakeOpenShell(binDir: string): string {

--- a/test/e2e/live/https-pin-proxy.test.ts
+++ b/test/e2e/live/https-pin-proxy.test.ts
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression guard for #4684.
+ *
+ * The bug was not that SSRF validation failed; it was that DNS-backed HTTPS
+ * endpoints were validated and then handed to the downstream provider as the
+ * original hostname URL, letting the provider perform a second DNS lookup at
+ * connection time. This scenario exercises the real blueprint runner CLI path
+ * and asserts the provider receives only the loopback pin-proxy endpoint.
+ */
+
+import { spawn } from "node:child_process";
+import dns from "node:dns";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import YAML from "yaml";
+
+import { expect, test } from "../fixtures/e2e-test.ts";
+import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const RUN_HTTPS_PIN_PROXY_TEST = shouldRunLiveE2E() ? test : test.skip;
+const TEST_TIMEOUT_MS = 90_000;
+const PROXY_PORT = 21437;
+const VALIDATED_PUBLIC_IP = "93.184.216.34";
+const REBOUND_PRIVATE_IP = "10.0.0.5";
+
+type CommandResult = {
+  readonly exitCode: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+function runCommand(
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly cwd: string;
+    readonly env: NodeJS.ProcessEnv;
+    readonly timeoutMs?: number;
+  },
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 1_000).unref();
+    }, options.timeoutMs ?? 30_000);
+    timeout.unref();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (exitCode) => {
+      clearTimeout(timeout);
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+function writeBlueprint(workdir: string, sandboxName: string): void {
+  fs.writeFileSync(
+    path.join(workdir, "blueprint.yaml"),
+    YAML.stringify({
+      version: "1.0",
+      components: {
+        sandbox: {
+          image: "openclaw",
+          name: sandboxName,
+        },
+        inference: {
+          profiles: {
+            default: {
+              provider_type: "openai",
+              provider_name: "default",
+              endpoint: "https://rebinding.example.test/v1",
+              model: "e2e-model",
+              credential_env: "E2E_API_KEY",
+            },
+          },
+        },
+      },
+    }),
+  );
+}
+
+function ensureFakeExecaModule(cleanup: { add: (name: string, fn: () => void) => void }): void {
+  const execaDir = path.join(REPO_ROOT, "nemoclaw", "node_modules", "execa");
+  const packageJson = path.join(execaDir, "package.json");
+  if (fs.existsSync(packageJson)) return;
+
+  fs.mkdirSync(execaDir, { recursive: true });
+  fs.writeFileSync(packageJson, JSON.stringify({ type: "module", exports: "./index.js" }));
+  fs.writeFileSync(
+    path.join(execaDir, "index.js"),
+    `import { spawn } from "node:child_process";
+export function execa(command, args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ? { ...process.env, ...options.env } : process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+    child.stderr?.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    child.once("error", reject);
+    child.once("close", (exitCode) => {
+      const result = { exitCode: exitCode ?? 0, stdout, stderr };
+      if (result.exitCode !== 0 && options.reject !== false) {
+        const error = new Error(\`Command failed: \${command} \${args.join(" ")}\`);
+        Object.assign(error, result);
+        reject(error);
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+`,
+  );
+  cleanup.add("remove temporary fake execa module", () => {
+    fs.rmSync(execaDir, { recursive: true, force: true });
+  });
+}
+
+function writeFakeOpenShell(binDir: string): string {
+  const commandLogPath = path.join(binDir, "openshell-commands.jsonl");
+  const scriptPath = path.join(binDir, "openshell");
+  fs.writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const entry = { args, env: process.env };
+const configIndex = args.indexOf("--config");
+const configValue = configIndex >= 0 ? args[configIndex + 1] : "";
+if (configValue.includes("rebinding.example.test")) {
+  entry.simulatedDownstreamAddress = ${JSON.stringify(REBOUND_PRIVATE_IP)};
+}
+fs.appendFileSync(${JSON.stringify(commandLogPath)}, JSON.stringify(entry) + "\\n");
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+  return commandLogPath;
+}
+
+function readOpenShellCalls(commandLogPath: string): Array<{
+  readonly args: string[];
+  readonly env: Record<string, string | undefined>;
+  readonly simulatedDownstreamAddress?: string;
+}> {
+  return fs
+    .readFileSync(commandLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+RUN_HTTPS_PIN_PROXY_TEST(
+  "https-pin-proxy: blueprint apply gives downstream only the pinned loopback endpoint",
+  { timeout: TEST_TIMEOUT_MS },
+  async ({ artifacts, cleanup }) => {
+    ensureFakeExecaModule(cleanup);
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-https-pin-e2e-"));
+    const workdir = path.join(root, "blueprint");
+    const fakeBinDir = path.join(root, "bin");
+    const home = path.join(root, "home");
+    fs.mkdirSync(workdir, { recursive: true });
+    fs.mkdirSync(fakeBinDir, { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+
+    cleanup.add(`remove HTTPS pin proxy E2E temp root ${root}`, () => {
+      fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    const commandLogPath = writeFakeOpenShell(fakeBinDir);
+    writeBlueprint(workdir, "e2e-https-pin-proxy");
+    await artifacts.writeJson("scenario.json", {
+      id: "https-pin-proxy",
+      runner: "vitest",
+      issue: 4684,
+      contract: [
+        "DNS-backed HTTPS endpoint is validated once on the host",
+        "downstream provider receives a loopback HTTPS pin-proxy URL, not the original hostname",
+        "a DNS rebind after validation does not change the provider endpoint URL",
+      ],
+    });
+
+    const runnerScript = `
+import dns from "node:dns";
+import { main } from ${JSON.stringify(path.join(REPO_ROOT, "nemoclaw/src/blueprint/runner.ts"))};
+import { serveHttpsPinProxy } from ${JSON.stringify(path.join(REPO_ROOT, "nemoclaw/src/blueprint/https-pin-proxy.ts"))};
+
+const originalLookup = dns.lookup;
+const originalPromisesLookup = dns.promises.lookup;
+dns.lookup = ((hostname, options, callback) => {
+  if (hostname === "rebinding.example.test") {
+    const cb = typeof options === "function" ? options : callback;
+    if (typeof cb === "function") {
+      process.nextTick(() => cb(null, [{ address: ${JSON.stringify(VALIDATED_PUBLIC_IP)}, family: 4 }]));
+    }
+    return {};
+  }
+  return originalLookup(hostname, options, callback);
+});
+dns.promises.lookup = ((hostname, options) => {
+  if (hostname === "rebinding.example.test") {
+    return Promise.resolve([{ address: ${JSON.stringify(VALIDATED_PUBLIC_IP)}, family: 4 }]);
+  }
+  return originalPromisesLookup(hostname, options);
+});
+
+async function run() {
+  const proxyServer = await serveHttpsPinProxy(${PROXY_PORT});
+  try {
+    await main(["apply"]);
+  } finally {
+    await new Promise((resolve, reject) => proxyServer.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+run().catch((error) => {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+`;
+
+    const result = await runCommand(
+      process.execPath,
+      [
+        path.join(REPO_ROOT, "node_modules/tsx/dist/cli.mjs"),
+        "--input-type=module",
+        "--eval",
+        runnerScript,
+      ],
+      {
+        cwd: workdir,
+        timeoutMs: 45_000,
+        env: {
+          HOME: home,
+          PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          NEMOCLAW_HTTPS_PIN_PROXY_PORT: String(PROXY_PORT),
+          E2E_API_KEY: "e2e-fake-key",
+        },
+      },
+    );
+
+    await artifacts.writeJson("runner-result.json", result);
+    await artifacts.writeText(
+      "openshell-commands.jsonl",
+      fs.existsSync(commandLogPath) ? fs.readFileSync(commandLogPath, "utf8") : "",
+    );
+
+    expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+
+    const providerCreate = readOpenShellCalls(commandLogPath).find(
+      (entry) => entry.args[0] === "provider" && entry.args[1] === "create",
+    );
+    expect(
+      providerCreate,
+      "expected blueprint apply to configure an OpenShell provider",
+    ).toBeDefined();
+    const configIndex = providerCreate?.args.indexOf("--config") ?? -1;
+    expect(configIndex).toBeGreaterThan(-1);
+    const openaiBaseUrl = providerCreate?.args[configIndex + 1] ?? "";
+
+    expect(openaiBaseUrl).toMatch(
+      new RegExp(
+        `^OPENAI_BASE_URL=http://127\\.0\\.0\\.1:${PROXY_PORT}/\\.nemoclaw/https-pin/[a-f0-9]{24}/v1$`,
+      ),
+    );
+    expect(openaiBaseUrl).not.toContain("rebinding.example.test");
+    expect(openaiBaseUrl).not.toContain(REBOUND_PRIVATE_IP);
+    expect(providerCreate?.simulatedDownstreamAddress).toBeUndefined();
+  },
+);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fixes a DNS rebinding TOCTOU gap for DNS-backed HTTPS endpoints. NemoClaw now avoids handing the original hostname URL directly to the downstream provider after validation, and instead routes DNS-backed HTTPS endpoints through a local pinned proxy that connects to the validated IP while preserving TLS SNI and the Host header.

## Related Issue

Fixes #4684 

## Changes

- Add a local HTTPS pinning proxy for DNS-backed HTTPS inference endpoints.
- Route validated DNS-backed HTTPS blueprint and endpoint-override URLs through the proxy instead of returning the original hostname URL.
- Keep HTTP DNS pinning behavior unchanged.
- Keep IP-literal HTTPS endpoints unchanged.
- Fail closed for generic persisted config values that contain DNS-backed HTTPS URLs, since that path cannot attach SNI/Host-preserving connection pinning.
- Update SSRF, runner, proxy, config-set tests, and troubleshooting docs.

## Type of Change

- [x] Code change with doc updates
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification run:

- [x] `cd nemoclaw && npm run check`
- [x] `cd nemoclaw && npm run build`
- [x] `npm run typecheck:cli`
- [x] `npx vitest run test/config-set.test.ts --config vitest.config.ts`

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: 1PoPTRoN <vrxn.arp1traj@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTPS endpoint pinning proxy support to route external HTTPS targets through a secure local proxy.
  * Enhanced endpoint validation with detailed DNS resolution tracking.

* **Bug Fixes**
  * Stricter validation for HTTPS URLs in config persistence—DNS-backed HTTPS endpoints are now rejected to prevent connection failures.

* **Documentation**
  * Updated troubleshooting guide with explicit validation rules for config URL values, including DNS resolution behavior and credential handling guidance.

* **Tests**
  * Added comprehensive test coverage for HTTPS proxy lifecycle, request forwarding, and config URL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->