### PR TITLE
fix(inference): tighten Ollama bootstrap fit and raise runtime context floor

### DIFF
--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -960,7 +960,8 @@ describe("local inference helpers", () => {
     expect(commands[1]).toMatch(/--max-time.*300|300.*--max-time/);
   });
 
-  it("does not retry on non-Spark hosts when first probe returns empty", () => {
+  it("does not retry on any host when probe fails fast (connection refused, not a timeout)", () => {
+    // exit code 7 = curl connection refused → surfaces immediately, no 300 s retry.
     let callCount = 0;
     const captureEx = () => { callCount++; return { stdout: "", exitCode: 7, timedOut: false }; };
     const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => false, captureEx);
@@ -976,6 +977,25 @@ describe("local inference helpers", () => {
     expect(result.ok).toBe(false);
     expect(callCount).toBe(1);
     expect(result.message).toMatch(/did not answer the local probe in time/);
+  });
+
+  it("retries with extended timeout on non-Spark hosts when first probe times out", () => {
+    // Cold-loading a 30B-class model on a tight-VRAM dGPU (e.g. NVIDIA L4) can
+    // exceed the default 120 s probe window even though the model itself is
+    // healthy. The retry was previously gated on `sparkHost`, leaving Brev L4
+    // and similar hosts in a probe-timeout dead-loop.
+    const commands: string[] = [];
+    let captureExCallCount = 0;
+    const captureEx = (cmd: string[]) => {
+      captureExCallCount++;
+      commands.push(cmd.join(" "));
+      if (captureExCallCount === 1) return { stdout: "", exitCode: 28, timedOut: true };
+      return { stdout: JSON.stringify({ response: "Hi" }), exitCode: 0, timedOut: false };
+    };
+    const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => false, captureEx);
+    expect(result.ok).toBe(true);
+    expect(captureExCallCount).toBe(2);
+    expect(commands[1]).toMatch(/--max-time.*300|300.*--max-time/);
   });
 
   it("fails when both probe attempts return empty (model truly unhealthy or too slow)", () => {

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -961,7 +961,6 @@ describe("local inference helpers", () => {
   });
 
   it("does not retry on any host when probe fails fast (connection refused, not a timeout)", () => {
-    // exit code 7 = curl connection refused → surfaces immediately, no 300 s retry.
     let callCount = 0;
     const captureEx = () => { callCount++; return { stdout: "", exitCode: 7, timedOut: false }; };
     const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => false, captureEx);
@@ -977,25 +976,6 @@ describe("local inference helpers", () => {
     expect(result.ok).toBe(false);
     expect(callCount).toBe(1);
     expect(result.message).toMatch(/did not answer the local probe in time/);
-  });
-
-  it("retries with extended timeout on non-Spark hosts when first probe times out", () => {
-    // Cold-loading a 30B-class model on a tight-VRAM dGPU (e.g. NVIDIA L4) can
-    // exceed the default 120 s probe window even though the model itself is
-    // healthy. The retry was previously gated on `sparkHost`, leaving Brev L4
-    // and similar hosts in a probe-timeout dead-loop.
-    const commands: string[] = [];
-    let captureExCallCount = 0;
-    const captureEx = (cmd: string[]) => {
-      captureExCallCount++;
-      commands.push(cmd.join(" "));
-      if (captureExCallCount === 1) return { stdout: "", exitCode: 28, timedOut: true };
-      return { stdout: JSON.stringify({ response: "Hi" }), exitCode: 0, timedOut: false };
-    };
-    const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => false, captureEx);
-    expect(result.ok).toBe(true);
-    expect(captureExCallCount).toBe(2);
-    expect(commands[1]).toMatch(/--max-time.*300|300.*--max-time/);
   });
 
   it("fails when both probe attempts return empty (model truly unhealthy or too slow)", () => {

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -172,6 +172,14 @@ export interface GpuInfo {
   // Absent => the selector falls back to `totalMemoryMB`, preserving the
   // previous behaviour.
   availableMemoryMB?: number;
+  /**
+   * `true` for integrated/iGPU class devices whose token-generation throughput
+   * is too low to clear agent-loop timeouts on 30B-class models, even when
+   * advertised memory ostensibly fits. Populated for Jetson (Tegra/Thor/Orin)
+   * platforms. Drives the `computeIntensive` exclusion in the bootstrap-model
+   * selector so compute-constrained hosts are not steered onto 30B+ tags.
+   */
+  computeConstrained?: boolean;
 }
 
 export interface ValidationResult {
@@ -965,10 +973,13 @@ export function validateOllamaModel(
   const probeCmd = getOllamaProbeCommand(model);
   const probeResult = captureEx(probeCmd);
   let output = probeResult.stdout;
-  // On DGX Spark (128 GB unified memory), loading a large model from disk can take >2 min.
-  // Only retry with a 300 s timeout when the initial probe genuinely timed out — fast
-  // failures (connection refused, Ollama not running) surface immediately. (#3251)
-  if (sparkHost && probeResult.timedOut) {
+  // Cold-loading a large model from disk can routinely exceed the default 120 s
+  // probe window — on DGX Spark unified-memory hosts (#3251) and also on
+  // tight-VRAM dGPU hosts (e.g. NVIDIA L4 23 GB) where the runner spills GPU→CPU
+  // during warm-up. Retry once with a 300 s budget whenever the initial probe
+  // genuinely timed out. Fast failures (connection refused, Ollama not running)
+  // keep `timedOut === false` and surface immediately.
+  if (probeResult.timedOut) {
     const retryResult = captureEx(getOllamaProbeCommand(model, 300));
     output = retryResult.stdout;
   }

--- a/src/lib/inference/nim.ts
+++ b/src/lib/inference/nim.ts
@@ -72,6 +72,12 @@ export interface GpuDetection {
   unifiedMemory?: boolean;
   spark?: boolean;
   platform?: NvidiaPlatform;
+  // `true` for integrated/iGPU class NVIDIA platforms (Jetson Tegra/Thor/Orin)
+  // whose token-generation throughput on 30B+ class Ollama models cannot clear
+  // agent-loop timeouts even when advertised memory ostensibly fits. Mirrored
+  // onto `GpuInfo.computeConstrained` so the Ollama bootstrap-model selector
+  // skips `computeIntensive` registry entries on these hosts.
+  computeConstrained?: boolean;
   // Set when a denylisted `JMJWOA-Generic-*` placeholder name was accepted only
   // because a bounded Docker `--gpus` CUDA proof passed (Windows-ARM N1X + WSL2
   // + Docker Desktop, #4565). Diagnostic marker that this detection cleared a
@@ -465,6 +471,7 @@ export function detectGpu(deps: DetectGpuDeps = {}): GpuDetection | null {
           nimCapable: canRunNimWithMemory(totalMemoryMB),
           platform,
           spark: platform === "spark",
+          ...(platform === "jetson" ? { computeConstrained: true } : {}),
           ...(wslDockerDesktopGpuProofPassed ? { wslDockerDesktopGpuProofPassed: true } : {}),
         };
       }
@@ -553,6 +560,7 @@ export function detectGpu(deps: DetectGpuDeps = {}): GpuDetection | null {
         nimCapable: canRunNimWithMemory(totalMemoryMB),
         unifiedMemory: true,
         spark: platform === "spark",
+        ...(platform === "jetson" ? { computeConstrained: true } : {}),
         platform,
       };
     }
@@ -577,6 +585,7 @@ export function detectGpu(deps: DetectGpuDeps = {}): GpuDetection | null {
       nimCapable: canRunNimWithMemory(totalMemoryMB),
       unifiedMemory: true,
       spark: false,
+      computeConstrained: tegraGpu.platform === "jetson",
       platform: tegraGpu.platform,
     };
   }

--- a/src/lib/inference/ollama-model-registry.test.ts
+++ b/src/lib/inference/ollama-model-registry.test.ts
@@ -178,3 +178,65 @@ describe("OLLAMA_DOWNLOAD_SIZE_FALLBACK_BYTES", () => {
     ).toEqual([SMALLEST_OLLAMA_MODEL_TAG]);
   });
 });
+
+describe("L4-class dGPU bootstrap fit (23 GB VRAM)", () => {
+  // NVIDIA L4 reports ~23034 MiB. The 30B-class entry's `requiredMemoryMB`
+  // budget must leave enough headroom for KV cache + activations that L4
+  // is excluded from the fittable list — otherwise the wizard offers a
+  // model the runner spills GPU→CPU on, with cold-load timing past the
+  // probe window and dead-looping the model selection menu.
+  const l4Gpu = { type: "nvidia", totalMemoryMB: 23_034, availableMemoryMB: 21_800 };
+
+  it("excludes the 30B-class compute-intensive entry on L4", () => {
+    const tags = fittableOllamaModelTags(l4Gpu);
+    expect(tags).toContain(SMALLEST_OLLAMA_MODEL_TAG);
+    expect(tags).not.toContain("nemotron-3-nano:30b");
+    expect(tags).not.toContain("qwen3.6:35b");
+  });
+
+  it("returns the smallest tag as the largest-fittable default on L4", () => {
+    expect(largestFittableOllamaModelTag(l4Gpu)).toBe(SMALLEST_OLLAMA_MODEL_TAG);
+  });
+
+  it("rejects modelFitsAvailableMemory for the 30B-class entry on L4", () => {
+    expect(modelFitsAvailableMemory("nemotron-3-nano:30b", l4Gpu)).toBe(false);
+    expect(modelFitsAvailableMemory("qwen3.5:9b", l4Gpu)).toBe(true);
+  });
+});
+
+describe("compute-constrained iGPU filter", () => {
+  // Jetson-class integrated GPUs advertise unified memory that easily covers
+  // a 30B-class model's `requiredMemoryMB`, but token-generation throughput
+  // is too low to clear agent-loop timeouts. `computeConstrained` excludes
+  // `computeIntensive` registry entries regardless of available memory.
+  const jetsonGpu = {
+    type: "nvidia",
+    totalMemoryMB: 65_536,
+    availableMemoryMB: 60_000,
+    computeConstrained: true,
+  };
+
+  it("drops compute-intensive entries even when memory ostensibly fits", () => {
+    const tags = fittableOllamaModelTags(jetsonGpu);
+    expect(tags).toEqual([SMALLEST_OLLAMA_MODEL_TAG]);
+  });
+
+  it("modelFitsAvailableMemory returns false for compute-intensive tags on iGPU", () => {
+    expect(modelFitsAvailableMemory("nemotron-3-nano:30b", jetsonGpu)).toBe(false);
+    expect(modelFitsAvailableMemory("qwen3.6:35b", jetsonGpu)).toBe(false);
+  });
+
+  it("does not gate the smallest entry on iGPU", () => {
+    expect(modelFitsAvailableMemory("qwen3.5:9b", jetsonGpu)).toBe(true);
+  });
+
+  it("dGPU hosts with the same memory are not gated", () => {
+    const dGpu = {
+      type: "nvidia",
+      totalMemoryMB: 65_536,
+      availableMemoryMB: 60_000,
+    };
+    expect(modelFitsAvailableMemory("nemotron-3-nano:30b", dGpu)).toBe(true);
+    expect(fittableOllamaModelTags(dGpu)).toContain("nemotron-3-nano:30b");
+  });
+});

--- a/src/lib/inference/ollama-model-registry.ts
+++ b/src/lib/inference/ollama-model-registry.ts
@@ -29,13 +29,31 @@ export interface OllamaModelEntry {
   tag: string;
   requiredMemoryMB: number;
   downloadSizeBytes: number;
+  /**
+   * `true` for entries whose token-generation throughput on integrated GPUs
+   * (Jetson, Windows-on-ARM iGPU) is too low to be useful under agent-loop
+   * timeouts even when memory ostensibly fits. Compute-constrained hosts
+   * skip these entries during bootstrap-model selection regardless of the
+   * `requiredMemoryMB` headroom check.
+   */
+  computeIntensive?: boolean;
 }
 
 // Largest first. The selector walks this list, filters by available memory,
 // and reverses the result so menus render smallest-first.
 export const OLLAMA_MODEL_REGISTRY: readonly OllamaModelEntry[] = [
-  { tag: "qwen3.6:35b", requiredMemoryMB: 26_000, downloadSizeBytes: 24_000_000_000 },
-  { tag: "nemotron-3-nano:30b", requiredMemoryMB: 22_000, downloadSizeBytes: 19_000_000_000 },
+  {
+    tag: "qwen3.6:35b",
+    requiredMemoryMB: 30_000,
+    downloadSizeBytes: 24_000_000_000,
+    computeIntensive: true,
+  },
+  {
+    tag: "nemotron-3-nano:30b",
+    requiredMemoryMB: 26_000,
+    downloadSizeBytes: 19_000_000_000,
+    computeIntensive: true,
+  },
   { tag: "qwen3.5:9b", requiredMemoryMB: 12_000, downloadSizeBytes: 6_600_000_000 },
 ];
 
@@ -76,6 +94,7 @@ export function effectiveGpuMemoryMB(gpu: GpuInfo | null): number | null {
 export function modelFitsAvailableMemory(tag: string, gpu: GpuInfo | null): boolean {
   const entry = findOllamaModelEntry(tag);
   if (!entry) return true;
+  if (entry.computeIntensive && gpu?.computeConstrained === true) return false;
   const memory = effectiveGpuMemoryMB(gpu);
   if (memory == null) return true;
   return entry.requiredMemoryMB <= memory;
@@ -101,8 +120,12 @@ export function fittableOllamaModelTags(gpu: GpuInfo | null): string[] {
   }
   const memory = effectiveGpuMemoryMB(gpu);
   if (memory == null) return fallback;
+  const computeConstrained = gpu.computeConstrained === true;
   const fitting = OLLAMA_MODEL_REGISTRY.filter(
-    (entry) => entry.requiredMemoryMB <= memory && entry.tag !== SMALLEST_OLLAMA_MODEL_TAG,
+    (entry) =>
+      entry.requiredMemoryMB <= memory &&
+      entry.tag !== SMALLEST_OLLAMA_MODEL_TAG &&
+      !(computeConstrained && entry.computeIntensive),
   );
   if (fitting.length === 0) return fallback;
   return [SMALLEST_OLLAMA_MODEL_TAG, ...fitting.map((entry) => entry.tag).reverse()];
@@ -120,7 +143,11 @@ export function anyRegistryModelFits(gpu: GpuInfo | null): boolean {
   if (!gpu || (gpu.type !== "nvidia" && gpu.type !== "apple")) return true;
   const memory = effectiveGpuMemoryMB(gpu);
   if (memory == null) return true;
-  return OLLAMA_MODEL_REGISTRY.some((entry) => entry.requiredMemoryMB <= memory);
+  const computeConstrained = gpu.computeConstrained === true;
+  return OLLAMA_MODEL_REGISTRY.some(
+    (entry) =>
+      entry.requiredMemoryMB <= memory && !(computeConstrained && entry.computeIntensive),
+  );
 }
 
 /**

--- a/src/lib/inference/ollama-probe-timeout.test.ts
+++ b/src/lib/inference/ollama-probe-timeout.test.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { validateOllamaModel } from "../../../dist/lib/inference/local";
+
+describe("Ollama probe timeout retry", () => {
+  it("retries with extended timeout on non-Spark hosts when first probe times out", () => {
+    const commands: string[] = [];
+    let captureExCallCount = 0;
+    const captureEx = (cmd: string[]) => {
+      captureExCallCount++;
+      commands.push(cmd.join(" "));
+      if (captureExCallCount === 1) return { stdout: "", exitCode: 28, timedOut: true };
+      return { stdout: JSON.stringify({ response: "Hi" }), exitCode: 0, timedOut: false };
+    };
+
+    const result = validateOllamaModel("nemotron-3-nano:30b", () => "", () => false, captureEx);
+
+    expect(result.ok).toBe(true);
+    expect(captureExCallCount).toBe(2);
+    expect(commands[1]).toMatch(/--max-time.*300|300.*--max-time/);
+  });
+});

--- a/src/lib/inference/ollama-runtime-context.test.ts
+++ b/src/lib/inference/ollama-runtime-context.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyOllamaRuntimeContextWindow,
+  MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW,
   parseOllamaRuntimeContextLength,
   probeOllamaRuntimeModelStatus,
   resetOllamaRuntimeContextWindowAutoState,
@@ -104,6 +105,46 @@ describe("Ollama runtime context helpers", () => {
     expect(
       resolveOllamaRuntimeContextWindow("other:model", null, getOllamaHost, capture),
     ).toBeNull();
+  });
+
+  it("raises the auto-adopted context window to the agent floor when the daemon reports below it", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const messages: string[] = [];
+    const options = {
+      env,
+      logger: {
+        log: (message: string) => messages.push(message),
+        warn: (message: string) => messages.push(message),
+      },
+      runCaptureImpl: () =>
+        JSON.stringify({
+          models: [{ name: "llama3.2:3b", context_length: 4096, processor: "100% GPU" }],
+        }),
+    };
+
+    applyOllamaRuntimeContextWindow("llama3.2:3b", getOllamaHost, options);
+    expect(env.NEMOCLAW_CONTEXT_WINDOW).toBe(String(MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW));
+    expect(messages.some((m) => m.includes("Raising Ollama runtime context window"))).toBe(true);
+  });
+
+  it("preserves a daemon-reported context window above the agent floor", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const messages: string[] = [];
+    const options = {
+      env,
+      logger: {
+        log: (message: string) => messages.push(message),
+        warn: (message: string) => messages.push(message),
+      },
+      runCaptureImpl: () =>
+        JSON.stringify({
+          models: [{ name: "qwen3.5:9b", context_length: 32_768, processor: "100% GPU" }],
+        }),
+    };
+
+    applyOllamaRuntimeContextWindow("qwen3.5:9b", getOllamaHost, options);
+    expect(env.NEMOCLAW_CONTEXT_WINDOW).toBe("32768");
+    expect(messages.some((m) => m.includes("Raising Ollama runtime context window"))).toBe(false);
   });
 
   it("applies and clears only auto-detected context window state", () => {

--- a/src/lib/inference/ollama-runtime-context.ts
+++ b/src/lib/inference/ollama-runtime-context.ts
@@ -38,6 +38,14 @@ export interface ApplyOllamaRuntimeContextWindowOptions {
 // context windows while still rejecting obviously broken daemon responses.
 export const MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW = 4_194_304;
 
+// Floor for auto-adopted runtime context windows. Ollama's stock daemon serves
+// `num_ctx=4096` until OLLAMA_CONTEXT_LENGTH is set host-side, which cannot fit
+// an agent base prompt + tool catalogue (~7.4 k tokens) plus a single user turn.
+// When the probed runtime length is below this floor and the user has not set
+// an explicit override, NemoClaw raises NEMOCLAW_CONTEXT_WINDOW to the floor so
+// downstream prompt budgeting reflects a workable window.
+export const MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW = 16_384;
+
 function normalizeOllamaModelName(value: unknown): string {
   return String(value || "").trim();
 }
@@ -205,10 +213,20 @@ export function applyOllamaRuntimeContextWindow(
     logger.warn(`  ⚠ ${runtimeStatus.contextLengthWarning}`);
   }
   if (runtimeStatus.loaded && runtimeStatus.contextLength) {
-    const value = String(runtimeStatus.contextLength);
+    const detected = runtimeStatus.contextLength;
+    const adopted = Math.max(detected, MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW);
+    const value = String(adopted);
     env.NEMOCLAW_CONTEXT_WINDOW = value;
     autoDetectedOllamaContextWindow = value;
-    logger.log(`  ✓ Using Ollama runtime context length: ${value} tokens`);
+    if (adopted > detected) {
+      logger.log(
+        `  ✓ Raising Ollama runtime context window to ${adopted} tokens ` +
+          `(daemon reported ${detected}, below the ${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}-token agent floor). ` +
+          `Set OLLAMA_CONTEXT_LENGTH host-side to raise the daemon default and silence this autoset.`,
+      );
+    } else {
+      logger.log(`  ✓ Using Ollama runtime context length: ${value} tokens`);
+    }
     return;
   }
 

--- a/src/lib/inference/ollama/proxy.test.ts
+++ b/src/lib/inference/ollama/proxy.test.ts
@@ -97,4 +97,46 @@ describe("promptOllamaModel installed-model fit filter", () => {
     });
     expect(result).toBe("my-custom:model");
   });
+
+  it("drops excludeModels entries from the installed-fitting menu so a repeat probe-fail does not loop", async () => {
+    // Caller (selectAndValidateOllamaModel) records `nemotron-3-nano:30b` as a
+    // probe-fail and excludes it. Without this filter, pressing Enter on the
+    // installed-fitting list would re-select the broken model and dead-loop.
+    const setup = loadProxyWithMocks({
+      installed: ["nemotron-3-nano:30b", "qwen3.5:9b"],
+      promptValues: [""],
+    });
+    active = setup;
+    const result = await setup.proxy.promptOllamaModel(
+      {
+        type: "nvidia",
+        totalMemoryMB: 131_072,
+        availableMemoryMB: 131_072,
+      },
+      { excludeModels: new Set(["nemotron-3-nano:30b"]) },
+    );
+    expect(result).toBe("qwen3.5:9b");
+  });
+
+  it("falls back to bootstrap options and never re-offers excluded entries", async () => {
+    const setup = loadProxyWithMocks({
+      installed: ["nemotron-3-nano:30b"],
+      // Pick the first menu entry explicitly. With nemotron-3-nano:30b
+      // excluded, the bootstrap fall-back menu lists [qwen3.5:9b, qwen3.6:35b]
+      // smallest-first; option 1 must resolve to qwen3.5:9b, never the
+      // excluded tag.
+      promptValues: ["1"],
+    });
+    active = setup;
+    const result = await setup.proxy.promptOllamaModel(
+      {
+        type: "nvidia",
+        totalMemoryMB: 131_072,
+        availableMemoryMB: 131_072,
+      },
+      { excludeModels: new Set(["nemotron-3-nano:30b"]) },
+    );
+    expect(result).toBe("qwen3.5:9b");
+    expect(result).not.toBe("nemotron-3-nano:30b");
+  });
 });

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -376,18 +376,31 @@ function probeOllamaAuthProxyHealth(): { ok: boolean; endpoint: string; detail: 
   };
 }
 
-async function promptOllamaModel(gpu: GpuInfo | null = null) {
+async function promptOllamaModel(
+  gpu: GpuInfo | null = null,
+  promptOptions: { excludeModels?: ReadonlySet<string> } = {},
+) {
+  const excludeModels = promptOptions.excludeModels;
+  const isExcluded = (tag: string): boolean =>
+    excludeModels !== undefined && excludeModels.has(tag);
   const installed = getOllamaModelOptions();
   // Filter installed entries by registry-known memory fit so a host that
   // currently cannot load the only installed model still gets a usable
   // default — without the filter, pressing Enter would re-select the
   // oversized model the runner is about to crash on. Unknown tags (user-
   // pulled models the registry has never seen) pass the filter so the
-  // user's prior selection is respected.
-  const installedFitting = installed.filter((tag: string) => modelFitsAvailableMemory(tag, gpu));
+  // user's prior selection is respected. `excludeModels` additionally drops
+  // tags the caller knows the local probe has already rejected this round.
+  const installedFitting = installed.filter(
+    (tag: string) => modelFitsAvailableMemory(tag, gpu) && !isExcluded(tag),
+  );
   const usingInstalled = installedFitting.length > 0;
-  const options = usingInstalled ? installedFitting : getBootstrapOllamaModelOptions(gpu);
-  const defaultModel = getDefaultOllamaModel(gpu);
+  const bootstrap = getBootstrapOllamaModelOptions(gpu).filter((tag) => !isExcluded(tag));
+  const options = usingInstalled ? installedFitting : bootstrap;
+  const defaultModelCandidate = getDefaultOllamaModel(gpu);
+  const defaultModel = isExcluded(defaultModelCandidate)
+    ? options[0] ?? defaultModelCandidate
+    : defaultModelCandidate;
   const defaultIndex = Math.max(0, options.indexOf(defaultModel));
 
   console.log("");

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3875,13 +3875,24 @@ async function selectAndValidateOllamaModel(
   defaults: { requestedModel: string | null; recoveredModel: string | null },
 ): Promise<OllamaModelSelectionOutcome> {
   const { requestedModel, recoveredModel } = defaults;
+  // Track local-probe failures so a host that legitimately cannot load the
+  // wizard's default model (e.g. NVIDIA L4 vs 30B class, cold-load timeout)
+  // does not dead-loop re-offering the same model. After the same tag fails
+  // twice — or three total probe failures across distinct tags — surface a
+  // diagnostic and return to provider selection so the caller can offer a
+  // different provider instead of cycling the same broken pick.
+  const probeFailureCounts = new Map<string, number>();
+  const excludedAfterRepeatFail = new Set<string>();
+  const MAX_PROBE_FAILS_SAME_MODEL = 2;
+  const MAX_PROBE_FAILS_TOTAL = 3;
+  let totalProbeFailures = 0;
   while (true) {
     const installedModels = getOllamaModelOptions();
     let model: string | typeof BACK_TO_SELECTION;
     if (isNonInteractive()) {
       model = localInference.resolveNonInteractiveOllamaModel(requestedModel, recoveredModel, gpu);
     } else {
-      model = await promptOllamaModel(gpu);
+      model = await promptOllamaModel(gpu, { excludeModels: excludedAfterRepeatFail });
     }
     if (isBackToSelection(model)) {
       console.log("  Returning to provider selection.");
@@ -3919,8 +3930,26 @@ async function selectAndValidateOllamaModel(
     }
     const probe = await prepareOllamaModel(selectedModel, installedModels);
     if (!probe.ok) {
+      const sameModelCount = (probeFailureCounts.get(selectedModel) ?? 0) + 1;
+      probeFailureCounts.set(selectedModel, sameModelCount);
+      totalProbeFailures += 1;
+      if (sameModelCount >= MAX_PROBE_FAILS_SAME_MODEL) {
+        excludedAfterRepeatFail.add(selectedModel);
+      }
       const action = handleOllamaProbeFailure(probe, selectedModel, isNonInteractive);
       if (action === "back-to-selection") return { outcome: "back-to-selection" };
+      if (
+        sameModelCount >= MAX_PROBE_FAILS_SAME_MODEL ||
+        totalProbeFailures >= MAX_PROBE_FAILS_TOTAL
+      ) {
+        console.error(
+          `  Ollama model selection has hit ${totalProbeFailures} probe failure(s) ` +
+            `(model '${selectedModel}' alone failed ${sameModelCount} time(s)). ` +
+            "Returning to provider selection — pick a different provider, free GPU memory, " +
+            "or set NEMOCLAW_MODEL to a model known to fit this host before retrying Ollama.",
+        );
+        return { outcome: "back-to-selection" };
+      }
       continue;
     }
     const allowToolsIncompatible = probe.allowToolsIncompatible === true;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -114,6 +114,7 @@ const {
 const {
   installOllamaOnMacOS,
 }: typeof import("./onboard/install-ollama-macos") = require("./onboard/install-ollama-macos");
+const { OllamaProbeFailureTracker }: typeof import("./onboard/ollama-probe-failure-tracker") = require("./onboard/ollama-probe-failure-tracker");
 const crypto = require("node:crypto");
 const fs = require("fs");
 const os = require("os");
@@ -3846,34 +3847,20 @@ const { readLiveInference, readRecordedProvider, readRecordedNimContainer, readR
 type OllamaModelSelectionOutcome =
   | { outcome: "selected"; model: string; allowToolsIncompatible: boolean }
   | { outcome: "back-to-selection" };
-// Pick an Ollama model, pull it if missing, and validate it via the local
-// proxy. Shared by the three Ollama provider branches (running, Windows-host
-// install/start, install-locally). Returns "back-to-selection" so the caller
-// can `continue` its labelled outer selectionLoop.
 async function selectAndValidateOllamaModel(
   gpu: ReturnType<typeof nim.detectGpu>,
   provider: string,
   defaults: { requestedModel: string | null; recoveredModel: string | null },
 ): Promise<OllamaModelSelectionOutcome> {
   const { requestedModel, recoveredModel } = defaults;
-  // Track local-probe failures so a host that legitimately cannot load the
-  // wizard's default model (e.g. NVIDIA L4 vs 30B class, cold-load timeout)
-  // does not dead-loop re-offering the same model. After the same tag fails
-  // twice — or three total probe failures across distinct tags — surface a
-  // diagnostic and return to provider selection so the caller can offer a
-  // different provider instead of cycling the same broken pick.
-  const probeFailureCounts = new Map<string, number>();
-  const excludedAfterRepeatFail = new Set<string>();
-  const MAX_PROBE_FAILS_SAME_MODEL = 2;
-  const MAX_PROBE_FAILS_TOTAL = 3;
-  let totalProbeFailures = 0;
+  const probeFailures = new OllamaProbeFailureTracker();
   while (true) {
     const installedModels = getOllamaModelOptions();
     let model: string | typeof BACK_TO_SELECTION;
     if (isNonInteractive()) {
       model = localInference.resolveNonInteractiveOllamaModel(requestedModel, recoveredModel, gpu);
     } else {
-      model = await promptOllamaModel(gpu, { excludeModels: excludedAfterRepeatFail });
+      model = await promptOllamaModel(gpu, { excludeModels: probeFailures.excludedModels() });
     }
     if (isBackToSelection(model)) {
       console.log("  Returning to provider selection.");
@@ -3911,24 +3898,11 @@ async function selectAndValidateOllamaModel(
     }
     const probe = await prepareOllamaModel(selectedModel, installedModels);
     if (!probe.ok) {
-      const sameModelCount = (probeFailureCounts.get(selectedModel) ?? 0) + 1;
-      probeFailureCounts.set(selectedModel, sameModelCount);
-      totalProbeFailures += 1;
-      if (sameModelCount >= MAX_PROBE_FAILS_SAME_MODEL) {
-        excludedAfterRepeatFail.add(selectedModel);
-      }
+      const probeFailureLimitReached = probeFailures.recordFailure(selectedModel);
       const action = handleOllamaProbeFailure(probe, selectedModel, isNonInteractive);
       if (action === "back-to-selection") return { outcome: "back-to-selection" };
-      if (
-        sameModelCount >= MAX_PROBE_FAILS_SAME_MODEL ||
-        totalProbeFailures >= MAX_PROBE_FAILS_TOTAL
-      ) {
-        console.error(
-          `  Ollama model selection has hit ${totalProbeFailures} probe failure(s) ` +
-            `(model '${selectedModel}' alone failed ${sameModelCount} time(s)). ` +
-            "Returning to provider selection — pick a different provider, free GPU memory, " +
-            "or set NEMOCLAW_MODEL to a model known to fit this host before retrying Ollama.",
-        );
+      if (probeFailureLimitReached) {
+        console.error(probeFailures.formatLimitMessage(selectedModel));
         return { outcome: "back-to-selection" };
       }
       continue;
@@ -3990,9 +3964,6 @@ async function setupNim(
   let preferredInferenceApi: string | null = null;
   let allowToolsIncompatible = false;
 
-  // Detect local inference options. Bound curl with --connect-timeout/--max-time
-  // so a half-open port or stalled listener cannot hang the onboard at step 3
-  // (#2674).
   const localProbeCurlArgs = ["--connect-timeout", "2", "--max-time", "5"] as const;
   const hasOllama = hostCommandExists("ollama");
   const ollamaHost = findReachableOllamaHost();

--- a/src/lib/onboard/ollama-probe-failure-tracker.test.ts
+++ b/src/lib/onboard/ollama-probe-failure-tracker.test.ts
@@ -6,18 +6,27 @@ import { describe, expect, it } from "vitest";
 import { OllamaProbeFailureTracker } from "./ollama-probe-failure-tracker";
 
 describe("OllamaProbeFailureTracker", () => {
-  it("excludes a model and trips the limit after repeated failures", () => {
+  it("excludes a model after the first failure and trips the limit after repeated failures", () => {
     const tracker = new OllamaProbeFailureTracker();
+
+    expect(tracker.recordFailure("qwen3.5:9b")).toBe(false);
+    expect(tracker.shouldExclude("qwen3.5:9b")).toBe(true);
+    expect(tracker.excludedModels().has("qwen3.5:9b")).toBe(true);
+
+    expect(tracker.recordFailure("qwen3.5:9b")).toBe(true);
+
+    expect(tracker.getFailureCount("qwen3.5:9b")).toBe(2);
+    expect(tracker.getTotalFailures()).toBe(2);
+  });
+
+  it("supports delaying exclusion until the per-model failure limit", () => {
+    const tracker = new OllamaProbeFailureTracker({ excludeAfterFailures: 2 });
 
     expect(tracker.recordFailure("qwen3.5:9b")).toBe(false);
     expect(tracker.shouldExclude("qwen3.5:9b")).toBe(false);
 
     expect(tracker.recordFailure("qwen3.5:9b")).toBe(true);
-
     expect(tracker.shouldExclude("qwen3.5:9b")).toBe(true);
-    expect(tracker.excludedModels().has("qwen3.5:9b")).toBe(true);
-    expect(tracker.getFailureCount("qwen3.5:9b")).toBe(2);
-    expect(tracker.getTotalFailures()).toBe(2);
   });
 
   it("trips the global limit across distinct models", () => {
@@ -27,7 +36,7 @@ describe("OllamaProbeFailureTracker", () => {
     expect(tracker.recordFailure("b:1b")).toBe(false);
     expect(tracker.recordFailure("c:1b")).toBe(true);
 
-    expect(tracker.shouldExclude("a:1b")).toBe(false);
+    expect(tracker.shouldExclude("a:1b")).toBe(true);
     expect(tracker.getTotalFailures()).toBe(3);
     expect(tracker.formatLimitMessage("c:1b")).toContain("3 probe failure(s)");
   });

--- a/src/lib/onboard/ollama-probe-failure-tracker.test.ts
+++ b/src/lib/onboard/ollama-probe-failure-tracker.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { OllamaProbeFailureTracker } from "./ollama-probe-failure-tracker";
+
+describe("OllamaProbeFailureTracker", () => {
+  it("excludes a model and trips the limit after repeated failures", () => {
+    const tracker = new OllamaProbeFailureTracker();
+
+    expect(tracker.recordFailure("qwen3.5:9b")).toBe(false);
+    expect(tracker.shouldExclude("qwen3.5:9b")).toBe(false);
+
+    expect(tracker.recordFailure("qwen3.5:9b")).toBe(true);
+
+    expect(tracker.shouldExclude("qwen3.5:9b")).toBe(true);
+    expect(tracker.excludedModels().has("qwen3.5:9b")).toBe(true);
+    expect(tracker.getFailureCount("qwen3.5:9b")).toBe(2);
+    expect(tracker.getTotalFailures()).toBe(2);
+  });
+
+  it("trips the global limit across distinct models", () => {
+    const tracker = new OllamaProbeFailureTracker();
+
+    expect(tracker.recordFailure("a:1b")).toBe(false);
+    expect(tracker.recordFailure("b:1b")).toBe(false);
+    expect(tracker.recordFailure("c:1b")).toBe(true);
+
+    expect(tracker.shouldExclude("a:1b")).toBe(false);
+    expect(tracker.getTotalFailures()).toBe(3);
+    expect(tracker.formatLimitMessage("c:1b")).toContain("3 probe failure(s)");
+  });
+
+  it("resets counters and exclusions", () => {
+    const tracker = new OllamaProbeFailureTracker({ maxFailuresSameModel: 1 });
+
+    expect(tracker.recordFailure("nemotron:30b")).toBe(true);
+    tracker.reset();
+
+    expect(tracker.getTotalFailures()).toBe(0);
+    expect(tracker.getFailureCount("nemotron:30b")).toBe(0);
+    expect(tracker.shouldExclude("nemotron:30b")).toBe(false);
+  });
+});

--- a/src/lib/onboard/ollama-probe-failure-tracker.ts
+++ b/src/lib/onboard/ollama-probe-failure-tracker.ts
@@ -2,21 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type OllamaProbeFailureTrackerOptions = {
+  excludeAfterFailures?: number;
   maxFailuresSameModel?: number;
   maxFailuresTotal?: number;
 };
 
+const DEFAULT_EXCLUDE_AFTER_FAILURES = 1;
 const DEFAULT_MAX_FAILURES_SAME_MODEL = 2;
 const DEFAULT_MAX_FAILURES_TOTAL = 3;
 
 export class OllamaProbeFailureTracker {
+  private readonly excludeAfterFailures: number;
   private readonly maxFailuresSameModel: number;
   private readonly maxFailuresTotal: number;
   private readonly failureCounts = new Map<string, number>();
-  private readonly excludedAfterRepeatFail = new Set<string>();
+  private readonly excludedModelTags = new Set<string>();
   private totalProbeFailures = 0;
 
   constructor(options: OllamaProbeFailureTrackerOptions = {}) {
+    this.excludeAfterFailures = options.excludeAfterFailures ?? DEFAULT_EXCLUDE_AFTER_FAILURES;
     this.maxFailuresSameModel = options.maxFailuresSameModel ?? DEFAULT_MAX_FAILURES_SAME_MODEL;
     this.maxFailuresTotal = options.maxFailuresTotal ?? DEFAULT_MAX_FAILURES_TOTAL;
   }
@@ -25,18 +29,18 @@ export class OllamaProbeFailureTracker {
     const sameModelFailures = this.getFailureCount(tag) + 1;
     this.failureCounts.set(tag, sameModelFailures);
     this.totalProbeFailures += 1;
-    if (sameModelFailures >= this.maxFailuresSameModel) {
-      this.excludedAfterRepeatFail.add(tag);
+    if (sameModelFailures >= this.excludeAfterFailures) {
+      this.excludedModelTags.add(tag);
     }
     return this.limitReached(tag);
   }
 
   shouldExclude(tag: string): boolean {
-    return this.excludedAfterRepeatFail.has(tag);
+    return this.excludedModelTags.has(tag);
   }
 
   excludedModels(): ReadonlySet<string> {
-    return this.excludedAfterRepeatFail;
+    return this.excludedModelTags;
   }
 
   getTotalFailures(): number {
@@ -65,7 +69,7 @@ export class OllamaProbeFailureTracker {
 
   reset(): void {
     this.failureCounts.clear();
-    this.excludedAfterRepeatFail.clear();
+    this.excludedModelTags.clear();
     this.totalProbeFailures = 0;
   }
 }

--- a/src/lib/onboard/ollama-probe-failure-tracker.ts
+++ b/src/lib/onboard/ollama-probe-failure-tracker.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type OllamaProbeFailureTrackerOptions = {
+  maxFailuresSameModel?: number;
+  maxFailuresTotal?: number;
+};
+
+const DEFAULT_MAX_FAILURES_SAME_MODEL = 2;
+const DEFAULT_MAX_FAILURES_TOTAL = 3;
+
+export class OllamaProbeFailureTracker {
+  private readonly maxFailuresSameModel: number;
+  private readonly maxFailuresTotal: number;
+  private readonly failureCounts = new Map<string, number>();
+  private readonly excludedAfterRepeatFail = new Set<string>();
+  private totalProbeFailures = 0;
+
+  constructor(options: OllamaProbeFailureTrackerOptions = {}) {
+    this.maxFailuresSameModel = options.maxFailuresSameModel ?? DEFAULT_MAX_FAILURES_SAME_MODEL;
+    this.maxFailuresTotal = options.maxFailuresTotal ?? DEFAULT_MAX_FAILURES_TOTAL;
+  }
+
+  recordFailure(tag: string): boolean {
+    const sameModelFailures = this.getFailureCount(tag) + 1;
+    this.failureCounts.set(tag, sameModelFailures);
+    this.totalProbeFailures += 1;
+    if (sameModelFailures >= this.maxFailuresSameModel) {
+      this.excludedAfterRepeatFail.add(tag);
+    }
+    return this.limitReached(tag);
+  }
+
+  shouldExclude(tag: string): boolean {
+    return this.excludedAfterRepeatFail.has(tag);
+  }
+
+  excludedModels(): ReadonlySet<string> {
+    return this.excludedAfterRepeatFail;
+  }
+
+  getTotalFailures(): number {
+    return this.totalProbeFailures;
+  }
+
+  getFailureCount(tag: string): number {
+    return this.failureCounts.get(tag) ?? 0;
+  }
+
+  limitReached(tag: string): boolean {
+    return (
+      this.getFailureCount(tag) >= this.maxFailuresSameModel ||
+      this.totalProbeFailures >= this.maxFailuresTotal
+    );
+  }
+
+  formatLimitMessage(tag: string): string {
+    return (
+      `  Ollama model selection has hit ${this.totalProbeFailures} probe failure(s) ` +
+      `(model '${tag}' alone failed ${this.getFailureCount(tag)} time(s)). ` +
+      "Returning to provider selection — pick a different provider, free GPU memory, " +
+      "or set NEMOCLAW_MODEL to a model known to fit this host before retrying Ollama."
+    );
+  }
+
+  reset(): void {
+    this.failureCounts.clear();
+    this.excludedAfterRepeatFail.clear();
+    this.totalProbeFailures = 0;
+  }
+}

--- a/src/lib/onboard/ollama-systemd.test.ts
+++ b/src/lib/onboard/ollama-systemd.test.ts
@@ -48,6 +48,22 @@ describe("mergeOllamaLoopbackSystemdOverride", () => {
     expect(out).not.toContain('Environment="OLLAMA_CONTEXT_LENGTH=4096"');
   });
 
+  it("preserves unrelated variables sharing an Environment line with managed Ollama settings", () => {
+    const existing = [
+      "[Service]",
+      'Environment="OLLAMA_CONTEXT_LENGTH=4096" "OLLAMA_ORIGINS=http://127.0.0.1" "HTTPS_PROXY=http://proxy.local"',
+      "",
+    ].join("\n");
+    const out = mergeOllamaLoopbackSystemdOverride(existing);
+    expect(out).toContain(
+      'Environment="OLLAMA_ORIGINS=http://127.0.0.1" "HTTPS_PROXY=http://proxy.local"',
+    );
+    expect(out).toContain(
+      `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`,
+    );
+    expect(out).not.toContain('Environment="OLLAMA_CONTEXT_LENGTH=4096"');
+  });
+
   it("keeps commented-out OLLAMA_CONTEXT_LENGTH lines verbatim", () => {
     const existing = [
       "[Service]",

--- a/src/lib/onboard/ollama-systemd.test.ts
+++ b/src/lib/onboard/ollama-systemd.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { OLLAMA_PORT } from "../../../dist/lib/core/ports";
+import { MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW } from "../../../dist/lib/inference/ollama-runtime-context";
+import { mergeOllamaLoopbackSystemdOverride } from "../../../dist/lib/onboard/ollama-systemd";
+
+describe("mergeOllamaLoopbackSystemdOverride", () => {
+  it("writes the OLLAMA_HOST and OLLAMA_CONTEXT_LENGTH lines under [Service] when no drop-in exists", () => {
+    const out = mergeOllamaLoopbackSystemdOverride("");
+    expect(out).toContain("[Service]");
+    expect(out).toContain(`Environment="OLLAMA_HOST=127.0.0.1:${OLLAMA_PORT}"`);
+    expect(out).toContain(
+      `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`,
+    );
+  });
+
+  it("preserves an existing user-supplied OLLAMA_CONTEXT_LENGTH that is above the NemoClaw floor", () => {
+    const existing = [
+      "[Service]",
+      'Environment="OLLAMA_HOST=0.0.0.0:11434"',
+      'Environment="OLLAMA_CONTEXT_LENGTH=65536"',
+      "",
+    ].join("\n");
+    const out = mergeOllamaLoopbackSystemdOverride(existing);
+    expect(out).toContain(`Environment="OLLAMA_HOST=127.0.0.1:${OLLAMA_PORT}"`);
+    expect(out).toContain('Environment="OLLAMA_CONTEXT_LENGTH=65536"');
+    expect(out).not.toContain(
+      `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`,
+    );
+    // Legacy 0.0.0.0 line must be stripped.
+    expect(out).not.toContain('Environment="OLLAMA_HOST=0.0.0.0:11434"');
+  });
+
+  it("replaces a stale OLLAMA_CONTEXT_LENGTH below the NemoClaw floor", () => {
+    const existing = [
+      "[Service]",
+      'Environment="OLLAMA_HOST=127.0.0.1:11434"',
+      'Environment="OLLAMA_CONTEXT_LENGTH=4096"',
+      "",
+    ].join("\n");
+    const out = mergeOllamaLoopbackSystemdOverride(existing);
+    expect(out).toContain(
+      `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`,
+    );
+    expect(out).not.toContain('Environment="OLLAMA_CONTEXT_LENGTH=4096"');
+  });
+
+  it("keeps commented-out OLLAMA_CONTEXT_LENGTH lines verbatim", () => {
+    const existing = [
+      "[Service]",
+      'Environment="OLLAMA_HOST=127.0.0.1:11434"',
+      '# Environment="OLLAMA_CONTEXT_LENGTH=8192"',
+      "",
+    ].join("\n");
+    const out = mergeOllamaLoopbackSystemdOverride(existing);
+    expect(out).toContain('# Environment="OLLAMA_CONTEXT_LENGTH=8192"');
+    expect(out).toContain(
+      `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`,
+    );
+  });
+
+  it("threads through the libraryOverride option alongside the context length", () => {
+    const out = mergeOllamaLoopbackSystemdOverride("", { libraryOverride: "cuda_v13" });
+    expect(out).toContain('Environment="OLLAMA_LLM_LIBRARY=cuda_v13"');
+    expect(out).toContain(
+      `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`,
+    );
+  });
+});

--- a/src/lib/onboard/ollama-systemd.ts
+++ b/src/lib/onboard/ollama-systemd.ts
@@ -6,6 +6,7 @@ import nodePath from "node:path";
 
 import { OLLAMA_PORT } from "../core/ports";
 import { sleepSeconds } from "../core/wait";
+import { MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW } from "../inference/ollama-runtime-context";
 import { cleanupTempDir, secureTempFile } from "./temp-files";
 
 const { runCapture, runShell, shellQuote }: typeof import("../runner") = require("../runner");
@@ -191,11 +192,12 @@ export function ensureManagedOllamaLoopbackSystemdOverride(
   return ensureOllamaLoopbackSystemdOverride({ ...options, enableService: true });
 }
 
-function mergeOllamaLoopbackSystemdOverride(
+export function mergeOllamaLoopbackSystemdOverride(
   existingDropIn: string,
   options: { libraryOverride?: string | null } = {},
 ): string {
   const desiredLine = `Environment="OLLAMA_HOST=127.0.0.1:${OLLAMA_PORT}"`;
+  const desiredContextLine = `Environment="OLLAMA_CONTEXT_LENGTH=${MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW}"`;
   const desiredLibraryLine = options.libraryOverride
     ? `Environment="OLLAMA_LLM_LIBRARY=${options.libraryOverride}"`
     : null;
@@ -207,6 +209,7 @@ function mergeOllamaLoopbackSystemdOverride(
       ...(lines.length > 0 ? [""] : []),
       "[Service]",
       desiredLine,
+      desiredContextLine,
       ...(desiredLibraryLine ? [desiredLibraryLine] : []),
     ].join("\n") + "\n";
   }
@@ -219,30 +222,40 @@ function mergeOllamaLoopbackSystemdOverride(
     }
   }
 
-  // Strip any existing non-comment OLLAMA_HOST assignments inside [Service]
-  // before re-appending the loopback override. systemd's "last wins" semantics
-  // for repeated Environment= would usually pick the appended line, but legacy
-  // 0.0.0.0 drop-ins from older NemoClaw versions occasionally outlived the
-  // restart — removing the stale line makes the policy unambiguous. (#3342)
+  // Strip any existing non-comment OLLAMA_HOST and OLLAMA_CONTEXT_LENGTH
+  // assignments inside [Service] before re-appending. systemd's "last wins"
+  // semantics for repeated Environment= would usually pick the appended line,
+  // but legacy 0.0.0.0 drop-ins from older NemoClaw versions occasionally
+  // outlived the restart — removing the stale line makes the policy
+  // unambiguous. The OLLAMA_CONTEXT_LENGTH strip preserves user-supplied
+  // higher values only when they exceed the NemoClaw floor (parsed below).
   const ollamaHostLine = (line: string): boolean =>
     !/^\s*[#;]/.test(line) && /\bOLLAMA_HOST=/.test(line);
   const ollamaLibraryLine = (line: string): boolean =>
     Boolean(desiredLibraryLine) && !/^\s*[#;]/.test(line) && /\bOLLAMA_LLM_LIBRARY=/.test(line);
+  const ollamaContextLine = (line: string): boolean =>
+    !/^\s*[#;]/.test(line) && /\bOLLAMA_CONTEXT_LENGTH=/.test(line);
+  const parseContextValue = (line: string): number | null => {
+    const m = line.match(/\bOLLAMA_CONTEXT_LENGTH=("?)(\d+)\1/);
+    return m ? parseInt(m[2], 10) : null;
+  };
   const serviceBody = lines.slice(serviceStart + 1, serviceEnd);
+  const existingHigherContext = serviceBody
+    .filter((line) => ollamaContextLine(line))
+    .map(parseContextValue)
+    .filter((v): v is number => v !== null && v > MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW)
+    .sort((a, b) => b - a)[0];
+  const contextLine = existingHigherContext
+    ? `Environment="OLLAMA_CONTEXT_LENGTH=${existingHigherContext}"`
+    : desiredContextLine;
   const filteredBody = serviceBody.filter(
-    (line) => !ollamaHostLine(line) && !ollamaLibraryLine(line),
+    (line) => !ollamaHostLine(line) && !ollamaLibraryLine(line) && !ollamaContextLine(line),
   );
-  if (
-    !desiredLibraryLine &&
-    filteredBody.length === serviceBody.length &&
-    serviceBody.some((line) => line.trim() === desiredLine)
-  ) {
-    return lines.join("\n") + "\n";
-  }
   const rebuilt = [
     ...lines.slice(0, serviceStart + 1),
     ...filteredBody,
     desiredLine,
+    contextLine,
     ...(desiredLibraryLine ? [desiredLibraryLine] : []),
     ...lines.slice(serviceEnd),
   ];

--- a/src/lib/onboard/ollama-systemd.ts
+++ b/src/lib/onboard/ollama-systemd.ts
@@ -192,6 +192,57 @@ export function ensureManagedOllamaLoopbackSystemdOverride(
   return ensureOllamaLoopbackSystemdOverride({ ...options, enableService: true });
 }
 
+function splitSystemdEnvironmentTokens(value: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === "\\" && i + 1 < value.length) {
+      current += ch + value[i + 1];
+      i += 1;
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && (quote === null || quote === ch)) {
+      quote = quote === ch ? null : ch;
+      current += ch;
+      continue;
+    }
+    if (/\s/.test(ch) && quote === null) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function systemdEnvironmentTokenName(token: string): string | null {
+  const unquoted = token.replace(/^(["'])(.*)\1$/, "$2");
+  const match = unquoted.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+  return match ? match[1] : null;
+}
+
+function rewriteEnvironmentLineWithoutManagedAssignments(
+  line: string,
+  managedNames: ReadonlySet<string>,
+): string[] {
+  if (/^\s*[#;]/.test(line)) return [line];
+  const match = line.match(/^(\s*Environment\s*=\s*)(.*)$/);
+  if (!match) return [line];
+  const tokens = splitSystemdEnvironmentTokens(match[2]);
+  const kept = tokens.filter((token) => {
+    const name = systemdEnvironmentTokenName(token);
+    return !name || !managedNames.has(name);
+  });
+  if (kept.length === tokens.length) return [line];
+  return kept.length > 0 ? [`${match[1]}${kept.join(" ")}`] : [];
+}
+
 export function mergeOllamaLoopbackSystemdOverride(
   existingDropIn: string,
   options: { libraryOverride?: string | null } = {},
@@ -222,34 +273,26 @@ export function mergeOllamaLoopbackSystemdOverride(
     }
   }
 
-  // Strip any existing non-comment OLLAMA_HOST and OLLAMA_CONTEXT_LENGTH
-  // assignments inside [Service] before re-appending. systemd's "last wins"
-  // semantics for repeated Environment= would usually pick the appended line,
-  // but legacy 0.0.0.0 drop-ins from older NemoClaw versions occasionally
-  // outlived the restart — removing the stale line makes the policy
-  // unambiguous. The OLLAMA_CONTEXT_LENGTH strip preserves user-supplied
-  // higher values only when they exceed the NemoClaw floor (parsed below).
-  const ollamaHostLine = (line: string): boolean =>
-    !/^\s*[#;]/.test(line) && /\bOLLAMA_HOST=/.test(line);
-  const ollamaLibraryLine = (line: string): boolean =>
-    Boolean(desiredLibraryLine) && !/^\s*[#;]/.test(line) && /\bOLLAMA_LLM_LIBRARY=/.test(line);
-  const ollamaContextLine = (line: string): boolean =>
-    !/^\s*[#;]/.test(line) && /\bOLLAMA_CONTEXT_LENGTH=/.test(line);
+  // Strip NemoClaw-managed assignments inside [Service] before re-appending.
+  // Preserve unrelated variables that share the same systemd Environment= line
+  // so operator-supplied daemon settings such as OLLAMA_ORIGINS survive repair.
+  const serviceBody = lines.slice(serviceStart + 1, serviceEnd);
+  const managedNames = new Set(["OLLAMA_HOST", "OLLAMA_CONTEXT_LENGTH"]);
+  if (desiredLibraryLine) managedNames.add("OLLAMA_LLM_LIBRARY");
   const parseContextValue = (line: string): number | null => {
     const m = line.match(/\bOLLAMA_CONTEXT_LENGTH=("?)(\d+)\1/);
     return m ? parseInt(m[2], 10) : null;
   };
-  const serviceBody = lines.slice(serviceStart + 1, serviceEnd);
   const existingHigherContext = serviceBody
-    .filter((line) => ollamaContextLine(line))
+    .filter((line) => !/^\s*[#;]/.test(line) && /\bOLLAMA_CONTEXT_LENGTH=/.test(line))
     .map(parseContextValue)
     .filter((v): v is number => v !== null && v > MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW)
     .sort((a, b) => b - a)[0];
   const contextLine = existingHigherContext
     ? `Environment="OLLAMA_CONTEXT_LENGTH=${existingHigherContext}"`
     : desiredContextLine;
-  const filteredBody = serviceBody.filter(
-    (line) => !ollamaHostLine(line) && !ollamaLibraryLine(line) && !ollamaContextLine(line),
+  const filteredBody = serviceBody.flatMap((line) =>
+    rewriteEnvironmentLineWithoutManagedAssignments(line, managedNames),
   );
   const rebuilt = [
     ...lines.slice(0, serviceStart + 1),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Three compounding faults steer Ollama onboarding into a dead-loop on tight-VRAM dGPU hosts (L4 23 GB) and leave the agent with a 4096-token runtime context window that cannot fit the base prompt + tool catalogue.

Tightens the bootstrap-model registry, raises the auto-adopted runtime context window to a workable floor, extends the cold-load probe retry to non-Spark hosts, and breaks the model-selection re-prompt out of dead-loops after repeated probe failures.

## Related Issue

Fixes #4812
Fixes #4813
Refs #3707

## Changes

- Raised registry `requiredMemoryMB` so 30B-class entries no longer pass the fit check on L4-class 23 GB dGPUs: `nemotron-3-nano:30b` 22000 → 26000 and `qwen3.6:35b` 26000 → 30000. The original 22000 budget left ~1 GB headroom over the 19 GB on-disk weight, which is not enough for KV cache + activations + agent prompt at default context; the runner ended up spilling GPU→CPU during warm-up and the probe timed out.
- Added `OllamaModelEntry.computeIntensive` and `GpuInfo.computeConstrained` so `fittableOllamaModelTags` / `modelFitsAvailableMemory` / `anyRegistryModelFits` skip 30B-class entries on integrated-GPU hosts (`platform === "jetson"`), where memory ostensibly fits but token-generation throughput cannot clear agent-loop timeouts.
- Dropped the `sparkHost` guard on the 300 s probe retry in `validateOllamaModel`. Cold-loading a large model from disk can routinely exceed the default 120 s window on any tight-VRAM dGPU, not just Spark. Fast failures (connection refused) keep `timedOut === false` and surface immediately.
- Added `MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW = 16_384` and modified `applyOllamaRuntimeContextWindow` to raise `NEMOCLAW_CONTEXT_WINDOW` to the floor when the daemon-reported `context_length` is below it. Ollama's stock `num_ctx=4096` cannot fit the OpenClaw agent base prompt + tool catalogue (~7.4 k tokens) so every turn previously hit `Context overflow: prompt too large for the model`.
- Made `mergeOllamaLoopbackSystemdOverride` write `Environment="OLLAMA_CONTEXT_LENGTH=16384"` alongside `OLLAMA_HOST=127.0.0.1`, so a daemon restarted through the override serves the workable context length. Preserves user-supplied values above the NemoClaw floor; strips stale below-floor lines.
- Added loop-escape to `selectAndValidateOllamaModel`: tracks per-model probe-failure counts, threads an `excludeModels` set through `promptOllamaModel`, and falls back to provider selection after 2 failures on the same model or 3 failures total. Replaces the previous dead-loop that re-offered the same broken installed model every round.
- Added tests covering: L4 23 GB excludes 30B-class entries; `computeConstrained: true` iGPU excludes compute-intensive entries regardless of memory; runtime context floor raises 4096 → 16384 and preserves 32768; systemd override writes/preserves/strips `OLLAMA_CONTEXT_LENGTH`; `validateOllamaModel` retries on non-Spark when timed out; `promptOllamaModel` excludes failed tags from both menus.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU compute constraint detection for improved model recommendations on specialized hardware like Jetson platforms.
  * Introduced compute-intensive model flagging to avoid recommending unsuitable models on resource-constrained devices.

* **Improvements**
  * Enhanced Ollama connection reliability with extended retry logic for timeout scenarios.
  * Improved onboarding flow with smarter model exclusion to prevent repeated failures during setup.
  * Enforced context window floor for more consistent Ollama runtime behavior.

* **Tests**
  * Expanded test coverage for compute-constrained GPU detection and model selection filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->