### PR TITLE
fix(policy): allow apt node for OpenClaw registry access

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -38,8 +38,8 @@ The following endpoint groups are allowed by default:
 | Policy | Endpoints | Binaries | Rules |
 | --- | --- | --- | --- |
 | `nvidia` | `integrate.api.nvidia.com:443`, `inference-api.nvidia.com:443` | `/usr/local/bin/openclaw` | POST to inference and embedding paths, GET to model listings |
-| `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
-| `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node` | GET, POST |
+| `clawhub` | `clawhub.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
+| `openclaw_api` | `openclaw.ai:443` | `/usr/local/bin/openclaw`, `/usr/local/bin/node`, `/usr/bin/node` | GET, POST |
 | `openclaw_docs` | `docs.openclaw.ai:443` | `/usr/local/bin/openclaw` | GET only |
 | `npm_registry` | `registry.npmjs.org:443` | `/usr/local/bin/openclaw` only (openclaw plugins install) | GET only |
 

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -134,6 +134,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   openclaw_api:
     name: openclaw_api
@@ -148,6 +149,7 @@ network_policies:
     binaries:
       - { path: /usr/local/bin/openclaw }
       - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
 
   openclaw_docs:
     name: openclaw_docs

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -374,6 +374,19 @@ describe("base sandbox policy", () => {
     ]);
   });
 
+  it("regression #4104: OpenClaw plugin registry policies allow apt-installed Node", () => {
+    const np = policy.network_policies ?? {};
+
+    for (const policyName of ["clawhub", "openclaw_api"]) {
+      const binaries = (np[policyName]?.binaries ?? []).map((b) => b.path).sort();
+      expect(binaries).toEqual([
+        "/usr/bin/node",
+        "/usr/local/bin/node",
+        "/usr/local/bin/openclaw",
+      ]);
+    }
+  });
+
   it("does not reference the absent Claude CLI binary", () => {
     const serialized = JSON.stringify(policy.network_policies ?? {});
     expect(serialized).not.toContain("/usr/local/bin/claude");


### PR DESCRIPTION
## Summary
Allow OpenClaw's default `clawhub` and `openclaw_api` policy entries to be reached by Node when it is installed at `/usr/bin/node`, which is common on apt-based Linux images. This fixes the default sandbox policy gap that can block `openclaw plugins install` before it reaches ClawHub/OpenClaw API, without broadening the baseline `npm_registry` policy.

## Related Issue
Fixes #4104

## Changes
- Added `/usr/bin/node` to the baseline `clawhub` and `openclaw_api` binary allowlists in `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`.
- Added regression coverage asserting both OpenClaw registry/API policies include `/usr/bin/node`, `/usr/local/bin/node`, and `/usr/local/bin/openclaw`.
- Updated the network policy reference table to document the new binary allowlist.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification run:

```bash
npm run build:cli
NPM_CONFIG_CACHE=/tmp/nemoclaw-4104-current-npm-cache npx vitest run test/validate-blueprint.test.ts test/rebuild-policy-presets.test.ts test/policy-preset-sync.test.ts test/security-method-wildcards.test.ts
git diff --check
```

All focused checks passed. A broader local `test/policies.test.ts` run was attempted after `npm run build:cli`; it ran 152 tests with 134 passing, but 18 interactive policy command tests timed out in this local environment, so it is not marked as a passing full-suite check here.

---
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated network policy reference documentation to reflect changes in allowed execution binaries for sandbox environments.

* **Tests**
  * Added regression tests to validate network policy configurations and binary allowlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->