### PR TITLE
fix(blueprint): disable native tool search for Nemotron managed inference

### DIFF
--- a/nemoclaw-blueprint/model-specific-setup/openclaw/nemotron-3-super-120b-managed-inference.json
+++ b/nemoclaw-blueprint/model-specific-setup/openclaw/nemotron-3-super-120b-managed-inference.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../schema.json",
+  "id": "nemotron-3-super-120b-managed-inference",
+  "agent": "openclaw",
+  "description": "Disables OpenClaw's native code-based tool search for nvidia/nemotron-3-super-120b-a12b on the NemoClaw managed inference.local route. The model emits invalid JavaScript for the tool_search_code surface (CommonJS require, openclaw.tools.search called with an object, bad describe/call ids), flooding successful runs with '[tools] tool_search_code failed' errors (#4780); routing it back to the structured tool-calling surface avoids the noise.",
+  "match": {
+    "modelIds": ["nvidia/nemotron-3-super-120b-a12b"],
+    "providerKey": "inference",
+    "inferenceApi": "openai-completions",
+    "baseUrl": "https://inference.local/v1"
+  },
+  "effects": {
+    "openclawTools": {
+      "toolSearch": false
+    }
+  }
+}

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -1477,6 +1477,47 @@ describe("generate-openclaw-config.mts: config generation", () => {
     }
   }, 20_000);
 
+  // #4780: Nemotron generates invalid JS for OpenClaw's native code-based tool
+  // search (`tool_search_code`): CommonJS `require`, `openclaw.tools.search`
+  // called with an object instead of a string, `tool_describe`/`tool_call`
+  // invoked with bad ids. The run still succeeds via fallback, but the logs are
+  // flooded with `[tools] tool_search_code failed` errors. Disabling native
+  // tool search for this managed-inference route routes the model back to the
+  // structured tool-calling surface it handles correctly.
+  it("disables native OpenClaw Tool Search for Nemotron managed inference (#4780)", () => {
+    const config = runConfigScript({
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_PROVIDER_KEY: "inference",
+      NEMOCLAW_PRIMARY_MODEL_REF: "inference/nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+      NEMOCLAW_INFERENCE_API: "openai-completions",
+    });
+
+    expect(config.tools?.toolSearch).toBe(false);
+  });
+
+  it("does not disable native Tool Search for Nemotron on non-matching routes (#4780)", () => {
+    const cases = [
+      { NEMOCLAW_MODEL: "nvidia/nemotron-3-nano:30b" },
+      { NEMOCLAW_PROVIDER_KEY: "nvidia" },
+      { NEMOCLAW_INFERENCE_API: "responses" },
+      { NEMOCLAW_INFERENCE_BASE_URL: "https://integrate.api.nvidia.com/v1" },
+    ];
+
+    for (const envCase of cases) {
+      const config = runConfigScript({
+        NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+        NEMOCLAW_PROVIDER_KEY: "inference",
+        NEMOCLAW_PRIMARY_MODEL_REF: "inference/nvidia/nemotron-3-super-120b-a12b",
+        NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+        NEMOCLAW_INFERENCE_API: "openai-completions",
+        ...envCase,
+      });
+
+      expect(config.tools?.toolSearch).toBe(true);
+    }
+  }, 20_000);
+
   it("rejects model-specific setup manifests without a known agent", () => {
     const blueprintDir = path.join(tmpDir, "fixture-blueprint");
     const registryDir = writeRegistryManifest(


### PR DESCRIPTION
## Summary
On the NemoClaw managed `inference.local` route, `nvidia/nemotron-3-super-120b-a12b` floods otherwise-successful agent runs with repeated `[tools] tool_search_code failed` errors because it generates invalid JavaScript for OpenClaw's native code-based tool search. This adds a model-specific-setup manifest that disables native tool search for that route, routing the model back to the structured tool-calling surface it handles correctly.

## Related Issue
Fixes #4780

## Changes
- Add `nemoclaw-blueprint/model-specific-setup/openclaw/nemotron-3-super-120b-managed-inference.json` setting `effects.openclawTools.toolSearch: false` for the Nemotron managed inference route (`providerKey: inference`, `inferenceApi: openai-completions`, `baseUrl: https://inference.local/v1`), mirroring the existing `kimi-k2.6-managed-inference.json` precedent.
- Add regression tests in `test/generate-openclaw-config.test.ts`: one asserting `tools.toolSearch === false` for the Nemotron managed route, and one asserting non-matching routes (different model, provider, API, or base URL) keep `toolSearch === true`.

### Root cause
`scripts/generate-openclaw-config.mts` defaults `tools.toolSearch: true`, which enables OpenClaw's native code-based `tool_search_code`. That surface requires the model to emit JS calling `openclaw.tools.search/describe/call`. Nemotron emits invalid JS for it (CommonJS `require`, `search` called with `{ query }` instead of a string, bad `describe`/`call` ids), producing the noisy failures. The `openclaw.tools.*` API is OpenClaw-native, and NemoClaw's own compact-catalog patch intentionally skips when native tool search is present, so the `toolSearch` config flag is the correct NemoClaw-side lever — the same one used for Kimi K2.6.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Honest status: see notes below. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

**Verification notes:**
- The commit's pre-commit hook passed. `prek run` on the changed files passed; I did not record a clean `prek run --all-files` because that hook set scans pre-existing untracked worktree directories in my local checkout that are unrelated to this change.
- The suites that exercise this change all pass locally: `generate-openclaw-config.test.ts` (incl. the two new #4780 tests), `validate-config-schemas.test.ts` (validates the new manifest against `schema.json`), `generate-hermes-config.test.ts`, and `openclaw-tool-catalog-patch.test.ts`.
- The full `npm test` shows 17 pre-existing, environment-dependent failures unrelated to this change (blocked network egress to `api.telegram.org`/Slack/OpenAI, no running Docker/gateway, and an unbuilt `nemoclaw/dist` for `ssrf-parity.test.ts`). A declarative JSON manifest plus a config-generation test cannot affect those paths. CI should run them in a complete environment.

---
Signed-off-by: Jason Ma <jama@nvidia.com>