### PR TITLE
fix(blueprint): route unconfigured strict SSRF fetches through sandbox proxy (#4687)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,6 +198,24 @@ RUN set -eu; \
 # sandbox. The generic SSRF helper and strict/direct DNS-pinned paths remain
 # unmodified, so metadata/link-local/private IP literals are unchanged.
 #
+# === Patch 4: route unconfigured strict SSRF fetches through the egress proxy ===
+# (NVIDIA/NemoClaw#4687). fetchWithSsrFGuard builds a per-request DNS-pinned
+# *direct* undici dispatcher for STRICT-mode fetches that pass no explicit
+# dispatcherPolicy — e.g. the @openclaw/googlechat inbound JWT signing-cert
+# fetch from www.googleapis.com/service_accounts/v1/metadata/x509/.... A direct
+# dispatcher ignores the global EnvHttpProxyAgent installed by
+# NODE_USE_ENV_PROXY=1, so the request never reaches the OpenShell L7 proxy and
+# fails in the proxy-only sandbox netns — rejecting every inbound Google Chat
+# webhook. OpenClaw already has a "managed proxy" branch that routes such
+# fetches through the env proxy (createHttp1EnvHttpProxyAgent) while still
+# resolving + SSRF-validating the target hostname, but it is gated on
+# isManagedProxyActive() (OPENCLAW_PROXY_ACTIVE=1), which NemoClaw does not set.
+# Inside an OpenShell sandbox the configured egress proxy IS the managed proxy,
+# so extend that activation to OPENSHELL_SANDBOX=1 for fetches that supply no
+# explicit dispatcherPolicy. Explicit-proxy and direct(mTLS) dispatcher policies
+# (Google auth proxy / client-cert paths) keep their existing behavior, and
+# resolvePinnedHostnameWithPolicy still blocks private/link-local targets.
+#
 # === Removal criteria ===
 # Patch 1: drop when OpenClaw deprecates withStrictGuardedFetchMode or
 #   when all media-fetch callsites unconditionally pass useEnvProxy.
@@ -207,6 +225,9 @@ RUN set -eu; \
 # Patch 2b: drop when OpenClaw ships a reviewed web_fetch trusted-proxy SSRF
 #   policy surface that can allow host.openshell.internal without allowing
 #   broader private/special-use hostnames.
+# Patch 4: drop when OpenClaw routes unconfigured strict fetches through the
+#   env proxy in proxy-only environments without OPENCLAW_PROXY_ACTIVE, or when
+#   NemoClaw sets OPENCLAW_PROXY_ACTIVE=1 in the sandbox runtime instead.
 #
 # SYNC WITH OPENCLAW: these patches classify the compiled OpenClaw dist at
 # build time. They apply the legacy patch when the old target exists, skip
@@ -323,6 +344,40 @@ RUN set -eu; \
             echo "ERROR: Patch 2b target missing but web_fetch/trusted-proxy references remain:" >&2; \
             printf '%s\n' "$web_fetch_proxy_refs" | head -n 5 >&2; \
             patch_fail "Patch 2b cannot safely skip"; \
+        fi; \
+    fi; \
+    # --- Patch 4: route unconfigured strict fetches through the sandbox egress proxy (#4687) --- \
+    # Reviewed against openclaw@2026.5.27 dist fetch-guard: the STRICT-mode \
+    # managed-proxy gate is `mode === GUARDED_FETCH_MODE.STRICT && \
+    # isManagedProxyActive() && hasProxyEnvConfigured()`. Extend activation to \
+    # OPENSHELL_SANDBOX=1 only for fetches with no explicit dispatcherPolicy so \
+    # the per-request direct dispatcher reuses the env proxy (EnvHttpProxyAgent) \
+    # like the managed-proxy path already does; explicit-proxy / direct dispatcher \
+    # policies and out-of-sandbox behavior are unchanged. \
+    mp_files="$(grep -RIlF --include='*.js' 'const canUseManagedProxy = mode === GUARDED_FETCH_MODE.STRICT && isManagedProxyActive() && hasProxyEnvConfigured();' "$OC_DIST" || true)"; \
+    if [ -n "$mp_files" ]; then \
+        patched_managed_proxy=0; \
+        for f in $mp_files; do \
+            if grep -q 'nemoclaw: route unconfigured strict fetch' "$f"; then \
+                echo "INFO: Patch 4 already present in $f"; \
+            else \
+                sed -i -E 's#const canUseManagedProxy = mode === GUARDED_FETCH_MODE\.STRICT \&\& isManagedProxyActive\(\) \&\& hasProxyEnvConfigured\(\);#const canUseManagedProxy = mode === GUARDED_FETCH_MODE.STRICT \&\& (isManagedProxyActive() || (process.env.OPENSHELL_SANDBOX === "1" \&\& !params.dispatcherPolicy)) \&\& hasProxyEnvConfigured(); /* nemoclaw: route unconfigured strict fetch through sandbox egress proxy, see Dockerfile */#' "$f"; \
+                grep -Fq 'process.env.OPENSHELL_SANDBOX === "1" && !params.dispatcherPolicy' "$f" \
+                    || patch_fail "Patch 4 verification failed for $f"; \
+                patched_managed_proxy=1; \
+            fi; \
+        done; \
+        if [ "$patched_managed_proxy" = "1" ]; then \
+            echo "INFO: Patch 4 applied to OpenClaw ${OC_VERSION} managed-proxy strict-fetch activation"; \
+        fi; \
+    else \
+        managed_proxy_refs="$(grep -RIlE --include='*.js' 'canUseManagedProxy|isManagedProxyActive' "$OC_DIST" || true)"; \
+        if [ -z "$managed_proxy_refs" ]; then \
+            echo "INFO: OpenClaw ${OC_VERSION} has no managed-proxy strict-fetch gate; Patch 4 not needed"; \
+        else \
+            echo "ERROR: Patch 4 target missing but managed-proxy references remain:" >&2; \
+            printf '%s\n' "$managed_proxy_refs" | head -n 5 >&2; \
+            patch_fail "Patch 4 cannot safely skip"; \
         fi; \
     fi; \
     # --- Patch 3: follow symlinks in plugin-install path checks (#2203) --- \

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -32,6 +32,8 @@ const REVIEWED_OPENCLAW_2026_5_27_WEB_FETCH_SHAPE = [
   "  return fetchWithSsrFGuard(useEnvProxy ? withTrustedEnvProxyGuardedFetchMode(resolved) : withStrictGuardedFetchMode(resolved));",
   "}",
 ].join("\n");
+const REVIEWED_OPENCLAW_2026_5_27_MANAGED_PROXY_SHAPE =
+  "const canUseManagedProxy = mode === GUARDED_FETCH_MODE.STRICT && isManagedProxyActive() && hasProxyEnvConfigured();";
 const REVIEWED_OPENCLAW_2026_5_27_SSRF_POLICY_SHAPE = [
   "function shouldSkipPrivateNetworkChecks(hostname, policy) {",
   "  return isPrivateNetworkAllowedByPolicy(policy) || normalizeHostnameSet(policy?.allowedHostnames).has(hostname);",
@@ -1077,6 +1079,121 @@ if (!blocked) throw new Error('private IP literal was not blocked');`,
       expect(patch.stdout).toContain("Patch 2 applied");
       const patched = fs.readFileSync(modulePath, "utf-8");
       expect(patched).toContain("nemoclaw: env-gated bypass");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("activates the managed-proxy path for unconfigured strict fetches only inside the sandbox (#4687)", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-fetch-guard-managed-proxy-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(path.join(tmp, "package.json"), '{"type":"module"}\n');
+    const modulePath = path.join(dist, "fetch-guard-managed-proxy.js");
+    fs.writeFileSync(
+      modulePath,
+      [
+        "const withStrictGuardedFetchMode = Symbol('strict');",
+        "const withTrustedEnvProxyGuardedFetchMode = Symbol('trusted');",
+        "const GUARDED_FETCH_MODE = { STRICT: 'strict' };",
+        "function isManagedProxyActive() { return process.env.OPENCLAW_PROXY_ACTIVE === '1'; }",
+        "function hasProxyEnvConfigured() { return true; }",
+        "function computeCanUseManagedProxy(mode, params) {",
+        `  ${REVIEWED_OPENCLAW_2026_5_27_MANAGED_PROXY_SHAPE}`,
+        "  return canUseManagedProxy;",
+        "}",
+        "export { withStrictGuardedFetchMode as a, withTrustedEnvProxyGuardedFetchMode as b, computeCanUseManagedProxy as g };",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const patch = runFetchGuardPatchBlock(dist, tmp, CURRENT_REVIEWED_OPENCLAW_PATCH_CLASSIFIER_VERSION);
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      expect(patch.stdout).toContain("Patch 4 applied");
+      const patched = fs.readFileSync(modulePath, "utf-8");
+      expect(patched).toContain("nemoclaw: route unconfigured strict fetch");
+
+      const mod = await import(`${modulePath}?${Date.now()}`);
+      const prevSandbox = process.env.OPENSHELL_SANDBOX;
+      const prevManaged = process.env.OPENCLAW_PROXY_ACTIVE;
+      try {
+        // In-sandbox, no explicit dispatcher policy -> reuse the env proxy.
+        process.env.OPENSHELL_SANDBOX = "1";
+        delete process.env.OPENCLAW_PROXY_ACTIVE;
+        expect(mod.g("strict", {})).toBe(true);
+        // In-sandbox but an explicit dispatcher policy is supplied -> untouched.
+        expect(mod.g("strict", { dispatcherPolicy: { mode: "explicit-proxy" } })).toBe(false);
+        // Outside the sandbox -> original strict/direct behavior is preserved.
+        delete process.env.OPENSHELL_SANDBOX;
+        expect(mod.g("strict", {})).toBe(false);
+        // Upstream managed-proxy activation still works regardless of sandbox.
+        process.env.OPENCLAW_PROXY_ACTIVE = "1";
+        expect(mod.g("strict", {})).toBe(true);
+        // Non-strict modes never take the managed-proxy branch.
+        process.env.OPENSHELL_SANDBOX = "1";
+        delete process.env.OPENCLAW_PROXY_ACTIVE;
+        expect(mod.g("trusted_env_proxy", {})).toBe(false);
+      } finally {
+        if (prevSandbox === undefined) delete process.env.OPENSHELL_SANDBOX;
+        else process.env.OPENSHELL_SANDBOX = prevSandbox;
+        if (prevManaged === undefined) delete process.env.OPENCLAW_PROXY_ACTIVE;
+        else process.env.OPENCLAW_PROXY_ACTIVE = prevManaged;
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("reports Patch 4 not needed when the managed-proxy gate is absent", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-fetch-guard-managed-proxy-absent-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(
+      path.join(dist, "fetch-guard-no-managed-proxy.js"),
+      [
+        "const withStrictGuardedFetchMode = Symbol('strict');",
+        "const withTrustedEnvProxyGuardedFetchMode = Symbol('trusted');",
+        "export { withStrictGuardedFetchMode as a, withTrustedEnvProxyGuardedFetchMode as b };",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const patch = runFetchGuardPatchBlock(dist, tmp, "2026.6.1");
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      expect(patch.stdout).toContain("Patch 4 not needed");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the managed-proxy gate drifts but managed-proxy references remain", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-fetch-guard-managed-proxy-drift-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(
+      path.join(dist, "fetch-guard-managed-proxy-drift.js"),
+      [
+        "const withStrictGuardedFetchMode = Symbol('strict');",
+        "const withTrustedEnvProxyGuardedFetchMode = Symbol('trusted');",
+        "function isManagedProxyActive() { return process.env.OPENCLAW_PROXY_ACTIVE === '1'; }",
+        "function proxyEnvSet() { return true; }",
+        // Drifted shape: renamed variables, so the exact reviewed gate is gone.
+        "const canUseManagedProxy = currentMode === 'strict' && isManagedProxyActive() && proxyEnvSet();",
+        "export { withStrictGuardedFetchMode as a, withTrustedEnvProxyGuardedFetchMode as b };",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      const patch = runFetchGuardPatchBlock(dist, tmp, "2026.6.1");
+      expect(patch.status).toBe(1);
+      expect(patch.stderr).toContain(
+        "Patch 4 target missing but managed-proxy references remain",
+      );
+      expect(patch.stderr).toContain("Patch 4 cannot safely skip");
+      expect(patch.stderr).toContain("OpenClaw 2026.6.1");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

`@openclaw/googlechat` rejects every inbound Google Chat webhook in a NemoClaw sandbox because JWT verification cannot fetch Google's signing certs. The plugin's `fetchChatCerts()` calls OpenClaw's `fetchWithSsrFGuard` with no explicit dispatcher policy, which builds a per-request DNS-pinned **direct** undici dispatcher that bypasses the global `EnvHttpProxyAgent` (`NODE_USE_ENV_PROXY=1`). In the proxy-only sandbox netns the direct connect never reaches the OpenShell L7 proxy and fails. This routes such fetches through the sandbox egress proxy while preserving SSRF protections.

## Related Issue

Fixes #4687

## Changes

- **`Dockerfile` (Patch 4):** OpenClaw's `fetch-guard` already has a managed-proxy branch that routes strict fetches through the env proxy (`createHttp1EnvHttpProxyAgent`) while still running `resolvePinnedHostnameWithPolicy`, but it's gated on `isManagedProxyActive()` (`OPENCLAW_PROXY_ACTIVE=1`), which NemoClaw never sets. The patch extends the `canUseManagedProxy` gate so that inside an OpenShell sandbox (`OPENSHELL_SANDBOX=1`) the configured egress proxy is treated as the managed proxy — **only** for STRICT-mode fetches that supply no explicit `dispatcherPolicy`.
  - Explicit-proxy and direct (mTLS) dispatcher policies are untouched (Google auth proxy / client-cert paths keep their behavior).
  - Out-of-sandbox behavior is unchanged.
  - `resolvePinnedHostnameWithPolicy` still resolves and SSRF-validates the target, so private/link-local/metadata targets remain blocked.
  - The classifier fails the image build loudly on OpenClaw dist-shape drift, like Patches 1/2/2b.
- **`test/fetch-guard-patch-regression.test.ts`:** anchors the reviewed `canUseManagedProxy` gate, and covers the applied / not-needed / fail-closed classifier paths plus the in-sandbox vs explicit-policy vs out-of-sandbox activation matrix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

Real Google Chat webhook E2E requires a Google Workspace service account + published Chat app + inbound webhook credentials, which are unavailable in this environment. Per the issue's documented fallback, the fix was reproduced through the **exact** OpenClaw SSRF dispatcher path the plugin's `fetchChatCerts()` uses, against the real pinned `openclaw@2026.5.27` dist:

- **Before:** cert fetch selects a per-request direct `Agent` — bypasses the env proxy (bug reproduced).
- **After (real Dockerfile Patch 4 block applied to the dist):** cert fetch selects `EnvHttpProxyAgent` — routes through the proxy.
- **Guards:** explicit-proxy → `ProxyAgent`; direct/mTLS → `Agent`; outside sandbox → `Agent`; private/link-local target → still SSRF-blocked.

- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Targeted `test/fetch-guard-patch-regression.test.ts` passes (22 tests); other Dockerfile-parsing suites pass. Pre-existing `service-env`/`nemoclaw-start` failures are uid-ownership environment artifacts unrelated to this change (confirmed identical on the pristine tree).

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Patch 4 to adjust strict-mode fetch routing in sandboxed environments so unconfigured strict fetches are routed via the proxy; build now detects and verifies this managed-proxy gate and includes updated patch lifecycle handling.

* **Tests**
  * Added regression tests covering Patch 4 behavior and failure modes across sandboxed, non-sandboxed, strict/non-strict, and managed-proxy activation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->