### PR TITLE
test(onboard): cover Windows Ollama negative probe paths

### DIFF
--- a/src/lib/onboard/windows-host-ollama.test.ts
+++ b/src/lib/onboard/windows-host-ollama.test.ts
@@ -40,4 +40,25 @@ describe("detectWindowsHostOllama", () => {
       loopbackOnly: false,
     });
   });
+
+  it("returns uninstalled when not on WSL", () => {
+    vi.mocked(isWsl).mockReturnValue(false);
+
+    expect(detectWindowsHostOllama()).toEqual({
+      installed: false,
+      installedPath: "",
+      loopbackOnly: false,
+    });
+    expect(runCapture).not.toHaveBeenCalled();
+  });
+
+  it("returns uninstalled when all Windows Ollama probes miss", () => {
+    runCapture.mockImplementation(() => "");
+
+    expect(detectWindowsHostOllama()).toEqual({
+      installed: false,
+      installedPath: "",
+      loopbackOnly: false,
+    });
+  });
 });

--- a/src/lib/onboard/windows-host-ollama.ts
+++ b/src/lib/onboard/windows-host-ollama.ts
@@ -75,6 +75,8 @@ export function detectWindowsHostOllama(): WindowsHostOllamaState {
     return { installed: false, installedPath: "", loopbackOnly: false };
   }
   const installedPath = probeInstalledPath();
+  // `installed` reflects binary presence on disk, not a live daemon. Onboard
+  // still gates Start/Restart on reachability and loopback binding (#3949).
   const installed = installedPath.length > 0;
   const loopbackOnly = installed ? probeLoopbackOnly() : false;
   return { installed, installedPath, loopbackOnly };


### PR DESCRIPTION
## Summary
Follow-up to #4089: add negative-path tests for `detectWindowsHostOllama` and clarify that `installed` reflects on-disk binary presence while onboard still gates Start/Restart on reachability (#3949).

## Related Issue
Follow-up to #4089 (closed #4066).

## Changes
- Add tests for `!isWsl()` early return and all-probes-miss → `installed: false`
- Document consumer-side Start/Restart gating in `windows-host-ollama.ts`

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Thabhelo <50872400+Thabhelo@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for Ollama detection on Windows.

* **Documentation**
  * Added internal clarifications for detection behavior and system integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->