### PR TITLE
fix(messaging): restore per-account Discord proxy for gateway WebSocket

### DIFF
--- a/scripts/generate-openclaw-config.mts
+++ b/scripts/generate-openclaw-config.mts
@@ -891,8 +891,13 @@ export function buildConfig(env: Env = process.env): JsonObject {
     if (ch === "slack") {
       account.appToken = placeholder(ch, "SLACK_APP_TOKEN");
     }
-    if (ch === "telegram") {
+    // The Discord gateway client and the Telegram long-poll client only honor
+    // a per-account proxy; they ignore the managed env proxy, so route them
+    // through the sandbox proxy explicitly (Discord gateway: re-fix of #3894).
+    if (ch === "telegram" || ch === "discord") {
       account.proxy = proxyUrl;
+    }
+    if (ch === "telegram") {
       account.groupPolicy = "open";
     }
     if (isObject(allowedIds) && ch in allowedIds && allowedIds[ch]) {

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -6,11 +6,11 @@
 // Runs the actual TypeScript script with controlled env vars and asserts on
 // the generated openclaw.json output.
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { buildConfig, main } from "../scripts/generate-openclaw-config.mts";
 
@@ -711,10 +711,10 @@ describe("generate-openclaw-config.mts: config generation", () => {
       "openshell:resolve:env:DISCORD_BOT_TOKEN",
     );
     expect(config.channels.telegram.accounts.default.proxy).toBe("http://10.200.0.1:3128");
-    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:3128");
   });
 
-  it("#3894: routes Discord gateway traffic through OpenClaw's managed proxy", () => {
+  it("#3894: routes Discord gateway traffic through the per-account proxy", () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const config = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
@@ -731,10 +731,10 @@ describe("generate-openclaw-config.mts: config generation", () => {
       token: "openshell:resolve:env:DISCORD_BOT_TOKEN",
       enabled: true,
     });
-    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.201.0.9:43128");
   });
 
-  it("does not write a Discord account proxy when the managed proxy is configured", () => {
+  it("writes the Discord account proxy alongside the managed proxy (re-fix of #3894)", () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const config = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
@@ -742,7 +742,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
 
     expect(config.proxy.proxyUrl).toBe("http://10.200.0.1:43128");
-    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:43128");
   });
 
   it("can defer OpenClaw managed proxy config for build-time doctor", () => {
@@ -753,7 +753,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
 
     expect(config.proxy).toBeUndefined();
-    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:3128");
   });
 
   it("ignores the OpenShell loopback proxy env var when using OpenClaw managed proxy", () => {
@@ -765,10 +765,10 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
 
     expect(config.proxy.proxyUrl).toBe("http://10.200.0.1:3128");
-    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:3128");
   });
 
-  it("keeps Telegram on the OpenShell proxy while Discord relies on the managed proxy", () => {
+  it("routes both Telegram and Discord through the per-account proxy", () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
     const config = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
@@ -778,7 +778,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
 
     expect(config.proxy.proxyUrl).toBe("http://10.201.0.9:43128");
     expect(config.channels.telegram.accounts.default.proxy).toBe("http://10.201.0.9:43128");
-    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
+    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.201.0.9:43128");
   });
 
   it("emits Bolt-shape placeholders for Slack so the SDK's prefix regex passes", () => {


### PR DESCRIPTION
## Summary

A sandbox onboarded with the Discord channel comes up degraded: the bot sends via the Discord REST API but never establishes the Discord Gateway WebSocket, so it receives zero inbound `MESSAGE_CREATE` / mention events. This is the same symptom as #3894.

The Discord gateway client honors only the per-account proxy (`channels.discord.accounts.default.proxy`), not the managed env proxy. In `extensions/discord/src/monitor/gateway-plugin.ts`, the gateway socket is opened with the classic `ws` transport and an explicit agent that tunnels through the proxy only when the per-account value is set; otherwise it falls back to a direct-DNS `https.Agent`, which has no resolver to answer in a proxy-only sandbox (`EAI_AGAIN`). This is unchanged across OpenClaw 2026.5.18, 2026.5.27, and 2026.6.1, so a version bump does not address it.

#3935 set the per-account Discord proxy to fix #3894. The config-generator port in #4277 narrowed the per-account proxy assignment to Telegram only, relying on the top-level managed proxy (applied via `HTTP(S)_PROXY` env injection) to cover Discord. The gateway client does not read those env vars, so dropping the per-account proxy re-regressed #3894.

This restores Discord to the per-account proxy assignment, mirroring Telegram.

## Related Issue

Closes #5075 (re-regression of #3894).

## Changes

- `scripts/generate-openclaw-config.mts`: set `account.proxy = proxyUrl` for Discord as well as Telegram, so the generated `channels.discord.accounts.default.proxy` routes the gateway client through the sandbox proxy. Telegram keeps its `groupPolicy: "open"`.
- `test/generate-openclaw-config.test.ts`: update the Discord proxy expectations (previously asserted absent) to expect the per-account proxy, and rename the affected cases.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- `npx vitest run --project cli test/generate-openclaw-config.test.ts` — 133/133 pass
- `npm run typecheck:cli` — clean

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Discord now consistently uses per-account proxy settings, matching Telegram behavior and avoiding missed proxy assignments.
  * Fixed regression where Discord account proxy wasn’t written alongside managed/global proxy settings.

* **Tests**
  * Improved test coverage to validate per-account proxy routing and the regression fix across proxy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->