### PR TITLE
fix(release): configure latest tag identity

### DIFF
--- a/scripts/release-latest-tag.sh
+++ b/scripts/release-latest-tag.sh
@@ -14,6 +14,19 @@ fail() {
   exit 1
 }
 
+ensure_tag_identity() {
+  if git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
+    return
+  fi
+
+  git config user.name "${RELEASE_TAGGER_NAME:-github-actions[bot]}"
+  git config user.email "${RELEASE_TAGGER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+
+  if ! git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
+    fail "Unable to configure a git committer identity for latest tag promotion"
+  fi
+}
+
 if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   fail "Refusing to promote non-semver tag: $RELEASE_TAG"
 fi
@@ -74,6 +87,7 @@ if [[ -n "$previous_remote_semver" ]]; then
   fi
 fi
 
+ensure_tag_identity
 git tag -fa latest "$release_commit" -m "latest -> $RELEASE_TAG"
 
 if [[ "$PUSH_LATEST" != "0" ]]; then

--- a/scripts/release-notes-data.ts
+++ b/scripts/release-notes-data.ts
@@ -25,9 +25,12 @@ type PullRequestWarning = {
   message: string;
 };
 
+const RELEASE_NOTES_COMMAND_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
+
 function run(command: string, args: string[]): string {
   return execFileSync(command, args, {
     encoding: "utf8",
+    maxBuffer: RELEASE_NOTES_COMMAND_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
   });
 }

--- a/scripts/release-notes-data.ts
+++ b/scripts/release-notes-data.ts
@@ -96,8 +96,15 @@ function prNumbersFromCompare(compare: {
   const numbers = new Set<number>();
   for (const commit of compare.commits ?? []) {
     const headline = commit.commit?.message?.split("\n")[0] ?? "";
-    for (const match of headline.matchAll(/#(\d+)/g)) {
-      numbers.add(Number(match[1]));
+    const squashMatch = /\(#(\d+)\)\s*$/.exec(headline);
+    if (squashMatch) {
+      numbers.add(Number(squashMatch[1]));
+      continue;
+    }
+
+    const mergeMatch = /^Merge pull request #(\d+)\b/.exec(headline);
+    if (mergeMatch) {
+      numbers.add(Number(mergeMatch[1]));
     }
   }
   return Array.from(numbers).sort((a, b) => a - b);

--- a/scripts/release-wait-latest.sh
+++ b/scripts/release-wait-latest.sh
@@ -56,6 +56,19 @@ target="$(json_field originMainCommit)"
 plan_hash="$(json_field planHash)"
 lkg_before="$(node -e 'const fs=require("fs"); const data=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(data.lkgBefore?.peeledSha || data.lkgBefore?.objectSha || "")' "$PLAN_PATH")"
 
+remote_tag_commit_or_object() {
+  local remote_tag="$1"
+  local peeled=""
+  local object=""
+  peeled="$(git ls-remote --tags origin "refs/tags/${remote_tag}^{}" | awk '{print $1}')"
+  if [[ -n "$peeled" ]]; then
+    printf '%s' "$peeled"
+    return
+  fi
+  object="$(git ls-remote --tags origin "refs/tags/${remote_tag}" | awk '{print $1}')"
+  printf '%s' "$object"
+}
+
 deadline=$((SECONDS + TIMEOUT_SECS))
 latest_peeled=""
 semver_peeled=""
@@ -74,7 +87,7 @@ done
 [[ "$semver_peeled" == "$target" ]] || fail "$tag peeled to $semver_peeled, expected $target"
 [[ "$latest_peeled" == "$target" ]] || fail "latest peeled to $latest_peeled, expected $target"
 
-lkg_after="$(git ls-remote --tags origin 'refs/tags/lkg^{}' | awk '{print $1}')"
+lkg_after="$(remote_tag_commit_or_object lkg)"
 if [[ -n "$lkg_before" && "$lkg_after" != "$lkg_before" ]]; then
   fail "lkg changed from $lkg_before to $lkg_after"
 fi

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -126,6 +126,39 @@ function runReleaseLatest(
   });
 }
 
+function runReleaseLatestWithoutIdentity(
+  fixture: Fixture,
+  releaseTag: string,
+): ReturnType<typeof spawnSync> {
+  const home = path.join(fixture.root, "empty-home");
+  const xdgConfigHome = path.join(fixture.root, "empty-xdg-config");
+  fs.mkdirSync(home);
+  fs.mkdirSync(xdgConfigHome);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "user.useConfigOnly",
+    GIT_CONFIG_VALUE_0: "true",
+    GIT_CONFIG_KEY_1: "tag.gpgSign",
+    GIT_CONFIG_VALUE_1: "false",
+    GITHUB_STEP_SUMMARY: fixture.summary,
+    HOME: home,
+    RELEASE_TAG: releaseTag,
+    REMOTE_NAME: "origin",
+    XDG_CONFIG_HOME: xdgConfigHome,
+  };
+  delete env.GIT_AUTHOR_NAME;
+  delete env.GIT_AUTHOR_EMAIL;
+  delete env.GIT_COMMITTER_NAME;
+  delete env.GIT_COMMITTER_EMAIL;
+
+  return spawnSync("bash", [latestScriptPath], {
+    cwd: fixture.work,
+    encoding: "utf8",
+    env,
+  });
+}
+
 function runScript(
   cwd: string,
   args: string[],
@@ -226,6 +259,25 @@ describe("release-latest-tag.sh", () => {
     expect(fs.readFileSync(fixture.summary, "utf8")).toContain(
       "Not touched: `lkg`",
     );
+  });
+
+  it("configures a bot identity when promoting latest on a runner without git identity", () => {
+    const fixture = createFixture();
+    const releaseCommit = commit(fixture, "release commit");
+    pushTag(fixture, "v0.0.1");
+    run(fixture.work, ["git", "config", "--unset", "user.name"]);
+    run(fixture.work, ["git", "config", "--unset", "user.email"]);
+
+    const result = runReleaseLatestWithoutIdentity(fixture, "v0.0.1");
+
+    expect(result.status).toBe(0);
+    expect(remoteCommit(fixture, "refs/tags/latest")).toBe(releaseCommit);
+    expect(
+      run(fixture.work, ["git", "config", "--local", "user.name"]).trim(),
+    ).toBe("github-actions[bot]");
+    expect(
+      run(fixture.work, ["git", "config", "--local", "user.email"]).trim(),
+    ).toBe("41898282+github-actions[bot]@users.noreply.github.com");
   });
 
   it("rejects non-semver tags", () => {

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -476,6 +476,73 @@ describe("release-latest-tag.sh", () => {
     );
   });
 
+  it("extracts only squash-merge PR numbers from release notes compare commits", () => {
+    const fixture = createFixture();
+    const binDir = path.join(fixture.root, "bin");
+    fs.mkdirSync(binDir);
+    const ghPath = path.join(binDir, "gh");
+    fs.writeFileSync(
+      ghPath,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "api" ]; then
+  printf '%s\n' '{"commits":[{"commit":{"message":"fix: use issue ref (#123) (#456)"}},{"commit":{"message":"docs: closes #789 (#987)"}},{"commit":{"message":"Merge pull request #654 from branch"}}]}'
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '{"number":%s,"title":"pr %s"}\n' "$3" "$3"
+  exit 0
+fi
+exit 2
+`,
+      "utf8",
+    );
+    fs.chmodSync(ghPath, 0o755);
+    const planPath = path.join(fixture.root, "release", "plan.json");
+    fs.mkdirSync(path.dirname(planPath), { recursive: true });
+    fs.writeFileSync(
+      planPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          mode: "tag-only",
+          previousTag: "v0.0.1",
+          nextTag: "v0.0.2",
+          originMainCommit: "0123456789abcdef0123456789abcdef01234567",
+          planHash: "a".repeat(64),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    const outputPath = path.join(fixture.root, "release", "notes-data.json");
+
+    const result = runScript(
+      fixture.work,
+      [
+        tsxPath,
+        path.join(repoRoot, "scripts", "release-notes-data.ts"),
+        "--plan",
+        planPath,
+        "--output",
+        outputPath,
+      ],
+      {
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const data = readJson(outputPath);
+    expect(data).toMatchObject({ status: "ok", prNumbers: [456, 654, 987] });
+    expect(data.pullRequests).toEqual([
+      { number: 456, title: "pr 456" },
+      { number: 654, title: "pr 654" },
+      { number: 987, title: "pr 987" },
+    ]);
+  });
+
   it("marks release notes data as partial when a PR metadata lookup fails", () => {
     const fixture = createFixture();
     const binDir = path.join(fixture.root, "bin");

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -425,6 +425,36 @@ describe("release-latest-tag.sh", () => {
     expect(cutResult.stderr).toContain("planHash mismatch");
   });
 
+  it("verifies unchanged lightweight lkg tags", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "lkg", fixture.firstCommit, false);
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const releaseCommit = commit(fixture, "planned release commit");
+    const planPath = path.join(fixture.root, "release", "plan.json");
+    const { plan } = createPlan(fixture, planPath, releaseCommit);
+    expect(plan.lkgBefore).toMatchObject({
+      objectSha: fixture.firstCommit,
+      tag: "lkg",
+    });
+    expect(plan.lkgBefore.peeledSha).toBeUndefined();
+    expect(cutFromPlan(fixture, planPath, plan.confirmationPhrase).status).toBe(
+      0,
+    );
+    expect(runReleaseLatest(fixture, "v0.0.2").status).toBe(0);
+
+    const waitResult = waitForLatest(fixture, planPath);
+
+    expect(waitResult.status).toBe(0);
+    expect(
+      readJson(path.join(fixture.root, "release", "latest-result.json")),
+    ).toMatchObject({
+      tag: "v0.0.2",
+      targetCommit: releaseCommit,
+      lkgPeeledCommitBefore: fixture.firstCommit,
+      lkgPeeledCommitAfter: fixture.firstCommit,
+    });
+  });
+
   it("detects lkg creation after a plan captured lkg as absent", () => {
     const fixture = createFixture();
     pushTag(fixture, "v0.0.1", fixture.firstCommit);


### PR DESCRIPTION
## Summary
Configure a default bot git identity before the release helper creates the annotated `latest` tag. This prevents the `Release latest tag` workflow from failing on runners without `user.name` and `user.email` configured.

## Changes
- Add an `ensure_tag_identity` guard to `scripts/release-latest-tag.sh` before `git tag -fa latest`.
- Default the latest-tag committer identity to `github-actions[bot]` while preserving existing configured identities.
- Add coverage for promoting `latest` when the runner has no git identity.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure a committer identity is configured before creating or force-updating annotated release tags, improving reliability in automated environments.
  * Improve remote tag resolution to more reliably detect peeled vs. unpeeled tag targets when advancing releases.
  * Cap command output buffering when invoking external tools and tighten extraction rules to only recognize explicit PR reference formats.

* **Tests**
  * Added tests validating release behavior when identity is missing, verifying handling of unchanged lightweight tags, and asserting correct PR extraction in release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->