### PR TITLE
ci(e2e): withhold live messaging secrets from target refs

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -360,19 +360,19 @@ jobs:
       env_json: '{"DISCORD_BOT_TOKEN":"test-fake-discord-token-e2e","NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_POLICY_TIER":"open","NEMOCLAW_SANDBOX_NAME":"e2e-msg-provider","SLACK_APP_TOKEN":"xapp-fake-slack-app-token-e2e","SLACK_BOT_TOKEN":"xoxb-fake-slack-token-e2e","TELEGRAM_BOT_TOKEN":"test-fake-telegram-token-e2e"}'
       nvidia_api_key: true
       github_token: true
-      messaging_live_secrets: true
+      messaging_live_secrets: ${{ github.event_name != 'workflow_dispatch' || inputs.target_ref == '' }}
     secrets:
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
       BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
       DOCKERHUB_USERNAME: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.DOCKERHUB_USERNAME || '' }}
       DOCKERHUB_TOKEN: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.DOCKERHUB_TOKEN || '' }}
-      TELEGRAM_BOT_TOKEN_REAL: ${{ secrets.TELEGRAM_BOT_TOKEN_REAL }}
-      TELEGRAM_CHAT_ID_E2E: ${{ secrets.TELEGRAM_CHAT_ID_E2E }}
-      DISCORD_BOT_TOKEN_REAL: ${{ secrets.DISCORD_BOT_TOKEN_REAL }}
-      DISCORD_CHANNEL_ID_E2E: ${{ secrets.DISCORD_CHANNEL_ID_E2E }}
-      SLACK_BOT_TOKEN_REAL: ${{ secrets.SLACK_BOT_TOKEN_REAL }}
-      SLACK_APP_TOKEN_REAL: ${{ secrets.SLACK_APP_TOKEN_REAL }}
-      SLACK_CHANNEL_ID_E2E: ${{ secrets.SLACK_CHANNEL_ID_E2E }}
+      TELEGRAM_BOT_TOKEN_REAL: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.TELEGRAM_BOT_TOKEN_REAL || '' }}
+      TELEGRAM_CHAT_ID_E2E: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.TELEGRAM_CHAT_ID_E2E || '' }}
+      DISCORD_BOT_TOKEN_REAL: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.DISCORD_BOT_TOKEN_REAL || '' }}
+      DISCORD_CHANNEL_ID_E2E: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.DISCORD_CHANNEL_ID_E2E || '' }}
+      SLACK_BOT_TOKEN_REAL: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.SLACK_BOT_TOKEN_REAL || '' }}
+      SLACK_APP_TOKEN_REAL: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.SLACK_APP_TOKEN_REAL || '' }}
+      SLACK_CHANNEL_ID_E2E: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.SLACK_CHANNEL_ID_E2E || '' }}
   openclaw-slack-pairing-e2e:
     if: >-
       github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'workflow_dispatch' ||

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -42,14 +42,15 @@ describe("E2E reusable workflow contract", () => {
       DOCKERHUB_TOKEN:
         "${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.DOCKERHUB_TOKEN || '' }}",
     };
+    const trustedRefGuard = "github.event_name != 'workflow_dispatch' || inputs.target_ref == ''";
     const messagingLiveSecrets = {
-      TELEGRAM_BOT_TOKEN_REAL: "${{ secrets.TELEGRAM_BOT_TOKEN_REAL }}",
-      TELEGRAM_CHAT_ID_E2E: "${{ secrets.TELEGRAM_CHAT_ID_E2E }}",
-      DISCORD_BOT_TOKEN_REAL: "${{ secrets.DISCORD_BOT_TOKEN_REAL }}",
-      DISCORD_CHANNEL_ID_E2E: "${{ secrets.DISCORD_CHANNEL_ID_E2E }}",
-      SLACK_BOT_TOKEN_REAL: "${{ secrets.SLACK_BOT_TOKEN_REAL }}",
-      SLACK_APP_TOKEN_REAL: "${{ secrets.SLACK_APP_TOKEN_REAL }}",
-      SLACK_CHANNEL_ID_E2E: "${{ secrets.SLACK_CHANNEL_ID_E2E }}",
+      TELEGRAM_BOT_TOKEN_REAL: `\${{ (${trustedRefGuard}) && secrets.TELEGRAM_BOT_TOKEN_REAL || '' }}`,
+      TELEGRAM_CHAT_ID_E2E: `\${{ (${trustedRefGuard}) && secrets.TELEGRAM_CHAT_ID_E2E || '' }}`,
+      DISCORD_BOT_TOKEN_REAL: `\${{ (${trustedRefGuard}) && secrets.DISCORD_BOT_TOKEN_REAL || '' }}`,
+      DISCORD_CHANNEL_ID_E2E: `\${{ (${trustedRefGuard}) && secrets.DISCORD_CHANNEL_ID_E2E || '' }}`,
+      SLACK_BOT_TOKEN_REAL: `\${{ (${trustedRefGuard}) && secrets.SLACK_BOT_TOKEN_REAL || '' }}`,
+      SLACK_APP_TOKEN_REAL: `\${{ (${trustedRefGuard}) && secrets.SLACK_APP_TOKEN_REAL || '' }}`,
+      SLACK_CHANNEL_ID_E2E: `\${{ (${trustedRefGuard}) && secrets.SLACK_CHANNEL_ID_E2E || '' }}`,
     };
 
     expect(reusableJobs.length).toBeGreaterThan(20);
@@ -58,18 +59,39 @@ describe("E2E reusable workflow contract", () => {
       const expectedSecrets =
         expectsLiveMessaging ? { ...defaultSecrets, ...messagingLiveSecrets } : defaultSecrets;
       expect(job.secrets, name).toEqual(expectedSecrets);
-      expect(job.with?.messaging_live_secrets ?? false, name).toBe(expectsLiveMessaging);
+      expect(job.with?.messaging_live_secrets ?? false, name).toBe(
+        expectsLiveMessaging
+          ? "${{ github.event_name != 'workflow_dispatch' || inputs.target_ref == '' }}"
+          : false,
+      );
     }
   });
 
-  it("requires an explicit opt-in before exposing live messaging secrets to scripts", () => {
+  it("requires trusted target refs and an explicit opt-in before exposing live messaging secrets", () => {
     const callInputs =
       runnerWorkflow.on?.workflow_call?.inputs ??
       runnerWorkflow.true?.workflow_call?.inputs ??
       {};
     const runStep = runnerWorkflow.jobs.run.steps.find((step) => step.name === "Run E2E script");
+    const messagingJob = nightlyWorkflow.jobs["messaging-providers-e2e"];
 
     expect(callInputs.messaging_live_secrets?.default).toBe(false);
+    expect(messagingJob.with?.messaging_live_secrets).toBe(
+      "${{ github.event_name != 'workflow_dispatch' || inputs.target_ref == '' }}",
+    );
+    for (const name of [
+      "TELEGRAM_BOT_TOKEN_REAL",
+      "TELEGRAM_CHAT_ID_E2E",
+      "DISCORD_BOT_TOKEN_REAL",
+      "DISCORD_CHANNEL_ID_E2E",
+      "SLACK_BOT_TOKEN_REAL",
+      "SLACK_APP_TOKEN_REAL",
+      "SLACK_CHANNEL_ID_E2E",
+    ]) {
+      expect(messagingJob.secrets?.[name], name).toBe(
+        `\${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.${name} || '' }}`,
+      );
+    }
     expect(runStep?.env?.TELEGRAM_BOT_TOKEN_REAL).toBe(
       "${{ inputs.messaging_live_secrets && secrets.TELEGRAM_BOT_TOKEN_REAL || '' }}",
     );

--- a/test/validate-e2e-coverage.test.ts
+++ b/test/validate-e2e-coverage.test.ts
@@ -306,7 +306,9 @@ describe("nightly E2E workflow validation", () => {
     const messagingSecrets =
       (messagingJob?.secrets as Record<string, unknown> | undefined) ?? {};
     const messagingWith = (messagingJob?.with as Record<string, unknown> | undefined) ?? {};
-    if (messagingWith.messaging_live_secrets !== true) {
+    const trustedRefExpression =
+      "${{ github.event_name != 'workflow_dispatch' || inputs.target_ref == '' }}";
+    if (messagingWith.messaging_live_secrets !== trustedRefExpression) {
       missing.push("nightly messaging-providers-e2e with.messaging_live_secrets");
     }
 
@@ -317,7 +319,10 @@ describe("nightly E2E workflow validation", () => {
       if (runStepEnv[name] !== `\${{ inputs.messaging_live_secrets && secrets.${name} || '' }}`) {
         missing.push(`e2e-script Run E2E script env.${name}`);
       }
-      if (messagingSecrets[name] !== `\${{ secrets.${name} }}`) {
+      if (
+        messagingSecrets[name] !==
+        `\${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.${name} || '' }}`
+      ) {
         missing.push(`nightly messaging-providers-e2e secrets.${name}`);
       }
     }


### PR DESCRIPTION
## Summary
Prevent selective nightly E2E dispatches with an explicit target ref from receiving live messaging provider secrets. The messaging providers job now opts into live secrets only on trusted refs and blanks each live Slack, Discord, and Telegram secret for target-ref dispatches.

## Changes
- Guard `messaging_live_secrets` in `.github/workflows/nightly-e2e.yaml` with the same trusted-ref predicate used for Docker Hub credentials.
- Blank live messaging provider secret mappings when `workflow_dispatch` supplies `inputs.target_ref`.
- Update workflow contract tests to assert target-ref dispatches cannot expose live messaging secrets.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted checks run:
- `npx vitest run test/e2e-script-workflow.test.ts test/validate-e2e-coverage.test.ts --testTimeout 60000`
- `npm run checks`
- commit and pre-push hooks

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced protection of messaging provider credentials by conditionally gating access to live secrets, ensuring they are only available in trusted workflow scenarios.

* **Tests**
  * Strengthened E2E workflow contract tests to enforce stricter security gating for live messaging secrets in reusable workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->