### PR TITLE
test(hermes): use benign secret-boundary sentinels

### DIFF
--- a/test/e2e/test-hermes-sandbox-secret-boundary.sh
+++ b/test/e2e/test-hermes-sandbox-secret-boundary.sh
@@ -391,22 +391,23 @@ docker image inspect "$MANAGED_IMAGE" >/dev/null 2>&1 || fail "image not found: 
 
 inspect_image_boundary "$IMAGE"
 inspect_managed_tool_boundary "$MANAGED_IMAGE"
+RAW_SECRET_SENTINEL="SENTINEL_RAW_SECRET_VALUE"
 assert_startup_rejects_env_entry \
-  "DEVTEST_API_TOKEN=01234567-89ab-cdef-0123-456789abcdef" \
+  "DEVTEST_API_TOKEN=${RAW_SECRET_SENTINEL}" \
   "DEVTEST_API_TOKEN" \
-  "01234567-89ab-cdef-0123-456789abcdef"
+  "$RAW_SECRET_SENTINEL"
 assert_startup_rejects_env_entry \
-  "INTERNAL_API=01234567-89ab-cdef-0123-456789abcdef" \
+  "INTERNAL_API=${RAW_SECRET_SENTINEL}" \
   "INTERNAL_API" \
-  "01234567-89ab-cdef-0123-456789abcdef"
+  "$RAW_SECRET_SENTINEL"
 assert_startup_rejects_env_entry \
   "OPENAI_API_KEY=sk-OPENSHELL-PROXY-REWRITE" \
   "OPENAI_API_KEY" \
   "sk-OPENSHELL-PROXY-REWRITE"
 assert_startup_rejects_runtime_env_entry \
-  "DEVTEST_API_TOKEN=01234567-89ab-cdef-0123-456789abcdef" \
+  "DEVTEST_API_TOKEN=${RAW_SECRET_SENTINEL}" \
   "DEVTEST_API_TOKEN" \
-  "01234567-89ab-cdef-0123-456789abcdef"
+  "$RAW_SECRET_SENTINEL"
 assert_startup_rejects_runtime_env_entry \
   "NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN=raw-refresh-token" \
   "NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN" \

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -182,7 +182,7 @@ describe("agents/hermes/generate-config.ts", () => {
   });
 
   it("flags bare API-named .env secrets while allowing API server config", () => {
-    const rawSecret = "01234567-89ab-cdef-0123-456789abcdef";
+    const rawSecret = "SENTINEL_RAW_SECRET_VALUE";
 
     expect(
       findRawSecretEnvEntries(

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -582,7 +582,7 @@ describe("agents/hermes/start.sh env secret boundary", () => {
   });
 
   it("rejects raw secret-shaped values without printing the value", () => {
-    const rawToken = "01234567-89ab-cdef-0123-456789abcdef";
+    const rawToken = "SENTINEL_RAW_SECRET_VALUE";
     const result = runHermesEnvSecretBoundary({
       envFile: `DEVTEST_API_TOKEN=${rawToken}\n`,
     });
@@ -594,7 +594,7 @@ describe("agents/hermes/start.sh env secret boundary", () => {
   });
 
   it("rejects bare API-named raw values without printing the value", () => {
-    const rawToken = "01234567-89ab-cdef-0123-456789abcdef";
+    const rawToken = "SENTINEL_RAW_SECRET_VALUE";
     const result = runHermesEnvSecretBoundary({
       envFile: `INTERNAL_API=${rawToken}\n`,
     });
@@ -643,7 +643,7 @@ describe("agents/hermes/start.sh env secret boundary", () => {
   });
 
   it("rejects raw secret-shaped process env values without printing the value", () => {
-    const rawToken = "01234567-89ab-cdef-0123-456789abcdef";
+    const rawToken = "SENTINEL_RAW_SECRET_VALUE";
     const result = runHermesRuntimeEnvSecretBoundary({
       DEVTEST_API_TOKEN: rawToken,
       NEMOCLAW_HERMES_TOOL_GATEWAY_REFRESH_TOKEN: "raw-refresh-token",


### PR DESCRIPTION
## Summary
Replace GUID-like Hermes secret-boundary fixture values with benign sentinels. The tests still validate raw non-placeholder secret-shaped values are rejected without committing scanner-shaped literals.

## Changes
- Replace GUID-like E2E secret-boundary payloads in `test/e2e/test-hermes-sandbox-secret-boundary.sh`.
- Replace GUID-like raw secret fixtures in `test/generate-hermes-config.test.ts` and `test/hermes-start.test.ts`.
- Keep the existing startup rejection and no-value-echo assertions unchanged in behavior.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted checks run:
- `bash -n test/e2e/test-hermes-sandbox-secret-boundary.sh`
- `npx vitest run test/hermes-start.test.ts test/generate-hermes-config.test.ts --testTimeout 60000`
- `npm run checks`
- commit and pre-push hooks

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>