### PR TITLE
fix(sandbox): target the sandbox's own gateway on non-default NEMOCLAW_GATEWAY_PORT

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -29,6 +29,7 @@ import {
   probeOllamaAuthProxyHealth,
 } from "../../inference/ollama/proxy";
 import { LOCAL_INFERENCE_TIMEOUT_SECS } from "../../onboard/env";
+import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { isWsl } from "../../platform";
 import { ROOT } from "../../runner";
 import * as sandboxVersion from "../../sandbox/version";
@@ -56,8 +57,6 @@ import {
   applyOpenShellVmDnsMonkeypatch,
   shouldApplyVmDnsMonkeypatch,
 } from "./vm-dns-monkeypatch";
-
-const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 
 export type SandboxConnectOptions = {
   probeOnly?: boolean;
@@ -281,7 +280,9 @@ function failConnectReadinessDockerRuntimeDown(sandboxName: string): never {
 }
 
 function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {
-  const lifecycle = getNamedGatewayLifecycleState();
+  const lifecycle = getNamedGatewayLifecycleState(
+    resolveSandboxGatewayName(registry.getSandbox(sandboxName)),
+  );
   if (isBlockingGatewayLifecycle(lifecycle)) {
     failConnectReadinessGatewayUnavailable(
       sandboxName,
@@ -524,7 +525,7 @@ function repairSandboxInferenceRouteIfNeeded(
       reapplyVmInferenceRoute,
       repairLegacyDnsProxy: (name, isQuiet) =>
         runSetupDnsProxy(
-          { gatewayName: NEMOCLAW_GATEWAY_NAME, sandboxName: name },
+          { gatewayName: resolveSandboxGatewayName(sb), sandboxName: name },
           { log: isQuiet ? () => undefined : console.log },
         ),
     },

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -19,15 +19,16 @@ import {
   shouldCleanupGatewayAfterDestroy,
   shouldStopHostServicesAfterDestroy,
 } from "../../domain/sandbox/destroy";
-import { stopStaleDashboardListeners } from "../../onboard/stale-gateway-cleanup";
+import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { stopHostGatewayProcesses } from "../../onboard/host-gateway-process";
 import {
-  SANDBOX_PROVIDER_SUFFIXES,
   emitProviderDetachResidualHint,
   runSandboxProviderPreDeleteCleanup,
+  SANDBOX_PROVIDER_SUFFIXES,
 } from "../../onboard/sandbox-provider-cleanup";
-import { redact } from "../../security/redact";
+import { stopStaleDashboardListeners } from "../../onboard/stale-gateway-cleanup";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
+import { redact } from "../../security/redact";
 import { killTimer as defaultKillShieldsTimer } from "../../shields/timer-control";
 import type { Session } from "../../state/onboard-session";
 import * as onboardSession from "../../state/onboard-session";
@@ -84,10 +85,9 @@ type RemoveShieldsStateDeps = {
   warn?: (message: string) => void;
 };
 
-const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 const DASHBOARD_FORWARD_PORT = String(DASHBOARD_PORT);
 
-function cleanupGatewayAfterLastSandbox(): void {
+function cleanupGatewayAfterLastSandbox(gatewayName: string): void {
   const { runOpenshell } = require("../../adapters/openshell/runtime") as {
     runOpenshell: (
       args: string[],
@@ -118,24 +118,24 @@ function cleanupGatewayAfterLastSandbox(): void {
     // The uninstall path keeps the broader sweep on (run-plan.ts).
     stopHostGatewayProcesses({}, { usePgrepFallback: false });
     const removeResult = runOpenshell(
-      ["gateway", "remove", NEMOCLAW_GATEWAY_NAME],
+      ["gateway", "remove", gatewayName],
       {
         ignoreError: true,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
     if (removeResult.status !== 0) {
-      runOpenshell(["gateway", "destroy", "-g", NEMOCLAW_GATEWAY_NAME], {
+      runOpenshell(["gateway", "destroy", "-g", gatewayName], {
         ignoreError: true,
         stdio: ["ignore", "pipe", "pipe"],
       });
     }
   } else {
-    runOpenshell(["gateway", "destroy", "-g", NEMOCLAW_GATEWAY_NAME], {
+    runOpenshell(["gateway", "destroy", "-g", gatewayName], {
       ignoreError: true,
     });
   }
-  dockerRemoveVolumesByPrefix(`openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`, {
+  dockerRemoveVolumesByPrefix(`openshell-cluster-${gatewayName}`, {
     ignoreError: true,
   });
 }
@@ -500,15 +500,18 @@ export async function destroySandbox(
       noLiveSandboxes: hasNoLiveSandboxes(),
     })
   ) {
+    // Resolve from the entry captured before deletion; the registry record may
+    // already be gone by now. Falls back to the bare default for older entries.
+    const destroyedGatewayName = resolveSandboxGatewayName(sb);
     const shouldCleanupGateway =
       await resolveCleanupGatewayDecision(normalized);
     if (shouldCleanupGateway) {
-      cleanupGatewayAfterLastSandbox();
+      cleanupGatewayAfterLastSandbox(destroyedGatewayName);
     } else {
       const gatewayRemovalHint =
         process.platform === "linux"
-          ? `openshell gateway remove ${NEMOCLAW_GATEWAY_NAME}`
-          : `openshell gateway destroy -g ${NEMOCLAW_GATEWAY_NAME}`;
+          ? `openshell gateway remove ${destroyedGatewayName}`
+          : `openshell gateway destroy -g ${destroyedGatewayName}`;
       console.log(
         `  Shared NemoClaw gateway preserved. Re-run '${gatewayRemovalHint}' to remove it,`,
       );

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -19,6 +19,7 @@ import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import { parseGatewayInference } from "../../inference/config";
 import { type ProviderHealthStatus, probeProviderHealth } from "../../inference/health";
 import { isLinuxDockerDriverGatewayEnabled } from "../../onboard/docker-driver-platform";
+import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { executeSandboxCommandForVerification } from "../../onboard/sandbox-verification-exec";
 import { ROOT } from "../../runner";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
@@ -37,8 +38,6 @@ import {
 import { captureHostCommand } from "./doctor-host-command";
 import { buildToolScopeChecks } from "./doctor-tool-scope";
 import { probeSandboxInferenceGatewayHealth } from "./process-recovery";
-
-const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 
 type DoctorStatus = "ok" | "warn" | "fail" | "info";
 
@@ -589,7 +588,8 @@ export async function runSandboxDoctor(
 
   let openshellConnected = false;
   if (openshellBin) {
-    const recovery = await recoverNamedGatewayRuntime();
+    const gatewayName = resolveSandboxGatewayName(sb);
+    const recovery = await recoverNamedGatewayRuntime({ gatewayName });
     const lifecycle = recovery.after || recovery.before;
     const cleanStatus = stripAnsi(lifecycle?.status || "");
     openshellConnected = lifecycle?.state === "healthy_named";
@@ -598,15 +598,15 @@ export async function runSandboxDoctor(
       label: "OpenShell status",
       status: openshellConnected ? "ok" : "fail",
       detail: openshellConnected
-        ? "connected to nemoclaw"
-        : oneLine(cleanStatus || lifecycle?.gatewayInfo || "not connected to nemoclaw"),
-      hint: openshellConnected ? undefined : "run `openshell gateway select nemoclaw` and retry",
+        ? `connected to ${gatewayName}`
+        : oneLine(cleanStatus || lifecycle?.gatewayInfo || `not connected to ${gatewayName}`),
+      hint: openshellConnected ? undefined : `run \`openshell gateway select ${gatewayName}\` and retry`,
     });
   }
 
   if (shouldInspectLegacyGatewayContainer(sb)) {
     checks.push(
-      ...dockerInspectGateway(`openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`, {
+      ...dockerInspectGateway(`openshell-cluster-${resolveSandboxGatewayName(sb)}`, {
         namedGatewayConnected: openshellConnected,
       }),
     );

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -11,7 +11,9 @@ import {
   getNamedGatewayLifecycleState,
   recoverNamedGatewayRuntime,
 } from "../../gateway-runtime-action";
+import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { isTerminalSandboxPhase, parseSandboxPhase } from "../../state/gateway";
+import * as registry from "../../state/registry";
 
 const { pruneKnownHostsEntries } = require("../../onboard") as {
   pruneKnownHostsEntries: (contents: string) => string;
@@ -216,9 +218,10 @@ export function reconcileMissingAgainstNamedGateway(
   sandboxName: string,
   missingLookup: SandboxGatewayState,
 ): SandboxGatewayState {
-  const lifecycle = getNamedGatewayLifecycleState();
+  const gwName = resolveSandboxGatewayName(registry.getSandbox(sandboxName));
+  const lifecycle = getNamedGatewayLifecycleState(gwName);
   if (lifecycle.state === "connected_other") {
-    runOpenshell(["gateway", "select", "nemoclaw"], {
+    runOpenshell(["gateway", "select", gwName], {
       ignoreError: true,
       timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
     });
@@ -230,7 +233,7 @@ export function reconcileMissingAgainstNamedGateway(
       return retry;
     }
     if (retry.state === "missing") {
-      const after = getNamedGatewayLifecycleState();
+      const after = getNamedGatewayLifecycleState(gwName);
       if (after.state === "healthy_named") {
         return retry;
       }
@@ -331,6 +334,7 @@ export async function getReconciledSandboxGatewayState(
   opts: { getState?: SandboxGatewayStateLookup } = {},
 ): Promise<SandboxGatewayState> {
   const getState = opts.getState ?? getSandboxGatewayState;
+  const gwName = resolveSandboxGatewayName(registry.getSandbox(sandboxName));
   const lookup = await getState(sandboxName);
   if (lookup.state === "present") {
     return lookup;
@@ -340,7 +344,7 @@ export async function getReconciledSandboxGatewayState(
   }
 
   if (lookup.state === "gateway_error") {
-    const recovery = await recoverNamedGatewayRuntime();
+    const recovery = await recoverNamedGatewayRuntime({ gatewayName: gwName });
     if (recovery.recovered) {
       const retried = await getState(sandboxName);
       if (retried.state === "present" || retried.state === "missing") {
@@ -356,7 +360,7 @@ export async function getReconciledSandboxGatewayState(
       }
       return { ...retried, recoveredGateway: true, recoveryVia: recovery.via || null };
     }
-    const latestLifecycle = getNamedGatewayLifecycleState();
+    const latestLifecycle = getNamedGatewayLifecycleState(gwName);
     const latestStatus = stripAnsi(latestLifecycle.status || "");
     if (/No gateway configured/i.test(latestStatus)) {
       return {
@@ -392,6 +396,7 @@ export async function ensureLiveSandboxOrExit(
   sandboxName: string,
   { allowNonReadyPhase = false }: { allowNonReadyPhase?: boolean } = {},
 ): Promise<SandboxGatewayState> {
+  const gwName = resolveSandboxGatewayName(registry.getSandbox(sandboxName));
   const lookup = await getReconciledSandboxGatewayState(sandboxName);
   if (lookup.state === "present") {
     const phase = parseSandboxPhase(lookup.output || "");
@@ -421,7 +426,7 @@ export async function ensureLiveSandboxOrExit(
     process.exit(1);
   }
   if (lookup.state === "missing") {
-    const guard = getNamedGatewayLifecycleState();
+    const guard = getNamedGatewayLifecycleState(gwName);
     if (guard.state !== "healthy_named") {
       if (guard.state === "connected_other") {
         printWrongGatewayActiveGuidance(sandboxName, guard.activeGateway, console.error);

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -28,6 +28,7 @@ import {
   resolveMessagingChannelConfigEnvValue,
   sanitizeMessagingChannelConfig,
 } from "../../messaging-channel-config";
+import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { hashCredential } from "../../security/credential-hash";
 
 const { isNonInteractive } = require("../../onboard") as { isNonInteractive: () => boolean };
@@ -497,7 +498,9 @@ async function applyChannelAddToGatewayAndRegistry(
     token,
   }));
   if (tokenDefs.length > 0) {
-    const recovery = await recoverNamedGatewayRuntime();
+    const recovery = await recoverNamedGatewayRuntime({
+      gatewayName: resolveSandboxGatewayName(registry.getSandbox(sandboxName)),
+    });
     if (!recovery.recovered) {
       console.error(
         `  Could not reach the ${CLI_DISPLAY_NAME} OpenShell gateway. Tokens were staged`,
@@ -539,7 +542,9 @@ async function applyChannelRemoveToGatewayAndRegistry(
   let gatewayReachable = true;
 
   if (channelTokenKeys.length > 0) {
-    const recovery = await recoverNamedGatewayRuntime();
+    const recovery = await recoverNamedGatewayRuntime({
+      gatewayName: resolveSandboxGatewayName(registry.getSandbox(sandboxName)),
+    });
     if (!recovery.recovered) {
       console.error(
         `  Could not reach the ${CLI_DISPLAY_NAME} OpenShell gateway to delete the bridge.`,

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -9,6 +9,7 @@ import { captureOpenshell, getOpenshellBinary, runOpenshell } from "../../adapte
 import { CLI_NAME } from "../../cli/branding";
 import { prompt as askPrompt } from "../../credentials/store";
 import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
+import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import * as policies from "../../policy";
 import { ROOT, run, shellQuote, validateName } from "../../runner";
 import { parseLiveSandboxNames } from "../../runtime-recovery";
@@ -26,8 +27,6 @@ const G = useColor ? (trueColor ? "\x1b[38;2;118;185;0m" : "\x1b[38;5;148m") : "
 const B = useColor ? "\x1b[1m" : "";
 const D = useColor ? "\x1b[2m" : "";
 const R = useColor ? "\x1b[0m" : "";
-
-const NEMOCLAW_GATEWAY_NAME = "nemoclaw";
 
 export type SnapshotRequest =
   | { kind: "help" }
@@ -110,7 +109,7 @@ function resolveSrcPodImage(srcName: string, srcEntry?: SandboxEntry | { name: s
     return registeredImage ?? null;
   }
 
-  const gatewayContainer = `openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`;
+  const gatewayContainer = `openshell-cluster-${resolveSandboxGatewayName(registry.getSandbox(srcName))}`;
   try {
     const output = dockerCapture(
       [
@@ -202,7 +201,9 @@ async function autoCreateSandboxFromSource(
   const dnsScript = path.join(ROOT, "scripts", "setup-dns-proxy.sh");
   const srcDriver = (srcEntry as { openshellDriver?: string | null }).openshellDriver;
   if (srcDriver === "kubernetes" && fs.existsSync(dnsScript)) {
-    run(["bash", dnsScript, NEMOCLAW_GATEWAY_NAME, dstName], { ignoreError: true });
+    run(["bash", dnsScript, resolveSandboxGatewayName(registry.getSandbox(srcName)), dstName], {
+      ignoreError: true,
+    });
   }
 
   // Register dst in the NemoClaw registry, cloning most fields from src.
@@ -289,9 +290,9 @@ function deleteSandboxForRestore(name: string): void {
 
 // Docker/VM-driver sandboxes do not expose the legacy cluster container, so
 // verify gateway health through OpenShell metadata instead.
-function probeGatewayMetadataHealth(): boolean {
+function probeGatewayMetadataHealth(gatewayName: string): boolean {
   const status = captureOpenshell(["status"], { ignoreError: true, timeout: 10000 });
-  const namedGatewayInfo = captureOpenshell(["gateway", "info", "-g", NEMOCLAW_GATEWAY_NAME], {
+  const namedGatewayInfo = captureOpenshell(["gateway", "info", "-g", gatewayName], {
     ignoreError: true,
     timeout: 10000,
   });
@@ -312,10 +313,11 @@ function usesGatewayMetadataProbe(driver: string | null | undefined): boolean {
 
 function probeGatewayRunning(sandboxName?: string): boolean {
   const entry = sandboxName ? registry.getSandbox(sandboxName) : null;
+  const gatewayName = resolveSandboxGatewayName(entry);
   if (usesGatewayMetadataProbe(entry?.openshellDriver)) {
-    return probeGatewayMetadataHealth();
+    return probeGatewayMetadataHealth(gatewayName);
   }
-  const container = `openshell-cluster-${NEMOCLAW_GATEWAY_NAME}`;
+  const container = `openshell-cluster-${gatewayName}`;
   const result = dockerInspect(
     ["--type", "container", "--format", "{{.State.Running}}", container],
     { ignoreError: true, suppressOutput: true },

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -4,12 +4,15 @@
 const { startGatewayForRecovery } = require("./onboard") as {
   startGatewayForRecovery: () => Promise<void>;
 };
-import { OPENSHELL_OPERATION_TIMEOUT_MS, OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
+
 import { stripAnsi } from "./adapters/openshell/client";
 import { captureOpenshell, runOpenshell } from "./adapters/openshell/runtime";
+import { OPENSHELL_OPERATION_TIMEOUT_MS, OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
+import { GATEWAY_PORT } from "./core/ports";
+import { resolveGatewayName } from "./onboard/gateway-binding";
 
-function hasNamedGateway(output = ""): boolean {
-  return stripAnsi(output).includes("Gateway: nemoclaw");
+function hasNamedGateway(output = "", gatewayName: string): boolean {
+  return getActiveGatewayName(output) === gatewayName;
 }
 
 function getActiveGatewayName(output = ""): string | null {
@@ -17,19 +20,21 @@ function getActiveGatewayName(output = ""): string | null {
   return match ? match[1].trim() : null;
 }
 
-export function getNamedGatewayLifecycleState() {
+export function getNamedGatewayLifecycleState(
+  gatewayName: string = resolveGatewayName(GATEWAY_PORT),
+) {
   const status = captureOpenshell(["status"], { timeout: OPENSHELL_PROBE_TIMEOUT_MS });
-  const gatewayInfo = captureOpenshell(["gateway", "info", "-g", "nemoclaw"], {
+  const gatewayInfo = captureOpenshell(["gateway", "info", "-g", gatewayName], {
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
   });
   const cleanStatus = stripAnsi(status.output);
   const activeGateway = getActiveGatewayName(status.output);
   const connected = /^\s*Status:\s*Connected\b/im.test(cleanStatus);
-  const named = hasNamedGateway(gatewayInfo.output);
+  const named = hasNamedGateway(gatewayInfo.output, gatewayName);
   const refusing = /Connection refused|client error \(Connect\)|tcp connect error/i.test(
     cleanStatus,
   );
-  if (connected && activeGateway === "nemoclaw" && named) {
+  if (connected && activeGateway === gatewayName && named) {
     return {
       state: "healthy_named",
       status: status.output,
@@ -37,7 +42,7 @@ export function getNamedGatewayLifecycleState() {
       activeGateway,
     };
   }
-  if (activeGateway === "nemoclaw" && named && refusing) {
+  if (activeGateway === gatewayName && named && refusing) {
     return {
       state: "named_unreachable",
       status: status.output,
@@ -45,7 +50,7 @@ export function getNamedGatewayLifecycleState() {
       activeGateway,
     };
   }
-  if (activeGateway === "nemoclaw" && named) {
+  if (activeGateway === gatewayName && named) {
     return {
       state: "named_unhealthy",
       status: status.output,
@@ -73,10 +78,13 @@ type NamedGatewayLifecycleStateName = ReturnType<typeof getNamedGatewayLifecycle
 
 export type RecoverNamedGatewayRuntimeOptions = {
   recoverableStates?: readonly NamedGatewayLifecycleStateName[];
+  /** Gateway registration to operate on; defaults to the env-resolved per-port name. */
+  gatewayName?: string;
 };
 
 /** Attempt to recover the named NemoClaw gateway after a restart or connectivity loss. */
 export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRuntimeOptions = {}) {
+  const gatewayName = options.gatewayName ?? resolveGatewayName(GATEWAY_PORT);
   const recoverableStates = new Set<NamedGatewayLifecycleStateName>(
     options.recoverableStates ?? [
       "missing_named",
@@ -85,7 +93,7 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
       "connected_other",
     ],
   );
-  const before = getNamedGatewayLifecycleState();
+  const before = getNamedGatewayLifecycleState(gatewayName);
   if (before.state === "healthy_named") {
     return { recovered: true, before, after: before, attempted: false };
   }
@@ -93,13 +101,13 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
     return { recovered: false, before, after: before, attempted: false };
   }
 
-  runOpenshell(["gateway", "select", "nemoclaw"], {
+  runOpenshell(["gateway", "select", gatewayName], {
     ignoreError: true,
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
-  let after = getNamedGatewayLifecycleState();
+  let after = getNamedGatewayLifecycleState(gatewayName);
   if (after.state === "healthy_named") {
-    process.env.OPENSHELL_GATEWAY = "nemoclaw";
+    process.env.OPENSHELL_GATEWAY = gatewayName;
     return { recovered: true, before, after, attempted: true, via: "select" };
   }
 
@@ -115,13 +123,13 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
       // Fall through to the lifecycle re-check below so we preserve the
       // existing recovery result shape and emit the correct classification.
     }
-    runOpenshell(["gateway", "select", "nemoclaw"], {
+    runOpenshell(["gateway", "select", gatewayName], {
       ignoreError: true,
       timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
     });
-    after = getNamedGatewayLifecycleState();
+    after = getNamedGatewayLifecycleState(gatewayName);
     if (after.state === "healthy_named") {
-      process.env.OPENSHELL_GATEWAY = "nemoclaw";
+      process.env.OPENSHELL_GATEWAY = gatewayName;
       return { recovered: true, before, after, attempted: true, via: "start" };
     }
   }

--- a/src/lib/onboard/gateway-binding.test.ts
+++ b/src/lib/onboard/gateway-binding.test.ts
@@ -21,6 +21,7 @@ import {
   resolveGatewayCompatContainerName,
   resolveGatewayName,
   resolveGatewayStateDirName,
+  resolveSandboxGatewayName,
 } from "../../../dist/lib/onboard/gateway-binding";
 
 describe("gateway-binding resolver (#4422)", () => {
@@ -44,6 +45,28 @@ describe("gateway-binding resolver (#4422)", () => {
     expect(resolveGatewayName(a)).not.toBe(resolveGatewayName(b));
     expect(resolveGatewayStateDirName(a)).not.toBe(resolveGatewayStateDirName(b));
     expect(resolveGatewayCompatContainerName(a)).not.toBe(resolveGatewayCompatContainerName(b));
+  });
+});
+
+describe("resolveSandboxGatewayName (#4422 lifecycle gap)", () => {
+  it("prefers the persisted gatewayName", () => {
+    expect(resolveSandboxGatewayName({ gatewayName: "nemoclaw-8090", gatewayPort: 8090 })).toBe(
+      "nemoclaw-8090",
+    );
+  });
+
+  it("resolves from the persisted port when no name is stored", () => {
+    expect(resolveSandboxGatewayName({ gatewayPort: 8081 })).toBe("nemoclaw-8081");
+    expect(resolveSandboxGatewayName({ gatewayPort: DEFAULT_GATEWAY_PORT })).toBe(BASE_GATEWAY_NAME);
+  });
+
+  it("falls back to the bare default for entries with neither field", () => {
+    expect(resolveSandboxGatewayName(null)).toBe(BASE_GATEWAY_NAME);
+    expect(resolveSandboxGatewayName(undefined)).toBe(BASE_GATEWAY_NAME);
+    expect(resolveSandboxGatewayName({})).toBe(BASE_GATEWAY_NAME);
+    expect(resolveSandboxGatewayName({ gatewayName: null, gatewayPort: null })).toBe(
+      BASE_GATEWAY_NAME,
+    );
   });
 });
 

--- a/src/lib/onboard/gateway-binding.ts
+++ b/src/lib/onboard/gateway-binding.ts
@@ -67,6 +67,26 @@ export function resolveGatewayCompatContainerName(port: number): string {
     : `${BASE_GATEWAY_COMPAT_CONTAINER_NAME}-${port}`;
 }
 
+/**
+ * Resolve the gateway registration name bound to a specific sandbox. Sandbox
+ * lifecycle commands (connect/destroy/doctor/snapshot) must target the
+ * sandbox's own gateway — which is `nemoclaw-<port>` for any non-default
+ * `NEMOCLAW_GATEWAY_PORT` — rather than the hardcoded default `nemoclaw`.
+ * Prefer the name persisted at onboard; fall back to the persisted port, then
+ * to the bare default name for older entries that predate those fields.
+ */
+export function resolveSandboxGatewayName(
+  sb: { gatewayName?: string | null; gatewayPort?: number | null } | null | undefined,
+): string {
+  if (sb?.gatewayName) {
+    return sb.gatewayName;
+  }
+  if (typeof sb?.gatewayPort === "number") {
+    return resolveGatewayName(sb.gatewayPort);
+  }
+  return BASE_GATEWAY_NAME;
+}
+
 /** Gateway state classifiers from `state/gateway`, each bound to a gateway name. */
 export interface GatewayNameBoundClassifiers {
   hasStaleGateway(gwInfoOutput?: string): boolean;


### PR DESCRIPTION
## Summary
Sandbox lifecycle commands (`connect`/`destroy`/`doctor`/`snapshot`) and the shared gateway recovery/health path hardcoded the gateway registration name `nemoclaw` and ignored `NEMOCLAW_GATEWAY_PORT`. Since #4422 a non-default port registers the gateway as `nemoclaw-<port>`, so these paths targeted a gateway that doesn't exist: `doctor` reported a **connected** `nemoclaw-<port>` gateway as failed and tried to start one on the default port (often "Address already in use"); `destroy`/`snapshot` used the wrong gateway/container name; `connect`'s readiness gate mis-resolved. Setting `NEMOCLAW_GATEWAY_PORT` did not help because the name was a literal.

## Related Issue
Fixes #4985. Completes the per-port migration started in #4422 (distinct from the multi-instance issue #4865).

## Changes
- `src/lib/onboard/gateway-binding.ts` — new `resolveSandboxGatewayName(sb)` resolving the sandbox's persisted `gatewayName`/`gatewayPort` (falls back to the bare default for older entries).
- `src/lib/gateway-runtime-action.ts` — `getNamedGatewayLifecycleState` / `recoverNamedGatewayRuntime` take a `gatewayName`, defaulting to the **env-resolved** per-port name (`resolveGatewayName(GATEWAY_PORT)`), so non-sandbox callers honor `NEMOCLAW_GATEWAY_PORT`; the `healthy_named` classifier now compares against the resolved name instead of the literal `"nemoclaw"`.
- `src/lib/actions/sandbox/{connect,destroy,doctor,snapshot,gateway-state,policy-channel}.ts` — resolve the gateway from the sandbox entry instead of the hardcoded `NEMOCLAW_GATEWAY_NAME` constant; thread it through gateway `select`/`info`/`remove`/`destroy`, the docker-driver container/DNS names, and the recovery/health calls. `doctor` status detail/hint now name the actual gateway.
- `src/lib/onboard/gateway-binding.test.ts` — unit tests for `resolveSandboxGatewayName` (name / port-derived / fallback).

## Behavior
- Sandbox-scoped commands resolve `nemoclaw-<port>` from the registry; non-sandbox commands honor `NEMOCLAW_GATEWAY_PORT`.
- Backward compatible: default port and entries without the persisted fields keep the bare `nemoclaw` name.
- Known follow-up: `startGatewayForRecovery()` (the gateway *start* path) still reads onboarding's process-global port; the common "gateway already running" path is fully resolved here.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## Verification
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- Ran the affected suites locally: gateway-binding, gateway-state-drift, sandbox actions, status-health, doctor-gateway-token (408 tests pass); `npm run typecheck:cli` clean; Biome clean. Relying on CI for the full matrix (a fixed set of NIM/GPU/install suites fail identically on a clean `main` on this aarch64 host).

---
Signed-off-by: Jason Hubbard <jasonahubbard@gmail.com>