### PR TITLE
fix(onboard): ignore policy tier env in interactive mode

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6134,9 +6134,12 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
     console.error("  A sandbox name cannot be prompted for in this context.");
     process.exit(1);
   }
-  // Same fail-fast contract for NEMOCLAW_POLICY_TIER (#3741):
-  // validate before usage-notice state, preflight, gateway, or inference work.
-  policyTierEnv.validatePolicyTierEnvEarly();
+  // Same fail-fast contract for NEMOCLAW_POLICY_TIER (#3741) in non-interactive
+  // mode: validate before usage-notice state, preflight, gateway, or inference
+  // work. Interactive onboarding ignores the env var and prompts instead.
+  if (isNonInteractive()) {
+    policyTierEnv.validatePolicyTierEnvEarly();
+  }
   const noticeAccepted = await ensureUsageNoticeConsent({
     nonInteractive: isNonInteractive(),
     acceptedByFlag: opts.acceptThirdPartySoftware === true,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -6134,12 +6134,8 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
     console.error("  A sandbox name cannot be prompted for in this context.");
     process.exit(1);
   }
-  // Same fail-fast contract for NEMOCLAW_POLICY_TIER (#3741) in non-interactive
-  // mode: validate before usage-notice state, preflight, gateway, or inference
-  // work. Interactive onboarding ignores the env var and prompts instead.
-  if (isNonInteractive()) {
-    policyTierEnv.validatePolicyTierEnvEarly();
-  }
+  // Fail fast for NEMOCLAW_POLICY_TIER only where selectPolicyTier reads it.
+  if (isNonInteractive()) policyTierEnv.validatePolicyTierEnvEarly();
   const noticeAccepted = await ensureUsageNoticeConsent({
     nonInteractive: isNonInteractive(),
     acceptedByFlag: opts.acceptThirdPartySoftware === true,

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -17,18 +17,26 @@ const repoRoot = path.join(import.meta.dirname, "..");
  * Run a small inline Node script that mocks out the minimal dependencies of
  * onboard.js, calls the given async expression, and prints a JSON payload.
  */
-function runScript(scriptBody: string): SpawnSyncReturns<string> {
+function runScript(
+  scriptBody: string,
+  envOverrides: Record<string, string | undefined> = {},
+): SpawnSyncReturns<string> {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-tier-onboard-"));
   const scriptPath = path.join(tmpDir, "script.js");
   fs.writeFileSync(scriptPath, scriptBody);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: tmpDir,
+    NEMOCLAW_NON_INTERACTIVE: "1",
+    ...envOverrides,
+  };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete env[key];
+  }
   const result = spawnSync(process.execPath, [scriptPath], {
     cwd: repoRoot,
     encoding: "utf-8",
-    env: {
-      ...process.env,
-      HOME: tmpDir,
-      NEMOCLAW_NON_INTERACTIVE: "1",
-    },
+    env,
     timeout: 15000,
   });
   fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -195,6 +203,44 @@ process.exit = (code = 0) => {
     );
     assert.doesNotMatch(result.stderr, /Third-Party Software Notice/);
     assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /\[1\/8\] Preflight checks/);
+    assert.ok(!result.stdout.includes("UNEXPECTED_SUCCESS"));
+  });
+
+  it("ignores invalid NEMOCLAW_POLICY_TIER during interactive onboarding", () => {
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const script = String.raw`
+process.env.NEMOCLAW_POLICY_TIER = "invalid_tier";
+delete process.env.NEMOCLAW_NON_INTERACTIVE;
+const { onboard } = require(${onboardPath});
+const exitMarker = "__NEMOCLAW_TEST_PROCESS_EXIT__";
+process.exit = (code = 0) => {
+  const err = new Error(exitMarker);
+  err.code = Number(code);
+  throw err;
+};
+(async () => {
+  try {
+    await onboard({
+      acceptThirdPartySoftware: true,
+      sandboxName: "tier-test",
+    });
+    process.stdout.write("UNEXPECTED_SUCCESS\n");
+    process.exitCode = 0;
+  } catch (err) {
+    if (!err || err.message !== exitMarker) {
+      process.stderr.write((err && err.stack) || String(err));
+      process.exitCode = 99;
+      return;
+    }
+    process.stdout.write(JSON.stringify({ exitCode: err.code }) + "\n");
+    process.exitCode = err.code;
+  }
+})();
+`;
+    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: undefined });
+    assert.equal(result.status, 1, result.stderr);
+    assert.doesNotMatch(result.stderr, /Unknown policy tier: invalid_tier/);
+    assert.match(result.stderr, /Interactive onboarding requires a TTY/);
     assert.ok(!result.stdout.includes("UNEXPECTED_SUCCESS"));
   });
 


### PR DESCRIPTION
## Summary
Keep the early `NEMOCLAW_POLICY_TIER` validation scoped to non-interactive onboarding, where the environment variable is actually consumed. Interactive onboarding now ignores an invalid policy-tier env var and continues to its normal interactive prompt/TTY flow.

## Changes
- Guard `policyTierEnv.validatePolicyTierEnvEarly()` with `isNonInteractive()` in `src/lib/onboard.ts`.
- Update policy-tier onboarding tests to cover the interactive invalid-env path.
- Keep the existing non-interactive fail-fast behavior for invalid `NEMOCLAW_POLICY_TIER`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted checks run:
- `npm run build:cli`
- `npm run typecheck:cli`
- `npx vitest run test/policy-tiers-onboard.test.ts --testTimeout 60000`
- `npm run checks`
- commit and pre-push hooks

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified policy tier validation to execute only in non-interactive mode, improving the interactive onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->