### PR TITLE
test(cli): trim logs subprocess coverage

### DIFF
--- a/src/commands/sandbox/logs.test.ts
+++ b/src/commands/sandbox/logs.test.ts
@@ -64,6 +64,16 @@ describe("SandboxLogsCommand", () => {
     expect(showSandboxLogs).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { args: ["alpha", "--tail"], pattern: /tail/i },
+    { args: ["alpha", "-n", "foo"], pattern: /integer|tail/i },
+    { args: ["alpha", "--since"], pattern: /since/i },
+  ])("rejects malformed logs flags %# before running the logs action", async ({ args, pattern }) => {
+    await expect(SandboxLogsCommand.run(args, rootDir)).rejects.toThrow(pattern);
+
+    expect(showSandboxLogs).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed since values before running the logs action", async () => {
     await expect(SandboxLogsCommand.run(["alpha", "--since", "someday"], rootDir)).rejects.toThrow(
       /since requires a positive duration/,

--- a/src/commands/sandbox/logs.test.ts
+++ b/src/commands/sandbox/logs.test.ts
@@ -55,4 +55,20 @@ describe("SandboxLogsCommand", () => {
       since: null,
     });
   });
+
+  it("rejects invalid tail values before running the logs action", async () => {
+    await expect(SandboxLogsCommand.run(["alpha", "--tail", "0"], rootDir)).rejects.toThrow(
+      /tail/i,
+    );
+
+    expect(showSandboxLogs).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed since values before running the logs action", async () => {
+    await expect(SandboxLogsCommand.run(["alpha", "--since", "someday"], rootDir)).rejects.toThrow(
+      /since requires a positive duration/,
+    );
+
+    expect(showSandboxLogs).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/actions/sandbox/logs.test.ts
+++ b/src/lib/actions/sandbox/logs.test.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import type { LogProbeResult } from "../../domain/sandbox/logs";
+import { showSandboxLogsWithDeps } from "./logs";
+
+vi.mock("../../runner", () => ({ ROOT: process.cwd() }));
+
+class ExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+type CapturedLogsRun = {
+  calls: { args: string[]; options: Record<string, unknown> }[];
+  errors: string[];
+  exitCode: number | null;
+  stdout: string;
+};
+
+function captureLogsRun(
+  options: Parameters<typeof showSandboxLogsWithDeps>[1],
+  results: Record<string, LogProbeResult>,
+  overrides: Partial<Parameters<typeof showSandboxLogsWithDeps>[2]> = {},
+): CapturedLogsRun {
+  const calls: CapturedLogsRun["calls"] = [];
+  const stdout: string[] = [];
+  const errors: string[] = [];
+  let exitCode: number | null = null;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    errors.push(args.map(String).join(" "));
+  });
+
+  const runOpenshell = vi.fn((args: string[], callOptions = {}) => {
+    calls.push({ args, options: callOptions as Record<string, unknown> });
+    return results[args[0]] ?? { status: 0 };
+  });
+
+  try {
+    showSandboxLogsWithDeps("alpha", options, {
+      exit: (code) => {
+        exitCode = code;
+        throw new ExitError(code);
+      },
+      isDockerRuntimeDown: () => false,
+      runOpenshell,
+      writeStdout: (chunk) => stdout.push(chunk),
+      ...overrides,
+    });
+  } catch (error) {
+    if (!(error instanceof ExitError)) throw error;
+  } finally {
+    errorSpy.mockRestore();
+  }
+
+  return { calls, errors, exitCode, stdout: stdout.join("") };
+}
+
+describe("showSandboxLogsWithDeps", () => {
+  it("enables audit logs, reads both log sources, and writes merged output", () => {
+    const result = captureLogsRun(
+      { follow: false, lines: "50", since: null },
+      {
+        settings: { status: 0 },
+        sandbox: { status: 0, stdout: "[1] gateway\n" },
+        logs: { status: 0, stdout: "[2] openshell\n" },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("[1] gateway\n[2] openshell\n");
+    expect(result.calls.map((call) => call.args)).toEqual([
+      ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
+      ["sandbox", "exec", "-n", "alpha", "--", "tail", "-n", "50", "/tmp/gateway.log"],
+      ["logs", "alpha", "-n", "50", "--source", "all"],
+    ]);
+  });
+
+  it("skips the OpenClaw gateway tail when --since targets OpenShell logs", () => {
+    const result = captureLogsRun(
+      { follow: false, lines: "200", since: "5m" },
+      {
+        settings: { status: 0 },
+        logs: { status: 0, stdout: "[3] openshell only\n" },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("[3] openshell only\n");
+    expect(result.calls.map((call) => call.args)).toEqual([
+      ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
+      ["logs", "alpha", "-n", "200", "--source", "all", "--since", "5m"],
+    ]);
+  });
+
+  it("warns about degraded audit and OpenClaw sources while continuing to OpenShell logs", () => {
+    const timeout = new Error("spawn openshell ETIMEDOUT");
+    const result = captureLogsRun(
+      { follow: false, lines: "200", since: null },
+      {
+        settings: { status: 7, stderr: "settings unavailable\n" },
+        sandbox: { status: null, error: timeout },
+        logs: { status: 0, stdout: "[4] openshell fallback\n" },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("[4] openshell fallback\n");
+    expect(result.errors.join("\n")).toContain(
+      "failed to enable OpenShell audit logs for sandbox 'alpha' (exit 7)",
+    );
+    expect(result.errors.join("\n")).toContain("settings unavailable");
+    expect(result.errors.join("\n")).toContain("Policy denial events may be missing");
+    expect(result.errors.join("\n")).toContain(
+      "OpenClaw log source unavailable (spawn openshell ETIMEDOUT)",
+    );
+  });
+
+  it("prints Docker outage guidance and exits before OpenShell log probes", () => {
+    const guidance = vi.fn();
+    const result = captureLogsRun(
+      { follow: false, lines: "200", since: null },
+      {},
+      {
+        isDockerRuntimeDown: () => true,
+        printDockerRuntimeDownGuidance: guidance,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(guidance).toHaveBeenCalledWith("alpha", { retryCommand: "logs" });
+    expect(result.calls).toEqual([]);
+  });
+});

--- a/src/lib/actions/sandbox/logs.test.ts
+++ b/src/lib/actions/sandbox/logs.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import type { LogProbeResult } from "../../domain/sandbox/logs";
 import { showSandboxLogsWithDeps } from "./logs";
@@ -17,8 +18,42 @@ type CapturedLogsRun = {
   calls: { args: string[]; options: Record<string, unknown> }[];
   errors: string[];
   exitCode: number | null;
+  spawns: { command: string; args: string[]; options: Record<string, unknown> }[];
   stdout: string;
 };
+
+type SandboxLogsDeps = NonNullable<Parameters<typeof showSandboxLogsWithDeps>[2]>;
+type SpawnFn = NonNullable<SandboxLogsDeps["spawn"]>;
+
+function createExitedChild(): ReturnType<SpawnFn> {
+  const child = new EventEmitter() as ReturnType<SpawnFn>;
+  Object.assign(child, {
+    killed: false,
+    exitCode: null,
+    signalCode: null,
+    kill: vi.fn(() => true),
+  });
+  const originalOn = child.on.bind(child);
+  child.on = ((eventName: string, listener: (...args: unknown[]) => void) => {
+    originalOn(eventName, listener);
+    if (eventName === "exit") {
+      listener(0, null);
+    }
+    return child;
+  }) as typeof child.on;
+  return child;
+}
+
+function restoreProcessSignalListeners(
+  signal: NodeJS.Signals,
+  before: NodeJS.SignalsListener[],
+): void {
+  for (const listener of process.listeners(signal)) {
+    if (!before.includes(listener as NodeJS.SignalsListener)) {
+      process.removeListener(signal, listener);
+    }
+  }
+}
 
 function captureLogsRun(
   options: Parameters<typeof showSandboxLogsWithDeps>[1],
@@ -26,9 +61,12 @@ function captureLogsRun(
   overrides: Partial<Parameters<typeof showSandboxLogsWithDeps>[2]> = {},
 ): CapturedLogsRun {
   const calls: CapturedLogsRun["calls"] = [];
+  const spawns: CapturedLogsRun["spawns"] = [];
   const stdout: string[] = [];
   const errors: string[] = [];
   let exitCode: number | null = null;
+  const sigintListeners = process.listeners("SIGINT") as NodeJS.SignalsListener[];
+  const sigtermListeners = process.listeners("SIGTERM") as NodeJS.SignalsListener[];
   const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
     errors.push(args.map(String).join(" "));
   });
@@ -37,6 +75,14 @@ function captureLogsRun(
     calls.push({ args, options: callOptions as Record<string, unknown> });
     return results[args[0]] ?? { status: 0 };
   });
+  const spawn = ((command: string, args: readonly string[], callOptions = {}) => {
+    spawns.push({
+      command,
+      args: [...args],
+      options: callOptions as Record<string, unknown>,
+    });
+    return createExitedChild();
+  }) as unknown as SpawnFn;
 
   try {
     showSandboxLogsWithDeps("alpha", options, {
@@ -45,7 +91,9 @@ function captureLogsRun(
         throw new ExitError(code);
       },
       isDockerRuntimeDown: () => false,
+      getOpenshellBinary: () => "openshell",
       runOpenshell,
+      spawn,
       writeStdout: (chunk) => stdout.push(chunk),
       ...overrides,
     });
@@ -53,9 +101,11 @@ function captureLogsRun(
     if (!(error instanceof ExitError)) throw error;
   } finally {
     errorSpy.mockRestore();
+    restoreProcessSignalListeners("SIGINT", sigintListeners);
+    restoreProcessSignalListeners("SIGTERM", sigtermListeners);
   }
 
-  return { calls, errors, exitCode, stdout: stdout.join("") };
+  return { calls, errors, exitCode, spawns, stdout: stdout.join("") };
 }
 
 describe("showSandboxLogsWithDeps", () => {
@@ -92,6 +142,42 @@ describe("showSandboxLogsWithDeps", () => {
     expect(result.calls.map((call) => call.args)).toEqual([
       ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
       ["logs", "alpha", "-n", "200", "--source", "all", "--since", "5m"],
+    ]);
+  });
+
+  it("streams follow logs with the requested tail count", () => {
+    const result = captureLogsRun(
+      { follow: true, lines: "50", since: null },
+      {
+        settings: { status: 0 },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.calls.map((call) => call.args)).toEqual([
+      ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
+    ]);
+    expect(result.spawns.map((call) => call.command)).toEqual(["openshell", "openshell"]);
+    expect(result.spawns.map((call) => call.args)).toEqual([
+      ["sandbox", "exec", "-n", "alpha", "--", "tail", "-n", "50", "-f", "/tmp/gateway.log"],
+      ["logs", "alpha", "-n", "50", "--source", "all", "--tail"],
+    ]);
+  });
+
+  it("streams follow logs with --since through OpenShell without an unfiltered gateway tail", () => {
+    const result = captureLogsRun(
+      { follow: true, lines: "200", since: "5m" },
+      {
+        settings: { status: 0 },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.calls.map((call) => call.args)).toEqual([
+      ["settings", "set", "alpha", "--key", "ocsf_json_enabled", "--value", "true"],
+    ]);
+    expect(result.spawns.map((call) => call.args)).toEqual([
+      ["logs", "alpha", "-n", "200", "--source", "all", "--since", "5m", "--tail"],
     ]);
   });
 

--- a/src/lib/actions/sandbox/logs.ts
+++ b/src/lib/actions/sandbox/logs.ts
@@ -21,22 +21,40 @@ import {
   printDockerRuntimeDownGuidance,
 } from "./gateway-failure-classifier";
 
-function exitWithSpawnResult(result: LogProbeResult) {
+type RunOpenshellOptions = Parameters<typeof runOpenshell>[1];
+type RunOpenshellFn = (args: string[], options?: RunOpenshellOptions) => LogProbeResult;
+type SpawnFn = typeof spawn;
+type ExitFn = (code: number) => never;
+
+export type SandboxLogsRuntimeDeps = {
+  env?: NodeJS.ProcessEnv;
+  exit?: ExitFn;
+  getOpenshellBinary?: typeof getOpenshellBinary;
+  isDockerRuntimeDown?: typeof isDockerRuntimeDown;
+  printDockerRuntimeDownGuidance?: typeof printDockerRuntimeDownGuidance;
+  runOpenshell?: RunOpenshellFn;
+  spawn?: SpawnFn;
+  writeStdout?: (chunk: string) => void;
+};
+
+function exitWithSpawnResult(result: LogProbeResult, deps: SandboxLogsRuntimeDeps) {
+  const exit = deps.exit ?? process.exit;
   if (result.status !== null) {
-    process.exit(result.status);
+    exit(result.status);
   }
 
-  process.exit(exitCodeFromSignal(result.signal ?? null));
+  exit(exitCodeFromSignal(result.signal ?? null));
 }
 
 function runOpenclawGatewayLogs(
   sandboxName: string,
   options: SandboxLogsOptions,
+  deps: SandboxLogsRuntimeDeps,
 ): LogProbeResult {
   const args = buildSandboxOpenclawGatewayLogsArgs(sandboxName, options);
   // Capture stdout so the caller can merge with the OpenShell source
   // (closes #4100). stderr still inherits so warnings print directly.
-  const result = runOpenshell(args, {
+  const result = (deps.runOpenshell ?? runOpenshell)(args, {
     stdio: ["ignore", "pipe", "inherit"],
     ignoreError: true,
     timeout: getLogsProbeTimeoutMs(),
@@ -50,14 +68,19 @@ function runOpenclawGatewayLogs(
   return result;
 }
 
-function streamSandboxFollowLogs(sandboxName: string, options: SandboxLogsOptions): void {
+function streamSandboxFollowLogs(
+  sandboxName: string,
+  options: SandboxLogsOptions,
+  deps: SandboxLogsRuntimeDeps,
+): void {
   const openclawArgs = options.since
     ? null
     : buildSandboxOpenclawGatewayLogsArgs(sandboxName, options);
   const openshellArgs = buildSandboxLogsArgs(sandboxName, options);
+  const exit = deps.exit ?? process.exit;
   const spawnOptions = {
     cwd: ROOT,
-    env: process.env,
+    env: deps.env ?? process.env,
     stdio: "inherit" as const,
   };
   const sources: Array<{
@@ -88,7 +111,7 @@ function streamSandboxFollowLogs(sandboxName: string, options: SandboxLogsOption
       clearTimeout(forcedExitTimer);
       forcedExitTimer = null;
     }
-    process.exit(requestedExitCode ?? finalStatus);
+    exit(requestedExitCode ?? finalStatus);
   };
   const markSourceDone = (
     source: (typeof sources)[number],
@@ -112,7 +135,7 @@ function streamSandboxFollowLogs(sandboxName: string, options: SandboxLogsOption
     exiting = true;
     requestedExitCode = exitCode;
     stopChildren(signal);
-    forcedExitTimer = setTimeout(() => process.exit(exitCode), 2000);
+    forcedExitTimer = setTimeout(() => exit(exitCode), 2000);
     forcedExitTimer.unref?.();
     maybeExit();
   };
@@ -125,10 +148,12 @@ function streamSandboxFollowLogs(sandboxName: string, options: SandboxLogsOption
   });
 
   const addSource = (label: string, args: string[]) => {
+    const spawnProcess = deps.spawn ?? spawn;
+    const openshellBinary = (deps.getOpenshellBinary ?? getOpenshellBinary)();
     const source = {
       label,
       args,
-      child: spawn(getOpenshellBinary(), args, spawnOptions),
+      child: spawnProcess(openshellBinary, args, spawnOptions),
       done: false,
     };
     sources.push(source);
@@ -143,15 +168,15 @@ function streamSandboxFollowLogs(sandboxName: string, options: SandboxLogsOption
   if (openclawArgs) {
     addSource("OpenClaw log source", openclawArgs);
   }
-  enableSandboxAuditLogs(sandboxName);
+  enableSandboxAuditLogs(sandboxName, deps);
   addSource("OpenShell log source", openshellArgs);
   setupComplete = true;
   maybeExit();
 }
 
-function enableSandboxAuditLogs(sandboxName: string) {
+function enableSandboxAuditLogs(sandboxName: string, deps: SandboxLogsRuntimeDeps) {
   const args = buildEnableSandboxAuditLogsArgs(sandboxName);
-  const result = runOpenshell(args, {
+  const result = (deps.runOpenshell ?? runOpenshell)(args, {
     stdio: ["ignore", "ignore", "pipe"],
     ignoreError: true,
     timeout: getLogsProbeTimeoutMs(),
@@ -178,6 +203,14 @@ function warnSandboxAuditLogsUnavailable(
 }
 
 export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions | boolean) {
+  showSandboxLogsWithDeps(sandboxName, options);
+}
+
+export function showSandboxLogsWithDeps(
+  sandboxName: string,
+  options: SandboxLogsOptions | boolean,
+  deps: SandboxLogsRuntimeDeps = {},
+) {
   // Normalize/validate options before any host I/O so malformed flags still
   // surface their own error rather than a Docker-outage message.
   const logsOptions = normalizeSandboxLogsOptions(options);
@@ -185,28 +218,30 @@ export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions
   // Preflight the Docker daemon so a host runtime outage is named as such
   // instead of surfacing as opaque "log source unavailable" failures from the
   // underlying OpenShell commands (#4428).
-  if (isDockerRuntimeDown(sandboxName)) {
-    printDockerRuntimeDownGuidance(sandboxName, { retryCommand: "logs" });
-    process.exit(1);
+  if ((deps.isDockerRuntimeDown ?? isDockerRuntimeDown)(sandboxName)) {
+    (deps.printDockerRuntimeDownGuidance ?? printDockerRuntimeDownGuidance)(sandboxName, {
+      retryCommand: "logs",
+    });
+    (deps.exit ?? process.exit)(1);
   }
 
   if (logsOptions.follow) {
-    streamSandboxFollowLogs(sandboxName, logsOptions);
+    streamSandboxFollowLogs(sandboxName, logsOptions, deps);
     return;
   }
 
-  enableSandboxAuditLogs(sandboxName);
+  enableSandboxAuditLogs(sandboxName, deps);
 
   // Capture stdout from both sources so --tail N can be applied once
   // to the merged stream rather than independently per source
   // (which previously returned up to 2*N lines). Closes #4100.
   let gatewayResult: LogProbeResult | null = null;
   if (!logsOptions.since) {
-    gatewayResult = runOpenclawGatewayLogs(sandboxName, logsOptions);
+    gatewayResult = runOpenclawGatewayLogs(sandboxName, logsOptions, deps);
   }
 
   const openshellArgs = buildSandboxLogsArgs(sandboxName, logsOptions);
-  const openshellResult = runOpenshell(openshellArgs, {
+  const openshellResult = (deps.runOpenshell ?? runOpenshell)(openshellArgs, {
     stdio: ["ignore", "pipe", "inherit"],
     ignoreError: true,
   });
@@ -218,7 +253,7 @@ export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions
   if (openshellResult.stdout) sources.push(String(openshellResult.stdout));
   const merged = mergeTailLogLines(sources, maxLines);
   if (merged) {
-    process.stdout.write(merged);
+    (deps.writeStdout ?? process.stdout.write.bind(process.stdout))(merged);
   }
 
   if (openshellResult.status !== 0) {
@@ -226,5 +261,5 @@ export function showSandboxLogs(sandboxName: string, options: SandboxLogsOptions
       `  Command failed (exit ${openshellResult.status}): openshell ${openshellArgs.join(" ")}`,
     );
   }
-  exitWithSpawnResult(openshellResult);
+  exitWithSpawnResult(openshellResult, deps);
 }

--- a/test/cli/logs.test.ts
+++ b/test/cli/logs.test.ts
@@ -62,7 +62,6 @@ describe("CLI dispatch", () => {
     const setup = createLogsTestSetup("nemoclaw-cli-logs-openclaw-timeout-", [
       'if [ "$1" = "sandbox" ]; then',
       "  while true; do :; done",
-      "  exit 0",
       "fi",
     ]);
 

--- a/test/cli/logs.test.ts
+++ b/test/cli/logs.test.ts
@@ -13,7 +13,6 @@ import {
   FAKE_OPENSHELL_LOG_LINE,
   createLogsTestSetup,
   isChildRunning,
-  readRecordedArgs,
   runWithEnv,
   testTimeout,
   testTimeoutOptions,
@@ -50,86 +49,6 @@ describe("CLI dispatch", () => {
     expect(setup.readCalls()).toEqual([]);
   });
 
-  it("passes --tail line count to both log sources", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-tail-");
-    const r = setup.runLogs("alpha logs --tail 50");
-
-    const calls = setup.readCalls();
-    expect(r.code).toBe(0);
-    expect(calls).toEqual([
-      "settings set alpha --key ocsf_json_enabled --value true",
-      "sandbox exec -n alpha -- tail -n 50 /tmp/gateway.log",
-      "logs alpha -n 50 --source all",
-    ]);
-  });
-
-  it("passes -n line count to both log sources", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-n-");
-    const r = setup.runLogs("alpha logs -n 25");
-
-    const calls = setup.readCalls();
-    expect(r.code).toBe(0);
-    expect(calls).toEqual([
-      "settings set alpha --key ocsf_json_enabled --value true",
-      "sandbox exec -n alpha -- tail -n 25 /tmp/gateway.log",
-      "logs alpha -n 25 --source all",
-    ]);
-  });
-
-  it("passes --follow --tail line count to both streaming log sources", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-follow-tail-");
-    const r = setup.runLogs("alpha logs --follow --tail 50");
-
-    const calls = setup.readCalls();
-    expect(r.code).toBe(0);
-    expect(calls).toContain("settings set alpha --key ocsf_json_enabled --value true");
-    expect(calls).toContain("sandbox exec -n alpha -- tail -n 50 -f /tmp/gateway.log");
-    expect(calls).toContain("logs alpha -n 50 --source all --tail");
-  });
-
-  it("passes --since to OpenShell logs without an unfiltered gateway tail", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-since-");
-    const r = setup.runLogs("alpha logs --since 5m");
-
-    const calls = setup.readCalls();
-    expect(r.code).toBe(0);
-    expect(calls).toEqual([
-      "settings set alpha --key ocsf_json_enabled --value true",
-      "logs alpha -n 200 --source all --since 5m",
-    ]);
-    expect(calls.some((call) => call.startsWith("sandbox exec -n alpha"))).toBe(false);
-  });
-
-  it("passes --follow --since to OpenShell logs without an unfiltered gateway tail", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-since-follow-");
-    const r = setup.runLogs("alpha logs --follow --since 5m");
-
-    const calls = setup.readCalls();
-    expect(r.code).toBe(0);
-    expect(calls).toContain("settings set alpha --key ocsf_json_enabled --value true");
-    expect(calls).toContain("logs alpha -n 200 --source all --since 5m --tail");
-    expect(calls.some((call) => call.startsWith("sandbox exec -n alpha"))).toBe(false);
-  });
-
-  it("rejects malformed logs flags before calling OpenShell", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-malformed-");
-    const missingTail = setup.runLogs("alpha logs --tail 2>&1");
-    const zeroTail = setup.runLogs("alpha logs --tail 0 2>&1");
-    const nonNumericTail = setup.runLogs("alpha logs -n foo 2>&1");
-    const missingSince = setup.runLogs("alpha logs --since 2>&1");
-    const malformedSince = setup.runLogs("alpha logs --since someday 2>&1");
-
-    for (const result of [missingTail, zeroTail, nonNumericTail, missingSince, malformedSince]) {
-      expect(result.code).not.toBe(0);
-    }
-    expect(missingTail.out).toContain("--tail");
-    expect(zeroTail.out).toContain("--tail");
-    expect(nonNumericTail.out).toContain("Expected an integer");
-    expect(missingSince.out).toContain("--since");
-    expect(malformedSince.out).toContain("--since requires a positive duration");
-    expect(setup.readCalls()).toEqual([]);
-  });
-
   it("rejects unknown logs flags before calling OpenShell", () => {
     const setup = createLogsTestSetup("nemoclaw-cli-logs-unknown-");
     const r = setup.runLogs("alpha logs --bogus 2>&1");
@@ -139,60 +58,15 @@ describe("CLI dispatch", () => {
     expect(setup.readCalls()).toEqual([]);
   });
 
-  it("enables OpenShell audit events before reading logs", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-audit-");
-    const r = setup.runLogs();
-
-    const calls = setup.readCalls();
-    expect(r.code).toBe(0);
-    expect(calls[0]).toBe("settings set alpha --key ocsf_json_enabled --value true");
-    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
-  });
-
-  it("warns when OpenShell audit events cannot be enabled", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-audit-failed-", [
-      'if [ "$1" = "settings" ]; then',
-      "  echo 'settings unavailable' >&2",
-      "  exit 7",
-      "fi",
-    ]);
-
-    const r = setup.runLogs("alpha logs 2>&1");
-
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("failed to enable OpenShell audit logs for sandbox 'alpha'");
-    expect(r.out).toContain("openshell settings set alpha --key ocsf_json_enabled --value true");
-    expect(r.out).toContain("settings unavailable");
-    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
-    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
-  });
-
-  it("continues log collection when audit enable times out", () => {
-    const setup = createLogsTestSetup("nemoclaw-cli-logs-audit-timeout-", [
-      'if [ "$1" = "settings" ]; then',
-      "  sleep 5",
-      "  exit 0",
-      "fi",
-    ]);
-
-    const r = setup.runLogs("alpha logs 2>&1", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "1500" });
-
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("failed to enable OpenShell audit logs for sandbox 'alpha'");
-    expect(r.out).toContain("ETIMEDOUT");
-    expect(r.out).toContain(FAKE_OPENCLAW_LOG_LINE);
-    expect(r.out).toContain(FAKE_OPENSHELL_LOG_LINE);
-  });
-
   it("continues to OpenShell logs when the OpenClaw gateway log probe times out", () => {
     const setup = createLogsTestSetup("nemoclaw-cli-logs-openclaw-timeout-", [
       'if [ "$1" = "sandbox" ]; then',
-      "  sleep 2",
+      "  while true; do :; done",
       "  exit 0",
       "fi",
     ]);
 
-    const r = setup.runLogs("alpha logs 2>&1", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "500" });
+    const r = setup.runLogs("alpha logs 2>&1", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "50" });
 
     expect(r.code).toBe(0);
     expect(r.out).toContain("OpenClaw log source unavailable");
@@ -220,7 +94,7 @@ describe("CLI dispatch", () => {
       "nemoclaw-cli-logs-follow-audit-slow-",
       [
         'if [ "$1" = "settings" ]; then',
-        "  sleep 1",
+        "  sleep 0.05",
         `  printf '%s\\n' ${JSON.stringify(auditCompleteMarker)} >> "$marker_file"`,
         "  exit 0",
         "fi",
@@ -232,7 +106,7 @@ describe("CLI dispatch", () => {
     const r = setup.runLogs("alpha logs --follow", { NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "2000" });
     const calls = setup.readCalls();
 
-    expect(Date.now() - start).toBeGreaterThanOrEqual(900);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40);
     expect(r.code).toBe(0);
     // All three calls must happen: OpenClaw log stream, audit enable, OpenShell log stream.
     expect(calls).toContain("sandbox exec -n alpha -- tail -n 200 -f /tmp/gateway.log");
@@ -481,52 +355,6 @@ describe("CLI dispatch", () => {
     );
     expect(log).toContain("sandbox exec -n alpha -- sh -c tail -n 10 /tmp/gateway.log 2>/dev/null");
     expect(log).not.toContain("sandbox exec alpha sh -c");
-  });
-
-  it("passes plain logs through without the tail flag", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-logs-plain-"));
-    const localBin = path.join(home, "bin");
-    const registryDir = path.join(home, ".nemoclaw");
-    const markerFile = path.join(home, "logs-plain-args");
-    fs.mkdirSync(localBin, { recursive: true });
-    fs.mkdirSync(registryDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(registryDir, "sandboxes.json"),
-      JSON.stringify({
-        sandboxes: {
-          alpha: {
-            name: "alpha",
-            model: "test-model",
-            provider: "nvidia-prod",
-            gpuEnabled: false,
-            policies: [],
-          },
-        },
-        defaultSandbox: "alpha",
-      }),
-      { mode: 0o600 },
-    );
-    fs.writeFileSync(
-      path.join(localBin, "openshell"),
-      [
-        "#!/usr/bin/env bash",
-        `marker_file=${JSON.stringify(markerFile)}`,
-        'printf \'%s \' "$@" > "$marker_file"',
-        "exit 0",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
-    writeHealthyDockerStub(localBin);
-
-    const r = runWithEnv("alpha logs", {
-      HOME: home,
-      PATH: `${localBin}:${process.env.PATH || ""}`,
-    });
-
-    expect(r.code).toBe(0);
-    const recordedArgs = readRecordedArgs(markerFile);
-    expect(recordedArgs).toEqual(["logs", "alpha", "-n", "200", "--source", "all"]);
-    expect(recordedArgs).not.toContain("--tail");
   });
 
   it("preserves SIGINT exit semantics for logs --follow", () => {


### PR DESCRIPTION
## Summary
This PR targets the next slow CLI runtime bucket from #4892 by moving non-follow sandbox logs coverage out of subprocess-heavy CLI tests and into fast action/command unit tests. The public logs CLI smoke and follow/signal tests stay in `test/cli/logs.test.ts`, while source selection, audit setup, degraded-source behavior, merged output, and Docker outage handling are covered through injected dependencies.

## Related Issue
Part of #4892

## Changes
- Add `showSandboxLogsWithDeps` so sandbox logs behavior can be tested with fake OpenShell, Docker, stdout, and exit dependencies.
- Add action-level logs tests for audit setup, source selection, degraded source warnings, merged output, and Docker outage short-circuiting.
- Move malformed `--tail` and `--since` parser coverage into `src/commands/sandbox/logs.test.ts`.
- Trim `test/cli/logs.test.ts` from 20 subprocess tests to 10 runtime smokes and shorten the remaining timeout/order waits.
- Local profile: `test/cli/logs.test.ts` moved from 17.95s / 20 tests to 5.66s / 10 tests; the focused 10-file hot set moved from 14.95s to 12.85s wall-clock.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for sandbox logs, including input validation and log orchestration scenarios
  * Optimized test execution performance

* **Chores**
  * Refactored sandbox logs implementation to improve testability through dependency injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->