### PR TITLE
fix(inference): restart the vLLM container after host reboot (#4886)

### DIFF
--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -27,7 +27,7 @@ vi.mock("./nim", () => ({
   getGpuIndicesByName: mocks.getGpuIndicesByName,
 }));
 
-import { detectVllmProfile, pullImage } from "./vllm";
+import { buildVllmRunCommand, detectVllmProfile, pullImage } from "./vllm";
 
 describe("vLLM profile detection", () => {
   beforeEach(() => {
@@ -123,5 +123,25 @@ describe("vLLM image pull", () => {
     mocks.dockerPullWithProgressWatchdog.mockResolvedValue(result);
 
     await expect(pullImage(profile!)).resolves.toEqual({ ok: false, reason });
+  });
+});
+
+describe("vLLM run command", () => {
+  it("adds --restart unless-stopped so the container survives a host reboot (#4886)", () => {
+    const profile = detectVllmProfile({ platform: "spark", type: "nvidia" });
+    expect(profile).not.toBeNull();
+    const cmd = buildVllmRunCommand(profile!, profile!.defaultModel, profile!.dockerRunFlags.join(" "));
+    expect(cmd).toContain("docker run -d --restart unless-stopped");
+    expect(cmd).toContain(`--name ${profile!.containerName}`);
+    expect(cmd).toContain(":8000");
+  });
+
+  it("preserves the profile run flags and image", () => {
+    const profile = detectVllmProfile({ platform: "station", type: "nvidia" });
+    expect(profile).not.toBeNull();
+    const cmd = buildVllmRunCommand(profile!, profile!.defaultModel, "--gpus device=0 --ipc=host");
+    expect(cmd).toContain("--restart unless-stopped --gpus device=0 --ipc=host");
+    expect(cmd).toContain(profile!.image);
+    expect(cmd).toContain("--entrypoint /bin/bash");
   });
 });

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -331,6 +331,23 @@ function downloadModel(
   });
 }
 
+// Build the `docker run` command for the long-lived vLLM inference container.
+// Exported for testing. `--restart unless-stopped` makes the container come
+// back after a host reboot or Docker daemon restart (#4886); without a restart
+// policy the container stays down after a reboot and `nemoclaw inference get`
+// fails until a full `nemoclaw onboard --fresh --gpu` recreates it.
+export function buildVllmRunCommand(
+  profile: VllmProfile,
+  model: VllmModelDef,
+  runFlags: string,
+): string {
+  const extra = runFlags ? ` ${runFlags}` : "";
+  return (
+    `docker run -d --restart unless-stopped${extra} -p ${String(VLLM_PORT)}:8000 ` +
+    `--name ${profile.containerName} --entrypoint /bin/bash ${profile.image} -lc ${JSON.stringify(buildVllmServeCommand(model))}`
+  );
+}
+
 function startContainer(
   profile: VllmProfile,
   model: VllmModelDef,
@@ -352,9 +369,7 @@ function startContainer(
   // the value stays out of /proc/<pid>/cmdline.
   const hfTokenFlags = buildHfTokenDockerArgs().join(" ");
   const flags = [resolvedFlags.join(" "), hfTokenFlags].filter(Boolean).join(" ");
-  const cmd =
-    `docker run -d ${flags} -p ${String(VLLM_PORT)}:8000 ` +
-    `--name ${profile.containerName} --entrypoint /bin/bash ${profile.image} -lc ${JSON.stringify(buildVllmServeCommand(model))}`;
+  const cmd = buildVllmRunCommand(profile, model, flags);
   const result = runShell(cmd, {
     ignoreError: true,
     suppressOutput: true,


### PR DESCRIPTION
## Summary
The long-lived vLLM inference container is started with `docker run -d` and no restart policy, so after a host reboot or a Docker daemon restart the inference container does not come back up. `nemoclaw inference get` then fails and the only recovery path is re-running `nemoclaw onboard --fresh --gpu`. This adds `--restart unless-stopped` to the vLLM run command so the container is brought back automatically, covering the DGX Spark, DGX Station, and generic Linux profiles in one place. It matches the restart-policy handling already used for the GPU-patched gateway container in `docker-gpu-patch.ts`.

## Related Issue
Closes #4886

## Changes
- Extract the vLLM `docker run` construction into an exported `buildVllmRunCommand()` helper in `src/lib/inference/vllm.ts`.
- Add `--restart unless-stopped` to that command so the container survives a host reboot or Docker daemon restart.
- Add unit tests asserting the restart policy is present and that profile run flags and image are preserved.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
- [x] New and existing unit tests pass locally.

Ran: `npx vitest run src/lib/inference/vllm.test.ts` (9 passed), `npx tsc -p tsconfig.src.json`, `npm run typecheck:cli`, and `npx @biomejs/biome lint src/lib/inference/vllm.ts` (all clean).

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for vLLM container command generation and validation.

* **Refactor**
  * Enhanced vLLM container resilience with automatic restart policy on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->