### PR TITLE
fix(vllm): switch DGX Spark from upstream nightly build to NGC vllm 26.05.post1

### DIFF
--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -49,10 +49,10 @@ export interface VllmProfile {
   loadTimeoutSec: number;
 }
 
-// vllm 0.21.1rc1.dev323+g1fc2cee50
-const UPSTREAM_VLLM_IMAGE =
-  "vllm/vllm-openai:nightly-1fc2cee50a09a094b9f2bbdfcb0ab0cadb536712";
-const NGC_VLLM_IMAGE = "nvcr.io/nvidia/vllm:26.03.post1-py3";
+const VLLM_IMAGES = {
+  ngc2603Post1: "nvcr.io/nvidia/vllm:26.03.post1-py3",
+  ngc2605Post1: "nvcr.io/nvidia/vllm:26.05.post1-py3",
+} as const;
 
 function nemotronNanoModel(): VllmModelDef {
   const match = VLLM_MODELS.find((m) => m.envValue === "nemotron-3-nano-4b");
@@ -114,7 +114,7 @@ export function buildHfTokenForwardEnv(
 
 const SPARK_PROFILE: VllmProfile = {
   name: "DGX Spark",
-  image: UPSTREAM_VLLM_IMAGE,
+  image: VLLM_IMAGES.ngc2605Post1,
   defaultModel: qwen35bNvfp4Model(),
   containerName: "nemoclaw-vllm",
   dockerRunFlags: [
@@ -133,7 +133,7 @@ const SPARK_PROFILE: VllmProfile = {
 // DGX Station.
 const STATION_PROFILE: VllmProfile = {
   name: "DGX Station",
-  image: NGC_VLLM_IMAGE,
+  image: VLLM_IMAGES.ngc2603Post1,
   defaultModel: DEFAULT_VLLM_MODEL,
   containerName: "nemoclaw-vllm",
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
@@ -163,7 +163,7 @@ const STATION_PROFILE: VllmProfile = {
 // most GPUs.
 const GENERIC_LINUX_PROFILE: VllmProfile = {
   name: "Linux + NVIDIA GPU",
-  image: NGC_VLLM_IMAGE,
+  image: VLLM_IMAGES.ngc2603Post1,
   defaultModel: nemotronNanoModel(),
   containerName: "nemoclaw-vllm",
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,

--- a/test/detect-vllm-profile.test.ts
+++ b/test/detect-vllm-profile.test.ts
@@ -15,9 +15,7 @@ describe("detectVllmProfile", () => {
     expect(profile).not.toBeNull();
     expect(profile!.name).toBe("DGX Spark");
     expect(profile!.defaultModel.id).toBe("nvidia/Qwen3.6-35B-A3B-NVFP4");
-    expect(profile!.image).toBe(
-      "vllm/vllm-openai:nightly-1fc2cee50a09a094b9f2bbdfcb0ab0cadb536712",
-    );
+    expect(profile!.image).toBe("nvcr.io/nvidia/vllm:26.05.post1-py3");
   });
 
   it("returns the Spark profile when legacy gpu.spark is true", () => {
@@ -30,7 +28,6 @@ describe("detectVllmProfile", () => {
     const profile = detectVllmProfile({ platform: "station", type: "nvidia" });
     expect(profile).not.toBeNull();
     expect(profile!.name).toBe("DGX Station");
-    // Station is unchanged by the Spark NVFP4 move: NGC image + Qwen3.6-27B.
     expect(profile!.image).toBe("nvcr.io/nvidia/vllm:26.03.post1-py3");
     expect(profile!.defaultModel.id).toBe("Qwen/Qwen3.6-27B-FP8");
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Switches the DGX Spark vLLM profile from the upstream `vllm/vllm-openai` nightly  to the stable NGC release `nvcr.io/nvidia/vllm:26.05.post1-py3

## Changes
- Added a `VLLM_IMAGES` map for profile-specific vLLM image selection.
- Updated the DGX Spark profile to use `nvcr.io/nvidia/vllm:26.05.post1-py3`.
- Updated vLLM profile detection tests for the Spark image change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized and updated vLLM container image configuration for supported platforms.

* **Tests**
  * Updated vLLM profile detection tests with latest supported container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->