### PR TITLE
fix(docs): correct Hermes quickstart link in Manage Sandbox Lifecycle

### DIFF
--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -17,7 +17,7 @@ import { AgentOnly } from "../_components/AgentGuide";
 Use this guide after you finish the [OpenClaw quickstart](../get-started/quickstart).
 </AgentOnly>
 <AgentOnly variant="hermes">
-Use this guide after you finish [Quickstart with Hermes](../get-started/quickstart).
+Use this guide after you finish [Quickstart with Hermes](../get-started/quickstart-hermes).
 </AgentOnly>
 It covers day-two sandbox operations such as listing sandboxes, checking health, managing ports, rebuilding safely, upgrading, and uninstalling.
 <AgentOnly variant="openclaw">


### PR DESCRIPTION
## Description

The Hermes `AgentOnly` intro block in `docs/manage-sandboxes/lifecycle.mdx` linked to the OpenClaw quickstart (`../get-started/quickstart`) instead of the Hermes quickstart (`../get-started/quickstart-hermes`).

Users following the Hermes variant's "start here → then manage lifecycle" flow would land on the wrong quickstart page.

## Changes

- Updated link target in Hermes `AgentOnly` block from `../get-started/quickstart` to `../get-started/quickstart-hermes`

## Verification

- Confirmed `docs/get-started/quickstart-hermes.mdx` exists in the repo
- Scope limited to the single file mentioned in the issue; other files with the same pattern are tracked by separate issues

Closes #5086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the Hermes quickstart reference in lifecycle management documentation to direct users to the Hermes-specific guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->