### PR TITLE
docs(policy): refine shared triage taxonomy

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-policies/references/examples.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/examples.md
@@ -88,7 +88,117 @@ Dry run:
 Anti-examples:
 
 - Do not add `documentation`; set native Issue Type `Documentation`.
-- Do not add `status: triage`; use `needs: triage` only if maintainer workflow review is still needed.
+- Do not add `status: triage` or `needs: triage` from normal triage output.
+
+### Named Integration Issue
+
+Evidence:
+
+- The title is `[hermes] Missing hermes TUI`.
+- The affected subject is the Hermes integration.
+
+Dry run:
+
+```json
+{
+  "item_number": 104,
+  "item_kind": "issue",
+  "issue_type_to_set": "Bug",
+  "labels_to_add": ["integration: hermes", "area: ui"],
+  "labels_to_remove": [],
+  "labels_to_create": [],
+  "labels_to_delete": [],
+  "issue_fields_to_set": {},
+  "project_fields_to_set": {
+    "Status": "Backlog"
+  },
+  "recommended_action": "triage",
+  "confidence": "high",
+  "rationale": {
+    "issue_type_to_set": "The report describes missing expected UI behavior.",
+    "integration: hermes": "The title names Hermes as the affected integration.",
+    "area: ui": "The missing surface is the TUI."
+  },
+  "questions_for_author": [],
+  "human_review_required": false
+}
+```
+
+Anti-examples:
+
+- Do not use only `area: integrations` when a listed integration such as Hermes is the affected subject.
+- Do not add `needs: info` if the title and body already provide enough routing evidence.
+
+### OpenClaw E2E Failure
+
+Evidence:
+
+- The title includes `openclaw-tui-chat-correlation-e2e`.
+- The report is a nightly/e2e failure involving OpenClaw.
+
+Dry run:
+
+```json
+{
+  "item_number": 105,
+  "item_kind": "issue",
+  "issue_type_to_set": "Bug",
+  "labels_to_add": ["area: e2e", "area: ci", "integration: openclaw"],
+  "labels_to_remove": [],
+  "labels_to_create": [],
+  "labels_to_delete": [],
+  "issue_fields_to_set": {},
+  "project_fields_to_set": {
+    "Status": "Backlog"
+  },
+  "recommended_action": "triage",
+  "confidence": "high",
+  "rationale": {
+    "issue_type_to_set": "The report describes a failing validation path.",
+    "area: e2e": "The affected test is an e2e flow.",
+    "area: ci": "The failure is from nightly validation infrastructure.",
+    "integration: openclaw": "The test name identifies OpenClaw as the affected integration."
+  },
+  "questions_for_author": [],
+  "human_review_required": false
+}
+```
+
+### Windows ARM Install Failure In WSL
+
+Evidence:
+
+- The title includes `[Windows ARM][Install]`.
+- The body says WSL2 has no Ubuntu distro.
+
+Dry run:
+
+```json
+{
+  "item_number": 106,
+  "item_kind": "issue",
+  "issue_type_to_set": "Bug",
+  "labels_to_add": ["area: install", "platform: windows", "platform: arm64", "platform: wsl"],
+  "labels_to_remove": [],
+  "labels_to_create": [],
+  "labels_to_delete": [],
+  "issue_fields_to_set": {},
+  "project_fields_to_set": {
+    "Status": "Backlog"
+  },
+  "recommended_action": "triage",
+  "confidence": "high",
+  "rationale": {
+    "issue_type_to_set": "The report describes broken install behavior.",
+    "area: install": "The failure occurs during installation.",
+    "platform: windows": "The title identifies Windows as the host platform.",
+    "platform: arm64": "The title identifies Windows ARM.",
+    "platform: wsl": "The body identifies WSL2 as part of the failing setup."
+  },
+  "questions_for_author": [],
+  "human_review_required": false
+}
+```
 
 ### Feature Request Needing Design
 

--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
@@ -59,7 +59,7 @@
       "family": "pr_type",
       "item_kinds": ["pull_request"],
       "description": "PR primarily fixes broken behavior.",
-      "positive_signals": ["regression fix", "failing test fix", "crash fix", "incorrect output fix"],
+      "positive_signals": ["fix conventional commit prefix", "regression fix", "failing test fix", "crash fix", "incorrect output fix"],
       "negative_signals": ["new capability", "docs only", "tooling only"],
       "mutually_exclusive_group": "pr_type"
     },
@@ -68,7 +68,7 @@
       "family": "pr_type",
       "item_kinds": ["pull_request"],
       "description": "PR adds or expands user-visible capability.",
-      "positive_signals": ["new command", "new provider", "new workflow", "new user-facing behavior"],
+      "positive_signals": ["feat conventional commit prefix", "new command", "new provider", "new workflow", "new user-facing behavior"],
       "negative_signals": ["bug-only fix", "docs only"],
       "mutually_exclusive_group": "pr_type"
     },
@@ -77,7 +77,7 @@
       "family": "pr_type",
       "item_kinds": ["pull_request"],
       "description": "PR restructures code without intended behavior change.",
-      "positive_signals": ["cleanup", "decomposition", "architecture simplification"],
+      "positive_signals": ["refactor conventional commit prefix", "cleanup", "decomposition", "architecture simplification"],
       "negative_signals": ["intended behavior change"],
       "mutually_exclusive_group": "pr_type"
     },
@@ -86,7 +86,7 @@
       "family": "pr_type",
       "item_kinds": ["pull_request"],
       "description": "Docs, CI, dependencies, packaging, policy, or maintenance.",
-      "positive_signals": ["docs", "CI", "dependency", "skill policy", "automation", "packaging"],
+      "positive_signals": ["chore conventional commit prefix", "docs-only", "CI-only", "dependency", "skill policy", "generated skill sync", "automation", "packaging"],
       "negative_signals": ["primary product behavior change"],
       "mutually_exclusive_group": "pr_type"
     },
@@ -103,18 +103,18 @@
       "name": "needs: triage",
       "family": "needs",
       "item_kinds": ["issue", "pull_request"],
-      "description": "New issue or PR needs maintainer review for project workflow assignment, labeling, ownership, or next action.",
-      "positive_signals": ["new issue", "new PR", "project workflow assignment needed", "labeling needed", "ownership needed", "next action unclear"],
-      "negative_signals": ["already classified", "project workflow assignment complete", "owner assigned", "next action clear"],
+      "description": "Existing inbox/placeholder signal for unprocessed items; normal triage agents should not newly add it.",
+      "positive_signals": ["pre-triage inbox state before an agent produces recommendations"],
+      "negative_signals": ["normal triage output", "Type recommended", "labels recommended", "Project fields recommended", "already classified", "project workflow assignment complete", "owner assigned", "next action clear"],
       "mutually_exclusive_group": null
     },
     {
       "name": "needs: info",
       "family": "needs",
       "item_kinds": ["issue", "pull_request"],
-      "description": "Waiting on author for missing details.",
-      "positive_signals": ["missing repro", "missing logs", "missing version", "missing platform", "unclear intent"],
-      "negative_signals": ["enough context to act", "review-ready PR"],
+      "description": "Waiting on author for missing details required before work can proceed.",
+      "positive_signals": ["missing repro required for investigation", "missing logs required for investigation", "missing version required for routing", "missing platform required for routing", "unclear intent blocks review"],
+      "negative_signals": ["optional clarifying question only", "enough context to act", "enough context to route", "review-ready PR"],
       "mutually_exclusive_group": "primary_blocking_need"
     },
     {
@@ -122,8 +122,8 @@
       "family": "needs",
       "item_kinds": ["issue", "pull_request"],
       "description": "Requires product or architecture direction.",
-      "positive_signals": ["cross-cutting change", "unclear architecture", "product decision needed"],
-      "negative_signals": ["straightforward implementation"],
+      "positive_signals": ["cross-cutting change with no clear owner", "unclear architecture blocks implementation", "product decision needed before work can proceed"],
+      "negative_signals": ["straightforward implementation", "specific integration bug", "test flake", "documentation gap"],
       "mutually_exclusive_group": null
     },
     {
@@ -180,7 +180,9 @@
         "Use area labels for the affected product or code surface, not for every concept mentioned in the report.",
         "For install/onboarding/packaging overlap: use area: install for prerequisites or setup mechanics, area: onboarding for first-run flow and onboarding state, and area: packaging for shipped artifacts, images, registries, or distribution.",
         "For inference/providers/routing/local-models overlap: use area: inference for model execution or output behavior, area: providers for provider integration/configuration/selection work, area: routing for dispatch/fallback/model-selection logic, and area: local-models for local runtime, download, launch, or connectivity.",
-        "For integrations/messaging overlap: use area: integrations for external app or bridge behavior, area: messaging when message delivery/channel lifecycle is the affected subsystem, and add a specific integration:* label when one listed integration is involved."
+        "For integrations/messaging overlap: use area: integrations for external app or bridge behavior, area: messaging when message delivery/channel lifecycle is the affected subsystem, and add a specific integration:* label when one listed integration is involved.",
+        "Do not use only area: integrations when a canonical integration is named or clearly implicated; include the matching integration:* label.",
+        "For CI/e2e overlap: use area: ci for workflow, check, release automation, nightly-runner, or test infrastructure failures. Do not add area: ci merely because an e2e failure was observed in CI; use both area: ci and area: e2e only when the CI workflow, runner, scheduling, logs, or test infrastructure is part of the affected surface."
       ],
       "values": [
         "area: architecture",
@@ -217,8 +219,8 @@
         {
           "name": "area: ci",
           "description": "CI workflows, checks, release automation, or GitHub Actions.",
-          "positive_signals": ["GitHub Actions", "workflow failure", "CI check", "release automation", "test runner infrastructure"],
-          "negative_signals": ["runtime bug found by CI but not caused by CI", "manual test failure"]
+          "positive_signals": ["GitHub Actions", "workflow failure", "CI check", "release automation", "test runner infrastructure", "nightly runner", "e2e workflow or runner issue", "CI log or scheduling issue"],
+          "negative_signals": ["e2e failure merely observed in CI", "runtime bug found by CI but not caused by CI", "manual test failure"]
         },
         {
           "name": "area: cli",
@@ -254,7 +256,7 @@
           "name": "area: integrations",
           "description": "External app, tool, channel, or OpenClaw integration behavior.",
           "positive_signals": ["external app", "bridge", "channel", "integration setup", "third-party tool"],
-          "negative_signals": ["core product behavior with no external integration"]
+          "negative_signals": ["core product behavior with no external integration", "specific canonical integration named but matching integration:* label omitted"]
         },
         {
           "name": "area: local-models",
@@ -379,7 +381,7 @@
         {
           "name": "platform: arm64",
           "description": "ARM64 or aarch64-specific behavior.",
-          "positive_signals": ["ARM64-only failure", "aarch64 build failure", "architecture-specific binary or dependency", "reproduction differs between ARM64 and x86_64"],
+          "positive_signals": ["ARM64-only failure", "Windows ARM", "Windows ARM64", "aarch64 build failure", "architecture-specific binary or dependency", "reproduction differs between ARM64 and x86_64"],
           "negative_signals": ["platform only listed in environment", "same failure on x86_64", "Apple Silicon or Jetson issue better routed by platform: macos or platform: jetson alone"]
         },
         {
@@ -457,7 +459,7 @@
         {
           "name": "platform: wsl",
           "description": "Windows Subsystem for Linux behavior.",
-          "positive_signals": ["WSL", "WSL2", "Windows Subsystem for Linux", "WSL networking", "WSL filesystem path"],
+          "positive_signals": ["WSL", "WSL2", "Ubuntu on WSL", "Ubuntu on WSL2", "Windows Subsystem for Linux", "WSL networking", "WSL filesystem path"],
           "negative_signals": ["native Windows issue", "generic Linux issue without WSL-specific evidence"]
         }
       ],
@@ -520,7 +522,8 @@
       "selection_guidance": [
         "Apply integration labels only when a listed external app, channel, tool, or agent integration is specifically involved.",
         "Use area: integrations for integration subsystem work, and add integration:* when a listed integration is named or clearly implicated.",
-        "Use area: messaging when delivery, channel lifecycle, manifests, or bridge messages are the affected subsystem; combine it with integration:* when the messaging issue is specific to a listed integration."
+        "Use area: messaging when delivery, channel lifecycle, manifests, or bridge messages are the affected subsystem; combine it with integration:* when the messaging issue is specific to a listed integration.",
+        "If the title, body, linked issue, test name, file path, or PR prefix names a canonical integration as the affected subject, include the corresponding integration:* label. Do not replace the specific label with only area: integrations."
       ],
       "values": [
         "integration: brave",
@@ -547,14 +550,14 @@
         },
         {
           "name": "integration: hermes",
-          "description": "Hermes startup, plugin, or sandbox behavior.",
-          "positive_signals": ["Hermes", "Hermes plugin", "Hermes startup", "Hermes sandbox"],
+          "description": "Hermes startup, plugin, sandbox, TUI, or Hermes model/tool-call behavior.",
+          "positive_signals": ["Hermes", "[hermes]", "fix(hermes)", "agents/hermes", "Hermes-3", "Hermes TUI", "Hermes tool call", "Hermes plugin", "Hermes startup", "Hermes sandbox"],
           "negative_signals": ["generic plugin issue without Hermes evidence"]
         },
         {
           "name": "integration: openclaw",
-          "description": "OpenClaw runtime, plugins, configuration, or bridge.",
-          "positive_signals": ["OpenClaw", "OpenClaw runtime", "OpenClaw plugin", "OpenClaw bridge"],
+          "description": "OpenClaw runtime, TUI, e2e tests, stubs, plugins, configuration, or bridge.",
+          "positive_signals": ["OpenClaw", "openclaw", "openclaw-tui", "openclaw e2e", "OpenClaw runtime", "OpenClaw plugin", "OpenClaw bridge", "OpenClaw config", "OpenClaw stub"],
           "negative_signals": ["NemoClaw core behavior without OpenClaw involvement"]
         },
         {

--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
@@ -59,7 +59,8 @@ Use area labels for the affected product or code surface, not for every concept 
 
 - `area: install` for prerequisites or setup mechanics; `area: onboarding` for first-run flow and onboarding state; `area: packaging` for shipped artifacts, images, registries, or distribution.
 - `area: inference` for model execution or output behavior; `area: providers` for provider integration, configuration, or selection work; `area: routing` for dispatch, fallback, or model-selection logic; `area: local-models` for local runtime, download, launch, or connectivity.
-- `area: integrations` for external app or bridge behavior; `area: messaging` when message delivery or channel lifecycle is the affected subsystem; add a specific `integration:*` label when one listed integration is involved.
+- `area: integrations` for external app or bridge behavior; `area: messaging` when message delivery or channel lifecycle is the affected subsystem; add the specific `integration:*` label when one listed integration is named or clearly implicated. Do not use only `area: integrations` when the affected integration is one of the canonical `integration:*` values.
+- `area: ci` for workflow, check, release automation, nightly-runner, or test infrastructure failures. Do not add `area: ci` merely because an e2e failure was observed in CI; use both `area: ci` and `area: e2e` only when the CI workflow, runner, scheduling, logs, or test infrastructure is part of the affected surface.
 
 | Label | Description |
 |---|---|
@@ -96,6 +97,8 @@ Positive signals include platform-specific errors, platform-specific code paths,
 When evidence is ambiguous, use the platform label only when the platform seems routing-relevant or likely causal. Otherwise, leave it off and explain what evidence would make it platform-specific.
 
 When a more specific platform label applies, prefer it over a broader one unless both are independently routing-relevant. Do not add `platform: container`, `platform: arm64`, or an OS label just because the environment template mentions Docker, CPU architecture, or OS.
+
+Use the specific platform labels when the platform appears in the reported failure signature, title, or affected install path. For example, `Windows ARM`, `Windows ARM64`, or `aarch64` failure text supports `platform: arm64`; `WSL`, `WSL2`, or "Windows Subsystem for Linux" supports `platform: wsl`.
 
 | Label | Description |
 |---|---|
@@ -136,12 +139,14 @@ Integration labels apply when a recurring external app, channel, tool, or agent 
 
 Use `area: integrations` for integration subsystem work, and add `integration:*` when a listed integration is named or clearly implicated. Use `area: messaging` when delivery, channel lifecycle, manifests, or bridge messages are the affected subsystem; combine it with `integration:*` when the messaging issue is specific to a listed integration.
 
+Specific integration labels are routing labels. If the title, body, linked issue, test name, file path, or PR prefix names `Hermes`, `OpenClaw`, `Discord`, `Slack`, `Telegram`, `WeChat`, `WhatsApp`, or `Brave` as the affected subject, include the corresponding `integration:*` label. Do not replace the specific label with only `area: integrations`.
+
 | Label | Description |
 |---|---|
 | `integration: brave` | Brave integration behavior. |
 | `integration: discord` | Discord bridge or channel lifecycle. |
-| `integration: hermes` | Hermes startup, plugin, or sandbox behavior. |
-| `integration: openclaw` | OpenClaw runtime, plugins, configuration, or bridge. |
+| `integration: hermes` | Hermes startup, plugin, sandbox, TUI, or Hermes model/tool-call behavior. |
+| `integration: openclaw` | OpenClaw runtime, TUI, e2e tests, stubs, plugins, configuration, or bridge. |
 | `integration: slack` | Slack bridge, manifest, auth, or delivery behavior. |
 | `integration: telegram` | Telegram bot, bridge, polling, or delivery. |
 | `integration: wechat` | WeChat channel or bridge behavior. |
@@ -149,15 +154,15 @@ Use `area: integrations` for integration subsystem work, and add `integration:*`
 
 ### Needs
 
-`needs:*` labels are action queues. Remove them when the action is complete. `Needs Review` is a Project Status value, not a label.
+`needs:*` labels are blocking action queues. Remove them when the action is complete. `Needs Review` is a Project Status value, not a label. Normal initial triage should not add `needs: triage`; that label is an inbox/placeholder signal for unprocessed items.
 
 | Label | Applies To | Description |
 |---|---|---|
 | `needs: cleanup-review` | Issue, PR | Stale, superseded, competing, convergence-needed, or closure-candidate item needs maintainer judgment. |
 | `needs: design` | Issue, PR | Product or architecture direction is unclear or cross-cutting. |
-| `needs: info` | Issue, PR | Missing repro, logs, version, platform, answer, or PR context. |
+| `needs: info` | Issue, PR | Missing repro, logs, version, platform, answer, or PR context required before work can proceed. Optional clarifying questions should use `questions_for_author` without this label. |
 | `needs: rebase` | PR | Merge conflicts, dirty merge state, or rebase requested. |
-| `needs: triage` | Issue, PR | New issue or PR needs maintainer review for project workflow assignment, labeling, ownership, or next action. |
+| `needs: triage` | Issue, PR | Existing inbox/placeholder signal for unprocessed items. Do not newly add from normal triage once Type, labels, and Project fields are being recommended. |
 | `needs: unblock` | Issue, PR | Blocked item needs a dependency or decision resolved. |
 
 Do not combine:

--- a/.agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md
@@ -15,13 +15,14 @@ These instructions are for agents and skills that evaluate NemoClaw issues and P
 - Keep changes minimal: only add labels or fields that change routing, actionability, or reporting.
 - Project Status is a Project field, not a label. Valid values include `No Status`, `Backlog`, `In Progress`, `Blocked`, `Needs Review`, `NV QA`, `Done`, `Won't Fix`, and `Duplicate`.
 - Set `human_review_required: true` when the proposed write is outside the current authorization context, has elevated risk, or needs maintainer judgment before execution.
+- Normal initial triage should not add inbox or placeholder labels such as `needs: triage`. Use `questions_for_author` without a `needs:*` label when a question is useful but the item is still actionable.
 
 ## Issue Flow
 
 1. Classify the issue using native GitHub Issue Type: `Bug`, `Enhancement`, `Task`, `Documentation`, `Epic`, or `Initiative`.
 2. Add area labels only when the affected surface is clear.
-3. Add platform, provider, or integration labels only with explicit evidence.
-4. Add `needs:*` only when an immediate action queue is needed.
+3. Add platform, provider, or integration labels only with explicit evidence. When a listed integration is named as the affected subject, include the matching `integration:*` label rather than only the broad `area: integrations` label.
+4. Add `needs:*` only when an immediate blocking action queue is needed. Do not add `needs: triage` during normal triage.
 5. Recommend Project Priority from impact evidence, not user urgency language.
 6. Recommend Project Status separately from labels.
 7. Ask for missing information when the report is not actionable.
@@ -30,12 +31,12 @@ These instructions are for agents and skills that evaluate NemoClaw issues and P
 ## PR Flow
 
 1. Identify whether the PR is draft, conflicted, stale, blocked, or review-ready.
-2. Apply exactly one PR type label only when enough evidence exists: `bug-fix`, `feature`, `refactor`, or `chore`.
+2. Apply exactly one PR type label only when enough evidence exists: `bug-fix`, `feature`, `refactor`, or `chore`. Conventional commit prefixes are strong evidence: `fix` maps to `bug-fix`, `feat` maps to `feature`, `refactor` maps to `refactor`, and `chore`, docs-only, CI-only, skill-sync, dependency, packaging, or generated-policy maintenance maps to `chore`.
 3. Add `security` when the PR touches credentials, permissions, SSRF, sandbox escape risk, policy enforcement, or trusted installer paths.
 4. Add area/platform/provider/integration labels based on files changed and PR intent when useful for review routing.
 5. Recommend Project Status `Needs Review` for non-draft, conflict-free PRs that are awaiting maintainer review.
 6. Add `needs: rebase` when conflicts or rebase state blocks review.
-7. Add `needs: info` when contributor intent or required context is missing.
+7. Add `needs: info` only when contributor action is required before review can proceed. If the title, body, linked issue, or files changed provide enough routing evidence, ask optional questions without adding `needs: info`.
 8. Daily `v0.0.x` labels activate PRs for daily release work; adding one is not a readiness claim.
 
 ## Minimal Labeling
@@ -47,7 +48,7 @@ For issues, a high-quality dry run often includes:
 - Native Issue Type.
 - Zero to two area labels.
 - Optional platform/provider/integration labels when directly evidenced.
-- Optional `needs:*`.
+- Optional blocking `needs:*`; do not add `needs: triage` in normal triage output.
 - Project Priority and Status recommendations.
 - Optional daily release label only when the issue needs daily tracking, regression attention, or "needs PR" coordination.
 
@@ -56,7 +57,7 @@ For PRs, a high-quality dry run often includes:
 - One PR type label.
 - Area labels for review routing.
 - Optional `security`.
-- Optional `needs:*`.
+- Optional blocking `needs:*`; do not add `needs: triage` in normal triage output.
 - Project Status recommendation.
 - Optional daily release label only when the maintainer workflow activates the PR.
 
@@ -74,9 +75,9 @@ Never apply a label from a low-confidence inference.
 
 ## When To Ask For Info
 
-Use `needs: info` and ask targeted questions when:
+Use `needs: info` and ask targeted questions only when author action is required before work can proceed:
 
-- A bug report lacks reproduction steps, expected behavior, actual behavior, version, environment, or logs.
+- A bug report lacks the specific reproduction steps, expected behavior, actual behavior, version, environment, or logs needed to route or investigate it.
 - A platform-specific claim lacks platform details.
 - A provider or integration issue lacks provider/integration configuration.
 - A PR does not explain intent, scope, or linked issue and the diff could be interpreted multiple ways.
@@ -86,9 +87,9 @@ Ask for exact missing fields. Do not ask broad questions like "Can you provide m
 
 ## When To Use Needs Labels
 
-- `needs: triage`: Newly created issue or PR needs maintainer review for project workflow assignment, labeling, ownership, or next action.
-- `needs: info`: Author action is required before work can proceed.
-- `needs: design`: Product or architecture decision is required.
+- `needs: triage`: Existing inbox or placeholder label for unprocessed items. Normal triage agents should not newly add it once they are producing Type, label, and Project field recommendations.
+- `needs: info`: Author action is required before work can proceed; optional clarifying questions alone are not enough.
+- `needs: design`: Product or architecture decision is required and implementation cannot proceed from the current report.
 - `needs: rebase`: PR cannot proceed because of conflicts or stale base.
 - `needs: unblock`: Blocked item needs a decision or dependency resolved.
 - `needs: cleanup-review`: Stale, superseded, competing, convergence-needed, or closure-candidate item needs maintainer judgment.
@@ -187,7 +188,7 @@ Recommendation:
 ### Anti-Examples
 
 - Do not add `bug` to a new issue. Set native Issue Type `Bug`.
-- Do not add `status: triage`; use `needs: triage` only if an action queue is still needed.
+- Do not add `status: triage` or `needs: triage` from normal triage output.
 - Do not add `priority: high`; recommend Project Priority instead.
 - Do not treat an issue `v0.0.x` label as release inclusion; PR labels own daily release activation.
 - Do not add `needs: review`; use Project Status `Needs Review` for review-ready PRs.


### PR DESCRIPTION
## Summary

Updates the shared NemoClaw maintainer policy references used by triage agents and downstream consumers.

This PR keeps the policy package as the source of truth and tightens the taxonomy/routing guidance needed for the nvoss-velocity shared-policy migration:

- clarifies that normal initial triage should not newly add `needs: triage`
- narrows `needs:*` guidance to blocking action queues, especially `needs: info` and `needs: design`
- adds PR type evidence from conventional commit prefixes
- tightens specific integration routing so named Hermes/OpenClaw/etc. evidence gets the matching `integration:*` label
- clarifies `area: ci` versus `area: e2e` so CI is not added just because an e2e failure was observed in CI
- improves Windows ARM / WSL platform routing signals
- adds concrete shared-policy examples for named integrations, OpenClaw e2e failures, and Windows ARM install failures

No application code changes are included here.

## Evaluation

This policy version was evaluated in the nvoss-velocity migration experiment using a deterministic 100-item NemoClaw fixture: 50 issues and 50 PRs, all numbered `#2000+`.

The evaluation compares recommendations after translating legacy labels into the new shared-policy concepts, rather than raw old-label equality.

Baseline, current Llama with this v2 policy:

- Label F1: `0.485`
- Label precision: `0.402`
- Label recall: `0.611`
- Issue Type match: `0.976`
- Project field match: `1.000`
- Parse failures: `0`

Best Nemotron Ultra Preview candidate used the same policy files:

- Label F1: `0.493`
- Label precision: `0.392`
- Label recall: `0.663`
- Issue Type match: `0.976`
- Project field match: `1.000`
- Parse failures: `0`

The Ultra result did not require separate policy-file changes; it used the same v2 shared policy plus model-specific runtime controls in nvoss-velocity.

## Validation

- Parsed `.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json` with `python3 -m json.tool`
- Ran `git diff --check`
- Confirmed this branch starts from current `origin/main`
- Confirmed only the shared policy reference files are modified

## Notes

This is the policy-only first step. A follow-up nvoss-velocity PR will consume this shared policy package and switch normal triage runtime behavior to the selected model profile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined issue triage and labeling guidance with clarified rules for label taxonomy, improved concrete examples, and tightened requirements for maintainer workflows to ensure better issue categorization and reduce placeholder labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->