### PR TITLE
ci(pr): drop duplicate self-hosted vitest run

### DIFF
--- a/.github/actions/ci-installer-integration/action.yaml
+++ b/.github/actions/ci-installer-integration/action.yaml
@@ -15,7 +15,15 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: npm install --ignore-scripts
+      run: |
+        npm install --ignore-scripts
+        cd nemoclaw && npm install --ignore-scripts
+
+    - name: Build installer integration artifacts
+      shell: bash
+      run: |
+        npm run build:cli
+        cd nemoclaw && npm run build
 
     - name: Run installer integration tests
       shell: bash

--- a/.github/actions/ci-installer-integration/action.yaml
+++ b/.github/actions/ci-installer-integration/action.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: ci-installer-integration
+description: Run CI-gated installer integration Vitest tests.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: "22"
+        cache: npm
+
+    - name: Install dependencies
+      shell: bash
+      run: npm install --ignore-scripts
+
+    - name: Run installer integration tests
+      shell: bash
+      run: CI=true npx vitest run --project installer-integration

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,18 @@ jobs:
       - name: Run build and type checks
         uses: ./.github/actions/ci-build-typecheck
 
+  installer-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run installer integration tests
+        uses: ./.github/actions/ci-installer-integration
+
   cli-test-shards:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -122,6 +134,7 @@ jobs:
     needs:
       - static-checks
       - build-typecheck
+      - installer-integration
       - cli-tests
       - plugin-tests
       - test-e2e-ollama-proxy
@@ -133,6 +146,7 @@ jobs:
         env:
           STATIC_RESULT: ${{ needs['static-checks'].result }}
           BUILD_TYPECHECK_RESULT: ${{ needs['build-typecheck'].result }}
+          INSTALLER_INTEGRATION_RESULT: ${{ needs['installer-integration'].result }}
           CLI_TESTS_RESULT: ${{ needs['cli-tests'].result }}
           PLUGIN_TESTS_RESULT: ${{ needs['plugin-tests'].result }}
           E2E_PROXY_RESULT: ${{ needs['test-e2e-ollama-proxy'].result }}
@@ -150,6 +164,7 @@ jobs:
 
           require_success "static-checks" "$STATIC_RESULT"
           require_success "build-typecheck" "$BUILD_TYPECHECK_RESULT"
+          require_success "installer-integration" "$INSTALLER_INTEGRATION_RESULT"
           require_success "cli-tests" "$CLI_TESTS_RESULT"
           require_success "plugin-tests" "$PLUGIN_TESTS_RESULT"
           require_success "test-e2e-ollama-proxy" "$E2E_PROXY_RESULT"

--- a/.github/workflows/pr-self-hosted.yaml
+++ b/.github/workflows/pr-self-hosted.yaml
@@ -36,34 +36,6 @@ jobs:
       - id: get-pr-info
         uses: nv-gha-runners/get-pr-info@090577647b8ddc4e06e809e264f7881650ecdccf # main
 
-  unit-vitest-linux:
-    runs-on: linux-amd64-cpu4
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "22"
-          cache: npm
-
-      - name: Install dependencies
-        run: |
-          npm ci --ignore-scripts
-          cd nemoclaw
-          npm ci --ignore-scripts
-
-      - name: Build CLI and plugin
-        run: |
-          npm run build:cli
-          cd nemoclaw
-          npm run build
-
-      - name: Run full Vitest suite
-        run: npx vitest run --testTimeout 60000
-
   build-sandbox-images:
     runs-on: linux-amd64-cpu4
     timeout-minutes: 15

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,6 +92,7 @@ jobs:
             .github/actions/ci-cli-coverage-shard
             .github/actions/ci-cli-coverage-merge
             .github/actions/ci-plugin-coverage
+            .github/actions/ci-installer-integration
           sparse-checkout-cone-mode: false
 
       - name: Run static checks
@@ -120,10 +121,35 @@ jobs:
             .github/actions/ci-cli-coverage-shard
             .github/actions/ci-cli-coverage-merge
             .github/actions/ci-plugin-coverage
+            .github/actions/ci-installer-integration
           sparse-checkout-cone-mode: false
 
       - name: Run build and type checks
         uses: ./.trusted-ci-actions/.github/actions/ci-build-typecheck
+
+  installer-integration:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-installer-integration
+          sparse-checkout-cone-mode: false
+
+      - name: Run installer integration tests
+        uses: ./.trusted-ci-actions/.github/actions/ci-installer-integration
 
   cli-test-shards:
     needs: changes
@@ -152,6 +178,7 @@ jobs:
             .github/actions/ci-cli-coverage-shard
             .github/actions/ci-cli-coverage-merge
             .github/actions/ci-plugin-coverage
+            .github/actions/ci-installer-integration
           sparse-checkout-cone-mode: false
 
       - name: Run CLI coverage shard
@@ -194,6 +221,7 @@ jobs:
             .github/actions/ci-cli-coverage-shard
             .github/actions/ci-cli-coverage-merge
             .github/actions/ci-plugin-coverage
+            .github/actions/ci-installer-integration
           sparse-checkout-cone-mode: false
 
       - name: Merge CLI coverage
@@ -224,6 +252,7 @@ jobs:
             .github/actions/ci-cli-coverage-shard
             .github/actions/ci-cli-coverage-merge
             .github/actions/ci-plugin-coverage
+            .github/actions/ci-installer-integration
           sparse-checkout-cone-mode: false
 
       - name: Run plugin coverage
@@ -253,6 +282,7 @@ jobs:
       - docs-only-checks
       - static-checks
       - build-typecheck
+      - installer-integration
       - cli-tests
       - plugin-tests
       - test-e2e-ollama-proxy
@@ -267,6 +297,7 @@ jobs:
           DOCS_ONLY_RESULT: ${{ needs['docs-only-checks'].result }}
           STATIC_RESULT: ${{ needs['static-checks'].result }}
           BUILD_TYPECHECK_RESULT: ${{ needs['build-typecheck'].result }}
+          INSTALLER_INTEGRATION_RESULT: ${{ needs['installer-integration'].result }}
           CLI_TESTS_RESULT: ${{ needs['cli-tests'].result }}
           PLUGIN_TESTS_RESULT: ${{ needs['plugin-tests'].result }}
           E2E_PROXY_RESULT: ${{ needs['test-e2e-ollama-proxy'].result }}
@@ -300,6 +331,7 @@ jobs:
             allow_success_or_skipped "docs-only-checks" "$DOCS_ONLY_RESULT"
             require_success "static-checks" "$STATIC_RESULT"
             require_success "build-typecheck" "$BUILD_TYPECHECK_RESULT"
+            require_success "installer-integration" "$INSTALLER_INTEGRATION_RESULT"
             require_success "cli-tests" "$CLI_TESTS_RESULT"
             require_success "plugin-tests" "$PLUGIN_TESTS_RESULT"
             require_success "test-e2e-ollama-proxy" "$E2E_PROXY_RESULT"
@@ -307,6 +339,7 @@ jobs:
             require_success "docs-only-checks" "$DOCS_ONLY_RESULT"
             allow_success_or_skipped "static-checks" "$STATIC_RESULT"
             allow_success_or_skipped "build-typecheck" "$BUILD_TYPECHECK_RESULT"
+            allow_success_or_skipped "installer-integration" "$INSTALLER_INTEGRATION_RESULT"
             allow_success_or_skipped "cli-tests" "$CLI_TESTS_RESULT"
             allow_success_or_skipped "plugin-tests" "$PLUGIN_TESTS_RESULT"
             allow_success_or_skipped "test-e2e-ollama-proxy" "$E2E_PROXY_RESULT"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,8 +148,36 @@ jobs:
             .github/actions/ci-installer-integration
           sparse-checkout-cone-mode: false
 
+      - name: Detect trusted installer integration action
+        id: trusted-installer-integration
+        shell: bash
+        run: |
+          if [ -f .trusted-ci-actions/.github/actions/ci-installer-integration/action.yaml ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run installer integration tests
+        if: ${{ steps.trusted-installer-integration.outputs.available == 'true' }}
         uses: ./.trusted-ci-actions/.github/actions/ci-installer-integration
+
+      - name: Setup Node.js for installer integration
+        if: ${{ steps.trusted-installer-integration.outputs.available != 'true' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install installer integration dependencies
+        if: ${{ steps.trusted-installer-integration.outputs.available != 'true' }}
+        shell: bash
+        run: npm install --ignore-scripts
+
+      - name: Run installer integration tests (bootstrap)
+        if: ${{ steps.trusted-installer-integration.outputs.available != 'true' }}
+        shell: bash
+        run: CI=true npx vitest run --project installer-integration
 
   cli-test-shards:
     needs: changes

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -172,7 +172,16 @@ jobs:
       - name: Install installer integration dependencies
         if: ${{ steps.trusted-installer-integration.outputs.available != 'true' }}
         shell: bash
-        run: npm install --ignore-scripts
+        run: |
+          npm install --ignore-scripts
+          cd nemoclaw && npm install --ignore-scripts
+
+      - name: Build installer integration artifacts
+        if: ${{ steps.trusted-installer-integration.outputs.available != 'true' }}
+        shell: bash
+        run: |
+          npm run build:cli
+          cd nemoclaw && npm run build
 
       - name: Run installer integration tests (bootstrap)
         if: ${{ steps.trusted-installer-integration.outputs.available != 'true' }}

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -253,6 +253,12 @@ describe("pull request and main workflow contracts", () => {
     expect(stepUses(prWorkflow.jobs["installer-integration"])).not.toContain(
       sharedActionPaths.installerIntegration,
     );
+    expect(stepUses(mainWorkflow.jobs["installer-integration"])).toContain(
+      sharedActionPaths.installerIntegration,
+    );
+    expect(stepUses(mainWorkflow.jobs["installer-integration"])).not.toContain(
+      trustedPrActionPaths.installerIntegration,
+    );
     const installerTrustedCheckout = requiredWorkflowStep(
       prWorkflow.jobs["installer-integration"],
       "Checkout trusted CI actions",
@@ -267,6 +273,51 @@ describe("pull request and main workflow contracts", () => {
     expect(String(installerTrustedCheckout.with?.["sparse-checkout"])).toContain(
       ".github/actions/ci-installer-integration",
     );
+    const installerActionProbe = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Detect trusted installer integration action",
+    );
+    expect(installerActionProbe.id).toBe("trusted-installer-integration");
+    expect(installerActionProbe.run).toContain(
+      ".trusted-ci-actions/.github/actions/ci-installer-integration/action.yaml",
+    );
+    expect(installerActionProbe.run).toContain("available=true");
+    expect(installerActionProbe.run).toContain("available=false");
+    const installerActionStep = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Run installer integration tests",
+    );
+    expect(installerActionStep.if).toBe(
+      "${{ steps.trusted-installer-integration.outputs.available == 'true' }}",
+    );
+    const bootstrapSetup = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Setup Node.js for installer integration",
+    );
+    expect(bootstrapSetup.if).toBe(
+      "${{ steps.trusted-installer-integration.outputs.available != 'true' }}",
+    );
+    expect(bootstrapSetup.uses).toContain("actions/setup-node@");
+    expect(bootstrapSetup.with?.["node-version"]).toBe("22");
+    expect(bootstrapSetup.with?.cache).toBe("npm");
+    const bootstrapInstall = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Install installer integration dependencies",
+    );
+    expect(bootstrapInstall.if).toBe(
+      "${{ steps.trusted-installer-integration.outputs.available != 'true' }}",
+    );
+    expect(bootstrapInstall.run).toBe("npm install --ignore-scripts");
+    const bootstrapRun = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Run installer integration tests (bootstrap)",
+    );
+    expect(bootstrapRun.if).toBe(
+      "${{ steps.trusted-installer-integration.outputs.available != 'true' }}",
+    );
+    expect(bootstrapRun.run).toBe(
+      "CI=true npx vitest run --project installer-integration",
+    );
     expect(
       requiredWorkflowStepIndex(
         prWorkflow.jobs["installer-integration"],
@@ -276,6 +327,17 @@ describe("pull request and main workflow contracts", () => {
       requiredWorkflowStepIndex(
         prWorkflow.jobs["installer-integration"],
         "Run installer integration tests",
+      ),
+    );
+    expect(
+      requiredWorkflowStepIndex(
+        prWorkflow.jobs["installer-integration"],
+        "Detect trusted installer integration action",
+      ),
+    ).toBeLessThan(
+      requiredWorkflowStepIndex(
+        prWorkflow.jobs["installer-integration"],
+        "Run installer integration tests (bootstrap)",
       ),
     );
 
@@ -405,10 +467,17 @@ describe("pull request and main workflow contracts", () => {
     const vitestConfig = readFileSync("vitest.config.ts", "utf8");
     const cliShardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
     const installerRuns = stepRuns(sharedActions.installerIntegration).join("\n");
+    const prInstallerRuns = stepRuns(prWorkflow.jobs["installer-integration"]).join("\n");
 
     expect(installerRuns).toContain("CI=true npx vitest run --project installer-integration");
+    expect(prInstallerRuns).toContain(
+      "CI=true npx vitest run --project installer-integration",
+    );
     expect(stepUses(prWorkflow.jobs["installer-integration"])).toContain(
       trustedPrActionPaths.installerIntegration,
+    );
+    expect(stepUses(mainWorkflow.jobs["installer-integration"])).toContain(
+      sharedActionPaths.installerIntegration,
     );
     expect(vitestConfig).toContain('name: "installer-integration"');
 
@@ -590,6 +659,7 @@ describe("pull request and main workflow contracts", () => {
     expect(mainChecks.needs).toEqual([
       "static-checks",
       "build-typecheck",
+      "installer-integration",
       "cli-tests",
       "plugin-tests",
       "test-e2e-ollama-proxy",
@@ -598,6 +668,7 @@ describe("pull request and main workflow contracts", () => {
     for (const jobName of [
       "static-checks",
       "build-typecheck",
+      "installer-integration",
       "cli-tests",
       "plugin-tests",
       "test-e2e-ollama-proxy",
@@ -625,6 +696,10 @@ describe("pull request and main workflow contracts", () => {
       run.includes("npm install"),
     );
     expect(docsOnlyInstall).toBe("npm install --ignore-scripts");
+    const installerBootstrapInstall = stepRuns(
+      prWorkflow.jobs["installer-integration"],
+    ).find((run) => run.includes("npm install"));
+    expect(installerBootstrapInstall).toBe("npm install --ignore-scripts");
   });
 
   it("does not persist checkout credentials in PR or main jobs", () => {

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -307,7 +307,19 @@ describe("pull request and main workflow contracts", () => {
     expect(bootstrapInstall.if).toBe(
       "${{ steps.trusted-installer-integration.outputs.available != 'true' }}",
     );
-    expect(bootstrapInstall.run).toBe("npm install --ignore-scripts");
+    expect(bootstrapInstall.run).toContain("npm install --ignore-scripts");
+    expect(bootstrapInstall.run).toContain(
+      "cd nemoclaw && npm install --ignore-scripts",
+    );
+    const bootstrapBuild = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Build installer integration artifacts",
+    );
+    expect(bootstrapBuild.if).toBe(
+      "${{ steps.trusted-installer-integration.outputs.available != 'true' }}",
+    );
+    expect(bootstrapBuild.run).toContain("npm run build:cli");
+    expect(bootstrapBuild.run).toContain("cd nemoclaw && npm run build");
     const bootstrapRun = requiredWorkflowStep(
       prWorkflow.jobs["installer-integration"],
       "Run installer integration tests (bootstrap)",
@@ -460,6 +472,9 @@ describe("pull request and main workflow contracts", () => {
     );
 
     expect(installerRuns).toContain("npm install --ignore-scripts");
+    expect(installerRuns).toContain("cd nemoclaw && npm install --ignore-scripts");
+    expect(installerRuns).toContain("npm run build:cli");
+    expect(installerRuns).toContain("cd nemoclaw && npm run build");
     expect(installerRuns).toContain("CI=true npx vitest run --project installer-integration");
   });
 
@@ -699,7 +714,10 @@ describe("pull request and main workflow contracts", () => {
     const installerBootstrapInstall = stepRuns(
       prWorkflow.jobs["installer-integration"],
     ).find((run) => run.includes("npm install"));
-    expect(installerBootstrapInstall).toBe("npm install --ignore-scripts");
+    expect(installerBootstrapInstall).toContain("npm install --ignore-scripts");
+    expect(installerBootstrapInstall).toContain(
+      "cd nemoclaw && npm install --ignore-scripts",
+    );
   });
 
   it("does not persist checkout credentials in PR or main jobs", () => {

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 
 import {
   readYaml,
@@ -24,6 +25,7 @@ const sharedActionPaths = {
   cliCoverageShard: "./.github/actions/ci-cli-coverage-shard",
   cliCoverageMerge: "./.github/actions/ci-cli-coverage-merge",
   pluginCoverage: "./.github/actions/ci-plugin-coverage",
+  installerIntegration: "./.github/actions/ci-installer-integration",
 } as const;
 
 const trustedPrActionPaths = {
@@ -32,6 +34,7 @@ const trustedPrActionPaths = {
   cliCoverageShard: "./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard",
   cliCoverageMerge: "./.trusted-ci-actions/.github/actions/ci-cli-coverage-merge",
   pluginCoverage: "./.trusted-ci-actions/.github/actions/ci-plugin-coverage",
+  installerIntegration: "./.trusted-ci-actions/.github/actions/ci-installer-integration",
 } as const;
 
 const trustedCheckoutAction =
@@ -43,6 +46,7 @@ const trustedActionDirs = [
   ".github/actions/ci-cli-coverage-shard",
   ".github/actions/ci-cli-coverage-merge",
   ".github/actions/ci-plugin-coverage",
+  ".github/actions/ci-installer-integration",
 ] as const;
 
 const cliShardMatrix = [1, 2, 3, 4, 5] as const;
@@ -145,6 +149,9 @@ describe("pull request and main workflow contracts", () => {
     pluginCoverage: readYaml<CompositeAction>(
       ".github/actions/ci-plugin-coverage/action.yaml",
     ),
+    installerIntegration: readYaml<CompositeAction>(
+      ".github/actions/ci-installer-integration/action.yaml",
+    ),
   };
 
   it("routes only code-changing PRs through the code-check path", () => {
@@ -240,6 +247,38 @@ describe("pull request and main workflow contracts", () => {
       ).toBeLessThan(requiredWorkflowStepIndex(prWorkflow.jobs[jobName], stepName));
     }
 
+    expect(stepUses(prWorkflow.jobs["installer-integration"])).toContain(
+      trustedPrActionPaths.installerIntegration,
+    );
+    expect(stepUses(prWorkflow.jobs["installer-integration"])).not.toContain(
+      sharedActionPaths.installerIntegration,
+    );
+    const installerTrustedCheckout = requiredWorkflowStep(
+      prWorkflow.jobs["installer-integration"],
+      "Checkout trusted CI actions",
+    );
+    expect(installerTrustedCheckout.uses).toBe(trustedCheckoutAction);
+    expect(installerTrustedCheckout.with?.ref).toBe(
+      "${{ github.event.pull_request.base.sha }}",
+    );
+    expect(installerTrustedCheckout.with?.path).toBe(".trusted-ci-actions");
+    expect(installerTrustedCheckout.with?.["persist-credentials"]).toBe(false);
+    expect(installerTrustedCheckout.with?.["sparse-checkout-cone-mode"]).toBe(false);
+    expect(String(installerTrustedCheckout.with?.["sparse-checkout"])).toContain(
+      ".github/actions/ci-installer-integration",
+    );
+    expect(
+      requiredWorkflowStepIndex(
+        prWorkflow.jobs["installer-integration"],
+        "Checkout trusted CI actions",
+      ),
+    ).toBeLessThan(
+      requiredWorkflowStepIndex(
+        prWorkflow.jobs["installer-integration"],
+        "Run installer integration tests",
+      ),
+    );
+
     expect(stepUses(mainWorkflow.jobs.checks)).not.toContain(
       "./.github/actions/basic-checks",
     );
@@ -282,6 +321,7 @@ describe("pull request and main workflow contracts", () => {
     const cliShardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
     const cliMergeRuns = stepRuns(sharedActions.cliCoverageMerge).join("\n");
     const pluginRuns = stepRuns(sharedActions.pluginCoverage).join("\n");
+    const installerRuns = stepRuns(sharedActions.installerIntegration).join("\n");
 
     expect(staticRuns).toContain("npm install --ignore-scripts");
     expect(staticRuns).toContain("npm run validate:configs");
@@ -356,6 +396,31 @@ describe("pull request and main workflow contracts", () => {
     expect(pluginRuns).toContain(
       'scripts/check-coverage-ratchet.ts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json "Plugin coverage"',
     );
+
+    expect(installerRuns).toContain("npm install --ignore-scripts");
+    expect(installerRuns).toContain("CI=true npx vitest run --project installer-integration");
+  });
+
+  it("keeps PR coverage for non-opt-in Vitest projects after removing the self-hosted full run", () => {
+    const vitestConfig = readFileSync("vitest.config.ts", "utf8");
+    const cliShardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
+    const installerRuns = stepRuns(sharedActions.installerIntegration).join("\n");
+
+    expect(installerRuns).toContain("CI=true npx vitest run --project installer-integration");
+    expect(stepUses(prWorkflow.jobs["installer-integration"])).toContain(
+      trustedPrActionPaths.installerIntegration,
+    );
+    expect(vitestConfig).toContain('name: "installer-integration"');
+
+    // The e2e scenario framework remains part of the sharded CLI project:
+    // its tests live under test/e2e-scenario, while the CLI project only
+    // excludes the legacy test/e2e tree and installer-integration tests.
+    expect(cliShardRuns).toContain("npx vitest run --project cli");
+    expect(vitestConfig).toContain('name: "e2e-scenario-framework"');
+    expect(vitestConfig).toContain('include: ["test/**/*.test.{js,ts}", "src/**/*.test.ts"]');
+    expect(vitestConfig).toContain('"test/e2e/**"');
+    expect(vitestConfig).toContain('"test/install-preflight.test.ts"');
+    expect(vitestConfig).toContain('"test/install-openshell-version-check.test.ts"');
   });
 
   it("validates CLI shard inputs before using them in shell commands", () => {
@@ -501,6 +566,7 @@ describe("pull request and main workflow contracts", () => {
       "docs-only-checks",
       "static-checks",
       "build-typecheck",
+      "installer-integration",
       "cli-tests",
       "plugin-tests",
       "test-e2e-ollama-proxy",
@@ -511,6 +577,7 @@ describe("pull request and main workflow contracts", () => {
       "changes",
       "static-checks",
       "build-typecheck",
+      "installer-integration",
       "cli-tests",
       "plugin-tests",
       "test-e2e-ollama-proxy",


### PR DESCRIPTION
## Summary
Drop the duplicate full Vitest job from the self-hosted PR workflow. Regular PR CI already runs the CLI and plugin Vitest coverage gates, so the self-hosted workflow can focus on sandbox image builds and Docker E2E validation.

## Changes
- Removed the `unit-vitest-linux` job from `.github/workflows/pr-self-hosted.yaml`.
- Kept the self-hosted sandbox image build, arm64 image build, and Docker E2E jobs unchanged.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added installer integration test verification to the CI/CD pipeline
  * Updated workflow requirements to include installer integration checks before final code verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->