### PR TITLE
fix(sandbox): stage patch-openclaw-slack-deny-feedback.mts in build context

### DIFF
--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -160,6 +160,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "patch-openclaw-chat-send.js"),
     path.join(stagedScriptsDir, "patch-openclaw-chat-send.js"),
   );
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "patch-openclaw-slack-deny-feedback.mts"),
+    path.join(stagedScriptsDir, "patch-openclaw-slack-deny-feedback.mts"),
+  );
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -80,6 +80,7 @@ describe("sandbox build context staging", () => {
     writeFixture(path.join("scripts", "seed-wechat-accounts.py"));
     writeFixture(path.join("scripts", "patch-openclaw-tool-catalog.js"));
     writeFixture(path.join("scripts", "patch-openclaw-chat-send.js"));
+    writeFixture(path.join("scripts", "patch-openclaw-slack-deny-feedback.mts"));
   }
 
   function expectStagedNemoclawModes(buildCtx: string) {
@@ -265,6 +266,9 @@ describe("sandbox build context staging", () => {
       expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-chat-send.js"))).toBe(
         true,
       );
+      expect(
+        fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-slack-deny-feedback.mts")),
+      ).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "lib", "sandbox-init.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -83,6 +83,18 @@ describe("sandbox build context staging", () => {
     writeFixture(path.join("scripts", "patch-openclaw-slack-deny-feedback.mts"));
   }
 
+  function expectDockerfileScriptCopiesExist(buildCtx: string, stagedDockerfile: string) {
+    const dockerfile = fs.readFileSync(stagedDockerfile, "utf8");
+    const copiedScripts = [...dockerfile.matchAll(/^COPY\s+scripts\/(\S+)/gm)].map(
+      ([, relativePath]) => relativePath,
+    );
+    expect(copiedScripts).not.toHaveLength(0);
+
+    for (const relativePath of copiedScripts) {
+      expect(fs.existsSync(path.join(buildCtx, "scripts", relativePath))).toBe(true);
+    }
+  }
+
   function expectStagedNemoclawModes(buildCtx: string) {
     const stagedNemoclaw = path.join(buildCtx, "nemoclaw");
     const stagedSrc = path.join(stagedNemoclaw, "src");
@@ -212,7 +224,8 @@ describe("sandbox build context staging", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-opt-"));
 
     try {
-      const { buildCtx } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
+      const { buildCtx, stagedDockerfile } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
+      expectDockerfileScriptCopiesExist(buildCtx, stagedDockerfile);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw-blueprint", ".venv"))).toBe(false);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw-blueprint", "blueprint.yaml"))).toBe(true);
       expect(


### PR DESCRIPTION
## Summary

Nightly E2E run [27154074940](https://github.com/NVIDIA/NemoClaw/actions/runs/27154074940) lost **48 of 67 jobs** to a single root cause: every E2E job that exercises onboard/install died at the same Dockerfile step with

```
COPY failed: file not found in build context: stat
scripts/patch-openclaw-slack-deny-feedback.mts: file does not exist
```

PR #4933 added `scripts/patch-openclaw-slack-deny-feedback.mts` and the matching `COPY` line in `Dockerfile`, but did **not** register the new file in `stageOptimizedSandboxBuildContext` (`src/lib/sandbox/build-context.ts`). The optimized staging path hand-copies a curated set of files into a temp build context — its two existing siblings (`patch-openclaw-tool-catalog.js`, `patch-openclaw-chat-send.js`) are listed there explicitly. The new `.mts` patch was missed, so `docker build` couldn't see it.

PR #4933 itself was green because PR-time builds were satisfied by other paths or cached layers; the gap only showed up when nightly built from main against the staged context.

## Change

- `src/lib/sandbox/build-context.ts`: stage `patch-openclaw-slack-deny-feedback.mts` next to its siblings.
- `test/sandbox-build-context.test.ts`: extend the fixture + assertion so any future drop of this file is caught locally before it can take down nightly.
- `test/sandbox-build-context.test.ts`: parse staged Dockerfile `COPY scripts/...` lines and verify every referenced script exists in the optimized staged context, folding in the broader guard from #4971.

## Validation

- `npx vitest run test/sandbox-build-context.test.ts` → 7/7 passing locally.
- GitHub PR checks on updated head `7fca86f78` are green, including `build-sandbox-images`, `build-sandbox-images-arm64`, `unit-vitest-linux`, `cli-tests`, and downstream self-hosted smoke jobs.
- After merge, rerun `nightly-e2e.yaml` (or `gh run rerun 27154074940 --failed`). A single onboard-stage job clearing Dockerfile step 23 confirms all 48 failures are resolved.

## Follow-up (suggested, not in this PR)

The two-place duplication (`Dockerfile` `COPY` + hand-listed staging) is the structural cause of this incident. This PR now adds a contract test for that duplication; a future cleanup could still drive the staged list from a glob (`scripts/patch-openclaw-*.{js,mts}`) or shared manifest.

cc @yimoj (PR #4933 author).