### PR TITLE
fix(runtime-context): try sandbox network/file actions before reporting them unavailable

### DIFF
--- a/nemoclaw/src/runtime-context.test.ts
+++ b/nemoclaw/src/runtime-context.test.ts
@@ -84,10 +84,10 @@ describe("getRuntimeSummary", () => {
     expect(summary.sandboxName).toBe("openclaw");
     expect(summary.sandboxPhase).toBeNull();
     expect(summary.networkLines).toContain(
-      "outbound network is deny-by-default; assume no arbitrary internet access",
+      "outbound network is deny-by-default, but allowed endpoints work, so verify by attempting a request rather than assuming a host is unreachable",
     );
     expect(summary.filesystemLines).toContain(
-      "filesystem/process access is sandboxed; do not assume host-level access",
+      "filesystem and process access are scoped to the sandbox, not the host; do not assume access to host paths outside it",
     );
   });
 
@@ -137,6 +137,13 @@ describe("registerRuntimeContext", () => {
     expect(result.prependSystemContext).toContain("Network policy:");
     expect(result.prependSystemContext).toContain("Filesystem policy:");
     expect(result.prependSystemContext).toContain("</nemoclaw-runtime>");
+    // Grounding directive: the agent must attempt before asserting a host is
+    // blocked rather than refusing preemptively, and report the real failure
+    // mode instead of assuming a specific status code.
+    expect(result.prependSystemContext).toContain(
+      "unless you have actually attempted it this turn",
+    );
+    expect(result.prependSystemContext).toContain("raises an operator approval request");
   });
 
   it("uses the persisted sandbox name in the injected context", async () => {

--- a/nemoclaw/src/runtime-context.ts
+++ b/nemoclaw/src/runtime-context.ts
@@ -12,12 +12,13 @@ interface RuntimeSummary {
 }
 
 const STATIC_NETWORK_LINES = [
-  "outbound network is deny-by-default; assume no arbitrary internet access",
-  "blocked requests can return proxy 403 and may need operator approval or policy changes",
+  "outbound network is deny-by-default, but allowed endpoints work, so verify by attempting a request rather than assuming a host is unreachable",
+  "attempting a restricted endpoint is productive: a proxy or policy denial raises an operator approval request in OpenShell, so make the request rather than refusing preemptively; if it fails, report the actual error and distinguish a policy denial (which the operator can approve) from other network errors such as DNS, timeout, or TLS failures",
 ];
 
 const STATIC_FILESYSTEM_LINES = [
-  "filesystem/process access is sandboxed; do not assume host-level access",
+  "filesystem and process access are scoped to the sandbox, not the host; do not assume access to host paths outside it",
+  "within the sandbox you can create, edit, and run files (for example in /tmp or /sandbox) using your file and shell tools; try the operation and report if it fails rather than assuming it is unavailable",
 ];
 
 /**
@@ -63,8 +64,9 @@ function buildRuntimeContextText(summary: RuntimeSummary): string {
     "Filesystem policy:",
     ...summary.filesystemLines.map((line) => `- ${line}`),
     "Behavior:",
-    "- Do not claim unrestricted host or internet access.",
-    "- if access is blocked, say it is blocked and ask the operator to adjust policy or approve it in OpenShell",
+    "- Do not assert that a URL or host is blocked or unreachable unless you have actually attempted it this turn; report the actual result rather than speculating.",
+    "- Distinguish a proxy/policy denial, which raises an operator approval request in OpenShell, from other failures such as DNS, timeout, or TLS errors; only a policy denial is something the operator can approve.",
+    "- Do not claim unrestricted host or internet access either. When unsure, attempt the action and rely on the real result instead of speculating about the environment.",
     "</nemoclaw-runtime>",
   ].filter((line): line is string => Boolean(line));
   return lines.join("\n");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #4850

## Changes
<!-- Bullet list of key changes. -->
- Network guidance now states allowed endpoints work and instructs the agent to attempt a request rather than assume a host is unreachable; clarifies that attempting a restricted endpoint is what raises the operator approval request in OpenShell.
 - Removed the literal `403` as the required proof of "blocked"; the agent now reports the actual error and distinguishes a proxy/policy denial (operator-approvable) from DNS, timeout, or TLS failures.
 - Filesystem guidance keeps the accurate "no host-level access" caveat but adds that the agent can create, edit, and run files inside the sandbox (e.g. `/tmp` or `/sandbox`) and should try the operation and report if it fails.
 - Generalized the `Behavior:` directives to "verify before asserting" in both directions: don't claim something is blocked/unavailable without attempting it this turn, and don't claim unrestricted access either.
 - Updated `runtime-context.test.ts` assertions to match the new strings and added guards for the grounding directive.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved clarity of network and filesystem policy messages to better distinguish between policy denials and network failures (DNS timeouts, TLS errors).
  * Enhanced guidance for more accurate behavior when attempting actions before asserting access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->