### PR TITLE
feat(policies): add gemini preset

### DIFF
--- a/nemoclaw-blueprint/policies/presets/gemini.yaml
+++ b/nemoclaw-blueprint/policies/presets/gemini.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+preset:
+  name: gemini
+  description: "Google Gemini API access"
+
+network_policies:
+  gemini:
+    name: gemini
+    endpoints:
+      - host: generativelanguage.googleapis.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/v1beta/openai/**" }
+          - allow: { method: POST, path: "/v1beta/openai/**" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+      - { path: /usr/bin/curl }

--- a/test/gemini-preset.test.ts
+++ b/test/gemini-preset.test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import * as policies from "../dist/lib/policy";
+
+const requireForTest = createRequire(import.meta.url);
+const YAML = requireForTest("yaml");
+
+function requirePresetContent(content: string | null): string {
+  expect(content).toBeTruthy();
+  if (!content) {
+    throw new Error("Expected preset content to be present");
+  }
+  return content;
+}
+
+function parsePresetYaml(presetName: string): Record<string, any> {
+  return YAML.parse(requirePresetContent(policies.loadPreset(presetName))) as Record<string, any>;
+}
+
+describe("gemini preset", () => {
+  it("routes the Google Gemini API with node and curl access", () => {
+    const parsed = parsePresetYaml("gemini");
+    const endpoints: Array<Record<string, unknown>> =
+      parsed?.network_policies?.gemini?.endpoints ?? [];
+    const endpoint = endpoints.find((item) => item.host === "generativelanguage.googleapis.com");
+    if (!endpoint) throw new Error("expected generativelanguage.googleapis.com endpoint");
+
+    expect(endpoint.port).toBe(443);
+    expect(endpoint.protocol).toBe("rest");
+    expect(endpoint.enforcement).toBe("enforce");
+    expect(endpoint.rules).toEqual([
+      { allow: { method: "GET", path: "/v1beta/openai/**" } },
+      { allow: { method: "POST", path: "/v1beta/openai/**" } },
+    ]);
+
+    const binaries: Array<{ path: string }> = parsed?.network_policies?.gemini?.binaries ?? [];
+    expect(binaries.map((entry) => entry.path).sort()).toEqual([
+      "/usr/bin/curl",
+      "/usr/bin/node",
+      "/usr/local/bin/node",
+    ]);
+  });
+
+  it("extracts hosts from gemini preset", () => {
+    const content = requirePresetContent(policies.loadPreset("gemini"));
+    const hosts = policies.getPresetEndpoints(content);
+    expect(hosts).toEqual(["generativelanguage.googleapis.com"]);
+  });
+});

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -181,6 +181,7 @@ describe("policies", () => {
         "brew",
         "claude-code",
         "discord",
+        "gemini",
         "github",
         "huggingface",
         "jira",
@@ -227,6 +228,30 @@ describe("policies", () => {
         expect(content).toContain("/usr/local/bin/node");
         expect(content).toContain("/usr/bin/node");
       }
+    });
+
+    it("gemini preset routes the Google Gemini API with node and curl access", () => {
+      const parsed = parsePresetYaml("gemini");
+      const endpoints: Array<Record<string, unknown>> =
+        parsed?.network_policies?.gemini?.endpoints ?? [];
+      const endpoint = endpoints.find((item) => item.host === "generativelanguage.googleapis.com");
+      if (!endpoint) throw new Error("expected generativelanguage.googleapis.com endpoint");
+
+      expect(endpoint.port).toBe(443);
+      expect(endpoint.protocol).toBe("rest");
+      expect(endpoint.enforcement).toBe("enforce");
+      expect(endpoint.rules).toEqual([
+        { allow: { method: "GET", path: "/v1beta/openai/**" } },
+        { allow: { method: "POST", path: "/v1beta/openai/**" } },
+      ]);
+
+      const binaries: Array<{ path: string }> =
+        parsed?.network_policies?.gemini?.binaries ?? [];
+      expect(binaries.map((entry) => entry.path).sort()).toEqual([
+        "/usr/bin/curl",
+        "/usr/bin/node",
+        "/usr/local/bin/node",
+      ]);
     });
 
     it("whatsapp preset routes web.whatsapp.com as a raw L4 tunnel with TLS pass-through", () => {
@@ -472,6 +497,12 @@ describe("policies", () => {
       const content = requirePresetContent(policies.loadPreset("telegram"));
       const hosts = policies.getPresetEndpoints(content);
       expect(hosts).toEqual(["api.telegram.org"]);
+    });
+
+    it("extracts hosts from gemini preset", () => {
+      const content = requirePresetContent(policies.loadPreset("gemini"));
+      const hosts = policies.getPresetEndpoints(content);
+      expect(hosts).toEqual(["generativelanguage.googleapis.com"]);
     });
 
     it("extracts the explicit iLink hosts from wechat preset", () => {

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -230,30 +230,6 @@ describe("policies", () => {
       }
     });
 
-    it("gemini preset routes the Google Gemini API with node and curl access", () => {
-      const parsed = parsePresetYaml("gemini");
-      const endpoints: Array<Record<string, unknown>> =
-        parsed?.network_policies?.gemini?.endpoints ?? [];
-      const endpoint = endpoints.find((item) => item.host === "generativelanguage.googleapis.com");
-      if (!endpoint) throw new Error("expected generativelanguage.googleapis.com endpoint");
-
-      expect(endpoint.port).toBe(443);
-      expect(endpoint.protocol).toBe("rest");
-      expect(endpoint.enforcement).toBe("enforce");
-      expect(endpoint.rules).toEqual([
-        { allow: { method: "GET", path: "/v1beta/openai/**" } },
-        { allow: { method: "POST", path: "/v1beta/openai/**" } },
-      ]);
-
-      const binaries: Array<{ path: string }> =
-        parsed?.network_policies?.gemini?.binaries ?? [];
-      expect(binaries.map((entry) => entry.path).sort()).toEqual([
-        "/usr/bin/curl",
-        "/usr/bin/node",
-        "/usr/local/bin/node",
-      ]);
-    });
-
     it("whatsapp preset routes web.whatsapp.com as a raw L4 tunnel with TLS pass-through", () => {
       // The /ws/chat upgrade is HTTP/1.1-only; if the proxy terminates TLS it
       // negotiates h2 ALPN with Meta's edge and the WS upgrade fails (Meta
@@ -497,12 +473,6 @@ describe("policies", () => {
       const content = requirePresetContent(policies.loadPreset("telegram"));
       const hosts = policies.getPresetEndpoints(content);
       expect(hosts).toEqual(["api.telegram.org"]);
-    });
-
-    it("extracts hosts from gemini preset", () => {
-      const content = requirePresetContent(policies.loadPreset("gemini"));
-      const hosts = policies.getPresetEndpoints(content);
-      expect(hosts).toEqual(["generativelanguage.googleapis.com"]);
     });
 
     it("extracts the explicit iLink hosts from wechat preset", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds a new `gemini` policy preset for Google Gemini API access so the repo can route the Generative Language API through a dedicated, security-scoped preset. This keeps Gemini access consistent with the other policy presets and makes the allowed network surface explicit.

## Related Issue
None.

## Changes
- Added `nemoclaw-blueprint/policies/presets/gemini.yaml` with the Gemini host, REST routing rules, and binary allowlist.
- Updated `test/policies.test.ts` to include the new preset in the preset list assertions.
- Added coverage for preset endpoint extraction and the Gemini preset policy details.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Additional Verification
- `npm run build:cli`
- `npm test -- --run test/policies.test.ts`

---
DCO sign-off required by CI.
Signed-off-by: AbbyJL <454816714@qq.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Google Gemini API preset providing secure, pre-configured access to Generative Language API endpoints with network security policies and authorized binary allowlist.

* **Tests**
  * Added comprehensive test coverage for the Gemini preset, validating endpoint extraction, network policy configuration, REST routing rules, and authorized binary restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->