### PR TITLE
fix(onboard): prove GPU sandbox local inference from the agent runtime (#4509)

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3422,12 +3422,16 @@ async function createSandbox(
     }
   }
   const buildId = String(Date.now());
-  const sandboxInferenceBaseUrlOverride =
-    dockerGpuLocalInference.dockerGpuPatchHostNetworkInferenceBaseUrl(
-      effectiveSandboxGpuConfig,
-      provider,
-      { dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(), log: console.log },
-    );
+  // OpenClaw never uses a direct container-loopback inference URL: the agent's
+  // isolated sandbox netns can't reach the host loopback even under --network
+  // host. For local providers this drops the host-network GPU opt-in so
+  // inference uses the reachable inference.local route (re-checking the bridge
+  // it now needs); OpenClaw falls back to OpenShell-managed routing (#4509).
+  await dockerGpuLocalInference.enforceDockerGpuPatchPreserveNetwork(provider, effectiveSandboxGpuConfig, {
+    dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(),
+    log: console.log,
+  });
+  const sandboxInferenceBaseUrlOverride = null;
   patchStagedDockerfile(
     stagedDockerfile,
     model,
@@ -6234,11 +6238,6 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
         /* lspci not available — skip hint */
       }
     }
-    dockerGpuLocalInference.configureLocalInferenceForDockerGpuHostNetwork(sandboxGpuConfig, {
-      dockerDriverGateway: isLinuxDockerDriverGatewayEnabled(),
-      note,
-    });
-
     const gatewaySnapshot = selectNamedGatewayForReuseIfNeeded(getGatewayReuseSnapshot());
     const gatewayResult = await handleGatewayState({
       resume,

--- a/src/lib/onboard/docker-gpu-local-inference.test.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.test.ts
@@ -4,38 +4,32 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  printDockerGpuHostNetworkInferenceVerificationFailure,
+  enforceDockerGpuPatchPreserveNetwork,
+  getSandboxRuntimeInferenceEndpoint,
+  printDockerGpuSandboxInferenceVerificationFailure,
   shouldUseDockerGpuPatchHostNetwork,
-  verifyDockerGpuHostNetworkLocalInference,
+  verifyDockerGpuSandboxLocalInference,
   verifyGpuSandboxAfterReady,
 } from "../../../dist/lib/onboard/docker-gpu-local-inference";
 
 const HOST_NETWORK_ENV = { NEMOCLAW_DOCKER_GPU_PATCH_NETWORK: "host" } as NodeJS.ProcessEnv;
 const GPU_CONFIG = { sandboxGpuEnabled: true };
 
-function hostNetworkOptions(extra: Record<string, unknown> = {}) {
+function gpuPatchOptions(extra: Record<string, unknown> = {}) {
   return {
     sandboxName: "alpha",
     dockerDriverGateway: true,
     platform: "linux" as NodeJS.Platform,
-    env: HOST_NETWORK_ENV,
+    env: {} as NodeJS.ProcessEnv,
     ...extra,
   };
 }
 
-function inspectWithNetworkMode(mode: string): string {
-  return JSON.stringify([{ HostConfig: { NetworkMode: mode } }]);
-}
-
-const CURL_CHECK_PROBE = "command -v curl >/dev/null 2>&1";
-
-// Build a dockerRun mock that reports curl as present and returns `probeResult`
-// for the actual reachability probe (curl -sf ...).
-function dockerRunWithCurl(probeResult: { status: number; stderr?: string }) {
-  return vi.fn((args: readonly string[]) => {
-    if (args.includes(CURL_CHECK_PROBE)) return { status: 0 };
-    return probeResult;
-  });
+// The gate runs a single combined script via `openshell sandbox exec` that
+// emits either `NO_CURL` or `HTTP_<code>`. This mock answers with `stdout`.
+// Typed `(sandboxName, script)` so `.mock.calls[i][1]` (the script) type-checks.
+function execEmitting(stdout: string, { status = 0, stderr = "" } = {}) {
+  return vi.fn((_sandboxName: string, _script: string) => ({ status, stdout, stderr }));
 }
 
 describe("shouldUseDockerGpuPatchHostNetwork", () => {
@@ -47,7 +41,7 @@ describe("shouldUseDockerGpuPatchHostNetwork", () => {
         env: HOST_NETWORK_ENV,
       }),
     ).toBe(true);
-    // Not host network mode.
+    // Default (preserve) network mode.
     expect(
       shouldUseDockerGpuPatchHostNetwork(GPU_CONFIG, {
         dockerDriverGateway: true,
@@ -66,185 +60,196 @@ describe("shouldUseDockerGpuPatchHostNetwork", () => {
   });
 });
 
-describe("verifyDockerGpuHostNetworkLocalInference", () => {
-  it("skips when the host-network GPU patch is not active", () => {
-    const result = verifyDockerGpuHostNetworkLocalInference(
+describe("enforceDockerGpuPatchPreserveNetwork", () => {
+  it("downgrades a LOCAL provider to preserve and re-checks the bridge (#4509)", async () => {
+    const env = { ...HOST_NETWORK_ENV };
+    const log = vi.fn();
+    const reverifyBridgeReachability = vi.fn();
+    const downgraded = await enforceDockerGpuPatchPreserveNetwork("ollama-local", GPU_CONFIG, {
+      dockerDriverGateway: true,
+      platform: "linux",
+      env,
+      log,
+      reverifyBridgeReachability,
+    });
+    expect(downgraded).toBe(true);
+    expect(env.NEMOCLAW_DOCKER_GPU_PATCH_NETWORK).toBe("preserve");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("OpenShell bridge networking"));
+    // The bridge reachability probe is re-run now that we are committed to it.
+    expect(reverifyBridgeReachability).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves host networking untouched for NON-local providers (cloud/routed/custom)", async () => {
+    const env = { ...HOST_NETWORK_ENV };
+    const reverifyBridgeReachability = vi.fn();
+    expect(
+      await enforceDockerGpuPatchPreserveNetwork("nvidia", GPU_CONFIG, {
+        dockerDriverGateway: true,
+        platform: "linux",
+        env,
+        reverifyBridgeReachability,
+      }),
+    ).toBe(false);
+    expect(env.NEMOCLAW_DOCKER_GPU_PATCH_NETWORK).toBe("host");
+    expect(reverifyBridgeReachability).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when host networking was not requested", async () => {
+    const env = {} as NodeJS.ProcessEnv;
+    expect(
+      await enforceDockerGpuPatchPreserveNetwork("ollama-local", GPU_CONFIG, {
+        dockerDriverGateway: true,
+        platform: "linux",
+        env,
+        reverifyBridgeReachability: vi.fn(),
+      }),
+    ).toBe(false);
+    expect(env.NEMOCLAW_DOCKER_GPU_PATCH_NETWORK).toBeUndefined();
+  });
+
+  it("is a no-op when the GPU patch does not apply (no sandbox GPU)", async () => {
+    const env = { ...HOST_NETWORK_ENV };
+    expect(
+      await enforceDockerGpuPatchPreserveNetwork("ollama-local", { sandboxGpuEnabled: false }, {
+        dockerDriverGateway: true,
+        platform: "linux",
+        env,
+        reverifyBridgeReachability: vi.fn(),
+      }),
+    ).toBe(false);
+    expect(env.NEMOCLAW_DOCKER_GPU_PATCH_NETWORK).toBe("host");
+  });
+});
+
+describe("getSandboxRuntimeInferenceEndpoint", () => {
+  it("uses the OpenShell inference route, not a host loopback or gateway alias", () => {
+    expect(getSandboxRuntimeInferenceEndpoint("ollama-local")).toBe(
+      "https://inference.local/v1/models",
+    );
+    expect(getSandboxRuntimeInferenceEndpoint("vllm-local")).toBe(
+      "https://inference.local/v1/models",
+    );
+    expect(getSandboxRuntimeInferenceEndpoint("build")).toBeNull();
+  });
+});
+
+describe("verifyDockerGpuSandboxLocalInference", () => {
+  it("skips when the Docker GPU patch is not active", () => {
+    const result = verifyDockerGpuSandboxLocalInference(
       GPU_CONFIG,
       "ollama-local",
-      hostNetworkOptions({ env: {} }),
+      gpuPatchOptions({ env: { NEMOCLAW_DOCKER_GPU_PATCH: "0" } }),
     );
-    expect(result.status).toBe("skipped");
+    expect(result).toEqual({ status: "skipped", reason: "not-docker-gpu-patch" });
   });
 
   it("skips for non-local providers", () => {
-    const result = verifyDockerGpuHostNetworkLocalInference(
-      GPU_CONFIG,
-      "build",
-      hostNetworkOptions(),
-    );
+    const result = verifyDockerGpuSandboxLocalInference(GPU_CONFIG, "build", gpuPatchOptions());
     expect(result).toEqual({ status: "skipped", reason: "not-local-provider" });
   });
 
-  it("skips when the Docker GPU patch is explicitly disabled", () => {
-    const dockerRun = vi.fn();
-    const result = verifyDockerGpuHostNetworkLocalInference(
-      GPU_CONFIG,
-      "ollama-local",
-      hostNetworkOptions({
-        env: { ...HOST_NETWORK_ENV, NEMOCLAW_DOCKER_GPU_PATCH: "0" },
-        deps: {
-          findContainerIds: () => [],
-          dockerCapture: vi.fn(),
-          dockerRun,
-          sleep: vi.fn(),
-        },
-      }),
-    );
-    expect(result.status).toBe("skipped");
-    // No container lookup or probe is attempted when the patch is opted out.
-    expect(dockerRun).not.toHaveBeenCalled();
-  });
-
-  it("passes when the container is on host network and the probe succeeds", () => {
-    const dockerCapture = vi.fn(() => inspectWithNetworkMode("host"));
-    const dockerRun = dockerRunWithCurl({ status: 0 });
-    const result = verifyDockerGpuHostNetworkLocalInference(
+  it("probes inference.local from the runtime context, never a loopback or docker exec", () => {
+    const execInSandbox = execEmitting("HTTP_200");
+    const result = verifyDockerGpuSandboxLocalInference(
       GPU_CONFIG,
       "vllm-local",
-      hostNetworkOptions({
-        deps: {
-          findContainerIds: () => ["container-abc"],
-          dockerCapture,
-          dockerRun,
-          sleep: vi.fn(),
-        },
-      }),
+      gpuPatchOptions({ deps: { execInSandbox, sleep: vi.fn() } }),
     );
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
-      expect(result.containerId).toBe("container-abc");
-      expect(result.networkMode).toBe("host");
-      expect(result.endpoint).toContain("/v1/models");
+      expect(result.httpCode).toBe("200");
+      expect(result.endpoint).toBe("https://inference.local/v1/models");
     }
-    // Probe runs curl inside the recreated container against the direct URL.
-    expect(dockerRun).toHaveBeenCalledWith(
-      expect.arrayContaining(["exec", "container-abc", "curl", "-sf"]),
-      expect.objectContaining({ ignoreError: true }),
-    );
+    expect(execInSandbox).toHaveBeenCalledWith("alpha", expect.any(String));
+    const script = execInSandbox.mock.calls[0][1];
+    expect(script).toContain("command -v curl");
+    expect(script).toContain("inference.local");
+    expect(script).toContain("%{http_code}");
+    expect(script).not.toContain("127.0.0.1");
+    expect(script).not.toContain("docker exec");
   });
 
-  it("fails when no recreated container is found", () => {
-    const result = verifyDockerGpuHostNetworkLocalInference(
+  it("fails on a 4xx — route reached but not usable (auth/route misconfig), not the #4509 proof", () => {
+    const result = verifyDockerGpuSandboxLocalInference(
       GPU_CONFIG,
       "ollama-local",
-      hostNetworkOptions({
-        deps: {
-          findContainerIds: () => [],
-          dockerCapture: vi.fn(),
-          dockerRun: vi.fn(),
-          sleep: vi.fn(),
-        },
-      }),
+      gpuPatchOptions({ deps: { execInSandbox: execEmitting("HTTP_404"), sleep: vi.fn() } }),
     );
     expect(result.status).toBe("failed");
     if (result.status === "failed") {
-      expect(result.kind).toBe("container-not-found");
+      expect(result.kind).toBe("unreachable");
+      expect(result.detail).toContain("404");
+    }
+  });
+
+  it("fails (unreachable) and retries on HTTP 000 — the #4509 regression", () => {
+    const execInSandbox = execEmitting("HTTP_000");
+    const sleep = vi.fn();
+    const result = verifyDockerGpuSandboxLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      gpuPatchOptions({ deps: { execInSandbox, sleep } }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("unreachable");
+      expect(result.detail).toContain("HTTP 000");
+      expect(result.endpoint).toBe("https://inference.local/v1/models");
       expect(result.recovery.length).toBeGreaterThan(0);
     }
-  });
-
-  it("fails when the recreated container is not on host network", () => {
-    const dockerRun = vi.fn(() => ({ status: 0 }));
-    const result = verifyDockerGpuHostNetworkLocalInference(
-      GPU_CONFIG,
-      "ollama-local",
-      hostNetworkOptions({
-        deps: {
-          findContainerIds: () => ["container-xyz"],
-          dockerCapture: vi.fn(() => inspectWithNetworkMode("openshell-docker")),
-          dockerRun,
-          sleep: vi.fn(),
-        },
-      }),
-    );
-    expect(result.status).toBe("failed");
-    if (result.status === "failed") {
-      expect(result.kind).toBe("network-mode");
-      expect(result.networkMode).toBe("openshell-docker");
-    }
-    // Do not probe when the network mode is already wrong.
-    expect(dockerRun).not.toHaveBeenCalled();
-  });
-
-  it("fails and retries when the direct endpoint probe never succeeds", () => {
-    const dockerRun = dockerRunWithCurl({ status: 7, stderr: "Connection refused" });
-    const sleep = vi.fn();
-    const result = verifyDockerGpuHostNetworkLocalInference(
-      GPU_CONFIG,
-      "ollama-local",
-      hostNetworkOptions({
-        deps: {
-          findContainerIds: () => ["container-xyz"],
-          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-          dockerRun,
-          sleep,
-        },
-      }),
-    );
-    expect(result.status).toBe("failed");
-    if (result.status === "failed") {
-      expect(result.kind).toBe("probe");
-      expect(result.detail).toContain("Connection refused");
-      expect(result.endpoint).toContain("/api/tags");
-    }
-    // 1 curl-availability check + 3 probe attempts.
-    expect(dockerRun).toHaveBeenCalledTimes(4);
+    expect(execInSandbox).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(2);
   });
 
-  it("soft-skips with a warning when the container image lacks curl", () => {
-    // dockerRun reports curl missing (non-zero for the curl-availability check).
-    const dockerRun = vi.fn(() => ({ status: 1 }));
-    const log = vi.fn();
-    const result = verifyDockerGpuHostNetworkLocalInference(
+  it("fails when the inference route is up but the local backend errors (HTTP 502)", () => {
+    const result = verifyDockerGpuSandboxLocalInference(
       GPU_CONFIG,
       "ollama-local",
-      hostNetworkOptions({
-        log,
-        deps: {
-          findContainerIds: () => ["container-xyz"],
-          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-          dockerRun,
-          sleep: vi.fn(),
-        },
-      }),
+      gpuPatchOptions({ deps: { execInSandbox: execEmitting("HTTP_502"), sleep: vi.fn() } }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("unreachable");
+      expect(result.detail).toContain("502");
+    }
+  });
+
+  it("soft-skips when the sandbox image genuinely lacks curl (custom --from base)", () => {
+    const log = vi.fn();
+    const result = verifyDockerGpuSandboxLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      gpuPatchOptions({ log, deps: { execInSandbox: execEmitting("NO_CURL"), sleep: vi.fn() } }),
     );
     expect(result).toEqual({ status: "skipped", reason: "probe-tool-unavailable" });
-    // Only the curl-availability check runs; no curl probe is attempted.
-    expect(dockerRun).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(expect.stringContaining("curl is not available"));
   });
 
-  it("surfaces the curl-missing skip warning even without a logger", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    try {
-      const result = verifyDockerGpuHostNetworkLocalInference(
-        GPU_CONFIG,
-        "ollama-local",
-        hostNetworkOptions({
-          // No log provided — the warning must still reach the operator.
-          deps: {
-            findContainerIds: () => ["container-xyz"],
-            dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-            dockerRun: vi.fn(() => ({ status: 1 })),
-            sleep: vi.fn(),
-          },
-        }),
-      );
-      expect(result).toEqual({ status: "skipped", reason: "probe-tool-unavailable" });
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("curl is not available"));
-    } finally {
-      warnSpy.mockRestore();
+  it("fails (exec) — not soft-skip — when sandbox exec cannot run", () => {
+    const result = verifyDockerGpuSandboxLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      gpuPatchOptions({ deps: { execInSandbox: vi.fn(() => null), sleep: vi.fn() } }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("exec");
+      expect(result.detail).toContain("did not run");
+    }
+  });
+
+  it("fails (exec) when exec runs but emits no sentinel (sandbox Error / exec denied)", () => {
+    const result = verifyDockerGpuSandboxLocalInference(
+      GPU_CONFIG,
+      "ollama-local",
+      gpuPatchOptions({
+        deps: { execInSandbox: execEmitting("", { status: 1, stderr: "exec denied" }), sleep: vi.fn() },
+      }),
+    );
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.kind).toBe("exec");
+      expect(result.detail).toContain("exec denied");
     }
   });
 });
@@ -255,7 +260,7 @@ describe("verifyGpuSandboxAfterReady", () => {
       sandboxName: "alpha",
       dockerDriverGateway: true,
       platform: "linux" as NodeJS.Platform,
-      env: HOST_NETWORK_ENV,
+      env: {} as NodeJS.ProcessEnv,
       useDockerGpuPatch: true,
       verifyDirectSandboxGpu: vi.fn(),
       selectedMode: () => null,
@@ -265,7 +270,7 @@ describe("verifyGpuSandboxAfterReady", () => {
     };
   }
 
-  it("runs the GPU proof and the host-network inference gate when the patch is active", () => {
+  it("runs the GPU proof and the runtime inference gate when the patch is active", () => {
     const log = vi.fn();
     const verifyDirectSandboxGpu = vi.fn();
     verifyGpuSandboxAfterReady(
@@ -274,42 +279,15 @@ describe("verifyGpuSandboxAfterReady", () => {
       baseOptions({
         verifyDirectSandboxGpu,
         log,
-        deps: {
-          findContainerIds: () => ["container-abc"],
-          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-          dockerRun: dockerRunWithCurl({ status: 0 }),
-          sleep: vi.fn(),
-        },
+        deps: { execInSandbox: execEmitting("HTTP_200"), sleep: vi.fn() },
       }),
     );
     expect(verifyDirectSandboxGpu).toHaveBeenCalledWith("alpha");
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("reachable from sandbox"));
-  });
-
-  it("uses Docker GPU patch verifier when supplied", () => {
-    const verifyDirectSandboxGpu = vi.fn();
-    const verifyGpuOrExit = vi.fn((proof: (sandboxName: string) => void) => proof("alpha"));
-    verifyGpuSandboxAfterReady(
-      GPU_CONFIG,
-      "vllm-local",
-      baseOptions({
-        verifyDirectSandboxGpu,
-        verifyGpuOrExit,
-        deps: {
-          findContainerIds: () => ["container-abc"],
-          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-          dockerRun: dockerRunWithCurl({ status: 0 }),
-          sleep: vi.fn(),
-        },
-      }),
-    );
-    expect(verifyGpuOrExit).toHaveBeenCalledWith(verifyDirectSandboxGpu);
-    expect(verifyDirectSandboxGpu).toHaveBeenCalledWith("alpha");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("reached local inference"));
   });
 
   it("captures the CUDA-usability proof onto the config for status persistence (#4231)", () => {
     const proof = { status: "verified" as const, cudaVerified: true, at: "t" };
-    // Fresh config so the assignment does not leak into the shared GPU_CONFIG.
     const config: { sandboxGpuEnabled: boolean; sandboxGpuProof?: typeof proof | null } = {
       sandboxGpuEnabled: true,
     };
@@ -318,12 +296,7 @@ describe("verifyGpuSandboxAfterReady", () => {
       "vllm-local",
       baseOptions({
         verifyDirectSandboxGpu: vi.fn(() => proof),
-        deps: {
-          findContainerIds: () => ["container-abc"],
-          dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-          dockerRun: dockerRunWithCurl({ status: 0 }),
-          sleep: vi.fn(),
-        },
+        deps: { execInSandbox: execEmitting("HTTP_200"), sleep: vi.fn() },
       }),
     );
     expect(config.sandboxGpuProof).toEqual(proof);
@@ -336,11 +309,7 @@ describe("verifyGpuSandboxAfterReady", () => {
     });
     const logError = vi.fn();
     expect(() =>
-      verifyGpuSandboxAfterReady(
-        GPU_CONFIG,
-        "ollama-local",
-        baseOptions({ verifyGpuOrExit, logError }),
-      ),
+      verifyGpuSandboxAfterReady(GPU_CONFIG, "ollama-local", baseOptions({ verifyGpuOrExit, logError })),
     ).toThrow(proofError);
     expect(logError).not.toHaveBeenCalled();
   });
@@ -357,12 +326,7 @@ describe("verifyGpuSandboxAfterReady", () => {
           "ollama-local",
           baseOptions({
             logError,
-            deps: {
-              findContainerIds: () => ["container-xyz"],
-              dockerCapture: vi.fn(() => inspectWithNetworkMode("host")),
-              dockerRun: dockerRunWithCurl({ status: 7, stderr: "Connection refused" }),
-              sleep: vi.fn(),
-            },
+            deps: { execInSandbox: execEmitting("HTTP_000"), sleep: vi.fn() },
           }),
         ),
       ).toThrow("process.exit");
@@ -375,8 +339,8 @@ describe("verifyGpuSandboxAfterReady", () => {
     }
   });
 
-  it("skips the inference gate when the Docker GPU patch did not recreate the container", () => {
-    const findContainerIds = vi.fn(() => ["container-abc"]);
+  it("skips the inference gate when the Docker GPU patch did not run", () => {
+    const execInSandbox = vi.fn();
     const verifyDirectSandboxGpu = vi.fn();
     verifyGpuSandboxAfterReady(
       GPU_CONFIG,
@@ -384,37 +348,33 @@ describe("verifyGpuSandboxAfterReady", () => {
       baseOptions({
         useDockerGpuPatch: false,
         verifyDirectSandboxGpu,
-        deps: { findContainerIds, dockerCapture: vi.fn(), dockerRun: vi.fn(), sleep: vi.fn() },
+        deps: { execInSandbox, sleep: vi.fn() },
       }),
     );
     expect(verifyDirectSandboxGpu).toHaveBeenCalledWith("alpha");
-    // No container resolution happens when the patch is not in play.
-    expect(findContainerIds).not.toHaveBeenCalled();
+    expect(execInSandbox).not.toHaveBeenCalled();
   });
 });
 
-describe("printDockerGpuHostNetworkInferenceVerificationFailure", () => {
-  it("surfaces endpoint, network mode, container id, and recovery hints", () => {
+describe("printDockerGpuSandboxInferenceVerificationFailure", () => {
+  it("surfaces endpoint, provider label, detail, and recovery hints", () => {
     const lines: string[] = [];
-    printDockerGpuHostNetworkInferenceVerificationFailure(
+    printDockerGpuSandboxInferenceVerificationFailure(
       {
         status: "failed",
-        kind: "probe",
+        kind: "unreachable",
         provider: "ollama-local",
+        endpoint: "https://inference.local/v1/models",
         message: "unreachable",
-        containerId: "container-xyz",
-        networkMode: "host",
-        endpoint: "http://127.0.0.1:11434/api/tags",
-        detail: "Connection refused",
+        detail: "returned HTTP 000",
         recovery: ["do the thing"],
       },
       (line) => lines.push(line),
     );
     const text = lines.join("\n");
-    expect(text).toContain("container=container-xyz");
-    expect(text).toContain("network_mode=host");
-    expect(text).toContain("endpoint=http://127.0.0.1:11434/api/tags");
+    expect(text).toContain("endpoint=https://inference.local/v1/models");
     expect(text).toContain("Local Ollama");
+    expect(text).toContain("HTTP 000");
     expect(text).toContain("do the thing");
   });
 });

--- a/src/lib/onboard/docker-gpu-local-inference.ts
+++ b/src/lib/onboard/docker-gpu-local-inference.ts
@@ -1,33 +1,32 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { dockerCapture, dockerRun } from "../adapters/docker";
-import {
-  getLocalProviderHealthEndpoint,
-  getLocalProviderLabel,
-  getLocalProviderValidationBaseUrl,
-  LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV,
-} from "../inference/local";
+import { getLocalProviderLabel } from "../inference/local";
 import type { SandboxGpuProofResult } from "../state/registry";
 import {
   DOCKER_GPU_PATCH_NETWORK_ENV,
   type DockerGpuPatchMode,
-  findOpenShellDockerSandboxContainerIds,
   getDockerGpuPatchNetworkMode,
-  parseDockerInspectJson,
   printDockerGpuProofFailure,
   shouldApplyDockerGpuPatch,
 } from "./docker-gpu-patch";
+import { executeSandboxCommandForVerification } from "./sandbox-verification-exec";
 
 const {
   LOCAL_INFERENCE_PROVIDERS,
 }: { LOCAL_INFERENCE_PROVIDERS: string[] } = require("./providers");
 
-const DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS = 30_000;
 const DOCKER_GPU_INFERENCE_PROBE_CONNECT_TIMEOUT_SECS = 5;
 const DOCKER_GPU_INFERENCE_PROBE_MAX_TIME_SECS = 10;
 const DOCKER_GPU_INFERENCE_PROBE_MAX_ATTEMPTS = 3;
 const DOCKER_GPU_INFERENCE_PROBE_RETRY_DELAY_SECS = 2;
+
+// The OpenShell inference route OpenClaw's LLM client actually uses inside the
+// sandbox. It is served by the OpenShell L7 proxy/router and routes to the
+// configured provider backend — the same hostname the agent talks to (see
+// verify-deployment.ts:verifyInferenceRoute). Probing it from the sandbox
+// runtime exercises the exact path the agent uses, not a host-only shortcut.
+const SANDBOX_RUNTIME_INFERENCE_ENDPOINT = "https://inference.local/v1/models";
 
 type DockerGpuLocalInferenceConfig = {
   sandboxGpuEnabled: boolean;
@@ -45,10 +44,14 @@ type DockerGpuLocalInferenceOptions = {
   log?: (message: string) => void;
 };
 
+function isLocalInferenceProvider(provider: string | null | undefined): provider is string {
+  return Boolean(provider && LOCAL_INFERENCE_PROVIDERS.includes(provider));
+}
+
 /**
- * True only on the Linux Docker-driver GPU patch path with
- * `NEMOCLAW_DOCKER_GPU_PATCH_NETWORK=host`, i.e. when the recreated sandbox
- * uses host networking and local inference is wired to the direct loopback URL.
+ * True on the Linux Docker-driver GPU patch path with
+ * `NEMOCLAW_DOCKER_GPU_PATCH_NETWORK=host`, i.e. when the recreated sandbox was
+ * requested with host networking.
  */
 export function shouldUseDockerGpuPatchHostNetwork(
   config: DockerGpuLocalInferenceConfig,
@@ -63,308 +66,285 @@ export function shouldUseDockerGpuPatchHostNetwork(
   );
 }
 
-export function configureLocalInferenceForDockerGpuHostNetwork(
-  config: DockerGpuLocalInferenceConfig,
-  options: DockerGpuLocalInferenceOptions & { note: (message: string) => void },
-): void {
-  const env = options.env ?? process.env;
-  if (!shouldUseDockerGpuPatchHostNetwork(config, options)) return;
-  if (!env[LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV]) {
-    env[LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV] = "http://127.0.0.1";
-    options.note(
-      "  Docker-driver GPU patch will use host networking; local inference providers will use sandbox loopback.",
-    );
-    return;
-  }
-  options.note(
-    `  Docker-driver GPU patch will use host networking; local inference providers will use ${LOCAL_INFERENCE_SANDBOX_HOST_URL_ENV}.`,
-  );
-}
-
-export function dockerGpuPatchHostNetworkInferenceBaseUrl(
-  config: DockerGpuLocalInferenceConfig,
+/**
+ * The OpenShell Docker-driver sandbox runs the agent in its own (isolated)
+ * network namespace — see `detectSandboxFallbackDns` in docker-gpu-patch.ts —
+ * so `127.0.0.1` inside the agent runtime is the sandbox's own loopback, not
+ * the host's, even when the recreated outer container is `--network host`. The
+ * opt-in host-network GPU mode (`NEMOCLAW_DOCKER_GPU_PATCH_NETWORK=host`) was
+ * only ever meant to let OpenClaw reach a host-loopback inference server
+ * directly, but that loopback is unreachable from the sandbox namespace: the
+ * agent fails at runtime with `ECONNREFUSED` ("LLM request failed: network
+ * connection error") while a `docker exec` probe — running in the container's
+ * main namespace, which IS the host under `--network host` — falsely succeeds.
+ * That mismatch is the reopened-#4509 false positive.
+ *
+ * Host networking is also unnecessary for GPU device access (that comes from
+ * the GPU mode flags — `--gpus`/CDI/NVIDIA runtime — independent of the
+ * container network mode). So downgrade the recreate to the OpenShell-managed
+ * bridge network (`preserve`), where local inference routes through the
+ * reachable `inference.local` path the sandbox namespace can use.
+ *
+ * Scoped to LOCAL inference providers — that is the only case the host-network
+ * opt-in was meant to serve, and the only one this breaks. Non-local (cloud /
+ * routed / custom) GPU sandboxes keep their requested network mode untouched.
+ * Runs at sandbox build time, after the provider is resolved and before the GPU
+ * container recreate reads the network mode.
+ *
+ * When a downgrade is applied, also re-runs the sandbox bridge reachability
+ * probe (with UFW auto-fix): gateway startup skipped it on the assumption that
+ * the sandbox would be on host networking, but the sandbox is now committed to
+ * the OpenShell bridge, so a default-deny firewall must fail fast / self-heal
+ * before the build rather than surface as a late, opaque failure.
+ *
+ * Returns true when a downgrade was applied.
+ */
+export async function enforceDockerGpuPatchPreserveNetwork(
   provider: string | null | undefined,
-  options: DockerGpuLocalInferenceOptions,
-): string | null {
-  if (!shouldUseDockerGpuPatchHostNetwork(config, options)) return null;
-  if (!provider || !LOCAL_INFERENCE_PROVIDERS.includes(provider)) return null;
-  const baseUrl = getLocalProviderValidationBaseUrl(provider);
-  if (baseUrl) {
-    options.log?.(
-      `  Docker-driver GPU host networking: OpenClaw local inference will use direct sandbox URL ${baseUrl}.`,
-    );
-  }
-  return baseUrl;
+  config: DockerGpuLocalInferenceConfig,
+  options: DockerGpuLocalInferenceOptions & {
+    reverifyBridgeReachability?: () => void | Promise<void>;
+  },
+): Promise<boolean> {
+  if (!isLocalInferenceProvider(provider)) return false;
+  if (!shouldUseDockerGpuPatchHostNetwork(config, options)) return false;
+  const env = options.env ?? process.env;
+  env[DOCKER_GPU_PATCH_NETWORK_ENV] = "preserve";
+  options.log?.(
+    "  Docker-driver GPU patch keeps OpenShell bridge networking for local inference: the host " +
+      "loopback is not reachable from the sandbox network namespace, so OpenClaw routes through " +
+      "the OpenShell-managed inference path (host networking is not needed for GPU device access).",
+  );
+  await (options.reverifyBridgeReachability ?? defaultReverifyBridgeReachability)();
+  return true;
 }
 
-type DockerRunResult = {
-  status?: number | null;
-  stdout?: string | Buffer | null;
-  stderr?: string | Buffer | null;
-};
+/** Re-run the sandbox→gateway bridge reachability probe (with UFW auto-fix). */
+function defaultReverifyBridgeReachability(): Promise<void> {
+  const { verifySandboxBridgeGatewayReachableOrExit } =
+    require("./gateway-sandbox-reachability") as typeof import("./gateway-sandbox-reachability");
+  return verifySandboxBridgeGatewayReachableOrExit(true, { skip: false });
+}
 
-export type DockerGpuHostNetworkInferenceVerifyDeps = {
-  findContainerIds?: (sandboxName: string) => string[];
-  dockerCapture?: (args: readonly string[], opts?: Record<string, unknown>) => string;
-  dockerRun?: (args: readonly string[], opts?: Record<string, unknown>) => DockerRunResult;
+export type SandboxExecResult = { status: number; stdout: string; stderr: string } | null;
+
+export type DockerGpuSandboxInferenceVerifyDeps = {
+  execInSandbox?: (sandboxName: string, script: string) => SandboxExecResult;
   sleep?: (seconds: number) => void;
 };
 
-export type DockerGpuHostNetworkInferenceVerification =
+export type DockerGpuSandboxInferenceVerification =
   | { status: "skipped"; reason: string }
-  | { status: "ok"; provider: string; containerId: string; networkMode: string; endpoint: string }
+  | { status: "ok"; provider: string; endpoint: string; httpCode: string }
   | {
       status: "failed";
-      kind: "container-not-found" | "network-mode" | "probe";
+      kind: "exec" | "unreachable";
       provider: string;
+      endpoint: string;
       message: string;
-      containerId: string | null;
-      networkMode: string | null;
-      endpoint: string | null;
       detail: string | null;
       recovery: string[];
     };
 
-/** Flatten a docker run result's stderr/stdout into a single trimmed string. */
-function resultText(result: DockerRunResult | null | undefined): string {
-  if (!result) return "";
-  return `${String(result.stderr || "")} ${String(result.stdout || "")}`.trim();
+/** The runtime inference route to probe for a provider (local providers only). */
+export function getSandboxRuntimeInferenceEndpoint(provider: string | null | undefined): string | null {
+  return isLocalInferenceProvider(provider) ? SANDBOX_RUNTIME_INFERENCE_ENDPOINT : null;
 }
+
+type RuntimeProbeOutcome =
+  | { kind: "ok"; httpCode: string }
+  | { kind: "no-curl" }
+  | { kind: "exec-failed"; detail: string }
+  | { kind: "unreachable"; detail: string };
 
 /**
- * Inspect a container and return its `HostConfig.NetworkMode`, or `null` when
- * the inspect output is empty or unparseable.
+ * Probe the inference route from the actual OpenClaw runtime context via
+ * `openshell sandbox exec` — the sandbox's own network namespace, the context
+ * the agent's LLM client runs in — rather than `docker exec` against the
+ * recreated container, whose main namespace is the host's under `--network
+ * host` and therefore masked the #4509 failure.
+ *
+ * A single script proves the exec path works (it emits a sentinel), reports a
+ * genuinely missing `curl` separately from an exec failure, and otherwise hits
+ * `inference.local` exactly as OpenClaw does (through the sandbox proxy). This
+ * mirrors verify-deployment.ts:verifyInferenceRoute: any HTTP status means the
+ * route resolves and responds; `000` means DNS failure or connection refused —
+ * the reopened-#4509 symptom.
  */
-function inspectContainerNetworkMode(
-  containerId: string,
-  dockerCaptureFn: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerCapture"]>,
-): string | null {
-  try {
-    const output = dockerCaptureFn(["inspect", "--type", "container", containerId], {
-      ignoreError: true,
-      timeout: DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS,
-    });
-    if (!output || !output.trim()) return null;
-    const inspect = parseDockerInspectJson(output);
-    const mode = String(inspect.HostConfig?.NetworkMode || "").trim();
-    return mode || null;
-  } catch {
-    return null;
-  }
-}
-
-/** Returns true when `curl` is on PATH inside the container (probe tooling). */
-function containerHasCurl(
-  containerId: string,
-  dockerRunFn: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerRun"]>,
-): boolean {
-  try {
-    const result = dockerRunFn(
-      ["exec", containerId, "sh", "-lc", "command -v curl >/dev/null 2>&1"],
-      {
-        ignoreError: true,
-        suppressOutput: true,
-        timeout: DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS,
-      },
-    );
-    return Number(result?.status ?? 1) === 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Probe the direct loopback inference endpoint from inside the container with
- * bounded retries. Returns `{ ok: true }` on the first 2xx, otherwise `ok:
- * false` with the last failure detail.
- */
-function probeContainerInferenceEndpoint(
-  containerId: string,
+function probeSandboxRuntimeInference(
+  sandboxName: string,
   endpoint: string,
   deps: {
-    dockerRun: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["dockerRun"]>;
-    sleep: NonNullable<DockerGpuHostNetworkInferenceVerifyDeps["sleep"]>;
+    execInSandbox: NonNullable<DockerGpuSandboxInferenceVerifyDeps["execInSandbox"]>;
+    sleep: NonNullable<DockerGpuSandboxInferenceVerifyDeps["sleep"]>;
   },
-): { ok: boolean; detail: string | null } {
-  let detail: string | null = null;
+): RuntimeProbeOutcome {
+  // Single-quote the endpoint (POSIX-escaping any embedded quotes) so it can
+  // never break out of the curl argument. It is a constant today, but the
+  // signature accepts any string — keep the shell construction injection-safe.
+  const safeEndpoint = `'${endpoint.replace(/'/g, "'\\''")}'`;
+  const script =
+    `if ! command -v curl >/dev/null 2>&1; then echo NO_CURL; exit 0; fi; ` +
+    `code=$(curl -so /dev/null -w '%{http_code}' ` +
+    `--connect-timeout ${DOCKER_GPU_INFERENCE_PROBE_CONNECT_TIMEOUT_SECS} ` +
+    `--max-time ${DOCKER_GPU_INFERENCE_PROBE_MAX_TIME_SECS} ${safeEndpoint} 2>/dev/null || echo 000); ` +
+    `echo "HTTP_$code"`;
+  let last: RuntimeProbeOutcome = {
+    kind: "exec-failed",
+    detail: "openshell sandbox exec did not run (sandbox unreachable or exec timed out)",
+  };
   for (let attempt = 1; attempt <= DOCKER_GPU_INFERENCE_PROBE_MAX_ATTEMPTS; attempt++) {
-    try {
-      // Run curl from inside the recreated host-network container so the probe
-      // exercises the exact loopback path OpenClaw will use (127.0.0.1 ->
-      // host loopback under --network host). Inherit the container's own proxy
-      // env so NO_PROXY/loopback handling matches the agent runtime.
-      const result = deps.dockerRun(
-        [
-          "exec",
-          containerId,
-          "curl",
-          "-sf",
-          "--connect-timeout",
-          String(DOCKER_GPU_INFERENCE_PROBE_CONNECT_TIMEOUT_SECS),
-          "--max-time",
-          String(DOCKER_GPU_INFERENCE_PROBE_MAX_TIME_SECS),
-          "-o",
-          "/dev/null",
-          endpoint,
-        ],
-        {
-          ignoreError: true,
-          suppressOutput: true,
-          timeout: DOCKER_GPU_INFERENCE_VERIFY_TIMEOUT_MS,
-        },
-      );
-      if (Number(result?.status ?? 1) === 0) return { ok: true, detail: null };
-      detail = resultText(result) || "docker exec curl exited non-zero";
-    } catch (error) {
-      detail = error instanceof Error ? error.message : String(error);
+    const result = deps.execInSandbox(sandboxName, script);
+    if (result === null) {
+      last = {
+        kind: "exec-failed",
+        detail: "openshell sandbox exec did not run (sandbox unreachable or exec timed out)",
+      };
+    } else {
+      const out = (result.stdout || "").trim();
+      if (out === "NO_CURL") return { kind: "no-curl" };
+      const match = out.match(/HTTP_(\d{3})/);
+      if (match) {
+        const httpCode = match[1];
+        // This gate is the #4509 runtime proof, so only a 2xx — the model list
+        // actually returned through the proxy with injected auth — counts as
+        // success. `000` is the reported failure (DNS / connection refused). A
+        // 4xx (wrong provider route, or auth the proxy failed to inject) or 5xx
+        // (local Ollama/vLLM backend down) means OpenClaw's real request would
+        // fail too, so do NOT report it as reachable.
+        if (/^2\d\d$/.test(httpCode)) return { kind: "ok", httpCode };
+        last = {
+          kind: "unreachable",
+          detail:
+            httpCode === "000"
+              ? `${endpoint} returned HTTP 000 (DNS failure or connection refused)`
+              : `${endpoint} returned HTTP ${httpCode} (inference route reached but not usable — provider route/auth misconfigured or the local backend is failing)`,
+        };
+      } else {
+        // The exec ran but produced no sentinel — the sandbox runtime exec
+        // path itself is broken (e.g. sandbox in Error, exec denied). Treat as
+        // an exec failure, NOT a missing-curl soft-skip, so we never declare
+        // success without actually exercising the runtime (#4509 review).
+        const noise = (out || result.stderr || "").slice(0, 160);
+        last = { kind: "exec-failed", detail: `unexpected sandbox exec output: ${noise}` };
+      }
     }
     if (attempt < DOCKER_GPU_INFERENCE_PROBE_MAX_ATTEMPTS) {
       deps.sleep(DOCKER_GPU_INFERENCE_PROBE_RETRY_DELAY_SECS);
     }
   }
-  return { ok: false, detail };
+  return last;
 }
 
 /**
- * Post-recreate reachability gate for Docker-driver GPU host-network local
- * inference (#4509). After the GPU patch recreates the sandbox container with
- * `--network host` and OpenClaw is wired to the direct `127.0.0.1` provider
- * URL, prove the real container can actually reach that endpoint before
- * onboarding declares success — otherwise the failure only surfaces later as
- * an opaque `ECONNREFUSED` during an agent prompt.
+ * Post-ready local-inference reachability gate for the Docker-driver GPU path
+ * (#4509). After the sandbox reaches Ready, prove the OpenClaw agent runtime
+ * can actually reach the local inference route — from inside the sandbox's own
+ * network namespace, the context the agent's LLM client uses — before
+ * onboarding declares success. Otherwise an unreachable provider only surfaces
+ * later as an opaque `ECONNREFUSED` / "LLM request failed: network connection
+ * error" during the first agent prompt.
  *
- * Self-gates: returns `skipped` unless the host-network GPU patch is active
- * for a local inference provider.
+ * Self-gates: returns `skipped` unless the GPU Docker-driver patch is active
+ * for a local inference provider. Soft-skips (with a warning) only when the
+ * sandbox image genuinely lacks `curl` — OpenClaw's HTTP client does not need
+ * it, so a missing probe tool must not block an otherwise usable sandbox.
  */
-export function verifyDockerGpuHostNetworkLocalInference(
+export function verifyDockerGpuSandboxLocalInference(
   config: DockerGpuLocalInferenceConfig,
   provider: string | null | undefined,
   options: DockerGpuLocalInferenceOptions & {
     sandboxName: string;
-    deps?: DockerGpuHostNetworkInferenceVerifyDeps;
+    deps?: DockerGpuSandboxInferenceVerifyDeps;
   },
-): DockerGpuHostNetworkInferenceVerification {
-  if (!shouldUseDockerGpuPatchHostNetwork(config, options)) {
-    return { status: "skipped", reason: "not-host-network-gpu" };
+): DockerGpuSandboxInferenceVerification {
+  if (
+    !shouldApplyDockerGpuPatch(config, {
+      dockerDriverGateway: options.dockerDriverGateway,
+      env: options.env,
+      platform: options.platform,
+    })
+  ) {
+    return { status: "skipped", reason: "not-docker-gpu-patch" };
   }
-  if (!provider || !LOCAL_INFERENCE_PROVIDERS.includes(provider)) {
+  if (!isLocalInferenceProvider(provider)) {
     return { status: "skipped", reason: "not-local-provider" };
   }
-  const endpoint = getLocalProviderHealthEndpoint(provider);
+  const endpoint = getSandboxRuntimeInferenceEndpoint(provider);
   if (!endpoint) {
-    return { status: "skipped", reason: "no-health-endpoint" };
+    return { status: "skipped", reason: "no-runtime-endpoint" };
   }
 
   const deps = options.deps ?? {};
-  const findContainerIds =
-    deps.findContainerIds ?? ((name: string) => findOpenShellDockerSandboxContainerIds(name));
-  const dockerCaptureFn = deps.dockerCapture ?? dockerCapture;
-  const dockerRunFn = deps.dockerRun ?? dockerRun;
+  const execInSandbox = deps.execInSandbox ?? executeSandboxCommandForVerification;
   const sleep =
     deps.sleep ??
     ((seconds: number) => {
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, seconds) * 1000);
     });
 
-  const containerId = findContainerIds(options.sandboxName)[0];
-  if (!containerId) {
-    return {
-      status: "failed",
-      kind: "container-not-found",
-      provider,
-      message: `Could not find the recreated OpenShell Docker container for sandbox '${options.sandboxName}'.`,
-      containerId: null,
-      networkMode: null,
-      endpoint,
-      detail: null,
-      recovery: [
-        "Confirm the sandbox container is running:  openshell sandbox list",
-        "Re-run onboarding; the Docker GPU container recreate may not have completed.",
-      ],
-    };
-  }
+  const outcome = probeSandboxRuntimeInference(options.sandboxName, endpoint, {
+    execInSandbox,
+    sleep,
+  });
 
-  const networkMode = inspectContainerNetworkMode(containerId, dockerCaptureFn);
-  if (networkMode !== "host") {
-    return {
-      status: "failed",
-      kind: "network-mode",
-      provider,
-      message:
-        `Docker-driver GPU host networking was requested (${DOCKER_GPU_PATCH_NETWORK_ENV}=host) but the ` +
-        `recreated sandbox container is on network mode '${networkMode ?? "unknown"}'. OpenClaw is wired ` +
-        `to ${endpoint}, which is only reachable under --network host.`,
-      containerId,
-      networkMode: networkMode ?? null,
-      endpoint,
-      detail: null,
-      recovery: [
-        "The GPU patch only switches to --network host when it can rewrite OPENSHELL_ENDPOINT",
-        "  from host.openshell.internal to 127.0.0.1; check the recreate logs above.",
-        `Re-run with ${DOCKER_GPU_PATCH_NETWORK_ENV}=host, or omit it to use the proxy inference path.`,
-      ],
-    };
+  if (outcome.kind === "ok") {
+    return { status: "ok", provider, endpoint, httpCode: outcome.httpCode };
   }
-
-  // Minimal/custom images (e.g. some --from-dockerfile bases) may not ship
-  // curl. A missing probe tool must not be reported as an unreachable
-  // endpoint — that would turn a tooling gap into a false onboarding failure.
-  // Soft-skip with a visible warning instead, preserving prior behavior where
-  // there was no gate at all (#4509 review follow-up).
-  if (!containerHasCurl(containerId, dockerRunFn)) {
-    // Always surface this skip: it is the operator's only explanation for why
-    // the reachability proof did not run. Fall back to console.warn when no
-    // logger is wired so the warning is never silently dropped.
+  if (outcome.kind === "no-curl") {
+    // Minimal/custom images (e.g. some `--from-dockerfile` bases) may not ship
+    // curl. Soft-skip with a visible warning rather than fail onboarding; fall
+    // back to console.warn so the skip reason is never silently dropped.
     const warn = options.log ?? ((message: string) => console.warn(message));
     warn(
-      `  ⚠ Skipping host-network local inference reachability check: curl is not available in ${containerId}.`,
+      `  ⚠ Skipping GPU sandbox local inference reachability check: curl is not available in the sandbox (${options.sandboxName}).`,
     );
     return { status: "skipped", reason: "probe-tool-unavailable" };
   }
 
-  const probe = probeContainerInferenceEndpoint(containerId, endpoint, {
-    dockerRun: dockerRunFn,
-    sleep,
-  });
-  if (!probe.ok) {
-    return {
-      status: "failed",
-      kind: "probe",
-      provider,
-      message: `The recreated host-network sandbox container could not reach the local inference endpoint ${endpoint}.`,
-      containerId,
-      networkMode,
-      endpoint,
-      detail: probe.detail,
-      recovery: [
-        `Confirm the provider is listening on the host loopback:  curl ${endpoint}`,
-        "Ensure Ollama/vLLM binds 127.0.0.1 directly (not only a container bridge address).",
-        "Check that HTTP_PROXY/NO_PROXY inside the sandbox do not intercept the loopback request.",
-        "Set NEMOCLAW_DOCKER_GPU_PATCH=0 to skip the GPU container recreate and use the proxy path.",
-      ],
-    };
-  }
-
-  return { status: "ok", provider, containerId, networkMode, endpoint };
+  const recovery =
+    outcome.kind === "exec-failed"
+      ? [
+          "Confirm the sandbox is running and reachable:  openshell sandbox list",
+          "Re-run onboarding; the sandbox runtime exec path did not respond.",
+        ]
+      : [
+          "Ensure Ollama/vLLM is running and the OpenShell inference route is configured.",
+          "Check the sandbox can reach inference.local (proxy/router up):",
+          `  openshell sandbox exec -n ${options.sandboxName} -- curl -sS ${endpoint}`,
+          "If a host firewall (e.g. UFW) blocks the Docker bridge, allow it so the sandbox",
+          "  can reach the gateway/proxy, then re-run onboarding.",
+          "Do not force NEMOCLAW_DOCKER_GPU_PATCH_NETWORK=host for local inference — the host",
+          "  loopback is not reachable from the sandbox's isolated network namespace.",
+        ];
+  return {
+    status: "failed",
+    kind: outcome.kind === "exec-failed" ? "exec" : "unreachable",
+    provider,
+    endpoint,
+    message:
+      outcome.kind === "exec-failed"
+        ? "The GPU sandbox runtime exec path did not respond, so local inference reachability could not be proven."
+        : `The GPU sandbox runtime could not reach the local inference route ${endpoint} (the context OpenClaw's LLM client uses).`,
+    detail: outcome.detail,
+    recovery,
+  };
 }
 
 /**
- * Print a failed host-network inference verification result as actionable
- * operator output: the message, provider, container, network mode, endpoint,
- * truncated detail, and recovery hints. Defaults to `console.error`.
+ * Print a failed sandbox-runtime inference verification result as actionable
+ * operator output. Defaults to `console.error`.
  */
-export function printDockerGpuHostNetworkInferenceVerificationFailure(
-  verification: Extract<DockerGpuHostNetworkInferenceVerification, { status: "failed" }>,
+export function printDockerGpuSandboxInferenceVerificationFailure(
+  verification: Extract<DockerGpuSandboxInferenceVerification, { status: "failed" }>,
   log: (message: string) => void = (message) => console.error(message),
 ): void {
   const providerLabel = getLocalProviderLabel(verification.provider) ?? verification.provider;
   log("");
-  log("  Local inference reachability check failed for the GPU host-network sandbox.");
+  log("  Local inference reachability check failed for the GPU sandbox runtime.");
   log(`  ${verification.message}`);
   log(`  provider=${providerLabel}`);
-  if (verification.containerId) log(`  container=${verification.containerId}`);
-  if (verification.networkMode) log(`  network_mode=${verification.networkMode}`);
-  if (verification.endpoint) log(`  endpoint=${verification.endpoint}`);
+  log(`  endpoint=${verification.endpoint}`);
   if (verification.detail) log(`  detail=${verification.detail.slice(0, 300)}`);
   log("  Recovery:");
   for (const line of verification.recovery) log(`    ${line}`);
@@ -384,15 +364,16 @@ export type GpuSandboxAfterReadyOptions = {
   platform?: NodeJS.Platform;
   log?: (message: string) => void;
   logError?: (message: string) => void;
-  deps?: DockerGpuHostNetworkInferenceVerifyDeps;
+  deps?: DockerGpuSandboxInferenceVerifyDeps;
 };
 
 /**
  * Post-readiness GPU sandbox verification orchestrator (kept out of the
  * ~12k-line onboard.ts entrypoint per the codebase-growth guardrail). Runs the
- * direct GPU proof, then — only when the Docker GPU patch recreated the
- * container — gates on host-network local inference reachability (#4509). Exits
- * the process with actionable output if either proof fails.
+ * direct GPU proof, then — only when the Docker GPU patch is active for a local
+ * inference provider — gates on local inference reachability from the sandbox
+ * runtime (#4509). Exits the process with actionable output if either proof
+ * fails.
  */
 export function verifyGpuSandboxAfterReady(
   config: DockerGpuLocalInferenceConfig,
@@ -419,9 +400,9 @@ export function verifyGpuSandboxAfterReady(
   }
 
   // When NEMOCLAW_DOCKER_GPU_PATCH=0, useDockerGpuPatch is false and there is no
-  // recreated container to probe, so skip the host-network inference gate.
+  // GPU-patched sandbox to gate, so skip the local inference reachability gate.
   if (!options.useDockerGpuPatch) return;
-  const verification = verifyDockerGpuHostNetworkLocalInference(config, provider, {
+  const verification = verifyDockerGpuSandboxLocalInference(config, provider, {
     sandboxName: options.sandboxName,
     dockerDriverGateway: options.dockerDriverGateway,
     env: options.env,
@@ -431,12 +412,14 @@ export function verifyGpuSandboxAfterReady(
   });
   const log = options.log ?? console.log;
   if (verification.status === "ok") {
-    log(`  ✓ GPU host-network local inference reachable from sandbox: ${verification.endpoint}`);
+    log(
+      `  ✓ GPU sandbox runtime reached local inference: ${verification.endpoint} (HTTP ${verification.httpCode})`,
+    );
   } else if (verification.status === "failed") {
     // Route failure diagnostics through the caller-provided error sink so
     // wrappers / structured log collectors still see them; defaults to
     // console.error (onboard's stderr error channel).
-    printDockerGpuHostNetworkInferenceVerificationFailure(
+    printDockerGpuSandboxInferenceVerificationFailure(
       verification,
       options.logError ?? ((message) => console.error(message)),
     );

--- a/test/e2e/test-gpu-e2e.sh
+++ b/test/e2e/test-gpu-e2e.sh
@@ -320,19 +320,32 @@ else
   fail "Onboard GPU proof missing: cuInit(0)"
 fi
 
-# 4d.1: Host-network local inference reachability gate (#4509). When the GPU
-# patch wires OpenClaw to the direct 127.0.0.1 sandbox URL, onboard must prove
-# the recreated host-network container can actually reach that endpoint before
-# declaring success — instead of leaving an unreachable loopback to surface as
-# an opaque ECONNREFUSED during the first agent prompt.
-if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG"; then
-  if grep -Fq "GPU host-network local inference reachable from sandbox" "$INSTALL_LOG"; then
-    pass "Onboard proved host-network local inference reachable before success"
+# 4d.1: GPU sandbox local-inference reachability gate (#4509). Onboard must
+# prove the OpenClaw agent runtime can reach the local inference backend from
+# inside the sandbox's own network namespace — the context the agent's LLM
+# client uses — before declaring success. PR #4609 probed this with `docker
+# exec` against the recreated `--network host` container, whose main namespace
+# is the host's, so a probe there passed while the agent (in OpenShell's
+# isolated sandbox netns) still got ECONNREFUSED. The gate now probes via
+# `openshell sandbox exec`, so this proof reflects the real runtime path.
+if grep -Fq "Docker GPU mode selected" "$INSTALL_LOG"; then
+  if grep -Fq "GPU sandbox runtime reached local inference" "$INSTALL_LOG"; then
+    pass "Onboard proved local inference reachable from the sandbox runtime (#4509)"
   else
-    fail "Onboard did not prove host-network local inference reachability (#4509 gate missing)"
+    fail "Onboard did not prove sandbox-runtime local inference reachability (#4509 gate missing)"
   fi
 else
-  skip "Host-network direct sandbox URL not active; inference reachability gate not exercised"
+  skip "Docker GPU patch recreate not exercised; sandbox-runtime inference gate not asserted"
+fi
+# If host networking was opted into, onboard must downgrade it to the
+# OpenShell-managed bridge path for local inference (host loopback is not
+# reachable from the sandbox network namespace).
+if [ "${NEMOCLAW_DOCKER_GPU_PATCH_NETWORK:-}" = "host" ]; then
+  if grep -Fq "keeps OpenShell bridge networking for local inference" "$INSTALL_LOG"; then
+    pass "Host-network opt-in downgraded to bridge for local inference (#4509)"
+  else
+    fail "Host-network opt-in was NOT downgraded for local inference (#4509)"
+  fi
 fi
 
 # 4e: Inference provider is ollama-local
@@ -533,37 +546,16 @@ else
   fail "[LOCAL] Direct Ollama: empty response"
 fi
 
-# 5b: Inference through sandbox → provider route → Ollama. When the Docker GPU
-# patch preserves the original sandbox network, inference still goes through
-# inference.local; use docker exec only to avoid depending on OpenShell exec
-# after the container is recreated. Host-network GPU patch runs are the only
-# mode where OpenClaw is configured with a direct loopback Ollama URL.
+# 5b: Inference through the sandbox → OpenShell route → Ollama, proven from the
+# ACTUAL OpenClaw runtime context (#4509). This MUST go through `openshell
+# sandbox exec` — the agent runs in OpenShell's isolated sandbox network
+# namespace, so a `docker exec` probe against the recreated container (whose
+# main namespace is the host's under `--network host`) does NOT exercise the
+# path the agent uses and previously masked the reopened ECONNREFUSED. OpenClaw
+# is wired to the OpenShell-managed inference endpoint (inference.local), never
+# a direct container loopback URL.
 SANDBOX_INFERENCE_URL="https://inference.local/v1/chat/completions"
-SANDBOX_INFERENCE_EXEC="openshell"
-SANDBOX_INFERENCE_DOCKER_EXEC_ENV=()
-if grep -Fq "OpenClaw local inference will use direct sandbox URL" "$INSTALL_LOG"; then
-  OLLAMA_HOST_PORT="${NEMOCLAW_OLLAMA_PORT:-11434}"
-  SANDBOX_INFERENCE_URL="http://127.0.0.1:${OLLAMA_HOST_PORT}/v1/chat/completions"
-  SANDBOX_INFERENCE_EXEC="docker"
-elif grep -Fq "Docker-driver GPU patch active" "$INSTALL_LOG"; then
-  SANDBOX_INFERENCE_EXEC="docker"
-fi
-if [ "$SANDBOX_INFERENCE_EXEC" = "docker" ] && [[ "$SANDBOX_INFERENCE_URL" == https://inference.local/* ]]; then
-  INFERENCE_PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
-  INFERENCE_PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
-  INFERENCE_PROXY_URL="http://${INFERENCE_PROXY_HOST}:${INFERENCE_PROXY_PORT}"
-  INFERENCE_NO_PROXY="localhost,127.0.0.1,::1,${INFERENCE_PROXY_HOST}"
-  SANDBOX_INFERENCE_DOCKER_EXEC_ENV=(
-    --env "HTTP_PROXY=${INFERENCE_PROXY_URL}"
-    --env "HTTPS_PROXY=${INFERENCE_PROXY_URL}"
-    --env "NO_PROXY=${INFERENCE_NO_PROXY}"
-    --env "http_proxy=${INFERENCE_PROXY_URL}"
-    --env "https_proxy=${INFERENCE_PROXY_URL}"
-    --env "no_proxy=${INFERENCE_NO_PROXY}"
-  )
-  info "[LOCAL] Docker GPU inference proof will use OpenShell proxy ${INFERENCE_PROXY_URL}"
-fi
-info "[LOCAL] Sandbox inference test → ${SANDBOX_INFERENCE_URL} → Ollama on GPU..."
+info "[LOCAL] Sandbox inference test (via openshell sandbox exec) → ${SANDBOX_INFERENCE_URL} → Ollama on GPU..."
 sandbox_probe_failure=""
 sandbox_response=""
 TIMEOUT_CMD=""
@@ -577,19 +569,18 @@ sandbox_curl_cmd=$(printf "curl -skS --max-time 90 %q -H %q -d %q" \
 run_sandbox_inference_probe() {
   sandbox_probe_failure=""
   sandbox_response=""
-  if [ "$SANDBOX_INFERENCE_EXEC" = "docker" ]; then
-    sandbox_container_id=$(docker ps --quiet \
-      --filter "label=openshell.ai/managed-by=openshell" \
-      --filter "label=openshell.ai/sandbox-name=${SANDBOX_NAME}" \
-      | head -n 1)
-    if [ -n "$sandbox_container_id" ]; then
-      info "[LOCAL] Using docker exec for Docker GPU sandbox inference proof (${sandbox_container_id:0:12})..."
-      sandbox_response=$($TIMEOUT_CMD docker exec "${SANDBOX_INFERENCE_DOCKER_EXEC_ENV[@]}" "$sandbox_container_id" sh -lc "$sandbox_curl_cmd" 2>&1) || true
+  # Always exercise the real OpenClaw runtime context (the sandbox's own
+  # network namespace) so a host-only reachability path can never mask an
+  # agent-side ECONNREFUSED (#4509).
+  local probe_status
+  sandbox_response=$($TIMEOUT_CMD openshell sandbox exec -n "$SANDBOX_NAME" -- sh -lc "$sandbox_curl_cmd" 2>&1)
+  probe_status=$?
+  if [ "$probe_status" -ne 0 ]; then
+    if [ "$probe_status" -eq 124 ]; then
+      sandbox_probe_failure="sandbox inference probe timed out (openshell sandbox exec)"
     else
-      sandbox_probe_failure="OpenShell-managed Docker container not found for ${SANDBOX_NAME}"
+      sandbox_probe_failure="openshell sandbox exec failed (status ${probe_status}): ${sandbox_response:0:200}"
     fi
-  else
-    sandbox_response=$($TIMEOUT_CMD openshell sandbox exec -n "$SANDBOX_NAME" -- sh -lc "$sandbox_curl_cmd" 2>&1) || true
   fi
 }
 


### PR DESCRIPTION
## Summary

Reopened #4509: on an Ubuntu 24.04 GPU host-network setup, onboard printed "local inference reachable" yet the agent then failed with `ECONNREFUSED` / "LLM request failed: network connection error". PR #4609 proved reachability with `docker exec` against the recreated `--network host` container — whose *main* network namespace is the host's — but OpenClaw runs in OpenShell's **isolated sandbox network namespace**, which cannot reach the host loopback even under `--network host`. So the direct `127.0.0.1` provider URL was unreachable for the agent while the probe falsely passed. This fixes the URL/network mapping and verifies it from the real runtime context.

## Related Issue

Fixes #4509

## Changes

- **No direct container-loopback inference URL.** For local providers, an opted-in host-network GPU patch (`NEMOCLAW_DOCKER_GPU_PATCH_NETWORK=host`) is downgraded to the OpenShell bridge so inference routes through the reachable `inference.local` path. Host networking is unnecessary for GPU device access (that comes from the GPU mode flags). Non-local (cloud/routed/custom) GPU sandboxes are untouched.
- **Bridge reachability re-checked after the downgrade** (with UFW auto-fix), since gateway startup skipped that probe while host networking was still requested.
- **Runtime-context reachability gate.** The post-ready gate now probes `https://inference.local/v1/models` via `openshell sandbox exec` — the exact network namespace and route OpenClaw uses — instead of `docker exec`. Success requires a `2xx`; `000` (ECONNREFUSED), `4xx` (route/auth misconfig), and `5xx` (backend down) fail with actionable recovery. A genuinely missing `curl` soft-skips (OpenClaw's HTTP client does not need it); a broken sandbox exec path fails rather than masquerading as missing-curl.
- **GPU E2E** (`test/e2e/test-gpu-e2e.sh`) now proves inference through `openshell sandbox exec` (the real runtime) and asserts the new gate, removing the `docker exec` shortcut that masked the bug.
- `src/lib/onboard.ts` stays net-neutral (orchestration lives in `src/lib/onboard/`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npx prek run --files` on the changed files (TS/biome/spdx/shellcheck clean; the only failures were unrelated env-flakes — missing plugin `node_modules` and 5s CLI-spawn timeouts under a loaded host — which pass with deps installed and a normal timeout: 152/152)
- [x] `npm run build:cli`, `npm run typecheck:cli`
- [x] `npx vitest run` for the gate (21), `test/onboard.test.ts` (66), `docker-gpu-patch` (50), `inference/local` (65), `provider-inference` (13), `docker-gpu-sandbox-create` (5)
- [x] Tests added/updated for new and changed behavior (runtime-context probe, 2xx-only, local-only downgrade + bridge re-check, exec-failure vs missing-curl)
- [x] No secrets, API keys, or credentials committed

### Reporter-workflow E2E evidence

Full reporter reproduction requires Ubuntu 24.04 + NVIDIA GPU + native Docker (host-network GPU patch), which is not available on this CI-less dev host. The exact workflow is covered by the **GPU pipeline E2E** (`test/e2e/test-gpu-e2e.sh`, Brev GPU runner), which this PR extends to verify local inference **through `openshell sandbox exec`** (the agent runtime netns) and to assert the runtime-context gate — so a future regression cannot pass via the container-main-namespace shortcut.

The root-cause *mechanism* was reproduced locally and hermetically (no GPU needed), modeling the OpenShell Docker-driver topology — a `--network host` container plus an inner `unshare -n` namespace (how OpenShell runs the sandbox agent):

```
[A] container MAIN netns (== host loopback under --network host; what docker exec / PR #4609 hit):
    http_code=200   RESULT: OK-MAIN  (reaches host Ollama)
[B] INNER netns via unshare -n (== OpenShell sandbox agent runtime / openshell sandbox exec):
    http_code=000   RESULT: FAIL-INNER (ECONNREFUSED — matches the reporter)
```

This confirms why the `docker exec` probe passed while the agent got `ECONNREFUSED`, and why routing through the OpenShell-managed `inference.local` path (on the bridge) is the reachable fix.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verify GPU local inference from inside the sandbox runtime (not via host-network probes), reducing false positives and handling curl/unreachability scenarios more robustly.

* **Refactor**
  * Default Docker GPU patching for local providers now uses the OpenShell-managed bridge instead of host networking to improve inference accessibility and consistency.

* **Tests**
  * End-to-end and unit tests updated to exercise the sandbox-side inference path and cover success, skip, retry, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->