### PR TITLE
test(e2e): migrate provider-switch and compatible endpoint scenarios

### DIFF
--- a/test/e2e-scenario/framework-tests/e2e-clients.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-clients.test.ts
@@ -6,9 +6,9 @@ import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
-
-import { assertExitZero, type CommandRunner } from "../framework/clients/index.ts";
 import {
+  assertExitZero,
+  type CommandRunner,
   GatewayClient,
   HostCliClient,
   ProviderClient,
@@ -145,7 +145,7 @@ describe("E2E fixture clients", () => {
 
     expect(runner.calls[0]).toEqual({
       command: "openshell",
-      args: ["sandbox", "exec", "assistant", "--", "echo", "ok"],
+      args: ["sandbox", "exec", "--name", "assistant", "--", "echo", "ok"],
       options: {
         artifactName: "sandbox-exec-assistant",
       },
@@ -192,6 +192,7 @@ describe("E2E fixture clients", () => {
     expect(runner.calls[0]?.args).toEqual([
       "sandbox",
       "exec",
+      "--name",
       "assistant",
       "--",
       "sh",

--- a/test/e2e-scenario/framework-tests/e2e-expected-state.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-expected-state.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
 import { compileRunPlans } from "../scenarios/compiler.ts";
 import {
@@ -45,11 +45,31 @@ describe("typed expected-state registry id coverage", () => {
   it("getExpectedState returns the state for known ids", () => {
     expect(getExpectedState("cloud-openclaw-ready")?.id).toBe("cloud-openclaw-ready");
   });
+
+  it("tracks compatible endpoint inference metadata separately from cloud OpenClaw", () => {
+    expect(getExpectedState("openai-compatible-openclaw-ready")).toMatchObject({
+      inference: {
+        expected: "available",
+        provider: "compatible-endpoint",
+        model: "mock-compatible-model",
+        policyTier: "open",
+      },
+      credentials: { expected: "present", refs: ["COMPATIBLE_API_KEY"] },
+    });
+  });
 });
 
 describe("probesForState maps typed expected-state into probe ids", () => {
   it("ready cloud state emits cli-installed, gateway-healthy, sandbox-running", () => {
     expect(probesForState(requireExpectedState("cloud-openclaw-ready"))).toEqual([
+      "cli-installed",
+      "gateway-healthy",
+      "sandbox-running",
+    ]);
+  });
+
+  it("compatible endpoint ready state emits the same available-sandbox probes", () => {
+    expect(probesForState(requireExpectedState("openai-compatible-openclaw-ready"))).toEqual([
       "cli-installed",
       "gateway-healthy",
       "sandbox-running",

--- a/test/e2e-scenario/framework-tests/e2e-live-project-config.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-live-project-config.test.ts
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-
+import config from "../../../vitest.config.ts";
+import { readYaml, type WorkflowStep } from "../../helpers/e2e-workflow-contract.ts";
 import {
   shouldRunBranchValidationE2E,
   shouldRunInstallerIntegration,
   shouldRunLiveE2EScenarios,
 } from "../framework/live-project-gate.ts";
-import config from "../../../vitest.config.ts";
-import { readYaml, type WorkflowStep } from "../../helpers/e2e-workflow-contract.ts";
 
 interface ProjectConfig {
   test?: {
     name?: string;
     include?: string[];
+    exclude?: string[];
   };
 }
 
@@ -59,6 +59,10 @@ describe("gated E2E Vitest projects", () => {
     expect(projectConfig("e2e-branch-validation").test?.include).toEqual(
       shouldRunBranchValidationE2E() ? BRANCH_VALIDATION_E2E_TESTS : [],
     );
+  });
+
+  it("keeps live scenario tests out of the default CLI project", () => {
+    expect(projectConfig("cli").test?.exclude).toContain("test/e2e-scenario/live/**");
   });
 
   it("enables installer integration only in CI or with the installer opt-in env var", () => {

--- a/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
@@ -73,4 +73,32 @@ describe("live Vitest registry discovery support", () => {
       reasons: [],
     });
   });
+
+  it("wires the OpenAI-compatible scenario through the mock endpoint fixture", () => {
+    const scenario = listScenarios().find(
+      (entry) => entry.id === "ubuntu-repo-openai-compatible-openclaw",
+    );
+
+    expect(scenario).toBeTruthy();
+    expect(liveScenarioSupport(scenario!)).toMatchObject({
+      supported: true,
+      reasons: [],
+      runtimeSuites: ["openai-compatible-inference"],
+      pendingRuntimeSuites: ["smoke"],
+    });
+  });
+
+  it("keeps provider-switch blocked on a real lifecycle while wiring its runtime suite", () => {
+    const scenario = listScenarios().find(
+      (entry) => entry.id === "ubuntu-repo-cloud-openclaw-double-provider-switch",
+    );
+
+    expect(scenario).toBeTruthy();
+    expect(liveScenarioSupport(scenario!)).toMatchObject({
+      supported: false,
+      reasons: ["lifecycle 'double-provider-switch' is not wired for live Vitest fixtures"],
+      runtimeSuites: ["inference-switch"],
+      pendingRuntimeSuites: ["smoke"],
+    });
+  });
 });

--- a/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts
@@ -80,6 +80,7 @@ describe("live Vitest registry discovery support", () => {
     );
 
     expect(scenario).toBeTruthy();
+    expect(scenario!.expectedStateId).toBe("openai-compatible-openclaw-ready");
     expect(liveScenarioSupport(scenario!)).toMatchObject({
       supported: true,
       reasons: [],

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -302,6 +302,20 @@ describe("onboarding phase fixture", () => {
       ).resolves.toMatchObject({ status: 200 });
       await expect(
         fetch(`${localEndpoint}/chat/completions`, {
+          body: JSON.stringify({ model: "wrong-model" }),
+          headers: { Authorization: `Bearer ${compatibleApiKey}` },
+          method: "POST",
+        }),
+      ).resolves.toMatchObject({ status: 400 });
+      await expect(
+        fetch(`${localEndpoint}/chat/completions`, {
+          body: JSON.stringify({ model: "mock-compatible-model" }),
+          headers: { Authorization: `Bearer ${compatibleApiKey}` },
+          method: "POST",
+        }),
+      ).resolves.toMatchObject({ status: 200 });
+      await expect(
+        fetch(`${localEndpoint}/chat/completions`, {
           body: "x".repeat(70 * 1024),
           headers: { Authorization: `Bearer ${compatibleApiKey}` },
           method: "POST",

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, expectTypeOf, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
-import { HostCliClient, type CommandRunner } from "../framework/clients/index.ts";
+import { type CommandRunner, HostCliClient } from "../framework/clients/index.ts";
 import type { E2EScenarioFixtures } from "../framework/e2e-test.ts";
-import { OnboardingPhaseFixture, type OnboardingSecrets } from "../framework/phases/index.ts";
 import type { EnvironmentReady } from "../framework/phases/index.ts";
+import { OnboardingPhaseFixture, type OnboardingSecrets } from "../framework/phases/index.ts";
 import type {
   ShellProbeResult,
   ShellProbeRunOptions,
@@ -228,6 +228,90 @@ describe("onboarding phase fixture", () => {
     expect(secrets.requiredCalls).toEqual([]);
     expect(runner.calls).toEqual([]);
     expect(cleanup.calls).toEqual([]);
+  });
+
+  it("runs OpenAI-compatible onboarding against a fixture-owned mock endpoint", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(0, "onboarded compatible endpoint\n"));
+    const cleanup = new FakeCleanup();
+    const secrets = new FakeSecrets();
+    const onboard = new OnboardingPhaseFixture(new HostCliClient(runner), secrets, cleanup);
+
+    try {
+      const instance = await onboard.from(ready({ onboarding: "openai-compatible-openclaw" }), {
+        sandboxName: "e2e-openai-compatible",
+      });
+
+      expect(instance).toMatchObject({
+        onboarding: "openai-compatible-openclaw",
+        sandboxName: "e2e-openai-compatible",
+        agent: "openclaw",
+        provider: "compatible-endpoint",
+        providerEnv: "compatible",
+        model: "mock-compatible-model",
+        gatewayUrl: "http://127.0.0.1:18789",
+      });
+      expect(secrets.requiredCalls).toEqual([]);
+      expect(runner.calls).toEqual([
+        {
+          command: "nemoclaw",
+          args: ["onboard", "--non-interactive", "--yes", "--yes-i-accept-third-party-software"],
+          options: {
+            artifactName: "onboard-openai-compatible-openclaw",
+            env: expect.objectContaining({
+              COMPATIBLE_API_KEY: "test-compatible-endpoint-key",
+              NEMOCLAW_AGENT: "openclaw",
+              NEMOCLAW_ENDPOINT_URL: expect.stringMatching(
+                /^http:\/\/host\.openshell\.internal:\d+\/v1$/,
+              ),
+              NEMOCLAW_MODEL: "mock-compatible-model",
+              NEMOCLAW_POLICY_TIER: "open",
+              NEMOCLAW_PROVIDER: "custom",
+              NEMOCLAW_SANDBOX_NAME: "e2e-openai-compatible",
+              PATH: expect.any(String),
+            }),
+            redactionValues: ["test-compatible-endpoint-key"],
+            timeoutMs: 900_000,
+          },
+        },
+      ]);
+      expect(cleanup.calls.map((call) => call.name)).toEqual([
+        "stop OpenAI-compatible endpoint mock",
+        "destroy NemoClaw sandbox e2e-openai-compatible",
+      ]);
+    } finally {
+      await cleanup.calls
+        .find((call) => call.name === "stop OpenAI-compatible endpoint mock")
+        ?.run();
+    }
+  });
+
+  it("requires Docker for OpenAI-compatible onboarding", async () => {
+    const onboard = new OnboardingPhaseFixture(
+      new HostCliClient(new FakeRunner()),
+      new FakeSecrets(),
+      new FakeCleanup(),
+    );
+
+    await expect(
+      onboard.from(
+        ready({
+          onboarding: "openai-compatible-openclaw",
+          docker: { id: "docker-running", expectation: "required", available: false },
+        }),
+      ),
+    ).rejects.toThrow(/requires an available Docker runtime/);
+  });
+
+  it("requires cleanup registration for OpenAI-compatible endpoint mocks", async () => {
+    const onboard = new OnboardingPhaseFixture(
+      new HostCliClient(new FakeRunner()),
+      new FakeSecrets(),
+    );
+
+    await expect(onboard.from(ready({ onboarding: "openai-compatible-openclaw" }))).rejects.toThrow(
+      /requires cleanup registration/,
+    );
   });
 
   it("registers sandbox cleanup after successful cloud OpenClaw onboarding", async () => {

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -279,6 +279,30 @@ describe("onboarding phase fixture", () => {
         "stop OpenAI-compatible endpoint mock",
         "destroy NemoClaw sandbox e2e-openai-compatible",
       ]);
+
+      const endpointUrl = runner.calls[0]?.options?.env?.NEMOCLAW_ENDPOINT_URL;
+      expect(endpointUrl).toEqual(
+        expect.stringMatching(/^http:\/\/host\.openshell\.internal:\d+\/v1$/),
+      );
+      const localEndpointUrl = new URL(String(endpointUrl));
+      localEndpointUrl.hostname = "127.0.0.1";
+      const localEndpoint = localEndpointUrl.toString().replace(/\/$/, "");
+      await expect(fetch(`${localEndpoint}/models`)).resolves.toMatchObject({ status: 401 });
+      await expect(
+        fetch(`${localEndpoint}/models`, { headers: { Authorization: "Bearer wrong" } }),
+      ).resolves.toMatchObject({ status: 401 });
+      await expect(
+        fetch(`${localEndpoint}/models`, {
+          headers: { Authorization: "Bearer test-compatible-endpoint-key" },
+        }),
+      ).resolves.toMatchObject({ status: 200 });
+      await expect(
+        fetch(`${localEndpoint}/chat/completions`, {
+          body: "x".repeat(70 * 1024),
+          headers: { Authorization: "Bearer test-compatible-endpoint-key" },
+          method: "POST",
+        }),
+      ).resolves.toMatchObject({ status: 413 });
     } finally {
       await cleanup.calls
         .find((call) => call.name === "stop OpenAI-compatible endpoint mock")

--- a/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts
@@ -252,6 +252,10 @@ describe("onboarding phase fixture", () => {
         gatewayUrl: "http://127.0.0.1:18789",
       });
       expect(secrets.requiredCalls).toEqual([]);
+      const compatibleApiKey = String(runner.calls[0]?.options?.env?.COMPATIBLE_API_KEY);
+      expect(compatibleApiKey).toEqual(
+        expect.stringMatching(/^test-compatible-endpoint-[0-9a-f]{32}$/),
+      );
       expect(runner.calls).toEqual([
         {
           command: "nemoclaw",
@@ -259,7 +263,7 @@ describe("onboarding phase fixture", () => {
           options: {
             artifactName: "onboard-openai-compatible-openclaw",
             env: expect.objectContaining({
-              COMPATIBLE_API_KEY: "test-compatible-endpoint-key",
+              COMPATIBLE_API_KEY: compatibleApiKey,
               NEMOCLAW_AGENT: "openclaw",
               NEMOCLAW_ENDPOINT_URL: expect.stringMatching(
                 /^http:\/\/host\.openshell\.internal:\d+\/v1$/,
@@ -270,7 +274,7 @@ describe("onboarding phase fixture", () => {
               NEMOCLAW_SANDBOX_NAME: "e2e-openai-compatible",
               PATH: expect.any(String),
             }),
-            redactionValues: ["test-compatible-endpoint-key"],
+            redactionValues: [compatibleApiKey],
             timeoutMs: 900_000,
           },
         },
@@ -293,13 +297,13 @@ describe("onboarding phase fixture", () => {
       ).resolves.toMatchObject({ status: 401 });
       await expect(
         fetch(`${localEndpoint}/models`, {
-          headers: { Authorization: "Bearer test-compatible-endpoint-key" },
+          headers: { Authorization: `Bearer ${compatibleApiKey}` },
         }),
       ).resolves.toMatchObject({ status: 200 });
       await expect(
         fetch(`${localEndpoint}/chat/completions`, {
           body: "x".repeat(70 * 1024),
-          headers: { Authorization: "Bearer test-compatible-endpoint-key" },
+          headers: { Authorization: `Bearer ${compatibleApiKey}` },
           method: "POST",
         }),
       ).resolves.toMatchObject({ status: 413 });

--- a/test/e2e-scenario/framework-tests/e2e-phase-runtime.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-runtime.test.ts
@@ -155,6 +155,19 @@ describe("runtime phase fixture", () => {
     );
   });
 
+  it("rejects inference.local model probes missing the expected model", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(0, JSON.stringify({ data: [{ id: "other-model" }] })));
+
+    await expect(
+      fixture(runner).expectInferenceLocalModels(instance(), {
+        expectedModel: "mock-compatible-model",
+      }),
+    ).rejects.toThrow(
+      "inference.local models response missing expected model 'mock-compatible-model'",
+    );
+  });
+
   it("posts an OpenAI-compatible chat completion to inference.local without shell interpolation", async () => {
     const runner = new FakeRunner();
     runner.enqueue(shellResult(0, JSON.stringify({ choices: [{ message: { content: "ok" } }] })));
@@ -439,6 +452,18 @@ describe("runtime phase fixture", () => {
     await expect(fixture(runner).expectProviderModels(endpoint)).rejects.toThrow(
       "provider models response missing model data",
     );
+  });
+
+  it("rejects provider model probes missing the expected model", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(0, JSON.stringify({ models: [{ name: "llama3" }] })));
+    const endpoint = trustedProviderEndpoint("https://api.example.test/v1/models", {
+      allowedHosts: ["api.example.test"],
+    });
+
+    await expect(
+      fixture(runner).expectProviderModels(endpoint, { expectedModel: "mock-compatible-model" }),
+    ).rejects.toThrow("provider models response missing expected model 'mock-compatible-model'");
   });
 
   it("fails chat probes on malformed compatible responses without echoing the body", async () => {

--- a/test/e2e-scenario/framework-tests/e2e-phase-runtime.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-runtime.test.ts
@@ -4,16 +4,16 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
+  type CommandRunner,
   ProviderClient,
   SandboxClient,
   trustedProviderEndpoint,
-  type CommandRunner,
 } from "../framework/clients/index.ts";
 import type { E2EScenarioFixtures } from "../framework/e2e-test.ts";
 import {
   inferenceRouteUrl,
-  RuntimePhaseFixture,
   type NemoClawInstance,
+  RuntimePhaseFixture,
 } from "../framework/phases/index.ts";
 import type {
   ShellProbeResult,
@@ -111,6 +111,7 @@ describe("runtime phase fixture", () => {
         args: [
           "sandbox",
           "exec",
+          "--name",
           "e2e-ubuntu-repo-cloud-openclaw",
           "--",
           "curl",
@@ -170,6 +171,7 @@ describe("runtime phase fixture", () => {
     expect(call?.args).toEqual([
       "sandbox",
       "exec",
+      "--name",
       "e2e-ubuntu-repo-cloud-openclaw",
       "--",
       "curl",
@@ -183,7 +185,8 @@ describe("runtime phase fixture", () => {
       "https://inference.local/v1/chat/completions",
     ]);
     expect(call?.args).not.toContain("sh");
-    const payload = JSON.parse(call?.args[11] ?? "{}");
+    const payloadIndex = call?.args.indexOf("--data-raw") ?? -1;
+    const payload = JSON.parse(call?.args[payloadIndex + 1] ?? "{}");
     expect(payload).toEqual({
       model: "default",
       messages: [{ role: "user", content: "Reply with ok" }],
@@ -207,6 +210,7 @@ describe("runtime phase fixture", () => {
       args: [
         "sandbox",
         "exec",
+        "--name",
         "e2e-ubuntu-repo-cloud-openclaw",
         "--",
         "curl",
@@ -269,6 +273,53 @@ describe("runtime phase fixture", () => {
     expect(runner.calls.map((call) => call.options?.artifactName)).toEqual([
       "runtime-inference-routing-provider-route-health",
       "runtime-inference-routing-inference-local-chat-completion",
+    ]);
+  });
+
+  it("runs the OpenAI-compatible inference suite with the onboarded model", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(0, JSON.stringify({ data: [{ id: "mock-compatible-model" }] })));
+    runner.enqueue(shellResult(0, JSON.stringify({ choices: [{ message: { content: "PONG" } }] })));
+
+    const result = await fixture(runner).runSuite(
+      "openai-compatible-inference",
+      instance({
+        provider: "compatible-endpoint",
+        providerEnv: "compatible",
+        model: "mock-compatible-model",
+      }),
+    );
+
+    expect(result.suiteId).toBe("openai-compatible-inference");
+    expect(result.assertions.map((assertion) => assertion.id)).toEqual([
+      "runtime.openai-compatible.models-health",
+      "runtime.openai-compatible.chat-completion",
+    ]);
+    expect(runner.calls.map((call) => call.options?.artifactName)).toEqual([
+      "runtime-openai-compatible-inference-models-health",
+      "runtime-openai-compatible-inference-chat-completion",
+    ]);
+    const payload = JSON.parse(
+      runner.calls[1]?.args[runner.calls[1].args.indexOf("--data-raw") + 1] ?? "{}",
+    );
+    expect(payload.model).toBe("mock-compatible-model");
+  });
+
+  it("runs the inference-switch suite with post-switch route assertions", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue(shellResult(0, "200"));
+    runner.enqueue(shellResult(0, JSON.stringify({ choices: [{ message: { content: "PONG" } }] })));
+
+    const result = await fixture(runner).runSuite("inference-switch", instance());
+
+    expect(result.suiteId).toBe("inference-switch");
+    expect(result.assertions.map((assertion) => assertion.id)).toEqual([
+      "runtime.inference-switch.route-state-updated",
+      "runtime.inference-switch.switched-inference-local-chat",
+    ]);
+    expect(runner.calls.map((call) => call.options?.artifactName)).toEqual([
+      "runtime-inference-switch-route-state-updated",
+      "runtime-inference-switch-switched-inference-local-chat",
     ]);
   });
 

--- a/test/e2e-scenario/framework-tests/e2e-phase-state-validation.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-phase-state-validation.test.ts
@@ -4,13 +4,13 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
+  type CommandRunner,
   GatewayClient,
   HostCliClient,
   SandboxClient,
-  type CommandRunner,
 } from "../framework/clients/index.ts";
 import type { E2EScenarioFixtures } from "../framework/e2e-test.ts";
-import { StateValidationPhaseFixture, type NemoClawInstance } from "../framework/phases/index.ts";
+import { type NemoClawInstance, StateValidationPhaseFixture } from "../framework/phases/index.ts";
 import type {
   ShellProbeResult,
   ShellProbeRunOptions,
@@ -211,6 +211,7 @@ describe("state-validation phase fixture", () => {
       args: [
         "sandbox",
         "exec",
+        "--name",
         "e2e-ubuntu-repo-cloud-openclaw",
         "--",
         "curl",

--- a/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
@@ -132,6 +132,7 @@ describe("typed scenario matrix", () => {
     expect(buildLiveScenarioMatrix().map((entry) => entry.id)).toEqual([
       "ubuntu-repo-cloud-openclaw",
       "ubuntu-repo-docker-post-reboot-recovery",
+      "ubuntu-repo-openai-compatible-openclaw",
     ]);
     expect(buildLiveScenarioMatrix()[0]).toMatchObject({
       id: "ubuntu-repo-cloud-openclaw",
@@ -163,6 +164,20 @@ describe("typed scenario matrix", () => {
       supported: true,
       supportReasons: [],
     });
+    expect(buildLiveScenarioMatrix()[2]).toMatchObject({
+      id: "ubuntu-repo-openai-compatible-openclaw",
+      runner: "ubuntu-latest",
+      platform: "ubuntu-local",
+      install: "repo-current",
+      runtime: "docker-running",
+      onboarding: "openai-compatible-openclaw",
+      expectedStateId: "cloud-openclaw-ready",
+      requiredSecrets: [],
+      supported: true,
+      supportReasons: [],
+      runtimeSuites: ["openai-compatible-inference"],
+      pendingRuntimeSuites: ["smoke"],
+    });
   });
 
   it("keeps explicitly selected unsupported live scenarios in the matrix with skip reasons", () => {
@@ -184,6 +199,7 @@ describe("typed scenario matrix", () => {
     expect(parsed.map((entry: { id: string }) => entry.id)).toEqual([
       "ubuntu-repo-cloud-openclaw",
       "ubuntu-repo-docker-post-reboot-recovery",
+      "ubuntu-repo-openai-compatible-openclaw",
     ]);
   });
 

--- a/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
+++ b/test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts
@@ -171,7 +171,7 @@ describe("typed scenario matrix", () => {
       install: "repo-current",
       runtime: "docker-running",
       onboarding: "openai-compatible-openclaw",
-      expectedStateId: "cloud-openclaw-ready",
+      expectedStateId: "openai-compatible-openclaw-ready",
       requiredSecrets: [],
       supported: true,
       supportReasons: [],

--- a/test/e2e-scenario/framework/clients/sandbox.ts
+++ b/test/e2e-scenario/framework/clients/sandbox.ts
@@ -50,7 +50,7 @@ export class SandboxClient {
     options: ShellProbeRunOptions = {},
   ): Promise<ShellProbeResult> {
     validateSandboxName(name);
-    return this.openshell(["sandbox", "exec", name, "--", ...command], {
+    return this.openshell(["sandbox", "exec", "--name", name, "--", ...command], {
       artifactName: `sandbox-exec-${name}`,
       ...options,
     });

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -23,6 +23,7 @@ const ONBOARD_ARGS = [
 const DEFAULT_TIMEOUT_MS = 15 * 60_000;
 const OPENCLAW_GATEWAY_URL = "http://127.0.0.1:18789";
 const COMPATIBLE_ENDPOINT_API_KEY = "test-compatible-endpoint-key";
+const COMPATIBLE_ENDPOINT_MAX_BODY_BYTES = 64 * 1024;
 const COMPATIBLE_ENDPOINT_MODEL = "mock-compatible-model";
 const HOST_SANDBOX_ALIAS = "host.openshell.internal";
 const NEGATIVE_PREFLIGHT_LOG = "negative-preflight.log";
@@ -119,48 +120,64 @@ async function closeServer(server: Server): Promise<void> {
 async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
   const server = createServer((req, res) => {
     const path = req.url?.split("?", 1)[0] ?? "/";
+    const protectedRoute =
+      (req.method === "GET" && path === "/v1/models") ||
+      (req.method === "POST" && path === "/v1/chat/completions");
+    const writeJson = (status: number, payload: Record<string, unknown>) => {
+      if (res.writableEnded) return;
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(payload));
+    };
+    if (protectedRoute && req.headers.authorization !== `Bearer ${COMPATIBLE_ENDPOINT_API_KEY}`) {
+      req.resume();
+      writeJson(401, { error: "unauthorized" });
+      return;
+    }
+
     let body = "";
+    let bodyTooLarge = false;
+    let bodyBytes = 0;
     req.setEncoding("utf8");
     req.on("data", (chunk) => {
+      if (bodyTooLarge) return;
+      bodyBytes += Buffer.byteLength(chunk, "utf8");
+      if (bodyBytes > COMPATIBLE_ENDPOINT_MAX_BODY_BYTES) {
+        bodyTooLarge = true;
+        writeJson(413, { error: "request body too large" });
+        return;
+      }
       body += chunk;
     });
     req.on("end", () => {
+      if (bodyTooLarge || res.writableEnded) return;
       if (req.method === "GET" && path === "/health") {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true }));
+        writeJson(200, { ok: true });
         return;
       }
       if (req.method === "GET" && path === "/v1/models") {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({
-            object: "list",
-            data: [{ id: COMPATIBLE_ENDPOINT_MODEL, object: "model" }],
-          }),
-        );
+        writeJson(200, {
+          object: "list",
+          data: [{ id: COMPATIBLE_ENDPOINT_MODEL, object: "model" }],
+        });
         return;
       }
       if (req.method === "POST" && path === "/v1/chat/completions") {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({
-            id: "chatcmpl-nemoclaw-e2e",
-            object: "chat.completion",
-            model: COMPATIBLE_ENDPOINT_MODEL,
-            choices: [
-              {
-                index: 0,
-                message: { role: "assistant", content: "PONG" },
-                finish_reason: "stop",
-              },
-            ],
-            usage: { prompt_tokens: Math.max(1, body.length), completion_tokens: 1 },
-          }),
-        );
+        writeJson(200, {
+          id: "chatcmpl-nemoclaw-e2e",
+          object: "chat.completion",
+          model: COMPATIBLE_ENDPOINT_MODEL,
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "PONG" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: Math.max(1, body.length), completion_tokens: 1 },
+        });
         return;
       }
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "not found", path }));
+      writeJson(404, { error: "not found", path });
     });
   });
 

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -163,6 +163,23 @@ async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
         return;
       }
       if (req.method === "POST" && path === "/v1/chat/completions") {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(body || "{}");
+        } catch {
+          writeJson(400, { error: "invalid JSON request body" });
+          return;
+        }
+        const requestedModel =
+          parsed && typeof parsed === "object" ? (parsed as { model?: unknown }).model : undefined;
+        if (requestedModel !== COMPATIBLE_ENDPOINT_MODEL) {
+          writeJson(400, {
+            error: "unsupported model",
+            expected: COMPATIBLE_ENDPOINT_MODEL,
+            received: typeof requestedModel === "string" ? requestedModel : null,
+          });
+          return;
+        }
         writeJson(200, {
           id: "chatcmpl-nemoclaw-e2e",
           object: "chat.completion",

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-
+import { redactString } from "../../scenarios/orchestrators/redaction.ts";
 import { buildAvailabilityProbeEnv } from "../availability-env.ts";
 import { artifactLabel, assertExitZero } from "../clients/command.ts";
 import type { HostCliClient } from "../clients/host.ts";
 import { validateSandboxName } from "../clients/sandbox.ts";
 import type { ShellProbeResult } from "../shell-probe.ts";
-import { redactString } from "../../scenarios/orchestrators/redaction.ts";
 import type { EnvironmentReady } from "./environment.ts";
 
 const ONBOARD_ARGS = [
@@ -21,6 +22,9 @@ const ONBOARD_ARGS = [
 ];
 const DEFAULT_TIMEOUT_MS = 15 * 60_000;
 const OPENCLAW_GATEWAY_URL = "http://127.0.0.1:18789";
+const COMPATIBLE_ENDPOINT_API_KEY = "test-compatible-endpoint-key";
+const COMPATIBLE_ENDPOINT_MODEL = "mock-compatible-model";
+const HOST_SANDBOX_ALIAS = "host.openshell.internal";
 const NEGATIVE_PREFLIGHT_LOG = "negative-preflight.log";
 const DOCKER_MISSING_PATTERNS = [
   /Cannot connect to the Docker daemon/i,
@@ -64,8 +68,9 @@ export interface NemoClawInstance {
   onboarding: string;
   sandboxName: string;
   agent: "openclaw" | "hermes";
-  provider: "nvidia" | "ollama";
-  providerEnv: "cloud" | "local";
+  provider: "nvidia" | "ollama" | "compatible-endpoint";
+  providerEnv: "cloud" | "local" | "compatible";
+  model?: string;
   platformOs?: "ubuntu" | "macos" | "windows";
   gatewayUrl: string;
   result: ShellProbeResult;
@@ -85,10 +90,102 @@ function sandboxNameFromOptions(onboarding: string, options: OnboardingOptions):
 function commandEnv(sandboxName: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     ...buildAvailabilityProbeEnv(),
-    ...extra,
     NEMOCLAW_AGENT: "openclaw",
     NEMOCLAW_PROVIDER: "cloud",
     NEMOCLAW_SANDBOX_NAME: sandboxName,
+    ...extra,
+  };
+}
+
+interface CompatibleEndpointMock {
+  endpointUrl: string;
+  apiKey: string;
+  model: string;
+  close(): Promise<void>;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error && (error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
+  const server = createServer((req, res) => {
+    const path = req.url?.split("?", 1)[0] ?? "/";
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      if (req.method === "GET" && path === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      if (req.method === "GET" && path === "/v1/models") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            object: "list",
+            data: [{ id: COMPATIBLE_ENDPOINT_MODEL, object: "model" }],
+          }),
+        );
+        return;
+      }
+      if (req.method === "POST" && path === "/v1/chat/completions") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            id: "chatcmpl-nemoclaw-e2e",
+            object: "chat.completion",
+            model: COMPATIBLE_ENDPOINT_MODEL,
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: "PONG" },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: Math.max(1, body.length), completion_tokens: 1 },
+          }),
+        );
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "not found", path }));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "0.0.0.0", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("compatible endpoint mock did not bind to a TCP port");
+  }
+  let closed = false;
+  return {
+    endpointUrl: `http://${HOST_SANDBOX_ALIAS}:${(address as AddressInfo).port}/v1`,
+    apiKey: COMPATIBLE_ENDPOINT_API_KEY,
+    model: COMPATIBLE_ENDPOINT_MODEL,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await closeServer(server);
+    },
   };
 }
 
@@ -150,6 +247,8 @@ export class OnboardingPhaseFixture {
         return await this.cloudOpenClaw(environment, options);
       case "cloud-openclaw-no-docker":
         return await this.cloudOpenClawNoDocker(environment, options);
+      case "openai-compatible-openclaw":
+        return await this.openAiCompatibleOpenClaw(environment, options);
       default:
         throw new Error(`Unsupported onboarding profile '${environment.onboarding}'.`);
     }
@@ -233,6 +332,47 @@ export class OnboardingPhaseFixture {
     } finally {
       await rm(shimDir, { force: true, recursive: true });
     }
+  }
+
+  async openAiCompatibleOpenClaw(
+    environment: EnvironmentReady,
+    options: OnboardingOptions = {},
+  ): Promise<NemoClawInstance> {
+    if (!environment.docker.available) {
+      throw new Error(
+        "openai-compatible-openclaw onboarding requires an available Docker runtime.",
+      );
+    }
+    if (!this.cleanup) {
+      throw new Error("openai-compatible-openclaw onboarding requires cleanup registration.");
+    }
+    const sandboxName = sandboxNameFromOptions(environment.onboarding, options);
+    const mock = await startCompatibleEndpointMock();
+    this.cleanup.add("stop OpenAI-compatible endpoint mock", mock.close);
+    this.registerSandboxCleanup(sandboxName);
+    const result = await this.host.nemoclaw(ONBOARD_ARGS, {
+      artifactName: "onboard-openai-compatible-openclaw",
+      env: commandEnv(sandboxName, {
+        COMPATIBLE_API_KEY: mock.apiKey,
+        NEMOCLAW_ENDPOINT_URL: mock.endpointUrl,
+        NEMOCLAW_MODEL: mock.model,
+        NEMOCLAW_POLICY_TIER: "open",
+        NEMOCLAW_PROVIDER: "custom",
+      }),
+      redactionValues: [mock.apiKey],
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    });
+    assertExitZero(result, "openai-compatible-openclaw onboarding");
+    return {
+      onboarding: environment.onboarding,
+      sandboxName,
+      agent: "openclaw",
+      provider: "compatible-endpoint",
+      providerEnv: "compatible",
+      model: mock.model,
+      gatewayUrl: OPENCLAW_GATEWAY_URL,
+      result,
+    };
   }
 
   private registerSandboxCleanup(sandboxName: string): void {

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { randomBytes } from "node:crypto";
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -22,7 +23,6 @@ const ONBOARD_ARGS = [
 ];
 const DEFAULT_TIMEOUT_MS = 15 * 60_000;
 const OPENCLAW_GATEWAY_URL = "http://127.0.0.1:18789";
-const COMPATIBLE_ENDPOINT_API_KEY = "test-compatible-endpoint-key";
 const COMPATIBLE_ENDPOINT_MAX_BODY_BYTES = 64 * 1024;
 const COMPATIBLE_ENDPOINT_MODEL = "mock-compatible-model";
 const HOST_SANDBOX_ALIAS = "host.openshell.internal";
@@ -118,6 +118,7 @@ async function closeServer(server: Server): Promise<void> {
 }
 
 async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
+  const apiKey = `test-compatible-endpoint-${randomBytes(16).toString("hex")}`;
   const server = createServer((req, res) => {
     const path = req.url?.split("?", 1)[0] ?? "/";
     const protectedRoute =
@@ -128,7 +129,7 @@ async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
       res.writeHead(status, { "Content-Type": "application/json" });
       res.end(JSON.stringify(payload));
     };
-    if (protectedRoute && req.headers.authorization !== `Bearer ${COMPATIBLE_ENDPOINT_API_KEY}`) {
+    if (protectedRoute && req.headers.authorization !== `Bearer ${apiKey}`) {
       req.resume();
       writeJson(401, { error: "unauthorized" });
       return;
@@ -183,6 +184,10 @@ async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
+    // Docker-backed OpenShell sandboxes reach host services through
+    // host.openshell.internal; binding only localhost makes the mock
+    // unreachable from the sandbox on Linux. Protected routes require
+    // the per-run bearer token above.
     server.listen(0, "0.0.0.0", () => {
       server.off("error", reject);
       resolve();
@@ -196,7 +201,7 @@ async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
   let closed = false;
   return {
     endpointUrl: `http://${HOST_SANDBOX_ALIAS}:${(address as AddressInfo).port}/v1`,
-    apiKey: COMPATIBLE_ENDPOINT_API_KEY,
+    apiKey,
     model: COMPATIBLE_ENDPOINT_MODEL,
     close: async () => {
       if (closed) return;

--- a/test/e2e-scenario/framework/phases/onboarding.ts
+++ b/test/e2e-scenario/framework/phases/onboarding.ts
@@ -201,10 +201,15 @@ async function startCompatibleEndpointMock(): Promise<CompatibleEndpointMock> {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    // Docker-backed OpenShell sandboxes reach host services through
-    // host.openshell.internal; binding only localhost makes the mock
-    // unreachable from the sandbox on Linux. Protected routes require
-    // the per-run bearer token above.
+    // Source boundary: this is host-side E2E fixture infrastructure, not a
+    // NemoClaw product service. Docker-backed OpenShell sandboxes reach host
+    // services through host.openshell.internal, and binding only localhost
+    // makes the mock unreachable from the sandbox on Linux.
+    //
+    // Removal condition: narrow this bind to loopback or a specific
+    // host-gateway address once OpenShell exposes a stable host-loopback alias
+    // or the fixture can discover the sandbox-reachable host address. Protected
+    // /v1 routes require the per-run bearer token above while this is broad.
     server.listen(0, "0.0.0.0", () => {
       server.off("error", reject);
       resolve();

--- a/test/e2e-scenario/framework/phases/runtime.ts
+++ b/test/e2e-scenario/framework/phases/runtime.ts
@@ -63,6 +63,10 @@ export interface InferenceRuntimeRouteOptions extends InferenceRuntimeRequestOpt
   readonly route?: InferenceRoute;
 }
 
+export interface InferenceRuntimeModelsOptions extends InferenceRuntimeRouteOptions {
+  readonly expectedModel?: string;
+}
+
 export interface ProviderRuntimeRequestOptions extends InferenceRuntimeRequestOptions {
   readonly apiKey?: string;
 }
@@ -217,24 +221,36 @@ function assertChatCompletionShape(json: unknown, label: string): void {
   }
 }
 
-function hasModelIdentifier(entry: unknown): boolean {
-  if (typeof entry === "string") return entry.trim().length > 0;
-  if (!entry || typeof entry !== "object") return false;
+function modelIdentifiers(entry: unknown): string[] {
+  if (typeof entry === "string") {
+    const value = entry.trim();
+    return value ? [value] : [];
+  }
+  if (!entry || typeof entry !== "object") return [];
+  const identifiers: string[] = [];
   for (const key of ["id", "model", "name"]) {
     const value = (entry as Record<string, unknown>)[key];
-    if (typeof value === "string" && value.trim().length > 0) return true;
+    if (typeof value === "string" && value.trim().length > 0) {
+      identifiers.push(value.trim());
+    }
   }
-  return false;
+  return identifiers;
 }
 
-function assertModelListShape(json: unknown, label: string): void {
+function assertModelListShape(json: unknown, label: string, expectedModel?: string): void {
   if (!json || typeof json !== "object") {
     throw new Error(`${label} response was not an object`);
   }
   const body = json as { data?: unknown; models?: unknown };
-  const candidates = [body.data, body.models].filter(Array.isArray);
-  if (!candidates.some((items) => items.some(hasModelIdentifier))) {
+  const candidates = [body.data, body.models].filter((value): value is unknown[] =>
+    Array.isArray(value),
+  );
+  const identifiers = candidates.flatMap((items) => items.flatMap(modelIdentifiers));
+  if (identifiers.length === 0) {
     throw new Error(`${label} response missing model data`);
+  }
+  if (expectedModel && !identifiers.includes(expectedModel)) {
+    throw new Error(`${label} response missing expected model '${expectedModel}'`);
   }
 }
 
@@ -386,6 +402,7 @@ export class RuntimePhaseFixture {
         await this.expectInferenceLocalModels(instance, {
           artifactName: suiteArtifactName(suiteId, "models-health"),
           curlMaxTimeSeconds: 20,
+          expectedModel: model,
           route: "inference-local",
           timeoutMs: 30_000,
         }),
@@ -441,7 +458,7 @@ export class RuntimePhaseFixture {
 
   async expectInferenceLocalModels(
     instance: NemoClawInstance,
-    options: InferenceRuntimeRouteOptions = {},
+    options: InferenceRuntimeModelsOptions = {},
   ): Promise<InferenceRuntimeProbeResult> {
     const endpoint = inferenceRouteUrl(options.route, options.path ?? MODELS_PATH);
     const result = await this.sandbox.exec(
@@ -460,6 +477,7 @@ export class RuntimePhaseFixture {
     assertModelListShape(
       parseJsonBody(result.stdout, "inference.local models"),
       "inference.local models",
+      options.expectedModel,
     );
     return { endpoint, result };
   }
@@ -527,10 +545,10 @@ export class RuntimePhaseFixture {
 
   async expectProviderModels(
     endpoint: TrustedProviderEndpoint,
-    options: ProviderRuntimeRequestOptions = {},
+    options: ProviderRuntimeRequestOptions & { expectedModel?: string } = {},
   ): Promise<InferenceRuntimeProbeResult> {
     const response = await this.provider.requestJson(endpoint, providerRequestOptions(options));
-    assertModelListShape(response.json, "provider models");
+    assertModelListShape(response.json, "provider models", options.expectedModel);
     return { endpoint: endpoint.logLabel, result: response.result };
   }
 

--- a/test/e2e-scenario/framework/phases/runtime.ts
+++ b/test/e2e-scenario/framework/phases/runtime.ts
@@ -23,6 +23,8 @@ export const SUPPORTED_RUNTIME_SUITE_IDS = [
   "inference",
   "cloud-inference",
   "inference-routing",
+  "openai-compatible-inference",
+  "inference-switch",
 ] as const;
 
 export type RuntimeSuiteId = (typeof SUPPORTED_RUNTIME_SUITE_IDS)[number];
@@ -73,6 +75,8 @@ const DEFAULT_CHAT_MAX_TOKENS = 8;
 const CLOUD_INFERENCE_CHAT_MODEL = "nvidia/nemotron-3-super-120b-a12b";
 const CLOUD_INFERENCE_CHAT_PROMPT = "Reply with exactly one word: PONG";
 const CLOUD_INFERENCE_CHAT_MAX_TOKENS = 100;
+const COMPATIBLE_INFERENCE_CHAT_PROMPT = "Reply with exactly one word: PONG";
+const COMPATIBLE_INFERENCE_CHAT_MAX_TOKENS = 32;
 const MODELS_PATH = "/v1/models";
 const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
 const SENSITIVE_HEADER_NAME = /(authorization|api[-_]?key|token|secret|credential|password)/i;
@@ -288,6 +292,10 @@ export class RuntimePhaseFixture {
         return await this.runCloudInferenceSuite(suiteId, instance);
       case "inference-routing":
         return await this.runInferenceRoutingSuite(instance);
+      case "openai-compatible-inference":
+        return await this.runOpenAiCompatibleInferenceSuite(instance);
+      case "inference-switch":
+        return await this.runInferenceSwitchSuite(instance);
       default:
         throw new Error(`runtime suite '${suiteId}' is not wired for RuntimePhaseFixture`);
     }
@@ -358,6 +366,71 @@ export class RuntimePhaseFixture {
           maxTokens: CLOUD_INFERENCE_CHAT_MAX_TOKENS,
           model: CLOUD_INFERENCE_CHAT_MODEL,
           prompt: CLOUD_INFERENCE_CHAT_PROMPT,
+          route: "inference-local",
+          timeoutMs: 50_000,
+        }),
+      ),
+    );
+    return { suiteId, assertions };
+  }
+
+  private async runOpenAiCompatibleInferenceSuite(
+    instance: NemoClawInstance,
+  ): Promise<RuntimeSuiteResult> {
+    const suiteId = "openai-compatible-inference";
+    const model = instance.model ?? DEFAULT_CHAT_MODEL;
+    const assertions: RuntimeSuiteAssertionResult[] = [];
+    assertions.push(
+      assertionResult(
+        "runtime.openai-compatible.models-health",
+        await this.expectInferenceLocalModels(instance, {
+          artifactName: suiteArtifactName(suiteId, "models-health"),
+          curlMaxTimeSeconds: 20,
+          route: "inference-local",
+          timeoutMs: 30_000,
+        }),
+      ),
+    );
+    assertions.push(
+      assertionResult(
+        "runtime.openai-compatible.chat-completion",
+        await this.expectInferenceLocalChatCompletion(instance, {
+          artifactName: suiteArtifactName(suiteId, "chat-completion"),
+          curlMaxTimeSeconds: 40,
+          maxTokens: COMPATIBLE_INFERENCE_CHAT_MAX_TOKENS,
+          model,
+          prompt: COMPATIBLE_INFERENCE_CHAT_PROMPT,
+          route: "inference-local",
+          timeoutMs: 50_000,
+        }),
+      ),
+    );
+    return { suiteId, assertions };
+  }
+
+  private async runInferenceSwitchSuite(instance: NemoClawInstance): Promise<RuntimeSuiteResult> {
+    const suiteId = "inference-switch";
+    const assertions: RuntimeSuiteAssertionResult[] = [];
+    assertions.push(
+      assertionResult(
+        "runtime.inference-switch.route-state-updated",
+        await this.expectInferenceLocalStatus(instance, {
+          artifactName: suiteArtifactName(suiteId, "route-state-updated"),
+          curlMaxTimeSeconds: 20,
+          route: "inference-local",
+          timeoutMs: 30_000,
+        }),
+      ),
+    );
+    assertions.push(
+      assertionResult(
+        "runtime.inference-switch.switched-inference-local-chat",
+        await this.expectInferenceLocalChatCompletion(instance, {
+          artifactName: suiteArtifactName(suiteId, "switched-inference-local-chat"),
+          curlMaxTimeSeconds: 40,
+          maxTokens: COMPATIBLE_INFERENCE_CHAT_MAX_TOKENS,
+          model: instance.model ?? DEFAULT_CHAT_MODEL,
+          prompt: COMPATIBLE_INFERENCE_CHAT_PROMPT,
           route: "inference-local",
           timeoutMs: 50_000,
         }),

--- a/test/e2e-scenario/manifests/openclaw-openai-compatible.yaml
+++ b/test/e2e-scenario/manifests/openclaw-openai-compatible.yaml
@@ -21,4 +21,4 @@ spec:
   state:
     workspaceRef: default
     credentialRefs:
-      - OPENAI_COMPATIBLE_API_KEY
+      - COMPATIBLE_API_KEY

--- a/test/e2e-scenario/manifests/openclaw-openai-compatible.yaml
+++ b/test/e2e-scenario/manifests/openclaw-openai-compatible.yaml
@@ -16,7 +16,7 @@ spec:
     agent: openclaw
     provider: openai-compatible
     modelRoute: inference-local
-    policyTier: balanced
+    policyTier: open
     messaging: []
   state:
     workspaceRef: default

--- a/test/e2e-scenario/migration/legacy-inventory.json
+++ b/test/e2e-scenario/migration/legacy-inventory.json
@@ -44,18 +44,18 @@
       "bridgeProbes": ["test/e2e-scenario/live/registry-scenarios.test.ts"],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Partially represented by the ubuntu-repo-cloud-openclaw live Vitest scenario via RuntimePhaseFixture suite 'inference-routing'. Keep the legacy script until credential isolation, negative classification, cleanup, provider-route, and compatible-endpoint coverage migrate."
+      "notes": "Partially represented by the ubuntu-repo-cloud-openclaw live Vitest scenario via RuntimePhaseFixture suite 'inference-routing' and the ubuntu-repo-openai-compatible-openclaw live scenario via suite 'openai-compatible-inference'. Keep the legacy script until credential isolation, negative classification, cleanup, provider-route, and all compatible-endpoint cases migrate."
     },
     {
       "legacyScript": "test/e2e/test-openclaw-inference-switch.sh",
       "domain": "inference",
       "ownerIssue": "#4349",
-      "status": "not-migrated",
+      "status": "bridge-probe",
       "targetVitestScenarios": [],
-      "bridgeProbes": [],
+      "bridgeProbes": ["test/e2e-scenario/live/registry-scenarios.test.ts"],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "Provider switch behavior should migrate with the inference fixture family."
+      "notes": "The typed registry now declares the provider-switch scenario and RuntimePhaseFixture can run the post-switch route-health/chat assertions, but the real compatible provider registration, inference set operation, route/config/state checks, and OpenClaw agent turn still live in this legacy script. Do not delete until those actions migrate into a lifecycle/runtime fixture."
     },
     {
       "legacyScript": "test/e2e/test-messaging-providers.sh",

--- a/test/e2e-scenario/migration/legacy-inventory.json
+++ b/test/e2e-scenario/migration/legacy-inventory.json
@@ -50,12 +50,12 @@
       "legacyScript": "test/e2e/test-openclaw-inference-switch.sh",
       "domain": "inference",
       "ownerIssue": "#4349",
-      "status": "bridge-probe",
+      "status": "not-migrated",
       "targetVitestScenarios": [],
-      "bridgeProbes": ["test/e2e-scenario/live/registry-scenarios.test.ts"],
+      "bridgeProbes": [],
       "retiredReason": "",
       "deletionReady": false,
-      "notes": "The typed registry now declares the provider-switch scenario and RuntimePhaseFixture can run the post-switch route-health/chat assertions, but the real compatible provider registration, inference set operation, route/config/state checks, and OpenClaw agent turn still live in this legacy script. Do not delete until those actions migrate into a lifecycle/runtime fixture."
+      "notes": "The typed registry now declares the provider-switch scenario and RuntimePhaseFixture can run the post-switch route-health/chat assertions, but live Vitest still skips it because the double-provider-switch lifecycle is not wired. The real compatible provider registration, inference set operation, route/config/state checks, and OpenClaw agent turn still live in this legacy script. Do not mark bridge-probe or delete until those actions migrate into a lifecycle/runtime fixture."
     },
     {
       "legacyScript": "test/e2e/test-messaging-providers.sh",

--- a/test/e2e-scenario/scenarios/assertions/registry.ts
+++ b/test/e2e-scenario/scenarios/assertions/registry.ts
@@ -188,6 +188,38 @@ const inferenceRoutingSteps = [
   }),
 ];
 
+const openAiCompatibleInferenceSteps = [
+  probeStep(
+    "runtime.openai-compatible.models-health",
+    "runtime",
+    "RuntimePhaseFixture.expectInferenceLocalModels",
+  ),
+  probeStep(
+    "runtime.openai-compatible.chat-completion",
+    "runtime",
+    "RuntimePhaseFixture.expectInferenceLocalChatCompletion",
+    { reliability: { timeoutSeconds: 60, retry: { attempts: 2, on: ["provider-transient"] } } },
+  ),
+];
+
+const inferenceSwitchSteps = [
+  shellStep({
+    id: "runtime.inference-switch.route-state-updated",
+    phase: "runtime",
+    ref: "test/e2e-scenario/validation_suites/inference/switch/00-route-state-updated.sh",
+    reliability: { timeoutSeconds: 30, retry: { attempts: 2, on: ["gateway-transient"] } },
+  }),
+  shellStep({
+    id: "runtime.inference-switch.switched-inference-local-chat",
+    phase: "runtime",
+    ref: "test/e2e-scenario/validation_suites/inference/switch/01-switched-inference-local-chat.sh",
+    reliability: {
+      timeoutSeconds: 60,
+      retry: { attempts: 2, on: ["provider-transient", "model-toolcall-transient"] },
+    },
+  }),
+];
+
 const credentialsSteps = [
   shellStep({
     id: "security.credentials.present",
@@ -300,9 +332,9 @@ export const validationSuiteGroups: AssertionGroup[] = [
       ref: "test/e2e-scenario/validation_suites/inference/model-router/01-provider-routed-completion.sh",
     }),
   ]),
-  suiteGroup("openai-compatible-inference", cloudInferenceSteps),
+  suiteGroup("openai-compatible-inference", openAiCompatibleInferenceSteps),
   suiteGroup("inference-routing", inferenceRoutingSteps),
-  suiteGroup("inference-switch", cloudInferenceSteps),
+  suiteGroup("inference-switch", inferenceSwitchSteps),
   suiteGroup("kimi-compatibility", [
     shellStep({
       id: "runtime.kimi.plugin-wiring",

--- a/test/e2e-scenario/scenarios/expected-states.ts
+++ b/test/e2e-scenario/scenarios/expected-states.ts
@@ -29,6 +29,18 @@ const cloudOpenclawCustomPoliciesReady: ExpectedState = {
   id: "cloud-openclaw-custom-policies-ready",
 };
 
+const openAiCompatibleOpenclawReady: ExpectedState = {
+  ...cloudOpenclawReady,
+  id: "openai-compatible-openclaw-ready",
+  inference: {
+    expected: "available",
+    provider: "compatible-endpoint",
+    model: "mock-compatible-model",
+    policyTier: "open",
+  },
+  credentials: { expected: "present", refs: ["COMPATIBLE_API_KEY"] },
+};
+
 const cloudHermesReady: ExpectedState = {
   id: "cloud-hermes-ready",
   cli: { installed: true },
@@ -105,6 +117,7 @@ const postRebootRecoveryReady: ExpectedState = {
 const REGISTRY: readonly ExpectedState[] = [
   cloudOpenclawReady,
   cloudOpenclawCustomPoliciesReady,
+  openAiCompatibleOpenclawReady,
   cloudHermesReady,
   localOllamaOpenclawReady,
   macosCliReadyDockerOptional,

--- a/test/e2e-scenario/scenarios/runtime-support.ts
+++ b/test/e2e-scenario/scenarios/runtime-support.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ScenarioDefinition } from "./types.ts";
 import { isRuntimeSuiteSupported, type RuntimeSuiteId } from "../framework/phases/index.ts";
+import type { ScenarioDefinition } from "./types.ts";
 
 const SUPPORTED_PLATFORMS = new Set(["ubuntu-local"]);
 const SUPPORTED_INSTALLS = new Set(["repo-current"]);
 const SUPPORTED_RUNTIMES = new Set(["docker-running"]);
-const SUPPORTED_ONBOARDING = new Set(["cloud-openclaw"]);
+const SUPPORTED_ONBOARDING = new Set(["cloud-openclaw", "openai-compatible-openclaw"]);
 // Lifecycle profiles wired into the live Vitest driver. A profile is
 // supported only after both (a) `LifecyclePhaseFixture.simulate(profile)`
 // dispatches it, and (b) at least one expected-state declares the post-

--- a/test/e2e-scenario/scenarios/scenarios/baseline.ts
+++ b/test/e2e-scenario/scenarios/scenarios/baseline.ts
@@ -185,8 +185,7 @@ const canonicalScenarioInputs: CanonicalScenarioInput[] = [
     manifestName: "openclaw-openai-compatible",
     environment: ubuntuRepoDocker("openai-compatible-openclaw"),
     expectedStateId: "cloud-openclaw-ready",
-    suiteIds: ["smoke"],
-    requiredSecrets: ["OPENAI_COMPATIBLE_API_KEY"],
+    suiteIds: ["smoke", "openai-compatible-inference"],
   },
   {
     id: "ubuntu-repo-cloud-openclaw-brave",
@@ -263,9 +262,9 @@ const canonicalScenarioInputs: CanonicalScenarioInput[] = [
   {
     id: "ubuntu-repo-cloud-openclaw-double-provider-switch",
     manifestName: "openclaw-nvidia-double-provider-switch",
-    environment: ubuntuRepoDocker("cloud-nvidia-openclaw-double-provider-switch"),
+    environment: ubuntuRepoDockerLifecycle("cloud-openclaw", "double-provider-switch"),
     expectedStateId: "cloud-openclaw-ready",
-    suiteIds: ["smoke"],
+    suiteIds: ["smoke", "inference-switch"],
     requiredSecrets: ["NVIDIA_API_KEY"],
   },
   {

--- a/test/e2e-scenario/scenarios/scenarios/baseline.ts
+++ b/test/e2e-scenario/scenarios/scenarios/baseline.ts
@@ -184,7 +184,7 @@ const canonicalScenarioInputs: CanonicalScenarioInput[] = [
     id: "ubuntu-repo-openai-compatible-openclaw",
     manifestName: "openclaw-openai-compatible",
     environment: ubuntuRepoDocker("openai-compatible-openclaw"),
-    expectedStateId: "cloud-openclaw-ready",
+    expectedStateId: "openai-compatible-openclaw-ready",
     suiteIds: ["smoke", "openai-compatible-inference"],
   },
   {

--- a/test/e2e-scenario/scenarios/types.ts
+++ b/test/e2e-scenario/scenarios/types.ts
@@ -81,9 +81,12 @@ export interface ExpectedState {
   inference?: {
     expected: ExpectedInferenceAvail;
     provider?: string;
+    model?: string;
+    policyTier?: string;
   };
   credentials?: {
     expected: ExpectedPresence;
+    refs?: readonly string[];
   };
   // Host-side registry entry for the scenario's sandbox name.
   // "present" means `~/.nemoclaw/sandboxes.json` retains the entry,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             "**/node_modules/**",
             "**/.claude/**",
             "test/e2e/**",
+            "test/e2e-scenario/live/**",
             "test/install-preflight.test.ts",
             "test/install-openshell-version-check.test.ts",
           ],


### PR DESCRIPTION
## Summary
Migrates the compatible-endpoint half of the provider/endpoint inference slice from placeholder planning into the typed E2E scenario framework.

## Related Issue
Refs #4941
Refs #4990
Refs #4349
Stacked on #5057 via base branch `codex/e2e-fanout-06-cloud-inference-routing-scenarios`.

## Changes
- Adds fixture-owned OpenAI-compatible onboarding for OpenClaw using a local mock endpoint reachable from the sandbox via `host.openshell.internal`.
- Requires bearer auth on the compatible mock's `/v1/models` and `/v1/chat/completions` routes, uses a per-run mock bearer token, and caps request bodies so the live scenario proves credential propagation instead of accepting unauthenticated traffic.
- Marks the compatible-endpoint manifest as an explicit `open` policy scenario, matching the host-reachable mock endpoint boundary.
- Adds a compatible-specific expected-state ID so the scenario metadata records the compatible provider, mock model, open policy tier, and `COMPATIBLE_API_KEY` credential ref instead of reusing generic NVIDIA cloud state.
- Wires `openai-compatible-inference` into `RuntimePhaseFixture`, the assertion registry, live scenario support, and the live matrix so `ubuntu-repo-openai-compatible-openclaw` can run without external compatible-endpoint secrets.
- Declares the double-provider-switch scenario against the `inference-switch` runtime suite, while keeping it unsupported and `not-migrated` in legacy inventory until a real lifecycle fixture performs provider registration and `inference set`.
- Updates legacy inventory notes so the remaining shell-script coverage is explicit instead of pretending this slice is deletion-ready.
- Updates typed sandbox exec calls to the current OpenShell `sandbox exec --name <sandbox> -- <cmd>` form and keeps live scenario tests out of the default CLI project.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx vitest run --project e2e-scenario-framework --silent=false --reporter=default`
- [x] `npx vitest run --project e2e-scenario-framework test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts --silent=false --reporter=default`
- [x] `npx vitest run --project e2e-scenario-framework test/e2e-scenario/framework-tests/e2e-phase-onboarding.test.ts test/e2e-scenario/framework-tests/e2e-expected-state.test.ts test/e2e-scenario/framework-tests/e2e-scenario-matrix.test.ts test/e2e-scenario/framework-tests/e2e-live-registry-discovery.test.ts --silent=false --reporter=default`
- [x] `npx vitest run --project cli --passWithNoTests test/e2e-scenario/live/registry-scenarios.test.ts --silent=false --reporter=default`
- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] `git diff --check`
- [x] `NEMOCLAW_RUN_E2E_SCENARIOS=1 NEMOCLAW_CLI_BIN=/home/cvillela/src/github.com/nvidia/NemoClaw/bin/nemoclaw.js npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/registry-scenarios.test.ts -t '^ubuntu-repo-openai-compatible-openclaw$' --silent=false --reporter=default`
- [x] `HOME=$(mktemp -d) npx vitest run --project cli test/release-latest-tag.test.ts --silent=false --reporter=default`
- [ ] `npx prek run --all-files` passes locally; it failed only in `test/release-latest-tag.test.ts` because this workstation's global git signing config points at an unavailable signing key (`No private key found for public key "/home/cvillela/.ssh/git-signing-key.pub"`). The same release-tag test passes with a clean temporary `HOME`.
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
