### PR TITLE
fix(onboard): classify ARM64 image-tar upload 404 with image-ref workaround (#3266)

### DIFF
--- a/src/lib/build-context.test.ts
+++ b/src/lib/build-context.test.ts
@@ -3,7 +3,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { printSandboxCreateRecoveryHints, shouldIncludeBuildContextPath } from "../../dist/lib/build-context";
+import {
+  extractBuiltImageRef,
+  printSandboxCreateRecoveryHints,
+  reconstructImageRefCreateCommand,
+  shouldIncludeBuildContextPath,
+} from "../../dist/lib/build-context";
 
 type ConsoleErrorSpy = ReturnType<typeof vi.spyOn>;
 
@@ -75,5 +80,155 @@ describe("printSandboxCreateRecoveryHints", () => {
     expect(stderr()).toContain("image push/import stream was interrupted");
     expect(stderr()).toContain("onboard --resume");
     expect(stderr()).toContain("reached the gateway");
+  });
+
+  // Manual / ARM64 E2E note (#3266):
+  //
+  // The misleading "failed to upload image tar into container" Docker 404 only
+  // reproduces on Linux ARM64 (aarch64) hosts when OpenShell streams a large
+  // built image tar into the gateway container; it cannot be reproduced on
+  // x86_64. To verify on real aarch64 hardware:
+  //   1. `nemoclaw onboard` on a Linux ARM64 host with a large sandbox image.
+  //   2. Confirm OpenShell aborts with the upload-tar 404 against
+  //      `openshell-cluster-nemoclaw` even though the gateway container is up.
+  //   3. Confirm NemoClaw now prints the local-registry / image-ref workaround
+  //      (with the preserved built image tag) and the "Linux ARM64 (aarch64)"
+  //      note instead of the bare `onboard --resume` guidance.
+  //   4. Follow the printed steps — re-run NemoClaw's own create invocation with
+  //      `--from localhost:5000/<built-image>` swapped in (keeping the provider/
+  //      GPU/resource flags and the `-- env … nemoclaw-start` wrapper) — and
+  //      confirm the sandbox is created without rebuilding.
+  // This recovery path runs ONLY after the OpenShell upload failure is
+  // classified; ordinary x86_64 happy-path onboards never reach it. The tests
+  // below assert that branch deterministically by injecting platform/arch.
+  it("prints the local-registry workaround with the preserved built image tag for the #3266 upload 404", () => {
+    printSandboxCreateRecoveryHints(
+      [
+        "  Built image openshell/sandbox-from-nemoclaw:abcd1234",
+        "Error: failed to upload image tar into container",
+        "Docker responded with status code 404: the container does not exist",
+        'no container with name or ID "openshell-cluster-nemoclaw" found',
+      ].join("\n"),
+      { platform: "linux", arch: "x64" },
+    );
+
+    const out = stderr();
+    expect(out).toContain("failed to upload the image tar into the gateway container");
+    expect(out).toContain("gateway container is healthy");
+    expect(out).toContain("registry:2");
+    // Preserves the built image tag so the operator can re-tag/push without rebuilding.
+    expect(out).toContain("docker push localhost:5000/openshell/sandbox-from-nemoclaw:abcd1234");
+    // Covers buildah-built images (the ARM64 path that triggers #3266): a docker-only
+    // push fails with "No such image" when the image lives in buildah storage.
+    expect(out).toContain(
+      "buildah push openshell/sandbox-from-nemoclaw:abcd1234 docker://localhost:5000/openshell/sandbox-from-nemoclaw:abcd1234",
+    );
+    // Step 3 must point at NemoClaw's own create invocation (swap only --from), not a
+    // pared-down command that would drop the provider/GPU/resource/env flags.
+    expect(out).toContain("--from localhost:5000/openshell/sandbox-from-nemoclaw:abcd1234");
+    expect(out).toContain("nemoclaw-start");
+    expect(out).not.toContain("openshell sandbox create --from");
+    expect(out).toContain("onboard --resume");
+  });
+
+  it("adds the Linux ARM64 (aarch64) note for the #3266 upload 404 only on Linux arm64", () => {
+    printSandboxCreateRecoveryHints("failed to upload image tar into container", {
+      platform: "linux",
+      arch: "arm64",
+    });
+    expect(stderr()).toContain("known limitation on Linux ARM64 (aarch64)");
+  });
+
+  it("omits the ARM64 note for the #3266 upload 404 on x86_64 hosts", () => {
+    printSandboxCreateRecoveryHints("failed to upload image tar into container", {
+      platform: "linux",
+      arch: "x64",
+    });
+    const out = stderr();
+    expect(out).not.toContain("Linux ARM64 (aarch64)");
+    expect(out).toContain("Workaround without rebuilding the image");
+  });
+
+  it("reconstructs NemoClaw's create command (only --from swapped) when createArgs are supplied", () => {
+    printSandboxCreateRecoveryHints(
+      [
+        "  Built image openshell/sandbox-from-nemoclaw:abcd1234",
+        "failed to upload image tar into container",
+      ].join("\n"),
+      {
+        platform: "linux",
+        arch: "arm64",
+        createArgs: [
+          "--from",
+          "/tmp/nemoclaw-xyz/Dockerfile",
+          "--name",
+          "my-assistant",
+          "--policy",
+          "/tmp/nemoclaw-policy-xyz.yaml",
+          "--provider",
+          "my-assistant-slack",
+        ],
+      },
+    );
+
+    const out = stderr();
+    // --from points at the pushed registry ref, not the (cleaned-up) Dockerfile.
+    expect(out).toContain("--from localhost:5000/openshell/sandbox-from-nemoclaw:abcd1234");
+    expect(out).not.toContain("/tmp/nemoclaw-xyz/Dockerfile");
+    // The configured provider/name flags survive so the recreated sandbox is not misconfigured.
+    expect(out).toContain("--name my-assistant");
+    expect(out).toContain("--provider my-assistant-slack");
+    // The temporary policy path is not echoed; a placeholder takes its place.
+    expect(out).not.toContain("/tmp/nemoclaw-policy-xyz.yaml");
+    expect(out).toContain("<your-policy-file>");
+    // The runtime env wrapper is represented by a placeholder, never dumped verbatim.
+    expect(out).toContain("nemoclaw-start");
+    expect(out).toContain("<YOUR_RUNTIME_ENV>");
+  });
+
+  it("falls back to placeholder push commands when no built image tag is in the output", () => {
+    printSandboxCreateRecoveryHints("failed to upload image tar into container", {
+      platform: "linux",
+      arch: "arm64",
+    });
+    expect(stderr()).toContain("<built-image>");
+  });
+});
+
+describe("reconstructImageRefCreateCommand", () => {
+  it("swaps --from to the registry ref and masks the temporary --policy value", () => {
+    const cmd = reconstructImageRefCreateCommand(
+      ["--from", "/tmp/x/Dockerfile", "--name", "asst", "--policy", "/tmp/p.yaml", "--gpus", "all"],
+      "localhost:5000/openshell/sandbox:tag",
+    );
+    expect(cmd).toBe(
+      "openshell sandbox create --from localhost:5000/openshell/sandbox:tag --name asst " +
+        "--policy <your-policy-file> --gpus all -- env <YOUR_RUNTIME_ENV> nemoclaw-start",
+    );
+  });
+
+  it("handles a trailing --from with no following value without crashing", () => {
+    // Defensive: a malformed args array must not throw or duplicate the ref.
+    const cmd = reconstructImageRefCreateCommand(["--name", "asst", "--from"], "registry/ref:1");
+    expect(cmd).toBe("openshell sandbox create --name asst --from -- env <YOUR_RUNTIME_ENV> nemoclaw-start");
+  });
+});
+
+describe("extractBuiltImageRef", () => {
+  it("reads the ref from a 'Successfully tagged' line", () => {
+    expect(extractBuiltImageRef("Successfully tagged openshell/sandbox:tag1")).toBe(
+      "openshell/sandbox:tag1",
+    );
+  });
+
+  it("reads the ref from a '  Built image' line", () => {
+    expect(extractBuiltImageRef("  Built image openshell/sandbox-from-nemoclaw:abcd1234")).toBe(
+      "openshell/sandbox-from-nemoclaw:abcd1234",
+    );
+  });
+
+  it("returns null when no built image line is present", () => {
+    expect(extractBuiltImageRef("nothing relevant here")).toBeNull();
+    expect(extractBuiltImageRef("")).toBeNull();
   });
 });

--- a/src/lib/build-context.ts
+++ b/src/lib/build-context.ts
@@ -6,11 +6,11 @@
  * creation failures.
  */
 
-import { CLI_NAME } from "./cli/branding";
 import fs from "node:fs";
 import path from "node:path";
+import { CLI_NAME } from "./cli/branding";
 
-import { classifySandboxCreateFailure } from "./validation";
+import { classifySandboxCreateFailure, planSandboxCreateRecovery } from "./validation";
 
 const EXCLUDED_SEGMENTS = new Set([
   ".venv",
@@ -43,8 +43,115 @@ export function copyBuildContextDir(sourceDir: string, destinationDir: string): 
   });
 }
 
-export function printSandboxCreateRecoveryHints(output = ""): void {
+/**
+ * Pull the built sandbox image tag/ref out of the OpenShell create output so a
+ * recovery hint can tell the operator how to re-tag and push the *already
+ * built* image instead of rebuilding from the Dockerfile. OpenShell/Docker emit
+ * it on lines like "Successfully tagged <ref>" or "  Built image <ref>".
+ * Returns null when no tag is present in the captured output.
+ */
+export function extractBuiltImageRef(output = ""): string | null {
+  const text = String(output || "");
+  const patterns = [/^Successfully tagged\s+(\S+)/im, /^\s*Built image\s+(\S+)/im];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Reconstruct the `openshell sandbox create` command for the image-ref
+ * workaround from the structured `createArgs` onboard built. Swaps the
+ * `--from <Dockerfile>` value for the pushed registry ref and replaces the
+ * `--policy <tmp>` value with a placeholder, because onboard generates the
+ * policy into a temporary file that is cleaned up after a failed create.
+ *
+ * Only the structured flags (providers, GPU/resource, name) are echoed — never
+ * the `-- env … nemoclaw-start` runtime wrapper, which carries non-secret-by-
+ * design but still host-specific env (proxy host, dashboard URL) we do not want
+ * to dump to the console. The wrapper is represented by a placeholder instead.
+ */
+export function reconstructImageRefCreateCommand(
+  createArgs: readonly string[],
+  registryRef: string,
+): string {
+  const rebuilt: string[] = [];
+  for (let i = 0; i < createArgs.length; i++) {
+    const arg = createArgs[i];
+    rebuilt.push(arg);
+    if ((arg === "--from" || arg === "--policy") && i + 1 < createArgs.length) {
+      rebuilt.push(arg === "--from" ? registryRef : "<your-policy-file>");
+      i += 1; // skip the original (temporary) value
+    }
+  }
+  return `openshell sandbox create ${rebuilt.join(" ")} -- env <YOUR_RUNTIME_ENV> nemoclaw-start`;
+}
+
+export function printSandboxCreateRecoveryHints(
+  output = "",
+  {
+    platform = process.platform,
+    arch = process.arch,
+    createArgs,
+  }: {
+    platform?: NodeJS.Platform;
+    arch?: NodeJS.Architecture;
+    createArgs?: readonly string[];
+  } = {},
+): void {
   const failure = classifySandboxCreateFailure(output);
+  if (failure.kind === "image_upload_container_missing") {
+    const { arm64ImageRefWorkaround } = planSandboxCreateRecovery(failure, { platform, arch });
+    const builtRef = extractBuiltImageRef(output);
+    console.error(
+      "  Hint: OpenShell built the sandbox image but failed to upload the image tar into the gateway container",
+    );
+    console.error(
+      "        (Docker 404 'container does not exist'). The gateway container is healthy — this is the",
+    );
+    console.error("        OpenShell large-tar upload path failing, not a missing gateway.");
+    if (arm64ImageRefWorkaround) {
+      console.error("  This is a known limitation on Linux ARM64 (aarch64). Workaround without rebuilding:");
+    } else {
+      console.error("  Workaround without rebuilding the image:");
+    }
+    console.error("    1. Start a local registry the gateway can reach:");
+    console.error("         docker run -d -p 5000:5000 --restart=always --name registry registry:2");
+    const sourceRef = builtRef ?? "<built-image>";
+    const registryRef = `localhost:5000/${sourceRef}`;
+    // OpenShell builds the sandbox image with whichever builder the host uses
+    // (Docker on most hosts; buildah on the Linux ARM64 path that triggers
+    // #3266). A docker-only push fails with "No such image" when the image
+    // lives in buildah/containers storage, so emit both forms and let the
+    // operator match whichever the build log above showed. See #3266.
+    console.error("    2. Push the image OpenShell just built to that registry, using the same");
+    console.error("       builder the build log above used —");
+    console.error("       Docker build:");
+    console.error(`         docker tag ${sourceRef} ${registryRef}`);
+    console.error(`         docker push ${registryRef}`);
+    console.error("       buildah build (log shows `COMMIT` / buildah steps):");
+    console.error(`         buildah push ${sourceRef} docker://${registryRef}`);
+    // Reconstruct NemoClaw's own create command (when we have the structured
+    // args) so the operator does not have to guess the provider/GPU/resource
+    // flags onboard added. A pared-down command would build a misconfigured
+    // sandbox that then blocks `onboard --resume`. When the args are not
+    // available, fall back to describing the one-token swap.
+    if (createArgs && createArgs.length > 0) {
+      console.error("    3. Re-create the sandbox from that image ref. This is the create command");
+      console.error("       NemoClaw ran, with --from swapped to the pushed image. Replace the policy");
+      console.error("       placeholder with your policy file (onboard's was a temporary file) and the");
+      console.error("       runtime env placeholder with the env NemoClaw set (dashboard port, proxy):");
+      console.error(`         ${reconstructImageRefCreateCommand(createArgs, registryRef)}`);
+    } else {
+      console.error("    3. Re-run the sandbox create OpenShell just attempted, but replace the");
+      console.error(`       \`--from <…/Dockerfile>\` argument with \`--from ${registryRef}\` (this skips`);
+      console.error("       the tar upload). Keep every other flag NemoClaw used — the providers, any");
+      console.error("       GPU/resource flags, and the trailing `-- env … nemoclaw-start` command.");
+    }
+    console.error(`  If you would rather let NemoClaw rebuild and retry from scratch: ${CLI_NAME} onboard --resume`);
+    return;
+  }
   if (failure.kind === "image_transfer_timeout") {
     console.error("  Hint: image upload into the OpenShell gateway timed out.");
     console.error(`  Recovery: ${CLI_NAME} onboard --resume`);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3598,7 +3598,7 @@ async function createSandbox(
         console.error(createResult.output);
       }
       console.error("  Try:  openshell sandbox list        # check gateway state");
-      printSandboxCreateRecoveryHints(createResult.output);
+      printSandboxCreateRecoveryHints(createResult.output, { createArgs });
       process.exit(createResult.status || 1);
     }
   }

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,18 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 // Import from compiled dist/ so coverage is attributed correctly.
 import {
-  classifyValidationFailure,
   classifyApplyFailure,
   classifySandboxCreateFailure,
-  validateNvidiaApiKeyValue,
-  isSafeModelId,
+  classifyValidationFailure,
   isNvcfFunctionNotFoundForAccount,
+  isSafeModelId,
   nvcfFunctionNotFoundMessage,
-  shouldSkipResponsesProbe,
+  planSandboxCreateRecovery,
   shouldForceCompletionsApi,
+  shouldSkipResponsesProbe,
+  validateNvidiaApiKeyValue,
 } from "../../dist/lib/validation";
 
 describe("classifyValidationFailure", () => {
@@ -257,6 +258,66 @@ describe("classifySandboxCreateFailure", () => {
     const output = "Created sandbox: test-sandbox\nError: handshake verification failed";
     const result = classifySandboxCreateFailure(output);
     expect(result.kind).toBe("tls_cert_mismatch");
+  });
+
+  it("detects the misleading image-tar upload 404 from the upload-tar phrase (#3266)", () => {
+    const result = classifySandboxCreateFailure("Error: failed to upload image tar into container");
+    expect(result.kind).toBe("image_upload_container_missing");
+  });
+
+  it("detects the misleading image-tar upload 404 from the reported aarch64 output shape (#3266)", () => {
+    const output = [
+      "  Built image openshell/sandbox-from-nemoclaw:abcd1234",
+      "Docker responded with status code 404: the container does not exist",
+      'no container with name or ID "openshell-cluster-nemoclaw" found',
+    ].join("\n");
+    const result = classifySandboxCreateFailure(output);
+    expect(result.kind).toBe("image_upload_container_missing");
+  });
+
+  it("does NOT classify an unrelated 404 as image_upload_container_missing (#3266 regression guard)", () => {
+    // A generic 404 with no upload-tar phrase and no gateway container name
+    // must not be mistaken for the ARM64 upload failure.
+    expect(
+      classifySandboxCreateFailure("Docker responded with status code 404: the container does not exist").kind,
+    ).toBe("unknown");
+    expect(
+      classifySandboxCreateFailure("HTTP 404: model not found").kind,
+    ).toBe("unknown");
+  });
+});
+
+describe("planSandboxCreateRecovery", () => {
+  const uploadFailure = {
+    kind: "image_upload_container_missing" as const,
+    uploadedToGateway: false,
+  };
+
+  it("offers the image-ref workaround on Linux ARM64 (#3266)", () => {
+    expect(planSandboxCreateRecovery(uploadFailure, { platform: "linux", arch: "arm64" })).toEqual({
+      arm64ImageRefWorkaround: true,
+    });
+  });
+
+  it("does not offer the ARM64 workaround on x86_64 Linux (preserve x86_64 path)", () => {
+    expect(planSandboxCreateRecovery(uploadFailure, { platform: "linux", arch: "x64" })).toEqual({
+      arm64ImageRefWorkaround: false,
+    });
+  });
+
+  it("does not offer the ARM64 workaround on macOS ARM64 (Linux-only signature)", () => {
+    expect(planSandboxCreateRecovery(uploadFailure, { platform: "darwin", arch: "arm64" })).toEqual({
+      arm64ImageRefWorkaround: false,
+    });
+  });
+
+  it("does not offer the workaround for unrelated failure kinds even on Linux ARM64", () => {
+    expect(
+      planSandboxCreateRecovery(
+        { kind: "image_transfer_timeout", uploadedToGateway: false },
+        { platform: "linux", arch: "arm64" },
+      ),
+    ).toEqual({ arm64ImageRefWorkaround: false });
   });
 });
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -13,8 +13,25 @@ export interface ValidationClassification {
 }
 
 export interface SandboxCreateFailure {
-  kind: "image_transfer_timeout" | "image_transfer_reset" | "sandbox_create_incomplete" | "tls_cert_mismatch" | "unknown";
+  kind:
+    | "image_transfer_timeout"
+    | "image_transfer_reset"
+    | "image_upload_container_missing"
+    | "sandbox_create_incomplete"
+    | "tls_cert_mismatch"
+    | "unknown";
   uploadedToGateway: boolean;
+}
+
+export interface SandboxCreateRecoveryPlan {
+  /**
+   * Emit the Linux ARM64 (aarch64) local-registry / image-ref workaround for
+   * the misleading "failed to upload image tar into container" Docker 404. The
+   * gateway container is healthy; OpenShell's large-tar upload path is the
+   * problem, and pushing the built image to a local registry then creating
+   * from the image ref bypasses it. See #3266.
+   */
+  arm64ImageRefWorkaround: boolean;
 }
 
 export interface GatewayStartFailure {
@@ -92,10 +109,49 @@ export function classifySandboxCreateFailure(output = ""): SandboxCreateFailure 
   if (/invalid peer certificate|BadSignature|handshake verification failed|certificate verify failed|SSL certificate problem|x509: certificate|unknown authority/i.test(text)) {
     return { kind: "tls_cert_mismatch", uploadedToGateway };
   }
+  // Misleading "container does not exist" 404 raised while OpenShell streams the
+  // built image tar into the (healthy) gateway container. Reported on Linux
+  // ARM64 with large images: the gateway is up and a same-size archive PUT
+  // succeeds directly, so the Docker 404 is a symptom of the tar-upload path,
+  // not a missing gateway. Match the distinctive upload-tar phrase, or the
+  // combined 404 + container-missing + gateway-container-name shape. See #3266.
+  if (
+    /failed to upload image tar into container/i.test(text) ||
+    (/status code 404/i.test(text) &&
+      /(container does not exist|no container with name or ID)/i.test(text) &&
+      /openshell-cluster-nemoclaw/i.test(text))
+  ) {
+    return { kind: "image_upload_container_missing", uploadedToGateway };
+  }
   if (/Created sandbox:/i.test(text)) {
     return { kind: "sandbox_create_incomplete", uploadedToGateway: true };
   }
   return { kind: "unknown", uploadedToGateway };
+}
+
+/**
+ * Decide how to recover from a classified sandbox-create failure. Pure: takes
+ * the classification plus the host platform/arch, returns a typed plan. Kept
+ * separate from the I/O hint printer so the retry/workaround decision can be
+ * unit-tested without spying on the console.
+ *
+ * Today the only special-cased recovery is the Linux ARM64 image-tar-upload
+ * 404 (#3266); every other failure leaves the plan flags false so callers fall
+ * through to the existing generic resume guidance.
+ */
+export function planSandboxCreateRecovery(
+  failure: SandboxCreateFailure,
+  {
+    platform = process.platform,
+    arch = process.arch,
+  }: { platform?: NodeJS.Platform; arch?: NodeJS.Architecture } = {},
+): SandboxCreateRecoveryPlan {
+  return {
+    arm64ImageRefWorkaround:
+      failure.kind === "image_upload_container_missing" &&
+      platform === "linux" &&
+      arch === "arm64",
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

On Linux ARM64 (aarch64), OpenShell's `sandbox create --from <Dockerfile>` path can fail while streaming the built image tar into the gateway container with a misleading Docker 404 (`failed to upload image tar into container` / `the container does not exist` for `openshell-cluster-nemoclaw`). The gateway is actually healthy — a same-size archive PUT succeeds directly — so the 404 is a symptom of the large-tar upload path, not a missing gateway. NemoClaw previously classified this as `unknown` and printed the generic `onboard --resume` hint, which just re-runs the same deterministically failing path. This PR classifies the failure and emits a precise, leak-safe local-registry / image-ref workaround that preserves the built image tag so the operator can recreate the sandbox without rebuilding.

## Related Issue

Relates to #3266 (mitigation, not a closing fix). The root cause is OpenShell's image-tar upload path on ARM64; NemoClaw cannot make that upload succeed from its side. This change turns the misleading, unactionable failure into a classified error with an accurate workaround (the gateway is healthy; push the built image to a local registry and recreate from the image ref). Onboarding still does not complete automatically on the affected ARM64 path, so no closing keyword is used.

## Changes

- `classifySandboxCreateFailure`: new `image_upload_container_missing` kind detecting the upload-tar phrase, or the combined `status code 404` + container-missing + `openshell-cluster-nemoclaw` shape.
- New pure `planSandboxCreateRecovery(failure, {platform, arch})` that decides the Linux-ARM64-targeted workaround — unit-testable without console spying. Other platforms get the generic note.
- `printSandboxCreateRecoveryHints` now emits the workaround: start a local registry, push the built image with the matching builder (`docker push` **or** `buildah push` — the ARM64 build path uses buildah, where a docker-only push fails with `No such image`), then recreate from the registry ref.
- The recreate step reconstructs NemoClaw's **own** create command (via the existing `createArgs`) with only `--from` swapped to the registry ref, so the configured provider/GPU/resource flags are preserved and the recreated sandbox is not misconfigured. The temporary `--policy` path and the `-- env … nemoclaw-start` runtime wrapper are shown as placeholders rather than dumped verbatim (the temp policy is cleaned up; the env wrapper carries host-specific values).
- `onboard.ts`: net-zero single-line edit passing the existing `createArgs` to the hint.
- Unit tests for the classifier, the recovery decision, the builder-agnostic hints, the built-image-ref extraction, and the create-command reconstruction. Manual aarch64 E2E note added alongside the tests.

Normal x86_64 happy paths are untouched: this path runs only after the OpenShell upload failure is classified.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] Targeted tests pass: `vitest run --project cli src/lib/validation.test.ts src/lib/build-context.test.ts` (76 passed)
- [x] `npm run typecheck:cli` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] `codex review --uncommitted` clean (no actionable findings)

Reproduction: this host is x86_64 (`uname -m` → `x86_64`), so the ARM64 hardware bug cannot be reproduced directly. The classifier/decision path was reproduced through the built CLI (`dist/`) with a controlled OpenShell output fixture: before the fix it classified as `unknown` and printed only `onboard --resume`; after the fix it classifies as `image_upload_container_missing` and prints the workaround. `npm test` was run; the 39 failing tests are pre-existing environment-only subprocess-spawn timeouts (confirmed identical on a stashed baseline) and are unrelated to this change.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error recovery guidance when sandbox creation fails due to image upload issues.
  * Added platform-specific recovery recommendations for ARM64 Linux systems.
  * Improved recovery instructions with detailed step-by-step guidance and alternative deployment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->