### PR TITLE
ci(pr): trust base CI actions

### DIFF
--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -12,6 +12,25 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate shard inputs
+      id: validate-shard-inputs
+      shell: bash
+      env:
+        CLI_SHARD_COUNT: ${{ inputs.shard-count }}
+      run: |
+        set -euo pipefail
+
+        case "$CLI_SHARD_COUNT" in
+          ''|*[!0-9]*)
+            echo "::error title=Invalid CLI shard count::Expected positive integer, got ${CLI_SHARD_COUNT}"
+            exit 1
+            ;;
+        esac
+        if [ "$CLI_SHARD_COUNT" -lt 1 ]; then
+          echo "::error title=Invalid CLI shard count::Expected positive integer, got ${CLI_SHARD_COUNT}"
+          exit 1
+        fi
+
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
@@ -38,18 +57,20 @@ runs:
 
     - name: Verify CLI shard blob reports
       shell: bash
+      env:
+        CLI_SHARD_COUNT: ${{ inputs.shard-count }}
       run: |
         set -euo pipefail
-        for shard in $(seq 1 "${{ inputs.shard-count }}"); do
-          blob=".vitest-reports/blob-${shard}-${{ inputs.shard-count }}.json"
+        for shard in $(seq 1 "$CLI_SHARD_COUNT"); do
+          blob=".vitest-reports/blob-${shard}-${CLI_SHARD_COUNT}.json"
           if [ ! -s "$blob" ]; then
             echo "::error title=Missing CLI shard blob::Expected non-empty ${blob}"
             exit 1
           fi
         done
-        blob_count=$(find .vitest-reports -maxdepth 1 -type f -name 'blob-*-${{ inputs.shard-count }}.json' | wc -l | tr -d ' ')
-        if [ "$blob_count" != "${{ inputs.shard-count }}" ]; then
-          echo "::error title=Unexpected CLI shard blob count::Expected ${{ inputs.shard-count }} blob reports, found ${blob_count}"
+        blob_count=$(find .vitest-reports -maxdepth 1 -type f -name "blob-*-${CLI_SHARD_COUNT}.json" | wc -l | tr -d ' ')
+        if [ "$blob_count" != "$CLI_SHARD_COUNT" ]; then
+          echo "::error title=Unexpected CLI shard blob count::Expected ${CLI_SHARD_COUNT} blob reports, found ${blob_count}"
           find .vitest-reports -maxdepth 1 -type f -print
           exit 1
         fi

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -15,6 +15,32 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate shard inputs
+      id: validate-shard-inputs
+      shell: bash
+      env:
+        CLI_SHARD: ${{ inputs.shard }}
+        CLI_SHARD_COUNT: ${{ inputs.shard-count }}
+      run: |
+        set -euo pipefail
+
+        case "$CLI_SHARD" in
+          ''|*[!0-9]*)
+            echo "::error title=Invalid CLI shard::Expected positive integer, got ${CLI_SHARD}"
+            exit 1
+            ;;
+        esac
+        case "$CLI_SHARD_COUNT" in
+          ''|*[!0-9]*)
+            echo "::error title=Invalid CLI shard count::Expected positive integer, got ${CLI_SHARD_COUNT}"
+            exit 1
+            ;;
+        esac
+        if [ "$CLI_SHARD" -lt 1 ] || [ "$CLI_SHARD_COUNT" -lt 1 ] || [ "$CLI_SHARD" -gt "$CLI_SHARD_COUNT" ]; then
+          echo "::error title=Invalid CLI shard range::Expected 1 <= shard <= shard-count, got ${CLI_SHARD}/${CLI_SHARD_COUNT}"
+          exit 1
+        fi
+
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
@@ -33,25 +59,28 @@ runs:
 
     - name: Run CLI coverage shard
       shell: bash
+      env:
+        CLI_SHARD: ${{ inputs.shard }}
+        CLI_SHARD_COUNT: ${{ inputs.shard-count }}
       run: |
         node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
         npm run build:cli
         npx tsx scripts/check-dist-sourcemaps.ts dist
         npx vitest run --project cli \
-          --shard=${{ inputs.shard }}/${{ inputs.shard-count }} \
+          --shard="${CLI_SHARD}/${CLI_SHARD_COUNT}" \
           --reporter=github-actions \
           --reporter=blob \
-          --outputFile.blob=.vitest-reports/blob-${{ inputs.shard }}-${{ inputs.shard-count }}.json \
+          --outputFile.blob=".vitest-reports/blob-${CLI_SHARD}-${CLI_SHARD_COUNT}.json" \
           --coverage \
           --coverage.reporter=json-summary \
-          --coverage.reportsDirectory=coverage/cli/shard-${{ inputs.shard }} \
+          --coverage.reportsDirectory="coverage/cli/shard-${CLI_SHARD}" \
           --coverage.include="bin/**/*.js" \
           --coverage.include="dist/lib/**/*.js" \
           --coverage.exclude="test/**/*.js" \
           --coverage.exclude="test/**/*.ts"
 
     - name: Upload CLI shard blob report
-      if: always()
+      if: ${{ always() && steps.validate-shard-inputs.outcome == 'success' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cli-blob-report-${{ inputs.shard }}

--- a/.github/actions/ci-static-checks/action.yaml
+++ b/.github/actions/ci-static-checks/action.yaml
@@ -16,12 +16,13 @@ runs:
     - name: Install hadolint
       shell: bash
       run: |
+        set -euo pipefail
         HADOLINT_VERSION="v2.14.0"
         HADOLINT_URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-linux-x86_64"
+        HADOLINT_SHA256="6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47"
         curl -fsSL -o /usr/local/bin/hadolint "$HADOLINT_URL"
-        EXPECTED=$(curl -fsSL "${HADOLINT_URL}.sha256" | awk '{print $1}')
         ACTUAL=$(sha256sum /usr/local/bin/hadolint | awk '{print $1}')
-        [ "$EXPECTED" = "$ACTUAL" ] || { echo "::error::hadolint checksum mismatch"; exit 1; }
+        [ "$HADOLINT_SHA256" = "$ACTUAL" ] || { echo "::error::hadolint checksum mismatch"; exit 1; }
         chmod +x /usr/local/bin/hadolint
 
     - name: Install dependencies

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,8 +80,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-static-checks
+            .github/actions/ci-build-typecheck
+            .github/actions/ci-cli-coverage-shard
+            .github/actions/ci-cli-coverage-merge
+            .github/actions/ci-plugin-coverage
+          sparse-checkout-cone-mode: false
+
       - name: Run static checks
-        uses: ./.github/actions/ci-static-checks
+        uses: ./.trusted-ci-actions/.github/actions/ci-static-checks
 
   build-typecheck:
     needs: changes
@@ -94,8 +108,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-static-checks
+            .github/actions/ci-build-typecheck
+            .github/actions/ci-cli-coverage-shard
+            .github/actions/ci-cli-coverage-merge
+            .github/actions/ci-plugin-coverage
+          sparse-checkout-cone-mode: false
+
       - name: Run build and type checks
-        uses: ./.github/actions/ci-build-typecheck
+        uses: ./.trusted-ci-actions/.github/actions/ci-build-typecheck
 
   cli-test-shards:
     needs: changes
@@ -112,8 +140,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-static-checks
+            .github/actions/ci-build-typecheck
+            .github/actions/ci-cli-coverage-shard
+            .github/actions/ci-cli-coverage-merge
+            .github/actions/ci-plugin-coverage
+          sparse-checkout-cone-mode: false
+
       - name: Run CLI coverage shard
-        uses: ./.github/actions/ci-cli-coverage-shard
+        uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
 
@@ -139,8 +181,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-static-checks
+            .github/actions/ci-build-typecheck
+            .github/actions/ci-cli-coverage-shard
+            .github/actions/ci-cli-coverage-merge
+            .github/actions/ci-plugin-coverage
+          sparse-checkout-cone-mode: false
+
       - name: Merge CLI coverage
-        uses: ./.github/actions/ci-cli-coverage-merge
+        uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-merge
 
   plugin-tests:
     needs: changes
@@ -153,8 +209,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-static-checks
+            .github/actions/ci-build-typecheck
+            .github/actions/ci-cli-coverage-shard
+            .github/actions/ci-cli-coverage-merge
+            .github/actions/ci-plugin-coverage
+          sparse-checkout-cone-mode: false
+
       - name: Run plugin coverage
-        uses: ./.github/actions/ci-plugin-coverage
+        uses: ./.trusted-ci-actions/.github/actions/ci-plugin-coverage
 
   test-e2e-ollama-proxy:
     needs: changes

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -26,6 +26,25 @@ const sharedActionPaths = {
   pluginCoverage: "./.github/actions/ci-plugin-coverage",
 } as const;
 
+const trustedPrActionPaths = {
+  staticChecks: "./.trusted-ci-actions/.github/actions/ci-static-checks",
+  buildTypecheck: "./.trusted-ci-actions/.github/actions/ci-build-typecheck",
+  cliCoverageShard: "./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard",
+  cliCoverageMerge: "./.trusted-ci-actions/.github/actions/ci-cli-coverage-merge",
+  pluginCoverage: "./.trusted-ci-actions/.github/actions/ci-plugin-coverage",
+} as const;
+
+const trustedCheckoutAction =
+  "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
+
+const trustedActionDirs = [
+  ".github/actions/ci-static-checks",
+  ".github/actions/ci-build-typecheck",
+  ".github/actions/ci-cli-coverage-shard",
+  ".github/actions/ci-cli-coverage-merge",
+  ".github/actions/ci-plugin-coverage",
+] as const;
+
 function stepRuns(jobOrAction: WorkflowJob | CompositeAction): string[] {
   const steps = "runs" in jobOrAction ? jobOrAction.runs.steps : (jobOrAction.steps ?? []);
   return steps.flatMap((step) => (step.run ? [step.run] : []));
@@ -43,12 +62,31 @@ function requiredStep(action: CompositeAction, stepName: string): WorkflowStep {
   return step;
 }
 
+function requiredStepIndex(action: CompositeAction, stepName: string): number {
+  const stepIndex = action.runs.steps.findIndex(
+    (candidate) => candidate.name === stepName,
+  );
+  if (stepIndex === -1) {
+    throw new Error(`Missing shared action step: ${stepName}`);
+  }
+  return stepIndex;
+}
+
 function requiredWorkflowStep(job: WorkflowJob, stepName: string): WorkflowStep {
   const step = job.steps?.find((candidate) => candidate.name === stepName);
   if (!step) {
     throw new Error(`Missing workflow step: ${stepName}`);
   }
   return step;
+}
+
+function requiredWorkflowStepIndex(job: WorkflowJob, stepName: string): number {
+  const stepIndex =
+    job.steps?.findIndex((candidate) => candidate.name === stepName) ?? -1;
+  if (stepIndex === -1) {
+    throw new Error(`Missing workflow step: ${stepName}`);
+  }
+  return stepIndex;
 }
 
 function codeFilterMatchesChangedPaths(workflow: CiWorkflow, paths: string[]): boolean {
@@ -133,19 +171,70 @@ describe("pull request and main workflow contracts", () => {
   });
 
   it("reuses the same shared CI actions in PR and main workflows", () => {
-    for (const [jobName, actionPath] of [
-      ["static-checks", sharedActionPaths.staticChecks],
-      ["build-typecheck", sharedActionPaths.buildTypecheck],
-      ["cli-test-shards", sharedActionPaths.cliCoverageShard],
-      ["cli-tests", sharedActionPaths.cliCoverageMerge],
-      ["plugin-tests", sharedActionPaths.pluginCoverage],
+    for (const [jobName, stepName, trustedActionPath, mainActionPath] of [
+      [
+        "static-checks",
+        "Run static checks",
+        trustedPrActionPaths.staticChecks,
+        sharedActionPaths.staticChecks,
+      ],
+      [
+        "build-typecheck",
+        "Run build and type checks",
+        trustedPrActionPaths.buildTypecheck,
+        sharedActionPaths.buildTypecheck,
+      ],
+      [
+        "cli-test-shards",
+        "Run CLI coverage shard",
+        trustedPrActionPaths.cliCoverageShard,
+        sharedActionPaths.cliCoverageShard,
+      ],
+      [
+        "cli-tests",
+        "Merge CLI coverage",
+        trustedPrActionPaths.cliCoverageMerge,
+        sharedActionPaths.cliCoverageMerge,
+      ],
+      [
+        "plugin-tests",
+        "Run plugin coverage",
+        trustedPrActionPaths.pluginCoverage,
+        sharedActionPaths.pluginCoverage,
+      ],
     ] as const) {
       expect(stepUses(prWorkflow.jobs[jobName]), `PR ${jobName}`).toContain(
-        actionPath,
+        trustedActionPath,
       );
       expect(stepUses(mainWorkflow.jobs[jobName]), `main ${jobName}`).toContain(
-        actionPath,
+        mainActionPath,
       );
+      expect(stepUses(prWorkflow.jobs[jobName]), `PR ${jobName}`).not.toContain(
+        mainActionPath,
+      );
+      expect(stepUses(mainWorkflow.jobs[jobName]), `main ${jobName}`).not.toContain(
+        trustedActionPath,
+      );
+
+      const trustedCheckout = requiredWorkflowStep(
+        prWorkflow.jobs[jobName],
+        "Checkout trusted CI actions",
+      );
+      expect(trustedCheckout.uses).toBe(trustedCheckoutAction);
+      expect(trustedCheckout.with?.ref).toBe(
+        "${{ github.event.pull_request.base.sha }}",
+      );
+      expect(trustedCheckout.with?.path).toBe(".trusted-ci-actions");
+      expect(trustedCheckout.with?.["persist-credentials"]).toBe(false);
+      expect(trustedCheckout.with?.["sparse-checkout-cone-mode"]).toBe(false);
+      for (const trustedActionDir of trustedActionDirs) {
+        expect(String(trustedCheckout.with?.["sparse-checkout"])).toContain(
+          trustedActionDir,
+        );
+      }
+      expect(
+        requiredWorkflowStepIndex(prWorkflow.jobs[jobName], "Checkout trusted CI actions"),
+      ).toBeLessThan(requiredWorkflowStepIndex(prWorkflow.jobs[jobName], stepName));
     }
 
     expect(stepUses(mainWorkflow.jobs.checks)).not.toContain(
@@ -171,6 +260,7 @@ describe("pull request and main workflow contracts", () => {
 
   it("preserves the shared static, build, and coverage gates", () => {
     const staticRuns = stepRuns(sharedActions.staticChecks);
+    const staticRunsJoined = staticRuns.join("\n");
     const staticPrekRun = staticRuns.find((run) =>
       run.includes("npx prek run --all-files --stage pre-push"),
     );
@@ -199,6 +289,11 @@ describe("pull request and main workflow contracts", () => {
     expect(staticRuns).toContain("npm run test-size:check");
     expect(staticRuns).toContain("npx vitest run test/skills-frontmatter.test.ts");
     expect(staticRuns).toContain("python3 scripts/generate-platform-docs.py --check");
+    expect(staticRunsJoined).toContain(
+      'HADOLINT_SHA256="6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47"',
+    );
+    expect(staticRunsJoined).not.toContain('"${HADOLINT_URL}.sha256"');
+    expect(staticRunsJoined).not.toContain("EXPECTED=$(curl");
 
     expect(buildRuns.join("\n")).toContain("cd nemoclaw && npm install --ignore-scripts");
     expect(buildRuns).toContain("cd nemoclaw && npm run build");
@@ -212,23 +307,27 @@ describe("pull request and main workflow contracts", () => {
     expect(cliShardRuns).toContain("npm run build:cli");
     expect(cliShardRuns).toContain("npx tsx scripts/check-dist-sourcemaps.ts dist");
     expect(cliShardRuns).toContain("npx vitest run --project cli");
-    expect(cliShardRuns).toContain("--shard=${{ inputs.shard }}/${{ inputs.shard-count }}");
+    expect(cliShardRuns).toContain('--shard="${CLI_SHARD}/${CLI_SHARD_COUNT}"');
     expect(cliShardRuns).toContain("--reporter=github-actions");
     expect(cliShardRuns).toContain("--reporter=blob");
     expect(cliShardRuns).toContain(
-      "--outputFile.blob=.vitest-reports/blob-${{ inputs.shard }}-${{ inputs.shard-count }}.json",
+      '--outputFile.blob=".vitest-reports/blob-${CLI_SHARD}-${CLI_SHARD_COUNT}.json"',
     );
-    expect(cliShardRuns).toContain("--coverage.reportsDirectory=coverage/cli/shard-${{ inputs.shard }}");
+    expect(cliShardRuns).toContain(
+      '--coverage.reportsDirectory="coverage/cli/shard-${CLI_SHARD}"',
+    );
+    expect(cliShardRuns).not.toContain("${{ inputs.shard");
     expect(cliShardRuns).not.toContain("scripts/check-coverage-ratchet.ts");
 
     expect(cliMergeRuns).toContain("npm run build:cli");
     expect(cliMergeRuns).toContain("npx tsx scripts/check-dist-sourcemaps.ts dist");
     expect(cliMergeRuns).toContain(
-      'blob=".vitest-reports/blob-${shard}-${{ inputs.shard-count }}.json"',
+      'blob=".vitest-reports/blob-${shard}-${CLI_SHARD_COUNT}.json"',
     );
     expect(cliMergeRuns).toContain(
-      "find .vitest-reports -maxdepth 1 -type f -name 'blob-*-${{ inputs.shard-count }}.json'",
+      'find .vitest-reports -maxdepth 1 -type f -name "blob-*-${CLI_SHARD_COUNT}.json"',
     );
+    expect(cliMergeRuns).not.toContain("${{ inputs.shard-count");
     expect(cliMergeRuns).toContain("npx vitest --mergeReports .vitest-reports");
     expect(cliMergeRuns).toContain("--reporter=json");
     expect(cliMergeRuns).toContain(
@@ -243,6 +342,60 @@ describe("pull request and main workflow contracts", () => {
     expect(pluginRuns).toContain(
       'scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"',
     );
+  });
+
+  it("validates CLI shard inputs before using them in shell commands", () => {
+    const shardValidationStep = requiredStep(
+      sharedActions.cliCoverageShard,
+      "Validate shard inputs",
+    );
+    const shardValidationRun = shardValidationStep.run ?? "";
+    const shardRunStep = requiredStep(
+      sharedActions.cliCoverageShard,
+      "Run CLI coverage shard",
+    );
+    const mergeValidationStep = requiredStep(
+      sharedActions.cliCoverageMerge,
+      "Validate shard inputs",
+    );
+    const mergeValidationRun = mergeValidationStep.run ?? "";
+    const mergeVerifyStep = requiredStep(
+      sharedActions.cliCoverageMerge,
+      "Verify CLI shard blob reports",
+    );
+
+    expect(shardValidationStep.env).toEqual({
+      CLI_SHARD: "${{ inputs.shard }}",
+      CLI_SHARD_COUNT: "${{ inputs.shard-count }}",
+    });
+    expect(shardValidationRun).toContain("*[!0-9]*");
+    expect(shardValidationRun).toContain("Invalid CLI shard");
+    expect(shardValidationRun).toContain("Invalid CLI shard count");
+    expect(shardValidationRun).toContain("Invalid CLI shard range");
+    expect(shardRunStep.env).toEqual({
+      CLI_SHARD: "${{ inputs.shard }}",
+      CLI_SHARD_COUNT: "${{ inputs.shard-count }}",
+    });
+    expect(
+      requiredStepIndex(sharedActions.cliCoverageShard, "Validate shard inputs"),
+    ).toBeLessThan(requiredStepIndex(sharedActions.cliCoverageShard, "Run CLI coverage shard"));
+
+    expect(mergeValidationStep.env).toEqual({
+      CLI_SHARD_COUNT: "${{ inputs.shard-count }}",
+    });
+    expect(mergeValidationRun).toContain("*[!0-9]*");
+    expect(mergeValidationRun).toContain("Invalid CLI shard count");
+    expect(mergeVerifyStep.env).toEqual({
+      CLI_SHARD_COUNT: "${{ inputs.shard-count }}",
+    });
+    expect(
+      requiredStepIndex(sharedActions.cliCoverageMerge, "Validate shard inputs"),
+    ).toBeLessThan(
+      requiredStepIndex(sharedActions.cliCoverageMerge, "Verify CLI shard blob reports"),
+    );
+    expect(
+      requiredStepIndex(sharedActions.cliCoverageMerge, "Validate shard inputs"),
+    ).toBeLessThan(requiredStepIndex(sharedActions.cliCoverageMerge, "Merge CLI coverage"));
   });
 
   it("keeps the trusted test-size guard closed around budget policy changes", () => {
@@ -291,7 +444,9 @@ describe("pull request and main workflow contracts", () => {
       "Verify CLI shard blob reports",
     ).run;
 
-    expect(shardUploadStep.if).toBe("always()");
+    expect(shardUploadStep.if).toBe(
+      "${{ always() && steps.validate-shard-inputs.outcome == 'success' }}",
+    );
     expect(shardUploadStep.uses).toContain("actions/upload-artifact@");
     expect(shardUploadStep.with?.name).toBe("cli-blob-report-${{ inputs.shard }}");
     expect(shardUploadStep.with?.path).toBe(
@@ -305,9 +460,9 @@ describe("pull request and main workflow contracts", () => {
     expect(downloadStep.with?.path).toBe(".vitest-reports");
     expect(downloadStep.with?.["merge-multiple"]).toBe(true);
 
-    expect(verifyRun).toContain('seq 1 "${{ inputs.shard-count }}"');
+    expect(verifyRun).toContain('seq 1 "$CLI_SHARD_COUNT"');
     expect(verifyRun).toContain('[ ! -s "$blob" ]');
-    expect(verifyRun).toContain("Expected ${{ inputs.shard-count }} blob reports");
+    expect(verifyRun).toContain("Expected ${CLI_SHARD_COUNT} blob reports");
     expect(stepRuns(sharedActions.cliCoverageMerge).join("\n")).toContain(
       'scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"',
     );


### PR DESCRIPTION
## Summary
Address the PR Review Advisor follow-up from #4982 by keeping PR-required CI gates reusable while loading their composite action definitions from the trusted base SHA. This preserves the shared Vitest/static-check configuration from main without letting future pull requests rewrite the required gate implementation under the same job names.

## Related Issue
Follow-up to #4982 and refs #4892.

## Changes
- Checkout `.github/actions/ci-*` from `github.event.pull_request.base.sha` into `.trusted-ci-actions` before PR-required gate jobs invoke shared composite actions.
- Keep `main` workflow gates on the normal repo-local shared actions while PR gates use the trusted checkout path.
- Validate CLI coverage shard inputs as positive integers before shell/path use, pass them through quoted environment variables, and skip shard artifact upload when validation fails.
- Pin the hadolint binary checksum inside the static-checks composite action instead of fetching the checksum from the release origin during CI.
- Expand workflow contract tests for the trusted PR action boundary, shard input validation, and pinned hadolint checksum.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow validation with stricter input checks for shard parameters.
  * Implemented binary checksum verification for build tools to improve security.
  * Optimized CI action execution by using trusted actions from the base commit, improving workflow reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->