### PR TITLE
fix(onboard): suppress provider cleanup probe output

### DIFF
--- a/src/lib/onboard/sandbox-provider-cleanup.ts
+++ b/src/lib/onboard/sandbox-provider-cleanup.ts
@@ -115,7 +115,7 @@ export function detachSandboxProviders(
     const name = `${sandboxName}-${suffix}`;
     const result = runOpenshell(
       ["sandbox", "provider", "detach", sandboxName, name],
-      { ignoreError: true, stdio: ["ignore", "pipe", "pipe"] },
+      { ignoreError: true, stdio: ["ignore", "pipe", "pipe"], suppressOutput: true },
     );
     if (result.status === 0) {
       detached.push(name);
@@ -174,7 +174,7 @@ export function recoverAttachedProvider(
   for (const sandbox of attachedSandboxes) {
     const result = runOpenshell(
       ["sandbox", "provider", "detach", sandbox, providerName],
-      { ignoreError: true, stdio: ["ignore", "pipe", "pipe"] },
+      { ignoreError: true, stdio: ["ignore", "pipe", "pipe"], suppressOutput: true },
     );
     if (result.status === 0) {
       detached.push(sandbox);
@@ -268,6 +268,7 @@ export function deleteProviderWithRecovery(
   let result = runOpenshell(["provider", "delete", providerName], {
     ignoreError: true,
     stdio: ["ignore", "pipe", "pipe"],
+    suppressOutput: true,
   });
   let recoveryFailures: Array<{ sandbox: string; output: string }> = [];
   if (result.status !== 0) {
@@ -279,6 +280,7 @@ export function deleteProviderWithRecovery(
       result = runOpenshell(["provider", "delete", providerName], {
         ignoreError: true,
         stdio: ["ignore", "pipe", "pipe"],
+        suppressOutput: true,
       });
     }
   }

--- a/test/sandbox-provider-cleanup.test.ts
+++ b/test/sandbox-provider-cleanup.test.ts
@@ -159,6 +159,28 @@ describe("detachSandboxProviders", () => {
     expect(result.failures).toEqual([]);
   });
 
+  it("suppresses output for tolerated missing-sandbox detach probes", () => {
+    const { runOpenshell } = buildRunOpenshell(
+      new Map(),
+      { status: 1, stderr: "Error: status: NotFound, sandbox 'phantom' not found" },
+    );
+
+    const result = detachSandboxProviders("phantom", {
+      runOpenshell,
+      tolerateMissingSandbox: true,
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(runOpenshell).toHaveBeenCalledTimes(SANDBOX_PROVIDER_SUFFIXES.length);
+    for (const [, opts] of runOpenshell.mock.calls) {
+      expect(opts).toMatchObject({
+        ignoreError: true,
+        suppressOutput: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    }
+  });
+
   it("collects non-tolerated failures without aborting the loop", () => {
     const responses = new Map<string, RunResult>([
       [


### PR DESCRIPTION
## Summary
Suppress expected OpenShell provider-cleanup probe output during onboarding so fresh sandbox creation no longer prints repeated `sandbox not found` errors before the real create step. The cleanup still captures and classifies OpenShell failures internally, preserving the stale-provider recovery behavior added for rebuild and resume flows.

## Related Issue
Closes #5025

## Changes
- Add `suppressOutput: true` to captured provider detach/delete cleanup calls in `src/lib/onboard/sandbox-provider-cleanup.ts`.
- Add regression coverage proving tolerated missing-sandbox detach probes are quiet while still attempted for every provider suffix.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- [x] `npm run build:cli` passes
- [x] `npx vitest run test/sandbox-provider-cleanup.test.ts` passes
- [ ] `npx prek run --all-files` was attempted but failed in unrelated existing CLI hook failures/timeouts outside this change.

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for sandbox provider cleanup operations to validate proper handling when sandboxes are missing.

* **Refactor**
  * Enhanced command output handling in sandbox provider cleanup processes for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->