### PR TITLE
fix(backup): preserve OpenClaw openclaw.json settings across rebuild

### DIFF
--- a/agents/openclaw/manifest.yaml
+++ b/agents/openclaw/manifest.yaml
@@ -55,6 +55,19 @@ state_dirs:
   - whatsapp
   - credentials
 
+# ── Top-level durable state files ───────────────────────────────
+# openclaw.json holds the core OpenClaw settings the state dirs above do not
+# cover: model/provider config, MCP servers, custom agents, and channel
+# account blocks. Without this entry `nemoclaw backup-all` snapshotted the
+# data directories but dropped these settings, so they were lost on rebuild
+# (issue #5027). Backed up with the default copy strategy; the local backup is
+# credential-sanitized (gateway section dropped, secret-bearing fields scrubbed)
+# while OpenShell `resolve:env` placeholders and the `unused` provider sentinel
+# are preserved so the restored config keeps routing through proxy-injected
+# credentials.
+state_files:
+  - path: openclaw.json
+
 # ── Authentication ──────────────────────────────────────────────
 device_pairing: true
 web_auth_method: device_pairing

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -547,6 +547,33 @@ export async function runSandboxSnapshot(
         }
         snapshotExit(1);
       }
+      // #5027/#4538: openclaw.json restores via the generic copy strategy,
+      // which lands it at 0640. The always-on OpenClaw gateway needs the
+      // mutable config contract (setgid dir + group-writable openclaw.json) to
+      // keep writing config at runtime. Rebuild repairs this in its
+      // post-restore sequence; the standalone snapshot-restore path must do the
+      // same. Gated on openclaw.json having been restored (only OpenClaw
+      // declares it) and posture-aware (a no-op for shields-up/non-OpenClaw).
+      if (result.restoredFiles.includes("openclaw.json")) {
+        try {
+          const permRepair = shields.repairMutableConfigPerms(targetSandbox);
+          if (permRepair.applied && permRepair.verified) {
+            console.log(`  ${G}✓${R} OpenClaw config permissions restored`);
+          } else if (!permRepair.applied && permRepair.skipReason === "unreadable") {
+            console.warn(
+              `  Warning: could not verify OpenClaw config permissions: ${permRepair.reason}`,
+            );
+          } else if (permRepair.applied && !permRepair.verified) {
+            console.warn(
+              `  Warning: OpenClaw config permission repair incomplete: ${permRepair.errors.join("; ")}`,
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `  Warning: OpenClaw config permission repair errored: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
       // Reconcile the target's policy presets to match the snapshot manifest
       // exactly — add anything the snapshot recorded but the target is
       // missing, and remove anything the target has that the snapshot did

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -55,6 +55,9 @@ describe("agent definitions", () => {
       "whatsapp",
     ]);
     expect(openclaw.inferenceProviderOptions).toEqual([]);
+    // #5027: openclaw.json must be declared as a durable state file so
+    // backup-all/rebuild preserve core settings (model/provider, MCP, agents).
+    expect(openclaw.stateFiles).toEqual([{ path: "openclaw.json", strategy: "copy" }]);
     expect(openclaw.legacyPaths?.startScript).toContain("scripts/nemoclaw-start.sh");
   });
 

--- a/src/lib/security/credential-filter.test.ts
+++ b/src/lib/security/credential-filter.test.ts
@@ -9,10 +9,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   isConfigValue,
   isCredentialField,
+  isSafeCredentialPlaceholder,
   isSensitiveFile,
   sanitizeConfigFile,
   shouldScanSnapshotFileForCredentials,
   stripCredentials,
+  valueLooksLikeSecret,
 } from "./credential-filter.js";
 
 describe("isCredentialField", () => {
@@ -32,6 +34,34 @@ describe("isCredentialField", () => {
     expect(isCredentialField("bearerToken")).toBe(true);
     expect(isCredentialField("privateKey")).toBe(true);
     expect(isCredentialField("sessionToken")).toBe(true);
+    // OpenClaw channel token fields (#5027).
+    expect(isCredentialField("botToken")).toBe(true);
+    expect(isCredentialField("appToken")).toBe(true);
+  });
+
+  it("matches env-variable-style secret names (#5027)", () => {
+    expect(isCredentialField("GITHUB_TOKEN")).toBe(true);
+    expect(isCredentialField("BRAVE_API_KEY")).toBe(true);
+    expect(isCredentialField("OPENAI_API_KEY")).toBe(true);
+    expect(isCredentialField("DB_PASSWORD")).toBe(true);
+    expect(isCredentialField("SLACK_APP_TOKEN")).toBe(true);
+    // Bare uppercase secret words must also be scrubbed.
+    expect(isCredentialField("TOKEN")).toBe(true);
+    expect(isCredentialField("PASSWORD")).toBe(true);
+    expect(isCredentialField("SECRET")).toBe(true);
+    expect(isCredentialField("CREDENTIALS")).toBe(true);
+  });
+
+  it("matches well-known HTTP auth header names (#5027)", () => {
+    expect(isCredentialField("Authorization")).toBe(true);
+    expect(isCredentialField("authorization")).toBe(true);
+    expect(isCredentialField("Proxy-Authorization")).toBe(true);
+    expect(isCredentialField("X-API-Key")).toBe(true);
+    expect(isCredentialField("X-API-Token")).toBe(true);
+    expect(isCredentialField("x-auth-token")).toBe(true);
+    expect(isCredentialField("Private-Token")).toBe(true);
+    expect(isCredentialField("X-Custom-Auth")).toBe(true);
+    expect(isCredentialField("Cookie")).toBe(true);
   });
 
   it("does not match safe field names", () => {
@@ -40,6 +70,65 @@ describe("isCredentialField", () => {
     expect(isCredentialField("provider")).toBe(false);
     expect(isCredentialField("endpoint")).toBe(false);
     expect(isCredentialField("version")).toBe(false);
+    // Benign env/setting names must not be scrubbed.
+    expect(isCredentialField("NODE_ENV")).toBe(false);
+    expect(isCredentialField("LOG_LEVEL")).toBe(false);
+    expect(isCredentialField("PATH")).toBe(false);
+    expect(isCredentialField("tokenizer")).toBe(false);
+    expect(isCredentialField("maxTokens")).toBe(false);
+    expect(isCredentialField("X-Request-Id")).toBe(false);
+  });
+
+  it("does not strip public keys (verification material, not secrets)", () => {
+    expect(isCredentialField("publicKey")).toBe(false);
+    expect(isCredentialField("PUBLIC_KEY")).toBe(false);
+    expect(isCredentialField("public-key")).toBe(false);
+    expect(isCredentialField("X-Public-Key")).toBe(false);
+    expect(isCredentialField("GITHUB_PUBLIC_KEY")).toBe(false);
+    // But private keys and other secret fields still match.
+    expect(isCredentialField("privateKey")).toBe(true);
+    expect(isCredentialField("PRIVATE_KEY")).toBe(true);
+    expect(isCredentialField("apiKey")).toBe(true);
+  });
+});
+
+describe("valueLooksLikeSecret", () => {
+  it("matches recognizable secret formats", () => {
+    expect(valueLooksLikeSecret("ghp_0123456789abcdef")).toBe(true);
+    expect(valueLooksLikeSecret("sk-proj-0123456789abcdefghij")).toBe(true);
+    expect(valueLooksLikeSecret("xoxb-123456789-abcdefghij")).toBe(true);
+    expect(valueLooksLikeSecret("Bearer abcdef0123456789")).toBe(true);
+  });
+
+  it("does not match benign values", () => {
+    expect(valueLooksLikeSecret("npx")).toBe(false);
+    expect(valueLooksLikeSecret("https://integrate.api.nvidia.com/v1")).toBe(false);
+    expect(valueLooksLikeSecret("moonshotai/kimi-k2")).toBe(false);
+    expect(valueLooksLikeSecret("production")).toBe(false);
+  });
+});
+
+describe("isSafeCredentialPlaceholder", () => {
+  it("recognizes OpenShell resolve placeholders and the unused sentinel", () => {
+    expect(isSafeCredentialPlaceholder("openshell:resolve:env:DISCORD_BOT_TOKEN")).toBe(true);
+    expect(isSafeCredentialPlaceholder("openshell:resolve:env:BRAVE_API_KEY")).toBe(true);
+    expect(isSafeCredentialPlaceholder("xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN")).toBe(true);
+    expect(isSafeCredentialPlaceholder("xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN")).toBe(true);
+    expect(isSafeCredentialPlaceholder("unused")).toBe(true);
+    expect(isSafeCredentialPlaceholder("[STRIPPED_BY_MIGRATION]")).toBe(true);
+    expect(isSafeCredentialPlaceholder("Bearer openshell:resolve:env:REMOTE_MCP_TOKEN")).toBe(true);
+    // `Bearer <safe-literal>` proxy-auth sentinels are preserved too.
+    expect(isSafeCredentialPlaceholder("Bearer unused")).toBe(true);
+    expect(isSafeCredentialPlaceholder("Bearer [STRIPPED_BY_MIGRATION]")).toBe(true);
+  });
+
+  it("rejects raw secrets and malformed references", () => {
+    expect(isSafeCredentialPlaceholder("sk-1234567890")).toBe(false);
+    expect(isSafeCredentialPlaceholder("xoxb-987654321-realtoken")).toBe(false);
+    expect(isSafeCredentialPlaceholder("openshell:resolve:env:")).toBe(false);
+    expect(isSafeCredentialPlaceholder("openshell:resolve:env:BAD NAME")).toBe(false);
+    expect(isSafeCredentialPlaceholder(42)).toBe(false);
+    expect(isSafeCredentialPlaceholder(null)).toBe(false);
   });
 });
 
@@ -86,6 +175,123 @@ describe("stripCredentials", () => {
     expect(stripCredentials("hello")).toBe("hello");
     expect(stripCredentials(42)).toBe(42);
   });
+
+  it("preserves OpenShell resolve placeholders under credential fields (#5027)", () => {
+    const input = {
+      models: { providers: { nvidia: { apiKey: "unused", baseUrl: "https://x/v1" } } },
+      channels: {
+        discord: { accounts: { default: { token: "openshell:resolve:env:DISCORD_BOT_TOKEN" } } },
+        slack: {
+          accounts: { default: { botToken: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN" } },
+        },
+      },
+    };
+    const result = stripCredentials(input);
+    expect(result.models.providers.nvidia.apiKey).toBe("unused");
+    expect(result.models.providers.nvidia.baseUrl).toBe("https://x/v1");
+    expect(result.channels.discord.accounts.default.token).toBe(
+      "openshell:resolve:env:DISCORD_BOT_TOKEN",
+    );
+    expect(result.channels.slack.accounts.default.botToken).toBe(
+      "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+    );
+  });
+
+  it("strips raw channel tokens and MCP env secrets from openclaw.json (#5027)", () => {
+    const input = {
+      channels: {
+        slack: {
+          accounts: { default: { botToken: "xoxb-123-realsecret", appToken: "xapp-1-realsecret" } },
+        },
+      },
+      mcpServers: {
+        github: {
+          command: "npx",
+          env: {
+            GITHUB_TOKEN: "ghp_realsecret",
+            TOKEN: "raw",
+            PASSWORD: "pw",
+            NODE_ENV: "production",
+          },
+        },
+      },
+    };
+    const result = stripCredentials(input);
+    expect(result.channels.slack.accounts.default.botToken).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(result.channels.slack.accounts.default.appToken).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(result.mcpServers.github.env.GITHUB_TOKEN).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(result.mcpServers.github.env.TOKEN).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(result.mcpServers.github.env.PASSWORD).toBe("[STRIPPED_BY_MIGRATION]");
+    // Non-secret env vars and command survive.
+    expect(result.mcpServers.github.env.NODE_ENV).toBe("production");
+    expect(result.mcpServers.github.command).toBe("npx");
+  });
+
+  it("strips MCP HTTP auth headers by name and value backstop (#5027)", () => {
+    const input = {
+      mcpServers: {
+        remote: {
+          url: "https://mcp.example.com",
+          headers: {
+            Authorization: "Bearer ghp_0123456789abcdef",
+            "X-API-Key": "sk-0123456789abcdefghij",
+            // Opaque value (no recognizable prefix) caught by header name.
+            "X-API-Token": "plain-opaque-value-12345",
+            // Opaque value under a custom -auth header, caught by header name.
+            "X-Custom-Auth": "plain-opaque-value-67890",
+            // Bearer resolve reference must survive (only a reference, no secret).
+            "X-Auth-Token": "Bearer openshell:resolve:env:REMOTE_MCP_TOKEN",
+            "X-Request-Id": "req-12345",
+          },
+        },
+      },
+    };
+    const result = stripCredentials(input);
+    const headers = result.mcpServers.remote.headers;
+    expect(headers.Authorization).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(headers["X-API-Key"]).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(headers["X-API-Token"]).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(headers["X-Custom-Auth"]).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(headers["X-Auth-Token"]).toBe("Bearer openshell:resolve:env:REMOTE_MCP_TOKEN");
+    expect(headers["X-Request-Id"]).toBe("req-12345");
+    expect(result.mcpServers.remote.url).toBe("https://mcp.example.com");
+  });
+
+  it("scrubs secret strings and flag values inside array args (#5027)", () => {
+    const input = {
+      mcpServers: {
+        cli: {
+          command: "some-mcp",
+          args: [
+            "--api-key",
+            "opaqueOpaqueSecret123", // opaque value after a credential flag
+            "--verbose", // value-less flag must not be swallowed
+            "--token=plainOpaque", // inline credential flag form
+            "--name=server", // benign inline flag survives
+            "ghp_0123456789abcdef", // shape-based catch
+          ],
+        },
+      },
+    };
+    const result = stripCredentials(input);
+    const args = result.mcpServers.cli.args;
+    expect(args[0]).toBe("--api-key");
+    expect(args[1]).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(args[2]).toBe("--verbose");
+    expect(args[3]).toBe("--token=[STRIPPED_BY_MIGRATION]");
+    expect(args[4]).toBe("--name=server");
+    expect(args[5]).toBe("[STRIPPED_BY_MIGRATION]");
+  });
+
+  it("still strips raw secrets even under preserved-style sibling fields", () => {
+    const input = {
+      good: { apiKey: "openshell:resolve:env:GOOD_KEY" },
+      bad: { apiKey: "sk-actual-secret" },
+    };
+    const result = stripCredentials(input);
+    expect(result.good.apiKey).toBe("openshell:resolve:env:GOOD_KEY");
+    expect(result.bad.apiKey).toBe("[STRIPPED_BY_MIGRATION]");
+  });
 });
 
 describe("sanitizeConfigFile", () => {
@@ -115,6 +321,41 @@ describe("sanitizeConfigFile", () => {
     const result = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(result.model).toBe("gpt-4");
     expect(result.apiKey).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(result.gateway).toBeUndefined();
+  });
+
+  it("sanitizes a realistic openclaw.json without breaking restorable settings (#5027)", () => {
+    const configPath = join(tmpDir, "openclaw.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        models: {
+          mode: "merge",
+          providers: {
+            nvidia: { baseUrl: "https://x/v1", apiKey: "unused", models: [{ id: "kimi" }] },
+          },
+        },
+        mcpServers: { fs: { command: "npx" } },
+        channels: {
+          discord: { accounts: { default: { token: "openshell:resolve:env:DISCORD_BOT_TOKEN" } } },
+        },
+        customAgents: { researcher: { prompt: "be thorough" } },
+        leaked: { apiKey: "sk-real-secret" },
+        gateway: { port: 18789, authToken: "gw-token" },
+      }),
+    );
+
+    sanitizeConfigFile(configPath);
+
+    const result = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(result.models.providers.nvidia.apiKey).toBe("unused");
+    expect(result.models.providers.nvidia.models[0].id).toBe("kimi");
+    expect(result.mcpServers.fs.command).toBe("npx");
+    expect(result.channels.discord.accounts.default.token).toBe(
+      "openshell:resolve:env:DISCORD_BOT_TOKEN",
+    );
+    expect(result.customAgents.researcher.prompt).toBe("be thorough");
+    expect(result.leaked.apiKey).toBe("[STRIPPED_BY_MIGRATION]");
     expect(result.gateway).toBeUndefined();
   });
 

--- a/src/lib/security/credential-filter.ts
+++ b/src/lib/security/credential-filter.ts
@@ -23,6 +23,8 @@ import {
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+import { SECRET_PATTERNS } from "./secret-patterns";
+
 function parseJson<T>(text: string): T {
   return JSON.parse(text);
 }
@@ -110,16 +112,124 @@ const CREDENTIAL_FIELDS = new Set([
 /**
  * Pattern-based detection for credential field names not covered by the
  * explicit set above. Matches common suffixes like accessToken, privateKey,
- * clientSecret, etc.
+ * clientSecret, etc. `bot`/`app` cover the OpenClaw channel token fields
+ * (`botToken`, `appToken`) used by Slack/Telegram accounts.
  */
 const CREDENTIAL_FIELD_PATTERN =
-  /(?:access|refresh|client|bearer|auth|api|private|public|signing|session)(?:Token|Key|Secret|Password)$/;
+  /(?:access|refresh|client|bearer|auth|api|private|public|signing|session|bot|app)(?:Token|Key|Secret|Password)$/;
+
+/**
+ * Environment-variable-style secret names (SCREAMING_SNAKE_CASE) such as an MCP
+ * server's `env: { GITHUB_TOKEN, BRAVE_API_KEY, TOKEN }` block. These are not
+ * camelCase, so the suffix pattern above misses them. Matches an all-uppercase
+ * name that is, or ends in, a secret word (`TOKEN`, `KEY`, `SECRET`,
+ * `PASSWORD`, `PASSPHRASE`, `CREDENTIAL`, optionally pluralized) — covering both
+ * the prefixed (`GITHUB_TOKEN`) and bare (`TOKEN`) forms — while leaving benign
+ * env vars like `NODE_ENV`, `LOG_LEVEL`, or `PATH` untouched.
+ */
+const ENV_SECRET_FIELD_PATTERN =
+  /^(?:[A-Z0-9]+_)*(?:TOKEN|KEY|SECRET|PASSWORD|PASSPHRASE|CREDENTIAL)S?$/;
+
+/**
+ * Well-known HTTP auth header names (matched case-insensitively) whose entire
+ * value is a credential but that do not end in a secret word. Remote MCP
+ * servers in openclaw.json may carry these (issue #5027).
+ */
+const CREDENTIAL_HEADER_NAMES: ReadonlySet<string> = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+]);
+
+/**
+ * Hyphen-delimited header-style names ending in a secret word, e.g.
+ * `X-API-Key`, `X-API-Token`, `X-Auth-Token`, `Private-Token`. The required
+ * hyphen before the secret word keeps camelCase settings such as `maxTokens`
+ * (no hyphen) from matching, so only header-shaped names are scrubbed.
+ */
+const HEADER_CREDENTIAL_PATTERN = /-(?:key|token|secret|password|passphrase|credential|auth)s?$/i;
+
+/**
+ * Public keys are verification material, not secrets, so they must never be
+ * scrubbed even though they end in `Key`/`KEY`. Covers `publicKey`,
+ * `PUBLIC_KEY`, `public-key`, and prefixed forms like `X-Public-Key` /
+ * `GITHUB_PUBLIC_KEY`. Checked before the secret patterns below.
+ */
+const PUBLIC_KEY_FIELD_PATTERN = /(?:^|[-_])public[-_]?keys?$/i;
 
 /**
  * Check whether a field name should be treated as credential-bearing.
  */
 export function isCredentialField(key: string): boolean {
-  return CREDENTIAL_FIELDS.has(key) || CREDENTIAL_FIELD_PATTERN.test(key);
+  if (PUBLIC_KEY_FIELD_PATTERN.test(key)) return false;
+  return (
+    CREDENTIAL_FIELDS.has(key) ||
+    CREDENTIAL_FIELD_PATTERN.test(key) ||
+    ENV_SECRET_FIELD_PATTERN.test(key) ||
+    HEADER_CREDENTIAL_PATTERN.test(key) ||
+    CREDENTIAL_HEADER_NAMES.has(key.toLowerCase())
+  );
+}
+
+/**
+ * Value-level backstop: whether a string value matches a known secret format
+ * (provider key prefixes like `sk-`/`ghp_`/`xoxb-`, `Bearer <token>`, etc.).
+ * This scrubs raw secrets that sit under an unrecognized key name — e.g. a
+ * custom MCP auth header — without over-stripping benign settings, since these
+ * patterns only match credential-shaped values. Resolve placeholders are
+ * checked by the caller and never reach here.
+ */
+export function valueLooksLikeSecret(value: string): boolean {
+  for (const pattern of SECRET_PATTERNS) {
+    // SECRET_PATTERNS carry the global flag, so reset before each stateful test.
+    pattern.lastIndex = 0;
+    if (pattern.test(value)) return true;
+  }
+  return false;
+}
+
+/**
+ * Value patterns that are references to a credential, not the credential
+ * itself. NemoClaw never stores raw secrets in agent config files; provider
+ * keys and channel tokens are written as OpenShell `resolve:env:<NAME>`
+ * placeholders (the `<NAME>` is an environment variable name, not secret
+ * material) and resolved at gateway launch from OpenShell provider storage.
+ * Slack's Bolt SDK rejects a bare placeholder, so its tokens use the
+ * `xoxb`/`xapp` prefixed variants. `unused` is the sentinel OpenClaw writes for
+ * a provider whose auth is proxy-injected. Preserving these lets a sanitized
+ * backup restore into a working config (issue #5027) instead of replacing the
+ * reference with a dead `[STRIPPED_BY_MIGRATION]` marker.
+ */
+const SAFE_CREDENTIAL_PLACEHOLDER_PATTERNS: readonly RegExp[] = [
+  /^openshell:resolve:env:[A-Za-z0-9_]+$/,
+  // Auth headers carry the resolve reference after a `Bearer ` scheme prefix.
+  /^Bearer\s+openshell:resolve:env:[A-Za-z0-9_]+$/i,
+  /^xoxb-OPENSHELL-RESOLVE-ENV-[A-Za-z0-9_]+$/,
+  /^xapp-OPENSHELL-RESOLVE-ENV-[A-Za-z0-9_]+$/,
+];
+
+const SAFE_CREDENTIAL_PLACEHOLDER_LITERALS: ReadonlySet<string> = new Set([
+  "unused",
+  CREDENTIAL_PLACEHOLDER,
+]);
+
+/**
+ * Whether a value under a credential-named field is a non-secret reference
+ * that must be preserved rather than scrubbed.
+ */
+export function isSafeCredentialPlaceholder(value: ConfigValue): boolean {
+  if (typeof value !== "string") return false;
+  // Accept an optional `Bearer ` auth scheme in front of a safe literal, e.g.
+  // `Authorization: "Bearer unused"` for proxy-injected credentials.
+  const withoutScheme = value.replace(/^Bearer\s+/i, "");
+  if (
+    SAFE_CREDENTIAL_PLACEHOLDER_LITERALS.has(value) ||
+    SAFE_CREDENTIAL_PLACEHOLDER_LITERALS.has(withoutScheme)
+  ) {
+    return true;
+  }
+  return SAFE_CREDENTIAL_PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(value));
 }
 
 /**
@@ -168,15 +278,76 @@ export function stripCredentials(obj: ConfigValue): ConfigValue {
   if (obj === null || obj === undefined) return obj;
   if (typeof obj !== "object") return obj;
   if (Array.isArray(obj)) {
-    return obj.map((value) => stripCredentials(value));
+    // Arrays (e.g. an MCP server's `args`) can carry secrets both by shape and
+    // by CLI-flag context: `["--api-key", "<opaque>"]` or `"--api-key=<opaque>"`.
+    return obj.map((value, index) => scrubArrayElement(value, obj[index - 1]));
   }
   if (!isConfigObject(obj)) return obj;
 
   const result: ConfigObject = {};
   for (const [key, value] of Object.entries(obj)) {
-    result[key] = isCredentialField(key) ? CREDENTIAL_PLACEHOLDER : stripCredentials(value);
+    if (isCredentialField(key)) {
+      // Preserve non-secret references (OpenShell resolve placeholders, the
+      // `unused` sentinel); scrub anything else that looks like a raw secret.
+      result[key] = isSafeCredentialPlaceholder(value) ? value : CREDENTIAL_PLACEHOLDER;
+    } else {
+      result[key] = scrubConfigValue(value);
+    }
   }
   return result;
+}
+
+/**
+ * Scrub a value found under a non-credential key (or in an array): a raw secret
+ * detected by shape is replaced with the placeholder; resolve references are
+ * preserved; everything else recurses through stripCredentials.
+ */
+function scrubConfigValue(value: ConfigValue): ConfigValue {
+  if (typeof value === "string") {
+    if (isSafeCredentialPlaceholder(value)) return value;
+    return valueLooksLikeSecret(value) ? CREDENTIAL_PLACEHOLDER : value;
+  }
+  return stripCredentials(value);
+}
+
+/** Bare flag name from a CLI token: `--api-key` → `api-key`, else null. */
+function cliFlagName(token: string): string | null {
+  const match = /^--?([A-Za-z0-9][A-Za-z0-9._-]*)$/.exec(token);
+  return match ? match[1] : null;
+}
+
+/**
+ * Scrub one array element, adding CLI-flag context to the shape backstop: a
+ * value passed inline as `--api-key=<secret>` or positionally right after a
+ * credential flag (`["--api-key", "<secret>"]`) is scrubbed even when the
+ * secret itself is opaque (no recognizable prefix). MCP servers commonly pass
+ * credentials this way.
+ */
+function scrubArrayElement(value: ConfigValue, previous: ConfigValue): ConfigValue {
+  if (typeof value !== "string") return stripCredentials(value);
+  if (isSafeCredentialPlaceholder(value)) return value;
+
+  // Inline `--flag=value` form.
+  const eq = value.indexOf("=");
+  if (eq > 0 && value.startsWith("-")) {
+    const flagName = cliFlagName(value.slice(0, eq));
+    if (flagName && isCredentialField(flagName)) {
+      const inlineValue = value.slice(eq + 1);
+      return isSafeCredentialPlaceholder(inlineValue)
+        ? value
+        : `${value.slice(0, eq)}=${CREDENTIAL_PLACEHOLDER}`;
+    }
+  }
+
+  // Positional value immediately after a credential flag. Skip when this token
+  // is itself a flag (starts with `-`) so a value-less flag does not swallow
+  // the next flag.
+  if (!value.startsWith("-") && typeof previous === "string") {
+    const prevFlag = cliFlagName(previous);
+    if (prevFlag && isCredentialField(prevFlag)) return CREDENTIAL_PLACEHOLDER;
+  }
+
+  return valueLooksLikeSecret(value) ? CREDENTIAL_PLACEHOLDER : value;
 }
 
 /**

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 
 // Override HOME BEFORE importing sandbox-state — it reads process.env.HOME
 // at module-load time to compute REBUILD_BACKUPS_DIR. Captured original is
@@ -1067,6 +1067,13 @@ if (cmd.includes("[ -d ")) {
   process.stdout.write(existingDirs.join("\\n") + "\\n");
   process.exit(0);
 }
+if (cmd.includes("openclaw.json")) {
+  // No openclaw.json in this fixture: the state-file backup command's
+  // \`[ ! -e "$src" ] && exit 2\` fires (missing, not a failure). Handled
+  // before the generic \`find \` matcher below, which would otherwise catch
+  // the command's internal hardlink-check find.
+  process.exit(2);
+}
 if (cmd.includes("find ")) {
   // Simulate a permission-denied subdir: when the audit cmd lacks the
   // \`|| true\` tolerance wrapper (pre-fix shape), exit non-zero so the
@@ -1317,6 +1324,150 @@ process.exit(0);
       expect(loggedCommands).toContain("sqlite3.connect");
       expect(loggedCommands).toContain("src_conn.backup(dst_conn)");
       expect(loggedCommands).toContain("PRAGMA quick_check");
+    } finally {
+      if (oldOpenshell === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
+      }
+      process.env.PATH = oldPath;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("OpenClaw durable config file (#5027)", () => {
+  it("backs up and restores openclaw.json settings while sanitizing secrets", () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-snapshot-"));
+    const oldPath = process.env.PATH;
+    const oldOpenshell = process.env.NEMOCLAW_OPENSHELL_BIN;
+    try {
+      const binDir = path.join(fixture, "bin");
+      const fakeRoot = path.join(fixture, "sandbox-root");
+      const openclawDir = path.join(fakeRoot, ".openclaw");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(openclawDir, { recursive: true });
+
+      // Reporter-shaped config: model/provider/MCP/agent settings plus a
+      // provider apiKey sentinel, a channel resolve placeholder, a real inline
+      // secret, and a gateway block (regenerated at startup).
+      const original = {
+        models: {
+          mode: "merge",
+          providers: {
+            nvidia: {
+              baseUrl: "https://integrate.api.nvidia.com/v1",
+              apiKey: "unused",
+              models: [{ id: "moonshotai/kimi-k2" }],
+            },
+          },
+        },
+        mcpServers: {
+          filesystem: { command: "npx" },
+          github: {
+            command: "npx",
+            env: { GITHUB_TOKEN: "ghp_raw_secret", NODE_ENV: "production" },
+          },
+        },
+        channels: {
+          discord: {
+            accounts: { default: { token: "openshell:resolve:env:DISCORD_BOT_TOKEN" } },
+          },
+          slack: { accounts: { default: { botToken: "xoxb-123-raw-secret" } } },
+        },
+        customAgents: { researcher: { prompt: "be thorough" } },
+        leaked: { apiKey: "sk-real-secret" },
+        gateway: { port: 18789, authToken: "gw-token" },
+      };
+      fs.writeFileSync(path.join(openclawDir, "openclaw.json"), JSON.stringify(original, null, 2));
+
+      writeExecutable(
+        path.join(binDir, "openshell"),
+        `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "sandbox" && args[1] === "ssh-config") {
+  process.stdout.write("Host openshell-alpha\\n  HostName 127.0.0.1\\n  User sandbox\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+      );
+
+      writeExecutable(
+        path.join(binDir, "ssh"),
+        `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const dir = path.join(${JSON.stringify(fakeRoot)}, ".openclaw");
+const cmd = process.argv[process.argv.length - 1] || "";
+function readStdin() {
+  const chunks = [];
+  for (;;) {
+    const buf = Buffer.alloc(65536);
+    let n = 0;
+    try { n = fs.readSync(0, buf, 0, buf.length, null); } catch { break; }
+    if (n === 0) break;
+    chunks.push(buf.subarray(0, n));
+  }
+  return Buffer.concat(chunks);
+}
+if (cmd.includes("[ -d ")) { process.exit(0); }
+if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
+  process.stdout.write(fs.readFileSync(path.join(dir, "openclaw.json")));
+  process.exit(0);
+}
+if (cmd.includes(".nemoclaw-restore") && cmd.includes("openclaw.json")) {
+  fs.writeFileSync(path.join(dir, "openclaw.json"), readStdin());
+  process.exit(0);
+}
+process.exit(0);
+`,
+      );
+
+      writeOpenClawRegistry("alpha");
+      // writeOpenClawRegistry records agent:null → defaults to openclaw.
+
+      process.env.NEMOCLAW_OPENSHELL_BIN = path.join(binDir, "openshell");
+      process.env.PATH = `${binDir}:${oldPath || ""}`;
+
+      const backup = sandboxState.backupSandboxState("alpha");
+      expect(backup.success).toBe(true);
+      expect(backup.backedUpFiles).toEqual(["openclaw.json"]);
+      expect(backup.manifest?.stateFiles).toEqual([{ path: "openclaw.json", strategy: "copy" }]);
+
+      // The local backup is sanitized: secret stripped, gateway removed,
+      // restorable references preserved.
+      const backedUp = JSON.parse(
+        fs.readFileSync(path.join(backup.manifest!.backupPath, "openclaw.json"), "utf-8"),
+      );
+      expect(backedUp.models.providers.nvidia.apiKey).toBe("unused");
+      expect(backedUp.models.providers.nvidia.models[0].id).toBe("moonshotai/kimi-k2");
+      expect(backedUp.mcpServers.filesystem.command).toBe("npx");
+      expect(backedUp.channels.discord.accounts.default.token).toBe(
+        "openshell:resolve:env:DISCORD_BOT_TOKEN",
+      );
+      expect(backedUp.customAgents.researcher.prompt).toBe("be thorough");
+      expect(backedUp.leaked.apiKey).toBe("[STRIPPED_BY_MIGRATION]");
+      // Raw channel tokens and MCP env secrets must not leak into backups.
+      expect(backedUp.channels.slack.accounts.default.botToken).toBe("[STRIPPED_BY_MIGRATION]");
+      expect(backedUp.mcpServers.github.env.GITHUB_TOKEN).toBe("[STRIPPED_BY_MIGRATION]");
+      expect(backedUp.mcpServers.github.env.NODE_ENV).toBe("production");
+      expect(backedUp.gateway).toBeUndefined();
+
+      // Simulate a rebuild that recreates the sandbox with a settings-less
+      // config, then restore and confirm the reporter's settings survive.
+      fs.writeFileSync(
+        path.join(openclawDir, "openclaw.json"),
+        JSON.stringify({ models: { mode: "merge" } }, null, 2),
+      );
+      const restore = sandboxState.restoreSandboxState("alpha", backup.manifest!.backupPath);
+      expect(restore.success).toBe(true);
+      expect(restore.restoredFiles).toEqual(["openclaw.json"]);
+
+      const after = JSON.parse(fs.readFileSync(path.join(openclawDir, "openclaw.json"), "utf-8"));
+      expect(after.models.providers.nvidia.models[0].id).toBe("moonshotai/kimi-k2");
+      expect(after.mcpServers.filesystem.command).toBe("npx");
+      expect(after.customAgents.researcher.prompt).toBe("be thorough");
     } finally {
       if (oldOpenshell === undefined) {
         delete process.env.NEMOCLAW_OPENSHELL_BIN;


### PR DESCRIPTION
## Summary

`nemoclaw backup-all` (which drives the rebuild snapshot machinery) did not capture OpenClaw's core `openclaw.json` config, so model/provider settings, MCP servers, custom agents, and channel account blocks were lost after `nemoclaw <name> rebuild`. This declares `openclaw.json` as a durable state file and hardens the backup credential sanitizer so the restored config is both safe and usable.

## Related Issue

Fixes #5027

## Changes

- **`agents/openclaw/manifest.yaml`** — declare `openclaw.json` as a `state_files` entry (copy strategy) so backup-all/rebuild preserve core OpenClaw settings the state dirs don't cover (model/provider, MCP servers, custom agents, channel blocks).
- **`src/lib/security/credential-filter.ts`** — harden sanitization now that the full config is backed up:
  - Broaden credential-key detection: OpenClaw channel tokens (`botToken`/`appToken`), SCREAMING_SNAKE env secrets in MCP `env` blocks (`GITHUB_TOKEN`, `BRAVE_API_KEY`, bare `TOKEN`/`SECRET`/…), and HTTP auth header names (`Authorization`, `X-API-Key`, `X-*-Token`/`-Auth`).
  - Add a value-level backstop that scrubs raw secrets by shape (`sk-`/`ghp_`/`xoxb-`/`Bearer …`) under any key — including array elements and MCP CLI args passed as `--api-key <secret>` / `--api-key=<secret>`.
  - Preserve non-secret OpenShell `resolve:env`/`unused` placeholders (and the `Bearer <placeholder>` header form) so the restored config keeps routing through proxy-injected credentials instead of a dead marker.
- **`src/lib/actions/sandbox/snapshot.ts`** — after the standalone `snapshot restore` writes `openclaw.json`, run the posture-aware `repairMutableConfigPerms` so the always-on gateway keeps the setgid/group-writable config contract (#4538). Rebuild already does this in its post-restore sequence; the onboard recreate-restore path re-establishes it via `nemoclaw-start.sh` on the next gateway start.
- Tests: manifest assertion (`defs.test.ts`), credential-filter unit coverage (placeholders preserved, channel/env/header/array/flag secrets scrubbed, benign settings untouched), and an end-to-end OpenClaw `openclaw.json` backup→restore round-trip in `snapshot.test.ts` (settings survive, secrets stripped, gateway block dropped).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes (targeted: snapshot, credential-filter, agent defs, mutable-config-perms, snapshot command, config-set, secret-redaction — all green on this host; full `cli` project includes slow CLI-spawn integration tests gated by `NEMOCLAW_TEST_TIMEOUT`)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Reproduced the bug and verified the fix end-to-end through the real compiled backup/restore code path (backup omitted `openclaw.json` before; after the fix it is captured, sanitized, and restored with settings intact)

### Reviewed scope

Scoped to the reporter's workflow (backup-all → rebuild), which is fully correct: rebuild recreates the gateway (regenerating the `gateway` block) and repairs config perms. Two adversarial-review edge cases on adjacent paths are intentionally left as follow-ups: preserving the *live* `gateway` block on a same-sandbox `snapshot restore` (the block regenerates at startup), and perms on onboard recreate-restore (self-heals via `nemoclaw-start.sh`).

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backups and restores now include the OpenClaw durable config so essential settings (provider/MCP/channel/account/custom-agent) are preserved.
* **New Features**
  * Post-restore permission repair runs for restored OpenClaw configs to ensure correct access and emits targeted warnings on issues.
* **Security**
  * Expanded credential detection and scrubbing to better identify and redact secret-like values while preserving safe placeholders.
* **Tests**
  * Added tests verifying OpenClaw config backup/restore and enhanced credential-sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->