### PR TITLE
fix(e2e): write config capture to fd 3, bypassing tee race

### DIFF
--- a/test/e2e/test-runtime-overrides.sh
+++ b/test/e2e/test-runtime-overrides.sh
@@ -48,10 +48,17 @@ info "Logging Docker stderr to: $LOG_FILE"
 # The entrypoint patches config and starts the gateway — we only need the
 # config patch, so we override CMD to just cat the config and exit.
 # Docker stderr is captured to the log file for CI artifact visibility.
+#
+# The entrypoint redirects stdout through a `tee` process substitution
+# (exec > >(tee …)), which can race with container teardown: when PID 1
+# exits quickly (baseline, no overrides), Docker may SIGTERM the tee
+# process before it flushes to fd 3 (the real Docker stdout). Writing
+# directly to fd 3 bypasses the tee pipe entirely, making the capture
+# deterministic regardless of container lifetime.
 run_override() {
   local env_args=("$@")
   docker run --rm "${env_args[@]}" "$IMAGE" \
-    bash -c 'cat /sandbox/.openclaw/openclaw.json; printf "\n"' 2>>"$LOG_FILE"
+    bash -c 'cat /sandbox/.openclaw/openclaw.json >&3; printf "\n" >&3' 2>>"$LOG_FILE"
 }
 
 # Helper: run entrypoint with env vars and capture stderr for validation messages.


### PR DESCRIPTION
## Summary

Fixes an intermittent failure in the `runtime-overrides-e2e` nightly job where the baseline config capture returns empty, causing Test 6 (`CORS origin`) and Test 14 (`config unchanged after rejected override`) to fail.

## Root Cause

The sandbox entrypoint (`scripts/nemoclaw-start.sh`) redirects stdout through a `tee` process substitution:

```bash
exec 3>&1
exec > >(tee -a "$_START_LOG" >&3)
```

When PID 1 exits quickly — as in the baseline case with no overrides — Docker may `SIGTERM` the `tee` subprocess before it flushes its buffer to fd 3 (the real Docker stdout pipe). This race condition leaves `$BASELINE` empty in the test harness, which cascades into:

- **Test 6**: `[: : integer expression expected` — `$BASELINE_ORIGINS` is empty, used in an arithmetic comparison
- **Test 14**: Empty-string comparison — `$BASELINE_MODEL` and `$BASELINE_CTX` are empty

Override-bearing containers survive because the entrypoint does more work (apply patches, recompute hashes), giving the `tee` process enough time to flush before exit.

## Fix

Modify `run_override()` to write directly to fd 3 inside the container, bypassing the `tee` pipe entirely:

```bash
bash -c 'cat /sandbox/.openclaw/openclaw.json >&3; printf "\n" >&3'
```

This makes the capture deterministic regardless of container lifetime.

## Evidence

- **Failing run**: [nightly-e2e #27109353827](https://github.com/NVIDIA/NemoClaw/actions/runs/27109353827) (job `runtime-overrides-e2e`, id 80004075918)
- **Passing run (previous night)**: commit `8d9c573` — no relevant code changes between passing and failing runs
- All baseline jq extractions return empty strings; override tests (2–5, 7–13) pass consistently
- No stdout-polluting code found in the entrypoint path for the baseline (no-override) case

## Test Plan

- [ ] Verify `bash -n test/e2e/test-runtime-overrides.sh` passes (syntax check)
- [ ] Run `test-runtime-overrides.sh` locally with Docker — all 14 tests should pass
- [ ] Confirm baseline capture returns valid JSON on repeated runs (stress: 10×)

Refs: nightly-e2e run 27109353827

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #4926