### PR TITLE
refactor(messaging): migrate messagingChannels to messagingPlan with backward compatibility

### DIFF
--- a/src/lib/actions/sandbox/channel-status.test.ts
+++ b/src/lib/actions/sandbox/channel-status.test.ts
@@ -26,6 +26,7 @@ vi.mock("./process-recovery", () => ({
 }));
 
 import type { AgentDefinition } from "../../agent/defs";
+import type { SandboxMessagingPlan } from "../../messaging/manifest";
 import type { SandboxEntry } from "../../state/registry";
 import { showSandboxChannelStatus } from "./channel-status";
 
@@ -114,6 +115,36 @@ function entry(
     messagingChannels,
     disabledChannels,
   } as SandboxEntry;
+}
+
+function makePlan(
+  channels: readonly string[],
+  disabledChannels: readonly string[] = [],
+): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName: "alpha",
+    agent: "openclaw",
+    workflow: "rebuild",
+    channels: channels.map((channelId) => ({
+      channelId,
+      displayName: channelId,
+      authMode: "none",
+      active: !disabledChannels.includes(channelId),
+      selected: true,
+      configured: true,
+      disabled: disabledChannels.includes(channelId),
+      inputs: [],
+      hooks: [],
+    })),
+    disabledChannels,
+    credentialBindings: [],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  };
 }
 
 function makeDeps(opts: {
@@ -450,6 +481,27 @@ describe("showSandboxChannelStatus (whatsapp)", () => {
     expect(result && "verdict" in result && result.verdict).toBe("info");
     const dump = out_lines.join("\n");
     expect(dump).toMatch(/registered but currently paused/);
+  });
+
+  it("prefers messaging plan state over stale legacy channel fields", async () => {
+    const execSpy = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+    const { deps, out_lines } = makeDeps({
+      exec: () => ({ status: 0, stdout: "", stderr: "" }),
+      sandbox: {
+        ...entry(["discord"], ["discord"]),
+        messaging: {
+          schemaVersion: 1,
+          plan: makePlan(["whatsapp"], ["whatsapp"]),
+        },
+      } as SandboxEntry,
+    });
+    deps.execSandbox = execSpy as unknown as typeof deps.execSandbox;
+
+    const result = await showSandboxChannelStatus("alpha", { deps });
+
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(result && "channel" in result && result.channel).toBe("whatsapp");
+    expect(out_lines.join("\n")).toMatch(/whatsapp registered but currently paused/);
   });
 
   it("emits a basic per-channel report for non-whatsapp channels", async () => {

--- a/src/lib/actions/sandbox/channel-status.ts
+++ b/src/lib/actions/sandbox/channel-status.ts
@@ -14,6 +14,10 @@
 import { loadAgent, type AgentDefinition } from "../../agent/defs";
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
 import { B, D, G, R, RD, YW } from "../../cli/terminal-style";
+import {
+  getConfiguredChannelIdsFromMessagingState,
+  getDisabledChannelIdsFromMessagingState,
+} from "../../messaging";
 import * as policies from "../../policy";
 import { KNOWN_CHANNELS, knownChannelNames } from "../../sandbox/channels";
 import {
@@ -353,7 +357,8 @@ function buildWhatsappProbeInput(
   }
 
   const entry = deps.getSandbox(sandboxName);
-  const channelEnabledInRegistry = (entry?.messagingChannels ?? []).includes("whatsapp");
+  const channelEnabledInRegistry =
+    getConfiguredChannelIdsFromMessagingState(entry).includes("whatsapp");
 
   const appliedPresets = deps.getAppliedPresets(sandboxName);
   const presetInRegistry = appliedPresets.includes("whatsapp");
@@ -440,8 +445,8 @@ function buildBasicChannelReport(
   deps: Required<StatusDeps>,
 ): ChannelStatusReport {
   const entry = deps.getSandbox(sandboxName);
-  const enabled = (entry?.messagingChannels ?? []).includes(channelName);
-  const disabled = (entry?.disabledChannels ?? []).includes(channelName);
+  const enabled = getConfiguredChannelIdsFromMessagingState(entry).includes(channelName);
+  const disabled = getDisabledChannelIdsFromMessagingState(entry).includes(channelName);
   const appliedPresets = deps.getAppliedPresets(sandboxName);
   const presetInRegistry = appliedPresets.includes(channelName);
   const signals: DiagnosticSignal[] = [];
@@ -523,11 +528,12 @@ export async function showSandboxChannelStatus(
 
   let channelName = channelArg;
   if (!channelName) {
-    const enabled = (entry.messagingChannels ?? []).filter((name: string) => name === "whatsapp");
+    const configuredChannels = getConfiguredChannelIdsFromMessagingState(entry);
+    const enabled = configuredChannels.filter((name: string) => name === "whatsapp");
     if (enabled.length > 0) {
       channelName = "whatsapp";
-    } else if ((entry.messagingChannels ?? []).length > 0) {
-      channelName = entry.messagingChannels?.[0];
+    } else if (configuredChannels.length > 0) {
+      channelName = configuredChannels[0];
     } else {
       channelName = "whatsapp";
     }
@@ -551,7 +557,7 @@ export async function showSandboxChannelStatus(
 
   const agent = deps.loadAgent(entry.agent || "openclaw");
 
-  const disabledChannels = new Set(entry.disabledChannels ?? []);
+  const disabledChannels = new Set(getDisabledChannelIdsFromMessagingState(entry));
   const channelIsPaused = disabledChannels.has(channelName);
 
   let report: ChannelStatusReport;

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -17,6 +17,11 @@ import { GATEWAY_PORT, OLLAMA_PORT } from "../../core/ports";
 import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import { parseGatewayInference } from "../../inference/config";
 import { type ProviderHealthStatus, probeProviderHealth } from "../../inference/health";
+import {
+  getActiveChannelIdsFromMessagingState,
+  getConfiguredChannelIdsFromMessagingState,
+  getDisabledChannelIdsFromMessagingState,
+} from "../../messaging";
 import { isLinuxDockerDriverGatewayEnabled } from "../../onboard/docker-driver-platform";
 import { executeSandboxCommandForVerification } from "../../onboard/sandbox-verification-exec";
 import { ROOT } from "../../runner";
@@ -423,9 +428,9 @@ function channelRuntimeDoctorCheck(
 }
 
 function messagingDoctorCheck(sandboxName: string, sb: SandboxEntry): DoctorCheck {
-  const registeredChannels = Array.isArray(sb.messagingChannels) ? sb.messagingChannels : [];
-  const disabledChannels = new Set(Array.isArray(sb.disabledChannels) ? sb.disabledChannels : []);
-  const channels = registeredChannels.filter((channel: string) => !disabledChannels.has(channel));
+  const registeredChannels = getConfiguredChannelIdsFromMessagingState(sb);
+  const disabledChannels = new Set(getDisabledChannelIdsFromMessagingState(sb));
+  const channels = getActiveChannelIdsFromMessagingState(sb);
   const pausedChannels = registeredChannels.filter((channel: string) =>
     disabledChannels.has(channel),
   );
@@ -783,13 +788,7 @@ export async function runSandboxDoctor(
     // #4156: bridge the gap between "configured" and "runtime-visible" — the
     // existing messaging check above probes provider attachment, not whether
     // OpenClaw's runtime config actually surfaces each enabled channel.
-    const registeredChannels = Array.isArray(sb.messagingChannels) ? sb.messagingChannels : [];
-    const disabledChannelsSet = new Set(
-      Array.isArray(sb.disabledChannels) ? sb.disabledChannels : [],
-    );
-    const enabledChannels = registeredChannels.filter(
-      (channel: string) => !disabledChannelsSet.has(channel),
-    );
+    const enabledChannels = getActiveChannelIdsFromMessagingState(sb);
     const runtimeCheck = channelRuntimeDoctorCheck(sandboxName, enabledChannels);
     if (runtimeCheck) checks.push(runtimeCheck);
   }

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -12,6 +12,9 @@ import {
   type ChannelManifest,
   createBuiltInChannelManifestRegistry,
   createBuiltInMessagingHookRegistry,
+  getConfiguredChannelIdsFromMessagingState,
+  getMessagingChannelConfigFromMessagingState,
+  getMessagingChannelConfigFromPlan,
   getMessagingManifestAvailabilityContext,
   MessagingHostStateApplier,
   MessagingSetupApplier,
@@ -511,7 +514,7 @@ async function applyChannelAddToGatewayAndRegistry(
   // tokens on disk.
   const entry = registry.getSandbox(sandboxName);
   if (entry) {
-    const enabled = new Set(entry.messagingChannels || []);
+    const enabled = new Set(getConfiguredChannelIdsFromMessagingState(entry));
     enabled.add(channelName);
     const disabled = (entry.disabledChannels || []).filter((c: string) => c !== channelName);
     registry.updateSandbox(sandboxName, {
@@ -626,7 +629,9 @@ async function applyChannelRemoveToGatewayAndRegistry(
 
   const entry = registry.getSandbox(sandboxName);
   if (entry) {
-    const enabled = (entry.messagingChannels || []).filter((c: string) => c !== channelName);
+    const enabled = getConfiguredChannelIdsFromMessagingState(entry).filter(
+      (c: string) => c !== channelName,
+    );
     registry.updateSandbox(sandboxName, { messagingChannels: enabled });
   }
 
@@ -936,14 +941,22 @@ function persistManifestMessagingConfig(sandboxName: string, manifest: ChannelMa
   if (!config) return;
 
   const entry = registry.getSandbox(sandboxName);
-  const mergedRegistryConfig = mergeMessagingChannelConfigs(entry?.messagingChannelConfig, config);
+  const mergedRegistryConfig = mergeMessagingChannelConfigs(
+    getMessagingChannelConfigFromMessagingState(entry),
+    config,
+  );
   if (entry && mergedRegistryConfig) {
     registry.updateSandbox(sandboxName, { messagingChannelConfig: mergedRegistryConfig });
   }
 
   const session = safeLoadOnboardSession();
   if (session?.sandboxName !== sandboxName) return;
-  const mergedSessionConfig = mergeMessagingChannelConfigs(session.messagingChannelConfig, config);
+  const mergedSessionConfig = mergeMessagingChannelConfigs(
+    session.messagingPlan
+      ? getMessagingChannelConfigFromPlan(session.messagingPlan)
+      : session.messagingChannelConfig,
+    config,
+  );
   if (!mergedSessionConfig) return;
   try {
     onboardSession.updateSession((current) => {
@@ -1098,9 +1111,7 @@ export async function addSandboxChannel(
     process.exit(1);
   }
   const priorEntry = registry.getSandbox(sandboxName);
-  const priorMessagingChannels: string[] = priorEntry?.messagingChannels
-    ? [...priorEntry.messagingChannels]
-    : [];
+  const priorMessagingChannels: string[] = getConfiguredChannelIdsFromMessagingState(priorEntry);
   const wasAlreadyEnabled = priorMessagingChannels.includes(canonical);
   const channelTokenKeys = getChannelTokenKeys(channelDef);
   const priorCreds: Record<string, string> = {};
@@ -1402,7 +1413,7 @@ export async function removeSandboxChannel(
       ? sessionForSandbox.policyPresets
       : [];
   const hasChannelResidue =
-    (registryEntry?.messagingChannels || []).includes(canonical) ||
+    getConfiguredChannelIdsFromMessagingState(registryEntry).includes(canonical) ||
     (registryEntry?.policies || []).includes(canonical) ||
     sessionPolicyPresets.includes(canonical) ||
     policies.getAppliedPresets(sandboxName).includes(canonical);

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -45,6 +45,12 @@ import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import * as nim from "../../inference/nim";
 import {
   createBuiltInChannelManifestRegistry,
+  getConfiguredChannelIdsFromMessagingState,
+  getConfiguredChannelIdsFromPlan,
+  getDisabledChannelIdsFromMessagingState,
+  getDisabledChannelIdsFromPlan,
+  getMessagingChannelConfigFromMessagingState,
+  getMessagingChannelConfigFromPlan,
   MessagingSetupApplier,
   MessagingWorkflowPlanner,
   toMessagingAgentId,
@@ -765,21 +771,26 @@ export async function rebuildSandbox(
     // Mark session resumable and point at this sandbox; set env var as fallback.
     const sessionBefore = onboardSession.loadSession();
     const sessionMatchesSandbox = sessionBefore?.sandboxName === sandboxName;
-    const registryMessagingChannels = Array.isArray(sb.messagingChannels)
-      ? sb.messagingChannels.filter((value: unknown): value is string => typeof value === "string")
-      : null;
-    const sessionMessagingChannels =
-      sessionMatchesSandbox && Array.isArray(sessionBefore?.messagingChannels)
-        ? sessionBefore.messagingChannels.filter(
-            (value: unknown): value is string => typeof value === "string",
-          )
+    const registryMessagingChannels =
+      sb.messaging?.plan || Array.isArray(sb.messagingChannels)
+        ? getConfiguredChannelIdsFromMessagingState(sb)
         : null;
+    const sessionMessagingChannels =
+      sessionMatchesSandbox && sessionBefore?.messagingPlan
+        ? getConfiguredChannelIdsFromPlan(sessionBefore.messagingPlan)
+        : sessionMatchesSandbox && Array.isArray(sessionBefore?.messagingChannels)
+          ? sessionBefore.messagingChannels.filter(
+              (value: unknown): value is string => typeof value === "string",
+            )
+          : null;
     const rebuildMessagingChannels = registryMessagingChannels ?? sessionMessagingChannels ?? [];
     const sessionMessagingChannelConfig = sessionMatchesSandbox
-      ? (sessionBefore?.messagingChannelConfig ?? null)
+      ? sessionBefore?.messagingPlan
+        ? getMessagingChannelConfigFromPlan(sessionBefore.messagingPlan)
+        : (sessionBefore?.messagingChannelConfig ?? null)
       : null;
     const rebuildMessagingChannelConfig =
-      sb.messagingChannelConfig ?? sessionMessagingChannelConfig ?? null;
+      getMessagingChannelConfigFromMessagingState(sb) ?? sessionMessagingChannelConfig ?? null;
     const rebuildsHermesSandbox = rebuildAgent === "hermes";
     let registryHermesToolGateways: string[] | null = null;
     if (rebuildsHermesSandbox && Array.isArray(sb.hermesToolGateways)) {
@@ -815,9 +826,9 @@ export async function rebuildSandbox(
     // is downstream of the registry; re-stashing on every rebuild keeps a stale
     // ["telegram"] from a prior stop/rebuild cycle from leaking into the next
     // start/rebuild and filtering the channel back out.
-    const rebuildDisabledChannels = Array.isArray(sb.disabledChannels)
-      ? sb.disabledChannels.filter((value: unknown): value is string => typeof value === "string")
-      : [];
+    const rebuildDisabledChannels =
+      getDisabledChannelIdsFromPlan(rebuildMessagingPlan) ??
+      getDisabledChannelIdsFromMessagingState(sb);
     log(
       `Session before update: sandboxName=${sessionBefore?.sandboxName}, status=${sessionBefore?.status}, resumable=${sessionBefore?.resumable}, provider=${sessionBefore?.provider}, model=${sessionBefore?.model}, sessionMatch=${sessionMatchesSandbox}`,
     );

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -3,6 +3,8 @@
 
 import { CLI_NAME } from "../cli/branding";
 import type { GatewayInference } from "../inference/config";
+import { getConfiguredChannelIdsFromMessagingState } from "../messaging";
+import type { SandboxMessagingPlan } from "../messaging/manifest";
 import { redactFull } from "../security/redact";
 import { resolveDefaultSandboxName } from "../tunnel/service-command";
 
@@ -19,6 +21,7 @@ export interface SandboxEntry {
   openshellVersion?: string | null;
   policies?: string[] | null;
   messagingChannels?: string[] | null;
+  messaging?: { plan?: SandboxMessagingPlan | null } | null;
   agent?: string | null;
   dashboardPort?: number | null;
 }
@@ -494,8 +497,8 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
     // and the original `sandboxes` snapshot is stale.
     const refreshed = deps.listSandboxes().sandboxes;
     const defaultEntry = refreshed.find((sb) => sb.name === resolvedDefault);
-    const channels = defaultEntry?.messagingChannels;
-    if (Array.isArray(channels) && channels.length > 0) {
+    const channels = getConfiguredChannelIdsFromMessagingState(defaultEntry);
+    if (channels.length > 0) {
       const degraded = deps.checkMessagingBridgeHealth(resolvedDefault, channels);
       if (degraded.length > 0) {
         log("");

--- a/src/lib/messaging/compiler/manifest-compiler.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.ts
@@ -180,7 +180,7 @@ async function resolveChannelInputs(
 }> {
   let inputs = manifest.inputs.map((input) => resolveChannelInput(manifest, input, context));
   inputs = applyCredentialAvailability(manifest, inputs, context);
-  let hookInputs = buildCompilerHookInputs(manifest, inputs);
+  let hookInputs = buildCompilerHookInputs(manifest, inputs, context);
   const enrollmentHooks = options.runEnrollment
     ? manifest.hooks
         .filter((hook) => isHookForAgent(hook, context.agent))
@@ -250,7 +250,7 @@ function resolveChannelInput(
   context: ManifestCompilerContext,
 ): SandboxMessagingInputReference {
   const base = inputReferenceBase(manifest, input);
-  const envValue = readInputEnvValue(input);
+  const envValue = readInputEnvValue(input, context);
   if (envValue !== undefined) {
     return input.kind === "secret"
       ? { ...base, credentialAvailable: true }
@@ -278,9 +278,14 @@ function inputReferenceBase(
   };
 }
 
-function readInputEnvValue(input: ChannelInputSpec): MessagingSerializableValue | undefined {
+function readInputEnvValue(
+  input: ChannelInputSpec,
+  context: ManifestCompilerContext,
+): MessagingSerializableValue | undefined {
   if (!input.envKey) return undefined;
   if (input.kind === "config") {
+    const configuredValue = context.configValues?.[input.envKey];
+    if (configuredValue && configuredValue.trim().length > 0) return configuredValue;
     const resolved = resolveMessagingChannelConfigEnvValue(input.envKey, process.env);
     if (resolved.value) return resolved.value;
   }
@@ -375,12 +380,13 @@ function isHookOutputAvailable(
 function buildCompilerHookInputs(
   manifest: ChannelManifest,
   inputs: readonly SandboxMessagingInputReference[],
+  context: ManifestCompilerContext,
 ): Record<string, MessagingSerializableValue> {
   const inputSpecs = new Map(manifest.inputs.map((input) => [input.id, input]));
   const entries: Array<[string, MessagingSerializableValue]> = [];
   for (const input of inputs) {
     const spec = inputSpecs.get(input.inputId);
-    const value = input.value ?? (spec ? readInputEnvValue(spec) : undefined);
+    const value = input.value ?? (spec ? readInputEnvValue(spec, context) : undefined);
     if (value === undefined) continue;
     entries.push([input.inputId, value]);
     if (input.statePath) entries.push([input.statePath, value]);

--- a/src/lib/messaging/compiler/types.ts
+++ b/src/lib/messaging/compiler/types.ts
@@ -16,4 +16,6 @@ export interface ManifestCompilerContext {
   readonly disabledChannels?: readonly MessagingChannelId[];
   readonly supportedChannelIds?: readonly MessagingChannelId[];
   readonly credentialAvailability?: MessagingCompilerCredentialAvailability;
+  /** Non-secret config input values keyed by env var name. */
+  readonly configValues?: Readonly<Record<string, string>>;
 }

--- a/src/lib/messaging/compiler/workflow-planner.test.ts
+++ b/src/lib/messaging/compiler/workflow-planner.test.ts
@@ -651,17 +651,71 @@ describe("MessagingWorkflowPlanner", () => {
     );
   });
 
-  it("does not compile a rebuild plan when the sandbox entry has no stored plan", async () => {
+  it("compiles a rebuild plan from legacy sandbox fields when no stored plan exists", async () => {
     const rebuilt = await planner().buildRebuildPlanFromSandboxEntry({
       sandboxName: "demo",
       agent: "openclaw",
       sandboxEntry: {
         name: "demo",
         messagingChannels: ["telegram"],
+        messagingChannelConfig: {
+          TELEGRAM_REQUIRE_MENTION: "1",
+        },
+        disabledChannels: ["telegram"],
       },
     });
 
-    expect(rebuilt).toBeNull();
+    expect(rebuilt?.workflow).toBe("rebuild");
+    expect(rebuilt?.disabledChannels).toEqual(["telegram"]);
+    expect(rebuilt?.channels.find((channel) => channel.channelId === "telegram")).toMatchObject({
+      active: false,
+      configured: true,
+      disabled: true,
+    });
+    expect(
+      rebuilt?.channels
+        .find((channel) => channel.channelId === "telegram")
+        ?.inputs.find((input) => input.inputId === "requireMention"),
+    ).toMatchObject({
+      value: "1",
+    });
+    expect(
+      rebuilt?.credentialBindings.find(
+        (binding) => binding.providerEnvKey === "TELEGRAM_BOT_TOKEN",
+      ),
+    ).toMatchObject({
+      credentialAvailable: true,
+    });
+    expect(
+      rebuilt?.credentialBindings.find((binding) => binding.providerEnvKey === "TELEGRAM_BOT_TOKEN")
+        ?.credentialHash,
+    ).toBeUndefined();
+  });
+
+  it("merges channel adds with legacy sandbox fields when no stored plan exists", async () => {
+    const plan = await planner().buildChannelAddPlanFromSandboxEntry({
+      sandboxName: "demo",
+      agent: "openclaw",
+      sandboxEntry: {
+        name: "demo",
+        messagingChannels: ["telegram"],
+        disabledChannels: [],
+      },
+      channelId: "whatsapp",
+      isInteractive: false,
+      supportedChannelIds: ["telegram", "whatsapp"],
+    });
+
+    expect(plan.workflow).toBe("add-channel");
+    expect(plan.channels.map((channel) => channel.channelId)).toEqual(["telegram", "whatsapp"]);
+    expect(plan.channels.find((channel) => channel.channelId === "telegram")).toMatchObject({
+      active: true,
+      configured: true,
+    });
+    expect(plan.channels.find((channel) => channel.channelId === "whatsapp")).toMatchObject({
+      active: true,
+      configured: true,
+    });
   });
 
   it("reports unsupported channels deterministically before compiling", async () => {

--- a/src/lib/messaging/compiler/workflow-planner.ts
+++ b/src/lib/messaging/compiler/workflow-planner.ts
@@ -22,6 +22,7 @@ export interface MessagingWorkflowPlannerBuildContext {
   readonly disabledChannels?: readonly MessagingChannelId[];
   readonly supportedChannelIds?: readonly MessagingChannelId[];
   readonly credentialAvailability?: MessagingCompilerCredentialAvailability;
+  readonly configValues?: Readonly<Record<string, string>>;
 }
 
 export class MessagingWorkflowPlanner {
@@ -48,6 +49,7 @@ export class MessagingWorkflowPlanner {
       disabledChannels,
       supportedChannelIds: context.supportedChannelIds,
       credentialAvailability: context.credentialAvailability,
+      configValues: context.configValues,
     };
     return this.compiler.compile(compilerContext);
   }
@@ -55,7 +57,7 @@ export class MessagingWorkflowPlanner {
   async buildChannelAddPlanFromSandboxEntry(
     context: MessagingWorkflowPlannerChannelAddContext,
   ): Promise<SandboxMessagingPlan> {
-    const existingPlan = readSandboxEntryPlan(context);
+    const existingPlan = await this.resolveSandboxEntryPlan(context, "add-channel");
     const compiledPlan = await this.buildPlan({
       sandboxName: context.sandboxName,
       agent: context.agent,
@@ -97,7 +99,7 @@ export class MessagingWorkflowPlanner {
   async buildRebuildPlanFromSandboxEntry(
     context: MessagingWorkflowPlannerSandboxRebuildContext,
   ): Promise<SandboxMessagingPlan | null> {
-    const existingPlan = readSandboxEntryPlan(context);
+    const existingPlan = await this.resolveSandboxEntryPlan(context, "rebuild");
     if (!existingPlan) return null;
     return setPlanDisabledChannels(
       existingPlan,
@@ -141,9 +143,36 @@ export class MessagingWorkflowPlanner {
     context: MessagingWorkflowPlannerChannelMutationContext,
     workflow: MessagingCompilerWorkflow,
   ): Promise<SandboxMessagingPlan | null> {
-    const existingPlan = readSandboxEntryPlan(context);
+    const existingPlan = await this.resolveSandboxEntryPlan(context, workflow);
     if (existingPlan) return { ...clonePlan(existingPlan), workflow };
     return null;
+  }
+
+  private async resolveSandboxEntryPlan(
+    context: MessagingWorkflowPlannerSandboxContext,
+    workflow: MessagingCompilerWorkflow,
+  ): Promise<SandboxMessagingPlan | null> {
+    const existingPlan = readSandboxEntryPlan(context);
+    if (existingPlan) return existingPlan;
+
+    const legacyConfiguredChannels = legacyMessagingChannelsFromSandboxEntry(context.sandboxEntry);
+    if (legacyConfiguredChannels.length === 0) return null;
+
+    const legacyWorkflow = workflow === "add-channel" ? "rebuild" : workflow;
+    return this.buildPlan({
+      sandboxName: context.sandboxName,
+      agent: context.agent,
+      workflow: legacyWorkflow,
+      isInteractive: false,
+      configuredChannels: legacyConfiguredChannels,
+      disabledChannels: legacyDisabledChannelsFromSandboxEntry(context.sandboxEntry),
+      supportedChannelIds: context.supportedChannelIds,
+      credentialAvailability: mergeAvailability(
+        this.credentialAvailabilityFromSandboxEntry(context.sandboxEntry, legacyConfiguredChannels),
+        context.credentialAvailability,
+      ),
+      configValues: legacyMessagingChannelConfigFromSandboxEntry(context.sandboxEntry),
+    });
   }
 
   private credentialAvailabilityFromSandboxEntry(
@@ -151,17 +180,32 @@ export class MessagingWorkflowPlanner {
     channelIds: readonly MessagingChannelId[],
   ): MessagingCompilerCredentialAvailability | undefined {
     const plan = sandboxEntry?.messaging?.plan;
-    if (!plan) return undefined;
-
     const availability: Record<string, boolean> = {};
+    if (plan) {
+      for (const channelId of channelIds) {
+        const manifest = this.registry.get(channelId);
+        if (!manifest) continue;
+        for (const credential of manifest.credentials) {
+          const binding = plan.credentialBindings.find(
+            (b) => b.channelId === channelId && b.providerEnvKey === credential.providerEnvKey,
+          );
+          if (!binding?.credentialAvailable) continue;
+          availability[credential.sourceInput] = true;
+          availability[`${manifest.id}.${credential.sourceInput}`] = true;
+          availability[credential.id] = true;
+          availability[`${manifest.id}.${credential.id}`] = true;
+          availability[credential.providerEnvKey] = true;
+        }
+      }
+      return Object.keys(availability).length > 0 ? availability : undefined;
+    }
+
+    const legacyConfiguredChannels = new Set(legacyMessagingChannelsFromSandboxEntry(sandboxEntry));
     for (const channelId of channelIds) {
+      if (!legacyConfiguredChannels.has(channelId)) continue;
       const manifest = this.registry.get(channelId);
       if (!manifest) continue;
       for (const credential of manifest.credentials) {
-        const binding = plan.credentialBindings.find(
-          (b) => b.channelId === channelId && b.providerEnvKey === credential.providerEnvKey,
-        );
-        if (!binding?.credentialAvailable) continue;
         availability[credential.sourceInput] = true;
         availability[`${manifest.id}.${credential.sourceInput}`] = true;
         availability[credential.id] = true;
@@ -177,6 +221,7 @@ export interface MessagingWorkflowPlannerSandboxEntry {
   readonly name: string;
   readonly agent?: string | null;
   readonly messagingChannels?: readonly MessagingChannelId[] | null;
+  readonly messagingChannelConfig?: Readonly<Record<string, string>> | null;
   readonly disabledChannels?: readonly MessagingChannelId[] | null;
   readonly messaging?: {
     readonly schemaVersion: 1;
@@ -238,11 +283,36 @@ function disabledChannelsFromSandboxEntry(
   sandboxEntry: MessagingWorkflowPlannerSandboxEntry | null | undefined,
   fallbackPlan: SandboxMessagingPlan | null,
 ): MessagingChannelId[] {
+  if (fallbackPlan) return uniqueChannels(fallbackPlan.disabledChannels);
+  return legacyDisabledChannelsFromSandboxEntry(sandboxEntry);
+}
+
+function legacyMessagingChannelsFromSandboxEntry(
+  sandboxEntry: MessagingWorkflowPlannerSandboxEntry | null | undefined,
+): MessagingChannelId[] {
   return uniqueChannels(
-    Array.isArray(sandboxEntry?.disabledChannels)
-      ? sandboxEntry.disabledChannels
-      : (fallbackPlan?.disabledChannels ?? []),
+    Array.isArray(sandboxEntry?.messagingChannels) ? sandboxEntry.messagingChannels : [],
   );
+}
+
+function legacyDisabledChannelsFromSandboxEntry(
+  sandboxEntry: MessagingWorkflowPlannerSandboxEntry | null | undefined,
+): MessagingChannelId[] {
+  return uniqueChannels(
+    Array.isArray(sandboxEntry?.disabledChannels) ? sandboxEntry.disabledChannels : [],
+  );
+}
+
+function legacyMessagingChannelConfigFromSandboxEntry(
+  sandboxEntry: MessagingWorkflowPlannerSandboxEntry | null | undefined,
+): Record<string, string> | undefined {
+  const rawConfig = sandboxEntry?.messagingChannelConfig;
+  if (!rawConfig || typeof rawConfig !== "object" || Array.isArray(rawConfig)) return undefined;
+  const config: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawConfig)) {
+    if (typeof key === "string" && typeof value === "string") config[key] = value;
+  }
+  return Object.keys(config).length > 0 ? config : undefined;
 }
 
 function clonePlan(plan: SandboxMessagingPlan): SandboxMessagingPlan {

--- a/src/lib/messaging/utils.ts
+++ b/src/lib/messaging/utils.ts
@@ -7,6 +7,7 @@ import type {
   ChannelManifestAvailabilityContext,
   MessagingAgentId,
   MessagingChannelId,
+  SandboxMessagingPlan,
 } from "./manifest";
 
 export interface MessagingAgentDescriptor {
@@ -66,6 +67,110 @@ export function hasMessagingManifestRequiredInputs(
   });
 }
 
+export function getConfiguredChannelIdsFromPlan(
+  plan: SandboxMessagingPlan | null | undefined,
+): string[] | null {
+  if (!plan) return null;
+  return plan.channels.map((channel) => channel.channelId);
+}
+
+export function getActiveChannelIdsFromMessagingPlan(
+  plan: SandboxMessagingPlan | null | undefined,
+): string[] | null {
+  if (!plan) return null;
+  const disabled = new Set(plan.disabledChannels);
+  const active = plan.channels
+    .filter((channel) => channel.active && !channel.disabled && !disabled.has(channel.channelId))
+    .map((channel) => channel.channelId);
+  return active.length > 0 ? active : [];
+}
+
+export function getDisabledChannelIdsFromPlan(
+  plan: SandboxMessagingPlan | null | undefined,
+): string[] | null {
+  if (!plan) return null;
+  return plan.disabledChannels.length > 0 ? [...plan.disabledChannels] : [];
+}
+
+export interface MessagingPlanStateLike {
+  readonly messaging?: {
+    readonly plan?: SandboxMessagingPlan | null;
+  } | null;
+  readonly messagingChannels?: readonly string[] | null;
+  readonly disabledChannels?: readonly string[] | null;
+  readonly messagingChannelConfig?: Readonly<Record<string, string>> | null;
+}
+
+export function getConfiguredChannelIdsFromMessagingState(
+  state: MessagingPlanStateLike | null | undefined,
+): string[] {
+  return (
+    getConfiguredChannelIdsFromPlan(state?.messaging?.plan) ??
+    uniqueStringArray(state?.messagingChannels)
+  );
+}
+
+export function getActiveChannelIdsFromMessagingState(
+  state: MessagingPlanStateLike | null | undefined,
+): string[] {
+  const fromPlan = getActiveChannelIdsFromMessagingPlan(state?.messaging?.plan);
+  if (fromPlan) return fromPlan;
+  const disabled = new Set(uniqueStringArray(state?.disabledChannels));
+  return uniqueStringArray(state?.messagingChannels).filter(
+    (channelId) => !disabled.has(channelId),
+  );
+}
+
+export function getDisabledChannelIdsFromMessagingState(
+  state: MessagingPlanStateLike | null | undefined,
+): string[] {
+  return (
+    getDisabledChannelIdsFromPlan(state?.messaging?.plan) ??
+    uniqueStringArray(state?.disabledChannels)
+  );
+}
+
+export function getMessagingChannelConfigFromPlan(
+  plan: SandboxMessagingPlan | null | undefined,
+): Record<string, string> | null {
+  if (!plan) return null;
+  const config: Record<string, string> = {};
+  for (const channel of plan.channels) {
+    for (const input of channel.inputs) {
+      if (
+        input.kind === "config" &&
+        input.sourceEnv &&
+        typeof input.value === "string" &&
+        input.value.length > 0
+      ) {
+        config[input.sourceEnv] = input.value;
+      }
+    }
+  }
+  return Object.keys(config).length > 0 ? config : null;
+}
+
+export function getMessagingChannelConfigFromMessagingState(
+  state: MessagingPlanStateLike | null | undefined,
+): Record<string, string> | null {
+  if (state?.messaging?.plan) return getMessagingChannelConfigFromPlan(state.messaging.plan);
+  return sanitizeStringRecord(state?.messagingChannelConfig);
+}
+
 function hasResolvedInputValue(value: string | null): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function uniqueStringArray(values: readonly string[] | null | undefined): string[] {
+  if (!Array.isArray(values)) return [];
+  return [...new Set(values.filter((value): value is string => typeof value === "string"))];
+}
+
+function sanitizeStringRecord(value: unknown): Record<string, string> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof key === "string" && typeof entry === "string") record[key] = entry;
+  }
+  return Object.keys(record).length > 0 ? record : null;
 }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -109,14 +109,8 @@ const {
   readMessagingPlanFromEnv,
   writePlanToEnv,
   getRegistrySandboxMessagingPlan,
-  MessagingHostStateApplier,
+  readMessagingPlanStateFromEnvForSandbox,
 } = require("./onboard/messaging-channel-setup") as typeof import("./onboard/messaging-channel-setup");
-const {
-  getConfiguredChannelIdsFromMessagingState,
-  getConfiguredChannelIdsFromPlan,
-  getDisabledChannelIdsFromPlan,
-  getMessagingChannelConfigFromPlan,
-} = require("./messaging") as typeof import("./messaging");
 const {
   clearAgentScopedResumeState,
 }: typeof import("./onboard/agent-resume-state") = require("./onboard/agent-resume-state");
@@ -3548,11 +3542,6 @@ async function createSandbox(
 
   console.log(`  Creating sandbox '${sandboxName}' (this takes a few minutes on first run)...`);
   const messagingChannelConfig = readMessagingChannelConfigFromEnv();
-  const envMessagingPlan = readMessagingPlanFromEnv();
-  const effectiveMessagingChannelConfig =
-    getMessagingChannelConfigFromPlan(
-      envMessagingPlan?.sandboxName === sandboxName ? envMessagingPlan : null,
-    ) ?? messagingChannelConfig;
   const enabledTokenEnvKeys = new Set(messagingTokenDefs.map(({ envKey }) => envKey));
   const activeChannelNames = new Set(activeMessagingChannels);
   const { messagingAllowedIds, discordGuilds, slackConfig } = collectMessagingBuildConfig({
@@ -3582,7 +3571,7 @@ async function createSandbox(
         ? { requireMention: telegramConfig.requireMention as boolean }
         : null;
     current.wechatConfig = toSessionWechatConfig(wechatConfig);
-    current.messagingChannelConfig = effectiveMessagingChannelConfig;
+    messagingConfig.setSessionMessagingConfig(current, sandboxName, messagingChannelConfig);
     return current;
   });
   // Pull the base image and resolve its digest so the Dockerfile is pinned to
@@ -3890,12 +3879,7 @@ async function createSandbox(
   const resolvedImageTag = resolveSandboxImageTagFromCreateOutput(createResult.output, buildId);
 
   const sandboxRuntimeFields = getSandboxRuntimeRegistryFields(effectiveSandboxGpuConfig);
-  const plannedMessagingState = MessagingHostStateApplier.readPlanStateFromEnv();
-  const messagingState =
-    plannedMessagingState?.plan.sandboxName === sandboxName ? plannedMessagingState : undefined;
-  const plannedMessagingChannels = getConfiguredChannelIdsFromPlan(messagingState?.plan);
-  const plannedDisabledChannels = getDisabledChannelIdsFromPlan(messagingState?.plan);
-  const plannedMessagingChannelConfig = getMessagingChannelConfigFromPlan(messagingState?.plan);
+  const messagingState = readMessagingPlanStateFromEnvForSandbox(sandboxName);
   registry.registerSandbox({
     name: sandboxName,
     model: model || null,
@@ -3909,15 +3893,13 @@ async function createSandbox(
     // X, but X is still configured — losing it here means a later `channels start
     // X` has nothing to re-enable (the next rebuild sees an empty channel set and
     // never reattaches the gateway bridge). See #3381.
-    messagingChannels:
-      plannedMessagingChannels ??
-      (enabledChannels != null ? [...new Set(enabledChannels)] : activeMessagingChannels),
-    messagingChannelConfig: plannedMessagingChannelConfig ?? messagingChannelConfig ?? undefined,
-    messaging: messagingState,
-    disabledChannels:
-      (plannedDisabledChannels ?? disabledChannels).length > 0
-        ? [...(plannedDisabledChannels ?? disabledChannels)]
-        : undefined,
+    ...messagingConfig.getSandboxRegistrationMessagingFields({
+      messagingState,
+      messagingChannelConfig,
+      enabledChannels,
+      activeMessagingChannels,
+      disabledChannels,
+    }),
     hermesToolGateways: hermesToolGateways.length > 0 ? [...hermesToolGateways] : undefined,
     ...onboardHermesDashboard.getHermesDashboardRegistryFields(finalHermesDashboardState),
     dashboardPort: actualDashboardPort,
@@ -5445,8 +5427,7 @@ function getRecordedMessagingChannelsForResume(
 ): string[] | null {
   return getRecordedMessagingChannelsForResumeFromState({
     resume,
-    sessionMessagingChannels:
-      getConfiguredChannelIdsFromPlan(session?.messagingPlan) ?? session?.messagingChannels,
+    sessionMessagingChannels: messagingConfig.getSessionMessagingChannelsForResume(session),
     sandboxName,
     channels: MESSAGING_CHANNELS,
     getCredential,
@@ -6648,10 +6629,7 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           configureWebSearch,
           startRecordedStep,
           getRecordedMessagingChannelsForResume,
-          getSandboxMessagingChannels: (name) => {
-            const entry = registry.getSandbox(name);
-            return entry ? getConfiguredChannelIdsFromMessagingState(entry) : null;
-          },
+          getSandboxMessagingChannels: messagingConfig.getSandboxMessagingChannelsFromRegistry,
           setupMessagingChannels,
           readMessagingChannelConfigFromEnv,
           readMessagingPlanFromEnv,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -112,6 +112,12 @@ const {
   MessagingHostStateApplier,
 } = require("./onboard/messaging-channel-setup") as typeof import("./onboard/messaging-channel-setup");
 const {
+  getConfiguredChannelIdsFromMessagingState,
+  getConfiguredChannelIdsFromPlan,
+  getDisabledChannelIdsFromPlan,
+  getMessagingChannelConfigFromPlan,
+} = require("./messaging") as typeof import("./messaging");
+const {
   clearAgentScopedResumeState,
 }: typeof import("./onboard/agent-resume-state") = require("./onboard/agent-resume-state");
 const {
@@ -3542,6 +3548,11 @@ async function createSandbox(
 
   console.log(`  Creating sandbox '${sandboxName}' (this takes a few minutes on first run)...`);
   const messagingChannelConfig = readMessagingChannelConfigFromEnv();
+  const envMessagingPlan = readMessagingPlanFromEnv();
+  const effectiveMessagingChannelConfig =
+    getMessagingChannelConfigFromPlan(
+      envMessagingPlan?.sandboxName === sandboxName ? envMessagingPlan : null,
+    ) ?? messagingChannelConfig;
   const enabledTokenEnvKeys = new Set(messagingTokenDefs.map(({ envKey }) => envKey));
   const activeChannelNames = new Set(activeMessagingChannels);
   const { messagingAllowedIds, discordGuilds, slackConfig } = collectMessagingBuildConfig({
@@ -3571,7 +3582,7 @@ async function createSandbox(
         ? { requireMention: telegramConfig.requireMention as boolean }
         : null;
     current.wechatConfig = toSessionWechatConfig(wechatConfig);
-    current.messagingChannelConfig = messagingChannelConfig;
+    current.messagingChannelConfig = effectiveMessagingChannelConfig;
     return current;
   });
   // Pull the base image and resolve its digest so the Dockerfile is pinned to
@@ -3882,6 +3893,9 @@ async function createSandbox(
   const plannedMessagingState = MessagingHostStateApplier.readPlanStateFromEnv();
   const messagingState =
     plannedMessagingState?.plan.sandboxName === sandboxName ? plannedMessagingState : undefined;
+  const plannedMessagingChannels = getConfiguredChannelIdsFromPlan(messagingState?.plan);
+  const plannedDisabledChannels = getDisabledChannelIdsFromPlan(messagingState?.plan);
+  const plannedMessagingChannelConfig = getMessagingChannelConfigFromPlan(messagingState?.plan);
   registry.registerSandbox({
     name: sandboxName,
     model: model || null,
@@ -3896,10 +3910,14 @@ async function createSandbox(
     // X` has nothing to re-enable (the next rebuild sees an empty channel set and
     // never reattaches the gateway bridge). See #3381.
     messagingChannels:
-      enabledChannels != null ? [...new Set(enabledChannels)] : activeMessagingChannels,
-    messagingChannelConfig: messagingChannelConfig || undefined,
+      plannedMessagingChannels ??
+      (enabledChannels != null ? [...new Set(enabledChannels)] : activeMessagingChannels),
+    messagingChannelConfig: plannedMessagingChannelConfig ?? messagingChannelConfig ?? undefined,
     messaging: messagingState,
-    disabledChannels: disabledChannels.length > 0 ? [...disabledChannels] : undefined,
+    disabledChannels:
+      (plannedDisabledChannels ?? disabledChannels).length > 0
+        ? [...(plannedDisabledChannels ?? disabledChannels)]
+        : undefined,
     hermesToolGateways: hermesToolGateways.length > 0 ? [...hermesToolGateways] : undefined,
     ...onboardHermesDashboard.getHermesDashboardRegistryFields(finalHermesDashboardState),
     dashboardPort: actualDashboardPort,
@@ -5427,7 +5445,8 @@ function getRecordedMessagingChannelsForResume(
 ): string[] | null {
   return getRecordedMessagingChannelsForResumeFromState({
     resume,
-    sessionMessagingChannels: session?.messagingChannels,
+    sessionMessagingChannels:
+      getConfiguredChannelIdsFromPlan(session?.messagingPlan) ?? session?.messagingChannels,
     sandboxName,
     channels: MESSAGING_CHANNELS,
     getCredential,
@@ -6629,7 +6648,10 @@ async function onboard(opts: OnboardOptions = {}): Promise<void> {
           configureWebSearch,
           startRecordedStep,
           getRecordedMessagingChannelsForResume,
-          getSandboxMessagingChannels: (name) => registry.getSandbox(name)?.messagingChannels,
+          getSandboxMessagingChannels: (name) => {
+            const entry = registry.getSandbox(name);
+            return entry ? getConfiguredChannelIdsFromMessagingState(entry) : null;
+          },
           setupMessagingChannels,
           readMessagingChannelConfigFromEnv,
           readMessagingPlanFromEnv,

--- a/src/lib/onboard/channel-state.ts
+++ b/src/lib/onboard/channel-state.ts
@@ -3,8 +3,13 @@
 
 import * as onboardSession from "../state/onboard-session";
 import * as registry from "../state/registry";
+import { getDisabledChannelIdsFromPlan } from "../messaging";
+import type { SandboxMessagingPlan } from "../messaging/manifest";
 
-type DisabledChannelsSession = Pick<onboardSession.Session, "disabledChannels">;
+type DisabledChannelsSession = {
+  disabledChannels?: string[] | null;
+  messagingPlan?: SandboxMessagingPlan | null;
+};
 
 export type DisabledChannelsDeps = {
   loadSession: () => DisabledChannelsSession | null;
@@ -17,8 +22,9 @@ export function resolveDisabledChannels(
 ): string[] {
   // `rebuild` destroys the registry entry before `onboard --resume` reaches
   // createSandbox, so the session mirror is authoritative when present.
-  const sessionDisabledChannels = (deps?.loadSession ?? onboardSession.loadSession)()
-    ?.disabledChannels;
+  const session = (deps?.loadSession ?? onboardSession.loadSession)();
+  const sessionDisabledChannels =
+    getDisabledChannelIdsFromPlan(session?.messagingPlan) ?? session?.disabledChannels;
   if (Array.isArray(sessionDisabledChannels)) {
     return sessionDisabledChannels;
   }

--- a/src/lib/onboard/machine/events.ts
+++ b/src/lib/onboard/machine/events.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { JsonObject, JsonValue } from "../../core/json-types";
+import { getConfiguredChannelIdsFromPlan } from "../../messaging";
 import { redactSensitiveText, redactUrl } from "../../security/redact";
 import type { HermesAuthMethod, Session } from "../../state/onboard-session";
 import {
@@ -128,7 +129,9 @@ export function buildOnboardMachineContext(session: Session): OnboardMachineCont
     hermesAuthMethod: hermesAuthMethod(session.hermesAuthMethod),
     hermesToolGateways: stringArray(session.hermesToolGateways),
     policyPresets: stringArray(session.policyPresets),
-    messagingChannels: stringArray(session.messagingChannels),
+    messagingChannels: stringArray(
+      getConfiguredChannelIdsFromPlan(session.messagingPlan) ?? session.messagingChannels,
+    ),
     gpuPassthrough: booleanValue(session.gpuPassthrough),
   };
 }

--- a/src/lib/onboard/machine/final-flow-phases.test.ts
+++ b/src/lib/onboard/machine/final-flow-phases.test.ts
@@ -29,7 +29,7 @@ describe("final onboard flow phases", () => {
 
     const result = await policiesPhase.run(context({ selectedMessagingChannels: ["slack"] }));
 
-    expect(mergePolicyMessagingChannels).toHaveBeenCalledWith(["slack"], [], undefined, undefined);
+    expect(mergePolicyMessagingChannels).toHaveBeenCalledWith(["slack"], [], null, null);
     expect(result.context.selectedMessagingChannels).toEqual(["slack", "discord"]);
   });
 

--- a/src/lib/onboard/machine/handlers/policies.test.ts
+++ b/src/lib/onboard/machine/handlers/policies.test.ts
@@ -3,11 +3,42 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import type { SandboxMessagingPlan } from "../../../messaging/manifest";
 import { createSession, type Session, type SessionUpdates } from "../../../state/onboard-session";
 import { handlePoliciesState, type PoliciesStateOptions } from "./policies";
 
 type Agent = { name: string } | null;
 type WebSearchConfig = { fetchEnabled: true };
+
+function makePlan(
+  channels: readonly string[],
+  disabledChannels: readonly string[] = [],
+): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName: "my-assistant",
+    agent: "openclaw",
+    workflow: "rebuild",
+    channels: channels.map((channelId) => ({
+      channelId,
+      displayName: channelId,
+      authMode: "none",
+      active: !disabledChannels.includes(channelId),
+      selected: true,
+      configured: true,
+      disabled: disabledChannels.includes(channelId),
+      inputs: [],
+      hooks: [],
+    })),
+    disabledChannels,
+    credentialBindings: [],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  };
+}
 
 function createDeps(overrides: Partial<PoliciesStateOptions<Agent, WebSearchConfig>["deps"]> = {}) {
   let session = createSession();
@@ -147,6 +178,47 @@ describe("handlePoliciesState", () => {
     expect(calls.setupPolicies).toHaveBeenCalledWith(
       "my-assistant",
       expect.objectContaining({ enabledChannels: ["slack"] }),
+    );
+  });
+
+  it("prefers recorded messaging plan channels over stale session legacy fields", async () => {
+    const session = createSession({
+      messagingChannels: ["slack"],
+      messagingPlan: makePlan(["telegram"]),
+    });
+    const { deps, calls, setSession } = createDeps({
+      getActiveSandbox: vi.fn(() => ({ messagingChannels: null, disabledChannels: null })),
+    });
+    setSession(session);
+
+    await handlePoliciesState(baseOptions(deps));
+
+    expect(calls.setupPolicies).toHaveBeenCalledWith(
+      "my-assistant",
+      expect.objectContaining({ enabledChannels: ["telegram"] }),
+    );
+  });
+
+  it("prefers active sandbox messaging plan state over stale registry legacy fields", async () => {
+    const { deps, calls } = createDeps({
+      getActiveSandbox: vi.fn(() => ({
+        messagingChannels: ["slack"],
+        disabledChannels: [],
+        messaging: {
+          plan: makePlan(["telegram"], ["telegram"]),
+        },
+      })),
+    });
+
+    await handlePoliciesState(baseOptions(deps));
+
+    expect(calls.mergeChannels).toHaveBeenCalledWith([], [], ["telegram"], ["telegram"]);
+    expect(calls.prepareResume).toHaveBeenCalledWith(
+      "my-assistant",
+      expect.objectContaining({
+        enabledChannels: ["telegram"],
+        disabledChannels: ["telegram"],
+      }),
     );
   });
 

--- a/src/lib/onboard/machine/handlers/policies.ts
+++ b/src/lib/onboard/machine/handlers/policies.ts
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  getConfiguredChannelIdsFromMessagingState,
+  getConfiguredChannelIdsFromPlan,
+  getDisabledChannelIdsFromMessagingState,
+} from "../../../messaging";
+import type { SandboxMessagingPlan } from "../../../messaging/manifest";
 import type { Session, SessionUpdates } from "../../../state/onboard-session";
 import { advanceTo, type OnboardStateTransitionResult } from "../result";
 
@@ -12,6 +18,27 @@ function normalizeAgentName(name: string | null | undefined): string {
   return trimmed && trimmed !== "openclaw" ? trimmed : "openclaw";
 }
 
+function getActiveSandboxMessagingChannels(
+  activeSandbox: ActiveSandboxPolicyState | null | undefined,
+): string[] | null {
+  if (!activeSandbox) return null;
+  if (activeSandbox.messaging?.plan)
+    return getConfiguredChannelIdsFromMessagingState(activeSandbox);
+  return Array.isArray(activeSandbox.messagingChannels)
+    ? getConfiguredChannelIdsFromMessagingState(activeSandbox)
+    : null;
+}
+
+function getActiveSandboxDisabledChannels(
+  activeSandbox: ActiveSandboxPolicyState | null | undefined,
+): string[] | null {
+  if (!activeSandbox) return null;
+  if (activeSandbox.messaging?.plan) return getDisabledChannelIdsFromMessagingState(activeSandbox);
+  return Array.isArray(activeSandbox.disabledChannels)
+    ? getDisabledChannelIdsFromMessagingState(activeSandbox)
+    : null;
+}
+
 export interface PolicyPresetEntry {
   name: string;
   [key: string]: unknown;
@@ -19,6 +46,7 @@ export interface PolicyPresetEntry {
 
 export interface ActiveSandboxPolicyState {
   messagingChannels?: string[] | null;
+  messaging?: { plan?: SandboxMessagingPlan | null } | null;
   disabledChannels?: string[] | null;
 }
 
@@ -133,15 +161,17 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
   const recordedPolicyPresets = Array.isArray(latestSession?.policyPresets)
     ? latestSession.policyPresets
     : null;
-  const recordedMessagingChannels = Array.isArray(latestSession?.messagingChannels)
-    ? latestSession.messagingChannels
-    : [];
+  const recordedMessagingChannels =
+    getConfiguredChannelIdsFromPlan(latestSession?.messagingPlan) ??
+    (Array.isArray(latestSession?.messagingChannels) ? latestSession.messagingChannels : []);
   const activeSandbox = deps.getActiveSandbox(sandboxName);
+  const activeSandboxMessagingChannels = getActiveSandboxMessagingChannels(activeSandbox);
+  const activeSandboxDisabledChannels = getActiveSandboxDisabledChannels(activeSandbox);
   const policyMessagingChannels = deps.mergePolicyMessagingChannels(
     selectedMessagingChannels,
     recordedMessagingChannels,
-    activeSandbox?.messagingChannels,
-    activeSandbox?.disabledChannels,
+    activeSandboxMessagingChannels,
+    activeSandboxDisabledChannels,
   );
   deps.verifyCompatibleEndpointSandboxSmoke({
     sandboxName,
@@ -155,7 +185,7 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
 
   const policyResumeSelection = deps.preparePolicyPresetResumeSelection(sandboxName, {
     recordedPolicyPresets,
-    disabledChannels: activeSandbox?.disabledChannels,
+    disabledChannels: activeSandboxDisabledChannels,
     enabledChannels: policyMessagingChannels,
     hermesToolGateways,
     agent: normalizeAgentName((agent as { name?: string } | null)?.name),
@@ -210,7 +240,7 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
         ? recordedPolicyPresetsForSupport
         : null,
       enabledChannels: policyMessagingChannels,
-      disabledChannels: activeSandbox?.disabledChannels,
+      disabledChannels: activeSandboxDisabledChannels,
       webSearchConfig,
       provider,
       // selectOnboardAgent returns null for the default OpenClaw path (no

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  getConfiguredChannelIdsFromPlan,
+  getMessagingChannelConfigFromPlan,
+} from "../../../messaging";
 import type { SandboxMessagingPlan } from "../../../messaging/manifest";
 import type { Session, SessionUpdates } from "../../../state/onboard-session";
 import { withSandboxPhaseTrace } from "../../tracing";
@@ -248,7 +252,8 @@ export async function handleSandboxState<
   if (resumeSandbox) {
     if (webSearchConfig)
       deps.note("  [resume] Reusing Brave Search configuration already baked into the sandbox.");
-    selectedMessagingChannels = session?.messagingChannels ?? [];
+    selectedMessagingChannels =
+      getConfiguredChannelIdsFromPlan(session?.messagingPlan) ?? session?.messagingChannels ?? [];
     deps.skippedStepMessage("sandbox", sandboxName);
     await deps.recordStateSkipped("sandbox", { reason: "resume", sandboxName });
   } else {
@@ -353,12 +358,19 @@ export async function handleSandboxState<
       }
     } else {
       const existing = sandboxName
-        ? (deps.getSandboxMessagingChannels(sandboxName) ?? session?.messagingChannels ?? null)
-        : (session?.messagingChannels ?? null);
+        ? (deps.getSandboxMessagingChannels(sandboxName) ??
+          getConfiguredChannelIdsFromPlan(session?.messagingPlan) ??
+          session?.messagingChannels ??
+          null)
+        : (getConfiguredChannelIdsFromPlan(session?.messagingPlan) ??
+          session?.messagingChannels ??
+          null);
       selectedMessagingChannels = await deps.setupMessagingChannels(agent, existing, sandboxName);
       messagingPlan = deps.readMessagingPlanFromEnv();
     }
-    const messagingChannelConfig = deps.readMessagingChannelConfigFromEnv();
+    const messagingChannelConfig =
+      deps.readMessagingChannelConfigFromEnv() ??
+      (getMessagingChannelConfigFromPlan(messagingPlan) as MessagingChannelConfig | null);
     session = deps.updateSession((current) => {
       current.messagingChannels = selectedMessagingChannels;
       current.messagingChannelConfig = messagingChannelConfig as Session["messagingChannelConfig"];

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -266,6 +266,13 @@ export function getRegistrySandboxMessagingPlan(sandboxName: string): SandboxMes
   return registry.getSandbox(sandboxName)?.messaging?.plan ?? null;
 }
 
+export function readMessagingPlanStateFromEnvForSandbox(
+  sandboxName: string,
+): registry.SandboxMessagingState | undefined {
+  const state = MessagingHostStateApplier.readPlanStateFromEnv();
+  return state?.plan.sandboxName === sandboxName ? state : undefined;
+}
+
 function resolveMessagingSetupSandboxName(options: SetupSelectedMessagingChannelsOptions): string {
   const explicitName = normalizeSandboxName(options.sandboxName);
   if (explicitName) return explicitName;

--- a/src/lib/onboard/messaging-config.ts
+++ b/src/lib/onboard/messaging-config.ts
@@ -7,6 +7,10 @@ import {
   resolveMessagingChannelConfigEnvValue,
   sanitizeMessagingChannelConfig,
 } from "../messaging-channel-config";
+import {
+  getMessagingChannelConfigFromMessagingState,
+  getMessagingChannelConfigFromPlan,
+} from "../messaging";
 import type { Session } from "../state/onboard-session";
 import * as onboardSession from "../state/onboard-session";
 import * as registry from "../state/registry";
@@ -106,13 +110,18 @@ export function getStoredMessagingChannelConfig(
   sandboxName: string | null,
   session: Session | null,
 ): MessagingChannelConfig | null {
+  const registryEntry = sandboxName ? registry.getSandbox(sandboxName) : null;
   const registryConfig = sandboxName
-    ? sanitizeMessagingChannelConfig(registry.getSandbox(sandboxName)?.messagingChannelConfig)
+    ? sanitizeMessagingChannelConfig(getMessagingChannelConfigFromMessagingState(registryEntry))
     : null;
   const sessionMatchesSandbox =
     !session?.sandboxName || !sandboxName || session.sandboxName === sandboxName;
   const sessionConfig = sessionMatchesSandbox
-    ? sanitizeMessagingChannelConfig(session?.messagingChannelConfig)
+    ? sanitizeMessagingChannelConfig(
+        session?.messagingPlan
+          ? getMessagingChannelConfigFromPlan(session.messagingPlan)
+          : session?.messagingChannelConfig,
+      )
     : null;
   return mergeMessagingChannelConfigs(registryConfig, sessionConfig);
 }

--- a/src/lib/onboard/messaging-config.ts
+++ b/src/lib/onboard/messaging-config.ts
@@ -8,12 +8,17 @@ import {
   sanitizeMessagingChannelConfig,
 } from "../messaging-channel-config";
 import {
+  getConfiguredChannelIdsFromMessagingState,
+  getConfiguredChannelIdsFromPlan,
+  getDisabledChannelIdsFromPlan,
   getMessagingChannelConfigFromMessagingState,
   getMessagingChannelConfigFromPlan,
+  MessagingSetupApplier,
 } from "../messaging";
 import type { Session } from "../state/onboard-session";
 import * as onboardSession from "../state/onboard-session";
 import * as registry from "../state/registry";
+import type { SandboxEntry, SandboxMessagingState } from "../state/registry";
 
 type EnvLike = Record<string, string | undefined>;
 
@@ -35,6 +40,19 @@ export type CollectMessagingBuildConfigOptions = {
   env?: EnvLike;
   discordSnowflakeRe: RegExp;
   warn?: (message: string) => void;
+};
+
+type SandboxRegistrationMessagingField = Pick<
+  SandboxEntry,
+  "messagingChannels" | "messagingChannelConfig" | "messaging" | "disabledChannels"
+>;
+
+export type SandboxRegistrationMessagingFieldOptions = {
+  messagingState?: SandboxMessagingState;
+  messagingChannelConfig: MessagingChannelConfig | null;
+  enabledChannels?: readonly string[] | null;
+  activeMessagingChannels: readonly string[];
+  disabledChannels: readonly string[];
 };
 
 // Read TELEGRAM_REQUIRE_MENTION (set either by the interactive mention prompt
@@ -104,6 +122,61 @@ export function collectMessagingBuildConfig({
   }
 
   return { messagingAllowedIds, discordGuilds, slackConfig };
+}
+
+export function getEffectiveMessagingChannelConfigForSandbox(
+  sandboxName: string,
+  fallbackConfig: MessagingChannelConfig | null,
+): MessagingChannelConfig | null {
+  const plan = MessagingSetupApplier.readPlanFromEnv();
+  return (
+    getMessagingChannelConfigFromPlan(plan?.sandboxName === sandboxName ? plan : null) ??
+    fallbackConfig
+  );
+}
+
+export function setSessionMessagingConfig(
+  session: Session,
+  sandboxName: string,
+  fallbackConfig: MessagingChannelConfig | null,
+): void {
+  session.messagingChannelConfig = getEffectiveMessagingChannelConfigForSandbox(
+    sandboxName,
+    fallbackConfig,
+  );
+}
+
+export function getSessionMessagingChannelsForResume(
+  session: Session | null,
+): string[] | null | undefined {
+  return getConfiguredChannelIdsFromPlan(session?.messagingPlan) ?? session?.messagingChannels;
+}
+
+export function getSandboxMessagingChannelsFromRegistry(sandboxName: string): string[] | null {
+  const entry = registry.getSandbox(sandboxName);
+  return entry ? getConfiguredChannelIdsFromMessagingState(entry) : null;
+}
+
+export function getSandboxRegistrationMessagingFields({
+  messagingState,
+  messagingChannelConfig,
+  enabledChannels,
+  activeMessagingChannels,
+  disabledChannels,
+}: SandboxRegistrationMessagingFieldOptions): SandboxRegistrationMessagingField {
+  const plannedMessagingChannels = getConfiguredChannelIdsFromPlan(messagingState?.plan);
+  const plannedDisabledChannels = getDisabledChannelIdsFromPlan(messagingState?.plan);
+  const plannedMessagingChannelConfig = getMessagingChannelConfigFromPlan(messagingState?.plan);
+  const effectiveDisabledChannels = plannedDisabledChannels ?? disabledChannels;
+  return {
+    messagingChannels:
+      plannedMessagingChannels ??
+      (enabledChannels != null ? [...new Set(enabledChannels)] : [...activeMessagingChannels]),
+    messagingChannelConfig: plannedMessagingChannelConfig ?? messagingChannelConfig ?? undefined,
+    messaging: messagingState,
+    disabledChannels:
+      effectiveDisabledChannels.length > 0 ? [...effectiveDisabledChannels] : undefined,
+  };
 }
 
 export function getStoredMessagingChannelConfig(

--- a/src/lib/onboard/messaging-reuse.ts
+++ b/src/lib/onboard/messaging-reuse.ts
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  getConfiguredChannelIdsFromMessagingState,
+  getDisabledChannelIdsFromMessagingState,
+  type MessagingPlanStateLike,
+} from "../messaging";
+
 type MessagingChannel = { name: string; envKey: string };
-type SandboxEntry = { messagingChannels?: string[] | null } | null | undefined;
+type SandboxEntry = MessagingPlanStateLike | null | undefined;
 
 export function getMessagingProviderNamesForChannel(
   sandboxName: string,
@@ -48,11 +54,15 @@ export function getNonInteractiveStoredMessagingChannels(
     return null;
   }
 
+  const sandboxEntry = getSandbox(sandboxName);
   const configuredChannels = getKnownMessagingChannels(
-    getSandbox(sandboxName)?.messagingChannels,
+    getConfiguredChannelIdsFromMessagingState(sandboxEntry),
     messagingChannels,
   );
-  const disabledChannels = new Set(getDisabledChannels(sandboxName));
+  const disabledChannels = new Set(getDisabledChannelIdsFromMessagingState(sandboxEntry));
+  if (!sandboxEntry?.messaging?.plan) {
+    for (const channel of getDisabledChannels(sandboxName)) disabledChannels.add(channel);
+  }
   const reusableChannels = configuredChannels.filter((channel) => {
     if (disabledChannels.has(channel)) return false;
     const providers = getMessagingProviderNamesForChannel(sandboxName, channel);

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isErrnoException } from "../core/errno";
 import type { SandboxMessagingPlan } from "../messaging/manifest";
+import { getDisabledChannelIdsFromMessagingState } from "../messaging/utils";
 import type { MessagingChannelConfig } from "../messaging-channel-config";
 import { ensureConfigDir, readConfigFile, writeConfigFile } from "./config-io";
 
@@ -498,7 +499,7 @@ export function removeCustomPolicyByName(name: string, presetName: string): bool
 
 export function getDisabledChannels(name: string): string[] {
   const data = load();
-  return data.sandboxes[name]?.disabledChannels ?? [];
+  return getDisabledChannelIdsFromMessagingState(data.sandboxes[name]);
 }
 
 export function setChannelDisabled(name: string, channel: string, disabled: boolean): boolean {


### PR DESCRIPTION
## Summary
Make `messagingPlan` the canonical messaging state while preserving compatibility for registry entries that only have legacy `messagingChannels`, `messagingChannelConfig`, and `disabledChannels`.

This keeps onboard resume, sandbox rebuild, policy, credentials, doctor, inventory, and channel commands compatible with pre-migration state.

## Related Issue
Fixes #4947

## Changes
- Prefer `messaging.plan` when resolving configured, active, and disabled channels and channel config across onboard, sandbox, policy, credentials, doctor, inventory, and registry paths.
- Compile legacy messaging registry fields into an effective plan when `messaging.plan` is absent, preserving configured channels and non-secret channel config.
- Preserve disabled-channel semantics and merge legacy-derived plans into channel add and rebuild workflows.
- Add and update unit coverage for planner fallback, channel status, policy handling, and onboard final-flow behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Passed:
- `npx vitest run src/lib/messaging/compiler/workflow-planner.test.ts src/lib/actions/sandbox/channel-status.test.ts src/lib/onboard/machine/handlers/policies.test.ts src/lib/onboard/channel-state.test.ts src/lib/onboard/machine/final-flow-phases.test.ts`
- `npm run build:cli`
- `git diff --check`
- Local pre-push TypeScript and repository checks ran successfully before the hook timed out.

Known local gate failures:
- `npx prek run --all-files` / commit hook reaches the repository-wide CLI/e2e suite and fails in unrelated environment-sensitive tests, including CLI timeouts, shell signal expectations, `${name,,}` shell compatibility, and active-gateway dependent cases.
- `npm test` did not complete cleanly locally for the same repository-wide CLI/e2e area.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messaging "plans" are now first-class: channel configuration, enable/disable state, and per-channel settings are used across onboarding, resume, status, and rebuild flows.

* **Bug Fixes**
  * Channel selection and enabled/disabled fallbacks now consistently prefer plan-state (fixes paused/WhatsApp detection and resume behavior).
  * Environment-driven config resolution now prefers supplied config values when present.

* **Tests**
  * Added tests covering plan-aware channel handling and legacy-to-plan migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->