### PR TITLE
test(cli): cover policy mutation public route

### DIFF
--- a/test/cli/sandbox-mutations.test.ts
+++ b/test/cli/sandbox-mutations.test.ts
@@ -8,6 +8,47 @@ import { describe, expect, it } from "vitest";
 
 import { runWithEnv, testTimeoutOptions, writeSandboxRegistry } from "./helpers";
 
+function readSandboxPolicies(home: string, sandboxName = "alpha"): string[] {
+  const registryPath = path.join(home, ".nemoclaw", "sandboxes.json");
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    sandboxes?: Record<string, { policies?: unknown }>;
+  };
+  const policies = registry.sandboxes?.[sandboxName]?.policies;
+  return Array.isArray(policies)
+    ? policies.filter((policy): policy is string => typeof policy === "string")
+    : [];
+}
+
+function writePolicyMutationOpenshellStub(home: string): string {
+  const localBin = path.join(home, "bin");
+  fs.mkdirSync(localBin, { recursive: true });
+  const openshell = path.join(localBin, "openshell");
+  fs.writeFileSync(
+    openshell,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'if [ "$1" = "policy" ] && [ "$2" = "get" ]; then',
+      "  cat <<'YAML'",
+      "version: 1",
+      "network_policies:",
+      "  github:",
+      "    name: github",
+      "    host: github.com",
+      "YAML",
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "policy" ] && [ "$2" = "set" ]; then',
+      "  exit 0",
+      "fi",
+      'printf "unexpected openshell args: %s\\n" "$*" >&2',
+      "exit 1",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return openshell;
+}
+
 describe("CLI dispatch", () => {
   it("connect help uses native oclif usage through the public sandbox route", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-inspection-help-"));
@@ -66,6 +107,44 @@ describe("CLI dispatch", () => {
     const snapshots = runWithEnv("sandbox snapshot list alpha", { HOME: home });
     expect(snapshots.code).toBe(0);
     expect(snapshots.out).toContain("No snapshots found for 'alpha'.");
+  });
+
+  it("keeps public policy-add/remove built-in mutation routes", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-policy-mutation-"));
+    writeSandboxRegistry(home);
+    const openshell = writePolicyMutationOpenshellStub(home);
+
+    const add = runWithEnv("alpha policy-add github --yes", {
+      HOME: home,
+      NEMOCLAW_OPENSHELL_BIN: openshell,
+    });
+    expect(add.code).toBe(0);
+    expect(add.out).toContain("Applied preset: github");
+    expect(readSandboxPolicies(home)).toContain("github");
+
+    const remove = runWithEnv("alpha policy-remove github -y", {
+      HOME: home,
+      NEMOCLAW_OPENSHELL_BIN: openshell,
+    });
+    expect(remove.code).toBe(0);
+    expect(remove.out).toContain("Removed preset: github");
+    expect(readSandboxPolicies(home)).not.toContain("github");
+  });
+
+  it("keeps public policy-add non-interactive missing-preset failure before mutation", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-policy-noninteractive-"));
+    writeSandboxRegistry(home);
+    const openshell = writePolicyMutationOpenshellStub(home);
+
+    const result = runWithEnv("alpha policy-add", {
+      HOME: home,
+      NEMOCLAW_NON_INTERACTIVE: "1",
+      NEMOCLAW_OPENSHELL_BIN: openshell,
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("Non-interactive mode requires a preset name.");
+    expect(readSandboxPolicies(home)).toEqual([]);
   });
 
   it("sandbox channels start rejects a sandbox missing from the registry (#4584)", () => {


### PR DESCRIPTION
## Summary
This PR adds focused public CLI smokes for the sandbox-first built-in policy mutation routes after #4920 moved most confirmation coverage into same-process action tests. The tests keep coverage for dispatching `policy-add` / `policy-remove` through the user-facing route without restoring the old subprocess-heavy matrix.

## Related Issue
Part of #4892

## Changes
- Add a hermetic fake OpenShell policy helper for `test/cli/sandbox-mutations.test.ts`.
- Verify `nemoclaw <sandbox> policy-add github --yes` and `nemoclaw <sandbox> policy-remove github -y` mutate the temp registry through the public sandbox-first route.
- Verify `NEMOCLAW_NON_INTERACTIVE=1 nemoclaw <sandbox> policy-add` fails before selecting or applying a preset.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>