### PR TITLE
test(cli): table-drive utility specs

### DIFF
--- a/src/lib/core/errno.test.ts
+++ b/src/lib/core/errno.test.ts
@@ -5,46 +5,30 @@ import { describe, it, expect } from "vitest";
 import { isErrnoException, isPermissionError } from "./errno";
 
 describe("isErrnoException", () => {
-  it("returns true for Error with code property", () => {
-    const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-    expect(isErrnoException(err)).toBe(true);
+  it.each([
+    [
+      "Error with code property",
+      () => Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    ],
+    ["plain object with code property", () => ({ code: "EACCES" })],
+    ["object with errno property", () => ({ errno: -2 })],
+    [
+      "Error with both code and errno",
+      () => Object.assign(new Error("fail"), { code: "ENOENT", errno: -2 }),
+    ],
+  ] as const)("returns true for %s", (_label, createValue) => {
+    expect(isErrnoException(createValue())).toBe(true);
   });
 
-  it("returns true for plain object with code property", () => {
-    expect(isErrnoException({ code: "EACCES" })).toBe(true);
-  });
-
-  it("returns true for object with errno property", () => {
-    expect(isErrnoException({ errno: -2 })).toBe(true);
-  });
-
-  it("returns true for Error with both code and errno", () => {
-    const err = Object.assign(new Error("fail"), { code: "ENOENT", errno: -2 });
-    expect(isErrnoException(err)).toBe(true);
-  });
-
-  it("returns false for null", () => {
-    expect(isErrnoException(null)).toBe(false);
-  });
-
-  it("returns false for undefined", () => {
-    expect(isErrnoException(undefined)).toBe(false);
-  });
-
-  it("returns false for a string", () => {
-    expect(isErrnoException("ENOENT")).toBe(false);
-  });
-
-  it("returns false for a number", () => {
-    expect(isErrnoException(42)).toBe(false);
-  });
-
-  it("returns false for a plain Error without code/errno", () => {
-    expect(isErrnoException(new Error("oops"))).toBe(false);
-  });
-
-  it("returns false for an empty object", () => {
-    expect(isErrnoException({})).toBe(false);
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "ENOENT"],
+    ["a number", 42],
+    ["a plain Error without code/errno", new Error("oops")],
+    ["an empty object", {}],
+  ] as const)("returns false for %s", (_label, value) => {
+    expect(isErrnoException(value)).toBe(false);
   });
 
   it("narrows the type so .code is accessible", () => {
@@ -59,24 +43,18 @@ describe("isErrnoException", () => {
 });
 
 describe("isPermissionError", () => {
-  it("returns true for EACCES", () => {
-    const err = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    expect(isPermissionError(err)).toBe(true);
-  });
-
-  it("returns true for EPERM", () => {
-    const err = Object.assign(new Error("not permitted"), { code: "EPERM" });
-    expect(isPermissionError(err)).toBe(true);
-  });
-
-  it("returns false for ENOENT", () => {
-    const err = Object.assign(new Error("not found"), { code: "ENOENT" });
-    expect(isPermissionError(err)).toBe(false);
-  });
-
-  it("returns false for non-errno values", () => {
-    expect(isPermissionError(null)).toBe(false);
-    expect(isPermissionError("EACCES")).toBe(false);
-    expect(isPermissionError(new Error("oops"))).toBe(false);
+  it.each([
+    [
+      "EACCES",
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      true,
+    ],
+    ["EPERM", Object.assign(new Error("not permitted"), { code: "EPERM" }), true],
+    ["ENOENT", Object.assign(new Error("not found"), { code: "ENOENT" }), false],
+    ["null", null, false],
+    ["a string", "EACCES", false],
+    ["a plain Error", new Error("oops"), false],
+  ] as const)("classifies %s", (_label, value, expected) => {
+    expect(isPermissionError(value)).toBe(expected);
   });
 });

--- a/src/lib/core/ports.test.ts
+++ b/src/lib/core/ports.test.ts
@@ -26,58 +26,30 @@ describe("parsePort", () => {
     delete process.env[ENV_KEY];
   });
 
-  it("returns fallback when env var is unset", () => {
-    expect(parsePort(ENV_KEY, 8080)).toBe(8080);
+  it.each([
+    ["an unset env var", undefined, 8080],
+    ["an empty env var", "", 8080],
+    ["a valid port", "9000", 9000],
+    ["surrounding whitespace", "  3000  ", 3000],
+    ["the lower bound", "1024", 1024],
+    ["the upper bound", "65535", 65535],
+  ] as const)("parses %s", (_label, value, expected) => {
+    if (value !== undefined) {
+      process.env[ENV_KEY] = value;
+    }
+
+    expect(parsePort(ENV_KEY, 8080)).toBe(expected);
   });
 
-  it("returns fallback when env var is empty", () => {
-    process.env[ENV_KEY] = "";
-    expect(parsePort(ENV_KEY, 8080)).toBe(8080);
-  });
-
-  it("parses a valid port", () => {
-    process.env[ENV_KEY] = "9000";
-    expect(parsePort(ENV_KEY, 8080)).toBe(9000);
-  });
-
-  it("trims whitespace", () => {
-    process.env[ENV_KEY] = "  3000  ";
-    expect(parsePort(ENV_KEY, 8080)).toBe(3000);
-  });
-
-  it("rejects non-numeric input", () => {
-    process.env[ENV_KEY] = "abc";
-    expect(() => parsePort(ENV_KEY, 8080)).toThrow("Invalid port");
-  });
-
-  it("rejects mixed alphanumeric input", () => {
-    process.env[ENV_KEY] = "80a80";
-    expect(() => parsePort(ENV_KEY, 8080)).toThrow("Invalid port");
-  });
-
-  it("rejects port below 1024", () => {
-    process.env[ENV_KEY] = "80";
-    expect(() => parsePort(ENV_KEY, 8080)).toThrow("1024 and 65535");
-  });
-
-  it("rejects port above 65535", () => {
-    process.env[ENV_KEY] = "70000";
-    expect(() => parsePort(ENV_KEY, 8080)).toThrow("1024 and 65535");
-  });
-
-  it("accepts port 1024 (lower bound)", () => {
-    process.env[ENV_KEY] = "1024";
-    expect(parsePort(ENV_KEY, 8080)).toBe(1024);
-  });
-
-  it("accepts port 65535 (upper bound)", () => {
-    process.env[ENV_KEY] = "65535";
-    expect(parsePort(ENV_KEY, 8080)).toBe(65535);
-  });
-
-  it("rejects special characters that could break pgrep patterns", () => {
-    process.env[ENV_KEY] = ".*";
-    expect(() => parsePort(ENV_KEY, 8080)).toThrow("Invalid port");
+  it.each([
+    ["non-numeric input", "abc", "Invalid port"],
+    ["mixed alphanumeric input", "80a80", "Invalid port"],
+    ["a port below 1024", "80", "1024 and 65535"],
+    ["a port above 65535", "70000", "1024 and 65535"],
+    ["special characters that could break pgrep patterns", ".*", "Invalid port"],
+  ] as const)("rejects %s", (_label, value, expectedMessage) => {
+    process.env[ENV_KEY] = value;
+    expect(() => parsePort(ENV_KEY, 8080)).toThrow(expectedMessage);
   });
 });
 

--- a/src/lib/core/url-utils.test.ts
+++ b/src/lib/core/url-utils.test.ts
@@ -37,68 +37,50 @@ describe("stripEndpointSuffix", () => {
 });
 
 describe("normalizeProviderBaseUrl", () => {
-  it("strips OpenAI suffixes", () => {
-    expect(normalizeProviderBaseUrl("https://api.openai.com/v1/chat/completions", "openai")).toBe(
+  it.each([
+    [
+      "OpenAI suffix",
+      "https://api.openai.com/v1/chat/completions",
+      "openai",
       "https://api.openai.com/v1",
-    );
-  });
-
-  it("strips Anthropic suffixes", () => {
-    expect(normalizeProviderBaseUrl("https://api.anthropic.com/v1/messages", "anthropic")).toBe(
+    ],
+    [
+      "Anthropic messages suffix",
+      "https://api.anthropic.com/v1/messages",
+      "anthropic",
       "https://api.anthropic.com",
-    );
-    expect(normalizeProviderBaseUrl("https://proxy.example.com/v1", "anthropic")).toBe(
+    ],
+    [
+      "Anthropic v1 suffix",
+      "https://proxy.example.com/v1",
+      "anthropic",
       "https://proxy.example.com",
-    );
-    expect(normalizeProviderBaseUrl("https://proxy.example.com/v1/messages", "anthropic")).toBe(
+    ],
+    [
+      "proxied Anthropic messages suffix",
+      "https://proxy.example.com/v1/messages",
+      "anthropic",
       "https://proxy.example.com",
-    );
-  });
-
-  it("strips trailing slashes", () => {
-    expect(normalizeProviderBaseUrl("https://example.com/v1/", "openai")).toBe(
-      "https://example.com/v1",
-    );
-  });
-
-  it("returns origin for root path", () => {
-    expect(normalizeProviderBaseUrl("https://example.com/", "openai")).toBe(
-      "https://example.com",
-    );
-  });
-
-  it("handles empty input", () => {
-    expect(normalizeProviderBaseUrl("", "openai")).toBe("");
-  });
-
-  it("handles invalid URL gracefully", () => {
-    expect(normalizeProviderBaseUrl("not-a-url", "openai")).toBe("not-a-url");
+    ],
+    ["trailing slashes", "https://example.com/v1/", "openai", "https://example.com/v1"],
+    ["root path", "https://example.com/", "openai", "https://example.com"],
+    ["empty input", "", "openai", ""],
+    ["invalid URL", "not-a-url", "openai", "not-a-url"],
+  ] as const)("normalizes %s", (_label, input, provider, expected) => {
+    expect(normalizeProviderBaseUrl(input, provider)).toBe(expected);
   });
 });
 
 describe("isLoopbackHostname", () => {
-  it("matches localhost", () => {
-    expect(isLoopbackHostname("localhost")).toBe(true);
-  });
-
-  it("matches 127.0.0.1", () => {
-    expect(isLoopbackHostname("127.0.0.1")).toBe(true);
-  });
-
-  it("matches ::1", () => {
-    expect(isLoopbackHostname("::1")).toBe(true);
-  });
-
-  it("matches bracketed IPv6", () => {
-    expect(isLoopbackHostname("[::1]")).toBe(true);
-  });
-
-  it("rejects external hostname", () => {
-    expect(isLoopbackHostname("example.com")).toBe(false);
-  });
-
-  it("handles empty input", () => {
-    expect(isLoopbackHostname("")).toBe(false);
+  it.each([
+    ["localhost", true],
+    ["127.0.0.1", true],
+    ["::1", true],
+    ["[::1]", true],
+    ["example.com", false],
+    ["", false],
+  ] as const)("classifies %s", (input, expected) => {
+    expect(isLoopbackHostname(input)).toBe(expected);
   });
 });
 
@@ -109,19 +91,12 @@ describe("formatEnvAssignment", () => {
 });
 
 describe("parsePolicyPresetEnv", () => {
-  it("parses comma-separated values", () => {
-    expect(parsePolicyPresetEnv("web,local-inference")).toEqual(["web", "local-inference"]);
-  });
-
-  it("trims whitespace", () => {
-    expect(parsePolicyPresetEnv(" web , local ")).toEqual(["web", "local"]);
-  });
-
-  it("filters empty segments", () => {
-    expect(parsePolicyPresetEnv("web,,local")).toEqual(["web", "local"]);
-  });
-
-  it("handles empty string", () => {
-    expect(parsePolicyPresetEnv("")).toEqual([]);
+  it.each([
+    ["comma-separated values", "web,local-inference", ["web", "local-inference"]],
+    ["whitespace", " web , local ", ["web", "local"]],
+    ["empty segments", "web,,local", ["web", "local"]],
+    ["empty string", "", []],
+  ] as const)("parses %s", (_label, input, expected) => {
+    expect(parsePolicyPresetEnv(input)).toEqual(expected);
   });
 });

--- a/src/lib/domain/duration.test.ts
+++ b/src/lib/domain/duration.test.ts
@@ -5,64 +5,34 @@ import { describe, it, expect } from "vitest";
 import { parseDuration, MAX_SECONDS, DEFAULT_SECONDS } from "./duration";
 
 describe("parseDuration", () => {
-  it("parses minutes", () => {
-    expect(parseDuration("5m")).toBe(300);
-    expect(parseDuration("30m")).toBe(1800);
-    expect(parseDuration("1m")).toBe(60);
+  it.each([
+    ["5m", 300],
+    ["30m", 1800],
+    ["1m", 60],
+    ["90s", 90],
+    ["1800s", 1800],
+    ["300", 300],
+    ["1800", 1800],
+    ["  5m  ", 300],
+    ["5M", 300],
+    ["90S", 90],
+  ] as const)("parses %s as %i seconds", (input, expected) => {
+    expect(parseDuration(input)).toBe(expected);
   });
 
-  it("parses seconds", () => {
-    expect(parseDuration("90s")).toBe(90);
-    expect(parseDuration("1800s")).toBe(1800);
-  });
-
-  it("rejects hours that exceed max", () => {
-    expect(() => parseDuration("1h")).toThrow("exceeds maximum"); // 3600 > 1800
-  });
-
-  it("rejects non-integer hour values", () => {
-    expect(() => parseDuration("0.5h")).toThrow("Invalid duration");
-  });
-
-  it("treats bare numbers as seconds", () => {
-    expect(parseDuration("300")).toBe(300);
-    expect(parseDuration("1800")).toBe(1800);
-  });
-
-  it("trims whitespace", () => {
-    expect(parseDuration("  5m  ")).toBe(300);
-  });
-
-  it("is case-insensitive", () => {
-    expect(parseDuration("5M")).toBe(300);
-    expect(parseDuration("90S")).toBe(90);
-  });
-
-  it("rejects empty input", () => {
-    expect(() => parseDuration("")).toThrow("Duration cannot be empty");
-    expect(() => parseDuration("   ")).toThrow("Duration cannot be empty");
-  });
-
-  it("rejects non-numeric input", () => {
-    expect(() => parseDuration("abc")).toThrow("Invalid duration");
-    expect(() => parseDuration("five minutes")).toThrow("Invalid duration");
-  });
-
-  it("rejects zero duration", () => {
-    expect(() => parseDuration("0s")).toThrow("greater than zero");
-    expect(() => parseDuration("0m")).toThrow("greater than zero");
-  });
-
-  it("rejects durations exceeding 30 minutes", () => {
-    expect(() => parseDuration("31m")).toThrow("exceeds maximum");
-    expect(() => parseDuration("1801")).toThrow("exceeds maximum");
-    expect(() => parseDuration("1h")).toThrow("exceeds maximum");
-  });
-
-  it("accepts exactly 30 minutes", () => {
-    expect(parseDuration("30m")).toBe(1800);
-    expect(parseDuration("1800s")).toBe(1800);
-    expect(parseDuration("1800")).toBe(1800);
+  it.each([
+    ["empty input", "", "Duration cannot be empty"],
+    ["whitespace-only input", "   ", "Duration cannot be empty"],
+    ["non-numeric text", "abc", "Invalid duration"],
+    ["word-based duration", "five minutes", "Invalid duration"],
+    ["non-integer hours", "0.5h", "Invalid duration"],
+    ["zero seconds", "0s", "greater than zero"],
+    ["zero minutes", "0m", "greater than zero"],
+    ["minutes over the maximum", "31m", "exceeds maximum"],
+    ["bare seconds over the maximum", "1801", "exceeds maximum"],
+    ["hours over the maximum", "1h", "exceeds maximum"],
+  ] as const)("rejects %s", (_label, input, expectedMessage) => {
+    expect(() => parseDuration(input)).toThrow(expectedMessage);
   });
 });
 


### PR DESCRIPTION
## Summary
Refactors repeated pure utility specs into `it.each` tables so the input and expected-result matrices are easier to scan. The change keeps behavior coverage equivalent while reducing duplicated test bodies.

## Changes
- Table-drives `parsePort` valid and invalid cases in `src/lib/core/ports.test.ts`.
- Table-drives duration parsing and rejection cases in `src/lib/domain/duration.test.ts`.
- Table-drives errno and permission-error classification cases in `src/lib/core/errno.test.ts`.
- Table-drives URL normalization, loopback hostname, and policy preset env parsing cases in `src/lib/core/url-utils.test.ts`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suites to use parameterized table-driven testing approach, improving test organization and maintainability across core utility and domain modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->