### PR TITLE
fix(inference): sync anthropic runtime routes

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -55,6 +55,9 @@
 #   hermes-inference-switch-e2e
 #                            Switches a running Hermes sandbox with `nemohermes inference set`
 #                            and verifies route, config.yaml, hashes, and live requests.
+#   hermes-anthropic-inference-switch-e2e
+#                            Switches a running Hermes sandbox to a compatible
+#                            Anthropic Messages provider and verifies agent traffic.
 #   hermes-discord-e2e       Hermes Discord onboarding — validates the top-level Hermes
 #                            Discord schema plus OpenShell placeholder/token isolation.
 #   hermes-slack-e2e         Hermes Slack onboarding — validates the Hermes Slack policy,
@@ -62,6 +65,9 @@
 #   openclaw-inference-switch-e2e
 #                            Switches a running OpenClaw sandbox with `nemoclaw inference set`
 #                            and verifies route, openclaw.json, hashes, and live requests.
+#   openclaw-anthropic-inference-switch-e2e
+#                            Switches a running OpenClaw sandbox to a compatible
+#                            Anthropic Messages provider and verifies agent traffic.
 #   issue-4434-tui-unreachable-inference-e2e
 #                            Recreates #4434's NVIDIA endpoint firewall block and verifies
 #                            OpenClaw TUI shows a visible error and stops the active spinner.
@@ -108,8 +114,10 @@ on:
           token-rotation-e2e, sandbox-survival-e2e, issue-2478-crash-loop-recovery-e2e,
           hermes-e2e, hermes-dashboard-e2e, hermes-root-entrypoint-smoke-e2e,
           openclaw-onboard-security-posture-e2e, hermes-onboard-security-posture-e2e,
-          hermes-inference-switch-e2e, hermes-discord-e2e, hermes-slack-e2e,
-          sandbox-operations-e2e, inference-routing-e2e, openclaw-inference-switch-e2e,
+          hermes-inference-switch-e2e, hermes-anthropic-inference-switch-e2e,
+          hermes-discord-e2e, hermes-slack-e2e, sandbox-operations-e2e,
+          inference-routing-e2e, openclaw-inference-switch-e2e,
+          openclaw-anthropic-inference-switch-e2e,
           network-policy-e2e, state-backup-restore-e2e, tunnel-lifecycle-e2e,
           diagnostics-e2e, credential-migration-e2e, snapshot-commands-e2e,
           shields-config-e2e, vm-driver-privileged-exec-routing-e2e, rebuild-openclaw-e2e,
@@ -995,6 +1003,22 @@ jobs:
       nvidia_api_key: true
       github_token: true
     secrets: *nightly-e2e-default-secrets
+  hermes-anthropic-inference-switch-e2e:
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'workflow_dispatch' ||
+       inputs.jobs == '' ||
+       contains(format(',{0},', inputs.jobs), ',hermes-anthropic-inference-switch-e2e,'))
+    uses: ./.github/workflows/e2e-script.yaml
+    with:
+      ref: ${{ inputs.target_ref || github.ref }}
+      script: test/e2e/test-hermes-inference-switch.sh
+      timeout_minutes: 60
+      artifact_name: "hermes-anthropic-inference-switch-install-log"
+      artifact_path: "/tmp/nemoclaw-e2e-hermes-inference-switch-install.log"
+      env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_AGENT":"hermes","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-hermes-anthropic-inference-switch","NEMOCLAW_SWITCH_INFERENCE_API":"anthropic-messages","NEMOCLAW_SWITCH_MOCK_ANTHROPIC":"1","NEMOCLAW_SWITCH_MODEL":"mock-anthropic-model","NEMOCLAW_SWITCH_PROVIDER":"compatible-anthropic-endpoint"}'
+      nvidia_api_key: true
+      github_token: true
+    secrets: *nightly-e2e-default-secrets
   hermes-discord-e2e:
     if: >-
       github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'workflow_dispatch' ||
@@ -1302,6 +1326,21 @@ jobs:
       artifact_name: "openclaw-inference-switch-install-log"
       artifact_path: "/tmp/nemoclaw-e2e-openclaw-inference-switch-install.log"
       env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-openclaw-inference-switch"}'
+      nvidia_api_key: true
+      github_token: true
+    secrets: *nightly-e2e-default-secrets
+  openclaw-anthropic-inference-switch-e2e:
+    if: >-
+      github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'workflow_dispatch' ||
+       inputs.jobs == '' ||
+       contains(format(',{0},', inputs.jobs), ',openclaw-anthropic-inference-switch-e2e,'))
+    uses: ./.github/workflows/e2e-script.yaml
+    with:
+      ref: ${{ inputs.target_ref || github.ref }}
+      script: test/e2e/test-openclaw-inference-switch.sh
+      artifact_name: "openclaw-anthropic-inference-switch-install-log"
+      artifact_path: "/tmp/nemoclaw-e2e-openclaw-inference-switch-install.log"
+      env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-openclaw-anthropic-inference-switch","NEMOCLAW_SWITCH_INFERENCE_API":"anthropic-messages","NEMOCLAW_SWITCH_MOCK_ANTHROPIC":"1","NEMOCLAW_SWITCH_MODEL":"mock-anthropic-model","NEMOCLAW_SWITCH_PROVIDER":"compatible-anthropic-endpoint"}'
       nvidia_api_key: true
       github_token: true
     secrets: *nightly-e2e-default-secrets
@@ -2044,11 +2083,13 @@ jobs:
         openclaw-onboard-security-posture-e2e,
         hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
+        hermes-anthropic-inference-switch-e2e,
         hermes-discord-e2e,
         hermes-slack-e2e,
         sandbox-operations-e2e,
         inference-routing-e2e,
         openclaw-inference-switch-e2e,
+        openclaw-anthropic-inference-switch-e2e,
         network-policy-e2e,
         state-backup-restore-e2e,
         tunnel-lifecycle-e2e,
@@ -2155,11 +2196,13 @@ jobs:
         openclaw-onboard-security-posture-e2e,
         hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
+        hermes-anthropic-inference-switch-e2e,
         hermes-discord-e2e,
         hermes-slack-e2e,
         sandbox-operations-e2e,
         inference-routing-e2e,
         openclaw-inference-switch-e2e,
+        openclaw-anthropic-inference-switch-e2e,
         network-policy-e2e,
         state-backup-restore-e2e,
         tunnel-lifecycle-e2e,
@@ -2323,11 +2366,13 @@ jobs:
         openclaw-onboard-security-posture-e2e,
         hermes-onboard-security-posture-e2e,
         hermes-inference-switch-e2e,
+        hermes-anthropic-inference-switch-e2e,
         hermes-discord-e2e,
         hermes-slack-e2e,
         sandbox-operations-e2e,
         inference-routing-e2e,
         openclaw-inference-switch-e2e,
+        openclaw-anthropic-inference-switch-e2e,
         network-policy-e2e,
         state-backup-restore-e2e,
         tunnel-lifecycle-e2e,

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1017,7 +1017,6 @@ jobs:
       artifact_path: "/tmp/nemoclaw-e2e-hermes-inference-switch-install.log"
       env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_AGENT":"hermes","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-hermes-anthropic-inference-switch","NEMOCLAW_SWITCH_INFERENCE_API":"anthropic-messages","NEMOCLAW_SWITCH_MOCK_ANTHROPIC":"1","NEMOCLAW_SWITCH_MODEL":"mock-anthropic-model","NEMOCLAW_SWITCH_PROVIDER":"compatible-anthropic-endpoint"}'
       nvidia_api_key: true
-      github_token: true
     secrets: *nightly-e2e-default-secrets
   hermes-discord-e2e:
     if: >-
@@ -1340,9 +1339,8 @@ jobs:
       script: test/e2e/test-openclaw-inference-switch.sh
       artifact_name: "openclaw-anthropic-inference-switch-install-log"
       artifact_path: "/tmp/nemoclaw-e2e-openclaw-inference-switch-install.log"
-      env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-openclaw-anthropic-inference-switch","NEMOCLAW_SWITCH_INFERENCE_API":"anthropic-messages","NEMOCLAW_SWITCH_MOCK_ANTHROPIC":"1","NEMOCLAW_SWITCH_MODEL":"mock-anthropic-model","NEMOCLAW_SWITCH_PROVIDER":"compatible-anthropic-endpoint"}'
+      env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_AGENT":"openclaw","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_SANDBOX_NAME":"e2e-openclaw-anthropic-inference-switch","NEMOCLAW_SWITCH_INFERENCE_API":"anthropic-messages","NEMOCLAW_SWITCH_MOCK_ANTHROPIC":"1","NEMOCLAW_SWITCH_MODEL":"mock-anthropic-model","NEMOCLAW_SWITCH_PROVIDER":"compatible-anthropic-endpoint"}'
       nvidia_api_key: true
-      github_token: true
     secrets: *nightly-e2e-default-secrets
   network-policy-e2e:
     if: >-

--- a/src/lib/actions/inference-route-api.test.ts
+++ b/src/lib/actions/inference-route-api.test.ts
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import type { ConfigObject } from "../security/credential-filter";
+import type { Session } from "../state/onboard-session";
+import { hermesApiMode, normalizeInferenceApi, resolveRuntimeInferenceApi } from "./inference-route-api";
+
+vi.mock("../inference/local", () => ({
+  DEFAULT_OLLAMA_MODEL: "llama3.1",
+}));
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    version: 1,
+    sessionId: "session-1",
+    resumable: true,
+    status: "complete",
+    mode: "onboard",
+    startedAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T00:00:00.000Z",
+    lastStepStarted: null,
+    lastCompletedStep: null,
+    failure: null,
+    agent: "openclaw",
+    sandboxName: "alpha",
+    provider: "compatible-anthropic-endpoint",
+    model: "old-model",
+    endpointUrl: "https://inference.local/v1",
+    credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+    hermesAuthMethod: null,
+    preferredInferenceApi: "openai-completions",
+    nimContainer: null,
+    routerPid: null,
+    routerCredentialHash: null,
+    webSearchConfig: null,
+    policyPresets: null,
+    messagingChannels: null,
+    messagingChannelConfig: null,
+    disabledChannels: null,
+    migratedLegacyValueHashes: null,
+    hermesToolGateways: null,
+    gpuPassthrough: false,
+    telegramConfig: null,
+    wechatConfig: null,
+    metadata: { gatewayName: "nemoclaw", fromDockerfile: null },
+    machine: {
+      version: 1,
+      state: "complete",
+      stateEnteredAt: "2026-05-11T00:00:00.000Z",
+      revision: 0,
+    },
+    steps: {},
+    ...overrides,
+  } as Session;
+}
+
+function resolve(config: ConfigObject, overrides: Partial<Parameters<typeof resolveRuntimeInferenceApi>[0]> = {}) {
+  return resolveRuntimeInferenceApi({
+    agentName: "openclaw",
+    config,
+    currentProvider: "compatible-anthropic-endpoint",
+    provider: "compatible-anthropic-endpoint",
+    sandboxName: "alpha",
+    session: null,
+    ...overrides,
+  });
+}
+
+describe("normalizeInferenceApi", () => {
+  it("accepts supported route API names only", () => {
+    expect(normalizeInferenceApi("openai-completions")).toBe("openai-completions");
+    expect(normalizeInferenceApi("anthropic-messages")).toBe("anthropic-messages");
+    expect(normalizeInferenceApi("openai-responses")).toBe("openai-responses");
+    expect(normalizeInferenceApi("openai")).toBeNull();
+    expect(normalizeInferenceApi(null)).toBeNull();
+  });
+});
+
+describe("resolveRuntimeInferenceApi", () => {
+  it("uses matching onboard session route API before config fallbacks", () => {
+    expect(
+      resolve(
+        {
+          agents: { defaults: { model: { primary: "anthropic/old-model" } } },
+          models: {
+            providers: {
+              anthropic: { api: "anthropic-messages" },
+            },
+          },
+        },
+        {
+          session: session({ preferredInferenceApi: "openai-completions" }),
+        },
+      ),
+    ).toBe("openai-completions");
+  });
+
+  it("defaults compatible Anthropic provider-family switches to Anthropic Messages", () => {
+    expect(
+      resolve(
+        {},
+        {
+          currentProvider: "nvidia-prod",
+          session: session({ provider: "nvidia-prod", preferredInferenceApi: "openai-completions" }),
+        },
+      ),
+    ).toBe("anthropic-messages");
+  });
+
+  it("uses OpenClaw primary inference refs before stale Anthropic provider blocks", () => {
+    expect(
+      resolve({
+        agents: {
+          defaults: {
+            model: { primary: "inference/anthropic.claude-3-5-sonnet-20240620-v1:0" },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: { api: "anthropic-messages" },
+            inference: { api: "openai-completions" },
+          },
+        },
+      }),
+    ).toBe("openai-completions");
+  });
+
+  it("uses OpenClaw primary Anthropic refs before stale inference provider blocks", () => {
+    expect(
+      resolve({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-proxy" },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: { api: "anthropic-messages" },
+            inference: { api: "openai-completions" },
+          },
+        },
+      }),
+    ).toBe("anthropic-messages");
+  });
+
+  it("does not let malformed inference provider blocks select a stale Anthropic family", () => {
+    expect(
+      resolve({
+        agents: {
+          defaults: {
+            model: { primary: "inference/anthropic.claude-3-5-sonnet-20240620-v1:0" },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: { api: "anthropic-messages" },
+            inference: null,
+          },
+        },
+      }),
+    ).toBe("openai-completions");
+  });
+
+  it("preserves OpenAI Responses when the active inference provider block uses it", () => {
+    expect(
+      resolve({
+        agents: {
+          defaults: {
+            model: { primary: "inference/openai/gpt-5.4" },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: { api: "anthropic-messages" },
+            inference: { api: "openai-responses" },
+          },
+        },
+      }),
+    ).toBe("openai-responses");
+  });
+
+  it("reads Hermes api_mode for same-provider Hermes switches", () => {
+    expect(
+      resolve(
+        { model: { api_mode: "anthropic_messages" } },
+        { agentName: "hermes", session: null },
+      ),
+    ).toBe("anthropic-messages");
+  });
+});
+
+describe("hermesApiMode", () => {
+  it("maps managed route API values to Hermes config modes", () => {
+    expect(hermesApiMode("openai-completions")).toBeNull();
+    expect(hermesApiMode("anthropic-messages")).toBe("anthropic_messages");
+    expect(hermesApiMode("openai-responses")).toBe("codex_responses");
+  });
+});

--- a/src/lib/actions/inference-route-api.ts
+++ b/src/lib/actions/inference-route-api.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getSandboxInferenceConfig } from "../inference/config";
+import type { ConfigObject } from "../security/credential-filter";
+import { isConfigObject } from "../security/credential-filter";
+import type { Session } from "../state/onboard-session";
+
+export type InferenceApi = "openai-completions" | "anthropic-messages" | "openai-responses";
+
+const SUPPORTED_INFERENCE_APIS = new Set<InferenceApi>([
+  "openai-completions",
+  "anthropic-messages",
+  "openai-responses",
+]);
+
+export function normalizeInferenceApi(value: unknown): InferenceApi | null {
+  return typeof value === "string" && SUPPORTED_INFERENCE_APIS.has(value as InferenceApi)
+    ? (value as InferenceApi)
+    : null;
+}
+
+function readProviderApi(config: ConfigObject, providerKey: string): InferenceApi | null {
+  const models = config.models;
+  if (!isConfigObject(models)) return null;
+  const providers = models.providers;
+  if (!isConfigObject(providers)) return null;
+  const provider = providers[providerKey];
+  if (!isConfigObject(provider)) return null;
+  return normalizeInferenceApi(provider.api);
+}
+
+function readOpenClawPrimaryProviderKey(config: ConfigObject): "anthropic" | "inference" | null {
+  const agents = config.agents;
+  if (!isConfigObject(agents)) return null;
+  const defaults = agents.defaults;
+  if (!isConfigObject(defaults)) return null;
+  const model = defaults.model;
+  if (!isConfigObject(model)) return null;
+  const primary = model.primary;
+  if (typeof primary !== "string") return null;
+
+  if (primary.startsWith("anthropic/")) return "anthropic";
+  if (primary.startsWith("inference/")) return "inference";
+  return null;
+}
+
+function readOpenClawPrimaryRouteApi(config: ConfigObject): InferenceApi | null {
+  const providerKey = readOpenClawPrimaryProviderKey(config);
+  if (providerKey === "anthropic") {
+    return "anthropic-messages";
+  }
+  if (providerKey === "inference") {
+    const api = readProviderApi(config, "inference");
+    return api === "openai-responses" ? "openai-responses" : "openai-completions";
+  }
+  return null;
+}
+
+function readOpenClawRouteApi(config: ConfigObject, provider: string): InferenceApi | null {
+  if (provider === "anthropic-prod") return readProviderApi(config, "anthropic");
+  if (provider === "compatible-anthropic-endpoint") {
+    // Source-of-truth boundary: old sandboxes may only have config state, not
+    // session preferredInferenceApi. In OpenClaw config, the active provider
+    // family is the primary model ref. Provider blocks are merged and may
+    // contain stale sibling entries, so read them only after the primary ref.
+    return (
+      readOpenClawPrimaryRouteApi(config) ||
+      readProviderApi(config, "anthropic") ||
+      readProviderApi(config, "inference")
+    );
+  }
+  return readProviderApi(config, getSandboxInferenceConfig("", provider).providerKey);
+}
+
+function readHermesRouteApi(config: ConfigObject): InferenceApi | null {
+  const model = config.model;
+  if (!isConfigObject(model)) return null;
+  switch (model.api_mode) {
+    case "anthropic_messages":
+      return "anthropic-messages";
+    case "codex_responses":
+      return "openai-responses";
+    case undefined:
+    case null:
+    case "":
+      return "openai-completions";
+    default:
+      return null;
+  }
+}
+
+function sessionRouteApi(
+  session: Session | null,
+  sandboxName: string,
+  provider: string,
+): InferenceApi | null {
+  if (!session || session.sandboxName !== sandboxName || session.provider !== provider) return null;
+  return normalizeInferenceApi(session.preferredInferenceApi);
+}
+
+export function resolveRuntimeInferenceApi(options: {
+  agentName: string;
+  config: ConfigObject;
+  currentProvider: string | null | undefined;
+  provider: string;
+  sandboxName: string;
+  session: Session | null;
+}): InferenceApi | null {
+  const { agentName, config, currentProvider, provider, sandboxName, session } = options;
+  if (provider === "anthropic-prod") return "anthropic-messages";
+
+  const sameProvider = currentProvider === provider;
+  const sessionApi = sameProvider ? sessionRouteApi(session, sandboxName, provider) : null;
+  if (sessionApi) return sessionApi;
+
+  const configApi =
+    sameProvider && agentName === "hermes"
+      ? readHermesRouteApi(config)
+      : sameProvider
+        ? readOpenClawRouteApi(config, provider)
+        : null;
+  if (configApi) return configApi;
+
+  if (provider === "compatible-anthropic-endpoint") return "anthropic-messages";
+  return null;
+}
+
+export function hermesApiMode(inferenceApi: string): string | null {
+  switch (inferenceApi) {
+    case "":
+    case "openai-completions":
+      return null;
+    case "anthropic-messages":
+      return "anthropic_messages";
+    case "openai-responses":
+      return "codex_responses";
+    default:
+      return null;
+  }
+}

--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -295,6 +295,73 @@ describe("patchHermesInferenceConfig", () => {
     });
     expect(config.terminal).toEqual({ backend: "local" });
   });
+
+  it("sets Hermes Anthropic Messages mode for Anthropic routes", () => {
+    const config: ConfigObject = {
+      model: {
+        default: "openai/gpt-5.4-mini",
+        provider: "custom",
+        base_url: "https://inference.local/v1",
+      },
+    };
+
+    const result = patchHermesInferenceConfig(config, "anthropic-prod", "claude-sonnet-4-6");
+
+    expect(result.route).toMatchObject({
+      providerKey: "anthropic",
+      primaryModelRef: "anthropic/claude-sonnet-4-6",
+      inferenceBaseUrl: "https://inference.local",
+      inferenceApi: "anthropic-messages",
+    });
+    expect(config.model).toEqual({
+      default: "claude-sonnet-4-6",
+      provider: "custom",
+      base_url: "https://inference.local",
+      api_mode: "anthropic_messages",
+    });
+  });
+
+  it("clears stale Hermes API mode when switching back to OpenAI-style routes", () => {
+    const config: ConfigObject = {
+      model: {
+        default: "claude-sonnet-4-6",
+        provider: "custom",
+        base_url: "https://inference.local",
+        api_mode: "anthropic_messages",
+      },
+    };
+
+    patchHermesInferenceConfig(config, "nvidia-prod", "nvidia/nemotron-3-super-120b-a12b");
+
+    expect(config.model).toEqual({
+      default: "nvidia/nemotron-3-super-120b-a12b",
+      provider: "custom",
+      base_url: "https://inference.local/v1",
+    });
+  });
+
+  it("keeps Bedrock Runtime adapter routes OpenAI-compatible for Hermes", () => {
+    const config: ConfigObject = { model: {} };
+
+    const result = patchHermesInferenceConfig(
+      config,
+      "compatible-anthropic-endpoint",
+      "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      "openai-completions",
+    );
+
+    expect(result.route).toMatchObject({
+      providerKey: "inference",
+      primaryModelRef: "inference/anthropic.claude-3-5-sonnet-20240620-v1:0",
+      inferenceBaseUrl: "https://inference.local/v1",
+      inferenceApi: "openai-completions",
+    });
+    expect(config.model).toEqual({
+      default: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      provider: "custom",
+      base_url: "https://inference.local/v1",
+    });
+  });
 });
 
 describe("runInferenceSet", () => {
@@ -435,6 +502,7 @@ describe("runInferenceSet", () => {
       provider: "hermes-provider",
       model: "openai/gpt-5.4-mini",
       endpointUrl: "https://inference.local/v1",
+      preferredInferenceApi: "openai-completions",
     });
     expect(deps.calls.appendAuditEntry).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -451,6 +519,232 @@ describe("runInferenceSet", () => {
       providerKey: "inference",
       configChanged: true,
       sessionUpdated: true,
+    });
+  });
+
+  it("syncs OpenClaw compatible Anthropic switches to Anthropic Messages when changing provider families", async () => {
+    const config: ConfigObject = {
+      agents: { defaults: { model: { primary: "inference/nvidia/model-a" } } },
+      models: {
+        providers: {
+          inference: {
+            baseUrl: "https://inference.local/v1",
+            api: "openai-completions",
+            models: [{ id: "nvidia/model-a", name: "inference/nvidia/model-a" }],
+          },
+        },
+      },
+    };
+    const deps = createDeps({ config, session: baseSession() });
+
+    const result = await runInferenceSet(
+      {
+        provider: "compatible-anthropic-endpoint",
+        model: "claude-sonnet-proxy",
+        noVerify: true,
+      },
+      deps,
+    );
+
+    expect(config.agents).toEqual({
+      defaults: { model: { primary: "anthropic/claude-sonnet-proxy" } },
+    });
+    expect(config.models).toEqual({
+      mode: "merge",
+      providers: {
+        inference: {
+          baseUrl: "https://inference.local/v1",
+          api: "openai-completions",
+          models: [{ id: "nvidia/model-a", name: "inference/nvidia/model-a" }],
+        },
+        anthropic: {
+          baseUrl: "https://inference.local",
+          apiKey: "unused",
+          api: "anthropic-messages",
+          models: [{ id: "claude-sonnet-proxy", name: "anthropic/claude-sonnet-proxy" }],
+        },
+      },
+    });
+    expect(deps.getSession()).toMatchObject({
+      provider: "compatible-anthropic-endpoint",
+      model: "claude-sonnet-proxy",
+      preferredInferenceApi: "anthropic-messages",
+    });
+    expect(result).toMatchObject({
+      providerKey: "anthropic",
+      primaryModelRef: "anthropic/claude-sonnet-proxy",
+    });
+  });
+
+  it("preserves same-provider Bedrock Runtime adapter routing for OpenClaw switches", async () => {
+    const config: ConfigObject = {
+      agents: {
+        defaults: {
+          model: { primary: "inference/anthropic.claude-3-5-sonnet-20240620-v1:0" },
+        },
+      },
+      models: {
+        providers: {
+          inference: {
+            baseUrl: "https://inference.local/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                name: "inference/anthropic.claude-3-5-sonnet-20240620-v1:0",
+              },
+            ],
+          },
+        },
+      },
+    };
+    const deps = createDeps({
+      config,
+      entry: {
+        name: "alpha",
+        agent: "openclaw",
+        provider: "compatible-anthropic-endpoint",
+        model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      },
+      session: baseSession({
+        provider: "compatible-anthropic-endpoint",
+        model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        preferredInferenceApi: "openai-completions",
+      }),
+    });
+
+    const result = await runInferenceSet(
+      {
+        provider: "compatible-anthropic-endpoint",
+        model: "anthropic.claude-sonnet-4-6-20260101-v1:0",
+        noVerify: true,
+      },
+      deps,
+    );
+
+    expect(config.agents).toEqual({
+      defaults: {
+        model: { primary: "inference/anthropic.claude-sonnet-4-6-20260101-v1:0" },
+      },
+    });
+    expect(config.models).toMatchObject({
+      providers: {
+        inference: {
+          baseUrl: "https://inference.local/v1",
+          api: "openai-completions",
+          models: [
+            {
+              id: "anthropic.claude-sonnet-4-6-20260101-v1:0",
+              name: "inference/anthropic.claude-sonnet-4-6-20260101-v1:0",
+            },
+          ],
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      providerKey: "inference",
+      primaryModelRef: "inference/anthropic.claude-sonnet-4-6-20260101-v1:0",
+    });
+  });
+
+  it("syncs Hermes compatible Anthropic switches to Anthropic Messages when changing provider families", async () => {
+    const config: ConfigObject = {
+      model: {
+        default: "openai/gpt-5.4-mini",
+        provider: "custom",
+        base_url: "https://inference.local/v1",
+      },
+    };
+    const deps = createDeps({
+      config,
+      entry: {
+        name: "hermes",
+        agent: "hermes",
+        provider: "hermes-provider",
+        model: "openai/gpt-5.4-mini",
+      },
+      defaultSandbox: "hermes",
+      target: HERMES_TARGET,
+      session: baseSession({
+        agent: "hermes",
+        sandboxName: "hermes",
+        provider: "hermes-provider",
+        model: "openai/gpt-5.4-mini",
+      }),
+    });
+
+    const result = await runInferenceSet(
+      {
+        provider: "compatible-anthropic-endpoint",
+        model: "claude-sonnet-proxy",
+        sandboxName: "hermes",
+        noVerify: true,
+      },
+      deps,
+    );
+
+    expect(config.model).toEqual({
+      default: "claude-sonnet-proxy",
+      provider: "custom",
+      base_url: "https://inference.local",
+      api_mode: "anthropic_messages",
+    });
+    expect(deps.getSession()).toMatchObject({
+      provider: "compatible-anthropic-endpoint",
+      model: "claude-sonnet-proxy",
+      preferredInferenceApi: "anthropic-messages",
+    });
+    expect(result).toMatchObject({
+      providerKey: "anthropic",
+      primaryModelRef: "anthropic/claude-sonnet-proxy",
+    });
+  });
+
+  it("preserves same-provider Bedrock Runtime adapter routing for Hermes switches", async () => {
+    const config: ConfigObject = {
+      model: {
+        default: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        provider: "custom",
+        base_url: "https://inference.local/v1",
+      },
+    };
+    const deps = createDeps({
+      config,
+      entry: {
+        name: "hermes",
+        agent: "hermes",
+        provider: "compatible-anthropic-endpoint",
+        model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      },
+      defaultSandbox: "hermes",
+      target: HERMES_TARGET,
+      session: baseSession({
+        agent: "hermes",
+        sandboxName: "hermes",
+        provider: "compatible-anthropic-endpoint",
+        model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        preferredInferenceApi: "openai-completions",
+      }),
+    });
+
+    const result = await runInferenceSet(
+      {
+        provider: "compatible-anthropic-endpoint",
+        model: "anthropic.claude-sonnet-4-6-20260101-v1:0",
+        sandboxName: "hermes",
+        noVerify: true,
+      },
+      deps,
+    );
+
+    expect(config.model).toEqual({
+      default: "anthropic.claude-sonnet-4-6-20260101-v1:0",
+      provider: "custom",
+      base_url: "https://inference.local/v1",
+    });
+    expect(result).toMatchObject({
+      providerKey: "inference",
+      primaryModelRef: "inference/anthropic.claude-sonnet-4-6-20260101-v1:0",
     });
   });
 

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -44,6 +44,7 @@ export interface InferenceSetResult {
 }
 
 type OpenshellRunResult = Pick<SpawnSyncReturns<string>, "status" | "stdout" | "stderr">;
+type InferenceApi = "openai-completions" | "anthropic-messages" | "openai-responses";
 
 export interface InferenceSetDeps {
   getDefaultSandbox: () => string | null;
@@ -91,6 +92,12 @@ const SUPPORTED_PROVIDER_NAMES = [
   "ollama-local",
   "vllm-local",
 ] as const;
+
+const SUPPORTED_INFERENCE_APIS = new Set<InferenceApi>([
+  "openai-completions",
+  "anthropic-messages",
+  "openai-responses",
+]);
 
 function defaultDeps(): InferenceSetDeps {
   return {
@@ -208,6 +215,97 @@ function asConfigObject(value: Record<string, unknown>): ConfigObject {
   return result;
 }
 
+function normalizeInferenceApi(value: unknown): InferenceApi | null {
+  return typeof value === "string" && SUPPORTED_INFERENCE_APIS.has(value as InferenceApi)
+    ? (value as InferenceApi)
+    : null;
+}
+
+function readProviderApi(config: ConfigObject, providerKey: string): InferenceApi | null {
+  const models = config.models;
+  if (!isConfigObject(models)) return null;
+  const providers = models.providers;
+  if (!isConfigObject(providers)) return null;
+  const provider = providers[providerKey];
+  if (!isConfigObject(provider)) return null;
+  return normalizeInferenceApi(provider.api);
+}
+
+function readOpenClawRouteApi(config: ConfigObject, provider: string): InferenceApi | null {
+  if (provider === "anthropic-prod") return readProviderApi(config, "anthropic");
+  if (provider === "compatible-anthropic-endpoint") {
+    return readProviderApi(config, "anthropic") || readProviderApi(config, "inference");
+  }
+  return readProviderApi(config, getSandboxInferenceConfig("", provider).providerKey);
+}
+
+function readHermesRouteApi(config: ConfigObject): InferenceApi | null {
+  const model = config.model;
+  if (!isConfigObject(model)) return null;
+  switch (model.api_mode) {
+    case "anthropic_messages":
+      return "anthropic-messages";
+    case "codex_responses":
+      return "openai-responses";
+    case undefined:
+    case null:
+    case "":
+      return "openai-completions";
+    default:
+      return null;
+  }
+}
+
+function sessionRouteApi(
+  session: onboardSession.Session | null,
+  sandboxName: string,
+  provider: string,
+): InferenceApi | null {
+  if (!session || session.sandboxName !== sandboxName || session.provider !== provider) return null;
+  return normalizeInferenceApi(session.preferredInferenceApi);
+}
+
+function resolveRuntimeInferenceApi(options: {
+  agentName: string;
+  config: ConfigObject;
+  currentProvider: string | null | undefined;
+  provider: string;
+  sandboxName: string;
+  session: onboardSession.Session | null;
+}): InferenceApi | null {
+  const { agentName, config, currentProvider, provider, sandboxName, session } = options;
+  if (provider === "anthropic-prod") return "anthropic-messages";
+
+  const sameProvider = currentProvider === provider;
+  const sessionApi = sameProvider ? sessionRouteApi(session, sandboxName, provider) : null;
+  if (sessionApi) return sessionApi;
+
+  const configApi =
+    sameProvider && agentName === "hermes"
+      ? readHermesRouteApi(config)
+      : sameProvider
+        ? readOpenClawRouteApi(config, provider)
+        : null;
+  if (configApi) return configApi;
+
+  if (provider === "compatible-anthropic-endpoint") return "anthropic-messages";
+  return null;
+}
+
+function hermesApiMode(inferenceApi: string): string | null {
+  switch (inferenceApi) {
+    case "":
+    case "openai-completions":
+      return null;
+    case "anthropic-messages":
+      return "anthropic_messages";
+    case "openai-responses":
+      return "codex_responses";
+    default:
+      return null;
+  }
+}
+
 function updateAgentPrimary(config: ConfigObject, primaryModelRef: string): void {
   const agents = ensureObject(config, "agents");
   const defaults = ensureObject(agents, "defaults");
@@ -263,13 +361,20 @@ export function patchHermesInferenceConfig(
   config: ConfigObject,
   provider: string,
   model: string,
+  preferredInferenceApi: string | null = null,
 ): { changed: boolean; route: SandboxInferenceConfig } {
   const before = JSON.stringify(config);
-  const route = getSandboxInferenceConfig(model, provider);
+  const route = getSandboxInferenceConfig(model, provider, preferredInferenceApi);
   const modelConfig = ensureObject(config, "model");
   modelConfig.default = model;
   modelConfig.base_url = route.inferenceBaseUrl;
   modelConfig.provider = "custom";
+  const apiMode = hermesApiMode(route.inferenceApi);
+  if (apiMode) {
+    modelConfig.api_mode = apiMode;
+  } else {
+    delete modelConfig.api_mode;
+  }
 
   return { changed: before !== JSON.stringify(config), route };
 }
@@ -278,6 +383,7 @@ function updateMatchingOnboardSession(
   sandboxName: string,
   provider: string,
   model: string,
+  route: SandboxInferenceConfig,
   deps: Pick<InferenceSetDeps, "loadSession" | "updateSession">,
 ): boolean {
   const session = deps.loadSession();
@@ -288,6 +394,7 @@ function updateMatchingOnboardSession(
     current.model = model;
     current.endpointUrl =
       getProviderSelectionConfig(provider, model)?.endpointUrl ?? current.endpointUrl;
+    current.preferredInferenceApi = route.inferenceApi;
     return current;
   });
   return true;
@@ -336,7 +443,7 @@ export async function runInferenceSet(
     );
   }
 
-  const { sandboxName, agentName } = resolveTargetSandbox(options.sandboxName, deps);
+  const { sandboxName, entry, agentName } = resolveTargetSandbox(options.sandboxName, deps);
   if (agentName !== "openclaw" && agentName !== "hermes") {
     throw new InferenceSetError(
       `nemoclaw inference set supports OpenClaw and Hermes sandboxes; '${sandboxName}' uses '${agentName}'.`,
@@ -373,10 +480,23 @@ export async function runInferenceSet(
   }
 
   const config = deps.readSandboxConfig(sandboxName, target);
+  const preferredInferenceApi = resolveRuntimeInferenceApi({
+    agentName,
+    config,
+    currentProvider: entry.provider,
+    provider,
+    sandboxName,
+    session: deps.loadSession(),
+  });
   const patched =
     agentName === "hermes"
-      ? patchHermesInferenceConfig(config, provider, model)
-      : patchOpenClawInferenceConfig(config, provider, model, getPreferredInferenceApi(config));
+      ? patchHermesInferenceConfig(config, provider, model, preferredInferenceApi)
+      : patchOpenClawInferenceConfig(
+          config,
+          provider,
+          model,
+          preferredInferenceApi || getPreferredInferenceApi(config),
+        );
 
   deps.log(
     agentName === "hermes"
@@ -414,7 +534,7 @@ export async function runInferenceSet(
       `  Run '${CLI_NAME} ${sandboxName} rebuild' to finish applying the model inside the sandbox.`,
     );
   }
-  const sessionUpdated = updateMatchingOnboardSession(sandboxName, provider, model, deps);
+  const sessionUpdated = updateMatchingOnboardSession(sandboxName, provider, model, patched.route, deps);
 
   deps.appendAuditEntry({
     action: "inference_set",

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -24,6 +24,7 @@ import * as onboardSession from "../state/onboard-session";
 import type { SandboxEntry } from "../state/registry";
 import * as registry from "../state/registry";
 import { isSafeModelId } from "../validation";
+import { hermesApiMode, resolveRuntimeInferenceApi } from "./inference-route-api";
 
 export interface InferenceSetOptions {
   provider: string;
@@ -44,7 +45,6 @@ export interface InferenceSetResult {
 }
 
 type OpenshellRunResult = Pick<SpawnSyncReturns<string>, "status" | "stdout" | "stderr">;
-type InferenceApi = "openai-completions" | "anthropic-messages" | "openai-responses";
 
 export interface InferenceSetDeps {
   getDefaultSandbox: () => string | null;
@@ -92,12 +92,6 @@ const SUPPORTED_PROVIDER_NAMES = [
   "ollama-local",
   "vllm-local",
 ] as const;
-
-const SUPPORTED_INFERENCE_APIS = new Set<InferenceApi>([
-  "openai-completions",
-  "anthropic-messages",
-  "openai-responses",
-]);
 
 function defaultDeps(): InferenceSetDeps {
   return {
@@ -213,97 +207,6 @@ function asConfigObject(value: Record<string, unknown>): ConfigObject {
     if (isConfigValue(entry as ConfigValue)) result[key] = entry as ConfigValue;
   }
   return result;
-}
-
-function normalizeInferenceApi(value: unknown): InferenceApi | null {
-  return typeof value === "string" && SUPPORTED_INFERENCE_APIS.has(value as InferenceApi)
-    ? (value as InferenceApi)
-    : null;
-}
-
-function readProviderApi(config: ConfigObject, providerKey: string): InferenceApi | null {
-  const models = config.models;
-  if (!isConfigObject(models)) return null;
-  const providers = models.providers;
-  if (!isConfigObject(providers)) return null;
-  const provider = providers[providerKey];
-  if (!isConfigObject(provider)) return null;
-  return normalizeInferenceApi(provider.api);
-}
-
-function readOpenClawRouteApi(config: ConfigObject, provider: string): InferenceApi | null {
-  if (provider === "anthropic-prod") return readProviderApi(config, "anthropic");
-  if (provider === "compatible-anthropic-endpoint") {
-    return readProviderApi(config, "anthropic") || readProviderApi(config, "inference");
-  }
-  return readProviderApi(config, getSandboxInferenceConfig("", provider).providerKey);
-}
-
-function readHermesRouteApi(config: ConfigObject): InferenceApi | null {
-  const model = config.model;
-  if (!isConfigObject(model)) return null;
-  switch (model.api_mode) {
-    case "anthropic_messages":
-      return "anthropic-messages";
-    case "codex_responses":
-      return "openai-responses";
-    case undefined:
-    case null:
-    case "":
-      return "openai-completions";
-    default:
-      return null;
-  }
-}
-
-function sessionRouteApi(
-  session: onboardSession.Session | null,
-  sandboxName: string,
-  provider: string,
-): InferenceApi | null {
-  if (!session || session.sandboxName !== sandboxName || session.provider !== provider) return null;
-  return normalizeInferenceApi(session.preferredInferenceApi);
-}
-
-function resolveRuntimeInferenceApi(options: {
-  agentName: string;
-  config: ConfigObject;
-  currentProvider: string | null | undefined;
-  provider: string;
-  sandboxName: string;
-  session: onboardSession.Session | null;
-}): InferenceApi | null {
-  const { agentName, config, currentProvider, provider, sandboxName, session } = options;
-  if (provider === "anthropic-prod") return "anthropic-messages";
-
-  const sameProvider = currentProvider === provider;
-  const sessionApi = sameProvider ? sessionRouteApi(session, sandboxName, provider) : null;
-  if (sessionApi) return sessionApi;
-
-  const configApi =
-    sameProvider && agentName === "hermes"
-      ? readHermesRouteApi(config)
-      : sameProvider
-        ? readOpenClawRouteApi(config, provider)
-        : null;
-  if (configApi) return configApi;
-
-  if (provider === "compatible-anthropic-endpoint") return "anthropic-messages";
-  return null;
-}
-
-function hermesApiMode(inferenceApi: string): string | null {
-  switch (inferenceApi) {
-    case "":
-    case "openai-completions":
-      return null;
-    case "anthropic-messages":
-      return "anthropic_messages";
-    case "openai-responses":
-      return "codex_responses";
-    default:
-      return null;
-  }
 }
 
 function updateAgentPrimary(config: ConfigObject, primaryModelRef: string): void {

--- a/test/e2e/lib/anthropic-switch-provider.sh
+++ b/test/e2e/lib/anthropic-switch-provider.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helpers for inference-switch E2Es that need a compatible Anthropic
+# Messages provider. The mock provider runs on the host; agents still reach it
+# only through OpenShell-managed inference.local.
+
+ANTHROPIC_SWITCH_MOCK_PID=""
+ANTHROPIC_SWITCH_MOCK_LOG="${ANTHROPIC_SWITCH_MOCK_LOG:-/tmp/nemoclaw-e2e-anthropic-switch-provider.log}"
+
+parse_anthropic_content() {
+  python3 -c '
+import json, sys
+try:
+    r = json.load(sys.stdin)
+    parts = r.get("content") or []
+    text = []
+    for part in parts:
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            text.append(part["text"])
+    print(" ".join(text).strip())
+except Exception as e:
+    print(f"PARSE_ERROR: {e}", file=sys.stderr)
+    sys.exit(1)
+'
+}
+
+start_mock_anthropic_switch_provider() {
+  local port="${SWITCH_MOCK_PORT:-18766}"
+  SWITCH_ENDPOINT_URL="http://127.0.0.1:${port}"
+  export SWITCH_ENDPOINT_URL
+
+  python3 - "$port" >"$ANTHROPIC_SWITCH_MOCK_LOG" 2>&1 <<'PY' &
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+port = int(sys.argv[1])
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        sys.stderr.write((fmt % args) + "\n")
+
+    def _json(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json(200, {"ok": True})
+            return
+        if self.path in ("/v1/models", "/v1/models/mock-anthropic-model"):
+            self._json(200, {"data": [{"id": "mock-anthropic-model"}]})
+            return
+        self._json(404, {"error": "not found", "path": self.path})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or "0")
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            payload = json.loads(raw.decode("utf-8") or "{}")
+        except Exception:
+            payload = {}
+        if self.path != "/v1/messages":
+            self._json(404, {"error": "unexpected path", "path": self.path})
+            return
+        model = payload.get("model") or "mock-anthropic-model"
+        self._json(200, {
+            "id": "msg_mock",
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [{"type": "text", "text": "PONG"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        })
+
+ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
+  ANTHROPIC_SWITCH_MOCK_PID=$!
+
+  local attempt=1
+  while [ "$attempt" -le 5 ]; do
+    if curl -sf --max-time 2 "${SWITCH_ENDPOINT_URL}/health" >/dev/null 2>&1; then
+      pass "Mock Anthropic Messages provider is listening on ${SWITCH_ENDPOINT_URL}"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  fail "Mock Anthropic Messages provider did not start; log: ${ANTHROPIC_SWITCH_MOCK_LOG}"
+  return 1
+}
+
+stop_mock_anthropic_switch_provider() {
+  if [ -n "${ANTHROPIC_SWITCH_MOCK_PID:-}" ]; then
+    kill "$ANTHROPIC_SWITCH_MOCK_PID" >/dev/null 2>&1 || true
+    wait "$ANTHROPIC_SWITCH_MOCK_PID" >/dev/null 2>&1 || true
+    ANTHROPIC_SWITCH_MOCK_PID=""
+  fi
+}
+
+ensure_compatible_anthropic_switch_provider() {
+  if [ "${SWITCH_PROVIDER:-}" != "compatible-anthropic-endpoint" ]; then
+    return 0
+  fi
+  if [ "${SWITCH_INFERENCE_API:-}" != "anthropic-messages" ]; then
+    return 0
+  fi
+
+  if [ "${SWITCH_MOCK_ANTHROPIC:-}" = "1" ]; then
+    start_mock_anthropic_switch_provider || return 1
+    export COMPATIBLE_ANTHROPIC_API_KEY="${COMPATIBLE_ANTHROPIC_API_KEY:-test-compatible-anthropic-key}"
+  elif [ -z "${COMPATIBLE_ANTHROPIC_API_KEY:-}" ] && [ -n "${NVIDIA_API_KEY:-}" ]; then
+    export COMPATIBLE_ANTHROPIC_API_KEY="$NVIDIA_API_KEY"
+  fi
+
+  if [ -z "${SWITCH_ENDPOINT_URL:-}" ]; then
+    fail "NEMOCLAW_SWITCH_ENDPOINT_URL is required for compatible Anthropic inference switches"
+    return 1
+  fi
+  if [ -z "${COMPATIBLE_ANTHROPIC_API_KEY:-}" ]; then
+    fail "COMPATIBLE_ANTHROPIC_API_KEY is required for compatible Anthropic inference switches"
+    return 1
+  fi
+
+  if openshell provider get -g nemoclaw compatible-anthropic-endpoint >/dev/null 2>&1; then
+    openshell provider update -g nemoclaw compatible-anthropic-endpoint \
+      --credential COMPATIBLE_ANTHROPIC_API_KEY \
+      --config "ANTHROPIC_BASE_URL=${SWITCH_ENDPOINT_URL}" >/dev/null
+  else
+    openshell provider create -g nemoclaw \
+      --name compatible-anthropic-endpoint \
+      --type anthropic \
+      --credential COMPATIBLE_ANTHROPIC_API_KEY \
+      --config "ANTHROPIC_BASE_URL=${SWITCH_ENDPOINT_URL}" >/dev/null
+  fi
+  pass "OpenShell provider compatible-anthropic-endpoint is registered for ${SWITCH_ENDPOINT_URL}"
+}

--- a/test/e2e/lib/anthropic-switch-provider.sh
+++ b/test/e2e/lib/anthropic-switch-provider.sh
@@ -28,7 +28,9 @@ except Exception as e:
 
 start_mock_anthropic_switch_provider() {
   local port="${SWITCH_MOCK_PORT:-18766}"
-  SWITCH_ENDPOINT_URL="http://127.0.0.1:${port}"
+  local host="${SWITCH_MOCK_HOST:-host.openshell.internal}"
+  local health_url="http://127.0.0.1:${port}/health"
+  SWITCH_ENDPOINT_URL="${SWITCH_ENDPOINT_URL:-http://${host}:${port}}"
   export SWITCH_ENDPOINT_URL
 
   python3 - "$port" >"$ANTHROPIC_SWITCH_MOCK_LOG" 2>&1 <<'PY' &
@@ -80,13 +82,13 @@ class Handler(BaseHTTPRequestHandler):
             "usage": {"input_tokens": 1, "output_tokens": 1},
         })
 
-ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()
+ThreadingHTTPServer(("0.0.0.0", port), Handler).serve_forever()
 PY
   ANTHROPIC_SWITCH_MOCK_PID=$!
 
   local attempt=1
   while [ "$attempt" -le 5 ]; do
-    if curl -sf --max-time 2 "${SWITCH_ENDPOINT_URL}/health" >/dev/null 2>&1; then
+    if curl -sf --max-time 2 "$health_url" >/dev/null 2>&1; then
       pass "Mock Anthropic Messages provider is listening on ${SWITCH_ENDPOINT_URL}"
       return 0
     fi

--- a/test/e2e/lib/anthropic-switch-provider.sh
+++ b/test/e2e/lib/anthropic-switch-provider.sh
@@ -37,6 +37,7 @@ start_mock_anthropic_switch_provider() {
 import json
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
 
 port = int(sys.argv[1])
 
@@ -52,26 +53,71 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _sse(self, events):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        for name, payload in events:
+            self.wfile.write(("event: " + name + "\n").encode("utf-8"))
+            self.wfile.write(("data: " + json.dumps(payload) + "\n\n").encode("utf-8"))
+        self.wfile.flush()
+
     def do_GET(self):
-        if self.path == "/health":
+        path = urlparse(self.path).path
+        if path == "/health":
             self._json(200, {"ok": True})
             return
-        if self.path in ("/v1/models", "/v1/models/mock-anthropic-model"):
+        if path in ("/v1/models", "/v1/models/mock-anthropic-model"):
             self._json(200, {"data": [{"id": "mock-anthropic-model"}]})
             return
-        self._json(404, {"error": "not found", "path": self.path})
+        self._json(404, {"error": "not found", "path": path})
 
     def do_POST(self):
+        path = urlparse(self.path).path
         length = int(self.headers.get("Content-Length") or "0")
         raw = self.rfile.read(length) if length else b"{}"
         try:
             payload = json.loads(raw.decode("utf-8") or "{}")
         except Exception:
             payload = {}
-        if self.path != "/v1/messages":
-            self._json(404, {"error": "unexpected path", "path": self.path})
+        if path != "/v1/messages":
+            self._json(404, {"error": "unexpected path", "path": path})
             return
         model = payload.get("model") or "mock-anthropic-model"
+        if payload.get("stream") is True:
+            message = {
+                "id": "msg_mock",
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            }
+            self._sse([
+                ("message_start", {"type": "message_start", "message": message}),
+                (
+                    "content_block_start",
+                    {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                ),
+                (
+                    "content_block_delta",
+                    {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "PONG"}},
+                ),
+                ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+                (
+                    "message_delta",
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                        "usage": {"output_tokens": 1},
+                    },
+                ),
+                ("message_stop", {"type": "message_stop"}),
+            ])
+            return
         self._json(200, {
             "id": "msg_mock",
             "type": "message",

--- a/test/e2e/lib/anthropic-switch-provider.sh
+++ b/test/e2e/lib/anthropic-switch-provider.sh
@@ -165,8 +165,6 @@ ensure_compatible_anthropic_switch_provider() {
   if [ "${SWITCH_MOCK_ANTHROPIC:-}" = "1" ]; then
     start_mock_anthropic_switch_provider || return 1
     export COMPATIBLE_ANTHROPIC_API_KEY="${COMPATIBLE_ANTHROPIC_API_KEY:-test-compatible-anthropic-key}"
-  elif [ -z "${COMPATIBLE_ANTHROPIC_API_KEY:-}" ] && [ -n "${NVIDIA_API_KEY:-}" ]; then
-    export COMPATIBLE_ANTHROPIC_API_KEY="$NVIDIA_API_KEY"
   fi
 
   if [ -z "${SWITCH_ENDPOINT_URL:-}" ]; then
@@ -179,15 +177,21 @@ ensure_compatible_anthropic_switch_provider() {
   fi
 
   if openshell provider get -g nemoclaw compatible-anthropic-endpoint >/dev/null 2>&1; then
-    openshell provider update -g nemoclaw compatible-anthropic-endpoint \
+    if ! openshell provider update -g nemoclaw compatible-anthropic-endpoint \
       --credential COMPATIBLE_ANTHROPIC_API_KEY \
-      --config "ANTHROPIC_BASE_URL=${SWITCH_ENDPOINT_URL}" >/dev/null
+      --config "ANTHROPIC_BASE_URL=${SWITCH_ENDPOINT_URL}" >/dev/null; then
+      fail "Failed to update OpenShell provider compatible-anthropic-endpoint"
+      return 1
+    fi
   else
-    openshell provider create -g nemoclaw \
+    if ! openshell provider create -g nemoclaw \
       --name compatible-anthropic-endpoint \
       --type anthropic \
       --credential COMPATIBLE_ANTHROPIC_API_KEY \
-      --config "ANTHROPIC_BASE_URL=${SWITCH_ENDPOINT_URL}" >/dev/null
+      --config "ANTHROPIC_BASE_URL=${SWITCH_ENDPOINT_URL}" >/dev/null; then
+      fail "Failed to create OpenShell provider compatible-anthropic-endpoint"
+      return 1
+    fi
   fi
   pass "OpenShell provider compatible-anthropic-endpoint is registered for ${SWITCH_ENDPOINT_URL}"
 }

--- a/test/e2e/lib/inference-switch-retry.sh
+++ b/test/e2e/lib/inference-switch-retry.sh
@@ -8,7 +8,7 @@
 # attempts fail with transient upstream/network symptoms.
 
 is_transient_inference_set_failure() {
-  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|502|503|504|temporar' <<<"$1"
+  grep -qiE 'timed? out|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|failed to connect|error sending request|failed to verify inference endpoint|502|503|504|temporar' <<<"$1"
 }
 
 log_inference_switch_retry_info() {

--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -198,13 +198,19 @@ assert_hermes_config() {
   # simple model block and should move to PyYAML if nested or multiline values
   # become relevant.
   probe=$(
-    CONFIG_TEXT="$config" EXPECTED_MODEL="$SWITCH_MODEL" python3 - <<'PY'
+    CONFIG_TEXT="$config" EXPECTED_MODEL="$SWITCH_MODEL" EXPECTED_INFERENCE_API="$SWITCH_INFERENCE_API" python3 - <<'PY'
 import os
 import re
 
 text = os.environ["CONFIG_TEXT"]
 expected = os.environ["EXPECTED_MODEL"]
+expected_api = os.environ["EXPECTED_INFERENCE_API"]
 errors = []
+expected_base = "https://inference.local" if expected_api == "anthropic-messages" else "https://inference.local/v1"
+expected_api_mode = {
+    "anthropic-messages": "anthropic_messages",
+    "openai-responses": "codex_responses",
+}.get(expected_api)
 
 model = {}
 in_model = False
@@ -224,10 +230,15 @@ for line in text.splitlines():
 
 if model.get("default") != expected:
     errors.append(f"model.default={model.get('default')!r}")
-if model.get("base_url") != "https://inference.local/v1":
+if model.get("base_url") != expected_base:
     errors.append(f"model.base_url={model.get('base_url')!r}")
 if model.get("provider") != "custom":
     errors.append(f"model.provider={model.get('provider')!r}")
+if expected_api_mode:
+    if model.get("api_mode") != expected_api_mode:
+        errors.append(f"model.api_mode={model.get('api_mode')!r}")
+elif "api_mode" in model:
+    errors.append(f"stale model.api_mode={model.get('api_mode')!r}")
 api_key = model.get("api_key")
 if not isinstance(api_key, str) or not api_key.startswith("sk-"):
     errors.append(f"model.api_key={api_key!r}")
@@ -297,17 +308,28 @@ assert_env_hash_unchanged() {
 
 check_inference_local() {
   local payload payload_arg response rc content attempt last_fail http_code body remote transient=0
-  payload=$(SWITCH_MODEL="$SWITCH_MODEL" python3 -c '
+  payload=$(SWITCH_MODEL="$SWITCH_MODEL" SWITCH_INFERENCE_API="$SWITCH_INFERENCE_API" python3 -c '
 import json
 import os
-print(json.dumps({
-    "model": os.environ["SWITCH_MODEL"],
-    "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}],
-    "max_tokens": 100,
-}))
+if os.environ["SWITCH_INFERENCE_API"] == "anthropic-messages":
+    print(json.dumps({
+        "model": os.environ["SWITCH_MODEL"],
+        "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}],
+        "max_tokens": 32,
+    }))
+else:
+    print(json.dumps({
+        "model": os.environ["SWITCH_MODEL"],
+        "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}],
+        "max_tokens": 100,
+    }))
 ')
   payload_arg="$(printf '%q' "$payload")"
-  remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
+  if [ "$SWITCH_INFERENCE_API" = "anthropic-messages" ]; then
+    remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/messages -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
+  else
+    remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
+  fi
   last_fail=""
 
   for attempt in 1 2 3; do
@@ -327,7 +349,11 @@ print(json.dumps({
     elif [ "$http_code" != "200" ]; then
       last_fail="HTTP ${http_code}: ${body:0:300}"
     else
-      content=$(printf '%s' "$body" | parse_chat_content 2>/dev/null) || content=""
+      if [ "$SWITCH_INFERENCE_API" = "anthropic-messages" ]; then
+        content=$(printf '%s' "$body" | parse_anthropic_content 2>/dev/null) || content=""
+      else
+        content=$(printf '%s' "$body" | parse_chat_content 2>/dev/null) || content=""
+      fi
       if grep -qi "PONG" <<<"$content"; then
         pass "Hermes sandbox inference.local returned PONG with ${SWITCH_MODEL}"
         return
@@ -413,9 +439,15 @@ fi
 E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=test/e2e/lib/inference-switch-retry.sh
 . "${E2E_DIR}/lib/inference-switch-retry.sh"
+# shellcheck source=test/e2e/lib/anthropic-switch-provider.sh
+. "${E2E_DIR}/lib/anthropic-switch-provider.sh"
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-hermes-inference-switch}"
 SWITCH_PROVIDER="${NEMOCLAW_SWITCH_PROVIDER:-nvidia-prod}"
 SWITCH_MODEL="${NEMOCLAW_SWITCH_MODEL:-z-ai/glm-5.1}"
+SWITCH_INFERENCE_API="${NEMOCLAW_SWITCH_INFERENCE_API:-openai-completions}"
+SWITCH_ENDPOINT_URL="${NEMOCLAW_SWITCH_ENDPOINT_URL:-}"
+SWITCH_MOCK_ANTHROPIC="${NEMOCLAW_SWITCH_MOCK_ANTHROPIC:-0}"
+SWITCH_MOCK_PORT="${NEMOCLAW_SWITCH_MOCK_PORT:-18766}"
 INSTALL_LOG="/tmp/nemoclaw-e2e-hermes-inference-switch-install.log"
 ENV_HASH_BEFORE=""
 
@@ -423,6 +455,7 @@ export NEMOCLAW_AGENT="${NEMOCLAW_AGENT:-hermes}"
 
 # shellcheck source=test/e2e/lib/sandbox-teardown.sh
 . "${E2E_DIR}/lib/sandbox-teardown.sh"
+trap 'stop_mock_anthropic_switch_provider; _nemoclaw_sandbox_teardown' EXIT
 # shellcheck source=test/e2e/lib/install-path-refresh.sh
 . "${E2E_DIR}/lib/install-path-refresh.sh"
 register_sandbox_for_teardown "$SANDBOX_NAME"
@@ -511,6 +544,7 @@ command -v openshell >/dev/null 2>&1 || {
 }
 pass "nemohermes and openshell are on PATH"
 assert_hermes_health
+ensure_compatible_anthropic_switch_provider || exit 1
 
 section "Phase 3: Switch inference"
 pid_before="$(hermes_gateway_pid)"

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -188,25 +188,31 @@ assert_openclaw_config() {
     return
   }
 
-  probe=$(EXPECTED_MODEL="$SWITCH_MODEL" python3 -c '
+  probe=$(EXPECTED_MODEL="$SWITCH_MODEL" EXPECTED_INFERENCE_API="$SWITCH_INFERENCE_API" python3 -c '
 import json
 import os
 import sys
 
 expected = os.environ["EXPECTED_MODEL"]
+expected_api = os.environ["EXPECTED_INFERENCE_API"]
 doc = json.load(sys.stdin)
 errors = []
 primary = (((doc.get("agents") or {}).get("defaults") or {}).get("model") or {}).get("primary")
-if primary != f"inference/{expected}":
+expected_provider_key = "anthropic" if expected_api == "anthropic-messages" else "inference"
+expected_primary = f"{expected_provider_key}/{expected}"
+if primary != expected_primary:
     errors.append(f"primary={primary!r}")
 
-provider = (((doc.get("models") or {}).get("providers") or {}).get("inference") or {})
-if provider.get("baseUrl") != "https://inference.local/v1":
+provider = (((doc.get("models") or {}).get("providers") or {}).get(expected_provider_key) or {})
+expected_base = "https://inference.local" if expected_api == "anthropic-messages" else "https://inference.local/v1"
+if provider.get("baseUrl") != expected_base:
     errors.append("baseUrl={!r}".format(provider.get("baseUrl")))
+if provider.get("api") != expected_api:
+    errors.append("api={!r}".format(provider.get("api")))
 models = provider.get("models") or []
 if not models or models[0].get("id") != expected:
     errors.append("model id={!r}".format(models[0].get("id") if models else None))
-if not models or models[0].get("name") != f"inference/{expected}":
+if not models or models[0].get("name") != expected_primary:
     errors.append("model name={!r}".format(models[0].get("name") if models else None))
 
 if errors:
@@ -217,7 +223,7 @@ print("OK")
     fail "OpenClaw config was not patched correctly: ${probe:0:400}"
     return
   }
-  pass "OpenClaw config uses inference/${SWITCH_MODEL}"
+  pass "OpenClaw config uses ${SWITCH_INFERENCE_API} route for ${SWITCH_MODEL}"
 
   hash_check=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sh -lc \
     'cd /sandbox/.openclaw && sha256sum -c .config-hash --status && echo OK' 2>&1 || true)
@@ -230,17 +236,28 @@ print("OK")
 
 check_sandbox_inference() {
   local payload payload_arg response rc content attempt last_fail http_code body remote transient=0
-  payload=$(SWITCH_MODEL="$SWITCH_MODEL" python3 -c '
+  payload=$(SWITCH_MODEL="$SWITCH_MODEL" SWITCH_INFERENCE_API="$SWITCH_INFERENCE_API" python3 -c '
 import json
 import os
-print(json.dumps({
-    "model": os.environ["SWITCH_MODEL"],
-    "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}],
-    "max_tokens": 100,
-}))
+if os.environ["SWITCH_INFERENCE_API"] == "anthropic-messages":
+    print(json.dumps({
+        "model": os.environ["SWITCH_MODEL"],
+        "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}],
+        "max_tokens": 32,
+    }))
+else:
+    print(json.dumps({
+        "model": os.environ["SWITCH_MODEL"],
+        "messages": [{"role": "user", "content": "Reply with exactly one word: PONG"}],
+        "max_tokens": 100,
+    }))
 ')
   payload_arg="$(printf '%q' "$payload")"
-  remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
+  if [ "$SWITCH_INFERENCE_API" = "anthropic-messages" ]; then
+    remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/messages -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
+  else
+    remote="tmp=\$(mktemp); code=\$(curl -sS -o \"\$tmp\" -w '%{http_code}' --max-time 90 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' -d $payload_arg); rc=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf '\n__NEMOCLAW_HTTP_STATUS__=%s\n' \"\${code:-000}\"; exit \"\$rc\""
+  fi
   last_fail=""
 
   for attempt in 1 2 3; do
@@ -260,7 +277,11 @@ print(json.dumps({
     elif [ "$http_code" != "200" ]; then
       last_fail="HTTP ${http_code}: ${body:0:300}"
     else
-      content=$(printf '%s' "$body" | parse_chat_content 2>/dev/null) || content=""
+      if [ "$SWITCH_INFERENCE_API" = "anthropic-messages" ]; then
+        content=$(printf '%s' "$body" | parse_anthropic_content 2>/dev/null) || content=""
+      else
+        content=$(printf '%s' "$body" | parse_chat_content 2>/dev/null) || content=""
+      fi
       if grep -qi "PONG" <<<"$content"; then
         pass "Sandbox inference.local returned PONG with ${SWITCH_MODEL}"
         return
@@ -327,13 +348,20 @@ E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${E2E_DIR}/lib/openclaw-json.sh"
 # shellcheck source=test/e2e/lib/inference-switch-retry.sh
 . "${E2E_DIR}/lib/inference-switch-retry.sh"
+# shellcheck source=test/e2e/lib/anthropic-switch-provider.sh
+. "${E2E_DIR}/lib/anthropic-switch-provider.sh"
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-openclaw-inference-switch}"
 SWITCH_PROVIDER="${NEMOCLAW_SWITCH_PROVIDER:-nvidia-prod}"
 SWITCH_MODEL="${NEMOCLAW_SWITCH_MODEL:-z-ai/glm-5.1}"
+SWITCH_INFERENCE_API="${NEMOCLAW_SWITCH_INFERENCE_API:-openai-completions}"
+SWITCH_ENDPOINT_URL="${NEMOCLAW_SWITCH_ENDPOINT_URL:-}"
+SWITCH_MOCK_ANTHROPIC="${NEMOCLAW_SWITCH_MOCK_ANTHROPIC:-0}"
+SWITCH_MOCK_PORT="${NEMOCLAW_SWITCH_MOCK_PORT:-18767}"
 INSTALL_LOG="/tmp/nemoclaw-e2e-openclaw-inference-switch-install.log"
 
 # shellcheck source=test/e2e/lib/sandbox-teardown.sh
 . "${E2E_DIR}/lib/sandbox-teardown.sh"
+trap 'stop_mock_anthropic_switch_provider; _nemoclaw_sandbox_teardown' EXIT
 # shellcheck source=test/e2e/lib/install-path-refresh.sh
 . "${E2E_DIR}/lib/install-path-refresh.sh"
 register_sandbox_for_teardown "$SANDBOX_NAME"
@@ -419,6 +447,7 @@ command -v openshell >/dev/null 2>&1 || {
   exit 1
 }
 pass "nemoclaw and openshell are on PATH"
+ensure_compatible_anthropic_switch_provider || exit 1
 
 section "Phase 3: Switch inference"
 pid_before="$(openclaw_gateway_pid)"

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -303,7 +303,7 @@ else:
 }
 
 check_openclaw_agent_turn() {
-  local ssh_config session_id raw rc reply
+  local ssh_config session_id raw stderr_file rc reply warnings
   ssh_config="$(mktemp)"
   if ! openshell sandbox ssh-config "$SANDBOX_NAME" >"$ssh_config" 2>/dev/null; then
     rm -f "$ssh_config"
@@ -312,6 +312,7 @@ check_openclaw_agent_turn() {
   fi
 
   session_id="e2e-inference-switch-openclaw-$(date +%s)-$$"
+  stderr_file="$(mktemp)"
   rc=0
   raw=$(run_with_timeout 120 ssh -F "$ssh_config" \
     -o StrictHostKeyChecking=no \
@@ -319,18 +320,20 @@ check_openclaw_agent_turn() {
     -o ConnectTimeout=10 \
     -o LogLevel=ERROR \
     "openshell-${SANDBOX_NAME}" \
-    "openclaw agent --agent main --json --session-id '${session_id}' -m 'What is 6 multiplied by 7? Reply with only the integer, no extra words.'" \
-    2>&1) || rc=$?
+    "openclaw agent --agent main --json --session-id '${session_id}' -m 'Reply with exactly one word: PONG'" \
+    2>"$stderr_file") || rc=$?
+  warnings="$(cat "$stderr_file" 2>/dev/null || true)"
   rm -f "$ssh_config"
+  rm -f "$stderr_file"
 
   reply=$(printf '%s' "$raw" | parse_openclaw_agent_text 2>/dev/null) || true
 
-  if [ "$rc" -eq 0 ] && grep -qE '(^|[^0-9])42([^0-9]|$)' <<<"$reply"; then
+  if [ "$rc" -eq 0 ] && grep -qi "PONG" <<<"$reply"; then
     pass "OpenClaw agent answered through the switched inference route"
   elif [ "$rc" -eq 124 ]; then
     skip "OpenClaw agent turn timed out after switch; route/config checks already passed"
   else
-    fail "OpenClaw agent turn failed after switch (exit ${rc}); reply='${reply:0:200}', raw='${raw:0:200}'"
+    fail "OpenClaw agent turn failed after switch (exit ${rc}); reply='${reply:0:200}', raw='${raw:0:200}', stderr='${warnings:0:200}'"
   fi
 }
 
@@ -354,8 +357,11 @@ SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-openclaw-inference-switch}"
 SWITCH_PROVIDER="${NEMOCLAW_SWITCH_PROVIDER:-nvidia-prod}"
 SWITCH_MODEL="${NEMOCLAW_SWITCH_MODEL:-z-ai/glm-5.1}"
 SWITCH_INFERENCE_API="${NEMOCLAW_SWITCH_INFERENCE_API:-openai-completions}"
+# shellcheck disable=SC2034  # consumed by anthropic-switch-provider.sh helpers
 SWITCH_ENDPOINT_URL="${NEMOCLAW_SWITCH_ENDPOINT_URL:-}"
+# shellcheck disable=SC2034  # consumed by anthropic-switch-provider.sh helpers
 SWITCH_MOCK_ANTHROPIC="${NEMOCLAW_SWITCH_MOCK_ANTHROPIC:-0}"
+# shellcheck disable=SC2034  # consumed by anthropic-switch-provider.sh helpers
 SWITCH_MOCK_PORT="${NEMOCLAW_SWITCH_MOCK_PORT:-18767}"
 INSTALL_LOG="/tmp/nemoclaw-e2e-openclaw-inference-switch-install.log"
 


### PR DESCRIPTION
## Summary
- Resolve the managed inference API family during `nemoclaw inference set` / `nemohermes inference set` before patching in-sandbox config.
- Set Hermes `model.api_mode` for Anthropic Messages and OpenAI Responses routes, and clear stale `api_mode` when switching back to OpenAI-style chat completions.
- Preserve the Bedrock Runtime adapter exception: same-provider compatible-Anthropic routes that were resolved as OpenAI-compatible stay on `/v1/chat/completions`.
- Add hermetic Anthropic Messages switch coverage for both Hermes and OpenClaw: the E2E scripts can register a compatible Anthropic mock provider, verify `/v1/messages` through `inference.local`, then exercise the agent path after the switch.

## Why
#4809 reported a `403 connection not allowed by policy` while the agent was calling `https://inference.local`, so the right fix is not to open direct sandbox egress to the upstream inference host. #4402 fixed fresh Hermes onboarding by allowing managed `/v1/messages` and baking `api_mode: anthropic_messages`. This PR covers the remaining runtime-switch path so both Hermes and OpenClaw keep using OpenShell-managed inference correctly after `inference set`.

## References
- Refs #4809
- Related #4230
- Builds on #4402

## Validation
- `npx vitest run src/lib/actions/inference-set.test.ts`
- `npx vitest run src/lib/actions/inference-set.test.ts src/lib/inference/config.test.ts test/generate-hermes-config.test.ts test/generate-openclaw-config.test.ts` (initial combined run hit two existing 5s per-test timeouts in `test/generate-openclaw-config.test.ts`; rerun below passed with a larger timeout)
- `npx vitest run test/generate-openclaw-config.test.ts --testTimeout 20000`
- `npx vitest run test/validate-e2e-coverage.test.ts`
- `shellcheck test/e2e/test-hermes-inference-switch.sh test/e2e/test-openclaw-inference-switch.sh test/e2e/lib/anthropic-switch-provider.sh test/e2e/lib/inference-switch-retry.sh`
- `bash -n test/e2e/test-hermes-inference-switch.sh test/e2e/test-openclaw-inference-switch.sh test/e2e/lib/anthropic-switch-provider.sh test/e2e/lib/inference-switch-retry.sh`
- `npx biome check src/lib/actions/inference-set.ts src/lib/actions/inference-set.test.ts`
- `npm run build:cli`
- `npm run validate:configs`
- `git diff --check`
- PR checks green on head `e21952d57e8ef23caa266d6862e7367ec3bd3814`, including commit-lint and DCO.
- Targeted E2E run `27014755537` passed both new agent-path proofs:
  - `hermes-anthropic-inference-switch-e2e / run`
  - `openclaw-anthropic-inference-switch-e2e / run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for switching between OpenAI and Anthropic inference API modes in sandbox configurations.

* **Tests**
  * Introduced nightly E2E test jobs for validating Anthropic inference switching across agents.
  * Expanded test coverage for inference API configuration validation and provider switching scenarios.
  * Added mock Anthropic provider support for local E2E testing.

* **Chores**
  * Updated CI/CD workflow to include new inference-switch E2E test jobs and orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final confidence pass
- Required scenario E2E passed on head `5c09efefe6e30e2fe3708dfa3b864d3cd3ece95a`: `ubuntu-repo-cloud-openclaw-double-provider-switch`, `ubuntu-repo-cloud-openclaw-double-same-provider` — run `27023280926`.
- Required switch E2Es passed on head `5c09efefe6e30e2fe3708dfa3b864d3cd3ece95a`: `hermes-inference-switch-e2e`, `openclaw-inference-switch-e2e` — run `27023413644`.
- Required Anthropic switch E2Es and optional `hermes-e2e` passed on head `5c09efefe6e30e2fe3708dfa3b864d3cd3ece95a`: run `27041002798`.
- Optional E2Es passed on head `5c09efefe6e30e2fe3708dfa3b864d3cd3ece95a`: `bedrock-runtime-compatible-anthropic-e2e`, `inference-routing-e2e` — run `27023295295`.
