### PR TITLE
fix(sandbox): recover stale sandbox on rebuild instead of dead-ending (#4497)

### DIFF
--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -252,6 +252,10 @@ export function printWrongGatewayActiveGuidance(
   sandboxName: string,
   activeGateway: string | null | undefined,
   writer: (message: string) => void = console.error,
+  // The command to re-run after switching gateways. Defaults to `connect`;
+  // callers in a different recovery flow (e.g. `rebuild`) pass their own so the
+  // guidance points back to the workflow the user actually invoked.
+  retryCommand = "connect",
 ): void {
   const other = activeGateway && activeGateway !== "nemoclaw" ? activeGateway : "another gateway";
   writer(
@@ -259,7 +263,7 @@ export function printWrongGatewayActiveGuidance(
   );
   writer("  Switch gateways and retry:");
   writer("      openshell gateway select nemoclaw");
-  writer(`  Then re-run: ${CLI_NAME} ${sandboxName} connect`);
+  writer(`  Then re-run: ${CLI_NAME} ${sandboxName} ${retryCommand}`);
 }
 
 /** Print troubleshooting hints based on gateway lifecycle state in the output. */

--- a/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
@@ -116,22 +116,61 @@ describe("rebuild gateway drift preflight", () => {
     expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
   });
 
-  it("recovers the named gateway and retries the liveness query before deciding running state", async () => {
+  it("recovers the named gateway and retries the liveness query before entering stale recovery", async () => {
     detectPreflightIssueSpy.mockReturnValue(null);
-    captureOpenshellSpy
-      .mockReturnValueOnce({ status: 1, output: "client error (Connect): Connection refused" })
-      .mockReturnValueOnce({ status: 0, output: "beta Ready" });
+    // First `sandbox list` fails (gateway down) and triggers recovery; the retry
+    // shows only 'beta', so 'alpha' is absent. Before treating that as stale,
+    // rebuild reconciles against the NAMED gateway, which reports a healthy
+    // nemoclaw (status Connected + gateway info), confirming the sandbox is
+    // genuinely gone (#4497).
+    let listCalls = 0;
+    captureOpenshellSpy.mockImplementation((args: string[]) => {
+      if (args[0] === "sandbox" && args[1] === "list") {
+        listCalls += 1;
+        return listCalls === 1
+          ? { status: 1, output: "client error (Connect): Connection refused" }
+          : { status: 0, output: "beta Ready" };
+      }
+      if (args[0] === "status") {
+        return {
+          status: 0,
+          output: "Server Status\n\n  Gateway: nemoclaw\n  Status: Connected\n",
+        };
+      }
+      if (args[0] === "gateway" && args[1] === "info") {
+        return { status: 0, output: "Gateway Info\n\nGateway: nemoclaw\n" };
+      }
+      if (args[0] === "sandbox" && args[1] === "get") {
+        return { status: 1, output: "Error:   × Not Found: sandbox not found" };
+      }
+      return { status: 0, output: "" };
+    });
+
+    // The reconcile confirms the stale state, so rather than dead-ending at
+    // "Cannot back up state", rebuild skips backup and recreates from the
+    // preserved registry metadata. Stub the destructive steps + recreate handoff
+    // so the path stays hermetic, and assert the recreate failure surfaces the
+    // stale-recovery message instead of "not running".
+    const openshellRuntime = requireDist("../../../../dist/lib/adapters/openshell/runtime.js");
+    const destroy = requireDist("../../../../dist/lib/actions/sandbox/destroy.js");
+    const onboardMod = requireDist("../../../../dist/lib/onboard.js");
+    spies.push(
+      vi
+        .spyOn(openshellRuntime, "runOpenshell")
+        .mockReturnValue({ status: 0, output: "" } as never),
+      vi.spyOn(destroy, "removeSandboxRegistryEntry").mockImplementation(() => undefined),
+      vi.spyOn(onboardMod, "onboard").mockRejectedValue(new Error("recreate-stub")),
+    );
 
     await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
-      "Sandbox 'alpha' is not running.",
+      /stale-sandbox recovery/,
     );
 
     expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
       recoverableStates: ["missing_named", "named_unhealthy", "named_unreachable"],
     });
-    expect(captureOpenshellSpy).toHaveBeenCalledTimes(2);
-    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(1, ["sandbox", "list"]);
-    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(2, ["sandbox", "list"]);
+    // The liveness query ran twice (initial failure + post-recovery retry).
+    expect(listCalls).toBe(2);
   });
 
   it("does not recover generic sandbox list failures", async () => {

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -41,6 +41,7 @@ import { ensureAgentBaseImage } from "../../agent/onboard";
 import * as agentRuntime from "../../agent/runtime";
 import { RD as _RD, B, D, G, R, YW } from "../../cli/terminal-style";
 import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
+import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import * as nim from "../../inference/nim";
 import {
   createBuiltInChannelManifestRegistry,
@@ -68,11 +69,17 @@ import {
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
 import { removeSandboxRegistryEntry } from "./destroy";
+import {
+  getReconciledSandboxGatewayState,
+  printGatewayLifecycleHint,
+  printWrongGatewayActiveGuidance,
+} from "./gateway-state";
 import { executeSandboxCommand } from "./process-recovery";
 import { buildRebuildRecreateOnboardOpts } from "./rebuild-gpu-opt-out";
 import {
   openRebuildShieldsWindow,
   printRebuildShieldsRecovery,
+  type RebuildShieldsWindow,
   relockRebuildShieldsWindow,
 } from "./rebuild-shields";
 
@@ -491,11 +498,120 @@ export async function rebuildSandbox(
   }
   const liveNames = parseLiveSandboxNames(isLive.output || "");
   log(`Live sandboxes: ${Array.from(liveNames).join(", ") || "(none)"}`);
+  // Stale-sandbox recovery (#4497): the local registry still holds this entry,
+  // but the live OpenShell gateway no longer lists the sandbox — a stuck or
+  // diverged provision, or the live container was reaped. This is exactly the
+  // state `status` flags with a `rebuild --yes` hint, and the non-destructive
+  // `connect` recovery now preserves the registry entry so this rebuild can act
+  // on it. There is no live workspace state to back up, so rather than aborting
+  // with "Cannot back up state" — which dead-ended the very recovery path the
+  // CLI recommended — skip the backup/restore steps and recreate the sandbox
+  // from the preserved registry + onboard-session metadata.
+  let staleRecovery = false;
+  // Full registry snapshot captured before stale recovery touches anything
+  // destructive. If the recovery recreate fails after the entry was removed,
+  // the snapshot is restored verbatim so no local metadata (defaultSandbox,
+  // customPolicies, every field) is silently dropped or mutated (#4497).
+  let staleRegistrySnapshot: ReturnType<typeof registry.load> | null = null;
   if (!liveNames.has(sandboxName)) {
-    console.error(`  Sandbox '${sandboxName}' is not running. Cannot back up state.`);
-    console.error(`  Start it first or recreate with \`${CLI_NAME} onboard --recreate-sandbox\`.`);
-    bail(`Sandbox '${sandboxName}' is not running.`);
-    return;
+    // The default-gateway liveness checks below can only authoritatively reason
+    // about the default `nemoclaw` gateway. A sandbox created on a non-default
+    // per-port gateway (#4645, e.g. `nemoclaw-9000`) that is simply not the
+    // active gateway would look absent here, and recreating-from-scratch would
+    // orphan its live workspace. Refuse the destructive path in that case and
+    // point the operator at the sandbox's own gateway. (If that gateway were
+    // active, the sandbox would have appeared in the list above.)
+    const recordedGateway =
+      typeof sb.gatewayName === "string" && sb.gatewayName ? sb.gatewayName : "nemoclaw";
+    if (recordedGateway !== "nemoclaw") {
+      console.error(
+        `  Sandbox '${sandboxName}' is registered on the '${recordedGateway}' OpenShell gateway, which is not the active gateway.`,
+      );
+      console.error(
+        "  Its live state could not be confirmed — your local registry entry has been preserved.",
+      );
+      console.error("  Select that gateway and retry:");
+      console.error(`      openshell gateway select ${recordedGateway}`);
+      console.error(`  Then re-run: ${CLI_NAME} ${sandboxName} rebuild --yes`);
+      bail(
+        `Sandbox '${sandboxName}' is on the non-default gateway '${recordedGateway}'; select it before rebuilding.`,
+      );
+      return;
+    }
+
+    // The active-gateway `sandbox list` does not show this sandbox. That alone
+    // is NOT proof it is gone: a different active gateway (multi-gateway setups,
+    // #4645) would hide a live NemoClaw sandbox, and `sandbox list` can omit a
+    // sandbox that `sandbox get` still resolves. Recreating on that false
+    // signal would destroy live workspace state. So confirm authoritatively
+    // against the NAMED NemoClaw gateway: getReconciledSandboxGatewayState runs
+    // `sandbox get`, re-selecting/recovering nemoclaw as needed, and only
+    // reports "missing" once the named gateway is confirmed healthy and the
+    // sandbox is genuinely absent.
+    const reconciled = await getReconciledSandboxGatewayState(sandboxName);
+    if (reconciled.state === "present") {
+      // `sandbox get` resolved the sandbox, but that query ran against whatever
+      // gateway is currently active. Only trust it as live when the named
+      // nemoclaw gateway is the active healthy one — otherwise a foreign active
+      // gateway with a same-named sandbox (or a list/get inconsistency) could
+      // send the destructive backup/delete below at the wrong sandbox. If a
+      // foreign gateway is active, abort with guidance instead.
+      const lifecycle = getNamedGatewayLifecycleState();
+      if (lifecycle.state !== "healthy_named") {
+        printWrongGatewayActiveGuidance(
+          sandboxName,
+          lifecycle.activeGateway,
+          console.error,
+          "rebuild --yes",
+        );
+        bail(
+          `Could not confirm '${sandboxName}' against the NemoClaw gateway (gateway '${lifecycle.activeGateway ?? "unknown"}' is active).`,
+        );
+        return;
+      }
+      // Live on the healthy named gateway (the list omitted it). Fall through to
+      // the normal backup/rebuild path so workspace state is preserved.
+      log("Sandbox live on the healthy named gateway; using normal rebuild path");
+    } else if (reconciled.state === "missing") {
+      // Genuinely absent on a healthy named gateway — stale-sandbox recovery.
+      staleRecovery = true;
+      staleRegistrySnapshot = JSON.parse(JSON.stringify(registry.load()));
+      console.log("");
+      console.log(
+        `  ${YW}⚠${R} Sandbox '${sandboxName}' is registered locally but absent from the live OpenShell gateway.`,
+      );
+      console.log(
+        "  No live workspace state to back up — recreating from the preserved registry metadata.",
+      );
+      log(
+        "Stale-sandbox recovery: live sandbox missing on healthy named gateway; skipping backup/restore and recreating from registry metadata",
+      );
+    } else if (reconciled.state === "gateway_schema_mismatch") {
+      console.error(reconciled.output);
+      bail("OpenShell gateway schema mismatch.");
+      return;
+    } else {
+      // Ambiguous gateway state (wrong gateway active, or the named gateway is
+      // missing/unreachable/drifted). Do NOT destroy — a transient gateway
+      // problem must never be mistaken for a gone sandbox. Surface guidance and
+      // abort with the registry entry intact.
+      if (reconciled.state === "wrong_gateway_active") {
+        printWrongGatewayActiveGuidance(
+          sandboxName,
+          reconciled.activeGateway,
+          console.error,
+          "rebuild --yes",
+        );
+      } else {
+        console.error(
+          `  Sandbox '${sandboxName}' is not visible on the NemoClaw gateway and its live state could not be confirmed.`,
+        );
+        console.error("  Your local registry entry has been preserved — nothing was removed.");
+        printGatewayLifecycleHint(reconciled.output || "", sandboxName, console.error);
+      }
+      bail(`Could not confirm live state of '${sandboxName}' (gateway not in a known-good state).`);
+      return;
+    }
   }
 
   // Build agent base layers before backup/delete so Dockerfile.base errors leave
@@ -516,7 +632,23 @@ export async function rebuildSandbox(
     }
   }
 
-  const rebuildShieldsWindow = openRebuildShieldsWindow(sandboxName, CLI_NAME);
+  // On stale-sandbox recovery the live sandbox is gone, so the normal
+  // unlock→recreate→relock cycle cannot run: openRebuildShieldsWindow would call
+  // `shieldsDown`, which captures policy from the absent sandbox and fails, and
+  // a later `shieldsUp` would try to re-seal the fresh image against the gone
+  // sandbox's stale file-hash seal and may refuse (#4497). Instead, just note
+  // whether the sandbox was locked (read-only). The stale shields state is reset
+  // only AFTER the recreate succeeds (below) so a failed recreate leaves the
+  // lockdown record intact for a retry; the operator re-applies `shields up`
+  // post-recovery (printed on success) since the workspace state was lost anyway.
+  let staleSandboxWasLocked = false;
+  let rebuildShieldsWindow: RebuildShieldsWindow | null;
+  if (staleRecovery) {
+    staleSandboxWasLocked = !shields.isShieldsDown(sandboxName);
+    rebuildShieldsWindow = { relocked: false, wasLocked: false };
+  } else {
+    rebuildShieldsWindow = openRebuildShieldsWindow(sandboxName, CLI_NAME);
+  }
   if (!rebuildShieldsWindow) return bail("Failed to auto-unlock shields.");
 
   const relockShieldsIfNeeded = (sandboxStillExists: boolean): boolean =>
@@ -524,59 +656,67 @@ export async function rebuildSandbox(
 
   let sandboxStillExists = true;
 
+  // backupManifest stays null on stale-sandbox recovery (#4497): the live
+  // sandbox is gone, so there is nothing to back up and the downstream
+  // restore/preset steps are skipped in favor of recreating from registry
+  // metadata.
+  let backupManifest: sandboxState.RebuildManifest | null = null;
+
   try {
-    // Step 2: Backup
-    console.log("  Backing up sandbox state...");
-    log(`Agent type: ${sb.agent || "openclaw"}, stateDirs from manifest`);
-    const backup = sandboxState.backupSandboxState(sandboxName);
-    log(
-      `Backup result: success=${backup.success}, backed=${backup.backedUpDirs.join(",")}; files=${backup.backedUpFiles.join(",")}, failed=${backup.failedDirs.join(",")}; failedFiles=${backup.failedFiles.join(",")}`,
-    );
-    const hasAnyBackup = backup.backedUpDirs.length > 0 || backup.backedUpFiles.length > 0;
-    if (!backup.success && !hasAnyBackup) {
-      // Total failure — nothing was backed up at all.
-      console.error("  Failed to back up sandbox state.");
-      if (backup.failedDirs.length > 0) {
-        console.error(`  Failed: ${backup.failedDirs.join(", ")}`);
-      }
-      if (backup.failedFiles.length > 0) {
-        console.error(`  Failed files: ${backup.failedFiles.join(", ")}`);
-      }
-      console.error("  Aborting rebuild to prevent data loss.");
-      relockShieldsIfNeeded(true);
-      bail("Failed to back up sandbox state.");
-      return;
-    }
-    const backupManifest = backup.manifest;
-    if (!backupManifest) {
-      console.error("  Failed to record backup metadata.");
-      console.error("  Aborting rebuild to prevent data loss.");
-      relockShieldsIfNeeded(true);
-      bail("Failed to record backup metadata.");
-      return;
-    }
-    if (!backup.success) {
-      // Partial backup — some state succeeded, some failed (e.g. root-owned
-      // files caused tar permission errors).  Proceed with a warning so the
-      // rebuild isn't blocked by a handful of inaccessible files (#2727).
-      console.warn(
-        `  ${YW}⚠${R} Partial backup: ${backup.backedUpDirs.length} dirs and ` +
-          `${backup.backedUpFiles.length} files OK; ${backup.failedDirs.length} dirs and ` +
-          `${backup.failedFiles.length} files failed`,
+    // Step 2: Backup (skipped on stale-sandbox recovery -- no live state exists)
+    if (!staleRecovery) {
+      console.log("  Backing up sandbox state...");
+      log(`Agent type: ${sb.agent || "openclaw"}, stateDirs from manifest`);
+      const backup = sandboxState.backupSandboxState(sandboxName);
+      log(
+        `Backup result: success=${backup.success}, backed=${backup.backedUpDirs.join(",")}; files=${backup.backedUpFiles.join(",")}, failed=${backup.failedDirs.join(",")}; failedFiles=${backup.failedFiles.join(",")}`,
       );
-      if (backup.failedDirs.length > 0) {
-        console.warn(`    Failed dirs: ${backup.failedDirs.join(", ")}`);
+      const hasAnyBackup = backup.backedUpDirs.length > 0 || backup.backedUpFiles.length > 0;
+      if (!backup.success && !hasAnyBackup) {
+        // Total failure — nothing was backed up at all.
+        console.error("  Failed to back up sandbox state.");
+        if (backup.failedDirs.length > 0) {
+          console.error(`  Failed: ${backup.failedDirs.join(", ")}`);
+        }
+        if (backup.failedFiles.length > 0) {
+          console.error(`  Failed files: ${backup.failedFiles.join(", ")}`);
+        }
+        console.error("  Aborting rebuild to prevent data loss.");
+        relockShieldsIfNeeded(true);
+        bail("Failed to back up sandbox state.");
+        return;
       }
-      if (backup.failedFiles.length > 0) {
-        console.warn(`    Failed files: ${backup.failedFiles.join(", ")}`);
+      backupManifest = backup.manifest ?? null;
+      if (!backupManifest) {
+        console.error("  Failed to record backup metadata.");
+        console.error("  Aborting rebuild to prevent data loss.");
+        relockShieldsIfNeeded(true);
+        bail("Failed to record backup metadata.");
+        return;
       }
-      console.warn("    Rebuild will continue — failed state could not be preserved.");
-    } else {
-      console.log(
-        `  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
-      );
+      if (!backup.success) {
+        // Partial backup — some state succeeded, some failed (e.g. root-owned
+        // files caused tar permission errors).  Proceed with a warning so the
+        // rebuild isn't blocked by a handful of inaccessible files (#2727).
+        console.warn(
+          `  ${YW}⚠${R} Partial backup: ${backup.backedUpDirs.length} dirs and ` +
+            `${backup.backedUpFiles.length} files OK; ${backup.failedDirs.length} dirs and ` +
+            `${backup.failedFiles.length} files failed`,
+        );
+        if (backup.failedDirs.length > 0) {
+          console.warn(`    Failed dirs: ${backup.failedDirs.join(", ")}`);
+        }
+        if (backup.failedFiles.length > 0) {
+          console.warn(`    Failed files: ${backup.failedFiles.join(", ")}`);
+        }
+        console.warn("    Rebuild will continue — failed state could not be preserved.");
+      } else {
+        console.log(
+          `  ${G}\u2713${R} State backed up (${backup.backedUpDirs.length} directories, ${backup.backedUpFiles.length} files)`,
+        );
+      }
+      console.log(`    Backup: ${backupManifest.backupPath}`);
     }
-    console.log(`    Backup: ${backupManifest.backupPath}`);
 
     // Step 3: Delete sandbox without tearing down gateway or session.
     // sandboxDestroy() cleans up the gateway when it's the last sandbox and
@@ -603,7 +743,9 @@ export async function rebuildSandbox(
     log(`Delete result: exit=${deleteResult.status}, alreadyGone=${alreadyGone}`);
     if (deleteResult.status !== 0 && !alreadyGone) {
       console.error("  Failed to delete sandbox. Aborting rebuild.");
-      console.error("  State backup is preserved at: " + backupManifest.backupPath);
+      if (backupManifest) {
+        console.error("  State backup is preserved at: " + backupManifest.backupPath);
+      }
       relockShieldsIfNeeded(true);
       bail("Failed to delete sandbox.", deleteResult.status || 1);
       return;
@@ -802,26 +944,71 @@ export async function rebuildSandbox(
         /* best effort */
       }
 
+      // Stale-sandbox recovery had no backup to fall back on and already removed
+      // the registry entry before the recreate. If the recreate failed, restore
+      // the captured entry so the recommended `rebuild --yes` (and `connect`)
+      // remain retryable instead of failing at dispatch with "not found in
+      // registry" (#4497). Restore unconditionally — overwriting any partial entry
+      // a failed `onboard` may have registered — so the original metadata
+      // (defaultSandbox, customPolicies, every field) wins, not a half-written
+      // recreate entry. The restore targets only this sandbox under the registry
+      // lock, leaving other sandboxes' concurrent changes intact.
+      const snapshotEntry = staleRegistrySnapshot?.sandboxes?.[sandboxName];
+      if (staleRecovery && snapshotEntry) {
+        try {
+          registry.restoreSandboxEntry(snapshotEntry, {
+            reclaimDefault:
+              staleRegistrySnapshot?.defaultSandbox === sandboxName ? sandboxName : null,
+          });
+          log("Stale-recovery recreate failed: restored preserved registry entry for retry");
+        } catch (err) {
+          log(
+            `Failed to restore registry entry after stale-recovery recreate failure: ${String(err)}`,
+          );
+        }
+      }
+
       console.error("");
-      console.error(`  ${_RD}Recreate failed after sandbox was destroyed.${R}`);
-      console.error(`  Backup is preserved at: ${backupManifest.backupPath}`);
+      if (staleRecovery) {
+        console.error(`  ${_RD}Recovery recreate failed.${R}`);
+        console.error(
+          "  Your local registry entry has been preserved — you can retry once the issue above is fixed.",
+        );
+      } else {
+        console.error(`  ${_RD}Recreate failed after sandbox was destroyed.${R}`);
+      }
+      if (backupManifest) {
+        console.error(`  Backup is preserved at: ${backupManifest.backupPath}`);
+      }
       console.error("");
       console.error("  To recover manually:");
       console.error(`    1. Fix the issue above (missing credential, Docker problem, etc.)`);
       console.error(`    2. Run: ${CLI_NAME} onboard --resume`);
       console.error(`       This will recreate sandbox '${sandboxName}'.`);
-      console.error(`    3. Then restore your workspace state:`);
-      console.error(
-        `       ${CLI_NAME} ${sandboxName} snapshot restore "${backupManifest.timestamp}"`,
-      );
+      if (backupManifest) {
+        console.error(`    3. Then restore your workspace state:`);
+        console.error(
+          `       ${CLI_NAME} ${sandboxName} snapshot restore "${backupManifest.timestamp}"`,
+        );
+      }
       printRebuildShieldsRecovery(sandboxName, rebuildShieldsWindow, CLI_NAME);
       console.error("");
       relockShieldsIfNeeded(false);
       bail(
-        `Recreate failed (sandbox destroyed). Backup: ${backupManifest.backupPath}`,
+        backupManifest
+          ? `Recreate failed (sandbox destroyed). Backup: ${backupManifest.backupPath}`
+          : "Recreate failed (stale-sandbox recovery).",
         onboardExitCode,
       );
       return;
+    }
+
+    // Recreate succeeded. For stale recovery, reset the now-stale shields state so
+    // the freshly recreated (mutable) sandbox reports its true posture instead of
+    // the gone sandbox's old lock seal. Deferred until here so a failed recreate
+    // above leaves the lockdown record intact for a retry (#4497).
+    if (staleRecovery) {
+      shields.clearShieldsState(sandboxName);
     }
 
     const preservedRegistryFields = {
@@ -836,33 +1023,46 @@ export async function rebuildSandbox(
       registry.updateSandbox(sandboxName, preservedRegistryFields);
     }
 
-    // Step 5: Restore
-    console.log("");
-    console.log("  Restoring workspace state...");
-    log(`Restoring from: ${backupManifest.backupPath} into sandbox: ${sandboxName}`);
-    const restore = sandboxState.restoreSandboxState(sandboxName, backupManifest.backupPath);
-    log(
-      `Restore result: success=${restore.success}, restored=${restore.restoredDirs.join(",")}; files=${restore.restoredFiles.join(",")}, failed=${restore.failedDirs.join(",")}; failedFiles=${restore.failedFiles.join(",")}`,
-    );
-    if (!restore.success) {
-      console.error(`  Partial restore: ${restore.restoredDirs.join(", ") || "none"}`);
-      console.error(`  Failed: ${restore.failedDirs.join(", ")}`);
-      if (restore.failedFiles.length > 0) {
-        console.error(`  Failed files: ${restore.failedFiles.join(", ")}`);
-      }
-      console.error(`  Manual restore available from: ${backupManifest.backupPath}`);
-    } else {
-      console.log(
-        `  ${G}\u2713${R} State restored (${restore.restoredDirs.length} directories, ${restore.restoredFiles.length} files)`,
+    // Step 5: Restore (skipped on stale-sandbox recovery -- no backup exists)
+    let restoreSucceeded = true;
+    if (backupManifest) {
+      console.log("");
+      console.log("  Restoring workspace state...");
+      log(`Restoring from: ${backupManifest.backupPath} into sandbox: ${sandboxName}`);
+      const restore = sandboxState.restoreSandboxState(sandboxName, backupManifest.backupPath);
+      log(
+        `Restore result: success=${restore.success}, restored=${restore.restoredDirs.join(",")}; files=${restore.restoredFiles.join(",")}, failed=${restore.failedDirs.join(",")}; failedFiles=${restore.failedFiles.join(",")}`,
       );
+      restoreSucceeded = restore.success;
+      if (!restore.success) {
+        console.error(`  Partial restore: ${restore.restoredDirs.join(", ") || "none"}`);
+        console.error(`  Failed: ${restore.failedDirs.join(", ")}`);
+        if (restore.failedFiles.length > 0) {
+          console.error(`  Failed files: ${restore.failedFiles.join(", ")}`);
+        }
+        console.error(`  Manual restore available from: ${backupManifest.backupPath}`);
+      } else {
+        console.log(
+          `  ${G}\u2713${R} State restored (${restore.restoredDirs.length} directories, ${restore.restoredFiles.length} files)`,
+        );
+      }
     }
 
     // Step 5.5: Restore policy presets (#1952)
-    // Policy presets live in the gateway policy engine, not the sandbox filesystem.
-    // They are lost when the sandbox is destroyed and recreated. Re-apply any
-    // presets that were captured in the backup manifest.
+    // Built-in policy presets live in the gateway policy engine, not the sandbox
+    // filesystem, so they are lost when the sandbox is destroyed and recreated.
+    // Re-apply the presets captured in the backup manifest. On stale-sandbox
+    // recovery there is no manifest, so fall back to the built-in preset names
+    // recorded on the registry entry (`sb.policies`) — the same source the backup
+    // manifest is built from — so the recovered sandbox keeps its built-in egress
+    // presets (#4497). Custom `policy-add --from-file/--from-dir` rules
+    // (`sb.customPolicies`) are not re-applied here; like a normal rebuild, they
+    // follow the recreate/onboard path and must be re-added if they were in use.
+    const registryPolicyPresets = Array.isArray(sb.policies)
+      ? sb.policies.filter((value: unknown): value is string => typeof value === "string")
+      : [];
     const savedPresets = pruneDisabledMessagingPolicyPresets(
-      backupManifest.policyPresets || [],
+      backupManifest?.policyPresets ?? registryPolicyPresets,
       rebuildDisabledChannels,
     );
     if (savedPresets.length > 0) {
@@ -1008,8 +1208,13 @@ export async function rebuildSandbox(
     if (!relockShieldsIfNeeded(true)) return bail("Failed to re-apply shields lockdown.");
 
     console.log("");
-    if (restore.success && !mutablePermsRepairUnverified) {
+    if (restoreSucceeded && !mutablePermsRepairUnverified) {
       console.log(`  ${G}\u2713${R} Sandbox '${sandboxName}' rebuilt successfully`);
+      if (staleRecovery) {
+        console.log(
+          `    ${D}Recovered from a stale registry entry \u2014 no prior workspace state was available to restore.${R}`,
+        );
+      }
       if (versionCheck.expectedVersion) {
         console.log(`    Now running: ${rebuiltAgentName} v${versionCheck.expectedVersion}`);
       }
@@ -1021,7 +1226,7 @@ export async function rebuildSandbox(
       console.log(
         `  ${YW}\u26a0${R} Sandbox '${sandboxName}' rebuilt but some post-restore steps were incomplete`,
       );
-      if (!restore.success) {
+      if (!restoreSucceeded && backupManifest) {
         console.log(
           `    State restore was incomplete \u2014 backup available at: ${backupManifest.backupPath}`,
         );
@@ -1031,6 +1236,14 @@ export async function rebuildSandbox(
           `    Mutable config permissions were not verified \u2014 run \`${CLI_NAME} ${sandboxName} doctor --fix\` to restore the OpenClaw config permission contract`,
         );
       }
+    }
+    // Stale recovery reset the shields state to mutable (the gone sandbox's lock
+    // seal could not carry over to the fresh image). If lockdown had been enabled,
+    // tell the operator to re-apply it on the recreated sandbox (#4497).
+    if (staleRecovery && staleSandboxWasLocked) {
+      console.log(
+        `    ${YW}\u26a0${R} Shields were previously enabled but the recreated sandbox starts unlocked \u2014 run \`${CLI_NAME} ${sandboxName} shields up\` to restore lockdown.`,
+      );
     }
   } finally {
     if (!rebuildShieldsWindow.relocked) {

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -1530,11 +1530,30 @@ function isShieldsDown(sandboxName: string, allowInlineRecovery = false): boolea
   return mode !== "locked";
 }
 
+/**
+ * Remove the local shields state for a sandbox, returning it to the
+ * `mutable_default` posture. Used by stale-sandbox rebuild recovery (#4497):
+ * the live sandbox is gone, so the recorded lock seal/file-hashes no longer
+ * correspond to any live image. Clearing the state prevents a stale seal from
+ * blocking a fresh `shields up` and stops a freshly recreated (mutable) sandbox
+ * from being reported as locked. Best-effort: a missing state file is fine.
+ */
+function clearShieldsState(sandboxName: string): void {
+  validateName(sandboxName, "sandbox name");
+  killTimer(sandboxName);
+  try {
+    fs.rmSync(stateFilePath(sandboxName), { force: true });
+  } catch {
+    /* best effort — absent or unreadable state is already mutable_default */
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
 export {
+  clearShieldsState,
   DEFAULT_TIMEOUT_SECONDS,
   deriveShieldsMode,
   getShieldsPosture,

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -407,6 +407,36 @@ export function removeSandbox(name: string): boolean {
   });
 }
 
+/**
+ * Restore a previously-removed sandbox entry verbatim under the registry lock,
+ * preserving every field exactly (unlike `registerSandbox`, which rebuilds a
+ * fresh entry from known fields). Used to roll back a failed stale-sandbox
+ * rebuild recovery (#4497): the entry was removed before the recreate, and on
+ * failure it must come back intact. Operates on the CURRENT registry (it does
+ * not clobber other sandboxes' entries another command added during the rebuild
+ * window).
+ *
+ * `reclaimDefault` undoes the default-pointer move the original `removeSandbox`
+ * performed: when this sandbox was the default, `removeSandbox` reassigned
+ * `defaultSandbox` to another remaining sandbox (or null), so the rollback puts
+ * it back. This is best-effort "undo my operation" — a deliberate default change
+ * by a concurrent command during the rebuild window is an inherent race and may
+ * be overwritten.
+ */
+export function restoreSandboxEntry(
+  entry: SandboxEntry,
+  options: { reclaimDefault?: string | null } = {},
+): void {
+  withLock(() => {
+    const data = load();
+    data.sandboxes[entry.name] = entry;
+    if (options.reclaimDefault && data.defaultSandbox !== options.reclaimDefault) {
+      data.defaultSandbox = options.reclaimDefault;
+    }
+    save(data);
+  });
+}
+
 export function listSandboxes(): { sandboxes: SandboxEntry[]; defaultSandbox: string | null } {
   const data = load();
   return {

--- a/test/e2e/test-double-onboard.sh
+++ b/test/e2e/test-double-onboard.sh
@@ -780,38 +780,95 @@ else
   fail "connect removed '$SANDBOX_A' from the registry (must be preserved, #4497)"
 fi
 
-# The preserved entry must still be locatable by the recovery command the
-# status hint recommends: rebuild must get past the dispatcher and into its
-# own flow rather than failing with "does not exist".
+# #4497 (reopened) acceptance gate — the EXACT reporter workflow:
+#   status recommends `rebuild --yes` → connect preserves the registry →
+#   `rebuild --yes` must actually RECOVER the sandbox, not dead-end.
+#
+# The first fix (PR #4647) only stopped connect from deleting the entry; rebuild
+# still aborted at its backup step with "Cannot back up state" whenever the live
+# sandbox was absent — precisely this stale state. A probe that only checks for
+# "does not exist" would pass against that bug, so this drives the full recovery
+# rebuild and asserts it (a) never prints the dead-end errors, (b) reports the
+# stale state and skips the impossible backup, and (c) recreates a live sandbox.
+#
+# The recreate runs `onboard --resume` in-process, so it needs the same provider
+# env the original onboard used. Allow a full phase timeout for the rebuild.
 REBUILD_LOG="$(mktemp)"
 rebuild_exit=0
-run_with_timeout "$RECOVERY_PROBE_TIMEOUT_SECONDS" \
-  env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || rebuild_exit=$?
+run_with_timeout "$PHASE_TIMEOUT" \
+  env \
+  COMPATIBLE_API_KEY=dummy \
+  NEMOCLAW_NON_INTERACTIVE=1 \
+  NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
+  NEMOCLAW_PROVIDER=custom \
+  "NEMOCLAW_ENDPOINT_URL=${FAKE_BASE_URL}" \
+  NEMOCLAW_MODEL=test-model \
+  "NEMOCLAW_SANDBOX_NAME=${SANDBOX_A}" \
+  NEMOCLAW_POLICY_MODE=skip \
+  NEMOCLAW_DASHBOARD_PORT= \
+  CHAT_UI_URL= \
+  "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" rebuild --yes >"$REBUILD_LOG" 2>&1 || rebuild_exit=$?
 rebuild_output="$(cat "$REBUILD_LOG")"
 rm -f "$REBUILD_LOG"
 
-# A timeout (124 from `timeout`/`gtimeout`) must fail, not silently pass: a
-# killed process produces output without "does not exist", so guard the exit
-# code before the content assertion.
+# A timeout (124 from `timeout`/`gtimeout`) must fail, not silently pass.
 if [ "$rebuild_exit" -eq 124 ]; then
-  fail "rebuild probe timed out after ${RECOVERY_PROBE_TIMEOUT_SECONDS}s (possible prompt regression, #4497)"
+  dump_diagnostics "stale rebuild recovery (#4497)"
+  fail "rebuild recovery timed out after ${PHASE_TIMEOUT}s (#4497)"
+fi
+
+# (a) The pre-fix dead-ends must never appear.
+if grep -q "Cannot back up state" <<<"$rebuild_output"; then
+  fail "rebuild dead-ended at 'Cannot back up state' on a stale sandbox (#4497)"
 elif grep -q "does not exist" <<<"$rebuild_output"; then
   fail "rebuild could not locate the preserved sandbox '$SANDBOX_A' (#4497)"
 else
-  pass "rebuild located the preserved sandbox '$SANDBOX_A' (#4497)"
+  pass "rebuild did not dead-end on the stale sandbox (#4497)"
 fi
 
-# #4497: the explicit `destroy` command is the intended way to purge a stale
-# entry now that routine status/connect no longer delete it. Purge it here,
-# while the gateway is still healthy, so the preserved entry does not leak into
-# Phase 7 cleanup (which runs against a stopped gateway and cannot remove it).
+# (b) It must recognize the stale state and skip the impossible backup.
+if grep -q "absent from the live OpenShell gateway" <<<"$rebuild_output" \
+  && grep -q "No live workspace state to back up" <<<"$rebuild_output"; then
+  pass "rebuild reported the stale state and skipped backup (#4497)"
+else
+  dump_diagnostics "stale rebuild recovery markers (#4497)"
+  fail "rebuild did not report the stale-recovery path (#4497)"
+fi
+if grep -q "Creating new sandbox with current image" <<<"$rebuild_output"; then
+  pass "rebuild proceeded to recreate from preserved metadata (#4497)"
+else
+  fail "rebuild did not proceed to recreate the sandbox (#4497)"
+fi
+
+# (c) The recovery must succeed end-to-end: a live sandbox is back and the
+# registry entry survived the whole workflow.
+if [ "$rebuild_exit" -eq 0 ]; then
+  pass "rebuild recovery exited 0 (#4497)"
+else
+  dump_diagnostics "stale rebuild recovery exit=$rebuild_exit (#4497)"
+  fail "rebuild recovery exited $rebuild_exit (expected 0, #4497)"
+fi
+if openshell sandbox get "$SANDBOX_A" >/dev/null 2>&1; then
+  pass "OpenShell reports '$SANDBOX_A' live again after recovery rebuild (#4497)"
+else
+  dump_diagnostics "stale rebuild recovery liveness (#4497)"
+  fail "'$SANDBOX_A' is still absent from OpenShell after recovery rebuild (#4497)"
+fi
+if registry_has "$SANDBOX_A"; then
+  pass "Registry still contains '$SANDBOX_A' after recovery rebuild (#4497)"
+else
+  fail "Recovery rebuild lost the '$SANDBOX_A' registry entry (#4497)"
+fi
+
+# Teardown the now-live sandbox while the gateway is healthy so it does not leak
+# into Phase 7 cleanup (which runs against a stopped gateway).
 run_with_timeout "$RECOVERY_PROBE_TIMEOUT_SECONDS" \
   env NEMOCLAW_NON_INTERACTIVE=1 "${NEMOCLAW_CMD[@]}" "$SANDBOX_A" destroy --yes 2>/dev/null || true
 openshell sandbox delete "$SANDBOX_A" 2>/dev/null || true
 if registry_has "$SANDBOX_A"; then
-  fail "destroy did not purge the stale '$SANDBOX_A' registry entry (#4497)"
+  fail "destroy did not purge the recovered '$SANDBOX_A' registry entry (#4497)"
 else
-  pass "destroy purged the stale '$SANDBOX_A' registry entry (#4497)"
+  pass "destroy purged the recovered '$SANDBOX_A' registry entry (#4497)"
 fi
 
 # ══════════════════════════════════════════════════════════════════

--- a/test/gateway-state-reconcile-2276.test.ts
+++ b/test/gateway-state-reconcile-2276.test.ts
@@ -30,7 +30,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { testTimeout } from "./helpers/timeouts";
 
 const TIMEOUT_MS = testTimeout(20_000);
@@ -699,14 +699,19 @@ describe("Scenario 12: skill install — wrong gateway active yields guidance, n
 });
 
 // ─── Scenario 14 (#4497) ─── connect preserves enough state for rebuild ─────
-// End-to-end recovery contract: a healthy gateway reports the sandbox as gone,
-// `connect` must NOT delete the registry entry, and a follow-up
-// `rebuild --yes` must still be able to LOCATE the sandbox (it now gets past
-// the dispatcher's "does not exist" guard and into the rebuild flow, where it
-// stops at the credential preflight with the sandbox untouched). Before the
-// fix, `connect` removed the entry and `rebuild` failed with "does not exist".
+// End-to-end recovery contract for the REOPENED issue: a healthy gateway
+// reports the sandbox as gone, `connect` must NOT delete the registry entry,
+// and the follow-up `rebuild --yes` must actually RECOVER it.
+//
+// The first fix (PR #4647) only stopped `connect` from deleting the entry. But
+// `rebuild` then still dead-ended at its backup step with "Cannot back up
+// state" because the live sandbox was absent — exactly this stale state. So the
+// recommended recovery path was still broken. This scenario now asserts rebuild
+// (a) locates the preserved entry (no "does not exist"), (b) does NOT dead-end
+// at "Cannot back up state", and (c) reports the stale state and proceeds to
+// recreate from the preserved registry metadata instead of aborting.
 describe("Scenario 14 (#4497): connect preserves registry so rebuild can recover", () => {
-  it("after a non-destructive connect, `rebuild --yes` still finds the sandbox", {
+  it("after a non-destructive connect, `rebuild --yes` recovers the stale sandbox", {
     timeout: TIMEOUT_MS,
   }, () => {
     writeStubOpenshell({
@@ -728,11 +733,11 @@ describe("Scenario 14 (#4497): connect preserves registry so rebuild can recover
     assert.equal(connect.sessionSandboxName, SANDBOX_NAME, "session must survive connect");
     assert.doesNotMatch(connect.stderr, /Removed stale local registry entry/);
 
-    // Step 4: the previously-suggested rebuild can still locate the sandbox.
-    // The registry provider is `nvidia-prod`; with NVIDIA_API_KEY unset the
-    // rebuild stops at the credential preflight (before any destructive
-    // backup/delete) — proving it located the entry rather than tripping the
-    // dispatcher's "does not exist" guard.
+    // Step 4: the previously-suggested rebuild must RECOVER the stale sandbox.
+    // The live `sandbox list` does not report it, so rebuild enters its
+    // stale-recovery path: it locates the preserved registry entry, skips the
+    // impossible backup (instead of dead-ending at "Cannot back up state"),
+    // and proceeds to recreate from the preserved metadata.
     const repoRoot = path.join(import.meta.dirname, "..");
     const rebuild = spawnSync(
       process.execPath,
@@ -747,8 +752,10 @@ describe("Scenario 14 (#4497): connect preserves registry so rebuild can recover
           PATH: `${homeLocalBin}:/usr/bin:/bin`,
           NO_COLOR: "1",
           NEMOCLAW_NON_INTERACTIVE: "1",
-          // Force the credential preflight to fail deterministically so the
-          // rebuild halts the moment after it locates the sandbox.
+          // The recreate handoff (onboard --resume) fails fast in this stubbed
+          // HOME — fine: the assertions below target the recovery markers that
+          // are emitted BEFORE the recreate, proving rebuild crossed the
+          // backup gate that previously blocked it.
           NVIDIA_API_KEY: "",
           NEMOCLAW_PROVIDER_KEY: "",
         },
@@ -761,19 +768,39 @@ describe("Scenario 14 (#4497): connect preserves registry so rebuild can recover
       /does not exist/,
       `rebuild must locate the preserved sandbox, got:\n${rebuildOut}`,
     );
+    // The reopened-issue dead-end must be gone.
+    assert.doesNotMatch(
+      rebuildOut,
+      /Cannot back up state/,
+      `rebuild must not dead-end on the stale sandbox (#4497), got:\n${rebuildOut}`,
+    );
     assert.match(
       rebuildOut,
       new RegExp(`Rebuild sandbox '${SANDBOX_NAME}'`),
       `rebuild must enter the rebuild flow, got:\n${rebuildOut}`,
     );
-    // Registry entry still intact after the located-but-halted rebuild.
-    const registryPath = path.join(registryDir, "sandboxes.json");
-    const reg = fs.existsSync(registryPath)
-      ? JSON.parse(fs.readFileSync(registryPath, "utf-8"))
-      : null;
-    assert.ok(
-      reg?.sandboxes?.[SANDBOX_NAME],
-      `registry entry must remain after rebuild preflight, got: ${JSON.stringify(reg)}`,
+    // It must recognize the stale state and skip the impossible backup.
+    assert.match(
+      rebuildOut,
+      /absent from the live OpenShell gateway/,
+      `rebuild must report the stale-recovery state (#4497), got:\n${rebuildOut}`,
+    );
+    assert.match(
+      rebuildOut,
+      /No live workspace state to back up/,
+      `rebuild must skip backup on stale recovery (#4497), got:\n${rebuildOut}`,
+    );
+    assert.doesNotMatch(
+      rebuildOut,
+      /Backing up sandbox state/,
+      `rebuild must not attempt backup on a stale sandbox (#4497), got:\n${rebuildOut}`,
+    );
+    // And it must proceed to recreate from the preserved metadata — this line
+    // is printed right before the onboard --resume handoff.
+    assert.match(
+      rebuildOut,
+      /Creating new sandbox with current image/,
+      `rebuild must proceed to recreate the sandbox (#4497), got:\n${rebuildOut}`,
     );
   });
 });

--- a/test/rebuild-stale-recovery.test.ts
+++ b/test/rebuild-stale-recovery.test.ts
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression for issue #4497 (reopened): stale sandbox rebuild recovery.
+ *
+ * Reporter workflow:
+ *   1. A sandbox is registered locally but its live OpenShell/Docker state has
+ *      diverged (stuck/stale provision, container reaped) — it no longer shows
+ *      up in `openshell sandbox list`.
+ *   2. `status` prints a `rebuild --yes` recovery hint.
+ *   3. `connect` runs and (after PR #4647) preserves the registry entry.
+ *   4. The user runs the recommended `rebuild --yes`.
+ *
+ * The first fix (PR #4647) stopped `connect` from deleting the registry entry,
+ * but `rebuild` still aborted at the backup step with
+ * "Sandbox '<name>' is not running. Cannot back up state." whenever the live
+ * sandbox was absent — which is precisely the stale-recovery state. That left
+ * the recommended recovery path dead-ended.
+ *
+ * This suite asserts that `rebuild --yes` now treats a registered-but-not-live
+ * sandbox as a recovery rebuild: it skips the (impossible) backup, reports the
+ * stale state, and proceeds to recreate from the preserved registry metadata.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const NODE_BIN = path.dirname(process.execPath);
+const tmpFixtures: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpFixtures.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* */
+    }
+  }
+});
+
+/**
+ * Build a temp HOME whose registry holds `my-assistant`, whose onboard session
+ * matches it, and whose fake `openshell sandbox list` returns EMPTY — modelling
+ * the stale state where the live gateway no longer knows the sandbox.
+ */
+function createStaleFixture(
+  opts: {
+    liveListIncludesSandbox?: boolean;
+    foreignGatewayActive?: boolean;
+    gatewayName?: string | null;
+  } = {},
+) {
+  const {
+    liveListIncludesSandbox = false,
+    foreignGatewayActive = false,
+    gatewayName = null,
+  } = opts;
+  const sandboxName = "my-assistant";
+  const provider = "nvidia-prod";
+  const credentialEnv = "NVIDIA_API_KEY";
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-4497-"));
+  tmpFixtures.push(tmpDir);
+  const nemoclawDir = path.join(tmpDir, ".nemoclaw");
+  fs.mkdirSync(nemoclawDir, { recursive: true, mode: 0o700 });
+
+  fs.writeFileSync(
+    path.join(nemoclawDir, "sandboxes.json"),
+    JSON.stringify({
+      defaultSandbox: sandboxName,
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          model: "meta/llama-3.3-70b-instruct",
+          provider,
+          gpuEnabled: false,
+          policies: [],
+          agent: null,
+          messagingChannels: null,
+          ...(gatewayName ? { gatewayName } : {}),
+        },
+      },
+    }),
+    { mode: 0o600 },
+  );
+
+  fs.writeFileSync(
+    path.join(nemoclawDir, "onboard-session.json"),
+    JSON.stringify({
+      version: 1,
+      sessionId: "s",
+      resumable: true,
+      status: "complete",
+      mode: "interactive",
+      startedAt: "2026-01-01",
+      updatedAt: "2026-01-01",
+      lastStepStarted: null,
+      lastCompletedStep: "policies",
+      failure: null,
+      agent: null,
+      sandboxName,
+      provider,
+      model: "meta/llama-3.3-70b-instruct",
+      endpointUrl: null,
+      credentialEnv,
+      hermesAuthMethod: null,
+      preferredInferenceApi: null,
+      nimContainer: null,
+      webSearchConfig: null,
+      policyPresets: [],
+      messagingChannels: null,
+      metadata: { gatewayName: "nemoclaw", fromDockerfile: null },
+      steps: {},
+    }),
+    { mode: 0o600 },
+  );
+
+  // Provider credential present so the rebuild preflight passes and we reach
+  // the liveness check that this regression targets.
+  fs.writeFileSync(
+    path.join(nemoclawDir, "credentials.json"),
+    JSON.stringify({ [credentialEnv]: "nvapi-test-key-for-rebuild" }),
+    { mode: 0o600 },
+  );
+
+  // Fake openshell. `sandbox list` returns empty (stale) unless the test asks
+  // for the live-present control case. `gateway info`/`status` report a healthy
+  // named gateway so the rebuild does not bail on gateway recovery first.
+  const listBody = liveListIncludesSandbox
+    ? `process.stdout.write("${sandboxName}\\n"); process.exit(0);`
+    : `process.stdout.write("\\n"); process.exit(0);`;
+  // When a foreign gateway is active, `status` reports a different active
+  // gateway even though the named nemoclaw gateway still exists. This models
+  // the multi-gateway data-loss risk: the sandbox is hidden from the active
+  // gateway's list but rebuild must NOT destroy it.
+  const statusBody = foreignGatewayActive
+    ? `process.stdout.write("Server Status\\n\\n  Gateway: other-gw\\n  Server: http://127.0.0.1:9090\\n  Status: Connected\\n"); process.exit(0);`
+    : `process.stdout.write("Server Status\\n\\n  Gateway: nemoclaw\\n  Server: http://127.0.0.1:8080\\n  Status: Connected\\n"); process.exit(0);`;
+  fs.writeFileSync(
+    path.join(tmpDir, "openshell"),
+    `#!/usr/bin/env node
+const a = process.argv.slice(2);
+if (a[0]==="sandbox" && a[1]==="list")       { ${listBody} }
+if (a[0]==="sandbox" && a[1]==="delete")     { process.exit(0); }
+if (a[0]==="sandbox" && a[1]==="get")        { process.stderr.write("Error:   × Not Found: sandbox not found\\n"); process.exit(1); }
+if (a[0]==="status")                         { ${statusBody} }
+if (a[0]==="gateway" && a[1]==="info")       { process.stdout.write("Gateway Info\\n\\nGateway: nemoclaw\\nGateway endpoint: https://127.0.0.1:8080/\\n"); process.exit(0); }
+if (a[0]==="gateway" && a[1]==="select")     { process.exit(0); }
+if (a[0]==="gateway")                        { process.stdout.write("nemoclaw\\n"); process.exit(0); }
+if (a[0]==="inference" && a[1]==="get")      { process.stdout.write('{"provider":"${provider}","model":"meta/llama-3.3-70b-instruct"}\\n'); process.exit(0); }
+if (a[0]==="provider" && a[1]==="get")       { process.exit(0); }
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+
+  // Fake docker — recreate path may shell out; succeed on common probes.
+  fs.writeFileSync(
+    path.join(tmpDir, "docker"),
+    `#!/usr/bin/env node
+const a = process.argv.slice(2);
+if (a[0]==="build") { process.exit(0); }
+if (a[0]==="image" && a[1]==="inspect") { process.exit(0); }
+if (a[0]==="inspect") { process.stdout.write("true\\n"); process.exit(0); }
+if (a[0]==="ps") { process.exit(0); }
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+
+  return { tmpDir, nemoclawDir, sandboxName };
+}
+
+function runRebuild(fixture: { tmpDir: string; sandboxName: string }) {
+  return spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, "bin", "nemoclaw.js"), fixture.sandboxName, "rebuild", "--yes"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      env: {
+        HOME: fixture.tmpDir,
+        PATH: fixture.tmpDir + ":" + NODE_BIN + ":/usr/bin:/bin",
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_NO_CONNECT_HINT: "1",
+        NO_COLOR: "1",
+      },
+      timeout: 60_000,
+    },
+  );
+}
+
+function registryHasSandbox(fixture: { nemoclawDir: string; sandboxName: string }): boolean {
+  const regPath = path.join(fixture.nemoclawDir, "sandboxes.json");
+  if (!fs.existsSync(regPath)) return false;
+  try {
+    const reg = JSON.parse(fs.readFileSync(regPath, "utf-8"));
+    return Boolean(reg.sandboxes?.[fixture.sandboxName]);
+  } catch {
+    return false;
+  }
+}
+
+describe("Issue #4497: stale sandbox rebuild recovery", () => {
+  it("does NOT abort with 'Cannot back up state' when the live sandbox is gone", {
+    timeout: 90_000,
+  }, () => {
+    const f = createStaleFixture({ liveListIncludesSandbox: false });
+    const result = runRebuild(f);
+    const output = (result.stderr || "") + (result.stdout || "");
+
+    // The pre-fix dead-end must be gone.
+    expect(output).not.toContain("Cannot back up state");
+    expect(output).not.toContain("is not running. Cannot back up state");
+  });
+
+  it("reports the stale state and recreates from preserved registry metadata", {
+    timeout: 90_000,
+  }, () => {
+    const f = createStaleFixture({ liveListIncludesSandbox: false });
+    const result = runRebuild(f);
+    const output = (result.stderr || "") + (result.stdout || "");
+
+    // Surfaces the recovery state to the operator.
+    expect(output).toContain("absent from the live OpenShell gateway");
+    expect(output).toContain("No live workspace state to back up");
+    // Skips the (impossible) backup step entirely.
+    expect(output).not.toContain("Backing up sandbox state");
+    // Proceeds to recreate — this line is printed right before onboard() runs,
+    // proving the rebuild crossed the backup gate that previously blocked it.
+    expect(output).toContain("Creating new sandbox with current image");
+  });
+
+  it("still backs up normally when the live sandbox IS present (control case)", {
+    timeout: 90_000,
+  }, () => {
+    const f = createStaleFixture({ liveListIncludesSandbox: true });
+    const result = runRebuild(f);
+    const output = (result.stderr || "") + (result.stdout || "");
+
+    // Live sandbox present → normal backup path, not stale recovery.
+    expect(output).toContain("Backing up sandbox state");
+    expect(output).not.toContain("absent from the live OpenShell gateway");
+  });
+
+  it("does NOT destroy/recreate when a foreign gateway is active (multi-gateway guard)", {
+    timeout: 90_000,
+  }, () => {
+    // A different OpenShell gateway is active, so the sandbox is missing from
+    // the active gateway's list — but it may still be live on the named
+    // nemoclaw gateway. Rebuild must reconcile against the named gateway and
+    // refuse to recreate from scratch, or it would destroy live workspace
+    // state in multi-gateway setups (#4497 / #4645).
+    const f = createStaleFixture({ foreignGatewayActive: true });
+    const result = runRebuild(f);
+    const output = (result.stderr || "") + (result.stdout || "");
+
+    // Must NOT take the destructive stale-recovery path.
+    expect(output).not.toContain("No live workspace state to back up");
+    expect(output).not.toContain("Deleting old sandbox");
+    expect(output).not.toContain("Creating new sandbox with current image");
+    // Must surface the wrong-gateway guidance and preserve the registry entry.
+    expect(output).toContain("NOT been removed");
+    expect(registryHasSandbox(f)).toBe(true);
+  });
+
+  it("does NOT stale-recover a sandbox recorded on a non-default per-port gateway", {
+    timeout: 90_000,
+  }, () => {
+    // The sandbox was created on a non-default gateway (#4645). It is absent
+    // from the active (default) gateway's list, but its live workspace may be
+    // intact on its own gateway. Rebuild must not recreate-from-scratch on the
+    // wrong gateway; it must point the operator at the recorded gateway and
+    // preserve the registry entry.
+    const f = createStaleFixture({ gatewayName: "nemoclaw-9000" });
+    const result = runRebuild(f);
+    const output = (result.stderr || "") + (result.stdout || "");
+
+    expect(output).not.toContain("No live workspace state to back up");
+    expect(output).not.toContain("Deleting old sandbox");
+    expect(output).not.toContain("Creating new sandbox with current image");
+    expect(output).toContain("openshell gateway select nemoclaw-9000");
+    expect(registryHasSandbox(f)).toBe(true);
+  });
+
+  it("preserves the registry entry when the recovery recreate fails", { timeout: 90_000 }, () => {
+    // Stale recovery removes the registry entry before the recreate (the
+    // recreate re-adds it on success). The fixture's onboard --resume cannot
+    // complete, so the recreate fails — the entry must be restored so the
+    // recommended `rebuild --yes` stays retryable instead of failing at
+    // dispatch with "not found in registry" (#4497).
+    const f = createStaleFixture({ liveListIncludesSandbox: false });
+    const result = runRebuild(f);
+    const output = (result.stderr || "") + (result.stdout || "");
+
+    // Proof we took the stale-recovery path and the recreate did not succeed.
+    expect(output).toContain("No live workspace state to back up");
+    expect(output).toContain("Recovery recreate failed");
+    // The preserved entry must survive the failed recreate, and the full
+    // registry snapshot (including defaultSandbox) must be restored verbatim.
+    expect(registryHasSandbox(f)).toBe(true);
+    const reg = JSON.parse(fs.readFileSync(path.join(f.nemoclawDir, "sandboxes.json"), "utf-8"));
+    expect(reg.defaultSandbox).toBe(f.sandboxName);
+  });
+});


### PR DESCRIPTION
## Summary

`rebuild --yes` no longer dead-ends on a stale sandbox. When a sandbox is registered locally but absent from a healthy OpenShell gateway (stuck/diverged provision, container reaped), rebuild now treats it as a recovery: it skips the impossible backup and recreates from the preserved registry + onboard-session metadata, instead of aborting with "Cannot back up state."

## Related Issue

Fixes #4497

## Changes

- `rebuild`: when the sandbox is missing from the active gateway's `sandbox list`, confirm absence authoritatively against the **named** nemoclaw gateway (`getReconciledSandboxGatewayState` runs `sandbox get`). Only enter the destructive stale-recovery path once it is genuinely gone on a healthy named gateway.
- Stale recovery skips backup/restore and recreates from registry/session metadata; built-in policy presets are re-applied from `sb.policies` (the same source the backup manifest uses).
- **Multi-gateway data-loss guards:** never recreate-from-scratch when (a) a foreign gateway is active (a `present`/list result there is not trusted), or (b) the sandbox is recorded on a non-default per-port gateway (#4645) — the operator is pointed at `openshell gateway select` instead.
- **Crash-safety:** on recreate failure, restore the captured registry entry verbatim (target-only, under the registry lock — no clobbering concurrent changes) and reclaim the default-sandbox pointer, so `rebuild`/`connect` stay retryable.
- **Shields:** reset the gone sandbox's stale lock seal only *after* a successful recreate (a failed recreate keeps the lockdown record for retry), and prompt the operator to re-apply `shields up` if it had been locked.
- New `registry.restoreSandboxEntry` and `shields.clearShieldsState` helpers.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes (only the pre-existing `test/ssrf-parity.test.ts` fails, identically on clean `upstream/main` — unrelated to this change)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] `npx biome check` clean on changed files; `shfmt`/`shellcheck` clean on the E2E script; `tsc` type-check passes

### Local end-to-end proof (exact reporter workflow on a real OpenShell gateway)

Drove `status -> connect -> rebuild --yes` against a real healthy gateway with a registered-but-not-live sandbox:

```
⚠ Sandbox 'repro4497stale' is registered locally but absent from the live OpenShell gateway.
No live workspace state to back up — recreating from the preserved registry metadata.
Deleting old sandbox...
✓ Old sandbox deleted
Creating new sandbox with current image...
```

No "Cannot back up state", no "Backing up sandbox state" — rebuild crossed the gate that previously dead-ended and proceeded into the recreate (`onboard --resume`). The user's other registry entries were untouched.

### Regression + pipeline coverage

- `test/rebuild-stale-recovery.test.ts` — recover, live-control, foreign-gateway guard, non-default per-port guard, failed-recreate registry rollback (incl. `defaultSandbox`).
- `test/gateway-state-reconcile-2276.test.ts` Scenario 14 and `rebuild-gateway-drift.test.ts` updated to assert recovery rather than the dead-end.
- `test/e2e/test-double-onboard.sh` Phase 5 strengthened so the exact reporter workflow must recreate a **live** sandbox (the prior probe only checked for "does not exist" and would have passed against this bug).

### Known limitation (pre-existing, shared with normal rebuild)

Custom `policy-add --from-file/--from-dir` egress rules (`customPolicies`) are not re-applied to the recreated sandbox — this is identical to a normal rebuild's recreate path (the registry entry is removed before `onboard --resume` runs) and is out of scope for this dead-end fix.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sandbox recovery when a sandbox exists locally but is missing from the live gateway, preventing unnecessary destructive operations and enabling a “stale-sandbox” recovery path.
  * Improved rebuild behavior to preserve and restore local registry metadata so retrying recovery no longer fails.

* **Improvements**
  * Updated post-recreate and error messaging to include clearer context and preserved backup paths; retry guidance is now configurable.
  * Shield handling adjusted to avoid unsafe unlock/relock behavior during stale recovery.

* **New Features**
  * Added APIs to restore a removed registry entry and to clear persisted shields state.

* **Tests**
  * Added and expanded end-to-end and unit tests covering stale-sandbox recovery scenarios and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->