### PR TITLE
fix(hermes): add make and g++ to Dockerfile.base for native addon builds

### DIFF
--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -47,6 +47,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         "dos2unix=7.5.2-1*" \
         jq=1.7.1-6+deb13u2 \
         vim-tiny=2:9.1.1230-2 \
+        make \
+        g++ \
     && rm -rf /var/lib/apt/lists/*
 
 # gosu for privilege separation (gateway vs sandbox user).


### PR DESCRIPTION
## Summary

**✨ [AI-generated PR]**

The `rebuild-hermes-stale-base-e2e` nightly job fails because the Hermes sandbox base image (`agents/hermes/Dockerfile.base`) lacks `make` and `g++`. When `better-sqlite3`'s `prebuild-install` times out (transient network issue), `npm ci` falls back to `node-gyp rebuild`, which requires these build tools for native compilation.

### Root cause

`prebuild-install` attempted to download a prebuilt binary for `better-sqlite3` but the request timed out. The fallback to `node-gyp rebuild --release` then failed with:

```
gyp ERR! stack Error: not found: make
```

The `node:22-trixie-slim` base image does not include build tools, and the `apt-get install` list in `agents/hermes/Dockerfile.base` did not include `make` or `g++`.

### Fix

Add `make` and `g++` to the `apt-get install` list in `agents/hermes/Dockerfile.base` so the `node-gyp` fallback succeeds when prebuilt binaries are unavailable.

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets (`rebuild-hermes-stale-base-e2e / run (#79424403117)`), on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`fix/nightly-e2e-hermes-base-missing-make-f03b8f3-custom-e2e`](https://github.com/hunglp6d/NemoClaw/tree/fix/nightly-e2e-hermes-base-missing-make-f03b8f3-custom-e2e) on `hunglp6d/NemoClaw`
- Validation run: [#26923860297](https://github.com/hunglp6d/NemoClaw/actions/runs/26923860297) — **success**
- Original failing run: [26922066760](https://github.com/NVIDIA/NemoClaw/actions/runs/26922066760) on `f03b8f3fe3a16588dccaa6f8ad8d4f26b705890b`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-running the validation: push any commit to `fix/nightly-e2e-hermes-base-missing-make-f03b8f3-custom-e2e`.

## Test plan

- [x] `rebuild-hermes-stale-base-e2e` passes on the validation branch
- [ ] Confirm image size delta is acceptable (make + g++ add ~100 MB)

Signed-off-by: Hung Le <hple@nvidia.com>


Fixes #4740
