### PR TITLE
fix(sandbox): stage Slack deny-feedback patch script

### DIFF
--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -160,6 +160,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "patch-openclaw-chat-send.js"),
     path.join(stagedScriptsDir, "patch-openclaw-chat-send.js"),
   );
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "patch-openclaw-slack-deny-feedback.mts"),
+    path.join(stagedScriptsDir, "patch-openclaw-slack-deny-feedback.mts"),
+  );
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -80,6 +80,19 @@ describe("sandbox build context staging", () => {
     writeFixture(path.join("scripts", "seed-wechat-accounts.py"));
     writeFixture(path.join("scripts", "patch-openclaw-tool-catalog.js"));
     writeFixture(path.join("scripts", "patch-openclaw-chat-send.js"));
+    writeFixture(path.join("scripts", "patch-openclaw-slack-deny-feedback.mts"));
+  }
+
+  function expectDockerfileScriptCopiesExist(buildCtx: string, stagedDockerfile: string) {
+    const dockerfile = fs.readFileSync(stagedDockerfile, "utf8");
+    const copiedScripts = [...dockerfile.matchAll(/^COPY\s+scripts\/(\S+)/gm)].map(
+      ([, relativePath]) => relativePath,
+    );
+    expect(copiedScripts).not.toHaveLength(0);
+
+    for (const relativePath of copiedScripts) {
+      expect(fs.existsSync(path.join(buildCtx, "scripts", relativePath))).toBe(true);
+    }
   }
 
   function expectStagedNemoclawModes(buildCtx: string) {
@@ -211,7 +224,8 @@ describe("sandbox build context staging", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-opt-"));
 
     try {
-      const { buildCtx } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
+      const { buildCtx, stagedDockerfile } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
+      expectDockerfileScriptCopiesExist(buildCtx, stagedDockerfile);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw-blueprint", ".venv"))).toBe(false);
       expect(fs.existsSync(path.join(buildCtx, "nemoclaw-blueprint", "blueprint.yaml"))).toBe(true);
       expect(
@@ -265,6 +279,9 @@ describe("sandbox build context staging", () => {
       expect(fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-chat-send.js"))).toBe(
         true,
       );
+      expect(
+        fs.existsSync(path.join(buildCtx, "scripts", "patch-openclaw-slack-deny-feedback.mts")),
+      ).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "lib", "sandbox-init.sh"))).toBe(true);
       expect(fs.existsSync(path.join(buildCtx, "scripts", "setup.sh"))).toBe(false);
     } finally {


### PR DESCRIPTION
## Summary
Stage the Slack deny-feedback patch script in the optimized sandbox build context so OpenClaw source installs can satisfy every `COPY scripts/...` line in the Dockerfile. This fixes the nightly E2E image-build failure where Docker could not find `scripts/patch-openclaw-slack-deny-feedback.mts`.

## Changes
- Copy `scripts/patch-openclaw-slack-deny-feedback.mts` into the optimized sandbox build context alongside the existing OpenClaw patch scripts.
- Add a regression assertion that parses staged Dockerfile `COPY scripts/...` entries and verifies every referenced script exists in the staged context.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded build context staging test coverage with helper validation to verify all staged scripts exist in the build context

* **Chores**
  * Added staging support for an additional support script in the optimized build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->