### PR TITLE
fix(hermes): preserve strip think method binding

### DIFF
--- a/agents/hermes/plugin/__init__.py
+++ b/agents/hermes/plugin/__init__.py
@@ -22,6 +22,7 @@ chat transcript.
 """
 
 import atexit
+import inspect
 import ipaddress
 import json
 import os
@@ -1149,17 +1150,40 @@ def _install_messaging_response_patch():
     if agent_cls is None or getattr(agent_cls, _MESSAGING_RESPONSE_PATCH_ATTR, False):
         return False
 
+    raw_original = inspect.getattr_static(agent_cls, "_strip_think_blocks", None)
     original = getattr(agent_cls, "_strip_think_blocks", None)
     if not callable(original):
         return False
 
-    def _strip_think_blocks(content):
-        return _normalize_raw_messaging_tool_response(
-            original(content),
-            current_platform=_get_current_messaging_platform(),
-        )
+    if isinstance(raw_original, staticmethod):
+        original_func = raw_original.__func__
 
-    agent_cls._strip_think_blocks = staticmethod(_strip_think_blocks)
+        def _strip_think_blocks(content):
+            return _normalize_raw_messaging_tool_response(
+                original_func(content),
+                current_platform=_get_current_messaging_platform(),
+            )
+
+        agent_cls._strip_think_blocks = staticmethod(_strip_think_blocks)
+    elif isinstance(raw_original, classmethod):
+        original_func = raw_original.__func__
+
+        def _strip_think_blocks(cls, content):
+            return _normalize_raw_messaging_tool_response(
+                original_func(cls, content),
+                current_platform=_get_current_messaging_platform(),
+            )
+
+        agent_cls._strip_think_blocks = classmethod(_strip_think_blocks)
+    else:
+        def _strip_think_blocks(self, content):
+            return _normalize_raw_messaging_tool_response(
+                original(self, content),
+                current_platform=_get_current_messaging_platform(),
+            )
+
+        agent_cls._strip_think_blocks = _strip_think_blocks
+
     setattr(agent_cls, _MESSAGING_RESPONSE_PATCH_ATTR, True)
     return True
 

--- a/test/hermes-plugin-handlers.test.ts
+++ b/test/hermes-plugin-handlers.test.ts
@@ -328,6 +328,63 @@ print(json.dumps(result))
     );
   });
 
+  it("preserves instance-method strip_think_blocks binding", () => {
+    const output = runPython(`
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+
+plugin_path = pathlib.Path(sys.argv[1])
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *_args, **_kwargs: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
+run_agent = types.ModuleType("run_agent")
+class AIAgent:
+    def __init__(self):
+        self.calls = 0
+
+    def _strip_think_blocks(self, content):
+        self.calls += 1
+        return content
+run_agent.AIAgent = AIAgent
+sys.modules["run_agent"] = run_agent
+
+spec = importlib.util.spec_from_file_location("hermes_plugin", plugin_path)
+plugin = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plugin)
+
+patched = plugin._install_messaging_response_patch()
+plugin._set_current_messaging_platform("telegram")
+agent = AIAgent()
+normalized = agent._strip_think_blocks(
+    'send_message: "to telegram: Hello from an instance method."'
+)
+plain = agent._strip_think_blocks("plain response")
+
+print(json.dumps({
+    "patched": patched,
+    "normalized": normalized,
+    "plain": plain,
+    "calls": agent.calls,
+}))
+`);
+
+    const result = JSON.parse(output) as {
+      patched: boolean;
+      normalized: string;
+      plain: string;
+      calls: number;
+    };
+
+    expect(result.patched).toBe(true);
+    expect(result.normalized).toBe("Hello from an instance method.");
+    expect(result.plain).toBe("plain response");
+    expect(result.calls).toBe(2);
+  });
+
   it("anchors the strip_think_blocks patch via _pre_llm_call gateway hook", () => {
     const output = runPython(`
 import importlib.util


### PR DESCRIPTION
## Summary
Preserves the descriptor binding for Hermes' patched `AIAgent._strip_think_blocks` method. This prevents the messaging response normalizer from turning an instance method into a staticmethod and breaking Hermes chat completions with a missing `content` argument.

## Changes
- Detect whether `_strip_think_blocks` is a staticmethod, classmethod, or instance method before patching it.
- Wrap each method shape with the matching descriptor so the original call signature is preserved.
- Add regression coverage for the real instance-method binding shape that failed in the Bedrock-compatible Hermes E2E job.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method binding in the Hermes plugin's messaging response handling to ensure correct execution semantics.
  * Improved normalization of messaging responses across different platforms.

* **Tests**
  * Added test coverage for messaging response patch behavior and instance method binding verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->