### PR TITLE
ci(pr): shard CLI coverage gate

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -167,11 +167,15 @@ jobs:
       - name: Verify package version matches git tags
         run: bash scripts/check-version-tag-sync.sh
 
-  cli-tests:
+  cli-test-shards:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -192,13 +196,79 @@ jobs:
       - name: Build TypeScript plugin
         run: cd nemoclaw && npm run build
 
-      - name: Run CLI coverage
+      - name: Run CLI coverage shard
         run: |
           node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
           npm run build:cli
           npx tsx scripts/check-dist-sourcemaps.ts dist
           npx vitest run --project cli \
+            --shard=${{ matrix.shard }}/3 \
             --reporter=github-actions \
+            --reporter=blob \
+            --coverage \
+            --coverage.reporter=json-summary \
+            --coverage.reportsDirectory=coverage/cli/shard-${{ matrix.shard }} \
+            --coverage.include="bin/**/*.js" \
+            --coverage.include="dist/lib/**/*.js" \
+            --coverage.exclude="test/**/*.js" \
+            --coverage.exclude="test/**/*.ts"
+
+      - name: Upload CLI shard blob report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cli-blob-report-${{ matrix.shard }}
+          path: .vitest-reports/blob-${{ matrix.shard }}-3.json
+          if-no-files-found: warn
+          retention-days: 1
+
+  cli-tests:
+    needs:
+      - changes
+      - cli-test-shards
+    if: ${{ always() && needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify CLI shards completed
+        env:
+          CLI_SHARD_RESULT: ${{ needs['cli-test-shards'].result }}
+        run: |
+          if [ "$CLI_SHARD_RESULT" != "success" ]; then
+            echo "::error title=CLI coverage shards failed::Expected success, got ${CLI_SHARD_RESULT}"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Build CLI TypeScript modules
+        run: |
+          node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
+          npm run build:cli
+          npx tsx scripts/check-dist-sourcemaps.ts dist
+
+      - name: Download CLI shard blob reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cli-blob-report-*
+          path: .vitest-reports
+          merge-multiple: true
+
+      - name: Merge CLI coverage
+        run: |
+          npx vitest --mergeReports .vitest-reports \
             --reporter=json \
             --outputFile.json=coverage/cli/vitest-results.json \
             --coverage \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -205,6 +205,7 @@ jobs:
             --shard=${{ matrix.shard }}/3 \
             --reporter=github-actions \
             --reporter=blob \
+            --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}-3.json \
             --coverage \
             --coverage.reporter=json-summary \
             --coverage.reportsDirectory=coverage/cli/shard-${{ matrix.shard }} \
@@ -219,7 +220,7 @@ jobs:
         with:
           name: cli-blob-report-${{ matrix.shard }}
           path: .vitest-reports/blob-${{ matrix.shard }}-3.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 1
 
   cli-tests:
@@ -265,6 +266,23 @@ jobs:
           pattern: cli-blob-report-*
           path: .vitest-reports
           merge-multiple: true
+
+      - name: Verify CLI shard blob reports
+        run: |
+          set -euo pipefail
+          for shard in 1 2 3; do
+            blob=".vitest-reports/blob-${shard}-3.json"
+            if [ ! -s "$blob" ]; then
+              echo "::error title=Missing CLI shard blob::Expected non-empty ${blob}"
+              exit 1
+            fi
+          done
+          blob_count=$(find .vitest-reports -maxdepth 1 -type f -name 'blob-*-3.json' | wc -l | tr -d ' ')
+          if [ "$blob_count" != "3" ]; then
+            echo "::error title=Unexpected CLI shard blob count::Expected 3 blob reports, found ${blob_count}"
+            find .vitest-reports -maxdepth 1 -type f -print
+            exit 1
+          fi
 
       - name: Merge CLI coverage
         run: |

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -13,6 +13,10 @@ export type WorkflowJob = {
   secrets?: Record<string, string>;
   steps?: WorkflowStep[];
   with?: Record<string, string>;
+  strategy?: {
+    "fail-fast"?: boolean;
+    matrix?: Record<string, unknown>;
+  };
 };
 
 export type WorkflowStep = {

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./helpers/e2e-workflow-contract";
 
 type PullRequestWorkflow = {
-  jobs: Record<string, WorkflowJob & { if?: string; needs?: string[] }>;
+  jobs: Record<string, WorkflowJob & { if?: string; needs?: string | string[] }>;
 };
 
 type CodebaseGrowthGuardrailsWorkflow = {
@@ -99,6 +99,7 @@ describe("pull request workflow contract", () => {
     const basicChecks = readYaml<CompositeAction>(".github/actions/basic-checks/action.yaml");
     const staticRuns = stepRuns(workflow.jobs["static-checks"]);
     const buildRuns = stepRuns(workflow.jobs["build-typecheck"]);
+    const cliShardRun = stepRuns(workflow.jobs["cli-test-shards"]).join("\n");
     const cliTestRun = stepRuns(workflow.jobs["cli-tests"]).join("\n");
     const pluginTestRun = stepRuns(workflow.jobs["plugin-tests"]).join("\n");
     const staticPrekRun = staticRuns.find((run) =>
@@ -129,12 +130,23 @@ describe("pull request workflow contract", () => {
     expect(buildRuns).toContain("cd nemoclaw && npx tsc --noEmit --incremental");
     expect(buildRuns).toContain("npx tsc -p jsconfig.json");
     expect(buildRuns).toContain("bash scripts/check-version-tag-sync.sh");
-    expect(cliTestRun).toContain("npx vitest run --project cli");
-    expect(cliTestRun).toContain("--reporter=github-actions");
+    expect(cliShardRun).toContain("cd nemoclaw && npm run build");
+    expect(cliShardRun).toContain("npm run build:cli");
+    expect(cliShardRun).toContain("npx tsx scripts/check-dist-sourcemaps.ts dist");
+    expect(cliShardRun).toContain("npx vitest run --project cli");
+    expect(cliShardRun).toContain("--shard=${{ matrix.shard }}/3");
+    expect(cliShardRun).toContain("--reporter=github-actions");
+    expect(cliShardRun).toContain("--reporter=blob");
+    expect(cliShardRun).toContain("--coverage.reportsDirectory=coverage/cli/shard-${{ matrix.shard }}");
+    expect(cliShardRun).not.toContain("scripts/check-coverage-ratchet.ts");
+    expect(cliTestRun).toContain("npm run build:cli");
+    expect(cliTestRun).toContain("npx tsx scripts/check-dist-sourcemaps.ts dist");
+    expect(cliTestRun).toContain("npx vitest --mergeReports .vitest-reports");
     expect(cliTestRun).toContain("--reporter=json");
     expect(cliTestRun).toContain(
       "--outputFile.json=coverage/cli/vitest-results.json",
     );
+    expect(cliTestRun).toContain("--coverage.reportsDirectory=coverage/cli");
     expect(cliTestRun).toContain("npx tsx scripts/check-coverage-ratchet.ts");
     expect(pluginTestRun).toContain("npx vitest run --project plugin");
     expect(pluginTestRun).toContain("npx tsx scripts/check-coverage-ratchet.ts");
@@ -174,6 +186,52 @@ describe("pull request workflow contract", () => {
     expect(uploadStep?.with?.["retention-days"]).toBe(14);
   });
 
+  it("runs CLI coverage in shards and merges coverage before ratcheting", () => {
+    const shardJob = workflow.jobs["cli-test-shards"];
+    const mergeJob = workflow.jobs["cli-tests"];
+    const shardRuns = stepRuns(shardJob).join("\n");
+    const mergeRuns = stepRuns(mergeJob).join("\n");
+    const shardUploadStep = shardJob.steps?.find(
+      (step) => step.name === "Upload CLI shard blob report",
+    );
+    const downloadStep = mergeJob.steps?.find(
+      (step) => step.name === "Download CLI shard blob reports",
+    );
+
+    expect(shardJob.needs).toBe("changes");
+    expect(shardJob.if).toBe("needs.changes.outputs.code == 'true'");
+    expect(shardJob.strategy?.["fail-fast"]).toBe(false);
+    expect(shardJob.strategy?.matrix?.shard).toEqual([1, 2, 3]);
+    expect(shardRuns).toContain("--shard=${{ matrix.shard }}/3");
+    expect(shardRuns).toContain("--reporter=blob");
+    expect(shardRuns).toContain("--coverage");
+    expect(shardRuns).not.toContain("--outputFile.json=coverage/cli/vitest-results.json");
+    expect(shardRuns).not.toContain("scripts/check-coverage-ratchet.ts");
+
+    expect(shardUploadStep?.if).toBe("always()");
+    expect(shardUploadStep?.uses).toContain("actions/upload-artifact@");
+    expect(shardUploadStep?.with?.name).toBe("cli-blob-report-${{ matrix.shard }}");
+    expect(shardUploadStep?.with?.path).toBe(
+      ".vitest-reports/blob-${{ matrix.shard }}-3.json",
+    );
+    expect(shardUploadStep?.with?.["retention-days"]).toBe(1);
+
+    expect(mergeJob.needs).toEqual(["changes", "cli-test-shards"]);
+    expect(mergeJob.if).toBe("${{ always() && needs.changes.outputs.code == 'true' }}");
+    expect(mergeRuns).toContain("CLI_SHARD_RESULT");
+    expect(mergeRuns).toContain("npx vitest --mergeReports .vitest-reports");
+    expect(mergeRuns).toContain("--outputFile.json=coverage/cli/vitest-results.json");
+    expect(mergeRuns).toContain("--coverage.reportsDirectory=coverage/cli");
+    expect(mergeRuns).toContain(
+      'scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"',
+    );
+
+    expect(downloadStep?.uses).toContain("actions/download-artifact@");
+    expect(downloadStep?.with?.pattern).toBe("cli-blob-report-*");
+    expect(downloadStep?.with?.path).toBe(".vitest-reports");
+    expect(downloadStep?.with?.["merge-multiple"]).toBe(true);
+  });
+
   it("keeps the final checks job as the branch-protection aggregate", () => {
     const checks = workflow.jobs.checks;
     const checksRun = stepRuns(checks).join("\n");
@@ -188,6 +246,7 @@ describe("pull request workflow contract", () => {
       "plugin-tests",
       "test-e2e-ollama-proxy",
     ]);
+    expect(workflow.jobs["cli-tests"].needs).toContain("cli-test-shards");
 
     for (const jobName of [
       "changes",
@@ -204,7 +263,7 @@ describe("pull request workflow contract", () => {
   });
 
   it("does not run npm lifecycle scripts during pull_request dependency installs", () => {
-    for (const jobName of ["build-typecheck", "cli-tests", "plugin-tests"]) {
+    for (const jobName of ["build-typecheck", "cli-test-shards", "plugin-tests"]) {
       const installRun = stepRuns(workflow.jobs[jobName]).find((run) =>
         run.includes("cd nemoclaw && npm install"),
       );
@@ -216,6 +275,11 @@ describe("pull request workflow contract", () => {
         "cd nemoclaw && npm install\n",
       );
     }
+
+    const aggregateCliInstall = stepRuns(workflow.jobs["cli-tests"]).find((run) =>
+      run.includes("npm install"),
+    );
+    expect(aggregateCliInstall).toBe("npm install --ignore-scripts");
   });
 
   it("does not persist checkout credentials in pull_request jobs", () => {

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -137,6 +137,9 @@ describe("pull request workflow contract", () => {
     expect(cliShardRun).toContain("--shard=${{ matrix.shard }}/3");
     expect(cliShardRun).toContain("--reporter=github-actions");
     expect(cliShardRun).toContain("--reporter=blob");
+    expect(cliShardRun).toContain(
+      "--outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}-3.json",
+    );
     expect(cliShardRun).toContain("--coverage.reportsDirectory=coverage/cli/shard-${{ matrix.shard }}");
     expect(cliShardRun).not.toContain("scripts/check-coverage-ratchet.ts");
     expect(cliTestRun).toContain("npm run build:cli");
@@ -197,6 +200,10 @@ describe("pull request workflow contract", () => {
     const downloadStep = mergeJob.steps?.find(
       (step) => step.name === "Download CLI shard blob reports",
     );
+    const verifyStep = mergeJob.steps?.find(
+      (step) => step.name === "Verify CLI shard blob reports",
+    );
+    const verifyRun = verifyStep?.run ?? "";
 
     expect(shardJob.needs).toBe("changes");
     expect(shardJob.if).toBe("needs.changes.outputs.code == 'true'");
@@ -204,6 +211,9 @@ describe("pull request workflow contract", () => {
     expect(shardJob.strategy?.matrix?.shard).toEqual([1, 2, 3]);
     expect(shardRuns).toContain("--shard=${{ matrix.shard }}/3");
     expect(shardRuns).toContain("--reporter=blob");
+    expect(shardRuns).toContain(
+      "--outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}-3.json",
+    );
     expect(shardRuns).toContain("--coverage");
     expect(shardRuns).not.toContain("--outputFile.json=coverage/cli/vitest-results.json");
     expect(shardRuns).not.toContain("scripts/check-coverage-ratchet.ts");
@@ -214,11 +224,19 @@ describe("pull request workflow contract", () => {
     expect(shardUploadStep?.with?.path).toBe(
       ".vitest-reports/blob-${{ matrix.shard }}-3.json",
     );
+    expect(shardUploadStep?.with?.["if-no-files-found"]).toBe("error");
     expect(shardUploadStep?.with?.["retention-days"]).toBe(1);
 
     expect(mergeJob.needs).toEqual(["changes", "cli-test-shards"]);
     expect(mergeJob.if).toBe("${{ always() && needs.changes.outputs.code == 'true' }}");
     expect(mergeRuns).toContain("CLI_SHARD_RESULT");
+    expect(verifyRun).toContain("for shard in 1 2 3");
+    expect(verifyRun).toContain('blob=".vitest-reports/blob-${shard}-3.json"');
+    expect(verifyRun).toContain('[ ! -s "$blob" ]');
+    expect(verifyRun).toContain(
+      "find .vitest-reports -maxdepth 1 -type f -name 'blob-*-3.json'",
+    );
+    expect(verifyRun).toContain("Expected 3 blob reports");
     expect(mergeRuns).toContain("npx vitest --mergeReports .vitest-reports");
     expect(mergeRuns).toContain("--outputFile.json=coverage/cli/vitest-results.json");
     expect(mergeRuns).toContain("--coverage.reportsDirectory=coverage/cli");


### PR DESCRIPTION
## Summary
Shard the pull-request CLI coverage gate into three Vitest shards and keep `cli-tests` as the aggregate merge/ratchet job. This preserves the existing branch-protection surface while allowing the expensive CLI coverage work to run in parallel.

## Related Issue
Fixes #4892

## Changes
- Add a `cli-test-shards` matrix job that runs `npx vitest run --project cli --shard=N/3` with blob reports and per-shard coverage output.
- Keep `cli-tests` as the aggregate job that verifies shard success, downloads blob artifacts, merges reports with `vitest --mergeReports`, uploads the stable timing JSON artifact, and runs the existing CLI coverage ratchet against merged coverage.
- Extend PR workflow contract tests to pin shard count, blob artifact naming, coverage merge behavior, branch-protection aggregation, and lifecycle-script-safe installs.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs CLI coverage in three parallel sharded jobs and merges per-shard reports, speeding pipeline feedback and improving reliability.
* **Tests**
  * Workflow contract tests updated to validate the shard-based execution flow, artifact upload/download and merged coverage checks, and adjusted job dependency expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->