### PR TITLE
refactor(onboard): extract docker gateway runtime helpers

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -51,6 +51,7 @@ const dockerGpuPatch: typeof import("./onboard/docker-gpu-patch") = require("./o
 const dockerGpuLocalInference: typeof import("./onboard/docker-gpu-local-inference") = require("./onboard/docker-gpu-local-inference");
 const dockerGpuSandboxCreate: typeof import("./onboard/docker-gpu-sandbox-create") = require("./onboard/docker-gpu-sandbox-create");
 const dockerDriverGatewayLaunch: typeof import("./onboard/docker-driver-gateway-launch") = require("./onboard/docker-driver-gateway-launch");
+const dockerDriverGatewayRuntime: typeof import("./onboard/docker-driver-gateway-runtime") = require("./onboard/docker-driver-gateway-runtime");
 const {
   findReadableNvidiaCdiSpecFiles,
   parseDockerCdiSpecDirs,
@@ -513,7 +514,6 @@ const { getDockerDriverGatewayEndpoint } = dockerDriverGatewayEnv;
 const dockerDriverGatewayRuntimeMarker: typeof import("./onboard/docker-driver-gateway-runtime-marker") =
   require("./onboard/docker-driver-gateway-runtime-marker");
 const gatewayBinding: typeof import("./onboard/gateway-binding") = require("./onboard/gateway-binding");
-const vmDriverProcess: typeof import("./onboard/vm-driver-process") = require("./onboard/vm-driver-process");
 const preflightUtils: typeof import("./onboard/preflight") = require("./onboard/preflight");
 const clusterImagePatch: typeof import("./cluster-image-patch") = require("./cluster-image-patch");
 const { assessHost, checkPortAvailable, ensureSwap, getMemoryInfo, planHostRemediation } =
@@ -604,6 +604,32 @@ const DIM = USE_COLOR ? "\x1b[2m" : "";
 const RESET = USE_COLOR ? "\x1b[0m" : "";
 let OPENSHELL_BIN: string | null = null;
 const GATEWAY_NAME = gatewayBinding.resolveGatewayName(GATEWAY_PORT);
+const {
+  clearDockerDriverGatewayRuntimeFiles,
+  getDockerDriverGatewayEnv,
+  getDockerDriverGatewayPid,
+  getDockerDriverGatewayPortListenerPid,
+  getDockerDriverGatewayRuntimeDrift,
+  getDockerDriverGatewayRuntimeDriftFromSnapshot,
+  getDockerDriverGatewayStateDir,
+  isDockerDriverGatewayPortListener,
+  isDockerDriverGatewayProcess,
+  isDockerDriverGatewayProcessAlive,
+  isPidAlive,
+  rememberDockerDriverGatewayPid,
+  resolveOpenShellGatewayBinary,
+  resolveOpenShellSandboxBinary,
+  shouldRequireDockerDriverEnv,
+} = dockerDriverGatewayRuntime.createDockerDriverGatewayRuntimeHelpers({
+  gatewayPort: GATEWAY_PORT,
+  getCachedOpenshellBinary: () => OPENSHELL_BIN,
+  getBlueprintMaxOpenshellVersion,
+  getInstalledOpenshellVersion,
+  isOpenshellDevVersion,
+  runCapture,
+  shouldUseOpenshellDevChannel,
+  supportedOpenshellFallbackVersion: SUPPORTED_OPENSHELL_FALLBACK_VERSION,
+});
 
 import type { JsonObject as LooseObject } from "./core/json-types";
 
@@ -1395,321 +1421,6 @@ const { gatewayClusterHealthcheckPassed, repairGatewayBootstrapSecrets } =
     run,
     runCapture,
   });
-
-function getDockerDriverGatewayStateDir(): string {
-  const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR;
-  if (configured && configured.trim()) return path.resolve(configured.trim());
-  const dir = gatewayBinding.resolveGatewayStateDirName(GATEWAY_PORT);
-  return path.join(os.homedir(), ".local", "state", "nemoclaw", dir);
-}
-
-function getDockerDriverGatewayPidFile(): string {
-  return path.join(getDockerDriverGatewayStateDir(), "openshell-gateway.pid");
-}
-
-function resolveSiblingBinary(binaryName: string): string | null {
-  const openshellBin = OPENSHELL_BIN || resolveOpenshell();
-  if (typeof openshellBin !== "string" || openshellBin.length === 0) return null;
-  const sibling = path.join(path.dirname(openshellBin), binaryName);
-  if (fs.existsSync(sibling)) return sibling;
-  return null;
-}
-
-function resolveOpenShellGatewayBinary(): string | null {
-  const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
-  if (configured && configured.trim()) return path.resolve(configured.trim());
-  const sibling = resolveSiblingBinary("openshell-gateway");
-  if (sibling) return sibling;
-  for (const candidate of [
-    path.join(os.homedir(), ".local", "bin", "openshell-gateway"),
-    "/usr/local/bin/openshell-gateway",
-    "/usr/bin/openshell-gateway",
-  ]) {
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-function resolveOpenShellSandboxBinary(): string | null {
-  const configured = process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
-  if (configured && configured.trim()) return path.resolve(configured.trim());
-  const sibling = resolveSiblingBinary("openshell-sandbox");
-  if (sibling) return sibling;
-  for (const candidate of [
-    path.join(os.homedir(), ".local", "bin", "openshell-sandbox"),
-    "/usr/local/bin/openshell-sandbox",
-    "/usr/bin/openshell-sandbox",
-  ]) {
-    if (fs.existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-function getOpenShellDockerSupervisorImage(versionOutput: string | null = null): string {
-  if (process.env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE) {
-    return process.env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE;
-  }
-  const installedVersion = getInstalledOpenshellVersion(versionOutput);
-  if (shouldUseOpenshellDevChannel() || isOpenshellDevVersion(versionOutput)) {
-    return "ghcr.io/nvidia/openshell/supervisor:dev";
-  }
-  const supportedVersion =
-    installedVersion ?? getBlueprintMaxOpenshellVersion() ?? SUPPORTED_OPENSHELL_FALLBACK_VERSION;
-  return `ghcr.io/nvidia/openshell/supervisor:${supportedVersion}`;
-}
-
-function getDockerDriverGatewayEnv(
-  versionOutput: string | null = null,
-  platform: NodeJS.Platform = process.platform,
-): Record<string, string> {
-  return dockerDriverGatewayEnv.buildDockerDriverGatewayEnv({
-    platform,
-    stateDir: getDockerDriverGatewayStateDir(),
-    dockerNetworkName: process.env.OPENSHELL_DOCKER_NETWORK_NAME || "openshell-docker",
-    getDockerSupervisorImage: () => getOpenShellDockerSupervisorImage(versionOutput),
-    resolveSandboxBin: resolveOpenShellSandboxBinary,
-  });
-}
-
-function isPidAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return isErrnoException(error) && error.code === "EPERM";
-  }
-}
-
-function getDockerDriverGatewayPid(): number | null {
-  try {
-    const raw = fs.readFileSync(getDockerDriverGatewayPidFile(), "utf-8").trim();
-    const pid = Number.parseInt(raw, 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
-  } catch {
-    return null;
-  }
-}
-
-function readProcessEnv(pid: number): Record<string, string> | null {
-  const procEnvPath = `/proc/${pid}/environ`;
-  const env: Record<string, string> = {};
-  try {
-    if (!fs.existsSync(procEnvPath)) return null;
-    for (const entry of fs.readFileSync(procEnvPath, "utf-8").split("\0")) {
-      if (!entry) continue;
-      const idx = entry.indexOf("=");
-      if (idx <= 0) continue;
-      env[entry.slice(0, idx)] = entry.slice(idx + 1);
-    }
-  } catch {
-    return null;
-  }
-  return env;
-}
-
-function hasDockerDriverGatewayEnv(pid: number): boolean {
-  const env = readProcessEnv(pid);
-  if (!env) return false;
-  return (
-    env.OPENSHELL_DRIVERS === "docker" ||
-    Boolean(env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE) ||
-    env.OPENSHELL_GRPC_ENDPOINT === getDockerDriverGatewayEndpoint()
-  );
-}
-
-function readProcessExe(pid: number): string | null {
-  try {
-    const procExePath = `/proc/${pid}/exe`;
-    if (!fs.existsSync(procExePath)) return null;
-    return fs.readlinkSync(procExePath);
-  } catch {
-    return null;
-  }
-}
-
-function normalizeGatewayExecutablePath(value: string | null | undefined): string | null {
-  if (!value) return null;
-  const withoutDeletedSuffix = value.replace(/ \(deleted\)$/, "");
-  try {
-    return fs.realpathSync.native(withoutDeletedSuffix);
-  } catch {
-    return path.resolve(withoutDeletedSuffix);
-  }
-}
-
-type DockerDriverGatewayRuntimeDrift = { reason: string };
-
-function shouldRequireDockerDriverEnv(platform: NodeJS.Platform = process.platform): boolean {
-  return platform === "linux";
-}
-
-function getDockerDriverGatewayRuntimeDriftFromSnapshot({
-  processEnv,
-  processExe,
-  desiredEnv,
-  gatewayBin,
-}: {
-  processEnv: Record<string, string> | null;
-  processExe: string | null;
-  desiredEnv: Record<string, string>;
-  gatewayBin?: string | null;
-}): DockerDriverGatewayRuntimeDrift | null {
-  if (!processEnv) {
-    return { reason: "could not verify process environment" };
-  }
-  for (const key of dockerDriverGatewayEnv.DOCKER_DRIVER_GATEWAY_RUNTIME_ENV_KEYS) {
-    const desired = desiredEnv[key];
-    if (typeof desired !== "string") continue;
-    const actual = processEnv[key];
-    if (actual !== desired) {
-      return { reason: `${key}=${actual || "<unset>"} (expected ${desired})` };
-    }
-  }
-
-  if (processExe === null) {
-    return { reason: "could not verify process executable" };
-  }
-  if (processExe.endsWith(" (deleted)")) {
-    return { reason: "gateway executable was replaced on disk" };
-  }
-  const expectedExe = normalizeGatewayExecutablePath(gatewayBin);
-  const actualExe = normalizeGatewayExecutablePath(processExe);
-  if (expectedExe && actualExe && actualExe !== expectedExe) {
-    return { reason: `executable=${actualExe} (expected ${expectedExe})` };
-  }
-  return null;
-}
-
-function getDockerDriverGatewayRuntimeDrift(
-  pid: number,
-  desiredEnv: Record<string, string>,
-  gatewayBin?: string | null,
-  platform: NodeJS.Platform = process.platform,
-): DockerDriverGatewayRuntimeDrift | null {
-  if (platform === "darwin" && desiredEnv.OPENSHELL_DRIVERS === "docker") {
-    const markerDrift =
-      dockerDriverGatewayRuntimeMarker.getDockerDriverGatewayRuntimeMarkerDriftForStateDir(
-        getDockerDriverGatewayStateDir(),
-        {
-          pid,
-          desiredEnv,
-          endpoint: getDockerDriverGatewayEndpoint(),
-          gatewayBin,
-          dockerHost: process.env.DOCKER_HOST || null,
-          platform,
-          arch: process.arch,
-        },
-      );
-    if (markerDrift) return markerDrift;
-    if (
-      vmDriverProcess.hasOpenShellVmDriverChildProcess(pid, (args) =>
-        runCapture([...args], { ignoreError: true }),
-      )
-    ) {
-      return { reason: "VM driver child process is still attached to the gateway" };
-    }
-  }
-  if (!shouldRequireDockerDriverEnv(platform)) return null;
-  return getDockerDriverGatewayRuntimeDriftFromSnapshot({
-    processEnv: readProcessEnv(pid),
-    processExe: readProcessExe(pid),
-    desiredEnv,
-    gatewayBin,
-  });
-}
-
-function isDockerDriverGatewayProcess(
-  pid: number,
-  gatewayBin?: string | null,
-  opts: { requireDockerDriverEnv?: boolean } = {},
-): boolean {
-  const procCmdlinePath = `/proc/${pid}/cmdline`;
-  let identity = "";
-  try {
-    if (fs.existsSync(procCmdlinePath)) {
-      identity = fs.readFileSync(procCmdlinePath, "utf-8").replace(/\0/g, " ").trim();
-    }
-  } catch {
-    identity = "";
-  }
-  if (!identity) {
-    identity = captureProcessArgs(pid);
-  }
-  if (!identity) return false;
-  const matchesGatewayBinary =
-    identity.includes("openshell-gateway") ||
-    (typeof gatewayBin === "string" && gatewayBin.length > 0 && identity.includes(gatewayBin));
-  if (!matchesGatewayBinary) return false;
-  if (opts.requireDockerDriverEnv && !hasDockerDriverGatewayEnv(pid)) return false;
-  return true;
-}
-
-function isDockerDriverGatewayProcessAlive(): boolean {
-  const pid = getDockerDriverGatewayPid();
-  if (pid === null || !isPidAlive(pid)) return false;
-  if (
-    !isDockerDriverGatewayProcess(pid, resolveOpenShellGatewayBinary(), {
-      requireDockerDriverEnv: shouldRequireDockerDriverEnv(),
-    })
-  ) {
-    clearDockerDriverGatewayRuntimeFiles();
-    return false;
-  }
-  return true;
-}
-
-function clearDockerDriverGatewayRuntimeFiles(): void {
-  fs.rmSync(getDockerDriverGatewayPidFile(), { force: true });
-  dockerDriverGatewayRuntimeMarker.clearDockerDriverGatewayRuntimeMarker(
-    getDockerDriverGatewayStateDir(),
-  );
-}
-
-function rememberDockerDriverGatewayPid(pid: number): void {
-  dockerDriverGatewayRuntimeMarker.writeDockerDriverGatewayPidFile(
-    getDockerDriverGatewayPidFile(),
-    pid,
-  );
-}
-
-function getDockerDriverGatewayPortListenerPid(
-  portCheck: import("./onboard/preflight").PortProbeResult,
-  opts: {
-    platform?: NodeJS.Platform;
-    arch?: NodeJS.Architecture;
-    gatewayBin?: string | null;
-    isPidAliveFn?: (pid: number) => boolean;
-    isDockerDriverGatewayProcessFn?: (pid: number, gatewayBin?: string | null) => boolean;
-  } = {},
-): number | null {
-  if (portCheck.ok) return null;
-  if (
-    !isLinuxDockerDriverGatewayEnabled(opts.platform ?? process.platform, opts.arch ?? process.arch)
-  )
-    return null;
-  const pid = Number(portCheck.pid);
-  if (!Number.isInteger(pid) || pid <= 0) return null;
-  const proc = String(portCheck.process || "").toLowerCase();
-  if (!proc.startsWith("openshell")) return null;
-  const alive = opts.isPidAliveFn ?? isPidAlive;
-  if (!alive(pid)) return null;
-  const isGateway =
-    opts.isDockerDriverGatewayProcessFn ??
-    ((candidatePid: number, gatewayBin?: string | null) =>
-      isDockerDriverGatewayProcess(candidatePid, gatewayBin, {
-        requireDockerDriverEnv: shouldRequireDockerDriverEnv(opts.platform ?? process.platform),
-      }));
-  if (!isGateway(pid, opts.gatewayBin)) return null;
-  return pid;
-}
-
-function isDockerDriverGatewayPortListener(
-  portCheck: import("./onboard/preflight").PortProbeResult,
-  opts: Parameters<typeof getDockerDriverGatewayPortListenerPid>[1] = {},
-): boolean {
-  return getDockerDriverGatewayPortListenerPid(portCheck, opts) !== null;
-}
 
 function registerDockerDriverGatewayEndpoint(): boolean {
   const selectExisting = runQuietOpenshell(["gateway", "select", GATEWAY_NAME]);

--- a/src/lib/onboard/docker-driver-gateway-runtime.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-runtime.test.ts
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createDockerDriverGatewayRuntimeHelpers,
+  type DockerDriverGatewayRuntimeDeps,
+} from "./docker-driver-gateway-runtime";
+import * as dockerDriverGatewayEnv from "./docker-driver-gateway-env";
+import {
+  getDockerDriverGatewayRuntimeMarkerPath,
+  writeDockerDriverGatewayRuntimeMarkerForStateDir,
+} from "./docker-driver-gateway-runtime-marker";
+
+function parseVersion(versionOutput: string | null | undefined): string | null {
+  return String(versionOutput ?? "").match(/\d+\.\d+\.\d+/)?.[0] ?? null;
+}
+
+function makeHelpers(overrides: Partial<DockerDriverGatewayRuntimeDeps> = {}): {
+  helpers: ReturnType<typeof createDockerDriverGatewayRuntimeHelpers>;
+  runCapture: ReturnType<
+    typeof vi.fn<(args: string[], opts?: { ignoreError?: boolean }) => string>
+  >;
+} {
+  const runCapture = vi.fn(() => "");
+  const deps: DockerDriverGatewayRuntimeDeps = {
+    gatewayPort: 18080,
+    getCachedOpenshellBinary: () => null,
+    getBlueprintMaxOpenshellVersion: () => null,
+    getInstalledOpenshellVersion: parseVersion,
+    isOpenshellDevVersion: () => false,
+    loadDockerDriverGatewayEnv: () => dockerDriverGatewayEnv,
+    runCapture,
+    shouldUseOpenshellDevChannel: () => false,
+    supportedOpenshellFallbackVersion: "0.0.44",
+    ...overrides,
+  };
+  return {
+    helpers: createDockerDriverGatewayRuntimeHelpers(deps),
+    runCapture: deps.runCapture as typeof runCapture,
+  };
+}
+
+function withEnv<T>(values: Record<string, string | undefined>, callback: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(values)) {
+    previous.set(key, process.env[key]);
+    if (values[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = values[key];
+    }
+  }
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+describe("docker-driver gateway runtime helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses env-configured state, gateway, sandbox, network, and fallback version values", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-runtime-"));
+    const stateDir = path.join(tempDir, "state");
+    const gatewayBin = path.join("relative-tools", "openshell-gateway");
+    const sandboxBin = path.join("relative-tools", "openshell-sandbox");
+    try {
+      withEnv(
+        {
+          NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR: stateDir,
+          NEMOCLAW_OPENSHELL_GATEWAY_BIN: gatewayBin,
+          NEMOCLAW_OPENSHELL_SANDBOX_BIN: sandboxBin,
+          OPENSHELL_DOCKER_NETWORK_NAME: "custom-openshell-docker",
+        },
+        () => {
+          const { helpers } = makeHelpers({
+            supportedOpenshellFallbackVersion: "0.0.99",
+          });
+
+          expect(helpers.getDockerDriverGatewayStateDir()).toBe(path.resolve(stateDir));
+          expect(helpers.resolveOpenShellGatewayBinary()).toBe(path.resolve(gatewayBin));
+          expect(helpers.resolveOpenShellSandboxBinary()).toBe(path.resolve(sandboxBin));
+
+          const env = helpers.getDockerDriverGatewayEnv(null, "linux");
+          expect(env.OPENSHELL_DOCKER_NETWORK_NAME).toBe("custom-openshell-docker");
+          expect(env.OPENSHELL_DOCKER_SUPERVISOR_BIN).toBe(path.resolve(sandboxBin));
+          expect(env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE).toBe(
+            "ghcr.io/nvidia/openshell/supervisor:0.0.99",
+          );
+          expect(env.OPENSHELL_DB_URL).toBe(
+            `sqlite:${path.join(path.resolve(stateDir), "openshell.db")}`,
+          );
+        },
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears custom state-dir PID and marker files when the recorded PID is not the gateway", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-runtime-"));
+    const pid = 9_876_543;
+    try {
+      withEnv({ NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR: stateDir }, () => {
+        const { helpers, runCapture } = makeHelpers({
+          runCapture: vi.fn(() => "node /tmp/not-openshell-gateway\n"),
+        });
+        const desiredEnv = { OPENSHELL_DRIVERS: "docker" };
+        helpers.rememberDockerDriverGatewayPid(pid);
+        writeDockerDriverGatewayRuntimeMarkerForStateDir(stateDir, {
+          pid,
+          desiredEnv,
+          endpoint: "http://127.0.0.1:8080",
+          platform: "linux",
+          arch: process.arch,
+        });
+        const pidFile = path.join(stateDir, "openshell-gateway.pid");
+        const markerPath = getDockerDriverGatewayRuntimeMarkerPath(stateDir);
+        expect(fs.existsSync(pidFile)).toBe(true);
+        expect(fs.existsSync(markerPath)).toBe(true);
+
+        const originalExistsSync = fs.existsSync;
+        vi.spyOn(process, "kill").mockImplementation((() => true) as typeof process.kill);
+        vi.spyOn(fs, "existsSync").mockImplementation(((candidate) => {
+          if (String(candidate) === `/proc/${pid}/cmdline`) return false;
+          return originalExistsSync(candidate);
+        }) as typeof fs.existsSync);
+
+        expect(helpers.isDockerDriverGatewayProcessAlive()).toBe(false);
+
+        expect(runCapture).toHaveBeenCalledWith(["ps", "-p", String(pid), "-o", "args="], {
+          ignoreError: true,
+        });
+        expect(fs.existsSync(pidFile)).toBe(false);
+        expect(fs.existsSync(markerPath)).toBe(false);
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports macOS VM-driver child drift after the runtime marker matches", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-runtime-"));
+    const pid = 98_765;
+    const gatewayBin = path.join(stateDir, "openshell-gateway");
+    try {
+      withEnv(
+        {
+          DOCKER_HOST: "unix:///tmp/docker.sock",
+          NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR: stateDir,
+        },
+        () => {
+          const { helpers, runCapture } = makeHelpers({
+            runCapture: vi.fn((args) =>
+              args.join(" ") === "ps -axo pid=,ppid=,command="
+                ? [
+                    `${pid} 1 ${gatewayBin}`,
+                    `${pid + 1} ${pid} /usr/local/bin/openshell-driver-vm --bind-socket /tmp/vm.sock`,
+                  ].join("\n")
+                : "",
+            ),
+          });
+          const desiredEnv = helpers.getDockerDriverGatewayEnv(null, "darwin");
+          writeDockerDriverGatewayRuntimeMarkerForStateDir(stateDir, {
+            pid,
+            desiredEnv,
+            endpoint: desiredEnv.OPENSHELL_GRPC_ENDPOINT,
+            gatewayBin,
+            dockerHost: process.env.DOCKER_HOST,
+            platform: "darwin",
+            arch: process.arch,
+          });
+
+          expect(
+            helpers.getDockerDriverGatewayRuntimeDrift(pid, desiredEnv, gatewayBin, "darwin")
+              ?.reason,
+          ).toContain("VM driver child process is still attached");
+          expect(runCapture).toHaveBeenCalledWith(["ps", "-axo", "pid=,ppid=,command="], {
+            ignoreError: true,
+          });
+        },
+      );
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an openshell port listener when the injected gateway identity check fails", () => {
+    const { helpers } = makeHelpers();
+    const isDockerDriverGatewayProcessFn = vi.fn(() => false);
+
+    expect(
+      helpers.getDockerDriverGatewayPortListenerPid(
+        { ok: false, process: "openshell-gateway", pid: 1234 },
+        {
+          platform: "linux",
+          gatewayBin: "/opt/openshell/openshell-gateway",
+          isPidAliveFn: () => true,
+          isDockerDriverGatewayProcessFn,
+        },
+      ),
+    ).toBeNull();
+
+    expect(isDockerDriverGatewayProcessFn).toHaveBeenCalledWith(
+      1234,
+      "/opt/openshell/openshell-gateway",
+    );
+  });
+});

--- a/src/lib/onboard/docker-driver-gateway-runtime.ts
+++ b/src/lib/onboard/docker-driver-gateway-runtime.ts
@@ -16,6 +16,7 @@ import * as vmDriverProcess from "./vm-driver-process";
 export type DockerDriverGatewayRuntimeDrift = { reason: string };
 
 type RunCapture = (args: string[], opts?: { ignoreError?: boolean }) => string;
+type DockerDriverGatewayEnvModule = typeof import("./docker-driver-gateway-env");
 
 export interface DockerDriverGatewayRuntimeDeps {
   gatewayPort: number;
@@ -23,6 +24,7 @@ export interface DockerDriverGatewayRuntimeDeps {
   getBlueprintMaxOpenshellVersion(): string | null;
   getInstalledOpenshellVersion(versionOutput?: string | null): string | null;
   isOpenshellDevVersion(versionOutput: string | null | undefined): boolean;
+  loadDockerDriverGatewayEnv?(): DockerDriverGatewayEnvModule;
   runCapture: RunCapture;
   shouldUseOpenshellDevChannel(): boolean;
   supportedOpenshellFallbackVersion: string;
@@ -79,8 +81,8 @@ export function createDockerDriverGatewayRuntimeHelpers(deps: DockerDriverGatewa
   resolveOpenShellSandboxBinary(): string | null;
   shouldRequireDockerDriverEnv(platform?: NodeJS.Platform): boolean;
 } {
-  const dockerDriverGatewayEnv: typeof import("./docker-driver-gateway-env") =
-    require("./docker-driver-gateway-env");
+  const dockerDriverGatewayEnv: DockerDriverGatewayEnvModule =
+    deps.loadDockerDriverGatewayEnv?.() ?? require("./docker-driver-gateway-env");
 
   function getDockerDriverGatewayStateDir(): string {
     const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR;

--- a/src/lib/onboard/docker-driver-gateway-runtime.ts
+++ b/src/lib/onboard/docker-driver-gateway-runtime.ts
@@ -1,0 +1,429 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveOpenshell } from "../adapters/openshell/resolve";
+import { isErrnoException } from "../core/errno";
+import * as dockerDriverGatewayRuntimeMarker from "./docker-driver-gateway-runtime-marker";
+import { isLinuxDockerDriverGatewayEnabled } from "./docker-driver-platform";
+import * as gatewayBinding from "./gateway-binding";
+import type { PortProbeResult } from "./preflight";
+import * as vmDriverProcess from "./vm-driver-process";
+
+export type DockerDriverGatewayRuntimeDrift = { reason: string };
+
+type RunCapture = (args: string[], opts?: { ignoreError?: boolean }) => string;
+
+export interface DockerDriverGatewayRuntimeDeps {
+  gatewayPort: number;
+  getCachedOpenshellBinary(): string | null;
+  getBlueprintMaxOpenshellVersion(): string | null;
+  getInstalledOpenshellVersion(versionOutput?: string | null): string | null;
+  isOpenshellDevVersion(versionOutput: string | null | undefined): boolean;
+  runCapture: RunCapture;
+  shouldUseOpenshellDevChannel(): boolean;
+  supportedOpenshellFallbackVersion: string;
+}
+
+export function createDockerDriverGatewayRuntimeHelpers(deps: DockerDriverGatewayRuntimeDeps): {
+  clearDockerDriverGatewayRuntimeFiles(): void;
+  getDockerDriverGatewayEnv(
+    versionOutput?: string | null,
+    platform?: NodeJS.Platform,
+  ): Record<string, string>;
+  getDockerDriverGatewayPid(): number | null;
+  getDockerDriverGatewayPidFile(): string;
+  getDockerDriverGatewayPortListenerPid(
+    portCheck: PortProbeResult,
+    opts?: {
+      platform?: NodeJS.Platform;
+      arch?: NodeJS.Architecture;
+      gatewayBin?: string | null;
+      isPidAliveFn?: (pid: number) => boolean;
+      isDockerDriverGatewayProcessFn?: (pid: number, gatewayBin?: string | null) => boolean;
+    },
+  ): number | null;
+  getDockerDriverGatewayRuntimeDrift(
+    pid: number,
+    desiredEnv: Record<string, string>,
+    gatewayBin?: string | null,
+    platform?: NodeJS.Platform,
+  ): DockerDriverGatewayRuntimeDrift | null;
+  getDockerDriverGatewayRuntimeDriftFromSnapshot(snapshot: {
+    processEnv: Record<string, string> | null;
+    processExe: string | null;
+    desiredEnv: Record<string, string>;
+    gatewayBin?: string | null;
+  }): DockerDriverGatewayRuntimeDrift | null;
+  getDockerDriverGatewayStateDir(): string;
+  isDockerDriverGatewayPortListener(
+    portCheck: PortProbeResult,
+    opts?: Parameters<
+      ReturnType<
+        typeof createDockerDriverGatewayRuntimeHelpers
+      >["getDockerDriverGatewayPortListenerPid"]
+    >[1],
+  ): boolean;
+  isDockerDriverGatewayProcess(
+    pid: number,
+    gatewayBin?: string | null,
+    opts?: { requireDockerDriverEnv?: boolean },
+  ): boolean;
+  isDockerDriverGatewayProcessAlive(): boolean;
+  isPidAlive(pid: number): boolean;
+  rememberDockerDriverGatewayPid(pid: number): void;
+  resolveOpenShellGatewayBinary(): string | null;
+  resolveOpenShellSandboxBinary(): string | null;
+  shouldRequireDockerDriverEnv(platform?: NodeJS.Platform): boolean;
+} {
+  const dockerDriverGatewayEnv: typeof import("./docker-driver-gateway-env") =
+    require("./docker-driver-gateway-env");
+
+  function getDockerDriverGatewayStateDir(): string {
+    const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR;
+    if (configured && configured.trim()) return path.resolve(configured.trim());
+    const dir = gatewayBinding.resolveGatewayStateDirName(deps.gatewayPort);
+    return path.join(os.homedir(), ".local", "state", "nemoclaw", dir);
+  }
+
+  function getDockerDriverGatewayPidFile(): string {
+    return path.join(getDockerDriverGatewayStateDir(), "openshell-gateway.pid");
+  }
+
+  function resolveSiblingBinary(binaryName: string): string | null {
+    const openshellBin = deps.getCachedOpenshellBinary() || resolveOpenshell();
+    if (typeof openshellBin !== "string" || openshellBin.length === 0) return null;
+    const sibling = path.join(path.dirname(openshellBin), binaryName);
+    if (fs.existsSync(sibling)) return sibling;
+    return null;
+  }
+
+  function resolveOpenShellGatewayBinary(): string | null {
+    const configured = process.env.NEMOCLAW_OPENSHELL_GATEWAY_BIN;
+    if (configured && configured.trim()) return path.resolve(configured.trim());
+    const sibling = resolveSiblingBinary("openshell-gateway");
+    if (sibling) return sibling;
+    for (const candidate of [
+      path.join(os.homedir(), ".local", "bin", "openshell-gateway"),
+      "/usr/local/bin/openshell-gateway",
+      "/usr/bin/openshell-gateway",
+    ]) {
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    return null;
+  }
+
+  function resolveOpenShellSandboxBinary(): string | null {
+    const configured = process.env.NEMOCLAW_OPENSHELL_SANDBOX_BIN;
+    if (configured && configured.trim()) return path.resolve(configured.trim());
+    const sibling = resolveSiblingBinary("openshell-sandbox");
+    if (sibling) return sibling;
+    for (const candidate of [
+      path.join(os.homedir(), ".local", "bin", "openshell-sandbox"),
+      "/usr/local/bin/openshell-sandbox",
+      "/usr/bin/openshell-sandbox",
+    ]) {
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    return null;
+  }
+
+  function getOpenShellDockerSupervisorImage(versionOutput: string | null = null): string {
+    if (process.env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE) {
+      return process.env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE;
+    }
+    const installedVersion = deps.getInstalledOpenshellVersion(versionOutput);
+    if (deps.shouldUseOpenshellDevChannel() || deps.isOpenshellDevVersion(versionOutput)) {
+      return "ghcr.io/nvidia/openshell/supervisor:dev";
+    }
+    const supportedVersion =
+      installedVersion ??
+      deps.getBlueprintMaxOpenshellVersion() ??
+      deps.supportedOpenshellFallbackVersion;
+    return `ghcr.io/nvidia/openshell/supervisor:${supportedVersion}`;
+  }
+
+  function getDockerDriverGatewayEnv(
+    versionOutput: string | null = null,
+    platform: NodeJS.Platform = process.platform,
+  ): Record<string, string> {
+    return dockerDriverGatewayEnv.buildDockerDriverGatewayEnv({
+      platform,
+      stateDir: getDockerDriverGatewayStateDir(),
+      dockerNetworkName: process.env.OPENSHELL_DOCKER_NETWORK_NAME || "openshell-docker",
+      getDockerSupervisorImage: () => getOpenShellDockerSupervisorImage(versionOutput),
+      resolveSandboxBin: resolveOpenShellSandboxBinary,
+    });
+  }
+
+  function isPidAlive(pid: number): boolean {
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return isErrnoException(error) && error.code === "EPERM";
+    }
+  }
+
+  function getDockerDriverGatewayPid(): number | null {
+    try {
+      const raw = fs.readFileSync(getDockerDriverGatewayPidFile(), "utf-8").trim();
+      const pid = Number.parseInt(raw, 10);
+      return Number.isInteger(pid) && pid > 0 ? pid : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function readProcessEnv(pid: number): Record<string, string> | null {
+    const procEnvPath = `/proc/${pid}/environ`;
+    const env: Record<string, string> = {};
+    try {
+      if (!fs.existsSync(procEnvPath)) return null;
+      for (const entry of fs.readFileSync(procEnvPath, "utf-8").split("\0")) {
+        if (!entry) continue;
+        const idx = entry.indexOf("=");
+        if (idx <= 0) continue;
+        env[entry.slice(0, idx)] = entry.slice(idx + 1);
+      }
+    } catch {
+      return null;
+    }
+    return env;
+  }
+
+  function hasDockerDriverGatewayEnv(pid: number): boolean {
+    const env = readProcessEnv(pid);
+    if (!env) return false;
+    return (
+      env.OPENSHELL_DRIVERS === "docker" ||
+      Boolean(env.OPENSHELL_DOCKER_SUPERVISOR_IMAGE) ||
+      env.OPENSHELL_GRPC_ENDPOINT === dockerDriverGatewayEnv.getDockerDriverGatewayEndpoint()
+    );
+  }
+
+  function readProcessExe(pid: number): string | null {
+    try {
+      const procExePath = `/proc/${pid}/exe`;
+      if (!fs.existsSync(procExePath)) return null;
+      return fs.readlinkSync(procExePath);
+    } catch {
+      return null;
+    }
+  }
+
+  function normalizeGatewayExecutablePath(value: string | null | undefined): string | null {
+    if (!value) return null;
+    const withoutDeletedSuffix = value.replace(/ \(deleted\)$/, "");
+    try {
+      return fs.realpathSync.native(withoutDeletedSuffix);
+    } catch {
+      return path.resolve(withoutDeletedSuffix);
+    }
+  }
+
+  function shouldRequireDockerDriverEnv(platform: NodeJS.Platform = process.platform): boolean {
+    return platform === "linux";
+  }
+
+  function getDockerDriverGatewayRuntimeDriftFromSnapshot({
+    processEnv,
+    processExe,
+    desiredEnv,
+    gatewayBin,
+  }: {
+    processEnv: Record<string, string> | null;
+    processExe: string | null;
+    desiredEnv: Record<string, string>;
+    gatewayBin?: string | null;
+  }): DockerDriverGatewayRuntimeDrift | null {
+    if (!processEnv) {
+      return { reason: "could not verify process environment" };
+    }
+    for (const key of dockerDriverGatewayEnv.DOCKER_DRIVER_GATEWAY_RUNTIME_ENV_KEYS) {
+      const desired = desiredEnv[key];
+      if (typeof desired !== "string") continue;
+      const actual = processEnv[key];
+      if (actual !== desired) {
+        return { reason: `${key}=${actual || "<unset>"} (expected ${desired})` };
+      }
+    }
+
+    if (processExe === null) {
+      return { reason: "could not verify process executable" };
+    }
+    if (processExe.endsWith(" (deleted)")) {
+      return { reason: "gateway executable was replaced on disk" };
+    }
+    const expectedExe = normalizeGatewayExecutablePath(gatewayBin);
+    const actualExe = normalizeGatewayExecutablePath(processExe);
+    if (expectedExe && actualExe && actualExe !== expectedExe) {
+      return { reason: `executable=${actualExe} (expected ${expectedExe})` };
+    }
+    return null;
+  }
+
+  function getDockerDriverGatewayRuntimeDrift(
+    pid: number,
+    desiredEnv: Record<string, string>,
+    gatewayBin?: string | null,
+    platform: NodeJS.Platform = process.platform,
+  ): DockerDriverGatewayRuntimeDrift | null {
+    if (platform === "darwin" && desiredEnv.OPENSHELL_DRIVERS === "docker") {
+      const markerDrift =
+        dockerDriverGatewayRuntimeMarker.getDockerDriverGatewayRuntimeMarkerDriftForStateDir(
+          getDockerDriverGatewayStateDir(),
+          {
+            pid,
+            desiredEnv,
+            endpoint: dockerDriverGatewayEnv.getDockerDriverGatewayEndpoint(),
+            gatewayBin,
+            dockerHost: process.env.DOCKER_HOST || null,
+            platform,
+            arch: process.arch,
+          },
+        );
+      if (markerDrift) return markerDrift;
+      if (
+        vmDriverProcess.hasOpenShellVmDriverChildProcess(pid, (args) =>
+          deps.runCapture([...args], { ignoreError: true }),
+        )
+      ) {
+        return { reason: "VM driver child process is still attached to the gateway" };
+      }
+    }
+    if (!shouldRequireDockerDriverEnv(platform)) return null;
+    return getDockerDriverGatewayRuntimeDriftFromSnapshot({
+      processEnv: readProcessEnv(pid),
+      processExe: readProcessExe(pid),
+      desiredEnv,
+      gatewayBin,
+    });
+  }
+
+  function captureProcessArgs(pid: number): string {
+    return deps
+      .runCapture(["ps", "-p", String(pid), "-o", "args="], {
+        ignoreError: true,
+      })
+      .trim();
+  }
+
+  function isDockerDriverGatewayProcess(
+    pid: number,
+    gatewayBin?: string | null,
+    opts: { requireDockerDriverEnv?: boolean } = {},
+  ): boolean {
+    const procCmdlinePath = `/proc/${pid}/cmdline`;
+    let identity = "";
+    try {
+      if (fs.existsSync(procCmdlinePath)) {
+        identity = fs.readFileSync(procCmdlinePath, "utf-8").replace(/\0/g, " ").trim();
+      }
+    } catch {
+      identity = "";
+    }
+    if (!identity) {
+      identity = captureProcessArgs(pid);
+    }
+    if (!identity) return false;
+    const matchesGatewayBinary =
+      identity.includes("openshell-gateway") ||
+      (typeof gatewayBin === "string" && gatewayBin.length > 0 && identity.includes(gatewayBin));
+    if (!matchesGatewayBinary) return false;
+    if (opts.requireDockerDriverEnv && !hasDockerDriverGatewayEnv(pid)) return false;
+    return true;
+  }
+
+  function isDockerDriverGatewayProcessAlive(): boolean {
+    const pid = getDockerDriverGatewayPid();
+    if (pid === null || !isPidAlive(pid)) return false;
+    if (
+      !isDockerDriverGatewayProcess(pid, resolveOpenShellGatewayBinary(), {
+        requireDockerDriverEnv: shouldRequireDockerDriverEnv(),
+      })
+    ) {
+      clearDockerDriverGatewayRuntimeFiles();
+      return false;
+    }
+    return true;
+  }
+
+  function clearDockerDriverGatewayRuntimeFiles(): void {
+    fs.rmSync(getDockerDriverGatewayPidFile(), { force: true });
+    dockerDriverGatewayRuntimeMarker.clearDockerDriverGatewayRuntimeMarker(
+      getDockerDriverGatewayStateDir(),
+    );
+  }
+
+  function rememberDockerDriverGatewayPid(pid: number): void {
+    dockerDriverGatewayRuntimeMarker.writeDockerDriverGatewayPidFile(
+      getDockerDriverGatewayPidFile(),
+      pid,
+    );
+  }
+
+  function getDockerDriverGatewayPortListenerPid(
+    portCheck: PortProbeResult,
+    opts: {
+      platform?: NodeJS.Platform;
+      arch?: NodeJS.Architecture;
+      gatewayBin?: string | null;
+      isPidAliveFn?: (pid: number) => boolean;
+      isDockerDriverGatewayProcessFn?: (pid: number, gatewayBin?: string | null) => boolean;
+    } = {},
+  ): number | null {
+    if (portCheck.ok) return null;
+    if (
+      !isLinuxDockerDriverGatewayEnabled(
+        opts.platform ?? process.platform,
+        opts.arch ?? process.arch,
+      )
+    )
+      return null;
+    const pid = Number(portCheck.pid);
+    if (!Number.isInteger(pid) || pid <= 0) return null;
+    const proc = String(portCheck.process || "").toLowerCase();
+    if (!proc.startsWith("openshell")) return null;
+    const alive = opts.isPidAliveFn ?? isPidAlive;
+    if (!alive(pid)) return null;
+    const isGateway =
+      opts.isDockerDriverGatewayProcessFn ??
+      ((candidatePid: number, gatewayBin?: string | null) =>
+        isDockerDriverGatewayProcess(candidatePid, gatewayBin, {
+          requireDockerDriverEnv: shouldRequireDockerDriverEnv(opts.platform ?? process.platform),
+        }));
+    if (!isGateway(pid, opts.gatewayBin)) return null;
+    return pid;
+  }
+
+  function isDockerDriverGatewayPortListener(
+    portCheck: PortProbeResult,
+    opts: Parameters<typeof getDockerDriverGatewayPortListenerPid>[1] = {},
+  ): boolean {
+    return getDockerDriverGatewayPortListenerPid(portCheck, opts) !== null;
+  }
+
+  return {
+    clearDockerDriverGatewayRuntimeFiles,
+    getDockerDriverGatewayEnv,
+    getDockerDriverGatewayPid,
+    getDockerDriverGatewayPidFile,
+    getDockerDriverGatewayPortListenerPid,
+    getDockerDriverGatewayRuntimeDrift,
+    getDockerDriverGatewayRuntimeDriftFromSnapshot,
+    getDockerDriverGatewayStateDir,
+    isDockerDriverGatewayPortListener,
+    isDockerDriverGatewayProcess,
+    isDockerDriverGatewayProcessAlive,
+    isPidAlive,
+    rememberDockerDriverGatewayPid,
+    resolveOpenShellGatewayBinary,
+    resolveOpenShellSandboxBinary,
+    shouldRequireDockerDriverEnv,
+  };
+}

--- a/src/lib/onboard/docker-driver-gateway-runtime.ts
+++ b/src/lib/onboard/docker-driver-gateway-runtime.ts
@@ -18,6 +18,14 @@ export type DockerDriverGatewayRuntimeDrift = { reason: string };
 type RunCapture = (args: string[], opts?: { ignoreError?: boolean }) => string;
 type DockerDriverGatewayEnvModule = typeof import("./docker-driver-gateway-env");
 
+// Source boundary: OpenShell does not currently expose an authoritative local
+// host-gateway identity/drift endpoint for the Docker-driver runtime NemoClaw
+// started for this port/configuration. Until that exists, reuse must fail
+// closed here for missing binaries or PID files, dead or foreign PIDs,
+// unreadable Linux /proc env/exe state, replaced gateway executables, stale
+// runtime markers, non-matching port owners, and macOS VM-driver children still
+// attached to a Docker-driver gateway. These heuristics can be retired when
+// OpenShell owns and reports the same runtime identity fields directly.
 export interface DockerDriverGatewayRuntimeDeps {
   gatewayPort: number;
   getCachedOpenshellBinary(): string | null;


### PR DESCRIPTION
## Summary
Extracts the Docker-driver gateway runtime/process helpers from `src/lib/onboard.ts` into a focused onboarding module. This keeps the gateway startup orchestration in `onboard.ts` while moving the state-dir, PID, runtime drift, executable resolution, and port-listener helpers behind an injected helper factory.

## Related Issue
Refs #3802

## Changes
- Added `src/lib/onboard/docker-driver-gateway-runtime.ts` with the Docker-driver gateway runtime helper factory.
- Replaced the inline runtime/process helper implementations in `src/lib/onboard.ts` with destructured helpers wired to the existing onboarding dependencies.
- Preserved existing `onboard.ts` compatibility exports for gateway environment, runtime drift, PID, and port-listener helpers.
- Kept launch orchestration, runtime marker writes, and dashboard-forward cleanup in `onboard.ts`.
- Added direct tests for the extracted helper factory covering env-configured binary/state resolution, stale PID/marker cleanup, macOS VM-driver child drift, and injected port-listener identity rejection.
- Documented the OpenShell source boundary and removal condition for the local Docker-driver gateway runtime heuristics.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Focused local checks passed:
- `npx @biomejs/biome format --write src/lib/onboard.ts src/lib/onboard/docker-driver-gateway-runtime.ts src/lib/onboard/docker-driver-gateway-runtime.test.ts`
- `npx @biomejs/biome lint src/lib/onboard.ts src/lib/onboard/docker-driver-gateway-runtime.ts src/lib/onboard/docker-driver-gateway-runtime.test.ts`
- `npm run typecheck:cli`
- `npm run build:cli`
- `git diff --check`
- `npx vitest run src/lib/onboard/docker-driver-gateway-runtime.test.ts test/onboard-gateway-runtime.test.ts test/gateway-start-wait.test.ts test/gateway-final-failure-cleanup.test.ts test/gateway-start-failure-integration.test.ts src/lib/onboard/docker-driver-gateway-service.test.ts src/lib/onboard/gateway-binding.test.ts`
- `npx vitest run src/lib/onboard/docker-driver-gateway-env.test.ts src/lib/onboard/docker-driver-gateway-launch.test.ts src/lib/onboard/docker-driver-gateway-runtime-marker.test.ts src/lib/onboard/host-gateway-process.test.ts`

Remote checks passed:
- PR CI, CodeQL, macOS E2E, CLI parity, all CLI shards, static checks, build/typecheck, installer integration, plugin tests, commit lint, and DCO.
- PR Review Advisor: 0 needs attention, 0 worth checking, 0 nice ideas.
- Regression E2Es: `gateway-health-honest-e2e`, `gateway-drift-preflight-e2e` ([run](https://github.com/NVIDIA/NemoClaw/actions/runs/27265179677)).
- Vitest scenario E2Es: `ubuntu-repo-cloud-openclaw`, `ubuntu-repo-docker-post-reboot-recovery` ([run](https://github.com/NVIDIA/NemoClaw/actions/runs/27265179528)).
- Nightly E2E: `concurrent-gateway-ports-e2e` passed on rerun ([run](https://github.com/NVIDIA/NemoClaw/actions/runs/27265179682)); the first attempt failed before PR-specific behavior on Docker Hub pull timeouts.

Full local hook/test note: regular commit hooks and regular pre-push hooks currently fail only in `test/release-latest-tag.test.ts` because this workstation's global git config enables commit signing with `/home/cvillela/.ssh/git-signing-key.pub`, but the matching private key is unavailable. I did not touch that test or git configuration.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>