### PR TITLE
docs: refresh 0.0.59 release notes

### DIFF
--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -204,8 +204,8 @@ Commit changes and open a pull request with a concise summary of the doc updates
 - #<doc-impacting-PR-number> -> `docs/path.mdx`: Description of the doc change reflecting the source code changes in the PR.
 ```
 
-Apply the `documentation` label and the corresponding release label so reviewers can identify doc-only changes for the target release.
-When creating the PR with `gh pr create`, pass both labels, for example `--label documentation --label v0.0.37`.
+Apply the `area: docs`, `area: skills`, and corresponding release labels so reviewers can identify doc-only changes for the target release and generated skill updates.
+When creating the PR with `gh pr create`, pass all labels, for example `--label "area: docs" --label "area: skills" --label v0.0.37`.
 If the release label does not exist, report that instead of substituting another label.
 
 ## Tips
@@ -229,7 +229,7 @@ User says: "Catch up the docs for everything merged since v0.1.0."
 7. **Release prep only:** Run `python3 scripts/docs-to-skills.py docs/ .agents/skills/ skills/ --prefix nemoclaw-user --doc-platform fern-mdx`.
 8. Present the summary.
 9. Build with `npm run docs` to verify.
-10. **Release prep only:** Commit changes and open a pull request with the `documentation` label and the corresponding `vX.Y.Z` release label. Include a concise summary of the doc updates and a source summary that links each identified merged PR to its matching doc page. Include the PR number, affected doc page, links, and description of the doc change in this shape:
+10. **Release prep only:** Commit changes and open a pull request with the `area: docs`, `area: skills`, and corresponding `vX.Y.Z` release labels. Include a concise summary of the doc updates and a source summary that links each identified merged PR to its matching doc page. Include the PR number, affected doc page, links, and description of the doc change in this shape:
 
    ```markdown
    - #<doc-impacting-PR-number> -> `docs/path.mdx`: Description of the doc change reflecting the source code changes in the PR.

--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -168,7 +168,7 @@ This does not delete downloaded model files.
 
 ```bash
 NEMOCLAW_PROVIDER=ollama \
-  NEMOCLAW_MODEL=qwen2.5:14b \
+  NEMOCLAW_MODEL=qwen3.5:9b \
   nemoclaw onboard --non-interactive --yes
 ```
 

--- a/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
@@ -53,7 +53,7 @@ The managed install/start vLLM entry appears by default on DGX Spark and DGX Sta
 
 | Option | Description | Curated models |
 |--------|-------------|----------------|
-| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, GLM-5.1, MiniMax M2.7, GPT-OSS 120B, DeepSeek V4 Pro |
+| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_API_KEY`. | Nemotron 3 Super 120B, Nemotron 3 Ultra 550B, GLM-5.1, MiniMax M2.7, GPT-OSS 120B, DeepSeek V4 Pro |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
 | Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. NemoClaw uses `/v1/chat/completions` at runtime by default; set `NEMOCLAW_PREFERRED_API=openai-responses` to allow `/v1/responses` for proxies that implement it, such as some llama.cpp builds. The wizard prompts for a base URL and model name. Works with OpenRouter, LocalAI, llama.cpp, or any compatible proxy. When you enable Telegram messaging, onboarding also runs a bounded sandbox-side smoke check through `https://inference.local/v1/chat/completions`. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |

--- a/.agents/skills/nemoclaw-user-configure-security/references/credential-storage.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/credential-storage.md
@@ -45,6 +45,9 @@ This means you can:
 - Use short-lived or rotated credentials in CI by exporting them once per pipeline run
 - Avoid registering credentials in the gateway entirely if your environment supplies them
 
+When the host environment is empty, day-two operations such as `nemoclaw <name> rebuild` and remote-provider updates can reuse the credential already registered with the OpenShell gateway.
+Export the credential only when you want to create, replace, or rotate the stored provider value.
+
 ## Deploy Reads from Environment Only
 
 `nemoclaw deploy` (which provisions a remote Brev box) cannot read secrets back from the gateway, so it requires every credential to be present in the host environment at invocation time.

--- a/.agents/skills/nemoclaw-user-overview/references/release-notes.md
+++ b/.agents/skills/nemoclaw-user-overview/references/release-notes.md
@@ -4,6 +4,16 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.59
+
+NemoClaw v0.0.59 improves OpenClaw runtime compatibility, inference setup, credential reuse, messaging safeguards, and sandbox startup diagnostics:
+
+- OpenClaw sandboxes stay aligned with the live gateway and current runtime layout. Sandbox startup reconciles the agent model from the live gateway, refreshes the OpenClaw plugin registry after gateway startup, pins OpenClaw home, state, and workspace paths inside the sandbox, and handles OpenClaw 2026.5.27 approval compatibility. For more information, refer to NemoClaw CLI Commands Reference (use the `nemoclaw-user-reference` skill).
+- Inference setup has newer model choices and longer first-start budgets for local runtimes. NVIDIA Endpoints includes the Nemotron 3 Ultra 550B option, Local Ollama uses `qwen3.5:9b` as the starter fallback, managed vLLM on DGX Spark uses a 128K context window for `nvidia/Qwen3.6-35B-A3B-NVFP4`, and Local NVIDIA NIM waits longer for first container startup while still failing fast when the container exits. For more information, refer to NemoClaw Inference Options (use the `nemoclaw-user-configure-inference` skill).
+- Hermes sandboxes can route Anthropic Messages API traffic through managed inference, and runtime model switches keep the Hermes config synchronized with the OpenShell route. For more information, refer to Switch Inference Models at Runtime (use the `nemoclaw-user-configure-inference` skill).
+- Credential and messaging boundaries are clearer during day-two operations. Rebuild and remote-provider update paths can reuse credentials already stored in the OpenShell gateway when the host environment is empty, `channels add` warns or aborts before multiple sandboxes compete for the same token-based messaging credential, and `status` reports cross-sandbox channel overlaps. For more information, refer to Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill).
+- Sandbox startup and host preflight failures provide more actionable recovery guidance. NemoClaw heals `~/.nemoclaw` directory and config-file permissions on read paths, detects missing or stale NVIDIA CDI specs before GPU containers fail, probes legacy gateway containers before host-alias operations, and preserves argument validation before runtime probing. For more information, refer to Troubleshooting (use the `nemoclaw-user-reference` skill).
+
 ## v0.0.58
 
 NemoClaw v0.0.58 improves GPU proof reporting, local-inference metadata, policy failure handling, Hermes messaging reliability, OpenClaw diagnostics, and release-prep documentation:

--- a/.agents/skills/nemoclaw-user-reference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-reference/SKILL.md
@@ -9,7 +9,7 @@ license: "Apache-2.0"
 ## References
 
 - **Load [references/architecture.md](references/architecture.md)** when looking up architecture, agent integration, plugin structure, or blueprint design. Describes the NemoClaw integration layer and blueprint architecture and how they orchestrate compatible agent sandboxes.
-- **[references/cli-selection-guide.md](references/cli-selection-guide.md)** — Explains when to use `$$nemoclaw` versus `openshell` for NemoClaw-managed sandboxes, including lifecycle, inference, policy, monitoring, file transfer, and gateway operations.
+- **Load [references/cli-selection-guide.md](references/cli-selection-guide.md)** when user asks to decide whether to use `$$nemoclaw` or `openshell`. Explains when to use `$$nemoclaw` versus `openshell` for NemoClaw-managed sandboxes, including lifecycle, inference, policy, monitoring, file transfer, and gateway operations.
 - **Load [references/commands.md](references/commands.md)** when looking up a specific `$$nemoclaw`, `nemohermes`, or `/nemoclaw` subcommand, flag, argument, or exit code. Includes the full CLI reference for standalone NemoClaw commands and agent-specific in-sandbox commands.
 - **Load [references/network-policies.md](references/network-policies.md)** when looking up a specific default endpoint, filesystem path, or the runtime approval sequence NemoClaw applies on blocked requests. Covers the baseline network policy, filesystem rules, and operator approval flow.
 - **Load [references/troubleshooting.md](references/troubleshooting.md)** when diagnosing a reported NemoClaw error, a failed onboard, or unexpected sandbox behavior. Lists fixes for common installation, onboarding, and runtime issues.

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -567,7 +567,7 @@ Existing sandboxes do not auto-upgrade when a newer NemoClaw release ships a new
 ```console
 $ nemoclaw my-assistant status
 ...
-    Agent:    OpenClaw v2026.5.22
+    Agent:    OpenClaw v2026.5.27
 ...
 ```
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -57,6 +57,13 @@ reviews:
           `bash`, `sh`, or `powershell`, and must not include prompt markers
           such as `$`. Reserve `console` blocks for terminal transcripts that
           include prompts, output, or interactive sessions.
+        - Do not flag `$$nemoclaw` in docs. It is the correct build-time
+          variant placeholder for shared OpenClaw and Hermes command examples.
+        - When a docs PR adds a command-line example that works across all
+          NemoClaw agent aliases, comment if it uses a concrete alias such as
+          `nemoclaw` or `nemohermes`; ask the author to use `$$nemoclaw`
+          instead so generated OpenClaw and Hermes docs render the right
+          command name.
         - Use Fern callout components (<Note>, <Tip>, <Warning>) for callouts
           in MDX pages, not bold text or blockquotes. MyST admonitions are
           acceptable only in legacy .md pages that have not migrated yet.

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -13,6 +13,16 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.59
+
+NemoClaw v0.0.59 improves OpenClaw runtime compatibility, inference setup, credential reuse, messaging safeguards, and sandbox startup diagnostics:
+
+- OpenClaw sandboxes stay aligned with the live gateway and current runtime layout. Sandbox startup reconciles the agent model from the live gateway, refreshes the OpenClaw plugin registry after gateway startup, pins OpenClaw home, state, and workspace paths inside the sandbox, and handles OpenClaw 2026.5.27 approval compatibility. For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands).
+- Inference setup has newer model choices and longer first-start budgets for local runtimes. NVIDIA Endpoints includes the Nemotron 3 Ultra 550B option, Local Ollama uses `qwen3.5:9b` as the starter fallback, managed vLLM on DGX Spark uses a 128K context window for `nvidia/Qwen3.6-35B-A3B-NVFP4`, and Local NVIDIA NIM waits longer for first container startup while still failing fast when the container exits. For more information, refer to [NemoClaw Inference Options](../inference/inference-options).
+- Hermes sandboxes can route Anthropic Messages API traffic through managed inference, and runtime model switches keep the Hermes config synchronized with the OpenShell route. For more information, refer to [Switch Inference Models at Runtime](../inference/switch-inference-providers).
+- Credential and messaging boundaries are clearer during day-two operations. Rebuild and remote-provider update paths can reuse credentials already stored in the OpenShell gateway when the host environment is empty, `channels add` warns or aborts before multiple sandboxes compete for the same token-based messaging credential, and `status` reports cross-sandbox channel overlaps. For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels).
+- Sandbox startup and host preflight failures provide more actionable recovery guidance. NemoClaw heals `~/.nemoclaw` directory and config-file permissions on read paths, detects missing or stale NVIDIA CDI specs before GPU containers fail, probes legacy gateway containers before host-alias operations, and preserves argument validation before runtime probing. For more information, refer to [Troubleshooting](../reference/troubleshooting).
+
 ## v0.0.58
 
 NemoClaw v0.0.58 improves GPU proof reporting, local-inference metadata, policy failure handling, Hermes messaging reliability, OpenClaw diagnostics, and release-prep documentation:

--- a/docs/inference/use-local-inference.mdx
+++ b/docs/inference/use-local-inference.mdx
@@ -171,7 +171,7 @@ This does not delete downloaded model files.
 
 ```bash
 NEMOCLAW_PROVIDER=ollama \
-  NEMOCLAW_MODEL=qwen2.5:14b \
+  NEMOCLAW_MODEL=qwen3.5:9b \
   $$nemoclaw onboard --non-interactive --yes
 ```
 

--- a/docs/reference/cli-selection-guide.mdx
+++ b/docs/reference/cli-selection-guide.mdx
@@ -4,7 +4,7 @@
 title: "Choose Between NemoClaw and OpenShell CLIs"
 sidebar-title: "Which CLI to Use"
 description: "Choose between the NemoClaw CLI and the OpenShell CLI for common sandbox operations."
-description-agent: "Explains when to use `$$nemoclaw` versus `openshell` for NemoClaw-managed sandboxes, including lifecycle, inference, policy, monitoring, file transfer, and gateway operations."
+description-agent: "Explains when to use `$$nemoclaw` versus `openshell` for NemoClaw-managed sandboxes, including lifecycle, inference, policy, monitoring, file transfer, and gateway operations. Use when user asks to decide whether to use `$$nemoclaw` or `openshell`."
 keywords: ["nemoclaw vs openshell", "which cli", "nemoclaw cli", "openshell cli", "sandbox commands"]
 content:
   type: "reference"

--- a/docs/security/credential-storage.mdx
+++ b/docs/security/credential-storage.mdx
@@ -54,6 +54,9 @@ This means you can:
 - Use short-lived or rotated credentials in CI by exporting them once per pipeline run
 - Avoid registering credentials in the gateway entirely if your environment supplies them
 
+When the host environment is empty, day-two operations such as `$$nemoclaw <name> rebuild` and remote-provider updates can reuse the credential already registered with the OpenShell gateway.
+Export the credential only when you want to create, replace, or rotate the stored provider value.
+
 ## Deploy Reads from Environment Only
 
 `$$nemoclaw deploy` (which provisions a remote Brev box) cannot read secrets back from the gateway, so it requires every credential to be present in the host environment at invocation time.


### PR DESCRIPTION
## Summary
- Add the v0.0.59 release notes from the GitHub announcement discussion.
- Refresh local inference and credential-storage guidance for the current release behavior.
- Regenerate the user skills from the updated Fern docs.
- Tighten release-prep and docs review guidance for generated skills, PR labels, and shared `$$nemoclaw` command placeholders.

## Verification
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx`
- `rg "permissive mode|shields down|shields up|shields status|config rotate-token|rotate-token" --glob '*.{md,mdx}'`
- `git diff --check`
- `npm run docs` (rerun outside sandbox after sandbox-only `tsx` IPC permission failure)
- `npm run typecheck:cli`
- Pre-commit hooks during commit passed, including markdownlint, docs-to-skills verification, gitleaks, commitlint, and skills YAML tests.

## Source Summary
- #3679, #4437, #4681, #4766, #4772, #4775, #4786 -> `docs/about/release-notes.mdx`, `docs/reference/commands.mdx`, `docs/reference/troubleshooting.mdx`: Summarize OpenClaw 2026.5.27 compatibility, runtime path pinning, plugin registry recovery, live gateway reconciliation, and clearer host-alias/startup diagnostics.
- #4332, #4402, #4769, #4776, #4779 -> `docs/about/release-notes.mdx`, `docs/inference/inference-options.mdx`, `docs/inference/use-local-inference.mdx`, `docs/inference/switch-inference-providers.mdx`: Document the release inference changes covering Local NIM waits, Hermes Anthropic routing, Nemotron 3 Ultra, the current Ollama starter fallback, and Spark managed-vLLM context length.
- #4628, #4652, #4733, #4745 -> `docs/about/release-notes.mdx`, `docs/security/credential-storage.mdx`, `docs/manage-sandboxes/messaging-channels.mdx`, `docs/reference/troubleshooting.mdx`: Capture permission healing, gateway-stored credential reuse, cross-sandbox messaging credential conflict checks, and CDI preflight diagnostics.
- #4728, #4737, #4743, #4744, #4782 -> `.agents/skills/nemoclaw-user-*`: Regenerate the user skill references from the updated source docs.
- Follow-up maintenance -> `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`, `.coderabbit.yaml`: Add release-prep area labels for docs and skills PRs, and teach docs review guidance that `$$nemoclaw` is the correct shared command placeholder for examples that work across agent aliases.

Note: the `documentation` label was not present in the repository, so this PR is labeled with `v0.0.59` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated default model for local Ollama inference setup to qwen3.5:9b
  * Added Nemotron 3 Ultra 550B as an NVIDIA Endpoints model option
  * Clarified credential storage and reuse behavior for post-deployment (day-two) operations
  * Added v0.0.59 release notes covering OpenClaw compatibility, inference options, Hermes messaging sync, and troubleshooting
  * Clarified CLI selection guidance and updated OpenClaw version example in status output
  * Revised release-prep instructions and docs review guidance for CLI alias usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->