### PR TITLE
fix(onboard): reject the Hermes dashboard internal port when it collides with the dashboard port

### DIFF
--- a/src/lib/onboard/hermes-dashboard.test.ts
+++ b/src/lib/onboard/hermes-dashboard.test.ts
@@ -21,6 +21,19 @@ describe("onboard Hermes dashboard helpers", () => {
     ).toThrow(/must not equal the Hermes API port/);
   });
 
+  it("rejects the internal dashboard port colliding with the OpenClaw dashboard port", () => {
+    // The external port was already guarded against effectivePort; the internal
+    // port must be too, or NEMOCLAW_HERMES_DASHBOARD_INTERNAL_PORT set to the
+    // chat-UI port silently collides at forward time.
+    expect(() =>
+      resolveHermesDashboardOnboardState({
+        agentName: "hermes",
+        effectivePort: 19119,
+        env: { NEMOCLAW_HERMES_DASHBOARD: "1" },
+      }),
+    ).toThrow(/NEMOCLAW_HERMES_DASHBOARD_INTERNAL_PORT must not equal the Hermes API port/);
+  });
+
   it("tracks registry drift for enabled dashboard settings", () => {
     const state = resolveHermesDashboardOnboardState({
       agentName: "hermes",

--- a/src/lib/onboard/hermes-dashboard.ts
+++ b/src/lib/onboard/hermes-dashboard.ts
@@ -51,6 +51,11 @@ export function resolveHermesDashboardOnboardState({
       if (fail) return fail(message);
       throw new Error(message);
     }
+    if (config.internalPort === effectivePort) {
+      const message = `${HERMES_DASHBOARD_INTERNAL_PORT_ENV} must not equal the Hermes API port (${effectivePort}).`;
+      if (fail) return fail(message);
+      throw new Error(message);
+    }
   }
 
   return { config, enabled: config.enabled === true };


### PR DESCRIPTION
## Summary
A Hermes agent's dashboard uses two ports: an external one people connect to and an internal one it serves on. Before creating the sandbox, NemoClaw already refuses to continue if the external dashboard port clashes with the resolved chat-UI port or with the internal port. It never ran the same check for the internal port, so setting the internal port to the chat-UI port's value slipped through onboarding validation and only failed later, when NemoClaw tried to open the dashboard forward on a port that was already in use. This adds the missing symmetric check so the conflict is reported up front with a clear message, the same way the external port already is.

## Related Issue
Closes #4930

## Changes
- In `resolveHermesDashboardOnboardState` (`src/lib/onboard/hermes-dashboard.ts`), reject the internal Hermes dashboard port when it equals the resolved dashboard port (`config.internalPort === effectivePort`), mirroring the existing external-port guard.
- Add a unit test covering the new case.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
- [x] New and existing unit tests pass locally.

Ran: `npx vitest run src/lib/onboard/hermes-dashboard.test.ts` (4 passed), `npx tsc -p tsconfig.src.json`, `npm run typecheck:cli`, and Biome lint on the changed files, all clean.

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now prevents port conflicts between dashboard and API settings.

* **Tests**
  * Added test case validating port conflict detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->