### PR TITLE
fix(hermes): harden history repair contract

### DIFF
--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -89,8 +89,13 @@ state_dirs:
 # exposes compatibility symlinks such as .hermes/state.db -> runtime/state.db.
 # The SQLite database is captured with SQLite's online backup API; WAL/SHM
 # files are intentionally omitted because the backup produces a consistent DB.
+# .hermes_history is user runtime history: prompt_toolkit appends to it on
+# every TUI keypress, so NemoClaw intentionally keeps it sandbox-writable even
+# when shields-up locks the parent config dir. It can be removed from this
+# contract if upstream Hermes supports redirecting or disabling FileHistory.
 state_files:
   - path: SOUL.md
+  - path: .hermes_history
   - path: runtime/state.db
     strategy: sqlite_backup
 

--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -27,7 +27,12 @@ filesystem_policy:
     - /sandbox
     - /tmp
     - /dev/null
-    - /sandbox/.hermes              # Agent config (lockable via shields up)
+    # Agent config/state root. Shields-up locks config.yaml/.env and the
+    # parent directory, but intentionally leaves /sandbox/.hermes/.hermes_history
+    # as sandbox:sandbox 0660 because prompt_toolkit FileHistory appends there
+    # on every Hermes TUI keypress. Remove that exception if upstream supports
+    # redirecting or disabling file history.
+    - /sandbox/.hermes
 
 landlock:
   compatibility: best_effort

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -368,39 +368,96 @@ ensure_hermes_state_dir() {
 ensure_hermes_history_file() {
   local file="$1"
   local mode="$2"
-  local nlinks
 
-  if [ -L "$file" ]; then
-    echo "[SECURITY] Refusing Hermes layout repair because ${file} is a symlink" >&2
-    return 1
-  fi
-  if [ -e "$file" ] && [ ! -f "$file" ]; then
-    echo "[SECURITY] Refusing Hermes layout repair because ${file} is not a regular file" >&2
-    return 1
-  fi
+  # Use a no-follow fd workflow instead of check-then-use shell path
+  # operations. /sandbox/.hermes is intentionally sandbox-writable while
+  # shields are down, so root must not validate the pathname and then later
+  # chown/chmod whatever an agent swaps into that path. Python gives us
+  # O_NOFOLLOW + fstat/fchown/fchmod against the actual opened inode.
+  NEMOCLAW_HERMES_HISTORY_FILE="$file" \
+    NEMOCLAW_HERMES_HISTORY_MODE="$mode" \
+    python3 - <<'PYHISTORY'
+import errno
+import grp
+import os
+import pwd
+import stat
+import sys
 
-  # Reject hard-linked targets. An attacker who controls the sandbox user
-  # before shields-up can pre-create .hermes_history as a hard link to
-  # config.yaml or .env. Both -L and -f pass, so without this guard the
-  # subsequent chown sandbox:sandbox + chmod 660 would walk the shared
-  # inode and silently undo the shields-up root:root 0444 lock on the
-  # config file after verify_config_integrity has already passed.
-  if [ -e "$file" ]; then
-    nlinks="$(stat -c '%h' "$file" 2>/dev/null || stat -f '%l' "$file" 2>/dev/null || true)"
-    if [ "${nlinks:-}" != "1" ]; then
-      echo "[SECURITY] Refusing Hermes layout repair because ${file} has hard-link count ${nlinks:-unknown}" >&2
-      return 1
-    fi
-  fi
+path = os.environ["NEMOCLAW_HERMES_HISTORY_FILE"]
+mode_text = os.environ["NEMOCLAW_HERMES_HISTORY_MODE"]
+try:
+    mode = int(mode_text, 8)
+except ValueError:
+    print(f"[SECURITY] Refusing Hermes layout repair because requested mode {mode_text!r} is invalid", file=sys.stderr)
+    sys.exit(1)
 
-  if [ ! -e "$file" ]; then
-    : >"$file" || return 1
-  fi
+if not hasattr(os, "O_NOFOLLOW"):
+    print("[SECURITY] Refusing Hermes layout repair because O_NOFOLLOW is unavailable", file=sys.stderr)
+    sys.exit(1)
 
-  if [ "$(id -u)" -eq 0 ]; then
-    chown sandbox:sandbox "$file"
-  fi
-  chmod "$mode" "$file"
+flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW
+for optional_flag in ("O_CLOEXEC", "O_NONBLOCK"):
+    flags |= getattr(os, optional_flag, 0)
+
+
+def describe_unsafe_existing_path() -> str:
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return "could not be opened safely"
+    if stat.S_ISLNK(st.st_mode):
+        return "is a symlink"
+    if not stat.S_ISREG(st.st_mode):
+        return "is not a regular file"
+    return "could not be opened safely"
+
+try:
+    fd = os.open(path, flags, mode)
+except OSError as exc:
+    reason = describe_unsafe_existing_path()
+    detail = exc.strerror or errno.errorcode.get(exc.errno, str(exc.errno))
+    print(f"[SECURITY] Refusing Hermes layout repair because {path} {reason}: {detail}", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        print(f"[SECURITY] Refusing Hermes layout repair because {path} is not a regular file", file=sys.stderr)
+        sys.exit(1)
+
+    # Reject hard-linked targets. An attacker who controls the sandbox user
+    # before shields-up can pre-create .hermes_history as a hard link to
+    # config.yaml or .env. O_NOFOLLOW and regular-file checks pass, so without
+    # this guard fchown/fchmod would walk the shared inode and silently undo
+    # the shields-up root:root 0444 lock on the config file after
+    # verify_config_integrity has already passed.
+    if st.st_nlink != 1:
+        print(f"[SECURITY] Refusing Hermes layout repair because {path} has hard-link count {st.st_nlink}", file=sys.stderr)
+        sys.exit(1)
+
+    if os.geteuid() == 0:
+        try:
+            uid = pwd.getpwnam("sandbox").pw_uid
+            gid = grp.getgrnam("sandbox").gr_gid
+        except KeyError as exc:
+            print(f"[SECURITY] Refusing Hermes layout repair because sandbox account lookup failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+        os.fchown(fd, uid, gid)
+    os.fchmod(fd, mode)
+
+    st = os.fstat(fd)
+    try:
+        current = os.stat(path, follow_symlinks=False)
+    except OSError as exc:
+        print(f"[SECURITY] Refusing Hermes layout repair because {path} no longer names the opened history file: {exc.strerror}", file=sys.stderr)
+        sys.exit(1)
+    if (current.st_dev, current.st_ino) != (st.st_dev, st.st_ino):
+        print(f"[SECURITY] Refusing Hermes layout repair because {path} changed during repair", file=sys.stderr)
+        sys.exit(1)
+finally:
+    os.close(fd)
+PYHISTORY
 }
 
 repair_hermes_startup_layout() {

--- a/src/lib/shields/state-dir-lock.ts
+++ b/src/lib/shields/state-dir-lock.ts
@@ -41,10 +41,15 @@ export interface PrivilegedExec {
 //
 // Coverage tracks the union of state_dirs declared by every shipped agent
 // manifest (agents/openclaw/manifest.yaml, agents/hermes/manifest.yaml).
-// Runtime-mutable subtrees that must keep being writable while shields are
-// up are intentionally omitted:
+// Runtime-mutable subtrees/files that must keep being writable while shields
+// are up are intentionally omitted:
 //   - `sessions` (Hermes top-level) and `agents/*/sessions` (OpenClaw) — the
 //     latter is restored via WRITABLE_RUNTIME_SUBPATHS after the lock loop.
+//   - `.hermes_history` (Hermes top-level file) — prompt_toolkit appends to
+//     this file from the sandbox user on every TUI keypress. It is deliberately
+//     precreated/repaired as `sandbox:sandbox 0660` while the parent config dir
+//     can remain `root:root 0755` under shields-up. Removal condition: upstream
+//     Hermes exposes a supported option to redirect or disable FileHistory.
 //   - `memories`, `logs`, `cache`, `plans` (Hermes) — runtime mutables.
 //   - `openclaw-weixin` is regenerated from envs at image-build time
 //     (see src/lib/actions/sandbox/rebuild.ts) and is not a manifest state_dir.

--- a/test/e2e-scenario/validation_suites/hermes/01-history-writable.sh
+++ b/test/e2e-scenario/validation_suites/hermes/01-history-writable.sh
@@ -10,10 +10,13 @@
 # user can only succeed when the file exists as a sandbox-owned regular
 # file before shields-up engages. The probe reproduces the exact
 # open(filename, "ab") call against the running sandbox and asserts the
-# write succeeds in both shields-down and shields-up states. The step
-# leaves shields-up engaged on exit when it had to toggle, because the
-# hermes-specific suite runs last in the scenario plan and the scenario
-# teardown owns sandbox cleanup.
+# write succeeds in both shields-down and shields-up states. This is the
+# accepted scenario-level proxy for #2432's interactive `/exit` symptom: the
+# reported `/exit` loop was caused by this append failing after every input
+# buffer reset, while a full TUI pty+provider conversation would be much more
+# brittle in the generic scenario fan-out. The step leaves shields-up engaged
+# on exit when it had to toggle, because the hermes-specific suite runs last
+# in the scenario plan and the scenario teardown owns sandbox cleanup.
 
 set -euo pipefail
 

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1188,6 +1188,7 @@ describe("Hermes durable state files", () => {
       fs.mkdirSync(binDir, { recursive: true });
       fs.mkdirSync(runtimeDir, { recursive: true });
       fs.writeFileSync(path.join(hermesDir, "SOUL.md"), "original soul\n");
+      fs.writeFileSync(path.join(hermesDir, ".hermes_history"), "original history\n");
       fs.writeFileSync(path.join(runtimeDir, "state.db"), "original sqlite backup\n");
       fs.writeFileSync(path.join(hermesDir, "config.yaml"), "token: should-not-copy\n");
       fs.writeFileSync(path.join(hermesDir, ".env"), "API_TOKEN=should-not-copy\n");
@@ -1237,6 +1238,10 @@ if (cmd.includes("SOUL.md") && cmd.includes("cat --")) {
   process.stdout.write(fs.readFileSync(path.join(hermesDir, "SOUL.md")));
   process.exit(0);
 }
+if (cmd.includes(".hermes_history") && cmd.includes("cat --")) {
+  process.stdout.write(fs.readFileSync(path.join(hermesDir, ".hermes_history")));
+  process.exit(0);
+}
 if (cmd.includes("nemoclaw-sqlite-restore")) {
   fs.mkdirSync(path.join(hermesDir, "runtime"), { recursive: true });
   fs.writeFileSync(path.join(hermesDir, "runtime", "state.db"), readStdin());
@@ -1244,6 +1249,10 @@ if (cmd.includes("nemoclaw-sqlite-restore")) {
 }
 if (cmd.includes(".nemoclaw-restore") && cmd.includes("SOUL.md")) {
   fs.writeFileSync(path.join(hermesDir, "SOUL.md"), readStdin());
+  process.exit(0);
+}
+if (cmd.includes(".nemoclaw-restore") && cmd.includes(".hermes_history")) {
+  fs.writeFileSync(path.join(hermesDir, ".hermes_history"), readStdin());
   process.exit(0);
 }
 process.exit(0);
@@ -1273,14 +1282,18 @@ process.exit(0);
 
       const backup = sandboxState.backupSandboxState("hermes", { name: "hermes-state" });
       expect(backup.success).toBe(true);
-      expect(backup.backedUpFiles).toEqual(["SOUL.md", "runtime/state.db"]);
+      expect(backup.backedUpFiles).toEqual(["SOUL.md", ".hermes_history", "runtime/state.db"]);
       expect(backup.failedFiles).toEqual([]);
       expect(backup.manifest?.stateFiles).toEqual([
         { path: "SOUL.md", strategy: "copy" },
+        { path: ".hermes_history", strategy: "copy" },
         { path: "runtime/state.db", strategy: "sqlite_backup" },
       ]);
       expect(fs.readFileSync(path.join(backup.manifest!.backupPath, "SOUL.md"), "utf-8")).toBe(
         "original soul\n",
+      );
+      expect(fs.readFileSync(path.join(backup.manifest!.backupPath, ".hermes_history"), "utf-8")).toBe(
+        "original history\n",
       );
       expect(
         fs.readFileSync(path.join(backup.manifest!.backupPath, "runtime", "state.db"), "utf-8"),
@@ -1290,11 +1303,15 @@ process.exit(0);
       expect(fs.existsSync(path.join(backup.manifest!.backupPath, "auth.json"))).toBe(false);
 
       fs.writeFileSync(path.join(hermesDir, "SOUL.md"), "changed soul\n");
+      fs.writeFileSync(path.join(hermesDir, ".hermes_history"), "changed history\n");
       fs.writeFileSync(path.join(runtimeDir, "state.db"), "changed db\n");
       const restore = sandboxState.restoreSandboxState("hermes", backup.manifest!.backupPath);
       expect(restore.success).toBe(true);
-      expect(restore.restoredFiles).toEqual(["SOUL.md", "runtime/state.db"]);
+      expect(restore.restoredFiles).toEqual(["SOUL.md", ".hermes_history", "runtime/state.db"]);
       expect(fs.readFileSync(path.join(hermesDir, "SOUL.md"), "utf-8")).toBe("original soul\n");
+      expect(fs.readFileSync(path.join(hermesDir, ".hermes_history"), "utf-8")).toBe(
+        "original history\n",
+      );
       expect(fs.readFileSync(path.join(runtimeDir, "state.db"), "utf-8")).toBe(
         "original sqlite backup\n",
       );


### PR DESCRIPTION
## Summary
Hardens the Hermes `.hermes_history` repair added in #4708 so startup no longer performs privileged check-then-use mutations on a sandbox-writable pathname. It also records the shields-up history-file exception in the central Hermes/shields contracts and preserves history through Hermes state backups.

## Related Issue
Follow-up to #4708; refs #2432.

## Changes
- Replace path-based `.hermes_history` repair in `agents/hermes/start.sh` with an `O_NOFOLLOW` fd-based Python helper that validates, `fchown`s, and `fchmod`s the opened inode.
- Document the intentional `sandbox:sandbox 0660` `.hermes_history` exception in `src/lib/shields/state-dir-lock.ts`, `agents/hermes/manifest.yaml`, and `agents/hermes/policy-additions.yaml`.
- Add `.hermes_history` to Hermes `state_files` and update snapshot coverage so history is backed up and restored.
- Clarify that the scenario E2E history append probe is the accepted proxy for the `/exit` symptom from #2432.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hermes history file is now included in backup and restore operations, ensuring command history is preserved across sessions.

* **Bug Fixes**
  * Enhanced reliability of history file handling with improved validation and robustness during repair operations.

* **Tests**
  * Expanded test coverage for history file backup and restore scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->