### PR TITLE
ci(pr): add docs-only fast path and split code checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,12 +26,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          predicate-quantifier: every
+          predicate-quantifier: some
           filters: |
             code:
               - '**'
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js for docs-only checks
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -73,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -92,6 +98,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install --ignore-scripts
+
+      - name: Validate config schemas
+        run: npm run validate:configs
 
       - name: Run static hook checks
         run: |
@@ -122,6 +131,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -132,7 +143,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --ignore-scripts
-          cd nemoclaw && npm install
+          cd nemoclaw && npm install --ignore-scripts
 
       - name: Build TypeScript plugin
         run: cd nemoclaw && npm run build
@@ -160,6 +171,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -170,7 +183,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --ignore-scripts
-          cd nemoclaw && npm install
+          cd nemoclaw && npm install --ignore-scripts
 
       - name: Build TypeScript plugin
         run: cd nemoclaw && npm run build
@@ -199,6 +212,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -209,7 +224,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install --ignore-scripts
-          cd nemoclaw && npm install
+          cd nemoclaw && npm install --ignore-scripts
 
       - name: Run plugin coverage
         run: |
@@ -230,6 +245,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,6 +39,7 @@ jobs:
               - '!docs/**'
 
   checks:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -46,7 +47,27 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run basic checks
+        if: needs.changes.outputs.code == 'true'
         uses: ./.github/actions/basic-checks
+
+      - name: Setup Node.js for docs-only checks
+        if: needs.changes.outputs.code != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install docs-only check dependencies
+        if: needs.changes.outputs.code != 'true'
+        run: npm install --ignore-scripts
+
+      - name: Fetch base commit for docs-only checks
+        if: needs.changes.outputs.code != 'true'
+        run: git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+
+      - name: Run docs-only hook checks
+        if: needs.changes.outputs.code != 'true'
+        run: npx prek run --from-ref "${{ github.event.pull_request.base.sha }}" --to-ref HEAD
 
       - name: Verify platform matrix is in sync
         run: python3 scripts/generate-platform-docs.py --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          predicate-quantifier: some
+          predicate-quantifier: every
           filters: |
             code:
               - '**'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,42 +38,187 @@ jobs:
               - '!**/*.md'
               - '!docs/**'
 
-  checks:
+  docs-only-checks:
     needs: changes
+    if: needs.changes.outputs.code != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Run basic checks
-        if: needs.changes.outputs.code == 'true'
-        uses: ./.github/actions/basic-checks
-
       - name: Setup Node.js for docs-only checks
-        if: needs.changes.outputs.code != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: npm
 
       - name: Install docs-only check dependencies
-        if: needs.changes.outputs.code != 'true'
         run: npm install --ignore-scripts
 
       - name: Fetch base commit for docs-only checks
-        if: needs.changes.outputs.code != 'true'
         run: git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
 
       - name: Run docs-only hook checks
-        if: needs.changes.outputs.code != 'true'
         run: npx prek run --from-ref "${{ github.event.pull_request.base.sha }}" --to-ref HEAD
 
       - name: Verify platform matrix is in sync
         run: python3 scripts/generate-platform-docs.py --check
 
+  static-checks:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install hadolint
+        run: |
+          HADOLINT_VERSION="v2.14.0"
+          HADOLINT_URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-linux-x86_64"
+          curl -fsSL -o /usr/local/bin/hadolint "$HADOLINT_URL"
+          EXPECTED=$(curl -fsSL "${HADOLINT_URL}.sha256" | awk '{print $1}')
+          ACTUAL=$(sha256sum /usr/local/bin/hadolint | awk '{print $1}')
+          [ "$EXPECTED" = "$ACTUAL" ] || { echo "::error::hadolint checksum mismatch"; exit 1; }
+          chmod +x /usr/local/bin/hadolint
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run static hook checks
+        run: |
+          npx prek run --all-files --stage pre-push \
+            --skip tsc-plugin \
+            --skip tsc-js \
+            --skip tsc-cli \
+            --skip version-tag-sync \
+            --skip test-cli \
+            --skip test-plugin \
+            --skip source-shape-test-budget \
+            --skip test-skills-yaml
+
+      - name: Run source-shape budget
+        run: npm run source-shape:check
+
+      - name: Run skills YAML tests
+        run: npx vitest run test/skills-frontmatter.test.ts
+
+      - name: Verify platform matrix is in sync
+        run: python3 scripts/generate-platform-docs.py --check
+
+  build-typecheck:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm install --ignore-scripts
+          cd nemoclaw && npm install
+
+      - name: Build TypeScript plugin
+        run: cd nemoclaw && npm run build
+
+      - name: Build CLI TypeScript modules
+        run: npm run build:cli
+
+      - name: Typecheck CLI + tests
+        run: npm run typecheck:cli
+
+      - name: Typecheck plugin
+        run: cd nemoclaw && npx tsc --noEmit --incremental
+
+      - name: Typecheck JavaScript config
+        run: npx tsc -p jsconfig.json
+
+      - name: Verify package version matches git tags
+        run: bash scripts/check-version-tag-sync.sh
+
+  cli-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run CLI coverage
+        run: |
+          node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
+          npm run build:cli
+          npx tsx scripts/check-dist-sourcemaps.ts dist
+          npx vitest run --project cli \
+            --coverage \
+            --coverage.reporter=text-summary \
+            --coverage.reporter=json-summary \
+            --coverage.reportsDirectory=coverage/cli \
+            --coverage.include="bin/**/*.js" \
+            --coverage.include="dist/lib/**/*.js" \
+            --coverage.exclude="test/**/*.js" \
+            --coverage.exclude="test/**/*.ts"
+          npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"
+
+  plugin-tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          npm install --ignore-scripts
+          cd nemoclaw && npm install
+
+      - name: Run plugin coverage
+        run: |
+          npx vitest run --project plugin \
+            --coverage \
+            --coverage.reporter=text-summary \
+            --coverage.reporter=json-summary \
+            --coverage.reportsDirectory=coverage/plugin \
+            --coverage.include="nemoclaw/src/**/*.ts" \
+            --coverage.exclude="**/*.test.ts"
+          npx tsx scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"
+
   test-e2e-ollama-proxy:
-    needs: [checks, changes]
+    needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -86,6 +231,71 @@ jobs:
           node-version: "22"
       - name: Run Ollama auth proxy E2E tests
         run: bash test/e2e-ollama-proxy.sh
+
+  checks:
+    needs:
+      - changes
+      - docs-only-checks
+      - static-checks
+      - build-typecheck
+      - cli-tests
+      - plugin-tests
+      - test-e2e-ollama-proxy
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify required PR checks
+        env:
+          CODE_CHANGED: ${{ needs.changes.outputs.code }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          DOCS_ONLY_RESULT: ${{ needs['docs-only-checks'].result }}
+          STATIC_RESULT: ${{ needs['static-checks'].result }}
+          BUILD_TYPECHECK_RESULT: ${{ needs['build-typecheck'].result }}
+          CLI_TESTS_RESULT: ${{ needs['cli-tests'].result }}
+          PLUGIN_TESTS_RESULT: ${{ needs['plugin-tests'].result }}
+          E2E_PROXY_RESULT: ${{ needs['test-e2e-ollama-proxy'].result }}
+        run: |
+          set -euo pipefail
+
+          require_success() {
+            local name="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error title=${name} failed::Expected success, got ${result}"
+              exit 1
+            fi
+          }
+
+          allow_success_or_skipped() {
+            local name="$1"
+            local result="$2"
+            case "$result" in
+              success|skipped) ;;
+              *)
+                echo "::error title=${name} failed::Expected success or skipped, got ${result}"
+                exit 1
+                ;;
+            esac
+          }
+
+          require_success "changes" "$CHANGES_RESULT"
+
+          if [ "$CODE_CHANGED" = "true" ]; then
+            allow_success_or_skipped "docs-only-checks" "$DOCS_ONLY_RESULT"
+            require_success "static-checks" "$STATIC_RESULT"
+            require_success "build-typecheck" "$BUILD_TYPECHECK_RESULT"
+            require_success "cli-tests" "$CLI_TESTS_RESULT"
+            require_success "plugin-tests" "$PLUGIN_TESTS_RESULT"
+            require_success "test-e2e-ollama-proxy" "$E2E_PROXY_RESULT"
+          else
+            require_success "docs-only-checks" "$DOCS_ONLY_RESULT"
+            allow_success_or_skipped "static-checks" "$STATIC_RESULT"
+            allow_success_or_skipped "build-typecheck" "$BUILD_TYPECHECK_RESULT"
+            allow_success_or_skipped "cli-tests" "$CLI_TESTS_RESULT"
+            allow_success_or_skipped "plugin-tests" "$PLUGIN_TESTS_RESULT"
+            allow_success_or_skipped "test-e2e-ollama-proxy" "$E2E_PROXY_RESULT"
+          fi
 
   # Sandbox image builds and E2E tests have moved to pr-self-hosted.yaml,
   # which runs on NVIDIA self-hosted runners via copy-pr-bot.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -168,7 +168,12 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: |
+          npm install --ignore-scripts
+          cd nemoclaw && npm install
+
+      - name: Build TypeScript plugin
+        run: cd nemoclaw && npm run build
 
       - name: Run CLI coverage
         run: |

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -16,6 +16,7 @@ export type WorkflowJob = {
 };
 
 export type WorkflowStep = {
+  id?: string;
   name?: string;
   if?: string;
   uses?: string;

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -10,36 +10,155 @@ import {
 } from "./helpers/e2e-workflow-contract";
 
 type PullRequestWorkflow = {
-  jobs: Record<string, WorkflowJob>;
+  jobs: Record<string, WorkflowJob & { if?: string; needs?: string[] }>;
 };
 
 function stepRuns(job: WorkflowJob): string[] {
   return (job.steps ?? []).flatMap((step) => (step.run ? [step.run] : []));
 }
 
+function requiredRun(action: CompositeAction, stepName: string): string {
+  const run = action.runs.steps.find((step) => step.name === stepName)?.run;
+  if (!run) {
+    throw new Error(`Missing basic-checks step: ${stepName}`);
+  }
+  return run;
+}
+
+function codeFilterMatchesChangedPaths(
+  workflow: PullRequestWorkflow,
+  paths: string[],
+): boolean {
+  const filterStep = workflow.jobs.changes.steps?.find(
+    (step) => step.id === "filter",
+  );
+  const quantifier = filterStep?.with?.["predicate-quantifier"];
+  const filters = String(filterStep?.with?.filters ?? "");
+  const patterns = filters
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2).replace(/^['"]|['"]$/g, ""));
+
+  const patternMatches = (path: string, pattern: string): boolean => {
+    switch (pattern) {
+      case "**":
+        return true;
+      case "!**/*.md":
+        return !path.endsWith(".md");
+      case "!docs/**":
+        return !path.startsWith("docs/");
+      default:
+        throw new Error(`Unhandled PR workflow code filter pattern: ${pattern}`);
+    }
+  };
+
+  return paths.some((path) => {
+    if (quantifier === "every") {
+      return patterns.every((pattern) => patternMatches(path, pattern));
+    }
+    if (quantifier === "some") {
+      return patterns.some((pattern) => patternMatches(path, pattern));
+    }
+    throw new Error(`Unhandled PR workflow predicate quantifier: ${String(quantifier)}`);
+  });
+}
+
 describe("pull request workflow contract", () => {
   const workflow = readYaml<PullRequestWorkflow>(".github/workflows/pr.yaml");
 
-  it("routes mixed docs and code PRs through the code-check path", () => {
+  it("routes only code-changing PRs through the code-check path", () => {
     const filterStep = workflow.jobs.changes.steps?.find(
       (step) => step.id === "filter",
     );
 
     expect(filterStep?.uses).toContain("dorny/paths-filter");
-    expect(filterStep?.with?.["predicate-quantifier"]).toBe("some");
+    expect(filterStep?.with?.["predicate-quantifier"]).toBe("every");
     expect(filterStep?.with?.filters).toContain("code:");
     expect(filterStep?.with?.filters).toContain("!**/*.md");
     expect(filterStep?.with?.filters).toContain("!docs/**");
+
+    expect(codeFilterMatchesChangedPaths(workflow, ["docs/get-started/prerequisites.mdx"])).toBe(
+      false,
+    );
+    expect(codeFilterMatchesChangedPaths(workflow, ["README.md"])).toBe(false);
+    expect(codeFilterMatchesChangedPaths(workflow, ["src/lib/runner.ts"])).toBe(true);
+    expect(
+      codeFilterMatchesChangedPaths(workflow, [
+        "docs/get-started/prerequisites.mdx",
+        "src/lib/runner.ts",
+      ]),
+    ).toBe(true);
   });
 
-  it("preserves the basic-checks config validation gate for code PRs", () => {
+  it("preserves the basic-checks gates for code PRs", () => {
     const basicChecks = readYaml<CompositeAction>(".github/actions/basic-checks/action.yaml");
-    const requiredValidationRun = basicChecks.runs.steps.find(
-      (step) => step.name === "Validate config schemas",
-    )?.run;
+    const staticRuns = stepRuns(workflow.jobs["static-checks"]);
+    const buildRuns = stepRuns(workflow.jobs["build-typecheck"]);
+    const cliTestRun = stepRuns(workflow.jobs["cli-tests"]).join("\n");
+    const pluginTestRun = stepRuns(workflow.jobs["plugin-tests"]).join("\n");
+    const staticPrekRun = staticRuns.find((run) =>
+      run.includes("npx prek run --all-files --stage pre-push"),
+    );
 
-    expect(requiredValidationRun).toBe("npm run validate:configs");
-    expect(stepRuns(workflow.jobs["static-checks"])).toContain(requiredValidationRun);
+    expect(staticRuns).toContain(requiredRun(basicChecks, "Install hadolint"));
+    expect(buildRuns).toContain(requiredRun(basicChecks, "Build TypeScript plugin"));
+    expect(buildRuns).toContain(requiredRun(basicChecks, "Build CLI TypeScript modules"));
+    expect(buildRuns).toContain(requiredRun(basicChecks, "Typecheck CLI + tests (strict)"));
+    expect(staticRuns).toContain(requiredRun(basicChecks, "Validate config schemas"));
+    expect(staticPrekRun).toContain("npx prek run --all-files --stage pre-push");
+
+    for (const skippedHook of [
+      "tsc-plugin",
+      "tsc-js",
+      "tsc-cli",
+      "version-tag-sync",
+      "test-cli",
+      "test-plugin",
+      "source-shape-test-budget",
+      "test-skills-yaml",
+    ]) {
+      expect(staticPrekRun).toContain(`--skip ${skippedHook}`);
+    }
+
+    expect(buildRuns).toContain("cd nemoclaw && npx tsc --noEmit --incremental");
+    expect(buildRuns).toContain("npx tsc -p jsconfig.json");
+    expect(buildRuns).toContain("bash scripts/check-version-tag-sync.sh");
+    expect(cliTestRun).toContain("npx vitest run --project cli");
+    expect(cliTestRun).toContain("npx tsx scripts/check-coverage-ratchet.ts");
+    expect(pluginTestRun).toContain("npx vitest run --project plugin");
+    expect(pluginTestRun).toContain("npx tsx scripts/check-coverage-ratchet.ts");
+    expect(staticRuns).toContain("npm run source-shape:check");
+    expect(staticRuns).toContain("npx vitest run test/skills-frontmatter.test.ts");
+  });
+
+  it("keeps the final checks job as the branch-protection aggregate", () => {
+    const checks = workflow.jobs.checks;
+    const checksRun = stepRuns(checks).join("\n");
+
+    expect(checks.if).toBe("always()");
+    expect(checks.needs).toEqual([
+      "changes",
+      "docs-only-checks",
+      "static-checks",
+      "build-typecheck",
+      "cli-tests",
+      "plugin-tests",
+      "test-e2e-ollama-proxy",
+    ]);
+
+    for (const jobName of [
+      "changes",
+      "static-checks",
+      "build-typecheck",
+      "cli-tests",
+      "plugin-tests",
+      "test-e2e-ollama-proxy",
+    ]) {
+      expect(checksRun).toContain(`require_success "${jobName}"`);
+    }
+
+    expect(checksRun).toContain('require_success "docs-only-checks"');
   });
 
   it("does not run npm lifecycle scripts during pull_request dependency installs", () => {

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  readYaml,
+  type CompositeAction,
+  type WorkflowJob,
+} from "./helpers/e2e-workflow-contract";
+
+type PullRequestWorkflow = {
+  jobs: Record<string, WorkflowJob>;
+};
+
+function stepRuns(job: WorkflowJob): string[] {
+  return (job.steps ?? []).flatMap((step) => (step.run ? [step.run] : []));
+}
+
+describe("pull request workflow contract", () => {
+  const workflow = readYaml<PullRequestWorkflow>(".github/workflows/pr.yaml");
+
+  it("routes mixed docs and code PRs through the code-check path", () => {
+    const filterStep = workflow.jobs.changes.steps?.find(
+      (step) => step.id === "filter",
+    );
+
+    expect(filterStep?.uses).toContain("dorny/paths-filter");
+    expect(filterStep?.with?.["predicate-quantifier"]).toBe("some");
+    expect(filterStep?.with?.filters).toContain("code:");
+    expect(filterStep?.with?.filters).toContain("!**/*.md");
+    expect(filterStep?.with?.filters).toContain("!docs/**");
+  });
+
+  it("preserves the basic-checks config validation gate for code PRs", () => {
+    const basicChecks = readYaml<CompositeAction>(".github/actions/basic-checks/action.yaml");
+    const requiredValidationRun = basicChecks.runs.steps.find(
+      (step) => step.name === "Validate config schemas",
+    )?.run;
+
+    expect(requiredValidationRun).toBe("npm run validate:configs");
+    expect(stepRuns(workflow.jobs["static-checks"])).toContain(requiredValidationRun);
+  });
+
+  it("does not run npm lifecycle scripts during pull_request dependency installs", () => {
+    for (const jobName of ["build-typecheck", "cli-tests", "plugin-tests"]) {
+      const installRun = stepRuns(workflow.jobs[jobName]).find((run) =>
+        run.includes("cd nemoclaw && npm install"),
+      );
+
+      expect(installRun, `${jobName} plugin install`).toContain(
+        "cd nemoclaw && npm install --ignore-scripts",
+      );
+      expect(installRun, `${jobName} plugin install`).not.toContain(
+        "cd nemoclaw && npm install\n",
+      );
+    }
+  });
+
+  it("does not persist checkout credentials in pull_request jobs", () => {
+    for (const [jobName, job] of Object.entries(workflow.jobs)) {
+      for (const step of job.steps ?? []) {
+        if (!step.uses?.startsWith("actions/checkout@")) {
+          continue;
+        }
+
+        expect(step.with?.["persist-credentials"], `${jobName} checkout`).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Parallelizes the pull request workflow so code PRs no longer hide all validation inside one serial `basic-checks` job, while preserving the final `checks` job name for branch protection. Also keeps a docs-only fast path so Markdown/docs-only PRs avoid the full all-files pre-push suite.

## Changes
- Splits the PR workflow into `static-checks`, `build-typecheck`, `cli-tests`, `plugin-tests`, and `test-e2e-ollama-proxy` jobs that can run in parallel for code changes.
- Keeps a final `checks` job that verifies the required split jobs succeeded, preserving the existing required-check name.
- Keeps docs-only validation in a separate `docs-only-checks` path that installs root dependencies, fetches the PR base commit, runs diff-scoped `prek`, and verifies the platform matrix.
- Moves the Ollama proxy E2E job off the final `checks` dependency so it can run alongside the other code-check jobs.
- Prepares plugin dependencies and plugin dist artifacts inside `cli-tests`, since the CLI coverage suite depends on the plugin package during several integration tests.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- `python3` YAML parse for `.github/workflows/pr.yaml` passes.
- Workflow job graph check for the expected split jobs and final `checks` dependencies passes.
- `git diff --check` passes.
- `python3 scripts/generate-platform-docs.py --check` passes.
- `cd nemoclaw && npm run build` passes locally.
- PR run `27051222944` passed the split workflow: `changes`, `static-checks`, `build-typecheck`, `cli-tests`, `plugin-tests`, `test-e2e-ollama-proxy`, and final `checks` all succeeded.
- `npx prek run --files .github/workflows/pr.yaml` could not complete locally because the runner attempted external GitHub fetches that returned HTTP 503.
- Local `npm test` was rerun after rebuilding CLI and plugin artifacts; it still failed in unrelated CLI/status/rebuild/config permission tests (`57` failed, `7226` passed, `25` skipped). The PR CI split run passed.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PR validation workflow refactored to run targeted checks for docs-only vs. code changes, speeding up validations and reducing unnecessary job runs while keeping overall protection gates.

* **Tests**
  * Added CI workflow contract tests to validate routing, required validations, and install behavior, ensuring workflow consistency and predictable checks across PR types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->