### PR TITLE
docs: document custom Docker build performance

### DIFF
--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -66,9 +66,11 @@ If you need a second sandbox alongside an existing one, use a dedicated build di
 
 ## Keep Custom Builds Fast
 
-Custom plugin images are normal Docker builds, so most build-time surprises come from the build context and Docker cache state rather than the plugin itself.
+Custom plugin images are normal Docker builds.
+Most build-time surprises come from the build context and Docker cache state rather than the plugin itself.
 Use a small, dedicated build directory for every custom image.
-The Dockerfile's parent directory is the context that NemoClaw stages before the Docker build starts; broad directories such as your home directory, `/tmp`, or a repo root with large generated artifacts can make onboarding look stuck while Docker is only preparing context.
+The Dockerfile's parent directory is the context that NemoClaw stages before the Docker build starts.
+Broad directories such as your home directory, `/tmp`, or a repo root with large generated artifacts can make onboarding look stuck while Docker is only preparing context.
 
 Use this checklist before running `nemoclaw onboard --from` or rebuilding a sandbox from a custom Dockerfile:
 

--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -64,6 +64,20 @@ nemoclaw onboard --from ./my-plugin-sandbox/Dockerfile
 
 If you need a second sandbox alongside an existing one, use a dedicated build directory and rerun onboarding with the sandbox name and ports you intend to use.
 
+## Keep Custom Builds Fast
+
+Custom plugin images are normal Docker builds, so most build-time surprises come from the build context and Docker cache state rather than the plugin itself. Use a small, dedicated build directory for every custom image. The Dockerfile's parent directory is the context that NemoClaw stages before the Docker build starts; broad directories such as your home directory, `/tmp`, or a repo root with large generated artifacts can make onboarding look stuck while Docker is only preparing context.
+
+Use this checklist before running `nemoclaw onboard --from` or rebuilding a sandbox from a custom Dockerfile:
+
+- Keep the Dockerfile next to only the files it needs to `COPY`.
+- Add a `.dockerignore` for project-specific outputs such as `dist/`, `build/`, `target/`, coverage reports, caches, local datasets, and downloaded model artifacts. NemoClaw also applies its own safety exclusions for common credential files and directories, but `.dockerignore` is still the right place to describe your project's build context.
+- Put slow-changing dependency installation steps before frequently changing source-code `COPY` steps so warm rebuilds can reuse Docker layers.
+- Pin the base image or release ref intentionally. A cold first run may still need to pull or resolve the base image; later rebuilds are faster when the base and earlier layers are already cached locally.
+- Treat the first build on a fresh host differently from a warm rebuild. Cold downloads, package indexes, and base-image pulls can dominate wall-clock time even when NemoClaw is healthy.
+
+When a custom build feels slow, rerun with `NEMOCLAW_TRACE=1` or set `NEMOCLAW_TRACE_DIR` / `NEMOCLAW_TRACE_FILE` to capture onboard trace artifacts. The trace helps separate context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness time.
+
 ## Network Access
 
 Plugins still run inside the sandbox policy boundary.

--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -66,17 +66,23 @@ If you need a second sandbox alongside an existing one, use a dedicated build di
 
 ## Keep Custom Builds Fast
 
-Custom plugin images are normal Docker builds, so most build-time surprises come from the build context and Docker cache state rather than the plugin itself. Use a small, dedicated build directory for every custom image. The Dockerfile's parent directory is the context that NemoClaw stages before the Docker build starts; broad directories such as your home directory, `/tmp`, or a repo root with large generated artifacts can make onboarding look stuck while Docker is only preparing context.
+Custom plugin images are normal Docker builds, so most build-time surprises come from the build context and Docker cache state rather than the plugin itself.
+Use a small, dedicated build directory for every custom image.
+The Dockerfile's parent directory is the context that NemoClaw stages before the Docker build starts; broad directories such as your home directory, `/tmp`, or a repo root with large generated artifacts can make onboarding look stuck while Docker is only preparing context.
 
 Use this checklist before running `nemoclaw onboard --from` or rebuilding a sandbox from a custom Dockerfile:
 
 - Keep the Dockerfile next to only the files it needs to `COPY`.
-- Add a `.dockerignore` for project-specific outputs such as `dist/`, `build/`, `target/`, coverage reports, caches, local datasets, and downloaded model artifacts. NemoClaw also applies its own safety exclusions for common credential files and directories, but `.dockerignore` is still the right place to describe your project's build context.
+- Add a `.dockerignore` for project-specific outputs such as `dist/`, `build/`, `target/`, coverage reports, caches, local datasets, and downloaded model artifacts.
+  NemoClaw also applies its own safety exclusions for common credential files and directories, but `.dockerignore` is still the right place to describe your project's build context.
 - Put slow-changing dependency installation steps before frequently changing source-code `COPY` steps so warm rebuilds can reuse Docker layers.
-- Pin the base image or release ref intentionally. A cold first run may still need to pull or resolve the base image; later rebuilds are faster when the base and earlier layers are already cached locally.
-- Treat the first build on a fresh host differently from a warm rebuild. Cold downloads, package indexes, and base-image pulls can dominate wall-clock time even when NemoClaw is healthy.
+- Pin the base image or release ref intentionally.
+  A cold first run may still need to pull or resolve the base image; later rebuilds are faster when the base and earlier layers are already cached locally.
+- Treat the first build on a fresh host differently from a warm rebuild.
+  Cold downloads, package indexes, and base-image pulls can dominate wall-clock time even when NemoClaw is healthy.
 
-When a custom build feels slow, rerun with `NEMOCLAW_TRACE=1` or set `NEMOCLAW_TRACE_DIR` / `NEMOCLAW_TRACE_FILE` to capture onboard trace artifacts. The trace helps separate context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness time.
+When a custom build feels slow, rerun with `NEMOCLAW_TRACE=1` or set `NEMOCLAW_TRACE_DIR` / `NEMOCLAW_TRACE_FILE` to capture onboard trace artifacts.
+The trace helps separate context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness time.
 
 ## Network Access
 

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -252,9 +252,20 @@ Build the sandbox image from a custom Dockerfile instead of the stock NemoClaw i
 The entire parent directory of the specified file is used as the Docker build context, so any files your Dockerfile references (scripts, config, etc.) must live alongside it.
 Onboarding skips common large directories (`node_modules`, `.git`, `.venv`, and `__pycache__`) while staging this context.
 It also skips credential-style files and directories such as `.env*`, `.ssh/`, `.aws/`, `.netrc`, `.npmrc`, `secrets/`, `*.pem`, and `*.key`.
-Other build outputs such as `dist/`, `target/`, or `build/` are still included.
-If the staged context is larger than 100 MB, onboarding prints a warning before the Docker build starts.
+These built-in exclusions reduce accidental secret and cache staging, but they are not a substitute for a project-specific `.dockerignore`.
+Other build outputs such as `dist/`, `target/`, or `build/` are still included unless you ignore or move them.
+If the staged context is larger than 100 MB, onboarding prints a warning before the Docker build starts; respond by moving the Dockerfile into a smaller dedicated directory or adding `.dockerignore` entries for generated artifacts.
 If the directory contains unreadable files (for example, Windows system files visible in WSL), onboarding exits with an error suggesting you move the Dockerfile to a dedicated directory.
+
+For predictable build performance:
+
+- Prefer a dedicated build directory over pointing `--from` at a Dockerfile in a broad repo or home directory.
+- Keep the context limited to files that Dockerfile `COPY` or `ADD` instructions need.
+- Use `.dockerignore` for project outputs, dependency caches, coverage reports, local datasets, downloaded models, and other large files that NemoClaw cannot infer safely.
+- Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files. This makes warm rebuilds reuse cached layers.
+- Expect a fresh host or fresh base image tag to spend time pulling and resolving layers. A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
+
+Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds. The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.
 
 ```bash
 nemohermes onboard --from path/to/Dockerfile

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -265,7 +265,8 @@ For predictable build performance:
 - Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files. This makes warm rebuilds reuse cached layers.
 - Expect a fresh host or fresh base image tag to spend time pulling and resolving layers. A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
 
-Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds. The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.
+Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds.
+The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.
 
 ```bash
 nemohermes onboard --from path/to/Dockerfile

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -262,8 +262,10 @@ For predictable build performance:
 - Prefer a dedicated build directory over pointing `--from` at a Dockerfile in a broad repo or home directory.
 - Keep the context limited to files that Dockerfile `COPY` or `ADD` instructions need.
 - Use `.dockerignore` for project outputs, dependency caches, coverage reports, local datasets, downloaded models, and other large files that NemoClaw cannot infer safely.
-- Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files. This makes warm rebuilds reuse cached layers.
-- Expect a fresh host or fresh base image tag to spend time pulling and resolving layers. A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
+- Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files.
+  This makes warm rebuilds reuse cached layers.
+- Expect a fresh host or fresh base image tag to spend time pulling and resolving layers.
+  A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
 
 Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds.
 The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -323,7 +323,8 @@ For predictable build performance:
 - Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files. This makes warm rebuilds reuse cached layers.
 - Expect a fresh host or fresh base image tag to spend time pulling and resolving layers. A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
 
-Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds. The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.
+Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds.
+The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.
 
 ```bash
 $$nemoclaw onboard --from path/to/Dockerfile

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -310,9 +310,20 @@ Build the sandbox image from a custom Dockerfile instead of the stock NemoClaw i
 The entire parent directory of the specified file is used as the Docker build context, so any files your Dockerfile references (scripts, config, etc.) must live alongside it.
 Onboarding skips common large directories (`node_modules`, `.git`, `.venv`, and `__pycache__`) while staging this context.
 It also skips credential-style files and directories such as `.env*`, `.ssh/`, `.aws/`, `.netrc`, `.npmrc`, `secrets/`, `*.pem`, and `*.key`.
-Other build outputs such as `dist/`, `target/`, or `build/` are still included.
-If the staged context is larger than 100 MB, onboarding prints a warning before the Docker build starts.
+These built-in exclusions reduce accidental secret and cache staging, but they are not a substitute for a project-specific `.dockerignore`.
+Other build outputs such as `dist/`, `target/`, or `build/` are still included unless you ignore or move them.
+If the staged context is larger than 100 MB, onboarding prints a warning before the Docker build starts; respond by moving the Dockerfile into a smaller dedicated directory or adding `.dockerignore` entries for generated artifacts.
 If the directory contains unreadable files (for example, Windows system files visible in WSL), onboarding exits with an error suggesting you move the Dockerfile to a dedicated directory.
+
+For predictable build performance:
+
+- Prefer a dedicated build directory over pointing `--from` at a Dockerfile in a broad repo or home directory.
+- Keep the context limited to files that Dockerfile `COPY` or `ADD` instructions need.
+- Use `.dockerignore` for project outputs, dependency caches, coverage reports, local datasets, downloaded models, and other large files that NemoClaw cannot infer safely.
+- Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files. This makes warm rebuilds reuse cached layers.
+- Expect a fresh host or fresh base image tag to spend time pulling and resolving layers. A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
+
+Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds. The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.
 
 ```bash
 $$nemoclaw onboard --from path/to/Dockerfile

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -320,8 +320,10 @@ For predictable build performance:
 - Prefer a dedicated build directory over pointing `--from` at a Dockerfile in a broad repo or home directory.
 - Keep the context limited to files that Dockerfile `COPY` or `ADD` instructions need.
 - Use `.dockerignore` for project outputs, dependency caches, coverage reports, local datasets, downloaded models, and other large files that NemoClaw cannot infer safely.
-- Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files. This makes warm rebuilds reuse cached layers.
-- Expect a fresh host or fresh base image tag to spend time pulling and resolving layers. A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
+- Order Dockerfile layers from least-changing to most-changing work: base image, OS/package installs, dependency manifests, dependency install, then source files.
+  This makes warm rebuilds reuse cached layers.
+- Expect a fresh host or fresh base image tag to spend time pulling and resolving layers.
+  A warm rebuild with the same pinned base image and unchanged dependency layers should be much faster, but NemoClaw does not guarantee exact timings.
 
 Set `NEMOCLAW_TRACE=1` before onboarding when diagnosing slow builds.
 The trace separates context staging, Docker build, image upload/import, sandbox readiness, and dashboard readiness phases so you can distinguish a cold-cache download from a stalled sandbox.


### PR DESCRIPTION
## Summary

- add a custom build performance checklist to the OpenClaw plugin installation guide
- expand `onboard --from` reference docs with dedicated build directory, `.dockerignore`, context-size warning, cold-cache, warm-cache, layer-ordering, and trace guidance
- sync the NemoHermes command reference variant

Fixes #4683.

## Validation

- `npx tsx scripts/sync-agent-variant-docs.ts`
- `npm run docs:strict`
- `git diff --check`
- `git verify-commit HEAD`

Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Keep Custom Builds Fast" checklist with practical tips to speed Docker builds and onboarding.
  * Documented built-in staging exclusions and clarified that project-specific ignores are still needed for build outputs.
  * Added warnings and troubleshooting for oversized or unreadable build contexts.
  * Added guidance for predictable build performance and trace options (e.g., NEMOCLAW_TRACE) to diagnose slow builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->