### PR TITLE
docs: generate agent variant code samples

### DIFF
--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -116,7 +116,7 @@ Write the doc update following these conventions:
 - **Start sections with an introductory sentence** that orients the reader.
 - **No superlatives.** Say what the feature does, not how great it is.
 - **Copyable code examples use language-specific fences** such as `bash`, `sh`, or `powershell`, without prompt markers.
-- **Shared NemoClaw CLI examples use `$$nemoclaw`.** In shared OpenClaw/Hermes variant pages, write host CLI examples with the `$$nemoclaw` sentinel so the docs build renders `nemoclaw` on OpenClaw pages and `nemohermes` on Hermes pages before Fern renders fenced code blocks.
+- **Shared NemoClaw CLI examples use `$$nemoclaw`.** In shared OpenClaw/Hermes variant pages, write host CLI examples with the `$$nemoclaw` build-time placeholder so the docs build renders `nemoclaw` on OpenClaw pages and `nemohermes` on Hermes pages before Fern renders fenced code blocks.
 - **Do not duplicate code blocks for binary-name-only differences.** Use one fenced block with `$$nemoclaw` when the only difference is `nemoclaw` versus `nemohermes`; keep `<AgentOnly>` only when the surrounding text, flags, behavior, or setup steps actually differ.
 - **Use `console` only for terminal transcripts** that include prompts, output, or interactive sessions.
 - **Include the SPDX header** if creating a new page.

--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -116,6 +116,8 @@ Write the doc update following these conventions:
 - **Start sections with an introductory sentence** that orients the reader.
 - **No superlatives.** Say what the feature does, not how great it is.
 - **Copyable code examples use language-specific fences** such as `bash`, `sh`, or `powershell`, without prompt markers.
+- **Shared NemoClaw CLI examples use `$$nemoclaw`.** In shared OpenClaw/Hermes variant pages, write host CLI examples with the `$$nemoclaw` sentinel so the docs build renders `nemoclaw` on OpenClaw pages and `nemohermes` on Hermes pages before Fern renders fenced code blocks.
+- **Do not duplicate code blocks for binary-name-only differences.** Use one fenced block with `$$nemoclaw` when the only difference is `nemoclaw` versus `nemohermes`; keep `<AgentOnly>` only when the surrounding text, flags, behavior, or setup steps actually differ.
 - **Use `console` only for terminal transcripts** that include prompts, output, or interactive sessions.
 - **Include the SPDX header** if creating a new page.
 - **Match existing frontmatter format** if creating a new page.

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -48,14 +48,11 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Install Fern CLI
-        run: |
-          FERN_VERSION=$(node -p "require('./fern/fern.config.json').version")
-          npm install -g "fern-api@${FERN_VERSION}"
+      - name: Install docs dependencies
+        run: npm ci --ignore-scripts
 
       - name: Validate docs
-        working-directory: ./fern
-        run: fern check
+        run: npm run docs
 
       - name: Generate preview URL
         if: ${{ steps.fern-preview.outputs.enabled == 'true' }}
@@ -63,10 +60,11 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PREVIEW_ID: pr-${{ github.event.pull_request.number }}
-        working-directory: ./fern
         run: |
+          npm run docs:check-agent-variants
+          FERN_VERSION=$(node -p "require('./fern/fern.config.json').version")
           set +e
-          OUTPUT=$(fern generate --docs --preview --id "$PREVIEW_ID" 2>&1)
+          OUTPUT=$(cd fern && npx --yes "fern-api@${FERN_VERSION}" generate --docs --preview --id "$PREVIEW_ID" 2>&1)
           STATUS=$?
           set -e
           echo "$OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 coverage/
 dist/
 docs/_build/
+docs/**/*.generated.mdx
 node_modules/
 
 # OS metadata

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -261,7 +261,7 @@ These patterns are common in LLM-generated text and erode trust with technical r
   $$nemoclaw onboard
   ```
 
-- Use `$$nemoclaw` for NemoClaw host CLI command examples in shared variant pages.
+- Use `$$nemoclaw` as a build-time placeholder for NemoClaw host CLI command examples in shared variant pages.
   The docs build resolves it to `nemoclaw` for OpenClaw pages and `nemohermes` for Hermes pages before Fern renders code blocks.
   This preserves Fern's native fenced-code UI while keeping one source sample.
 - Do not write duplicate `<AgentOnly>` fenced code blocks when the only difference is `nemoclaw` versus `nemohermes`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -258,10 +258,13 @@ These patterns are common in LLM-generated text and erode trust with technical r
   Put only the command text in copyable blocks:
 
   ```bash
-  nemoclaw onboard
+  $$nemoclaw onboard
   ```
 
-- For command examples that differ only by the host CLI binary, write `$$nemoclaw` in the shared source page and let `scripts/sync-agent-variant-docs.ts` render `nemoclaw` or `nemohermes` for Fern.
+- Use `$$nemoclaw` for NemoClaw host CLI command examples in shared variant pages.
+  The docs build resolves it to `nemoclaw` for OpenClaw pages and `nemohermes` for Hermes pages before Fern renders code blocks.
+  This preserves Fern's native fenced-code UI while keeping one source sample.
+- Do not write duplicate `<AgentOnly>` fenced code blocks when the only difference is `nemoclaw` versus `nemohermes`.
   Use `<AgentOnly>` blocks only when the surrounding content differs between the OpenClaw and Hermes variants.
 
 - Use `powershell` for Windows PowerShell commands.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -261,6 +261,9 @@ These patterns are common in LLM-generated text and erode trust with technical r
   nemoclaw onboard
   ```
 
+- For command examples that differ only by the host CLI binary, write `$$nemoclaw` in the shared source page and let `scripts/sync-agent-variant-docs.ts` render `nemoclaw` or `nemohermes` for Fern.
+  Use `<AgentOnly>` blocks only when the surrounding content differs between the OpenClaw and Hermes variants.
+
 - Use `powershell` for Windows PowerShell commands.
   Use `bash` or `sh` for Linux, macOS, and WSL shell commands.
   Reserve `console` blocks for terminal transcripts that include prompts, output, or interactive sessions.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -71,7 +71,7 @@ navigation:
             collapsed: open-by-default
             contents:
               - page: "Manage Sandbox Lifecycle"
-                path: manage-sandboxes/lifecycle.mdx
+                path: manage-sandboxes/lifecycle.openclaw.generated.mdx
                 slug: lifecycle
               - page: "Runtime Controls"
                 path: manage-sandboxes/runtime-controls.mdx
@@ -222,7 +222,7 @@ navigation:
             collapsed: open-by-default
             contents:
               - page: "Manage Sandbox Lifecycle"
-                path: manage-sandboxes/lifecycle.mdx
+                path: manage-sandboxes/lifecycle.hermes.generated.mdx
                 slug: lifecycle
               - page: "Runtime Controls"
                 path: manage-sandboxes/runtime-controls.mdx

--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -31,86 +31,44 @@ When a workflow uses the lower-level OpenShell CLI, see [CLI Selection Guide](..
 
 List every sandbox registered on this host:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw list
+$$nemoclaw list
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes list
-```
-</AgentOnly>
 
 The list shows each sandbox's model, provider, policy presets, active SSH session indicator, and dashboard URL when NemoClaw records a dashboard port.
 Use JSON output for scripts:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw list --json
+$$nemoclaw list --json
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes list --json
-```
-</AgentOnly>
 
 ## Check Sandbox Health
 
 Check a specific sandbox's health, inference route, active connections, live policy, update status, and messaging-channel overlap warnings:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw my-assistant status
+$$nemoclaw my-assistant status
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes my-assistant status
-```
-</AgentOnly>
 
 Use the host-level status command when you want the sandbox inventory plus host auxiliary service state, such as cloudflared:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw status
+$$nemoclaw status
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes status
-```
-</AgentOnly>
 
 ## Inspect Logs
 
 View recent sandbox logs:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw my-assistant logs
+$$nemoclaw my-assistant logs
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes my-assistant logs
-```
-</AgentOnly>
 
 Stream logs while you reproduce a problem:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw my-assistant logs --follow
+$$nemoclaw my-assistant logs --follow
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes my-assistant logs --follow
-```
-</AgentOnly>
 
 <AgentOnly variant="openclaw">
 The log command reads both OpenClaw gateway output and OpenShell audit events, so policy denials appear beside gateway logs.
@@ -123,29 +81,15 @@ The log command reads both Hermes gateway output and OpenShell audit events, so 
 
 Collect diagnostics for bug reports or support handoff:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw debug --sandbox my-assistant --output nemoclaw-debug.tar.gz
+$$nemoclaw debug --sandbox my-assistant --output nemoclaw-debug.tar.gz
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes debug --sandbox my-assistant --output nemoclaw-debug.tar.gz
-```
-</AgentOnly>
 
 Use `--quick` for a smaller local summary:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw debug --quick --sandbox my-assistant
+$$nemoclaw debug --quick --sandbox my-assistant
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes debug --quick --sandbox my-assistant
-```
-</AgentOnly>
 
 The debug command gathers system information, Docker state, gateway logs, and sandbox status.
 
@@ -175,46 +119,23 @@ When the default API port is already held by another sandbox, `nemohermes onboar
 If you intentionally run separate OpenShell gateways on the same host, set a different `NEMOCLAW_GATEWAY_PORT` before each onboarding run.
 NemoClaw isolates the gateway name and local state by port so one port-specific gateway does not replace another.
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw onboard                                      # first sandbox uses 18789
-nemoclaw onboard                                      # second sandbox uses the next free port, such as 18790
+$$nemoclaw onboard                                      # first sandbox uses 18789
+$$nemoclaw onboard                                      # second sandbox uses the next free port, such as 18790
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes onboard                                      # first sandbox uses 18789
-nemohermes onboard                                      # second sandbox uses the next free port, such as 18790
-```
-</AgentOnly>
 
 To choose a specific port, pass `--control-ui-port`:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw onboard --control-ui-port 19000
+$$nemoclaw onboard --control-ui-port 19000
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes onboard --control-ui-port 19000
-```
-</AgentOnly>
 
 You can also set `CHAT_UI_URL` or `NEMOCLAW_DASHBOARD_PORT` before onboarding:
 
-<AgentOnly variant="openclaw">
 ```bash
-CHAT_UI_URL=http://127.0.0.1:19000 nemoclaw onboard
-NEMOCLAW_DASHBOARD_PORT=19000 nemoclaw onboard
+CHAT_UI_URL=http://127.0.0.1:19000 $$nemoclaw onboard
+NEMOCLAW_DASHBOARD_PORT=19000 $$nemoclaw onboard
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-CHAT_UI_URL=http://127.0.0.1:19000 nemohermes onboard
-NEMOCLAW_DASHBOARD_PORT=19000 nemohermes onboard
-```
-</AgentOnly>
 
 For full details on port conflicts and overrides, refer to [Port already in use](../reference/troubleshooting#port-already-in-use).
 
@@ -226,16 +147,9 @@ Recover from a misconfigured sandbox without re-running the full onboard wizard 
 
 Change the active model or provider at runtime without rebuilding the sandbox:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw inference set --model <model> --provider <provider>
+$$nemoclaw inference set --model <model> --provider <provider>
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes inference set --model <model> --provider <provider>
-```
-</AgentOnly>
 
 Refer to [Switch Inference Providers](../inference/switch-inference-providers) for provider-specific model IDs and API compatibility notes.
 
@@ -248,16 +162,9 @@ If `nemoclaw <name> status` reports the sandbox is alive but the gateway is not 
 If `nemohermes <name> status` reports the sandbox is alive but the Hermes gateway is not running, run the recover command instead of opening a shell.
 </AgentOnly>
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw <sandbox-name> recover
+$$nemoclaw <sandbox-name> recover
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes <sandbox-name> recover
-```
-</AgentOnly>
 
 The command restarts the in-sandbox gateway and re-establishes the dashboard port-forward in one step.
 It is idempotent and safe to script.
@@ -272,20 +179,11 @@ Refer to the command reference for details on `nemohermes <name> recover`.
 
 If you entered a provider credential incorrectly during onboarding, clear the gateway-registered value and re-enter it on the next onboard run:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw credentials list                # see which providers are registered
-nemoclaw credentials reset <PROVIDER>    # clear a single provider, for example nvidia-prod
-nemoclaw onboard                         # re-run to re-enter the cleared provider
+$$nemoclaw credentials list                # see which providers are registered
+$$nemoclaw credentials reset <PROVIDER>    # clear a single provider, for example nvidia-prod
+$$nemoclaw onboard                         # re-run to re-enter the cleared provider
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes credentials list                # see which providers are registered
-nemohermes credentials reset <PROVIDER>    # clear a single provider, for example nvidia-prod
-nemohermes onboard                         # re-run to re-enter the cleared provider
-```
-</AgentOnly>
 
 <AgentOnly variant="openclaw">
 The command reference documents [`nemoclaw credentials reset <PROVIDER>`](../reference/commands#nemoclaw-credentials-reset-provider) in full.
@@ -303,16 +201,9 @@ If you changed the underlying Dockerfile, upgraded OpenClaw, or want to pick up 
 If you changed the underlying Dockerfile, upgraded Hermes, or want to pick up a new base image without losing your sandbox's state files, use `rebuild` instead of destroying and recreating:
 </AgentOnly>
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw <sandbox-name> rebuild
+$$nemoclaw <sandbox-name> rebuild
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes <sandbox-name> rebuild
-```
-</AgentOnly>
 
 Rebuild preserves the mounted workspace and registered policies while recreating the container.
 If NemoClaw cannot archive any requested state path, it reports the backup failure and stops before deleting the original sandbox.
@@ -327,16 +218,9 @@ Refer to the [Commands reference](../reference/commands) for `nemohermes <name> 
 
 Apply an additional preset, such as Telegram or GitHub, to a running sandbox without re-onboarding:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw <sandbox-name> policy-add
+$$nemoclaw <sandbox-name> policy-add
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes <sandbox-name> policy-add
-```
-</AgentOnly>
 
 Refer to [`nemoclaw <name> policy-add`](../reference/commands#nemoclaw-name-policy-add) for usage details and flags.
 
@@ -401,22 +285,12 @@ The installer checks registered sandboxes after onboarding succeeds and runs `ne
 Use `upgrade-sandboxes` directly to verify the result, rebuild when you skipped the installer or onboarding step, or handle sandboxes that were stopped or could not be version checked.
 The upgrade flow is non-destructive by default because NemoClaw preserves manifest-defined workspace state, but a manual snapshot before any major upgrade gives you a state restore point.
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw <sandbox-name> snapshot create --name pre-upgrade   # optional, recommended
-nemoclaw update --yes                                        # updates CLI through the maintained installer flow
-nemoclaw upgrade-sandboxes --check                            # verify or list remaining stale/unknown sandboxes
-nemoclaw upgrade-sandboxes                                    # manually rebuild remaining stale running sandboxes
+$$nemoclaw <sandbox-name> snapshot create --name pre-upgrade   # optional, recommended
+$$nemoclaw update --yes                                        # updates CLI through the maintained installer flow
+$$nemoclaw upgrade-sandboxes --check                            # verify or list remaining stale/unknown sandboxes
+$$nemoclaw upgrade-sandboxes                                    # manually rebuild remaining stale running sandboxes
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes <sandbox-name> snapshot create --name pre-upgrade   # optional, recommended
-nemohermes update --yes                                        # updates CLI through the maintained installer flow
-nemohermes upgrade-sandboxes --check                            # verify or list remaining stale/unknown sandboxes
-nemohermes upgrade-sandboxes                                    # manually rebuild remaining stale running sandboxes
-```
-</AgentOnly>
 
 <AgentOnly variant="openclaw">
 `nemoclaw update` is the CLI wrapper around the same installer path as `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash`.
@@ -437,16 +311,9 @@ For scripted manual rebuilds, use `nemohermes upgrade-sandboxes --auto` to skip 
 If the upgraded sandbox needs its workspace state reverted, restore the pre-upgrade snapshot into the running sandbox.
 This restores saved state directories only; it does not downgrade the sandbox image or agent/runtime:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw <sandbox-name> snapshot restore pre-upgrade
+$$nemoclaw <sandbox-name> snapshot restore pre-upgrade
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes <sandbox-name> snapshot restore pre-upgrade
-```
-</AgentOnly>
 
 ### What Changes During a Rebuild
 
@@ -494,16 +361,9 @@ Your existing container keeps serving traffic until the new image is ready.
 
 To remove NemoClaw and all resources created during setup, run the CLI's built-in uninstall command:
 
-<AgentOnly variant="openclaw">
 ```bash
-nemoclaw uninstall
+$$nemoclaw uninstall
 ```
-</AgentOnly>
-<AgentOnly variant="hermes">
-```bash
-nemohermes uninstall
-```
-</AgentOnly>
 
 | Flag               | Effect                                               |
 |--------------------|------------------------------------------------------|

--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -168,12 +168,7 @@ $$nemoclaw <sandbox-name> recover
 
 The command restarts the in-sandbox gateway and re-establishes the dashboard port-forward in one step.
 It is idempotent and safe to script.
-<AgentOnly variant="openclaw">
-Refer to [`nemoclaw <name> recover`](../reference/commands#nemoclaw-name-recover) for details.
-</AgentOnly>
-<AgentOnly variant="hermes">
-Refer to the command reference for details on `nemohermes <name> recover`.
-</AgentOnly>
+Refer to [`$$nemoclaw <name> recover`](../reference/commands#$$nemoclaw-name-recover) for details.
 
 ### Reset a Stored Credential
 
@@ -185,12 +180,7 @@ $$nemoclaw credentials reset <PROVIDER>    # clear a single provider, for exampl
 $$nemoclaw onboard                         # re-run to re-enter the cleared provider
 ```
 
-<AgentOnly variant="openclaw">
-The command reference documents [`nemoclaw credentials reset <PROVIDER>`](../reference/commands#nemoclaw-credentials-reset-provider) in full.
-</AgentOnly>
-<AgentOnly variant="hermes">
-The [Commands reference](../reference/commands) documents the credentials command in full.
-</AgentOnly>
+The command reference documents [`$$nemoclaw credentials reset <PROVIDER>`](../reference/commands#$$nemoclaw-credentials-reset-provider) in full.
 
 ### Rebuild a Sandbox While Preserving Workspace State
 
@@ -207,12 +197,7 @@ $$nemoclaw <sandbox-name> rebuild
 
 Rebuild preserves the mounted workspace and registered policies while recreating the container.
 If NemoClaw cannot archive any requested state path, it reports the backup failure and stops before deleting the original sandbox.
-<AgentOnly variant="openclaw">
-Refer to [`nemoclaw <name> rebuild`](../reference/commands#nemoclaw-name-rebuild) for flag details.
-</AgentOnly>
-<AgentOnly variant="hermes">
-Refer to the [Commands reference](../reference/commands) for `nemohermes <name> rebuild` flag details.
-</AgentOnly>
+Refer to [`$$nemoclaw <name> rebuild`](../reference/commands#$$nemoclaw-name-rebuild) for flag details.
 
 ### Add a Network Preset After Onboarding
 
@@ -222,20 +207,16 @@ Apply an additional preset, such as Telegram or GitHub, to a running sandbox wit
 $$nemoclaw <sandbox-name> policy-add
 ```
 
-Refer to [`nemoclaw <name> policy-add`](../reference/commands#nemoclaw-name-policy-add) for usage details and flags.
+Refer to [`$$nemoclaw <name> policy-add`](../reference/commands#$$nemoclaw-name-policy-add) for usage details and flags.
 
 Non-interactive re-onboards in the default `suggested` policy mode preserve presets added this way.
 To make a re-onboard authoritative, set `NEMOCLAW_POLICY_MODE=custom` and provide `NEMOCLAW_POLICY_PRESETS` with the exact list to apply; onboarding removes anything else.
-See [`NEMOCLAW_POLICY_MODE`](../reference/commands#nemoclaw-onboard) for the full table.
+See [`NEMOCLAW_POLICY_MODE`](../reference/commands#$$nemoclaw-onboard) for the full table.
 
 ## Update to the Maintained Version
 
-<AgentOnly variant="openclaw">
-When a maintained NemoClaw release becomes available, update the `nemoclaw` CLI on your host and check existing sandboxes for stale agent/runtime versions.
-</AgentOnly>
-<AgentOnly variant="hermes">
-When a maintained NemoClaw release becomes available, update the `nemohermes` CLI on your host and check existing sandboxes for stale agent/runtime versions.
-</AgentOnly>
+When a maintained NemoClaw release becomes available, update the `$$nemoclaw` CLI on your host and check existing sandboxes for stale agent/runtime versions.
+
 The standard installer follows the admin-promoted `lkg` release tag by default, so it can trail the newest semver or `latest` tag while validation completes.
 To pin a specific release in a `curl | bash` install, set `NEMOCLAW_INSTALL_TAG` on the `bash` side of the pipe, or export it before the pipeline:
 
@@ -252,12 +233,8 @@ If the requested ref cannot be fetched, the installer exits with a clear error i
 ### Update the NemoClaw CLI
 
 Re-run the installer.
-<AgentOnly variant="openclaw">
-Before it onboards anything, the installer calls [`nemoclaw backup-all`](../reference/commands#nemoclaw-backup-all) automatically, storing a snapshot of each running sandbox in `~/.nemoclaw/rebuild-backups/` as a safety net.
-</AgentOnly>
-<AgentOnly variant="hermes">
-Before it onboards anything, the installer calls `nemohermes backup-all` automatically, storing a snapshot of each running sandbox in `~/.nemoclaw/rebuild-backups/` as a safety net.
-</AgentOnly>
+Before it onboards anything, the installer calls [`$$nemoclaw backup-all`](../reference/commands#$$nemoclaw-backup-all) automatically, storing a snapshot of each running sandbox in `~/.nemoclaw/rebuild-backups/` as a safety net.
+
 If your existing gateway is from OpenShell earlier than `0.0.37`, the installer prompts before it runs the new automatic gateway upgrade path.
 <AgentOnly variant="openclaw">
 The installer offers the automatic path only when the existing `nemoclaw` CLI supports `backup-all`.
@@ -276,12 +253,7 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 ### Upgrade Sandboxes with Stale Agent and Runtime Versions
 
-<AgentOnly variant="openclaw">
-The installer checks registered sandboxes after onboarding succeeds and runs `nemoclaw upgrade-sandboxes --auto` for stale running sandboxes.
-</AgentOnly>
-<AgentOnly variant="hermes">
-The installer checks registered sandboxes after onboarding succeeds and runs `nemohermes upgrade-sandboxes --auto` for stale running sandboxes.
-</AgentOnly>
+The installer checks registered sandboxes after onboarding succeeds and runs `$$nemoclaw upgrade-sandboxes --auto` for stale running sandboxes.
 Use `upgrade-sandboxes` directly to verify the result, rebuild when you skipped the installer or onboarding step, or handle sandboxes that were stopped or could not be version checked.
 The upgrade flow is non-destructive by default because NemoClaw preserves manifest-defined workspace state, but a manual snapshot before any major upgrade gives you a state restore point.
 
@@ -301,12 +273,7 @@ Use `nemoclaw update --check` when you only want to inspect version state and se
 Use `nemohermes update --check` when you only want to inspect version state and see the maintained update command.
 </AgentOnly>
 
-<AgentOnly variant="openclaw">
-For scripted manual rebuilds, use `nemoclaw upgrade-sandboxes --auto` to skip the confirmation prompt.
-</AgentOnly>
-<AgentOnly variant="hermes">
-For scripted manual rebuilds, use `nemohermes upgrade-sandboxes --auto` to skip the confirmation prompt.
-</AgentOnly>
+For scripted manual rebuilds, use `$$nemoclaw upgrade-sandboxes --auto` to skip the confirmation prompt.
 
 If the upgraded sandbox needs its workspace state reverted, restore the pre-upgrade snapshot into the running sandbox.
 This restores saved state directories only; it does not downgrade the sandbox image or agent/runtime:
@@ -340,20 +307,11 @@ When a backup command reports partial archive output, NemoClaw keeps the usable 
 See [Backup and Restore](backup-restore) for the full list of state-preservation guarantees, snapshot retention, and instructions for manual backups when the auto-flow is not enough.
 
 <Note title="If the rebuild aborts with `Missing credential: <KEY>`">
-<AgentOnly variant="openclaw">
-The rebuild preflight reads the provider credential recorded by your last `nemoclaw onboard` session.
+The rebuild preflight reads the provider credential recorded by your last `$$nemoclaw onboard` session.
 If you have switched providers since onboarding, for example from a remote API to a local Ollama setup, the preflight can still reference the old key and fail before any destroy step runs.
 
-To recover, re-run `nemoclaw onboard` and select your current provider.
+To recover, re-run `$$nemoclaw onboard` and select your current provider.
 This refreshes the session metadata.
-</AgentOnly>
-<AgentOnly variant="hermes">
-The rebuild preflight reads the provider credential recorded by your last `nemohermes onboard` session.
-If you have switched providers since onboarding, for example from a remote API to a local Ollama setup, the preflight can still reference the old key and fail before any destroy step runs.
-
-To recover, re-run `nemohermes onboard` and select your current provider.
-This refreshes the session metadata.
-</AgentOnly>
 Your existing container keeps serving traffic until the new image is ready.
 </Note>
 
@@ -376,7 +334,7 @@ The uninstall command preserves `~/.nemoclaw/rebuild-backups/` (host-side snapsh
 Uninstall removes every other entry under `~/.nemoclaw/`.
 Interactive runs prompt before they remove the preserved entries; the default answer keeps them.
 For non-interactive runs (`--yes`, `NEMOCLAW_NON_INTERACTIVE=1`, or a non-TTY shell), set `NEMOCLAW_UNINSTALL_DESTROY_USER_DATA=1` to acknowledge data loss and remove the preserved entries as well.
-See the [Commands reference](../reference/commands#nemoclaw-uninstall) for the full preservation contract.
+See the [Commands reference](../reference/commands#$$nemoclaw-uninstall) for the full preservation contract.
 </Note>
 
 The CLI uninstall command runs the version-pinned `uninstall.sh` that shipped with your installed CLI, so it does not fetch anything over the network at uninstall time.
@@ -393,7 +351,7 @@ The same `--yes`, `--keep-openshell`, and `--delete-models` flags listed above a
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/refs/heads/main/uninstall.sh | bash -s -- --yes --delete-models
 ```
 
-For a full comparison of the two forms, including what they fetch, what they trust, and when to prefer each, refer to [`nemoclaw uninstall` vs. the hosted `uninstall.sh`](../reference/commands#nemoclaw-uninstall-vs-the-hosted-uninstallsh).
+For a full comparison of the two forms, including what they fetch, what they trust, and when to prefer each, refer to [`$$nemoclaw uninstall` vs. the hosted `uninstall.sh`](../reference/commands#$$nemoclaw-uninstall-vs-the-hosted-uninstallsh).
 
 ## Related Topics
 

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1521,6 +1521,10 @@ Set them before running `nemohermes onboard`.
 | `NEMOCLAW_OLLAMA_INSTALL_MODE` | `system`, `user`, or empty/unset | Pins the Linux Ollama install location; see the Linux Ollama install mode details below. |
 | `NEMOCLAW_PROXY_HOST` | hostname or IP | Overrides the sandbox-side outbound HTTP proxy host. Defaults to `10.200.0.1`. |
 | `NEMOCLAW_PROXY_PORT` | integer port | Overrides the sandbox-side outbound HTTP proxy port. Defaults to `3128`. |
+| `NEMOCLAW_OPENCLAW_OTEL` | `1` to enable | Enables OpenClaw conversation diagnostics export through the `diagnostics-otel` plugin. Disabled by default. |
+| `NEMOCLAW_OPENCLAW_OTEL_ENDPOINT` | OTLP/HTTP URL | Sets the OpenTelemetry collector endpoint for OpenClaw diagnostics. Defaults to `http://host.openshell.internal:4318` when `NEMOCLAW_OPENCLAW_OTEL=1`. |
+| `NEMOCLAW_OPENCLAW_OTEL_SERVICE_NAME` | service name | Sets the OTEL `service.name` for OpenClaw gateway spans. Defaults to `openclaw-gateway`. |
+| `NEMOCLAW_OPENCLAW_OTEL_SAMPLE_RATE` | `0.0` to `1.0` | Sets OpenClaw's root-span sample rate for conversation diagnostics. Defaults to `1.0`. |
 | `NEMOCLAW_OPENSHELL_BIN` | path | Overrides the `openshell` binary the CLI invokes. Defaults to `openshell` (resolved via `PATH`). |
 | `NEMOCLAW_SANDBOX` | sandbox name | Alternate spelling of `NEMOCLAW_SANDBOX_NAME`; used by `services` and `debug` lookups when neither a flag nor `NEMOCLAW_SANDBOX_NAME` is set. |
 | `NEMOCLAW_INSTALL_REF` | git ref | For internal installer commands: the git ref to install from. Overridden by the `--install-ref` flag. |
@@ -1593,6 +1597,29 @@ NEMOCLAW_TRACE_FILE=/tmp/nemoclaw-onboard-trace.json nemohermes onboard
 Trace artifacts include onboard phase timing, sandbox and dashboard readiness waits, policy application, inference validation probes, curl probe results, and sandbox build progress events.
 Secret-like metadata such as API keys, bearer tokens, cookies, and credentials is redacted before the file is written.
 
+### OpenClaw Conversation OTEL Diagnostics
+
+Set `NEMOCLAW_OPENCLAW_OTEL=1` before onboarding or rebuilding an OpenClaw sandbox to enable runtime conversation traces through OpenClaw's `diagnostics-otel` plugin.
+This is separate from `NEMOCLAW_TRACE`, which records NemoClaw onboarding phases to a local JSON file.
+NemoClaw configures OpenClaw for OTLP/HTTP protobuf traces only by default: metrics and logs are disabled, and prompt/tool content capture is not enabled.
+
+For a local Jaeger collector:
+
+```bash
+docker run --rm --name nemoclaw-jaeger \
+    -e COLLECTOR_OTLP_ENABLED=true \
+    -p 16686:16686 \
+    -p 4318:4318 \
+    jaegertracing/all-in-one:1.57
+NEMOCLAW_OPENCLAW_OTEL=1 nemohermes onboard
+```
+
+Onboarding automatically applies the `openclaw-diagnostics-otel-local` preset at sandbox create and again during the policy step when `NEMOCLAW_OPENCLAW_OTEL=1`, so OTLP export is allowed before the gateway's first trace flush. If you enabled OTEL after an existing sandbox was created, run `nemohermes <sandbox-name> policy-add openclaw-diagnostics-otel-local --yes` or recreate the sandbox with OTEL enabled at build time.
+
+Then open `http://localhost:16686` and select the `openclaw-gateway` service.
+The built-in `openclaw-diagnostics-otel-local` preset allows only `POST /v1/traces` (and subpaths) to `host.openshell.internal:4318` from `openclaw` and `node`.
+For a remote collector, create a custom preset for the collector host and port instead of using the local host-gateway preset.
+
 ### Probe Timeouts
 
 These tune how long internal probes wait before giving up.
@@ -1633,6 +1660,19 @@ These flags change defaults for commands that manage existing sandboxes.
 | `NEMOCLAW_CLEANUP_GATEWAY` | `1`, `true`, or `yes` to enable; `0`, `false`, or `no` to disable | Sets the default for whether `nemohermes <name> destroy` removes the shared gateway when destroying the last sandbox. Command-line `--cleanup-gateway` and `--no-cleanup-gateway` still take precedence. |
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `nemohermes <name> connect` and `nemohermes <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 | `NEMOCLAW_SHIELDS_ACCEPT_LEGACY_BASELINE` | `1` to opt in | Allows advanced immutable-config verification to trust the current on-disk bytes for older or partial content baselines. Use only after you have rebuilt or manually inspected the sandbox state and accepted that the baseline is operator-approved. |
+
+### Remote Deployment
+
+These variables seed defaults for `nemohermes deploy` and `nemohermes onboard --remote`, which provision a sandbox on a Brev instance.
+Each has a flag equivalent on `deploy`; the env var lets non-interactive runs skip the prompt.
+For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](../deployment/deploy-to-remote-gpu.md).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `NEMOCLAW_BREV_PROVIDER` | `gcp` | Cloud provider for Brev instance creation. |
+| `NEMOCLAW_GPU` | `a2-highgpu-1g:nvidia-tesla-a100:1` | GPU specification (instance type and GPU model) for the Brev instance. |
+| `NEMOCLAW_DEPLOY_NO_CONNECT` | unset | When set to `1`, skips the automatic `connect` step after the remote deploy completes. |
+| `NEMOCLAW_DEPLOY_NO_START_SERVICES` | unset | When set to `1`, skips starting services automatically after the remote deploy. |
 
 ### Legacy `nemohermes setup`
 

--- a/scripts/docs-to-skills.py
+++ b/scripts/docs-to-skills.py
@@ -410,6 +410,8 @@ def parse_doc(path: Path, doc_platform: str = "myst-md") -> DocPage:
     """Parse a documentation file into a DocPage."""
     raw = path.read_text(encoding="utf-8")
     fm, body = parse_yaml_frontmatter(raw)
+    if doc_platform == "fern-mdx":
+        body = body.replace("$$nemoclaw", "nemoclaw")
     body = strip_commented_out_blocks(body)
 
     page = DocPage(path=path, raw=raw, frontmatter=fm, body=body)
@@ -1888,6 +1890,8 @@ EXCLUDED_PATTERNS = {
 
 def _is_excluded_doc(path: Path, doc_platform: str) -> bool:
     """Return whether a page should be skipped for the selected source format."""
+    if path.name.endswith(".generated.mdx"):
+        return True
     if path.name in EXCLUDED_PATTERNS:
         return True
     if doc_platform == "fern-mdx" and path.with_suffix(".md").name in EXCLUDED_PATTERNS:

--- a/scripts/sync-agent-variant-docs.ts
+++ b/scripts/sync-agent-variant-docs.ts
@@ -1,16 +1,27 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const sourcePath = path.join(repoRoot, "docs/reference/commands.mdx");
 const targetPath = path.join(repoRoot, "docs/reference/commands-nemohermes.mdx");
+const lifecyclePath = path.join(repoRoot, "docs/manage-sandboxes/lifecycle.mdx");
+const agentVariants = ["openclaw", "hermes"] as const;
+
+type AgentVariant = (typeof agentVariants)[number];
+type RenderedFile = {
+  path: string;
+  contents: string;
+};
 
 const GENERATED_NOTICE =
   "{/* This file is generated from docs/reference/commands.mdx by scripts/sync-agent-variant-docs.ts. Run `npm run docs:sync-agent-variants` to regenerate it. Do not edit by hand. */}";
+const GENERATED_VARIANT_NOTICE =
+  "{/* This file is generated from a shared agent-variant source by scripts/sync-agent-variant-docs.ts. Run `npm run docs:sync-agent-variants` to regenerate it. Do not edit by hand. */}";
+const CLI_SENTINEL = "$$nemoclaw";
 
 const checkOnly = process.argv.includes("--check");
 
@@ -18,6 +29,7 @@ function main(): void {
   const source = readFileSync(sourcePath, "utf8");
   const rendered = renderHermesCommandsReference(source);
   const existing = readOptionalTarget();
+  const generatedVariantPages = renderGeneratedAgentVariantPages();
 
   if (checkOnly) {
     if (existing !== rendered) {
@@ -26,6 +38,7 @@ function main(): void {
       );
       process.exit(1);
     }
+    writeGeneratedFiles(generatedVariantPages);
     return;
   }
 
@@ -35,6 +48,7 @@ function main(): void {
   } else {
     console.log(`${path.relative(repoRoot, targetPath)} is already up to date`);
   }
+  writeGeneratedFiles(generatedVariantPages);
 }
 
 export function renderHermesCommandsReference(source: string): string {
@@ -91,13 +105,52 @@ function replaceFrontmatterLine(frontmatter: string, key: string, value: string)
 }
 
 function stripAgentOnlyBlocks(body: string): string {
+  return stripAgentOnlyBlocksForVariant(body, "hermes");
+}
+
+function stripAgentOnlyBlocksForVariant(body: string, activeVariant: AgentVariant): string {
   return body.replace(
     /\n?<AgentOnly variant="(openclaw|hermes)">\n([\s\S]*?)\n<\/AgentOnly>\n?/g,
     (_match, variant: string, content: string) => {
-      if (variant !== "hermes") return "\n";
+      if (variant !== activeVariant) return "\n";
       return `\n${content.trim()}\n`;
     },
   );
+}
+
+export function renderAgentVariantPage(source: string, variant: AgentVariant): string {
+  const { frontmatter, body } = splitFrontmatter(source);
+  const renderedBody = stripAgentOnlyBlocksForVariant(
+    body.replace(/^import \{ AgentOnly \} from "\.\.\/_components\/AgentGuide";\n\n?/m, ""),
+    variant,
+  )
+    .replaceAll(CLI_SENTINEL, variant === "hermes" ? "nemohermes" : "nemoclaw")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimStart();
+
+  return `${frontmatter}${GENERATED_VARIANT_NOTICE}\n\n${renderedBody}`.replace(/\s*$/, "\n");
+}
+
+function renderGeneratedAgentVariantPages(): RenderedFile[] {
+  const source = readFileSync(lifecyclePath, "utf8");
+  const sourceDirectory = path.dirname(lifecyclePath);
+  const basename = path.basename(lifecyclePath, ".mdx");
+  return agentVariants.map((variant) => ({
+    path: path.join(sourceDirectory, `${basename}.${variant}.generated.mdx`),
+    contents: renderAgentVariantPage(source, variant),
+  }));
+}
+
+function writeGeneratedFiles(files: RenderedFile[]): void {
+  for (const file of files) {
+    if (readOptionalFile(file.path) === file.contents) {
+      console.log(`${path.relative(repoRoot, file.path)} is already up to date`);
+      continue;
+    }
+    mkdirSync(path.dirname(file.path), { recursive: true });
+    writeFileSync(file.path, file.contents);
+    console.log(`Wrote ${path.relative(repoRoot, file.path)}`);
+  }
 }
 
 function transformNemoclawCliInvocations(body: string): string {
@@ -137,8 +190,12 @@ function restoreProtectedLiterals(body: string): string {
 }
 
 function readOptionalTarget(): string | null {
+  return readOptionalFile(targetPath);
+}
+
+function readOptionalFile(filePath: string): string | null {
   try {
-    return readFileSync(targetPath, "utf8");
+    return readFileSync(filePath, "utf8");
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") return null;
     throw error;

--- a/scripts/watch-fern-preview.ts
+++ b/scripts/watch-fern-preview.ts
@@ -148,7 +148,10 @@ function isNodeError(error: unknown): error is NodeError {
 }
 
 function shouldIgnorePath(candidatePath: string): boolean {
-  return candidatePath.split(path.sep).some((part) => ignoredDirectoryNames.has(part));
+  return (
+    candidatePath.endsWith(".generated.mdx") ||
+    candidatePath.split(path.sep).some((part) => ignoredDirectoryNames.has(part))
+  );
 }
 
 function scheduleRun(): void {

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { renderAgentVariantPage } from "../scripts/sync-agent-variant-docs";
+
+const source = `---
+title: "Example"
+---
+import { AgentOnly } from "../_components/AgentGuide";
+
+<AgentOnly variant="openclaw">
+OpenClaw only.
+</AgentOnly>
+<AgentOnly variant="hermes">
+Hermes only.
+</AgentOnly>
+
+\`\`\`bash
+$$nemoclaw list
+\`\`\`
+`;
+
+describe("agent variant docs", () => {
+  it("renders OpenClaw sentinel code and content", () => {
+    const rendered = renderAgentVariantPage(source, "openclaw");
+
+    expect(rendered).toContain("OpenClaw only.");
+    expect(rendered).not.toContain("Hermes only.");
+    expect(rendered).toContain("nemoclaw list");
+    expect(rendered).not.toContain("$$nemoclaw");
+    expect(rendered).not.toContain("AgentOnly");
+  });
+
+  it("renders Hermes sentinel code and content", () => {
+    const rendered = renderAgentVariantPage(source, "hermes");
+
+    expect(rendered).not.toContain("OpenClaw only.");
+    expect(rendered).toContain("Hermes only.");
+    expect(rendered).toContain("nemohermes list");
+    expect(rendered).not.toContain("$$nemoclaw");
+    expect(rendered).not.toContain("AgentOnly");
+  });
+});


### PR DESCRIPTION
## Summary
Adds build-time generation for agent-specific docs variants so shared source samples can use `$$nemoclaw` while Fern still renders native fenced code blocks.

Tested preview: 
- nemoclaw: https://nvidia-preview-pr-4721.docs.buildwithfern.com/nemoclaw/latest/user-guide/openclaw/manage-sandboxes/lifecycle
- nemohermes: https://nvidia-preview-pr-4721.docs.buildwithfern.com/nemoclaw/latest/user-guide/hermes/manage-sandboxes/lifecycle

## Changes
- Generate OpenClaw and Hermes lifecycle docs from `docs/manage-sandboxes/lifecycle.mdx` and route both Fern variants to generated pages.
- Collapse simple duplicate lifecycle code blocks to `$$nemoclaw` sentinel samples while keeping `AgentOnly` for real content differences.
- Keep generated MDX ignored and idempotent so `docs:preview:watch` does not loop on generated files.
- Update docs-to-skills handling and add a focused variant-rendering test.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
`git commit --no-verify` and `git push --no-verify` were used at the user's request after a hook run failed in unrelated broad tests.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verified locally:
- `npm test -- test/agent-variant-docs.test.ts`
- `npm run docs` (passes with the existing Fern warning)
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx --dry-run`

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variables for OpenClaw conversation diagnostics and remote deployment configuration
  * Introduced agent-variant-specific documentation generation

* **Documentation**
  * Updated CLI command examples and contributor guidelines with standardized formatting rules
  * Added guidance for OpenClaw OTEL diagnostics configuration
  * Added remote deployment documentation

* **Chores**
  * Updated build workflow to use project-local tooling
  * Updated documentation generation configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->