### PR TITLE
test(e2e): migrate smoke and onboarding scenarios

### DIFF
--- a/test/e2e-scenario/framework-tests/e2e-live-project-config.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-live-project-config.test.ts
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-
+import config from "../../../vitest.config.ts";
+import { readYaml, type WorkflowStep } from "../../helpers/e2e-workflow-contract.ts";
 import {
   shouldRunBranchValidationE2E,
   shouldRunInstallerIntegration,
   shouldRunLiveE2EScenarios,
 } from "../framework/live-project-gate.ts";
-import config from "../../../vitest.config.ts";
-import { readYaml, type WorkflowStep } from "../../helpers/e2e-workflow-contract.ts";
 
 interface ProjectConfig {
   test?: {
     name?: string;
     include?: string[];
+    exclude?: string[];
   };
 }
 
@@ -28,6 +28,7 @@ const INSTALLER_INTEGRATION_TESTS = [
   "test/install-preflight.test.ts",
   "test/install-openshell-version-check.test.ts",
 ];
+const CLI_E2E_SCENARIO_EXCLUDES = ["test/e2e-scenario/**"];
 const LIVE_E2E_SCENARIO_TESTS = ["test/e2e-scenario/live/**/*.test.ts"];
 const BRANCH_VALIDATION_E2E_TESTS = ["test/e2e/brev-e2e.test.ts"];
 
@@ -50,6 +51,9 @@ function projectConfig(name: string): ProjectConfig {
 
 describe("gated E2E Vitest projects", () => {
   it("selects gated project includes from the current process environment", () => {
+    expect(projectConfig("cli").test?.exclude).toEqual(
+      expect.arrayContaining(CLI_E2E_SCENARIO_EXCLUDES),
+    );
     expect(projectConfig("installer-integration").test?.include).toEqual(
       shouldRunInstallerIntegration() ? INSTALLER_INTEGRATION_TESTS : [],
     );

--- a/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
@@ -39,15 +39,39 @@ describe("live Vitest registry discovery support", () => {
     });
   });
 
-  it("keeps no-Docker negatives skipped until runtime prep is matrix-owned", () => {
+  it("wires the smoke/onboarding migration family through phase fixtures", () => {
+    const supportedIds = [
+      "ubuntu-repo-cloud-openclaw",
+      "ubuntu-no-docker-preflight-negative",
+      "ubuntu-repo-cloud-openclaw-resume",
+      "ubuntu-repo-cloud-openclaw-repair",
+      "ubuntu-repo-cloud-openclaw-double-same-provider",
+      "ubuntu-repo-cloud-openclaw-custom-policies",
+      "ubuntu-invalid-nvidia-key-negative",
+      "ubuntu-gateway-port-conflict-negative",
+    ];
+
+    for (const id of supportedIds) {
+      const scenario = listScenarios().find((entry) => entry.id === id);
+      expect(scenario, `${id} must exist`).toBeTruthy();
+      expect(liveScenarioSupport(scenario!), `${id} should be live-supported`).toMatchObject({
+        supported: true,
+        reasons: [],
+      });
+    }
+  });
+
+  it("keeps provider-switch onboarding skipped until inference fixtures own it", () => {
     const scenario = listScenarios().find(
-      (entry) => entry.id === "ubuntu-no-docker-preflight-negative",
+      (entry) => entry.id === "ubuntu-repo-cloud-openclaw-double-provider-switch",
     );
 
     expect(scenario).toBeTruthy();
     expect(liveScenarioSupport(scenario!)).toMatchObject({
       supported: false,
-      reasons: ["runtime 'docker-missing' is not wired for live Vitest fixtures"],
+      reasons: [
+        "onboarding 'cloud-nvidia-openclaw-double-provider-switch' is not wired for live Vitest fixtures",
+      ],
     });
   });
 

--- a/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
@@ -75,6 +75,26 @@ describe("live Vitest registry discovery support", () => {
     });
   });
 
+  it("keeps docker-missing scenarios skipped unless the executable onboarding profile is wired", () => {
+    const base = listScenarios().find((entry) => entry.id === "ubuntu-repo-cloud-hermes");
+    expect(base).toBeTruthy();
+    const scenario = {
+      ...base!,
+      id: "synthetic-docker-missing-hermes",
+      environment: {
+        ...base!.environment!,
+        runtime: "docker-missing",
+        onboarding: "cloud-hermes",
+      },
+      expectedStateId: "preflight-failure-no-sandbox",
+    };
+
+    expect(liveScenarioSupport(scenario)).toMatchObject({
+      supported: false,
+      reasons: ["onboarding 'cloud-hermes-no-docker' is not wired for live Vitest fixtures"],
+    });
+  });
+
   it("keeps unwhitelisted lifecycle profiles skipped with the lifecycle reason", () => {
     const scenario = listScenarios().find((entry) => entry.id === "ubuntu-rebuild-openclaw");
 

--- a/test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const ONBOARD_DIR = path.join(REPO_ROOT, "test/e2e-scenario/nemoclaw_scenarios/onboard");
+
+function runBash(script: string, env: Record<string, string> = {}): SpawnSyncReturns<string> {
+  return spawnSync("bash", ["--noprofile", "--norc"], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    input: script,
+    timeout: Number(process.env.E2E_SPAWN_TIMEOUT_MS ?? 60_000),
+    cwd: REPO_ROOT,
+  });
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("server did not bind to a TCP port")));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function canBindPort(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+describe("E2E onboarding shell dispatcher", () => {
+  it("holds the requested gateway port during conflict-negative onboarding", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-gateway-conflict-"));
+    const fakeBin = path.join(tmp, "bin");
+    const port = await getAvailablePort();
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(
+      path.join(fakeBin, "nemoclaw"),
+      `#!/usr/bin/env bash
+if [[ "\${1:-}" = "onboard" ]]; then
+  expected='onboard --non-interactive --yes'
+  if [[ "$*" != "\${expected}" ]]; then
+    echo "unexpected nemoclaw args: $*" >&2
+    exit 2
+  fi
+  if [[ "\${NEMOCLAW_GATEWAY_PORT:-}" != "\${EXPECTED_PORT}" ]]; then
+    echo "unexpected gateway port: \${NEMOCLAW_GATEWAY_PORT:-unset}" >&2
+    exit 2
+  fi
+  node -e 'const net=require("node:net"); const port=Number(process.argv[1]); const s=net.connect(port, "127.0.0.1"); s.once("connect", () => { s.destroy(); process.exit(0); }); s.once("error", () => process.exit(1)); setTimeout(() => process.exit(1), 250);' "\${EXPECTED_PORT}" || {
+    echo "gateway conflict port was not held" >&2
+    exit 2
+  }
+  echo "Port \${NEMOCLAW_GATEWAY_PORT} is not available." >&2
+  exit 1
+fi
+echo "unexpected nemoclaw invocation: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "context.env"),
+        "E2E_SCENARIO=ubuntu-gateway-port-conflict-negative\nE2E_SANDBOX_NAME=e2e-port-conflict\n",
+      );
+      const result = runBash(
+        `
+        set -euo pipefail
+        test/e2e-scenario/nemoclaw_scenarios/dispatch-action.sh e2e_onboard cloud-openclaw-gateway-port-conflict "${ONBOARD_DIR}/dispatch.sh"
+      `,
+        {
+          E2E_ACTION_ID: "onboarding.profile.cloud-openclaw-gateway-port-conflict",
+          E2E_CONTEXT_DIR: tmp,
+          E2E_PHASE: "onboarding",
+          EXPECTED_PORT: String(port),
+          NEMOCLAW_ONBOARD_NEGATIVE_CONFLICT_PORT: String(port),
+          NVIDIA_API_KEY: "secret-token",
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          TMPDIR: tmp,
+        },
+      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(`${result.stdout}\n${result.stderr}`).toContain(`Port ${port} is not available`);
+      expect(await canBindPort(port)).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts
@@ -11,9 +11,20 @@ import { describe, expect, it } from "vitest";
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const ONBOARD_DIR = path.join(REPO_ROOT, "test/e2e-scenario/nemoclaw_scenarios/onboard");
 
-function runBash(script: string, env: Record<string, string> = {}): SpawnSyncReturns<string> {
+function runBash(
+  script: string,
+  env: Record<string, string | undefined> = {},
+): SpawnSyncReturns<string> {
+  const childEnv = { ...process.env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete childEnv[key];
+    } else {
+      childEnv[key] = value;
+    }
+  }
   return spawnSync("bash", ["--noprofile", "--norc"], {
-    env: { ...process.env, ...env },
+    env: childEnv,
     encoding: "utf8",
     input: script,
     timeout: Number(process.env.E2E_SPAWN_TIMEOUT_MS ?? 60_000),
@@ -48,6 +59,69 @@ async function canBindPort(port: number): Promise<boolean> {
 }
 
 describe("E2E onboarding shell dispatcher", () => {
+  it("injects the fixture NVIDIA key for invalid-key negative onboarding", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-invalid-nvidia-key-"));
+    const fakeBin = path.join(tmp, "bin");
+    const capturedEnv = path.join(tmp, "captured-env");
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(
+      path.join(fakeBin, "nemoclaw"),
+      `#!/usr/bin/env bash
+if [[ "\${1:-}" = "onboard" ]]; then
+  expected='onboard --non-interactive --yes'
+  if [[ "$*" != "\${expected}" ]]; then
+    echo "unexpected nemoclaw args: $*" >&2
+    exit 2
+  fi
+  {
+    printf 'NVIDIA_API_KEY=%s\\n' "\${NVIDIA_API_KEY:-unset}"
+    printf 'NEMOCLAW_POLICY_MODE=%s\\n' "\${NEMOCLAW_POLICY_MODE:-unset}"
+  } >"${capturedEnv}"
+  if [[ "\${NVIDIA_API_KEY:-}" != "not-a-nvidia-key" ]]; then
+    echo "unexpected NVIDIA_API_KEY: \${NVIDIA_API_KEY:-unset}" >&2
+    exit 2
+  fi
+  if [[ "\${NEMOCLAW_POLICY_MODE:-}" != "skip" ]]; then
+    echo "unexpected NEMOCLAW_POLICY_MODE: \${NEMOCLAW_POLICY_MODE:-unset}" >&2
+    exit 2
+  fi
+  echo "Invalid NVIDIA API key. Must start with nvapi-" >&2
+  exit 1
+fi
+echo "unexpected nemoclaw invocation: $*" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "context.env"),
+        "E2E_SCENARIO=ubuntu-invalid-nvidia-key-negative\nE2E_SANDBOX_NAME=e2e-invalid-key\n",
+      );
+      const result = runBash(
+        `
+        set -euo pipefail
+        test/e2e-scenario/nemoclaw_scenarios/dispatch-action.sh e2e_onboard cloud-openclaw-invalid-nvidia-key "${ONBOARD_DIR}/dispatch.sh"
+      `,
+        {
+          E2E_ACTION_ID: "onboarding.profile.cloud-openclaw-invalid-nvidia-key",
+          E2E_CONTEXT_DIR: tmp,
+          E2E_PHASE: "onboarding",
+          NVIDIA_API_KEY: undefined,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          TMPDIR: tmp,
+        },
+      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(`${result.stdout}\n${result.stderr}`).toContain("Invalid NVIDIA API key");
+      expect(fs.readFileSync(capturedEnv, "utf8")).toBe(
+        "NVIDIA_API_KEY=not-a-nvidia-key\nNEMOCLAW_POLICY_MODE=skip\n",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("rejects malformed gateway conflict ports before invoking onboarding", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-gateway-conflict-bad-port-"));
     const fakeBin = path.join(tmp, "bin");

--- a/test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts
@@ -48,6 +48,51 @@ async function canBindPort(port: number): Promise<boolean> {
 }
 
 describe("E2E onboarding shell dispatcher", () => {
+  it("rejects malformed gateway conflict ports before invoking onboarding", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-gateway-conflict-bad-port-"));
+    const fakeBin = path.join(tmp, "bin");
+    const invoked = path.join(tmp, "nemoclaw-invoked");
+    fs.mkdirSync(fakeBin);
+    fs.writeFileSync(
+      path.join(fakeBin, "nemoclaw"),
+      `#!/usr/bin/env bash
+touch "${invoked}"
+echo "nemoclaw should not have been invoked" >&2
+exit 2
+`,
+      { mode: 0o755 },
+    );
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "context.env"),
+        "E2E_SCENARIO=ubuntu-gateway-port-conflict-negative\nE2E_SANDBOX_NAME=e2e-port-conflict\n",
+      );
+      const result = runBash(
+        `
+        set -euo pipefail
+        test/e2e-scenario/nemoclaw_scenarios/dispatch-action.sh e2e_onboard cloud-openclaw-gateway-port-conflict "${ONBOARD_DIR}/dispatch.sh"
+      `,
+        {
+          E2E_ACTION_ID: "onboarding.profile.cloud-openclaw-gateway-port-conflict",
+          E2E_CONTEXT_DIR: tmp,
+          E2E_PHASE: "onboarding",
+          NEMOCLAW_ONBOARD_NEGATIVE_CONFLICT_PORT: "../18080",
+          NVIDIA_API_KEY: "secret-token",
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          TMPDIR: tmp,
+        },
+      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
+      expect(`${result.stdout}\n${result.stderr}`).toContain("invalid gateway conflict port");
+      expect(fs.existsSync(invoked)).toBe(false);
+      expect(fs.readdirSync(tmp).some((entry) => entry.startsWith("gateway-port-holder-"))).toBe(
+        false,
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("holds the requested gateway port during conflict-negative onboarding", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-gateway-conflict-"));
     const fakeBin = path.join(tmp, "bin");

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -630,6 +630,46 @@ describe("onboarding phase fixture", () => {
     expect(cleanup.calls[0]?.name).toBe("destroy NemoClaw sandbox e2e-no-docker");
   });
 
+  it("routes raw docker-missing cloud onboarding metadata to the no-Docker executable profile", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(7, "Cannot connect to the Docker daemon"));
+    const onboard = new OnboardingPhaseFixture(
+      new HostCliClient(runner),
+      new FakeSecrets({ NVIDIA_API_KEY: "secret-token" }),
+    );
+
+    const instance = await onboard.from(
+      ready({
+        runtime: "docker-missing",
+        onboarding: "cloud-openclaw",
+        docker: { id: "docker-missing", expectation: "missing", available: true },
+      }),
+      { sandboxName: "e2e-ubuntu-no-docker-preflight-negative" },
+    );
+
+    expect(instance).toMatchObject({
+      onboarding: "cloud-openclaw-no-docker",
+      sandboxName: "e2e-ubuntu-no-docker-preflight-negative",
+      expectedFailure: {
+        phase: "preflight",
+        errorClass: "docker-missing",
+      },
+    });
+    expect(runner.calls[0]).toMatchObject({
+      command: "nemoclaw",
+      args: ["onboard", "--non-interactive", "--yes", "--yes-i-accept-third-party-software"],
+      options: {
+        artifactName: "onboard-cloud-openclaw-no-docker",
+        env: expect.objectContaining({
+          NEMOCLAW_SANDBOX_NAME: "e2e-ubuntu-no-docker-preflight-negative",
+          NVIDIA_API_KEY: "secret-token",
+        }),
+        redactionValues: ["secret-token"],
+        timeoutMs: 900_000,
+      },
+    });
+  });
+
   it("publishes redacted legacy preflight evidence for the no-Docker negative path", async () => {
     const previousContextDir = process.env.E2E_CONTEXT_DIR;
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-typed-no-docker-"));

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -178,8 +178,13 @@ describe("onboarding phase fixture", () => {
 
     expect(cleanup.calls).toHaveLength(1);
     expect(cleanup.calls[0]?.name).toBe("destroy NemoClaw sandbox e2e-partial-onboard");
-    runner.enqueue(shellResult(1, "Error: sandbox e2e-partial-onboard not found"));
-    await cleanup.calls[0]?.run();
+    runner.enqueue(
+      shellResult(
+        1,
+        "Sandbox 'e2e-partial-onboard' does not exist.\nRun 'nemoclaw onboard' to create one.",
+      ),
+    );
+    await expect(cleanup.calls[0]?.run()).resolves.toBeUndefined();
     expect(runner.calls[1]).toMatchObject({
       command: "nemoclaw",
       args: ["e2e-partial-onboard", "destroy", "--yes"],
@@ -340,7 +345,12 @@ describe("onboarding phase fixture", () => {
 
   it("runs the gateway port conflict negative path with a local port holder", async () => {
     const runner = new FakeRunner();
-    runner.enqueue(shellResult(1, "listen tcp 127.0.0.1:18080: bind: address already in use"));
+    runner.enqueue(
+      shellResult(
+        1,
+        "Port 18080 is not available.\nOpenShell gateway needs this port.\nDetail: lsof reports node listening on port 18080",
+      ),
+    );
     const onboard = new OnboardingPhaseFixture(
       new HostCliClient(runner),
       new FakeSecrets({ NVIDIA_API_KEY: "secret-token" }),

--- a/test/e2e-scenario/framework-tests/e2e-phase-orchestrators.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-orchestrators.test.ts
@@ -995,17 +995,24 @@ describe("framework-owned secret hygiene at the spawn boundary", () => {
     ).toThrow(/secret-key shape/);
   });
 
-  it("should declare NVIDIA API key only for cloud onboarding actions", async () => {
+  it("should declare NVIDIA API key only for onboarding actions that use a live cloud secret", async () => {
     const { compileRunPlans } = await import("../scenarios/compiler.ts");
-    const plans = compileRunPlans(["ubuntu-repo-cloud-openclaw", "gpu-repo-local-ollama-openclaw"]);
-    const cloudOnboard = plans[0].phases
-      .find((p) => p.name === "onboarding")
-      ?.actions.find((a) => a.id.startsWith("onboarding.profile."));
-    const localOnboard = plans[1].phases
-      .find((p) => p.name === "onboarding")
-      ?.actions.find((a) => a.id.startsWith("onboarding.profile."));
-    expect(cloudOnboard?.secretEnv).toEqual(["NVIDIA_API_KEY"]);
-    expect(localOnboard?.secretEnv).toEqual([]);
+    const plans = compileRunPlans([
+      "ubuntu-repo-cloud-openclaw",
+      "ubuntu-invalid-nvidia-key-negative",
+      "ubuntu-gateway-port-conflict-negative",
+      "gpu-repo-local-ollama-openclaw",
+    ]);
+    const secretEnvFor = (scenarioId: string) =>
+      plans
+        .find((plan) => plan.scenarioId === scenarioId)
+        ?.phases.find((p) => p.name === "onboarding")
+        ?.actions.find((a) => a.id.startsWith("onboarding.profile."))?.secretEnv;
+
+    expect(secretEnvFor("ubuntu-repo-cloud-openclaw")).toEqual(["NVIDIA_API_KEY"]);
+    expect(secretEnvFor("ubuntu-invalid-nvidia-key-negative")).toEqual([]);
+    expect(secretEnvFor("ubuntu-gateway-port-conflict-negative")).toEqual(["NVIDIA_API_KEY"]);
+    expect(secretEnvFor("gpu-repo-local-ollama-openclaw")).toEqual([]);
   });
 });
 

--- a/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
@@ -30,6 +30,18 @@ function runEmitLiveMatrix(args: string[] = []) {
   });
 }
 
+const LIVE_ONBOARDING_SCENARIO_IDS = [
+  "ubuntu-gateway-port-conflict-negative",
+  "ubuntu-invalid-nvidia-key-negative",
+  "ubuntu-no-docker-preflight-negative",
+  "ubuntu-repo-cloud-openclaw",
+  "ubuntu-repo-cloud-openclaw-custom-policies",
+  "ubuntu-repo-cloud-openclaw-double-same-provider",
+  "ubuntu-repo-cloud-openclaw-repair",
+  "ubuntu-repo-cloud-openclaw-resume",
+  "ubuntu-repo-docker-post-reboot-recovery",
+];
+
 describe("typed scenario matrix", () => {
   it("emits one matrix entry per registered scenario", () => {
     const matrix = buildScenarioMatrix();
@@ -129,11 +141,11 @@ describe("typed scenario matrix", () => {
   });
 
   it("builds the default live Vitest matrix from fixture-supported scenarios only", () => {
-    expect(buildLiveScenarioMatrix().map((entry) => entry.id)).toEqual([
-      "ubuntu-repo-cloud-openclaw",
-      "ubuntu-repo-docker-post-reboot-recovery",
-    ]);
-    expect(buildLiveScenarioMatrix()[0]).toMatchObject({
+    const liveMatrix = buildLiveScenarioMatrix();
+    const byId = new Map(liveMatrix.map((entry) => [entry.id, entry]));
+
+    expect(liveMatrix.map((entry) => entry.id)).toEqual(LIVE_ONBOARDING_SCENARIO_IDS);
+    expect(byId.get("ubuntu-repo-cloud-openclaw")).toMatchObject({
       id: "ubuntu-repo-cloud-openclaw",
       runner: "ubuntu-latest",
       platform: "ubuntu-local",
@@ -146,11 +158,24 @@ describe("typed scenario matrix", () => {
       supportReasons: [],
       pendingRuntimeSuites: ["smoke", "inference", "credentials"],
     });
+    expect(byId.get("ubuntu-no-docker-preflight-negative")).toMatchObject({
+      id: "ubuntu-no-docker-preflight-negative",
+      runner: "ubuntu-latest",
+      platform: "ubuntu-local",
+      install: "repo-current",
+      runtime: "docker-missing",
+      onboarding: "cloud-openclaw",
+      expectedStateId: "preflight-failure-no-sandbox",
+      requiredSecrets: ["NVIDIA_API_KEY"],
+      supported: true,
+      supportReasons: [],
+      pendingRuntimeSuites: [],
+    });
     // Failing-test-first guard for #4423. Pinned in the matrix to
     // confirm the lifecycle whitelist + post-reboot-recovery scenario
     // are wired together; the actual RED/GREEN behavior is exercised
     // by the live runner (gates on the fix landing in src/lib/).
-    expect(buildLiveScenarioMatrix()[1]).toMatchObject({
+    expect(byId.get("ubuntu-repo-docker-post-reboot-recovery")).toMatchObject({
       id: "ubuntu-repo-docker-post-reboot-recovery",
       runner: "ubuntu-latest",
       platform: "ubuntu-local",
@@ -161,6 +186,13 @@ describe("typed scenario matrix", () => {
       requiredSecrets: ["NVIDIA_API_KEY"],
       supported: true,
       supportReasons: [],
+    });
+    expect(byId.get("ubuntu-invalid-nvidia-key-negative")).toMatchObject({
+      id: "ubuntu-invalid-nvidia-key-negative",
+      requiredSecrets: [],
+      supported: true,
+      supportReasons: [],
+      pendingRuntimeSuites: [],
     });
   });
 
@@ -180,10 +212,7 @@ describe("typed scenario matrix", () => {
     const lines = result.stdout.trim().split("\n");
     expect(lines.length, "live matrix output must be a single line").toBe(1);
     const parsed = JSON.parse(lines[0]);
-    expect(parsed.map((entry: { id: string }) => entry.id)).toEqual([
-      "ubuntu-repo-cloud-openclaw",
-      "ubuntu-repo-docker-post-reboot-recovery",
-    ]);
+    expect(parsed.map((entry: { id: string }) => entry.id)).toEqual(LIVE_ONBOARDING_SCENARIO_IDS);
   });
 
   it("--emit-live-matrix honors explicit scenario selections", () => {

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -5,6 +5,7 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { resolveExecutableOnboardingProfile } from "../../scenarios/onboarding-profiles.ts";
 import { redactString } from "../../scenarios/orchestrators/redaction.ts";
 import { buildAvailabilityProbeEnv } from "../availability-env.ts";
 import { artifactLabel, assertExitZero } from "../clients/command.ts";
@@ -245,10 +246,8 @@ function assertRepairStepResult(
 }
 
 function executableOnboardingEnvironment(environment: EnvironmentReady): EnvironmentReady {
-  if (environment.runtime === "docker-missing" && environment.onboarding === "cloud-openclaw") {
-    return { ...environment, onboarding: "cloud-openclaw-no-docker" };
-  }
-  return environment;
+  const onboarding = resolveExecutableOnboardingProfile(environment);
+  return onboarding === environment.onboarding ? environment : { ...environment, onboarding };
 }
 
 export class OnboardingPhaseFixture {

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -244,6 +244,13 @@ function assertRepairStepResult(
   assertExitZero(result, label);
 }
 
+function executableOnboardingEnvironment(environment: EnvironmentReady): EnvironmentReady {
+  if (environment.runtime === "docker-missing" && environment.onboarding === "cloud-openclaw") {
+    return { ...environment, onboarding: "cloud-openclaw-no-docker" };
+  }
+  return environment;
+}
+
 export class OnboardingPhaseFixture {
   constructor(
     private readonly host: HostCliClient,
@@ -255,25 +262,26 @@ export class OnboardingPhaseFixture {
     environment: EnvironmentReady,
     options: OnboardingOptions = {},
   ): Promise<NemoClawInstance> {
-    switch (environment.onboarding) {
+    const executableEnvironment = executableOnboardingEnvironment(environment);
+    switch (executableEnvironment.onboarding) {
       case "cloud-openclaw":
-        return await this.cloudOpenClaw(environment, options);
+        return await this.cloudOpenClaw(executableEnvironment, options);
       case "cloud-openclaw-custom-policies":
-        return await this.cloudOpenClawCustomPolicies(environment, options);
+        return await this.cloudOpenClawCustomPolicies(executableEnvironment, options);
       case "cloud-openclaw-invalid-nvidia-key":
-        return await this.cloudOpenClawInvalidNvidiaKey(environment, options);
+        return await this.cloudOpenClawInvalidNvidiaKey(executableEnvironment, options);
       case "cloud-openclaw-gateway-port-conflict":
-        return await this.cloudOpenClawGatewayPortConflict(environment, options);
+        return await this.cloudOpenClawGatewayPortConflict(executableEnvironment, options);
       case "cloud-openclaw-no-docker":
-        return await this.cloudOpenClawNoDocker(environment, options);
+        return await this.cloudOpenClawNoDocker(executableEnvironment, options);
       case "cloud-nvidia-openclaw-resume-after-interrupt":
-        return await this.cloudNvidiaOpenClawResumeAfterInterrupt(environment, options);
+        return await this.cloudNvidiaOpenClawResumeAfterInterrupt(executableEnvironment, options);
       case "cloud-nvidia-openclaw-repair-existing-config":
-        return await this.cloudNvidiaOpenClawRepairExistingConfig(environment, options);
+        return await this.cloudNvidiaOpenClawRepairExistingConfig(executableEnvironment, options);
       case "cloud-nvidia-openclaw-double-same-provider":
-        return await this.cloudNvidiaOpenClawDoubleSameProvider(environment, options);
+        return await this.cloudNvidiaOpenClawDoubleSameProvider(executableEnvironment, options);
       default:
-        throw new Error(`Unsupported onboarding profile '${environment.onboarding}'.`);
+        throw new Error(`Unsupported onboarding profile '${executableEnvironment.onboarding}'.`);
     }
   }
 

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -49,6 +49,7 @@ const MISSING_SANDBOX_DELETE_PATTERNS = [
   /sandbox not found/i,
   /sandbox .* not found/i,
   /sandbox .* not present/i,
+  /sandbox .* does not exist/i,
   /sandbox does not exist/i,
   /no such sandbox/i,
 ];
@@ -68,7 +69,7 @@ const INVALID_NVIDIA_API_KEY_PATTERNS = [
 ];
 const GATEWAY_PORT_CONFLICT_PATTERNS = [
   /address already in use/i,
-  /port .*18080.*(?:in use|occupied|unavailable)/i,
+  /port .*18080.*(?:in use|occupied|unavailable|not available)/i,
   /gateway port .*18080/i,
   /port conflict/i,
 ];

--- a/test/e2e-scenario/live/registry-scenarios.test.ts
+++ b/test/e2e-scenario/live/registry-scenarios.test.ts
@@ -5,14 +5,35 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { expect, test } from "../framework/e2e-test.ts";
-import type { LifecycleProfile } from "../framework/phases/index.ts";
+import type { LifecycleProfile, NemoClawInstance } from "../framework/phases/index.ts";
 import { listScenarios } from "../scenarios/registry.ts";
 import { liveScenarioSupport, liveScenarioTestName } from "../scenarios/runtime-support.ts";
+import type { ExpectedFailureContract, ScenarioDefinition } from "../scenarios/types.ts";
 
 const LIFECYCLE_PROFILES: ReadonlySet<LifecycleProfile> = new Set(["post-reboot-recovery"]);
 
 function isLifecycleProfile(value: string | undefined): value is LifecycleProfile {
   return value !== undefined && LIFECYCLE_PROFILES.has(value as LifecycleProfile);
+}
+
+function assertExpectedFailureContract(
+  scenario: Pick<ScenarioDefinition, "id" | "expectedFailure">,
+  instance: NemoClawInstance,
+): ExpectedFailureContract | undefined {
+  if (!scenario.expectedFailure) {
+    expect(instance.expectedFailure, `${scenario.id} must not report an expected failure`).toBe(
+      undefined,
+    );
+    return undefined;
+  }
+
+  expect(instance.expectedFailure, `${scenario.id} must report its expected failure`).toMatchObject(
+    {
+      phase: scenario.expectedFailure.phase,
+      errorClass: scenario.expectedFailure.errorClass,
+    },
+  );
+  return scenario.expectedFailure;
 }
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
@@ -62,6 +83,7 @@ for (const scenario of listScenarios()) {
 
       const ready = await environment.assertReady(scenario.environment);
       const instance = await onboard.from(ready, { sandboxName: `e2e-${scenario.id}` });
+      const expectedFailure = assertExpectedFailureContract(scenario, instance);
 
       // Lifecycle phase runs between onboard and state-validation.
       // Scenarios opt in by setting `environment.lifecycle` to a
@@ -90,6 +112,7 @@ for (const scenario of listScenarios()) {
         expectedStateId: validation.state.id,
         probes: validation.probes.map((probe) => probe.id),
         pendingRuntimeSuites: support.pendingRuntimeSuites,
+        expectedFailure,
         lifecycle: lifecycleResult
           ? { profile: lifecycleResult.profile, steps: lifecycleResult.steps.map((s) => s.id) }
           : undefined,

--- a/test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh
+++ b/test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh
@@ -99,6 +99,10 @@ e2e_onboard_cloud_openclaw_gateway_port_conflict() {
   return "${status}"
 }
 
+e2e_onboard_cloud_openclaw_invalid_nvidia_key() {
+  NVIDIA_API_KEY=not-a-nvidia-key NEMOCLAW_POLICY_MODE=skip e2e_onboard_cloud_openclaw
+}
+
 e2e_onboard() {
   local profile="${1:-}"
   if [[ -z "${profile}" ]]; then
@@ -122,7 +126,7 @@ e2e_onboard() {
       NEMOCLAW_MODEL="${E2E_ONBOARDING_MODEL}" NEMOCLAW_POLICY_MODE=custom NEMOCLAW_POLICY_PRESETS="${E2E_ONBOARDING_POLICY_PRESETS}" e2e_onboard_cloud_openclaw
       ;;
     cloud-openclaw-invalid-nvidia-key)
-      e2e_onboard_cloud_openclaw
+      e2e_onboard_cloud_openclaw_invalid_nvidia_key
       ;;
     cloud-openclaw-gateway-port-conflict)
       e2e_onboard_cloud_openclaw_gateway_port_conflict

--- a/test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh
+++ b/test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh
@@ -21,6 +21,68 @@ _E2E_ONBOARD_RUNTIME_LIB="$(cd "${_E2E_ONBOARD_DIR}/../../runtime/lib" && pwd)"
 # shellcheck source=local-ollama-openclaw.sh
 . "${_E2E_ONBOARD_DIR}/local-ollama-openclaw.sh"
 
+e2e_onboard_gateway_port_is_reachable() {
+  local port="${1:-}"
+  node -e 'const net=require("node:net"); const port=Number(process.argv[1]); const socket=net.connect(port, "127.0.0.1"); socket.once("connect", () => { socket.destroy(); process.exit(0); }); socket.once("error", () => process.exit(1)); setTimeout(() => process.exit(1), 250);' "${port}" >/dev/null 2>&1
+}
+
+e2e_onboard_start_gateway_port_holder() {
+  local port="${1:-}"
+  local log_path="${E2E_CONTEXT_DIR:-.e2e}/gateway-port-holder-${port}.log"
+  mkdir -p "$(dirname "${log_path}")"
+  node - "${port}" <<'NODE' >"${log_path}" 2>&1 &
+const net = require("node:net");
+const port = Number(process.argv[2]);
+const server = net.createServer((socket) => socket.end());
+server.on("error", (error) => {
+  console.error(error && error.message ? error.message : error);
+  process.exit(2);
+});
+server.listen(port, "127.0.0.1", () => {
+  console.log("ready");
+});
+setInterval(() => {}, 1000);
+NODE
+  printf '%s\n' "$!"
+}
+
+e2e_onboard_cloud_openclaw_gateway_port_conflict() {
+  local port="${NEMOCLAW_ONBOARD_NEGATIVE_CONFLICT_PORT:-18080}"
+  local holder_pid=""
+  if ! e2e_onboard_gateway_port_is_reachable "${port}"; then
+    holder_pid="$(e2e_onboard_start_gateway_port_holder "${port}")"
+    local attempts=0
+    while ((attempts < 40)); do
+      if e2e_onboard_gateway_port_is_reachable "${port}"; then
+        break
+      fi
+      if ! kill -0 "${holder_pid}" >/dev/null 2>&1; then
+        holder_pid=""
+        echo "e2e_onboard: gateway port holder exited before port ${port} became reachable" >&2
+        return 2
+      fi
+      sleep 0.25
+      attempts=$((attempts + 1))
+    done
+    if ! e2e_onboard_gateway_port_is_reachable "${port}"; then
+      if [[ -n "${holder_pid}" ]]; then
+        kill "${holder_pid}" >/dev/null 2>&1 || true
+        wait "${holder_pid}" >/dev/null 2>&1 || true
+      fi
+      echo "e2e_onboard: failed to hold gateway port ${port}" >&2
+      return 2
+    fi
+  fi
+
+  local status=0
+  NEMOCLAW_GATEWAY_PORT="${port}" NEMOCLAW_POLICY_MODE=skip e2e_onboard_cloud_openclaw || status=$?
+  if [[ -n "${holder_pid}" ]]; then
+    kill "${holder_pid}" >/dev/null 2>&1 || true
+    wait "${holder_pid}" >/dev/null 2>&1 || true
+  fi
+  return "${status}"
+}
+
 e2e_onboard() {
   local profile="${1:-}"
   if [[ -z "${profile}" ]]; then
@@ -43,8 +105,11 @@ e2e_onboard() {
       e2e_context_set E2E_ONBOARDING_REGISTRY_PROVIDER "nvidia-prod"
       NEMOCLAW_MODEL="${E2E_ONBOARDING_MODEL}" NEMOCLAW_POLICY_MODE=custom NEMOCLAW_POLICY_PRESETS="${E2E_ONBOARDING_POLICY_PRESETS}" e2e_onboard_cloud_openclaw
       ;;
-    cloud-openclaw-invalid-nvidia-key | cloud-openclaw-gateway-port-conflict)
+    cloud-openclaw-invalid-nvidia-key)
       e2e_onboard_cloud_openclaw
+      ;;
+    cloud-openclaw-gateway-port-conflict)
+      e2e_onboard_cloud_openclaw_gateway_port_conflict
       ;;
     cloud-hermes)
       e2e_onboard_cloud_hermes

--- a/test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh
+++ b/test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh
@@ -21,6 +21,16 @@ _E2E_ONBOARD_RUNTIME_LIB="$(cd "${_E2E_ONBOARD_DIR}/../../runtime/lib" && pwd)"
 # shellcheck source=local-ollama-openclaw.sh
 . "${_E2E_ONBOARD_DIR}/local-ollama-openclaw.sh"
 
+_E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID=""
+
+e2e_onboard_validate_gateway_conflict_port() {
+  local port="${1:-}"
+  if [[ ! "${port}" =~ ^[0-9]+$ ]] || ((port < 1 || port > 65535)); then
+    echo "e2e_onboard: invalid gateway conflict port: ${port}" >&2
+    return 2
+  fi
+}
+
 e2e_onboard_gateway_port_is_reachable() {
   local port="${1:-}"
   node -e 'const net=require("node:net"); const port=Number(process.argv[1]); const socket=net.connect(port, "127.0.0.1"); socket.once("connect", () => { socket.destroy(); process.exit(0); }); socket.once("error", () => process.exit(1)); setTimeout(() => process.exit(1), 250);' "${port}" >/dev/null 2>&1
@@ -46,18 +56,28 @@ NODE
   printf '%s\n' "$!"
 }
 
+e2e_onboard_cleanup_gateway_port_holder() {
+  if [[ -n "${_E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID}" ]]; then
+    kill "${_E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID}" >/dev/null 2>&1 || true
+    wait "${_E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID}" >/dev/null 2>&1 || true
+    _E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID=""
+  fi
+}
+
 e2e_onboard_cloud_openclaw_gateway_port_conflict() {
   local port="${NEMOCLAW_ONBOARD_NEGATIVE_CONFLICT_PORT:-18080}"
-  local holder_pid=""
+  e2e_onboard_validate_gateway_conflict_port "${port}" || return 2
+  trap e2e_onboard_cleanup_gateway_port_holder EXIT INT TERM
   if ! e2e_onboard_gateway_port_is_reachable "${port}"; then
-    holder_pid="$(e2e_onboard_start_gateway_port_holder "${port}")"
+    _E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID="$(e2e_onboard_start_gateway_port_holder "${port}")"
     local attempts=0
     while ((attempts < 40)); do
       if e2e_onboard_gateway_port_is_reachable "${port}"; then
         break
       fi
-      if ! kill -0 "${holder_pid}" >/dev/null 2>&1; then
-        holder_pid=""
+      if ! kill -0 "${_E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID}" >/dev/null 2>&1; then
+        _E2E_ONBOARD_GATEWAY_PORT_HOLDER_PID=""
+        trap - EXIT INT TERM
         echo "e2e_onboard: gateway port holder exited before port ${port} became reachable" >&2
         return 2
       fi
@@ -65,10 +85,8 @@ e2e_onboard_cloud_openclaw_gateway_port_conflict() {
       attempts=$((attempts + 1))
     done
     if ! e2e_onboard_gateway_port_is_reachable "${port}"; then
-      if [[ -n "${holder_pid}" ]]; then
-        kill "${holder_pid}" >/dev/null 2>&1 || true
-        wait "${holder_pid}" >/dev/null 2>&1 || true
-      fi
+      e2e_onboard_cleanup_gateway_port_holder
+      trap - EXIT INT TERM
       echo "e2e_onboard: failed to hold gateway port ${port}" >&2
       return 2
     fi
@@ -76,10 +94,8 @@ e2e_onboard_cloud_openclaw_gateway_port_conflict() {
 
   local status=0
   NEMOCLAW_GATEWAY_PORT="${port}" NEMOCLAW_POLICY_MODE=skip e2e_onboard_cloud_openclaw || status=$?
-  if [[ -n "${holder_pid}" ]]; then
-    kill "${holder_pid}" >/dev/null 2>&1 || true
-    wait "${holder_pid}" >/dev/null 2>&1 || true
-  fi
+  e2e_onboard_cleanup_gateway_port_holder
+  trap - EXIT INT TERM
   return "${status}"
 }
 

--- a/test/e2e-scenario/scenarios/compiler.ts
+++ b/test/e2e-scenario/scenarios/compiler.ts
@@ -129,7 +129,9 @@ const ONBOARD_PROFILE_SECRET_ENV: Readonly<Record<string, readonly string[]>> = 
   // NVIDIA cloud provider via NVIDIA_API_KEY.
   "cloud-openclaw": ["NVIDIA_API_KEY"],
   "cloud-openclaw-custom-policies": ["NVIDIA_API_KEY"],
-  "cloud-openclaw-invalid-nvidia-key": ["NVIDIA_API_KEY"],
+  // Negative scenario: the fixture injects its own known-bad key and must not
+  // pass a live NVIDIA_API_KEY through from the parent environment.
+  "cloud-openclaw-invalid-nvidia-key": [],
   "cloud-openclaw-gateway-port-conflict": ["NVIDIA_API_KEY"],
   // Negative scenario: nemoclaw onboard runs against a docker shim that
   // exits non-zero. Onboard never reaches the cloud auth step, but the

--- a/test/e2e-scenario/scenarios/compiler.ts
+++ b/test/e2e-scenario/scenarios/compiler.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getExpectedState, probesForState } from "./expected-states.ts";
 import { loadManifest } from "./manifests.ts";
+import { resolveExecutableOnboardingProfile } from "./onboarding-profiles.ts";
 import { requireScenarios } from "./registry.ts";
 import type {
   AssertionGroup,
@@ -181,17 +182,7 @@ function phaseActions(phase: PhaseName, scenario: ScenarioDefinition): PhaseActi
     if (!baseOnboardingId) {
       throw new Error(`Scenario ${scenario.id} is missing environment.onboarding`);
     }
-    // Negative-runtime scenarios route to a dedicated onboarding profile
-    // that sets up the failure condition (e.g. docker-missing) BEFORE
-    // invoking `nemoclaw onboard` and captures the resulting output to
-    // the log file the assertion phase reads. The profile id convention
-    // is `<base>-no-docker`. New negative profiles register a worker in
-    // nemoclaw_scenarios/onboard/dispatch.sh and a secret-env mapping
-    // above.
-    const onboardingId =
-      scenario.environment.runtime === "docker-missing"
-        ? `${baseOnboardingId}-no-docker`
-        : baseOnboardingId;
+    const onboardingId = resolveExecutableOnboardingProfile(scenario.environment);
     // secretEnv defaults to [] (no parent-env secrets pass through)
     // unless the profile is explicitly listed above. Unknown profiles
     // get the safest setting and surface the gap loudly the first

--- a/test/e2e-scenario/scenarios/onboarding-profiles.ts
+++ b/test/e2e-scenario/scenarios/onboarding-profiles.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ScenarioEnvironment } from "./types.ts";
+
+export function resolveExecutableOnboardingProfile(
+  environment: Pick<ScenarioEnvironment, "runtime" | "onboarding">,
+): string {
+  if (environment.runtime === "docker-missing" && !environment.onboarding.endsWith("-no-docker")) {
+    return `${environment.onboarding}-no-docker`;
+  }
+  return environment.onboarding;
+}

--- a/test/e2e-scenario/scenarios/runtime-support.ts
+++ b/test/e2e-scenario/scenarios/runtime-support.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { resolveExecutableOnboardingProfile } from "./onboarding-profiles.ts";
 import type { ScenarioDefinition } from "./types.ts";
 
 const SUPPORTED_PLATFORMS = new Set(["ubuntu-local"]);
@@ -11,6 +12,7 @@ const SUPPORTED_ONBOARDING = new Set([
   "cloud-openclaw-custom-policies",
   "cloud-openclaw-invalid-nvidia-key",
   "cloud-openclaw-gateway-port-conflict",
+  "cloud-openclaw-no-docker",
   "cloud-nvidia-openclaw-resume-after-interrupt",
   "cloud-nvidia-openclaw-repair-existing-config",
   "cloud-nvidia-openclaw-double-same-provider",
@@ -54,8 +56,9 @@ export function liveScenarioSupport(scenario: ScenarioDefinition): LiveScenarioS
     if (!SUPPORTED_RUNTIMES.has(environment.runtime)) {
       reasons.push(`runtime '${environment.runtime}' is not wired for live Vitest fixtures`);
     }
-    if (!SUPPORTED_ONBOARDING.has(environment.onboarding)) {
-      reasons.push(`onboarding '${environment.onboarding}' is not wired for live Vitest fixtures`);
+    const onboarding = resolveExecutableOnboardingProfile(environment);
+    if (!SUPPORTED_ONBOARDING.has(onboarding)) {
+      reasons.push(`onboarding '${onboarding}' is not wired for live Vitest fixtures`);
     }
     if (environment.lifecycle && !SUPPORTED_LIFECYCLES.has(environment.lifecycle)) {
       reasons.push(`lifecycle '${environment.lifecycle}' is not wired for live Vitest fixtures`);

--- a/test/e2e-scenario/scenarios/runtime-support.ts
+++ b/test/e2e-scenario/scenarios/runtime-support.ts
@@ -5,8 +5,16 @@ import type { ScenarioDefinition } from "./types.ts";
 
 const SUPPORTED_PLATFORMS = new Set(["ubuntu-local"]);
 const SUPPORTED_INSTALLS = new Set(["repo-current"]);
-const SUPPORTED_RUNTIMES = new Set(["docker-running"]);
-const SUPPORTED_ONBOARDING = new Set(["cloud-openclaw"]);
+const SUPPORTED_RUNTIMES = new Set(["docker-running", "docker-missing"]);
+const SUPPORTED_ONBOARDING = new Set([
+  "cloud-openclaw",
+  "cloud-openclaw-custom-policies",
+  "cloud-openclaw-invalid-nvidia-key",
+  "cloud-openclaw-gateway-port-conflict",
+  "cloud-nvidia-openclaw-resume-after-interrupt",
+  "cloud-nvidia-openclaw-repair-existing-config",
+  "cloud-nvidia-openclaw-double-same-provider",
+]);
 // Lifecycle profiles wired into the live Vitest driver. A profile is
 // supported only after both (a) `LifecyclePhaseFixture.simulate(profile)`
 // dispatches it, and (b) at least one expected-state declares the post-

--- a/test/e2e-scenario/scenarios/scenarios/baseline.ts
+++ b/test/e2e-scenario/scenarios/scenarios/baseline.ts
@@ -299,7 +299,6 @@ const canonicalScenarioInputs: CanonicalScenarioInput[] = [
     expectedStateId: "onboarding-failure-invalid-nvidia-key",
     onboardingAssertionIds: ["base-installed"],
     suiteIds: [],
-    requiredSecrets: ["NVIDIA_API_KEY"],
     expectedFailure: {
       phase: "onboarding",
       errorClass: "invalid-nvidia-api-key",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             "**/node_modules/**",
             "**/.claude/**",
             "test/e2e/**",
+            "test/e2e-scenario/**",
             "test/install-preflight.test.ts",
             "test/install-openshell-version-check.test.ts",
           ],


### PR DESCRIPTION
## Summary
Migrate the smoke/onboarding family from placeholder status into registry-backed live Vitest coverage.

This PR expands the live Vitest scenario runner so onboarding fixtures can execute the supported smoke/onboarding variants directly from typed scenario metadata. It also keeps the legacy typed shell runner aligned for the migrated negative onboarding paths until that runner is retired.

## Related Issue
Refs #4941
Refs #4990
Refs #4348
Depends on #5046, #5052, and #5053.
Stacked on branch `codex/e2e-fanout-02-onboarding-variant-fixtures`.

## Changes
- Mark the smoke/onboarding family as live-supported where fixtures now own the setup:
  - cloud OpenClaw smoke
  - no-Docker preflight negative
  - resume after interrupt
  - repair existing config
  - double same-provider onboarding
  - custom policies
  - invalid NVIDIA key negative
  - gateway port conflict negative
- Keep provider-switch onboarding unsupported until inference/provider-switch fixtures own that behavior.
- Stop requiring a real `NVIDIA_API_KEY` for the invalid-key negative scenario; both the Vitest fixture path and shell dispatcher path inject `not-a-nvidia-key`.
- Assert and record expected-failure contracts in `scenario-result.json` for negative live scenarios.
- Hold the configured gateway port in the legacy shell dispatcher for `cloud-openclaw-gateway-port-conflict`, with validation and cleanup coverage.
- Exclude `test/e2e-scenario/**` from the regular `cli` Vitest project so live scenario tests remain opt-in through `e2e-scenarios-live`.
- Update matrix, support, compiler, dispatcher, and project-gating tests for the migrated scenario family.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx biome check --write test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh`
- [x] `npx vitest run --project e2e-scenario-framework test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts --silent=false --reporter=default` -> 1 file, 3 tests passed
- [x] `npx prek run --files test/e2e-scenario/nemoclaw_scenarios/onboard/dispatch.sh test/e2e-scenario/framework-tests/e2e-onboard-dispatch.test.ts --skip test-cli`
- [x] `npx vitest run --project e2e-scenario-framework --silent=false --reporter=default` -> 27 files, 340 tests passed
- [x] `npm run typecheck:cli`
- [x] `git diff --check`
- [x] PR checks on head `2c149cab786a809d3f41fc21b2bbfe88277e5217` are green, including `static-checks`, `build-typecheck`, `cli-tests`, `plugin-tests`, `macos-e2e`, `wsl-e2e`, CodeQL, E2E recommendation, and PR review advisor.
- [x] Live Vitest scenario tiles passed for the migrated family:
  - `ubuntu-repo-cloud-openclaw` — run `27235877649`
  - `ubuntu-no-docker-preflight-negative` — run `27235876285`
  - `ubuntu-repo-cloud-openclaw-resume` — run `27235883637`
  - `ubuntu-repo-cloud-openclaw-repair` — run `27235882301`
  - `ubuntu-repo-cloud-openclaw-double-same-provider` — run `27235880807`
  - `ubuntu-repo-cloud-openclaw-custom-policies` — run `27235879233`
  - `ubuntu-invalid-nvidia-key-negative` — run `27235874787`
  - `ubuntu-gateway-port-conflict-negative` — run `27235873305`
- [x] Typed shell scenario runner evidence:
  - `ubuntu-invalid-nvidia-key-negative` — run `27238468247` on head `2c149cab786a809d3f41fc21b2bbfe88277e5217`; log shows expected failure `{ "phase": "onboarding", "errorClass": "invalid-nvidia-api-key" }`, `gateway-absent` and `sandbox-absent` state-validation actions, and `negative-contract: passed`.
  - `ubuntu-no-docker-preflight-negative` — run `27235876305`
  - `ubuntu-gateway-port-conflict-negative` — run `27237583030` after shell bridge hardening
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: the full touched-file commit hook remains blocked in this local environment by unrelated SSH signing failures inside `test/release-latest-tag.test.ts` temporary git repositories. The relevant touched-file hooks were run with `--skip test-cli`, and the full framework/typecheck/CI checks above passed.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
