### PR TITLE
chore(github): tighten bug report intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,30 @@
 name: Bug Report
-description: Report a bug you encountered and can reproduce.
+description: Report a bug. Your agent should investigate first - see CONTRIBUTING.md.
 type: Bug
 labels: ["needs: triage"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Agent-First Troubleshooting
+
+        NemoClaw is an agent-first project. Before filing this bug, point your coding agent at the repo and have it investigate using the available skills (`nemoclaw-skills-guide`, `nemoclaw-user-monitor-sandbox`, `nemoclaw-user-manage-sandboxes`, etc.). See [CONTRIBUTING.md](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md) for issue expectations.
+
+  - type: textarea
+    id: agent-diagnostic
+    attributes:
+      label: Agent Diagnostic
+      description: |
+        Paste the output from your agent's investigation of this bug. What skills did it load? What did it find? What did it try?
+      placeholder: |
+        Example:
+        - Loaded `nemoclaw-user-monitor-sandbox`
+        - Ran `nemoclaw status`, `nemoclaw list`, and `nemoclaw debug --quick`
+        - Found the sandbox is registered but not ready after onboarding
+        - Tried `nemoclaw debug --output /tmp/nemoclaw-debug.tar.gz`; the attached bundle still shows the failure
+    validations:
+      required: false
+
   - type: textarea
     id: description
     attributes:
@@ -46,7 +68,7 @@ body:
         tarball, or paste the output of `nemoclaw debug --quick` below.
       render: shell
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: logs
@@ -55,7 +77,7 @@ body:
       description: Any additional log output, error messages, or stack traces not covered by the debug output above.
       render: shell
     validations:
-      required: false
+      required: true
 
   - type: checkboxes
     id: checklist

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,15 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Have a question?
+    url: https://github.com/NVIDIA/NemoClaw/discussions
+    about: >
+      Use GitHub Discussions for setup questions, usage questions, design
+      exploration, and ideas that are not ready for an issue.
+  - name: Need troubleshooting help?
+    url: https://github.com/NVIDIA/NemoClaw/blob/main/docs/reference/troubleshooting.mdx
+    about: >
+      Check the troubleshooting guide and point your coding agent at the repo
+      before opening a bug report.
   - name: Security vulnerability?
     url: https://github.com/NVIDIA/NemoClaw/blob/main/SECURITY.md
     about: >


### PR DESCRIPTION
## Summary
This PR tightens NemoClaw bug report intake so maintainers get enough context to triage issues. Bug reports now require debug output and logs; agent diagnostics are encouraged but optional.

Bug reports now require:
- `Description`
- `Reproduction Steps`
- `Environment`
- `Debug Output`
- `Logs`
- Checklist confirmation that the bug is reproducible and not a duplicate

Feature request and documentation issue templates are unchanged.

## Changes
- Add optional agent-first troubleshooting guidance and an optional `Agent Diagnostic` field to bug reports.
- Make `Debug Output` and `Logs` required in bug reports.
- Add contact links for Discussions and troubleshooting so questions are routed away from issues.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Passing verification:
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/doc_issue.yml .github/ISSUE_TEMPLATE/config.yml`
- `npx prek run --files .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/doc_issue.yml .github/ISSUE_TEMPLATE/config.yml`

Full `npx prek run --all-files` was attempted but still fails in unrelated existing CLI tests. No runtime code or tests are changed by this PR.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <san1201.bkhn@gmail.com>
