### PR TITLE
fix(onboard): accept messaging selector key sequences

### DIFF
--- a/src/lib/onboard/messaging-channel-setup-fallback.test.ts
+++ b/src/lib/onboard/messaging-channel-setup-fallback.test.ts
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import readline from "node:readline";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getCredential, prompt } from "../credentials/store";
+import { MESSAGING_SETUP_APPLIER_ENV_KEY } from "../messaging/applier/types";
+import { validateSlackCredentials } from "../messaging/channels/slack/hooks/credential-validation";
+import { setupMessagingChannels } from "./messaging-channel-setup";
+
+vi.mock("../credentials/store", () => ({
+  getCredential: vi.fn(() => null),
+  normalizeCredentialValue: vi.fn((value: unknown) =>
+    typeof value === "string" ? value.trim() : "",
+  ),
+  prompt: vi.fn(async () => ""),
+  saveCredential: vi.fn(),
+}));
+
+vi.mock("../messaging/channels/slack/hooks/credential-validation", () => ({
+  formatSlackValidationFailure: vi.fn((result: { message: string }) => result.message),
+  validateSlackCredentials: vi.fn(() => ({ ok: true })),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_STDIN_IS_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const ORIGINAL_STDIN_SET_RAW_MODE = Object.getOwnPropertyDescriptor(
+  process.stdin,
+  "setRawMode",
+);
+const ORIGINAL_STDERR_IS_TTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+
+function mockLineModeAnswer(answer: string): { questions: string[] } {
+  const questions: string[] = [];
+  const rl = {
+    question(question: string, callback: (answer: string) => void) {
+      questions.push(question);
+      callback(answer);
+      return rl;
+    },
+    close() {},
+    on() {
+      return rl;
+    },
+  } as unknown as readline.Interface;
+
+  vi.spyOn(readline, "createInterface").mockReturnValue(rl);
+  return { questions };
+}
+
+function forceLineModeStdio(): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: false,
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: false,
+  });
+}
+
+function restoreDescriptor(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, property);
+}
+
+function stubTelegramReachability(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return { ok: true };
+      },
+      async text() {
+        return "";
+      },
+    })),
+  );
+}
+
+describe("setupMessagingChannels selector fallback", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.clearAllMocks();
+    vi.mocked(getCredential).mockReturnValue(null);
+    vi.mocked(prompt).mockResolvedValue("");
+    vi.mocked(validateSlackCredentials).mockReturnValue({ ok: true });
+    stubTelegramReachability();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
+    restoreDescriptor(process.stdin, "setRawMode", ORIGINAL_STDIN_SET_RAW_MODE);
+    restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses line-mode fallback and keeps seeded channels on empty selection", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:telegram-token";
+    const { questions } = mockLineModeAnswer("");
+    forceLineModeStdio();
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    const result = await setupMessagingChannels(null, null, {
+      isNonInteractive: () => false,
+    });
+
+    expect(readline.createInterface).toHaveBeenCalledOnce();
+    expect(questions).toEqual(["  Messaging channel numbers/IDs: "]);
+    expect(result).toEqual(["telegram"]);
+    expect(logs.join("\n")).toContain("telegram — already configured");
+  });
+
+  it("uses line-mode fallback and clears seeded channels for none", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:telegram-token";
+    process.env[MESSAGING_SETUP_APPLIER_ENV_KEY] = "stale-plan";
+    const { questions } = mockLineModeAnswer("none");
+    forceLineModeStdio();
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    const result = await setupMessagingChannels(null, null, {
+      isNonInteractive: () => false,
+    });
+
+    expect(readline.createInterface).toHaveBeenCalledOnce();
+    expect(questions).toEqual(["  Messaging channel numbers/IDs: "]);
+    expect(result).toEqual([]);
+    expect(process.env[MESSAGING_SETUP_APPLIER_ENV_KEY]).toBeUndefined();
+    expect(logs.join("\n")).toContain("Skipping messaging channels.");
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("skips the interactive selector when no channels are available", async () => {
+    const createInterfaceSpy = vi.spyOn(readline, "createInterface");
+    const setRawMode = vi.fn(() => {
+      throw new Error("raw selector should not start when no channels are available");
+    });
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawMode,
+    });
+    Object.defineProperty(process.stderr, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    const result = await setupMessagingChannels(
+      {
+        name: "openclaw",
+        messagingPlatforms: ["unsupported-channel"],
+      } as unknown as Parameters<typeof setupMessagingChannels>[0],
+      null,
+      { isNonInteractive: () => false },
+    );
+
+    expect(result).toEqual([]);
+    expect(setRawMode).not.toHaveBeenCalled();
+    expect(createInterfaceSpy).not.toHaveBeenCalled();
+    expect(logs.join("\n")).toContain("Skipping messaging channels.");
+  });
+});

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -37,6 +37,10 @@ vi.mock("../messaging/channels/slack/hooks/credential-validation", () => ({
 
 const ORIGINAL_ENV = { ...process.env };
 const ORIGINAL_STDIN_IS_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const ORIGINAL_STDIN_SET_RAW_MODE = Object.getOwnPropertyDescriptor(
+  process.stdin,
+  "setRawMode",
+);
 const ORIGINAL_STDERR_IS_TTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
 const manifestRegistry = createBuiltInChannelManifestRegistry();
 
@@ -118,6 +122,7 @@ describe("setupSelectedMessagingChannels", () => {
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
     restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
+    restoreDescriptor(process.stdin, "setRawMode", ORIGINAL_STDIN_SET_RAW_MODE);
     restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -419,6 +424,7 @@ describe("setupMessagingChannels", () => {
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
     restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
+    restoreDescriptor(process.stdin, "setRawMode", ORIGINAL_STDIN_SET_RAW_MODE);
     restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -543,7 +549,7 @@ describe("setupMessagingChannels", () => {
     });
 
     expect(readline.createInterface).toHaveBeenCalledOnce();
-    expect(questions).toEqual(["  Messaging channels: "]);
+    expect(questions).toEqual(["  Messaging channel numbers/IDs: "]);
     expect(result).toEqual(["telegram"]);
     expect(logs.join("\n")).toContain("telegram — already configured");
   });
@@ -563,11 +569,48 @@ describe("setupMessagingChannels", () => {
     });
 
     expect(readline.createInterface).toHaveBeenCalledOnce();
-    expect(questions).toEqual(["  Messaging channels: "]);
+    expect(questions).toEqual(["  Messaging channel numbers/IDs: "]);
     expect(result).toEqual([]);
     expect(process.env[MESSAGING_SETUP_APPLIER_ENV_KEY]).toBeUndefined();
     expect(logs.join("\n")).toContain("Skipping messaging channels.");
     expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("skips the interactive selector when no channels are available", async () => {
+    const createInterfaceSpy = vi.spyOn(readline, "createInterface");
+    const setRawMode = vi.fn(() => {
+      throw new Error("raw selector should not start when no channels are available");
+    });
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawMode,
+    });
+    Object.defineProperty(process.stderr, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    const result = await setupMessagingChannels(
+      {
+        name: "openclaw",
+        messagingPlatforms: ["unsupported-channel"],
+      } as unknown as Parameters<typeof setupMessagingChannels>[0],
+      null,
+      { isNonInteractive: () => false },
+    );
+
+    expect(result).toEqual([]);
+    expect(setRawMode).not.toHaveBeenCalled();
+    expect(createInterfaceSpy).not.toHaveBeenCalled();
+    expect(logs.join("\n")).toContain("Skipping messaging channels.");
   });
 
   it("disables Slack when Slack API rejects prompted credentials", async () => {

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import readline from "node:readline";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getCredential, prompt, saveCredential } from "../credentials/store";
@@ -34,6 +36,8 @@ vi.mock("../messaging/channels/slack/hooks/credential-validation", () => ({
 }));
 
 const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_STDIN_IS_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const ORIGINAL_STDERR_IS_TTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
 const manifestRegistry = createBuiltInChannelManifestRegistry();
 
 function manifests(...channelIds: string[]) {
@@ -60,6 +64,47 @@ function stubTelegramReachability(): void {
   );
 }
 
+function mockLineModeAnswer(answer: string): { questions: string[] } {
+  const questions: string[] = [];
+  const rl = {
+    question(question: string, callback: (answer: string) => void) {
+      questions.push(question);
+      callback(answer);
+      return rl;
+    },
+    close() {},
+    on() {
+      return rl;
+    },
+  } as unknown as readline.Interface;
+
+  vi.spyOn(readline, "createInterface").mockReturnValue(rl);
+  return { questions };
+}
+
+function forceLineModeStdio(): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: false,
+  });
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: false,
+  });
+}
+
+function restoreDescriptor(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, property);
+}
+
 describe("setupSelectedMessagingChannels", () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
@@ -72,6 +117,8 @@ describe("setupSelectedMessagingChannels", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
+    restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -371,6 +418,8 @@ describe("setupMessagingChannels", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
+    restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -477,6 +526,47 @@ describe("setupMessagingChannels", () => {
     ]);
     expect(logs.join("\n")).toContain("Slack bot tokens start with 'xoxb-'");
     expect(logs.join("\n")).toContain("Skipped slack (invalid token format)");
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("uses line-mode fallback and keeps seeded channels on empty selection", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:telegram-token";
+    const { questions } = mockLineModeAnswer("");
+    forceLineModeStdio();
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    const result = await setupMessagingChannels(null, null, {
+      isNonInteractive: () => false,
+    });
+
+    expect(readline.createInterface).toHaveBeenCalledOnce();
+    expect(questions).toEqual(["  Messaging channels: "]);
+    expect(result).toEqual(["telegram"]);
+    expect(logs.join("\n")).toContain("telegram — already configured");
+  });
+
+  it("uses line-mode fallback and clears seeded channels for none", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:telegram-token";
+    process.env[MESSAGING_SETUP_APPLIER_ENV_KEY] = "stale-plan";
+    const { questions } = mockLineModeAnswer("none");
+    forceLineModeStdio();
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((message = "") => {
+      logs.push(String(message));
+    });
+
+    const result = await setupMessagingChannels(null, null, {
+      isNonInteractive: () => false,
+    });
+
+    expect(readline.createInterface).toHaveBeenCalledOnce();
+    expect(questions).toEqual(["  Messaging channels: "]);
+    expect(result).toEqual([]);
+    expect(process.env[MESSAGING_SETUP_APPLIER_ENV_KEY]).toBeUndefined();
+    expect(logs.join("\n")).toContain("Skipping messaging channels.");
     expect(prompt).not.toHaveBeenCalled();
   });
 

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import readline from "node:readline";
-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getCredential, prompt, saveCredential } from "../credentials/store";
@@ -36,12 +34,6 @@ vi.mock("../messaging/channels/slack/hooks/credential-validation", () => ({
 }));
 
 const ORIGINAL_ENV = { ...process.env };
-const ORIGINAL_STDIN_IS_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-const ORIGINAL_STDIN_SET_RAW_MODE = Object.getOwnPropertyDescriptor(
-  process.stdin,
-  "setRawMode",
-);
-const ORIGINAL_STDERR_IS_TTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
 const manifestRegistry = createBuiltInChannelManifestRegistry();
 
 function manifests(...channelIds: string[]) {
@@ -68,47 +60,6 @@ function stubTelegramReachability(): void {
   );
 }
 
-function mockLineModeAnswer(answer: string): { questions: string[] } {
-  const questions: string[] = [];
-  const rl = {
-    question(question: string, callback: (answer: string) => void) {
-      questions.push(question);
-      callback(answer);
-      return rl;
-    },
-    close() {},
-    on() {
-      return rl;
-    },
-  } as unknown as readline.Interface;
-
-  vi.spyOn(readline, "createInterface").mockReturnValue(rl);
-  return { questions };
-}
-
-function forceLineModeStdio(): void {
-  Object.defineProperty(process.stdin, "isTTY", {
-    configurable: true,
-    value: false,
-  });
-  Object.defineProperty(process.stderr, "isTTY", {
-    configurable: true,
-    value: false,
-  });
-}
-
-function restoreDescriptor(
-  target: object,
-  property: string,
-  descriptor: PropertyDescriptor | undefined,
-): void {
-  if (descriptor) {
-    Object.defineProperty(target, property, descriptor);
-    return;
-  }
-  Reflect.deleteProperty(target, property);
-}
-
 describe("setupSelectedMessagingChannels", () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
@@ -121,9 +72,6 @@ describe("setupSelectedMessagingChannels", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
-    restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
-    restoreDescriptor(process.stdin, "setRawMode", ORIGINAL_STDIN_SET_RAW_MODE);
-    restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -423,9 +371,6 @@ describe("setupMessagingChannels", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
-    restoreDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
-    restoreDescriptor(process.stdin, "setRawMode", ORIGINAL_STDIN_SET_RAW_MODE);
-    restoreDescriptor(process.stderr, "isTTY", ORIGINAL_STDERR_IS_TTY);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -533,84 +478,6 @@ describe("setupMessagingChannels", () => {
     expect(logs.join("\n")).toContain("Slack bot tokens start with 'xoxb-'");
     expect(logs.join("\n")).toContain("Skipped slack (invalid token format)");
     expect(prompt).not.toHaveBeenCalled();
-  });
-
-  it("uses line-mode fallback and keeps seeded channels on empty selection", async () => {
-    process.env.TELEGRAM_BOT_TOKEN = "123456:telegram-token";
-    const { questions } = mockLineModeAnswer("");
-    forceLineModeStdio();
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((message = "") => {
-      logs.push(String(message));
-    });
-
-    const result = await setupMessagingChannels(null, null, {
-      isNonInteractive: () => false,
-    });
-
-    expect(readline.createInterface).toHaveBeenCalledOnce();
-    expect(questions).toEqual(["  Messaging channel numbers/IDs: "]);
-    expect(result).toEqual(["telegram"]);
-    expect(logs.join("\n")).toContain("telegram — already configured");
-  });
-
-  it("uses line-mode fallback and clears seeded channels for none", async () => {
-    process.env.TELEGRAM_BOT_TOKEN = "123456:telegram-token";
-    process.env[MESSAGING_SETUP_APPLIER_ENV_KEY] = "stale-plan";
-    const { questions } = mockLineModeAnswer("none");
-    forceLineModeStdio();
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((message = "") => {
-      logs.push(String(message));
-    });
-
-    const result = await setupMessagingChannels(null, null, {
-      isNonInteractive: () => false,
-    });
-
-    expect(readline.createInterface).toHaveBeenCalledOnce();
-    expect(questions).toEqual(["  Messaging channel numbers/IDs: "]);
-    expect(result).toEqual([]);
-    expect(process.env[MESSAGING_SETUP_APPLIER_ENV_KEY]).toBeUndefined();
-    expect(logs.join("\n")).toContain("Skipping messaging channels.");
-    expect(prompt).not.toHaveBeenCalled();
-  });
-
-  it("skips the interactive selector when no channels are available", async () => {
-    const createInterfaceSpy = vi.spyOn(readline, "createInterface");
-    const setRawMode = vi.fn(() => {
-      throw new Error("raw selector should not start when no channels are available");
-    });
-    Object.defineProperty(process.stdin, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    Object.defineProperty(process.stdin, "setRawMode", {
-      configurable: true,
-      value: setRawMode,
-    });
-    Object.defineProperty(process.stderr, "isTTY", {
-      configurable: true,
-      value: true,
-    });
-    const logs: string[] = [];
-    vi.spyOn(console, "log").mockImplementation((message = "") => {
-      logs.push(String(message));
-    });
-
-    const result = await setupMessagingChannels(
-      {
-        name: "openclaw",
-        messagingPlatforms: ["unsupported-channel"],
-      } as unknown as Parameters<typeof setupMessagingChannels>[0],
-      null,
-      { isNonInteractive: () => false },
-    );
-
-    expect(result).toEqual([]);
-    expect(setRawMode).not.toHaveBeenCalled();
-    expect(createInterfaceSpy).not.toHaveBeenCalled();
-    expect(logs.join("\n")).toContain("Skipping messaging channels.");
   });
 
   it("disables Slack when Slack API rejects prompted credentials", async () => {

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -92,24 +92,26 @@ export async function setupMessagingChannels(
   const statusForChannel = (manifest: ChannelManifest): string =>
     hasManifestRequiredInputs(manifest) ? " (configured)" : "";
 
-  if (!input.isTTY || !output.isTTY || typeof input.setRawMode !== "function") {
-    await promptMessagingChannelLineSelection(availableChannels, enabled, statusForChannel);
-  } else {
-    const linesAbovePrompt = availableChannels.length + 3;
-    let firstDraw = true;
-    const showList = () => {
-      if (!firstDraw) {
-        output.write(`\r\x1b[${linesAbovePrompt}A\x1b[J`);
-      }
-      firstDraw = false;
-      renderMessagingChannelList(output, availableChannels, enabled, statusForChannel);
-      output.write(
-        `  Press 1-${availableChannels.length} to toggle, Enter when done (none selected skips): `,
-      );
-    };
+  if (availableChannels.length > 0) {
+    if (!input.isTTY || !output.isTTY || typeof input.setRawMode !== "function") {
+      await promptMessagingChannelLineSelection(availableChannels, enabled, statusForChannel);
+    } else {
+      const linesAbovePrompt = availableChannels.length + 3;
+      let firstDraw = true;
+      const showList = () => {
+        if (!firstDraw) {
+          output.write(`\r\x1b[${linesAbovePrompt}A\x1b[J`);
+        }
+        firstDraw = false;
+        renderMessagingChannelList(output, availableChannels, enabled, statusForChannel);
+        output.write(
+          `  Press 1-${availableChannels.length} to toggle, Enter when done (none selected skips): `,
+        );
+      };
 
-    showList();
-    await readMessagingChannelSelection(availableChannels, enabled, showList);
+      showList();
+      await readMessagingChannelSelection(availableChannels, enabled, showList);
+    }
   }
 
   const selected = Array.from(enabled);

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -17,6 +17,13 @@ import {
   toMessagingAgentId,
 } from "../messaging";
 import { resolveMessagingChannelConfigEnvValue } from "../messaging-channel-config";
+import {
+  promptMessagingChannelLineSelection,
+  readMessagingChannelSelection,
+  renderMessagingChannelList,
+  type MessagingSelectorInput,
+  type MessagingSelectorOutput,
+} from "./messaging-selector";
 
 export interface SetupSelectedMessagingChannelsOptions {
   readonly agent?: { readonly name?: string } | null;
@@ -80,31 +87,30 @@ export async function setupMessagingChannels(
   }
 
   const enabled = new Set(seedFromState(true));
-  const output = process.stderr;
-  const linesAbovePrompt = availableChannels.length + 3;
-  let firstDraw = true;
-  const showList = () => {
-    if (!firstDraw) {
-      output.write(`\r\x1b[${linesAbovePrompt}A\x1b[J`);
-    }
-    firstDraw = false;
-    output.write("\n");
-    output.write("  Available messaging channels:\n");
-    availableChannels.forEach((manifest, i) => {
-      const marker = enabled.has(manifest.id) ? "●" : "○";
-      const status = hasManifestRequiredInputs(manifest) ? " (configured)" : "";
-      output.write(
-        `    [${i + 1}] ${marker} ${manifest.id} — ${
-          manifest.description ?? manifest.displayName
-        }${status}\n`,
-      );
-    });
-    output.write("\n");
-    output.write(`  Press 1-${availableChannels.length} to toggle, Enter when done: `);
-  };
+  const input = process.stdin as MessagingSelectorInput;
+  const output = process.stderr as MessagingSelectorOutput;
+  const statusForChannel = (manifest: ChannelManifest): string =>
+    hasManifestRequiredInputs(manifest) ? " (configured)" : "";
 
-  showList();
-  await readMessagingChannelSelection(availableChannels, enabled, showList);
+  if (!input.isTTY || !output.isTTY || typeof input.setRawMode !== "function") {
+    await promptMessagingChannelLineSelection(availableChannels, enabled, statusForChannel);
+  } else {
+    const linesAbovePrompt = availableChannels.length + 3;
+    let firstDraw = true;
+    const showList = () => {
+      if (!firstDraw) {
+        output.write(`\r\x1b[${linesAbovePrompt}A\x1b[J`);
+      }
+      firstDraw = false;
+      renderMessagingChannelList(output, availableChannels, enabled, statusForChannel);
+      output.write(
+        `  Press 1-${availableChannels.length} to toggle, Enter when done (none selected skips): `,
+      );
+    };
+
+    showList();
+    await readMessagingChannelSelection(availableChannels, enabled, showList);
+  }
 
   const selected = Array.from(enabled);
   if (selected.length === 0) {
@@ -186,80 +192,6 @@ export async function setupSelectedMessagingChannels(
   }
 
   return plan;
-}
-
-function readMessagingChannelSelection(
-  availableChannels: readonly ChannelManifest[],
-  enabled: Set<string>,
-  showList: () => void,
-): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const input = process.stdin;
-    const output = process.stderr;
-    let rawModeEnabled = false;
-    let finished = false;
-
-    function cleanup() {
-      input.removeListener("data", onData);
-      if (rawModeEnabled && typeof input.setRawMode === "function") {
-        input.setRawMode(false);
-      }
-      if (typeof input.pause === "function") {
-        input.pause();
-      }
-      if (typeof input.unref === "function") {
-        input.unref();
-      }
-    }
-
-    function finish(): void {
-      if (finished) return;
-      finished = true;
-      cleanup();
-      output.write("\n");
-      resolve();
-    }
-
-    function onData(chunk: Buffer | string): void {
-      const text = chunk.toString("utf8");
-      for (let i = 0; i < text.length; i += 1) {
-        const ch = text[i];
-        if (ch === "\u0003") {
-          cleanup();
-          reject(Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" }));
-          process.kill(process.pid, "SIGINT");
-          return;
-        }
-        if (ch === "\r" || ch === "\n") {
-          finish();
-          return;
-        }
-        const num = parseInt(ch, 10);
-        if (num >= 1 && num <= availableChannels.length) {
-          const channel = availableChannels[num - 1];
-          if (enabled.has(channel.id)) {
-            enabled.delete(channel.id);
-          } else {
-            enabled.add(channel.id);
-          }
-          showList();
-        }
-      }
-    }
-
-    if (typeof input.ref === "function") {
-      input.ref();
-    }
-    input.setEncoding("utf8");
-    if (typeof input.resume === "function") {
-      input.resume();
-    }
-    if (typeof input.setRawMode === "function") {
-      input.setRawMode(true);
-      rawModeEnabled = true;
-    }
-    input.on("data", onData);
-  });
 }
 
 function uniqueSelectedChannels(

--- a/src/lib/onboard/messaging-selector.test.ts
+++ b/src/lib/onboard/messaging-selector.test.ts
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   applyMessagingSelectorKey,
   createMessagingSelectorNormalizerState,
   normalizeMessagingSelectorInput,
+  readMessagingChannelSelection,
   resolveMessagingChannelSelectorEntry,
 } from "./messaging-selector";
 
@@ -15,6 +18,51 @@ const channels = [
   { id: "discord", displayName: "Discord", description: "Discord bot messaging" },
   { id: "wechat", displayName: "WeChat", description: "WeChat bot messaging" },
 ];
+
+const ORIGINAL_STDIN = Object.getOwnPropertyDescriptor(process, "stdin");
+const ORIGINAL_STDERR = Object.getOwnPropertyDescriptor(process, "stderr");
+
+function restoreProcessDescriptor(
+  property: "stdin" | "stderr",
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(process, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(process, property);
+}
+
+function createMockSelectorInput(): EventEmitter & {
+  setRawMode: ReturnType<typeof vi.fn>;
+  setEncoding: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  ref: ReturnType<typeof vi.fn>;
+  unref: ReturnType<typeof vi.fn>;
+} {
+  const input = new EventEmitter() as EventEmitter & {
+    setRawMode: ReturnType<typeof vi.fn>;
+    setEncoding: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    ref: ReturnType<typeof vi.fn>;
+    unref: ReturnType<typeof vi.fn>;
+  };
+  input.setRawMode = vi.fn();
+  input.setEncoding = vi.fn();
+  input.resume = vi.fn();
+  input.pause = vi.fn();
+  input.ref = vi.fn();
+  input.unref = vi.fn();
+  return input;
+}
+
+afterEach(() => {
+  restoreProcessDescriptor("stdin", ORIGINAL_STDIN);
+  restoreProcessDescriptor("stderr", ORIGINAL_STDERR);
+  vi.restoreAllMocks();
+});
 
 describe("messaging selector key handling", () => {
   it("toggles numeric raw keypresses before Enter confirms", () => {
@@ -52,5 +100,39 @@ describe("messaging selector key handling", () => {
     expect(resolveMessagingChannelSelectorEntry("2", channels)?.id).toBe("discord");
     expect(resolveMessagingChannelSelectorEntry("WeChat", channels)?.id).toBe("wechat");
     expect(resolveMessagingChannelSelectorEntry("mattermost", channels)).toBeNull();
+  });
+
+  it("restores raw mode and removes listeners when SIGTERM interrupts", async () => {
+    const input = createMockSelectorInput();
+    const output = { write: vi.fn() };
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: input,
+    });
+    Object.defineProperty(process, "stderr", {
+      configurable: true,
+      value: output,
+    });
+    const processOn = vi.spyOn(process, "on");
+    const processRemoveListener = vi.spyOn(process, "removeListener");
+    const processKill = vi
+      .spyOn(process, "kill")
+      .mockImplementation((_pid: number, _signal?: string | number) => true);
+
+    const selection = readMessagingChannelSelection(channels, new Set<string>(), () => {});
+    const sigtermHandler = processOn.mock.calls.find(([signal]) => signal === "SIGTERM")?.[1];
+    expect(sigtermHandler).toBeTypeOf("function");
+
+    (sigtermHandler as () => void)();
+
+    await expect(selection).rejects.toMatchObject({ code: "SIGTERM" });
+    expect(input.setRawMode).toHaveBeenNthCalledWith(1, true);
+    expect(input.setRawMode).toHaveBeenNthCalledWith(2, false);
+    expect(input.pause).toHaveBeenCalledOnce();
+    expect(input.unref).toHaveBeenCalledOnce();
+    expect(input.listenerCount("data")).toBe(0);
+    expect(processRemoveListener).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(processRemoveListener).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(processKill).toHaveBeenCalledWith(process.pid, "SIGTERM");
   });
 });

--- a/src/lib/onboard/messaging-selector.test.ts
+++ b/src/lib/onboard/messaging-selector.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyMessagingSelectorKey,
+  createMessagingSelectorNormalizerState,
+  normalizeMessagingSelectorInput,
+  resolveMessagingChannelSelectorEntry,
+} from "./messaging-selector";
+
+const channels = [
+  { id: "telegram", displayName: "Telegram", description: "Telegram bot messaging" },
+  { id: "discord", displayName: "Discord", description: "Discord bot messaging" },
+  { id: "wechat", displayName: "WeChat", description: "WeChat bot messaging" },
+];
+
+describe("messaging selector key handling", () => {
+  it("toggles numeric raw keypresses before Enter confirms", () => {
+    const enabled = new Set<string>();
+
+    expect(applyMessagingSelectorKey("1", enabled, channels)).toBe("redraw");
+    expect([...enabled]).toEqual(["telegram"]);
+    expect(applyMessagingSelectorKey("2", enabled, channels)).toBe("redraw");
+    expect([...enabled]).toEqual(["telegram", "discord"]);
+    expect(applyMessagingSelectorKey("\r", enabled, channels)).toBe("finish");
+  });
+
+  it("normalizes complete terminal keypad and extended numeric sequences", () => {
+    expect(normalizeMessagingSelectorInput("\x1bOq")).toBe("1");
+    expect(normalizeMessagingSelectorInput("\x1b[49;5u")).toBe("1");
+    expect(normalizeMessagingSelectorInput("\x1bOM")).toBe("\r");
+    expect(normalizeMessagingSelectorInput("\x1b[13u")).toBe("\r");
+  });
+
+  it("buffers split terminal keypad and extended numeric sequences", () => {
+    const state = createMessagingSelectorNormalizerState();
+
+    expect(normalizeMessagingSelectorInput("\x1bO", state)).toBe("");
+    expect(state.carry).toBe("\x1bO");
+    expect(normalizeMessagingSelectorInput("q", state)).toBe("1");
+    expect(state.carry).toBe("");
+
+    expect(normalizeMessagingSelectorInput("\x1b[49;", state)).toBe("");
+    expect(state.carry).toBe("\x1b[49;");
+    expect(normalizeMessagingSelectorInput("5u", state)).toBe("1");
+    expect(state.carry).toBe("");
+  });
+
+  it("resolves line-mode selections by number or channel id", () => {
+    expect(resolveMessagingChannelSelectorEntry("2", channels)?.id).toBe("discord");
+    expect(resolveMessagingChannelSelectorEntry("WeChat", channels)?.id).toBe("wechat");
+    expect(resolveMessagingChannelSelectorEntry("mattermost", channels)).toBeNull();
+  });
+});

--- a/src/lib/onboard/messaging-selector.ts
+++ b/src/lib/onboard/messaging-selector.ts
@@ -122,9 +122,9 @@ export async function promptMessagingChannelLineSelection<T extends MessagingCha
   statusForChannel: (channel: T) => string,
 ): Promise<void> {
   renderMessagingChannelList(process.stderr, availableChannels, enabled, statusForChannel);
-  console.error("  Enter comma-separated numbers/names, Enter for current selection, or 'none'.");
+  console.error("  Enter comma-separated numbers/IDs, Enter for current selection, or 'none'.");
 
-  const answer = (await promptMessagingSelectorLine("  Messaging channels: ")).trim();
+  const answer = (await promptMessagingSelectorLine("  Messaging channel numbers/IDs: ")).trim();
   if (!answer) return;
   if (/^(none|no|skip)$/i.test(answer)) {
     enabled.clear();

--- a/src/lib/onboard/messaging-selector.ts
+++ b/src/lib/onboard/messaging-selector.ts
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import readline from "node:readline";
+
+export interface MessagingChannelSelectorEntry {
+  readonly id: string;
+  readonly displayName: string;
+  readonly description?: string;
+}
+
+export type MessagingSelectorInput = typeof process.stdin & {
+  readonly isTTY?: boolean;
+  setRawMode?: (mode: boolean) => void;
+};
+
+export type MessagingSelectorOutput = typeof process.stderr & {
+  readonly isTTY?: boolean;
+};
+
+export type MessagingSelectorKeyAction = "continue" | "redraw" | "finish" | "interrupt";
+
+export interface MessagingSelectorNormalizerState {
+  carry: string;
+}
+
+const APPLICATION_KEYPAD_DIGITS: Record<string, string> = {
+  p: "0",
+  q: "1",
+  r: "2",
+  s: "3",
+  t: "4",
+  u: "5",
+  v: "6",
+  w: "7",
+  x: "8",
+  y: "9",
+  M: "\r",
+};
+
+export function createMessagingSelectorNormalizerState(): MessagingSelectorNormalizerState {
+  return { carry: "" };
+}
+
+export function normalizeMessagingSelectorInput(
+  text: string,
+  state?: MessagingSelectorNormalizerState,
+): string {
+  const combined = `${state?.carry ?? ""}${text}`;
+  const { complete, carry } = splitIncompleteMessagingSelectorInput(combined);
+  if (state) state.carry = carry;
+
+  return complete
+    .replace(/\x1bO([Mp-y])/g, (_match, key: string) => APPLICATION_KEYPAD_DIGITS[key] || "")
+    .replace(/\x1b\[(\d+)(?:;\d+)*u/g, (_match, code: string) => {
+      const charCode = Number.parseInt(code, 10);
+      if (charCode >= 48 && charCode <= 57) return String.fromCharCode(charCode);
+      if (charCode === 13) return "\r";
+      return "";
+    });
+}
+
+export function applyMessagingSelectorKey(
+  key: string,
+  enabled: Set<string>,
+  availableChannels: readonly MessagingChannelSelectorEntry[],
+): MessagingSelectorKeyAction {
+  if (key === "\u0003") return "interrupt";
+  if (key === "\r" || key === "\n") return "finish";
+
+  const num = Number.parseInt(key, 10);
+  if (num >= 1 && num <= availableChannels.length) {
+    const channel = availableChannels[num - 1];
+    if (enabled.has(channel.id)) {
+      enabled.delete(channel.id);
+    } else {
+      enabled.add(channel.id);
+    }
+    return "redraw";
+  }
+
+  return "continue";
+}
+
+export function renderMessagingChannelList<T extends MessagingChannelSelectorEntry>(
+  output: Pick<MessagingSelectorOutput, "write">,
+  availableChannels: readonly T[],
+  enabled: Set<string>,
+  statusForChannel: (channel: T) => string,
+): void {
+  output.write("\n");
+  output.write("  Available messaging channels:\n");
+  availableChannels.forEach((channel, index) => {
+    const marker = enabled.has(channel.id) ? "●" : "○";
+    output.write(
+      `    [${index + 1}] ${marker} ${channel.id} — ${
+        channel.description ?? channel.displayName
+      }${statusForChannel(channel)}\n`,
+    );
+  });
+  output.write("\n");
+}
+
+export function resolveMessagingChannelSelectorEntry<T extends MessagingChannelSelectorEntry>(
+  value: string,
+  availableChannels: readonly T[],
+): T | null {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  const numeric = Number.parseInt(trimmed, 10);
+  if (String(numeric) === trimmed && numeric >= 1 && numeric <= availableChannels.length) {
+    return availableChannels[numeric - 1] ?? null;
+  }
+
+  return availableChannels.find((channel) => channel.id === trimmed) ?? null;
+}
+
+export async function promptMessagingChannelLineSelection<T extends MessagingChannelSelectorEntry>(
+  availableChannels: readonly T[],
+  enabled: Set<string>,
+  statusForChannel: (channel: T) => string,
+): Promise<void> {
+  renderMessagingChannelList(process.stderr, availableChannels, enabled, statusForChannel);
+  console.error("  Enter comma-separated numbers/names, Enter for current selection, or 'none'.");
+
+  const answer = (await promptMessagingSelectorLine("  Messaging channels: ")).trim();
+  if (!answer) return;
+  if (/^(none|no|skip)$/i.test(answer)) {
+    enabled.clear();
+    return;
+  }
+
+  const next = new Set<string>();
+  for (const part of answer.split(/[\s,]+/).filter(Boolean)) {
+    const channel = resolveMessagingChannelSelectorEntry(part, availableChannels);
+    if (!channel) {
+      console.error(`  Unknown messaging channel selection: ${part}`);
+      process.exit(1);
+    }
+    next.add(channel.id);
+  }
+
+  enabled.clear();
+  for (const channel of next) enabled.add(channel);
+}
+
+export function readMessagingChannelSelection<T extends MessagingChannelSelectorEntry>(
+  availableChannels: readonly T[],
+  enabled: Set<string>,
+  showList: () => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const input = process.stdin as MessagingSelectorInput;
+    const output = process.stderr;
+    const normalizerState = createMessagingSelectorNormalizerState();
+    let rawModeEnabled = false;
+    let finished = false;
+
+    function cleanup() {
+      input.removeListener("data", onData);
+      process.removeListener("SIGINT", sigintHandler);
+      process.removeListener("SIGTERM", sigtermHandler);
+      if (rawModeEnabled && typeof input.setRawMode === "function") {
+        input.setRawMode(false);
+      }
+      if (typeof input.pause === "function") {
+        input.pause();
+      }
+      if (typeof input.unref === "function") {
+        input.unref();
+      }
+    }
+
+    function finish(): void {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      output.write("\n");
+      resolve();
+    }
+
+    function interrupt(signal: NodeJS.Signals): void {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      reject(Object.assign(new Error("Prompt interrupted"), { code: signal }));
+      process.kill(process.pid, signal);
+    }
+
+    function sigintHandler(): void {
+      interrupt("SIGINT");
+    }
+
+    function sigtermHandler(): void {
+      interrupt("SIGTERM");
+    }
+
+    function onData(chunk: Buffer | string): void {
+      const text = normalizeMessagingSelectorInput(chunk.toString("utf8"), normalizerState);
+      for (let index = 0; index < text.length; index += 1) {
+        const action = applyMessagingSelectorKey(text[index], enabled, availableChannels);
+        if (action === "interrupt") {
+          interrupt("SIGINT");
+          return;
+        }
+        if (action === "finish") {
+          finish();
+          return;
+        }
+        if (action === "redraw") {
+          showList();
+        }
+      }
+    }
+
+    if (typeof input.ref === "function") {
+      input.ref();
+    }
+    input.setEncoding("utf8");
+    if (typeof input.resume === "function") {
+      input.resume();
+    }
+    if (typeof input.setRawMode === "function") {
+      input.setRawMode(true);
+      rawModeEnabled = true;
+    }
+    process.on("SIGINT", sigintHandler);
+    process.on("SIGTERM", sigtermHandler);
+    input.on("data", onData);
+  });
+}
+
+function splitIncompleteMessagingSelectorInput(text: string): {
+  complete: string;
+  carry: string;
+} {
+  const incomplete =
+    text.match(/\x1b\[[0-9;]*$/)?.[0] ??
+    text.match(/\x1bO$/)?.[0] ??
+    text.match(/\x1b$/)?.[0] ??
+    "";
+
+  if (!incomplete) return { complete: text, carry: "" };
+  return {
+    complete: text.slice(0, text.length - incomplete.length),
+    carry: incomplete,
+  };
+}
+
+function promptMessagingSelectorLine(question: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (typeof process.stdin.ref === "function") {
+      process.stdin.ref();
+    }
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    let finished = false;
+
+    function cleanup() {
+      rl.close();
+      if (typeof process.stdin.pause === "function") {
+        process.stdin.pause();
+      }
+      if (typeof process.stdin.unref === "function") {
+        process.stdin.unref();
+      }
+    }
+
+    function resolvePrompt(value: string) {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve(value);
+    }
+
+    function rejectPrompt(error: Error) {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      reject(error);
+    }
+
+    rl.on("SIGINT", () => {
+      rejectPrompt(Object.assign(new Error("Prompt interrupted"), { code: "SIGINT" }));
+      process.kill(process.pid, "SIGINT");
+    });
+    rl.question(question, resolvePrompt);
+  });
+}


### PR DESCRIPTION
## Summary
Supersedes #4626 by salvaging the messaging-channel selector fix on current `main`. The selector now keeps the interactive numeric toggle behavior, handles split keypad/CSI-u terminal sequences, restores raw terminal state on SIGTERM, and keeps the selector logic outside the main messaging setup flow.

## Changes
- Move messaging selector rendering, raw-mode input handling, line-mode fallback, and key normalization into `src/lib/onboard/messaging-selector.ts`.
- Wire `setupMessagingChannels` through the selector helper module while preserving seeded channel selection and token/config enrollment behavior.
- Add regression coverage for numeric toggles, keypad/CSI-u normalization, split escape sequence buffering, and line-mode selection resolution.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- `bash -lc 'umask 022; npx prek run --all-files'` passes
- `npm run build:cli` passes
- `npm run typecheck:cli` passes
- `npx vitest run src/lib/onboard/messaging-selector.test.ts src/lib/onboard/messaging-channel-setup.test.ts --maxWorkers=1 --testTimeout=60000` passes
- `npx vitest run test/onboard-messaging.test.ts --maxWorkers=1 --testTimeout=60000` passes
- `bash -lc 'umask 022; npm test'` was attempted; it failed in unrelated `test/install-preflight.test.ts > warns on Podman but still runs onboarding`, where this host's CDI/sudo preflight produced a blocking issue instead of the warning-only path expected by the test.

- [x] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced interactive messaging channel selection with improved keyboard and ANSI escape sequence handling.
  * Added fallback selection mode for environments that don't support interactive terminal features.

* **Tests**
  * Added comprehensive test coverage for messaging channel selection input handling and edge cases.
  * Test coverage for fallback selection scenarios and signal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->