### PR TITLE
fix(e2e): switch agent-turn-latency model to nemotron-3-super-120b-a12b

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -252,7 +252,7 @@ jobs:
         /tmp/nemoclaw-e2e-openclaw-turn-latency-install.log
         /tmp/nemoclaw-e2e-hermes-turn-latency-install.log
         /tmp/nemoclaw-e2e-agent-turn-latency.json
-      env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_TURN_LATENCY_MODEL":"nvidia/nemotron-3-ultra-550b-a55b"}'
+      env_json: '{"NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE":"1","NEMOCLAW_NON_INTERACTIVE":"1","NEMOCLAW_RECREATE_SANDBOX":"1","NEMOCLAW_TURN_LATENCY_MODEL":"nvidia/nemotron-3-super-120b-a12b"}'
       nvidia_api_key: true
     secrets: *nightly-e2e-default-secrets
   skill-agent-e2e:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

**✨ [AI-generated PR]**

Switch the `agent-turn-latency-e2e` nightly job's hardcoded model from `nvidia/nemotron-3-ultra-550b-a55b` to `nvidia/nemotron-3-super-120b-a12b`. The 550B model fails NVIDIA Build endpoint validation intermittently with "Function not found for account", breaking the Hermes install leg of the turn-latency test. The 120B model is the same one used by `cloud-onboard` and `openclaw-tui-chat-correlation` E2E jobs and passed validation in the same failing run.

## Related Issue

Fixes #4883

## Changes

- `.github/workflows/nightly-e2e.yaml`: Change `NEMOCLAW_TURN_LATENCY_MODEL` from `nvidia/nemotron-3-ultra-550b-a55b` to `nvidia/nemotron-3-super-120b-a12b` in the `agent-turn-latency-e2e` job's `env_json`.

## Validation

A focused `custom-e2e.yaml` workflow was run on a sibling branch to confirm this fix repairs the regression. The workflow re-runs **only** the jobs from the original nightly that this PR targets, on `ubuntu-latest`, off the same fix commit as this PR.

- Validation branch: [`fix/nightly-e2e-agent-turn-latency-model-unavail-2b68caa-custom-e2e`](https://github.com/hunglp6d/NemoClaw/tree/fix/nightly-e2e-agent-turn-latency-model-unavail-2b68caa-custom-e2e) on `hunglp6d/NemoClaw`
- Validation run: [#27048471391](https://github.com/hunglp6d/NemoClaw/actions/runs/27048471391) — **success**
- Targeted jobs: `agent-turn-latency-e2e / run (#79835012951)`
- Original failing run: [27047055659](https://github.com/NVIDIA/NemoClaw/actions/runs/27047055659) on `2b68caa1ce6f88eaf416fa3257c39b8299d3c0a5`

The validation branch is intentionally **not** the head of this PR — it carries an extra `.github/workflows/custom-e2e.yaml` commit that is scaffolding, not part of the fix. Re-run the validation by pushing any commit to the validation branch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>