### PR TITLE
fix(docs): resolve Fern routes in link checker

### DIFF
--- a/test/check-docs-links.test.ts
+++ b/test/check-docs-links.test.ts
@@ -10,9 +10,10 @@ import path from "node:path";
 const REPO_ROOT = path.dirname(import.meta.dirname);
 const CHECK_DOCS = path.join(import.meta.dirname, "e2e", "e2e-cloud-experimental", "check-docs.sh");
 
-function runCheckDocs(filePath: string) {
+function runCheckDocs(filePath: string, env: Record<string, string> = {}) {
   return spawnSync("bash", [CHECK_DOCS, "--only-links", "--local-only", filePath], {
     encoding: "utf-8",
+    env: { ...process.env, ...env },
   });
 }
 
@@ -66,8 +67,10 @@ describe("check-docs link validation", () => {
         "# Guide",
         "",
         "[OpenClaw overview](/user-guide/openclaw/about/overview)",
+        "[OpenClaw home](/openclaw)",
         "[OpenClaw hardening](/user-guide/openclaw/manage-sandboxes/sandbox-hardening)",
         '<Card title="Hermes overview" href="/user-guide/hermes/about/overview">',
+        '<Card title="Hermes home" href="/user-guide/hermes">',
         "",
       ].join("\n"),
     );
@@ -90,6 +93,38 @@ describe("check-docs link validation", () => {
       "../manage-sandboxes/sandbox-hardening",
     );
     expect(slugAliasResult.status).toBe(0);
+  });
+
+  it("rejects broken Fern site routes", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-check-docs-bad-fern-"));
+    const mdPath = path.join(tempDir, "guide.mdx");
+    fs.writeFileSync(
+      mdPath,
+      ["# Guide", "", "[Missing](/user-guide/openclaw/no-such-section/no-such-page)", ""].join(
+        "\n",
+      ),
+    );
+
+    const result = runCheckDocs(mdPath);
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      `broken site route in ${mdPath}:3 -> /user-guide/openclaw/no-such-section/no-such-page`,
+    );
+  });
+
+  it("fails loudly when the Fern route index cannot be built", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-check-docs-bad-nav-"));
+    const mdPath = path.join(tempDir, "guide.mdx");
+    const navPath = path.join(tempDir, "index.yml");
+    fs.writeFileSync(navPath, "navigation: []\n");
+    fs.writeFileSync(mdPath, ["# Guide", "", "[Overview](/user-guide/openclaw/about/overview)", ""].join("\n"));
+
+    const result = runCheckDocs(mdPath, { CHECK_DOCS_FERN_NAV_YML: navPath });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}${result.stderr}`).toContain("failed to parse Fern navigation");
+    expect(`${result.stdout}${result.stderr}`).toContain("no Fern routes found");
   });
 
   it("ignores broken links inside tilde-fenced code blocks", () => {

--- a/test/check-docs-links.test.ts
+++ b/test/check-docs-links.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+const REPO_ROOT = path.dirname(import.meta.dirname);
 const CHECK_DOCS = path.join(import.meta.dirname, "e2e", "e2e-cloud-experimental", "check-docs.sh");
 
 function runCheckDocs(filePath: string) {
@@ -65,6 +66,7 @@ describe("check-docs link validation", () => {
         "# Guide",
         "",
         "[OpenClaw overview](/user-guide/openclaw/about/overview)",
+        "[OpenClaw hardening](/user-guide/openclaw/manage-sandboxes/sandbox-hardening)",
         '<Card title="Hermes overview" href="/user-guide/hermes/about/overview">',
         "",
       ].join("\n"),
@@ -73,6 +75,21 @@ describe("check-docs link validation", () => {
     const result = runCheckDocs(mdPath);
 
     expect(result.status).toBe(0);
+  });
+
+  it("resolves Fern extensionless and route-relative links from docs pages", () => {
+    const routeRelativePage = path.join(REPO_ROOT, "docs", "get-started", "windows-preparation.mdx");
+    const slugAliasPage = path.join(REPO_ROOT, "docs", "about", "how-it-works.mdx");
+
+    const routeRelativeResult = runCheckDocs(routeRelativePage);
+    const slugAliasResult = runCheckDocs(slugAliasPage);
+
+    expect(`${routeRelativeResult.stdout}${routeRelativeResult.stderr}`).not.toContain("../quickstart");
+    expect(routeRelativeResult.status).toBe(0);
+    expect(`${slugAliasResult.stdout}${slugAliasResult.stderr}`).not.toContain(
+      "../manage-sandboxes/sandbox-hardening",
+    );
+    expect(slugAliasResult.status).toBe(0);
   });
 
   it("ignores broken links inside tilde-fenced code blocks", () => {

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -698,6 +698,231 @@ extract_targets() {
   ' -- "$1"
 }
 
+FERN_ROUTE_INDEX_LOADED=0
+FERN_ROUTE_INDEX=""
+
+load_fern_route_index() {
+  [[ "$FERN_ROUTE_INDEX_LOADED" -eq 1 ]] && return 0
+  FERN_ROUTE_INDEX_LOADED=1
+
+  local nav_yml="$REPO_ROOT/docs/index.yml"
+  [[ -f "$nav_yml" ]] || return 0
+  if ! command -v "$NODE" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Build a lightweight route index from Fern navigation without requiring npm
+  # dependencies. Each emitted row is: <docs source path> TAB <canonical route>.
+  # The parser intentionally handles the subset used by docs/index.yml:
+  # variants, nested sections with slugs, and pages/sections with path+slug.
+  FERN_ROUTE_INDEX="$(
+    "$NODE" - "$nav_yml" <<'NODE' 2>/dev/null || true
+const fs = require("node:fs");
+const navPath = process.argv[2];
+const lines = fs.readFileSync(navPath, "utf8").split(/\r?\n/);
+
+let variant = "";
+let stack = [];
+let current = null;
+const rows = [];
+
+function clean(value) {
+  let out = value.trim();
+  const hash = out.indexOf(" #");
+  if (hash >= 0) out = out.slice(0, hash).trim();
+  if ((out.startsWith('"') && out.endsWith('"')) || (out.startsWith("'") && out.endsWith("'"))) {
+    out = out.slice(1, -1);
+  }
+  return out;
+}
+
+function maybeEmit(item) {
+  if (!item || item.emitted || !variant || !item.path || !item.slug || item.indent <= 6) return;
+  const route = ["user-guide", variant, ...item.parent, item.slug].join("/");
+  rows.push(`${item.path}\t${route}`);
+  item.emitted = true;
+}
+
+function maybePushSection(item) {
+  if (!item || item.pushed || item.type !== "section" || !item.slug || item.indent <= 6) return;
+  stack.push({ indent: item.indent, slug: item.slug });
+  item.pushed = true;
+}
+
+for (const line of lines) {
+  const itemMatch = line.match(/^(\s*)-\s+(page|section|link|title):/);
+  if (itemMatch) {
+    const indent = itemMatch[1].length;
+    const type = itemMatch[2];
+    while (stack.length && stack[stack.length - 1].indent >= indent) stack.pop();
+    if (indent === 6 && type === "title") {
+      variant = "";
+      stack = [];
+    }
+    current = {
+      indent,
+      type,
+      parent: stack.map((part) => part.slug),
+      path: "",
+      slug: "",
+      emitted: false,
+      pushed: false,
+    };
+    continue;
+  }
+
+  const propMatch = line.match(/^(\s*)(path|slug):\s*(.+?)\s*$/);
+  if (!propMatch || !current) continue;
+  const indent = propMatch[1].length;
+  if (indent !== current.indent + 2) continue;
+
+  const key = propMatch[2];
+  const value = clean(propMatch[3]);
+  if (current.indent === 6 && key === "slug") {
+    variant = value;
+    stack = [];
+    continue;
+  }
+  if (key === "path") current.path = value;
+  if (key === "slug") current.slug = value;
+  maybeEmit(current);
+  maybePushSection(current);
+}
+
+process.stdout.write(rows.join("\n"));
+NODE
+  )"
+}
+
+normalize_fern_route_path() {
+  local input="$1" part
+  input="${input#/}"
+  case "$input" in
+    nemoclaw/latest/*) input="${input#nemoclaw/latest/}" ;;
+    nemoclaw/*) input="${input#nemoclaw/}" ;;
+    latest/*) input="${input#latest/}" ;;
+  esac
+
+  local -a parts=() out=()
+  local IFS='/'
+  read -r -a parts <<<"$input"
+  unset IFS
+  for part in "${parts[@]}"; do
+    case "$part" in
+      "" | .) ;;
+      ..)
+        if [[ "${#out[@]}" -eq 0 ]]; then
+          return 1
+        fi
+        unset 'out[${#out[@]}-1]'
+        ;;
+      *) out+=("$part") ;;
+    esac
+  done
+
+  local joined
+  joined="$(
+    IFS=/
+    printf '%s' "${out[*]}"
+  )"
+  printf '%s' "$joined"
+}
+
+fern_route_exists() {
+  local route="$1" candidate
+  load_fern_route_index
+  [[ -n "$FERN_ROUTE_INDEX" ]] || return 1
+
+  route="$(normalize_fern_route_path "$route")" || return 1
+  local -a candidates=("$route")
+  case "$route" in
+    openclaw/* | hermes/*)
+      candidates+=("user-guide/$route")
+      ;;
+    user-guide/*) ;;
+    about/* | get-started/* | inference/* | manage-sandboxes/* | network-policy/* | deployment/* | monitoring/* | security/* | reference/* | resources/*)
+      candidates+=("user-guide/openclaw/$route")
+      ;;
+  esac
+  if [[ "$route" == get-started/quickstart-hermes ]]; then
+    candidates+=("user-guide/hermes/get-started/quickstart-hermes")
+  elif [[ "$route" == get-started/hermes/* ]]; then
+    candidates+=("user-guide/hermes/get-started/${route#get-started/hermes/}")
+  fi
+
+  local _source indexed_route
+  for candidate in "${candidates[@]}"; do
+    while IFS=$'\t' read -r _source indexed_route || [[ -n "${indexed_route:-}" ]]; do
+      [[ "$indexed_route" == "$candidate" ]] && return 0
+    done <<<"$FERN_ROUTE_INDEX"
+  done
+  return 1
+}
+
+fern_relative_ref_exists() {
+  local md_path="$1" stripped="$2"
+  local abs_md="$md_path" source_rel current route
+  [[ "$abs_md" == /* ]] || abs_md="$REPO_ROOT/$abs_md"
+  case "$abs_md" in
+    "$REPO_ROOT/docs/"*) source_rel="${abs_md#"$REPO_ROOT/docs/"}" ;;
+    *) return 1 ;;
+  esac
+
+  load_fern_route_index
+  [[ -n "$FERN_ROUTE_INDEX" ]] || return 1
+
+  while IFS=$'\t' read -r _source current || [[ -n "${current:-}" ]]; do
+    [[ "$_source" == "$source_rel" ]] || continue
+    route="${current%/*}/$stripped"
+    if fern_route_exists "$route"; then
+      return 0
+    fi
+  done <<<"$FERN_ROUTE_INDEX"
+  return 1
+}
+
+source_ref_exists() {
+  local base_dir="$1" stripped="$2" candidate
+  local -a candidates=("$stripped")
+  if [[ "$stripped" == */ ]]; then
+    candidates+=("${stripped}index.mdx" "${stripped}index.md")
+  else
+    candidates+=("$stripped.mdx" "$stripped.md" "$stripped/index.mdx" "$stripped/index.md")
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    if (cd "$base_dir" && [[ -e "$candidate" ]]); then
+      return 0
+    fi
+  done
+  return 1
+}
+
+site_source_ref_exists() {
+  local stripped="$1"
+  local site_path="${stripped#/}"
+  local -a site_paths=("$site_path")
+  case "$site_path" in
+    nemoclaw/latest/*) site_paths+=("${site_path#nemoclaw/latest/}") ;;
+    nemoclaw/*) site_paths+=("${site_path#nemoclaw/}") ;;
+    latest/*) site_paths+=("${site_path#latest/}") ;;
+  esac
+  case "$site_path" in
+    user-guide/openclaw/*) site_paths+=("${site_path#user-guide/openclaw/}") ;;
+    user-guide/hermes/*) site_paths+=("${site_path#user-guide/hermes/}") ;;
+    openclaw/*) site_paths+=("${site_path#openclaw/}") ;;
+    hermes/*) site_paths+=("${site_path#hermes/}") ;;
+  esac
+
+  local route_path
+  for route_path in "${site_paths[@]}"; do
+    if source_ref_exists "$REPO_ROOT/docs" "$route_path"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 check_local_ref() {
   local md_path="$1" line_no="$2" target="$3"
   local stripped
@@ -718,33 +943,14 @@ check_local_ref() {
   fi
 
   if [[ "$stripped" == /* ]]; then
-    local site_path="${stripped#/}"
-    local -a site_paths=("$site_path")
-    case "$site_path" in
-      user-guide/openclaw/*)
-        site_paths+=("${site_path#user-guide/openclaw/}")
-        ;;
-      user-guide/hermes/*)
-        site_paths+=("${site_path#user-guide/hermes/}")
-        ;;
-    esac
-
-    local route_path candidate
-    for route_path in "${site_paths[@]}"; do
-      for candidate in \
-        "$REPO_ROOT/docs/$route_path" \
-        "$REPO_ROOT/docs/$route_path.mdx" \
-        "$REPO_ROOT/docs/$route_path.md" \
-        "$REPO_ROOT/docs/$route_path/index.mdx" \
-        "$REPO_ROOT/docs/$route_path/index.md"; do
-        [[ -e "$candidate" ]] && return 0
-      done
-    done
+    if fern_route_exists "$stripped" || site_source_ref_exists "$stripped"; then
+      return 0
+    fi
     echo "check-docs: [links] broken site route in $md_path:$line_no -> $target" >&2
     return 1
   fi
 
-  if (cd "$(dirname "$md_path")" && [[ -e "$stripped" ]]); then
+  if source_ref_exists "$(dirname "$md_path")" "$stripped" || fern_relative_ref_exists "$md_path" "$stripped"; then
     return 0
   fi
   echo "check-docs: [links] broken local link in $md_path:$line_no -> $target" >&2
@@ -856,7 +1062,7 @@ run_links_check() {
   local failures=0
   declare -a REMOTE_URLS=()
 
-  log "[links] phase 1/2: local file targets for [](url) / ![]() / <https://> (code fences skipped)"
+  log "[links] phase 1/2: local file targets and Fern routes for [](url) / ![]() / <https://> (code fences skipped)"
   for md in "${DOC_FILES[@]}"; do
     if [[ ! -f "$md" ]]; then
       echo "check-docs: [links] missing file: $md" >&2
@@ -894,7 +1100,7 @@ run_links_check() {
     log "[links] phase 1 failed"
     return 1
   fi
-  log "[links] phase 1 OK (local paths resolve from each .md directory)"
+  log "[links] phase 1 OK (local paths and Fern routes resolve)"
 
   local _n_raw _deduped _unique _i _u url
   _n_raw="${#REMOTE_URLS[@]}"

--- a/test/e2e/e2e-cloud-experimental/check-docs.sh
+++ b/test/e2e/e2e-cloud-experimental/check-docs.sh
@@ -705,7 +705,7 @@ load_fern_route_index() {
   [[ "$FERN_ROUTE_INDEX_LOADED" -eq 1 ]] && return 0
   FERN_ROUTE_INDEX_LOADED=1
 
-  local nav_yml="$REPO_ROOT/docs/index.yml"
+  local nav_yml="${CHECK_DOCS_FERN_NAV_YML:-$REPO_ROOT/docs/index.yml}"
   [[ -f "$nav_yml" ]] || return 0
   if ! command -v "$NODE" >/dev/null 2>&1; then
     return 0
@@ -715,8 +715,10 @@ load_fern_route_index() {
   # dependencies. Each emitted row is: <docs source path> TAB <canonical route>.
   # The parser intentionally handles the subset used by docs/index.yml:
   # variants, nested sections with slugs, and pages/sections with path+slug.
-  FERN_ROUTE_INDEX="$(
-    "$NODE" - "$nav_yml" <<'NODE' 2>/dev/null || true
+  local _fern_route_index_err
+  _fern_route_index_err="$(mktemp)"
+  if ! FERN_ROUTE_INDEX="$(
+    "$NODE" - "$nav_yml" <<'NODE' 2>"$_fern_route_index_err"
 const fs = require("node:fs");
 const navPath = process.argv[2];
 const lines = fs.readFileSync(navPath, "utf8").split(/\r?\n/);
@@ -789,9 +791,17 @@ for (const line of lines) {
   maybePushSection(current);
 }
 
+if (rows.length === 0) {
+  throw new Error(`no Fern routes found in ${navPath}`);
+}
 process.stdout.write(rows.join("\n"));
 NODE
-  )"
+  )"; then
+    echo "check-docs: [links] failed to parse Fern navigation ${nav_yml#"$REPO_ROOT"/}: $(tr '\n' ' ' <"$_fern_route_index_err" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//')" >&2
+    rm -f "$_fern_route_index_err"
+    return 1
+  fi
+  rm -f "$_fern_route_index_err"
 }
 
 normalize_fern_route_path() {
@@ -830,12 +840,23 @@ normalize_fern_route_path() {
 
 fern_route_exists() {
   local route="$1" candidate
-  load_fern_route_index
+  if ! load_fern_route_index; then
+    return 3
+  fi
   [[ -n "$FERN_ROUTE_INDEX" ]] || return 1
 
   route="$(normalize_fern_route_path "$route")" || return 1
   local -a candidates=("$route")
   case "$route" in
+    openclaw)
+      candidates+=("user-guide/openclaw/home")
+      ;;
+    hermes)
+      candidates+=("user-guide/hermes/home")
+      ;;
+    user-guide/openclaw | user-guide/hermes)
+      candidates+=("$route/home")
+      ;;
     openclaw/* | hermes/*)
       candidates+=("user-guide/$route")
       ;;
@@ -868,14 +889,23 @@ fern_relative_ref_exists() {
     *) return 1 ;;
   esac
 
-  load_fern_route_index
+  if ! load_fern_route_index; then
+    return 3
+  fi
   [[ -n "$FERN_ROUTE_INDEX" ]] || return 1
 
   while IFS=$'\t' read -r _source current || [[ -n "${current:-}" ]]; do
     [[ "$_source" == "$source_rel" ]] || continue
     route="${current%/*}/$stripped"
-    if fern_route_exists "$route"; then
+    local _fern_rc
+    set +e
+    fern_route_exists "$route"
+    _fern_rc=$?
+    set -e
+    if [[ "$_fern_rc" -eq 0 ]]; then
       return 0
+    elif [[ "$_fern_rc" -eq 3 ]]; then
+      return 3
     fi
   done <<<"$FERN_ROUTE_INDEX"
   return 1
@@ -943,15 +973,35 @@ check_local_ref() {
   fi
 
   if [[ "$stripped" == /* ]]; then
-    if fern_route_exists "$stripped" || site_source_ref_exists "$stripped"; then
+    local _fern_rc
+    set +e
+    fern_route_exists "$stripped"
+    _fern_rc=$?
+    set -e
+    if [[ "$_fern_rc" -eq 0 ]]; then
+      return 0
+    elif [[ "$_fern_rc" -eq 3 ]]; then
+      return 1
+    fi
+    if site_source_ref_exists "$stripped"; then
       return 0
     fi
     echo "check-docs: [links] broken site route in $md_path:$line_no -> $target" >&2
     return 1
   fi
 
-  if source_ref_exists "$(dirname "$md_path")" "$stripped" || fern_relative_ref_exists "$md_path" "$stripped"; then
+  if source_ref_exists "$(dirname "$md_path")" "$stripped"; then
     return 0
+  fi
+  local _fern_relative_rc
+  set +e
+  fern_relative_ref_exists "$md_path" "$stripped"
+  _fern_relative_rc=$?
+  set -e
+  if [[ "$_fern_relative_rc" -eq 0 ]]; then
+    return 0
+  elif [[ "$_fern_relative_rc" -eq 3 ]]; then
+    return 1
   fi
   echo "check-docs: [links] broken local link in $md_path:$line_no -> $target" >&2
   return 1


### PR DESCRIPTION
## Summary
Update the docs link checker so it validates Fern-style routes instead of treating extensionless MDX and variant-navigation links as broken filesystem paths. This fixes docs-validation failures after the Fern migration while keeping local link validation active.

## Changes
- Build a lightweight route index from `docs/index.yml` during `check-docs.sh` link validation.
- Resolve extensionless `.md` / `.mdx` links, route-relative Fern links, and OpenClaw/Hermes variant routes.
- Add regression tests for Fern variant routes, route-relative links, and nav slugs that differ from source file paths.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests verifying documentation link rewriting and that local docs and site-route links resolve; includes checks that failures are reported for broken or unbuildable site routes.

* **Chores**
  * Enhanced the docs link checker to resolve site-route-style links, normalize varied path formats, and more reliably detect missing or misreferenced documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->