### PR TITLE
refactor(onboard): extract policy selection prompts

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -576,6 +576,7 @@ import {
   type SetupPresetSuggestionOptions,
   setupPoliciesWithSelection as setupPoliciesWithSelectionImpl,
 } from "./onboard/policy-selection";
+import { createPolicySelectionPromptHelpers } from "./onboard/policy-selection-prompts";
 import {
   backupSandboxBeforeRecreate,
   shouldSkipPreRecreateBackup,
@@ -5482,468 +5483,41 @@ function arePolicyPresetsApplied(sandboxName: string, selectedPresets: string[] 
   return selectedPresets.every((preset) => applied.has(preset));
 }
 
-/**
- * Prompt the user to select a policy tier (restricted / balanced / open).
- * Uses the same radio-style TUI as presetsCheckboxSelector (single-select).
- * In non-interactive mode reads NEMOCLAW_POLICY_TIER (default: balanced).
- * Returns the tier name string.
- *
- * @returns {Promise<string>}
- */
-async function selectPolicyTier(): Promise<string> {
-  const allTiers = tiers.listTiers();
-  const defaultTier = allTiers.find((t) => t.name === "balanced") || allTiers[1];
-
-  if (isNonInteractive()) {
-    const name = policyTierEnv.resolvePolicyTierFromEnv();
-    note(`  [non-interactive] Policy tier: ${name}`);
-    return name;
-  }
-
-  const RADIO_ON = USE_COLOR ? "[\x1b[32m✓\x1b[0m]" : "[✓]";
-  const RADIO_OFF = USE_COLOR ? "\x1b[2m[ ]\x1b[0m" : "[ ]";
-
-  // ── Fallback: non-TTY ─────────────────────────────────────────────
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    console.log("");
-    console.log("  Policy tier — controls which network presets are enabled:");
-    allTiers.forEach((t) => {
-      const marker = t.name === defaultTier.name ? RADIO_ON : RADIO_OFF;
-      console.log(`    ${marker} ${t.label}`);
-    });
-    console.log("");
-    const answer = await prompt(
-      `  Select tier [1-${allTiers.length}] (default: ${allTiers.indexOf(defaultTier) + 1} ${defaultTier.name}): `,
-    );
-    const chosen = selectFromNumberedMenuOrExit(
-      answer,
-      allTiers.indexOf(defaultTier) + 1,
-      allTiers,
-    );
-    console.log(`  Tier: ${chosen.label}`);
-    return chosen.name;
-  }
-
-  // ── Raw-mode TUI (radio — single selection) ───────────────────────
-  let cursor = allTiers.indexOf(defaultTier);
-  let selectedIdx = cursor;
-  const n = allTiers.length;
-
-  const G = USE_COLOR ? "\x1b[32m" : "";
-  const D = USE_COLOR ? "\x1b[2m" : "";
-  const R = USE_COLOR ? "\x1b[0m" : "";
-  const HINT = USE_COLOR
-    ? `  ${G}↑/↓ j/k${R}  ${D}move${R}    ${G}Space${R}  ${D}select${R}    ${G}Enter${R}  ${D}confirm${R}`
-    : "  ↑/↓ j/k  move    Space  select    Enter  confirm";
-
-  const renderLines = () => {
-    const lines = ["  Policy tier — controls which network presets are enabled:"];
-    allTiers.forEach((t, i) => {
-      const radio = i === selectedIdx ? RADIO_ON : RADIO_OFF;
-      const arrow = i === cursor ? ">" : " ";
-      lines.push(`   ${arrow} ${radio} ${t.label}`);
-    });
-    lines.push("");
-    lines.push(HINT);
-    return lines;
-  };
-
-  process.stdout.write("\n");
-  const initial = renderLines();
-  for (const line of initial) process.stdout.write(`${line}\n`);
-  let lineCount = initial.length;
-
-  const redraw = () => {
-    process.stdout.write(`\x1b[${lineCount}A`);
-    const lines = renderLines();
-    for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
-    lineCount = lines.length;
-  };
-
-  // Re-attach stdin to the event loop. A prior prompt cleanup may have
-  // unref'd it (sticky), and resume() alone would leave the raw-mode read
-  // detached from the loop.
-  if (typeof process.stdin.ref === "function") process.stdin.ref();
-  process.stdin.setRawMode(true);
-  process.stdin.resume();
-  process.stdin.setEncoding("utf8");
-
-  return new Promise<string>((resolve) => {
-    const cleanup = () => {
-      process.stdin.setRawMode(false);
-      process.stdin.pause();
-      // Symmetric with the ref() at the entry; lets the wizard exit
-      // naturally if this is the last prompt.
-      if (typeof process.stdin.unref === "function") process.stdin.unref();
-      process.stdin.removeListener("data", onData);
-      process.removeListener("SIGTERM", onSigterm);
-    };
-
-    const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
-    process.once("SIGTERM", onSigterm);
-
-    const onData = (key: string) => {
-      if (key === "\r" || key === "\n") {
-        cleanup();
-        process.stdout.write("\n");
-        resolve(allTiers[selectedIdx].name);
-      } else if (key === " ") {
-        selectedIdx = cursor;
-        redraw();
-      } else if (key === "\x03") {
-        makeOnboardCancelExit(sandboxCancelRollback, cleanup)();
-      } else if (key === "\x1b[A" || key === "k") {
-        cursor = (cursor - 1 + n) % n;
-        redraw();
-      } else if (key === "\x1b[B" || key === "j") {
-        cursor = (cursor + 1) % n;
-        redraw();
-      }
-    };
-
-    process.stdin.on("data", onData);
+function getPolicySelectionPromptHelpers(): ReturnType<typeof createPolicySelectionPromptHelpers> {
+  return createPolicySelectionPromptHelpers({
+    tiers,
+    policyTierEnv,
+    isNonInteractive,
+    note,
+    prompt,
+    selectFromNumberedMenuOrExit,
+    makeOnboardCancelExit,
+    sandboxCancelRollback,
+    useColor: USE_COLOR,
   });
 }
 
-/**
- * Combined preset selector: shows ALL available presets, pre-checks those in
- * the chosen tier, and lets the user include/exclude any preset and toggle
- * per-preset access (read vs read-write).
- *
- * Tier presets are listed first (in tier order), then remaining presets
- * alphabetically. Tier presets are pre-checked; others start unchecked.
- *
- * Keys:
- *   ↑/↓ j/k — move cursor
- *   Space    — include / exclude current preset
- *   r        — toggle read / read-write for current preset
- *   Enter    — confirm
- *
- * @param {string} tierName
- * @param {Array<{name: string}>} allPresets
- * @param {string[]} [extraSelected]  — names pre-checked even if not in tier (e.g. already-applied)
- * @returns {Promise<Array<{name: string, access: string}>>}
- */
+async function selectPolicyTier(): Promise<string> {
+  return getPolicySelectionPromptHelpers().selectPolicyTier();
+}
+
 async function selectTierPresetsAndAccess(
   tierName: string,
   allPresets: Array<{ name: string; description?: string }>,
   extraSelected: string[] = [],
 ): Promise<Array<{ name: string; access: string }>> {
-  const tierDef = tiers.getTier(tierName);
-  const tierPresetMap: Record<string, string> = {};
-  if (tierDef) {
-    for (const p of tierDef.presets) {
-      tierPresetMap[p.name] = p.access;
-    }
-  }
-
-  // Tier presets first (in tier order), then the rest in their original order.
-  const tierNames = tierDef ? tierDef.presets.map((p) => p.name) : [];
-  const tierSet = new Set(tierNames);
-  const ordered: Array<{ name: string; description?: string }> = [
-    ...tierNames
-      .map((name) => allPresets.find((p) => p.name === name))
-      .filter((p): p is { name: string; description?: string } => Boolean(p)),
-    ...allPresets.filter((p) => !tierSet.has(p.name)),
-  ];
-
-  // Initial inclusion: tier presets + any already-applied extras.
-  const included = new Set([
-    ...tierNames,
-    ...extraSelected.filter((n) => ordered.find((p) => p.name === n)),
-  ]);
-
-  // Access levels: tier defaults for tier presets, read-write default for others.
-  const accessModes: Record<string, string> = {};
-  for (const p of ordered) {
-    accessModes[p.name] = tierPresetMap[p.name] ?? "read-write";
-  }
-
-  const G = USE_COLOR ? "\x1b[32m" : "";
-  const O = USE_COLOR ? "\x1b[38;5;208m" : "";
-  const D = USE_COLOR ? "\x1b[2m" : "";
-  const R = USE_COLOR ? "\x1b[0m" : "";
-  const GREEN_CHECK = USE_COLOR ? `[${G}✓${R}]` : "[✓]";
-  const EMPTY_CHECK = USE_COLOR ? `${D}[ ]${R}` : "[ ]";
-  const TOGGLE_RW = USE_COLOR ? `[${O}rw${R}]` : "[rw]";
-  const TOGGLE_R = USE_COLOR ? `${D}[ r]${R}` : "[ r]";
-
-  const label = tierDef ? `  Presets  (${tierDef.label} defaults):` : "  Presets:";
-  const n = ordered.length;
-
-  // ── Non-interactive: return tier defaults silently ─────────────────
-  if (isNonInteractive()) {
-    return ordered
-      .filter((p) => included.has(p.name))
-      .map((p) => ({ name: p.name, access: accessModes[p.name] }));
-  }
-
-  // ── Fallback: non-TTY ─────────────────────────────────────────────
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    console.log("");
-    console.log(label);
-    ordered.forEach((p) => {
-      const isIncluded = included.has(p.name);
-      const isRw = accessModes[p.name] === "read-write";
-      const check = isIncluded ? GREEN_CHECK : EMPTY_CHECK;
-      const badge = isIncluded ? (isRw ? "[rw]" : "[ r]") : "    ";
-      console.log(`    ${check} ${badge} ${p.name}`);
-    });
-    console.log("");
-    const rawInclude = await prompt(
-      "  Include presets (comma-separated names, Enter to keep defaults): ",
-    );
-    if (rawInclude.trim()) {
-      const knownNames = new Set(ordered.map((p) => p.name));
-      included.clear();
-      for (const name of rawInclude
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean)) {
-        if (knownNames.has(name)) {
-          included.add(name);
-        } else {
-          console.error(`  Unknown preset name ignored: ${name}`);
-        }
-      }
-    }
-    return ordered
-      .filter((p) => included.has(p.name))
-      .map((p) => ({ name: p.name, access: accessModes[p.name] }));
-  }
-
-  // ── Raw-mode TUI ─────────────────────────────────────────────────
-  let cursor = 0;
-
-  const HINT = USE_COLOR
-    ? `  ${G}↑/↓ j/k${R}  ${D}move${R}    ${G}Space${R}  ${D}include${R}    ${G}r${R}  ${D}toggle rw${R}    ${G}Enter${R}  ${D}confirm${R}`
-    : "  ↑/↓ j/k  move    Space  include    r  toggle rw    Enter  confirm";
-
-  const renderLines = () => {
-    const lines = [label];
-    ordered.forEach((p, i) => {
-      const isIncluded = included.has(p.name);
-      const isRw = accessModes[p.name] === "read-write";
-      const check = isIncluded ? GREEN_CHECK : EMPTY_CHECK;
-      // badge is 4 visible chars + 1 space; blank when unchecked to keep name aligned
-      const badge = isIncluded ? (isRw ? TOGGLE_RW + " " : TOGGLE_R + " ") : "     ";
-      const arrow = i === cursor ? ">" : " ";
-      lines.push(`   ${arrow} ${check} ${badge}${p.name}`);
-    });
-    lines.push("");
-    lines.push(HINT);
-    return lines;
-  };
-
-  process.stdout.write("\n");
-  const initial = renderLines();
-  for (const line of initial) process.stdout.write(`${line}\n`);
-  let lineCount = initial.length;
-
-  const redraw = () => {
-    process.stdout.write(`\x1b[${lineCount}A`);
-    const lines = renderLines();
-    for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
-    lineCount = lines.length;
-  };
-
-  // Re-attach stdin to the event loop. A prior prompt cleanup may have
-  // unref'd it (sticky), and resume() alone would leave the raw-mode read
-  // detached from the loop.
-  if (typeof process.stdin.ref === "function") process.stdin.ref();
-  process.stdin.setRawMode(true);
-  process.stdin.resume();
-  process.stdin.setEncoding("utf8");
-
-  return new Promise<Array<{ name: string; access: string }>>((resolve) => {
-    const cleanup = () => {
-      process.stdin.setRawMode(false);
-      process.stdin.pause();
-      // Symmetric with the ref() at the entry; lets the wizard exit
-      // naturally if this is the last prompt.
-      if (typeof process.stdin.unref === "function") process.stdin.unref();
-      process.stdin.removeListener("data", onData);
-      process.removeListener("SIGTERM", onSigterm);
-    };
-
-    const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
-    process.once("SIGTERM", onSigterm);
-
-    const onData = (key: string) => {
-      if (key === "\r" || key === "\n") {
-        cleanup();
-        process.stdout.write("\n");
-        resolve(
-          ordered
-            .filter((p) => included.has(p.name))
-            .map((p) => ({ name: p.name, access: accessModes[p.name] })),
-        );
-      } else if (key === "\x03") {
-        makeOnboardCancelExit(sandboxCancelRollback, cleanup)();
-      } else if (key === "\x1b[A" || key === "k") {
-        cursor = (cursor - 1 + n) % n;
-        redraw();
-      } else if (key === "\x1b[B" || key === "j") {
-        cursor = (cursor + 1) % n;
-        redraw();
-      } else if (key === " ") {
-        const currentPreset = ordered[cursor];
-        if (!currentPreset) return;
-        const name = currentPreset.name;
-        if (included.has(name)) {
-          included.delete(name);
-        } else {
-          included.add(name);
-        }
-        redraw();
-      } else if (key === "r" || key === "R") {
-        const currentPreset = ordered[cursor];
-        if (!currentPreset) return;
-        const name = currentPreset.name;
-        accessModes[name] = accessModes[name] === "read-write" ? "read" : "read-write";
-        redraw();
-      }
-    };
-
-    process.stdin.on("data", onData);
-  });
+  return getPolicySelectionPromptHelpers().selectTierPresetsAndAccess(
+    tierName,
+    allPresets,
+    extraSelected,
+  );
 }
 
-/**
- * Raw-mode TUI preset selector.
- * Keys: ↑/↓ or k/j to move, Space to toggle, a to select/unselect all, Enter to confirm.
- * Falls back to a simple line-based prompt when stdin is not a TTY.
- */
 async function presetsCheckboxSelector(
   allPresets: Array<{ name: string; description: string }>,
   initialSelected: string[],
 ): Promise<string[]> {
-  const selected = new Set<string>(initialSelected);
-  const n = allPresets.length;
-
-  // ── Zero-presets guard ────────────────────────────────────────────
-  if (n === 0) {
-    console.log("  No policy presets are available.");
-    return [];
-  }
-
-  const GREEN_CHECK = USE_COLOR ? "[\x1b[32m✓\x1b[0m]" : "[✓]";
-
-  // ── Fallback: non-TTY or redirected stdout (piped input) ──────────
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    console.log("");
-    console.log("  Available policy presets:");
-    allPresets.forEach((p) => {
-      const marker = selected.has(p.name) ? GREEN_CHECK : "[ ]";
-      console.log(`    ${marker} ${p.name.padEnd(14)} — ${p.description}`);
-    });
-    console.log("");
-    const raw = await prompt("  Select presets (comma-separated names, Enter to skip): ");
-    if (!raw.trim()) {
-      console.log("  Skipping policy presets.");
-      return [];
-    }
-    const knownNames = new Set(allPresets.map((p) => p.name));
-    const chosen = [];
-    for (const name of raw
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean)) {
-      if (knownNames.has(name)) {
-        chosen.push(name);
-      } else {
-        console.error(`  Unknown preset name ignored: ${name}`);
-      }
-    }
-    return chosen;
-  }
-
-  // ── Raw-mode TUI ─────────────────────────────────────────────────
-  let cursor = 0;
-
-  const G = USE_COLOR ? "\x1b[32m" : "";
-  const D = USE_COLOR ? "\x1b[2m" : "";
-  const R = USE_COLOR ? "\x1b[0m" : "";
-  const HINT = USE_COLOR
-    ? `  ${G}↑/↓ j/k${R}  ${D}move${R}    ${G}Space${R}  ${D}toggle${R}    ${G}a${R}  ${D}all/none${R}    ${G}Enter${R}  ${D}confirm${R}`
-    : "  ↑/↓ j/k  move    Space  toggle    a  all/none    Enter  confirm";
-
-  const renderLines = () => {
-    const lines = ["  Available policy presets:"];
-    allPresets.forEach((p, i) => {
-      const check = selected.has(p.name) ? GREEN_CHECK : "[ ]";
-      const arrow = i === cursor ? ">" : " ";
-      lines.push(`   ${arrow} ${check} ${p.name.padEnd(14)} — ${p.description}`);
-    });
-    lines.push("");
-    lines.push(HINT);
-    return lines;
-  };
-
-  // Initial paint
-  process.stdout.write("\n");
-  const initial = renderLines();
-  for (const line of initial) process.stdout.write(`${line}\n`);
-  let lineCount = initial.length;
-
-  const redraw = () => {
-    process.stdout.write(`\x1b[${lineCount}A`);
-    const lines = renderLines();
-    for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
-    lineCount = lines.length;
-  };
-
-  // Re-attach stdin to the event loop. A prior prompt cleanup may have
-  // unref'd it (sticky), and resume() alone would leave the raw-mode read
-  // detached from the loop.
-  if (typeof process.stdin.ref === "function") process.stdin.ref();
-  process.stdin.setRawMode(true);
-  process.stdin.resume();
-  process.stdin.setEncoding("utf8");
-
-  return new Promise<string[]>((resolve) => {
-    const cleanup = () => {
-      process.stdin.setRawMode(false);
-      process.stdin.pause();
-      // Symmetric with the ref() at the entry; lets the wizard exit
-      // naturally if this is the last prompt.
-      if (typeof process.stdin.unref === "function") process.stdin.unref();
-      process.stdin.removeListener("data", onData);
-      process.removeListener("SIGTERM", onSigterm);
-    };
-
-    const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
-    process.once("SIGTERM", onSigterm);
-
-    const onData = (key: string) => {
-      if (key === "\r" || key === "\n") {
-        cleanup();
-        process.stdout.write("\n");
-        resolve([...selected]);
-      } else if (key === "\x03") {
-        makeOnboardCancelExit(sandboxCancelRollback, cleanup)(); // Ctrl+C
-      } else if (key === "\x1b[A" || key === "k") {
-        cursor = (cursor - 1 + n) % n;
-        redraw();
-      } else if (key === "\x1b[B" || key === "j") {
-        cursor = (cursor + 1) % n;
-        redraw();
-      } else if (key === " ") {
-        const currentPreset = allPresets[cursor];
-        if (!currentPreset) return;
-        const name = currentPreset.name;
-        if (selected.has(name)) selected.delete(name);
-        else selected.add(name);
-        redraw();
-      } else if (key === "a") {
-        if (selected.size === n) selected.clear();
-        else for (const p of allPresets) selected.add(p.name);
-        redraw();
-      }
-    };
-
-    process.stdin.on("data", onData);
-  });
+  return getPolicySelectionPromptHelpers().presetsCheckboxSelector(allPresets, initialSelected);
 }
 
 const computeSetupPresetSuggestions = (

--- a/src/lib/onboard/policy-selection-prompts.test.ts
+++ b/src/lib/onboard/policy-selection-prompts.test.ts
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TierDefinition } from "../policy/tiers";
+import { createPolicySelectionPromptHelpers } from "./policy-selection-prompts";
+import { selectFromNumberedMenuOrExit } from "./prompt-helpers";
+
+class FakeInput extends EventEmitter {
+  isTTY: boolean;
+  ref = vi.fn();
+  pause = vi.fn();
+  resume = vi.fn();
+  setEncoding = vi.fn();
+  setRawMode = vi.fn();
+  unref = vi.fn();
+
+  constructor(isTTY = true) {
+    super();
+    this.isTTY = isTTY;
+  }
+}
+
+class FakeOutput {
+  isTTY: boolean;
+  chunks: string[] = [];
+  write = vi.fn((chunk: string | Uint8Array) => {
+    this.chunks.push(String(chunk));
+    return true;
+  });
+
+  constructor(isTTY = true) {
+    this.isTTY = isTTY;
+  }
+}
+
+const TIERS: TierDefinition[] = [
+  {
+    name: "restricted",
+    label: "Restricted",
+    description: "Minimal egress",
+    presets: [],
+  },
+  {
+    name: "balanced",
+    label: "Balanced",
+    description: "Common package registries",
+    presets: [
+      { name: "npm", access: "read" },
+      { name: "pypi", access: "read-write" },
+    ],
+  },
+  {
+    name: "open",
+    label: "Open",
+    description: "Permissive egress",
+    presets: [
+      { name: "npm", access: "read-write" },
+      { name: "github", access: "read-write" },
+    ],
+  },
+];
+
+function createHarness({
+  tiers = TIERS,
+  stdinTTY = true,
+  stdoutTTY = true,
+  promptReplies = [],
+}: {
+  tiers?: TierDefinition[];
+  stdinTTY?: boolean;
+  stdoutTTY?: boolean;
+  promptReplies?: string[];
+} = {}) {
+  const stdin = new FakeInput(stdinTTY);
+  const stdout = new FakeOutput(stdoutTTY);
+  const processEvents = new EventEmitter();
+  const markCancelled = vi.fn();
+  const prompt = vi.fn(async () => promptReplies.shift() ?? "");
+
+  const helpers = createPolicySelectionPromptHelpers({
+    tiers: {
+      listTiers: () => tiers,
+      getTier: (name) => tiers.find((tier) => tier.name === name) ?? null,
+    },
+    policyTierEnv: {
+      resolvePolicyTierFromEnv: () => "balanced",
+    },
+    isNonInteractive: () => false,
+    note: vi.fn(),
+    prompt,
+    selectFromNumberedMenuOrExit,
+    makeOnboardCancelExit: (rollback, cleanup) => () => {
+      cleanup();
+      rollback.markCancelled();
+    },
+    sandboxCancelRollback: { markCancelled },
+    useColor: false,
+    stdin,
+    stdout,
+    processEvents,
+  });
+
+  return { helpers, markCancelled, processEvents, prompt, stdin, stdout };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createPolicySelectionPromptHelpers", () => {
+  it("selectPolicyTier resolves numbered choices in the non-TTY fallback", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers, prompt } = createHarness({
+      stdinTTY: false,
+      stdoutTTY: false,
+      promptReplies: ["3"],
+    });
+
+    await expect(helpers.selectPolicyTier()).resolves.toBe("open");
+    expect(prompt).toHaveBeenCalledWith(expect.stringContaining("Select tier [1-3]"));
+  });
+
+  it("selectPolicyTier keeps the balanced default on blank non-TTY input", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers } = createHarness({
+      stdinTTY: false,
+      stdoutTTY: false,
+      promptReplies: [""],
+    });
+
+    await expect(helpers.selectPolicyTier()).resolves.toBe("balanced");
+  });
+
+  it("selectTierPresetsAndAccess honors comma-separated non-TTY allowlists", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { helpers } = createHarness({
+      stdinTTY: false,
+      stdoutTTY: false,
+      promptReplies: ["github, npm, missing"],
+    });
+
+    await expect(
+      helpers.selectTierPresetsAndAccess("balanced", [
+        { name: "npm" },
+        { name: "pypi" },
+        { name: "github" },
+      ]),
+    ).resolves.toEqual([
+      { name: "npm", access: "read" },
+      { name: "github", access: "read-write" },
+    ]);
+    expect(errorSpy).toHaveBeenCalledWith("  Unknown preset name ignored: missing");
+  });
+
+  it("selectTierPresetsAndAccess returns raw-mode access toggles on Enter", async () => {
+    const { helpers, markCancelled, stdin } = createHarness();
+    const result = helpers.selectTierPresetsAndAccess("balanced", [
+      { name: "npm" },
+      { name: "pypi" },
+      { name: "github" },
+    ]);
+
+    stdin.emit("data", "\x1b[B");
+    stdin.emit("data", "\x1b[B");
+    stdin.emit("data", " ");
+    stdin.emit("data", "r");
+    stdin.emit("data", "\r");
+
+    await expect(result).resolves.toEqual([
+      { name: "npm", access: "read" },
+      { name: "pypi", access: "read-write" },
+      { name: "github", access: "read" },
+    ]);
+    expect(markCancelled).not.toHaveBeenCalled();
+    expect(stdin.setRawMode).toHaveBeenNthCalledWith(1, true);
+    expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+    expect(stdin.listenerCount("data")).toBe(0);
+  });
+
+  it("selectPolicyTier marks rollback and restores raw mode on SIGTERM", () => {
+    const { helpers, markCancelled, processEvents, stdin } = createHarness();
+
+    void helpers.selectPolicyTier();
+    processEvents.emit("SIGTERM");
+
+    expect(markCancelled).toHaveBeenCalledOnce();
+    expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+    expect(stdin.listenerCount("data")).toBe(0);
+  });
+
+  it("presetsCheckboxSelector marks rollback and restores raw mode on Ctrl-C", () => {
+    const { helpers, markCancelled, stdin } = createHarness();
+
+    void helpers.presetsCheckboxSelector([{ name: "npm", description: "npm registry" }], []);
+    stdin.emit("data", "\x03");
+
+    expect(markCancelled).toHaveBeenCalledOnce();
+    expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+    expect(stdin.listenerCount("data")).toBe(0);
+  });
+
+  it("selectPolicyTier rejects when no policy tiers are configured", async () => {
+    const { helpers } = createHarness({ tiers: [] });
+
+    await expect(helpers.selectPolicyTier()).rejects.toThrow("No policy tiers are configured.");
+  });
+});

--- a/src/lib/onboard/policy-selection-prompts.ts
+++ b/src/lib/onboard/policy-selection-prompts.ts
@@ -6,6 +6,25 @@ import type { TierDefinition } from "../policy/tiers";
 
 type PresetWithDescription = { name: string; description?: string };
 type PresetWithAccess = { name: string; access: string };
+type PolicyPromptInput = {
+  isTTY?: boolean;
+  on(event: "data", listener: (key: string) => void): unknown;
+  pause(): unknown;
+  removeListener(event: "data", listener: (key: string) => void): unknown;
+  resume(): unknown;
+  setEncoding(encoding: BufferEncoding): unknown;
+  setRawMode(mode: boolean): unknown;
+  ref?: () => void;
+  unref?: () => void;
+};
+type PolicyPromptOutput = {
+  isTTY?: boolean;
+  write(chunk: string): unknown;
+};
+type PolicyPromptProcessEvents = {
+  once(event: "SIGTERM", listener: () => void): unknown;
+  removeListener(event: "SIGTERM", listener: () => void): unknown;
+};
 
 export interface PolicySelectionPromptDeps {
   tiers: {
@@ -25,6 +44,9 @@ export interface PolicySelectionPromptDeps {
   ): () => void;
   sandboxCancelRollback: Pick<SandboxCancelRollback, "markCancelled">;
   useColor: boolean;
+  stdin?: PolicyPromptInput;
+  stdout?: PolicyPromptOutput;
+  processEvents?: PolicyPromptProcessEvents;
 }
 
 export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDeps): {
@@ -50,6 +72,9 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
     sandboxCancelRollback,
     useColor,
   } = deps;
+  const stdin = deps.stdin ?? process.stdin;
+  const stdout = deps.stdout ?? process.stdout;
+  const processEvents = deps.processEvents ?? process;
 
   /**
    * Prompt the user to select a policy tier (restricted / balanced / open).
@@ -75,7 +100,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
     const RADIO_OFF = useColor ? "\x1b[2m[ ]\x1b[0m" : "[ ]";
 
     // ── Fallback: non-TTY ─────────────────────────────────────────────
-    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    if (!stdin.isTTY || !stdout.isTTY) {
       console.log("");
       console.log("  Policy tier — controls which network presets are enabled:");
       allTiers.forEach((tier) => {
@@ -119,44 +144,44 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
       return lines;
     };
 
-    process.stdout.write("\n");
+    stdout.write("\n");
     const initial = renderLines();
-    for (const line of initial) process.stdout.write(`${line}\n`);
+    for (const line of initial) stdout.write(`${line}\n`);
     let lineCount = initial.length;
 
     const redraw = () => {
-      process.stdout.write(`\x1b[${lineCount}A`);
+      stdout.write(`\x1b[${lineCount}A`);
       const lines = renderLines();
-      for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
+      for (const line of lines) stdout.write(`\r\x1b[2K${line}\n`);
       lineCount = lines.length;
     };
 
     // Re-attach stdin to the event loop. A prior prompt cleanup may have
     // unref'd it (sticky), and resume() alone would leave the raw-mode read
     // detached from the loop.
-    if (typeof process.stdin.ref === "function") process.stdin.ref();
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
+    if (typeof stdin.ref === "function") stdin.ref();
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
 
     return new Promise<string>((resolve) => {
       const cleanup = () => {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
+        stdin.setRawMode(false);
+        stdin.pause();
         // Symmetric with the ref() at the entry; lets the wizard exit
         // naturally if this is the last prompt.
-        if (typeof process.stdin.unref === "function") process.stdin.unref();
-        process.stdin.removeListener("data", onData);
-        process.removeListener("SIGTERM", onSigterm);
+        if (typeof stdin.unref === "function") stdin.unref();
+        stdin.removeListener("data", onData);
+        processEvents.removeListener("SIGTERM", onSigterm);
       };
 
       const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
-      process.once("SIGTERM", onSigterm);
+      processEvents.once("SIGTERM", onSigterm);
 
       const onData = (key: string) => {
         if (key === "\r" || key === "\n") {
           cleanup();
-          process.stdout.write("\n");
+          stdout.write("\n");
           resolve(allTiers[selectedIdx].name);
         } else if (key === " ") {
           selectedIdx = cursor;
@@ -172,7 +197,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
         }
       };
 
-      process.stdin.on("data", onData);
+      stdin.on("data", onData);
     });
   }
 
@@ -239,7 +264,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
     }
 
     // ── Fallback: non-TTY ─────────────────────────────────────────────
-    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    if (!stdin.isTTY || !stdout.isTTY) {
       console.log("");
       console.log(label);
       ordered.forEach((preset) => {
@@ -295,44 +320,44 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
       return lines;
     };
 
-    process.stdout.write("\n");
+    stdout.write("\n");
     const initial = renderLines();
-    for (const line of initial) process.stdout.write(`${line}\n`);
+    for (const line of initial) stdout.write(`${line}\n`);
     let lineCount = initial.length;
 
     const redraw = () => {
-      process.stdout.write(`\x1b[${lineCount}A`);
+      stdout.write(`\x1b[${lineCount}A`);
       const lines = renderLines();
-      for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
+      for (const line of lines) stdout.write(`\r\x1b[2K${line}\n`);
       lineCount = lines.length;
     };
 
     // Re-attach stdin to the event loop. A prior prompt cleanup may have
     // unref'd it (sticky), and resume() alone would leave the raw-mode read
     // detached from the loop.
-    if (typeof process.stdin.ref === "function") process.stdin.ref();
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
+    if (typeof stdin.ref === "function") stdin.ref();
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
 
     return new Promise<PresetWithAccess[]>((resolve) => {
       const cleanup = () => {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
+        stdin.setRawMode(false);
+        stdin.pause();
         // Symmetric with the ref() at the entry; lets the wizard exit
         // naturally if this is the last prompt.
-        if (typeof process.stdin.unref === "function") process.stdin.unref();
-        process.stdin.removeListener("data", onData);
-        process.removeListener("SIGTERM", onSigterm);
+        if (typeof stdin.unref === "function") stdin.unref();
+        stdin.removeListener("data", onData);
+        processEvents.removeListener("SIGTERM", onSigterm);
       };
 
       const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
-      process.once("SIGTERM", onSigterm);
+      processEvents.once("SIGTERM", onSigterm);
 
       const onData = (key: string) => {
         if (key === "\r" || key === "\n") {
           cleanup();
-          process.stdout.write("\n");
+          stdout.write("\n");
           resolve(
             ordered
               .filter((preset) => included.has(preset.name))
@@ -365,7 +390,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
         }
       };
 
-      process.stdin.on("data", onData);
+      stdin.on("data", onData);
     });
   }
 
@@ -390,7 +415,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
     const GREEN_CHECK = useColor ? "[\x1b[32m✓\x1b[0m]" : "[✓]";
 
     // ── Fallback: non-TTY or redirected stdout (piped input) ──────────
-    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    if (!stdin.isTTY || !stdout.isTTY) {
       console.log("");
       console.log("  Available policy presets:");
       allPresets.forEach((preset) => {
@@ -441,44 +466,44 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
     };
 
     // Initial paint
-    process.stdout.write("\n");
+    stdout.write("\n");
     const initial = renderLines();
-    for (const line of initial) process.stdout.write(`${line}\n`);
+    for (const line of initial) stdout.write(`${line}\n`);
     let lineCount = initial.length;
 
     const redraw = () => {
-      process.stdout.write(`\x1b[${lineCount}A`);
+      stdout.write(`\x1b[${lineCount}A`);
       const lines = renderLines();
-      for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
+      for (const line of lines) stdout.write(`\r\x1b[2K${line}\n`);
       lineCount = lines.length;
     };
 
     // Re-attach stdin to the event loop. A prior prompt cleanup may have
     // unref'd it (sticky), and resume() alone would leave the raw-mode read
     // detached from the loop.
-    if (typeof process.stdin.ref === "function") process.stdin.ref();
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
+    if (typeof stdin.ref === "function") stdin.ref();
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
 
     return new Promise<string[]>((resolve) => {
       const cleanup = () => {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
+        stdin.setRawMode(false);
+        stdin.pause();
         // Symmetric with the ref() at the entry; lets the wizard exit
         // naturally if this is the last prompt.
-        if (typeof process.stdin.unref === "function") process.stdin.unref();
-        process.stdin.removeListener("data", onData);
-        process.removeListener("SIGTERM", onSigterm);
+        if (typeof stdin.unref === "function") stdin.unref();
+        stdin.removeListener("data", onData);
+        processEvents.removeListener("SIGTERM", onSigterm);
       };
 
       const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
-      process.once("SIGTERM", onSigterm);
+      processEvents.once("SIGTERM", onSigterm);
 
       const onData = (key: string) => {
         if (key === "\r" || key === "\n") {
           cleanup();
-          process.stdout.write("\n");
+          stdout.write("\n");
           resolve([...selected]);
         } else if (key === "\x03") {
           makeOnboardCancelExit(sandboxCancelRollback, cleanup)();
@@ -502,7 +527,7 @@ export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDe
         }
       };
 
-      process.stdin.on("data", onData);
+      stdin.on("data", onData);
     });
   }
 

--- a/src/lib/onboard/policy-selection-prompts.ts
+++ b/src/lib/onboard/policy-selection-prompts.ts
@@ -1,0 +1,514 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SandboxCancelRollback } from "./cancel-rollback";
+import type { TierDefinition } from "../policy/tiers";
+
+type PresetWithDescription = { name: string; description?: string };
+type PresetWithAccess = { name: string; access: string };
+
+export interface PolicySelectionPromptDeps {
+  tiers: {
+    listTiers(): TierDefinition[];
+    getTier(name: string): TierDefinition | null;
+  };
+  policyTierEnv: {
+    resolvePolicyTierFromEnv(): string;
+  };
+  isNonInteractive(): boolean;
+  note(message: string): void;
+  prompt(question: string): Promise<string>;
+  selectFromNumberedMenuOrExit<T>(rawChoice: string, defaultIdx: number, options: T[]): T;
+  makeOnboardCancelExit(
+    rollback: Pick<SandboxCancelRollback, "markCancelled">,
+    cleanup: () => void,
+  ): () => void;
+  sandboxCancelRollback: Pick<SandboxCancelRollback, "markCancelled">;
+  useColor: boolean;
+}
+
+export function createPolicySelectionPromptHelpers(deps: PolicySelectionPromptDeps): {
+  selectPolicyTier(): Promise<string>;
+  selectTierPresetsAndAccess(
+    tierName: string,
+    allPresets: PresetWithDescription[],
+    extraSelected?: string[],
+  ): Promise<PresetWithAccess[]>;
+  presetsCheckboxSelector(
+    allPresets: Array<{ name: string; description: string }>,
+    initialSelected: string[],
+  ): Promise<string[]>;
+} {
+  const {
+    tiers,
+    policyTierEnv,
+    isNonInteractive,
+    note,
+    prompt,
+    selectFromNumberedMenuOrExit,
+    makeOnboardCancelExit,
+    sandboxCancelRollback,
+    useColor,
+  } = deps;
+
+  /**
+   * Prompt the user to select a policy tier (restricted / balanced / open).
+   * Uses the same radio-style TUI as presetsCheckboxSelector (single-select).
+   * In non-interactive mode reads NEMOCLAW_POLICY_TIER (default: balanced).
+   * Returns the tier name string.
+   */
+  async function selectPolicyTier(): Promise<string> {
+    const allTiers = tiers.listTiers();
+    const defaultTier = allTiers.find((tier) => tier.name === "balanced") ?? allTiers[1];
+
+    if (!defaultTier) {
+      throw new Error("No policy tiers are configured.");
+    }
+
+    if (isNonInteractive()) {
+      const name = policyTierEnv.resolvePolicyTierFromEnv();
+      note(`  [non-interactive] Policy tier: ${name}`);
+      return name;
+    }
+
+    const RADIO_ON = useColor ? "[\x1b[32m✓\x1b[0m]" : "[✓]";
+    const RADIO_OFF = useColor ? "\x1b[2m[ ]\x1b[0m" : "[ ]";
+
+    // ── Fallback: non-TTY ─────────────────────────────────────────────
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      console.log("");
+      console.log("  Policy tier — controls which network presets are enabled:");
+      allTiers.forEach((tier) => {
+        const marker = tier.name === defaultTier.name ? RADIO_ON : RADIO_OFF;
+        console.log(`    ${marker} ${tier.label}`);
+      });
+      console.log("");
+      const answer = await prompt(
+        `  Select tier [1-${allTiers.length}] (default: ${allTiers.indexOf(defaultTier) + 1} ${defaultTier.name}): `,
+      );
+      const chosen = selectFromNumberedMenuOrExit(
+        answer,
+        allTiers.indexOf(defaultTier) + 1,
+        allTiers,
+      );
+      console.log(`  Tier: ${chosen.label}`);
+      return chosen.name;
+    }
+
+    // ── Raw-mode TUI (radio — single selection) ───────────────────────
+    let cursor = allTiers.indexOf(defaultTier);
+    let selectedIdx = cursor;
+    const n = allTiers.length;
+
+    const G = useColor ? "\x1b[32m" : "";
+    const D = useColor ? "\x1b[2m" : "";
+    const R = useColor ? "\x1b[0m" : "";
+    const HINT = useColor
+      ? `  ${G}↑/↓ j/k${R}  ${D}move${R}    ${G}Space${R}  ${D}select${R}    ${G}Enter${R}  ${D}confirm${R}`
+      : "  ↑/↓ j/k  move    Space  select    Enter  confirm";
+
+    const renderLines = () => {
+      const lines = ["  Policy tier — controls which network presets are enabled:"];
+      allTiers.forEach((tier, index) => {
+        const radio = index === selectedIdx ? RADIO_ON : RADIO_OFF;
+        const arrow = index === cursor ? ">" : " ";
+        lines.push(`   ${arrow} ${radio} ${tier.label}`);
+      });
+      lines.push("");
+      lines.push(HINT);
+      return lines;
+    };
+
+    process.stdout.write("\n");
+    const initial = renderLines();
+    for (const line of initial) process.stdout.write(`${line}\n`);
+    let lineCount = initial.length;
+
+    const redraw = () => {
+      process.stdout.write(`\x1b[${lineCount}A`);
+      const lines = renderLines();
+      for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
+      lineCount = lines.length;
+    };
+
+    // Re-attach stdin to the event loop. A prior prompt cleanup may have
+    // unref'd it (sticky), and resume() alone would leave the raw-mode read
+    // detached from the loop.
+    if (typeof process.stdin.ref === "function") process.stdin.ref();
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+
+    return new Promise<string>((resolve) => {
+      const cleanup = () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        // Symmetric with the ref() at the entry; lets the wizard exit
+        // naturally if this is the last prompt.
+        if (typeof process.stdin.unref === "function") process.stdin.unref();
+        process.stdin.removeListener("data", onData);
+        process.removeListener("SIGTERM", onSigterm);
+      };
+
+      const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
+      process.once("SIGTERM", onSigterm);
+
+      const onData = (key: string) => {
+        if (key === "\r" || key === "\n") {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(allTiers[selectedIdx].name);
+        } else if (key === " ") {
+          selectedIdx = cursor;
+          redraw();
+        } else if (key === "\x03") {
+          makeOnboardCancelExit(sandboxCancelRollback, cleanup)();
+        } else if (key === "\x1b[A" || key === "k") {
+          cursor = (cursor - 1 + n) % n;
+          redraw();
+        } else if (key === "\x1b[B" || key === "j") {
+          cursor = (cursor + 1) % n;
+          redraw();
+        }
+      };
+
+      process.stdin.on("data", onData);
+    });
+  }
+
+  /**
+   * Combined preset selector: shows ALL available presets, pre-checks those in
+   * the chosen tier, and lets the user include/exclude any preset and toggle
+   * per-preset access (read vs read-write).
+   *
+   * Tier presets are listed first (in tier order), then remaining presets
+   * alphabetically. Tier presets are pre-checked; others start unchecked.
+   */
+  async function selectTierPresetsAndAccess(
+    tierName: string,
+    allPresets: PresetWithDescription[],
+    extraSelected: string[] = [],
+  ): Promise<PresetWithAccess[]> {
+    const tierDef = tiers.getTier(tierName);
+    const tierPresetMap: Record<string, string> = {};
+    if (tierDef) {
+      for (const preset of tierDef.presets) {
+        tierPresetMap[preset.name] = preset.access;
+      }
+    }
+
+    // Tier presets first (in tier order), then the rest in their original order.
+    const tierNames = tierDef ? tierDef.presets.map((preset) => preset.name) : [];
+    const tierSet = new Set(tierNames);
+    const ordered: PresetWithDescription[] = [
+      ...tierNames
+        .map((name) => allPresets.find((preset) => preset.name === name))
+        .filter((preset): preset is PresetWithDescription => Boolean(preset)),
+      ...allPresets.filter((preset) => !tierSet.has(preset.name)),
+    ];
+
+    // Initial inclusion: tier presets + any already-applied extras.
+    const included = new Set([
+      ...tierNames,
+      ...extraSelected.filter((name) => ordered.find((preset) => preset.name === name)),
+    ]);
+
+    // Access levels: tier defaults for tier presets, read-write default for others.
+    const accessModes: Record<string, string> = {};
+    for (const preset of ordered) {
+      accessModes[preset.name] = tierPresetMap[preset.name] ?? "read-write";
+    }
+
+    const G = useColor ? "\x1b[32m" : "";
+    const O = useColor ? "\x1b[38;5;208m" : "";
+    const D = useColor ? "\x1b[2m" : "";
+    const R = useColor ? "\x1b[0m" : "";
+    const GREEN_CHECK = useColor ? `[${G}✓${R}]` : "[✓]";
+    const EMPTY_CHECK = useColor ? `${D}[ ]${R}` : "[ ]";
+    const TOGGLE_RW = useColor ? `[${O}rw${R}]` : "[rw]";
+    const TOGGLE_R = useColor ? `${D}[ r]${R}` : "[ r]";
+
+    const label = tierDef ? `  Presets  (${tierDef.label} defaults):` : "  Presets:";
+    const n = ordered.length;
+
+    // ── Non-interactive: return tier defaults silently ─────────────────
+    if (isNonInteractive()) {
+      return ordered
+        .filter((preset) => included.has(preset.name))
+        .map((preset) => ({ name: preset.name, access: accessModes[preset.name] }));
+    }
+
+    // ── Fallback: non-TTY ─────────────────────────────────────────────
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      console.log("");
+      console.log(label);
+      ordered.forEach((preset) => {
+        const isIncluded = included.has(preset.name);
+        const isRw = accessModes[preset.name] === "read-write";
+        const check = isIncluded ? GREEN_CHECK : EMPTY_CHECK;
+        const badge = isIncluded ? (isRw ? "[rw]" : "[ r]") : "    ";
+        console.log(`    ${check} ${badge} ${preset.name}`);
+      });
+      console.log("");
+      const rawInclude = await prompt(
+        "  Include presets (comma-separated names, Enter to keep defaults): ",
+      );
+      if (rawInclude.trim()) {
+        const knownNames = new Set(ordered.map((preset) => preset.name));
+        included.clear();
+        for (const name of rawInclude
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean)) {
+          if (knownNames.has(name)) {
+            included.add(name);
+          } else {
+            console.error(`  Unknown preset name ignored: ${name}`);
+          }
+        }
+      }
+      return ordered
+        .filter((preset) => included.has(preset.name))
+        .map((preset) => ({ name: preset.name, access: accessModes[preset.name] }));
+    }
+
+    // ── Raw-mode TUI ─────────────────────────────────────────────────
+    let cursor = 0;
+
+    const HINT = useColor
+      ? `  ${G}↑/↓ j/k${R}  ${D}move${R}    ${G}Space${R}  ${D}include${R}    ${G}r${R}  ${D}toggle rw${R}    ${G}Enter${R}  ${D}confirm${R}`
+      : "  ↑/↓ j/k  move    Space  include    r  toggle rw    Enter  confirm";
+
+    const renderLines = () => {
+      const lines = [label];
+      ordered.forEach((preset, index) => {
+        const isIncluded = included.has(preset.name);
+        const isRw = accessModes[preset.name] === "read-write";
+        const check = isIncluded ? GREEN_CHECK : EMPTY_CHECK;
+        // badge is 4 visible chars + 1 space; blank when unchecked to keep name aligned
+        const badge = isIncluded ? (isRw ? TOGGLE_RW + " " : TOGGLE_R + " ") : "     ";
+        const arrow = index === cursor ? ">" : " ";
+        lines.push(`   ${arrow} ${check} ${badge}${preset.name}`);
+      });
+      lines.push("");
+      lines.push(HINT);
+      return lines;
+    };
+
+    process.stdout.write("\n");
+    const initial = renderLines();
+    for (const line of initial) process.stdout.write(`${line}\n`);
+    let lineCount = initial.length;
+
+    const redraw = () => {
+      process.stdout.write(`\x1b[${lineCount}A`);
+      const lines = renderLines();
+      for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
+      lineCount = lines.length;
+    };
+
+    // Re-attach stdin to the event loop. A prior prompt cleanup may have
+    // unref'd it (sticky), and resume() alone would leave the raw-mode read
+    // detached from the loop.
+    if (typeof process.stdin.ref === "function") process.stdin.ref();
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+
+    return new Promise<PresetWithAccess[]>((resolve) => {
+      const cleanup = () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        // Symmetric with the ref() at the entry; lets the wizard exit
+        // naturally if this is the last prompt.
+        if (typeof process.stdin.unref === "function") process.stdin.unref();
+        process.stdin.removeListener("data", onData);
+        process.removeListener("SIGTERM", onSigterm);
+      };
+
+      const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
+      process.once("SIGTERM", onSigterm);
+
+      const onData = (key: string) => {
+        if (key === "\r" || key === "\n") {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(
+            ordered
+              .filter((preset) => included.has(preset.name))
+              .map((preset) => ({ name: preset.name, access: accessModes[preset.name] })),
+          );
+        } else if (key === "\x03") {
+          makeOnboardCancelExit(sandboxCancelRollback, cleanup)();
+        } else if (key === "\x1b[A" || key === "k") {
+          cursor = (cursor - 1 + n) % n;
+          redraw();
+        } else if (key === "\x1b[B" || key === "j") {
+          cursor = (cursor + 1) % n;
+          redraw();
+        } else if (key === " ") {
+          const currentPreset = ordered[cursor];
+          if (!currentPreset) return;
+          const name = currentPreset.name;
+          if (included.has(name)) {
+            included.delete(name);
+          } else {
+            included.add(name);
+          }
+          redraw();
+        } else if (key === "r" || key === "R") {
+          const currentPreset = ordered[cursor];
+          if (!currentPreset) return;
+          const name = currentPreset.name;
+          accessModes[name] = accessModes[name] === "read-write" ? "read" : "read-write";
+          redraw();
+        }
+      };
+
+      process.stdin.on("data", onData);
+    });
+  }
+
+  /**
+   * Raw-mode TUI preset selector.
+   * Keys: ↑/↓ or k/j to move, Space to toggle, a to select/unselect all, Enter to confirm.
+   * Falls back to a simple line-based prompt when stdin is not a TTY.
+   */
+  async function presetsCheckboxSelector(
+    allPresets: Array<{ name: string; description: string }>,
+    initialSelected: string[],
+  ): Promise<string[]> {
+    const selected = new Set<string>(initialSelected);
+    const n = allPresets.length;
+
+    // ── Zero-presets guard ────────────────────────────────────────────
+    if (n === 0) {
+      console.log("  No policy presets are available.");
+      return [];
+    }
+
+    const GREEN_CHECK = useColor ? "[\x1b[32m✓\x1b[0m]" : "[✓]";
+
+    // ── Fallback: non-TTY or redirected stdout (piped input) ──────────
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      console.log("");
+      console.log("  Available policy presets:");
+      allPresets.forEach((preset) => {
+        const marker = selected.has(preset.name) ? GREEN_CHECK : "[ ]";
+        console.log(`    ${marker} ${preset.name.padEnd(14)} — ${preset.description}`);
+      });
+      console.log("");
+      const raw = await prompt("  Select presets (comma-separated names, Enter to skip): ");
+      if (!raw.trim()) {
+        console.log("  Skipping policy presets.");
+        return [];
+      }
+      const knownNames = new Set(allPresets.map((preset) => preset.name));
+      const chosen = [];
+      for (const name of raw
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean)) {
+        if (knownNames.has(name)) {
+          chosen.push(name);
+        } else {
+          console.error(`  Unknown preset name ignored: ${name}`);
+        }
+      }
+      return chosen;
+    }
+
+    // ── Raw-mode TUI ─────────────────────────────────────────────────
+    let cursor = 0;
+
+    const G = useColor ? "\x1b[32m" : "";
+    const D = useColor ? "\x1b[2m" : "";
+    const R = useColor ? "\x1b[0m" : "";
+    const HINT = useColor
+      ? `  ${G}↑/↓ j/k${R}  ${D}move${R}    ${G}Space${R}  ${D}toggle${R}    ${G}a${R}  ${D}all/none${R}    ${G}Enter${R}  ${D}confirm${R}`
+      : "  ↑/↓ j/k  move    Space  toggle    a  all/none    Enter  confirm";
+
+    const renderLines = () => {
+      const lines = ["  Available policy presets:"];
+      allPresets.forEach((preset, index) => {
+        const check = selected.has(preset.name) ? GREEN_CHECK : "[ ]";
+        const arrow = index === cursor ? ">" : " ";
+        lines.push(`   ${arrow} ${check} ${preset.name.padEnd(14)} — ${preset.description}`);
+      });
+      lines.push("");
+      lines.push(HINT);
+      return lines;
+    };
+
+    // Initial paint
+    process.stdout.write("\n");
+    const initial = renderLines();
+    for (const line of initial) process.stdout.write(`${line}\n`);
+    let lineCount = initial.length;
+
+    const redraw = () => {
+      process.stdout.write(`\x1b[${lineCount}A`);
+      const lines = renderLines();
+      for (const line of lines) process.stdout.write(`\r\x1b[2K${line}\n`);
+      lineCount = lines.length;
+    };
+
+    // Re-attach stdin to the event loop. A prior prompt cleanup may have
+    // unref'd it (sticky), and resume() alone would leave the raw-mode read
+    // detached from the loop.
+    if (typeof process.stdin.ref === "function") process.stdin.ref();
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+
+    return new Promise<string[]>((resolve) => {
+      const cleanup = () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        // Symmetric with the ref() at the entry; lets the wizard exit
+        // naturally if this is the last prompt.
+        if (typeof process.stdin.unref === "function") process.stdin.unref();
+        process.stdin.removeListener("data", onData);
+        process.removeListener("SIGTERM", onSigterm);
+      };
+
+      const onSigterm = makeOnboardCancelExit(sandboxCancelRollback, cleanup);
+      process.once("SIGTERM", onSigterm);
+
+      const onData = (key: string) => {
+        if (key === "\r" || key === "\n") {
+          cleanup();
+          process.stdout.write("\n");
+          resolve([...selected]);
+        } else if (key === "\x03") {
+          makeOnboardCancelExit(sandboxCancelRollback, cleanup)();
+        } else if (key === "\x1b[A" || key === "k") {
+          cursor = (cursor - 1 + n) % n;
+          redraw();
+        } else if (key === "\x1b[B" || key === "j") {
+          cursor = (cursor + 1) % n;
+          redraw();
+        } else if (key === " ") {
+          const currentPreset = allPresets[cursor];
+          if (!currentPreset) return;
+          const name = currentPreset.name;
+          if (selected.has(name)) selected.delete(name);
+          else selected.add(name);
+          redraw();
+        } else if (key === "a") {
+          if (selected.size === n) selected.clear();
+          else for (const preset of allPresets) selected.add(preset.name);
+          redraw();
+        }
+      };
+
+      process.stdin.on("data", onData);
+    });
+  }
+
+  return {
+    selectPolicyTier,
+    selectTierPresetsAndAccess,
+    presetsCheckboxSelector,
+  };
+}


### PR DESCRIPTION
## Summary
Extracts the policy tier and preset prompt UI helpers from `src/lib/onboard.ts` into a focused onboarding module. The public helper exports from `onboard.ts` remain intact, so this is intended as a behavior-neutral first slice of the onboard.ts slimming stack.

## Related Issue
Refs #3802

## Changes
- Added `src/lib/onboard/policy-selection-prompts.ts` with the policy tier, tier preset/access, and legacy checkbox prompt helpers.
- Replaced the large inline prompt implementations in `src/lib/onboard.ts` with thin compatibility wrappers that inject the existing onboarding dependencies.
- Added focused tests for the extracted prompt helper factory, including non-TTY tier defaults/selections, comma-separated preset allowlists, raw-mode access toggles, Ctrl-C/SIGTERM cleanup, and the empty-tier guard.
- Left policy application logic in `src/lib/onboard/policy-selection.ts` unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Focused local checks passed:
- `npx vitest run src/lib/onboard/policy-selection-prompts.test.ts test/policy-tiers-onboard.test.ts test/presets-checkbox.test.ts test/onboard-preset-diff.test.ts test/onboard-policy-suggestions.test.ts`
- `npm run typecheck:cli`
- `npx @biomejs/biome lint src/lib/onboard.ts src/lib/onboard/policy-selection-prompts.ts src/lib/onboard/policy-selection-prompts.test.ts`
- `npm run build:cli`
- `git diff --check`

Full local hook/test note: `npx prek run --all-files`, `npm test`, regular commit hooks, and regular pre-push hooks all currently fail only in `test/release-latest-tag.test.ts` because this workstation's global git config enables commit signing with `/home/cvillela/.ssh/git-signing-key.pub`, but the matching private key is unavailable. The live FSM stale-artifact test passed after `npm run build:cli`.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
