### PR TITLE
ci(cli): expand coverage to five shards

### DIFF
--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -7,7 +7,7 @@ description: Merge shared CLI coverage shard blob reports and run the coverage r
 inputs:
   shard-count:
     description: Total number of CLI coverage shards to merge.
-    default: "3"
+    default: "5"
 
 runs:
   using: composite

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -10,7 +10,7 @@ inputs:
     required: true
   shard-count:
     description: Total number of CLI coverage shards.
-    default: "3"
+    default: "5"
 
 runs:
   using: composite

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -62,6 +62,7 @@ jobs:
         uses: ./.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
+          shard-count: "5"
 
   cli-tests:
     needs: cli-test-shards
@@ -85,6 +86,8 @@ jobs:
 
       - name: Merge CLI coverage
         uses: ./.github/actions/ci-cli-coverage-merge
+        with:
+          shard-count: "5"
 
   plugin-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -158,6 +158,7 @@ jobs:
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard
         with:
           shard: ${{ matrix.shard }}
+          shard-count: "5"
 
   cli-tests:
     needs:
@@ -197,6 +198,8 @@ jobs:
 
       - name: Merge CLI coverage
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-merge
+        with:
+          shard-count: "5"
 
   plugin-tests:
     needs: changes

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -52,6 +52,7 @@ export type RunnerWorkflow = {
 };
 
 export type CompositeAction = {
+  inputs?: Record<string, { default?: unknown }>;
   runs: {
     steps: WorkflowStep[];
   };

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -45,6 +45,9 @@ const trustedActionDirs = [
   ".github/actions/ci-plugin-coverage",
 ] as const;
 
+const cliShardMatrix = [1, 2, 3, 4, 5] as const;
+const cliShardCount = String(cliShardMatrix.length);
+
 function stepRuns(jobOrAction: WorkflowJob | CompositeAction): string[] {
   const steps = "runs" in jobOrAction ? jobOrAction.runs.steps : (jobOrAction.steps ?? []);
   return steps.flatMap((step) => (step.run ? [step.run] : []));
@@ -243,19 +246,30 @@ describe("pull request and main workflow contracts", () => {
     expect(prWorkflow.jobs["cli-test-shards"].strategy?.["fail-fast"]).toBe(false);
     expect(mainWorkflow.jobs["cli-test-shards"].strategy?.["fail-fast"]).toBe(false);
     expect(prWorkflow.jobs["cli-test-shards"].strategy?.matrix?.shard).toEqual([
-      1, 2, 3,
+      ...cliShardMatrix,
     ]);
     expect(mainWorkflow.jobs["cli-test-shards"].strategy?.matrix?.shard).toEqual([
-      1, 2, 3,
+      ...cliShardMatrix,
     ]);
-    expect(
-      requiredWorkflowStep(prWorkflow.jobs["cli-test-shards"], "Run CLI coverage shard")
-        .with?.shard,
-    ).toBe("${{ matrix.shard }}");
-    expect(
-      requiredWorkflowStep(mainWorkflow.jobs["cli-test-shards"], "Run CLI coverage shard")
-        .with?.shard,
-    ).toBe("${{ matrix.shard }}");
+    for (const [workflowName, workflow] of [
+      ["pull_request", prWorkflow],
+      ["main", mainWorkflow],
+    ] as const) {
+      const shardStep = requiredWorkflowStep(
+        workflow.jobs["cli-test-shards"],
+        "Run CLI coverage shard",
+      );
+      const mergeStep = requiredWorkflowStep(workflow.jobs["cli-tests"], "Merge CLI coverage");
+      expect(shardStep.with?.shard, `${workflowName} shard input`).toBe(
+        "${{ matrix.shard }}",
+      );
+      expect(shardStep.with?.["shard-count"], `${workflowName} shard-count input`).toBe(
+        cliShardCount,
+      );
+      expect(mergeStep.with?.["shard-count"], `${workflowName} merge shard-count`).toBe(
+        cliShardCount,
+      );
+    }
   });
 
   it("preserves the shared static, build, and coverage gates", () => {
@@ -431,6 +445,13 @@ describe("pull request and main workflow contracts", () => {
   });
 
   it("runs CLI coverage in shards and merges coverage before ratcheting", () => {
+    expect(sharedActions.cliCoverageShard.inputs?.["shard-count"]?.default).toBe(
+      cliShardCount,
+    );
+    expect(sharedActions.cliCoverageMerge.inputs?.["shard-count"]?.default).toBe(
+      cliShardCount,
+    );
+
     const shardUploadStep = requiredStep(
       sharedActions.cliCoverageShard,
       "Upload CLI shard blob report",


### PR DESCRIPTION
## Summary
Increase the CLI coverage fan-out from three shards to five so the current slowest CLI shard has a smaller critical-path share. The workflows pass `shard-count: "5"` explicitly so PR runs continue to work while trusted composite action definitions are loaded from the base SHA.

## Related Issue
Follow-up to #4892.

## Changes
- Expand the PR and main `cli-test-shards` matrices from `[1, 2, 3]` to `[1, 2, 3, 4, 5]`.
- Pass `shard-count: "5"` into both CLI shard and merge composite action calls in PR and main workflows.
- Update the shared CLI coverage action defaults to five shards for direct reuse after merge.
- Extend workflow contract coverage for the five-shard matrix, explicit shard-count inputs, and composite action defaults.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>