### PR TITLE
fix(cli): handle local gateway doctor and large backups

### DIFF
--- a/src/lib/actions/sandbox/doctor-gateway-fallback.ts
+++ b/src/lib/actions/sandbox/doctor-gateway-fallback.ts
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GATEWAY_PORT } from "../../core/ports";
+import { HOST_GATEWAY_PGREP_PATTERN } from "../../onboard/host-gateway-process";
+import type { DoctorCheck } from "./doctor";
+import { captureHostCommand, type CommandCapture } from "./doctor-host-command";
+
+export type GatewayInspectOptions = {
+  namedGatewayConnected?: boolean;
+};
+
+type LocalGatewayProbe = {
+  portListening: boolean;
+  processRunning: boolean;
+  unavailableTools: string[];
+};
+
+function commandUnavailable(capture: CommandCapture): boolean {
+  const errorCode = (capture.error as NodeJS.ErrnoException | undefined)?.code;
+  if (errorCode === "ENOENT" || errorCode === "EACCES") return true;
+  const detail = `${capture.stderr}\n${capture.error?.message ?? ""}`.toLowerCase();
+  return detail.includes("command not found") || detail.includes("permission denied");
+}
+
+function probeLocalGatewayProcess(): LocalGatewayProbe {
+  const processCheck = captureHostCommand("pgrep", ["-f", HOST_GATEWAY_PGREP_PATTERN], 5000);
+  const portCheck = captureHostCommand("ss", ["-ltn", `( sport = :${GATEWAY_PORT} )`], 5000);
+  const pgrepUnavailable = commandUnavailable(processCheck);
+  const ssUnavailable = commandUnavailable(portCheck);
+  return {
+    processRunning:
+      !pgrepUnavailable && processCheck.status === 0 && processCheck.stdout.trim().length > 0,
+    portListening:
+      !ssUnavailable && portCheck.status === 0 && portCheck.stdout.includes(`:${GATEWAY_PORT}`),
+    unavailableTools: [
+      pgrepUnavailable ? "pgrep" : null,
+      ssUnavailable ? "ss" : null,
+    ].filter((tool): tool is string => tool !== null),
+  };
+}
+
+export function buildGatewayInspectFailureChecks(
+  containerName: string,
+  options: GatewayInspectOptions,
+): DoctorCheck[] {
+  const checks: DoctorCheck[] = [];
+  const probe = probeLocalGatewayProcess();
+
+  // Compatibility boundary: Docker-driver gateways are verified by OpenShell's
+  // named-gateway status and a host openshell-gateway process, while older
+  // installs still use the legacy openshell-cluster-* container inspection.
+  // Keep both sources until the legacy container path is retired, then remove
+  // this fallback with the stale inspect check.
+  if (probe.processRunning && probe.portListening) {
+    checks.push({
+      group: "Gateway",
+      label: "Local gateway process",
+      status: options.namedGatewayConnected ? "ok" : "info",
+      detail: options.namedGatewayConnected
+        ? `openshell-gateway is running, listening on port ${GATEWAY_PORT}, and verified by OpenShell`
+        : `openshell-gateway process and port ${GATEWAY_PORT} are present, but the named gateway is not verified`,
+      hint: options.namedGatewayConnected
+        ? undefined
+        : "check the OpenShell status result below before trusting the local gateway probe",
+    });
+    return checks;
+  }
+
+  if (options.namedGatewayConnected) {
+    if (probe.unavailableTools.length > 0) {
+      checks.push({
+        group: "Gateway",
+        label: "Local gateway probe",
+        status: "info",
+        detail: `local probe skipped (${probe.unavailableTools.join(", ")} unavailable); OpenShell reports the named gateway connected`,
+      });
+      return checks;
+    }
+
+    checks.push({
+      group: "Gateway",
+      label: "Legacy Docker container",
+      status: "info",
+      detail: `${containerName} not inspectable; OpenShell reports the named gateway connected`,
+    });
+    return checks;
+  }
+
+  if (probe.unavailableTools.length > 0) {
+    checks.push({
+      group: "Gateway",
+      label: "Local gateway probe",
+      status: "info",
+      detail: `skipped because ${probe.unavailableTools.join(", ")} unavailable`,
+      hint: "install procps/iproute2 or use the OpenShell status check below for gateway confirmation",
+    });
+  }
+
+  checks.push({
+    group: "Gateway",
+    label: "Docker container",
+    status: "fail",
+    detail: `${containerName} not found or not inspectable`,
+    hint: `run \`docker ps --filter name=${containerName}\``,
+  });
+  return checks;
+}

--- a/src/lib/actions/sandbox/doctor-host-command.test.ts
+++ b/src/lib/actions/sandbox/doctor-host-command.test.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { captureHostCommand } from "./doctor-host-command";
+
+describe("captureHostCommand", () => {
+  it("treats signal-terminated processes as failed", () => {
+    const result = captureHostCommand(process.execPath, [
+      "-e",
+      "process.kill(process.pid, 'SIGTERM')",
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/src/lib/actions/sandbox/doctor-host-command.ts
+++ b/src/lib/actions/sandbox/doctor-host-command.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { ROOT } from "../../runner";
+import { ROOT } from "../../state/paths";
 
 export type CommandCapture = {
   status: number;
@@ -24,7 +24,7 @@ export function captureHostCommand(
     timeout,
   });
   return {
-    status: result.status ?? (result.error ? 1 : 0),
+    status: result.status ?? (result.error || result.signal ? 1 : 0),
     stdout: String(result.stdout || ""),
     stderr: String(result.stderr || ""),
     error: result.error,

--- a/src/lib/actions/sandbox/doctor-host-command.ts
+++ b/src/lib/actions/sandbox/doctor-host-command.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { ROOT } from "../../runner";
+
+export type CommandCapture = {
+  status: number;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+export function captureHostCommand(
+  command: string,
+  args: string[],
+  timeout = 5000,
+): CommandCapture {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    env: process.env,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout,
+  });
+  return {
+    status: result.status ?? (result.error ? 1 : 0),
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+    error: result.error,
+  };
+}

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { buildValidatedCurlCommandArgs } from "../../adapters/http/curl-args";
@@ -20,7 +19,6 @@ import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import { parseGatewayInference } from "../../inference/config";
 import { type ProviderHealthStatus, probeProviderHealth } from "../../inference/health";
 import { isLinuxDockerDriverGatewayEnabled } from "../../onboard/docker-driver-platform";
-import { HOST_GATEWAY_PGREP_PATTERN } from "../../onboard/host-gateway-process";
 import { executeSandboxCommandForVerification } from "../../onboard/sandbox-verification-exec";
 import { ROOT } from "../../runner";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
@@ -31,6 +29,11 @@ import * as registry from "../../state/registry";
 import { buildStatusCommandDeps } from "../../status-command-deps";
 import { readCloudflaredState } from "../../tunnel/services";
 import { buildConfigPermsCheck } from "./doctor-config-perms";
+import {
+  buildGatewayInspectFailureChecks,
+  type GatewayInspectOptions,
+} from "./doctor-gateway-fallback";
+import { captureHostCommand } from "./doctor-host-command";
 import { probeSandboxInferenceGatewayHealth } from "./process-recovery";
 
 const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
@@ -54,23 +57,6 @@ export type DoctorReport = {
   checks: DoctorCheck[];
 };
 
-type CommandCapture = {
-  status: number;
-  stdout: string;
-  stderr: string;
-  error?: Error;
-};
-
-type GatewayInspectOptions = {
-  namedGatewayConnected?: boolean;
-};
-
-type LocalGatewayProbe = {
-  portListening: boolean;
-  processRunning: boolean;
-  unavailableTools: string[];
-};
-
 function pushInferenceHealthCheck(
   checks: DoctorCheck[],
   probe: ProviderHealthStatus,
@@ -91,35 +77,8 @@ function pushInferenceHealthCheck(
   });
 }
 
-function captureHostCommand(
-  command: string,
-  args: string[],
-  timeout = 5000,
-): CommandCapture {
-  const result = spawnSync(command, args, {
-    cwd: ROOT,
-    env: process.env,
-    encoding: "utf-8",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout,
-  });
-  return {
-    status: result.status ?? (result.error ? 1 : 0),
-    stdout: String(result.stdout || ""),
-    stderr: String(result.stderr || ""),
-    error: result.error,
-  };
-}
-
 function oneLine(value = ""): string {
   return String(value).replace(/\s+/g, " ").trim();
-}
-
-function commandUnavailable(capture: CommandCapture): boolean {
-  const errorCode = (capture.error as NodeJS.ErrnoException | undefined)?.code;
-  if (errorCode === "ENOENT" || errorCode === "EACCES") return true;
-  const detail = `${capture.stderr}\n${capture.error?.message ?? ""}`.toLowerCase();
-  return detail.includes("command not found") || detail.includes("permission denied");
 }
 
 function doctorSummary(checks: DoctorCheck[]): {
@@ -205,84 +164,6 @@ function renderDoctorReport(report: DoctorReport, asJson: boolean): number {
   }
   console.log("");
   return doctorReportExitCode(report);
-}
-
-function probeLocalGatewayProcess(): LocalGatewayProbe {
-  const processCheck = captureHostCommand("pgrep", ["-f", HOST_GATEWAY_PGREP_PATTERN], 5000);
-  const portCheck = captureHostCommand("ss", ["-ltn", `( sport = :${GATEWAY_PORT} )`], 5000);
-  const pgrepUnavailable = commandUnavailable(processCheck);
-  const ssUnavailable = commandUnavailable(portCheck);
-  return {
-    processRunning:
-      !pgrepUnavailable && processCheck.status === 0 && processCheck.stdout.trim().length > 0,
-    portListening:
-      !ssUnavailable && portCheck.status === 0 && portCheck.stdout.includes(`:${GATEWAY_PORT}`),
-    unavailableTools: [
-      pgrepUnavailable ? "pgrep" : null,
-      ssUnavailable ? "ss" : null,
-    ].filter((tool): tool is string => tool !== null),
-  };
-}
-
-function buildGatewayInspectFailureChecks(
-  containerName: string,
-  options: GatewayInspectOptions,
-): DoctorCheck[] {
-  const checks: DoctorCheck[] = [];
-  const probe = probeLocalGatewayProcess();
-  if (probe.processRunning && probe.portListening) {
-    checks.push({
-      group: "Gateway",
-      label: "Local gateway process",
-      status: options.namedGatewayConnected ? "ok" : "info",
-      detail: options.namedGatewayConnected
-        ? `openshell-gateway is running, listening on port ${GATEWAY_PORT}, and verified by OpenShell`
-        : `openshell-gateway process and port ${GATEWAY_PORT} are present, but the named gateway is not verified`,
-      hint: options.namedGatewayConnected
-        ? undefined
-        : "check the OpenShell status result below before trusting the local gateway probe",
-    });
-    return checks;
-  }
-
-  if (options.namedGatewayConnected) {
-    if (probe.unavailableTools.length > 0) {
-      checks.push({
-        group: "Gateway",
-        label: "Local gateway probe",
-        status: "info",
-        detail: `local probe skipped (${probe.unavailableTools.join(", ")} unavailable); OpenShell reports the named gateway connected`,
-      });
-      return checks;
-    }
-
-    checks.push({
-      group: "Gateway",
-      label: "Legacy Docker container",
-      status: "info",
-      detail: `${containerName} not inspectable; OpenShell reports the named gateway connected`,
-    });
-    return checks;
-  }
-
-  if (probe.unavailableTools.length > 0) {
-    checks.push({
-      group: "Gateway",
-      label: "Local gateway probe",
-      status: "info",
-      detail: `skipped because ${probe.unavailableTools.join(", ")} unavailable`,
-      hint: "install procps/iproute2 or use the OpenShell status check below for gateway confirmation",
-    });
-  }
-
-  checks.push({
-    group: "Gateway",
-    label: "Docker container",
-    status: "fail",
-    detail: `${containerName} not found or not inspectable`,
-    hint: `run \`docker ps --filter name=${containerName}\``,
-  });
-  return checks;
 }
 
 function dockerInspectGateway(

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -61,6 +61,16 @@ type CommandCapture = {
   error?: Error;
 };
 
+type GatewayInspectOptions = {
+  namedGatewayConnected?: boolean;
+};
+
+type LocalGatewayProbe = {
+  portListening: boolean;
+  processRunning: boolean;
+  unavailableTools: string[];
+};
+
 function pushInferenceHealthCheck(
   checks: DoctorCheck[],
   probe: ProviderHealthStatus,
@@ -103,6 +113,13 @@ function captureHostCommand(
 
 function oneLine(value = ""): string {
   return String(value).replace(/\s+/g, " ").trim();
+}
+
+function commandUnavailable(capture: CommandCapture): boolean {
+  const errorCode = (capture.error as NodeJS.ErrnoException | undefined)?.code;
+  if (errorCode === "ENOENT" || errorCode === "EACCES") return true;
+  const detail = `${capture.stderr}\n${capture.error?.message ?? ""}`.toLowerCase();
+  return detail.includes("command not found") || detail.includes("permission denied");
 }
 
 function doctorSummary(checks: DoctorCheck[]): {
@@ -190,7 +207,88 @@ function renderDoctorReport(report: DoctorReport, asJson: boolean): number {
   return doctorReportExitCode(report);
 }
 
-function dockerInspectGateway(containerName: string): DoctorCheck[] {
+function probeLocalGatewayProcess(): LocalGatewayProbe {
+  const processCheck = captureHostCommand("pgrep", ["-f", HOST_GATEWAY_PGREP_PATTERN], 5000);
+  const portCheck = captureHostCommand("ss", ["-ltn", `( sport = :${GATEWAY_PORT} )`], 5000);
+  const pgrepUnavailable = commandUnavailable(processCheck);
+  const ssUnavailable = commandUnavailable(portCheck);
+  return {
+    processRunning:
+      !pgrepUnavailable && processCheck.status === 0 && processCheck.stdout.trim().length > 0,
+    portListening:
+      !ssUnavailable && portCheck.status === 0 && portCheck.stdout.includes(`:${GATEWAY_PORT}`),
+    unavailableTools: [
+      pgrepUnavailable ? "pgrep" : null,
+      ssUnavailable ? "ss" : null,
+    ].filter((tool): tool is string => tool !== null),
+  };
+}
+
+function buildGatewayInspectFailureChecks(
+  containerName: string,
+  options: GatewayInspectOptions,
+): DoctorCheck[] {
+  const checks: DoctorCheck[] = [];
+  const probe = probeLocalGatewayProcess();
+  if (probe.processRunning && probe.portListening) {
+    checks.push({
+      group: "Gateway",
+      label: "Local gateway process",
+      status: options.namedGatewayConnected ? "ok" : "info",
+      detail: options.namedGatewayConnected
+        ? `openshell-gateway is running, listening on port ${GATEWAY_PORT}, and verified by OpenShell`
+        : `openshell-gateway process and port ${GATEWAY_PORT} are present, but the named gateway is not verified`,
+      hint: options.namedGatewayConnected
+        ? undefined
+        : "check the OpenShell status result below before trusting the local gateway probe",
+    });
+    return checks;
+  }
+
+  if (options.namedGatewayConnected) {
+    if (probe.unavailableTools.length > 0) {
+      checks.push({
+        group: "Gateway",
+        label: "Local gateway probe",
+        status: "info",
+        detail: `local probe skipped (${probe.unavailableTools.join(", ")} unavailable); OpenShell reports the named gateway connected`,
+      });
+      return checks;
+    }
+
+    checks.push({
+      group: "Gateway",
+      label: "Legacy Docker container",
+      status: "info",
+      detail: `${containerName} not inspectable; OpenShell reports the named gateway connected`,
+    });
+    return checks;
+  }
+
+  if (probe.unavailableTools.length > 0) {
+    checks.push({
+      group: "Gateway",
+      label: "Local gateway probe",
+      status: "info",
+      detail: `skipped because ${probe.unavailableTools.join(", ")} unavailable`,
+      hint: "install procps/iproute2 or use the OpenShell status check below for gateway confirmation",
+    });
+  }
+
+  checks.push({
+    group: "Gateway",
+    label: "Docker container",
+    status: "fail",
+    detail: `${containerName} not found or not inspectable`,
+    hint: `run \`docker ps --filter name=${containerName}\``,
+  });
+  return checks;
+}
+
+function dockerInspectGateway(
+  containerName: string,
+  options: GatewayInspectOptions = {},
+): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const inspect = captureHostCommand(
     "docker",
@@ -203,28 +301,7 @@ function dockerInspectGateway(containerName: string): DoctorCheck[] {
     5000,
   );
   if (inspect.status !== 0) {
-    const processCheck = captureHostCommand("pgrep", ["-f", HOST_GATEWAY_PGREP_PATTERN], 5000);
-    const portCheck = captureHostCommand("ss", ["-ltn", `( sport = :${GATEWAY_PORT} )`], 5000);
-    const processRunning = processCheck.status === 0 && processCheck.stdout.trim().length > 0;
-    const portListening = portCheck.status === 0 && portCheck.stdout.includes(`:${GATEWAY_PORT}`);
-    if (processRunning && portListening) {
-      checks.push({
-        group: "Gateway",
-        label: "Local gateway process",
-        status: "ok",
-        detail: `openshell-gateway is running and listening on port ${GATEWAY_PORT}`,
-      });
-      return checks;
-    }
-
-    checks.push({
-      group: "Gateway",
-      label: "Docker container",
-      status: "fail",
-      detail: `${containerName} not found or not inspectable`,
-      hint: `run \`docker ps --filter name=${containerName}\``,
-    });
-    return checks;
+    return buildGatewayInspectFailureChecks(containerName, options);
   }
 
   const [runningRaw, healthRaw, imageRaw] = inspect.stdout.trim().split("\t");
@@ -622,10 +699,6 @@ export async function runSandboxDoctor(
     hint: openshellBin ? undefined : "install OpenShell before using sandbox commands",
   });
 
-  if (shouldInspectLegacyGatewayContainer(sb)) {
-    checks.push(...dockerInspectGateway(`openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`));
-  }
-
   let openshellConnected = false;
   if (openshellBin) {
     const recovery = await recoverNamedGatewayRuntime();
@@ -641,6 +714,14 @@ export async function runSandboxDoctor(
         : oneLine(cleanStatus || lifecycle?.gatewayInfo || "not connected to nemoclaw"),
       hint: openshellConnected ? undefined : "run `openshell gateway select nemoclaw` and retry",
     });
+  }
+
+  if (shouldInspectLegacyGatewayContainer(sb)) {
+    checks.push(
+      ...dockerInspectGateway(`openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`, {
+        namedGatewayConnected: openshellConnected,
+      }),
+    );
   }
 
   if (openshellBin && openshellConnected) {

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -20,6 +20,7 @@ import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import { parseGatewayInference } from "../../inference/config";
 import { type ProviderHealthStatus, probeProviderHealth } from "../../inference/health";
 import { isLinuxDockerDriverGatewayEnabled } from "../../onboard/docker-driver-platform";
+import { HOST_GATEWAY_PGREP_PATTERN } from "../../onboard/host-gateway-process";
 import { executeSandboxCommandForVerification } from "../../onboard/sandbox-verification-exec";
 import { ROOT } from "../../runner";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
@@ -202,6 +203,20 @@ function dockerInspectGateway(containerName: string): DoctorCheck[] {
     5000,
   );
   if (inspect.status !== 0) {
+    const processCheck = captureHostCommand("pgrep", ["-f", HOST_GATEWAY_PGREP_PATTERN], 5000);
+    const portCheck = captureHostCommand("ss", ["-ltn", `( sport = :${GATEWAY_PORT} )`], 5000);
+    const processRunning = processCheck.status === 0 && processCheck.stdout.trim().length > 0;
+    const portListening = portCheck.status === 0 && portCheck.stdout.includes(`:${GATEWAY_PORT}`);
+    if (processRunning && portListening) {
+      checks.push({
+        group: "Gateway",
+        label: "Local gateway process",
+        status: "ok",
+        detail: `openshell-gateway is running and listening on port ${GATEWAY_PORT}`,
+      });
+      return checks;
+    }
+
     checks.push({
       group: "Gateway",
       label: "Docker container",

--- a/src/lib/onboard/host-gateway-process.ts
+++ b/src/lib/onboard/host-gateway-process.ts
@@ -61,7 +61,7 @@ const DOCKER_DRIVER_GATEWAY_MOUNT_PATH = "/opt/nemoclaw/openshell-gateway";
 // sees the cmdline string, not argv0; without an argv0 gate the compat mount
 // path could match unrelated commands. The compat parent is rediscovered via
 // the PID file written at launch time.
-const HOST_GATEWAY_PGREP_PATTERN = "^(/[^ ]*/)?openshell-gateway( |$)";
+export const HOST_GATEWAY_PGREP_PATTERN = "^(/[^ ]*/)?openshell-gateway( |$)";
 const DEFAULT_TERM_WAIT_MS = 1000;
 const DEFAULT_KILL_WAIT_MS = 1000;
 const DEFAULT_POLL_INTERVAL_MS = 50;

--- a/src/lib/onboard/host-gateway-process.ts
+++ b/src/lib/onboard/host-gateway-process.ts
@@ -61,6 +61,7 @@ const DOCKER_DRIVER_GATEWAY_MOUNT_PATH = "/opt/nemoclaw/openshell-gateway";
 // sees the cmdline string, not argv0; without an argv0 gate the compat mount
 // path could match unrelated commands. The compat parent is rediscovered via
 // the PID file written at launch time.
+/** Anchored pgrep pattern for direct host openshell-gateway processes. */
 export const HOST_GATEWAY_PGREP_PATTERN = "^(/[^ ]*/)?openshell-gateway( |$)";
 const DEFAULT_TERM_WAIT_MS = 1000;
 const DEFAULT_KILL_WAIT_MS = 1000;

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -39,6 +39,7 @@ const HOME_DIR = path.resolve(process.env.HOME || os.homedir());
 const REBUILD_BACKUPS_DIR = path.join(HOME_DIR, ".nemoclaw", "rebuild-backups");
 
 const MANIFEST_VERSION = 1;
+/** Allows large state archives to be listed without Node's default 1 MiB spawn buffer cap. */
 const TAR_LISTING_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
 
 function parseJson<T>(text: string): T {

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -12,23 +12,17 @@
 import { createHash } from "node:crypto";
 import {
   chmodSync,
-  closeSync,
   existsSync,
   lstatSync,
-  mkdtempSync,
   mkdirSync,
-  openSync,
-  readSync,
   readdirSync,
   readFileSync,
   readlinkSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { StringDecoder } from "node:string_decoder";
 import { spawnSync } from "child_process";
 
 import { captureSandboxSshConfigCommand } from "../adapters/openshell/client.js";
@@ -40,19 +34,12 @@ import { isRecord, type UnknownRecord } from "../core/json-types.js";
 import { shellQuote } from "../runner.js";
 import { isSensitiveFile, sanitizeConfigFile } from "../security/credential-filter.js";
 import * as registry from "./registry.js";
+import { runTarListing } from "./tar-listing.js";
 
 const HOME_DIR = path.resolve(process.env.HOME || os.homedir());
 const REBUILD_BACKUPS_DIR = path.join(HOME_DIR, ".nemoclaw", "rebuild-backups");
 
 const MANIFEST_VERSION = 1;
-// Compatibility boundary: existing backups are raw tar streams, so validation
-// still shells out to system tar. Route listings through a bounded temp file
-// instead of child-process stdout buffers; remove this path when backup
-// validation moves to a native streaming tar parser or indexed manifest format.
-const TAR_LISTING_STDERR_MAX_BUFFER_BYTES = 1024 * 1024;
-const TAR_LISTING_MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
-const TAR_LISTING_READ_CHUNK_BYTES = 64 * 1024;
-const TAR_LISTING_MAX_LINE_CHARS = 1024 * 1024;
 
 function parseJson<T>(text: string): T {
   return JSON.parse(text);
@@ -243,83 +230,6 @@ function rejectSymlinksOnPath(targetPath: string): void {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
     current = path.dirname(current);
-  }
-}
-
-function readTextLinesFromFile(filePath: string, onLine: (line: string) => void): void {
-  const fd = openSync(filePath, "r");
-  const decoder = new StringDecoder("utf8");
-  const chunk = Buffer.alloc(TAR_LISTING_READ_CHUNK_BYTES);
-  let pending = "";
-  try {
-    while (true) {
-      const bytesRead = readSync(fd, chunk, 0, chunk.length, null);
-      if (bytesRead === 0) break;
-      pending += decoder.write(chunk.subarray(0, bytesRead));
-      if (pending.length > TAR_LISTING_MAX_LINE_CHARS) {
-        throw new Error("tar listing line exceeds supported length");
-      }
-      let newlineIndex = pending.indexOf("\n");
-      while (newlineIndex >= 0) {
-        const line = pending.slice(0, newlineIndex).replace(/\r$/, "");
-        if (line.length > 0) onLine(line);
-        pending = pending.slice(newlineIndex + 1);
-        newlineIndex = pending.indexOf("\n");
-      }
-    }
-    pending += decoder.end();
-    if (pending.length > TAR_LISTING_MAX_LINE_CHARS) {
-      throw new Error("tar listing line exceeds supported length");
-    }
-    const lastLine = pending.replace(/\r$/, "");
-    if (lastLine.length > 0) onLine(lastLine);
-  } finally {
-    closeSync(fd);
-  }
-}
-
-function tarExitStatus(result: ReturnType<typeof spawnSync>): number {
-  return result.status ?? (result.error || result.signal ? 1 : 0);
-}
-
-function runTarListing(
-  tarBuffer: Buffer,
-  args: string[],
-  failureLabel: string,
-  onLine: (line: string) => void,
-): string | null {
-  const tempDir = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-tar-listing-"));
-  const listingPath = path.join(tempDir, "listing.txt");
-  let listingFd: number | null = null;
-  try {
-    listingFd = openSync(listingPath, "w");
-    const result = spawnSync("tar", args, {
-      input: tarBuffer,
-      encoding: "utf-8",
-      stdio: ["pipe", listingFd, "pipe"],
-      timeout: 60000,
-      maxBuffer: TAR_LISTING_STDERR_MAX_BUFFER_BYTES,
-    });
-    closeSync(listingFd);
-    listingFd = null;
-
-    const status = tarExitStatus(result);
-    if (status !== 0) {
-      return `${failureLabel} failed (exit ${status}): ${(result.stderr || "").substring(0, 200)}`;
-    }
-
-    const listingSize = statSync(listingPath).size;
-    if (listingSize > TAR_LISTING_MAX_OUTPUT_BYTES) {
-      return `${failureLabel} exceeded ${TAR_LISTING_MAX_OUTPUT_BYTES} bytes`;
-    }
-
-    readTextLinesFromFile(listingPath, onLine);
-    return null;
-  } catch (error) {
-    return `${failureLabel} failed: ${error instanceof Error ? error.message : String(error)}`;
-  } finally {
-    if (listingFd !== null) closeSync(listingFd);
-    rmSync(tempDir, { recursive: true, force: true });
   }
 }
 

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -39,6 +39,7 @@ const HOME_DIR = path.resolve(process.env.HOME || os.homedir());
 const REBUILD_BACKUPS_DIR = path.join(HOME_DIR, ".nemoclaw", "rebuild-backups");
 
 const MANIFEST_VERSION = 1;
+const TAR_LISTING_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
 
 function parseJson<T>(text: string): T {
   return JSON.parse(text);
@@ -242,6 +243,7 @@ export function validateTarEntries(tarBuffer: Buffer, targetDir: string): TarVal
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
     timeout: 60000,
+    maxBuffer: TAR_LISTING_MAX_BUFFER_BYTES,
   });
 
   if (result.status !== 0) {
@@ -376,6 +378,7 @@ export function rejectHardLinks(tarBuffer: Buffer): string[] {
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
     timeout: 60000,
+    maxBuffer: TAR_LISTING_MAX_BUFFER_BYTES,
   });
 
   if (result.status !== 0) {

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -12,17 +12,23 @@
 import { createHash } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
   lstatSync,
+  mkdtempSync,
   mkdirSync,
+  openSync,
+  readSync,
   readdirSync,
   readFileSync,
   readlinkSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { spawnSync } from "child_process";
 
 import { captureSandboxSshConfigCommand } from "../adapters/openshell/client.js";
@@ -39,8 +45,14 @@ const HOME_DIR = path.resolve(process.env.HOME || os.homedir());
 const REBUILD_BACKUPS_DIR = path.join(HOME_DIR, ".nemoclaw", "rebuild-backups");
 
 const MANIFEST_VERSION = 1;
-/** Allows large state archives to be listed without Node's default 1 MiB spawn buffer cap. */
-const TAR_LISTING_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+// Compatibility boundary: existing backups are raw tar streams, so validation
+// still shells out to system tar. Route listings through a bounded temp file
+// instead of child-process stdout buffers; remove this path when backup
+// validation moves to a native streaming tar parser or indexed manifest format.
+const TAR_LISTING_STDERR_MAX_BUFFER_BYTES = 1024 * 1024;
+const TAR_LISTING_MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
+const TAR_LISTING_READ_CHUNK_BYTES = 64 * 1024;
+const TAR_LISTING_MAX_LINE_CHARS = 1024 * 1024;
 
 function parseJson<T>(text: string): T {
   return JSON.parse(text);
@@ -234,33 +246,100 @@ function rejectSymlinksOnPath(targetPath: string): void {
   }
 }
 
+function readTextLinesFromFile(filePath: string, onLine: (line: string) => void): void {
+  const fd = openSync(filePath, "r");
+  const decoder = new StringDecoder("utf8");
+  const chunk = Buffer.alloc(TAR_LISTING_READ_CHUNK_BYTES);
+  let pending = "";
+  try {
+    while (true) {
+      const bytesRead = readSync(fd, chunk, 0, chunk.length, null);
+      if (bytesRead === 0) break;
+      pending += decoder.write(chunk.subarray(0, bytesRead));
+      if (pending.length > TAR_LISTING_MAX_LINE_CHARS) {
+        throw new Error("tar listing line exceeds supported length");
+      }
+      let newlineIndex = pending.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const line = pending.slice(0, newlineIndex).replace(/\r$/, "");
+        if (line.length > 0) onLine(line);
+        pending = pending.slice(newlineIndex + 1);
+        newlineIndex = pending.indexOf("\n");
+      }
+    }
+    pending += decoder.end();
+    if (pending.length > TAR_LISTING_MAX_LINE_CHARS) {
+      throw new Error("tar listing line exceeds supported length");
+    }
+    const lastLine = pending.replace(/\r$/, "");
+    if (lastLine.length > 0) onLine(lastLine);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function tarExitStatus(result: ReturnType<typeof spawnSync>): number {
+  return result.status ?? (result.error || result.signal ? 1 : 0);
+}
+
+function runTarListing(
+  tarBuffer: Buffer,
+  args: string[],
+  failureLabel: string,
+  onLine: (line: string) => void,
+): string | null {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-tar-listing-"));
+  const listingPath = path.join(tempDir, "listing.txt");
+  let listingFd: number | null = null;
+  try {
+    listingFd = openSync(listingPath, "w");
+    const result = spawnSync("tar", args, {
+      input: tarBuffer,
+      encoding: "utf-8",
+      stdio: ["pipe", listingFd, "pipe"],
+      timeout: 60000,
+      maxBuffer: TAR_LISTING_STDERR_MAX_BUFFER_BYTES,
+    });
+    closeSync(listingFd);
+    listingFd = null;
+
+    const status = tarExitStatus(result);
+    if (status !== 0) {
+      return `${failureLabel} failed (exit ${status}): ${(result.stderr || "").substring(0, 200)}`;
+    }
+
+    const listingSize = statSync(listingPath).size;
+    if (listingSize > TAR_LISTING_MAX_OUTPUT_BYTES) {
+      return `${failureLabel} exceeded ${TAR_LISTING_MAX_OUTPUT_BYTES} bytes`;
+    }
+
+    readTextLinesFromFile(listingPath, onLine);
+    return null;
+  } catch (error) {
+    return `${failureLabel} failed: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    if (listingFd !== null) closeSync(listingFd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 /**
  * List tar entries and validate every path is within targetDir.
  * Rejects absolute paths, path traversal (..), and null bytes.
  */
 export function validateTarEntries(tarBuffer: Buffer, targetDir: string): TarValidationResult {
-  const result = spawnSync("tar", ["-tf", "-"], {
-    input: tarBuffer,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    timeout: 60000,
-    maxBuffer: TAR_LISTING_MAX_BUFFER_BYTES,
+  const entries: string[] = [];
+  const listingFailure = runTarListing(tarBuffer, ["-tf", "-"], "tar listing", (line) => {
+    entries.push(line);
   });
-
-  if (result.status !== 0) {
+  if (listingFailure) {
     return {
       safe: false,
       entries: [],
-      violations: [
-        `tar listing failed (exit ${result.status}): ${(result.stderr || "").substring(0, 200)}`,
-      ],
+      violations: [listingFailure],
     };
   }
 
-  const entries = (result.stdout || "")
-    .trim()
-    .split("\n")
-    .filter((e) => e.length > 0);
   const violations: string[] = [];
 
   for (const entry of entries) {
@@ -374,31 +453,15 @@ function auditExtractedSymlinks(dirPath: string, allowedRoots: string[]): string
  * files outside the extraction root.
  */
 export function rejectHardLinks(tarBuffer: Buffer): string[] {
-  const result = spawnSync("tar", ["-tvf", "-"], {
-    input: tarBuffer,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    timeout: 60000,
-    maxBuffer: TAR_LISTING_MAX_BUFFER_BYTES,
-  });
-
-  if (result.status !== 0) {
-    return [`tar verbose listing failed (exit ${result.status})`];
-  }
-
   const violations: string[] = [];
-  const lines = (result.stdout || "")
-    .trim()
-    .split("\n")
-    .filter((l) => l.length > 0);
-
-  for (const line of lines) {
+  const listingFailure = runTarListing(tarBuffer, ["-tvf", "-"], "tar verbose listing", (line) => {
     // Both GNU tar and bsdtar prefix hard-link entries with 'h' in verbose mode
     // and include " link to " in the line.
     if (line.startsWith("h") || / link to /.test(line)) {
       violations.push(`hard link: ${line.trim()}`);
     }
-  }
+  });
+  if (listingFailure) return [listingFailure];
 
   return violations;
 }

--- a/src/lib/state/tar-listing.ts
+++ b/src/lib/state/tar-listing.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+// Compatibility boundary: existing backups are raw tar streams, so validation
+// still shells out to system tar. Route listings through a bounded temp file
+// instead of child-process stdout buffers; remove this path when backup
+// validation moves to a native streaming tar parser or indexed manifest format.
+const TAR_LISTING_STDERR_MAX_BUFFER_BYTES = 1024 * 1024;
+const TAR_LISTING_MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
+const TAR_LISTING_READ_CHUNK_BYTES = 64 * 1024;
+const TAR_LISTING_MAX_LINE_CHARS = 1024 * 1024;
+
+function readTextLinesFromFile(filePath: string, onLine: (line: string) => void): void {
+  const fd = openSync(filePath, "r");
+  const decoder = new StringDecoder("utf8");
+  const chunk = Buffer.alloc(TAR_LISTING_READ_CHUNK_BYTES);
+  let pending = "";
+  try {
+    while (true) {
+      const bytesRead = readSync(fd, chunk, 0, chunk.length, null);
+      if (bytesRead === 0) break;
+      pending += decoder.write(chunk.subarray(0, bytesRead));
+      if (pending.length > TAR_LISTING_MAX_LINE_CHARS) {
+        throw new Error("tar listing line exceeds supported length");
+      }
+      let newlineIndex = pending.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const line = pending.slice(0, newlineIndex).replace(/\r$/, "");
+        if (line.length > 0) onLine(line);
+        pending = pending.slice(newlineIndex + 1);
+        newlineIndex = pending.indexOf("\n");
+      }
+    }
+    pending += decoder.end();
+    if (pending.length > TAR_LISTING_MAX_LINE_CHARS) {
+      throw new Error("tar listing line exceeds supported length");
+    }
+    const lastLine = pending.replace(/\r$/, "");
+    if (lastLine.length > 0) onLine(lastLine);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function tarExitStatus(result: ReturnType<typeof spawnSync>): number {
+  return result.status ?? (result.error || result.signal ? 1 : 0);
+}
+
+export function runTarListing(
+  tarBuffer: Buffer,
+  args: string[],
+  failureLabel: string,
+  onLine: (line: string) => void,
+): string | null {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-tar-listing-"));
+  const listingPath = path.join(tempDir, "listing.txt");
+  let listingFd: number | null = null;
+  try {
+    listingFd = openSync(listingPath, "w");
+    const result = spawnSync("tar", args, {
+      input: tarBuffer,
+      encoding: "utf-8",
+      stdio: ["pipe", listingFd, "pipe"],
+      timeout: 60000,
+      maxBuffer: TAR_LISTING_STDERR_MAX_BUFFER_BYTES,
+    });
+    closeSync(listingFd);
+    listingFd = null;
+
+    const status = tarExitStatus(result);
+    if (status !== 0) {
+      return `${failureLabel} failed (exit ${status}): ${(result.stderr || "").substring(0, 200)}`;
+    }
+
+    const listingSize = statSync(listingPath).size;
+    if (listingSize > TAR_LISTING_MAX_OUTPUT_BYTES) {
+      return `${failureLabel} exceeded ${TAR_LISTING_MAX_OUTPUT_BYTES} bytes`;
+    }
+
+    readTextLinesFromFile(listingPath, onLine);
+    return null;
+  } catch (error) {
+    return `${failureLabel} failed: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    if (listingFd !== null) closeSync(listingFd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/test/cli/doctor-gateway-token.test.ts
+++ b/test/cli/doctor-gateway-token.test.ts
@@ -137,6 +137,80 @@ describe("CLI dispatch", () => {
     );
   });
 
+  it("doctor accepts a local openshell-gateway process when legacy inspect fails", () => {
+    const setup = createDoctorTestSetup("nemoclaw-cli-doctor-local-gateway-", [
+      'case "$*" in',
+      '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
+      '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+      '  "sandbox list") printf "NAME STATUS\\nalpha Ready\\n"; exit 0 ;;',
+      '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
+      "esac",
+    ]);
+    writeSandboxRegistry(setup.home, "alpha", { openshellDriver: "kubernetes" });
+
+    const hostCalls = path.join(setup.home, "host-calls");
+    fs.writeFileSync(
+      path.join(setup.localBin, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        `printf 'docker:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
+        'if [ "$1" = "info" ]; then echo "24.0.0"; exit 0; fi',
+        'if [ "$1" = "inspect" ]; then echo "Error: No such object: $3" >&2; exit 1; fi',
+        'if [ "$1" = "port" ]; then exit 1; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(setup.localBin, "pgrep"),
+      [
+        "#!/usr/bin/env bash",
+        `printf 'pgrep:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
+        "printf '9999887\\n'",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(setup.localBin, "ss"),
+      [
+        "#!/usr/bin/env bash",
+        `printf 'ss:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
+        "printf 'LISTEN 0 4096 127.0.0.1:8080 0.0.0.0:*\\n'",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(setup.localBin, "curl"),
+      ["#!/usr/bin/env bash", 'echo "{}"', "exit 0"].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = setup.runDoctor("alpha doctor --json");
+
+    expect(r.code).toBe(0);
+    const report = JSON.parse(r.out) as {
+      status: string;
+      checks: Array<{ group: string; label: string; status: string; detail: string }>;
+    };
+    expect(report.checks.find((check) => check.label === "Docker container")).toBeUndefined();
+    expect(report.checks.find((check) => check.label === "Local gateway process")).toEqual(
+      expect.objectContaining({
+        group: "Gateway",
+        status: "ok",
+        detail: "openshell-gateway is running and listening on port 8080",
+      }),
+    );
+    expect(report.checks.filter((check) => check.group === "Gateway" && check.status === "fail")).toEqual([]);
+    expect(report.status).toBe("ok");
+
+    const calls = fs.readFileSync(hostCalls, "utf8");
+    expect(calls).toContain("pgrep:-f ^(/[^ ]*/)?openshell-gateway( |$)");
+    expect(calls).not.toContain("pgrep:-af openshell-gateway");
+    expect(calls).not.toContain("docker:port");
+  });
+
   it(
     "doctor reports fresh shields state as not configured instead of down",
     testTimeoutOptions(30_000),

--- a/test/cli/doctor-gateway-token.test.ts
+++ b/test/cli/doctor-gateway-token.test.ts
@@ -84,6 +84,7 @@ function writeHealthyCurlStub(setup: DoctorTestSetup): void {
   );
 }
 
+// parseJsonPrefix keeps assertions stable when JSON output is followed by extra CLI text.
 function parseJsonPrefix<T>(output: string): T {
   const end = output.lastIndexOf("\n}");
   return JSON.parse(end >= 0 ? output.slice(0, end + 2) : output) as T;

--- a/test/cli/doctor-gateway-token.test.ts
+++ b/test/cli/doctor-gateway-token.test.ts
@@ -15,6 +15,80 @@ import {
   writeSandboxRegistry,
 } from "./helpers";
 
+type DoctorTestSetup = ReturnType<typeof createDoctorTestSetup>;
+
+function writeDockerInspectFailureStub(setup: DoctorTestSetup, hostCalls: string): void {
+  fs.writeFileSync(
+    path.join(setup.localBin, "docker"),
+    [
+      "#!/usr/bin/env bash",
+      `printf 'docker:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
+      'if [ "$1" = "info" ]; then echo "24.0.0"; exit 0; fi',
+      'if [ "$1" = "inspect" ]; then echo "Error: No such object: $3" >&2; exit 1; fi',
+      'if [ "$1" = "port" ]; then exit 1; fi',
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
+function writeLocalGatewayProbeStubs(
+  setup: DoctorTestSetup,
+  hostCalls: string,
+  options: {
+    portListening?: boolean;
+    processRunning?: boolean;
+    pgrepUnavailable?: boolean;
+    ssUnavailable?: boolean;
+  } = {},
+): void {
+  const processRunning = options.processRunning ?? true;
+  const portListening = options.portListening ?? true;
+  let pgrepBody = "exit 1";
+  if (options.pgrepUnavailable) {
+    pgrepBody = "printf 'pgrep: command not found\\n' >&2; exit 127";
+  } else if (processRunning) {
+    pgrepBody = "printf '9999887\\n'; exit 0";
+  }
+  let ssBody = "printf 'State Recv-Q Send-Q Local Address:Port Peer Address:Port\\n'; exit 0";
+  if (options.ssUnavailable) {
+    ssBody = "printf 'ss: command not found\\n' >&2; exit 127";
+  } else if (portListening) {
+    ssBody = "printf 'LISTEN 0 4096 127.0.0.1:8080 0.0.0.0:*\\n'; exit 0";
+  }
+  fs.writeFileSync(
+    path.join(setup.localBin, "pgrep"),
+    [
+      "#!/usr/bin/env bash",
+      `printf 'pgrep:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
+      pgrepBody,
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(setup.localBin, "ss"),
+    [
+      "#!/usr/bin/env bash",
+      `printf 'ss:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
+      ssBody,
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
+function writeHealthyCurlStub(setup: DoctorTestSetup): void {
+  fs.writeFileSync(
+    path.join(setup.localBin, "curl"),
+    ["#!/usr/bin/env bash", 'echo "{}"', "exit 0"].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
+function parseJsonPrefix<T>(output: string): T {
+  const end = output.lastIndexOf("\n}");
+  return JSON.parse(end >= 0 ? output.slice(0, end + 2) : output) as T;
+}
+
 describe("CLI dispatch", () => {
   it("gateway-token help uses native oclif usage", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-token-help-"));
@@ -149,43 +223,9 @@ describe("CLI dispatch", () => {
     writeSandboxRegistry(setup.home, "alpha", { openshellDriver: "kubernetes" });
 
     const hostCalls = path.join(setup.home, "host-calls");
-    fs.writeFileSync(
-      path.join(setup.localBin, "docker"),
-      [
-        "#!/usr/bin/env bash",
-        `printf 'docker:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
-        'if [ "$1" = "info" ]; then echo "24.0.0"; exit 0; fi',
-        'if [ "$1" = "inspect" ]; then echo "Error: No such object: $3" >&2; exit 1; fi',
-        'if [ "$1" = "port" ]; then exit 1; fi',
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(setup.localBin, "pgrep"),
-      [
-        "#!/usr/bin/env bash",
-        `printf 'pgrep:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
-        "printf '9999887\\n'",
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(setup.localBin, "ss"),
-      [
-        "#!/usr/bin/env bash",
-        `printf 'ss:%s\\n' "$*" >> ${JSON.stringify(hostCalls)}`,
-        "printf 'LISTEN 0 4096 127.0.0.1:8080 0.0.0.0:*\\n'",
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(setup.localBin, "curl"),
-      ["#!/usr/bin/env bash", 'echo "{}"', "exit 0"].join("\n"),
-      { mode: 0o755 },
-    );
+    writeDockerInspectFailureStub(setup, hostCalls);
+    writeLocalGatewayProbeStubs(setup, hostCalls);
+    writeHealthyCurlStub(setup);
 
     const r = setup.runDoctor("alpha doctor --json");
 
@@ -199,7 +239,7 @@ describe("CLI dispatch", () => {
       expect.objectContaining({
         group: "Gateway",
         status: "ok",
-        detail: "openshell-gateway is running and listening on port 8080",
+        detail: "openshell-gateway is running, listening on port 8080, and verified by OpenShell",
       }),
     );
     expect(report.checks.filter((check) => check.group === "Gateway" && check.status === "fail")).toEqual([]);
@@ -209,6 +249,75 @@ describe("CLI dispatch", () => {
     expect(calls).toContain("pgrep:-f ^(/[^ ]*/)?openshell-gateway( |$)");
     expect(calls).not.toContain("pgrep:-af openshell-gateway");
     expect(calls).not.toContain("docker:port");
+  });
+
+  it("doctor treats local gateway process evidence as informational until OpenShell verifies the named gateway", () => {
+    const setup = createDoctorTestSetup("nemoclaw-cli-doctor-unverified-local-gateway-", [
+      'case "$*" in',
+      '  "status") printf "Server Status\\n\\n  Gateway: other\\n  Status: Connected\\n"; exit 0 ;;',
+      '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+      '  "gateway select nemoclaw") exit 1 ;;',
+      '  "gateway start --name nemoclaw --port 8080") exit 1 ;;',
+      '  "sandbox list") echo "should not query sandbox list" >> "$marker_file"; exit 0 ;;',
+      "esac",
+    ]);
+    writeSandboxRegistry(setup.home, "alpha", { openshellDriver: "kubernetes" });
+    const hostCalls = path.join(setup.home, "host-calls");
+    writeDockerInspectFailureStub(setup, hostCalls);
+    writeLocalGatewayProbeStubs(setup, hostCalls);
+
+    const r = setup.runDoctor("alpha doctor --json");
+
+    expect(r.code).toBe(1);
+    const report = parseJsonPrefix<{
+      checks: Array<{ group: string; label: string; status: string; detail: string }>;
+    }>(r.out);
+    expect(report.checks.find((check) => check.label === "Local gateway process")).toEqual(
+      expect.objectContaining({
+        group: "Gateway",
+        status: "info",
+        detail: "openshell-gateway process and port 8080 are present, but the named gateway is not verified",
+      }),
+    );
+    expect(report.checks.find((check) => check.label === "OpenShell status")).toEqual(
+      expect.objectContaining({ group: "Gateway", status: "fail" }),
+    );
+  });
+
+  it("doctor reports unavailable local gateway probe tools while trusting a verified named gateway", () => {
+    const setup = createDoctorTestSetup("nemoclaw-cli-doctor-missing-local-probe-tools-", [
+      'case "$*" in',
+      '  "status") printf "Server Status\\n\\n  Gateway: nemoclaw\\n  Status: Connected\\n"; exit 0 ;;',
+      '  "gateway info -g nemoclaw") printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+      '  "sandbox list") printf "NAME STATUS\\nalpha Ready\\n"; exit 0 ;;',
+      '  "inference get") printf "Provider: nvidia-prod\\nModel: test-model\\n"; exit 0 ;;',
+      "esac",
+    ]);
+    writeSandboxRegistry(setup.home, "alpha", { openshellDriver: "kubernetes" });
+    const hostCalls = path.join(setup.home, "host-calls");
+    writeDockerInspectFailureStub(setup, hostCalls);
+    writeLocalGatewayProbeStubs(setup, hostCalls, {
+      pgrepUnavailable: true,
+      ssUnavailable: true,
+    });
+    writeHealthyCurlStub(setup);
+
+    const r = setup.runDoctor("alpha doctor --json");
+
+    expect(r.code).toBe(0);
+    const report = JSON.parse(r.out) as {
+      status: string;
+      checks: Array<{ group: string; label: string; status: string; detail: string }>;
+    };
+    expect(report.checks.find((check) => check.label === "Local gateway probe")).toEqual(
+      expect.objectContaining({
+        group: "Gateway",
+        status: "info",
+        detail: "local probe skipped (pgrep, ss unavailable); OpenShell reports the named gateway connected",
+      }),
+    );
+    expect(report.checks.find((check) => check.label === "Docker container")).toBeUndefined();
+    expect(report.status).toBe("ok");
   });
 
   it(

--- a/test/security-sandbox-tar-traversal.test.ts
+++ b/test/security-sandbox-tar-traversal.test.ts
@@ -595,6 +595,25 @@ describe("Fix: rejectHardLinks blocks hard-link entries at validation time", () 
     expect(violations).toEqual([]);
   });
 
+  it("accepts a large archive whose path listing exceeds Node's default spawn buffer", async () => {
+    const { validateTarEntries } = await loadSandboxState();
+    const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-large-listing-"));
+    try {
+      const entries = Array.from({ length: 20_000 }, (_, index) => ({
+        path: `workspace/${index.toString().padStart(5, "0")}-${"segment".repeat(10)}.txt`,
+        content: "x",
+      }));
+
+      const result = validateTarEntries(buildTar(entries), targetDir);
+
+      expect(result.safe).toBe(true);
+      expect(result.violations).toEqual([]);
+      expect(result.entries).toHaveLength(entries.length);
+    } finally {
+      fs.rmSync(targetDir, { recursive: true, force: true });
+    }
+  });
+
   it("safeTarExtract rejects archive containing hard links", async () => {
     const { safeTarExtract } = await loadSandboxState();
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hardlink-"));

--- a/test/security-sandbox-tar-traversal.test.ts
+++ b/test/security-sandbox-tar-traversal.test.ts
@@ -583,6 +583,18 @@ describe("Fix: rejectHardLinks blocks hard-link entries at validation time", () 
     expect(violations.length).toBe(0);
   });
 
+  it("accepts a large archive whose verbose listing exceeds Node's default spawn buffer", async () => {
+    const { rejectHardLinks } = await loadSandboxState();
+    const entries = Array.from({ length: 20_000 }, (_, index) => ({
+      path: `workspace/file-${index.toString().padStart(5, "0")}.txt`,
+      content: "x",
+    }));
+
+    const violations = rejectHardLinks(buildTar(entries));
+
+    expect(violations).toEqual([]);
+  });
+
   it("safeTarExtract rejects archive containing hard links", async () => {
     const { safeTarExtract } = await loadSandboxState();
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hardlink-"));


### PR DESCRIPTION
## Summary
Salvages the intended fixes from #4583 on a clean branch. `nemoclaw doctor` now accepts a verified local `openshell-gateway` process when legacy container inspection fails, and tar listing validation has enough buffer headroom for large sandbox state backups.

## Changes
- Reuse the anchored host gateway pgrep pattern in `doctor` and report a local gateway as healthy only when both the process and gateway port are present.
- Increase the tar listing `spawnSync` buffer used by path validation and hard-link rejection.
- Add regression coverage for the local gateway doctor fallback and for large hard-link validation archives.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics: improved gateway checks — when container inspection fails, doctor probes the local gateway process/port, adjusts results based on available evidence and probe-tool availability, and more reliably captures host command outcomes.
  * Reliability: safer handling of very large tar archives by constraining command output buffering during archive inspection.

* **Tests**
  * Added integration and regression tests covering gateway fallback behaviors and large-tar scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->