### PR TITLE
docs: fix commands reference install-plugins link (#5080)

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1106,7 +1106,7 @@ Skill names must contain only alphanumeric characters, dots, hyphens, and unders
 
 <AgentOnly variant="openclaw">
 
-OpenClaw plugins are a different kind of extension. To install an OpenClaw plugin, see [Install OpenClaw Plugins](../manage-sandboxes/install-openclaw-plugins).
+OpenClaw plugins are a different kind of extension. To install an OpenClaw plugin, see [Install OpenClaw Plugins](../deployment/install-openclaw-plugins).
 For OpenClaw, the command uploads the skill to the OpenClaw state directory and mirrors it into `$HOME/.openclaw/skills/<name>` when the agent home directory differs from the state directory.
 That mirror makes skills listed by `openclaw skills list` available at session startup.
 If mirror creation fails, NemoClaw prints a warning so you can reinstall or inspect the home directory permissions.
@@ -1188,6 +1188,7 @@ $$nemoclaw my-assistant agents delete work --force --json
 
 List OpenClaw conversation sessions in the sandbox.
 With no subcommand the in-sandbox CLI lists stored sessions for the configured default agent.
+The `<name>` sandbox must already exist; if it does not, NemoClaw reports `Sandbox '<name>' does not exist` before invoking OpenClaw.
 This is a thin pass-through to `openclaw sessions` via `openshell sandbox exec`; flags accepted by the in-sandbox CLI are forwarded verbatim.
 
 ```bash

--- a/test/commands-reference-links.test.ts
+++ b/test/commands-reference-links.test.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const commandsReference = path.join(repoRoot, "docs/reference/commands.mdx");
+const installPluginsDoc = path.join(repoRoot, "docs/deployment/install-openclaw-plugins.mdx");
+
+describe("commands reference doc links (#5080)", () => {
+  it("links Install OpenClaw Plugins to the deployment guide", () => {
+    const markdown = fs.readFileSync(commandsReference, "utf8");
+
+    expect(markdown).toContain("[Install OpenClaw Plugins](../deployment/install-openclaw-plugins)");
+    expect(markdown).not.toContain("../manage-sandboxes/install-openclaw-plugins");
+    expect(fs.existsSync(installPluginsDoc)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the broken Install OpenClaw Plugins cross-link in the commands reference and documents current sandbox-scoped `sessions` behavior. The `tunnel status` and sessions dispatch issues reported on v0.0.55 are already fixed on main.

## Related Issue
Fixes #5080

## Changes
- Point `docs/reference/commands.mdx` plugin link from `../manage-sandboxes/install-openclaw-plugins` to `../deployment/install-openclaw-plugins`.
- Clarify that `nemoclaw <name> sessions` requires an existing sandbox and reports `Sandbox '<name>' does not exist` otherwise.
- Add `test/commands-reference-links.test.ts` regression test for the install-plugins link target.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Thabhelo <50872400+Thabhelo@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenClaw plugin installation reference link location in CLI commands documentation
  * Added clarification noting target sandbox must already exist when using NemoClaw sessions command

* **Tests**
  * Added validation tests for documentation link correctness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->