### PR TITLE
test(e2e): retire covered smoke/onboarding shell entrypoints

### DIFF
--- a/test/e2e-scenario/docs/MIGRATION.md
+++ b/test/e2e-scenario/docs/MIGRATION.md
@@ -101,6 +101,14 @@ Do not set `deletionReady: true` on a script entry or internal surface unless
 the record is `covered` or `retired` and the deletion approval is recorded
 through #4357.
 
+A domain migration can still have useful partial coverage before a direct legacy
+script is deletion-ready. In that case, leave the broad `test/e2e/test-*.sh`
+entry as `not-migrated`, record the narrow covered behavior in the owning issue
+or PR, and keep `deletionReady: false`. Internal bridge surfaces may be marked
+`covered` when equivalent Vitest fixture coverage exists, but they must still
+stay `deletionReady: false` while the YAML/bash bridge or assertion registry
+references them.
+
 After #4357 completes final legacy E2E reconciliation, remove the inventory if
 there are no remaining legacy entrypoints to guard. If maintainers keep it, keep
 it as an audit artifact rather than as a living migration checklist.

--- a/test/e2e-scenario/framework-tests/e2e-migration-inventory.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-migration-inventory.test.ts
@@ -4,7 +4,10 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import YAML from "yaml";
 import { describe, expect, it } from "vitest";
+
+import { onboardingAssertionGroups } from "../scenarios/assertions/registry.ts";
 
 const INVENTORY_PATH = path.resolve(import.meta.dirname, "../migration/legacy-inventory.json");
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
@@ -17,6 +20,23 @@ const INTERNAL_SURFACE_ROOTS = [
   "test/e2e-scenario/runtime/reports",
   "test/e2e-scenario/scenarios/orchestrators",
   "test/e2e-scenario/validation_suites",
+] as const;
+const SMOKE_ONBOARDING_LEGACY_SCRIPTS = [
+  "test/e2e/test-cloud-onboard-e2e.sh",
+  "test/e2e/test-device-auth-health.sh",
+  "test/e2e/test-double-onboard.sh",
+  "test/e2e/test-full-e2e.sh",
+  "test/e2e/test-hermes-e2e.sh",
+  "test/e2e/test-hermes-root-entrypoint-smoke.sh",
+  "test/e2e/test-launchable-smoke.sh",
+  "test/e2e/test-onboard-negative-paths.sh",
+  "test/e2e/test-onboard-repair.sh",
+  "test/e2e/test-onboard-resume.sh",
+] as const;
+const LEGACY_ONBOARDING_ASSERTION_SCRIPTS = [
+  "test/e2e-scenario/onboarding_assertions/base/00-cli-installed.sh",
+  "test/e2e-scenario/onboarding_assertions/preflight/00-preflight-expected-failed.sh",
+  "test/e2e-scenario/onboarding_assertions/preflight/00-preflight-passed.sh",
 ] as const;
 
 type MigrationStatus = "not-migrated" | "bridge-probe" | "covered" | "retired";
@@ -59,8 +79,21 @@ interface LegacyInventory {
   internalSurfaces: LegacyInternalSurface[];
 }
 
+interface YamlScenarioRegistry {
+  onboarding_assertions?: Record<string, { script?: string }>;
+}
+
 function loadInventory(): LegacyInventory {
   return JSON.parse(fs.readFileSync(INVENTORY_PATH, "utf8")) as LegacyInventory;
+}
+
+function loadYamlScenarioRegistry(): YamlScenarioRegistry {
+  return YAML.parse(
+    fs.readFileSync(
+      path.join(REPO_ROOT, "test/e2e-scenario/nemoclaw_scenarios/scenarios.yaml"),
+      "utf8",
+    ),
+  ) as YamlScenarioRegistry;
 }
 
 function repoPathExists(repoRelativePath: string): boolean {
@@ -97,6 +130,13 @@ function listRepoFilesUnder(repoRelativeDir: string): string[] {
 
 function isCoveredByInventoryPath(filePath: string, inventoryPath: string): boolean {
   return filePath === inventoryPath || filePath.startsWith(`${inventoryPath}/`);
+}
+
+function findInternalSurface(
+  inventory: LegacyInventory,
+  id: string,
+): LegacyInternalSurface | undefined {
+  return inventory.internalSurfaces.find((surface) => surface.id === id);
 }
 
 function expectPathListIsRepoRelative(paths: readonly string[]) {
@@ -218,5 +258,60 @@ describe("E2E migration inventory deletion gates", () => {
     for (const surface of inventory.internalSurfaces) {
       expectMigrationRecordDeletionGate(surface);
     }
+  });
+
+  it("keeps smoke/onboarding direct shell scripts preserved until whole-script parity exists", () => {
+    const inventory = loadInventory();
+    const smokeOnboardingEntries = inventory.entries
+      .filter((entry) => entry.domain === "smoke-onboarding")
+      .sort((left, right) => left.legacyScript.localeCompare(right.legacyScript));
+
+    expect(smokeOnboardingEntries.map((entry) => entry.legacyScript)).toEqual([
+      ...SMOKE_ONBOARDING_LEGACY_SCRIPTS,
+    ]);
+
+    for (const entry of smokeOnboardingEntries) {
+      expect(repoPathExists(entry.legacyScript)).toBe(true);
+      expect(entry.status).toBe("not-migrated");
+      expect(entry.targetVitestScenarios).toEqual([]);
+      expect(entry.bridgeProbes).toEqual([]);
+      expect(entry.deletionReady).toBe(false);
+      expect(entry.deletionApprovalIssue).toBeUndefined();
+      expect(entry.notes).toMatch(/whole-script|not covered|not deletion-ready|Preserve/i);
+    }
+  });
+
+  it("records onboarding assertion workers as covered but still required by the bridge", () => {
+    const inventory = loadInventory();
+    const surface = findInternalSurface(inventory, "legacy-onboarding-assertion-workers");
+
+    expect(surface).toBeTruthy();
+    expect(surface).toMatchObject({
+      status: "covered",
+      replacementSurface: "test/e2e-scenario/framework/phases/onboarding.ts",
+      targetVitestScenarios: ["test/e2e-scenario/live/registry-scenarios.test.ts"],
+      bridgeProbes: [],
+      deletionReady: false,
+    });
+    expect(surface?.deletionApprovalIssue).toBeUndefined();
+    expect(surface?.notes).toContain("legacy YAML/bash bridge still references");
+
+    const assertionRegistryRefs = onboardingAssertionGroups
+      .flatMap((group) => group.steps.map((step) => step.implementation?.ref))
+      .filter((ref): ref is string => Boolean(ref))
+      .sort();
+    const yamlScenarioRegistryRefs = Object.values(
+      loadYamlScenarioRegistry().onboarding_assertions ?? {},
+    )
+      .map((entry) => entry.script)
+      .filter((script): script is string => Boolean(script))
+      .map((script) => `test/e2e-scenario/${script}`)
+      .sort();
+
+    for (const script of LEGACY_ONBOARDING_ASSERTION_SCRIPTS) {
+      expect(repoPathExists(script)).toBe(true);
+    }
+    expect(assertionRegistryRefs).toEqual([...LEGACY_ONBOARDING_ASSERTION_SCRIPTS].sort());
+    expect(yamlScenarioRegistryRefs).toEqual([...LEGACY_ONBOARDING_ASSERTION_SCRIPTS].sort());
   });
 });

--- a/test/e2e-scenario/migration/legacy-inventory.json
+++ b/test/e2e-scenario/migration/legacy-inventory.json
@@ -22,7 +22,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Do not delete until onboarding, gateway, sandbox, and inference smoke behavior has equivalent Vitest coverage."
+      "notes": "Partially exercised by the #5054 live-supported cloud OpenClaw Vitest scenario, but this broad script also covers install, gateway, sandbox, credentials, policy, and inference smoke behavior. Preserve until whole-script parity is recorded."
     },
     {
       "legacyScript": "test/e2e/test-cloud-onboard-e2e.sh",
@@ -33,7 +33,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Expected to migrate with the smoke/onboarding family after repo-local CLI smoke."
+      "notes": "Partially exercised by #5054 cloud OpenClaw Vitest onboarding coverage, but delegated sandbox, policy, Landlock, and inference-local checks still need whole-script parity before deletion."
     },
     {
       "legacyScript": "test/e2e/test-inference-routing.sh",
@@ -253,7 +253,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Device auth health behavior is not covered by the #5054 smoke/onboarding Vitest slice. Preserve until device-auth-specific fixture coverage exists."
     },
     {
       "legacyScript": "test/e2e/test-diagnostics.sh",
@@ -297,7 +297,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Partially exercised by the #5054 double-same-provider Vitest scenario, but the direct script's registry reconciliation, gateway reuse, alternate provider, and stale-state branches still need whole-script parity."
     },
     {
       "legacyScript": "test/e2e/test-gateway-drift-preflight.sh",
@@ -374,7 +374,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Hermes cloud onboarding is not covered by the #5054 OpenClaw-focused Vitest slice. Preserve until Hermes onboarding and health fixtures are wired."
     },
     {
       "legacyScript": "test/e2e/test-hermes-inference-switch.sh",
@@ -396,7 +396,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Hermes root-entrypoint smoke behavior is not covered by the #5054 OpenClaw-focused Vitest slice. Preserve until Hermes root-entrypoint fixture coverage exists."
     },
     {
       "legacyScript": "test/e2e/test-hermes-sandbox-secret-boundary.sh",
@@ -462,7 +462,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Launchable/public install behavior is not covered by the #5054 repo-current Vitest slice. Preserve until launchable source, sentinel, and installer evidence have parity."
     },
     {
       "legacyScript": "test/e2e/test-messaging-compatible-endpoint.sh",
@@ -517,7 +517,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Partially exercised by #5054 invalid-key, no-Docker, and gateway-conflict Vitest scenarios, but the direct script's policy-mode, custom-policy, bad-input, and side-effect checks still need whole-script parity."
     },
     {
       "legacyScript": "test/e2e/test-onboard-repair.sh",
@@ -528,7 +528,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Partially exercised by the #5054 repair Vitest scenario, but the direct script's conflicting resume and state-repair branches still need whole-script parity."
     },
     {
       "legacyScript": "test/e2e/test-onboard-resume.sh",
@@ -539,7 +539,7 @@
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Initial completeness row; classify detailed coverage and deletion evidence in the owning migration issue before deleting."
+      "notes": "Partially exercised by the #5054 resume Vitest scenario, but the direct script's cached-step, session-file, and rerun assertions still need whole-script parity."
     },
     {
       "legacyScript": "test/e2e/test-openclaw-discord-pairing.sh",
@@ -849,13 +849,13 @@
       "paths": ["test/e2e-scenario/onboarding_assertions"],
       "domain": "smoke-onboarding",
       "ownerIssue": "#4348",
-      "status": "not-migrated",
+      "status": "covered",
       "replacementSurface": "test/e2e-scenario/framework/phases/onboarding.ts",
-      "targetVitestScenarios": [],
+      "targetVitestScenarios": ["test/e2e-scenario/live/registry-scenarios.test.ts"],
       "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Retire after onboarding phase fixtures emit equivalent pass/fail evidence for base install and preflight assertions."
+      "notes": "Base install and preflight pass/fail assertion semantics are covered by the #5054 live registry Vitest onboarding fixture path. The legacy YAML/bash bridge still references these shell files, so deletionReady stays false until that bridge dependency is retired through #4357."
     },
     {
       "id": "legacy-validation-suites",


### PR DESCRIPTION
## Summary
Implements the conservative retirement guard for the smoke/onboarding fan-out slice.

#5054 moved useful smoke/onboarding behavior into the registry-backed Vitest path, but it did **not** prove whole-script parity for the broad direct legacy `test/e2e/test-*.sh` scripts. This PR records that boundary explicitly instead of deleting coverage too early.

## Related Issue
Refs #4941
Refs #4990
Refs #4348
Refs #4357
Depends on #5054.
Stacked on branch `codex/e2e-fanout-03-smoke-onboarding-scenarios`.

## Changes
- Marks the narrow `legacy-onboarding-assertion-workers` internal surface as covered by `test/e2e-scenario/live/registry-scenarios.test.ts`, while keeping `deletionReady: false` because the YAML/bash bridge and assertion registry still reference those shell files.
- Keeps every direct smoke/onboarding legacy `test/e2e/test-*.sh` entry as `not-migrated`, `deletionReady: false`, with notes describing what #5054 partially covered and what whole-script parity is still missing.
- Adds inventory tests that preserve the direct smoke/onboarding scripts until whole-script parity exists and prove the onboarding assertion worker scripts remain present while bridge metadata still consumes them.
- Documents the partial-coverage rule: a domain PR may record narrower Vitest coverage without turning a broad legacy entrypoint into a deletion-ready row.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx vitest run --project e2e-scenario-framework test/e2e-scenario/framework-tests/e2e-migration-inventory.test.ts test/e2e-scenario/framework-tests/e2e-migration-inventory-lock.test.ts --silent=false --reporter=default`
- [x] `npx vitest run --project e2e-scenario-framework --silent=false --reporter=default`
- [x] `npm run typecheck:cli`
- [x] `npx prek run --files test/e2e-scenario/migration/legacy-inventory.json test/e2e-scenario/framework-tests/e2e-migration-inventory.test.ts test/e2e-scenario/docs/MIGRATION.md --skip test-cli`
- [x] `git diff --check`
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
