### PR TITLE
fix(upgrade): detect NemoClaw image drift in upgrade-sandboxes (#5026)

### DIFF
--- a/src/lib/actions/gateway-drift-preflight.test.ts
+++ b/src/lib/actions/gateway-drift-preflight.test.ts
@@ -265,6 +265,8 @@ describe("gateway drift preflight for maintenance actions", () => {
       [{ name: "alpha", provider: "nvidia-prod", model: "nemotron" }],
       new Set(["alpha"]),
       expect.any(Function),
+      // #5026: the running NemoClaw build is passed so image drift is detected.
+      expect.objectContaining({ currentNemoclawVersion: expect.any(String) }),
     );
   });
 

--- a/src/lib/actions/upgrade-sandboxes.ts
+++ b/src/lib/actions/upgrade-sandboxes.ts
@@ -8,6 +8,7 @@ import {
 } from "../adapters/openshell/gateway-drift";
 import { CLI_NAME } from "../cli/branding";
 import { B, D, G, R, YW } from "../cli/terminal-style";
+import { getVersion } from "../core/version";
 import { prompt as askPrompt } from "../credentials/store";
 import {
   normalizeUpgradeSandboxesOptions,
@@ -17,6 +18,7 @@ import {
   classifyUpgradeableSandboxes,
   shouldSkipUpgradeConfirmation,
   splitRebuildableSandboxes,
+  type UpgradeSandboxCandidate,
 } from "../domain/maintenance/upgrade";
 import {
   captureSandboxListWithGatewayRecovery,
@@ -41,6 +43,39 @@ function checkAgentVersionForUpgrade(
     sandboxName,
     liveNames.has(sandboxName) ? { forceProbe: true } : undefined,
   );
+}
+
+/**
+ * Resolve the running NemoClaw build fingerprint used for image-drift
+ * detection. Returns null when the version cannot be read so classification
+ * falls back to agent-version-only (legacy) behavior (#5026).
+ */
+function resolveCurrentNemoclawVersion(): string | null {
+  try {
+    return getVersion();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a human-readable description of why a sandbox needs rebuilding, covering
+ * an outdated agent version, NemoClaw image/build drift, or both (#5026).
+ */
+function describeStaleUpgrade(s: UpgradeSandboxCandidate): string {
+  const reasons = s.reasons ?? [];
+  const parts: string[] = [];
+  if (reasons.includes("agent-version")) {
+    parts.push(`v${s.current || "?"} → v${s.expected}`);
+  } else if (reasons.includes("image-drift") && s.current) {
+    // Agent version is current; make clear it is the NemoClaw image that drifted.
+    parts.push(`v${s.current} unchanged`);
+  }
+  if (reasons.includes("image-drift")) {
+    const from = s.imageCurrent ? `v${s.imageCurrent}` : "unknown build";
+    parts.push(`NemoClaw image ${from} → v${s.imageExpected}`);
+  }
+  return parts.join("; ");
 }
 
 export async function upgradeSandboxes(
@@ -82,9 +117,14 @@ export async function upgradeSandboxes(
   }
   const liveNames = parseReadySandboxNames(liveResult.output || "");
 
-  // Classify sandboxes as stale, unknown, or current
-  const { stale, unknown } = classifyUpgradeableSandboxes(sandboxes, liveNames, (name) =>
-    checkAgentVersionForUpgrade(name, liveNames),
+  // Classify sandboxes as stale, unknown, or current. Pass the running NemoClaw
+  // build so a NemoClaw image/build change is detected even when the agent
+  // version is unchanged (#5026).
+  const { stale, unknown } = classifyUpgradeableSandboxes(
+    sandboxes,
+    liveNames,
+    (name) => checkAgentVersionForUpgrade(name, liveNames),
+    { currentNemoclawVersion: resolveCurrentNemoclawVersion() },
   );
 
   if (stale.length === 0 && unknown.length === 0) {
@@ -96,7 +136,7 @@ export async function upgradeSandboxes(
     console.log(`\n  ${B}Stale sandboxes:${R}`);
     for (const s of stale) {
       const status = s.running ? `${G}running${R}` : `${D}stopped${R}`;
-      console.log(`    ${s.name}  v${s.current || "?"} → v${s.expected}  (${status})`);
+      console.log(`    ${s.name}  ${describeStaleUpgrade(s)}  (${status})`);
     }
   }
   if (unknown.length > 0) {

--- a/src/lib/domain/maintenance/upgrade.test.ts
+++ b/src/lib/domain/maintenance/upgrade.test.ts
@@ -5,9 +5,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   classifyUpgradeableSandboxes,
+  isNemoclawImageStale,
+  type SandboxVersionCheck,
   shouldSkipUpgradeConfirmation,
   splitRebuildableSandboxes,
-  type SandboxVersionCheck,
 } from "./upgrade";
 
 describe("upgrade sandboxes helpers", () => {
@@ -38,10 +39,103 @@ describe("upgrade sandboxes helpers", () => {
       ),
     ).toEqual({
       stale: [
-        { name: "staleRunning", current: "1.0.0", expected: "2.0.0", running: true },
-        { name: "staleStopped", current: null, expected: "2.0.0", running: false },
+        {
+          name: "staleRunning",
+          current: "1.0.0",
+          expected: "2.0.0",
+          running: true,
+          reasons: ["agent-version"],
+        },
+        {
+          name: "staleStopped",
+          current: null,
+          expected: "2.0.0",
+          running: false,
+          reasons: ["agent-version"],
+        },
       ],
       unknown: [{ name: "unknown", expected: "2.0.0", running: true }],
+    });
+  });
+
+  it("detects NemoClaw image drift only on a recorded, differing fingerprint (#5026)", () => {
+    // Recorded fingerprint older than the running build = stale.
+    expect(isNemoclawImageStale("0.0.60", "0.0.61")).toBe(true);
+    // Matching fingerprint = current.
+    expect(isNemoclawImageStale("0.0.61", "0.0.61")).toBe(false);
+    // Missing fingerprint (legacy or custom image) = NOT flagged — ambiguous,
+    // so it opts in only once rebuilt and stamped. This avoids rebuilding a
+    // custom-image sandbox onto the default image.
+    expect(isNemoclawImageStale(undefined, "0.0.61")).toBe(false);
+    expect(isNemoclawImageStale(null, "0.0.61")).toBe(false);
+    // Unknown running build = drift detection disabled.
+    expect(isNemoclawImageStale("0.0.60", null)).toBe(false);
+  });
+
+  it("flags image drift even when the agent version is unchanged (#5026)", () => {
+    const checks: Record<string, SandboxVersionCheck> = {
+      // Agent version matches expected — agent-version check says "current".
+      imageDrift: {
+        isStale: false,
+        sandboxVersion: "2026.5.27",
+        expectedVersion: "2026.5.27",
+        detectionMethod: "registry",
+      },
+      // Both agent version and image are behind.
+      both: { isStale: true, sandboxVersion: "1.0.0", expectedVersion: "2.0.0" },
+      // No recorded fingerprint (legacy or custom image) but current agent
+      // version — NOT flagged; opts in once rebuilt and stamped (#5026).
+      legacy: {
+        isStale: false,
+        sandboxVersion: "2026.5.27",
+        expectedVersion: "2026.5.27",
+        detectionMethod: "registry",
+      },
+      // Fingerprint matches the running build — up to date.
+      current: {
+        isStale: false,
+        sandboxVersion: "2026.5.27",
+        expectedVersion: "2026.5.27",
+        detectionMethod: "registry",
+      },
+    };
+
+    expect(
+      classifyUpgradeableSandboxes(
+        [
+          { name: "imageDrift", nemoclawVersion: "0.0.60" },
+          { name: "both", nemoclawVersion: "0.0.60" },
+          { name: "legacy" },
+          { name: "current", nemoclawVersion: "0.0.61" },
+        ],
+        new Set(["imageDrift", "both", "legacy", "current"]),
+        (name) => checks[name],
+        { currentNemoclawVersion: "0.0.61" },
+      ),
+    ).toEqual({
+      stale: [
+        {
+          name: "imageDrift",
+          current: "2026.5.27",
+          expected: "2026.5.27",
+          running: true,
+          reasons: ["image-drift"],
+          imageCurrent: "0.0.60",
+          imageExpected: "0.0.61",
+        },
+        {
+          name: "both",
+          current: "1.0.0",
+          expected: "2.0.0",
+          running: true,
+          reasons: ["agent-version", "image-drift"],
+          imageCurrent: "0.0.60",
+          imageExpected: "0.0.61",
+        },
+      ],
+      // `legacy` (no fingerprint) and `current` (matching fingerprint) are both
+      // up to date.
+      unknown: [],
     });
   });
 

--- a/src/lib/domain/maintenance/upgrade.ts
+++ b/src/lib/domain/maintenance/upgrade.ts
@@ -10,11 +10,26 @@ export type SandboxVersionCheck = {
   detectionMethod?: string | null;
 };
 
+/**
+ * Why a sandbox is classified as needing an upgrade. A sandbox can be stale
+ * because its agent version is behind (`agent-version`), because the NemoClaw
+ * build that produced its image differs from the running NemoClaw
+ * (`image-drift`), or both (#5026).
+ */
+export type UpgradeStaleReason = "agent-version" | "image-drift";
+
 export type UpgradeSandboxCandidate = {
   name: string;
   current?: string | null;
   expected?: string | null;
   running: boolean;
+  // Present on stale candidates: the reasons the sandbox needs a rebuild.
+  reasons?: UpgradeStaleReason[];
+  // NemoClaw build fingerprint comparison, set only for `image-drift`.
+  // `imageCurrent` is the build recorded on the sandbox (null when it predates
+  // fingerprinting); `imageExpected` is the running NemoClaw build.
+  imageCurrent?: string | null;
+  imageExpected?: string | null;
 };
 
 export type UpgradeClassification = {
@@ -22,25 +37,69 @@ export type UpgradeClassification = {
   unknown: UpgradeSandboxCandidate[];
 };
 
+export interface ClassifyUpgradeOptions {
+  /**
+   * Running NemoClaw build fingerprint, used to detect image drift (#5026).
+   * When null/undefined, image-drift detection is disabled and only the agent
+   * version is considered (legacy behavior).
+   */
+  currentNemoclawVersion?: string | null;
+}
+
 export function shouldSkipUpgradeConfirmation(options: UpgradeSandboxesOptions): boolean {
   return options.auto === true || options.yes === true;
 }
 
+/**
+ * Whether the NemoClaw build recorded on a sandbox differs from the running
+ * build. Drift requires POSITIVE evidence: a recorded fingerprint that differs
+ * from the running build. Only NemoClaw-managed images carry a fingerprint, so
+ * this never flags a custom-image (`--from`) sandbox — which `upgrade-sandboxes`
+ * could otherwise rebuild onto the default image, losing the custom image. A
+ * missing fingerprint is therefore treated as "not drifted": it is ambiguous
+ * (a legacy managed image OR a legacy custom image, indistinguishable on disk),
+ * so the sandbox opts into drift detection once it is rebuilt and gains a
+ * fingerprint. Detection is also disabled when the running build is unknown.
+ * (#5026)
+ */
+export function isNemoclawImageStale(
+  recorded: string | null | undefined,
+  current: string | null | undefined,
+): boolean {
+  if (!current) return false;
+  if (!recorded) return false;
+  return recorded !== current;
+}
+
 export function classifyUpgradeableSandboxes(
-  sandboxes: Array<{ name: string }>,
+  sandboxes: Array<{ name: string; nemoclawVersion?: string | null }>,
   liveNames: ReadonlySet<string>,
   checkVersion: (name: string) => SandboxVersionCheck,
+  options: ClassifyUpgradeOptions = {},
 ): UpgradeClassification {
+  const currentNemoclawVersion = options.currentNemoclawVersion ?? null;
   const stale: UpgradeSandboxCandidate[] = [];
   const unknown: UpgradeSandboxCandidate[] = [];
   for (const sandbox of sandboxes) {
     const versionCheck = checkVersion(sandbox.name);
-    if (versionCheck.isStale) {
+    const reasons: UpgradeStaleReason[] = [];
+    if (versionCheck.isStale) reasons.push("agent-version");
+    const imageStale = isNemoclawImageStale(sandbox.nemoclawVersion, currentNemoclawVersion);
+    if (imageStale) reasons.push("image-drift");
+
+    if (reasons.length > 0) {
       stale.push({
         name: sandbox.name,
         current: versionCheck.sandboxVersion,
         expected: versionCheck.expectedVersion,
         running: liveNames.has(sandbox.name),
+        reasons,
+        ...(imageStale
+          ? {
+              imageCurrent: sandbox.nemoclawVersion ?? null,
+              imageExpected: currentNemoclawVersion,
+            }
+          : {}),
       });
     } else if (versionCheck.detectionMethod === "unavailable") {
       unknown.push({

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -396,10 +396,17 @@ export async function handleSandboxState<
         ),
     );
     webSearchConfig = nextWebSearchConfig;
+    // createSandbox() already wrote the NemoClaw build fingerprint correctly:
+    // a fresh build stamps the current version, while reuse preserves the
+    // existing value (updateReusedSandboxMetadata never overwrites it). Drop it
+    // from this supplementary update so reusing a sandbox after a NemoClaw
+    // upgrade does not re-stamp a stale image as current and mask drift (#5026).
+    const { nemoclawVersion: _builtFingerprint, ...agentRegistryFields } =
+      deps.getSandboxAgentRegistryFields(agent, !fromDockerfile);
     deps.updateSandboxRegistry(sandboxName, {
       model,
       provider,
-      ...deps.getSandboxAgentRegistryFields(agent, !fromDockerfile),
+      ...agentRegistryFields,
     });
     // Default-marking is deferred to finalization so a cancelled onboard never
     // leaves this sandbox registered as default (#4614).

--- a/src/lib/onboard/sandbox-agent.ts
+++ b/src/lib/onboard/sandbox-agent.ts
@@ -3,6 +3,7 @@
 
 import type { AgentDefinition } from "../agent/defs";
 import { loadAgent } from "../agent/defs";
+import { getVersion } from "../core/version";
 import { getNameValidationGuidance, NAME_ALLOWED_FORMAT } from "../name-validation";
 import { validateName } from "../runner";
 import type { SandboxEntry } from "../state/registry";
@@ -79,15 +80,39 @@ export function getAgentInferenceProviderOptions(
     : [];
 }
 
+/**
+ * Resolve the running NemoClaw build fingerprint stamped onto a freshly created
+ * or rebuilt sandbox image. Falls back to null when the version cannot be
+ * resolved so a transient failure never blocks registration; image-drift
+ * detection is simply skipped for that sandbox until its next rebuild (#5026).
+ */
+export function getNemoclawBuildFingerprint(): string | null {
+  try {
+    return getVersion();
+  } catch {
+    return null;
+  }
+}
+
 export function getSandboxAgentRegistryFields(
   agent: AgentDefinition | null | undefined,
   agentVersionKnown = true,
-): Pick<SandboxEntry, "agent" | "agentVersion"> {
+): Pick<SandboxEntry, "agent" | "agentVersion" | "nemoclawVersion"> {
   const effectiveAgent = getEffectiveSandboxAgent(agent);
   const agentName = normalizeSandboxAgentName(effectiveAgent.name);
   return {
     agent: agentName === "openclaw" ? null : agentName,
     agentVersion: agentVersionKnown ? effectiveAgent.expectedVersion || null : null,
+    // Stamp the NemoClaw build that produced this image, but ONLY for
+    // NemoClaw-managed images. `agentVersionKnown` is `!fromDockerfile` at the
+    // onboard call sites, so it doubles as "this is a managed image."
+    // Custom-image sandboxes (`--from`) are not defined by NemoClaw's build and
+    // are intentionally left without a fingerprint, so `upgrade-sandboxes` never
+    // auto-rebuilds them onto the default image. The reuse path
+    // (updateReusedSandboxMetadata) picks only `.agent` from these fields, so a
+    // reused (un-rebuilt) sandbox keeps its original fingerprint rather than
+    // being silently re-stamped as current. (#5026)
+    nemoclawVersion: agentVersionKnown ? getNemoclawBuildFingerprint() : null,
   };
 }
 

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -59,6 +59,13 @@ export interface SandboxEntry {
   policyPresetsFinalized?: boolean;
   agent?: string | null;
   agentVersion?: string | null;
+  // NemoClaw build fingerprint (the NemoClaw CLI/build version) stamped only on
+  // NemoClaw-managed images at create/rebuild time. `upgrade-sandboxes` compares
+  // it against the running NemoClaw build so an image/build change with an
+  // unchanged agent version is still detected as needing a rebuild. Custom-image
+  // (`--from`) sandboxes are intentionally left without a fingerprint so they
+  // are never auto-rebuilt onto the default image (#5026).
+  nemoclawVersion?: string | null;
   imageTag?: string | null;
   messagingChannels?: string[];
   messagingChannelConfig?: MessagingChannelConfig;
@@ -340,6 +347,7 @@ export function registerSandbox(entry: SandboxEntry): void {
       // cannot inherit a stale finalized marker. See #4621.
       agent: entry.agent || null,
       agentVersion: entry.agentVersion || null,
+      nemoclawVersion: entry.nemoclawVersion || null,
       imageTag: entry.imageTag || null,
       messagingChannels: entry.messagingChannels || [],
       messagingChannelConfig:

--- a/test/cli/list-share-live-inference.test.ts
+++ b/test/cli/list-share-live-inference.test.ts
@@ -1,12 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-import { runWithEnv, testTimeoutOptions, writeSandboxRegistry } from "./helpers";
+import {
+  OPENCLAW_EXPECTED_VERSION,
+  runWithEnv,
+  testTimeoutOptions,
+  writeSandboxRegistry,
+} from "./helpers";
 
 function createShareTestEnv(prefix: string): Record<string, string> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -339,6 +344,86 @@ describe("list shows live gateway inference", () => {
 
       expect(r.code).toBe(0);
       expect(r.out).toContain("up to date");
+    },
+  );
+
+  // ── Issue #5026: sandbox not upgraded after NemoClaw upgrade with an ──
+  // unchanged OpenClaw version. The agent version still matches, but the
+  // NemoClaw build that produced the image changed, so the sandbox needs a
+  // rebuild. A stale recorded NemoClaw fingerprint must be detected even when
+  // the agent version is current.
+  it(
+    "upgrade-sandboxes --check detects NemoClaw image drift when the agent version is unchanged (#5026)",
+    testTimeoutOptions(),
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-upgrade-imagedrift-"));
+      const localBin = path.join(home, "bin");
+      const nemoclawDir = path.join(home, ".nemoclaw");
+      fs.mkdirSync(localBin, { recursive: true });
+      fs.mkdirSync(nemoclawDir, { recursive: true });
+
+      // Sandbox at the CURRENT agent version but built by an older NemoClaw
+      // (stale fingerprint "0.0.1"). Only the NemoClaw image drifted.
+      fs.writeFileSync(
+        path.join(nemoclawDir, "sandboxes.json"),
+        JSON.stringify({
+          sandboxes: {
+            "my-agent": {
+              name: "my-agent",
+              model: "nvidia/nemotron-3-super-120b-a12b",
+              provider: "nvidia-prod",
+              gpuEnabled: false,
+              policies: [],
+              agentVersion: OPENCLAW_EXPECTED_VERSION,
+              nemoclawVersion: "0.0.1",
+            },
+          },
+          defaultSandbox: "my-agent",
+        }),
+        { mode: 0o600 },
+      );
+
+      fs.writeFileSync(
+        path.join(localBin, "openshell"),
+        [
+          "#!/usr/bin/env bash",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
+          '  echo "my-agent   Running   openclaw"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "sandbox" ] && [ "$2" = "ssh-config" ] && [ "$3" = "my-agent" ]; then',
+          "  echo 'Host openshell-my-agent'",
+          "  echo '  HostName 127.0.0.1'",
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "openshell 0.0.24"',
+          "  exit 0",
+          "fi",
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      // Live probe reports the CURRENT agent version, so agent-version is NOT stale.
+      fs.writeFileSync(
+        path.join(localBin, "ssh"),
+        ["#!/usr/bin/env bash", `echo 'OpenClaw ${OPENCLAW_EXPECTED_VERSION}'`, "exit 0"].join(
+          "\n",
+        ),
+        { mode: 0o755 },
+      );
+
+      const r = runWithEnv("upgrade-sandboxes --check 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+
+      expect(r.code).toBe(0);
+      expect(r.out).not.toContain("All sandboxes are up to date.");
+      expect(r.out).toContain("my-agent");
+      // Surfaces the NemoClaw image drift with the stale recorded fingerprint.
+      expect(r.out).toContain("NemoClaw image v0.0.1");
+      expect(r.out).toMatch(/stale|need upgrading/i);
     },
   );
 


### PR DESCRIPTION
## Summary

`nemoclaw upgrade-sandboxes` only compared the agent version inside a sandbox, so after a NemoClaw upgrade that left the bundled OpenClaw `expected_version` unchanged it printed `All sandboxes are up to date.` even though the NemoClaw image payload (scripts, patches, policies, Dockerfile, generated config) had changed. This adds a persisted NemoClaw build fingerprint so image/build drift is detected even when the agent version is unchanged.

## Related Issue

Fixes #5026

## Changes

- Persist a NemoClaw build fingerprint (`nemoclawVersion`, from `getVersion()`) on **managed** sandbox images at create/rebuild time, stamped via `getSandboxAgentRegistryFields` so `onboard.ts` stays net-neutral.
- `classifyUpgradeableSandboxes` now flags a sandbox when its agent version is stale **or** its recorded NemoClaw build differs from the running build, and reports the reason, e.g. `OpenClaw v2026.5.27 unchanged; NemoClaw image v0.0.60 → v0.0.61`.
- Drift is asserted only on **positive evidence** — a *recorded* fingerprint that differs. See the safety note below.
- The sandbox-reuse path no longer re-stamps the fingerprint, so reusing a sandbox after a NemoClaw upgrade cannot mask drift.
- Tests: unit coverage for `isNemoclawImageStale` / classification, and a CLI regression test that a current-agent-version sandbox with a stale recorded fingerprint is detected (`upgrade-sandboxes --check`).

### Design note — why missing fingerprints are not flagged (safe, forward-looking)

A **missing** fingerprint is intentionally treated as *not drifted*. It is ambiguous between a legacy NemoClaw-managed image (safe to rebuild) and a custom `--from` image, and auto-rebuilding a custom image whose Dockerfile path is unavailable would silently recreate it with the **default** image (data loss). Custom images are therefore left without a fingerprint, and pre-existing sandboxes opt into NemoClaw image-drift detection on their next rebuild. Every sandbox created or rebuilt on this release onward gets full drift detection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Reproduced #5026 and verified the fix end-to-end through the real `nemoclaw upgrade-sandboxes --check` CLI (stale recorded fingerprint and a drifting build are flagged; matching/missing fingerprints are not; a custom `--from` image is never auto-rebuilt).
- [x] `npm run typecheck:cli`, Biome, and the affected Vitest suites pass (`upgrade`, `gateway-drift-preflight`, `list-share-live-inference`, onboard sandbox state handler, registry). The full `cli` suite could not be run to completion in the dev sandbox due to a host resource cap (OOM/SIGKILL); remaining failures observed there were confirmed environmental (missing plugin deps / live host gateway / single-fork cross-file state).

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect NemoClaw image/build drift during sandbox upgrades and report richer reasons when sandboxes are stale, even if agent version is unchanged.

* **Bug Fixes**
  * Preserve recorded NemoClaw build fingerprint during sandbox creation/registry updates to avoid accidental overwrites.

* **Tests**
  * Added regression tests covering NemoClaw image drift detection (issue 5026) and CLI output for drift cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->