### PR TITLE
fix: reject channel start for missing sandbox

### DIFF
--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -1257,6 +1257,11 @@ async function sandboxChannelsSetEnabled(
     process.exit(1);
   }
 
+  if (!registry.getSandbox(sandboxName)) {
+    console.error(`  Sandbox '${sandboxName}' not found in the registry.`);
+    process.exit(1);
+  }
+
   const normalized = channelArg.trim().toLowerCase();
   const alreadyDisabled = registry.getDisabledChannels(sandboxName).includes(normalized);
   if (alreadyDisabled === disabled) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3069,6 +3069,15 @@ describe("CLI dispatch", () => {
     expect(start.out).toContain("Channel 'telegram' is already enabled for 'alpha'. Nothing to do.");
   });
 
+  it("rejects sandbox channels start for a missing sandbox", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-channels-missing-"));
+    writeSandboxRegistry(home);
+
+    const start = runWithEnv("sandbox channels start does-not-exist discord", { HOME: home });
+    expect(start.code).toBe(1);
+    expect(start.out).toContain("Sandbox 'does-not-exist' not found in the registry.");
+  });
+
   it("adds host aliases with a sandbox json patch", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-hosts-add-"));
     const localBin = path.join(home, "bin");


### PR DESCRIPTION
## Summary
- check that the sandbox exists before the channel start/stop no-op short-circuit
- make `nemoclaw sandbox channels start <missing> <channel>` report the same missing-registry error as the other command forms
- add CLI regression coverage for the previously misleading success case

Closes #4584

## Tests
- `npm run build:cli`
- `npm run test -- test/cli.test.ts -t 'channels mutation dry-run paths dispatch through oclif|rejects sandbox channels start for a missing sandbox'`
- `npm run lint -- src/lib/actions/sandbox/policy-channel.ts test/cli.test.ts` (passes; reports existing unrelated Biome warning in `src/lib/onboard/child-exit-tracker.test.ts`)
- `git diff --check`
- `git verify-commit HEAD`

Signed-off-by: Glenn-Agent <glenn_agent@163.com>
