### PR TITLE
fix(cli): align list default sandbox with env overrides (#1077)

### DIFF
--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getSandboxInventory,
@@ -543,14 +543,30 @@ describe("inventory commands", () => {
     expect(showServiceStatus).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
-  it("reuses the existing sandbox list when resolving status service sandbox", () => {
+  describe("#1077 — env-resolved default sandbox", () => {
     const savedSandboxName = process.env.SANDBOX_NAME;
     const savedNemoclawSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
     const savedNemoclawSandbox = process.env.NEMOCLAW_SANDBOX;
-    delete process.env.SANDBOX_NAME;
-    delete process.env.NEMOCLAW_SANDBOX_NAME;
-    delete process.env.NEMOCLAW_SANDBOX;
-    try {
+
+    beforeEach(() => {
+      delete process.env.SANDBOX_NAME;
+      delete process.env.NEMOCLAW_SANDBOX_NAME;
+      delete process.env.NEMOCLAW_SANDBOX;
+    });
+
+    afterEach(() => {
+      if (savedSandboxName !== undefined) process.env.SANDBOX_NAME = savedSandboxName;
+      else delete process.env.SANDBOX_NAME;
+      if (savedNemoclawSandboxName !== undefined) {
+        process.env.NEMOCLAW_SANDBOX_NAME = savedNemoclawSandboxName;
+      } else {
+        delete process.env.NEMOCLAW_SANDBOX_NAME;
+      }
+      if (savedNemoclawSandbox !== undefined) process.env.NEMOCLAW_SANDBOX = savedNemoclawSandbox;
+      else delete process.env.NEMOCLAW_SANDBOX;
+    });
+
+    it("reuses the existing sandbox list when resolving status service sandbox", () => {
       const listSandboxes = vi.fn(() => ({
         sandboxes: [{ name: "alpha", model: "nvidia/nemotron-3-super-120b-a12b" }],
         defaultSandbox: "alpha",
@@ -564,27 +580,9 @@ describe("inventory commands", () => {
       });
       expect(listSandboxes).toHaveBeenCalledOnce();
       expect(showServiceStatus).toHaveBeenCalledWith({ sandboxName: "alpha" });
-    } finally {
-      if (savedSandboxName !== undefined) process.env.SANDBOX_NAME = savedSandboxName;
-      else delete process.env.SANDBOX_NAME;
-      if (savedNemoclawSandboxName !== undefined) {
-        process.env.NEMOCLAW_SANDBOX_NAME = savedNemoclawSandboxName;
-      } else {
-        delete process.env.NEMOCLAW_SANDBOX_NAME;
-      }
-      if (savedNemoclawSandbox !== undefined) process.env.NEMOCLAW_SANDBOX = savedNemoclawSandbox;
-      else delete process.env.NEMOCLAW_SANDBOX;
-    }
-  });
+    });
 
-  it("reuses the existing sandbox list when resolving JSON status service sandbox", () => {
-    const savedSandboxName = process.env.SANDBOX_NAME;
-    const savedNemoclawSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
-    const savedNemoclawSandbox = process.env.NEMOCLAW_SANDBOX;
-    delete process.env.SANDBOX_NAME;
-    delete process.env.NEMOCLAW_SANDBOX_NAME;
-    delete process.env.NEMOCLAW_SANDBOX;
-    try {
+    it("reuses the existing sandbox list when resolving JSON status service sandbox", () => {
       const listSandboxes = vi.fn(() => ({
         sandboxes: [{ name: "alpha", model: "nvidia/nemotron-3-super-120b-a12b" }],
         defaultSandbox: "alpha",
@@ -599,27 +597,10 @@ describe("inventory commands", () => {
       expect(listSandboxes).toHaveBeenCalledOnce();
       expect(getServiceStatuses).toHaveBeenCalledWith({ sandboxName: "alpha" });
       expect(report.defaultSandbox).toBe("alpha");
-    } finally {
-      if (savedSandboxName !== undefined) process.env.SANDBOX_NAME = savedSandboxName;
-      else delete process.env.SANDBOX_NAME;
-      if (savedNemoclawSandboxName !== undefined) {
-        process.env.NEMOCLAW_SANDBOX_NAME = savedNemoclawSandboxName;
-      } else {
-        delete process.env.NEMOCLAW_SANDBOX_NAME;
-      }
-      if (savedNemoclawSandbox !== undefined) process.env.NEMOCLAW_SANDBOX = savedNemoclawSandbox;
-      else delete process.env.NEMOCLAW_SANDBOX;
-    }
-  });
+    });
 
-  it("resolves service status sandbox from SANDBOX_NAME env (#1077)", () => {
-    const savedSandboxName = process.env.SANDBOX_NAME;
-    const savedNemoclawSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
-    const savedNemoclawSandbox = process.env.NEMOCLAW_SANDBOX;
-    delete process.env.NEMOCLAW_SANDBOX_NAME;
-    delete process.env.NEMOCLAW_SANDBOX;
-    process.env.SANDBOX_NAME = "env-sandbox";
-    try {
+    it("resolves service status sandbox from SANDBOX_NAME env", () => {
+      process.env.SANDBOX_NAME = "env-sandbox";
       const showServiceStatus = vi.fn();
       showStatusCommand({
         listSandboxes: () => ({
@@ -631,27 +612,10 @@ describe("inventory commands", () => {
         log: vi.fn(),
       });
       expect(showServiceStatus).toHaveBeenCalledWith({ sandboxName: "env-sandbox" });
-    } finally {
-      if (savedSandboxName !== undefined) process.env.SANDBOX_NAME = savedSandboxName;
-      else delete process.env.SANDBOX_NAME;
-      if (savedNemoclawSandboxName !== undefined) {
-        process.env.NEMOCLAW_SANDBOX_NAME = savedNemoclawSandboxName;
-      } else {
-        delete process.env.NEMOCLAW_SANDBOX_NAME;
-      }
-      if (savedNemoclawSandbox !== undefined) process.env.NEMOCLAW_SANDBOX = savedNemoclawSandbox;
-      else delete process.env.NEMOCLAW_SANDBOX;
-    }
-  });
+    });
 
-  it("resolves JSON service status sandbox from NEMOCLAW_SANDBOX_NAME env (#1077)", () => {
-    const savedName = process.env.NEMOCLAW_SANDBOX_NAME;
-    const savedSandboxName = process.env.SANDBOX_NAME;
-    const savedNemoclawSandbox = process.env.NEMOCLAW_SANDBOX;
-    delete process.env.SANDBOX_NAME;
-    delete process.env.NEMOCLAW_SANDBOX;
-    process.env.NEMOCLAW_SANDBOX_NAME = "json-sandbox";
-    try {
+    it("resolves JSON service status sandbox from NEMOCLAW_SANDBOX_NAME env", () => {
+      process.env.NEMOCLAW_SANDBOX_NAME = "json-sandbox";
       const getServiceStatuses = vi.fn().mockReturnValue([]);
       const report = getStatusReport({
         listSandboxes: () => ({
@@ -665,14 +629,49 @@ describe("inventory commands", () => {
       expect(getServiceStatuses).toHaveBeenCalledWith({ sandboxName: "json-sandbox" });
       expect(report.defaultSandbox).toBe("json-sandbox");
       expect(report.sandboxes[0]?.isDefault).toBe(true);
-    } finally {
-      if (savedName !== undefined) process.env.NEMOCLAW_SANDBOX_NAME = savedName;
-      else delete process.env.NEMOCLAW_SANDBOX_NAME;
-      if (savedSandboxName !== undefined) process.env.SANDBOX_NAME = savedSandboxName;
-      else delete process.env.SANDBOX_NAME;
-      if (savedNemoclawSandbox !== undefined) process.env.NEMOCLAW_SANDBOX = savedNemoclawSandbox;
-      else delete process.env.NEMOCLAW_SANDBOX;
-    }
+    });
+
+    it("resolves list default sandbox from SANDBOX_NAME env", async () => {
+      process.env.SANDBOX_NAME = "env-sandbox";
+      const inventory = await getSandboxInventory({
+        recoverRegistryEntries: async () => ({
+          sandboxes: [
+            { name: "env-sandbox", model: "m1", provider: "p1" },
+            { name: "registry-default", model: "m2", provider: "p2" },
+          ],
+          defaultSandbox: "registry-default",
+        }),
+        getLiveInference: () => null,
+        loadLastSession: () => null,
+        getActiveSessionCount: () => 0,
+      });
+
+      expect(inventory.defaultSandbox).toBe("env-sandbox");
+      expect(inventory.sandboxes.find((row) => row.name === "env-sandbox")?.isDefault).toBe(true);
+      expect(inventory.sandboxes.find((row) => row.name === "registry-default")?.isDefault).toBe(
+        false,
+      );
+    });
+
+    it("marks the env-resolved sandbox with * in list output", async () => {
+      process.env.SANDBOX_NAME = "env-sandbox";
+      const lines: string[] = [];
+      await listSandboxesCommand({
+        recoverRegistryEntries: async () => ({
+          sandboxes: [
+            { name: "registry-default", model: "m1", provider: "p1" },
+            { name: "env-sandbox", model: "m2", provider: "p2" },
+          ],
+          defaultSandbox: "registry-default",
+        }),
+        getLiveInference: () => null,
+        loadLastSession: () => null,
+        log: (message = "") => lines.push(message),
+      });
+
+      expect(lines).toContain("    env-sandbox *");
+      expect(lines.some((line) => line.startsWith("    registry-default *"))).toBe(false);
+    });
   });
 
   it("does not annotate status when the live gateway matches the onboarded model", () => {

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -199,7 +199,8 @@ export async function getSandboxInventory(
   deps: ListSandboxesCommandDeps,
 ): Promise<SandboxInventoryResult> {
   const recovery = await deps.recoverRegistryEntries();
-  const defaultSandbox = recovery.defaultSandbox || null;
+  const resolvedDefault =
+    resolveDefaultSandboxName(() => ({ defaultSandbox: recovery.defaultSandbox ?? null })) ?? null;
   const lastSession = deps.loadLastSession();
   // #2753: only surface the last-onboarded name when its sandbox step
   // actually completed. Otherwise an interrupted onboard would leave the
@@ -211,14 +212,14 @@ export async function getSandboxInventory(
 
   return {
     schemaVersion: 1,
-    defaultSandbox,
+    defaultSandbox: resolvedDefault,
     recovery: {
       recoveredFromSession: recovery.recoveredFromSession === true,
       recoveredFromGateway: recovery.recoveredFromGateway || 0,
     },
     lastOnboardedSandbox,
     sandboxes: recovery.sandboxes.map((sandbox) =>
-      buildSandboxInventoryRow(sandbox, defaultSandbox, deps.getActiveSessionCount),
+      buildSandboxInventoryRow(sandbox, resolvedDefault, deps.getActiveSessionCount),
     ),
   };
 }

--- a/src/lib/tunnel/services.test.ts
+++ b/src/lib/tunnel/services.test.ts
@@ -150,6 +150,12 @@ describe("#1077 — status host service PID dir matches start/stop env", () => {
   const savedNemoclawSandbox = process.env.NEMOCLAW_SANDBOX;
   const savedNemoclawSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
 
+  beforeEach(() => {
+    delete process.env.SANDBOX_NAME;
+    delete process.env.NEMOCLAW_SANDBOX;
+    delete process.env.NEMOCLAW_SANDBOX_NAME;
+  });
+
   afterEach(() => {
     if (savedSandboxName !== undefined) process.env.SANDBOX_NAME = savedSandboxName;
     else delete process.env.SANDBOX_NAME;
@@ -165,8 +171,6 @@ describe("#1077 — status host service PID dir matches start/stop env", () => {
 
   it("reports running cloudflared when status passes env-resolved sandboxName", () => {
     resetIntegrationPidDirs();
-    delete process.env.NEMOCLAW_SANDBOX;
-    delete process.env.NEMOCLAW_SANDBOX_NAME;
     process.env.SANDBOX_NAME = INTEGRATION_ENV_SANDBOX;
     seedAliveCloudflaredPid(INTEGRATION_ENV_PID_DIR);
 
@@ -183,8 +187,6 @@ describe("#1077 — status host service PID dir matches start/stop env", () => {
 
   it("reports stopped cloudflared when status passes registry sandbox but env PID dir has the process", () => {
     resetIntegrationPidDirs();
-    delete process.env.NEMOCLAW_SANDBOX;
-    delete process.env.NEMOCLAW_SANDBOX_NAME;
     process.env.SANDBOX_NAME = INTEGRATION_ENV_SANDBOX;
     seedAliveCloudflaredPid(INTEGRATION_ENV_PID_DIR);
 
@@ -196,8 +198,6 @@ describe("#1077 — status host service PID dir matches start/stop env", () => {
 
   it("showStatus prints running cloudflared from env-resolved production PID dir", () => {
     resetIntegrationPidDirs();
-    delete process.env.NEMOCLAW_SANDBOX;
-    delete process.env.NEMOCLAW_SANDBOX_NAME;
     process.env.SANDBOX_NAME = INTEGRATION_ENV_SANDBOX;
     seedAliveCloudflaredPid(INTEGRATION_ENV_PID_DIR);
 


### PR DESCRIPTION
## Summary
Follow-up to #4756 / #1077: `nemoclaw list` and inventory JSON now resolve the default sandbox from `SANDBOX_NAME` / `NEMOCLAW_SANDBOX_NAME` / `NEMOCLAW_SANDBOX`, matching `status`, `start`, and `stop`. Also consolidates #1077 test env isolation into shared `beforeEach`/`afterEach` hooks.

## Related Issue
Related to #1077 (follow-up to merged #4756)

## Changes
- Wire `resolveDefaultSandboxName()` into `getSandboxInventory()` for `defaultSandbox` and `isDefault` rows
- Add list/inventory tests for env-resolved default sandbox marker (`*`)
- Refactor `#1077` inventory tests into a nested describe with shared env save/restore
- Add `beforeEach` env clearing in `services.test.ts` `#1077` describe block

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes (targeted: `src/lib/inventory/index.test.ts`, `src/lib/tunnel/services.test.ts`, including `-t '#1077'`)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Thabhelo <50872400+Thabhelo@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test organization and environment variable cleanup for better test reliability.

* **Refactor**
  * Enhanced internal sandbox resolution logic for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->