### PR TITLE
feat(inference): replace qwen2.5:7b with qwen3.5:9b as the default Ollama starter model

### DIFF
--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -589,17 +589,17 @@ describe("local inference helpers", () => {
     expect(
       parseOllamaTags(
         JSON.stringify({
-          models: [{ name: "nemotron-3-nano:30b" }, { name: "qwen2.5:7b" }],
+          models: [{ name: "nemotron-3-nano:30b" }, { name: "qwen3.5:9b" }],
         }),
       ),
-    ).toEqual(["nemotron-3-nano:30b", "qwen2.5:7b"]);
+    ).toEqual(["nemotron-3-nano:30b", "qwen3.5:9b"]);
   });
 
   it("returns no tags for malformed Ollama API output", () => {
     expect(parseOllamaTags("{not-json")).toEqual([]);
     expect(parseOllamaTags(JSON.stringify({ models: null }))).toEqual([]);
-    expect(parseOllamaTags(JSON.stringify({ models: [{}, { name: "qwen2.5:7b" }] }))).toEqual([
-      "qwen2.5:7b",
+    expect(parseOllamaTags(JSON.stringify({ models: [{}, { name: "qwen3.5:9b" }] }))).toEqual([
+      "qwen3.5:9b",
     ]);
   });
 
@@ -608,11 +608,11 @@ describe("local inference helpers", () => {
     const mockCapture = () => {
       call += 1;
       if (call === 1) {
-        return JSON.stringify({ models: [{ name: "qwen2.5:7b" }] });
+        return JSON.stringify({ models: [{ name: "qwen3.5:9b" }] });
       }
       return "";
     };
-    expect(getOllamaModelOptions(mockCapture)).toEqual(["qwen2.5:7b"]);
+    expect(getOllamaModelOptions(mockCapture)).toEqual(["qwen3.5:9b"]);
   });
 
   it("returns no installed ollama models when list output is empty", () => {
@@ -630,23 +630,23 @@ describe("local inference helpers", () => {
   });
 
   it("falls back to bootstrap model options when no Ollama models are installed", () => {
-    expect(getBootstrapOllamaModelOptions(null)).toEqual(["qwen2.5:7b"]);
+    expect(getBootstrapOllamaModelOptions(null)).toEqual(["qwen3.5:9b"]);
     // Below every registry entry's required memory: small only.
     expect(
       getBootstrapOllamaModelOptions({
         type: "nvidia",
         totalMemoryMB: 10_000,
       }),
-    ).toEqual(["qwen2.5:7b"]);
+    ).toEqual(["qwen3.5:9b"]);
     // Comfortably above every registry entry's required memory: all options.
     expect(
       getBootstrapOllamaModelOptions({
         type: "nvidia",
         totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB,
       }),
-    ).toEqual(["qwen2.5:7b", DEFAULT_OLLAMA_MODEL, QWEN3_6_OLLAMA_MODEL]);
+    ).toEqual(["qwen3.5:9b", DEFAULT_OLLAMA_MODEL, QWEN3_6_OLLAMA_MODEL]);
     expect(getDefaultOllamaModel({ type: "nvidia", totalMemoryMB: 10_000 }, () => "")).toBe(
-      "qwen2.5:7b",
+      "qwen3.5:9b",
     );
     expect(
       getDefaultOllamaModel(
@@ -667,13 +667,13 @@ describe("local inference helpers", () => {
         totalMemoryMB: 131_072,
         availableMemoryMB: 12_000,
       }),
-    ).toEqual(["qwen2.5:7b"]);
+    ).toEqual(["qwen3.5:9b"]);
     expect(
       getDefaultOllamaModel(
         { type: "nvidia", totalMemoryMB: 131_072, availableMemoryMB: 12_000 },
         () => "",
       ),
-    ).toBe("qwen2.5:7b");
+    ).toBe("qwen3.5:9b");
   });
 
   it("filters installed-model selection by memory fit", async () => {
@@ -681,10 +681,10 @@ describe("local inference helpers", () => {
     // Even though nemotron-3-nano:30b is installed, it does not fit a host
     // with only 12 GiB available — the selector must downgrade to a fitting
     // installed model rather than blindly returning DEFAULT_OLLAMA_MODEL.
-    const installed = () => "qwen2.5:7b  abc  4 GB  now\nnemotron-3-nano:30b  def  19 GB  now";
+    const installed = () => "qwen3.5:9b  abc  7 GB  now\nnemotron-3-nano:30b  def  19 GB  now";
     expect(
       gdom({ type: "nvidia", totalMemoryMB: 131_072, availableMemoryMB: 12_000 }, installed),
-    ).toBe("qwen2.5:7b");
+    ).toBe("qwen3.5:9b");
   });
 
   it("resolveNonInteractiveOllamaModel respects unknown tags and downgrades known oversize ones", async () => {
@@ -702,7 +702,7 @@ describe("local inference helpers", () => {
         { type: "nvidia", totalMemoryMB: 131_072, availableMemoryMB: 12_000 },
         log,
       ),
-    ).toBe("qwen2.5:7b");
+    ).toBe("qwen3.5:9b");
     expect(messages.some((m) => m.includes("qwen3.6:35b"))).toBe(true);
 
     // Unknown tag → respected as-is.
@@ -745,7 +745,7 @@ describe("local inference helpers", () => {
       { type: "nvidia", totalMemoryMB: 16_384, availableMemoryMB: 4_000 },
       log,
     );
-    expect(result).toBe("qwen2.5:7b");
+    expect(result).toBe("qwen3.5:9b");
     expect(messages.some((m) => m.includes("qwen3.6:35b"))).toBe(true);
     expect(messages.some((m) => m.includes("No known Ollama bootstrap model fits"))).toBe(true);
 
@@ -759,7 +759,7 @@ describe("local inference helpers", () => {
         log,
         () => "",
       ),
-    ).toBe("qwen2.5:7b");
+    ).toBe("qwen3.5:9b");
     expect(messages.some((m) => m.includes("No known Ollama bootstrap model fits"))).toBe(true);
   });
 
@@ -769,7 +769,7 @@ describe("local inference helpers", () => {
         type: "apple",
         totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB,
       }),
-    ).toEqual(["qwen2.5:7b", DEFAULT_OLLAMA_MODEL, QWEN3_6_OLLAMA_MODEL]);
+    ).toEqual(["qwen3.5:9b", DEFAULT_OLLAMA_MODEL, QWEN3_6_OLLAMA_MODEL]);
     expect(
       getDefaultOllamaModel(
         { type: "apple", totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB },
@@ -786,22 +786,22 @@ describe("local inference helpers", () => {
     // unspecified.
     expect(
       getBootstrapOllamaModelOptions({ totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB }),
-    ).toEqual(["qwen2.5:7b"]);
+    ).toEqual(["qwen3.5:9b"]);
     expect(
       getDefaultOllamaModel({ totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB }, () => ""),
-    ).toBe("qwen2.5:7b");
+    ).toBe("qwen3.5:9b");
     expect(
       getBootstrapOllamaModelOptions({
         type: "generic",
         totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB * 4,
       }),
-    ).toEqual(["qwen2.5:7b"]);
+    ).toEqual(["qwen3.5:9b"]);
     expect(
       getDefaultOllamaModel(
         { type: "generic", totalMemoryMB: LARGE_OLLAMA_FIT_MEMORY_MB * 4 },
         () => "",
       ),
-    ).toBe("qwen2.5:7b");
+    ).toBe("qwen3.5:9b");
   });
 
   it("builds a background warmup command for ollama models", () => {
@@ -813,9 +813,9 @@ describe("local inference helpers", () => {
   });
 
   it("supports custom probe and warmup tuning", () => {
-    const warmup = getOllamaWarmupCommand("qwen2.5:7b", "30m");
+    const warmup = getOllamaWarmupCommand("qwen3.5:9b", "30m");
     expect(warmup[2]).toMatch(/"keep_alive":"30m"/);
-    const probe1 = getOllamaProbeCommand("qwen2.5:7b", 30, "5m");
+    const probe1 = getOllamaProbeCommand("qwen3.5:9b", 30, "5m");
     expect(probe1).toContain("--max-time");
     expect(probe1).toContain("30");
     const payload1 = probe1[probe1.length - 1];

--- a/src/lib/inference/ollama-model-registry.test.ts
+++ b/src/lib/inference/ollama-model-registry.test.ts
@@ -135,7 +135,7 @@ describe("modelFitsAvailableMemory", () => {
 
   it("returns true when a known model fits", () => {
     expect(
-      modelFitsAvailableMemory("qwen2.5:7b", {
+      modelFitsAvailableMemory("qwen3.5:9b", {
         type: "nvidia",
         totalMemoryMB: 131_072,
         availableMemoryMB: 12_000,

--- a/src/lib/inference/ollama-model-registry.ts
+++ b/src/lib/inference/ollama-model-registry.ts
@@ -36,7 +36,7 @@ export interface OllamaModelEntry {
 export const OLLAMA_MODEL_REGISTRY: readonly OllamaModelEntry[] = [
   { tag: "qwen3.6:35b", requiredMemoryMB: 26_000, downloadSizeBytes: 24_000_000_000 },
   { tag: "nemotron-3-nano:30b", requiredMemoryMB: 22_000, downloadSizeBytes: 19_000_000_000 },
-  { tag: "qwen2.5:7b", requiredMemoryMB: 8_000, downloadSizeBytes: 4_683_073_184 },
+  { tag: "qwen3.5:9b", requiredMemoryMB: 12_000, downloadSizeBytes: 6_600_000_000 },
 ];
 
 export const SMALLEST_OLLAMA_MODEL_TAG =

--- a/src/lib/inference/ollama/model-size.test.ts
+++ b/src/lib/inference/ollama/model-size.test.ts
@@ -55,54 +55,54 @@ describe("buildManifestUrl", () => {
 
 describe("probeRegistrySize", () => {
   it("sums layer sizes from a manifest body", () => {
-    expect(probeRegistrySize("qwen2.5:7b", captureReturning(MANIFEST))).toBe(1_200_025_000);
+    expect(probeRegistrySize("qwen3.5:9b", captureReturning(MANIFEST))).toBe(1_200_025_000);
   });
 
   it("invokes curl with the resolved manifest URL", () => {
     const recorder = recordingCapture(MANIFEST);
-    probeRegistrySize("qwen2.5:7b", recorder.capture);
+    probeRegistrySize("qwen3.5:9b", recorder.capture);
     const [argv] = recorder.calls;
     expect(argv[0]).toBe("curl");
     expect(argv[argv.length - 1]).toBe(
-      "https://registry.ollama.ai/v2/library/qwen2.5/manifests/7b",
+      "https://registry.ollama.ai/v2/library/qwen3.5/manifests/9b",
     );
   });
 
   it("returns null when the registry returns an empty body", () => {
-    expect(probeRegistrySize("qwen2.5:7b", captureReturning(""))).toBeNull();
+    expect(probeRegistrySize("qwen3.5:9b", captureReturning(""))).toBeNull();
   });
 
   it("returns null when the body is not valid JSON", () => {
-    expect(probeRegistrySize("qwen2.5:7b", captureReturning("not-json"))).toBeNull();
+    expect(probeRegistrySize("qwen3.5:9b", captureReturning("not-json"))).toBeNull();
   });
 
   it("returns null when the manifest has no layers array", () => {
-    expect(probeRegistrySize("qwen2.5:7b", captureReturning("{}"))).toBeNull();
+    expect(probeRegistrySize("qwen3.5:9b", captureReturning("{}"))).toBeNull();
   });
 
   it("returns null when a layer has a non-numeric size", () => {
     const bad = JSON.stringify({ layers: [{ size: "huge" }] });
-    expect(probeRegistrySize("qwen2.5:7b", captureReturning(bad))).toBeNull();
+    expect(probeRegistrySize("qwen3.5:9b", captureReturning(bad))).toBeNull();
   });
 
   it("returns null when a layer entry is null or not an object", () => {
     expect(
-      probeRegistrySize("qwen2.5:7b", captureReturning(JSON.stringify({ layers: [null] }))),
+      probeRegistrySize("qwen3.5:9b", captureReturning(JSON.stringify({ layers: [null] }))),
     ).toBeNull();
     expect(
-      probeRegistrySize("qwen2.5:7b", captureReturning(JSON.stringify({ layers: [42] }))),
+      probeRegistrySize("qwen3.5:9b", captureReturning(JSON.stringify({ layers: [42] }))),
     ).toBeNull();
   });
 });
 
 describe("getOllamaModelSize", () => {
   it("prefers the registry probe over the fallback table", () => {
-    const lookup = getOllamaModelSize("qwen2.5:7b", captureReturning(MANIFEST));
+    const lookup = getOllamaModelSize("qwen3.5:9b", captureReturning(MANIFEST));
     expect(lookup).toEqual({ bytes: 1_200_025_000, source: "registry" });
   });
 
   it("falls back to the bundled table when the probe fails", () => {
-    const lookup = getOllamaModelSize("qwen2.5:7b", captureReturning(""));
+    const lookup = getOllamaModelSize("qwen3.5:9b", captureReturning(""));
     expect(lookup?.source).toBe("fallback");
     expect(lookup?.bytes).toBeGreaterThan(0);
   });

--- a/src/lib/inference/ollama/proxy.test.ts
+++ b/src/lib/inference/ollama/proxy.test.ts
@@ -66,12 +66,12 @@ describe("promptOllamaModel installed-model fit filter", () => {
       totalMemoryMB: 131_072,
       availableMemoryMB: 12_000,
     });
-    expect(result).toBe("qwen2.5:7b");
+    expect(result).toBe("qwen3.5:9b");
   });
 
   it("keeps a fitting installed model as the default", async () => {
     const setup = loadProxyWithMocks({
-      installed: ["qwen2.5:7b", "qwen3.6:35b"],
+      installed: ["qwen3.5:9b", "qwen3.6:35b"],
       promptValues: [""],
     });
     active = setup;
@@ -80,8 +80,8 @@ describe("promptOllamaModel installed-model fit filter", () => {
       totalMemoryMB: 131_072,
       availableMemoryMB: 12_000,
     });
-    // Only qwen2.5:7b fits; the menu offers only it, Enter selects it.
-    expect(result).toBe("qwen2.5:7b");
+    // Only qwen3.5:9b fits; the menu offers only it, Enter selects it.
+    expect(result).toBe("qwen3.5:9b");
   });
 
   it("respects unknown installed tags (not in the registry) even when nothing else fits", async () => {

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -603,7 +603,7 @@ describe("inventory commands", () => {
             model: "nvidia/nemotron-3-super-120b-a12b",
             provider: "nvidia-prod",
           },
-          { name: "beta", model: "qwen2.5:7b", provider: "ollama-local" },
+          { name: "beta", model: "qwen3.5:9b", provider: "ollama-local" },
         ],
         defaultSandbox: "alpha",
       }),
@@ -613,7 +613,7 @@ describe("inventory commands", () => {
     });
 
     expect(lines).toContain("      Inference: nvidia-prod / nvidia/nemotron-3-super-120b-a12b");
-    expect(lines).toContain("      Inference: ollama-local / qwen2.5:7b");
+    expect(lines).toContain("      Inference: ollama-local / qwen3.5:9b");
   });
 
   it("prefers live gateway provider for the default sandbox in the Inference line (#2604)", () => {

--- a/src/lib/onboard/dockerfile-patch.test.ts
+++ b/src/lib/onboard/dockerfile-patch.test.ts
@@ -242,7 +242,7 @@ describe("dockerfile patch helpers", () => {
 
     patchStagedDockerfile(
       dockerfilePath,
-      "qwen2.5:7b",
+      "qwen3.5:9b",
       "https://chat.example",
       "build-1",
       "ollama-local",

--- a/src/lib/onboard/ollama-probe-failure.test.ts
+++ b/src/lib/onboard/ollama-probe-failure.test.ts
@@ -92,7 +92,7 @@ describe("handleOllamaProbeFailure (#4365)", () => {
     try {
       const action = handleOllamaProbeFailure(
         { ok: false, message: "model runner has unexpectedly stopped", daemonFailure: true },
-        "qwen2.5:7b",
+        "qwen3.5:9b",
         () => false,
       );
       expect(action).toBe("back-to-selection");
@@ -122,7 +122,7 @@ describe("handleOllamaProbeFailure (#4365)", () => {
     try {
       const action = handleOllamaProbeFailure(
         { ok: false, message: "model requires more system memory" },
-        "qwen2.5:7b",
+        "qwen3.5:9b",
         () => false,
       );
       expect(action).toBe("continue");
@@ -153,13 +153,13 @@ describe("handleOllamaProbeFailure (#4365)", () => {
       expect(() =>
         handleOllamaProbeFailure(
           { ok: false, message: "model requires more system memory" },
-          "qwen2.5:7b",
+          "qwen3.5:9b",
           () => true,
         ),
       ).toThrow(/process\.exit:1/);
       const errLines = errSpy.mock.calls.map((c) => String(c[0]));
       expect(
-        errLines.some((l) => l.includes("Aborting: Ollama model 'qwen2.5:7b' unavailable")),
+        errLines.some((l) => l.includes("Aborting: Ollama model 'qwen3.5:9b' unavailable")),
       ).toBe(true);
     } finally {
       errSpy.mockRestore();

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -263,7 +263,7 @@ function sshEnv(
   cmd: string,
   { timeout = 600_000, stream = false }: { timeout?: number; stream?: boolean } = {},
 ): string {
-  const gpuE2eModel = process.env.NEMOCLAW_GPU_E2E_MODEL || "qwen2.5:7b";
+  const gpuE2eModel = process.env.NEMOCLAW_GPU_E2E_MODEL || "qwen3.5:9b";
   const envParts = [
     `export NVIDIA_API_KEY='${shellEscape(process.env.NVIDIA_API_KEY)}'`,
     `export GITHUB_TOKEN='${shellEscape(process.env.GITHUB_TOKEN)}'`,

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -1394,9 +1394,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
   it("enables supportsUsageInStreaming for Ollama provider keys (#2747)", () => {
     for (const providerKey of ["ollama", "ollama-local"]) {
       const config = runConfigScript({
-        NEMOCLAW_MODEL: "qwen2.5:7b",
+        NEMOCLAW_MODEL: "qwen3.5:9b",
         NEMOCLAW_PROVIDER_KEY: providerKey,
-        NEMOCLAW_PRIMARY_MODEL_REF: "qwen2.5:7b",
+        NEMOCLAW_PRIMARY_MODEL_REF: "qwen3.5:9b",
         NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
         NEMOCLAW_INFERENCE_API: "openai-completions",
       });
@@ -1436,9 +1436,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
   // ollama-keyed default — including when a manifest opts the flag *off*.
   it("respects existing supportsUsageInStreaming from inference compat (#2747)", () => {
     const config = runConfigScript({
-      NEMOCLAW_MODEL: "qwen2.5:7b",
+      NEMOCLAW_MODEL: "qwen3.5:9b",
       NEMOCLAW_PROVIDER_KEY: "ollama",
-      NEMOCLAW_PRIMARY_MODEL_REF: "qwen2.5:7b",
+      NEMOCLAW_PRIMARY_MODEL_REF: "qwen3.5:9b",
       NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
       NEMOCLAW_INFERENCE_API: "openai-completions",
       NEMOCLAW_INFERENCE_COMPAT_B64: Buffer.from(

--- a/test/get-ollama-model-options.test.ts
+++ b/test/get-ollama-model-options.test.ts
@@ -58,11 +58,11 @@ describe("getOllamaModelOptions host-pinned fallback", () => {
     const { capture, calls } = makeCapture([
       {
         match: /\/api\/tags/,
-        output: JSON.stringify({ models: [{ name: "qwen2.5:7b" }, { name: "gemma2:9b" }] }),
+        output: JSON.stringify({ models: [{ name: "qwen3.5:9b" }, { name: "gemma2:9b" }] }),
       },
     ]);
     const models = getOllamaModelOptions(capture);
-    expect(models).toEqual(["qwen2.5:7b", "gemma2:9b"]);
+    expect(models).toEqual(["qwen3.5:9b", "gemma2:9b"]);
     expect(calls.some((c) => c.argv.includes("list"))).toBe(false);
   });
 });

--- a/test/ollama-pull-timeout.test.ts
+++ b/test/ollama-pull-timeout.test.ts
@@ -75,7 +75,7 @@ const { pullOllamaModel } = require(${proxyPath});
 
 const originalLog = console.log;
 console.log = () => {};
-pullOllamaModel("qwen2.5:7b")
+pullOllamaModel("qwen3.5:9b")
   .then((ok) => {
     console.log = originalLog;
     originalLog(JSON.stringify({ ok, captured }));

--- a/test/ollama-tools-capability.test.ts
+++ b/test/ollama-tools-capability.test.ts
@@ -82,7 +82,7 @@ describe("probeOllamaModelCapabilities", () => {
         output: JSON.stringify({ capabilities: ["completion", "tools"] }),
       },
     ]);
-    const result = localInference.probeOllamaModelCapabilities("qwen2.5:7b", capture);
+    const result = localInference.probeOllamaModelCapabilities("qwen3.5:9b", capture);
     expect(result.source).toBe("api");
     expect(result.supportsTools).toBe(true);
     expect(result.capabilities).toEqual(["completion", "tools"]);
@@ -137,7 +137,7 @@ describe("probeOllamaModelCapabilities", () => {
     const { capture, calls } = makeCapture([
       { match: /\/api\/show/, output: JSON.stringify({ capabilities: ["tools"] }) },
     ]);
-    localInference.probeOllamaModelCapabilities("qwen2.5:7b", capture);
+    localInference.probeOllamaModelCapabilities("qwen3.5:9b", capture);
     expect(calls).toHaveLength(1);
     const argv = calls[0].argv;
     expect(argv[0]).toBe("curl");
@@ -157,7 +157,7 @@ describe("probeOllamaModelCapabilities", () => {
     // JSON body has model name
     const dIdx = argv.indexOf("-d");
     expect(dIdx).toBeGreaterThanOrEqual(0);
-    expect(argv[dIdx + 1]).toBe(JSON.stringify({ model: "qwen2.5:7b" }));
+    expect(argv[dIdx + 1]).toBe(JSON.stringify({ model: "qwen3.5:9b" }));
     // URL uses resolved host + OLLAMA_PORT (default 11434)
     expect(argv[argv.length - 1]).toBe("http://127.0.0.1:11434/api/show");
   });

--- a/test/onboard-ollama-autostart.test.ts
+++ b/test/onboard-ollama-autostart.test.ts
@@ -100,7 +100,7 @@ function runOllamaAutostartScenario(opts: ScenarioOptions): WizardResult {
   // this fake curl. Returning a tag matching the bootstrap fallback
   // (smallest registry entry) keeps the menu deterministic with gpu=null
   // and ensures the picked model is already-installed (no pull prompt).
-  const tagsBody = '{"models":[{"name":"qwen2.5:7b"}]}';
+  const tagsBody = '{"models":[{"name":"qwen3.5:9b"}]}';
   fs.writeFileSync(
     path.join(fakeBin, "curl"),
     `#!/usr/bin/env bash

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -2815,7 +2815,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "ollama-local");
-    assert.equal(payload.result.model, "qwen2.5:7b");
+    assert.equal(payload.result.model, "qwen3.5:9b");
     assert.ok(payload.lines.some((line: string) => line.includes("Ollama starter models:")));
     assert.ok(
       payload.lines.some((line: string) =>
@@ -2823,9 +2823,9 @@ const { setupNim } = require(${onboardPath});
       ),
     );
     assert.ok(
-      payload.lines.some((line: string) => line.includes("Pulling Ollama model: qwen2.5:7b")),
+      payload.lines.some((line: string) => line.includes("Pulling Ollama model: qwen3.5:9b")),
     );
-    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen2.5:7b");
+    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b");
   });
 
   it("reprompts inside the Ollama model flow when a pull fails", () => {
@@ -2861,7 +2861,7 @@ printf '%s' "$status"
       `#!/usr/bin/env bash
 if [ "$1" = "pull" ]; then
   echo "$2" >> ${JSON.stringify(pullLog)}
-  if [ "$2" = "qwen2.5:7b" ]; then
+  if [ "$2" = "qwen3.5:9b" ]; then
     exit 1
   fi
   exit 0
@@ -2933,7 +2933,7 @@ const { setupNim } = require(${onboardPath});
     assert.equal(payload.result.model, "llama3.2:3b");
     assert.ok(
       payload.lines.some((line: string) =>
-        line.includes("Failed to pull Ollama model 'qwen2.5:7b'"),
+        line.includes("Failed to pull Ollama model 'qwen3.5:9b'"),
       ),
     );
     assert.ok(
@@ -2945,7 +2945,7 @@ const { setupNim } = require(${onboardPath});
       payload.messages.filter((message: string) => /Ollama model id:/.test(message)).length,
       1,
     );
-    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen2.5:7b\nllama3.2:3b");
+    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b\nllama3.2:3b");
   });
 
   it("re-prompts for a model when the user declines the size confirmation", () => {
@@ -3045,14 +3045,14 @@ const { setupNim } = require(${onboardPath});
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "ollama-local");
-    assert.equal(payload.result.model, "qwen2.5:7b");
+    assert.equal(payload.result.model, "qwen3.5:9b");
     assert.ok(
       payload.lines.some((line: string) =>
-        line.includes("Skipped pulling Ollama model 'qwen2.5:7b'"),
+        line.includes("Skipped pulling Ollama model 'qwen3.5:9b'"),
       ),
     );
     // Pull only happened on the second confirmation, not on the declined first attempt.
-    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen2.5:7b");
+    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b");
     const downloadPrompts = payload.messages.filter((message: string) =>
       /Download Ollama model/.test(message),
     );
@@ -3163,8 +3163,8 @@ const { setupNim } = require(${onboardPath});
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
     assert.equal(payload.result.provider, "ollama-local");
-    assert.equal(payload.result.model, "qwen2.5:7b");
-    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen2.5:7b");
+    assert.equal(payload.result.model, "qwen3.5:9b");
+    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b");
     // No "Download Ollama model 'X'?" prompt was issued — the env var bypassed it.
     assert.equal(
       payload.messages.filter((message: string) => /Download Ollama model/.test(message)).length,
@@ -3175,7 +3175,7 @@ const { setupNim } = require(${onboardPath});
     // includes a size label or the "size unknown" fallback.
     const sizePattern = /\((\d+(\.\d+)? (B|KB|MB|GB|TB)( \(estimated\))?|size unknown)\)/;
     const pullingLine = payload.lines.find((line: string) =>
-      /Pulling Ollama model 'qwen2.5:7b'/.test(line),
+      /Pulling Ollama model 'qwen3.5:9b'/.test(line),
     );
     assert.ok(pullingLine, "expected a 'Pulling Ollama model' log line under NEMOCLAW_YES=1");
     assert.match(pullingLine, sizePattern);

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1450,7 +1450,7 @@ runner.runCapture = (command) => {
       "",
       "  Route: inference.local",
       "  Provider: ollama-local",
-      "  Model: qwen2.5:7b",
+      "  Model: qwen3.5:9b",
       "  Version: 1",
     ].join("\\n");
   }
@@ -1483,7 +1483,7 @@ proxy.persistAndProbeOllamaProxy = async (token) => {
 const { setupInference } = require(${onboardPath});
 
 (async () => {
-  await setupInference("test-box", "qwen2.5:7b", "ollama-local");
+  await setupInference("test-box", "qwen3.5:9b", "ollama-local");
   console.log(JSON.stringify({ commands, proxyCalls }));
 })().catch((error) => {
   console.error(error);
@@ -1589,7 +1589,7 @@ runner.runCapture = (command) => {
       "",
       "  Route: inference.local",
       "  Provider: ollama-local",
-      "  Model: qwen2.5:7b",
+      "  Model: qwen3.5:9b",
       "  Version: 1",
     ].join("\\n");
   }
@@ -1615,7 +1615,7 @@ const { setupInference } = require(${onboardPath});
 
 (async () => {
   try {
-    await setupInference("test-box", "qwen2.5:7b", "ollama-local");
+    await setupInference("test-box", "qwen3.5:9b", "ollama-local");
   } catch (err) {
     if (!err || !err.__exit) {
       origErr("[TEST] outer error:", err && err.message);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Updates the local Ollama starter model from `qwen2.5:7b` to `qwen3.5:9b` so new local-inference onboarding uses a newer tool-capable Qwen model.

## Changes
- Replaced the smallest Ollama bootstrap registry entry with `qwen3.5:9b`.
- Updated memory and download-size metadata for the new starter model.
- Updated onboarding, registry, proxy, model-size, config, inventory, and e2e test fixtures that assert starter-model behavior.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations and mock data across inference, onboarding, and E2E test suites to reflect the updated default Ollama model configuration.

* **Chores**
  * Updated Ollama model registry and associated default model references throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->