### PR TITLE
fix(hermes): preserve proxy api key on inference switch

### DIFF
--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -284,6 +284,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "openai/gpt-5.4-mini",
       provider: "custom",
       base_url: "https://inference.local/v1",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
       temperature: 0.2,
     });
     expect(config.models).toEqual({
@@ -317,6 +318,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "claude-sonnet-4-6",
       provider: "custom",
       base_url: "https://inference.local",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
       api_mode: "anthropic_messages",
     });
   });
@@ -337,6 +339,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "nvidia/nemotron-3-super-120b-a12b",
       provider: "custom",
       base_url: "https://inference.local/v1",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
     });
   });
 
@@ -360,6 +363,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "anthropic.claude-3-5-sonnet-20240620-v1:0",
       provider: "custom",
       base_url: "https://inference.local/v1",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
     });
   });
 });
@@ -485,6 +489,7 @@ describe("runInferenceSet", () => {
         default: "openai/gpt-5.4-mini",
         provider: "custom",
         base_url: "https://inference.local/v1",
+        api_key: "sk-OPENSHELL-PROXY-REWRITE",
       },
       terminal: { backend: "local" },
     });
@@ -687,6 +692,7 @@ describe("runInferenceSet", () => {
       default: "claude-sonnet-proxy",
       provider: "custom",
       base_url: "https://inference.local",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
       api_mode: "anthropic_messages",
     });
     expect(deps.getSession()).toMatchObject({
@@ -741,6 +747,7 @@ describe("runInferenceSet", () => {
       default: "anthropic.claude-sonnet-4-6-20260101-v1:0",
       provider: "custom",
       base_url: "https://inference.local/v1",
+      api_key: "sk-OPENSHELL-PROXY-REWRITE",
     });
     expect(result).toMatchObject({
       providerKey: "inference",

--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
+import { HERMES_PROXY_API_KEY_PLACEHOLDER } from "../hermes-proxy-api-key";
 import type { AgentConfigTarget } from "../sandbox/config";
 import type { ConfigObject } from "../security/credential-filter";
 import type { Session } from "../state/onboard-session";
@@ -284,7 +285,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "openai/gpt-5.4-mini",
       provider: "custom",
       base_url: "https://inference.local/v1",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
       temperature: 0.2,
     });
     expect(config.models).toEqual({
@@ -295,6 +296,23 @@ describe("patchHermesInferenceConfig", () => {
       },
     });
     expect(config.terminal).toEqual({ backend: "local" });
+  });
+
+  it("replaces stale Hermes API keys with the OpenShell proxy placeholder", () => {
+    for (const api_key of ["no-key-required", "sk-real-looking-key-that-must-not-survive"]) {
+      const config: ConfigObject = {
+        model: {
+          default: "old-model",
+          provider: "custom",
+          base_url: "https://old.example/v1",
+          api_key,
+        },
+      };
+
+      patchHermesInferenceConfig(config, "hermes-provider", "openai/gpt-5.4-mini");
+
+      expect((config.model as ConfigObject).api_key).toBe(HERMES_PROXY_API_KEY_PLACEHOLDER);
+    }
   });
 
   it("sets Hermes Anthropic Messages mode for Anthropic routes", () => {
@@ -318,7 +336,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "claude-sonnet-4-6",
       provider: "custom",
       base_url: "https://inference.local",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
       api_mode: "anthropic_messages",
     });
   });
@@ -339,7 +357,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "nvidia/nemotron-3-super-120b-a12b",
       provider: "custom",
       base_url: "https://inference.local/v1",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
     });
   });
 
@@ -363,7 +381,7 @@ describe("patchHermesInferenceConfig", () => {
       default: "anthropic.claude-3-5-sonnet-20240620-v1:0",
       provider: "custom",
       base_url: "https://inference.local/v1",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
     });
   });
 });
@@ -489,7 +507,7 @@ describe("runInferenceSet", () => {
         default: "openai/gpt-5.4-mini",
         provider: "custom",
         base_url: "https://inference.local/v1",
-        api_key: "sk-OPENSHELL-PROXY-REWRITE",
+        api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
       },
       terminal: { backend: "local" },
     });
@@ -692,7 +710,7 @@ describe("runInferenceSet", () => {
       default: "claude-sonnet-proxy",
       provider: "custom",
       base_url: "https://inference.local",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
       api_mode: "anthropic_messages",
     });
     expect(deps.getSession()).toMatchObject({
@@ -747,7 +765,7 @@ describe("runInferenceSet", () => {
       default: "anthropic.claude-sonnet-4-6-20260101-v1:0",
       provider: "custom",
       base_url: "https://inference.local/v1",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
     });
     expect(result).toMatchObject({
       providerKey: "inference",

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -5,6 +5,7 @@ import type { SpawnSyncReturns } from "node:child_process";
 
 import { runOpenshell } from "../adapters/openshell/runtime";
 import { CLI_NAME } from "../cli/branding";
+import { HERMES_PROXY_API_KEY_PLACEHOLDER } from "../hermes-proxy-api-key";
 import {
   getProviderSelectionConfig,
   getSandboxInferenceConfig,
@@ -46,7 +47,6 @@ export interface InferenceSetResult {
 
 type OpenshellRunResult = Pick<SpawnSyncReturns<string>, "status" | "stdout" | "stderr">;
 
-const HERMES_PROXY_API_KEY_PLACEHOLDER = "sk-OPENSHELL-PROXY-REWRITE";
 
 export interface InferenceSetDeps {
   getDefaultSandbox: () => string | null;

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -46,6 +46,8 @@ export interface InferenceSetResult {
 
 type OpenshellRunResult = Pick<SpawnSyncReturns<string>, "status" | "stdout" | "stderr">;
 
+const HERMES_PROXY_API_KEY_PLACEHOLDER = "sk-OPENSHELL-PROXY-REWRITE";
+
 export interface InferenceSetDeps {
   getDefaultSandbox: () => string | null;
   getSandbox: (name: string) => SandboxEntry | null;
@@ -272,6 +274,7 @@ export function patchHermesInferenceConfig(
   modelConfig.default = model;
   modelConfig.base_url = route.inferenceBaseUrl;
   modelConfig.provider = "custom";
+  modelConfig.api_key = HERMES_PROXY_API_KEY_PLACEHOLDER;
   const apiMode = hermesApiMode(route.inferenceApi);
   if (apiMode) {
     modelConfig.api_mode = apiMode;

--- a/src/lib/hermes-proxy-api-key.ts
+++ b/src/lib/hermes-proxy-api-key.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Non-secret OpenShell proxy rewrite sentinel shared by Hermes config paths.
+// Hermes/LiteLLM requires an `sk-`-prefixed value before it will issue a
+// request, but OpenShell strips this placeholder and injects the real route
+// credential at the egress boundary. Remove this once Hermes no longer gates
+// custom endpoints on a credential-shaped API key.
+export const HERMES_PROXY_API_KEY_PLACEHOLDER = "sk-OPENSHELL-PROXY-REWRITE";

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import YAML from "yaml";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { HERMES_PROXY_API_KEY_PLACEHOLDER } from "../src/lib/hermes-proxy-api-key";
 
 const SCRIPT_PATH = path.join(import.meta.dirname, "..", "agents", "hermes", "generate-config.ts");
 const CONFIG_MODULE_DIR = path.join(import.meta.dirname, "..", "agents", "hermes", "config");
@@ -105,7 +106,7 @@ describe("agents/hermes/generate-config.ts", () => {
       default: "test-model",
       provider: "custom",
       base_url: "https://inference.local/v1",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
     });
     expect(config.platforms).toEqual({
       api_server: {
@@ -131,7 +132,7 @@ describe("agents/hermes/generate-config.ts", () => {
       default: "test-model",
       provider: "custom",
       base_url: "https://inference.local",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
       api_mode: "anthropic_messages",
     });
   });
@@ -163,7 +164,13 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(typeof config.model.api_key).toBe("string");
     expect(config.model.api_key.startsWith("sk-")).toBe(true);
     expect(config.model.api_key).not.toBe("no-key-required");
-    expect(config.model.api_key).toMatch(/OPENSHELL/);
+    expect(config.model.api_key).toBe(HERMES_PROXY_API_KEY_PLACEHOLDER);
+  });
+
+  it("keeps generated and inference-switch Hermes proxy placeholders in sync", () => {
+    const { config } = runConfigScript();
+
+    expect(config.model.api_key).toBe(HERMES_PROXY_API_KEY_PLACEHOLDER);
   });
 
   it("generates managed-tool gateway config and env for selected Nous presets", () => {
@@ -432,7 +439,7 @@ describe("agents/hermes/generate-config.ts", () => {
       default: "moonshotai/kimi-k2.6",
       provider: "custom",
       base_url: "https://inference.local/v1",
-      api_key: "sk-OPENSHELL-PROXY-REWRITE",
+      api_key: HERMES_PROXY_API_KEY_PLACEHOLDER,
     });
     expect(config.kimi).toBeUndefined();
     expect(config.openclawPlugins).toBeUndefined();


### PR DESCRIPTION
## Summary
Hermes inference switches now keep the OpenShell proxy rewrite API-key placeholder in `model.api_key`. This prevents Hermes dashboard/TUI sessions from resolving `provider: custom` with the upstream `no-key-required` fallback after `nemohermes inference set` rewrites `/sandbox/.hermes/config.yaml`.

## Related Issue
Related to #4765.

## Changes
- Add a Hermes proxy API-key placeholder in `patchHermesInferenceConfig()`.
- Update Hermes inference-switch unit tests to assert `model.api_key: sk-OPENSHELL-PROXY-REWRITE` across OpenAI-compatible, Anthropic Messages, and Bedrock-compatible routes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation run:
- `npm run build:cli` passes
- `npm run typecheck:cli` passes after rebuilding `dist/`
- `npx vitest run src/lib/actions/inference-set.test.ts --maxWorkers=1 --testTimeout=30000` passes
- `npx prek run --files src/lib/actions/inference-set.ts src/lib/actions/inference-set.test.ts` passes
- Full pre-commit test hook was attempted and hit the existing/environmental `test/onboard-selection.test.ts -t "returns to provider selection when Ollama manual entry chooses back"` failure; that test passed when rerun in isolation.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced API key placeholder constant for Hermes proxy authentication configuration.
  * Updated Hermes inference configuration patching to consistently apply the placeholder.

* **Tests**
  * Updated test assertions to verify correct placeholder usage in Hermes configuration patching.
  * Synchronized test expectations for configuration generation and inference switching to use the placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->