### PR TITLE
docs: fix backup-all copyable example and add regression test (#4754)

### DIFF
--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -164,8 +164,8 @@ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/platforms/" /sandbox/.hermes/pl
 To back up every registered, running sandbox in one step, run `nemoclaw backup-all`.
 This is the recommended host-installed command before broad maintenance such as `nemoclaw update`, `nemoclaw upgrade-sandboxes`, or an OpenShell gateway migration.
 
-```console
-$ nemoclaw backup-all
+```bash
+$$nemoclaw backup-all
 ```
 
 `backup-all` walks the sandboxes registered on the host, creates a snapshot for each running sandbox, and stores the snapshot bundles under `~/.nemoclaw/rebuild-backups/<name>/`.

--- a/test/docs-copyable-command-blocks.test.ts
+++ b/test/docs-copyable-command-blocks.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const docsRoot = path.join(repoRoot, "docs");
+
+type FencedBlock = {
+  language: string;
+  line: number;
+  lines: string[];
+};
+
+const COPYABLE_LANGUAGES = new Set(["bash", "sh", "powershell", "console", ""]);
+
+function collectFencedBlocks(markdown: string): FencedBlock[] {
+  const lines = markdown.split(/\r?\n/);
+  const blocks: FencedBlock[] = [];
+  let current: FencedBlock | null = null;
+
+  for (const [index, line] of lines.entries()) {
+    const fence = line.match(/^```(\S*)\s*$/);
+    if (!fence) {
+      if (current) current.lines.push(line);
+      continue;
+    }
+
+    if (current) {
+      blocks.push(current);
+      current = null;
+      continue;
+    }
+
+    current = {
+      language: fence[1] ?? "",
+      line: index + 1,
+      lines: [],
+    };
+  }
+
+  return blocks;
+}
+
+function listDocMdxFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "_build" || entry.name === "_components") continue;
+      files.push(...listDocMdxFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe("docs copyable command blocks (#4754)", () => {
+  it("does not use shell prompt prefixes in copyable fenced code blocks", () => {
+    const violations: string[] = [];
+
+    for (const docPath of listDocMdxFiles(docsRoot)) {
+      const markdown = fs.readFileSync(docPath, "utf8");
+      const blocks = collectFencedBlocks(markdown);
+      for (const block of blocks) {
+        if (!COPYABLE_LANGUAGES.has(block.language)) continue;
+        for (const [offset, line] of block.lines.entries()) {
+          if (!/^\s*\$ /.test(line)) continue;
+          const lineNumber = block.line + offset + 1;
+          violations.push(
+            `${path.relative(repoRoot, docPath)}:${lineNumber} [${block.language || "plain"}]: ${line}`,
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the last copyable-command violation missed by #4759 in `backup-restore.mdx` and adds a repo-wide regression test so fenced `bash`/`console` blocks cannot reintroduce `$ ` shell prompts.

## Related Issue
Fixes #4754

## Changes
- Change `backup-restore.mdx` `backup-all` example from `console` + `$ nemoclaw backup-all` to `bash` + `$$nemoclaw backup-all` per `docs/CONTRIBUTING.md`.
- Add `test/docs-copyable-command-blocks.test.ts` to scan all `docs/**/*.mdx` for `$ ` prompt prefixes in copyable fences.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Thabhelo <50872400+Thabhelo@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backup and restore documentation examples with corrected command syntax and enhanced code block formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->