### PR TITLE
fix(sandbox): reset NPM_CONFIG_OFFLINE after build-time plugin install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -580,8 +580,10 @@ RUN NEMOCLAW_OPENCLAW_MANAGED_PROXY=0 node --experimental-strip-types /usr/local
 # hadolint ignore=DL3059,DL4006
 RUN python3 /usr/local/lib/nemoclaw/openclaw-build-messaging-plugins.py
 
-# Lock down npm: no further registry traffic in this image. Everything past
-# this point must resolve from local sources only.
+# Lock down npm for the next RUN: the local OpenClaw plugin install must
+# resolve from /opt/nemoclaw and the staged plugin-runtime-deps tree without
+# touching the registry. Reset to false after that RUN so the runtime image
+# does not propagate `only-if-cached` mode to in-sandbox `npx` / `npm install`.
 ENV NPM_CONFIG_OFFLINE=true \
     NPM_CONFIG_AUDIT=false \
     NPM_CONFIG_FUND=false
@@ -610,6 +612,10 @@ RUN openclaw plugins install /opt/nemoclaw \
             -name examples \
         \) -prune -exec rm -rf {} +; \
     fi
+
+# Release the offline lock so the runtime sandbox can install MCP servers,
+# skills, and ad-hoc packages via the OpenShell L7 proxy.
+ENV NPM_CONFIG_OFFLINE=false
 
 # SECURITY: Clear any gateway auth token that openclaw doctor/plugins may have
 # auto-generated. The real token is created at container startup by the

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -128,6 +128,11 @@ _TOOL_REDIRECTS=(
   'PYTHON_HISTORY=/tmp/.python_history'
   'CLAUDE_CONFIG_DIR=/tmp/.claude'
   'npm_config_prefix=/tmp/npm-global'
+  # Pin npm online at runtime so a stale base image or future build-time
+  # offline-lock regression cannot force `only-if-cached` mode on PID 1 or
+  # `openshell sandbox connect` sessions.
+  'npm_config_offline=false'
+  'NPM_CONFIG_OFFLINE=false'
 )
 for _redir in "${_TOOL_REDIRECTS[@]}"; do
   export "${_redir?}"

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -358,7 +358,7 @@ describe("fetch-guard patch regression guard", () => {
   it("fails the image build when the NemoClaw OpenClaw plugin cannot install", () => {
     const command = dockerRunCommandBetween(
       "# Install NemoClaw plugin into OpenClaw",
-      "# SECURITY: Clear any gateway auth token",
+      "# Release the offline lock",
     );
     const script = [
       "openclaw() {",

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -228,6 +228,45 @@ function runOpenclawRepairLayoutCase(legacy: boolean) {
   }
 }
 
+describe("sandbox provisioning: runtime npm online state", () => {
+  it("resets NPM_CONFIG_OFFLINE to false after the local plugin install", () => {
+    const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
+    const settings: { value: string; index: number }[] = [];
+    const re = /^ENV\s+NPM_CONFIG_OFFLINE=(\S+)/gm;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(dockerfile)) !== null) {
+      const value = match[1].replace(/[\\\s]+$/, "").toLowerCase();
+      settings.push({ value, index: match.index });
+    }
+    expect(
+      settings.length,
+      "Dockerfile should set NPM_CONFIG_OFFLINE at least once for the local plugin install",
+    ).toBeGreaterThanOrEqual(2);
+    const lockOn = settings.find((s) => s.value === "true");
+    const lockOff = settings.find((s) => s.value === "false");
+    expect(lockOn, "Dockerfile should still scope an offline lock around the plugin install").toBeDefined();
+    expect(
+      lockOff,
+      "Dockerfile must reset NPM_CONFIG_OFFLINE=false so the runtime image does not propagate `only-if-cached`",
+    ).toBeDefined();
+    expect(
+      settings[settings.length - 1].value,
+      "The last NPM_CONFIG_OFFLINE setting wins at runtime; it must be `false`",
+    ).toBe("false");
+
+    const pluginInstallIdx = dockerfile.indexOf("openclaw plugins install /opt/nemoclaw");
+    expect(pluginInstallIdx, "expected `openclaw plugins install` RUN in Dockerfile").toBeGreaterThan(-1);
+    expect(
+      lockOn!.index,
+      "The offline lock must precede the local plugin install",
+    ).toBeLessThan(pluginInstallIdx);
+    expect(
+      lockOff!.index,
+      "The offline reset must follow the local plugin install",
+    ).toBeGreaterThan(pluginInstallIdx);
+  });
+});
+
 describe("sandbox provisioning: image health checks (#1430)", () => {
   it.each([
     ["default dashboard URL", {}, "http://127.0.0.1:18789/health"],

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -229,43 +229,87 @@ function runOpenclawRepairLayoutCase(legacy: boolean) {
 }
 
 describe("sandbox provisioning: runtime npm online state", () => {
-  it("resets NPM_CONFIG_OFFLINE to false after the local plugin install", () => {
-    const dockerfile = fs.readFileSync(DOCKERFILE, "utf-8");
-    const settings: { value: string; index: number }[] = [];
-    const re = /^ENV\s+NPM_CONFIG_OFFLINE=(\S+)/gm;
-    let match: RegExpExecArray | null;
-    while ((match = re.exec(dockerfile)) !== null) {
-      const value = match[1].replace(/[\\\s]+$/, "").toLowerCase();
-      settings.push({ value, index: match.index });
+  it("replays the Dockerfile ENV directives so the runtime image inherits NPM_CONFIG_OFFLINE=false", () => {
+    const exports = collectDockerfileEnvExports(DOCKERFILE);
+    const probe = [
+      "#!/usr/bin/env bash",
+      "set -eo pipefail",
+      ...exports,
+      'printf "%s\\n" "${NPM_CONFIG_OFFLINE:-unset}"',
+    ].join("\n");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runtime-npm-online-"));
+    const scriptPath = path.join(tmp, "replay.sh");
+    try {
+      fs.writeFileSync(scriptPath, probe, { mode: 0o700 });
+      const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", timeout: 5000 });
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout.trim()).toBe("false");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
     }
-    expect(
-      settings.length,
-      "Dockerfile should set NPM_CONFIG_OFFLINE at least once for the local plugin install",
-    ).toBeGreaterThanOrEqual(2);
-    const lockOn = settings.find((s) => s.value === "true");
-    const lockOff = settings.find((s) => s.value === "false");
-    expect(lockOn, "Dockerfile should still scope an offline lock around the plugin install").toBeDefined();
-    expect(
-      lockOff,
-      "Dockerfile must reset NPM_CONFIG_OFFLINE=false so the runtime image does not propagate `only-if-cached`",
-    ).toBeDefined();
-    expect(
-      settings[settings.length - 1].value,
-      "The last NPM_CONFIG_OFFLINE setting wins at runtime; it must be `false`",
-    ).toBe("false");
+  });
 
-    const pluginInstallIdx = dockerfile.indexOf("openclaw plugins install /opt/nemoclaw");
-    expect(pluginInstallIdx, "expected `openclaw plugins install` RUN in Dockerfile").toBeGreaterThan(-1);
-    expect(
-      lockOn!.index,
-      "The offline lock must precede the local plugin install",
-    ).toBeLessThan(pluginInstallIdx);
-    expect(
-      lockOff!.index,
-      "The offline reset must follow the local plugin install",
-    ).toBeGreaterThan(pluginInstallIdx);
+  it("exercises the staged plugin install with the offline lock still applied", () => {
+    const stage = stageDockerfileUntil(DOCKERFILE, "openclaw plugins install /opt/nemoclaw");
+    const probe = [
+      "#!/usr/bin/env bash",
+      "set -eo pipefail",
+      ...stage,
+      'printf "%s\\n" "${NPM_CONFIG_OFFLINE:-unset}"',
+    ].join("\n");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runtime-npm-online-staged-"));
+    const scriptPath = path.join(tmp, "staged.sh");
+    try {
+      fs.writeFileSync(scriptPath, probe, { mode: 0o700 });
+      const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", timeout: 5000 });
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout.trim()).toBe("true");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
+
+function dockerfileEnvDirectives(text: string): string[] {
+  const lines = text.split("\n");
+  const directives: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? "";
+    if (!/^ENV\s/.test(raw)) continue;
+    let collected = raw.replace(/^ENV\s+/, "");
+    while (collected.endsWith("\\") && i + 1 < lines.length) {
+      collected = `${collected.slice(0, -1)} ${lines[++i] ?? ""}`;
+    }
+    directives.push(collected.trim());
+  }
+  return directives;
+}
+
+function envDirectiveToExports(directive: string): string[] {
+  const exports: string[] = [];
+  const pattern = /([A-Za-z_][A-Za-z0-9_]*)=("([^"]*)"|'([^']*)'|(\S+))/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(directive)) !== null) {
+    const name = match[1];
+    const value = match[3] ?? match[4] ?? match[5] ?? "";
+    exports.push(`export ${name}=${JSON.stringify(value)}`);
+  }
+  return exports;
+}
+
+function collectDockerfileEnvExports(file: string): string[] {
+  const text = fs.readFileSync(file, "utf-8");
+  return dockerfileEnvDirectives(text).flatMap(envDirectiveToExports);
+}
+
+function stageDockerfileUntil(file: string, runMarker: string): string[] {
+  const text = fs.readFileSync(file, "utf-8");
+  const cutoff = text.indexOf(runMarker);
+  if (cutoff === -1) {
+    throw new Error(`Dockerfile is missing expected RUN marker: ${runMarker}`);
+  }
+  return dockerfileEnvDirectives(text.slice(0, cutoff)).flatMap(envDirectiveToExports);
+}
 
 describe("sandbox provisioning: image health checks (#1430)", () => {
   it.each([

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -521,6 +521,12 @@ describe("service environment", () => {
         expect(envFile).toContain("GNUPGHOME=/tmp/.gnupg");
         expect(envFile).toContain("PYTHON_HISTORY=/tmp/.python_history");
         expect(envFile).toContain("npm_config_prefix=/tmp/npm-global");
+        // Pin npm online for connect sessions and PID 1 so a leaked
+        // build-time NPM_CONFIG_OFFLINE=true cannot force `only-if-cached`
+        // mode on dashboard-driven MCP installs, skill installers, or
+        // ad-hoc `npx -y` invocations inside the sandbox.
+        expect(envFile).toContain("npm_config_offline=false");
+        expect(envFile).toContain("NPM_CONFIG_OFFLINE=false");
         // Permission should be 444 (hardened via emit_sandbox_sourced_file)
         // Cross-platform: Linux uses stat -c '%a', macOS uses stat -f '%Lp'
         let perms: string;

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -309,6 +309,87 @@ describe("service environment", () => {
     });
   });
 
+  describe("runtime npm online state (issue #4773)", () => {
+    it("entrypoint exports npm_config_offline=false and NPM_CONFIG_OFFLINE=false at PID 1", () => {
+      const src = readFileSync(NEMOCLAW_START_SCRIPT, "utf-8");
+      const start = src.indexOf("_TOOL_REDIRECTS=(");
+      const end = src.indexOf("done", src.indexOf("for _redir", start));
+      if (start === -1 || end === -1 || end <= start) {
+        throw new Error("Failed to extract _TOOL_REDIRECTS block from scripts/nemoclaw-start.sh");
+      }
+      const block = `${src.slice(start, end)}done`;
+      const tmpFile = join(
+        tmpdir(),
+        `nemoclaw-tool-redirects-npm-online-${process.pid}.sh`,
+      );
+      try {
+        writeFileSync(
+          tmpFile,
+          [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            block,
+            'printf "npm_config_offline=%s\\n" "${npm_config_offline:-unset}"',
+            'printf "NPM_CONFIG_OFFLINE=%s\\n" "${NPM_CONFIG_OFFLINE:-unset}"',
+          ].join("\n"),
+          { mode: 0o700 },
+        );
+        const out = execFileSync("bash", [tmpFile], { encoding: "utf-8" });
+        expect(out).toContain("npm_config_offline=false");
+        expect(out).toContain("NPM_CONFIG_OFFLINE=false");
+      } finally {
+        try {
+          unlinkSync(tmpFile);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    it("a sandbox-connect shell sourcing the emitted proxy-env reports both npm offline env vars as false", () => {
+      const persistBlock = extractRuntimeShellEnvSnippet();
+      const toolRedirects = execFileSync(
+        "sed",
+        ["-n", "/^_TOOL_REDIRECTS=/,/^done$/p", NEMOCLAW_START_SCRIPT],
+        { encoding: "utf-8" },
+      ).trimEnd();
+      const sandboxInitSource = `source ${JSON.stringify(join(import.meta.dirname, "../scripts/lib/sandbox-init.sh"))}`;
+      const fakeDataDir = mkdtempSync(join(tmpdir(), "nemoclaw-connect-npm-online-"));
+      const tmpFile = join(tmpdir(), `nemoclaw-connect-npm-online-${process.pid}.sh`);
+      try {
+        const wrapper = [
+          "#!/usr/bin/env bash",
+          sandboxInitSource,
+          toolRedirects,
+          'PROXY_HOST="10.200.0.1"',
+          'PROXY_PORT="3128"',
+          '_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"',
+          '_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"',
+          'export OPENCLAW_GATEWAY_TOKEN="probe-token"',
+          persistBlock.replaceAll(
+            "/tmp/nemoclaw-proxy-env.sh",
+            `${fakeDataDir}/proxy-env.sh`,
+          ),
+          `env -i HOME=/tmp bash --noprofile --norc -c 'source ${fakeDataDir}/proxy-env.sh; printf "%s\\n" "$npm_config_offline" "$NPM_CONFIG_OFFLINE"'`,
+        ].join("\n");
+        writeFileSync(tmpFile, wrapper, { mode: 0o700 });
+        const out = execFileSync("bash", [tmpFile], { encoding: "utf-8" }).trim();
+        expect(out.split("\n")).toEqual(["false", "false"]);
+      } finally {
+        try {
+          unlinkSync(tmpFile);
+        } catch {
+          /* ignore */
+        }
+        try {
+          execFileSync("rm", ["-rf", fakeDataDir]);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+  });
+
   describe("XDG and tool cache redirects (issue #804)", () => {
     it("entrypoint pre-creates redirected dirs and restricts GNUPGHOME permissions", () => {
       const scriptPath = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -309,7 +309,7 @@ describe("service environment", () => {
     });
   });
 
-  describe("runtime npm online state (issue #4773)", () => {
+  describe("runtime npm online state", () => {
     it("entrypoint exports npm_config_offline=false and NPM_CONFIG_OFFLINE=false at PID 1", () => {
       const src = readFileSync(NEMOCLAW_START_SCRIPT, "utf-8");
       const start = src.indexOf("_TOOL_REDIRECTS=(");


### PR DESCRIPTION
## Summary
`ENV NPM_CONFIG_OFFLINE=true` at `Dockerfile:585` is scoped to the local OpenClaw plugin-install RUN, but the directive persists into the runtime image. PID 1 in the sandbox therefore exports `NPM_CONFIG_OFFLINE=true`, which forces every child `npm` / `npx` into `cache mode: only-if-cached` and fails dashboard "Add MCP", skill installers, and ad-hoc `npx -y` invocations with `ENOTCACHED`. Reset to `false` immediately after the plugin install and pin the runtime value from the entrypoint as a backstop.

## Related Issue
Fixes #4773.

## Changes
- `Dockerfile` — reset `NPM_CONFIG_OFFLINE=false` immediately after the `openclaw plugins install` RUN so the runtime image inherits `false` while the build-time isolation around that single RUN is preserved.
- `scripts/nemoclaw-start.sh` — add `npm_config_offline=false` and `NPM_CONFIG_OFFLINE=false` to `_TOOL_REDIRECTS` so PID 1 and `openshell sandbox connect` sessions pin the value regardless of a stale base image or future build-time regression.
- `test/sandbox-provisioning.test.ts` — two runtime regression guards: replays every Dockerfile `ENV` directive and asserts the runtime image ends with `NPM_CONFIG_OFFLINE=false`; replays the staged subset up to the local plugin-install RUN and asserts the offline lock is still `true` at that point. Pure runtime assertions — no source-text shape.
- `test/service-env.test.ts` — extended emission test asserts the generated `proxy-env.sh` carries `npm_config_offline=false` and `NPM_CONFIG_OFFLINE=false`. Two new tests source the actual `_TOOL_REDIRECTS` export loop from the entrypoint and re-source the emitted `proxy-env.sh` in a clean `env -i bash --noprofile --norc` shell, asserting both spellings resolve to `false` (PID 1 + sandbox-connect parity).
- `test/fetch-guard-patch-regression.test.ts` — narrow the existing test's end marker to `# Release the offline lock` so it brackets only the plugin-install RUN and ignores the follow-on ENV directive.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>
