### PR TITLE
fix(slack): notify sender on denied @-mention instead of dropping silently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,10 @@ ENV NPM_CONFIG_AUDIT=false \
 RUN npm ci --omit=dev
 COPY scripts/patch-openclaw-tool-catalog.js /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js
 COPY scripts/patch-openclaw-chat-send.js /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js
+COPY scripts/patch-openclaw-slack-deny-feedback.mts /usr/local/lib/nemoclaw/patch-openclaw-slack-deny-feedback.mts
 RUN chmod 755 /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js \
-        /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js
+        /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js \
+        /usr/local/lib/nemoclaw/patch-openclaw-slack-deny-feedback.mts
 
 # Upgrade OpenClaw if the base image is stale.
 #
@@ -579,6 +581,21 @@ RUN NEMOCLAW_OPENCLAW_MANAGED_PROXY=0 node --experimental-strip-types /usr/local
 
 # hadolint ignore=DL3059,DL4006
 RUN python3 /usr/local/lib/nemoclaw/openclaw-build-messaging-plugins.py
+
+# Patch the OpenClaw Slack channel (@openclaw/slack) so a denied explicit
+# @-mention still blocks the command but sends one bounded sender-facing
+# feedback message instead of dropping silently (NemoClaw #4752). The script
+# classifies the installed Slack dist by content signature, fails the build if
+# a @openclaw/slack package is present but the deny path shape is unrecognized,
+# and is a no-op when the Slack channel is not enabled for this image.
+# Scoped to the sandbox-writable OpenClaw config dir: `openclaw plugins install`
+# stages external channel packages under $HOME/.openclaw/npm, and this step runs
+# as the sandbox user, so do not scan the root-owned global node_modules tree.
+# Removal criteria: drop when upstream OpenClaw notifies the sender on a denied
+# explicit Slack @-mention, or when NemoClaw no longer ships @openclaw/slack.
+# hadolint ignore=DL3059
+RUN node --experimental-strip-types /usr/local/lib/nemoclaw/patch-openclaw-slack-deny-feedback.mts \
+    /sandbox/.openclaw
 
 # Lock down npm for the next RUN: the local OpenClaw plugin install must
 # resolve from /opt/nemoclaw and the staged plugin-runtime-deps tree without

--- a/scripts/patch-openclaw-slack-deny-feedback.mts
+++ b/scripts/patch-openclaw-slack-deny-feedback.mts
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * NemoClaw compatibility shim for the OpenClaw Slack channel (@openclaw/slack).
+ *
+ * When a non-allowlisted human explicitly @-mentions the bot in a channel,
+ * OpenClaw blocks the command (correct) but drops the event silently, leaving
+ * the sender with no indication the bot saw the mention (NemoClaw #4752).
+ *
+ * This patch keeps the command denied (still returns no prepared command) but
+ * adds exactly one bounded, sender-facing feedback message — an ephemeral reply
+ * in the mentioned channel, falling back to a DM — without revealing the
+ * configured allowlist or processing the command text.
+ *
+ * The patch classifies the compiled @openclaw/slack dist by content signature.
+ * It fails loudly when a @openclaw/slack package is present but the deny path
+ * shape is unrecognized, and is a no-op when @openclaw/slack is not installed
+ * (e.g. a sandbox image built without the Slack channel enabled).
+ *
+ * Removal criteria: drop when upstream OpenClaw notifies the sender on a denied
+ * explicit Slack @-mention, or when NemoClaw no longer ships @openclaw/slack.
+ *
+ * Usage: patch-openclaw-slack-deny-feedback.mts <search-root> [<search-root>...]
+ *   Each <search-root> is scanned (bounded depth) for installed @openclaw/slack
+ *   packages; the OpenClaw runtime dirs (HOME/.openclaw, npm global root) are
+ *   the expected roots.
+ */
+
+import { existsSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
+
+const HELPER_MARKER = "__nemoclawNotifyDeniedSlackMention";
+const CALL_MARKER = "nemoclaw: bounded denial feedback for explicit slack @-mentions";
+const DENY_LOG_SIGNATURE = "Blocked unauthorized slack sender";
+const MAX_SCAN_DEPTH = 12;
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) {
+  console.error("Usage: patch-openclaw-slack-deny-feedback.mts <search-root> [<search-root>...]");
+  process.exit(2);
+}
+
+function fail(message: string): never {
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+}
+
+function readJsonSafe(file: string): { name?: string } | null {
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as { name?: string };
+  } catch {
+    return null;
+  }
+}
+
+// Locate installed @openclaw/slack package roots under the given search roots.
+function findSlackPackageRoots(searchRoots: string[]): string[] {
+  const found = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (dir: string, depth: number): void => {
+    if (depth > MAX_SCAN_DEPTH) return;
+    let real: string;
+    try {
+      real = realpathSync(dir);
+    } catch {
+      return;
+    }
+    if (visited.has(real)) return;
+    visited.add(real);
+
+    const manifest = join(dir, "package.json");
+    if (existsSync(manifest)) {
+      const parsed = readJsonSafe(manifest);
+      if (parsed && parsed.name === "@openclaw/slack") {
+        found.add(dir);
+        return; // do not descend into a matched package
+      }
+    }
+
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      visit(join(dir, entry.name), depth + 1);
+    }
+  };
+  for (const root of searchRoots) {
+    if (existsSync(root)) visit(resolve(root), 0);
+  }
+  return [...found];
+}
+
+function listJsFiles(dir: string): string[] {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+    .map((entry) => join(dir, entry.name));
+}
+
+function locatePrepareModule(packageRoot: string): string {
+  const distDir = join(packageRoot, "dist");
+  const candidates = listJsFiles(distDir).filter((file) => {
+    const source = readFileSync(file, "utf8");
+    return (
+      source.includes("async function prepareSlackMessage") && source.includes(DENY_LOG_SIGNATURE)
+    );
+  });
+  if (candidates.length !== 1) {
+    fail(
+      `expected exactly one OpenClaw Slack prepare module under ${distDir}, found ${candidates.length}; ` +
+        "inspect the @openclaw/slack dist and update this patch for the new layout",
+    );
+  }
+  return candidates[0];
+}
+
+// Sender-facing feedback helper injected into the prepare module. Indented with
+// tabs to match the compiled OpenClaw dist.
+function buildHelperSource(): string {
+  return [
+    "async function __nemoclawNotifyDeniedSlackMention(params) {",
+    "\t// nemoclaw: bounded sender-facing feedback for an explicit @-mention whose",
+    "\t// command was denied by the channel allowlist. Keeps the command blocked,",
+    "\t// never reveals the allowlist, and emits exactly one sender-facing message",
+    "\t// (ephemeral in-channel, DM fallback). (#4752)",
+    "\tconst { ctx, message, senderId } = params;",
+    "\tif (!params.explicitMention) return;",
+    "\tconst client = ctx?.app?.client;",
+    "\tconst channel = message?.channel;",
+    "\tconst user = senderId ?? message?.user;",
+    "\tif (!client?.chat || !channel || !user) return;",
+    '\tconst text = "Sorry, you\'re not authorized to use this assistant in this channel, so your request was not processed.";',
+    "\tconst threadTs = message?.thread_ts ?? message?.ts;",
+    "\ttry {",
+    "\t\tawait client.chat.postEphemeral({ channel, user, text, ...threadTs ? { thread_ts: threadTs } : {} });",
+    "\t\treturn;",
+    "\t} catch (ephemeralError) {",
+    "\t\t// Only fall back to a DM when Slack definitively did not deliver the",
+    "\t\t// ephemeral. Ambiguous failures (network/HTTP, timeout, service errors)",
+    "\t\t// may have been accepted, so a DM there could double-notify the sender.",
+    '\t\tconst ephemeralErrorCode = ephemeralError?.data?.error ?? ephemeralError?.code;',
+    '\t\tctx?.logger?.warn?.({ err: ephemeralError, channel, code: ephemeralErrorCode }, "nemoclaw: slack denial ephemeral feedback failed (#4752)");',
+    '\t\tconst nonDeliveryCodes = ["user_not_in_channel", "not_in_channel", "channel_not_found", "cannot_reply_to_message", "is_archived", "messages_tab_disabled"];',
+    "\t\tif (!nonDeliveryCodes.includes(ephemeralErrorCode)) return;",
+    "\t\ttry {",
+    "\t\t\tconst opened = await client.conversations?.open?.({ users: user });",
+    "\t\t\tconst dmChannel = opened?.channel?.id;",
+    "\t\t\tif (dmChannel) await client.chat.postMessage({ channel: dmChannel, text });",
+    "\t\t} catch (dmError) {",
+    '\t\t\tctx?.logger?.warn?.({ err: dmError }, "nemoclaw: slack denial DM feedback failed (#4752)");',
+    "\t\t}",
+    "\t}",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function patchPrepareModule(file: string): boolean {
+  let source = readFileSync(file, "utf8");
+  const original = source;
+
+  // The denial feedback only fires for explicit bot mentions. Require the
+  // mention-state identifiers so the patch fails loudly if the deny path no
+  // longer exposes them, rather than emitting code that references undefined
+  // variables.
+  if (
+    !source.includes("explicitlyMentionedBotUser") ||
+    !source.includes("explicitlyMentionedBotSubteam")
+  ) {
+    fail(
+      `OpenClaw Slack mention-state shape not recognized in ${file}; ` +
+        "expected explicitlyMentionedBotUser/explicitlyMentionedBotSubteam in the prepare deny path",
+    );
+  }
+
+  if (!source.includes(CALL_MARKER)) {
+    const denyGate = new RegExp(
+      "(logVerbose\\(`Blocked unauthorized slack sender \\$\\{senderId\\} \\(not in channel users\\)`\\);\\n)(\\s*)return null;",
+    );
+    const next = source.replace(
+      denyGate,
+      (_match, logLine: string, indent: string) =>
+        `${logLine}${indent}await __nemoclawNotifyDeniedSlackMention({ ctx, message, senderId, ` +
+        'explicitMention: opts.source === "app_mention" || explicitlyMentionedBotUser || explicitlyMentionedBotSubteam }); ' +
+        `// ${CALL_MARKER} (#4752)\n${indent}return null;`,
+    );
+    if (next === source) {
+      fail(`OpenClaw Slack channel-users deny gate shape not recognized in ${file}`);
+    }
+    source = next;
+  }
+
+  if (!source.includes(`async function ${HELPER_MARKER}(`)) {
+    const anchor = "async function prepareSlackMessage(params) {";
+    if (!source.includes(anchor)) {
+      fail(`OpenClaw Slack prepareSlackMessage definition not found in ${file}`);
+    }
+    source = source.replace(anchor, `${buildHelperSource()}${anchor}`);
+  }
+
+  if (source !== original) {
+    writeFileSync(file, source);
+    return true;
+  }
+  return false;
+}
+
+const packageRoots = findSlackPackageRoots(roots);
+if (packageRoots.length === 0) {
+  console.log(
+    `INFO: no @openclaw/slack package found under ${roots.join(", ")}; skipping Slack denial-feedback patch`,
+  );
+  process.exit(0);
+}
+
+const patchedFiles: string[] = [];
+for (const packageRoot of packageRoots) {
+  const prepareFile = locatePrepareModule(packageRoot);
+  patchPrepareModule(prepareFile);
+  const patched = readFileSync(prepareFile, "utf8");
+  if (!patched.includes(`async function ${HELPER_MARKER}(`)) {
+    fail(`Slack denial-feedback helper did not apply in ${prepareFile}`);
+  }
+  if (!patched.includes(CALL_MARKER)) {
+    fail(`Slack denial-feedback deny-gate call did not apply in ${prepareFile}`);
+  }
+  patchedFiles.push(prepareFile);
+}
+
+console.log(
+  `INFO: patched OpenClaw Slack denial feedback in ${patchedFiles.map((file) => relative(process.cwd(), file)).join(", ")}`,
+);

--- a/test/e2e/lib/slack-api-proof.sh
+++ b/test/e2e/lib/slack-api-proof.sh
@@ -543,6 +543,10 @@ async function runOpenClawPrivateProof(location) {
   ) {
     fail("installed OpenClaw Slack test API does not expose the required proof helpers");
   }
+  // Records sender-facing feedback actions (chat.postEphemeral / chat.postMessage)
+  // so the proof can assert that a denied explicit @-mention still produces
+  // bounded feedback without preparing a command (NemoClaw #4752).
+  const senderFeedbackCalls = [];
   const appClient = {
     assistant: {
       threads: {
@@ -577,6 +581,25 @@ async function runOpenClawPrivateProof(location) {
         },
       }),
     },
+    chat: {
+      postEphemeral: async (payload) => {
+        senderFeedbackCalls.push({
+          method: "chat.postEphemeral",
+          channel: payload.channel,
+          user: payload.user,
+          text: payload.text,
+        });
+        return { ok: true, message_ts: "1710000000.000200" };
+      },
+      postMessage: async (payload) => {
+        senderFeedbackCalls.push({
+          method: "chat.postMessage",
+          channel: payload.channel,
+          text: payload.text,
+        });
+        return { ok: true, ts: "1710000000.000201" };
+      },
+    },
   };
 
   const ctx = createInboundSlackTestContext({
@@ -607,7 +630,11 @@ async function runOpenClawPrivateProof(location) {
   if (allowedPrepared.replyTarget !== `channel:${channelId}`) {
     fail(`unexpected allowed replyTarget: ${allowedPrepared.replyTarget}`);
   }
+  if (senderFeedbackCalls.length !== 0) {
+    fail(`allowed Slack app_mention unexpectedly produced sender feedback: ${JSON.stringify(senderFeedbackCalls)}`);
+  }
 
+  senderFeedbackCalls.length = 0;
   const deniedPrepared = await prepareSlackMessage({
     ctx,
     account,
@@ -615,6 +642,32 @@ async function runOpenClawPrivateProof(location) {
     opts: { source: "app_mention", wasMentioned: true },
   });
   if (deniedPrepared !== null) fail("denied Slack app_mention unexpectedly prepared");
+
+  // NemoClaw #4752: a denied explicit @-mention must still prepare no command
+  // (asserted above) yet send exactly one bounded, sender-facing feedback
+  // action, addressed to the denied sender, without leaking the allowlist.
+  if (senderFeedbackCalls.length !== 1) {
+    fail(
+      `denied Slack app_mention expected exactly one sender feedback action, got ${senderFeedbackCalls.length}: ${JSON.stringify(senderFeedbackCalls)}`,
+    );
+  }
+  const deniedFeedback = senderFeedbackCalls[0];
+  if (deniedFeedback.method !== "chat.postEphemeral") {
+    fail(`denied Slack app_mention expected an ephemeral feedback action, got ${deniedFeedback.method}`);
+  }
+  if (deniedFeedback.channel !== channelId) {
+    fail(`denied Slack feedback targeted unexpected channel: ${deniedFeedback.channel}`);
+  }
+  if (deniedFeedback.user !== deniedUser) {
+    fail(`denied Slack feedback addressed unexpected user: ${deniedFeedback.user}`);
+  }
+  const deniedFeedbackText = deniedFeedback.text ?? "";
+  if (!deniedFeedbackText) {
+    fail("denied Slack feedback message text was empty");
+  }
+  if (deniedFeedbackText.includes(allowedUser) || /allow\s*list|allowlist|allowed users/i.test(deniedFeedbackText)) {
+    fail(`denied Slack feedback leaked allowlist details: ${deniedFeedbackText}`);
+  }
 
   const fakeClient = {
     chat: {
@@ -651,6 +704,8 @@ async function runOpenClawPrivateProof(location) {
     proof: "openclaw-private-helper",
     allowedReplyTarget: allowedPrepared.replyTarget,
     deniedPrepared: deniedPrepared === null,
+    deniedFeedbackMethod: deniedFeedback.method,
+    deniedFeedbackCount: senderFeedbackCalls.length,
     messageId: sendResult.messageId,
     channelId: sendResult.channelId,
   };

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -2840,6 +2840,14 @@ for line in sys.stdin:
   else
     fail "M-S17c: Slack proof did not use the installed OpenClaw Slack send helper (proof=${sl_proof_kind:-missing})"
   fi
+  # M-S17d (#4752): a denied explicit @-mention prepares no command but must
+  # still emit exactly one bounded sender-facing feedback action.
+  if echo "$sl_channel_proof" | grep -q '"deniedFeedbackCount":1' \
+    && echo "$sl_channel_proof" | grep -q '"deniedFeedbackMethod":"chat.postEphemeral"'; then
+    pass "M-S17d: denied Slack @mention sent exactly one bounded sender feedback action"
+  else
+    fail "M-S17d: denied Slack @mention did not send bounded sender feedback: ${sl_channel_proof:0:500}"
+  fi
 elif [ "$fake_slack_ready" != "1" ]; then
   skip "M-S17: fake Slack API was not ready"
 elif [ -z "$sl_allowed_user" ]; then

--- a/test/openclaw-slack-deny-feedback-patch.test.ts
+++ b/test/openclaw-slack-deny-feedback-patch.test.ts
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const PATCH_SCRIPT = path.join(
+  import.meta.dirname,
+  "..",
+  "scripts",
+  "patch-openclaw-slack-deny-feedback.mts",
+);
+
+// Minimal stand-in for the compiled @openclaw/slack prepare module: a denying
+// channel gate that mirrors the real dist's deny-log line and exposes the same
+// in-scope identifiers the patch references.
+function prepareModuleSource(
+  options: { withMentionState?: boolean; denyLine?: string } = {},
+): string {
+  const withMentionState = options.withMentionState ?? true;
+  const denyLine =
+    options.denyLine ??
+    "logVerbose(`Blocked unauthorized slack sender ${senderId} (not in channel users)`);";
+  return [
+    "function logVerbose() {}",
+    "async function prepareSlackMessage(params) {",
+    "\tconst { ctx, account, message, opts } = params;",
+    "\tconst senderId = message.user;",
+    withMentionState
+      ? "\tconst explicitlyMentionedBotUser = Boolean(params.explicitlyMentionedBotUser);"
+      : "\tconst mentionedBotUser = Boolean(params.mentionedBotUser);",
+    withMentionState
+      ? "\tconst explicitlyMentionedBotSubteam = Boolean(params.explicitlyMentionedBotSubteam);"
+      : "\tconst mentionedBotSubteam = Boolean(params.mentionedBotSubteam);",
+    "\tconst isRoom = true;",
+    "\tconst messageIngress = { senderAccess: { gate: { allowed: false } } };",
+    "\tconst senderGate = messageIngress.senderAccess.gate;",
+    "\tif (isRoom && senderGate?.allowed === false) {",
+    `\t\t${denyLine}`,
+    "\t\treturn null;",
+    "\t}",
+    "\treturn { prepared: true };",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function writeSlackPackage(
+  root: string,
+  options: { withMentionState?: boolean; denyLine?: string } = {},
+): string {
+  const pkgDir = path.join(root, "node_modules", "@openclaw", "slack");
+  const distDir = path.join(pkgDir, "dist");
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({ name: "@openclaw/slack", version: "2026.5.27" }),
+  );
+  const prepareFile = path.join(distDir, "prepare-fixture.js");
+  fs.writeFileSync(prepareFile, prepareModuleSource(options));
+  return prepareFile;
+}
+
+function runPatch(...roots: string[]) {
+  return spawnSync(process.execPath, ["--experimental-strip-types", PATCH_SCRIPT, ...roots], {
+    encoding: "utf-8",
+    timeout: 10000,
+  });
+}
+
+type FeedbackCall = { method: string; channel?: string; user?: string; text?: string };
+
+async function runPatchedDenyPath(
+  patchedSource: string,
+  params: {
+    opts: { source?: string };
+    explicitlyMentionedBotUser?: boolean;
+    explicitlyMentionedBotSubteam?: boolean;
+    ephemeralErrorCode?: string;
+  },
+) {
+  const calls: FeedbackCall[] = [];
+  const client = {
+    chat: {
+      postEphemeral: async (payload: Omit<FeedbackCall, "method">) => {
+        calls.push({ ...payload, method: "chat.postEphemeral" });
+        if (params.ephemeralErrorCode) {
+          throw Object.assign(new Error("postEphemeral failed"), {
+            data: { error: params.ephemeralErrorCode },
+          });
+        }
+        return { ok: true };
+      },
+      postMessage: async (payload: Omit<FeedbackCall, "method">) => {
+        calls.push({ ...payload, method: "chat.postMessage" });
+        return { ok: true };
+      },
+    },
+    conversations: {
+      open: async ({ users }: { users: string }) => ({ ok: true, channel: { id: `D${users}` } }),
+    },
+  };
+  const ctx = { app: { client }, logger: { warn: () => {} } };
+  const message = { channel: "C1", user: "U999DENIED", ts: "100.1" };
+  const sandbox: Record<string, unknown> = { Boolean, Promise, JSON, Object };
+  const prepareSlackMessage = vm.runInNewContext(
+    `${patchedSource}\nprepareSlackMessage;`,
+    sandbox,
+  ) as (input: unknown) => Promise<unknown>;
+  const result = await prepareSlackMessage({
+    ctx,
+    account: {},
+    message,
+    opts: params.opts,
+    explicitlyMentionedBotUser: params.explicitlyMentionedBotUser,
+    explicitlyMentionedBotSubteam: params.explicitlyMentionedBotSubteam,
+  });
+  return { result, calls };
+}
+
+describe("OpenClaw Slack denial-feedback patch", () => {
+  it("injects bounded sender feedback while keeping the command denied", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-deny-"));
+    const prepareFile = writeSlackPackage(tmp);
+    try {
+      const patch = runPatch(tmp);
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      expect(patch.stdout).toContain("patched OpenClaw Slack denial feedback");
+
+      const patched = fs.readFileSync(prepareFile, "utf-8");
+      expect(patched).toContain("async function __nemoclawNotifyDeniedSlackMention(");
+      expect(patched).toContain(
+        "nemoclaw: bounded denial feedback for explicit slack @-mentions (#4752)",
+      );
+
+      // Denied explicit @-mention: command stays denied, exactly one ephemeral feedback.
+      const mention = await runPatchedDenyPath(patched, { opts: { source: "app_mention" } });
+      expect(mention.result).toBeNull();
+      expect(mention.calls).toHaveLength(1);
+      expect(mention.calls[0]).toMatchObject({
+        method: "chat.postEphemeral",
+        channel: "C1",
+        user: "U999DENIED",
+      });
+      expect(mention.calls[0].text).toBeTruthy();
+      expect(mention.calls[0].text).not.toContain("U0AR85ATALW");
+      expect(mention.calls[0].text?.toLowerCase()).not.toContain("allowlist");
+
+      // Denied non-mention: no sender feedback (stays silent, as before).
+      const silent = await runPatchedDenyPath(patched, { opts: { source: "message" } });
+      expect(silent.result).toBeNull();
+      expect(silent.calls).toHaveLength(0);
+
+      // Explicit bot mention on a non-app_mention event also triggers feedback.
+      const explicitUser = await runPatchedDenyPath(patched, {
+        opts: { source: "message" },
+        explicitlyMentionedBotUser: true,
+      });
+      expect(explicitUser.result).toBeNull();
+      expect(explicitUser.calls).toHaveLength(1);
+      expect(explicitUser.calls[0].method).toBe("chat.postEphemeral");
+
+      const explicitSubteam = await runPatchedDenyPath(patched, {
+        opts: { source: "message" },
+        explicitlyMentionedBotSubteam: true,
+      });
+      expect(explicitSubteam.result).toBeNull();
+      expect(explicitSubteam.calls).toHaveLength(1);
+      expect(explicitSubteam.calls[0].method).toBe("chat.postEphemeral");
+
+      // Definitive non-delivery (user_not_in_channel) falls back to a DM.
+      const fallback = await runPatchedDenyPath(patched, {
+        opts: { source: "app_mention" },
+        ephemeralErrorCode: "user_not_in_channel",
+      });
+      expect(fallback.result).toBeNull();
+      expect(fallback.calls.map((call) => call.method)).toEqual([
+        "chat.postEphemeral",
+        "chat.postMessage",
+      ]);
+      expect(fallback.calls[1]).toMatchObject({ channel: "DU999DENIED" });
+
+      // Ambiguous failure (Slack may have accepted it): log, no DM, no double-notify.
+      const ambiguous = await runPatchedDenyPath(patched, {
+        opts: { source: "app_mention" },
+        ephemeralErrorCode: "service_unavailable",
+      });
+      expect(ambiguous.result).toBeNull();
+      expect(ambiguous.calls.map((call) => call.method)).toEqual(["chat.postEphemeral"]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent across repeated runs", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-deny-idem-"));
+    const prepareFile = writeSlackPackage(tmp);
+    try {
+      expect(runPatch(tmp).status).toBe(0);
+      const rerun = runPatch(tmp);
+      expect(rerun.status, `${rerun.stdout}${rerun.stderr}`).toBe(0);
+      const patched = fs.readFileSync(prepareFile, "utf-8");
+      expect(patched.match(/async function __nemoclawNotifyDeniedSlackMention\(/g)).toHaveLength(1);
+      expect(
+        patched.match(/nemoclaw: bounded denial feedback for explicit slack @-mentions/g),
+      ).toHaveLength(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when no @openclaw/slack package is present", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-deny-none-"));
+    fs.mkdirSync(path.join(tmp, "node_modules", "openclaw"), { recursive: true });
+    try {
+      const patch = runPatch(tmp);
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      expect(patch.stdout).toContain("no @openclaw/slack package found");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly when the deny-gate shape changes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-deny-shape-"));
+    writeSlackPackage(tmp, {
+      denyLine: "logVerbose(`Blocked unauthorized slack sender ${senderId} (renamed gate)`);",
+    });
+    try {
+      const patch = runPatch(tmp);
+      expect(patch.status).toBe(1);
+      expect(patch.stderr).toContain("deny gate shape not recognized");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly when the mention-state shape changes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-slack-deny-mention-"));
+    writeSlackPackage(tmp, { withMentionState: false });
+    try {
+      const patch = runPatch(tmp);
+      expect(patch.status).toBe(1);
+      expect(patch.stderr).toContain("mention-state shape not recognized");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A non-allowlisted human who explicitly @-mentions the bot in a Slack channel had their command correctly blocked by the `SLACK_ALLOWED_USERS` / channel-users allowlist, but OpenClaw dropped the event silently — no reply, DM, or reaction — so the sender had no signal the bot saw them. This patches the deployed sandbox's OpenClaw Slack channel to keep the command denied while sending one bounded, sender-facing feedback message.

## Related Issue

Fixes #4752

## Changes

- **New `scripts/patch-openclaw-slack-deny-feedback.mts`** — NemoClaw-owned compatibility patch for the installed `@openclaw/slack` `prepareSlackMessage` deny path. On the channel-users deny gate it keeps returning no prepared command, but for an explicit @-mention (`app_mention` or an explicit bot mention) it sends exactly one sender-facing message: `chat.postEphemeral` in the mentioned channel, falling back to a DM. The denial text never reveals the allowlist contents and the command text is not processed. Non-mention denials stay silent as before.
- The patch classifies the compiled Slack dist by content signature, **fails the image build loudly** if a `@openclaw/slack` package is present but the deny-path/mention-state shape is unrecognized, and is a **no-op** when the Slack channel is not enabled for the image.
- **`Dockerfile`** — copy the patch script and run it after the messaging-plugin install (`/sandbox/.openclaw`, npm global root), mirroring the existing `patch-openclaw-*` shims.
- **`test/e2e/lib/slack-api-proof.sh`** — record sender-facing `chat.*` calls and assert a denied `app_mention` prepares no command yet produces exactly one ephemeral feedback action addressed to the sender, without leaking the allowlist; surface `deniedFeedbackMethod`/`deniedFeedbackCount` in the proof output.
- **`test/e2e/test-messaging-providers.sh`** — new `M-S17d` assertion on that bounded feedback.
- **`test/openclaw-slack-deny-feedback-patch.test.ts`** — unit coverage for injection + functional behavior (one ephemeral on mention, DM fallback on ephemeral failure, silent on non-mention), idempotency, no-op when no Slack package, and fail-loud on deny-gate / mention-state shape drift.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] Reproduced the bug against the exact shipped `@openclaw/slack@2026.5.27` dist: denied `app_mention` returned `null` with **zero** feedback; after the patch it returns `null` with **exactly one** `chat.postEphemeral` to the sender (DM fallback verified; non-mention denial stays silent).
- [x] `npx @biomejs/biome check` clean on new files; `tsc -p tsconfig.cli.json` clean.
- [x] New patch unit test passes (5/5); full `cli` vitest project passes except 3 pre-existing, environment-only failures unrelated to this change (openshell version fetch, rc-file ownership, GPU proof) — confirmed identical on a clean tree.
- [x] Tests added/updated for the changed behavior.
- [x] No secrets, API keys, or credentials committed.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack bot now sends a single, bounded sender-facing feedback message when an explicit `@-mention` is denied — delivered as an ephemeral in-channel message (with thread context when available) or a DM fallback, without exposing allowlist details.

* **Tests**
  * Added end-to-end and unit tests verifying denied-mention feedback behavior, DM fallback, non-leakage of identifiers, idempotency, and no-op behavior when Slack integration is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->