### PR TITLE
ci(e2e): route scenario advisor to Vitest workflow

### DIFF
--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -184,7 +184,7 @@ describe("E2E scenario advisor — normalization contract", () => {
         ],
         optional: [
           {
-            id: "ubuntu-repo-cloud-hermes",
+            id: "ubuntu-repo-docker-post-reboot-recovery",
             workflow: VITEST_SCENARIO_WORKFLOW,
             // Model claims this optional item is actually required.
             required: true,
@@ -263,13 +263,19 @@ describe("E2E scenario advisor — normalization contract", () => {
     expect(normalized.required.map((item) => item.id)).toEqual(["ubuntu-repo-cloud-openclaw"]);
   });
 
-  it("drops unknown registry ids while preserving the synthetic fan-out id", () => {
+  it("drops unknown or unsupported registry ids while preserving live-supported ids and fan-out", () => {
     const raw = {
       required: [
         {
           id: "valid-kebab-but-not-in-registry",
           workflow: VITEST_SCENARIO_WORKFLOW,
           reason: "model invented a scenario",
+          dispatchCommand: "gh ...",
+        },
+        {
+          id: "ubuntu-repo-cloud-hermes",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "registry scenario not wired for live Vitest fixtures",
           dispatchCommand: "gh ...",
         },
         {
@@ -316,7 +322,7 @@ describe("E2E scenario advisor — normalization contract", () => {
           dispatchCommand: "gh ...",
         },
         {
-          id: "ubuntu-repo-cloud-hermes",
+          id: "ubuntu-repo-docker-post-reboot-recovery",
           workflow: VITEST_SCENARIO_WORKFLOW,
           required: false,
           reason: "adjacent",
@@ -327,7 +333,9 @@ describe("E2E scenario advisor — normalization contract", () => {
       confidence: "medium",
     };
     const normalized = normalizeScenarioAdvisorResult(raw, metadata());
-    expect(normalized.optional.map((item) => item.id)).toEqual(["ubuntu-repo-cloud-hermes"]);
+    expect(normalized.optional.map((item) => item.id)).toEqual([
+      "ubuntu-repo-docker-post-reboot-recovery",
+    ]);
   });
 
   it("filters relevantChangedFiles to the metadata changedFiles set", () => {

--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -10,6 +10,7 @@ import {
   canonicalDispatchCommand,
   normalizeScenarioAdvisorResult,
   renderScenarioSummary,
+  SCENARIO_ADVISOR_WORKFLOWS,
   type ScenarioAdvisorResult,
 } from "../tools/e2e-advisor/scenarios.mts";
 
@@ -19,13 +20,15 @@ import {
 // downstream consumers (sticky comment, CI loop dispatch) depend on is
 // asserted here.
 
+const VITEST_SCENARIO_WORKFLOW = "e2e-vitest-scenarios.yaml";
+
 function metadata(
   overrides: Partial<{ baseRef: string; headRef: string; changedFiles: string[] }> = {},
 ) {
   return {
     baseRef: "origin/main",
     headRef: "HEAD",
-    changedFiles: ["test/e2e-scenario/runtime/run-scenario.sh"],
+    changedFiles: ["test/e2e-scenario/scenarios/runtime-support.ts"],
     ...overrides,
   };
 }
@@ -35,23 +38,34 @@ describe("E2E scenario advisor — prompt construction", () => {
     const prompt = buildPrompt({
       baseRef: "origin/main",
       headRef: "HEAD",
-      changedFiles: ["test/e2e-scenario/validation_suites/messaging/telegram/foo.sh"],
+      changedFiles: ["test/e2e-scenario/framework/phases/onboarding.ts"],
       diff: "+ echo ok",
     });
     // Caller of normalizeScenarioAdvisorResult re-injects metadata, but the
     // prompt must still surface enough context for the model to reason.
     expect(prompt).toContain("origin/main");
-    expect(prompt).toContain("test/e2e-scenario/validation_suites/messaging/telegram/foo.sh");
+    expect(prompt).toContain("test/e2e-scenario/framework/phases/onboarding.ts");
     expect(prompt).toContain("+ echo ok");
   });
 
   it("system prompt is non-empty and embeds the JSON schema for the model", () => {
     // The model receives the schema inline; we only assert that the prompt
-    // exists and includes the schema discriminator. Specific phrasing is an
-    // implementation detail and intentionally not asserted here.
+    // exists, includes the schema discriminator, and routes scenario
+    // recommendations to the Vitest workflow rather than the legacy
+    // typed-shell dispatch surfaces.
     const systemPrompt = buildSystemPrompt({ $id: "test-schema", type: "object" });
     expect(systemPrompt.length).toBeGreaterThan(0);
     expect(systemPrompt).toContain("test-schema");
+    expect(systemPrompt).toContain(VITEST_SCENARIO_WORKFLOW);
+    expect(systemPrompt).not.toContain("e2e-scenarios-all.yaml");
+    expect(systemPrompt).not.toContain("e2e-scenarios.yaml");
+  });
+
+  it("exports the Vitest scenario workflow for both targeted and fan-out recommendations", () => {
+    expect(SCENARIO_ADVISOR_WORKFLOWS).toEqual({
+      single: VITEST_SCENARIO_WORKFLOW,
+      all: VITEST_SCENARIO_WORKFLOW,
+    });
   });
 });
 
@@ -59,11 +73,11 @@ describe("E2E scenario advisor — normalization contract", () => {
   it("preserves valid recommendations and canonicalizes the dispatch command", () => {
     const raw = {
       version: 1,
-      relevantChangedFiles: ["test/e2e-scenario/runtime/run-scenario.sh"],
+      relevantChangedFiles: ["test/e2e-scenario/scenarios/runtime-support.ts"],
       required: [
         {
           id: "e2e-scenarios-all",
-          workflow: "e2e-scenarios-all.yaml",
+          workflow: VITEST_SCENARIO_WORKFLOW,
           required: true,
           reason: "shared scenario runtime changed",
           // Model returns a non-canonical command; sanitizer must overwrite it.
@@ -73,7 +87,7 @@ describe("E2E scenario advisor — normalization contract", () => {
       optional: [
         {
           id: "ubuntu-repo-cloud-openclaw",
-          workflow: "e2e-scenarios.yaml",
+          workflow: VITEST_SCENARIO_WORKFLOW,
           scenario: "ubuntu-repo-cloud-openclaw",
           required: false,
           reason: "smoke confirmation on the canonical scenario",
@@ -90,10 +104,10 @@ describe("E2E scenario advisor — normalization contract", () => {
     expect(normalized.required).toHaveLength(1);
     expect(normalized.optional).toHaveLength(1);
     expect(normalized.required[0]?.dispatchCommand).toBe(
-      canonicalDispatchCommand("e2e-scenarios-all.yaml", "e2e-scenarios-all"),
+      canonicalDispatchCommand(VITEST_SCENARIO_WORKFLOW, "e2e-scenarios-all"),
     );
     expect(normalized.optional[0]?.dispatchCommand).toBe(
-      canonicalDispatchCommand("e2e-scenarios.yaml", "ubuntu-repo-cloud-openclaw"),
+      canonicalDispatchCommand(VITEST_SCENARIO_WORKFLOW, "ubuntu-repo-cloud-openclaw"),
     );
     // Canonical fan-out command must not contain a scenarios field.
     expect(normalized.required[0]?.dispatchCommand).not.toContain("--field scenarios=");
@@ -124,32 +138,26 @@ describe("E2E scenario advisor — normalization contract", () => {
     expect(normalized.required).toHaveLength(0);
   });
 
-  it("rejects workflow/id pairing mismatches for the fan-out workflow", () => {
+  it("rejects legacy typed-shell workflows while accepting Vitest fan-out", () => {
     const normalized = normalizeScenarioAdvisorResult(
       {
         required: [
           {
-            // Fan-out workflow with a single-scenario id is incoherent: the
-            // sticky-comment dispatch line would falsely suggest you can
-            // narrow the fan-out to one scenario via this command.
             id: "ubuntu-repo-cloud-openclaw",
-            workflow: "e2e-scenarios-all.yaml",
-            reason: "mismatched workflow/id",
-            dispatchCommand: "gh ...",
-          },
-          {
-            // Inverse: synthetic fan-out id on the single-scenario workflow
-            // would render "--field scenarios=e2e-scenarios-all", which is
-            // not a real scenario in ROUTES.
-            id: "e2e-scenarios-all",
             workflow: "e2e-scenarios.yaml",
-            reason: "synthetic id on single-scenario workflow",
+            reason: "legacy single-scenario workflow",
             dispatchCommand: "gh ...",
           },
           {
             id: "e2e-scenarios-all",
             workflow: "e2e-scenarios-all.yaml",
-            reason: "valid pairing",
+            reason: "legacy fan-out workflow",
+            dispatchCommand: "gh ...",
+          },
+          {
+            id: "e2e-scenarios-all",
+            workflow: VITEST_SCENARIO_WORKFLOW,
+            reason: "valid Vitest fan-out",
             dispatchCommand: "gh ...",
           },
         ],
@@ -167,7 +175,7 @@ describe("E2E scenario advisor — normalization contract", () => {
         required: [
           {
             id: "ubuntu-repo-cloud-openclaw",
-            workflow: "e2e-scenarios.yaml",
+            workflow: VITEST_SCENARIO_WORKFLOW,
             // Model claims this required item is actually optional.
             required: false,
             reason: "in required[] but model marked optional",
@@ -177,7 +185,7 @@ describe("E2E scenario advisor — normalization contract", () => {
         optional: [
           {
             id: "ubuntu-repo-cloud-hermes",
-            workflow: "e2e-scenarios.yaml",
+            workflow: VITEST_SCENARIO_WORKFLOW,
             // Model claims this optional item is actually required.
             required: true,
             reason: "in optional[] but model marked required",
@@ -198,19 +206,19 @@ describe("E2E scenario advisor — normalization contract", () => {
         required: [
           {
             id: "ubuntu;rm -rf /",
-            workflow: "e2e-scenarios.yaml",
+            workflow: VITEST_SCENARIO_WORKFLOW,
             reason: "shell injection attempt",
             dispatchCommand: "gh ...",
           },
           {
             id: "Ubuntu_Repo_Cloud", // not kebab
-            workflow: "e2e-scenarios.yaml",
+            workflow: VITEST_SCENARIO_WORKFLOW,
             reason: "non-canonical id",
             dispatchCommand: "gh ...",
           },
           {
             id: "ubuntu-repo-cloud-openclaw",
-            workflow: "e2e-scenarios.yaml",
+            workflow: VITEST_SCENARIO_WORKFLOW,
             reason: "valid",
             dispatchCommand: "gh ...",
           },
@@ -226,10 +234,15 @@ describe("E2E scenario advisor — normalization contract", () => {
   it("drops malformed recommendations and de-duplicates by id", () => {
     const raw = {
       required: [
-        { id: "good", workflow: "e2e-scenarios.yaml", reason: "ok", dispatchCommand: "gh ..." },
-        { id: "good", workflow: "e2e-scenarios.yaml", reason: "dup", dispatchCommand: "gh ..." },
-        { id: "missing-reason", workflow: "e2e-scenarios.yaml", dispatchCommand: "gh ..." },
-        { workflow: "e2e-scenarios.yaml", reason: "no id", dispatchCommand: "gh ..." },
+        { id: "good", workflow: VITEST_SCENARIO_WORKFLOW, reason: "ok", dispatchCommand: "gh ..." },
+        {
+          id: "good",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "dup",
+          dispatchCommand: "gh ...",
+        },
+        { id: "missing-reason", workflow: VITEST_SCENARIO_WORKFLOW, dispatchCommand: "gh ..." },
+        { workflow: VITEST_SCENARIO_WORKFLOW, reason: "no id", dispatchCommand: "gh ..." },
       ],
       optional: [],
       noScenarioE2eReason: null,
@@ -244,7 +257,7 @@ describe("E2E scenario advisor — normalization contract", () => {
       required: [
         {
           id: "ubuntu-repo-cloud-openclaw",
-          workflow: "e2e-scenarios.yaml",
+          workflow: VITEST_SCENARIO_WORKFLOW,
           required: true,
           reason: "primary",
           dispatchCommand: "gh ...",
@@ -253,14 +266,14 @@ describe("E2E scenario advisor — normalization contract", () => {
       optional: [
         {
           id: "ubuntu-repo-cloud-openclaw",
-          workflow: "e2e-scenarios.yaml",
+          workflow: VITEST_SCENARIO_WORKFLOW,
           required: false,
           reason: "duplicate fallback",
           dispatchCommand: "gh ...",
         },
         {
           id: "ubuntu-repo-cloud-hermes",
-          workflow: "e2e-scenarios.yaml",
+          workflow: VITEST_SCENARIO_WORKFLOW,
           required: false,
           reason: "adjacent",
           dispatchCommand: "gh ...",
@@ -276,15 +289,20 @@ describe("E2E scenario advisor — normalization contract", () => {
   it("filters relevantChangedFiles to the metadata changedFiles set", () => {
     const normalized = normalizeScenarioAdvisorResult(
       {
-        relevantChangedFiles: ["test/e2e-scenario/runtime/run-scenario.sh", "fabricated/file.txt"],
+        relevantChangedFiles: [
+          "test/e2e-scenario/scenarios/runtime-support.ts",
+          "fabricated/file.txt",
+        ],
         required: [],
         optional: [],
         noScenarioE2eReason: "no impact",
         confidence: "low",
       },
-      metadata({ changedFiles: ["test/e2e-scenario/runtime/run-scenario.sh"] }),
+      metadata({ changedFiles: ["test/e2e-scenario/scenarios/runtime-support.ts"] }),
     );
-    expect(normalized.relevantChangedFiles).toEqual(["test/e2e-scenario/runtime/run-scenario.sh"]);
+    expect(normalized.relevantChangedFiles).toEqual([
+      "test/e2e-scenario/scenarios/runtime-support.ts",
+    ]);
   });
 
   it("supplies a default noScenarioE2eReason when none provided and there are no recommendations", () => {
@@ -307,15 +325,15 @@ describe("E2E scenario advisor — summary and comment rendering", () => {
       version: 1,
       baseRef: "origin/main",
       headRef: "HEAD",
-      changedFiles: [".github/workflows/e2e-scenarios.yaml"],
-      relevantChangedFiles: [".github/workflows/e2e-scenarios.yaml"],
+      changedFiles: [".github/workflows/e2e-vitest-scenarios.yaml"],
+      relevantChangedFiles: [".github/workflows/e2e-vitest-scenarios.yaml"],
       required: [
         {
           id: "e2e-scenarios-all",
-          workflow: "e2e-scenarios-all.yaml",
+          workflow: VITEST_SCENARIO_WORKFLOW,
           required: true,
           reason: "scenario workflow changed",
-          dispatchCommand: canonicalDispatchCommand("e2e-scenarios-all.yaml", "e2e-scenarios-all"),
+          dispatchCommand: canonicalDispatchCommand(VITEST_SCENARIO_WORKFLOW, "e2e-scenarios-all"),
         },
       ],
       optional: [],
@@ -328,7 +346,7 @@ describe("E2E scenario advisor — summary and comment rendering", () => {
     const summary = renderScenarioSummary(sampleResult());
     expect(summary).toContain("e2e-scenarios-all");
     expect(summary).toContain(
-      canonicalDispatchCommand("e2e-scenarios-all.yaml", "e2e-scenarios-all"),
+      canonicalDispatchCommand(VITEST_SCENARIO_WORKFLOW, "e2e-scenarios-all"),
     );
   });
 

--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -57,6 +57,8 @@ describe("E2E scenario advisor — prompt construction", () => {
     expect(systemPrompt.length).toBeGreaterThan(0);
     expect(systemPrompt).toContain("test-schema");
     expect(systemPrompt).toContain(VITEST_SCENARIO_WORKFLOW);
+    expect(systemPrompt).toContain("trusted advisor checkout");
+    expect(systemPrompt).toContain("recommend the `e2e-scenarios-all` fan-out");
     expect(systemPrompt).not.toContain("e2e-scenarios-all.yaml");
     expect(systemPrompt).not.toContain("e2e-scenarios.yaml");
   });

--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -234,11 +234,22 @@ describe("E2E scenario advisor — normalization contract", () => {
   it("drops malformed recommendations and de-duplicates by id", () => {
     const raw = {
       required: [
-        { id: "good", workflow: VITEST_SCENARIO_WORKFLOW, reason: "ok", dispatchCommand: "gh ..." },
         {
-          id: "good",
+          id: "ubuntu-repo-cloud-openclaw",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "ok",
+          dispatchCommand: "gh ...",
+        },
+        {
+          id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
           reason: "dup",
+          dispatchCommand: "gh ...",
+        },
+        {
+          id: "valid-kebab-but-not-in-registry",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "unknown scenario",
           dispatchCommand: "gh ...",
         },
         { id: "missing-reason", workflow: VITEST_SCENARIO_WORKFLOW, dispatchCommand: "gh ..." },
@@ -249,7 +260,40 @@ describe("E2E scenario advisor — normalization contract", () => {
       confidence: "medium",
     };
     const normalized = normalizeScenarioAdvisorResult(raw, metadata());
-    expect(normalized.required.map((item) => item.id)).toEqual(["good"]);
+    expect(normalized.required.map((item) => item.id)).toEqual(["ubuntu-repo-cloud-openclaw"]);
+  });
+
+  it("drops unknown registry ids while preserving the synthetic fan-out id", () => {
+    const raw = {
+      required: [
+        {
+          id: "valid-kebab-but-not-in-registry",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "model invented a scenario",
+          dispatchCommand: "gh ...",
+        },
+        {
+          id: "e2e-scenarios-all",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "shared scenario runtime changed",
+          dispatchCommand: "gh ...",
+        },
+        {
+          id: "ubuntu-repo-cloud-openclaw",
+          workflow: VITEST_SCENARIO_WORKFLOW,
+          reason: "known scenario",
+          dispatchCommand: "gh ...",
+        },
+      ],
+      optional: [],
+      noScenarioE2eReason: null,
+      confidence: "medium",
+    };
+    const normalized = normalizeScenarioAdvisorResult(raw, metadata());
+    expect(normalized.required.map((item) => item.id)).toEqual([
+      "e2e-scenarios-all",
+      "ubuntu-repo-cloud-openclaw",
+    ]);
   });
 
   it("removes optional recommendations whose id duplicates a required one", () => {

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -30,6 +30,7 @@ import {
   runReadOnlyAdvisor,
 } from "../advisors/session.mts";
 import { getScenario } from "../../test/e2e-scenario/scenarios/registry.ts";
+import { liveScenarioSupport } from "../../test/e2e-scenario/scenarios/runtime-support.ts";
 
 const root = process.cwd();
 const ADVISOR_PROVIDER = DEFAULT_ADVISOR_PROVIDER;
@@ -230,12 +231,12 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
     "",
     "Decision policy:",
     "- Required (all scenarios): changes to scenario runtime/runner code, scenario catalog metadata, expected-state metadata, live support classification, shared fixtures, or the Vitest scenario workflow itself. Recommend the `e2e-scenarios-all` fan-out through `e2e-vitest-scenarios.yaml`.",
-    "- Required (targeted): fixture, live test, manifest, runtime-support, or scenario changes that affect a specific subset. Recommend the smallest set of typed scenario IDs that exercises the changed surface.",
+    "- Required (targeted): fixture, live test, manifest, runtime-support, or scenario changes that affect a specific subset. Recommend the smallest set of live-supported typed scenario IDs that exercises the changed surface.",
     "- Optional: adjacent scenarios that exercise the same suite on a different platform/onboarding (e.g. macOS, WSL, GPU) but are not the primary target. Special-runner scenarios (`gpu-`, `macos-`, `wsl-`, `brev-`) should usually be optional unless they are the only path that exercises the change.",
     "- None: docs-only, comment-only, tests-only outside `test/e2e-scenario/`, or changes that cannot affect scenario E2E behavior. Set `noScenarioE2eReason` and return empty `required`/`optional` arrays.",
     "",
     "Hard rules:",
-    "- Only recommend typed scenario IDs that exist in the registry or the synthetic fan-out id `e2e-scenarios-all`. Do not invent IDs.",
+    "- Only recommend live-supported typed scenario IDs that exist in the registry or the synthetic fan-out id `e2e-scenarios-all`. Do not invent IDs.",
     "- The only allowed workflow is `e2e-vitest-scenarios.yaml`.",
     "- Each `dispatchCommand` for a single-scenario recommendation MUST be exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field scenarios=<id>`.",
     "- For the fan-out, use exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref>` and set `id`/`workflow` to `e2e-scenarios-all`/`e2e-vitest-scenarios.yaml`.",
@@ -325,7 +326,13 @@ function sanitizeRecommendations(value: unknown, requiredFlag: boolean): Scenari
     // trust the model to author shell-safe dispatch commands.
     if (!ALLOWED_WORKFLOWS.has(workflow)) continue;
     if (!SCENARIO_ID_PATTERN.test(id)) continue;
-    if (id !== SCENARIO_ALL_ID && !getScenario(id)) continue;
+    const scenarioDefinition = id === SCENARIO_ALL_ID ? undefined : getScenario(id);
+    if (
+      id !== SCENARIO_ALL_ID &&
+      (!scenarioDefinition || !liveScenarioSupport(scenarioDefinition).supported)
+    ) {
+      continue;
+    }
     if (seen.has(id)) continue;
     seen.add(id);
     const scenario = stringOrUndefined(item.scenario);

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -29,6 +29,7 @@ import {
   type RunAdvisorResult,
   runReadOnlyAdvisor,
 } from "../advisors/session.mts";
+import { getScenario } from "../../test/e2e-scenario/scenarios/registry.ts";
 
 const root = process.cwd();
 const ADVISOR_PROVIDER = DEFAULT_ADVISOR_PROVIDER;
@@ -324,6 +325,7 @@ function sanitizeRecommendations(value: unknown, requiredFlag: boolean): Scenari
     // trust the model to author shell-safe dispatch commands.
     if (!ALLOWED_WORKFLOWS.has(workflow)) continue;
     if (!SCENARIO_ID_PATTERN.test(id)) continue;
+    if (id !== SCENARIO_ALL_ID && !getScenario(id)) continue;
     if (seen.has(id)) continue;
     seen.add(id);
     const scenario = stringOrUndefined(item.scenario);

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -29,6 +29,12 @@ import {
   type RunAdvisorResult,
   runReadOnlyAdvisor,
 } from "../advisors/session.mts";
+// Intentionally resolves relative to the trusted advisor checkout, not the
+// analyzed PR workdir. The workflow runs this script from trusted `main` while
+// `process.cwd()` points at inert PR data, so normalization must not execute
+// PR-local registry/runtime-support code. PRs that add or newly wire scenarios
+// should use the fan-out recommendation until the trusted checkout knows their
+// targeted IDs are live-supported.
 import { getScenario } from "../../test/e2e-scenario/scenarios/registry.ts";
 import { liveScenarioSupport } from "../../test/e2e-scenario/scenarios/runtime-support.ts";
 
@@ -240,6 +246,7 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
     "- The only allowed workflow is `e2e-vitest-scenarios.yaml`.",
     "- Each `dispatchCommand` for a single-scenario recommendation MUST be exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field scenarios=<id>`.",
     "- For the fan-out, use exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref>` and set `id`/`workflow` to `e2e-scenarios-all`/`e2e-vitest-scenarios.yaml`.",
+    "- The normalizer validates targeted IDs against the trusted advisor checkout's registry/runtime-support modules, not PR-local TypeScript. If a PR adds or newly wires a scenario that is not live-supported on trusted `main` yet, recommend the `e2e-scenarios-all` fan-out rather than a targeted dispatch.",
     "- A `suiteFilter` may be set on a recommendation as analytical metadata explaining why the scenario was selected. It must NOT leak into the dispatch command.",
     "- `relevantChangedFiles` must be the subset of `changedFiles` under `test/e2e-scenario/`, `.github/workflows/e2e-vitest-scenarios.yaml`, or other directly scenario-relevant paths.",
     "",

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -34,17 +34,20 @@ const root = process.cwd();
 const ADVISOR_PROVIDER = DEFAULT_ADVISOR_PROVIDER;
 const ADVISOR_MODEL = DEFAULT_ADVISOR_MODEL;
 const ADVISOR_CREDENTIAL_ENV = ["E2E", "ADVISOR", "API", "KEY"].join("_");
-const SCENARIO_WORKFLOW = "e2e-scenarios.yaml";
-const SCENARIO_ALL_WORKFLOW = "e2e-scenarios-all.yaml";
-const ALLOWED_WORKFLOWS = new Set<string>([SCENARIO_WORKFLOW, SCENARIO_ALL_WORKFLOW]);
+const SCENARIO_WORKFLOW = "e2e-vitest-scenarios.yaml";
+const SCENARIO_ALL_ID = "e2e-scenarios-all";
+const ALLOWED_WORKFLOWS = new Set<string>([SCENARIO_WORKFLOW]);
 // Scenario IDs are embedded into the dispatch command we hand to users; restrict
 // to a strict kebab-case allowlist so a hallucinated id can never inject shell
 // metacharacters or non-canonical tokens into the dispatch line.
 const SCENARIO_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 export function canonicalDispatchCommand(workflow: string, id: string): string {
-  if (workflow === SCENARIO_ALL_WORKFLOW) {
-    return `gh workflow run ${SCENARIO_ALL_WORKFLOW} --ref <pr-head-ref>`;
+  if (workflow !== SCENARIO_WORKFLOW) {
+    throw new Error(`Unknown scenario workflow: ${workflow}`);
+  }
+  if (id === SCENARIO_ALL_ID) {
+    return `gh workflow run ${SCENARIO_WORKFLOW} --ref <pr-head-ref>`;
   }
   return `gh workflow run ${SCENARIO_WORKFLOW} --ref <pr-head-ref> --field scenarios=${id}`;
 }
@@ -213,30 +216,30 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
   return [
     "You are the NemoClaw E2E Scenario advisor for CI.",
     "",
-    "Your job is to recommend which **scenario E2E** jobs should run for a PR. Scenario E2E is the layered scenario suite under `test/e2e-scenario/`, dispatched via `.github/workflows/e2e-scenarios.yaml` (single-scenario) and `.github/workflows/e2e-scenarios-all.yaml` (fan-out).",
+    "Your job is to recommend which **Vitest scenario E2E** jobs should run for a PR. Scenario E2E is the layered scenario suite under `test/e2e-scenario/`, dispatched via `.github/workflows/e2e-vitest-scenarios.yaml`.",
     "",
     "You are a separate advisor from the general E2E recommendation advisor. Do not opine on legacy `test/e2e/` workflows or non-scenario E2E jobs; those are owned by the general advisor.",
     "",
     "Authoritative sources to inspect with your read-only tools:",
-    "- `.github/workflows/e2e-scenarios.yaml` — its `ROUTES` table is the ground truth for dispatchable scenario IDs and runner placement.",
-    "- `.github/workflows/e2e-scenarios-all.yaml` — fan-out workflow.",
-    "- `test/e2e-scenario/nemoclaw_scenarios/scenarios.yaml` — scenario metadata (`setup_scenarios`, `test_plans`, base/onboarding profiles).",
-    "- `test/e2e-scenario/nemoclaw_scenarios/expected-states.yaml` — expected-state contracts.",
-    "- `test/e2e-scenario/validation_suites/suites.yaml` — suite definitions and their scripts.",
-    "- `test/e2e-scenario/runtime/` — shared runner/runtime code (changes here usually require all-scenarios).",
+    "- `.github/workflows/e2e-vitest-scenarios.yaml` — canonical Vitest live scenario workflow.",
+    "- `test/e2e-scenario/scenarios/registry.ts` and `test/e2e-scenario/scenarios/scenarios/` — typed scenario IDs and metadata.",
+    "- `test/e2e-scenario/scenarios/runtime-support.ts` — which typed scenarios are wired for live Vitest execution.",
+    "- `test/e2e-scenario/live/registry-scenarios.test.ts` — live Vitest registry scenario entry point.",
+    "- `test/e2e-scenario/framework/` and `test/e2e-scenario/framework-tests/` — shared Vitest fixtures, clients, and phase helpers.",
     "",
     "Decision policy:",
-    "- Required (all scenarios): changes to scenario runtime/runner code, scenario catalog metadata, expected-state metadata, suite catalog metadata, or the scenario workflows themselves. Recommend the `e2e-scenarios-all` fan-out.",
-    "- Required (targeted): suite-script or onboarding/install-helper changes that affect a specific subset. Recommend the smallest set of scenario IDs from the `ROUTES` table that exercises the changed surface.",
+    "- Required (all scenarios): changes to scenario runtime/runner code, scenario catalog metadata, expected-state metadata, live support classification, shared fixtures, or the Vitest scenario workflow itself. Recommend the `e2e-scenarios-all` fan-out through `e2e-vitest-scenarios.yaml`.",
+    "- Required (targeted): fixture, live test, manifest, runtime-support, or scenario changes that affect a specific subset. Recommend the smallest set of typed scenario IDs that exercises the changed surface.",
     "- Optional: adjacent scenarios that exercise the same suite on a different platform/onboarding (e.g. macOS, WSL, GPU) but are not the primary target. Special-runner scenarios (`gpu-`, `macos-`, `wsl-`, `brev-`) should usually be optional unless they are the only path that exercises the change.",
     "- None: docs-only, comment-only, tests-only outside `test/e2e-scenario/`, or changes that cannot affect scenario E2E behavior. Set `noScenarioE2eReason` and return empty `required`/`optional` arrays.",
     "",
     "Hard rules:",
-    "- Only recommend scenario IDs that exist in the `ROUTES` table of `e2e-scenarios.yaml`. Do not invent IDs.",
-    "- The `e2e-scenarios.yaml` workflow accepts a single comma-separated `scenarios` input. Each `dispatchCommand` for a single-scenario recommendation MUST be exactly: `gh workflow run e2e-scenarios.yaml --ref <pr-head-ref> --field scenarios=<id>`.",
-    "- For the fan-out, use exactly: `gh workflow run e2e-scenarios-all.yaml --ref <pr-head-ref>` and set `id`/`workflow` to `e2e-scenarios-all`/`e2e-scenarios-all.yaml`.",
+    "- Only recommend typed scenario IDs that exist in the registry or the synthetic fan-out id `e2e-scenarios-all`. Do not invent IDs.",
+    "- The only allowed workflow is `e2e-vitest-scenarios.yaml`.",
+    "- Each `dispatchCommand` for a single-scenario recommendation MUST be exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field scenarios=<id>`.",
+    "- For the fan-out, use exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref>` and set `id`/`workflow` to `e2e-scenarios-all`/`e2e-vitest-scenarios.yaml`.",
     "- A `suiteFilter` may be set on a recommendation as analytical metadata explaining why the scenario was selected. It must NOT leak into the dispatch command.",
-    "- `relevantChangedFiles` must be the subset of `changedFiles` under `test/e2e-scenario/`, `.github/workflows/e2e-scenarios*.yaml`, or other directly scenario-relevant paths.",
+    "- `relevantChangedFiles` must be the subset of `changedFiles` under `test/e2e-scenario/`, `.github/workflows/e2e-vitest-scenarios.yaml`, or other directly scenario-relevant paths.",
     "",
     "Return JSON only matching this schema:",
     "```json",
@@ -316,17 +319,11 @@ function sanitizeRecommendations(value: unknown, requiredFlag: boolean): Scenari
     const reason = stringOrUndefined(item.reason);
     const workflow = stringOrUndefined(item.workflow);
     if (!id || !reason || !workflow) continue;
-    // Allowlist: only the two scenario workflows may be dispatched, and only
-    // kebab-case ids are accepted. Reject everything else; we do not trust
-    // the model to author shell-safe dispatch commands.
+    // Allowlist: only the Vitest scenario workflow may be dispatched, and
+    // only kebab-case ids are accepted. Reject everything else; we do not
+    // trust the model to author shell-safe dispatch commands.
     if (!ALLOWED_WORKFLOWS.has(workflow)) continue;
     if (!SCENARIO_ID_PATTERN.test(id)) continue;
-    // Workflow/id pairing invariant: e2e-scenarios-all.yaml fan-out is the
-    // only valid pairing for the synthetic id "e2e-scenarios-all", and that
-    // id is meaningless on the single-scenario workflow. Reject mismatches
-    // rather than render a misleading dispatch line.
-    if (workflow === SCENARIO_ALL_WORKFLOW && id !== "e2e-scenarios-all") continue;
-    if (workflow === SCENARIO_WORKFLOW && id === "e2e-scenarios-all") continue;
     if (seen.has(id)) continue;
     seen.add(id);
     const scenario = stringOrUndefined(item.scenario);
@@ -420,5 +417,5 @@ function unavailableResult(
 // Constants are exported so workflow tests can pin them without duplicating literals.
 export const SCENARIO_ADVISOR_WORKFLOWS = {
   single: SCENARIO_WORKFLOW,
-  all: SCENARIO_ALL_WORKFLOW,
+  all: SCENARIO_WORKFLOW,
 } as const;


### PR DESCRIPTION
## Summary
Route the E2E scenario advisor to the Vitest scenario workflow so new recommendations no longer point at the legacy typed-shell dispatch workflows. This keeps the advisor aligned with #5098 while the typed-shell retirement audit continues separately.

## Related Issue
Refs #5098

## Changes
- Updates `tools/e2e-advisor/scenarios.mts` so canonical targeted and fan-out dispatch commands both use `e2e-vitest-scenarios.yaml`.
- Refreshes the advisor system prompt to use Vitest registry, runtime-support, live test, and fixture paths as the authoritative scenario surfaces.
- Rejects legacy `e2e-scenarios.yaml` and `e2e-scenarios-all.yaml` recommendations during normalization.
- Updates advisor contract tests to pin the Vitest workflow export, prompt routing, canonical commands, and legacy workflow rejection.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Focused verification run:
- `npx vitest run --project cli test/e2e-scenario-advisor.test.ts --silent=false --reporter=default`
- `npm run typecheck:cli`
- `git diff --check`
- `SKIP=test-cli npx prek run --files tools/e2e-advisor/scenarios.mts test/e2e-scenario-advisor.test.ts`

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E scenario advisor test suite to validate Vitest workflow integration and ensure correct prompt construction, dispatch command generation, and result normalization.

* **Chores**
  * Consolidated E2E advisor tooling to use a unified Vitest scenario workflow, improving consistency and removing legacy workflow cross-pairing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->