### PR TITLE
docs(e2e): choose Vitest fixtures as scenario runner

### DIFF
--- a/test/e2e-scenario/docs/MIGRATION.md
+++ b/test/e2e-scenario/docs/MIGRATION.md
@@ -20,10 +20,12 @@ The scenario E2E migration is in a hybrid phase:
 - legacy `test/e2e/test-*.sh` scripts still provide most live nightly and
   platform coverage.
 
-This hybrid shape is not the target end state. #3588 should converge on a
-single scenario runner. Until that runner owns live execution, resolver,
-assertion, evidence, and redaction behavior, treat YAML and bash runner updates
-as bridge work rather than durable architecture.
+This hybrid shape is not the target end state. #3588 and #4941 should converge
+on one live execution path: **Vitest as the scenario runner, extended by
+NemoClaw fixtures and typed domain helpers**. Until that path owns live
+execution, resolver behavior, assertions, evidence, cleanup, and redaction,
+treat YAML and bash runner updates as bridge work rather than durable
+architecture.
 
 Do not assume legacy scripts are deletion-ready just because a scenario or suite
 name exists. The final reconciliation phase must show either evidence-complete
@@ -34,19 +36,21 @@ removed.
 
 The final scenario framework should have one execution path:
 
-- typed scenario definitions compile to the runner plan consumed by CI and local
-  runs;
-- the runner owns setup, onboarding, runtime actions, expected-state probes,
-  assertion execution, expected-failure matching, evidence artifacts, and
-  secret redaction;
+- Vitest owns live execution, filtering, reporters, timeouts, fixture lifecycle,
+  skip handling, and CI integration;
+- NemoClaw fixtures own setup, onboarding, runtime actions, expected-state
+  probes, assertion helpers, expected-failure matching, evidence artifacts,
+  cleanup, and secret redaction;
+- typed scenario definitions and matrix helpers describe stable scenario IDs and
+  supported combinations without becoming a second execution framework;
 - reusable assertions prefer TypeScript probes and typed clients;
 - shell scripts remain only for host, sandbox, process, or platform boundaries
   where shell is the thing being tested or the lowest-risk adapter;
-- shell execution is wrapped by the runner so environment scoping, timeout,
+- shell execution is wrapped by fixtures so environment scoping, timeout,
   redaction, artifact capture, and argument validation are consistent.
 
 When a bridge PR adds behavior to the current YAML/bash runner, preserve the
-requirement it proves, but port that requirement into the single-runner path
+requirement it proves, but port that requirement into the Vitest fixture path
 before removing legacy runner pieces. Do not deepen the bash runner as a second
 long-term source of truth.
 
@@ -57,6 +61,7 @@ Use these GitHub issues for status and follow-up work:
 | Issue | Purpose |
 | --- | --- |
 | #3588 | Parent architecture epic for layered single-runner scenario E2E |
+| #4941 | Decision issue for using Vitest fixtures as the scenario execution model |
 | #4347–#4356 | Domain-specific audit-coverage phases |
 | #4357 | Final audit reconciliation, placeholder cleanup, and deletion-readiness review |
 | #4378 | Friendly `setup_scenarios` aliases for layered test plans |
@@ -88,7 +93,7 @@ When moving behavior from a legacy E2E script into the scenario framework:
    canonical scenario ID.
 4. Add or update current YAML metadata only when the existing bridge runner must
    keep resolving the scenario during the migration.
-5. Add the reusable assertion or probe in the single-runner direction whenever
+5. Add the reusable assertion or probe in the Vitest fixture direction whenever
    possible instead of adding new bash-runner-only behavior.
 6. Add reusable suite or assertion helpers instead of copying entire legacy
    scripts.
@@ -119,7 +124,7 @@ npx vitest run --project e2e-scenario-framework --silent=false --reporter=defaul
 ## Cleanup rules
 
 - Prefer new scenario-matrix coverage over new legacy-style `test-*.sh` scripts.
-- Prefer single-runner behavior over new YAML/bash-runner behavior; if a bridge
+- Prefer Vitest fixture behavior over new YAML/bash-runner behavior; if a bridge
   change is unavoidable, document the porting requirement in the owning issue or
   PR.
 - Do not reintroduce the removed workflow-level parity report unless maintainers

--- a/test/e2e-scenario/docs/README.md
+++ b/test/e2e-scenario/docs/README.md
@@ -8,11 +8,15 @@ It combines typed scenario builders, product-facing setup manifests, YAML
 runtime metadata, and reusable shell suites while the older live E2E scripts
 continue to run in parallel.
 
-This hybrid model is transitional. The target architecture for #3588 is a
-single scenario runner that owns scenario resolution, orchestration, evidence
-collection, redaction, and assertion dispatch. Shell scripts should be kept to
-the smallest practical set of system-boundary probes or command fixtures, not a
-second planning or assertion-control runtime.
+This hybrid model is transitional. The target architecture for #3588 and #4941
+is **Vitest as the single scenario execution runner**, extended by NemoClaw
+fixtures and typed domain helpers. Vitest owns test discovery, filtering,
+timeouts, reporters, fixture lifecycle, skips, and CI integration. NemoClaw owns
+scenario vocabulary, setup/onboarding helpers, product clients, evidence
+collection, redaction, cleanup, and assertion helpers.
+
+Shell scripts should be kept to the smallest practical set of system-boundary
+probes or command fixtures, not a second planning or assertion-control runtime.
 
 ## Current sources of truth
 
@@ -34,11 +38,16 @@ maintainer-approved reason.
 
 ## Target runner model
 
-Future scenario coverage should move toward one runner with these properties:
+Future scenario coverage should move toward one Vitest-based runner with these
+properties:
 
-- the runner compiles one typed plan for each scenario and treats that plan as
-  the source of truth for setup, onboarding, expected state, suites, assertions,
-  evidence paths, and expected failures;
+- Vitest is the execution surface for live scenarios and owns lifecycle,
+  filtering, reporting, timeouts, and fixture scopes;
+- NemoClaw fixtures expose scenario-level helpers for setup, onboarding, host
+  CLI access, gateway checks, sandbox checks, provider fixtures, evidence
+  artifacts, redaction, and cleanup;
+- typed scenario data and matrix helpers describe stable scenario IDs and
+  supported combinations without becoming a second runner;
 - product-facing manifests remain declarative setup inputs, not executable test
   programs;
 - assertion modules prefer TypeScript probes and typed client helpers;
@@ -48,7 +57,7 @@ Future scenario coverage should move toward one runner with these properties:
   environment, timeout, redaction, artifact capture, and command/argument
   validation;
 - bridge work that expands the YAML/bash runner must also identify how that
-  behavior will move into the single runner before legacy runner paths are
+  behavior will move into Vitest fixtures before legacy runner paths are
   removed.
 
 The #4347-#4357 audit-phase issues should be read as acceptance coverage
@@ -79,8 +88,40 @@ The current YAML shell runner expresses this through:
 
 The typed scenario registry expresses the same intent as deterministic code and
 is used by the scenario workflow matrix and dry-run plan artifacts. The target
-single runner should collapse these parallel expressions into one executable
-plan model.
+Vitest fixture model should collapse these parallel expressions into one live
+execution path.
+
+## Fixture-first scenario shape
+
+Final-state live scenarios should read like regular Vitest tests that depend on
+NemoClaw fixtures:
+
+```ts
+import { test } from "../framework/e2e-test.ts";
+
+test("ubuntu repo cloud OpenClaw", async ({
+  repo,
+  openclaw,
+  gateway,
+  sandbox,
+  inference,
+}) => {
+  await repo.installCurrent();
+
+  const instance = await openclaw.onboard({
+    agent: "openclaw",
+    provider: "nvidia",
+  });
+
+  await gateway.expectHealthy(instance);
+  await sandbox.expectRunning(instance);
+  await inference.expectLocalChat(instance, { prompt: "Say ok.", expect: /ok/i });
+});
+```
+
+The test body should express product behavior. Fixture implementations should
+hide redacted process spawning, artifact paths, cleanup registration, secret
+gating, and retry/flake classification.
 
 ## How to run
 
@@ -148,14 +189,16 @@ test/e2e-scenario/
   `macos-e2e.yaml`, `wsl-e2e.yaml`, `ollama-proxy-e2e.yaml`, and
   `regression-e2e.yaml` still run legacy live E2E scripts during the migration.
 - `vitest.config.ts` contains the `e2e-scenario-framework` project for framework
-  and metadata tests.
+  and metadata tests. The live scenario target should be a separate opt-in
+  Vitest project so ordinary `npm test` remains fast and local-friendly.
 
 ## Migration tracking
 
 Migration status is tracked outside the repository in GitHub issues and PRs,
 not in repo-local checklists. The parent architecture issue is #3588. Active
 audit-coverage work is tracked by the #4347–#4357 issue set, with focused
-follow-ups such as #4378 for specific drift fixes.
+follow-ups such as #4378 for specific drift fixes. The execution-model decision
+is tracked in #4941.
 
 The old workflow-level parity report has been removed. Use scenario framework
 tests, the coverage report, PR review, and the audit issues to decide what to


### PR DESCRIPTION
## Summary
Documents #4941 as a Vitest fixture-based end state for E2E scenarios: one runner, typed NemoClaw scenario fixtures, and shell/YAML only as migration bridges. Draft stack PR 1/7. cc @jyaunches for review.

## Related Issue
Refs #4941.

## Changes
- Updates `test/e2e-scenario/docs/README.md` to describe the final Vitest scenario shape and the smallest expected test.
- Updates `test/e2e-scenario/docs/MIGRATION.md` to reconcile the legacy and scenario paths around the single-runner target.
- Captures the expected direction away from a hybrid shell-script E2E suite.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated testing infrastructure documentation to clarify the current hybrid approach and target end-state architecture.
* Refined migration roadmap and priorities to guide future testing framework improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->