### PR TITLE
docs(reference): fix remote GPU command links

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1665,7 +1665,7 @@ These flags change defaults for commands that manage existing sandboxes.
 
 These variables seed defaults for `nemohermes deploy` and `nemohermes onboard --remote`, which provision a sandbox on a Brev instance.
 Each has a flag equivalent on `deploy`; the env var lets non-interactive runs skip the prompt.
-For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](../deployment/deploy-to-remote-gpu.md).
+For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](../deployment/deploy-to-remote-gpu.mdx).
 
 | Variable | Default | Effect |
 |----------|---------|--------|

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1934,7 +1934,7 @@ These flags change defaults for commands that manage existing sandboxes.
 
 These variables seed defaults for `nemoclaw deploy` and `nemoclaw onboard --remote`, which provision a sandbox on a Brev instance.
 Each has a flag equivalent on `deploy`; the env var lets non-interactive runs skip the prompt.
-For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](../deployment/deploy-to-remote-gpu.md).
+For narrative how-to coverage of `NEMOCLAW_BREV_PROVIDER` and `NEMOCLAW_GPU`, see [Deploy to Remote GPU](../deployment/deploy-to-remote-gpu.mdx).
 
 | Variable | Default | Effect |
 |----------|---------|--------|


### PR DESCRIPTION
## Summary
Fixes the broken remote GPU documentation links that caused the Nightly docs-validation E2E job to fail. The command references now point at the existing Fern MDX page instead of a non-existent Markdown file.

## Changes
- Updated `docs/reference/commands.mdx` to link to `../deployment/deploy-to-remote-gpu.mdx`.
- Updated `docs/reference/commands-nemohermes.mdx` to link to the same existing MDX page.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Confirmed the failing path from https://github.com/NVIDIA/NemoClaw/actions/runs/26914255345/job/79399985216 with `CHECK_DOC_LINKS_REMOTE=0 bash test/e2e/test-docs-validation.sh`.
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected internal documentation links across remote deployment and configuration reference pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->