### PR TITLE
fix(security): use secure temp paths in tests

### DIFF
--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -235,9 +235,11 @@ describe("uninstall run plan", () => {
     const killed: number[] = [];
     const exited = new Set<number>();
     // Simulate the persisted PID file under ~/.nemoclaw/.
-    const tmpHome = "/tmp/nemoclaw-uninstall-test-2759-pidfile";
-    const pidFile = `${tmpHome}/.nemoclaw/ollama-auth-proxy.pid`;
-    fs.mkdirSync(`${tmpHome}/.nemoclaw`, { recursive: true });
+    const tmpHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-uninstall-test-2759-pidfile-"),
+    );
+    const pidFile = path.join(tmpHome, ".nemoclaw", "ollama-auth-proxy.pid");
+    fs.mkdirSync(path.join(tmpHome, ".nemoclaw"), { recursive: true });
     fs.writeFileSync(pidFile, "44321\n");
 
     try {
@@ -462,9 +464,11 @@ describe("uninstall run plan", () => {
     const logs: string[] = [];
     const warnings: string[] = [];
     const signals: NodeJS.Signals[] = [];
-    const tmpHome = "/tmp/nemoclaw-uninstall-test-2759-stuck";
-    const pidFile = `${tmpHome}/.nemoclaw/ollama-auth-proxy.pid`;
-    fs.mkdirSync(`${tmpHome}/.nemoclaw`, { recursive: true });
+    const tmpHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-uninstall-test-2759-stuck-"),
+    );
+    const pidFile = path.join(tmpHome, ".nemoclaw", "ollama-auth-proxy.pid");
+    fs.mkdirSync(path.join(tmpHome, ".nemoclaw"), { recursive: true });
     fs.writeFileSync(pidFile, "44322\n");
 
     try {

--- a/src/lib/tunnel/services-sandbox.test.ts
+++ b/src/lib/tunnel/services-sandbox.test.ts
@@ -366,8 +366,13 @@ describe("stopAll with sandbox channels", () => {
     const savedNemoclaw = process.env.NEMOCLAW_SANDBOX;
     const savedNemoclawName = process.env.NEMOCLAW_SANDBOX_NAME;
     const savedSandbox = process.env.SANDBOX_NAME;
-    const effectivePidDir = "/tmp/nemoclaw-services-name-sandbox";
-    const lowerPriorityPidDir = "/tmp/nemoclaw-services-other-sandbox";
+    const savedTmpDir = process.env.TMPDIR;
+    const pidRoot = mkdtempSync(join(tmpdir(), "nemoclaw-services-pid-root-"));
+    const effectivePidDir = join(pidRoot, "nemoclaw-services-name-sandbox");
+    const lowerPriorityPidDir = join(pidRoot, "nemoclaw-services-other-sandbox");
+    process.env.TMPDIR = pidRoot;
+    rmSync(effectivePidDir, { recursive: true, force: true });
+    rmSync(lowerPriorityPidDir, { recursive: true, force: true });
     mkdirSync(effectivePidDir, { recursive: true, mode: 0o700 });
     mkdirSync(lowerPriorityPidDir, { recursive: true, mode: 0o700 });
     writeFileSync(join(effectivePidDir, "cloudflared.pid"), "999999999");
@@ -393,8 +398,9 @@ describe("stopAll with sandbox channels", () => {
       else delete process.env.NEMOCLAW_SANDBOX_NAME;
       if (savedSandbox !== undefined) process.env.SANDBOX_NAME = savedSandbox;
       else delete process.env.SANDBOX_NAME;
-      rmSync(effectivePidDir, { recursive: true, force: true });
-      rmSync(lowerPriorityPidDir, { recursive: true, force: true });
+      if (savedTmpDir !== undefined) process.env.TMPDIR = savedTmpDir;
+      else delete process.env.TMPDIR;
+      rmSync(pidRoot, { recursive: true, force: true });
       logSpy.mockRestore();
     }
   });

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -14,6 +14,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { dockerSpawnSync } from "../adapters/docker";
 import { resolveOpenshell } from "../adapters/openshell/resolve";
@@ -34,7 +35,7 @@ export interface ServiceOptions {
   dashboardPort?: number;
   /** Repo root directory — used to locate scripts/. */
   repoDir?: string;
-  /** Override PID directory (default: /tmp/nemoclaw-services-{sandbox}). */
+  /** Override PID directory (default: {os.tmpdir()}/nemoclaw-services-{sandbox}). */
   pidDir?: string;
   /** Cloudflare named tunnel token. Falls back to CLOUDFLARE_TUNNEL_TOKEN. */
   cloudflareTunnelToken?: string;
@@ -385,7 +386,7 @@ function resolvePidDir(opts: ServiceOptions): string {
   const sandbox = validateSandboxName(
     opts.sandboxName ?? process.env.NEMOCLAW_SANDBOX ?? process.env.SANDBOX_NAME ?? "default",
   );
-  return opts.pidDir ?? `/tmp/nemoclaw-services-${sandbox}`;
+  return opts.pidDir ?? join(tmpdir(), `nemoclaw-services-${sandbox}`);
 }
 
 export function showStatus(opts: ServiceOptions = {}): void {

--- a/test/service-env.test.ts
+++ b/test/service-env.test.ts
@@ -228,10 +228,9 @@ describe("service environment", () => {
     });
 
     it("proxy-env.sh includes GIT_SSL_CAINFO when set", () => {
-      const fakeDataDir = join(tmpdir(), `nemoclaw-git-ssl-test-${process.pid}`);
+      const fakeDataDir = mkdtempSync(join(tmpdir(), "nemoclaw-git-ssl-test-"));
       const fakeCaBundle = join(fakeDataDir, "ca-bundle.pem");
-      execFileSync("mkdir", ["-p", fakeDataDir]);
-      const tmpFile = join(tmpdir(), `nemoclaw-git-ssl-env-${process.pid}.sh`);
+      const tmpFile = join(fakeDataDir, "git-ssl-env.sh");
       try {
         const persistBlock = extractRuntimeShellEnvSnippet();
         // Create a fake CA bundle so the -f check passes
@@ -265,7 +264,7 @@ describe("service environment", () => {
         expect(envFile).toContain(fakeCaBundle);
       } finally {
         try {
-          execFileSync("rm", ["-rf", fakeDataDir, tmpFile]);
+          execFileSync("rm", ["-rf", fakeDataDir]);
         } catch {
           /* ignore */
         }
@@ -1070,9 +1069,8 @@ describe("service environment", () => {
     });
 
     it("emit_sandbox_sourced_file prevents symlink-following attack on proxy-env.sh", () => {
-      const fakeDataDir = join(tmpdir(), `nemoclaw-symlink-test-${process.pid}`);
-      execFileSync("mkdir", ["-p", fakeDataDir]);
-      const tmpFile = join(tmpdir(), `nemoclaw-symlink-write-test-${process.pid}.sh`);
+      const fakeDataDir = mkdtempSync(join(tmpdir(), "nemoclaw-symlink-test-"));
+      const tmpFile = join(fakeDataDir, "symlink-write-test.sh");
       try {
         const persistBlock = extractRuntimeShellEnvSnippet();
         const sensitiveFile = join(fakeDataDir, "sensitive");
@@ -1110,8 +1108,7 @@ describe("service environment", () => {
     });
 
     it("[simulation] sourcing proxy-env.sh overrides narrow NO_PROXY and no_proxy", () => {
-      const fakeDataDir = join(tmpdir(), `nemoclaw-bashi-test-${process.pid}`);
-      execFileSync("mkdir", ["-p", fakeDataDir]);
+      const fakeDataDir = mkdtempSync(join(tmpdir(), "nemoclaw-bashi-test-"));
       try {
         const envContent = [
           'export HTTP_PROXY="http://10.200.0.1:3128"',


### PR DESCRIPTION
## Summary
Use private `mkdtempSync` roots for test artifacts that previously wrote predictable files under the OS temp directory. This clears the open CodeQL `js/insecure-temporary-file` findings while keeping the behavior-focused test coverage intact.

## Changes
- Use `os.tmpdir()` for the tunnel service default PID root so tests can bind it to a private temp directory.
- Move service environment wrapper scripts and proxy-env fixtures into `mkdtempSync` directories.
- Move uninstall PID-file test homes into `mkdtempSync` directories.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>