### PR TITLE
fix(plugin): validate /nemoclaw shields sub-argument instead of ignoring it

### DIFF
--- a/nemoclaw/src/commands/slash.test.ts
+++ b/nemoclaw/src/commands/slash.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { PluginCommandContext, OpenClawPluginApi } from "../index.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NemoClawState } from "../blueprint/state.js";
+import type { OpenClawPluginApi, PluginCommandContext } from "../index.js";
 import type { NemoClawOnboardConfig } from "../onboard/config.js";
 
 vi.mock("../blueprint/state.js", () => ({
@@ -24,18 +24,20 @@ vi.mock("./config-show.js", () => ({
   slashConfigShow: vi.fn(() => ({ text: "**NemoClaw Config**" })),
 }));
 
-import { handleSlashCommand } from "./slash.js";
 import { loadState } from "../blueprint/state.js";
 import {
-  loadOnboardConfig,
   describeOnboardEndpoint,
   describeOnboardProvider,
+  loadOnboardConfig,
 } from "../onboard/config.js";
+import { slashShieldsStatus } from "./shields-status.js";
+import { handleSlashCommand } from "./slash.js";
 
 const mockedLoadState = vi.mocked(loadState);
 const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 const mockedDescribeOnboardEndpoint = vi.mocked(describeOnboardEndpoint);
 const mockedDescribeOnboardProvider = vi.mocked(describeOnboardProvider);
+const mockedShieldsStatus = vi.mocked(slashShieldsStatus);
 
 function makeCtx(args?: string): PluginCommandContext {
   return {
@@ -116,9 +118,43 @@ describe("commands/slash", () => {
   // -------------------------------------------------------------------------
 
   describe("shields", () => {
-    it("routes to shields status handler", () => {
+    it("routes bare `shields` to the read-only status handler", () => {
       const result = handleSlashCommand(makeCtx("shields"), makeApi());
+      expect(mockedShieldsStatus).toHaveBeenCalledTimes(1);
       expect(result.text).toContain("Shields");
+    });
+
+    it("routes `shields status` to the read-only status handler", () => {
+      const result = handleSlashCommand(makeCtx("shields status"), makeApi());
+      expect(mockedShieldsStatus).toHaveBeenCalledTimes(1);
+      expect(result.text).toContain("Shields");
+    });
+
+    it("does not mutate on `shields down`; points to the host CLI (#5117)", () => {
+      const result = handleSlashCommand(makeCtx("shields down"), makeApi());
+      expect(mockedShieldsStatus).not.toHaveBeenCalled();
+      expect(result.text).toContain("managed from the host");
+      expect(result.text).toContain("nemoclaw <name> shields down");
+    });
+
+    it("does not mutate on `shields up`; points to the host CLI (#5117)", () => {
+      const result = handleSlashCommand(makeCtx("shields up"), makeApi());
+      expect(mockedShieldsStatus).not.toHaveBeenCalled();
+      expect(result.text).toContain("managed from the host");
+      expect(result.text).toContain("nemoclaw <name> shields up");
+    });
+
+    it("reports an unknown argument instead of silently showing status (#5117)", () => {
+      const result = handleSlashCommand(makeCtx("shields hihi"), makeApi());
+      expect(mockedShieldsStatus).not.toHaveBeenCalled();
+      expect(result.text).toContain("Unknown argument");
+      expect(result.text).toContain("hihi");
+    });
+
+    it("tolerates extra whitespace between tokens", () => {
+      const result = handleSlashCommand(makeCtx("shields   down"), makeApi());
+      expect(mockedShieldsStatus).not.toHaveBeenCalled();
+      expect(result.text).toContain("nemoclaw <name> shields down");
     });
   });
 

--- a/nemoclaw/src/commands/slash.ts
+++ b/nemoclaw/src/commands/slash.ts
@@ -12,26 +12,27 @@
  *   /nemoclaw          - show help
  */
 
+import { loadState } from "../blueprint/state.js";
 import {
   getPluginConfig,
   type OpenClawPluginApi,
   type PluginCommandContext,
   type PluginCommandResult,
 } from "../index.js";
-import { loadState } from "../blueprint/state.js";
 import {
   describeOnboardEndpoint,
   describeOnboardProvider,
   loadOnboardConfig,
 } from "../onboard/config.js";
-import { slashShieldsStatus } from "./shields-status.js";
 import { slashConfigShow } from "./config-show.js";
+import { slashShieldsStatus } from "./shields-status.js";
 
 export function handleSlashCommand(
   ctx: PluginCommandContext,
   api: OpenClawPluginApi,
 ): PluginCommandResult {
-  const subcommand = ctx.args?.trim().split(/\s+/)[0] ?? "";
+  const tokens = ctx.args?.trim().split(/\s+/).filter(Boolean) ?? [];
+  const subcommand = tokens[0] ?? "";
 
   switch (subcommand) {
     case "status":
@@ -41,11 +42,48 @@ export function handleSlashCommand(
     case "onboard":
       return slashOnboard();
     case "shields":
-      return slashShieldsStatus();
+      return slashShields(tokens[1] ?? "");
     case "config":
       return slashConfigShow();
     default:
       return slashHelp();
+  }
+}
+
+function slashShields(action: string): PluginCommandResult {
+  // `/nemoclaw shields` is read-only inside the sandbox — it reports status only.
+  // Shields can only be raised or lowered from the host CLI (security invariant;
+  // see ./shields-status.ts). Instead of silently ignoring any sub-argument
+  // (#5117), route status/empty to the status view, send up/down to the host CLI,
+  // and reject anything else as an unknown argument.
+  switch (action) {
+    case "":
+    case "status":
+      return slashShieldsStatus();
+    case "up":
+    case "down": {
+      const verb = action === "up" ? "raise" : "lower";
+      return {
+        text: [
+          "**Shields are managed from the host.**",
+          "",
+          `\`/nemoclaw shields\` is read-only here. To ${verb} shields, run on the host:`,
+          "",
+          "```",
+          `nemoclaw <name> shields ${action}`,
+          "```",
+        ].join("\n"),
+      };
+    }
+    default:
+      return {
+        text: [
+          `**Unknown argument:** \`${action}\``,
+          "",
+          "Usage: `/nemoclaw shields [status]` (read-only).",
+          "To change shields, use the host CLI: `nemoclaw <name> shields up|down|status`.",
+        ].join("\n"),
+      };
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The `/nemoclaw shields` TUI slash command parsed only its first token, so any sub-argument (`down`, `up`, `status`, or an invalid value) was silently dropped and the command always printed the read-only status. Mutating attempts like `/nemoclaw shields down` looked like silent no-ops, and typos like `shields stauts` were accepted as if valid. This PR parses the sub-argument and gives explicit feedback while keeping shields host-only.

Before → after (in the OpenClaw TUI):

| Input | Before | After |
| --- | --- | --- |
| `/nemoclaw shields` | status | status (unchanged) |
| `/nemoclaw shields status` | status | status (unchanged) |
| `/nemoclaw shields up` / `down` | status (silent) | "Shields are managed from the host" + host CLI command; no mutation |
| `/nemoclaw shields stauts` (typo) | status (silent) | "Unknown argument: stauts" + usage |

## Related Issue
Closes #5117 

## Changes
- `nemoclaw/src/commands/slash.ts`: tokenize the slash args once (filtering empties) and route on the first token; the `shields` case now dispatches to a new `slashShields(action)` helper that inspects the sub-argument.
- `slashShields()`: empty/`status` → existing read-only status; `up`/`down` → a clear "managed from the host" message plus the host CLI command (no mutation — preserves the security invariant that a sandbox cannot raise/lower its own shields); any other token → an "Unknown argument" usage error.
- `nemoclaw/src/commands/slash.test.ts`: 6 tests — status routing (bare + `status`), `up`/`down` host-pointer (asserting the status handler is NOT invoked), unknown-argument, and whitespace tolerance.
- No change to `shields-status.ts` (the read-only status renderer is untouched) or to any host-side shields behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shields command routing and validation.
  * Enforced read-only behavior for shields command, with clearer instructions directing users to the host CLI for shield management.
  * Enhanced error handling for unknown shield sub-arguments.

* **Tests**
  * Expanded test coverage for shields command scenarios including status, up/down, and invalid arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->