### PR TITLE
chore(release): bump version to v0.0.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ It provides guided onboarding, a hardened blueprint, routed inference, network p
 - [OpenClaw](https://openclaw.ai) (default)
 - [Hermes](https://get-hermes.ai/)
 
-For capabilities, architecture, security controls, and the full feature list, see the [NemoClaw documentation](https://docs.nvidia.com/nemoclaw/latest/).
+For capabilities, architecture, security controls, and the full feature list, see the [NemoClaw documentation](https://docs.nvidia.com/nemoclaw/0.0.57/).
 
 ## Get Started
 
-Review [Prerequisites](https://docs.nvidia.com/nemoclaw/latest/get-started/prerequisites.html) before installing.
+Review [Prerequisites](https://docs.nvidia.com/nemoclaw/0.0.57/get-started/prerequisites.html) before installing.
 For Hermes, set `NEMOCLAW_AGENT=hermes` before running the installer, or use the `nemohermes` alias after install.
 
 | Agent | Guide |
 |-------|-------|
-| OpenClaw (default) | [Quickstart with OpenClaw](https://docs.nvidia.com/nemoclaw/latest/get-started/quickstart.html) |
-| Hermes | [Quickstart with Hermes](https://docs.nvidia.com/nemoclaw/latest/get-started/quickstart-hermes.html) |
+| OpenClaw (default) | [Quickstart with OpenClaw](https://docs.nvidia.com/nemoclaw/0.0.57/get-started/quickstart.html) |
+| Hermes | [Quickstart with Hermes](https://docs.nvidia.com/nemoclaw/0.0.57/get-started/quickstart-hermes.html) |
 
 ## Documentation
 
@@ -35,18 +35,18 @@ Refer to the following pages on the official documentation website for more info
 
 | Page | Description |
 |------|-------------|
-| [Overview](https://docs.nvidia.com/nemoclaw/latest/about/overview.html) | What NemoClaw does and how it fits together. |
-| [Architecture Overview](https://docs.nvidia.com/nemoclaw/latest/about/how-it-works.html) | High-level overview of Plugin, blueprint, sandbox lifecycle, and protection layers. |
-| [Ecosystem](https://docs.nvidia.com/nemoclaw/latest/about/ecosystem.html) | How OpenClaw, OpenShell, and NemoClaw form a stack and when to use NemoClaw versus OpenShell alone. |
-| [Architecture Details](https://docs.nvidia.com/nemoclaw/latest/reference/architecture.html) | Detailed description of Plugin structure, blueprint lifecycle, sandbox environment, and host-side state. |
-| [Prerequisites](https://docs.nvidia.com/nemoclaw/latest/get-started/prerequisites.html) | Hardware, software, and supported platforms, with any platform-specific pre-setup. |
-| [Inference Options](https://docs.nvidia.com/nemoclaw/latest/inference/inference-options.html) | Supported providers, validation, and routed inference configuration. |
-| [Network Policies](https://docs.nvidia.com/nemoclaw/latest/reference/network-policies.html) | Baseline rules, operator approval flow, and egress control. |
-| [Customize Network Policy](https://docs.nvidia.com/nemoclaw/latest/network-policy/customize-network-policy.html) | Static and dynamic policy changes, presets. |
-| [Security Best Practices](https://docs.nvidia.com/nemoclaw/latest/security/best-practices.html) | Controls reference, risk framework, and posture profiles for sandbox security. |
-| [Sandbox Hardening](https://docs.nvidia.com/nemoclaw/latest/deployment/sandbox-hardening.html) | Container security measures, capability drops, process limits. |
-| [CLI Commands](https://docs.nvidia.com/nemoclaw/latest/reference/commands.html) | Full NemoClaw CLI command reference. |
-| [Troubleshooting](https://docs.nvidia.com/nemoclaw/latest/reference/troubleshooting.html) | Common issues and resolution steps. |
+| [Overview](https://docs.nvidia.com/nemoclaw/0.0.57/about/overview.html) | What NemoClaw does and how it fits together. |
+| [Architecture Overview](https://docs.nvidia.com/nemoclaw/0.0.57/about/how-it-works.html) | High-level overview of Plugin, blueprint, sandbox lifecycle, and protection layers. |
+| [Ecosystem](https://docs.nvidia.com/nemoclaw/0.0.57/about/ecosystem.html) | How OpenClaw, OpenShell, and NemoClaw form a stack and when to use NemoClaw versus OpenShell alone. |
+| [Architecture Details](https://docs.nvidia.com/nemoclaw/0.0.57/reference/architecture.html) | Detailed description of Plugin structure, blueprint lifecycle, sandbox environment, and host-side state. |
+| [Prerequisites](https://docs.nvidia.com/nemoclaw/0.0.57/get-started/prerequisites.html) | Hardware, software, and supported platforms, with any platform-specific pre-setup. |
+| [Inference Options](https://docs.nvidia.com/nemoclaw/0.0.57/inference/inference-options.html) | Supported providers, validation, and routed inference configuration. |
+| [Network Policies](https://docs.nvidia.com/nemoclaw/0.0.57/reference/network-policies.html) | Baseline rules, operator approval flow, and egress control. |
+| [Customize Network Policy](https://docs.nvidia.com/nemoclaw/0.0.57/network-policy/customize-network-policy.html) | Static and dynamic policy changes, presets. |
+| [Security Best Practices](https://docs.nvidia.com/nemoclaw/0.0.57/security/best-practices.html) | Controls reference, risk framework, and posture profiles for sandbox security. |
+| [Sandbox Hardening](https://docs.nvidia.com/nemoclaw/0.0.57/deployment/sandbox-hardening.html) | Container security measures, capability drops, process limits. |
+| [CLI Commands](https://docs.nvidia.com/nemoclaw/0.0.57/reference/commands.html) | Full NemoClaw CLI command reference. |
+| [Troubleshooting](https://docs.nvidia.com/nemoclaw/0.0.57/reference/troubleshooting.html) | Common issues and resolution steps. |
 
 ## Community
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -33,7 +33,7 @@ NemoClaw creates a fresh OpenClaw instance inside the sandbox during the onboard
 </Note>
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash # v0.0.57
 ```
 
 The third-party software notice runs before the installer installs Node.js or the NemoClaw CLI.

--- a/nemoclaw-blueprint/blueprint.yaml
+++ b/nemoclaw-blueprint/blueprint.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-version: "0.1.0"
+version: "0.0.57"
 min_openshell_version: "0.0.44"
 max_openshell_version: "0.0.44"
 min_openclaw_version: "2026.3.11"

--- a/nemoclaw/package-lock.json
+++ b/nemoclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nemoclaw",
-  "version": "0.1.0",
+  "version": "0.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nemoclaw",
-      "version": "0.1.0",
+      "version": "0.0.57",
       "license": "Apache-2.0",
       "dependencies": {
         "execa": "^9.6.1",

--- a/nemoclaw/package.json
+++ b/nemoclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemoclaw",
-  "version": "0.1.0",
+  "version": "0.0.57",
   "description": "Migrate and run OpenClaw inside OpenShell with optional NIM-backed inference",
   "license": "Apache-2.0",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nemoclaw",
-  "version": "0.1.0",
+  "version": "0.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nemoclaw",
-      "version": "0.1.0",
+      "version": "0.0.57",
       "bundleDependencies": [
         "p-retry"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemoclaw",
-  "version": "0.1.0",
+  "version": "0.0.57",
   "description": "NemoClaw — run OpenClaw inside OpenShell with NVIDIA inference",
   "license": "Apache-2.0",
   "bin": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,7 +45,7 @@ resolve_repo_root() {
   fi
   printf "%s\n" "$base"
 }
-DEFAULT_NEMOCLAW_VERSION="0.1.0"
+DEFAULT_NEMOCLAW_VERSION="0.0.57"
 DEFAULT_INSTALL_REF="lkg"
 TOTAL_STEPS=3
 

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -2675,7 +2675,7 @@ exit 1
         env: { HOME: tmp, PATH: TEST_SYSTEM_PATH },
       },
     );
-    expect(r.stdout.trim()).toBe("0.1.0");
+    expect(r.stdout.trim()).toBe("0.0.57");
   });
 
   it("installer_version_for_display: hides the placeholder default", () => {


### PR DESCRIPTION
## Summary
Bump NemoClaw release version to v0.0.57 across package metadata, blueprint manifest, installer defaults, docs links, lockfiles, and release-sensitive installer tests.

## Release flow note
Direct mode was requested, but pushing directly to main was blocked by repository rules requiring status checks. This PR carries the exact release commit already tagged locally/remotely as v0.0.57; merge with rebase/fast-forward semantics so main lands on commit f50caddd5.

## Testing
- npm run build:cli
- npm run typecheck:cli
- npm test
- pre-commit/pre-push hooks during commit and branch push

Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links and quickstart guide to reference version 0.0.57

* **Chores**
  * Version bump to 0.0.57 across configuration and build files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->