### PR TITLE
ci: upload CLI Vitest timing report

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -194,6 +194,9 @@ jobs:
           npm run build:cli
           npx tsx scripts/check-dist-sourcemaps.ts dist
           npx vitest run --project cli \
+            --reporter=github-actions \
+            --reporter=json \
+            --outputFile.json=coverage/cli/vitest-results.json \
             --coverage \
             --coverage.reporter=text-summary \
             --coverage.reporter=json-summary \
@@ -203,6 +206,15 @@ jobs:
             --coverage.exclude="test/**/*.js" \
             --coverage.exclude="test/**/*.ts"
           npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"
+
+      - name: Upload CLI Vitest timing report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cli-vitest-results
+          path: coverage/cli/vitest-results.json
+          if-no-files-found: warn
+          retention-days: 14
 
   plugin-tests:
     needs: changes

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -125,11 +125,29 @@ describe("pull request workflow contract", () => {
     expect(buildRuns).toContain("npx tsc -p jsconfig.json");
     expect(buildRuns).toContain("bash scripts/check-version-tag-sync.sh");
     expect(cliTestRun).toContain("npx vitest run --project cli");
+    expect(cliTestRun).toContain("--reporter=github-actions");
+    expect(cliTestRun).toContain("--reporter=json");
+    expect(cliTestRun).toContain(
+      "--outputFile.json=coverage/cli/vitest-results.json",
+    );
     expect(cliTestRun).toContain("npx tsx scripts/check-coverage-ratchet.ts");
     expect(pluginTestRun).toContain("npx vitest run --project plugin");
     expect(pluginTestRun).toContain("npx tsx scripts/check-coverage-ratchet.ts");
     expect(staticRuns).toContain("npm run source-shape:check");
     expect(staticRuns).toContain("npx vitest run test/skills-frontmatter.test.ts");
+  });
+
+  it("uploads CLI Vitest JSON results for timing analysis", () => {
+    const uploadStep = workflow.jobs["cli-tests"].steps?.find(
+      (step) => step.name === "Upload CLI Vitest timing report",
+    );
+
+    expect(uploadStep?.if).toBe("always()");
+    expect(uploadStep?.uses).toContain("actions/upload-artifact@");
+    expect(uploadStep?.with?.name).toBe("cli-vitest-results");
+    expect(uploadStep?.with?.path).toBe("coverage/cli/vitest-results.json");
+    expect(uploadStep?.with?.["if-no-files-found"]).toBe("warn");
+    expect(uploadStep?.with?.["retention-days"]).toBe(14);
   });
 
   it("keeps the final checks job as the branch-protection aggregate", () => {


### PR DESCRIPTION
## Summary
Add a JSON Vitest results artifact to the pull-request `cli-tests` job so maintainers can inspect per-test timing for the slow CLI coverage suite. This is an observability-only CI change; the existing CLI coverage command and coverage ratchet remain in place.

## Related Issue
Refs #4892

## Changes
- Configure the PR `cli-tests` Vitest command to keep GitHub Actions annotations while also writing `coverage/cli/vitest-results.json` with the JSON reporter.
- Upload the CLI Vitest JSON results as a short-retention artifact, including failed runs when the file is available.
- Extend the PR workflow contract test to pin the reporter flags and artifact upload path.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Ran targeted verification for this CI-only change:
- `npx vitest run test/pr-workflow-contract.test.ts` passes
- Vitest JSON reporter smoke test writes a nested `vitest-results.json` file with per-assertion durations
- `npm run typecheck:cli` passes
- Workflow YAML parses with the repo YAML parser
- `npm run checks` passes
- `git diff --check` passes
- `npx prek run check-yaml --files .github/workflows/pr.yaml` was attempted but could not fetch its remote hook package in this environment due `self-signed certificate in certificate chain`

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test result collection and artifact retention in the continuous integration workflow to improve quality assurance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->