### PR TITLE
docs: clarify community response expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Maintainers may ask you to move broad or still-forming proposals from an issue t
 ## Community Response Expectations
 
 NemoClaw is an alpha project, and maintainer availability varies with release, security, and stability work.
-Issues, discussions, and pull requests are reviewed on a best effort basis.
+Issues, discussions, and pull requests are reviewed on a best-effort basis.
 The project does not publish guaranteed response or review timelines.
 
 Maintainers prioritize work using severity, security impact, release readiness, reproducibility, maintainer capacity, and community impact.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ New contributors should start with issues labeled [`good first issue`](https://g
 Before starting larger work:
 
 - Search open issues and pull requests to avoid duplicates.
-- Open an issue to discuss your approach before writing code for significant changes.
+- Start a [GitHub Discussion](https://github.com/NVIDIA/NemoClaw/discussions) before writing code for significant changes.
+- Open an issue after the proposal has enough scope and design detail for maintainer review.
 - For questions, open a [GitHub Discussion](https://github.com/NVIDIA/NemoClaw/discussions) or comment on a related issue.
 
 ## Before You Open an Issue
@@ -41,6 +42,19 @@ Open an issue when you encounter one of the following situations.
 - A real bug that you confirmed and could not fix.
 - A feature proposal with a design — not a "please build this" request.
 - Security vulnerabilities must follow [SECURITY.md](SECURITY.md) — **not** GitHub issues.
+
+Use [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions) for questions, design exploration, and larger feature proposals before implementation.
+Maintainers may ask you to move broad or still-forming proposals from an issue to a discussion so the design can settle before code review.
+
+## Community Response Expectations
+
+NemoClaw is an alpha project, and maintainer availability varies with release, security, and stability work.
+Issues, discussions, and pull requests are reviewed on a best effort basis.
+The project does not publish guaranteed response or review timelines.
+
+Maintainers prioritize work using severity, security impact, release readiness, reproducibility, maintainer capacity, and community impact.
+For public roadmap context and current priorities, see [Current Priorities](README.md#current-priorities).
+That section is a planning aid, not a commitment that a specific issue or feature will ship in a specific release.
 
 ## Prerequisites
 
@@ -194,8 +208,9 @@ For user-skill definitions, docs-to-skills validation, release-prep regeneration
 ## Pull Requests
 
 We welcome contributions. Every PR requires maintainer review before merge. To keep the review queue healthy, limit the number of open PRs you have at any time to fewer than 10.
-
-Maintainers review all incoming PRs on a best-effort basis. Straightforward fixes typically receive initial feedback sooner than large or complex changes. If a PR has not received a response after two weeks, a polite comment asking for an update is welcome.
+Maintainers review pull requests according to project priority, security impact, release readiness, and reviewer availability.
+PRs that solve issues with Priority set to Urgent or High are more likely to receive earlier review when maintainers have capacity.
+For substantial features or behavior changes, start with a GitHub Discussion before opening a large implementation PR.
 
 ### DCO Sign-Off
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,17 @@ Refer to the following pages on the official documentation website for more info
 
 ## Community
 
-- [Discord](https://discord.gg/XFpfPv9Uvx)
-- [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions)
-- [GitHub Issues](https://github.com/NVIDIA/NemoClaw/issues)
+Join the NemoClaw community to ask questions, share feedback, and report issues.
+NemoClaw is an alpha project, so maintainers review issues, discussions, and pull requests on a best effort basis without guaranteed response timelines.
+
+| Need | Channel |
+|------|---------|
+| Setup or usage questions | [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions) or [Discord](https://discord.gg/XFpfPv9Uvx) |
+| Reproducible bugs | [GitHub Issues](https://github.com/NVIDIA/NemoClaw/issues) |
+| Feature proposals | Start with [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions), then open an issue when the scope is clear |
+| Current priorities | [Current Priorities](#current-priorities) |
+| Contribution help | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Security vulnerabilities | Use the private channels in [SECURITY.md](SECURITY.md); do not open public issues |
 
 ## Contributing
 
@@ -69,6 +77,19 @@ Use one of the private reporting channels described in [SECURITY.md](SECURITY.md
 - Use [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository) to submit a report directly on this repository.
 
 For security bulletins and PSIRT policies, visit the [NVIDIA Product Security](https://www.nvidia.com/en-us/security/) portal.
+
+## Current Priorities
+
+NemoClaw's current priorities are maintained here as a public orientation point for contributors and community members.
+This list is not a delivery commitment, support promise, or fixed roadmap; priorities can change as maintainers respond to security, quality, platform readiness, and community feedback.
+
+- Improve install and onboarding reliability across tested platforms.
+- Strengthen sandbox hardening, credential handling, and network-policy defaults.
+- Validate local and routed inference behavior for supported provider paths.
+- Keep documentation, troubleshooting guidance, and agent skills aligned with supported workflows.
+
+For specific scoped work, use [GitHub Issues](https://github.com/NVIDIA/NemoClaw/issues) and start broader proposals in [GitHub Discussions](https://github.com/NVIDIA/NemoClaw/discussions).
+Security vulnerabilities must use the private reporting channels in [SECURITY.md](SECURITY.md), not public issues.
 
 ## Notice and Disclaimer
 


### PR DESCRIPTION
## Summary
This PR documents NemoClaw's public community response and review expectations without promising fixed response timelines. It also clarifies where larger proposals should start and adds a README current-priorities section as the public roadmap orientation point.

## Related Issue
Fixes #3829

## Changes
- Add README community channel guidance by request type.
- Add a README Current Priorities section with non-commitment roadmap language.
- Document best effort issue, discussion, and PR review expectations in CONTRIBUTING.
- Route substantial feature proposals through GitHub Discussions before large implementation PRs.
- Note that PRs linked to Urgent or High priority issues are more likely to receive earlier review when maintainers have capacity.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Will Curran <wcurran@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution flow: start with a Discussion for substantial work, open an issue when scope/design are ready for review
  * Added “Community Response Expectations” noting alpha status, best-effort review timing, and maintainer prioritization criteria
  * Introduced a “Current Priorities” section and mapped channels for contribution types, including private reporting for security issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->