### PR TITLE
fix(vllm): raise Qwen3.6-35B-A3B-NVFP4 max-model-len to 131072 on Spark

### DIFF
--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -127,7 +127,7 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--enable-auto-tool-choice");
     expect(cmd).toContain("--tool-call-parser qwen3_coder");
     expect(cmd).toContain("--reasoning-parser qwen3");
-    expect(cmd).toContain("--max-model-len 65536");
+    expect(cmd).toContain("--max-model-len 131072");
     expect(cmd).toContain(
       `--speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'`,
     );

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -94,7 +94,7 @@ export const VLLM_MODELS: readonly VllmModelDef[] = [
     id: "nvidia/Qwen3.6-35B-A3B-NVFP4",
     label: "Qwen3.6 35B-A3B NVFP4",
     envValue: "qwen3.6-35b-a3b-nvfp4",
-    maxModelLen: 65536,
+    maxModelLen: 131072,
     // Additive flags on top of the shared serving defaults. The shared flags
     // already cover --tensor-parallel-size/--pipeline-parallel-size/
     // --data-parallel-size (all 1 — harmless on a single Spark node),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Updates the DGX Spark managed vLLM profile for the Qwen3.6 35B-A3B NVFP4 model to use a 128K context window. 

## Changes
<!-- Bullet list of key changes. -->
- Changed the Spark NVFP4 vLLM `--max-model-len` from `65536` to `131072`.
- Update the registry test to assert `--max-model-len 131072`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the maximum model length configuration for the Qwen3.6-35B-A3B-NVFP4 model from 65536 to 131072.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->