### PR TITLE
fix(plugin): forward shields sub-argument and surface host-only guidance

### DIFF
--- a/nemoclaw/src/commands/shields-status.test.ts
+++ b/nemoclaw/src/commands/shields-status.test.ts
@@ -176,4 +176,27 @@ describe("commands/shields-status", () => {
     expect(result.text).toContain("Shields down");
     expect(result.text).toContain("host-only");
   });
+
+  it("strips backticks from the echoed unknown argument so inline-code formatting cannot be broken", () => {
+    const result = slashShieldsStatus("`evil`");
+    expect(result.text).toContain("Unknown argument");
+    expect(result.text).not.toContain("`evil`");
+    expect(result.text).toContain("?evil?");
+  });
+
+  it("strips ASCII control characters from the echoed unknown argument", () => {
+    const result = slashShieldsStatus("ab\x01cd\x1Fef");
+    expect(result.text).toContain("Unknown argument");
+    expect(result.text).toContain("ab?cd?ef");
+    expect(result.text).not.toContain("\x01");
+    expect(result.text).not.toContain("\x1F");
+  });
+
+  it("truncates an overly long unknown argument with an ellipsis", () => {
+    const long = "a".repeat(64);
+    const result = slashShieldsStatus(long);
+    expect(result.text).toContain("Unknown argument");
+    expect(result.text).toContain(`${"a".repeat(32)}…`);
+    expect(result.text).not.toContain("a".repeat(33));
+  });
 });

--- a/nemoclaw/src/commands/shields-status.test.ts
+++ b/nemoclaw/src/commands/shields-status.test.ts
@@ -131,4 +131,49 @@ describe("commands/shields-status", () => {
     expect(result.text).toContain("not specified");
     expect(result.text).toContain("permissive");
   });
+
+  it("treats an empty string argument as a read-only status request", () => {
+    const result = slashShieldsStatus("");
+    expect(result.text).toContain("Shields: UP");
+  });
+
+  it("treats whitespace-only argument as a read-only status request", () => {
+    const result = slashShieldsStatus("   ");
+    expect(result.text).toContain("Shields: UP");
+  });
+
+  it("treats explicit `status` argument as a read-only status request", () => {
+    const result = slashShieldsStatus("status");
+    expect(result.text).toContain("Shields: UP");
+  });
+
+  it("returns a host-only guidance message for `down`", () => {
+    const result = slashShieldsStatus("down");
+    expect(result.text).toContain("Shields down");
+    expect(result.text).toContain("host-only");
+    expect(result.text).toContain("nemoclaw <name> shields down");
+    expect(mockedLoadState).not.toHaveBeenCalled();
+  });
+
+  it("returns a host-only guidance message for `up`", () => {
+    const result = slashShieldsStatus("up");
+    expect(result.text).toContain("Shields up");
+    expect(result.text).toContain("host-only");
+    expect(result.text).toContain("nemoclaw <name> shields up");
+    expect(mockedLoadState).not.toHaveBeenCalled();
+  });
+
+  it("returns an `Unknown argument` message for an unrecognised sub-argument", () => {
+    const result = slashShieldsStatus("abcxyz");
+    expect(result.text).toContain("Unknown argument");
+    expect(result.text).toContain("abcxyz");
+    expect(result.text).toContain("/nemoclaw shields [status]");
+    expect(mockedLoadState).not.toHaveBeenCalled();
+  });
+
+  it("trims surrounding whitespace before classifying the sub-argument", () => {
+    const result = slashShieldsStatus("  down  ");
+    expect(result.text).toContain("Shields down");
+    expect(result.text).toContain("host-only");
+  });
 });

--- a/nemoclaw/src/commands/shields-status.ts
+++ b/nemoclaw/src/commands/shields-status.ts
@@ -2,14 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Slash command handler for `/nemoclaw shields status`.
+ * Slash command handler for `/nemoclaw shields`.
  *
- * Read-only — reports the current shields state from inside the sandbox.
+ * Routes the optional sub-argument:
+ *   - empty / `status` — reports the current shields state (read-only).
+ *   - `up` / `down`    — returns host-only guidance pointing at the host CLI.
+ *   - anything else    — returns an `Unknown argument` message with usage.
+ *
  * Shields can only be lowered or raised from the host CLI (security invariant).
  */
 
 import type { PluginCommandResult } from "../index.js";
 import { loadState } from "../blueprint/state.js";
+
+const MAX_ARG_DISPLAY_LEN = 32;
+
+function sanitiseArgForDisplay(raw: string): string {
+  const stripped = raw.replace(/[\x00-\x1F\x7F`]/g, "?");
+  return stripped.length > MAX_ARG_DISPLAY_LEN
+    ? `${stripped.slice(0, MAX_ARG_DISPLAY_LEN)}…`
+    : stripped;
+}
 
 export function slashShieldsStatus(arg?: string): PluginCommandResult {
   const trimmed = (arg ?? "").trim();
@@ -33,7 +46,7 @@ export function slashShieldsStatus(arg?: string): PluginCommandResult {
   if (trimmed !== "" && trimmed !== "status") {
     return {
       text: [
-        `**Unknown argument:** \`${trimmed}\``,
+        `**Unknown argument:** \`${sanitiseArgForDisplay(trimmed)}\``,
         "",
         "Usage: `/nemoclaw shields [status]`",
         "",

--- a/nemoclaw/src/commands/shields-status.ts
+++ b/nemoclaw/src/commands/shields-status.ts
@@ -11,7 +11,37 @@
 import type { PluginCommandResult } from "../index.js";
 import { loadState } from "../blueprint/state.js";
 
-export function slashShieldsStatus(): PluginCommandResult {
+export function slashShieldsStatus(arg?: string): PluginCommandResult {
+  const trimmed = (arg ?? "").trim();
+
+  if (trimmed === "up" || trimmed === "down") {
+    return {
+      text: [
+        `**Shields ${trimmed}** is host-only.`,
+        "",
+        "Sandbox shields can only be raised or lowered from the host CLI:",
+        "",
+        "```",
+        `nemoclaw <name> shields ${trimmed}`,
+        "```",
+        "",
+        "Inside the sandbox, `/nemoclaw shields` is read-only. Use `/nemoclaw shields` or `/nemoclaw shields status` to see the current state.",
+      ].join("\n"),
+    };
+  }
+
+  if (trimmed !== "" && trimmed !== "status") {
+    return {
+      text: [
+        `**Unknown argument:** \`${trimmed}\``,
+        "",
+        "Usage: `/nemoclaw shields [status]`",
+        "",
+        "Shields can only be raised or lowered from the host CLI: `nemoclaw <name> shields up|down`.",
+      ].join("\n"),
+    };
+  }
+
   const state = loadState();
 
   if (!state.shieldsDown) {

--- a/nemoclaw/src/commands/slash.test.ts
+++ b/nemoclaw/src/commands/slash.test.ts
@@ -31,11 +31,13 @@ import {
   describeOnboardEndpoint,
   describeOnboardProvider,
 } from "../onboard/config.js";
+import { slashShieldsStatus } from "./shields-status.js";
 
 const mockedLoadState = vi.mocked(loadState);
 const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 const mockedDescribeOnboardEndpoint = vi.mocked(describeOnboardEndpoint);
 const mockedDescribeOnboardProvider = vi.mocked(describeOnboardProvider);
+const mockedSlashShieldsStatus = vi.mocked(slashShieldsStatus);
 
 function makeCtx(args?: string): PluginCommandContext {
   return {
@@ -116,9 +118,36 @@ describe("commands/slash", () => {
   // -------------------------------------------------------------------------
 
   describe("shields", () => {
-    it("routes to shields status handler", () => {
+    it("routes to shields status handler with no argument when only `shields` is given", () => {
       const result = handleSlashCommand(makeCtx("shields"), makeApi());
       expect(result.text).toContain("Shields");
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledTimes(1);
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledWith(undefined);
+    });
+
+    it("forwards `status` as the sub-argument", () => {
+      handleSlashCommand(makeCtx("shields status"), makeApi());
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledWith("status");
+    });
+
+    it("forwards `down` as the sub-argument", () => {
+      handleSlashCommand(makeCtx("shields down"), makeApi());
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledWith("down");
+    });
+
+    it("forwards `up` as the sub-argument", () => {
+      handleSlashCommand(makeCtx("shields up"), makeApi());
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledWith("up");
+    });
+
+    it("forwards an unknown sub-argument verbatim", () => {
+      handleSlashCommand(makeCtx("shields abcxyz"), makeApi());
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledWith("abcxyz");
+    });
+
+    it("ignores tokens past the second one", () => {
+      handleSlashCommand(makeCtx("shields down   --timeout 5m"), makeApi());
+      expect(mockedSlashShieldsStatus).toHaveBeenCalledWith("down");
     });
   });
 

--- a/nemoclaw/src/commands/slash.ts
+++ b/nemoclaw/src/commands/slash.ts
@@ -31,7 +31,9 @@ export function handleSlashCommand(
   ctx: PluginCommandContext,
   api: OpenClawPluginApi,
 ): PluginCommandResult {
-  const subcommand = ctx.args?.trim().split(/\s+/)[0] ?? "";
+  const tokens = ctx.args?.trim().split(/\s+/).filter(Boolean) ?? [];
+  const subcommand = tokens[0] ?? "";
+  const subArg = tokens[1];
 
   switch (subcommand) {
     case "status":
@@ -41,7 +43,7 @@ export function handleSlashCommand(
     case "onboard":
       return slashOnboard();
     case "shields":
-      return slashShieldsStatus();
+      return slashShieldsStatus(subArg);
     case "config":
       return slashConfigShow();
     default:


### PR DESCRIPTION
## Summary

The `/nemoclaw shields` slash command in the in-sandbox OpenClaw TUI previously discarded any token after `shields`, so `shields`, `shields status`, `shields up`, `shields down`, and `shields <invalid>` all rendered the identical read-only status output with zero feedback. The dispatcher now captures the sub-argument, and the shields handler routes it: `status` / empty → existing read-only status; `up` / `down` → an explicit host-only guidance message pointing at the host CLI; anything else → an `Unknown argument` message with usage. The echoed unknown token is sanitised (control characters and backticks stripped, length capped) so it cannot break the surrounding inline-code formatting.

## Related Issue

Fixes #5117
Closes #3942

## Changes

- `nemoclaw/src/commands/slash.ts` — tokenise `ctx.args` into `[subcommand, subArg, ...]` and forward `subArg` to `slashShieldsStatus`.
- `nemoclaw/src/commands/shields-status.ts` — widen `slashShieldsStatus` to accept an optional sub-argument; add `up` / `down` host-only guidance branch and an `Unknown argument` branch; preserve the existing read-only status path for empty / `status`. Sanitise the echoed unknown token (strip control characters and backticks, truncate to 32 characters with an ellipsis) before embedding it in Markdown. Update the file docstring to cover all routes.
- `nemoclaw/src/commands/slash.test.ts` — assert the dispatcher forwards `status`, `up`, `down`, an unknown token, and ignores tokens past the second.
- `nemoclaw/src/commands/shields-status.test.ts` — cover the new branches: host-only message for `up` / `down`, `Unknown argument` for unrecognised input, read-only status for empty / whitespace / `status`, whitespace trimming, and sanitisation (backticks, control characters, length cap).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] \`npx prek run --all-files\` passes
- [x] \`npm test\` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] \`npm run docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/shields status` accepts an optional argument (`up`, `down`, or `status`) and returns host-only guidance for `up`/`down` or full status reporting for `status`/empty.

* **Bug Fixes / UX**
  * Improved argument trimming and sanitization; ignores extra tokens after the second.

* **Tests**
  * Expanded tests covering argument parsing, unknown-argument messages, sanitization, trimming, and behavior for `up`/`down`/`status`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->