### PR TITLE
test(e2e): make framework test names readable

### DIFF
--- a/test/e2e-scenario/framework-tests/e2e-assertion-modules.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-assertion-modules.test.ts
@@ -36,7 +36,7 @@ function allPlannedAssertionGroupIds(): Set<string> {
 }
 
 describe("assertion modules", () => {
-  it("test_should_define_onboarding_assertions_in_modules", () => {
+  it("should define onboarding assertions in modules", () => {
     const onboardingGroups = assertionRegistry.groups.filter((group) => group.phase === "onboarding");
     const stepIds = new Set(onboardingGroups.flatMap((group) => group.steps.map((step) => step.id)));
 
@@ -49,7 +49,7 @@ describe("assertion modules", () => {
     }
   });
 
-  it("test_should_map_every_old_validation_suite_to_canonical_assertion_group", () => {
+  it("should map every old validation suite to canonical assertion group", () => {
     const suites = loadYaml(SUITES_PATH).suites as AnyRecord;
 
     for (const suiteId of Object.keys(suites)) {
@@ -60,7 +60,7 @@ describe("assertion modules", () => {
     }
   });
 
-  it("test_should_keep_snapshot_suite_distinct_from_snapshot_lifecycle", () => {
+  it("should keep snapshot suite distinct from snapshot lifecycle", () => {
     const snapshot = assertionGroupForSuite("snapshot");
     const snapshotLifecycle = assertionGroupForSuite("snapshot-lifecycle");
 
@@ -73,20 +73,20 @@ describe("assertion modules", () => {
     ]);
   });
 
-  it("test_should_require_each_assertion_group_to_have_steps", () => {
+  it("should require each assertion group to have steps", () => {
     const emptyGroup: AssertionGroup = { id: "empty", phase: "runtime", steps: [] };
 
     expect(() => validateAssertionGroups([...assertionRegistry.groups, emptyGroup], E2E_DIR)).toThrow(/empty/);
   });
 
-  it("test_should_require_each_assertion_group_to_be_used_by_a_scenario_plan", () => {
+  it("should require each assertion group to be used by a scenario plan", () => {
     const planned = allPlannedAssertionGroupIds();
     const unused = assertionRegistry.groups.map((group) => group.id).filter((id) => !planned.has(id));
 
     expect(unused, `unused assertion groups: ${unused.join(", ")}`).toEqual([]);
   });
 
-  it("test_should_fail_when_assertion_step_references_missing_script", () => {
+  it("should fail when assertion step references missing script", () => {
     const badGroup: AssertionGroup = {
       id: "bad.missing-script",
       phase: "runtime",
@@ -103,7 +103,7 @@ describe("assertion modules", () => {
     expect(() => validateAssertionGroups([badGroup], E2E_DIR)).toThrow(/does-not-exist/);
   });
 
-  it("test_should_fail_when_retry_attempts_lack_classifier", () => {
+  it("should fail when retry attempts lack classifier", () => {
     const badGroup: AssertionGroup = {
       id: "bad.retry",
       phase: "runtime",
@@ -121,7 +121,7 @@ describe("assertion modules", () => {
     expect(() => validateAssertionGroups([badGroup], E2E_DIR)).toThrow(/classifier|retry/i);
   });
 
-  it("test_should_block_complete_status_for_manual_classification_steps", () => {
+  it("should block complete status for manual classification steps", () => {
     expect(() => validateAssertionGroups(assertionRegistry.groups, E2E_DIR)).not.toThrow(/needs-manual-classification/);
     expect(assertionRegistry.groups.every((group) => group.migrationStatus === "complete")).toBe(true);
   });

--- a/test/e2e-scenario/framework-tests/e2e-context-helper.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-context-helper.test.ts
@@ -20,7 +20,7 @@ function runBash(script: string, env: Record<string, string> = {}): SpawnSyncRet
 }
 
 describe("E2E context helper (runtime/lib/context.sh)", () => {
-  it("context_should_write_and_source_values", () => {
+  it("context helper writes and sources values", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-ctx-"));
     try {
       const script = `
@@ -43,7 +43,7 @@ describe("E2E context helper (runtime/lib/context.sh)", () => {
     }
   });
 
-  it("context_require_should_fail_for_missing_value", () => {
+  it("context require fails for missing values", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-ctx-"));
     try {
       const script = `
@@ -61,7 +61,7 @@ describe("E2E context helper (runtime/lib/context.sh)", () => {
     }
   });
 
-  it("context_dump_should_redact_sensitive_values", () => {
+  it("context dump redacts sensitive values", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-ctx-"));
     try {
       const script = `

--- a/test/e2e-scenario/framework-tests/e2e-convention-lint.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-convention-lint.test.ts
@@ -51,7 +51,7 @@ describe("Phase 1.G convention lint", () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("lint_should_flag_step_that_reexports_noninteractive_env", () => {
+  it("flags steps that reexport noninteractive env", () => {
     writeStep(tmp, "00-bad.sh", 'export DEBIAN_FRONTEND=noninteractive\necho hi');
     const r = runTsx(LINT_BIN, ["--root", tmp]);
     expect(r.status).not.toBe(0);
@@ -59,7 +59,7 @@ describe("Phase 1.G convention lint", () => {
     expect(r.stdout + r.stderr).toMatch(/DEBIAN_FRONTEND|non.?interactive/i);
   });
 
-  it("lint_should_flag_step_that_registers_own_trap", () => {
+  it("flags steps that register their own trap", () => {
     writeStep(tmp, "00-trap.sh", 'trap cleanup EXIT');
     const r = runTsx(LINT_BIN, ["--root", tmp]);
     expect(r.status).not.toBe(0);
@@ -67,7 +67,7 @@ describe("Phase 1.G convention lint", () => {
     expect(r.stdout + r.stderr).toMatch(/trap/i);
   });
 
-  it("lint_should_flag_step_that_calls_section", () => {
+  it("flags steps that call section", () => {
     writeStep(tmp, "00-section.sh", 'section "Phase 3: X"');
     const r = runTsx(LINT_BIN, ["--root", tmp]);
     expect(r.status).not.toBe(0);
@@ -75,7 +75,7 @@ describe("Phase 1.G convention lint", () => {
     expect(r.stdout + r.stderr).toMatch(/section/i);
   });
 
-  it("lint_should_flag_step_writing_to_tmp_log_path", () => {
+  it("flags steps that write to a tmp log path", () => {
     writeStep(tmp, "00-tmplog.sh", 'echo hi > /tmp/foo.log');
     const r = runTsx(LINT_BIN, ["--root", tmp]);
     expect(r.status).not.toBe(0);
@@ -83,21 +83,21 @@ describe("Phase 1.G convention lint", () => {
     expect(r.stdout + r.stderr).toMatch(/\/tmp.*\.log|E2E_CONTEXT_DIR/);
   });
 
-  it("lint_should_flag_nonstandard_repo_root_discovery_pattern", () => {
+  it("flags nonstandard repo root discovery patterns", () => {
     writeStep(tmp, "00-reporoot.sh", 'REPO_ROOT="$(git rev-parse --show-toplevel)"');
     const r = runTsx(LINT_BIN, ["--root", tmp]);
     expect(r.status).not.toBe(0);
     expect(r.stdout + r.stderr).toMatch(/repo.?root|git rev-parse/i);
   });
 
-  it("lint_should_not_require_legacy_scripts_to_update_parity_map", () => {
+  it("does not require legacy scripts to update the parity map", () => {
     writeLegacy(tmp, "test-new-thing.sh", '# legacy script\npass "something"');
     const r = runTsx(LINT_BIN, ["--root", tmp]);
     expect(r.status, r.stdout + r.stderr).toBe(0);
   });
 
 
-  it("lint_should_pass_on_current_repo_state", () => {
+  it("passes on the current repo state", () => {
     const r = runTsx(LINT_BIN);
     expect(r.status, r.stdout + r.stderr).toBe(0);
   });

--- a/test/e2e-scenario/framework-tests/e2e-expected-state.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-expected-state.test.ts
@@ -112,7 +112,7 @@ describe("compiler emits state-validation phase actions from expected-state regi
     ]);
   });
 
-  it("compiler hard-errors on a scenario referencing an unknown expected_state id", () => {
+  it("compiler fails hard on a scenario referencing an unknown expected-state ID", () => {
     expect(() =>
       compileRunPlans([
         {

--- a/test/e2e-scenario/framework-tests/e2e-lib-helpers.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-lib-helpers.test.ts
@@ -32,7 +32,7 @@ function runBash(script: string, env: Record<string, string> = {}): SpawnSyncRet
 // ──────────────────────────────────────────────────────────────────────────
 
 describe("E2E shell helpers", () => {
-  it("test_should_source_inference_routing_helpers_under_strict_shell_mode", () => {
+  it("should source inference routing helpers under strict shell mode", () => {
     const r = runBash(`
       set -euo pipefail
       . "${VALIDATION_SUITES}/lib/inference_routing.sh"
@@ -41,7 +41,7 @@ describe("E2E shell helpers", () => {
     expect(r.status, r.stderr).toBe(0);
   });
 
-  it("test_should_fail_clearly_when_required_context_is_missing", () => {
+  it("should fail clearly when required context is missing", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-inf-missing-"));
     try {
       const r = runBash(
@@ -61,7 +61,7 @@ describe("E2E shell helpers", () => {
     }
   });
 
-  it("no_docker_onboarding_worker_should_preserve_seeded_context_and_redact_log", () => {
+  it("no-Docker onboarding worker should preserve seeded context and redact the log", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-no-docker-context-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -120,7 +120,7 @@ exit 2
     }
   });
 
-  it("no_docker_onboarding_worker_should_fail_on_unrelated_onboarding_errors", () => {
+  it("no-Docker onboarding worker should fail on unrelated onboarding errors", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-no-docker-unrelated-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -175,7 +175,7 @@ exit 2
     }
   });
 
-  it("no_docker_onboarding_worker_should_accept_current_preflight_wording", () => {
+  it("no-Docker onboarding worker should accept current preflight wording", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-no-docker-wording-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -218,7 +218,7 @@ exit 2
     }
   });
 
-  it("no_docker_redactor_fallback_should_redact_sensitive_env_values_without_python", () => {
+  it("no-Docker redactor fallback should redact sensitive env values without Python", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-no-docker-redactor-"));
     const noPythonBin = path.join(tmp, "bin");
     const logPath = path.join(tmp, "negative-preflight.log");
@@ -247,7 +247,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_load_with_context_library", () => {
+  it("security policy credentials helper should load with context library", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-context-"));
     try {
       fs.writeFileSync(path.join(tmp, "context.env"), "E2E_SCENARIO=test\nE2E_PROVIDER=nvidia\nE2E_CREDENTIALS_EXPECTED=present\n");
@@ -267,7 +267,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_fail_when_required_context_missing", () => {
+  it("security policy credentials helper should fail when required context is missing", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-context-missing-"));
     try {
       fs.writeFileSync(path.join(tmp, "context.env"), "E2E_SCENARIO=test\n");
@@ -286,7 +286,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_not_log_secret_values", () => {
+  it("security policy credentials helper should not log secret values", () => {
     const r = runBash(`
       set -euo pipefail
       . "${VALIDATION_SUITES}/lib/security_policy_credentials.sh"
@@ -299,7 +299,7 @@ exit 2
     expect(r.stdout).toMatch(/\[REDACTED\]/);
   });
 
-  it("security_policy_credentials_helper_should_reject_empty_gateway_credentials", () => {
+  it("security policy credentials helper should reject empty gateway credentials", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-credentials-empty-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -331,7 +331,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_reject_raw_credential_leaks", () => {
+  it("security policy credentials helper should reject raw credential leaks", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-credentials-leak-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -365,7 +365,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_reject_raw_credential_leaks_from_failed_list", () => {
+  it("security policy credentials helper should reject raw credential leaks from failed list", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-credentials-failed-leak-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -399,7 +399,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_verify_policy_and_shields_state", () => {
+  it("security policy credentials helper should verify policy and shields state", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-policy-shields-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -453,7 +453,7 @@ exit 2
     }
   });
 
-  it("security_policy_credentials_helper_should_fail_on_missing_policy_preset", () => {
+  it("security policy credentials helper should fail on missing policy preset", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-policy-missing-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -482,7 +482,7 @@ exit 0
     }
   });
 
-  it("security_policy_credentials_helper_should_verify_openshell_rewrite_markers", () => {
+  it("security policy credentials helper should verify OpenShell rewrite markers", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-openshell-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -515,7 +515,7 @@ exit 0
     }
   });
 
-  it("security_policy_credentials_helper_should_reject_below_minimum_openshell_version", () => {
+  it("security policy credentials helper should reject below minimum OpenShell version", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spc-openshell-old-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -548,7 +548,7 @@ exit 0
     }
   });
 
-  it("env_helper_should_set_standard_noninteractive_env", () => {
+  it("env helper should set standard noninteractive env", () => {
     const r = runBash(`
       set -euo pipefail
       . "${RUNTIME_LIB}/env.sh"
@@ -562,7 +562,7 @@ exit 0
     expect(r.stdout).toContain("DEBIAN_FRONTEND=noninteractive");
   });
 
-  it("sandbox_helper_should_fail_for_missing_sandbox_name", () => {
+  it("sandbox helper should fail for missing sandbox name", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-sb-"));
     try {
       // Initialise a context file without E2E_SANDBOX_NAME.
@@ -591,7 +591,7 @@ exit 0
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("rebuild/upgrade validation helpers", () => {
-  it("rebuild_upgrade_library_should_source_without_side_effects", () => {
+  it("rebuild/upgrade library should source without side effects", () => {
     const r = runBash(`
       set -euo pipefail
       . "${REBUILD_UPGRADE_LIB}"
@@ -601,7 +601,7 @@ describe("rebuild/upgrade validation helpers", () => {
     expect(r.stdout + r.stderr).not.toMatch(/install|onboard|rebuild/i);
   });
 
-  it("rebuild_upgrade_context_should_fail_with_missing_key_name", () => {
+  it("rebuild/upgrade context should fail with a missing key name", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-ru-"));
     try {
       fs.writeFileSync(path.join(tmp, "context.env"), "E2E_SCENARIO=test\n");
@@ -619,7 +619,7 @@ describe("rebuild/upgrade validation helpers", () => {
     }
   });
 
-  it("rebuild_upgrade_context_should_pass_when_required_keys_present", () => {
+  it("rebuild/upgrade context should pass when required keys are present", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-ru-"));
     try {
       fs.writeFileSync(
@@ -640,7 +640,7 @@ describe("rebuild/upgrade validation helpers", () => {
     }
   });
 
-  it("rebuild_upgrade_checks_should_allow_command_fakes", () => {
+  it("rebuild/upgrade checks should allow command fakes", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-ru-"));
     try {
       fs.writeFileSync(
@@ -679,7 +679,7 @@ describe("rebuild/upgrade validation helpers", () => {
     }
   });
 
-  it("policy_preset_check_should_match_endpoint_url_when_preset_name_absent", () => {
+  it("policy preset check should match endpoint URL when preset name absent", () => {
     // The legacy assertion called `nemoclaw policy status` (a command
     // that does not exist) and silently failed. The new assertion calls
     // `openshell policy get --full <sandbox>` and matches preset names
@@ -719,7 +719,7 @@ describe("rebuild/upgrade validation helpers", () => {
     }
   });
 
-  it("policy_preset_check_should_fail_with_diagnostic_when_preset_missing", () => {
+  it("policy preset check should fail with diagnostic when preset missing", () => {
     // Negative case: when a declared preset is absent from the live
     // policy dump, the assertion must fail AND emit a diagnostic line
     // identifying the missing preset and showing the policy head. The
@@ -757,7 +757,7 @@ describe("rebuild/upgrade validation helpers", () => {
 });
 
 describe("Phase 1.A logging helpers", () => {
-  it("logging_should_emit_stable_pass_marker_when_e2e_pass_called", () => {
+  it("logging should emit stable pass marker when E2E pass called", () => {
     const r = runBash(`
       set -euo pipefail
       . "${RUNTIME_LIB}/logging.sh"
@@ -767,7 +767,7 @@ describe("Phase 1.A logging helpers", () => {
     expect(r.stdout).toMatch(/^PASS:.*assertion X/m);
   });
 
-  it("logging_should_emit_stable_fail_marker_and_nonzero_exit_when_e2e_fail_called", () => {
+  it("logging should emit stable fail marker and nonzero exit when E2E fail called", () => {
     const r = runBash(`
       . "${RUNTIME_LIB}/logging.sh"
       ( e2e_fail "assertion Y" )
@@ -776,7 +776,7 @@ describe("Phase 1.A logging helpers", () => {
     expect(r.stdout + r.stderr).toMatch(/FAIL:.*assertion Y/);
   });
 
-  it("logging_should_include_phase_prefix_when_e2e_section_called", () => {
+  it("logging should include phase prefix when E2E section called", () => {
     const r = runBash(`
       set -euo pipefail
       . "${RUNTIME_LIB}/logging.sh"
@@ -786,7 +786,7 @@ describe("Phase 1.A logging helpers", () => {
     expect(r.stdout).toMatch(/^=== Phase 2:.*onboarding/m);
   });
 
-  it("logging_should_autosource_logging_when_env_sh_sourced", () => {
+  it("logging should autosource logging when env.sh is sourced", () => {
     const r = runBash(`
       set -euo pipefail
       . "${RUNTIME_LIB}/env.sh"
@@ -803,7 +803,7 @@ describe("Phase 1.A logging helpers", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("Phase 1.B sandbox-exec helper", () => {
-  it("sandbox_exec_should_propagate_exit_code_when_command_fails", () => {
+  it("sandbox exec should propagate exit code when command fails", () => {
     // Use a fake openshell on PATH that executes the command after `--`.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-sbex-fail-"));
     try {
@@ -839,7 +839,7 @@ exec "$@"
     }
   });
 
-  it("sandbox_exec_stdin_should_quote_args_safely_when_piped", () => {
+  it("sandbox exec stdin should quote args safely when input is piped", () => {
     // Verify that $TOKEN is NOT expanded on the host side before being
     // delivered to the sandbox. We stub openshell to echo back stdin.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-sbex-stdin-"));
@@ -873,7 +873,7 @@ exec "$@"
     }
   });
 
-  it("sandbox_exec_should_prefer_ssh_config_transport_when_openshell_offers_one", () => {
+  it("sandbox exec should prefer SSH config transport when OpenShell offers one", () => {
     // Verify the new default: when `openshell sandbox ssh-config <name>`
     // succeeds, the wrapper routes through `ssh -F <cfg>` instead of
     // `openshell sandbox exec`.
@@ -933,7 +933,7 @@ exit 0
     }
   });
 
-  it("sandbox_exec_should_fall_back_to_openshell_when_ssh_config_unavailable", () => {
+  it("sandbox exec should fall back to OpenShell when SSH config is unavailable", () => {
     // If `openshell sandbox ssh-config` fails, the wrapper must fall
     // back to `openshell sandbox exec`.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-sbex-fb-"));
@@ -984,7 +984,7 @@ exit 99
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("Phase 1.C fixtures", () => {
-  it("fake_openai_should_start_and_stop_cleanly_and_serve_chat_completions", () => {
+  it("fake OpenAI should start and stop cleanly and serve chat completions", () => {
     const r = runBash(`
       set -euo pipefail
       . "${FIXTURES}/fake-openai.sh"
@@ -1001,7 +1001,7 @@ describe("Phase 1.C fixtures", () => {
     expect(r.stdout).toMatch(/content/);
   });
 
-  it("older_base_image_should_emit_dockerfile_pointing_at_tagged_base", () => {
+  it("older base image should emit Dockerfile pointing at tagged base", () => {
     const r = runBash(`
       set -euo pipefail
       . "${FIXTURES}/older-base-image.sh"
@@ -1013,7 +1013,7 @@ describe("Phase 1.C fixtures", () => {
     expect(r.stdout).toMatch(/^FROM .*:v0\.0\.1-test/m);
   });
 
-  it("fake_messaging_fixtures_should_bind_a_port_and_accept_stub_requests", () => {
+  it("fake messaging fixtures should bind a port and accept stub requests", () => {
     for (const provider of ["telegram", "discord", "slack"]) {
       const r = runBash(`
         set -euo pipefail
@@ -1036,7 +1036,7 @@ describe("Phase 1.C fixtures", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("Phase 1.D assertion helpers", () => {
-  it("inference_works_should_pass_when_round_trip_returns_ok", () => {
+  it("inference works assertion should pass when the round trip returns ok", () => {
     const r = runBash(`
       set -euo pipefail
       . "${FIXTURES}/fake-openai.sh"
@@ -1051,7 +1051,7 @@ describe("Phase 1.D assertion helpers", () => {
     expect(r.status, r.stderr).toBe(0);
   });
 
-  it("no_credentials_leaked_should_fail_when_pattern_leaks_in_bundle", () => {
+  it("no credentials leaked assertion should fail when a pattern leaks in the bundle", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-creds-"));
     try {
       const bundle = path.join(tmp, "bundle");
@@ -1068,7 +1068,7 @@ describe("Phase 1.D assertion helpers", () => {
     }
   });
 
-  it("policy_preset_applied_should_pass_when_active_presets_match_declared_set", () => {
+  it("policy preset applied assertion should pass when active presets match the declared set", () => {
     // Stub `nemoclaw policies list` to emit a known set.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-pol-"));
     try {
@@ -1093,7 +1093,7 @@ describe("Phase 1.D assertion helpers", () => {
     }
   });
 
-  it("messaging_bridge_reachable_should_pass_when_provider_endpoint_alive", () => {
+  it("messaging bridge reachable assertion should pass when the provider endpoint is alive", () => {
     const r = runBash(`
       set -euo pipefail
       . "${FIXTURES}/fake-telegram.sh"
@@ -1125,7 +1125,7 @@ describe("Issue #3810 messaging provider helper library", () => {
     return tmp;
   }
 
-  it("should_source_messaging_provider_library_in_isolation", () => {
+  it("should source messaging provider library in isolation", () => {
     const r = runBash(`
       set -euo pipefail
       . "${VALIDATION_LIB}/messaging_providers.sh"
@@ -1135,7 +1135,7 @@ describe("Issue #3810 messaging provider helper library", () => {
     expect(r.stdout).toContain("e2e_messaging_load_context");
   });
 
-  it("should_fail_with_clear_diagnostic_when_context_missing", () => {
+  it("should fail with a clear diagnostic when context is missing", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-msgmissing-"));
     fs.rmSync(tmp, { recursive: true, force: true });
     const r = runBash(
@@ -1150,7 +1150,7 @@ describe("Issue #3810 messaging provider helper library", () => {
     expect(r.stderr).toMatch(/E2E_CONTEXT_DIR|context\.env/);
   });
 
-  it("should_derive_provider_names_for_messaging_channels", () => {
+  it("should derive provider names for messaging channels", () => {
     const cases: Array<[string, Record<string, string>, string]> = [
       ["telegram", { E2E_AGENT: "openclaw", E2E_MESSAGING_PROVIDER: "telegram" }, "telegram"],
       ["discord", { E2E_AGENT: "openclaw", E2E_MESSAGING_PROVIDER: "discord" }, "discord"],
@@ -1178,7 +1178,7 @@ describe("Issue #3810 messaging provider helper library", () => {
     }
   });
 
-  it("should_resolve_agent_config_paths", () => {
+  it("should resolve agent config paths", () => {
     const cases: Array<[string, string]> = [
       ["openclaw", "/sandbox/.openclaw/openclaw.json"],
       ["hermes", "/sandbox/.hermes/.env"],
@@ -1203,7 +1203,7 @@ describe("Issue #3810 messaging provider helper library", () => {
     }
   });
 
-  it("should_expose_placeholder_and_secret_leak_interfaces_without_live_secrets", () => {
+  it("should expose placeholder and secret leak interfaces without live secrets", () => {
     const r = runBash(`
       set -euo pipefail
       . "${VALIDATION_LIB}/messaging_providers.sh"
@@ -1220,12 +1220,12 @@ describe("Issue #3810 messaging provider helper library", () => {
 });
 
 describe("baseline onboarding validation helper", () => {
-  it("baseline_helper_should_source_under_strict_shell_options", () => {
+  it("baseline helper should source under strict shell options", () => {
     const r = runBash(`set -euo pipefail; source "${VALIDATION_SUITES}/lib/baseline_onboarding.sh"`);
     expect(r.status, r.stderr).toBe(0);
   });
 
-  it("baseline_cli_assertions_should_use_mocked_binaries", () => {
+  it("baseline CLI assertions should use mocked binaries", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "baseline-cli-"));
     try {
       const bin = path.join(tmp, "bin");
@@ -1262,7 +1262,7 @@ esac
 });
 
 describe("sandbox lifecycle validation helper", () => {
-  it("test_should_load_context_from_e2e_context_dir", () => {
+  it("should load context from E2E context dir", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-life-"));
     try {
       fs.writeFileSync(path.join(tmp, "context.env"), "E2E_SANDBOX_NAME=sb1\nE2E_GATEWAY_URL=http://127.0.0.1:1\n");
@@ -1272,14 +1272,14 @@ describe("sandbox lifecycle validation helper", () => {
     } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
   });
 
-  it("test_should_emit_stable_pass_and_fail_ids", () => {
+  it("should emit stable pass and fail IDs", () => {
     const r = runBash(`. "${VALIDATION_SUITES}/lib/sandbox_lifecycle.sh"; sandbox_lifecycle_pass validation.sandbox_lifecycle.gateway_health ok; sandbox_lifecycle_fail validation.sandbox_operations.logs_available nope`);
     expect(r.status).not.toBe(0);
     expect(r.stdout).toMatch(/PASS: validation\.sandbox_lifecycle\.gateway_health/);
     expect(r.stderr).toMatch(/FAIL: validation\.sandbox_operations\.logs_available/);
   });
 
-  it("test_should_apply_timeout_to_command_execution", () => {
+  it("should apply timeout to command execution", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-life-timeout-"));
     try {
       const bin = path.join(tmp, "bin"); fs.mkdirSync(bin);
@@ -1290,7 +1290,7 @@ describe("sandbox lifecycle validation helper", () => {
     } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
   });
 
-  it("test_should_validate_list_status_logs_exec_with_mocked_commands", () => {
+  it("should validate list status logs exec with mocked commands", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-life-mock-"));
     try {
       const bin = path.join(tmp, "bin"); fs.mkdirSync(bin);

--- a/test/e2e-scenario/framework-tests/e2e-manifests.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-manifests.test.ts
@@ -13,7 +13,7 @@ const SCENARIO_SUITE_DIR = path.join(REPO_ROOT, "test/e2e-scenario");
 const MANIFEST_DIR = path.join(SCENARIO_SUITE_DIR, "manifests");
 
 describe("NemoClawInstance manifests", () => {
-  it("test_should_validate_all_nemoclaw_instance_manifests", () => {
+  it("should validate all NemoClaw instance manifests", () => {
     const manifests = loadManifestsFromDir(MANIFEST_DIR);
 
     expect(manifests.length).toBeGreaterThanOrEqual(19);
@@ -22,7 +22,7 @@ describe("NemoClawInstance manifests", () => {
     }
   });
 
-  it("test_should_reject_manifest_with_assertion_or_suite_ids", () => {
+  it("should reject manifest with assertion or suite IDs", () => {
     const badManifest = {
       apiVersion: "nemoclaw.io/v1",
       kind: "NemoClawInstance",
@@ -38,7 +38,7 @@ describe("NemoClawInstance manifests", () => {
     expect(() => validateManifest(badManifest, "bad.yaml")).toThrow(/assertion|suite|product-facing/i);
   });
 
-  it("test_should_reject_raw_secret_values_in_manifest", () => {
+  it("should reject raw secret values in manifest", () => {
     const badManifest = {
       apiVersion: "nemoclaw.io/v1",
       kind: "NemoClawInstance",
@@ -53,7 +53,7 @@ describe("NemoClawInstance manifests", () => {
     expect(() => validateManifest(badManifest, "bad-secret.yaml")).toThrow(/raw secret|credentialRefs/i);
   });
 
-  it("test_should_cover_every_typed_scenario_manifest_need", () => {
+  it("should cover every typed scenario manifest need", () => {
     const manifestNames = new Set(loadManifestsFromDir(MANIFEST_DIR).map((manifest) => manifest.document.metadata.name));
     const missingManifests = listScenarios()
       .map((scenario) => scenario.manifestPath)
@@ -64,7 +64,7 @@ describe("NemoClawInstance manifests", () => {
     expect(missingManifests, `missing manifest files: ${missingManifests.join(", ")}`).toEqual([]);
   });
 
-  it("plan_only_output_should_show_resolved_manifest_setup_and_onboarding_choices", () => {
+  it("plan only output should show resolved manifest setup and onboarding choices", () => {
     const [plan] = compileRunPlans(["ubuntu-repo-cloud-openclaw"]);
 
     expect(plan.manifestPath).toBe("test/e2e-scenario/manifests/openclaw-nvidia.yaml");

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -174,7 +174,7 @@ describe("onboarding phase fixture", () => {
     });
   });
 
-  it("requires NVIDIA_API_KEY before spawning cloud OpenClaw onboarding", async () => {
+  it("requires NVIDIA API key before spawning cloud OpenClaw onboarding", async () => {
     const runner = new FakeRunner();
     const onboard = new OnboardingPhaseFixture(new HostCliClient(runner), new FakeSecrets());
 

--- a/test/e2e-scenario/framework-tests/e2e-phase-orchestrators.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-orchestrators.test.ts
@@ -98,7 +98,7 @@ function makePhaseWithActions(
 }
 
 describe("phase orchestrators - top-level delegation", () => {
-  it("test_should_execute_phase_assertions_from_phase_orchestrators_not_top_level_runner", async () => {
+  it("should execute phase assertions from phase orchestrators, not the top-level runner", async () => {
     const ctx = freshCtx();
     try {
       const [plan] = compileRunPlans(["ubuntu-repo-cloud-openclaw"]);
@@ -140,7 +140,7 @@ describe("phase orchestrators - top-level delegation", () => {
 });
 
 describe("phase orchestrators - real shell execution", () => {
-  it("shell_step_passes_when_script_exits_zero", async () => {
+  it("shell step passes when the script exits zero", async () => {
     const ctx = freshCtx();
     try {
       const script = writeTempScript(ctx.contextDir, "ok.sh", "echo hello-from-real-shell");
@@ -161,7 +161,7 @@ describe("phase orchestrators - real shell execution", () => {
     }
   });
 
-  it("shell_step_fails_when_script_exits_nonzero_and_records_stderr_tail", async () => {
+  it("shell step fails when the script exits nonzero and records the stderr tail", async () => {
     const ctx = freshCtx();
     try {
       const script = writeTempScript(ctx.contextDir, "fail.sh", 'echo "boom: real failure" >&2; exit 7');
@@ -180,7 +180,7 @@ describe("phase orchestrators - real shell execution", () => {
     }
   });
 
-  it("shell_step_times_out_via_orchestrator_policy_not_script", async () => {
+  it("shell step times out via orchestrator policy, not the script", async () => {
     const ctx = freshCtx();
     try {
       const script = writeTempScript(ctx.contextDir, "slow.sh", "sleep 30");
@@ -200,7 +200,7 @@ describe("phase orchestrators - real shell execution", () => {
     }
   }, 20_000);
 
-  it("shell_step_retries_on_classified_transient_then_passes", async () => {
+  it("shell step retries on a classified transient and then passes", async () => {
     const ctx = freshCtx();
     try {
       const counterFile = path.join(ctx.contextDir, "counter");
@@ -226,7 +226,7 @@ describe("phase orchestrators - real shell execution", () => {
     }
   });
 
-  it("shell_step_fails_with_clear_message_when_script_missing", async () => {
+  it("shell step fails with a clear message when the script is missing", async () => {
     const ctx = freshCtx();
     try {
       const step = shellStep("runtime.missing", "runtime", "test/e2e-scenario/does-not-exist.sh");
@@ -241,7 +241,7 @@ describe("phase orchestrators - real shell execution", () => {
     }
   });
 
-  it("probe_step_without_registered_probe_skips_visibly_never_passes_falsely", async () => {
+  it("probe step without a registered probe skips visibly and never passes falsely", async () => {
     const ctx = freshCtx();
     try {
       const step = probeStep("runtime.probe-pending", "runtime");
@@ -256,7 +256,7 @@ describe("phase orchestrators - real shell execution", () => {
     }
   });
 
-  it("pending_step_skips_visibly_with_pending_marker", async () => {
+  it("pending step skips visibly with a pending marker", async () => {
     const ctx = freshCtx();
     try {
       const step = pendingStep("runtime.pending", "runtime");
@@ -273,7 +273,7 @@ describe("phase orchestrators - real shell execution", () => {
 });
 
 describe("phase orchestrators - actions execute before assertions", () => {
-  it("phase_action_runs_before_assertions_and_records_evidence", async () => {
+  it("phase action runs before assertions and records evidence", async () => {
     const ctx = freshCtx();
     try {
       const actionScript = writeTempScript(ctx.contextDir, "setup.sh", "echo phase-action-evidence");
@@ -299,7 +299,7 @@ describe("phase orchestrators - actions execute before assertions", () => {
     }
   });
 
-  it("phase_action_failure_short_circuits_assertions", async () => {
+  it("phase action failure short-circuits assertions", async () => {
     const ctx = freshCtx();
     try {
       const failScript = writeTempScript(ctx.contextDir, "fail.sh", 'echo "setup boom" >&2; exit 5');
@@ -322,7 +322,7 @@ describe("phase orchestrators - actions execute before assertions", () => {
     }
   });
 
-  it("phase_action_times_out_via_orchestrator_policy", async () => {
+  it("phase action times out via orchestrator policy", async () => {
     const ctx = freshCtx();
     try {
       const slow = writeTempScript(ctx.contextDir, "slow.sh", "sleep 30");
@@ -346,7 +346,7 @@ describe("phase orchestrators - actions execute before assertions", () => {
     }
   });
 
-  it("phase_action_publishes_alias_path_on_success", async () => {
+  it("phase action publishes alias path on success", async () => {
     const ctx = freshCtx();
     try {
       const actionScript = writeTempScript(ctx.contextDir, "alias.sh", "echo aliased-output");
@@ -369,7 +369,7 @@ describe("phase orchestrators - actions execute before assertions", () => {
     }
   });
 
-  it("phase_action_evidence_log_is_flushed_before_resolve", async () => {
+  it("phase action evidence log is flushed before resolve", async () => {
     const ctx = freshCtx();
     try {
       const actionScript = writeTempScript(ctx.contextDir, "flush.sh", "echo flushed-phase-action-output");
@@ -389,7 +389,7 @@ describe("phase orchestrators - actions execute before assertions", () => {
 });
 
 describe("plan compiler emits phase actions for canonical scenarios", () => {
-  it("compiler_emits_install_and_onboard_actions_for_canonical_scenarios", async () => {
+  it("compiler emits install and onboard actions for canonical scenarios", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     const ids = [
       "ubuntu-repo-cloud-openclaw",
@@ -430,7 +430,7 @@ describe("plan compiler emits phase actions for canonical scenarios", () => {
     }
   });
 
-  it("compiler_routes_docker_missing_runtime_to_no_docker_onboarding_profile", async () => {
+  it("compiler routes Docker-missing runtime to the no-Docker onboarding profile", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     // Negative scenario declares runtime=docker-missing in scenarios.yaml.
     // The compiler must substitute the onboarding profile id from the
@@ -457,7 +457,7 @@ describe("plan compiler emits phase actions for canonical scenarios", () => {
     expect(posAction?.arg).toBe("cloud-openclaw");
   });
 
-  it("compiler_emits_lifecycle_phase_action_when_scenario_declares_lifecycle_profile", async () => {
+  it("compiler emits lifecycle phase action when scenario declares lifecycle profile", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     // Rebuild scenario declares environment.lifecycle =
     // 'rebuild-current-version'. The compiler must emit a single
@@ -481,7 +481,7 @@ describe("plan compiler emits phase actions for canonical scenarios", () => {
     expect(action.secretEnv).toContain("NVIDIA_API_KEY");
   });
 
-  it("compiler_emits_no_lifecycle_actions_when_scenario_does_not_declare_lifecycle", async () => {
+  it("compiler emits no lifecycle actions when scenario does not declare lifecycle", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     // Default scenarios omit environment.lifecycle. The lifecycle
     // phase still appears in the plan (deterministic phase order)
@@ -493,7 +493,7 @@ describe("plan compiler emits phase actions for canonical scenarios", () => {
     expect(lifecycle.assertionGroups).toHaveLength(0);
   });
 
-  it("compiler_drops_rebuild_and_upgrade_supplemental_suites_from_cloud_openclaw", async () => {
+  it("compiler drops rebuild and upgrade supplemental suites from cloud OpenClaw", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     // The 'rebuild' and 'upgrade' suites used to be supplementally
     // attached to ubuntu-repo-cloud-openclaw, which produced
@@ -508,7 +508,7 @@ describe("plan compiler emits phase actions for canonical scenarios", () => {
     expect(groupIds).not.toContain("suite.upgrade");
   });
 
-  it("compiler_includes_rebuild_and_upgrade_groups_on_ubuntu_rebuild_openclaw", async () => {
+  it("compiler includes rebuild and upgrade groups on ubuntu-rebuild-openclaw", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     const [plan] = compileRunPlans(["ubuntu-rebuild-openclaw"]);
     const runtime = plan.phases.find((p) => p.name === "runtime")!;
@@ -519,7 +519,7 @@ describe("plan compiler emits phase actions for canonical scenarios", () => {
 });
 
 describe("ScenarioRunner seeds context.env and short-circuits across phases", () => {
-  it("seedContextEnv_writes_normalized_keys_at_top_level_context_env_path", async () => {
+  it("seedContextEnv writes normalized keys at the top-level context env path", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     const { seedContextEnv } = await import("../scenarios/orchestrators/context.ts");
     const ctx = freshCtx();
@@ -543,7 +543,7 @@ describe("ScenarioRunner seeds context.env and short-circuits across phases", ()
     }
   });
 
-  it("hermes_scenario_seeds_hermes_gateway_url", async () => {
+  it("Hermes scenario seeds the Hermes gateway URL", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     const { seedContextEnv } = await import("../scenarios/orchestrators/context.ts");
     const ctx = freshCtx();
@@ -558,7 +558,7 @@ describe("ScenarioRunner seeds context.env and short-circuits across phases", ()
     }
   });
 
-  it("runner_skips_downstream_phases_when_prior_phase_action_fails", async () => {
+  it("runner skips downstream phases when a prior phase action fails", async () => {
     const { ScenarioRunner } = await import("../scenarios/orchestrators/runner.ts");
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     const ctx = freshCtx();
@@ -643,7 +643,7 @@ describe("ScenarioRunner seeds context.env and short-circuits across phases", ()
     }
   });
 
-  it("runner_does_not_short_circuit_on_assertion_failure_only", async () => {
+  it("runner does not short-circuit on assertion failures alone", async () => {
     // Assertion failures (as opposed to action failures) must not block
     // downstream phases - reviewers need to see all failure layers.
     const { ScenarioRunner } = await import("../scenarios/orchestrators/runner.ts");
@@ -685,7 +685,7 @@ describe("ScenarioRunner seeds context.env and short-circuits across phases", ()
 });
 
 describe("required probe and pending steps fail closed", () => {
-  it("test_required_probe_step_that_is_unregistered_fails_the_phase", async () => {
+  it("required probe step that is unregistered fails the phase", async () => {
     const ctx = freshCtx();
     try {
       const step: AssertionStep = {
@@ -708,7 +708,7 @@ describe("required probe and pending steps fail closed", () => {
     }
   });
 
-  it("test_non_required_probe_step_continues_to_skip_visibly", async () => {
+  it("non-required probe step continues to skip visibly", async () => {
     const ctx = freshCtx();
     try {
       const step: AssertionStep = {
@@ -737,7 +737,7 @@ describe("required probe and pending steps fail closed", () => {
     }
   });
 
-  it("test_required_pending_step_fails_closed", async () => {
+  it("required pending step fails closed", async () => {
     const ctx = freshCtx();
     try {
       const step: AssertionStep = {
@@ -759,7 +759,7 @@ describe("required probe and pending steps fail closed", () => {
     }
   });
 
-  it("test_security_suite_groups_in_registry_mark_their_steps_as_required", async () => {
+  it("security suite groups in registry mark their steps as required", async () => {
     const { assertionGroupForSuite } = await import("../scenarios/assertions/registry.ts");
     for (const suiteId of ["security-shields", "security-policy", "security-injection"]) {
       const group = assertionGroupForSuite(suiteId);
@@ -773,7 +773,7 @@ describe("required probe and pending steps fail closed", () => {
     }
   });
 
-  it("test_expected_failure_no_side_effects_step_is_not_in_active_registry", async () => {
+  it("expected-failure no-side-effects step is not in the active registry", async () => {
     const { assertionRegistry } = await import("../scenarios/assertions/registry.ts");
     const group = assertionRegistry.groups.find(
       (g) => g.id === "runtime.expected-failure.no-side-effects",
@@ -783,7 +783,7 @@ describe("required probe and pending steps fail closed", () => {
 });
 
 describe("framework-owned secret hygiene at the spawn boundary", () => {
-  it("test_should_not_persist_secret_shaped_child_output_into_evidence", async () => {
+  it("should not persist secret-shaped child output into evidence", async () => {
     const ctx = freshCtx();
     try {
       // Child writes secret-shaped tokens (NVIDIA, GitHub, OpenAI,
@@ -833,7 +833,7 @@ describe("framework-owned secret hygiene at the spawn boundary", () => {
     }
   });
 
-  it("test_should_drop_non_allowlisted_parent_env_unless_declared_in_secretEnv", async () => {
+  it("should drop non-allowlisted parent env unless declared in secretEnv", async () => {
     const ctx = freshCtx();
     const sentinelKey = "SECRET_LEAK_PROBE_TOKEN";
     const previous = process.env[sentinelKey];
@@ -866,7 +866,7 @@ describe("framework-owned secret hygiene at the spawn boundary", () => {
     }
   });
 
-  it("test_should_pass_declared_secretEnv_through_to_child", async () => {
+  it("should pass declared secretEnv through to child", async () => {
     const ctx = freshCtx();
     const declaredKey = "NEMOCLAW_TEST_API_KEY"; // matches SECRET_ENV_KEY_SHAPE
     const previous = process.env[declaredKey];
@@ -902,14 +902,14 @@ describe("framework-owned secret hygiene at the spawn boundary", () => {
     }
   });
 
-  it("test_should_reject_non_secret_shaped_keys_in_secretEnv_at_runtime", async () => {
+  it("should reject non-secret-shaped keys in secretEnv at runtime", async () => {
     const { buildChildEnv } = await import("../scenarios/orchestrators/redaction.ts");
     expect(() =>
       buildChildEnv(process.env, { secretEnv: ["FOO_VAR"], frameworkOverlay: {} }),
     ).toThrow(/secret-key shape/);
   });
 
-  it("test_should_declare_NVIDIA_API_KEY_only_for_cloud_onboarding_actions", async () => {
+  it("should declare NVIDIA API key only for cloud onboarding actions", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
     const plans = compileRunPlans([
       "ubuntu-repo-cloud-openclaw",
@@ -927,7 +927,7 @@ describe("framework-owned secret hygiene at the spawn boundary", () => {
 });
 
 describe("clients are pass/fail/policy free", () => {
-  it("test_should_keep_clients_free_of_pass_fail_and_retry_semantics", () => {
+  it("should keep clients free of pass/fail and retry semantics", () => {
     const observation = new HostCliClient().observeVersion();
 
     // The client returns a raw act/observe shape only: the command it would

--- a/test/e2e-scenario/framework-tests/e2e-plan-compiler.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-plan-compiler.test.ts
@@ -25,7 +25,7 @@ function runScenarioCli(args: string[], env: Record<string, string> = {}) {
 }
 
 describe("plan compiler", () => {
-  it("test_should_emit_machine_and_human_plan_artifacts_under_context_dir", () => {
+  it("should emit machine and human plan artifacts under context dir", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-plan-"));
     try {
       const result = runScenarioCli(["--scenarios", "ubuntu-repo-cloud-openclaw", "--plan-only"], {
@@ -45,7 +45,7 @@ describe("plan compiler", () => {
     }
   });
 
-  it("test_should_include_expanded_assertion_steps_by_phase", () => {
+  it("should include expanded assertion steps by phase", () => {
     const [plan] = compileRunPlans(["ubuntu-repo-cloud-openclaw"]);
     const onboarding = plan.phases.find((phase) => phase.name === "onboarding");
     const runtime = plan.phases.find((phase) => phase.name === "runtime");
@@ -57,7 +57,7 @@ describe("plan compiler", () => {
     );
   });
 
-  it("test_should_show_timeout_and_retry_policy_in_plan", () => {
+  it("should show timeout and retry policy in plan", () => {
     const summary = runScenarioCli(["--scenarios", "ubuntu-repo-cloud-openclaw", "--plan-only"]);
 
     expect(summary.status, summary.stderr).toBe(0);
@@ -65,7 +65,7 @@ describe("plan compiler", () => {
     expect(summary.stdout).toContain("retry=2 on gateway-transient");
   });
 
-  it("test_should_reject_incompatible_manifest_scenario_combination", () => {
+  it("should reject incompatible manifest scenario combination", () => {
     const badScenario: ScenarioDefinition = {
       id: "bad-platform",
       manifestPath: "test/e2e-scenario/manifests/openclaw-nvidia-macos.yaml",
@@ -84,7 +84,7 @@ describe("plan compiler", () => {
     expect(() => compileRunPlans([badScenario])).toThrow(/incompatible.*platform|platform.*incompatible/i);
   });
 
-  it("test_should_reject_suite_filter", () => {
+  it("should reject suite filter", () => {
     const result = runScenarioCli(["--scenarios", "ubuntu-repo-cloud-openclaw", "--plan-only"], {
       E2E_SUITE_FILTER: "smoke",
     });
@@ -93,7 +93,7 @@ describe("plan compiler", () => {
     expect(`${result.stdout}${result.stderr}`).toMatch(/E2E_SUITE_FILTER|scenario builders/i);
   });
 
-  it("plan_only_should_work_for_every_canonical_scenario_id", () => {
+  it("plan only should work for every canonical scenario ID", () => {
     const ids = listScenarios().map((scenario) => scenario.id);
     const plans = compileRunPlans(ids);
 

--- a/test/e2e-scenario/framework-tests/e2e-probes.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-probes.test.ts
@@ -34,35 +34,35 @@ describe("probe registry", () => {
     registerBuiltinProbes();
   });
 
-  it("registerProbe_lookupProbe_round_trip", () => {
+  it("round-trips registerProbe through lookupProbe", () => {
     const fn = async (): Promise<ProbeOutcome> => ({ status: "passed" });
     registerProbe("myProbe", fn);
     expect(lookupProbe("myProbe")).toBe(fn);
   });
 
-  it("lookupProbe_returns_undefined_for_unknown_ref", () => {
+  it("lookupProbe returns undefined for an unknown ref", () => {
     expect(lookupProbe("nonexistent")).toBeUndefined();
   });
 
-  it("registerProbe_rejects_duplicate_registration", () => {
+  it("registerProbe rejects duplicate registration", () => {
     const fn = async (): Promise<ProbeOutcome> => ({ status: "passed" });
     registerProbe("dup", fn);
     expect(() => registerProbe("dup", fn)).toThrow(/already registered/);
   });
 
-  it("registerProbe_rejects_empty_name", () => {
+  it("registerProbe rejects empty name", () => {
     const fn = async (): Promise<ProbeOutcome> => ({ status: "passed" });
     expect(() => registerProbe("", fn)).toThrow(/name is required/);
   });
 
-  it("listRegisteredProbes_returns_sorted_names", () => {
+  it("listRegisteredProbes returns names sorted", () => {
     registerProbe("zeta", async () => ({ status: "passed" }));
     registerProbe("alpha", async () => ({ status: "passed" }));
     registerProbe("mu", async () => ({ status: "passed" }));
     expect(listRegisteredProbes()).toEqual(["alpha", "mu", "zeta"]);
   });
 
-  it("registerBuiltinProbes_is_idempotent", () => {
+  it("registerBuiltinProbes is idempotent", () => {
     registerBuiltinProbes();
     const first = listRegisteredProbes();
     expect(first).toContain("diagnosticsProbe");
@@ -72,7 +72,7 @@ describe("probe registry", () => {
     expect(listRegisteredProbes()).toEqual(first);
   });
 
-  it("registerBuiltinProbes_registers_security_probes", () => {
+  it("registerBuiltinProbes registers security probes", () => {
     // shieldsConfig / networkPolicy / injectionBlocked are marked
     // `required: true` in scenarios/assertions/registry.ts. The
     // orchestrator fails closed when a required probe is missing,
@@ -153,7 +153,7 @@ function installFakeOnPath(
 }
 
 describe("diagnosticsProbe", () => {
-  it("passes_when_nemoclaw_debug_quick_writes_a_non_empty_archive", async () => {
+  it("passes when NemoClaw debug quick writes a non-empty archive", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "diag-probe-pass-"));
     const fake = installFakeOnPath(
       path.join(tmp, "bin"),
@@ -187,7 +187,7 @@ exit 0
     }
   });
 
-  it("fails_when_nemoclaw_exits_nonzero", async () => {
+  it("fails when NemoClaw exits nonzero", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "diag-probe-fail-"));
     const fake = installFakeOnPath(
       path.join(tmp, "bin"),
@@ -208,7 +208,7 @@ exit 0
     }
   });
 
-  it("fails_when_archive_is_empty", async () => {
+  it("fails when archive is empty", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "diag-probe-empty-"));
     const fake = installFakeOnPath(
       path.join(tmp, "bin"),
@@ -271,7 +271,7 @@ esac
     };
   }
 
-  it("passes_when_both_cli_and_links_checks_exit_zero", async () => {
+  it("passes when both CLI and links checks exit zero", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docs-probe-pass-"));
     try {
       const { ctx } = setupFakeCheckDocs(tmp, 0, 0);
@@ -289,7 +289,7 @@ esac
     }
   });
 
-  it("fails_when_cli_parity_check_exits_nonzero", async () => {
+  it("fails when CLI parity check exits nonzero", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docs-probe-cli-fail-"));
     try {
       const { ctx } = setupFakeCheckDocs(tmp, 3, 0);
@@ -302,7 +302,7 @@ esac
     }
   });
 
-  it("fails_when_links_check_exits_nonzero", async () => {
+  it("fails when links check exits nonzero", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docs-probe-links-fail-"));
     try {
       const { ctx } = setupFakeCheckDocs(tmp, 0, 5);
@@ -315,7 +315,7 @@ esac
     }
   });
 
-  it("fails_with_actionable_message_when_check_docs_script_missing", async () => {
+  it("fails with actionable message when check docs script missing", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "docs-probe-missing-"));
     try {
       const { docsValidationProbe } = await import("../scenarios/probes/docs-validation.ts");
@@ -365,7 +365,7 @@ function makeProbeCtxFor(
 }
 
 describe("shieldsConfigProbe", () => {
-  it("passes_when_shields_status_matches_expected_and_perms_match_state", async () => {
+  it("passes when shields status matches expected and perms match state", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shields-probe-pass-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -427,7 +427,7 @@ exit 99
     }
   });
 
-  it("fails_when_observed_state_disagrees_with_expected", async () => {
+  it("fails when observed state disagrees with expected", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shields-probe-mismatch-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -459,7 +459,7 @@ exit 99
     }
   });
 
-  it("fails_when_perms_dont_match_observed_state", async () => {
+  it("fails when permissions do not match observed state", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shields-probe-perms-"));
     const fakeBin = path.join(tmp, "bin");
     fs.mkdirSync(fakeBin);
@@ -537,7 +537,7 @@ exit 99
     );
   }
 
-  it("passes_when_blocked_url_returns_403", async () => {
+  it("passes when blocked URL returns 403", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netpolicy-probe-403-"));
     fakeOpenshellEmittingHttpStatus(path.join(tmp, "bin"), "403", 0);
     const oldPath = process.env.PATH;
@@ -554,7 +554,7 @@ exit 99
     }
   });
 
-  it("passes_when_curl_exits_nonzero_and_no_http_response", async () => {
+  it("passes when curl exits nonzero and no HTTP response", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netpolicy-probe-conn-"));
     // curl exit 7 = couldn't connect; status '000' = no HTTP response.
     fakeOpenshellEmittingHttpStatus(path.join(tmp, "bin"), "000", 7);
@@ -572,7 +572,7 @@ exit 99
     }
   });
 
-  it("fails_when_blocked_url_returns_200", async () => {
+  it("fails when blocked URL returns 200", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netpolicy-probe-200-"));
     fakeOpenshellEmittingHttpStatus(path.join(tmp, "bin"), "200", 0);
     const oldPath = process.env.PATH;
@@ -589,7 +589,7 @@ exit 99
     }
   });
 
-  it("fails_when_blocked_url_returns_401_indicating_policy_bypass", async () => {
+  it("fails when blocked URL returns 401 indicating policy bypass", async () => {
     // 401 means the request reached upstream auth, NOT that gateway
     // dropped it. The probe must classify this as a policy bypass.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netpolicy-probe-401-"));
@@ -665,7 +665,7 @@ exit 99
     };
   }
 
-  it("passes_when_payload_is_preserved_and_marker_absent", async () => {
+  it("passes when the payload is preserved and the marker is absent", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "inj-probe-pass-"));
     const stub = setupInjectionStub(tmp, false);
     try {
@@ -682,7 +682,7 @@ exit 99
     }
   });
 
-  it("fails_when_marker_file_was_created_indicating_command_substitution_executed", async () => {
+  it("fails when marker file creation indicates command substitution executed", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "inj-probe-fail-"));
     const stub = setupInjectionStub(tmp, true);
     try {

--- a/test/e2e-scenario/framework-tests/e2e-redaction-parity.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-redaction-parity.test.ts
@@ -35,7 +35,7 @@ function fingerprint(patterns: readonly RegExp[]): string[] {
 }
 
 describe("framework redaction parity with product source-of-truth", () => {
-  it("framework TOKEN_PREFIX_PATTERNS matches product TOKEN_PREFIX_PATTERNS", () => {
+  it("framework token prefix patterns match product token prefix patterns", () => {
     const framework = fingerprint(FRAMEWORK_TOKEN_PREFIX_PATTERNS);
     const product = fingerprint(PRODUCT_TOKEN_PREFIX_PATTERNS);
     expect(framework.length).toBeGreaterThan(0);
@@ -43,7 +43,7 @@ describe("framework redaction parity with product source-of-truth", () => {
     expect(framework).toEqual(product);
   });
 
-  it("framework CONTEXT_PATTERNS matches product CONTEXT_PATTERNS", () => {
+  it("framework context patterns match product context patterns", () => {
     const framework = fingerprint(FRAMEWORK_CONTEXT_PATTERNS);
     const product = fingerprint(PRODUCT_CONTEXT_PATTERNS);
     expect(framework.length).toBeGreaterThan(0);

--- a/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
@@ -102,7 +102,7 @@ describe("typed scenario matrix", () => {
     expect(() => resolveRunnerForScenario(broken)).toThrow(/no default for platform/);
   });
 
-  it("--emit-matrix prints a single-line JSON array compatible with $GITHUB_OUTPUT", () => {
+  it("--emit-matrix prints a single-line JSON array compatible with GitHub Actions output", () => {
     const result = runEmitMatrix();
     expect(result.status, result.stderr).toBe(0);
     const lines = result.stdout.trim().split("\n");

--- a/test/e2e-scenario/framework-tests/e2e-scenario-registry.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-registry.test.ts
@@ -22,14 +22,14 @@ function runScenarioCli(args: string[]) {
 }
 
 describe("deterministic scenario registry", () => {
-  it("test_should_reject_duplicate_scenario_ids", () => {
+  it("should reject duplicate scenario IDs", () => {
     const first = scenario("duplicate-id").manifest("test/e2e-scenario/manifests/openclaw-nvidia.yaml").build();
     const second = scenario("duplicate-id").manifest("test/e2e-scenario/manifests/hermes-nvidia.yaml").build();
 
     expect(() => buildScenarioRegistry([first, second])).toThrow(/duplicate-id/);
   });
 
-  it("test_should_return_actionable_unknown_scenario_error", () => {
+  it("should return actionable unknown scenario error", () => {
     const result = runScenarioCli(["--scenarios", "does-not-exist", "--plan-only"]);
 
     expect(result.status).not.toBe(0);
@@ -38,7 +38,7 @@ describe("deterministic scenario registry", () => {
     expect(`${result.stdout}${result.stderr}`).toMatch(/ubuntu-repo-cloud-openclaw/);
   });
 
-  it("test_should_compile_multiple_targeted_scenario_plans", () => {
+  it("should compile multiple targeted scenario plans", () => {
     const plans = compileRunPlans(["ubuntu-repo-cloud-openclaw", "ubuntu-repo-cloud-hermes"]);
 
     expect(plans.map((plan) => plan.scenarioId)).toEqual([
@@ -47,7 +47,7 @@ describe("deterministic scenario registry", () => {
     ]);
   });
 
-  it("cli_should_emit_two_plan_sections_for_comma_separated_scenarios", () => {
+  it("CLI should emit two plan sections for comma separated scenarios", () => {
     const result = runScenarioCli([
       "--scenarios",
       "ubuntu-repo-cloud-openclaw,ubuntu-repo-cloud-hermes",
@@ -60,7 +60,7 @@ describe("deterministic scenario registry", () => {
     expect(result.stdout).toContain("Scenario: ubuntu-repo-cloud-hermes");
   });
 
-  it("baseline_plan_should_match_legacy_resolver_semantics", () => {
+  it("baseline plan should match legacy resolver semantics", () => {
     const [plan] = compileRunPlans(["ubuntu-repo-cloud-openclaw"]);
 
     expect(plan.environment).toEqual({

--- a/test/e2e-scenario/framework-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenarios-workflow.test.ts
@@ -36,7 +36,7 @@ describe("e2e-scenarios workflow boundary", () => {
     expect(validateE2eScenariosWorkflowBoundary()).toEqual([]);
   });
 
-  it("routes_every_typed_scenario_id_to_its_resolved_runner", () => {
+  it("routes every typed scenario ID to its resolved runner", () => {
     const scenarios = listScenarios().sort((left, right) => left.id.localeCompare(right.id));
     const routes = routesFromWorkflow();
     const typedIds = scenarios.map((scenario) => scenario.id);

--- a/test/e2e-scenario/scenarios/orchestrators/redaction.ts
+++ b/test/e2e-scenario/scenarios/orchestrators/redaction.ts
@@ -27,9 +27,9 @@
  *
  * Tests:
  *   test/e2e-scenario/framework-tests/e2e-phase-orchestrators.test.ts
- *     - test_should_not_persist_secret_shaped_child_output_into_evidence
- *     - test_should_drop_non_allowlisted_parent_env_unless_declared_in_secretEnv
- *     - test_should_pass_declared_secretEnv_through_to_child
+ *     - child output redaction before evidence persistence
+ *     - parent env allowlist filtering unless declared in secretEnv
+ *     - declared secretEnv passthrough
  */
 
 import type { Readable, Writable } from "node:stream";


### PR DESCRIPTION
## Summary
Make the E2E scenario framework Vitest output readable by replacing snake_case `describe`/`it` names with sentence-style labels. This keeps machine-oriented scenario, assertion, and helper IDs unchanged while making test output easier to scan.

## Changes
- Renamed E2E scenario framework Vitest block names from snake_case identifiers to readable descriptions.
- Preserved technical names where useful, such as `seedContextEnv`, `secretEnv`, and product/env concepts expressed in prose.
- Updated the redaction orchestrator comment that referenced old snake_case test names.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Focused checks passed:
- `npx vitest run --project e2e-scenario-framework`
- `npx vitest run --project cli test/cli/list-inference.test.ts test/cli/list-share-live-inference.test.ts test/cli/sandbox-mutations.test.ts`
- `npx vitest run --project cli test/e2e-scenario/framework-tests/e2e-fixture-context.test.ts`
- `npx vitest run --project e2e-scenario-framework test/e2e-scenario/framework-tests/e2e-fixture-context.test.ts`
- Commit hook passed.
- Pre-push hook passed.

Notes: `npm test` passed once before the final one-line wording tweak. A later full retry hit unrelated 5s CLI dispatch timeouts, and the three failed files passed when rerun directly. A later `npx prek run --all-files` retry hit an unrelated signal-timing assertion in `e2e-fixture-context.test.ts`, and that file passed when rerun directly under both affected projects.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>