### PR TITLE
fix(onboard): recover --resume when sandbox container already destroyed

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -548,6 +548,7 @@ import {
 } from "./onboard/policy-selection";
 import {
   backupSandboxBeforeRecreate,
+  containerPresenceFromReuseState,
   shouldSkipPreRecreateBackup,
 } from "./onboard/sandbox-backup-on-recreate";
 import {
@@ -3238,7 +3239,13 @@ async function createSandbox(
 
     if (pendingStateRestore === null && !shouldSkipPreRecreateBackup(process.env)) {
       note("  Backing up workspace state before recreating sandbox...");
-      const result = backupSandboxBeforeRecreate({ sandboxName });
+      // #4757: if the sandbox is already gone (e.g. a non-atomic update
+      // destroyed the container before `onboard --resume` ran), there is
+      // nothing to back up — skip rather than abort so recovery can proceed.
+      const result = backupSandboxBeforeRecreate({
+        sandboxName,
+        containerPresence: containerPresenceFromReuseState(existingSandboxState),
+      });
       if (!result.ok) {
         console.error("  Set NEMOCLAW_RECREATE_WITHOUT_BACKUP=1 to recreate without preserving state.");
         process.exit(1);

--- a/src/lib/onboard/sandbox-backup-on-recreate.test.ts
+++ b/src/lib/onboard/sandbox-backup-on-recreate.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { BackupResult } from "../../../dist/lib/state/sandbox";
 import {
   backupSandboxBeforeRecreate,
+  containerPresenceFromReuseState,
   shouldSkipPreRecreateBackup,
 } from "../../../dist/lib/onboard/sandbox-backup-on-recreate";
 
@@ -97,6 +98,63 @@ describe("backupSandboxBeforeRecreate", () => {
     expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("aborting recreate"));
   });
 
+  it("skips backup and proceeds when the sandbox container is already gone", () => {
+    // Repro for #4757: a non-atomic update destroys the container before
+    // `onboard --resume` runs. There is nothing left in the container to back
+    // up, so the pre-recreate backup must short-circuit instead of aborting.
+    // Mirrors backupSandboxState's return when the container is gone and the
+    // SSH download cannot run: success=false, nothing backed up, all failed.
+    const backupImpl = vi.fn().mockReturnValue(
+      makeBackup({
+        success: false,
+        backedUpDirs: [],
+        failedDirs: ["workspace"],
+        backedUpFiles: [],
+        failedFiles: [],
+      }),
+    );
+    const log = vi.fn();
+    const errorLog = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      containerPresence: "absent",
+      backupImpl,
+      log,
+      errorLog,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.failureKind).toBe("no-container");
+    expect(result.backup).toBeNull();
+    // Nothing to back up from a destroyed container — don't even try.
+    expect(backupImpl).not.toHaveBeenCalled();
+    // Must not emit the data-loss abort warning.
+    expect(errorLog).not.toHaveBeenCalledWith(expect.stringContaining("aborting recreate"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("already gone"));
+  });
+
+  it("still aborts on an empty backup when container presence is unknown", () => {
+    // Safety: a transient probe error must not be mistaken for "container
+    // gone". Only a confirmed-absent container skips the backup.
+    const backup = makeBackup({
+      success: false,
+      backedUpDirs: [],
+      failedDirs: ["workspace"],
+      backedUpFiles: [],
+      failedFiles: [],
+    });
+    const errorLog = vi.fn();
+    const result = backupSandboxBeforeRecreate({
+      sandboxName: "my-assistant",
+      containerPresence: "unknown",
+      backupImpl: () => backup,
+      errorLog,
+      log: vi.fn(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe("empty");
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("aborting recreate"));
+  });
+
   it("returns ok:false with failureKind=threw when backup throws", () => {
     const errorLog = vi.fn();
     const result = backupSandboxBeforeRecreate({
@@ -111,6 +169,25 @@ describe("backupSandboxBeforeRecreate", () => {
     expect(result.failureKind).toBe("threw");
     expect(result.errorMessage).toBe("disk full");
     expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("State backup threw"));
+  });
+});
+
+describe("containerPresenceFromReuseState", () => {
+  // #4757: only a positively-confirmed missing sandbox (OpenShell `sandbox get`
+  // returns "sandbox not found") is safe to treat as "absent" and skip backup.
+  it("maps a confirmed-missing sandbox to absent", () => {
+    expect(containerPresenceFromReuseState("missing")).toBe("absent");
+  });
+
+  it("maps a ready sandbox to present", () => {
+    expect(containerPresenceFromReuseState("ready")).toBe("present");
+  });
+
+  it("maps an indeterminate state to unknown (fail safe)", () => {
+    // not_ready covers stale-Ready, Provisioning, Error, and transport errors —
+    // none of which positively confirm the container is gone, so never skip.
+    expect(containerPresenceFromReuseState("not_ready")).toBe("unknown");
+    expect(containerPresenceFromReuseState("anything-else")).toBe("unknown");
   });
 });
 

--- a/src/lib/onboard/sandbox-backup-on-recreate.ts
+++ b/src/lib/onboard/sandbox-backup-on-recreate.ts
@@ -6,14 +6,36 @@ import type { BackupResult } from "../state/sandbox";
 
 export type SandboxBackupImpl = (sandboxName: string) => BackupResult;
 
+/**
+ * Whether the sandbox container backing `sandboxName` is still alive.
+ *
+ * - `"present"`  — the container exists; back it up as usual.
+ * - `"absent"`   — the container is confirmed gone; nothing to back up.
+ * - `"unknown"`  — presence could not be determined (e.g. a transient gateway
+ *                  probe error). Treated like `"present"` so we fail safe and
+ *                  never destroy live state on an inconclusive probe.
+ */
+export type SandboxContainerPresence = "present" | "absent" | "unknown";
+
 export interface PreRecreateBackupOptions {
   sandboxName: string;
+  /**
+   * Result of probing whether the container still exists. When `"absent"`,
+   * the pre-recreate backup is skipped because a destroyed container holds no
+   * state left to preserve (see #4757). Defaults to `"unknown"` (fail safe).
+   */
+  containerPresence?: SandboxContainerPresence;
   backupImpl?: SandboxBackupImpl;
   log?: (msg: string) => void;
   errorLog?: (msg: string) => void;
 }
 
-export type PreRecreateBackupFailureKind = "none" | "partial" | "empty" | "threw";
+export type PreRecreateBackupFailureKind =
+  | "none"
+  | "partial"
+  | "empty"
+  | "threw"
+  | "no-container";
 
 export interface PreRecreateBackupResult {
   ok: boolean;
@@ -28,6 +50,18 @@ export function backupSandboxBeforeRecreate(
   const log = opts.log ?? ((m: string) => console.log(m));
   const errorLog = opts.errorLog ?? ((m: string) => console.error(m));
   const backupImpl = opts.backupImpl ?? sandboxState.backupSandboxState;
+
+  // #4757: a non-atomic update/rebuild can destroy the container before
+  // recovery runs. With the container confirmed gone there is nothing left to
+  // back up (state is pulled out of the live container over SSH), so aborting
+  // "to prevent data loss" would only block recovery of state that is already
+  // gone. Skip the backup and let recreate rebuild from the host-side registry.
+  // Only `"absent"` short-circuits; `"unknown"` falls through and fails safe.
+  if (opts.containerPresence === "absent") {
+    log("  Sandbox container is already gone — nothing to back up; proceeding with recreate.");
+    return { ok: true, backup: null, failureKind: "no-container" };
+  }
+
   try {
     const backup = backupImpl(opts.sandboxName);
     if (backup.success && backup.manifest?.backupPath) {
@@ -54,4 +88,24 @@ export function backupSandboxBeforeRecreate(
 
 export function shouldSkipPreRecreateBackup(env: NodeJS.ProcessEnv): boolean {
   return env.NEMOCLAW_RECREATE_WITHOUT_BACKUP === "1";
+}
+
+/**
+ * Map a `getSandboxReuseState()` result to container presence for the
+ * pre-recreate backup decision (#4757).
+ *
+ * Only `"missing"` — which `getSandboxStateFromOutputs` returns when OpenShell
+ * `sandbox get` reports `sandbox not found` (gRPC NotFound) — is a positive
+ * confirmation that the sandbox is gone, so it is the only state safe to skip
+ * backup for. A gateway transport error maps to `"not_ready"`, and a stale
+ * `Ready` entry whose container was destroyed maps to `"ready"`/`"not_ready"`;
+ * neither confirms absence, so both fall through to `"unknown"` and keep the
+ * fail-safe abort.
+ */
+export function containerPresenceFromReuseState(
+  reuseState: string,
+): SandboxContainerPresence {
+  if (reuseState === "missing") return "absent";
+  if (reuseState === "ready") return "present";
+  return "unknown";
 }


### PR DESCRIPTION
## Summary
`nemoclaw onboard --resume` could not recover a sandbox whose container was already destroyed (e.g. by a non-atomic update/rebuild): the pre-recreate state backup pulls state out of the live container over SSH, so with the container gone the backup returned empty and onboard aborted with `State backup failed — aborting recreate to prevent data loss`, forcing the operator to discover `NEMOCLAW_RECREATE_WITHOUT_BACKUP=1`. This teaches the backup step that a confirmed-gone sandbox has nothing to back up, so recovery proceeds automatically.

## Related Issue
Fixes #4757

## Changes
- `src/lib/onboard/sandbox-backup-on-recreate.ts`: add a tri-state `containerPresence` option to `backupSandboxBeforeRecreate`; when the container is `"absent"` it short-circuits with a new `failureKind: "no-container"` (logs "already gone — nothing to back up; proceeding with recreate") instead of aborting. Add `containerPresenceFromReuseState()` mapping helper.
- `src/lib/onboard.ts`: pass `containerPresenceFromReuseState(existingSandboxState)` into the pre-recreate backup so a confirmed-missing sandbox skips backup and recreate proceeds.
- Only a positively-confirmed missing sandbox (OpenShell `sandbox get` → gRPC `NotFound`, surfaced by `getSandboxStateFromOutputs` as `"missing"`) maps to `"absent"`. A gateway transport error or a stale `Ready` entry stays `"unknown"` and keeps the fail-safe abort, so a transient gateway blip can never destroy live state.
- Tests: cover the container-gone short-circuit, the `"unknown"` fail-safe path, and all three branches of the presence mapping.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

> Verification notes: This change's own tests pass — `src/lib/onboard/sandbox-backup-on-recreate.test.ts` (12/12), plus the full `onboard/`, `state/`, and rebuild suites green; `typecheck:cli` clean; `Test (plugin)` passes. `prek run --all-files` exited non-zero locally only on **pre-existing, environment-specific** failures unrelated to this diff: an unbuilt `nemoclaw/dist/` (ssrf-parity), oclif test timeouts, a missing `/usr/bin/sed` on the dev sandbox (fetch-guard), no network egress (e2e curl 403), and the `source-shape` budget tripping on stray local `.claude/worktrees/` checkouts. None touch `onboard.ts` or the backup path; leaving the two boxes unchecked pending CI on a clean runner.

---
Signed-off-by: Jason Ma <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox recreation now gracefully handles absent containers by skipping unnecessary backup steps, allowing resume recovery to proceed instead of aborting.
  * Enhanced container presence detection during sandbox state management for more robust recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->