### PR TITLE
chore(cli): clean up unused CodeQL declarations

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -12,7 +12,7 @@
     "test/onboard-messaging.test.ts": 2122,
     "test/onboard-selection.test.ts": 7757,
     "test/onboard.test.ts": 4887,
-    "test/policies.test.ts": 3147,
+    "test/policies.test.ts": 3145,
     "test/sandbox-connect-inference.test.ts": 1577
   }
 }

--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -8,7 +8,7 @@
     "test/channels-add-preset.test.ts": 1915,
     "test/generate-openclaw-config.test.ts": 2106,
     "test/install-preflight.test.ts": 4397,
-    "test/nemoclaw-start.test.ts": 5319,
+    "test/nemoclaw-start.test.ts": 5310,
     "test/onboard-messaging.test.ts": 2122,
     "test/onboard-selection.test.ts": 7757,
     "test/onboard.test.ts": 4887,

--- a/scripts/find-source-shape-tests.ts
+++ b/scripts/find-source-shape-tests.ts
@@ -210,18 +210,6 @@ function isReadFileCall(node: ts.CallExpression): boolean {
   return false;
 }
 
-function isSourceTextLikeName(name: string): boolean {
-  return /(src|source|text|content|body|block|snippet|heredoc|docker|script|shell|fn|lines?|matches|calls|usages)/i.test(
-    name,
-  );
-}
-
-function isTextDerivation(initText: string): boolean {
-  return /(\.indexOf\b|\.search\b|\.includes\b|\.match(All)?\b|\.slice\b|\.split\b|\.replace(All)?\b|\.trim(End)?\b|\.join\b|String\(|(?:YAML|yaml|JSON)\.parse\b|yaml\.load\b|Heredoc\b|Snippet\b|Block\b|extract[A-Z]|load[A-Z]|parse[A-Z])/.test(
-    initText,
-  );
-}
-
 function isExecutionResultDerivation(initText: string): boolean {
   return /\b(?:spawnSync|execFileSync|execSync|run(?:Logged|Docker|Bash|WithLib|Embedded|Patch|Hermes|Openclaw|Daemon|Fetch|Command)\w*)\b/.test(
     initText,

--- a/src/lib/cli/command-display-metadata.test.ts
+++ b/src/lib/cli/command-display-metadata.test.ts
@@ -4,7 +4,6 @@
 import { Config as OclifConfig } from "@oclif/core";
 import { describe, expect, it } from "vitest";
 
-import { getRegisteredOclifCommandsMetadata } from "./oclif-metadata";
 import { COMMANDS, visibleCommands } from "./command-registry";
 
 describe("public command display metadata", () => {
@@ -36,5 +35,4 @@ describe("public command display metadata", () => {
 
     expect(invalid).toEqual([]);
   });
-
 });

--- a/src/lib/dashboard-url-command.test.ts
+++ b/src/lib/dashboard-url-command.test.ts
@@ -3,11 +3,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  DashboardUrlCommandError,
-  buildDashboardUrl,
-  runDashboardUrlCommand,
-} from "./dashboard-url-command";
+import { buildDashboardUrl, runDashboardUrlCommand } from "./dashboard-url-command";
 
 function makeSinks() {
   const out: string[] = [];

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -9,7 +9,6 @@ import type { GpuInfo } from "../local";
 
 const path = require("path");
 const { spawn, spawnSync } = require("child_process");
-const http = require("http");
 const { ROOT, SCRIPTS, run, runCapture, shellQuote } = require("../../runner");
 const { OLLAMA_PORT, OLLAMA_PROXY_PORT } = require("../../core/ports");
 const { waitForPort } = require("../../core/wait");
@@ -38,7 +37,6 @@ const {
   loadLocalAdapterPid,
   persistLocalAdapterPid,
   readLocalAdapterTextFile,
-  removeLocalAdapterFile,
   spawnDetachedNodeAdapter,
   writeLocalAdapterSecretFile,
 } = require("../local-adapter-lifecycle");
@@ -120,10 +118,6 @@ function persistProxyPid(pid: number | null | undefined): void {
 
 function loadPersistedProxyPid(): number | null {
   return loadLocalAdapterPid(PROXY_PID_PATH);
-}
-
-function clearPersistedProxyPid(): void {
-  removeLocalAdapterFile(PROXY_PID_PATH);
 }
 
 // ── Process management ───────────────────────────────────────────

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -15,7 +15,6 @@ const {
 const {
   isNvcfFunctionNotFoundForAccount,
   nvcfFunctionNotFoundMessage,
-  shouldForceCompletionsApi,
 } = require("../validation");
 
 const {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -63,9 +63,6 @@ const {
   getGatewayBootstrapRepairPlan,
 }: typeof import("./onboard/gateway-bootstrap") = require("./onboard/gateway-bootstrap");
 const {
-  verifyWebSearchInsideSandbox: verifyWebSearchInsideSandboxWithDeps,
-}: typeof import("./onboard/web-search-verify") = require("./onboard/web-search-verify");
-const {
   buildDirectGpuPolicyYaml,
   buildDirectSandboxGpuProofCommands,
   prepareInitialSandboxCreatePolicy,
@@ -123,11 +120,10 @@ const pRetry = require("p-retry");
  *  Covers CSI (color, erase, cursor), OSC, and C1 two-byte escapes per ECMA-48. */
 const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/g;
 const runner: typeof import("./runner") = require("./runner");
-const { ROOT, SCRIPTS, redact, run, runShell, runCapture, runFile, shellQuote, validateName } =
-  runner;
+const { ROOT, SCRIPTS, redact, run, runCapture, runFile, validateName } = runner;
 const braveProviderProfile: typeof import("./onboard/brave-provider-profile") = require("./onboard/brave-provider-profile");
 const nameValidation: typeof import("./name-validation") = require("./name-validation");
-const { NAME_ALLOWED_FORMAT, getNameValidationGuidance } = nameValidation;
+const { getNameValidationGuidance } = nameValidation;
 const docker: typeof import("./adapters/docker") = require("./adapters/docker");
 const {
   dockerContainerInspectFormat,
@@ -178,14 +174,12 @@ const localInference: typeof import("./inference/local") = require("./inference/
 const {
   findReachableOllamaHost,
   resetOllamaHostCache,
-  getDefaultOllamaModel,
   getLocalProviderBaseUrl,
   getLocalProviderHealthCheck,
   getLocalProviderValidationBaseUrl,
   getOllamaModelOptions,
   getOllamaWarmupCommand,
   OLLAMA_HOST_DOCKER_INTERNAL,
-  validateOllamaModel,
   validateLocalProvider,
 } = localInference;
 const {
@@ -227,8 +221,6 @@ const {
   HERMES_AUTH_METHOD_API_KEY,
   HERMES_AUTH_METHOD_OAUTH,
   HERMES_NOUS_API_KEY_CREDENTIAL_ENV,
-  HERMES_NOUS_API_KEY_HELP_URL,
-  getRequestedHermesAuthMethod,
   hermesAuthMethodLabel,
   normalizeHermesAuthMethod,
 } = hermesAuth;
@@ -258,7 +250,6 @@ const {
   OLLAMA_PROXY_CREDENTIAL_ENV,
   VLLM_LOCAL_CREDENTIAL_ENV,
   getProviderLabel,
-  getEffectiveProviderName,
   getNonInteractiveProvider,
   getNonInteractiveModel,
   getSandboxInferenceConfig,
@@ -270,7 +261,6 @@ const {
   OLLAMA_PROXY_CREDENTIAL_ENV: string;
   VLLM_LOCAL_CREDENTIAL_ENV: string;
   getProviderLabel: (key: string) => string;
-  getEffectiveProviderName: (key: string | null | undefined) => string | null;
   getNonInteractiveProvider: () => string | null;
   getNonInteractiveModel: (providerKey: string) => string | null;
   getSandboxInferenceConfig: (
@@ -285,7 +275,7 @@ const {
     inferenceCompat: LooseObject | null;
   };
 };
-const { sleepSeconds, waitForHttp, waitUntil } = require("./core/wait");
+const { sleepSeconds, waitUntil } = require("./core/wait");
 const platformUtils: typeof import("./platform") = require("./platform");
 const { isWsl, shouldPatchCoredns } = platformUtils;
 const {
@@ -353,7 +343,6 @@ const {
   exitOnSandboxGpuConfigErrors,
   formatSandboxGpuPassthroughNote,
   resolveSandboxGpuFlagFromOptions,
-  sandboxGpuRemediationLines,
   validateSandboxGpuPreflight,
 } = sandboxGpuPreflight;
 const openshellVersion: typeof import("./onboard/openshell-version") = require("./onboard/openshell-version");
@@ -473,8 +462,6 @@ const { getDockerDriverGatewayEndpoint } = dockerDriverGatewayEnv;
 const dockerDriverGatewayRuntimeMarker: typeof import("./onboard/docker-driver-gateway-runtime-marker") =
   require("./onboard/docker-driver-gateway-runtime-marker");
 const gatewayBinding: typeof import("./onboard/gateway-binding") = require("./onboard/gateway-binding");
-const hostGatewayProcess: typeof import("./onboard/host-gateway-process") =
-  require("./onboard/host-gateway-process");
 const vmDriverProcess: typeof import("./onboard/vm-driver-process") = require("./onboard/vm-driver-process");
 const preflightUtils: typeof import("./onboard/preflight") = require("./onboard/preflight");
 const clusterImagePatch: typeof import("./cluster-image-patch") = require("./cluster-image-patch");
@@ -572,9 +559,6 @@ const DIM = USE_COLOR ? "\x1b[2m" : "";
 const RESET = USE_COLOR ? "\x1b[0m" : "";
 let OPENSHELL_BIN: string | null = null;
 const GATEWAY_NAME = gatewayBinding.resolveGatewayName(GATEWAY_PORT);
-const OPENCLAW_LAUNCH_AGENT_PLIST = "~/Library/LaunchAgents/ai.openclaw.gateway.plist";
-
-const BRAVE_SEARCH_HELP_URL = "https://brave.com/search/api/";
 
 import type {
   JsonObject as LooseObject,
@@ -647,7 +631,6 @@ const {
   openshellArgv,
   runOpenshell,
   runCaptureOpenshell,
-  safeOpenShellArgument,
   getGatewayPortArg,
   getDockerDriverGatewayEndpointArg,
 } = createOpenshellCliHelpers({
@@ -708,7 +691,7 @@ const selectOnboardAgent = createSelectOnboardAgent({
 });
 
 
-const { getTransportRecoveryMessage, getProbeRecovery } = validationRecovery;
+const { getTransportRecoveryMessage } = validationRecovery;
 
 // Validation functions — delegated to src/lib/validation.ts
 const {
@@ -718,7 +701,6 @@ const {
   validateNvidiaApiKeyValue,
   isSafeModelId,
   shouldSkipResponsesProbe,
-  shouldForceCompletionsApi,
 } = validation;
 
 // validateNvidiaApiKeyValue — see validation import above
@@ -731,7 +713,6 @@ const {
   resolveHermesNousApiKey,
   stageNousApiKeyProviderEnv,
   ensureHermesNousApiKeyEnv,
-  openshellResultMessage,
   checkHermesProviderStoreReachable,
 } = hermesAuth.createHermesAuthHelpers({
   isNonInteractive,
@@ -959,7 +940,6 @@ function isInferenceRouteReady(provider: string, model: string): boolean {
 }
 
 const {
-  sandboxExistsInGateway,
   pruneStaleSandboxEntry,
   shouldRestoreLatestBackupOnRecreate,
   confirmRecreateForSelectionDrift,
@@ -974,9 +954,6 @@ const {
 
 
 const {
-  validateBraveSearchApiKey,
-  promptBraveSearchRecovery,
-  promptBraveSearchApiKey,
   ensureValidatedBraveSearchCredential,
   configureWebSearch,
   verifyWebSearchInsideSandbox,
@@ -1000,8 +977,6 @@ const {
   verifyOnboardInferenceSmoke,
   getProbeAuthMode,
   getValidationProbeCurlArgs,
-  probeOpenAiLikeEndpoint,
-  probeAnthropicEndpoint,
 } = require("./inference/onboard-probes");
 
 const {
@@ -3840,7 +3815,7 @@ async function createSandbox(
 
 type ProviderChoice = { key: string; label: string };
 
-const { readLiveInference, readRecordedProvider, readRecordedNimContainer, readRecordedModel } =
+const { readRecordedProvider, readRecordedNimContainer, readRecordedModel } =
   providerRecovery.createProviderRecoveryHelpers({
     parseGatewayInference,
     runCaptureOpenshell,
@@ -6238,7 +6213,6 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
 
     const recordedSandboxName =
       session?.steps?.sandbox?.status === "complete" ? session?.sandboxName || null : null;
-    const resumeSandboxNameForGpu = recordedSandboxName || requestedSandboxName || null;
 
     console.log("");
     console.log(`  ${cliDisplayName()} Onboarding`);

--- a/src/lib/onboard/config-sync.test.ts
+++ b/src/lib/onboard/config-sync.test.ts
@@ -128,6 +128,7 @@ describe("sandbox config sync helpers", () => {
     try {
       const nemoclawDir = path.join(homeDir, ".nemoclaw");
       fs.mkdirSync(nemoclawDir, { mode: 0o755 });
+      fs.chmodSync(nemoclawDir, 0o755);
       writeFakeCommand(fakeBin, "id", "1234");
       writeFakeCommand(fakeBin, "stat", "0");
       const script = buildSandboxConfigSyncScript({

--- a/src/lib/state/config-io.test.ts
+++ b/src/lib/state/config-io.test.ts
@@ -215,10 +215,12 @@ describe("config-io", () => {
 
       const sibling = path.join(dir, "should-be-healed.json");
       fs.writeFileSync(sibling, "stale", { mode: 0o644 });
+      fs.chmodSync(sibling, 0o644);
 
       const outsideDir = makeTempDir();
       const outside = path.join(outsideDir, "target");
       fs.writeFileSync(outside, "outside", { mode: 0o644 });
+      fs.chmodSync(outside, 0o644);
       const linkPath = path.join(dir, "rogue-link");
       fs.symlinkSync(outside, linkPath);
 
@@ -243,6 +245,7 @@ describe("config-io", () => {
     const outsideDir = makeTempDir();
     const outside = path.join(outsideDir, "target.json");
     fs.writeFileSync(outside, JSON.stringify({ outside: true }), { mode: 0o644 });
+    fs.chmodSync(outside, 0o644);
     const symlinkPath = path.join(dir, "config.json");
     fs.symlinkSync(outside, symlinkPath);
 
@@ -281,6 +284,7 @@ describe("config-io", () => {
       fs.writeFileSync(target, JSON.stringify({ ok: true }), { mode: 0o600 });
       const sibling = path.join(unrelatedDir, "other.json");
       fs.writeFileSync(sibling, "stale", { mode: 0o644 });
+      fs.chmodSync(sibling, 0o644);
 
       readConfigFile(target, null);
 

--- a/test/cli-oclif-compatibility.test.ts
+++ b/test/cli-oclif-compatibility.test.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/test/e2e-scenario/framework-tests/e2e-scenario-registry.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-registry.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 
 import { scenario } from "../scenarios/builder.ts";
 import { compileRunPlans } from "../scenarios/compiler.ts";
-import { buildScenarioRegistry, listScenarios } from "../scenarios/registry.ts";
+import { buildScenarioRegistry } from "../scenarios/registry.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const RUN_SCENARIOS = path.join(REPO_ROOT, "test/e2e-scenario/scenarios/run.ts");

--- a/test/e2e/brev-e2e.test.ts
+++ b/test/e2e/brev-e2e.test.ts
@@ -52,7 +52,6 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, execFileSync, spawnSync, type StdioOptions } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
 
 // Instance configuration

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -57,8 +57,6 @@ const STATUS_MALFORMED = "??? garbage output ???";
 const SANDBOX_GET_READY =
   "Sandbox:\n\n  Id: abc\n  Name: my-assistant\n  Namespace: openshell\n  Phase: Ready\n";
 const SANDBOX_GET_NOT_FOUND = "Error:   × Not Found: sandbox not found";
-const SANDBOX_GET_TRANSPORT_ERROR =
-  "Error:   × transport error\n  ╰─▶ Connection reset by peer (os error 104)";
 
 interface ScenarioScript {
   // sandbox get responses, one per call (cycled / stops at last)

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -13,15 +13,6 @@ const APPROVAL_POLICY_DIR = path.join(import.meta.dirname, "..", "scripts", "lib
 const PRELOAD_SCRIPTS = path.join(import.meta.dirname, "..", "nemoclaw-blueprint", "scripts");
 const JSON5_MODULE = path.join(import.meta.dirname, "..", "nemoclaw", "node_modules", "json5");
 
-function configureGuardBlock(src: string): string {
-  const start = src.indexOf("# nemoclaw-configure-guard begin");
-  const end = src.indexOf("# nemoclaw-configure-guard end", start);
-  const endMarker = "# nemoclaw-configure-guard end";
-  expect(start).toBeGreaterThan(-1);
-  expect(end).toBeGreaterThan(start);
-  return src.slice(start, end + endMarker.length);
-}
-
 function runtimeShellEnvBlock(src: string): string {
   const start = src.indexOf("write_runtime_shell_env() {");
   const end = src.indexOf("# cleanup_on_signal", start);

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1045,24 +1045,19 @@ exit 1
     // `process.exit(1)` the matching `finally` does not run, so a temp dir
     // created before the exit gets orphaned in $TMPDIR. A mocked exit (which
     // throws) doesn't reproduce that — `finally` still runs and cleans up. To
-    // catch the real-world bug, snapshot $TMPDIR at the *moment* of exit:
+    // catch the real-world bug, spy on this process's mkdtempSync calls:
     // if the assertion fires before mkdtempSync, no nemoclaw-policy-* dir
-    // should exist yet.
+    // should be requested.
     it("applyPreset does not create temp dirs before the openshell resolvability check", () => {
-      const beforeCount = fs
-        .readdirSync(os.tmpdir())
-        .filter((entry) => entry.startsWith("nemoclaw-policy-")).length;
-      let countAtExit = -1;
+      const policyTempPrefix = path.join(os.tmpdir(), "nemoclaw-policy-");
 
       const resolveSpy = vi
         .spyOn(resolveOpenshellModule, "resolveOpenshell")
         .mockReturnValue(null);
+      const mkdtempSpy = vi.spyOn(fs, "mkdtempSync");
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
       const exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
-        countAtExit = fs
-          .readdirSync(os.tmpdir())
-          .filter((entry) => entry.startsWith("nemoclaw-policy-")).length;
         throw new Error("__test_exit__");
       }) as never);
 
@@ -1073,9 +1068,12 @@ exit 1
         expect(exitSpy).toHaveBeenCalledWith(1);
         // No `nemoclaw-policy-*` temp dir should have been created before
         // the resolvability check exited.
-        expect(countAtExit).toBe(beforeCount);
+        expect(
+          mkdtempSpy.mock.calls.filter(([prefix]) => String(prefix).startsWith(policyTempPrefix)),
+        ).toEqual([]);
       } finally {
         resolveSpy.mockRestore();
+        mkdtempSpy.mockRestore();
         errSpy.mockRestore();
         logSpy.mockRestore();
         exitSpy.mockRestore();

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -24,9 +24,6 @@ const DOCKERFILE_BASE = path.join(ROOT, "Dockerfile.base");
 const DOCKERFILE_SANDBOX = path.join(ROOT, "test", "Dockerfile.sandbox");
 const HERMES_DOCKERFILE = path.join(ROOT, "agents", "hermes", "Dockerfile");
 const HERMES_DOCKERFILE_BASE = path.join(ROOT, "agents", "hermes", "Dockerfile.base");
-const HERMES_POLICY = path.join(ROOT, "agents", "hermes", "policy-additions.yaml");
-const HERMES_POLICY_PERMISSIVE = path.join(ROOT, "agents", "hermes", "policy-permissive.yaml");
-const HERMES_START = path.join(ROOT, "agents", "hermes", "start.sh");
 
 function dockerRunCommandBetween(
   dockerfile: string,

--- a/test/skills-frontmatter.test.ts
+++ b/test/skills-frontmatter.test.ts
@@ -44,7 +44,6 @@ describe("repo skill markdown files", () => {
 
   for (const markdownFile of generatedUserSkillFiles) {
     const relPath = path.relative(repoRoot, markdownFile);
-    const isSkill = path.basename(markdownFile) === "SKILL.md";
 
     it(`does not include generated SPDX comments for ${relPath}`, () => {
       const raw = fs.readFileSync(markdownFile, "utf8");


### PR DESCRIPTION
## Summary
Removes unused declarations reported by CodeQL's `js/unused-local-variable` rule across onboarding, inference helpers, scripts, and tests. Also stabilizes two test fixtures that blocked local full-hook verification under a restrictive umask and parallel temp-dir usage.

## Changes
- Removed unused imports, constants, functions, and destructured bindings from `src/lib/onboard.ts`, inference helpers, the source-shape scanner, and affected tests.
- Ratcheted legacy test-file size budgets after shrinking oversized test files.
- Made permission and temp-dir assertions deterministic without changing production behavior.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test file imports and removed unused dependencies across multiple test suites.
  * Enhanced permission-handling tests for sandbox configuration validation scenarios.
  * Refactored test fixtures and improved test assertion clarity.

* **Chores**
  * Reduced test file size budgets to reflect code optimization.
  * Removed unused internal helper functions and imports throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->