### PR TITLE
fix(tunnel): keep service pid directory stable

### DIFF
--- a/src/lib/tunnel/services-sandbox.test.ts
+++ b/src/lib/tunnel/services-sandbox.test.ts
@@ -361,16 +361,14 @@ describe("stopAll with sandbox channels", () => {
     logSpy.mockRestore();
   });
 
-  it("uses the effective env-selected sandbox for host-side pid cleanup", () => {
+  it("uses the effective env-selected sandbox for sandbox cleanup with explicit host pidDir", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const savedNemoclaw = process.env.NEMOCLAW_SANDBOX;
     const savedNemoclawName = process.env.NEMOCLAW_SANDBOX_NAME;
     const savedSandbox = process.env.SANDBOX_NAME;
-    const savedTmpDir = process.env.TMPDIR;
     const pidRoot = mkdtempSync(join(tmpdir(), "nemoclaw-services-pid-root-"));
     const effectivePidDir = join(pidRoot, "nemoclaw-services-name-sandbox");
     const lowerPriorityPidDir = join(pidRoot, "nemoclaw-services-other-sandbox");
-    process.env.TMPDIR = pidRoot;
     rmSync(effectivePidDir, { recursive: true, force: true });
     rmSync(lowerPriorityPidDir, { recursive: true, force: true });
     mkdirSync(effectivePidDir, { recursive: true, mode: 0o700 });
@@ -382,7 +380,7 @@ describe("stopAll with sandbox channels", () => {
     delete process.env.SANDBOX_NAME;
 
     try {
-      stopAll();
+      stopAll({ pidDir: effectivePidDir });
 
       expect(spawnSyncSpy).toHaveBeenCalledWith(
         "/usr/local/bin/openshell",
@@ -398,8 +396,6 @@ describe("stopAll with sandbox channels", () => {
       else delete process.env.NEMOCLAW_SANDBOX_NAME;
       if (savedSandbox !== undefined) process.env.SANDBOX_NAME = savedSandbox;
       else delete process.env.SANDBOX_NAME;
-      if (savedTmpDir !== undefined) process.env.TMPDIR = savedTmpDir;
-      else delete process.env.TMPDIR;
       rmSync(pidRoot, { recursive: true, force: true });
       logSpy.mockRestore();
     }

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -14,7 +14,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { dockerSpawnSync } from "../adapters/docker";
 import { resolveOpenshell } from "../adapters/openshell/resolve";
@@ -35,7 +34,7 @@ export interface ServiceOptions {
   dashboardPort?: number;
   /** Repo root directory — used to locate scripts/. */
   repoDir?: string;
-  /** Override PID directory (default: {os.tmpdir()}/nemoclaw-services-{sandbox}). */
+  /** Override PID directory (default: /tmp/nemoclaw-services-{sandbox}). */
   pidDir?: string;
   /** Cloudflare named tunnel token. Falls back to CLOUDFLARE_TUNNEL_TOKEN. */
   cloudflareTunnelToken?: string;
@@ -386,7 +385,7 @@ function resolvePidDir(opts: ServiceOptions): string {
   const sandbox = validateSandboxName(
     opts.sandboxName ?? process.env.NEMOCLAW_SANDBOX ?? process.env.SANDBOX_NAME ?? "default",
   );
-  return opts.pidDir ?? join(tmpdir(), `nemoclaw-services-${sandbox}`);
+  return opts.pidDir ?? `/tmp/nemoclaw-services-${sandbox}`;
 }
 
 export function showStatus(opts: ServiceOptions = {}): void {


### PR DESCRIPTION
## Summary
Restores the tunnel service PID directory default to `/tmp/nemoclaw-services-<sandbox>` so the TypeScript service, legacy scripts, doctor, destroy, snapshot, and uninstall cleanup paths keep a single source of truth. This addresses the PR review advisor feedback on #4976 while preserving the secure private temp-directory test fixture.

## Changes
- Revert the production tunnel PID directory resolver from `os.tmpdir()` back to the existing `/tmp/nemoclaw-services-<sandbox>` contract.
- Keep the sandbox-channel test isolated by passing an explicit private `pidDir` created under `mkdtempSync`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated default PID directory path handling for consistency.

* **Tests**
  * Enhanced integration tests to validate PID cleanup behavior with explicit directory parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->