### PR TITLE
fix(hermes): set model.api_key placeholder so LiteLLM accepts inference.local

### DIFF
--- a/agents/hermes/config/hermes-config.ts
+++ b/agents/hermes/config/hermes-config.ts
@@ -34,6 +34,7 @@ export function buildHermesConfig(settings: HermesBuildSettings): Record<string,
       default: settings.model,
       provider: "custom",
       base_url: settings.baseUrl,
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
     },
     terminal: {
       backend: "local",

--- a/test/e2e/test-bedrock-runtime-compatible-anthropic.sh
+++ b/test/e2e/test-bedrock-runtime-compatible-anthropic.sh
@@ -650,6 +650,9 @@ if model.get("default") != expected:
     errors.append(f"model.default={model.get('default')!r}")
 if model.get("base_url") != "https://inference.local/v1":
     errors.append(f"model.base_url={model.get('base_url')!r}")
+api_key = model.get("api_key")
+if not isinstance(api_key, str) or not api_key.startswith("sk-"):
+    errors.append(f"model.api_key={api_key!r}")
 if re.search(r"(?ms)^models:\s*\n(?:[ \t].*\n)*?[ \t]+providers:", text):
     errors.append("OpenClaw-style models.providers block present")
 if "openshell:" in text:

--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -228,6 +228,9 @@ if model.get("base_url") != "https://inference.local/v1":
     errors.append(f"model.base_url={model.get('base_url')!r}")
 if model.get("provider") != "custom":
     errors.append(f"model.provider={model.get('provider')!r}")
+api_key = model.get("api_key")
+if not isinstance(api_key, str) or not api_key.startswith("sk-"):
+    errors.append(f"model.api_key={api_key!r}")
 
 if re.search(r"(?ms)^models:\s*\n(?:[ \t].*\n)*?[ \t]+providers:", text):
     errors.append("OpenClaw-style models.providers block present")

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -105,6 +105,7 @@ describe("agents/hermes/generate-config.ts", () => {
       default: "test-model",
       provider: "custom",
       base_url: "https://inference.local/v1",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
     });
     expect(config.platforms).toEqual({
       api_server: {
@@ -117,6 +118,15 @@ describe("agents/hermes/generate-config.ts", () => {
     });
     expect(envFile).toContain("API_SERVER_PORT=18642\n");
     expect(envFile).toContain("API_SERVER_HOST=127.0.0.1\n");
+  });
+
+  it("emits a model.api_key placeholder that satisfies the LiteLLM sk- prefix gate", () => {
+    const { config } = runConfigScript();
+
+    expect(typeof config.model.api_key).toBe("string");
+    expect(config.model.api_key.startsWith("sk-")).toBe(true);
+    expect(config.model.api_key).not.toBe("no-key-required");
+    expect(config.model.api_key).toMatch(/OPENSHELL/);
   });
 
   it("generates managed-tool gateway config and env for selected Nous presets", () => {
@@ -367,6 +377,7 @@ describe("agents/hermes/generate-config.ts", () => {
       default: "moonshotai/kimi-k2.6",
       provider: "custom",
       base_url: "https://inference.local/v1",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
     });
     expect(config.kimi).toBeUndefined();
     expect(config.openclawPlugins).toBeUndefined();


### PR DESCRIPTION
## Summary

Hermes `buildHermesConfig` never emitted `model.api_key`, so LiteLLM fell back to its `no-key-required` placeholder. LiteLLM's `Virtual Key` validator rejected that synchronously with HTTP 401 before any network call, breaking every `compatible-endpoint` (custom-provider) onboard on Hermes. Setting an `sk-`-prefixed placeholder satisfies the validator; OpenShell's L7 inference router strips client `Authorization` and injects the cluster-route credential at egress, so the placeholder is never seen by the upstream.

## Related Issue

Fixes #4711

## Changes

- `agents/hermes/config/hermes-config.ts` — emit `model.api_key: "sk-OPENSHELL-PROXY-REWRITE"` so LiteLLM passes its `sk-` prefix gate.
- `test/generate-hermes-config.test.ts` — assert the placeholder field in default + Kimi-compat paths, plus a dedicated contract test for the LiteLLM gate.
- `test/e2e/test-hermes-inference-switch.sh`, `test/e2e/test-bedrock-runtime-compatible-anthropic.sh` — `assert_hermes_config` validates `model.api_key` is present and `sk-`-prefixed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced configuration validation across end-to-end test suites to verify proper initialization in multiple deployment scenarios.
  * Added test coverage for configuration settings verification.

* **Chores**
  * Updated configuration initialization and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->