### PR TITLE
ci(github): require maintainer edits on fork PRs

### DIFF
--- a/.github/workflows/require-maintainer-edits.yaml
+++ b/.github/workflows/require-maintainer-edits.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI / Require Maintainer Edits
+
+# pull_request_target runs in the base repo context. This workflow is safe for
+# fork PRs because it never checks out or executes pull request code; it only
+# reads event metadata from the pull_request payload.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-maintainer-edits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require maintainer edits for fork PRs
+        env:
+          HEAD_REPO_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
+        run: |
+          set -euo pipefail
+
+          echo "head_repo_fork=${HEAD_REPO_FORK}"
+          echo "maintainer_can_modify=${MAINTAINER_CAN_MODIFY}"
+
+          if [ "${HEAD_REPO_FORK}" = "true" ] && [ "${MAINTAINER_CAN_MODIFY}" != "true" ]; then
+            echo "::error title=Maintainer edits required::Enable 'Allow edits by maintainers' on this pull request so maintainers can help resolve review feedback and CI issues."
+            exit 1
+          fi
+
+          echo "Maintainer edits requirement satisfied."


### PR DESCRIPTION
## Summary
Adds a lightweight pull_request_target workflow that fails fork PRs when maintainers cannot modify the branch. This makes the repository policy visible in CI without checking out or executing untrusted PR code.

## Changes
- Added `.github/workflows/require-maintainer-edits.yaml`.
- The new check passes for same-repository PRs and fork PRs with maintainer edits enabled.
- The new check fails fork PRs when `maintainer_can_modify` is false, with an actionable error message.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
`npm test` was attempted but did not pass because the existing `test/install-preflight.test.ts` case `warns on Podman but still runs onboarding` expected `Host preflight found warnings.` while the local output reported `Host preflight found issues...`; this appears unrelated to the workflow-only change.

- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>