### PR TITLE
refactor: inline single-use aliases

### DIFF
--- a/nemoclaw/src/blueprint/runner.ts
+++ b/nemoclaw/src/blueprint/runner.ts
@@ -180,8 +180,7 @@ function isBlueprint(value: unknown): value is Blueprint {
     return false;
   }
 
-  const version = value.version;
-  if (!isOptionalString(version)) {
+  if (!isOptionalString(value.version)) {
     return false;
   }
 

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -704,8 +704,7 @@ export function setConfigValue(document: UnknownRecord, configPath: string, valu
     if (isArrayIndex) {
       const array = requireArray(current, configPath);
       const arrayIndex = Number.parseInt(token, 10);
-      const entry = array[arrayIndex];
-      if (entry == null) {
+      if (array[arrayIndex] == null) {
         array[arrayIndex] = isArrayIndexToken(nextToken) ? [] : {};
       }
       current = array[arrayIndex];

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -300,8 +300,7 @@ export function removeShieldsState(
     } catch (error) {
       // force: true already suppresses ENOENT; warn on real failures
       // (e.g. EPERM) so stale state doesn't silently survive.
-      const errno = error as NodeJS.ErrnoException;
-      if (errno.code !== "ENOENT") {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         const message = error instanceof Error ? error.message : String(error);
         warn(
           `Failed to remove shields cleanup artifact '${filePath}': ${message}`,

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -127,8 +127,7 @@ function resolveSrcPodImage(srcName: string, srcEntry?: SandboxEntry | { name: s
       ],
       { ignoreError: true, timeout: 10000 },
     );
-    const img = output.trim().split(/\s+/)[0];
-    return img || null;
+    return output.trim().split(/\s+/)[0] || null;
   } catch {
     return null;
   }

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -723,8 +723,7 @@ function collectContainerDiagnostic(provider: string, capture: RunCaptureFn): st
     if (hostsOutput) {
       const gwLine = hostsOutput.split(/\r?\n/).find((l: string) => l.includes("host.openshell.internal"));
       if (gwLine) {
-        const ip = gwLine.trim().split(/\s+/)[0];
-        parts.push(`host-gateway resolved to: ${ip}`);
+        parts.push(`host-gateway resolved to: ${gwLine.trim().split(/\s+/)[0]}`);
       }
     }
     parts.push(`Retried ${CONTAINER_CHECK_MAX_ATTEMPTS} times over ~${(CONTAINER_CHECK_MAX_ATTEMPTS - 1) * CONTAINER_CHECK_RETRY_DELAY_SECS}s`);

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -96,8 +96,7 @@ function hasValidFunctionCallPayload(value) {
 function isStructuredChatCompletionsToolCall(value) {
   if (!value || typeof value !== "object") return false;
   if (value.type !== "function") return false;
-  const fn = value.function;
-  return hasValidFunctionCallPayload(fn);
+  return hasValidFunctionCallPayload(value.function);
 }
 
 function containsToolCallLikeValue(value) {

--- a/src/lib/messaging/compiler/manifest-compiler.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.ts
@@ -299,8 +299,7 @@ function readInputEnvValue(input: ChannelInputSpec): MessagingSerializableValue 
     const resolved = resolveMessagingChannelConfigEnvValue(input.envKey, process.env);
     if (resolved.value) return resolved.value;
   }
-  const value = process.env[input.envKey];
-  const normalized = value?.replace(/\r/g, "").trim();
+  const normalized = process.env[input.envKey]?.replace(/\r/g, "").trim();
   return normalized && normalized.length > 0 ? normalized : undefined;
 }
 

--- a/src/lib/shields/timer-control.ts
+++ b/src/lib/shields/timer-control.ts
@@ -78,8 +78,7 @@ function isProcessAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    return code === "EPERM";
+    return (error as NodeJS.ErrnoException).code === "EPERM";
   }
 }
 

--- a/src/lib/state/sandbox-session.ts
+++ b/src/lib/state/sandbox-session.ts
@@ -124,9 +124,8 @@ export function parseSshProcesses(
     if (!pidMatch) continue;
 
     const pid = Number.parseInt(pidMatch[1], 10);
-    const cmdline = pidMatch[2];
 
-    if (hostPattern.test(cmdline)) {
+    if (hostPattern.test(pidMatch[2])) {
       sessions.push({ sandboxName, pid, sshHost });
     }
   }

--- a/src/lib/state/tar-listing.ts
+++ b/src/lib/state/tar-listing.ts
@@ -85,8 +85,7 @@ export function runTarListing(
       return `${failureLabel} failed (exit ${status}): ${(result.stderr || "").substring(0, 200)}`;
     }
 
-    const listingSize = statSync(listingPath).size;
-    if (listingSize > TAR_LISTING_MAX_OUTPUT_BYTES) {
+    if (statSync(listingPath).size > TAR_LISTING_MAX_OUTPUT_BYTES) {
       return `${failureLabel} exceeded ${TAR_LISTING_MAX_OUTPUT_BYTES} bytes`;
     }
 


### PR DESCRIPTION
## Summary
This PR makes a focused first cleanup pass for the single-use alias audit by inlining adjacent, side-effect-free aliases in CLI and plugin production code. The selection intentionally skips named constants, test readability helpers, exhaustiveness guards, mutation snapshots, and longer expressions where the local variable still improves readability.

## Related Issue
Fixes #4876

## Changes
- Inline reviewed single-use aliases in sandbox, inference, messaging, shields, and state helpers under `src/lib`.
- Inline two plugin aliases in blueprint validation and migration state traversal under `nemoclaw/src`.
- Keep the scan helper out of the repo; candidates were generated locally and manually filtered for low-risk adjacent uses.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>