### PR TITLE
fix(hermes): enable platforms.slack in sandbox config.yaml when slack channel is attached

### DIFF
--- a/agents/hermes/config/hermes-config.ts
+++ b/agents/hermes/config/hermes-config.ts
@@ -99,7 +99,7 @@ export function buildHermesConfig(settings: HermesBuildSettings): Record<string,
   // API server — internal port only.
   // Hermes binds to 127.0.0.1 regardless of config (upstream bug).
   // socat in start.sh forwards 0.0.0.0:8642 -> 127.0.0.1:18642.
-  config.platforms = {
+  const platforms: Record<string, unknown> = {
     api_server: {
       enabled: true,
       extra: {
@@ -108,6 +108,12 @@ export function buildHermesConfig(settings: HermesBuildSettings): Record<string,
       },
     },
   };
+
+  if (settings.messaging.enabledChannels.has("slack")) {
+    platforms.slack = { enabled: true };
+  }
+
+  config.platforms = platforms;
 
   return config;
 }

--- a/test/e2e-scenario/manifests/hermes-nvidia-slack.yaml
+++ b/test/e2e-scenario/manifests/hermes-nvidia-slack.yaml
@@ -24,3 +24,4 @@ spec:
     credentialRefs:
       - NVIDIA_API_KEY
       - SLACK_BOT_TOKEN
+      - SLACK_APP_TOKEN

--- a/test/e2e-scenario/scenarios/scenarios/baseline.ts
+++ b/test/e2e-scenario/scenarios/scenarios/baseline.ts
@@ -184,7 +184,7 @@ const canonicalScenarioInputs: CanonicalScenarioInput[] = [
     environment: ubuntuRepoDocker("cloud-nvidia-hermes-slack"),
     expectedStateId: "cloud-hermes-ready",
     suiteIds: ["smoke"],
-    requiredSecrets: ["NVIDIA_API_KEY", "SLACK_BOT_TOKEN"],
+    requiredSecrets: ["NVIDIA_API_KEY", "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
   },
   {
     id: "ubuntu-repo-cloud-openclaw-resume",

--- a/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
+++ b/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
@@ -52,15 +52,15 @@ except Exception as exc:
   fi
 fi
 if [[ "${agent}" == "hermes" ]]; then
-  # This scenario asserts the static enablement contract:
-  #   1) config.yaml advertises platforms.slack.enabled=true so Hermes' gateway
-  #      instantiates the Slack adapter at boot (#4712 root cause).
-  #   2) gateway.log shows the Slack platform actually connected via Socket Mode.
+  # This scenario asserts the static enablement contract Hermes' gateway uses
+  # to start its Slack adapter:
+  #   1) config.yaml carries platforms.slack.enabled=true so the gateway
+  #      instantiates the Slack platform at boot. Without it, Hermes runs only
+  #      api_server and slack_bolt never starts.
+  #   2) gateway.log shows the Slack adapter actually authenticated and
+  #      connected via Socket Mode (not merely that startup began).
   #   3) SLACK_ALLOWED_CHANNELS is wired through .env so the adapter scopes
-  #      @-mention handling to the configured channel set.
-  # Dynamic @-mention -> bot-response round-trips against a real or simulated
-  # Slack workspace are covered by test/e2e/test-hermes-slack-e2e.sh and live
-  # outside the scenario-suite scope.
+  #      message handling to the configured channel set.
   if [[ -n "${E2E_DRY_RUN:-}" ]]; then
     e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled dry-run"
     e2e_pass "expected-state.messaging.slack.hermes-allowed-channels-scoped dry-run"
@@ -136,7 +136,7 @@ else:
     if [[ -z "${gateway_log}" ]]; then
       e2e_fail "expected-state.messaging.slack.hermes-gateway-running could not read gateway log from sandbox or entrypoint surface"
     fi
-    if printf '%s\n' "${gateway_log}" | grep -qE 'Connecting to slack|\[Slack\] Socket Mode connected|\[Slack\] Authenticated as|slack_bolt\.AsyncApp.*Bolt app is running'; then
+    if printf '%s\n' "${gateway_log}" | grep -qE '\[Slack\] Socket Mode connected|\[Slack\] Authenticated as|✓ slack connected|slack_bolt\.AsyncApp.*Bolt app is running'; then
       e2e_pass "expected-state.messaging.slack.hermes-gateway-running gateway booted slack platform"
     else
       sanitized_tail="$(printf '%s\n' "${gateway_log}" | tail -n 20 | sed -E \

--- a/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
+++ b/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
@@ -84,10 +84,16 @@ except Exception as exc:
         e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true in config.yaml"
         ;;
       yaml-missing)
-        if printf '%s\n' "${config_yaml}" | grep -E '^[[:space:]]*slack:[[:space:]]*$' -A2 | grep -qE '^[[:space:]]*enabled:[[:space:]]*true[[:space:]]*$'; then
-          e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true (grep fallback; yaml module absent)"
+        if printf '%s\n' "${config_yaml}" | awk '
+          /^platforms:[[:space:]]*$/ { in_pl=1; next }
+          /^[^[:space:]#]/            { in_pl=0; in_sl=0 }
+          in_pl && /^[[:space:]]+slack:[[:space:]]*$/ { in_sl=1; next }
+          in_pl && /^[[:space:]]+[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/ { in_sl=0 }
+          in_sl && /^[[:space:]]+enabled:[[:space:]]*true[[:space:]]*$/ { print "match"; exit 0 }
+        ' | grep -q "match"; then
+          e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true (awk fallback; yaml module absent)"
         else
-          e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled missing (grep fallback; yaml module absent)"
+          e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled missing under platforms (awk fallback; yaml module absent)"
         fi
         ;;
       *)
@@ -99,7 +105,7 @@ except Exception as exc:
     if [[ -z "${gateway_log}" ]]; then
       e2e_fail "expected-state.messaging.slack.hermes-gateway-running could not read /sandbox/.hermes/logs/gateway.log"
     fi
-    if printf '%s\n' "${gateway_log}" | grep -qE 'Gateway running with [^1] platform\(s\)|Connecting to slack|\[Slack\] Socket Mode connected'; then
+    if printf '%s\n' "${gateway_log}" | grep -qE 'Connecting to slack|\[Slack\] Socket Mode connected|\[Slack\] Authenticated as|slack_bolt\.AsyncApp.*Bolt app is running'; then
       e2e_pass "expected-state.messaging.slack.hermes-gateway-running gateway booted slack platform"
     else
       e2e_fail "expected-state.messaging.slack.hermes-gateway-running gateway log shows slack platform never started (tail: ${gateway_log: -300})"

--- a/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
+++ b/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
@@ -57,10 +57,10 @@ if [[ "${agent}" == "hermes" ]]; then
   #   1) config.yaml carries platforms.slack.enabled=true so the gateway
   #      instantiates the Slack platform at boot. Without it, Hermes runs only
   #      api_server and slack_bolt never starts.
-  #   2) gateway.log shows the Slack adapter actually authenticated and
-  #      connected via Socket Mode (not merely that startup began).
-  #   3) SLACK_ALLOWED_CHANNELS is wired through .env so the adapter scopes
-  #      message handling to the configured channel set.
+  #   2) gateway.log shows the Slack adapter completed Socket Mode connection
+  #      and the Bolt app reached the running state.
+  #   3) SLACK_ALLOWED_CHANNELS, when configured, is present in .env so the
+  #      allowlist values reach the adapter's environment.
   if [[ -n "${E2E_DRY_RUN:-}" ]]; then
     e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled dry-run"
     e2e_pass "expected-state.messaging.slack.hermes-allowed-channels-scoped dry-run"
@@ -136,7 +136,7 @@ else:
     if [[ -z "${gateway_log}" ]]; then
       e2e_fail "expected-state.messaging.slack.hermes-gateway-running could not read gateway log from sandbox or entrypoint surface"
     fi
-    if printf '%s\n' "${gateway_log}" | grep -qE '\[Slack\] Socket Mode connected|\[Slack\] Authenticated as|✓ slack connected|slack_bolt\.AsyncApp.*Bolt app is running'; then
+    if printf '%s\n' "${gateway_log}" | grep -qE '\[Slack\] Socket Mode connected|✓ slack connected|slack_bolt\.AsyncApp.*Bolt app is running'; then
       e2e_pass "expected-state.messaging.slack.hermes-gateway-running gateway booted slack platform"
     else
       sanitized_tail="$(printf '%s\n' "${gateway_log}" | tail -n 20 | sed -E \

--- a/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
+++ b/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
@@ -11,7 +11,8 @@ case "${provider}" in
   *) e2e_fail "expected-state.messaging.slack.provider-state expected slack provider, got ${provider}" ;;
 esac
 e2e_messaging_assert_provider_attached
-if [[ "$(e2e_context_get E2E_AGENT)" == "openclaw" ]]; then
+agent="$(e2e_context_get E2E_AGENT)"
+if [[ "${agent}" == "openclaw" ]]; then
   if [[ -n "${E2E_DRY_RUN:-}" ]]; then
     e2e_pass "expected-state.messaging.slack.openclaw-enabled dry-run"
     e2e_pass "expected-state.messaging.slack.runtime-discovery dry-run"
@@ -48,6 +49,61 @@ except Exception as exc:
       e2e_fail "expected-state.messaging.slack.runtime-discovery OpenClaw did not report Slack installed/configured (${runtime_state}; output=${runtime_json:0:300})"
     fi
     e2e_pass "expected-state.messaging.slack.runtime-discovery OpenClaw reports Slack installed and configured"
+  fi
+fi
+if [[ "${agent}" == "hermes" ]]; then
+  if [[ -n "${E2E_DRY_RUN:-}" ]]; then
+    e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled dry-run"
+    e2e_pass "expected-state.messaging.slack.hermes-gateway-running dry-run"
+  else
+    sandbox_name="$(e2e_context_get E2E_SANDBOX_NAME)"
+    config_yaml="$(openshell sandbox exec --name "${sandbox_name}" -- cat /sandbox/.hermes/config.yaml 2>/dev/null || true)"
+    if [[ -z "${config_yaml}" ]]; then
+      e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled could not read /sandbox/.hermes/config.yaml"
+    fi
+    platforms_state="$(printf '%s\n' "${config_yaml}" | python3 -c '
+import sys
+try:
+    import yaml
+except ImportError:
+    print("yaml-missing")
+    sys.exit(0)
+try:
+    cfg = yaml.safe_load(sys.stdin) or {}
+    platforms = cfg.get("platforms") or {}
+    slack = platforms.get("slack") or {}
+    if isinstance(slack, dict) and slack.get("enabled") is True:
+        print("yes")
+    else:
+        print("no slack=%r" % (slack,))
+except Exception as exc:
+    print("error %s" % exc)
+' 2>/dev/null || true)"
+    case "${platforms_state}" in
+      yes)
+        e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true in config.yaml"
+        ;;
+      yaml-missing)
+        if printf '%s\n' "${config_yaml}" | grep -E '^[[:space:]]*slack:[[:space:]]*$' -A2 | grep -qE '^[[:space:]]*enabled:[[:space:]]*true[[:space:]]*$'; then
+          e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true (grep fallback; yaml module absent)"
+        else
+          e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled missing (grep fallback; yaml module absent)"
+        fi
+        ;;
+      *)
+        e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled not true (${platforms_state})"
+        ;;
+    esac
+
+    gateway_log="$(openshell sandbox exec --name "${sandbox_name}" -- sh -c 'tail -n 200 /sandbox/.hermes/logs/gateway.log 2>/dev/null || true' 2>/dev/null || true)"
+    if [[ -z "${gateway_log}" ]]; then
+      e2e_fail "expected-state.messaging.slack.hermes-gateway-running could not read /sandbox/.hermes/logs/gateway.log"
+    fi
+    if printf '%s\n' "${gateway_log}" | grep -qE 'Gateway running with [^1] platform\(s\)|Connecting to slack|\[Slack\] Socket Mode connected'; then
+      e2e_pass "expected-state.messaging.slack.hermes-gateway-running gateway booted slack platform"
+    else
+      e2e_fail "expected-state.messaging.slack.hermes-gateway-running gateway log shows slack platform never started (tail: ${gateway_log: -300})"
+    fi
   fi
 fi
 e2e_pass "expected-state.messaging.slack.provider-state ${provider} provider state configured"

--- a/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
+++ b/test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh
@@ -52,63 +52,99 @@ except Exception as exc:
   fi
 fi
 if [[ "${agent}" == "hermes" ]]; then
+  # This scenario asserts the static enablement contract:
+  #   1) config.yaml advertises platforms.slack.enabled=true so Hermes' gateway
+  #      instantiates the Slack adapter at boot (#4712 root cause).
+  #   2) gateway.log shows the Slack platform actually connected via Socket Mode.
+  #   3) SLACK_ALLOWED_CHANNELS is wired through .env so the adapter scopes
+  #      @-mention handling to the configured channel set.
+  # Dynamic @-mention -> bot-response round-trips against a real or simulated
+  # Slack workspace are covered by test/e2e/test-hermes-slack-e2e.sh and live
+  # outside the scenario-suite scope.
   if [[ -n "${E2E_DRY_RUN:-}" ]]; then
     e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled dry-run"
+    e2e_pass "expected-state.messaging.slack.hermes-allowed-channels-scoped dry-run"
     e2e_pass "expected-state.messaging.slack.hermes-gateway-running dry-run"
   else
     sandbox_name="$(e2e_context_get E2E_SANDBOX_NAME)"
-    config_yaml="$(openshell sandbox exec --name "${sandbox_name}" -- cat /sandbox/.hermes/config.yaml 2>/dev/null || true)"
-    if [[ -z "${config_yaml}" ]]; then
-      e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled could not read /sandbox/.hermes/config.yaml"
-    fi
-    platforms_state="$(printf '%s\n' "${config_yaml}" | python3 -c '
+    # The Hermes venv is the same Python that loads config.yaml at runtime, so
+    # PyYAML is guaranteed there even when the host runner ships a minimal
+    # python3. Parsing inside the sandbox removes the awk fallback path.
+    platforms_state="$(openshell sandbox exec --name "${sandbox_name}" -- /opt/hermes/.venv/bin/python -c '
 import sys
+import yaml
+
 try:
-    import yaml
-except ImportError:
-    print("yaml-missing")
+    with open("/sandbox/.hermes/config.yaml", "r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh) or {}
+except FileNotFoundError:
+    print("missing-config")
     sys.exit(0)
-try:
-    cfg = yaml.safe_load(sys.stdin) or {}
-    platforms = cfg.get("platforms") or {}
-    slack = platforms.get("slack") or {}
-    if isinstance(slack, dict) and slack.get("enabled") is True:
-        print("yes")
-    else:
-        print("no slack=%r" % (slack,))
 except Exception as exc:
     print("error %s" % exc)
+    sys.exit(0)
+platforms = cfg.get("platforms") or {}
+slack = platforms.get("slack") or {}
+if isinstance(slack, dict) and slack.get("enabled") is True:
+    print("yes")
+else:
+    print("no slack=%r" % (slack,))
 ' 2>/dev/null || true)"
     case "${platforms_state}" in
       yes)
         e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true in config.yaml"
         ;;
-      yaml-missing)
-        if printf '%s\n' "${config_yaml}" | awk '
-          /^platforms:[[:space:]]*$/ { in_pl=1; next }
-          /^[^[:space:]#]/            { in_pl=0; in_sl=0 }
-          in_pl && /^[[:space:]]+slack:[[:space:]]*$/ { in_sl=1; next }
-          in_pl && /^[[:space:]]+[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/ { in_sl=0 }
-          in_sl && /^[[:space:]]+enabled:[[:space:]]*true[[:space:]]*$/ { print "match"; exit 0 }
-        ' | grep -q "match"; then
-          e2e_pass "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled true (awk fallback; yaml module absent)"
-        else
-          e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled missing under platforms (awk fallback; yaml module absent)"
-        fi
+      missing-config)
+        e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled /sandbox/.hermes/config.yaml not found"
         ;;
       *)
         e2e_fail "expected-state.messaging.slack.hermes-platforms-enabled platforms.slack.enabled not true (${platforms_state})"
         ;;
     esac
 
-    gateway_log="$(openshell sandbox exec --name "${sandbox_name}" -- sh -c 'tail -n 200 /sandbox/.hermes/logs/gateway.log 2>/dev/null || true' 2>/dev/null || true)"
+    env_state="$(openshell sandbox exec --name "${sandbox_name}" -- sh -c 'grep -E "^SLACK_ALLOWED_CHANNELS=" /sandbox/.hermes/.env 2>/dev/null | head -n1' 2>/dev/null || true)"
+    case "${env_state}" in
+      SLACK_ALLOWED_CHANNELS=*[!\ ]*)
+        e2e_pass "expected-state.messaging.slack.hermes-allowed-channels-scoped allowlist present in .env"
+        ;;
+      "")
+        e2e_pass "expected-state.messaging.slack.hermes-allowed-channels-scoped no channel allowlist requested (open scope)"
+        ;;
+      *)
+        e2e_fail "expected-state.messaging.slack.hermes-allowed-channels-scoped malformed SLACK_ALLOWED_CHANNELS entry"
+        ;;
+    esac
+
+    # Hermes ships two surfaces that carry the gateway boot trace:
+    #   - /sandbox/.hermes/logs/gateway.log: Hermes' own structured logger.
+    #   - <tmpdir>/gateway.log: stdout captured by agents/hermes/start.sh:862,910
+    #     when `hermes gateway run` is supervised by the entrypoint.
+    # Tail both; either is acceptable evidence the Slack platform booted.
+    tmp_dir=/tmp
+    gateway_log_basename=gateway.log
+    gateway_log=""
+    for log_path in "/sandbox/.hermes/logs/${gateway_log_basename}" "${tmp_dir}/${gateway_log_basename}"; do
+      chunk="$(openshell sandbox exec --name "${sandbox_name}" -- sh -c "tail -n 200 ${log_path} 2>/dev/null || true" 2>/dev/null || true)"
+      if [[ -n "${chunk}" ]]; then
+        if [[ -n "${gateway_log}" ]]; then
+          gateway_log="${gateway_log}"$'\n'"${chunk}"
+        else
+          gateway_log="${chunk}"
+        fi
+      fi
+    done
     if [[ -z "${gateway_log}" ]]; then
-      e2e_fail "expected-state.messaging.slack.hermes-gateway-running could not read /sandbox/.hermes/logs/gateway.log"
+      e2e_fail "expected-state.messaging.slack.hermes-gateway-running could not read gateway log from sandbox or entrypoint surface"
     fi
     if printf '%s\n' "${gateway_log}" | grep -qE 'Connecting to slack|\[Slack\] Socket Mode connected|\[Slack\] Authenticated as|slack_bolt\.AsyncApp.*Bolt app is running'; then
       e2e_pass "expected-state.messaging.slack.hermes-gateway-running gateway booted slack platform"
     else
-      e2e_fail "expected-state.messaging.slack.hermes-gateway-running gateway log shows slack platform never started (tail: ${gateway_log: -300})"
+      sanitized_tail="$(printf '%s\n' "${gateway_log}" | tail -n 20 | sed -E \
+        -e 's/xox[bpaors]-[A-Za-z0-9-]+/<redacted-slack-token>/g' \
+        -e 's/xapp-[A-Za-z0-9-]+/<redacted-slack-app-token>/g' \
+        -e 's/[Tt][0-9A-Z]{8,}/<redacted-team-id>/g' \
+        -e 's/[UCWBDG][0-9A-Z]{8,}/<redacted-slack-id>/g')"
+      e2e_fail "expected-state.messaging.slack.hermes-gateway-running gateway log shows slack platform never started (sanitized tail: ${sanitized_tail})"
     fi
   fi
 fi

--- a/test/e2e/test-hermes-slack-e2e.sh
+++ b/test/e2e/test-hermes-slack-e2e.sh
@@ -338,8 +338,14 @@ config_text = Path("/sandbox/.hermes/config.yaml").read_text(encoding="utf-8")
 cfg = yaml.safe_load(config_text) or {}
 errors = []
 platforms = cfg.get("platforms")
-if isinstance(platforms, dict) and "slack" in platforms:
-    errors.append("platforms.slack present")
+if not isinstance(platforms, dict):
+    errors.append("platforms map missing or not a mapping")
+else:
+    slack = platforms.get("slack")
+    if not isinstance(slack, dict):
+        errors.append("platforms.slack missing or not a mapping")
+    elif slack.get("enabled") is not True:
+        errors.append(f"platforms.slack.enabled is not true ({slack!r})")
 if "SLACK_BOT_TOKEN" in config_text or "SLACK_APP_TOKEN" in config_text:
     errors.append("config.yaml contains Slack token env keys")
 if errors:
@@ -350,7 +356,7 @@ PY
 )
 
 if [ "$config_probe" = "OK" ]; then
-  pass "config.yaml has no generic platforms.slack block or Slack token keys"
+  pass "config.yaml enables platforms.slack and contains no Slack token keys"
 else
   fail "config.yaml check failed: ${config_probe:0:400}"
 fi

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -238,7 +238,7 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("DISCORD_ALLOWED_USERS=");
   });
 
-  it("does not emit generic platforms blocks for Telegram or Slack messaging tokens", () => {
+  it("enables Slack under platforms and keeps Telegram top-level only when messaging tokens are configured", () => {
     const { config, envFile } = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram", "slack"]),
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
@@ -253,7 +253,7 @@ describe("agents/hermes/generate-config.ts", () => {
 
     expect(config.telegram).toEqual({ require_mention: true });
     expect(config.platforms.telegram).toBeUndefined();
-    expect(config.platforms.slack).toBeUndefined();
+    expect(config.platforms.slack).toEqual({ enabled: true });
     expect(envFile).toContain("TELEGRAM_BOT_TOKEN=openshell:resolve:env:TELEGRAM_BOT_TOKEN\n");
     expect(envFile).toContain("TELEGRAM_ALLOWED_USERS=123456789\n");
     expect(envFile).toContain(
@@ -266,6 +266,24 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("SLACK_APP_TOKEN=openshell:resolve:env:SLACK_APP_TOKEN\n");
     expect(envFile).toContain("SLACK_ALLOWED_USERS=U0123456789,U09ABCDEFGH\n");
     expect(envFile).toContain("SLACK_ALLOWED_CHANNELS=C012AB3CD,C987ZY6XW\n");
+  });
+
+  it("omits platforms.slack when Slack channel is not enabled", () => {
+    const { config } = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson([]),
+    });
+
+    expect(config.platforms.slack).toBeUndefined();
+    expect(Object.keys(config.platforms)).toEqual(["api_server"]);
+  });
+
+  it("enables Slack under platforms even when the slack token allowlist is empty", () => {
+    const { config } = runConfigScript({
+      NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["slack"]),
+    });
+
+    expect(config.platforms.slack).toEqual({ enabled: true });
+    expect(config.platforms.api_server.enabled).toBe(true);
   });
 
   it("bridges captured WeChat metadata to Hermes' WEIXIN_* env contract", () => {


### PR DESCRIPTION
## Summary

`nemohermes <sandbox> channels add slack` + `rebuild` left `/sandbox/.hermes/config.yaml` without a `platforms.slack` block, so the Hermes gateway booted with only `api_server`, `slack_bolt` never started, and the bot silently received no Slack events.

## Related Issue

Fixes #4712

## Changes

- `agents/hermes/config/hermes-config.ts:buildHermesConfig` — emit `platforms.slack = { enabled: true }` when `enabledChannels.has("slack")`. Discord/Telegram stay top-level only (their adapters auto-enable from `config.discord` / `config.telegram`); Slack has no top-level block in the Hermes schema, so the platforms-map entry is the only enable signal.
- `test/generate-hermes-config.test.ts` — invert the Slack assertion from absent → `{ enabled: true }`; add a negative-path test (no slack channel → `platforms.slack` undefined, only `api_server`) and a positive-path test that enables Slack without an allow-list (still emits `platforms.slack`). Telegram assertion unchanged.
- `test/e2e-scenario/validation_suites/messaging/slack/00-slack-provider-state.sh` — add a Hermes branch alongside the existing OpenClaw branch. Reads `/sandbox/.hermes/config.yaml` via `openshell sandbox exec`, asserts `platforms.slack.enabled` is `true` (PyYAML path with grep fallback when the module is unavailable), and tails `gateway.log` to verify the gateway booted with more than one platform / connected to Slack — directly reproducing the failing condition from the issue.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Slack platform config is now constructed and applied only when Slack is enabled in messaging channels.

* **Tests**
  * Validation and E2E tests tightened to assert presence and enabled state of the Slack platform, allowed-channel handling, and gateway startup signals; dry-run validations emit expected pass messages.

* **Chores**
  * Scenario and manifest inputs updated to require an additional Slack credential (SLACK_APP_TOKEN).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->