### PR TITLE
fix(ci): stabilize platform Vitest failures

### DIFF
--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -144,11 +144,7 @@ function readTextFileIfPresent(filePath: string): string {
   }
 }
 
-export function writeDockerGatewayDebEnvOverride(
-  getOverride: () => Record<string, string>,
-  opts: Parameters<typeof hasOpenShellGatewayUserService>[0] = {},
-): boolean {
-  if (!hasOpenShellGatewayUserService(opts)) return false;
+function writeDockerGatewayDebEnvOverrideFile(getOverride: () => Record<string, string>): void {
   const override = getOverride();
   const envDir = path.join(os.homedir(), ".config", "openshell");
   const envFile = path.join(envDir, "gateway.env");
@@ -160,6 +156,14 @@ export function writeDockerGatewayDebEnvOverride(
     mode: 0o600,
   });
   fs.chmodSync(envFile, 0o600);
+}
+
+export function writeDockerGatewayDebEnvOverride(
+  getOverride: () => Record<string, string>,
+  opts: Parameters<typeof hasOpenShellGatewayUserService>[0] = {},
+): boolean {
+  if (!hasOpenShellGatewayUserService(opts)) return false;
+  writeDockerGatewayDebEnvOverrideFile(getOverride);
   return true;
 }
 
@@ -179,6 +183,6 @@ export function startPackageManagedDockerDriverGatewayWithEnvOverride({
   return startPackageManagedDockerDriverGateway({
     ...options,
     prepareOpenShellGatewayUserServiceEnv: () =>
-      writeDockerGatewayDebEnvOverrideOrThrow(() => gatewayEnv),
+      writeDockerGatewayDebEnvOverrideFile(() => gatewayEnv),
   });
 }

--- a/test/cli/sandbox-mutations.test.ts
+++ b/test/cli/sandbox-mutations.test.ts
@@ -178,7 +178,10 @@ describe("CLI dispatch", () => {
 
       for (const action of ["add", "remove", "start", "stop"]) {
         const missingChannel = runWithEnv(`alpha channels ${action} 2>&1`, { HOME: home });
-        expect(missingChannel.code).toBe(PARSER_EXIT_CODE);
+        expect(
+          missingChannel.code,
+          `alpha channels ${action} exited ${missingChannel.code} with output:\n${missingChannel.out}`,
+        ).toBe(PARSER_EXIT_CODE);
         expect(missingChannel.out).toContain("Missing 1 required arg:");
         expect(missingChannel.out).toContain("channel  Messaging channel");
         expect(missingChannel.out).toContain("USAGE");

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -442,6 +442,16 @@ function runHermesGatewayRuntimeCleanup(opts: {
       "TCP:127.0.0.1:19119",
     ]);
   }
+  fs.writeFileSync(
+    path.join(tmpDir, "sitecustomize.py"),
+    [
+      "import os",
+      "",
+      "# Keep the Python helper aligned with the shell fixture's mocked id -u.",
+      "os.geteuid = lambda: 1000",
+      "",
+    ].join("\n"),
+  );
 
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
   fs.writeFileSync(
@@ -449,6 +459,8 @@ function runHermesGatewayRuntimeCleanup(opts: {
     [
       "#!/usr/bin/env bash",
       "set -euo pipefail",
+      `PYTHONPATH=${shellQuote(tmpDir)}`,
+      "export PYTHONPATH",
       extractShellFunctionFromSource(src, "cmdline_is_hermes_gateway"),
       extractShellFunctionFromSource(src, "has_live_hermes_gateway"),
       extractShellFunctionFromSource(src, "cleanup_orphan_socat_forwarders"),


### PR DESCRIPTION
## Summary
Stabilizes the macOS and WSL platform Vitest failures from the main watch run by removing platform-dependent assumptions in the gateway env and Hermes startup fixtures.

## Changes
- Split the OpenShell gateway env-file write path so package-managed startup does not re-run service detection after it has already selected the service path.
- Isolate the Hermes startup cleanup fixture from host uid/account state by aligning the embedded Python helper with the mocked non-root shell identity.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured Docker gateway env handling for improved maintainability and clearer error behavior during startup.

* **Tests**
  * Improved gateway startup test harness to align Python/runtime fixtures with shell mocks.
  * Strengthened CLI tests to include richer failure diagnostics when parser-required arguments are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->