### PR TITLE
test(cli): trim remaining subprocess waits

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -230,6 +230,7 @@ function runSandboxConnectProbe(sandboxName: string): void {
 
 function sleepSync(ms: number): void {
   if (ms <= 0) return;
+  if (process.env.VITEST === "true" || process.env.NEMOCLAW_TEST_NO_SLEEP === "1") return;
   spawnSync(process.execPath, ["-e", `setTimeout(() => {}, ${ms})`], {
     stdio: "ignore",
     timeout: ms + 1_000,

--- a/test/sandbox-stuck-recovery.test.ts
+++ b/test/sandbox-stuck-recovery.test.ts
@@ -146,11 +146,10 @@ describe("sandbox stuck in non-Ready phase (#2016)", () => {
     () => {
       const { tmpDir, sandboxName } = setupFixture("stuck-sandbox", "Provisioning");
 
-      // Short connect timeout so the test doesn't wait 120s. Provisioning
-      // is not a terminal state, so the readiness poll introduced in #466
-      // waits until NEMOCLAW_CONNECT_TIMEOUT elapses.
+      // Use the shortest accepted whole-second timeout so this still exercises
+      // the non-terminal readiness wait without adding avoidable wall time.
       const result = runCli(tmpDir, sandboxName, "connect", {
-        NEMOCLAW_CONNECT_TIMEOUT: "3",
+        NEMOCLAW_CONNECT_TIMEOUT: "1",
       });
       expect(result.status).not.toBe(0);
 


### PR DESCRIPTION
## Summary
This PR trims the next slow subprocess-heavy CLI target after #4913 by removing avoidable test-time waits from sandbox connect route repair and the stuck-sandbox timeout fixture. In the profiled six-file slow bucket, wall-clock runtime dropped from 28.07s to 12.14s locally.

## Related Issue
Part of #4892

## Changes
- Skip `sleepSync` route-repair backoff waits when CLI subprocesses run under Vitest or `NEMOCLAW_TEST_NO_SLEEP=1`, matching the existing inference probe test-wait convention.
- Keep the route-repair production retry contract intact; the unit tests still assert the real 3-attempt, 2s-delay probe options.
- Reduce the stuck Provisioning subprocess fixture from a 3s connect timeout to the shortest accepted 1s timeout.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution performance by skipping sleep operations during test runs.
  * Reduced test execution time for sandbox connectivity validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->