### PR TITLE
fix(e2e): add docker build retry for transient registry timeouts

### DIFF
--- a/test/e2e/test-rebuild-hermes.sh
+++ b/test/e2e/test-rebuild-hermes.sh
@@ -154,14 +154,25 @@ info "Phase 2: Building Hermes base image with ${OLD_HERMES_VERSION}..."
 
 OLD_BASE_TAG="nemoclaw-hermes-old-base:e2e-rebuild"
 
-docker build \
-  --build-arg "HERMES_VERSION=${OLD_HERMES_VERSION}" \
-  --build-arg "HERMES_TARBALL_SHA256=${OLD_HERMES_TARBALL_SHA256}" \
-  --build-arg "HERMES_UV_EXTRAS=messaging" \
-  -f "${REPO_ROOT}/agents/hermes/Dockerfile.base" \
-  -t "${OLD_BASE_TAG}" \
-  "${REPO_ROOT}" \
-  || fail "Failed to build old Hermes base image"
+# Retry docker build up to 3 times — transient Docker Hub registry timeouts
+# (e.g. dial tcp …:443: i/o timeout) are common on GitHub-hosted runners and
+# should not fail the entire E2E run.
+_build_old_base_ok=0
+for _attempt in 1 2 3; do
+  if docker build \
+    --build-arg "HERMES_VERSION=${OLD_HERMES_VERSION}" \
+    --build-arg "HERMES_TARBALL_SHA256=${OLD_HERMES_TARBALL_SHA256}" \
+    --build-arg "HERMES_UV_EXTRAS=messaging" \
+    -f "${REPO_ROOT}/agents/hermes/Dockerfile.base" \
+    -t "${OLD_BASE_TAG}" \
+    "${REPO_ROOT}"; then
+    _build_old_base_ok=1
+    break
+  fi
+  info "docker build attempt ${_attempt}/3 failed; retrying in $((10 * _attempt))s..."
+  sleep "$((10 * _attempt))"
+done
+[ "$_build_old_base_ok" = "1" ] || fail "Failed to build old Hermes base image after 3 attempts"
 
 pass "Old Hermes base image built (${OLD_HERMES_VERSION})"
 
@@ -289,11 +300,19 @@ if [ "${STALE_BASE_REBUILD}" = "1" ]; then
 else
   info "Phase 5: Building current Hermes base image..."
 
-  docker build \
-    -f "${REPO_ROOT}/agents/hermes/Dockerfile.base" \
-    -t "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest" \
-    "${REPO_ROOT}" \
-    || fail "Failed to build current Hermes base image"
+  _build_cur_base_ok=0
+  for _attempt in 1 2 3; do
+    if docker build \
+      -f "${REPO_ROOT}/agents/hermes/Dockerfile.base" \
+      -t "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest" \
+      "${REPO_ROOT}"; then
+      _build_cur_base_ok=1
+      break
+    fi
+    info "docker build attempt ${_attempt}/3 failed; retrying in $((10 * _attempt))s..."
+    sleep "$((10 * _attempt))"
+  done
+  [ "$_build_cur_base_ok" = "1" ] || fail "Failed to build current Hermes base image after 3 attempts"
 
   pass "Current Hermes base image built"
 fi


### PR DESCRIPTION
Fixes #4696

**✨ [AI-generated PR]**

## Summary

The `rebuild-hermes-e2e / run` job failed in
[nightly-e2e run #26856257187](https://github.com/NVIDIA/NemoClaw/actions/runs/26856257187)
([job #79199640102](https://github.com/NVIDIA/NemoClaw/actions/runs/26856257187/job/79199640102))
with a Docker Hub registry timeout:

```
dial tcp 54.224.69.1:443: i/o timeout
ERROR: failed to build: failed to solve: DeadlineExceeded: node:22-trixie-slim@sha256:2d9f…
```

### Root cause

Docker Hub (`registry-1.docker.io`) was transiently unreachable from the GitHub-hosted
runner during Phase 2 ("Building Hermes base image with v2026.4.13"). The `docker build`
command had no retry logic, so a single transient network error failed the entire test.

### Fix

Wrap both `docker build` invocations in `test/e2e/test-rebuild-hermes.sh` with a
3-attempt retry loop and exponential backoff (10 s, 20 s, 30 s):

- **Phase 2** — old Hermes base image build (`nemoclaw-hermes-old-base:e2e-rebuild`)
- **Phase 5** — current Hermes base image build (`ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest`)

Both hit Docker Hub for the `node:22-trixie-slim` digest-pinned base image and are
equally vulnerable to transient registry outages.

## Validation

The GitHub token used for this PR does not have the `workflow` scope required to push a
`custom-e2e.yaml` validation branch. To validate the fix, re-run the
`rebuild-hermes-e2e` job from this branch:

```bash
gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw \
  --ref fix/nightly-e2e-docker-registry-timeout-retry-f90000b \
  -f jobs=rebuild-hermes-e2e
```

- Original failing run: [#26856257187](https://github.com/NVIDIA/NemoClaw/actions/runs/26856257187) on `f90000b`

## Test plan

- [ ] Re-run `rebuild-hermes-e2e` on this branch and confirm the retry loop handles a transient registry timeout
- [ ] Verify no regressions in the rebuild flow (marker file survival, version upgrade, credential preservation)

Signed-off-by: Hung Le <hple@nvidia.com>
