### PR TITLE
fix(e2e): add retry loop to seed_main_session for scope-upgrade races

### DIFF
--- a/test/e2e/test-sessions-agents-cli.sh
+++ b/test/e2e/test-sessions-agents-cli.sh
@@ -225,7 +225,26 @@ for d in pending:
 
 seed_main_session() {
   section "Seed main session by sending one prompt"
-  if ! nemoclaw "$SANDBOX_NAME" exec -- openclaw agent --agent main -m "ping" 2>&1; then
+  local out exit_code attempt=1 max_attempts=5 backoff=4
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if out="$(nemoclaw "$SANDBOX_NAME" exec -- openclaw agent --agent main -m "ping" 2>&1)"; then
+      exit_code=0
+      break
+    else
+      exit_code=$?
+    fi
+    # Retry on scope-upgrade races and session-takeover conflicts that resolve
+    # once the gateway's auto-pair watcher catches up.
+    if ! grep -qE "scope upgrade pending|pairing required|session file changed|EmbeddedAttemptSessionTakeoverError" <<<"$out"; then
+      break
+    fi
+    info "seed: gateway scope/session conflict (attempt ${attempt}/${max_attempts}); approving and retrying"
+    approve_pending_pairing_requests >/dev/null 2>&1 || true
+    sleep "$backoff"
+    attempt=$((attempt + 1))
+  done
+  if [ "$exit_code" -ne 0 ]; then
+    echo "$out" >&2
     fail "seed: agent invocation failed; sessions store may not be populated"
     return 1
   fi


### PR DESCRIPTION
Fixes #4695

**✨ [AI-generated PR]**

## Summary

The `seed_main_session()` function in `test/e2e/test-sessions-agents-cli.sh` failed in
[nightly-e2e run #26856257187](https://github.com/NVIDIA/NemoClaw/actions/runs/26856257187)
(`sessions-agents-cli-e2e / run`,
[job #79199640068](https://github.com/NVIDIA/NemoClaw/actions/runs/26856257187/job/79199640068))
with:

```
EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released
```

### Root cause

A scope-upgrade request becomes pending between the pre-seed `approve_pending_pairing_requests`
call and the `openclaw agent --agent main -m "ping"` invocation. The gateway rejects the
connection, the CLI falls back to the embedded agent, and the embedded agent's session file
lock races with the auto-pair watcher — producing the `EmbeddedAttemptSessionTakeoverError`.

Sister test cases in the same file (`TC-SESS-03`, `TC-SESS-05`) already handle this with a
retry loop that approves pending requests between attempts. `seed_main_session` did not.

### Fix

Add a retry loop to `seed_main_session()` matching the established pattern: capture output,
detect retriable scope-upgrade and session-takeover errors, approve pending requests between
attempts, and retry up to 5 times with 4 s backoff.

## Validation

The GitHub token used for this PR does not have the `workflow` scope required to push a
`custom-e2e.yaml` validation branch. To validate the fix, re-run the
`sessions-agents-cli-e2e` job from this branch:

```bash
gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw \
  --ref fix/nightly-e2e-seed-session-scope-retry-f90000b \
  -f jobs=sessions-agents-cli-e2e
```

- Original failing run: [#26856257187](https://github.com/NVIDIA/NemoClaw/actions/runs/26856257187) on `f90000b`

## Test plan

- [ ] Re-run `sessions-agents-cli-e2e` on this branch and confirm the seed retry loop handles the scope-upgrade race
- [ ] Verify no regressions in other test cases (TC-SESS-01 through TC-SESS-05, TC-AGENT-01, TC-AGENT-02)

Signed-off-by: Hung Le <hple@nvidia.com>
