### PR TITLE
test(policy): import tier helpers by name

### DIFF
--- a/test/policy-tiers.test.ts
+++ b/test/policy-tiers.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from "vitest";
 import policies from "../dist/lib/policy";
-import tiers from "../dist/lib/policy/tiers";
+import { getTier, listTiers, resolveTierPresets } from "../dist/lib/policy/tiers";
 
 interface TierPreset {
   name: string;
@@ -56,7 +56,7 @@ function isTier(value: TierShape | null): value is Tier {
 }
 
 function mustGetTier(name: string): Tier {
-  const tier = tiers.getTier(name);
+  const tier = getTier(name);
   expect(tier).not.toBeNull();
   const tierObject: TierShape | null = typeof tier === "object" && tier !== null ? tier : null;
   if (!isTier(tierObject)) {
@@ -68,16 +68,16 @@ function mustGetTier(name: string): Tier {
 describe("tiers", () => {
   describe("listTiers", () => {
     it("returns exactly 3 tiers", () => {
-      expect(tiers.listTiers()).toHaveLength(3);
+      expect(listTiers()).toHaveLength(3);
     });
 
     it("tiers are ordered restricted → balanced → open", () => {
-      const names = tiers.listTiers().map((tier: Tier) => tier.name);
+      const names = listTiers().map((tier: Tier) => tier.name);
       expect(names).toEqual(["restricted", "balanced", "open"]);
     });
 
     it("each tier has name, label, description, and presets array", () => {
-      for (const tier of tiers.listTiers()) {
+      for (const tier of listTiers()) {
         expect(typeof tier.name).toBe("string");
         expect(typeof tier.label).toBe("string");
         expect(typeof tier.description).toBe("string");
@@ -86,7 +86,7 @@ describe("tiers", () => {
     });
 
     it("labels are human-readable capitalised strings", () => {
-      const labels = tiers.listTiers().map((tier: Tier) => tier.label);
+      const labels = listTiers().map((tier: Tier) => tier.label);
       expect(labels).toEqual(["Restricted", "Balanced", "Open"]);
     });
   });
@@ -108,7 +108,7 @@ describe("tiers", () => {
     });
 
     it("returns null for an unknown tier", () => {
-      expect(tiers.getTier("nonexistent")).toBeNull();
+      expect(getTier("nonexistent")).toBeNull();
     });
   });
 
@@ -220,7 +220,7 @@ describe("tiers", () => {
 
   describe("resolveTierPresets", () => {
     it("returns default presets for balanced with no overrides", () => {
-      const resolved: TierPreset[] = tiers.resolveTierPresets("balanced");
+      const resolved: TierPreset[] = resolveTierPresets("balanced");
       expect(resolved.length).toBeGreaterThanOrEqual(6);
       const accessByName = new Map(resolved.map((preset) => [preset.name, preset.access]));
       for (const name of ["npm", "pypi", "huggingface", "brew", "brave"]) {
@@ -230,7 +230,7 @@ describe("tiers", () => {
     });
 
     it("applies access override for a specific preset", () => {
-      const resolved: TierPreset[] = tiers.resolveTierPresets("balanced", {
+      const resolved: TierPreset[] = resolveTierPresets("balanced", {
         overrides: { npm: "read" },
       });
       const npm = requireTierPreset(
@@ -246,7 +246,7 @@ describe("tiers", () => {
     });
 
     it("restricts to selected presets when selected list is provided", () => {
-      const resolved: TierPreset[] = tiers.resolveTierPresets("balanced", {
+      const resolved: TierPreset[] = resolveTierPresets("balanced", {
         selected: ["npm", "pypi"],
       });
       expect(resolved).toHaveLength(2);
@@ -256,7 +256,7 @@ describe("tiers", () => {
     });
 
     it("applies overrides and selection together", () => {
-      const resolved: TierPreset[] = tiers.resolveTierPresets("balanced", {
+      const resolved: TierPreset[] = resolveTierPresets("balanced", {
         overrides: { npm: "read" },
         selected: ["npm"],
       });
@@ -266,35 +266,35 @@ describe("tiers", () => {
     });
 
     it("returns empty array for restricted tier", () => {
-      expect(tiers.resolveTierPresets("restricted")).toHaveLength(0);
+      expect(resolveTierPresets("restricted")).toHaveLength(0);
     });
 
     it("throws for an unknown tier", () => {
-      expect(() => tiers.resolveTierPresets("phantom")).toThrow("Unknown tier");
+      expect(() => resolveTierPresets("phantom")).toThrow("Unknown tier");
     });
 
     it("selected list with no matches returns empty array", () => {
-      const resolved: TierPreset[] = tiers.resolveTierPresets("balanced", {
+      const resolved: TierPreset[] = resolveTierPresets("balanced", {
         selected: ["nonexistent-preset"],
       });
       expect(resolved).toHaveLength(0);
     });
 
     it("null selected is treated as no filter (all presets returned)", () => {
-      const all: TierPreset[] = tiers.resolveTierPresets("balanced");
-      const withNull: TierPreset[] = tiers.resolveTierPresets("balanced", { selected: null });
+      const all: TierPreset[] = resolveTierPresets("balanced");
+      const withNull: TierPreset[] = resolveTierPresets("balanced", { selected: null });
       expect(withNull).toHaveLength(all.length);
     });
 
     it("open tier resolve returns all open presets", () => {
       const openTier = mustGetTier("open");
-      const resolved: TierPreset[] = tiers.resolveTierPresets("open");
+      const resolved: TierPreset[] = resolveTierPresets("open");
       expect(resolved).toHaveLength(openTier.presets.length);
     });
 
     it("each resolved preset has name and access fields", () => {
-      for (const tier of tiers.listTiers()) {
-        for (const preset of tiers.resolveTierPresets(tier.name)) {
+      for (const tier of listTiers()) {
+        for (const preset of resolveTierPresets(tier.name)) {
           expect(typeof preset.name).toBe("string");
           expect(typeof preset.access).toBe("string");
           expect(preset.access.length).toBeGreaterThan(0);
@@ -306,7 +306,7 @@ describe("tiers", () => {
   describe("integration: all tier presets exist on disk", () => {
     it("every preset referenced in tiers.yaml exists as a preset file", () => {
       const available = new Set(policies.listPresets().map((preset: Preset) => preset.name));
-      for (const tier of tiers.listTiers()) {
+      for (const tier of listTiers()) {
         for (const preset of tier.presets) {
           expect(
             available.has(preset.name),


### PR DESCRIPTION
## Summary
Updates the policy tier tests to import the tier helper functions by name instead of through a default module object. This resolves the CodeQL `js/property-access-on-non-object` alerts without changing test coverage or production behavior.

## Changes
- Replaced the default `tiers` import in `test/policy-tiers.test.ts` with named imports for `getTier`, `listTiers`, and `resolveTierPresets`.
- Updated tier test call sites to use those named helpers directly.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated policy tier tests to use named exports, improving test organization and consistency for tier listing, retrieval, and preset resolution operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->