### PR TITLE
fix(hermes): detect wrapped gateway argv

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -304,7 +304,7 @@ cmdline_is_hermes_gateway() {
   local cmdline=" $1 "
 
   case "$cmdline" in
-    *"/hermes gateway run "* | *" hermes gateway run "*) return 0 ;;
+    *"/hermes gateway run "* | *" hermes gateway run "* | *"/hermes.real gateway run "* | *" hermes.real gateway run "*) return 0 ;;
   esac
   return 1
 }

--- a/test/e2e/test-hermes-root-entrypoint-smoke.sh
+++ b/test/e2e/test-hermes-root-entrypoint-smoke.sh
@@ -149,7 +149,7 @@ assert_runtime_layout() {
 assert_gateway_process() {
   local container="$1"
   assert_container_sh "$container" "Hermes gateway process is not running as gateway user" \
-    "ps -eo user=,args= | awk '\$1 == \"gateway\" && index(\$0, \"hermes gateway run\") { found = 1 } END { exit found ? 0 : 1 }'"
+    "ps -eo user=,args= | awk '\$1 == \"gateway\" && (index(\$0, \"hermes gateway run\") || index(\$0, \"hermes.real gateway run\")) { found = 1 } END { exit found ? 0 : 1 }'"
   assert_container_sh "$container" "start log does not show gateway privilege separation" \
     "grep -F \"hermes gateway launched as 'gateway' user\" /tmp/nemoclaw-start.log"
 }

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -382,6 +382,7 @@ function lstatIfPresent(entry: string): fs.Stats | null {
 
 function runHermesGatewayRuntimeCleanup(opts: {
   liveGateway?: boolean;
+  liveGatewayArgv?: string[];
   orphanSocat?: boolean;
   orphanDashboardSocat?: boolean;
   staleLock?: boolean;
@@ -430,7 +431,11 @@ function runHermesGatewayRuntimeCleanup(opts: {
   if (opts.stalePid !== false) fs.writeFileSync(runtimePid, "999999\n");
   if (opts.staleLock !== false) fs.writeFileSync(runtimeLock, "stale lock");
   if (opts.liveGateway) {
-    writeFakeProcCmdline(procRoot, 123, ["/usr/local/bin/hermes", "gateway", "run"]);
+    writeFakeProcCmdline(
+      procRoot,
+      123,
+      opts.liveGatewayArgv ?? ["/usr/local/bin/hermes", "gateway", "run"],
+    );
   }
   if (opts.orphanSocat) {
     writeFakeProcCmdline(procRoot, 456, [
@@ -1060,6 +1065,21 @@ describe("agents/hermes/start.sh gateway runtime cleanup", () => {
 
   it("preserves Hermes runtime state when a gateway process is alive", () => {
     const run = runHermesGatewayRuntimeCleanup({ liveGateway: true, orphanSocat: true });
+
+    expect(run.result.status).toBe(0);
+    expect(run.runtimePidExists).toBe(true);
+    expect(run.runtimeLockExists).toBe(true);
+    expect(run.legacyPidIsSymlink).toBe(true);
+    expect(run.killLog).toBe("");
+    expect(run.result.stderr).toContain("Existing Hermes gateway process detected");
+  });
+
+  it("preserves Hermes runtime state when the wrapped gateway execs hermes.real", () => {
+    const run = runHermesGatewayRuntimeCleanup({
+      liveGateway: true,
+      liveGatewayArgv: ["/usr/local/bin/hermes.real", "gateway", "run"],
+      orphanSocat: true,
+    });
 
     expect(run.result.status).toBe(0);
     expect(run.runtimePidExists).toBe(true);


### PR DESCRIPTION
## Summary
- Treat `hermes.real gateway run` as a live Hermes gateway process after the PR #4981 wrapper execs the relocated binary.
- Update the Hermes root-entrypoint smoke assertion to accept both wrapped and unwrapped argv shapes.
- Add a shell-fixture regression test for the `hermes.real` process shape.

## Verification
- `npm test -- --run test/hermes-start.test.ts`
- `bash -n agents/hermes/start.sh`
- `bash -n test/e2e/test-hermes-root-entrypoint-smoke.sh`
- `git diff --check origin/main...HEAD`

Refs #4981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended Hermes gateway process detection to recognize additional invocation variants, improving health monitoring accuracy and cleanup operation reliability across deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->