### PR TITLE
fix(sandbox): grant /dev/pts so OpenClaw tmux-session flow can allocate a PTY (#4513)

### DIFF
--- a/agents/openclaw/policy-permissive.yaml
+++ b/agents/openclaw/policy-permissive.yaml
@@ -23,6 +23,10 @@ filesystem_policy:
   read_write:
     - /tmp
     - /dev/null
+    - /dev/pts                      # devpts PTY access for the tmux-session flow
+                                    # (#4513). Mirrors the baseline read_write so
+                                    # `shields down` does not remove a path
+                                    # (OpenShell rejects filesystem removals).
     - /sandbox/.openclaw
     - /sandbox/.nemoclaw
     - /home/linuxbrew

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -28,9 +28,9 @@ Hermes sandboxes use an agent-specific baseline policy in `agents/hermes/policy-
 | `/sandbox`, `/tmp`, `/dev/null`, `/dev/pts` | Read-write |
 | `/usr`, `/lib`, `/proc`, `/dev/urandom`, `/app`, `/etc`, `/var/log` | Read-only |
 
-`/dev/pts` is the pseudo-terminal (devpts) directory. It is writable so PTY-based
-tools — `tmux`, `script`, and interactive shells — can allocate a terminal;
-without it those tools fail with `fork failed: Permission denied`.
+`/dev/pts` is the pseudo-terminal (devpts) directory.
+It is writable so PTY-based tools (`tmux`, `script`, and interactive shells) can allocate a terminal.
+Without it, those tools fail with `fork failed: Permission denied`.
 
 The sandbox process runs as a dedicated `sandbox` user and group.
 Landlock LSM enforcement applies on a best-effort basis.

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -25,8 +25,12 @@ Hermes sandboxes use an agent-specific baseline policy in `agents/hermes/policy-
 
 | Path | Access |
 |---|---|
-| `/sandbox`, `/tmp`, `/dev/null` | Read-write |
+| `/sandbox`, `/tmp`, `/dev/null`, `/dev/pts` | Read-write |
 | `/usr`, `/lib`, `/proc`, `/dev/urandom`, `/app`, `/etc`, `/var/log` | Read-only |
+
+`/dev/pts` is the pseudo-terminal (devpts) directory. It is writable so PTY-based
+tools — `tmux`, `script`, and interactive shells — can allocate a terminal;
+without it those tools fail with `fork failed: Permission denied`.
 
 The sandbox process runs as a dedicated `sandbox` user and group.
 Landlock LSM enforcement applies on a best-effort basis.

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -256,11 +256,11 @@ Messaging sessions such as WhatsApp pairing can remain mutable by design so they
 
 ### Writable Paths
 
-The agent has read-write access to `/sandbox`, `/tmp`, and `/dev/null`.
+The agent has read-write access to `/sandbox`, `/tmp`, `/dev/null`, and `/dev/pts`.
 
 | Aspect | Detail |
 |---|---|
-| Default | `/sandbox` (agent workspace), `/tmp` (temporary files), `/dev/null`. |
+| Default | `/sandbox` (agent workspace), `/tmp` (temporary files), `/dev/null`, and `/dev/pts` (the devpts pseudo-terminal directory, required so PTY-based tools such as `tmux`, `script`, and interactive shells can allocate a terminal). |
 | What you can change | Add additional writable paths in `filesystem_policy.read_write`. |
 | Risk if relaxed | Each additional writable path expands the agent's ability to persist data and potentially modify system behavior. Adding `/var` lets the agent write to log directories. Adding `/home` gives access to other user directories. |
 | Recommendation | Keep writable paths to `/sandbox` and `/tmp`. If the agent needs a persistent working directory, create a subdirectory under `/sandbox`. |

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -28,6 +28,10 @@ filesystem_policy:
   read_write:
     - /tmp
     - /dev/null
+    - /dev/pts                      # devpts PTY access for the tmux-session flow
+                                    # (#4513). Must mirror the default policy —
+                                    # OpenShell rejects filesystem path removals
+                                    # when `shields down` swaps this policy in.
     - /sandbox/.openclaw
     - /sandbox/.nemoclaw
     - /home/linuxbrew

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -31,6 +31,17 @@ filesystem_policy:
   read_write:
     - /tmp
     - /dev/null
+    - /dev/pts                      # PTY multiplexer + slave devices (devpts).
+                                    # OpenClaw's bundled tmux-session flow — and
+                                    # any PTY allocation (tmux, script, expect,
+                                    # interactive shells) — opens /dev/ptmx
+                                    # (-> /dev/pts/ptmx) and a /dev/pts/<n> slave
+                                    # via forkpty(). Without this grant landlock
+                                    # denies the open with EACCES, which tmux
+                                    # surfaces as `create window failed: fork
+                                    # failed: Permission denied` (#4513). Grant
+                                    # the directory, not /dev/ptmx itself — the
+                                    # supervisor refuses to chown that symlink.
     - /sandbox/.openclaw            # Agent config (lockable via shields up)
     - /sandbox/.nemoclaw            # Plugin state and config (state.ts, config.ts).
                                     # Blueprints are root-owned; sticky bit (1755)

--- a/test/e2e/test-sandbox-operations.sh
+++ b/test/e2e/test-sandbox-operations.sh
@@ -454,10 +454,15 @@ test_sbx_04_log_streaming() {
 
 # ── TC-SBX-09: Tmux Session Flow ────────────────────────────────────────────
 # OpenClaw's bundled tmux-session flow shells out to `tmux` inside the sandbox.
-# The sandbox image must ship tmux (issue #4513) or that flow fails with
-# `tmux: command not found`. Assert the binary is present and can drive a full
-# detached session lifecycle (new-session → list → kill), which is the exact
-# shape the bundled flow exercises.
+# The sandbox image must ship tmux (issue #4513) AND the sandbox landlock policy
+# must grant the devpts PTY devices so tmux can actually allocate a window.
+#
+# History: #4606 installed tmux but the lifecycle drive then failed with
+# `create window failed: fork failed: Permission denied`; #4640 degraded that
+# branch to a soft skip. The real cause was landlock denying /dev/ptmx +
+# /dev/pts (EACCES on forkpty()), not a fork/seccomp/nproc limit. The base
+# policy now grants /dev/pts, so this drive MUST pass — a `fork failed` here is
+# a hard regression of #4513, never a skip.
 test_sbx_09_tmux_session_flow() {
   log "=== TC-SBX-09: Tmux Session Flow ==="
   require_sandbox "$SANDBOX_A" "TC-SBX-09" || return
@@ -470,6 +475,29 @@ test_sbx_09_tmux_session_flow() {
   fi
   pass "TC-SBX-09: tmux is installed in the sandbox ($(echo "$which_out" | head -1))"
 
+  # Pin the #4513 root cause directly: PTY allocation must succeed. This opens
+  # /dev/ptmx and a /dev/pts/<n> slave the same way tmux's forkpty() does, and
+  # fails fast with the underlying EACCES if the devpts grant ever regresses.
+  # Guarded on python3 (a diagnostic) so a missing interpreter cannot be
+  # mistaken for a devpts regression — the tmux lifecycle below is the gate.
+  # The PTY_OK sentinel is emitted by a shell `&& echo` only after openpty()
+  # exits 0 — it is deliberately NOT a literal inside the python source, because
+  # a Python traceback echoes the failing source line and would otherwise make
+  # `grep PTY_OK` match on the very EACCES regression this probe guards against.
+  # PY3_MISSING is gated solely on `command -v`, so an openpty() failure with
+  # python3 present falls through to `fail`, never to the soft skip.
+  local pty_out
+  pty_out=$(sandbox_exec "if command -v python3 >/dev/null 2>&1; then \
+    python3 -c 'import os; _,s=os.openpty(); print(os.ttyname(s))' && echo PTY_OK; \
+    else echo PY3_MISSING; fi" 2>&1) || true
+  if echo "$pty_out" | grep -q "PTY_OK"; then
+    pass "TC-SBX-09: PTY allocation works (slave $(echo "$pty_out" | grep -E '^/dev/pts/' | head -1))"
+  elif echo "$pty_out" | grep -q "PY3_MISSING"; then
+    log "TC-SBX-09: python3 unavailable; skipping direct openpty() probe (tmux lifecycle still gates devpts)"
+  else
+    fail "TC-SBX-09: PTY allocation" "openpty() failed — devpts not granted by sandbox policy (#4513): $(echo "$pty_out" | head -3)"
+  fi
+
   # Drive a detached session lifecycle the way the bundled flow does. tmux needs
   # a writable socket dir; /tmp is on the sandbox write set.
   local sess="nemoclaw-e2e-tmux-$$"
@@ -481,16 +509,10 @@ test_sbx_09_tmux_session_flow() {
 
   if echo "$flow_out" | grep -q "TMUX_FLOW_OK" && echo "$flow_out" | grep -q "${sess}"; then
     pass "TC-SBX-09: tmux new/list/kill session lifecycle works"
-  elif echo "$flow_out" | grep -qE "fork failed: (Permission denied|Resource temporarily unavailable|Operation not permitted)"; then
-    # Sandbox hardening (seccomp + no-new-privileges + nproc cap) can refuse
-    # tmux's fork-to-spawn child window under the e2e SSH session account.
-    # The binary-presence assertion above already covers the install surface;
-    # the lifecycle drive depends on runtime capabilities that are
-    # environment-dependent and not in scope of this case.
-    sandbox_exec "TMUX_TMPDIR=/tmp tmux kill-session -t '${sess}' 2>/dev/null || true" >/dev/null 2>&1 || true
-    skip "TC-SBX-09" "tmux lifecycle drive blocked by sandbox fork policy: $(echo "$flow_out" | head -3)"
   else
-    # Best-effort cleanup in case kill-session never ran.
+    # Best-effort cleanup in case kill-session never ran. A `fork failed`
+    # message here means the devpts grant regressed — fail loudly (#4513),
+    # do not skip.
     sandbox_exec "TMUX_TMPDIR=/tmp tmux kill-session -t '${sess}' 2>/dev/null || true" >/dev/null 2>&1 || true
     fail "TC-SBX-09: Tmux Session Flow" "Session lifecycle failed: $(echo "$flow_out" | head -5)"
   fi

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -923,10 +923,13 @@ describe("regression guards", () => {
     // Permission denied`. Root cause: the sandbox landlock filesystem policy
     // never granted the devpts PTY devices, so forkpty() open of /dev/ptmx
     // (-> /dev/pts/ptmx) and the /dev/pts/<n> slave was denied with EACCES.
-    const policyDir = path.join(repoRoot, "nemoclaw-blueprint", "policies");
-    for (const policyFile of ["openclaw-sandbox.yaml", "openclaw-sandbox-permissive.yaml"]) {
+    for (const policyFile of [
+      path.join("nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"),
+      path.join("nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"),
+      path.join("agents", "openclaw", "policy-permissive.yaml"),
+    ]) {
       it(`${policyFile} grants /dev/pts so PTY allocation (tmux) works`, () => {
-        const doc = YAML.parse(fs.readFileSync(path.join(policyDir, policyFile), "utf-8"));
+        const doc = YAML.parse(fs.readFileSync(path.join(repoRoot, policyFile), "utf-8"));
         const readWrite: string[] = doc.filesystem_policy?.read_write ?? [];
         // devpts must be writable — tmux opens the master and slave O_RDWR.
         expect(readWrite).toContain("/dev/pts");

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import YAML from "yaml";
 
 import { redact, runCapture } from "../dist/lib/runner";
 
@@ -915,6 +916,40 @@ describe("regression guards", () => {
       expect(src).toContain("command -v tmux");
       // The smoke must be wired into the run, not just defined.
       expect(src).toMatch(/^\s*test_sbx_09_tmux_session_flow\s*$/m);
+    });
+
+    // The reopened #4513: installing tmux was not enough — the bundled
+    // tmux-session flow still failed with `create window failed: fork failed:
+    // Permission denied`. Root cause: the sandbox landlock filesystem policy
+    // never granted the devpts PTY devices, so forkpty() open of /dev/ptmx
+    // (-> /dev/pts/ptmx) and the /dev/pts/<n> slave was denied with EACCES.
+    const policyDir = path.join(repoRoot, "nemoclaw-blueprint", "policies");
+    for (const policyFile of ["openclaw-sandbox.yaml", "openclaw-sandbox-permissive.yaml"]) {
+      it(`${policyFile} grants /dev/pts so PTY allocation (tmux) works`, () => {
+        const doc = YAML.parse(fs.readFileSync(path.join(policyDir, policyFile), "utf-8"));
+        const readWrite: string[] = doc.filesystem_policy?.read_write ?? [];
+        // devpts must be writable — tmux opens the master and slave O_RDWR.
+        expect(readWrite).toContain("/dev/pts");
+        // /dev/ptmx is a symlink to pts/ptmx; the supervisor refuses to chown a
+        // symlinked read_write path, so it must NOT be listed directly. The
+        // /dev/pts directory grant already covers ptmx via the landlock
+        // path hierarchy.
+        expect(readWrite).not.toContain("/dev/ptmx");
+      });
+    }
+
+    it("e2e TC-SBX-09 hard-asserts the tmux lifecycle and no longer skips on fork failure", () => {
+      const src = fs.readFileSync(
+        path.join(repoRoot, "test", "e2e", "test-sandbox-operations.sh"),
+        "utf-8",
+      );
+      // The PTY root cause is pinned with an explicit openpty() probe.
+      expect(src).toContain("os.openpty()");
+      // The #4640 soft-skip-on-fork-failure branch must be gone — a fork
+      // failure now means the devpts grant regressed and must fail loudly.
+      const tc09 = src.slice(src.indexOf("test_sbx_09_tmux_session_flow"));
+      const tc09Body = tc09.slice(0, tc09.indexOf("\n}\n"));
+      expect(tc09Body).not.toMatch(/skip "TC-SBX-09"/);
     });
   });
 });


### PR DESCRIPTION
## Summary

The reopened #4513: PR #4606 installed `tmux` in the sandbox image, but OpenClaw's bundled tmux-session flow still failed with `create window failed: fork failed: Permission denied`, and #4640 then degraded the e2e drive to a soft skip. This grants `/dev/pts` in the OpenClaw sandbox landlock filesystem policy so the flow can actually allocate a PTY, and restores the e2e to a hard assertion.

## Related Issue

Fixes #4513

## Changes

**Root cause (diagnosed, not assumed):** it is not fork/seccomp/nproc — plain `fork()` works and `nproc` (512) is nearly empty. It is **PTY allocation**. The OpenShell sandbox landlock `filesystem_policy` grants `/dev/null` and `/dev/urandom` but never `/dev/pts`, so `forkpty()` opening `/dev/ptmx` (→ `/dev/pts/ptmx`) and a `/dev/pts/<n>` slave is denied with `EACCES`. tmux surfaces that `EACCES` as `create window failed: fork failed: Permission denied`.

- `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`: add `/dev/pts` to `filesystem_policy.read_write` with the PTY rationale. Grant the **directory**, not `/dev/ptmx` — the supervisor refuses to `chown` the `/dev/ptmx` symlink, and the devpts directory grant covers `ptmx` + slaves via the landlock path hierarchy.
- `nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml` and `agents/openclaw/policy-permissive.yaml`: mirror `/dev/pts` so `shields down` never removes a live filesystem path (OpenShell rejects live filesystem removals). Same base+permissive pattern as the prior `/home/linuxbrew` (#3913) and GPU `/proc` additions, which `permissive-runtime` already unions on shields-down.
- `test/e2e/test-sandbox-operations.sh` (`TC-SBX-09`): restore the lifecycle drive to a **hard assertion** (drop the #4640 fork-failure soft skip), add an explicit `openpty()` probe that pins the root cause, and fail loudly if devpts ever regresses. The `PTY_OK` sentinel is emitted by a shell `&& echo` (not inside the python source) so a Python traceback echoing the source line cannot make the probe falsely pass.
- `test/runner.test.ts`: assert both OpenClaw policies grant `/dev/pts` (and not `/dev/ptmx`), and that `TC-SBX-09` no longer skips on fork failure.
- `docs/reference/network-policies.mdx`, `docs/security/best-practices.mdx`: list `/dev/pts` as a default writable path with the tmux rationale.

## Verification

**Reporter-workflow E2E — exact tmux-session/forkpty flow inside the hardened NemoClaw sandbox.**

Reproduced and verified hermetically with the **real `openshell-sandbox` supervisor** (which applies the live seccomp + landlock + `RLIMIT_NPROC` hardening; no gateway/GPU needed), running inside `ghcr.io/nvidia/nemoclaw/sandbox-base` + `tmux`, driven by the **actual edited `openclaw-sandbox.yaml`** as the policy data.

Command (same shape as `TC-SBX-09`):

```
openshell-sandbox --policy-rules sandbox-policy.rego --policy-data <openclaw-sandbox.yaml> -- \
  bash -lc 'export TMUX_TMPDIR=/tmp; python3 -c "import os; _,s=os.openpty(); print(os.ttyname(s))";
            tmux new-session -d -s smoke "sleep 30"; tmux list-sessions; tmux kill-session -t smoke; echo TMUX_FLOW_OK'
```

Logs:

```
# BEFORE (committed policy, no /dev/pts):
-- openpty --  PermissionError: [Errno 13] Permission denied
-- tmux --     create window failed: fork failed: Permission denied      (new/list/kill RC=1/1/1)

# AFTER (this PR's policy, /dev/pts granted):
-- openpty --  /dev/pts/0
-- tmux --     smoke: 1 windows (created ...)                            (new/list/kill RC=0/0/0)  TMUX_FLOW_OK
```

This is the exact bundled tmux-session lifecycle (`new-session` → `list-sessions` → `kill-session`) the reporter hit. **Pipeline coverage:** the restored `TC-SBX-09` (`test/e2e/test-sandbox-operations.sh`) drives this same lifecycle plus the `openpty()` root-cause probe against a live OpenShell sandbox on the scheduled E2E job, now as a hard assertion (a `fork failed` is a failure, not a skip).

PR CI on head `b75befddb`: all required checks green — `static-checks`, `build-typecheck`, `cli-test-shards (1–5)`, `plugin-tests`, `unit-vitest-linux`, `ShellCheck`, `CodeQL`, `wsl-e2e`, `macos-e2e`, `dco-check`, `commit-lint`, `codebase-growth-guardrails` (run `27184680225`).

- [x] `npx prek run --all-files` passes (all formatter/lint/security/docs hooks green; the heavy `Test (CLI)` hook shows only load-induced timeout flakes that pass in isolation — this change touches no `src/` code)
- [x] `npm test` — targeted suites pass (`runner`, `policies`, `initial-policy`, `permissive-runtime`, `policy-tiers`, `shields`); CI `cli-test-shards (1–5)` + `plugin-tests` + `unit-vitest-linux` all green on PR head
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates

## Notes — known, pre-existing limitation (out of scope)

On an OpenClaw sandbox **created before this change and upgraded without recreate**, a `shields down` then `shields up` cycle can leave the sandbox in shields-down state: `shields down` adds `/dev/pts` via the permissive policy, and `shields up` restores the pre-upgrade live snapshot, which omits `/dev/pts` (OpenShell rejects the resulting live filesystem removal). This is identical to the existing `/home/linuxbrew` (#3913), GPU `/proc`, and Hermes `/opt/hermes` base-policy additions — shields-up restore has never normalized the snapshot for any path. Such a sandbox has not received the creation-locked filesystem fix anyway; the remediation (recreate / re-onboard) resolves both the tmux fix and this edge case. A symmetric snapshot-normalization in shields-restore would address the whole class and belongs in its own change.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PTY allocation now works inside sandboxes, allowing terminal tools (tmux, script, interactive shells) and preventing "fork failed: Permission denied" failures.

* **Documentation**
  * Sandbox filesystem docs updated to include PTY device access and clarify configuration for terminal allocation tooling.

* **Tests**
  * End-to-end and unit tests tightened to assert PTY support and to fail when PTY allocation regresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->