### PR TITLE
fix(security): clean P2 tooling scan findings

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import YAML from "yaml";
 
 type Options = {
@@ -336,7 +337,7 @@ function updateDocsVersionLinks(nextDocsPublicUrl: string): void {
   }
 }
 
-function rewriteDocsPublicUrls(
+export function rewriteDocsPublicUrls(
   content: string,
   nextDocsPublicUrl: string,
 ): { updated: string; count: number } {
@@ -637,7 +638,7 @@ function verifyDocsLinks(filePath: string, expectedDocsPublicUrl: string): void 
   }
 }
 
-function collectDocsVersionSegments(content: string): string[] {
+export function collectDocsVersionSegments(content: string): string[] {
   const segments: string[] = [];
   let cursor = 0;
   for (;;) {
@@ -715,4 +716,6 @@ function log(message: string): void {
   console.log(`[bump-version] ${message}`);
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -67,6 +67,8 @@ const FILES_TO_STAGE = [
   INSTALL_SH,
   ...VERSIONED_DOC_LINK_FILES,
 ];
+const DOCS_PUBLIC_URL_PREFIX = "https://docs.nvidia.com/nemoclaw/";
+const DOCS_URL_SEGMENT_DELIMITERS = new Set(["/", "?", "#", ")", "]", '"', "'", "`", "<", ">"]);
 
 function main(): void {
   const options = parseArgs(process.argv.slice(2));
@@ -326,25 +328,58 @@ function updateInstallScriptDefaultVersion(previousVersion: string, nextVersion:
 function updateDocsVersionLinks(nextDocsPublicUrl: string): void {
   for (const filePath of VERSIONED_DOC_LINK_FILES) {
     const current = readText(filePath);
-    const updated = current.replaceAll(
-      /https:\/\/docs\.nvidia\.com\/nemoclaw\/(?:latest|[0-9]+\.[0-9]+\.[0-9]+)\//g,
-      `${nextDocsPublicUrl}/`,
-    );
-    if (updated === current) {
+    const { updated, count } = rewriteDocsPublicUrls(current, nextDocsPublicUrl);
+    if (count === 0) {
       throw new Error(`No docs.nvidia.com/nemoclaw links found in ${relative(filePath)}`);
     }
     writeFileSync(filePath, updated, "utf8");
-    replaceAnyDocsUrl(filePath, nextDocsPublicUrl);
   }
 }
 
-function replaceAnyDocsUrl(filePath: string, nextDocsPublicUrl: string): void {
-  const current = readText(filePath);
-  const updated = current.replaceAll(
-    /https:\/\/docs\.nvidia\.com\/nemoclaw\/(?:latest|[0-9]+\.[0-9]+\.[0-9]+)/g,
-    nextDocsPublicUrl,
-  );
-  writeFileSync(filePath, updated, "utf8");
+function rewriteDocsPublicUrls(
+  content: string,
+  nextDocsPublicUrl: string,
+): { updated: string; count: number } {
+  let cursor = 0;
+  let count = 0;
+  let updated = "";
+
+  for (;;) {
+    const start = content.indexOf(DOCS_PUBLIC_URL_PREFIX, cursor);
+    if (start === -1) {
+      updated += content.slice(cursor);
+      break;
+    }
+
+    const segmentStart = start + DOCS_PUBLIC_URL_PREFIX.length;
+    const segmentEnd = findDocsUrlSegmentEnd(content, segmentStart);
+    const segment = content.slice(segmentStart, segmentEnd);
+
+    updated += content.slice(cursor, start);
+    if (isDocsVersionSegment(segment)) {
+      updated += nextDocsPublicUrl;
+      count += 1;
+    } else {
+      updated += content.slice(start, segmentEnd);
+    }
+    cursor = segmentEnd;
+  }
+
+  return { updated, count };
+}
+
+function findDocsUrlSegmentEnd(content: string, start: number): number {
+  let index = start;
+  while (index < content.length) {
+    const char = content[index];
+    if (DOCS_URL_SEGMENT_DELIMITERS.has(char) || /\s/.test(char)) break;
+    index += 1;
+  }
+  return index;
+}
+
+function isDocsVersionSegment(segment: string): boolean {
+  return segment === "latest" || /^[0-9]+\.[0-9]+\.[0-9]+$/.test(segment);
 }
 
 function updateInstallAndUninstallDocs(nextDocsVersion: string): void {
@@ -586,22 +621,33 @@ function requireContains(filePath: string, text: string): void {
 
 function verifyDocsLinks(filePath: string, expectedDocsPublicUrl: string): void {
   const content = readText(filePath);
-  const matches = Array.from(
-    content.matchAll(/https:\/\/docs\.nvidia\.com\/nemoclaw\/([^/]+)\//g),
-    (match) => match[1],
-  );
+  const segments = collectDocsVersionSegments(content);
 
-  if (matches.length === 0) {
+  if (segments.length === 0) {
     throw new Error(`Expected at least one docs.nvidia.com/nemoclaw link in ${relative(filePath)}`);
   }
 
-  const expectedSegment = expectedDocsPublicUrl.replace("https://docs.nvidia.com/nemoclaw/", "");
-  for (const segment of matches) {
+  const expectedSegment = expectedDocsPublicUrl.slice(DOCS_PUBLIC_URL_PREFIX.length);
+  for (const segment of segments) {
     if (segment !== expectedSegment) {
       throw new Error(
         `Found unexpected docs version segment '${segment}' in ${relative(filePath)}; expected '${expectedSegment}'`,
       );
     }
+  }
+}
+
+function collectDocsVersionSegments(content: string): string[] {
+  const segments: string[] = [];
+  let cursor = 0;
+  for (;;) {
+    const start = content.indexOf(DOCS_PUBLIC_URL_PREFIX, cursor);
+    if (start === -1) return segments;
+    const segmentStart = start + DOCS_PUBLIC_URL_PREFIX.length;
+    const segmentEnd = findDocsUrlSegmentEnd(content, segmentStart);
+    const segment = content.slice(segmentStart, segmentEnd);
+    if (segment) segments.push(segment);
+    cursor = segmentEnd;
   }
 }
 

--- a/test/bump-version.test.ts
+++ b/test/bump-version.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { collectDocsVersionSegments, rewriteDocsPublicUrls } from "../scripts/bump-version";
+
+describe("bump-version docs URL helpers", () => {
+  it("rewrites latest and versioned docs URL segments while preserving suffix delimiters", () => {
+    const content = [
+      "See https://docs.nvidia.com/nemoclaw/latest/get-started/quickstart",
+      "Query https://docs.nvidia.com/nemoclaw/0.0.60?view=all#install",
+      "Markdown [docs](https://docs.nvidia.com/nemoclaw/0.0.59/)",
+      "Leave https://docs.nvidia.com/nemoclaw/api/reference unchanged",
+    ].join("\n");
+
+    const result = rewriteDocsPublicUrls(content, "https://docs.nvidia.com/nemoclaw/0.0.61");
+
+    expect(result.count).toBe(3);
+    expect(result.updated).toContain("https://docs.nvidia.com/nemoclaw/0.0.61/get-started/quickstart");
+    expect(result.updated).toContain("https://docs.nvidia.com/nemoclaw/0.0.61?view=all#install");
+    expect(result.updated).toContain("https://docs.nvidia.com/nemoclaw/0.0.61/)");
+    expect(result.updated).toContain("https://docs.nvidia.com/nemoclaw/api/reference");
+  });
+
+  it("reports no rewrites for non-version docs URL segments", () => {
+    const content = "See https://docs.nvidia.com/nemoclaw/api/reference for generated API docs";
+
+    const result = rewriteDocsPublicUrls(content, "https://docs.nvidia.com/nemoclaw/latest");
+
+    expect(result.count).toBe(0);
+    expect(result.updated).toBe(content);
+  });
+
+  it("collects docs URL segments for release verification", () => {
+    const content = [
+      "https://docs.nvidia.com/nemoclaw/latest/",
+      "https://docs.nvidia.com/nemoclaw/0.0.60?view=all",
+      "https://docs.nvidia.com/nemoclaw/api/reference",
+    ].join("\n");
+
+    expect(collectDocsVersionSegments(content)).toEqual(["latest", "0.0.60", "api"]);
+  });
+});

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -76,7 +76,7 @@ open(path, "w").write(text)
 PY
 }
 
-# shellcheck disable=SC2329 # Invoked indirectly by the EXIT trap.
+# shellcheck disable=SC2317,SC2329 # Invoked indirectly by the EXIT trap.
 cleanup() {
   local rc=$?
   redact_file "$ONBOARD_LOG"

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -648,8 +648,9 @@ install_old_nemoclaw_and_claw() {
     local old_head expected_head
     old_head="$(git -C "$HOME/.nemoclaw/source" rev-parse HEAD 2>/dev/null || true)"
     expected_head="$(git ls-remote https://github.com/NVIDIA/NemoClaw.git "refs/tags/${OLD_NEMOCLAW_REF}" | awk '{print $1}')"
-    [ -n "$old_head" ] && [ "$old_head" = "$expected_head" ] \
-      || fail "old installer source is ${old_head:-unknown}, expected ${expected_head:-$OLD_NEMOCLAW_REF}"
+    if [ -z "$old_head" ] || [ "$old_head" != "$expected_head" ]; then
+      fail "old installer source is ${old_head:-unknown}, expected ${expected_head:-$OLD_NEMOCLAW_REF}"
+    fi
     pass "Old NemoClaw source is ${OLD_NEMOCLAW_REF} (${old_head:0:12})"
   fi
 

--- a/test/e2e/test-state-backup-restore.sh
+++ b/test/e2e/test-state-backup-restore.sh
@@ -52,7 +52,7 @@ fail() {
   echo -e "${RED}  FAIL${NC} $1 — $2" | tee -a "$LOG_FILE"
 }
 # Record a skipped test.
-# shellcheck disable=SC2329
+# shellcheck disable=SC2317,SC2329 # Retained for manual triage paths not hit in every E2E run.
 skip() {
   ((SKIP += 1))
   ((TOTAL += 1))

--- a/test/install-preflight.test.ts
+++ b/test/install-preflight.test.ts
@@ -488,7 +488,7 @@ exit 98
     expect(output).toMatch(/NEMOCLAW_NON_INTERACTIVE_SUDO_MODE=prompt/);
     expect(output).toMatch(/NEMOCLAW_NO_EXPRESS=1/);
     expect(output).toMatch(/NEMOCLAW_SANDBOX_NAME/);
-    expect(output).toMatch(/nvidia\.com\/nemoclaw\.sh/);
+    expect(output).toContain("nvidia.com/nemoclaw.sh");
   });
 
   it("scripts/install.sh --help lists the full non-interactive provider set", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -2035,12 +2035,18 @@ exit 1
     });
 
     it("telegram REST preset relies on automatic TLS handling", () => {
-      const content = requirePresetContent(policies.loadPreset("telegram"));
-      expect(content).toBeTruthy();
-      expect(content).toMatch(
-        /host:\s*api\.telegram\.org[\s\S]*?protocol:\s*rest[\s\S]*?enforcement:\s*enforce/,
+      const parsed = parsePresetYaml("telegram");
+      const endpoint = parsed.network_policies?.telegram_bot?.endpoints?.find(
+        (candidate: { host?: string }) => candidate.host === "api.telegram.org",
       );
-      expect(content).not.toMatch(/host:\s*api\.telegram\.org[\s\S]*?tls:/);
+      expect(endpoint).toEqual(
+        expect.objectContaining({
+          host: "api.telegram.org",
+          protocol: "rest",
+          enforcement: "enforce",
+        }),
+      );
+      expect(endpoint).not.toHaveProperty("tls");
     });
 
     it("wechat REST preset enumerates explicit iLink hosts on port 443 with allow GET/POST", () => {
@@ -2049,17 +2055,25 @@ exit 1
       // listed explicitly. The proxy must still see
       // protocol/enforcement/method allowlists on each entry — dropping any
       // of those silently widens egress past what the preset documents.
-      const content = requirePresetContent(policies.loadPreset("wechat"));
-      for (const host of ["ilinkai\\.weixin\\.qq\\.com", "ilinkai\\.wechat\\.com"]) {
-        expect(content).toMatch(
-          new RegExp(
-            `host:\\s*"?${host}"?[\\s\\S]*?port:\\s*443[\\s\\S]*?protocol:\\s*rest[\\s\\S]*?enforcement:\\s*enforce`,
-          ),
+      const parsed = parsePresetYaml("wechat");
+      const endpoints = parsed.network_policies?.wechat_bridge?.endpoints ?? [];
+      for (const host of ["ilinkai.weixin.qq.com", "ilinkai.wechat.com"]) {
+        const endpoint = endpoints.find((candidate: { host?: string }) => candidate.host === host) as
+          | { rules?: Array<{ allow?: { method?: string } }> }
+          | undefined;
+        expect(endpoint).toEqual(
+          expect.objectContaining({
+            host,
+            port: 443,
+            protocol: "rest",
+            enforcement: "enforce",
+          }),
         );
-        expect(content).toMatch(
-          new RegExp(
-            `host:\\s*"?${host}"?[\\s\\S]*?allow:\\s*\\{\\s*method:\\s*GET[\\s\\S]*?allow:\\s*\\{\\s*method:\\s*POST`,
-          ),
+        expect(endpoint?.rules).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ allow: expect.objectContaining({ method: "GET" }) }),
+            expect.objectContaining({ allow: expect.objectContaining({ method: "POST" }) }),
+          ]),
         );
       }
     });


### PR DESCRIPTION
## Summary
Clean up the low-risk P2 scan findings that are independent of the pending P0 runtime hardening branch. This removes URL-shaped unanchored regex checks from release/tooling and policy tests, and narrows the remaining E2E ShellCheck findings with either explicit control flow or documented trap/manual-path suppressions.

## Related Issue
Refs #3654

## Changes
- Replace `scripts/bump-version.ts` docs URL regex rewrites/verification with deterministic `indexOf`-based URL segment parsing.
- Convert URL/host regex assertions in installer and policy tests to string/YAML-structure assertions.
- Rewrite the gateway-upgrade E2E `SC2015` pattern as explicit `if` control flow.
- Add narrow `SC2317` suppressions with rationale for E2E helpers retained for trap/manual triage paths.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: `npm test` was attempted, but the existing installer integration test `test/install-preflight.test.ts > warns on Podman but still runs onboarding` fails in this environment because host CDI detection turns the expected Podman warning path into a missing-CDI issue path before onboarding. Targeted policy/installer checks outside that environment-sensitive assertion, `npm run bump:version -- --help`, shell syntax checks, and `npx prek run --all-files` pass.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>