### PR TITLE
fix(sandbox): recover late dashboard tool-scope approvals via doctor (#4616)

### DIFF
--- a/src/commands/sandbox/doctor.ts
+++ b/src/commands/sandbox/doctor.ts
@@ -28,7 +28,7 @@ export default class SandboxDoctorCliCommand extends NemoClawCommand {
   static flags = {
     fix: Flags.boolean({
       description:
-        "Restore the mutable OpenClaw config permission contract if `openclaw doctor --fix` tightened it",
+        "Restore the mutable OpenClaw config permission contract if `openclaw doctor --fix` tightened it, and approve pending allowlisted dashboard/CLI tool-scope upgrades",
       default: false,
       // `--fix` mutates sandbox permissions; keep it out of the machine-readable
       // `--json` readiness-gate path so automation cannot trigger a silent repair.

--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTO_PAIR_MAX_APPROVALS,
+  buildAutoPairApprovalScript,
+  readAutoPairApprovalPolicyModule,
+  wrapSandboxShellScript,
+} from "./auto-pair-approval";
+
+const SUMMARY_MARKER = "__NEMOCLAW_AUTO_PAIR_APPROVED__";
+
+describe("buildAutoPairApprovalScript (#4263/#4616)", () => {
+  it("builds the bounded allowlisted approval pass", () => {
+    const script = buildAutoPairApprovalScript("UE9MSUNZ");
+    expect(script).toContain("/tmp/nemoclaw-proxy-env.sh");
+    expect(script).toContain("command -v openclaw");
+    expect(script).toContain("command -v python3");
+    expect(script).toContain("'devices', 'list', '--json'");
+    expect(script).toContain("'devices', 'approve'");
+    expect(script).toContain("approval_request_decision(device)");
+    expect(script).toContain("if not decision['allowed']:");
+    expect(script).toContain("approve_env = gateway_approval_env(os.environ)");
+    expect(script).toContain(`MAX_APPROVALS = ${AUTO_PAIR_MAX_APPROVALS}`);
+    expect(script).toContain("'UE9MSUNZ'");
+  });
+
+  it("omits the summary marker by default and appends it when requested", () => {
+    const silent = buildAutoPairApprovalScript("UE9MSUNZ");
+    const reporting = buildAutoPairApprovalScript("UE9MSUNZ", { emitSummary: true });
+    expect(silent).not.toContain(SUMMARY_MARKER);
+    expect(reporting).toContain(`print(f'${SUMMARY_MARKER}={approved_count}')`);
+    // The reporting script is the silent script with exactly the summary line
+    // inserted before the heredoc terminator — nothing else changes.
+    const stripped = reporting.replace(`print(f'${SUMMARY_MARKER}={approved_count}')\n`, "");
+    expect(stripped).toBe(silent);
+  });
+
+  it("reads the real policy module from disk", () => {
+    const module = readAutoPairApprovalPolicyModule();
+    expect(module).toBeTruthy();
+    expect(module).toContain("def approval_request_decision");
+    expect(module).toContain("def gateway_approval_env");
+  });
+});
+
+describe("wrapSandboxShellScript (#4616)", () => {
+  it("encodes a multi-line payload onto a single newline-free line", () => {
+    const wrapped = wrapSandboxShellScript("echo one\necho two\n");
+    expect(wrapped).not.toMatch(/[\n\r]/);
+    expect(wrapped).toContain("base64 -d");
+    expect(wrapped).toContain("mktemp");
+  });
+
+  it("round-trips and preserves the inner exit status when run", () => {
+    const inner = "echo line-one\nprintf 'exit-then\\n'\nexit 3\n";
+    const wrapped = wrapSandboxShellScript(inner);
+    const result = spawnSync("sh", ["-c", wrapped], { encoding: "utf-8", timeout: 10_000 });
+    expect(result.stdout).toContain("line-one");
+    expect(result.stdout).toContain("exit-then");
+    expect(result.status).toBe(3);
+  });
+});
+
+describe("auto-pair approval pass behaviour (#4616)", () => {
+  it("approves allowlisted upgrades, skips unknown clients, and reports the count", () => {
+    if (
+      spawnSync("sh", ["-c", "command -v python3"], { stdio: "ignore" }).status !== 0
+    ) {
+      // No python3 — the in-sandbox script can't run; skip the behavioural check.
+      return;
+    }
+    const policy = readAutoPairApprovalPolicyModule();
+    expect(policy).toBeTruthy();
+    const policyB64 = Buffer.from(policy as string, "utf-8").toString("base64");
+    const script = buildAutoPairApprovalScript(policyB64, { emitSummary: true });
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-"));
+    try {
+      const approvalsFile = path.join(tmpDir, "approvals.log");
+      const approveEnvFile = path.join(tmpDir, "approve-env.log");
+      const pending = [
+        {
+          requestId: "ok-webchat",
+          clientId: "openclaw-control-ui",
+          clientMode: "webchat",
+          scopes: ["operator.read", "operator.write"],
+        },
+        {
+          requestId: "ok-cli",
+          clientId: "openclaw-cli",
+          clientMode: "cli",
+          requestedScopes: ["operator.pairing"],
+        },
+        {
+          requestId: "deny-unknown",
+          clientId: "evil",
+          clientMode: "unknown",
+          scopes: ["operator.read"],
+        },
+        {
+          requestId: "deny-admin",
+          clientId: "openclaw-control-ui",
+          clientMode: "webchat",
+          scopes: ["operator.admin"],
+        },
+      ];
+      const listResponse = JSON.stringify({ pending, paired: [] });
+      fs.writeFileSync(
+        path.join(tmpDir, "openclaw"),
+        `#!${process.execPath}
+const fs = require("fs");
+const args = process.argv.slice(2);
+if (args[0] === "devices" && args[1] === "list") {
+  process.stdout.write(${JSON.stringify(`${listResponse}\n`)});
+  process.exit(0);
+}
+if (args[0] === "devices" && args[1] === "approve") {
+  fs.appendFileSync(${JSON.stringify(approvalsFile)}, args[2] + "\\n");
+  fs.appendFileSync(
+    ${JSON.stringify(approveEnvFile)},
+    [
+      process.env.OPENCLAW_GATEWAY_URL || "unset",
+      process.env.OPENCLAW_GATEWAY_PORT || "unset",
+      process.env.OPENCLAW_GATEWAY_TOKEN || "unset",
+    ].join(":") + "\\n",
+  );
+  process.stdout.write("{}\\n");
+  process.exit(0);
+}
+process.exit(2);
+`,
+        { mode: 0o755 },
+      );
+
+      const result = spawnSync("sh", ["-c", script], {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${tmpDir}:/usr/bin:/bin`,
+          OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_GATEWAY_TOKEN: "secret-token",
+        },
+        timeout: 10_000,
+      });
+
+      const approvals = fs.existsSync(approvalsFile)
+        ? fs.readFileSync(approvalsFile, "utf-8").trim().split("\n").filter(Boolean)
+        : [];
+      const approveEnv = fs.existsSync(approveEnvFile)
+        ? fs.readFileSync(approveEnvFile, "utf-8").trim().split("\n").filter(Boolean)
+        : [];
+
+      expect(approvals).toEqual(["ok-webchat", "ok-cli"]);
+      // Gateway env stripped on the approve subprocess (#4462 workaround).
+      expect(approveEnv).toEqual(["unset:unset:unset", "unset:unset:unset"]);
+      expect(result.stdout).toContain(`${SUMMARY_MARKER}=2`);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared, bounded OpenClaw device-scope approval pass.
+ *
+ * The in-sandbox auto-pair watcher (`scripts/nemoclaw-start.sh`) keeps
+ * approving allowlisted scope upgrades in slow-mode for hours after startup.
+ * This host-side pass is the defense-in-depth recovery for the cases where the
+ * watcher has exited (deadline reached), crashed, or was contended away by a
+ * second sandbox — leaving a late scope upgrade pending forever.
+ *
+ * It is used from two surfaces:
+ *   - `nemoclaw <sandbox> connect` (#4263), which runs it silently before SSH.
+ *   - `nemoclaw <sandbox> doctor --fix` (#4616), which runs it as a
+ *     dashboard-only recovery so a browser/dashboard user can repair pending
+ *     OpenClaw tool-scope approvals without ever opening an SSH `connect`.
+ *
+ * Both surfaces apply the SAME narrow allowlist as the startup watcher
+ * (`scripts/lib/openclaw_device_approval_policy.py`): `openclaw-control-ui`
+ * clients plus `webchat`/`cli` modes, restricted to operator.pairing/read/write
+ * scopes. Unknown clients are ignored, never approved.
+ *
+ * Workaround boundary (NemoClaw#4462): OpenClaw owns device-pairing approval
+ * semantics. In OpenClaw 2026.5.x, a gateway-pinned `devices approve` for a
+ * scope-upgrade can request the upgraded scopes for its own connection and
+ * return the pending-scope failure it is trying to resolve. The approval call
+ * therefore strips OPENCLAW_GATEWAY_URL/PORT/TOKEN from the child env to use
+ * OpenClaw's local pairing fallback; the list call stays gateway-pinned so it
+ * inspects the live gateway. Remove this local fallback path when OpenClaw
+ * approve can complete scope upgrades through the gateway using only
+ * operator.pairing.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { shellQuote } from "../../core/shell-quote";
+import { ROOT } from "../../state/paths";
+
+// Bound the in-sandbox work: 2s list + 1s × MAX_APPROVALS attempts plus
+// shell/python startup slack fits inside the outer spawnSync cap, so a wedged
+// sandbox can never block the caller.
+export const AUTO_PAIR_MAX_APPROVALS = 8;
+export const AUTO_PAIR_APPROVAL_TIMEOUT_MS = 12_000;
+
+const AUTO_PAIR_POLICY_PATH = path.join(
+  ROOT,
+  "scripts",
+  "lib",
+  "openclaw_device_approval_policy.py",
+);
+
+export type AutoPairApprovalResult = {
+  /** The sandbox-exec was issued (false only when the policy helper is absent). */
+  attempted: boolean;
+  /** The in-sandbox script reported a parseable summary (capture mode only). */
+  reported: boolean;
+  /** Number of pending requests approved this pass (capture mode only). */
+  approved: number;
+};
+
+/**
+ * Wrap a multi-line shell payload so it survives `openshell sandbox exec`.
+ *
+ * OpenShell's exec RPC rejects any argument containing a newline or carriage
+ * return ("command argument N contains newline or carriage return characters"),
+ * so a multi-line `sh -c <script>` is refused outright. We base64-encode the
+ * payload onto a single line, decode it to a temp file inside the sandbox, and
+ * run that file — preserving heredocs and the original exit status. `base64`
+ * from Node is unwrapped (no embedded newlines) and uses only shell-safe
+ * characters, so it is safe inside single quotes. This mirrors the
+ * base64-then-decode pattern the E2E harness uses for the same reason.
+ */
+export function wrapSandboxShellScript(script: string): string {
+  const encoded = Buffer.from(script, "utf-8").toString("base64");
+  return (
+    `__nemoclaw_s="$(mktemp)" && ` +
+    `printf %s '${encoded}' | base64 -d > "$__nemoclaw_s" && ` +
+    `sh "$__nemoclaw_s"; __nemoclaw_rc=$?; rm -f "$__nemoclaw_s"; exit "$__nemoclaw_rc"`
+  );
+}
+
+export function readAutoPairApprovalPolicyModule(): string | null {
+  try {
+    return readFileSync(AUTO_PAIR_POLICY_PATH, "utf-8");
+  } catch {
+    // Best-effort: a packaging/layout regression must not block connect or
+    // doctor. Build-context and package `files` coverage keep this helper
+    // present in supported installs.
+    return null;
+  }
+}
+
+/**
+ * Build the in-sandbox sh+python approval-pass script. When `emitSummary` is
+ * false the output is byte-identical to the historical connect-time script so
+ * the connect approval-pass tests keep asserting against a stable payload; when
+ * true it appends a single machine-readable summary marker so the doctor
+ * recovery path can report how many upgrades it approved.
+ */
+export function buildAutoPairApprovalScript(
+  approvalPolicyModuleB64: string,
+  options: { emitSummary?: boolean } = {},
+): string {
+  const summaryLine = options.emitSummary
+    ? "print(f'__NEMOCLAW_AUTO_PAIR_APPROVED__={approved_count}')\n"
+    : "";
+  return `
+PROXY_ENV=/tmp/nemoclaw-proxy-env.sh
+[ -r "$PROXY_ENV" ] && . "$PROXY_ENV"
+command -v openclaw >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+OPENCLAW_BIN="$(command -v openclaw)" NEMOCLAW_APPROVAL_POLICY_B64=${shellQuote(approvalPolicyModuleB64)} python3 - <<'PYAPPROVE'
+import base64
+import json
+import os
+import subprocess
+import sys
+
+try:
+    policy_source = base64.b64decode(
+        os.environ.get('NEMOCLAW_APPROVAL_POLICY_B64', ''), validate=True,
+    ).decode('utf-8')
+    policy_globals = {}
+    exec(compile(policy_source, 'openclaw_device_approval_policy.py', 'exec'), policy_globals)
+    approval_request_decision = policy_globals['approval_request_decision']
+    gateway_approval_env = policy_globals['gateway_approval_env']
+except Exception:
+    sys.exit(0)
+
+OPENCLAW = os.environ.get('OPENCLAW_BIN', 'openclaw')
+MAX_APPROVALS = ${AUTO_PAIR_MAX_APPROVALS}
+
+try:
+    proc = subprocess.run(
+        [OPENCLAW, 'devices', 'list', '--json'],
+        capture_output=True, text=True, timeout=2,
+    )
+except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+    sys.exit(0)
+if proc.returncode != 0 or not proc.stdout.strip():
+    sys.exit(0)
+try:
+    data = json.loads(proc.stdout)
+except ValueError:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+pending = data.get('pending')
+if not isinstance(pending, list):
+    sys.exit(0)
+approved_count = 0
+attempted_count = 0
+seen_request_ids = set()
+for device in pending:
+    if attempted_count >= MAX_APPROVALS:
+        break
+    if not isinstance(device, dict):
+        continue
+    request_id = device.get('requestId')
+    if not request_id or request_id in seen_request_ids:
+        continue
+    decision = approval_request_decision(device)
+    if not decision['allowed']:
+        continue
+    seen_request_ids.add(request_id)
+    approve_env = gateway_approval_env(os.environ)
+    attempted_count += 1
+    try:
+        approve_proc = subprocess.run(
+            [OPENCLAW, 'devices', 'approve', request_id, '--json'],
+            capture_output=True, text=True, timeout=1, env=approve_env,
+        )
+        if approve_proc.returncode == 0:
+            approved_count += 1
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        continue
+${summaryLine}PYAPPROVE
+exit 0
+`;
+}
+
+/**
+ * Run the bounded approval pass inside the named sandbox via `openshell sandbox
+ * exec`. Failure modes (timeout, sandbox-exec errors, missing openclaw, gateway
+ * unreachable, missing policy helper) are swallowed: callers treat this as
+ * best-effort and must never let it throw.
+ *
+ * When `capture` is true the script emits a summary marker and this function
+ * parses the approved count so doctor can report a repair outcome; otherwise it
+ * runs silently like the original connect-time pass.
+ */
+export function runSandboxAutoPairApprovalPass(
+  sandboxName: string,
+  options: { capture?: boolean } = {},
+): AutoPairApprovalResult {
+  const capture = options.capture === true;
+  const approvalPolicyModule = readAutoPairApprovalPolicyModule();
+  if (!approvalPolicyModule) {
+    return { attempted: false, reported: false, approved: 0 };
+  }
+  const approvalPolicyModuleB64 = Buffer.from(approvalPolicyModule, "utf-8").toString("base64");
+  const script = buildAutoPairApprovalScript(approvalPolicyModuleB64, { emitSummary: capture });
+  // Lazy require: `adapters/openshell/runtime` pulls in `runner`, whose
+  // load-time `require("./platform")` cannot be resolved by the Vitest TS
+  // loader. Importing it here keeps this module unit-testable in-process.
+  const { getOpenshellBinary } =
+    require("../../adapters/openshell/runtime") as typeof import("../../adapters/openshell/runtime");
+  try {
+    const result = spawnSync(
+      getOpenshellBinary(),
+      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", wrapSandboxShellScript(script)],
+      {
+        cwd: ROOT,
+        env: process.env,
+        stdio: capture ? ["ignore", "pipe", "pipe"] : ["ignore", "ignore", "ignore"],
+        encoding: "utf-8",
+        timeout: AUTO_PAIR_APPROVAL_TIMEOUT_MS,
+      },
+    );
+    if (!capture) {
+      return { attempted: true, reported: false, approved: 0 };
+    }
+    const match = String(result.stdout || "").match(/__NEMOCLAW_AUTO_PAIR_APPROVED__=(\d+)/);
+    if (!match) {
+      return { attempted: true, reported: false, approved: 0 };
+    }
+    return { attempted: true, reported: true, approved: Number(match[1]) };
+  } catch {
+    /* defense-in-depth — never throw from the connect or doctor path */
+    return { attempted: true, reported: false, approved: 0 };
+  }
+}

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import os from "node:os";
-import path from "node:path";
 import { resolveOpenshell } from "../../adapters/openshell/resolve";
 import {
   captureOpenshell,
@@ -32,7 +30,7 @@ import {
 } from "../../inference/ollama/proxy";
 import { LOCAL_INFERENCE_TIMEOUT_SECS } from "../../onboard/env";
 import { isWsl } from "../../platform";
-import { ROOT, shellQuote } from "../../runner";
+import { ROOT } from "../../runner";
 import * as sandboxVersion from "../../sandbox/version";
 import {
   isTerminalSandboxPhase,
@@ -46,6 +44,7 @@ import {
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
 import { runSetupDnsProxy } from "../dns";
+import { runSandboxAutoPairApprovalPass } from "./auto-pair-approval";
 import { preflightVllmModelEnvOrExit } from "./connect-vllm-preflight";
 import {
   isDockerRuntimeDown,
@@ -752,148 +751,6 @@ function ensureSandboxInferenceRouteOrExit(
   return result.sandbox;
 }
 
-// One-shot, defense-in-depth approval pass for late OpenClaw CLI/webchat
-// scope upgrades (NemoClaw#4263). The in-sandbox auto-pair watcher keeps
-// approving allowlisted requests in slow-mode for hours after startup; this
-// pass covers the case where the watcher has exited or is otherwise stuck
-// when the user runs `nemoclaw <sandbox> connect`. The script sources
-// `/tmp/nemoclaw-proxy-env.sh` (written by `nemoclaw-start.sh`) so the
-// in-sandbox `openclaw devices list` invocation targets the running gateway
-// with its token. Approvals then use OpenClaw's local fallback by removing
-// OPENCLAW_GATEWAY_URL only from the child env, and apply the same allowlist
-// as the startup watcher — `openclaw-control-ui` clients plus `webchat`/`cli`
-// modes. Unknown clients are ignored, not approved.
-//
-// Workaround boundary (NemoClaw#4462): OpenClaw owns device-pairing approval
-// semantics. In OpenClaw 2026.5.x, a gateway-pinned `devices approve` for a
-// scope-upgrade can request the upgraded scopes for its own connection and
-// return the pending-scope failure it is trying to resolve. Remove this local
-// fallback path when OpenClaw approve can complete scope upgrades through the
-// gateway using only operator.pairing.
-//
-// Failure modes (timeout, sandbox-exec errors, missing openclaw, gateway
-// unreachable) are swallowed: the connect flow must not be blocked by a
-// best-effort approval. Internal timeouts (2s list + 1s x MAX_APPROVALS
-// attempts) fit within the outer spawnSync cap, so a partial-completion
-// mid-loop kill cannot strand allowlisted requests within a normal batch.
-const CONNECT_AUTO_PAIR_MAX_APPROVALS = 8;
-const CONNECT_AUTO_PAIR_TIMEOUT_MS = 12_000;
-const CONNECT_AUTO_PAIR_POLICY_PATH = path.join(
-  ROOT,
-  "scripts",
-  "lib",
-  "openclaw_device_approval_policy.py",
-);
-
-function readConnectAutoPairPolicyModule(): string | null {
-  try {
-    return readFileSync(CONNECT_AUTO_PAIR_POLICY_PATH, "utf-8");
-  } catch {
-    // The approval pass is best-effort, so a packaging/layout regression must
-    // not block connect. Build-context and package `files` coverage keep this
-    // helper present in supported installs.
-    return null;
-  }
-}
-
-function runConnectAutoPairApprovalPass(sandboxName: string): void {
-  const approvalPolicyModule = readConnectAutoPairPolicyModule();
-  if (!approvalPolicyModule) {
-    return;
-  }
-  const approvalPolicyModuleB64 = Buffer.from(approvalPolicyModule, "utf-8").toString("base64");
-  const script = `
-PROXY_ENV=/tmp/nemoclaw-proxy-env.sh
-[ -r "$PROXY_ENV" ] && . "$PROXY_ENV"
-command -v openclaw >/dev/null 2>&1 || exit 0
-command -v python3 >/dev/null 2>&1 || exit 0
-OPENCLAW_BIN="$(command -v openclaw)" NEMOCLAW_APPROVAL_POLICY_B64=${shellQuote(approvalPolicyModuleB64)} python3 - <<'PYAPPROVE'
-import base64
-import json
-import os
-import subprocess
-import sys
-
-try:
-    policy_source = base64.b64decode(
-        os.environ.get('NEMOCLAW_APPROVAL_POLICY_B64', ''), validate=True,
-    ).decode('utf-8')
-    policy_globals = {}
-    exec(compile(policy_source, 'openclaw_device_approval_policy.py', 'exec'), policy_globals)
-    approval_request_decision = policy_globals['approval_request_decision']
-    gateway_approval_env = policy_globals['gateway_approval_env']
-except Exception:
-    sys.exit(0)
-
-OPENCLAW = os.environ.get('OPENCLAW_BIN', 'openclaw')
-MAX_APPROVALS = ${CONNECT_AUTO_PAIR_MAX_APPROVALS}
-
-try:
-    proc = subprocess.run(
-        [OPENCLAW, 'devices', 'list', '--json'],
-        capture_output=True, text=True, timeout=2,
-    )
-except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-    sys.exit(0)
-if proc.returncode != 0 or not proc.stdout.strip():
-    sys.exit(0)
-try:
-    data = json.loads(proc.stdout)
-except ValueError:
-    sys.exit(0)
-if not isinstance(data, dict):
-    sys.exit(0)
-pending = data.get('pending')
-if not isinstance(pending, list):
-    sys.exit(0)
-approved_count = 0
-attempted_count = 0
-seen_request_ids = set()
-for device in pending:
-    if attempted_count >= MAX_APPROVALS:
-        break
-    if not isinstance(device, dict):
-        continue
-    request_id = device.get('requestId')
-    if not request_id or request_id in seen_request_ids:
-        continue
-    decision = approval_request_decision(device)
-    if not decision['allowed']:
-        continue
-    seen_request_ids.add(request_id)
-    approve_env = gateway_approval_env(os.environ)
-    attempted_count += 1
-    try:
-        approve_proc = subprocess.run(
-            [OPENCLAW, 'devices', 'approve', request_id, '--json'],
-            capture_output=True, text=True, timeout=1, env=approve_env,
-        )
-        if approve_proc.returncode == 0:
-            approved_count += 1
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        continue
-PYAPPROVE
-exit 0
-`;
-  try {
-    // Best-effort: discard stdout/stderr. Outer cap is sized to cover the
-    // internal budget (2s list + 1s × MAX_APPROVALS plus shell/python
-    // startup slack) so a wedged sandbox can never block the connect flow.
-    spawnSync(
-      getOpenshellBinary(),
-      ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", script],
-      {
-        cwd: ROOT,
-        env: process.env,
-        stdio: ["ignore", "ignore", "ignore"],
-        timeout: CONNECT_AUTO_PAIR_TIMEOUT_MS,
-      },
-    );
-  } catch {
-    /* defense-in-depth — never throw from the connect path */
-  }
-}
-
 function maybeEnsureHermesToolGatewayBroker(sb: SandboxEntry | null): void {
   if (
     !sb ||
@@ -1117,8 +974,10 @@ export async function connectSandbox(
   // slow-mode keepalive, a brief approval pass before opening SSH
   // catches any pending allowlisted CLI/webchat scope upgrades that
   // piled up between startup and now (e.g., watcher crashed, watcher
-  // deadline exhausted, multi-sandbox gateway contention).
-  runConnectAutoPairApprovalPass(sandboxName);
+  // deadline exhausted, multi-sandbox gateway contention). The same pass
+  // is reachable without SSH via `doctor --fix` for dashboard-only users
+  // (#4616).
+  runSandboxAutoPairApprovalPass(sandboxName);
 
   // Print a one-shot hint before dropping the user into the sandbox
   // shell so a fresh user knows the first thing to type. Without this,

--- a/src/lib/actions/sandbox/doctor-tool-scope.test.ts
+++ b/src/lib/actions/sandbox/doctor-tool-scope.test.ts
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildToolScopeChecks,
+  buildToolScopeProbeScript,
+  interpretToolScopeProbe,
+  parseToolScopeProbe,
+  type ToolScopeProbe,
+} from "./doctor-tool-scope";
+
+const MARKER = "__NEMOCLAW_TOOL_SCOPE_PROBE__";
+
+type ProbeOverrides = Partial<Omit<ToolScopeProbe, "signals">> & {
+  signals?: Partial<ToolScopeProbe["signals"]>;
+};
+
+function probe(overrides: ProbeOverrides = {}): ToolScopeProbe {
+  const { signals: signalOverrides, ...rest } = overrides;
+  return {
+    ok: true,
+    devicesListOk: true,
+    pendingTotal: 0,
+    pendingAllowlisted: 0,
+    pendingUnknown: 0,
+    watcherActive: true,
+    dashboardPort: 18789,
+    ...rest,
+    signals: {
+      gateway1006: false,
+      scopePending: false,
+      loopbackDenied: false,
+      watcherDeadline: false,
+      rejectedClients: 0,
+      ...(signalOverrides ?? {}),
+    },
+  };
+}
+
+describe("buildToolScopeProbeScript (#4616)", () => {
+  it("embeds the read-only probe with the policy and log scans", () => {
+    const script = buildToolScopeProbeScript("UE9MSUNZ");
+    // read-only: lists, never approves
+    expect(script).toContain("devices");
+    expect(script).toContain("list");
+    expect(script).not.toContain("'approve'");
+    expect(script).toContain("/tmp/nemoclaw-proxy-env.sh");
+    expect(script).toContain("PYPROBE");
+    expect(script).toContain(MARKER);
+    // signal scans
+    expect(script).toContain("1006");
+    expect(script).toContain("scope upgrade pending approval");
+    expect(script).toContain("[auto-pair] rejected");
+    expect(script).toContain("[auto-pair] watcher deadline reached");
+    expect(script).toContain("127");
+    // watcher liveness via /proc fd
+    expect(script).toContain("/tmp/auto-pair.log");
+    // policy embedded
+    expect(script).toContain("'UE9MSUNZ'");
+  });
+
+  it("falls back to an empty policy when none is available", () => {
+    const script = buildToolScopeProbeScript("");
+    expect(script).toContain("NEMOCLAW_APPROVAL_POLICY_B64=''");
+  });
+});
+
+describe("parseToolScopeProbe (#4616)", () => {
+  it("parses the marker JSON payload", () => {
+    const raw = `noise\n${MARKER}${JSON.stringify({
+      ok: true,
+      devicesListOk: true,
+      pendingTotal: 2,
+      pendingAllowlisted: 1,
+      pendingUnknown: 1,
+      watcherActive: false,
+      dashboardPort: 18789,
+      signals: { gateway1006: true, scopePending: true, loopbackDenied: true, watcherDeadline: true, rejectedClients: 3 },
+    })}\ntrailing`;
+    const parsed = parseToolScopeProbe(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.pendingAllowlisted).toBe(1);
+    expect(parsed?.pendingUnknown).toBe(1);
+    expect(parsed?.watcherActive).toBe(false);
+    expect(parsed?.dashboardPort).toBe(18789);
+    expect(parsed?.signals.gateway1006).toBe(true);
+    expect(parsed?.signals.rejectedClients).toBe(3);
+  });
+
+  it("normalizes a failed probe", () => {
+    const parsed = parseToolScopeProbe(`${MARKER}{"ok": false}`);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.ok).toBe(false);
+  });
+
+  it("returns null without a marker or with garbage", () => {
+    expect(parseToolScopeProbe("no marker here")).toBeNull();
+    expect(parseToolScopeProbe(`${MARKER}not-json`)).toBeNull();
+    expect(parseToolScopeProbe("")).toBeNull();
+  });
+});
+
+describe("interpretToolScopeProbe (#4616)", () => {
+  const base = { sandboxName: "sb", cliName: "nemoclaw", wantsFix: false };
+
+  it("reports info when the probe is unavailable", () => {
+    for (const p of [null, probe({ ok: false })]) {
+      const checks = interpretToolScopeProbe(p, base);
+      expect(checks).toHaveLength(1);
+      expect(checks[0].status).toBe("info");
+      expect(checks[0].detail).toContain("unavailable");
+    }
+  });
+
+  it("fails with a fix hint when allowlisted upgrades are pending", () => {
+    const checks = interpretToolScopeProbe(
+      probe({
+        pendingTotal: 1,
+        pendingAllowlisted: 1,
+        watcherActive: false,
+        signals: { gateway1006: true, scopePending: true, loopbackDenied: true },
+      }),
+      base,
+    );
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe("fail");
+    expect(checks[0].detail).toContain("1 pending allowlisted tool-scope upgrade");
+    expect(checks[0].detail).toContain("gateway closed 1006");
+    expect(checks[0].detail).toContain("scope upgrade pending approval");
+    expect(checks[0].detail).toContain("127.0.0.1:18789");
+    expect(checks[0].detail).toContain("auto-pair watcher is not running");
+    expect(checks[0].hint).toContain("doctor --fix");
+  });
+
+  it("warns on a recent log signature only when the device list is unreadable", () => {
+    const checks = interpretToolScopeProbe(
+      probe({ devicesListOk: false, signals: { gateway1006: true } }),
+      base,
+    );
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe("warn");
+    expect(checks[0].detail).toContain("recent OpenClaw tool-scope failure");
+    expect(checks[0].detail).toContain("could not read the device list");
+    // Steer to gateway recovery first, since --fix alone would dead-end while
+    // the device list is unreadable.
+    expect(checks[0].hint).toContain("recover");
+    expect(checks[0].hint).toContain("doctor --fix");
+  });
+
+  it("reports ok (not a stale-log warning) when the device list shows nothing pending", () => {
+    // Logs still carry 1006/scope-pending lines from a just-completed fix, but
+    // the readable device list shows no backlog — current state wins.
+    const checks = interpretToolScopeProbe(
+      probe({ signals: { gateway1006: true, scopePending: true, loopbackDenied: true } }),
+      base,
+    );
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe("ok");
+    expect(checks[0].detail).toContain("no pending tool-scope approvals");
+  });
+
+  it("warns but does not offer auto-approval for non-allowlisted pending clients", () => {
+    const checks = interpretToolScopeProbe(probe({ pendingTotal: 2, pendingUnknown: 2 }), base);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe("warn");
+    expect(checks[0].detail).toContain("non-allowlisted");
+    expect(checks[0].detail).toContain("not auto-approved");
+    expect(checks[0].hint).not.toContain("--fix");
+  });
+
+  it("reports ok when there is nothing pending", () => {
+    const checks = interpretToolScopeProbe(probe(), base);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe("ok");
+    expect(checks[0].detail).toContain("no pending tool-scope approvals");
+  });
+
+  it("reports a repair line after --fix approves upgrades", () => {
+    const checks = interpretToolScopeProbe(probe(), {
+      ...base,
+      wantsFix: true,
+      fix: { reported: true, approved: 2 },
+    });
+    expect(checks).toHaveLength(2);
+    expect(checks[0].label).toContain("repair");
+    expect(checks[0].status).toBe("ok");
+    expect(checks[0].detail).toContain("approved 2 pending tool-scope upgrade");
+    expect(checks[1].status).toBe("ok");
+  });
+
+  it("reports info when the device list could not be read", () => {
+    const checks = interpretToolScopeProbe(probe({ devicesListOk: false }), base);
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe("info");
+    expect(checks[0].detail).toContain("could not read");
+  });
+});
+
+describe("buildToolScopeChecks (#4616)", () => {
+  function execReturning(probes: (ToolScopeProbe | null)[]) {
+    let call = 0;
+    return vi.fn((_name: string, _script: string) => {
+      const p = probes[Math.min(call, probes.length - 1)];
+      call += 1;
+      return p ? { status: 0, stdout: `${MARKER}${JSON.stringify(p)}`, stderr: "" } : null;
+    });
+  }
+
+  it("runs the repair pass and re-probes when --fix sees a backlog", () => {
+    const exec = execReturning([
+      probe({ pendingTotal: 1, pendingAllowlisted: 1, watcherActive: false }),
+      probe(), // clean after repair
+    ]);
+    const runApprovalPass = vi.fn(() => ({ reported: true, approved: 1 }));
+    const checks = buildToolScopeChecks("sb", "nemoclaw", true, {
+      exec,
+      runApprovalPass,
+      readPolicyModule: () => "policy",
+    });
+    expect(runApprovalPass).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(checks[0].label).toContain("repair");
+    expect(checks.some((c) => c.status === "ok" && c.detail.includes("no pending"))).toBe(true);
+  });
+
+  it("does not repair when --fix is not requested", () => {
+    const exec = execReturning([probe({ pendingTotal: 1, pendingAllowlisted: 1 })]);
+    const runApprovalPass = vi.fn(() => ({ reported: true, approved: 1 }));
+    const checks = buildToolScopeChecks("sb", "nemoclaw", false, {
+      exec,
+      runApprovalPass,
+      readPolicyModule: () => "policy",
+    });
+    expect(runApprovalPass).not.toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(checks[0].status).toBe("fail");
+  });
+
+  it("does not repair when --fix is set but no allowlisted backlog exists", () => {
+    const exec = execReturning([probe({ pendingTotal: 1, pendingUnknown: 1 })]);
+    const runApprovalPass = vi.fn(() => ({ reported: true, approved: 0 }));
+    const checks = buildToolScopeChecks("sb", "nemoclaw", true, {
+      exec,
+      runApprovalPass,
+      readPolicyModule: () => "policy",
+    });
+    expect(runApprovalPass).not.toHaveBeenCalled();
+    expect(checks[0].status).toBe("warn");
+  });
+
+  it("surfaces unavailable when the sandbox exec fails", () => {
+    const exec = vi.fn(() => null);
+    const checks = buildToolScopeChecks("sb", "nemoclaw", false, {
+      exec,
+      readPolicyModule: () => null,
+    });
+    expect(checks[0].status).toBe("info");
+    expect(checks[0].detail).toContain("unavailable");
+  });
+});

--- a/src/lib/actions/sandbox/doctor-tool-scope.ts
+++ b/src/lib/actions/sandbox/doctor-tool-scope.ts
@@ -1,0 +1,486 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `doctor` diagnostics for late OpenClaw dashboard/tool-call device-scope
+ * approvals (#4616).
+ *
+ * The reported symptom is "cron job creation fails" / "Tool exec not found",
+ * but the underlying failure is broader: an OpenClaw tool subprocess inherits
+ * `OPENCLAW_GATEWAY_URL=ws://127.0.0.1:<dashboardPort>`, opens a connection
+ * that requests a scope upgrade, and the upgrade never gets approved — so the
+ * gateway closes the socket (1006 abnormal closure) and OpenShell logs a
+ * loopback policy denial to `127.0.0.1:<dashboardPort>`. Dashboard-only users
+ * never run `nemoclaw connect`, so the connect-time approval pass never runs
+ * and the pending upgrade sits forever once the in-sandbox auto-pair watcher
+ * has exited.
+ *
+ * This module adds a read-only in-sandbox probe that surfaces the actual
+ * blocker (pending allowlisted scope upgrades, gateway 1006, scope-upgrade
+ * pending, loopback denial, auto-pair watcher state) and points the user at
+ * `doctor --fix`, which runs the same narrow allowlisted approval pass that
+ * `connect` runs. See `auto-pair-approval.ts` for the repair side.
+ */
+
+import { readAutoPairApprovalPolicyModule } from "./auto-pair-approval";
+
+export type DoctorToolScopeStatus = "ok" | "warn" | "fail" | "info";
+
+export type DoctorToolScopeCheck = {
+  group: string;
+  label: string;
+  status: DoctorToolScopeStatus;
+  detail: string;
+  hint?: string;
+};
+
+const TOOL_SCOPE_GROUP = "Gateway";
+const TOOL_SCOPE_LABEL = "Tool-call device scope";
+
+export type ToolScopeProbe = {
+  ok: boolean;
+  devicesListOk: boolean;
+  pendingTotal: number;
+  pendingAllowlisted: number;
+  pendingUnknown: number;
+  watcherActive: boolean;
+  dashboardPort: number | null;
+  signals: {
+    gateway1006: boolean;
+    scopePending: boolean;
+    loopbackDenied: boolean;
+    watcherDeadline: boolean;
+    rejectedClients: number;
+  };
+};
+
+export type SandboxExecResult = { status: number; stdout: string; stderr: string } | null;
+export type SandboxExec = (sandboxName: string, script: string) => SandboxExecResult;
+
+const PROBE_MARKER = "__NEMOCLAW_TOOL_SCOPE_PROBE__";
+
+/**
+ * Build the read-only in-sandbox probe script. It sources the proxy env so the
+ * gateway-pinned `openclaw devices list` sees the live gateway, classifies the
+ * pending requests with the shared approval policy, scans the gateway and
+ * auto-pair logs for the #4616 signatures, and prints a single JSON line
+ * prefixed with PROBE_MARKER. It never approves anything.
+ */
+export function buildToolScopeProbeScript(approvalPolicyModuleB64: string): string {
+  return `
+PROXY_ENV=/tmp/nemoclaw-proxy-env.sh
+[ -r "$PROXY_ENV" ] && . "$PROXY_ENV"
+command -v python3 >/dev/null 2>&1 || { echo '${PROBE_MARKER}{"ok": false}'; exit 0; }
+OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || echo openclaw)" \
+NEMOCLAW_APPROVAL_POLICY_B64=${approvalPolicyModuleB64 ? `'${approvalPolicyModuleB64}'` : "''"} \
+NEMOCLAW_TOOL_SCOPE_MARKER='${PROBE_MARKER}' python3 - <<'PYPROBE'
+import base64
+import json
+import os
+import re
+import subprocess
+
+MARKER = os.environ.get('NEMOCLAW_TOOL_SCOPE_MARKER', '')
+
+
+def emit(payload):
+    print(MARKER + json.dumps(payload, sort_keys=True))
+
+
+result = {
+    'ok': True,
+    'devicesListOk': False,
+    'pendingTotal': 0,
+    'pendingAllowlisted': 0,
+    'pendingUnknown': 0,
+    'watcherActive': False,
+    'dashboardPort': None,
+    'signals': {
+        'gateway1006': False,
+        'scopePending': False,
+        'loopbackDenied': False,
+        'watcherDeadline': False,
+        'rejectedClients': 0,
+    },
+}
+
+# Dashboard/gateway port the tool subprocess connects back to.
+port = ''
+for key in ('OPENCLAW_GATEWAY_PORT', 'NEMOCLAW_DASHBOARD_PORT'):
+    raw = os.environ.get(key, '').strip()
+    if raw.isdigit():
+        port = raw
+        break
+if not port:
+    url = os.environ.get('OPENCLAW_GATEWAY_URL', '')
+    m = re.search(r':(\\d+)', url)
+    if m:
+        port = m.group(1)
+if port.isdigit():
+    result['dashboardPort'] = int(port)
+
+# Classify pending device requests with the shared approval policy.
+approval_request_decision = None
+try:
+    policy_source = base64.b64decode(
+        os.environ.get('NEMOCLAW_APPROVAL_POLICY_B64', ''), validate=True,
+    ).decode('utf-8')
+    policy_globals = {}
+    exec(compile(policy_source, 'openclaw_device_approval_policy.py', 'exec'), policy_globals)
+    approval_request_decision = policy_globals.get('approval_request_decision')
+except Exception:
+    approval_request_decision = None
+
+openclaw = os.environ.get('OPENCLAW_BIN', 'openclaw')
+try:
+    proc = subprocess.run(
+        [openclaw, 'devices', 'list', '--json'],
+        capture_output=True, text=True, timeout=5,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        data = json.loads(proc.stdout)
+        if isinstance(data, dict):
+            pending = data.get('pending')
+            if isinstance(pending, list):
+                result['devicesListOk'] = True
+                for device in pending:
+                    if not isinstance(device, dict):
+                        continue
+                    result['pendingTotal'] += 1
+                    allowed = False
+                    if approval_request_decision is not None:
+                        try:
+                            allowed = bool(approval_request_decision(device).get('allowed'))
+                        except Exception:
+                            allowed = False
+                    if allowed:
+                        result['pendingAllowlisted'] += 1
+                    else:
+                        result['pendingUnknown'] += 1
+except Exception:
+    pass
+
+
+def tail_text(path, limit=400, max_bytes=131072):
+    # /tmp/gateway.log and /tmp/auto-pair.log are never truncated, so read only
+    # the last max_bytes from the end instead of loading the whole file: bounds
+    # both memory and the time spent inside the 15s sandbox-exec budget.
+    try:
+        with open(path, 'rb') as handle:
+            handle.seek(0, 2)
+            size = handle.tell()
+            handle.seek(max(0, size - max_bytes))
+            data = handle.read()
+        return data.decode('utf-8', 'replace').splitlines(keepends=True)[-limit:]
+    except Exception:
+        return []
+
+
+gateway_lines = tail_text('/tmp/gateway.log')
+auto_pair_lines = tail_text('/tmp/auto-pair.log')
+gateway_blob = ''.join(gateway_lines)
+auto_pair_blob = ''.join(auto_pair_lines)
+
+if re.search(r'1006|abnormal closure', gateway_blob, re.IGNORECASE):
+    result['signals']['gateway1006'] = True
+if re.search(r'scope upgrade pending approval', gateway_blob + auto_pair_blob, re.IGNORECASE):
+    result['signals']['scopePending'] = True
+if port:
+    denial = re.compile(
+        r'(DENIED|not in policy).*127\\.0\\.0\\.1:' + re.escape(port),
+        re.IGNORECASE,
+    )
+    alt = re.compile(
+        r'127\\.0\\.0\\.1:' + re.escape(port) + r'.*(DENIED|not in policy)',
+        re.IGNORECASE,
+    )
+    for line in gateway_lines:
+        if denial.search(line) or alt.search(line):
+            result['signals']['loopbackDenied'] = True
+            break
+if '[auto-pair] watcher deadline reached' in auto_pair_blob:
+    result['signals']['watcherDeadline'] = True
+result['signals']['rejectedClients'] = auto_pair_blob.count('[auto-pair] rejected')
+
+# Auto-pair watcher liveness: a live python3 whose stdout/stderr is the
+# auto-pair log. Mirrors the e2e watcher-inactivity probe.
+watcher_active = False
+try:
+    for entry in os.listdir('/proc'):
+        if not entry.isdigit():
+            continue
+        try:
+            with open('/proc/%s/cmdline' % entry, 'rb') as handle:
+                cmd = handle.read().replace(b'\\x00', b' ').decode('utf-8', 'replace')
+        except Exception:
+            continue
+        if 'python3' not in cmd:
+            continue
+        for fd in ('1', '2'):
+            try:
+                target = os.readlink('/proc/%s/fd/%s' % (entry, fd))
+            except Exception:
+                continue
+            if target == '/tmp/auto-pair.log':
+                watcher_active = True
+                break
+        if watcher_active:
+            break
+except Exception:
+    watcher_active = False
+result['watcherActive'] = watcher_active
+
+emit(result)
+PYPROBE
+exit 0
+`;
+}
+
+/** Extract and parse the probe's JSON payload from raw stdout. */
+export function parseToolScopeProbe(raw: string): ToolScopeProbe | null {
+  if (!raw) return null;
+  const idx = raw.lastIndexOf(PROBE_MARKER);
+  if (idx < 0) return null;
+  const jsonStart = idx + PROBE_MARKER.length;
+  const newline = raw.indexOf("\n", jsonStart);
+  const slice = (newline === -1 ? raw.slice(jsonStart) : raw.slice(jsonStart, newline)).trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(slice);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.ok === false) {
+    return {
+      ok: false,
+      devicesListOk: false,
+      pendingTotal: 0,
+      pendingAllowlisted: 0,
+      pendingUnknown: 0,
+      watcherActive: false,
+      dashboardPort: null,
+      signals: {
+        gateway1006: false,
+        scopePending: false,
+        loopbackDenied: false,
+        watcherDeadline: false,
+        rejectedClients: 0,
+      },
+    };
+  }
+  const signals = (obj.signals && typeof obj.signals === "object" ? obj.signals : {}) as Record<
+    string,
+    unknown
+  >;
+  const num = (value: unknown): number =>
+    typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return {
+    ok: obj.ok !== false,
+    devicesListOk: obj.devicesListOk === true,
+    pendingTotal: num(obj.pendingTotal),
+    pendingAllowlisted: num(obj.pendingAllowlisted),
+    pendingUnknown: num(obj.pendingUnknown),
+    watcherActive: obj.watcherActive === true,
+    dashboardPort:
+      typeof obj.dashboardPort === "number" && Number.isFinite(obj.dashboardPort)
+        ? obj.dashboardPort
+        : null,
+    signals: {
+      gateway1006: signals.gateway1006 === true,
+      scopePending: signals.scopePending === true,
+      loopbackDenied: signals.loopbackDenied === true,
+      watcherDeadline: signals.watcherDeadline === true,
+      rejectedClients: num(signals.rejectedClients),
+    },
+  };
+}
+
+export type ToolScopeInterpretOptions = {
+  sandboxName: string;
+  cliName: string;
+  wantsFix: boolean;
+  /** Outcome of the `--fix` approval pass, when it ran. */
+  fix?: { reported: boolean; approved: number };
+};
+
+function fixHint(cliName: string, sandboxName: string): string {
+  return `run \`${cliName} ${sandboxName} doctor --fix\` to approve pending dashboard/CLI tool-scope upgrades without an SSH connect`;
+}
+
+/**
+ * Turn a probe (and an optional `--fix` outcome) into doctor checks. Pure so it
+ * can be unit-tested without a live sandbox.
+ */
+export function interpretToolScopeProbe(
+  probe: ToolScopeProbe | null,
+  options: ToolScopeInterpretOptions,
+): DoctorToolScopeCheck[] {
+  const { sandboxName, cliName, wantsFix, fix } = options;
+  const checks: DoctorToolScopeCheck[] = [];
+
+  if (!probe || !probe.ok) {
+    checks.push({
+      group: TOOL_SCOPE_GROUP,
+      label: TOOL_SCOPE_LABEL,
+      status: "info",
+      detail: "tool-scope diagnostics unavailable (sandbox not reachable)",
+    });
+    return checks;
+  }
+
+  const sig = probe.signals;
+  const symptomParts: string[] = [];
+  if (sig.gateway1006) symptomParts.push("gateway closed 1006");
+  if (sig.scopePending) symptomParts.push("scope upgrade pending approval");
+  if (sig.loopbackDenied) {
+    const portText = probe.dashboardPort ? `127.0.0.1:${probe.dashboardPort}` : "the dashboard port";
+    symptomParts.push(`policy denial to ${portText}`);
+  }
+
+  // When --fix just approved something, lead with the repair outcome.
+  if (wantsFix && fix?.reported && fix.approved > 0) {
+    checks.push({
+      group: TOOL_SCOPE_GROUP,
+      label: `${TOOL_SCOPE_LABEL} (repair)`,
+      status: "ok",
+      detail: `approved ${fix.approved} pending tool-scope upgrade(s)`,
+    });
+  }
+
+  // Current device-list state is authoritative over log signatures. The gateway
+  // and auto-pair logs are never truncated, so a just-completed `doctor --fix`
+  // (or any older incident) leaves stale 1006/scope-pending/denial lines behind;
+  // keying off them would re-warn with another `--fix` hint even though nothing
+  // is pending. So when the device list is readable, decide from it and use the
+  // log symptoms only as supporting detail on the actionable failure.
+  if (probe.devicesListOk) {
+    // Primary actionable signal: pending allowlisted scope upgrades that --fix
+    // can repair. After a successful fix the re-probe shows 0.
+    if (probe.pendingAllowlisted > 0) {
+      const watcherNote = probe.watcherActive
+        ? ""
+        : "; the in-sandbox auto-pair watcher is not running";
+      const detail =
+        `${probe.pendingAllowlisted} pending allowlisted tool-scope upgrade(s) blocking OpenClaw tool calls` +
+        (symptomParts.length ? ` (${symptomParts.join("; ")})` : "") +
+        watcherNote;
+      checks.push({
+        group: TOOL_SCOPE_GROUP,
+        label: TOOL_SCOPE_LABEL,
+        status: "fail",
+        detail,
+        hint: fixHint(cliName, sandboxName),
+      });
+      return checks;
+    }
+
+    // Pending requests exist but none are allowlisted — do NOT auto-approve;
+    // they are unknown clients that the operator must review explicitly.
+    if (probe.pendingUnknown > 0) {
+      checks.push({
+        group: TOOL_SCOPE_GROUP,
+        label: TOOL_SCOPE_LABEL,
+        status: "warn",
+        detail: `${probe.pendingUnknown} pending device request(s) from non-allowlisted clients; not auto-approved`,
+        hint: `review with \`openclaw devices list\` inside \`${cliName} ${sandboxName} connect\` before approving`,
+      });
+      return checks;
+    }
+
+    // Nothing pending — healthy, regardless of stale log lines.
+    checks.push({
+      group: TOOL_SCOPE_GROUP,
+      label: TOOL_SCOPE_LABEL,
+      status: "ok",
+      detail: "no pending tool-scope approvals",
+    });
+    return checks;
+  }
+
+  // Device list unreadable: we cannot confirm pending state, so fall back to the
+  // log signature. When it shows the #4616 signature, surface it so the user
+  // knows tools were blocked by device scope, not by cron or a missing package.
+  // Do NOT hint `doctor --fix` here: the approval pass only runs when the device
+  // list is readable with an allowlisted backlog, so `--fix` would dead-end on
+  // this same branch. An unreadable device list points at gateway health, so
+  // steer the user to recover the gateway and re-probe instead.
+  if (symptomParts.length > 0) {
+    checks.push({
+      group: TOOL_SCOPE_GROUP,
+      label: TOOL_SCOPE_LABEL,
+      status: "warn",
+      detail:
+        `recent OpenClaw tool-scope failure in logs (${symptomParts.join("; ")}); ` +
+        "could not read the device list to confirm pending approvals",
+      hint:
+        `recover the gateway with \`${cliName} ${sandboxName} recover\`, ` +
+        `then re-run \`${cliName} ${sandboxName} doctor --fix\` to approve any pending tool-scope upgrades`,
+    });
+    return checks;
+  }
+
+  checks.push({
+    group: TOOL_SCOPE_GROUP,
+    label: TOOL_SCOPE_LABEL,
+    status: "info",
+    detail: "could not read OpenClaw device list from the sandbox",
+  });
+  return checks;
+}
+
+export type BuildToolScopeChecksDeps = {
+  exec: SandboxExec;
+  /** Repair callback used when wantsFix is set; defaults wired by the caller. */
+  runApprovalPass?: (sandboxName: string) => { reported: boolean; approved: number };
+  readPolicyModule?: () => string | null;
+};
+
+/**
+ * Orchestrate the probe, the optional `--fix` repair, and a re-probe, returning
+ * doctor checks. The exec/repair/policy dependencies are injected for testing.
+ */
+export function buildToolScopeChecks(
+  sandboxName: string,
+  cliName: string,
+  wantsFix: boolean,
+  deps: BuildToolScopeChecksDeps,
+): DoctorToolScopeCheck[] {
+  const readPolicy = deps.readPolicyModule ?? readAutoPairApprovalPolicyModule;
+  const policyModule = readPolicy();
+  const policyModuleB64 = policyModule
+    ? Buffer.from(policyModule, "utf-8").toString("base64")
+    : "";
+  const script = buildToolScopeProbeScript(policyModuleB64);
+
+  const firstRaw = deps.exec(sandboxName, script);
+  const firstProbe = parseToolScopeProbe(firstRaw?.stdout ?? "");
+
+  // Only repair when --fix is set AND the probe shows an allowlisted backlog.
+  // Avoids running an approval pass when there is nothing to approve.
+  if (
+    wantsFix &&
+    deps.runApprovalPass &&
+    firstProbe &&
+    firstProbe.ok &&
+    firstProbe.devicesListOk &&
+    firstProbe.pendingAllowlisted > 0
+  ) {
+    const passResult = deps.runApprovalPass(sandboxName);
+    const secondRaw = deps.exec(sandboxName, script);
+    const secondProbe = parseToolScopeProbe(secondRaw?.stdout ?? "") ?? firstProbe;
+    // Derive the repaired count from the pending delta rather than the approval
+    // pass's self-report: OpenClaw's local-fallback `devices approve` can apply
+    // the upgrade server-side after the bounded client subprocess has already
+    // timed out, so the delta is the authoritative "net cleared" signal.
+    const repaired = Math.max(
+      0,
+      firstProbe.pendingAllowlisted - secondProbe.pendingAllowlisted,
+    );
+    const fix = { reported: repaired > 0 || passResult.reported, approved: repaired };
+    return interpretToolScopeProbe(secondProbe, { sandboxName, cliName, wantsFix, fix });
+  }
+
+  return interpretToolScopeProbe(firstProbe, { sandboxName, cliName, wantsFix });
+}

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -28,12 +28,14 @@ import type { SandboxEntry } from "../../state/registry";
 import * as registry from "../../state/registry";
 import { buildStatusCommandDeps } from "../../status-command-deps";
 import { readCloudflaredState } from "../../tunnel/services";
+import { runSandboxAutoPairApprovalPass, wrapSandboxShellScript } from "./auto-pair-approval";
 import { buildConfigPermsCheck } from "./doctor-config-perms";
 import {
   buildGatewayInspectFailureChecks,
   type GatewayInspectOptions,
 } from "./doctor-gateway-fallback";
 import { captureHostCommand } from "./doctor-host-command";
+import { buildToolScopeChecks } from "./doctor-tool-scope";
 import { probeSandboxInferenceGatewayHealth } from "./process-recovery";
 
 const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
@@ -522,7 +524,8 @@ export async function runSandboxDoctor(
   const unknown = args.filter((arg) => !["--json", "--fix", "--help", "-h"].includes(arg));
   if (helpRequested) {
     console.log(`  Usage: ${CLI_NAME} <name> doctor [--json] [--fix]`);
-    console.log(`  --fix   Restore the mutable OpenClaw config permission contract if it was tightened`);
+    console.log(`  --fix   Restore the mutable OpenClaw config permission contract if it was tightened,`);
+    console.log(`          and approve pending allowlisted dashboard/CLI tool-scope upgrades`);
     return;
   }
   if (unknown.length > 0) {
@@ -543,6 +546,10 @@ export async function runSandboxDoctor(
 
   const sb = registry.getSandbox(sandboxName);
   const checks: DoctorCheck[] = [];
+  // Tracks whether the named sandbox is present-and-Ready, so live-only probes
+  // (e.g. the #4616 dashboard tool-scope diagnostic) only run when they can
+  // actually reach the sandbox via `openshell sandbox exec`.
+  let sandboxReachable = false;
 
   checks.push({
     group: "Host",
@@ -614,6 +621,7 @@ export async function runSandboxDoctor(
     const present = list.status === 0 && liveNames.has(sandboxName);
     const line = findSandboxListLine(list.output || "", sandboxName);
     const ready = inferSandboxReadyFromLine(line);
+    sandboxReachable = present && ready === true;
     checks.push({
       group: "Sandbox",
       label: "Live sandbox",
@@ -779,6 +787,30 @@ export async function runSandboxDoctor(
     );
     const runtimeCheck = channelRuntimeDoctorCheck(sandboxName, enabledChannels);
     if (runtimeCheck) checks.push(runtimeCheck);
+  }
+
+  // #4616: surface (and, with --fix, repair) late OpenClaw dashboard/tool-call
+  // device-scope approvals. Dashboard-only users never run `connect`, so a
+  // pending tool-scope upgrade — visible as a gateway 1006 close, a "scope
+  // upgrade pending approval" error, and a loopback policy denial — has no
+  // recovery path. The probe is read-only; `--fix` runs the same narrow
+  // allowlisted approval pass that `connect` runs. Only run it when the sandbox
+  // is actually reachable so a stopped sandbox doesn't add noise, and only for
+  // OpenClaw — the `openclaw devices`/auto-pair scope-upgrade mechanism is
+  // OpenClaw-specific. Hermes (device_pairing: false) uses a different tool
+  // gateway, so probing it would emit an inaccurate OpenClaw-only check.
+  // Legacy registry entries with no recorded agent default to OpenClaw.
+  if (sb && sandboxReachable && (sb.agent ?? "openclaw") === "openclaw") {
+    const toolScopeChecks = buildToolScopeChecks(sandboxName, CLI_NAME, wantsFix, {
+      // OpenShell exec rejects multi-line args, so base64-wrap the probe payload.
+      exec: (name, script) =>
+        executeSandboxCommandForVerification(name, wrapSandboxShellScript(script)),
+      runApprovalPass: (name) => {
+        const result = runSandboxAutoPairApprovalPass(name, { capture: true });
+        return { reported: result.reported, approved: result.approved };
+      },
+    });
+    for (const check of toolScopeChecks) checks.push(check);
   }
 
   checks.push(ollamaDoctorCheck(currentProvider));

--- a/test/sandbox-connect-inference/auto-pair-approval.test.ts
+++ b/test/sandbox-connect-inference/auto-pair-approval.test.ts
@@ -6,7 +6,13 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { testTimeoutOptions } from "../helpers/timeouts";
-import { extractApprovalPassScript, runApprovalPassScript, runConnect, setupFixture } from "./helpers";
+import {
+  decodeWrappedSandboxScript,
+  extractApprovalPassScript,
+  runApprovalPassScript,
+  runConnect,
+  setupFixture,
+} from "./helpers";
 
 describe("sandbox connect auto-pair approval pass (#4263)", () => {
   it(
@@ -197,13 +203,14 @@ describe("sandbox connect auto-pair approval pass (#4263)", () => {
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
       // Approval-pass exec was attempted (and the fake openshell exited
       // non-zero for it, per the hook above).
-      const approvalExec = (state.sandboxExecCalls as string[][]).find(
-        (call) =>
-          call.includes("--") &&
-          call.some((segment) => segment.includes("openclaw")) &&
-          call.some((segment) => segment.includes("devices")) &&
-          call.some((segment) => segment.includes("approve")),
-      );
+      const approvalExec = (state.sandboxExecCalls as string[][]).find((call) => {
+        if (!call.includes("--")) return false;
+        // The payload is base64-wrapped for OpenShell exec; decode to identify it.
+        const inner = decodeWrappedSandboxScript(call[call.length - 1] || "");
+        return (
+          inner.includes("openclaw") && inner.includes("devices") && inner.includes("approve")
+        );
+      });
       expect(approvalExec).toBeDefined();
       // Despite the approval-pass failure, SSH handoff still happens.
       expect(state.sandboxConnectCalls).toContainEqual([

--- a/test/sandbox-connect-inference/helpers.ts
+++ b/test/sandbox-connect-inference/helpers.ts
@@ -149,13 +149,23 @@ if (args[0] === "sandbox" && args[1] === "exec") {
     fs.writeFileSync(stateFile, JSON.stringify(state));
     // Test hook (#4263 / CodeRabbit): when the connect-time auto-pair
     // approval pass is specifically targeted, simulate the failure
-    // path the production code must tolerate. The approval-pass script
-    // is identifiable by its embedded \`openclaw devices approve\` call.
+    // path the production code must tolerate. The approval-pass script is
+    // base64-wrapped for OpenShell exec, so decode the payload first; it is
+    // identifiable by its embedded \`openclaw devices approve\` call.
+    let approvalCmd = command;
+    const wrapMatch = command.match(/printf %s '([A-Za-z0-9+/=]+)' \\| base64 -d/);
+    if (wrapMatch) {
+      try {
+        approvalCmd = Buffer.from(wrapMatch[1], "base64").toString("utf8");
+      } catch (_err) {
+        approvalCmd = command;
+      }
+    }
     if (
       process.env.NEMOCLAW_TEST_FAIL_APPROVAL_PASS === "1" &&
-      command.includes("openclaw") &&
-      command.includes("devices") &&
-      command.includes("approve")
+      approvalCmd.includes("openclaw") &&
+      approvalCmd.includes("devices") &&
+      approvalCmd.includes("approve")
     ) {
       process.stderr.write("simulated sandbox exec failure\\n");
       process.exit(7);
@@ -422,19 +432,34 @@ export function runConnect(
 
 export function extractApprovalPassScript(stateFile: string, sandboxName: string): string {
   const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
-  const approvalExec = (state.sandboxExecCalls as string[][]).find(
-    (call) =>
-      call.includes("--") &&
-      call.some((segment) => segment.includes("openclaw")) &&
-      call.some((segment) => segment.includes("devices")) &&
-      call.some((segment) => segment.includes("approve")),
-  );
+  // The approval pass is base64-wrapped so it survives OpenShell exec's
+  // no-newline-in-args rule (see wrapSandboxShellScript), so identify the call
+  // by its decoded payload, not by literal segments.
+  const approvalExec = (state.sandboxExecCalls as string[][]).find((call) => {
+    if (!call.includes("--")) return false;
+    const inner = decodeWrappedSandboxScript(call[call.length - 1] || "");
+    return inner.includes("openclaw") && inner.includes("devices") && inner.includes("approve");
+  });
   expect(approvalExec).toBeDefined();
   expect(approvalExec).toContain("sandbox");
   expect(approvalExec).toContain("exec");
   expect(approvalExec).toContain("--name");
   expect(approvalExec).toContain(sandboxName);
-  return approvalExec?.[approvalExec.length - 1] || "";
+  const lastArg = approvalExec?.[approvalExec.length - 1] || "";
+  // Decode it back to the literal payload so callers can assert on/run the
+  // real script.
+  return decodeWrappedSandboxScript(lastArg);
+}
+
+/**
+ * Reverse `wrapSandboxShellScript`: extract the base64 payload from a
+ * `printf %s '<b64>' | base64 -d` wrapper and decode it. Returns the input
+ * unchanged when it is not wrapped.
+ */
+export function decodeWrappedSandboxScript(wrapped: string): string {
+  const match = wrapped.match(/printf %s '([A-Za-z0-9+/=]+)' \| base64 -d/);
+  if (!match) return wrapped;
+  return Buffer.from(match[1], "base64").toString("utf-8");
 }
 
 export function runApprovalPassScript(


### PR DESCRIPTION
## Summary

Dashboard-only OpenClaw users can't create cron jobs (and other agent tool calls fail) because a late device **scope upgrade** never gets approved: the agent tool subprocess connects to `ws://127.0.0.1:<dashboardPort>`, the gateway closes with `1006 abnormal closure`, and OpenShell logs a policy denial to `127.0.0.1:<dashboardPort>`. The existing allowlisted approval pass only runs during `nemoclaw <sandbox> connect`, which dashboard users never invoke — so there is no recovery path. This adds a bounded recovery + diagnostic through `doctor`.

## Related Issue

Fixes #4616

## Changes

- **Reusable recovery pass.** Extracted the connect-time allowlisted approval pass into a shared `auto-pair-approval` module and reuse it from `doctor --fix`, so dashboard-only users can approve pending tool-scope upgrades without an SSH `connect`. The allowlist is unchanged and narrow (`openclaw-control-ui` + `webchat`/`cli`, `operator.pairing`/`read`/`write` only); unknown clients are never approved.
- **`doctor` tool-scope diagnostic (read-only).** Surfaces pending allowlisted upgrades, the `1006` / `scope upgrade pending approval` / loopback `127.0.0.1:<dashboardPort>` policy-denial log signatures, and whether the in-sandbox auto-pair watcher is alive — so the failure reads as device-scope, not as a cron/package problem. Current device-list state is authoritative over the never-truncated logs; logs are read bounded from the end. Gated to OpenClaw sandboxes (Hermes has `device_pairing: false`).
- **Newline-safe in-sandbox exec.** OpenShell `sandbox exec` rejects multi-line arguments, which had silently broken the existing connect-time recovery too. Both passes now base64-wrap their payload and decode it inside the sandbox, so the recovery actually runs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes (7413 passed, 25 skipped, 0 failed)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] `codex review --uncommitted` clean (no actionable findings)

Verified end-to-end on a live dashboard-only OpenClaw sandbox: an `openclaw agent` tool call triggered a stuck pending allowlisted scope upgrade (agent fell back to `embedded`/`fallbackFrom: gateway`); read-only `doctor` reported `[fail] Tool-call device scope: 1 pending allowlisted tool-scope upgrade(s) blocking OpenClaw tool calls; the in-sandbox auto-pair watcher is not running` with a `doctor --fix` hint; and `doctor --fix` cleared it (pending 1 → 0, `[fail]` → `[ok]`).

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenClaw device-scope diagnostics to detect stuck approval workflows and suggest remediation paths.
  * `sandbox doctor --fix` now automatically approves pending allowlisted tool-scope upgrades.

* **Improvements**
  * Sandbox connect flow now includes device approval diagnostics during initialization.

* **Tests**
  * Added comprehensive test coverage for device-scope approval and diagnostic workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->