### PR TITLE
fix(e2e): retry transient DNS errors in common-egress agent assertion

### DIFF
--- a/test/e2e/test-common-egress-agent-e2e.sh
+++ b/test/e2e/test-common-egress-agent-e2e.sh
@@ -286,10 +286,20 @@ run_openclaw_agent_assertion() {
     } >>"$log_file"
     rm -f "$stderr_file"
 
-    if printf '%s' "$raw" | grep -qiE "SsrFBlockedError|Blocked hostname|ECONNREFUSED|EAI_AGAIN|gateway unavailable|network connection error"; then
+    # Permanent SSRF policy blocks — never retry; the egress policy is wrong.
+    if printf '%s' "$raw" | grep -qiE "SsrFBlockedError|Blocked hostname"; then
       rm -f "$ssh_cfg"
-      fail "${label}: agent hit policy/transport error (exit ${rc}): ${raw:0:300}"
+      fail "${label}: agent hit SSRF policy block (exit ${rc}): ${raw:0:300}"
       return
+    fi
+
+    # Transient network errors — warn and allow the retry loop to continue so
+    # brief DNS outages or upstream blips do not immediately fail the test.
+    if printf '%s' "$raw" | grep -qiE "ECONNREFUSED|EAI_AGAIN|gateway unavailable|network connection error|fetch failed|DNS error"; then
+      printf '\033[33m  [warn]\033[0m %s: transient network error on attempt %d/3 (exit %s)\n' "$label" "$attempt" "$rc"
+      last_fail="transient network error on attempt ${attempt} (exit ${rc}): ${raw:0:240}"
+      [ "$attempt" -ge 3 ] || sleep $((attempt * 15))
+      continue
     fi
 
     reply=$(printf '%s' "$raw" | parse_openclaw_agent_text 2>/dev/null) || true


### PR DESCRIPTION
## Summary

Split the early-exit error guard in `run_openclaw_agent_assertion` (`test/e2e/test-common-egress-agent-e2e.sh`) to distinguish permanent SSRF policy blocks from transient network errors. Policy violations (`SsrFBlockedError`, `Blocked hostname`) still fail immediately. Transient errors (`EAI_AGAIN`, `ECONNREFUSED`, `gateway unavailable`, `network connection error`, `fetch failed`, `DNS error`) now warn and retry with progressive backoff (15s, 30s), using the existing 3-attempt loop.

This prevents brief third-party API outages (e.g. `restcountries.com` DNS hiccups observed in nightly run [#27315379233](https://github.com/NVIDIA/NemoClaw/actions/runs/27315379233)) from immediately failing the C2 OpenClaw open-tier assertion without retry.

## Related Issue

Fixes #5191

## Changes

- **`test/e2e/test-common-egress-agent-e2e.sh`**:
  - Split monolithic `grep -qiE` guard at line 289 into two checks:
    1. **SSRF policy blocks** (`SsrFBlockedError|Blocked hostname`) → immediate `fail` + `return` (unchanged behavior)
    2. **Transient network errors** (`ECONNREFUSED|EAI_AGAIN|gateway unavailable|network connection error|fetch failed|DNS error`) → `warn` + `continue` through the retry loop
  - Progressive backoff for transient errors: `sleep $((attempt * 15))` (15s, 30s) instead of fixed 5s

## Validation

The `custom-e2e` validation branch could not be pushed because the token lacks the `workflow` scope required to create `.github/workflows/custom-e2e.yaml`. To validate manually:

1. Re-run the `common-egress-agent-e2e / run` job from this branch via `gh workflow run nightly-e2e.yaml --repo NVIDIA/NemoClaw --ref fix/nightly-e2e-egress-agent-dns-retry-0f99ee5`
2. Alternatively, trigger the nightly and observe that transient DNS errors now retry instead of immediately failing

- Original failing run: [27315379233](https://github.com/NVIDIA/NemoClaw/actions/runs/27315379233) on `0f99ee593fa542f4a69981754e267534ee559313`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] No secrets, API keys, or credentials committed
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>