### PR TITLE
fix(rebuild): reuse gateway-stored credential when host env is empty

### DIFF
--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -23,10 +23,12 @@ const hermesProviderAuth = require("../../hermes-provider-auth") as {
     baseUrl?: string,
   ) => void;
 };
-const { LOCAL_INFERENCE_PROVIDERS, REMOTE_PROVIDER_CONFIG } = require("../../onboard/providers") as {
-  LOCAL_INFERENCE_PROVIDERS: string[];
-  REMOTE_PROVIDER_CONFIG: Record<string, { providerName: string; credentialEnv: string | null }>;
-};
+const { LOCAL_INFERENCE_PROVIDERS, REMOTE_PROVIDER_CONFIG, providerExistsInGateway } =
+  require("../../onboard/providers") as {
+    LOCAL_INFERENCE_PROVIDERS: string[];
+    REMOTE_PROVIDER_CONFIG: Record<string, { providerName: string; credentialEnv: string | null }>;
+    providerExistsInGateway: (name: string, runOpenshellFn: typeof runOpenshell) => boolean;
+  };
 
 import {
   detectOpenShellStateRpcPreflightIssue,
@@ -370,18 +372,29 @@ export async function rebuildSandbox(
       `Preflight credential check: ${rebuildCredentialEnv} → ${credentialValue ? "present" : "MISSING"}`,
     );
     if (!credentialValue) {
-      console.error("");
-      console.error(`  ${_RD}Rebuild preflight failed:${R} provider credential not found.`);
-      console.error(`  The non-interactive recreate step requires ${rebuildCredentialEnv},`);
-      console.error("  but it is not set in the environment.");
-      console.error("");
-      console.error("  To fix, do one of:");
-      console.error(`    export ${rebuildCredentialEnv}=<your-key>`);
-      console.error(`    ${CLI_NAME} onboard          # re-enter the key interactively`);
-      console.error("");
-      console.error("  Sandbox is untouched — no data was lost.");
-      bail(`Missing credential: ${rebuildCredentialEnv}`);
-      return;
+      // #3895: when the inference provider is already registered in the
+      // OpenShell gateway, the recreate step does not need a host env value —
+      // the gateway is the source of truth for the secret. Skip the env-only
+      // preflight in that case so flows like `channels add` + rebuild work
+      // when the user has logged out of the original shell.
+      if (rebuildProvider && providerExistsInGateway(rebuildProvider, runOpenshell)) {
+        log(
+          `Preflight credential check: provider '${rebuildProvider}' registered in gateway — skipping env check for ${rebuildCredentialEnv}`,
+        );
+      } else {
+        console.error("");
+        console.error(`  ${_RD}Rebuild preflight failed:${R} provider credential not found.`);
+        console.error(`  The non-interactive recreate step requires ${rebuildCredentialEnv},`);
+        console.error("  but it is not set in the environment.");
+        console.error("");
+        console.error("  To fix, do one of:");
+        console.error(`    export ${rebuildCredentialEnv}=<your-key>`);
+        console.error(`    ${CLI_NAME} onboard          # re-enter the key interactively`);
+        console.error("");
+        console.error("  Sandbox is untouched — no data was lost.");
+        bail(`Missing credential: ${rebuildCredentialEnv}`);
+        return;
+      }
     }
   } else {
     // No credentialEnv in session — local inference (Ollama/vLLM) or

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -372,11 +372,11 @@ export async function rebuildSandbox(
       `Preflight credential check: ${rebuildCredentialEnv} → ${credentialValue ? "present" : "MISSING"}`,
     );
     if (!credentialValue) {
-      // #3895: when the inference provider is already registered in the
-      // OpenShell gateway, the recreate step does not need a host env value —
-      // the gateway is the source of truth for the secret. Skip the env-only
-      // preflight in that case so flows like `channels add` + rebuild work
-      // when the user has logged out of the original shell.
+      // When the inference provider is already registered in the OpenShell
+      // gateway, the recreate step does not need a host env value — the
+      // gateway is the source of truth for the secret. Skip the env-only
+      // preflight in that case so flows like `channels add` + rebuild keep
+      // working when the user has logged out of the original shell.
       if (rebuildProvider && providerExistsInGateway(rebuildProvider, runOpenshell)) {
         log(
           `Preflight credential check: provider '${rebuildProvider}' registered in gateway — skipping env check for ${rebuildCredentialEnv}`,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -4432,14 +4432,21 @@ async function setupNim(
           if (isNonInteractive()) {
             const resolvedNvidiaKey = resolveProviderCredential("NVIDIA_API_KEY");
             if (!resolvedNvidiaKey) {
-              logMissingNvidiaApiKeyHelp(REMOTE_PROVIDER_CONFIG.build.helpUrl);
-              process.exit(1);
-            }
-            const keyError = validateNvidiaApiKeyValue(resolvedNvidiaKey);
-            if (keyError) {
-              console.error(keyError);
-              console.error(`  Get a key from ${REMOTE_PROVIDER_CONFIG.build.helpUrl}`);
-              process.exit(1);
+              // #3895: skip the env requirement when the provider is already
+              // registered in the gateway (rebuild flow after `channels add`).
+              // upsertProvider drops `--credential` from the `provider update`
+              // call when the host env is empty and the provider exists.
+              if (!providerExistsInGateway(provider)) {
+                logMissingNvidiaApiKeyHelp(REMOTE_PROVIDER_CONFIG.build.helpUrl);
+                process.exit(1);
+              }
+            } else {
+              const keyError = validateNvidiaApiKeyValue(resolvedNvidiaKey);
+              if (keyError) {
+                console.error(keyError);
+                console.error(`  Get a key from ${REMOTE_PROVIDER_CONFIG.build.helpUrl}`);
+                process.exit(1);
+              }
             }
           } else {
             await ensureApiKey();
@@ -4504,10 +4511,17 @@ async function setupNim(
           }
           if (isNonInteractive()) {
             if (!resolveProviderCredential(selectedCredentialEnv)) {
-              console.error(
-                `  ${selectedCredentialEnv} (or NEMOCLAW_PROVIDER_KEY) is required for ${remoteConfig.label} in non-interactive mode.`,
-              );
-              process.exit(1);
+              // #3895: skip the env requirement when the provider is already
+              // registered in the gateway. upsertProvider drops `--credential`
+              // from the `provider update` call when the host env is empty and
+              // the provider exists; the recreate step does not need to rotate
+              // the secret.
+              if (!providerExistsInGateway(provider)) {
+                console.error(
+                  `  ${selectedCredentialEnv} (or NEMOCLAW_PROVIDER_KEY) is required for ${remoteConfig.label} in non-interactive mode.`,
+                );
+                process.exit(1);
+              }
             }
           } else {
             const credentialResult = await ensureNamedCredential(

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -919,9 +919,7 @@ function upsertMessagingProviders(
   if (mutated) persistMigratedLegacyKeys();
   return upserted;
 }
-function providerExistsInGateway(name: string) {
-  return onboardProviders.providerExistsInGateway(name, runOpenshell);
-}
+const providerExistsInGateway = (name: string) => onboardProviders.providerExistsInGateway(name, runOpenshell);
 
 // Tri-state probe factory for messaging-conflict backfill. An upfront liveness
 // check is necessary because `openshell provider get` exits non-zero for both
@@ -4431,22 +4429,16 @@ async function setupNim(
           }
           if (isNonInteractive()) {
             const resolvedNvidiaKey = resolveProviderCredential("NVIDIA_API_KEY");
-            if (!resolvedNvidiaKey) {
-              // #3895: skip the env requirement when the provider is already
-              // registered in the gateway (rebuild flow after `channels add`).
-              // upsertProvider drops `--credential` from the `provider update`
-              // call when the host env is empty and the provider exists.
-              if (!providerExistsInGateway(provider)) {
-                logMissingNvidiaApiKeyHelp(REMOTE_PROVIDER_CONFIG.build.helpUrl);
-                process.exit(1);
-              }
-            } else {
+            if (resolvedNvidiaKey) {
               const keyError = validateNvidiaApiKeyValue(resolvedNvidiaKey);
               if (keyError) {
                 console.error(keyError);
                 console.error(`  Get a key from ${REMOTE_PROVIDER_CONFIG.build.helpUrl}`);
                 process.exit(1);
               }
+            } else if (!providerExistsInGateway(provider)) {
+              logMissingNvidiaApiKeyHelp(REMOTE_PROVIDER_CONFIG.build.helpUrl);
+              process.exit(1);
             }
           } else {
             await ensureApiKey();
@@ -4510,18 +4502,11 @@ async function setupNim(
             break;
           }
           if (isNonInteractive()) {
-            if (!resolveProviderCredential(selectedCredentialEnv)) {
-              // #3895: skip the env requirement when the provider is already
-              // registered in the gateway. upsertProvider drops `--credential`
-              // from the `provider update` call when the host env is empty and
-              // the provider exists; the recreate step does not need to rotate
-              // the secret.
-              if (!providerExistsInGateway(provider)) {
-                console.error(
-                  `  ${selectedCredentialEnv} (or NEMOCLAW_PROVIDER_KEY) is required for ${remoteConfig.label} in non-interactive mode.`,
-                );
-                process.exit(1);
-              }
+            if (!resolveProviderCredential(selectedCredentialEnv) && !providerExistsInGateway(provider)) {
+              console.error(
+                `  ${selectedCredentialEnv} (or NEMOCLAW_PROVIDER_KEY) is required for ${remoteConfig.label} in non-interactive mode.`,
+              );
+              process.exit(1);
             }
           } else {
             const credentialResult = await ensureNamedCredential(

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -168,6 +168,71 @@ describe("onboard provider helpers", () => {
     expect(commands[1]).toMatch(/--config OPENAI_BASE_URL=https:\/\/integrate\.api\.nvidia\.com\/v1/);
   });
 
+  it("omits --credential from the update args when the env value is empty (#3895)", () => {
+    const commands: string[] = [];
+    const result = upsertProvider(
+      "nvidia-prod",
+      "openai",
+      "NVIDIA_API_KEY",
+      "https://integrate.api.nvidia.com/v1",
+      {},
+      (command) => {
+        commands.push(command.join(" "));
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toMatch(/provider get/);
+    expect(commands[1]).toMatch(/^provider update nvidia-prod /);
+    // OpenShell CLI rejects `--credential KEY` when the host env is empty;
+    // dropping the flag turns the call into a no-op merge that succeeds.
+    expect(commands[1]).not.toMatch(/--credential/);
+    expect(commands[1]).toMatch(/OPENAI_BASE_URL=https:\/\/integrate\.api\.nvidia\.com\/v1/);
+  });
+
+  it("keeps --credential on the create path even when env is empty", () => {
+    // create cannot omit credentials — OpenShell rejects empty credential
+    // maps on creation. The caller is responsible for staging a value.
+    const commands: string[] = [];
+    upsertProvider(
+      "fresh-provider",
+      "generic",
+      "FRESH_TOKEN",
+      null,
+      {},
+      (command) => {
+        commands.push(command.join(" "));
+        if (command.includes("get")) return { status: 1, stdout: "", stderr: "" };
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    );
+
+    expect(commands).toHaveLength(2);
+    expect(commands[1]).toMatch(/^provider create --name fresh-provider /);
+    expect(commands[1]).toMatch(/--credential FRESH_TOKEN/);
+  });
+
+  it("keeps --credential on the update path when a value is staged in env", () => {
+    const commands: string[] = [];
+    upsertProvider(
+      "nvidia-prod",
+      "openai",
+      "NVIDIA_API_KEY",
+      null,
+      { NVIDIA_API_KEY: "nvapi-staged" },
+      (command) => {
+        commands.push(command.join(" "));
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    );
+
+    expect(commands).toHaveLength(2);
+    expect(commands[1]).toMatch(/^provider update nvidia-prod /);
+    expect(commands[1]).toMatch(/--credential NVIDIA_API_KEY/);
+  });
+
   it("returns redacted error details when create or update fails", () => {
     const result = upsertProvider("bad-provider", "generic", "SOME_KEY", null, {}, (command) => {
       if (command.includes("get")) return { status: 1, stdout: "", stderr: "" };

--- a/src/lib/onboard/providers.test.ts
+++ b/src/lib/onboard/providers.test.ts
@@ -168,7 +168,7 @@ describe("onboard provider helpers", () => {
     expect(commands[1]).toMatch(/--config OPENAI_BASE_URL=https:\/\/integrate\.api\.nvidia\.com\/v1/);
   });
 
-  it("omits --credential from the update args when the env value is empty (#3895)", () => {
+  it("omits --credential from the update args when the env value is empty", () => {
     const commands: string[] = [];
     const result = upsertProvider(
       "nvidia-prod",

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -234,13 +234,23 @@ function getRequestedModelHint(nonInteractive) {
  * @param {string} type - Provider type (e.g. "openai", "anthropic", "generic").
  * @param {string} credentialEnv - Credential environment variable name.
  * @param {string|null} baseUrl - Optional base URL for API-compatible endpoints.
+ * @param {{ includeCredential?: boolean }} [opts] - When `includeCredential` is
+ *   false, the `--credential` flag is omitted from the args. Used on the
+ *   `provider update` path when the host env does not carry the credential and
+ *   the gateway already holds it (no rotation needed). OpenShell's CLI rejects
+ *   `--credential KEY` when the local env var is empty, so passing the flag
+ *   would fail before reaching the gateway. See #3895.
  * @returns {string[]} Argument array for runOpenshell().
  */
-function buildProviderArgs(action, name, type, credentialEnv, baseUrl) {
+function buildProviderArgs(action, name, type, credentialEnv, baseUrl, opts = {}) {
+  const { includeCredential = true } = opts;
   const args =
     action === "create"
-      ? ["provider", "create", "--name", name, "--type", type, "--credential", credentialEnv]
-      : ["provider", "update", name, "--credential", credentialEnv];
+      ? ["provider", "create", "--name", name, "--type", type]
+      : ["provider", "update", name];
+  if (includeCredential) {
+    args.push("--credential", credentialEnv);
+  }
   if (baseUrl && type === "openai") {
     args.push("--config", `OPENAI_BASE_URL=${baseUrl}`);
   } else if (baseUrl && type === "anthropic") {
@@ -303,7 +313,15 @@ function upsertProvider(name, type, credentialEnv, baseUrl, env, _runOpenshell, 
     }
   }
   const action = exists && !options.replaceExisting ? "update" : "create";
-  const args = buildProviderArgs(action, name, type, credentialEnv, baseUrl);
+  // #3895: on the update path, the OpenShell CLI's `--credential KEY` form
+  // reads the value from the host env and aborts when empty. If the caller did
+  // not stage a credential value (rebuild after `channels add` with the
+  // original env unset), drop the flag so `provider update` becomes a no-op
+  // merge — the gateway already holds the secret.
+  const credentialValueAvailable =
+    !!credentialEnv && typeof env[credentialEnv] === "string" && env[credentialEnv].length > 0;
+  const includeCredential = action === "create" || credentialValueAvailable;
+  const args = buildProviderArgs(action, name, type, credentialEnv, baseUrl, { includeCredential });
   const runOpts = { ignoreError: true, env, stdio: ["ignore", "pipe", "pipe"] };
   const result = _runOpenshell(args, runOpts);
   if (result.status !== 0) {

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -239,7 +239,7 @@ function getRequestedModelHint(nonInteractive) {
  *   `provider update` path when the host env does not carry the credential and
  *   the gateway already holds it (no rotation needed). OpenShell's CLI rejects
  *   `--credential KEY` when the local env var is empty, so passing the flag
- *   would fail before reaching the gateway. See #3895.
+ *   would fail before reaching the gateway.
  * @returns {string[]} Argument array for runOpenshell().
  */
 function buildProviderArgs(action, name, type, credentialEnv, baseUrl, opts = {}) {
@@ -313,11 +313,11 @@ function upsertProvider(name, type, credentialEnv, baseUrl, env, _runOpenshell, 
     }
   }
   const action = exists && !options.replaceExisting ? "update" : "create";
-  // #3895: on the update path, the OpenShell CLI's `--credential KEY` form
-  // reads the value from the host env and aborts when empty. If the caller did
-  // not stage a credential value (rebuild after `channels add` with the
-  // original env unset), drop the flag so `provider update` becomes a no-op
-  // merge — the gateway already holds the secret.
+  // On the update path, the OpenShell CLI's `--credential KEY` form reads the
+  // value from the host env and aborts when empty. If the caller did not stage
+  // a credential value (rebuild after `channels add` with the original env
+  // unset), drop the flag so `provider update` becomes a no-op merge — the
+  // gateway already holds the secret.
   const credentialValueAvailable =
     !!credentialEnv && typeof env[credentialEnv] === "string" && env[credentialEnv].length > 0;
   const includeCredential = action === "create" || credentialValueAvailable;

--- a/test/e2e/test-channels-add-remove.sh
+++ b/test/e2e/test-channels-add-remove.sh
@@ -323,15 +323,15 @@ section "Phase 3: channels add telegram + rebuild"
 # the operator decides to add a channel and exports the token first.
 export TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN"
 
-# #3895 regression gate. Before the fix, the rebuild preflight aborted with
-# "provider credential not found" when NVIDIA_API_KEY was unset in the host
-# env even though the inference provider was already registered in the
-# OpenShell gateway. Drop the key from the env around `channels add` +
-# rebuild so the post-add rebuild has to reuse the gateway-stored
+# Gateway-credential reuse gate. Before the fix, the rebuild preflight
+# aborted with "provider credential not found" when NVIDIA_API_KEY was unset
+# in the host env even though the inference provider was already registered
+# in the OpenShell gateway. Drop the key from the env around `channels add`
+# + rebuild so the post-add rebuild has to reuse the gateway-stored
 # credential instead of demanding it back on the host.
 NVIDIA_API_KEY_BACKUP="${NVIDIA_API_KEY:-}"
 unset NVIDIA_API_KEY
-info "NVIDIA_API_KEY unset for #3895 regression gate; gateway must hold the credential"
+info "NVIDIA_API_KEY unset for gateway-credential-reuse gate; gateway must hold the credential"
 
 if nemoclaw "$SANDBOX_NAME" channels add telegram >/tmp/nc-add.log 2>&1; then
   add_rc=0
@@ -360,12 +360,12 @@ else
   print_summary
 fi
 
-# #3895 regression assertion: the rebuild must not have aborted with the
-# "provider credential not found" error.
+# Gateway-credential reuse assertion: the rebuild must not have aborted with
+# the "provider credential not found" error.
 if grep -q "provider credential not found" /tmp/nc-rebuild-add.log; then
-  fail "C3c: REGRESSION — rebuild aborted on missing NVIDIA_API_KEY despite gateway-registered credential (#3895)"
+  fail "C3c: REGRESSION — rebuild aborted on missing NVIDIA_API_KEY despite gateway-registered credential"
 else
-  pass "C3c: rebuild reused gateway-stored credential without NVIDIA_API_KEY (#3895)"
+  pass "C3c: rebuild reused gateway-stored credential without NVIDIA_API_KEY"
 fi
 
 # Restore for the remaining phases — `channels remove` + rebuild should

--- a/test/e2e/test-channels-add-remove.sh
+++ b/test/e2e/test-channels-add-remove.sh
@@ -323,6 +323,16 @@ section "Phase 3: channels add telegram + rebuild"
 # the operator decides to add a channel and exports the token first.
 export TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN"
 
+# #3895 regression gate. Before the fix, the rebuild preflight aborted with
+# "provider credential not found" when NVIDIA_API_KEY was unset in the host
+# env even though the inference provider was already registered in the
+# OpenShell gateway. Drop the key from the env around `channels add` +
+# rebuild so the post-add rebuild has to reuse the gateway-stored
+# credential instead of demanding it back on the host.
+NVIDIA_API_KEY_BACKUP="${NVIDIA_API_KEY:-}"
+unset NVIDIA_API_KEY
+info "NVIDIA_API_KEY unset for #3895 regression gate; gateway must hold the credential"
+
 if nemoclaw "$SANDBOX_NAME" channels add telegram >/tmp/nc-add.log 2>&1; then
   add_rc=0
 else
@@ -342,8 +352,28 @@ if run_rebuild_with_live_log /tmp/nc-rebuild-add.log; then
 else
   fail "C3b: rebuild (post-add) failed"
   tail -100 /tmp/nc-rebuild-add.log 2>/dev/null || true
+  # Restore env before bailing so later phases (and operators rerunning
+  # the script interactively) still see the original key.
+  if [ -n "$NVIDIA_API_KEY_BACKUP" ]; then
+    export NVIDIA_API_KEY="$NVIDIA_API_KEY_BACKUP"
+  fi
   print_summary
 fi
+
+# #3895 regression assertion: the rebuild must not have aborted with the
+# "provider credential not found" error.
+if grep -q "provider credential not found" /tmp/nc-rebuild-add.log; then
+  fail "C3c: REGRESSION — rebuild aborted on missing NVIDIA_API_KEY despite gateway-registered credential (#3895)"
+else
+  pass "C3c: rebuild reused gateway-stored credential without NVIDIA_API_KEY (#3895)"
+fi
+
+# Restore for the remaining phases — `channels remove` + rebuild should
+# work in the normal env-present case too.
+if [ -n "$NVIDIA_API_KEY_BACKUP" ]; then
+  export NVIDIA_API_KEY="$NVIDIA_API_KEY_BACKUP"
+fi
+unset NVIDIA_API_KEY_BACKUP
 
 # ══════════════════════════════════════════════════════════════════
 # Phase 4: Post-add assertions (Test 2 acceptance, regression #3437)

--- a/test/e2e/test-hermes-discord-e2e.sh
+++ b/test/e2e/test-hermes-discord-e2e.sh
@@ -580,7 +580,37 @@ else
   dump_hermes_discord_diagnostics
 fi
 
-section "Phase 8: Cleanup"
+section "Phase 8: Gateway-stored credential rebuild"
+
+# Rebuild with NVIDIA_API_KEY unset so the preflight is forced to reuse the
+# gateway-stored inference credential. Catches the Hermes regression that
+# motivated the gateway-aware credential check in setupNim + rebuild.
+NVIDIA_API_KEY_BACKUP="${NVIDIA_API_KEY:-}"
+unset NVIDIA_API_KEY
+info "NVIDIA_API_KEY unset; gateway must hold the inference credential"
+
+HERMES_REBUILD_LOG="/tmp/nc-hermes-rebuild-noenv.log"
+if nemoclaw "$SANDBOX_NAME" rebuild --yes >"$HERMES_REBUILD_LOG" 2>&1; then
+  rebuild_rc=0
+else
+  rebuild_rc=$?
+fi
+
+if [ "$rebuild_rc" -ne 0 ]; then
+  fail "Hermes rebuild failed with NVIDIA_API_KEY unset (rc=${rebuild_rc})"
+  tail -60 "$HERMES_REBUILD_LOG" 2>/dev/null || true
+elif grep -q "provider credential not found" "$HERMES_REBUILD_LOG"; then
+  fail "REGRESSION — rebuild aborted on missing NVIDIA_API_KEY despite gateway-registered credential"
+else
+  pass "Hermes rebuild reused gateway-stored credential without NVIDIA_API_KEY"
+fi
+
+if [ -n "$NVIDIA_API_KEY_BACKUP" ]; then
+  export NVIDIA_API_KEY="$NVIDIA_API_KEY_BACKUP"
+fi
+unset NVIDIA_API_KEY_BACKUP
+
+section "Phase 9: Cleanup"
 
 if [[ "${NEMOCLAW_E2E_KEEP_SANDBOX:-}" != "1" ]]; then
   nemoclaw "$SANDBOX_NAME" destroy --yes 2>&1 | tail -3 || true

--- a/test/e2e/test-hermes-discord-e2e.sh
+++ b/test/e2e/test-hermes-discord-e2e.sh
@@ -598,7 +598,9 @@ fi
 
 if [ "$rebuild_rc" -ne 0 ]; then
   fail "Hermes rebuild failed with NVIDIA_API_KEY unset (rc=${rebuild_rc})"
-  tail -60 "$HERMES_REBUILD_LOG" 2>/dev/null || true
+  echo "---- begin rebuild log (${HERMES_REBUILD_LOG}) ----"
+  cat "$HERMES_REBUILD_LOG" 2>/dev/null || true
+  echo "---- end rebuild log ----"
 elif grep -q "provider credential not found" "$HERMES_REBUILD_LOG"; then
   fail "REGRESSION — rebuild aborted on missing NVIDIA_API_KEY despite gateway-registered credential"
 else

--- a/test/e2e/test-hermes-discord-e2e.sh
+++ b/test/e2e/test-hermes-discord-e2e.sh
@@ -590,7 +590,10 @@ unset NVIDIA_API_KEY
 info "NVIDIA_API_KEY unset; gateway must hold the inference credential"
 
 HERMES_REBUILD_LOG="/tmp/nc-hermes-rebuild-noenv.log"
-if nemoclaw "$SANDBOX_NAME" rebuild --yes >"$HERMES_REBUILD_LOG" 2>&1; then
+# NEMOCLAW_REBUILD_VERBOSE=1 unlocks the rebuild's swallowed onboard error
+# stream so a failure here surfaces the real cause instead of just the
+# generic "Recreate failed" postmortem.
+if NEMOCLAW_REBUILD_VERBOSE=1 nemoclaw "$SANDBOX_NAME" rebuild --yes >"$HERMES_REBUILD_LOG" 2>&1; then
   rebuild_rc=0
 else
   rebuild_rc=$?

--- a/test/e2e/test-hermes-discord-e2e.sh
+++ b/test/e2e/test-hermes-discord-e2e.sh
@@ -585,6 +585,20 @@ section "Phase 8: Gateway-stored credential rebuild"
 # Rebuild with NVIDIA_API_KEY unset so the preflight is forced to reuse the
 # gateway-stored inference credential. Catches the Hermes regression that
 # motivated the gateway-aware credential check in setupNim + rebuild.
+
+# Phase 7's fake Discord Gateway leaves a root-owned scratch dir at
+# $REPO/.tmp/fake-discord.* via its Docker bind-mount. `nemoclaw rebuild`
+# recreates the sandbox by copying $REPO into a build context, which hits
+# EACCES on those files because the runner uid cannot read root-owned
+# bytes. Tear the container down and `sudo rm` the scratch before the
+# rebuild so the build context copy succeeds.
+if [ -n "${FAKE_DISCORD_GATEWAY_CONTAINER:-}" ]; then
+  docker rm -f "$FAKE_DISCORD_GATEWAY_CONTAINER" >/dev/null 2>&1 || true
+fi
+if [ -d "$REPO/.tmp" ]; then
+  sudo rm -rf "$REPO/.tmp"/fake-discord.* 2>/dev/null || rm -rf "$REPO/.tmp"/fake-discord.* 2>/dev/null || true
+fi
+
 NVIDIA_API_KEY_BACKUP="${NVIDIA_API_KEY:-}"
 unset NVIDIA_API_KEY
 info "NVIDIA_API_KEY unset; gateway must hold the inference credential"

--- a/test/e2e/test-hermes-discord-e2e.sh
+++ b/test/e2e/test-hermes-discord-e2e.sh
@@ -604,10 +604,7 @@ unset NVIDIA_API_KEY
 info "NVIDIA_API_KEY unset; gateway must hold the inference credential"
 
 HERMES_REBUILD_LOG="/tmp/nc-hermes-rebuild-noenv.log"
-# NEMOCLAW_REBUILD_VERBOSE=1 unlocks the rebuild's swallowed onboard error
-# stream so a failure here surfaces the real cause instead of just the
-# generic "Recreate failed" postmortem.
-if NEMOCLAW_REBUILD_VERBOSE=1 nemoclaw "$SANDBOX_NAME" rebuild --yes >"$HERMES_REBUILD_LOG" 2>&1; then
+if nemoclaw "$SANDBOX_NAME" rebuild --yes >"$HERMES_REBUILD_LOG" 2>&1; then
   rebuild_rc=0
 else
   rebuild_rc=$?
@@ -615,9 +612,7 @@ fi
 
 if [ "$rebuild_rc" -ne 0 ]; then
   fail "Hermes rebuild failed with NVIDIA_API_KEY unset (rc=${rebuild_rc})"
-  echo "---- begin rebuild log (${HERMES_REBUILD_LOG}) ----"
-  cat "$HERMES_REBUILD_LOG" 2>/dev/null || true
-  echo "---- end rebuild log ----"
+  tail -80 "$HERMES_REBUILD_LOG" 2>/dev/null || true
 elif grep -q "provider credential not found" "$HERMES_REBUILD_LOG"; then
   fail "REGRESSION — rebuild aborted on missing NVIDIA_API_KEY despite gateway-registered credential"
 else

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -4783,6 +4783,14 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
     const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
 
     fs.mkdirSync(fakeBin, { recursive: true });
+    // Fake openshell: report the inference provider as absent so the
+    // gateway-credential-reuse fallback does NOT swallow the missing-key
+    // error path under test.
+    fs.writeFileSync(
+      path.join(fakeBin, "openshell"),
+      `#!${process.execPath}\nprocess.exit(1);\n`,
+      { mode: 0o755 },
+    );
 
     const script = String.raw`
 const fs = require("fs");

--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -317,9 +317,11 @@ describe("Issue #2273: atomic rebuild", () => {
       "aborts rebuild BEFORE destroying sandbox when credential is missing",
       { timeout: 60_000 },
       () => {
-        // No credential in env or credentials.json
+        // No credential in env or credentials.json AND no gateway-registered
+        // provider — preflight must still abort so the sandbox is preserved.
         const f = createFixture({
           credentialEnv: "NVIDIA_API_KEY",
+          providerRegistered: false,
           // no savedCredential
         });
 
@@ -474,10 +476,12 @@ describe("Issue #2273: atomic rebuild", () => {
       "preflight works for non-NVIDIA providers (OpenAI, Anthropic, etc.)",
       { timeout: 60_000 },
       () => {
-        // OpenAI provider with no credential — should abort
+        // OpenAI provider with no credential AND no gateway registration —
+        // should abort.
         const f = createFixture({
           provider: "openai-api",
           credentialEnv: "OPENAI_API_KEY",
+          providerRegistered: false,
           // no savedCredential
         });
 
@@ -529,6 +533,54 @@ describe("Issue #2273: atomic rebuild", () => {
         expect(output).not.toContain("Missing credential: NOUS_API_KEY");
         expect(output).not.toContain("provider credential not found");
         expect(output).toContain("Backing up sandbox state");
+      },
+    );
+
+    it(
+      "uses the registered nvidia-prod provider in OpenShell instead of requiring NVIDIA_API_KEY (#3895)",
+      { timeout: 60_000 },
+      () => {
+        // Repro of #3895: after `nemohermes channels add wechat` the rebuild
+        // preflight aborted because NVIDIA_API_KEY was not set in the
+        // environment, even though `nvidia-prod` was already registered in
+        // the OpenShell gateway. Reuse the gateway-registered credential.
+        const f = createFixture({
+          provider: "nvidia-prod",
+          credentialEnv: "NVIDIA_API_KEY",
+          providerRegistered: true,
+          // no savedCredential — host env has no NVIDIA_API_KEY
+        });
+
+        const result = runRebuild(f);
+        const output = (result.stderr || "") + (result.stdout || "");
+
+        expect(output).not.toContain("Missing credential: NVIDIA_API_KEY");
+        expect(output).not.toContain("provider credential not found");
+        expect(output).toContain("Backing up sandbox state");
+      },
+    );
+
+    it(
+      "still aborts when nvidia-prod is missing from the gateway AND the env (#3895)",
+      { timeout: 60_000 },
+      () => {
+        // Negative gate for #3895: if the gateway also lost the provider
+        // (cold install, gateway state lost) and the env is empty, the
+        // preflight must still bail so the sandbox is preserved.
+        const f = createFixture({
+          provider: "nvidia-prod",
+          credentialEnv: "NVIDIA_API_KEY",
+          providerRegistered: false,
+        });
+
+        const result = runRebuild(f);
+        const output = (result.stderr || "") + (result.stdout || "");
+
+        expect(result.status).not.toBe(0);
+        expect(output).toContain("preflight failed");
+        expect(output).toContain("NVIDIA_API_KEY");
+        expect(output).toContain("untouched");
+        expect(registryHasSandbox(f)).toBe(true);
       },
     );
 
@@ -598,11 +650,13 @@ describe("Issue #2273: atomic rebuild", () => {
       "preflight failure exits non-zero when credential is missing",
       { timeout: 60_000 },
       () => {
-        // Verifies that missing credentials cause rebuild to exit non-zero.
-        // This is the observable CLI behavior — the preflight check fails
-        // and bail() calls process.exit with a non-zero code.
+        // Verifies that missing credentials cause rebuild to exit non-zero
+        // when no fallback exists in the gateway either. This is the
+        // observable CLI behavior — the preflight check fails and bail()
+        // calls process.exit with a non-zero code.
         const f = createFixture({
           credentialEnv: "NVIDIA_API_KEY",
+          providerRegistered: false,
           // No credential — preflight will fail and exit non-zero
         });
 

--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -537,13 +537,13 @@ describe("Issue #2273: atomic rebuild", () => {
     );
 
     it(
-      "uses the registered nvidia-prod provider in OpenShell instead of requiring NVIDIA_API_KEY (#3895)",
+      "uses the registered nvidia-prod provider in OpenShell instead of requiring NVIDIA_API_KEY",
       { timeout: 60_000 },
       () => {
-        // Repro of #3895: after `nemohermes channels add wechat` the rebuild
-        // preflight aborted because NVIDIA_API_KEY was not set in the
-        // environment, even though `nvidia-prod` was already registered in
-        // the OpenShell gateway. Reuse the gateway-registered credential.
+        // After `nemohermes channels add wechat` the rebuild preflight used to
+        // abort because NVIDIA_API_KEY was not set in the environment, even
+        // though `nvidia-prod` was already registered in the OpenShell
+        // gateway. Reuse the gateway-stored credential instead.
         const f = createFixture({
           provider: "nvidia-prod",
           credentialEnv: "NVIDIA_API_KEY",
@@ -561,12 +561,12 @@ describe("Issue #2273: atomic rebuild", () => {
     );
 
     it(
-      "still aborts when nvidia-prod is missing from the gateway AND the env (#3895)",
+      "still aborts when nvidia-prod is missing from the gateway AND the env",
       { timeout: 60_000 },
       () => {
-        // Negative gate for #3895: if the gateway also lost the provider
-        // (cold install, gateway state lost) and the env is empty, the
-        // preflight must still bail so the sandbox is preserved.
+        // Negative gate on gateway-credential reuse: if the gateway also lost
+        // the provider (cold install, gateway state lost) and the env is
+        // empty, the preflight must still bail so the sandbox is preserved.
         const f = createFixture({
           provider: "nvidia-prod",
           credentialEnv: "NVIDIA_API_KEY",


### PR DESCRIPTION
## Summary
Rebuild preflight aborted with `provider credential not found` when the inference provider was already registered in the OpenShell gateway but the credential env var was missing from the host shell (e.g. after `nemohermes channels add` from a fresh terminal). #3030 fixed this only for the Hermes Provider; non-Hermes providers like `nvidia-prod` still demanded the host env. Reuse the gateway-held secret when present and drop `--credential KEY` from `provider update` calls when the host env is empty so OpenShell's CLI does not reject the call before reaching the gateway.

## Related Issue
Fixes #3895

## Changes
- `src/lib/actions/sandbox/rebuild.ts`: skip the env-only preflight when `providerExistsInGateway(rebuildProvider)` returns true. The recreate step reuses the gateway-stored credential.
- `src/lib/onboard.ts`: gate the non-interactive `build` and remote-provider env checks in `setupNim` on `providerExistsInGateway(provider)` so a gateway-registered provider does not require the host env in recreate flows.
- `src/lib/onboard/providers.ts`: `upsertProvider` drops `--credential KEY` from `provider update` calls when the host env does not carry a value. OpenShell's CLI rejects `--credential KEY` with an empty env (`parse_credential_pairs`), so the flag had to go for the no-rotation update path to succeed. `provider create` still requires the credential.
- `test/rebuild-credential-preflight.test.ts`: regression tests for `nvidia-prod` with the gateway-registered credential and host env unset, plus the negative gate where both gateway and env are empty. Existing negative tests pinned to `providerRegistered: false` to keep their original intent.
- `src/lib/onboard/providers.test.ts`: new tests for the `update` arg builder with and without a staged env value, and for the `create` path still requiring the credential.
- `test/e2e/test-channels-add-remove.sh`: unset `NVIDIA_API_KEY` around the post-add rebuild so the channel-add flow regression-gates the gateway-credential reuse path. Restores the key for the later phases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] \`npm run docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebuilds and onboarding can proceed when a provider is already registered in the gateway, avoiding unnecessary aborts for missing credential environment variables.

* **Behavior Change**
  * Provider create/update commands now omit empty credentials to prevent failing CLI calls; credential checks will consult the gateway and skip env-missing failures when appropriate.

* **Tests**
  * Added unit, integration, and end-to-end tests to validate gateway-aware credential handling and rebuild credential reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->