### PR TITLE
feat(cli): add sandbox download/upload wrappers and sessions export

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1030,6 +1030,53 @@ nemohermes my-assistant sessions delete agent:main:slack:c-9 --json
 | `--json` | Print the delete result as JSON. |
 | `--verbose` | Print the gateway entry payload after a successful delete. |
 
+### `nemohermes <name> sessions export [keys...]`
+
+Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
+
+The command tars `/sandbox/.openclaw/agents/<agent>/sessions/` inside the sandbox via `openshell sandbox exec`, downloads the resulting tarball through `openshell sandbox download`, and best-effort removes the staging artifact even when the export fails partway.
+With no positional keys every session for the agent is exported; pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
+The session keys are resolved to on-disk file names through `openclaw sessions list --agent <id> --json`, so OpenClaw owns the key-to-file mapping.
+
+```bash
+nemohermes my-assistant sessions export
+nemohermes my-assistant sessions export main --agent main
+nemohermes my-assistant sessions export agent:work:telegram:t-1 --include-trajectory
+nemohermes my-assistant sessions export --out ./bundles/alpha.tgz --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--agent <id>` | Agent id when `<keys>` are aliases rather than the canonical `agent:<id>:<rest>` form. |
+| `--out <path>` | Host destination tarball path. Defaults to `./sessions-<sandbox>-<agent>.tgz`. |
+| `--include-trajectory` | Include the (large) `*.trajectory.jsonl` files in the bundle. Excluded by default. |
+| `--json` | Print the export manifest as JSON instead of a status line. |
+
+Mismatched `--agent` plus canonical-key combinations are refused before the in-sandbox tar runs.
+Session keys that begin with `-` are rejected at the command boundary instead of being silently dropped.
+The staging tarball is created with `umask 077` and removed after the host download completes, so a concurrent sandbox user cannot read the staged session JSONL out of `/tmp` between the tar step and the download step.
+
+### `nemohermes <name> download <sandbox-path> [host-dest]`
+
+Host-side wrapper around `openshell sandbox download` that adds a live-sandbox readiness check.
+The source path inside the sandbox and the host destination are forwarded to OpenShell verbatim, so the file-system semantics (single-file vs directory copy, trailing-slash handling, overwrite behaviour) follow the OpenShell transport.
+With no `host-dest` the destination defaults to the current directory.
+
+```bash
+nemohermes my-assistant download /sandbox/.openclaw/workspace/SOUL.md ./
+nemohermes my-assistant download /sandbox/.openclaw/agents/main/sessions/ ./sessions/
+```
+
+### `nemohermes <name> upload <host-path> [sandbox-dest]`
+
+Host-side wrapper around `openshell sandbox upload`, symmetric to the download wrapper.
+With no `sandbox-dest` the destination defaults to `/sandbox/` inside the sandbox.
+
+```bash
+nemohermes my-assistant upload ./local-file /sandbox/
+nemohermes my-assistant upload ./backups/SOUL.md /sandbox/.openclaw/workspace/SOUL.md
+```
+
 ### `nemohermes <name> rebuild`
 
 Upgrade a sandbox to the current agent version while preserving workspace state.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1035,8 +1035,10 @@ nemohermes my-assistant sessions delete agent:main:slack:c-9 --json
 Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
 
 The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
-With no positional keys every session for the agent is exported; pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
-The bundle is built inside the sandbox via `openshell sandbox exec`, downloaded through `openshell sandbox download`, and the staging artifact is removed by a best-effort cleanup that runs even when the export fails partway.
+With no positional keys, the command exports every session for the agent.
+Pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
+The command builds the bundle inside the sandbox via `openshell sandbox exec`, then downloads it through `openshell sandbox download`.
+A best-effort cleanup removes the staging artefact even when the export fails partway.
 
 ```bash
 nemohermes my-assistant sessions export

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1034,9 +1034,9 @@ nemohermes my-assistant sessions delete agent:main:slack:c-9 --json
 
 Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
 
-The command tars `/sandbox/.openclaw/agents/<agent>/sessions/` inside the sandbox via `openshell sandbox exec`, downloads the resulting tarball through `openshell sandbox download`, and best-effort removes the staging artifact even when the export fails partway.
+The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
 With no positional keys every session for the agent is exported; pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
-The session keys are resolved to on-disk file names through `openclaw sessions list --agent <id> --json`, so OpenClaw owns the key-to-file mapping.
+The bundle is built inside the sandbox via `openshell sandbox exec`, downloaded through `openshell sandbox download`, and the staging artifact is removed by a best-effort cleanup that runs even when the export fails partway.
 
 ```bash
 nemohermes my-assistant sessions export

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1032,31 +1032,31 @@ nemohermes my-assistant sessions delete agent:main:slack:c-9 --json
 
 ### `nemohermes <name> sessions export [keys...]`
 
-Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
+Export the OpenClaw session JSONL from a running sandbox to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
 
-The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
+The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and copies only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the export never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
+By default it writes a browsable directory of session files (`dir` format); pass `--format tar` for a single `.tgz` bundle suited to sharing or upload.
 With no positional keys, the command exports every session for the agent.
 Pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
-The command builds the bundle inside the sandbox via `openshell sandbox exec`, then downloads it through `openshell sandbox download`.
-A best-effort cleanup removes the staging artefact even when the export fails partway.
 
 ```bash
 nemohermes my-assistant sessions export
 nemohermes my-assistant sessions export main --agent main
 nemohermes my-assistant sessions export agent:work:telegram:t-1 --include-trajectory
-nemohermes my-assistant sessions export --out ./bundles/alpha.tgz --json
+nemohermes my-assistant sessions export --format tar --out ./bundles/alpha.tgz --json
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--agent <id>` | Agent id when `<keys>` are aliases rather than the canonical `agent:<id>:<rest>` form. |
-| `--out <path>` | Host destination tarball path. Defaults to `./sessions-<sandbox>-<agent>.tgz`. |
-| `--include-trajectory` | Include the (large) `*.trajectory.jsonl` files in the bundle. Excluded by default. |
+| `--format <dir\|tar>` | `dir` (default) writes a directory of session files; `tar` writes a single `.tgz` bundle for sharing/upload. |
+| `--out <path>` | Host destination. Defaults to `./sessions-<sandbox>/` for `dir`, or `./sessions-<sandbox>-<agent>.tgz` for `tar`. |
+| `--include-trajectory` | Include the (large) `*.trajectory.jsonl` files in the export. Excluded by default. |
 | `--json` | Print the export manifest as JSON instead of a status line. |
 
-Mismatched `--agent` plus canonical-key combinations are refused before the in-sandbox tar runs.
+Mismatched `--agent` plus canonical-key combinations are refused before any download runs.
 Session keys that begin with `-` are rejected at the command boundary instead of being silently dropped.
-The staging tarball is created with `umask 077` and removed after the host download completes, so a concurrent sandbox user cannot read the staged session JSONL out of `/tmp` between the tar step and the download step.
+Session JSONL can contain pasted secrets (API keys, tokens), so exported files are written owner-only (`0600`); for `tar` format the in-sandbox staging tarball is additionally created with `umask 077` and removed after the host download completes.
 
 ### `nemohermes <name> download <sandbox-path> [host-dest]`
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1247,6 +1247,53 @@ $$nemoclaw my-assistant sessions delete agent:main:slack:c-9 --json
 | `--json` | Print the delete result as JSON. |
 | `--verbose` | Print the gateway entry payload after a successful delete. |
 
+### `$$nemoclaw <name> sessions export [keys...]`
+
+Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
+
+The command tars `/sandbox/.openclaw/agents/<agent>/sessions/` inside the sandbox via `openshell sandbox exec`, downloads the resulting tarball through `openshell sandbox download`, and best-effort removes the staging artifact even when the export fails partway.
+With no positional keys every session for the agent is exported; pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
+The session keys are resolved to on-disk file names through `openclaw sessions list --agent <id> --json`, so OpenClaw owns the key-to-file mapping.
+
+```bash
+$$nemoclaw my-assistant sessions export
+$$nemoclaw my-assistant sessions export main --agent main
+$$nemoclaw my-assistant sessions export agent:work:telegram:t-1 --include-trajectory
+$$nemoclaw my-assistant sessions export --out ./bundles/alpha.tgz --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--agent <id>` | Agent id when `<keys>` are aliases rather than the canonical `agent:<id>:<rest>` form. |
+| `--out <path>` | Host destination tarball path. Defaults to `./sessions-<sandbox>-<agent>.tgz`. |
+| `--include-trajectory` | Include the (large) `*.trajectory.jsonl` files in the bundle. Excluded by default. |
+| `--json` | Print the export manifest as JSON instead of a status line. |
+
+Mismatched `--agent` plus canonical-key combinations are refused before the in-sandbox tar runs.
+Session keys that begin with `-` are rejected at the command boundary instead of being silently dropped.
+The staging tarball is created with `umask 077` and removed after the host download completes, so a concurrent sandbox user cannot read the staged session JSONL out of `/tmp` between the tar step and the download step.
+
+### `$$nemoclaw <name> download <sandbox-path> [host-dest]`
+
+Host-side wrapper around `openshell sandbox download` that adds a live-sandbox readiness check.
+The source path inside the sandbox and the host destination are forwarded to OpenShell verbatim, so the file-system semantics (single-file vs directory copy, trailing-slash handling, overwrite behaviour) follow the OpenShell transport.
+With no `host-dest` the destination defaults to the current directory.
+
+```bash
+$$nemoclaw my-assistant download /sandbox/.openclaw/workspace/SOUL.md ./
+$$nemoclaw my-assistant download /sandbox/.openclaw/agents/main/sessions/ ./sessions/
+```
+
+### `$$nemoclaw <name> upload <host-path> [sandbox-dest]`
+
+Host-side wrapper around `openshell sandbox upload`, symmetric to the download wrapper.
+With no `sandbox-dest` the destination defaults to `/sandbox/` inside the sandbox.
+
+```bash
+$$nemoclaw my-assistant upload ./local-file /sandbox/
+$$nemoclaw my-assistant upload ./backups/SOUL.md /sandbox/.openclaw/workspace/SOUL.md
+```
+
 ### `$$nemoclaw <name> rebuild`
 
 Upgrade a sandbox to the current agent version while preserving workspace state.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1252,8 +1252,10 @@ $$nemoclaw my-assistant sessions delete agent:main:slack:c-9 --json
 Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
 
 The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
-With no positional keys every session for the agent is exported; pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
-The bundle is built inside the sandbox via `openshell sandbox exec`, downloaded through `openshell sandbox download`, and the staging artifact is removed by a best-effort cleanup that runs even when the export fails partway.
+With no positional keys, the command exports every session for the agent.
+Pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
+The command builds the bundle inside the sandbox via `openshell sandbox exec`, then downloads it through `openshell sandbox download`.
+A best-effort cleanup removes the staging artefact even when the export fails partway.
 
 ```bash
 $$nemoclaw my-assistant sessions export

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1251,9 +1251,9 @@ $$nemoclaw my-assistant sessions delete agent:main:slack:c-9 --json
 
 Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
 
-The command tars `/sandbox/.openclaw/agents/<agent>/sessions/` inside the sandbox via `openshell sandbox exec`, downloads the resulting tarball through `openshell sandbox download`, and best-effort removes the staging artifact even when the export fails partway.
+The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
 With no positional keys every session for the agent is exported; pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
-The session keys are resolved to on-disk file names through `openclaw sessions list --agent <id> --json`, so OpenClaw owns the key-to-file mapping.
+The bundle is built inside the sandbox via `openshell sandbox exec`, downloaded through `openshell sandbox download`, and the staging artifact is removed by a best-effort cleanup that runs even when the export fails partway.
 
 ```bash
 $$nemoclaw my-assistant sessions export

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1249,31 +1249,31 @@ $$nemoclaw my-assistant sessions delete agent:main:slack:c-9 --json
 
 ### `$$nemoclaw <name> sessions export [keys...]`
 
-Bundle the OpenClaw session JSONL from a running sandbox and download the tarball to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
+Export the OpenClaw session JSONL from a running sandbox to the host, replacing the two-hop `docker exec kubectl cp` plus `docker cp` workaround.
 
-The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
+The command always enumerates the session store through `openclaw sessions list --agent <id> --json` and copies only the matching `<sessionId>.jsonl` (plus optional `<sessionId>.trajectory.jsonl`) files, so the export never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
+By default it writes a browsable directory of session files (`dir` format); pass `--format tar` for a single `.tgz` bundle suited to sharing or upload.
 With no positional keys, the command exports every session for the agent.
 Pass one or more keys (alias or canonical `agent:<id>:<rest>`) to filter.
-The command builds the bundle inside the sandbox via `openshell sandbox exec`, then downloads it through `openshell sandbox download`.
-A best-effort cleanup removes the staging artefact even when the export fails partway.
 
 ```bash
 $$nemoclaw my-assistant sessions export
 $$nemoclaw my-assistant sessions export main --agent main
 $$nemoclaw my-assistant sessions export agent:work:telegram:t-1 --include-trajectory
-$$nemoclaw my-assistant sessions export --out ./bundles/alpha.tgz --json
+$$nemoclaw my-assistant sessions export --format tar --out ./bundles/alpha.tgz --json
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--agent <id>` | Agent id when `<keys>` are aliases rather than the canonical `agent:<id>:<rest>` form. |
-| `--out <path>` | Host destination tarball path. Defaults to `./sessions-<sandbox>-<agent>.tgz`. |
-| `--include-trajectory` | Include the (large) `*.trajectory.jsonl` files in the bundle. Excluded by default. |
+| `--format <dir\|tar>` | `dir` (default) writes a directory of session files; `tar` writes a single `.tgz` bundle for sharing/upload. |
+| `--out <path>` | Host destination. Defaults to `./sessions-<sandbox>/` for `dir`, or `./sessions-<sandbox>-<agent>.tgz` for `tar`. |
+| `--include-trajectory` | Include the (large) `*.trajectory.jsonl` files in the export. Excluded by default. |
 | `--json` | Print the export manifest as JSON instead of a status line. |
 
-Mismatched `--agent` plus canonical-key combinations are refused before the in-sandbox tar runs.
+Mismatched `--agent` plus canonical-key combinations are refused before any download runs.
 Session keys that begin with `-` are rejected at the command boundary instead of being silently dropped.
-The staging tarball is created with `umask 077` and removed after the host download completes, so a concurrent sandbox user cannot read the staged session JSONL out of `/tmp` between the tar step and the download step.
+Session JSONL can contain pasted secrets (API keys, tokens), so exported files are written owner-only (`0600`); for `tar` format the in-sandbox staging tarball is additionally created with `umask 077` and removed after the host download completes.
 
 ### `$$nemoclaw <name> download <sandbox-path> [host-dest]`
 

--- a/src/commands/sandbox/download.ts
+++ b/src/commands/sandbox/download.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Args } from "@oclif/core";
+
+import { downloadFromSandbox } from "../../lib/actions/sandbox/download";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+import { sandboxNameArg } from "../../lib/sandbox/command-support";
+
+export default class SandboxDownloadCommand extends NemoClawCommand {
+  static id = "sandbox:download";
+  static strict = true;
+  static summary = "Download a file or directory from the sandbox to the host";
+  static description =
+    "Thin host-side wrapper around `openshell sandbox download`. Validates that the sandbox is alive, then forwards the source and destination verbatim to the OpenShell transport so its file-system semantics (single-file vs. directory copy, trailing-slash handling, overwrite behaviour) stay the same.";
+  static usage = ["<name> <sandbox-path> [host-dest]"];
+  static examples = [
+    "<%= config.bin %> sandbox download alpha /sandbox/.openclaw/workspace/SOUL.md ./",
+    "<%= config.bin %> sandbox download alpha /sandbox/.openclaw/agents/main/sessions/ ./sessions/",
+  ];
+  static args = {
+    sandboxName: sandboxNameArg,
+    sandboxPath: Args.string({
+      name: "sandbox-path",
+      description: "Path inside the sandbox to download.",
+      required: true,
+    }),
+    hostDest: Args.string({
+      name: "host-dest",
+      description: "Host destination (default: current directory).",
+      required: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(SandboxDownloadCommand);
+    try {
+      await downloadFromSandbox({
+        sandboxName: args.sandboxName,
+        sandboxPath: args.sandboxPath,
+        hostDest: args.hostDest,
+      });
+    } catch (error) {
+      this.failWithLines([`  ${(error as Error).message}`], 1);
+    }
+  }
+}

--- a/src/commands/sandbox/sessions/export.ts
+++ b/src/commands/sandbox/sessions/export.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flags } from "@oclif/core";
+
+import { exportSandboxSessions } from "../../../lib/actions/sandbox/sessions/export";
+import { NemoClawCommand } from "../../../lib/cli/nemoclaw-oclif-command";
+
+export default class SandboxSessionsExportCommand extends NemoClawCommand {
+  static id = "sandbox:sessions:export";
+  static strict = false;
+  static summary = "Export OpenClaw session JSONL out of a running sandbox";
+  static description = [
+    "Tar the OpenClaw session store inside the sandbox and download the bundle to",
+    "the host via `openshell sandbox download`. By default every session for the",
+    "agent is exported; pass one or more positional keys to filter.",
+    "",
+    "Keys may be either an alias (e.g. `main`, `telegram:t-1`) or the canonical",
+    "`agent:<id>:<rest>` form. Use --agent to scope aliases to a non-default",
+    "agent; mismatched --agent + canonical-key combinations are refused.",
+    "",
+    "Trajectory files are excluded by default (large) and re-added with",
+    "--include-trajectory.",
+  ].join("\n");
+  static usage = ["<name> [keys...] [--agent <id>] [--out <path>] [--include-trajectory] [--json]"];
+  static examples = [
+    "<%= config.bin %> sandbox sessions export alpha",
+    "<%= config.bin %> sandbox sessions export alpha main --agent main",
+    "<%= config.bin %> sandbox sessions export alpha agent:work:telegram:t-1 --include-trajectory",
+    "<%= config.bin %> sandbox sessions export alpha --out ./bundles/alpha.tgz --json",
+  ];
+  static flags = {
+    agent: Flags.string({
+      description: "Agent id when keys are aliases rather than canonical form.",
+    }),
+    out: Flags.string({
+      description: "Host destination tarball path (default: ./sessions-<sandbox>-<agent>.tgz).",
+    }),
+    "include-trajectory": Flags.boolean({
+      description: "Include the (large) trajectory.jsonl files in the bundle.",
+      default: false,
+    }),
+    json: Flags.boolean({
+      description: "Print the export manifest as JSON instead of a status line.",
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags, argv } = await this.parse(SandboxSessionsExportCommand);
+    const [sandboxName, ...rest] = argv as string[];
+    if (!sandboxName) {
+      this.failWithLines([`  Usage: ${SandboxSessionsExportCommand.usage[0]}`], 2);
+      return;
+    }
+    const keys = rest.filter((token) => !token.startsWith("-"));
+    try {
+      await exportSandboxSessions({
+        sandboxName,
+        agent: flags.agent,
+        keys,
+        out: flags.out,
+        includeTrajectory: flags["include-trajectory"],
+        json: flags.json,
+      });
+    } catch (error) {
+      this.failWithLines([`  ${(error as Error).message}`], 1);
+    }
+  }
+}

--- a/src/commands/sandbox/sessions/export.ts
+++ b/src/commands/sandbox/sessions/export.ts
@@ -53,12 +53,22 @@ export default class SandboxSessionsExportCommand extends NemoClawCommand {
       this.failWithLines([`  Usage: ${SandboxSessionsExportCommand.usage[0]}`], 2);
       return;
     }
-    const keys = rest.filter((token) => !token.startsWith("-"));
+    const stray = rest.filter((token) => token.startsWith("-"));
+    if (stray.length > 0) {
+      this.failWithLines(
+        [
+          `  Unknown flag or option-shaped key: ${stray.join(", ")}`,
+          "  Session keys must not start with '-'. Place flags after the sandbox name.",
+        ],
+        2,
+      );
+      return;
+    }
     try {
       await exportSandboxSessions({
         sandboxName,
         agent: flags.agent,
-        keys,
+        keys: rest,
         out: flags.out,
         includeTrajectory: flags["include-trajectory"],
         json: flags.json,

--- a/src/commands/sandbox/sessions/export.ts
+++ b/src/commands/sandbox/sessions/export.ts
@@ -26,22 +26,31 @@ export default class SandboxSessionsExportCommand extends NemoClawCommand {
     "downloaded bundle is written owner-only (0600); keep it private and avoid",
     "committing or sharing it without review.",
   ].join("\n");
-  static usage = ["<name> [keys...] [--agent <id>] [--out <path>] [--include-trajectory] [--json]"];
+  static usage = [
+    "<name> [keys...] [--agent <id>] [--format <dir|tar>] [--out <path>] [--include-trajectory] [--json]",
+  ];
   static examples = [
     "<%= config.bin %> sandbox sessions export alpha",
     "<%= config.bin %> sandbox sessions export alpha main --agent main",
     "<%= config.bin %> sandbox sessions export alpha agent:work:telegram:t-1 --include-trajectory",
-    "<%= config.bin %> sandbox sessions export alpha --out ./bundles/alpha.tgz --json",
+    "<%= config.bin %> sandbox sessions export alpha --format tar --out ./bundles/alpha.tgz --json",
   ];
   static flags = {
     agent: Flags.string({
       description: "Agent id when keys are aliases rather than canonical form.",
     }),
+    format: Flags.string({
+      description:
+        "Output format: 'dir' (default) writes a directory of session files; 'tar' writes a single .tgz bundle for sharing/upload.",
+      options: ["dir", "tar"],
+      default: "dir",
+    }),
     out: Flags.string({
-      description: "Host destination tarball path (default: ./sessions-<sandbox>-<agent>.tgz).",
+      description:
+        "Host destination. Defaults to ./sessions-<sandbox>/ for dir format, or ./sessions-<sandbox>-<agent>.tgz for tar format.",
     }),
     "include-trajectory": Flags.boolean({
-      description: "Include the (large) trajectory.jsonl files in the bundle.",
+      description: "Include the (large) trajectory.jsonl files in the export.",
       default: false,
     }),
     json: Flags.boolean({
@@ -73,6 +82,7 @@ export default class SandboxSessionsExportCommand extends NemoClawCommand {
         sandboxName,
         agent: flags.agent,
         keys: rest,
+        format: flags.format === "tar" ? "tar" : "dir",
         out: flags.out,
         includeTrajectory: flags["include-trajectory"],
         json: flags.json,

--- a/src/commands/sandbox/sessions/export.ts
+++ b/src/commands/sandbox/sessions/export.ts
@@ -21,6 +21,10 @@ export default class SandboxSessionsExportCommand extends NemoClawCommand {
     "",
     "Trajectory files are excluded by default (large) and re-added with",
     "--include-trajectory.",
+    "",
+    "Note: session JSONL can contain pasted secrets (API keys, tokens). The",
+    "downloaded bundle is written owner-only (0600); keep it private and avoid",
+    "committing or sharing it without review.",
   ].join("\n");
   static usage = ["<name> [keys...] [--agent <id>] [--out <path>] [--include-trajectory] [--json]"];
   static examples = [

--- a/src/commands/sandbox/upload.ts
+++ b/src/commands/sandbox/upload.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Args } from "@oclif/core";
+
+import { uploadToSandbox } from "../../lib/actions/sandbox/upload";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
+import { sandboxNameArg } from "../../lib/sandbox/command-support";
+
+export default class SandboxUploadCommand extends NemoClawCommand {
+  static id = "sandbox:upload";
+  static strict = true;
+  static summary = "Upload a file or directory from the host into the sandbox";
+  static description =
+    "Thin host-side wrapper around `openshell sandbox upload`. Validates that the sandbox is alive, then forwards the source and destination verbatim to the OpenShell transport so its file-system semantics (single-file vs. directory copy, trailing-slash handling, overwrite behaviour) stay the same.";
+  static usage = ["<name> <host-path> [sandbox-dest]"];
+  static examples = [
+    "<%= config.bin %> sandbox upload alpha ./local-file /sandbox/",
+    "<%= config.bin %> sandbox upload alpha ./backups/SOUL.md /sandbox/.openclaw/workspace/SOUL.md",
+  ];
+  static args = {
+    sandboxName: sandboxNameArg,
+    hostPath: Args.string({
+      name: "host-path",
+      description: "Path on the host to upload.",
+      required: true,
+    }),
+    sandboxDest: Args.string({
+      name: "sandbox-dest",
+      description: "Destination inside the sandbox (default: /sandbox/).",
+      required: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(SandboxUploadCommand);
+    try {
+      await uploadToSandbox({
+        sandboxName: args.sandboxName,
+        hostPath: args.hostPath,
+        sandboxDest: args.sandboxDest,
+      });
+    } catch (error) {
+      this.failWithLines([`  ${(error as Error).message}`], 1);
+    }
+  }
+}

--- a/src/lib/actions/sandbox/download.test.ts
+++ b/src/lib/actions/sandbox/download.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./gateway-state", () => ({
+  ensureLiveSandboxOrExit: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../adapters/openshell/runtime", () => ({
+  runOpenshell: vi.fn(),
+}));
+
+import { runOpenshell } from "../../adapters/openshell/runtime";
+import { downloadFromSandbox } from "./download";
+import { ensureLiveSandboxOrExit } from "./gateway-state";
+
+const runMock = runOpenshell as unknown as ReturnType<typeof vi.fn>;
+const ensureMock = ensureLiveSandboxOrExit as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  runMock.mockReset();
+  ensureMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("downloadFromSandbox", () => {
+  it("forwards verbatim args to `openshell sandbox download` after a live-sandbox check", async () => {
+    const result = await downloadFromSandbox({
+      sandboxName: "alpha",
+      sandboxPath: "/sandbox/.openclaw/workspace/SOUL.md",
+      hostDest: "./out",
+    });
+
+    expect(ensureMock).toHaveBeenCalledWith("alpha", { allowNonReadyPhase: true });
+    expect(runMock).toHaveBeenCalledWith(
+      ["sandbox", "download", "alpha", "/sandbox/.openclaw/workspace/SOUL.md", "./out"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    expect(result).toEqual({
+      sandboxPath: "/sandbox/.openclaw/workspace/SOUL.md",
+      hostDest: "./out",
+    });
+  });
+
+  it("defaults the host destination to the current directory when omitted", async () => {
+    await downloadFromSandbox({ sandboxName: "alpha", sandboxPath: "/sandbox/x" });
+    const args = runMock.mock.calls[0]?.[0];
+    expect(args?.at(-1)).toBe(".");
+  });
+
+  it("throws (does not exit) when no sandbox path is given", async () => {
+    await expect(downloadFromSandbox({ sandboxName: "alpha", sandboxPath: "" })).rejects.toThrow(
+      /No sandbox path provided/,
+    );
+    expect(ensureMock).not.toHaveBeenCalled();
+    expect(runMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/sandbox/download.ts
+++ b/src/lib/actions/sandbox/download.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runOpenshell } from "../../adapters/openshell/runtime";
+import { CLI_NAME } from "../../cli/branding";
+import { ensureLiveSandboxOrExit } from "./gateway-state";
+
+export interface SandboxDownloadOptions {
+  sandboxName: string;
+  sandboxPath: string;
+  hostDest?: string;
+  allowNonReadyPhase?: boolean;
+}
+
+export interface SandboxDownloadResult {
+  sandboxPath: string;
+  hostDest: string;
+}
+
+export async function downloadFromSandbox(
+  opts: SandboxDownloadOptions,
+): Promise<SandboxDownloadResult> {
+  const sandboxPath = (opts.sandboxPath ?? "").trim();
+  if (!sandboxPath) {
+    throw new Error(
+      `No sandbox path provided; usage: ${CLI_NAME} ${opts.sandboxName} download <sandbox-path> [host-dest]`,
+    );
+  }
+  const hostDest = (opts.hostDest ?? "").trim() || ".";
+
+  await ensureLiveSandboxOrExit(opts.sandboxName, {
+    allowNonReadyPhase: opts.allowNonReadyPhase ?? true,
+  });
+
+  runOpenshell(["sandbox", "download", opts.sandboxName, sandboxPath, hostDest], {
+    stdio: "inherit",
+  });
+
+  return { sandboxPath, hostDest };
+}

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -57,7 +57,8 @@ describe("buildSandboxTarArgv", () => {
       "-C",
       "/sandbox/.openclaw/agents/main/sessions",
       "--exclude=*.trajectory.jsonl",
-      ".",
+      "--",
+      "./",
     ]);
   });
 
@@ -69,10 +70,18 @@ describe("buildSandboxTarArgv", () => {
         resolvedFiles: null,
         includeTrajectory: true,
       }),
-    ).toEqual(["tar", "-czf", "/tmp/x.tgz", "-C", "/sandbox/.openclaw/agents/main/sessions", "."]);
+    ).toEqual([
+      "tar",
+      "-czf",
+      "/tmp/x.tgz",
+      "-C",
+      "/sandbox/.openclaw/agents/main/sessions",
+      "--",
+      "./",
+    ]);
   });
 
-  it("passes resolved files verbatim when keys filter the bundle", () => {
+  it("isolates resolved files behind `--` and prefixes each with './' so a leading-dash filename cannot be reinterpreted as a tar option", () => {
     expect(
       buildSandboxTarArgv({
         sourceDir: "/sandbox/.openclaw/agents/main/sessions",
@@ -86,8 +95,9 @@ describe("buildSandboxTarArgv", () => {
       "/tmp/x.tgz",
       "-C",
       "/sandbox/.openclaw/agents/main/sessions",
-      "sid-1.jsonl",
-      "sid-2.jsonl",
+      "--",
+      "./sid-1.jsonl",
+      "./sid-2.jsonl",
     ]);
   });
 });
@@ -133,8 +143,13 @@ describe("exportSandboxSessions", () => {
     expect(runMock).toHaveBeenCalledTimes(2);
     const tarCall = runMock.mock.calls[0]?.[0] as string[];
     expect(tarCall.slice(0, 5)).toEqual(["sandbox", "exec", "--name", "alpha", "--"]);
-    expect(tarCall).toContain("--exclude=*.trajectory.jsonl");
-    expect(tarCall.at(-1)).toBe(".");
+    // The tar command is wrapped in `sh -c "umask 077 && tar ... && chmod 600 ..."`
+    // so a concurrent sandbox user cannot read the staged session JSONL.
+    expect(tarCall.slice(5, 7)).toEqual(["sh", "-c"]);
+    const shellCommand = tarCall[7] as string;
+    expect(shellCommand).toMatch(/^umask 077 && tar -czf /);
+    expect(shellCommand).toMatch(/--exclude=\*\.trajectory\.jsonl/);
+    expect(shellCommand).toMatch(/&& chmod 600 /);
 
     expect(downloadMock).toHaveBeenCalledTimes(1);
     expect(downloadMock.mock.calls[0]?.[0]).toMatchObject({
@@ -164,9 +179,9 @@ describe("exportSandboxSessions", () => {
     });
 
     const tarCall = runMock.mock.calls[0]?.[0] as string[];
-    expect(tarCall).toContain("sid-2.jsonl");
-    expect(tarCall).toContain("sid-2.trajectory.jsonl");
-    expect(tarCall).not.toContain("sid-1.jsonl");
+    const shellCommand = tarCall[7] as string;
+    expect(shellCommand).toMatch(/-- \.\/sid-2\.jsonl \.\/sid-2\.trajectory\.jsonl/);
+    expect(shellCommand).not.toMatch(/sid-1\.jsonl/);
     expect(result.selectedKeys).toEqual(["agent:main:telegram:t-1"]);
     expect(result.resolvedFiles).toEqual(["sid-2.jsonl", "sid-2.trajectory.jsonl"]);
   });
@@ -187,7 +202,7 @@ describe("exportSandboxSessions", () => {
     expect(captureCall).toContain("--agent");
     expect(captureCall).toContain("work");
     const tarCall = runMock.mock.calls[0]?.[0] as string[];
-    expect(tarCall).toContain("sid-9.jsonl");
+    expect(tarCall[7]).toMatch(/sid-9\.jsonl/);
   });
 
   it("refuses canonical keys whose agent disagrees with --agent", async () => {
@@ -212,11 +227,40 @@ describe("exportSandboxSessions", () => {
     expect(runMock).not.toHaveBeenCalled();
   });
 
+  it("refuses to tar when a resolved session id starts with '-' (would be interpreted as a tar option)", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(
+        JSON.stringify([{ key: "agent:main:main", sessionId: "--checkpoint-action=exec=sh" }]),
+      ),
+    );
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        keys: ["agent:main:main"],
+      }),
+    ).rejects.toThrow(/contains unsafe characters or starts with '-'/);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
   it("cleans up the staging tarball after the host download succeeds", async () => {
     await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
     });
+    const cleanupCall = runMock.mock.calls.at(-1);
+    expect(cleanupCall?.[0]).toContain("rm");
+    expect(cleanupCall?.[0]).toContain("-f");
+    expect(cleanupCall?.[1]).toMatchObject({ ignoreError: true });
+  });
+
+  it("still cleans up the staging tarball when the host download throws", async () => {
+    downloadMock.mockRejectedValueOnce(new Error("openshell download exited 1"));
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        out: "./out.tgz",
+      }),
+    ).rejects.toThrow(/openshell download exited 1/);
     const cleanupCall = runMock.mock.calls.at(-1);
     expect(cleanupCall?.[0]).toContain("rm");
     expect(cleanupCall?.[0]).toContain("-f");

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -41,53 +41,17 @@ afterEach(() => {
   consoleLogSpy.mockRestore();
 });
 
+function makeCapture(output: string, status = 0) {
+  return { status, output, error: undefined as Error | undefined };
+}
+
 describe("buildSandboxTarArgv", () => {
-  it("tars the whole agent sessions dir and excludes trajectory by default", () => {
-    expect(
-      buildSandboxTarArgv({
-        sourceDir: "/sandbox/.openclaw/agents/main/sessions",
-        tarballRemote: "/tmp/x.tgz",
-        resolvedFiles: null,
-        includeTrajectory: false,
-      }),
-    ).toEqual([
-      "tar",
-      "-czf",
-      "/tmp/x.tgz",
-      "-C",
-      "/sandbox/.openclaw/agents/main/sessions",
-      "--exclude=*.trajectory.jsonl",
-      "--",
-      "./",
-    ]);
-  });
-
-  it("keeps trajectory files when includeTrajectory=true and no key filter", () => {
-    expect(
-      buildSandboxTarArgv({
-        sourceDir: "/sandbox/.openclaw/agents/main/sessions",
-        tarballRemote: "/tmp/x.tgz",
-        resolvedFiles: null,
-        includeTrajectory: true,
-      }),
-    ).toEqual([
-      "tar",
-      "-czf",
-      "/tmp/x.tgz",
-      "-C",
-      "/sandbox/.openclaw/agents/main/sessions",
-      "--",
-      "./",
-    ]);
-  });
-
   it("isolates resolved files behind `--` and prefixes each with './' so a leading-dash filename cannot be reinterpreted as a tar option", () => {
     expect(
       buildSandboxTarArgv({
         sourceDir: "/sandbox/.openclaw/agents/main/sessions",
         tarballRemote: "/tmp/x.tgz",
         resolvedFiles: ["sid-1.jsonl", "sid-2.jsonl"],
-        includeTrajectory: false,
       }),
     ).toEqual([
       "tar",
@@ -129,36 +93,63 @@ describe("parseSessionIndex", () => {
 });
 
 describe("exportSandboxSessions", () => {
-  function makeCapture(output: string, status = 0) {
-    return { status, output, error: undefined as Error | undefined };
-  }
+  it("enumerates every session via openclaw sessions list when no keys are supplied and tars only the resolved files", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-a" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-b" },
+        ]),
+      ),
+    );
 
-  it("tars all sessions when no keys are supplied and downloads via the wrapper", async () => {
     const result = await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
     });
 
-    expect(captureMock).not.toHaveBeenCalled();
-    expect(runMock).toHaveBeenCalledTimes(2);
+    expect(captureMock).toHaveBeenCalledTimes(1);
+    const captureCall = captureMock.mock.calls[0]?.[0] as string[];
+    expect(captureCall).toContain("openclaw");
+    expect(captureCall).toContain("sessions");
+    expect(captureCall).toContain("list");
+    expect(captureCall).toContain("--agent");
+    expect(captureCall).toContain("main");
+
     const tarCall = runMock.mock.calls[0]?.[0] as string[];
-    expect(tarCall.slice(0, 5)).toEqual(["sandbox", "exec", "--name", "alpha", "--"]);
-    // The tar command is wrapped in `sh -c "umask 077 && tar ... && chmod 600 ..."`
-    // so a concurrent sandbox user cannot read the staged session JSONL.
-    expect(tarCall.slice(5, 7)).toEqual(["sh", "-c"]);
+    expect(tarCall.slice(0, 7)).toEqual(["sandbox", "exec", "--name", "alpha", "--", "sh", "-c"]);
     const shellCommand = tarCall[7] as string;
     expect(shellCommand).toMatch(/^umask 077 && tar -czf /);
-    expect(shellCommand).toMatch(/--exclude=\*\.trajectory\.jsonl/);
+    expect(shellCommand).toMatch(/-- \.\/sid-a\.jsonl \.\/sid-b\.jsonl/);
     expect(shellCommand).toMatch(/&& chmod 600 /);
+    expect(shellCommand).not.toMatch(/sid-a\.trajectory\.jsonl/);
 
-    expect(downloadMock).toHaveBeenCalledTimes(1);
-    expect(downloadMock.mock.calls[0]?.[0]).toMatchObject({
-      sandboxName: "alpha",
-      hostDest: "./out.tgz",
-    });
     expect(result.selectedKeys).toBe("all");
-    expect(result.resolvedFiles).toBe("all");
-    expect(result.agent).toBe("main");
+    expect(result.resolvedFiles).toEqual(["sid-a.jsonl", "sid-b.jsonl"]);
+  });
+
+  it("includes trajectory files for every session when --include-trajectory is set and no keys filter", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-a" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-b" },
+        ]),
+      ),
+    );
+
+    const result = await exportSandboxSessions({
+      sandboxName: "alpha",
+      out: "./out.tgz",
+      includeTrajectory: true,
+    });
+
+    expect(result.resolvedFiles).toEqual([
+      "sid-a.jsonl",
+      "sid-a.trajectory.jsonl",
+      "sid-b.jsonl",
+      "sid-b.trajectory.jsonl",
+    ]);
   });
 
   it("resolves canonical keys to filenames via openclaw sessions list", async () => {
@@ -227,6 +218,17 @@ describe("exportSandboxSessions", () => {
     expect(runMock).not.toHaveBeenCalled();
   });
 
+  it("refuses to export when the agent has no sessions at all", async () => {
+    captureMock.mockReturnValueOnce(makeCapture(JSON.stringify([])));
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        out: "./out.tgz",
+      }),
+    ).rejects.toThrow(/agent 'main' has no sessions to bundle/);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
   it("refuses to tar when a resolved session id starts with '-' (would be interpreted as a tar option)", async () => {
     captureMock.mockReturnValueOnce(
       makeCapture(
@@ -243,6 +245,9 @@ describe("exportSandboxSessions", () => {
   });
 
   it("cleans up the staging tarball after the host download succeeds", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(JSON.stringify([{ key: "agent:main:main", sessionId: "sid-a" }])),
+    );
     await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
@@ -254,6 +259,9 @@ describe("exportSandboxSessions", () => {
   });
 
   it("still cleans up the staging tarball when the host download throws", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(JSON.stringify([{ key: "agent:main:main", sessionId: "sid-a" }])),
+    );
     downloadMock.mockRejectedValueOnce(new Error("openshell download exited 1"));
     await expect(
       exportSandboxSessions({
@@ -268,6 +276,9 @@ describe("exportSandboxSessions", () => {
   });
 
   it("emits a JSON manifest when --json is set", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(JSON.stringify([{ key: "agent:main:main", sessionId: "sid-a" }])),
+    );
     await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
@@ -279,6 +290,7 @@ describe("exportSandboxSessions", () => {
       sandboxName: "alpha",
       agent: "main",
       selectedKeys: "all",
+      resolvedFiles: ["sid-a.jsonl"],
       hostDest: "./out.tgz",
     });
   });

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../gateway-state", () => ({
+  ensureLiveSandboxOrExit: vi.fn(async () => undefined),
+}));
+
+vi.mock("../download", () => ({
+  downloadFromSandbox: vi.fn(async () => ({ sandboxPath: "", hostDest: "" })),
+}));
+
+vi.mock("../../../adapters/openshell/runtime", () => ({
+  captureOpenshell: vi.fn(),
+  runOpenshell: vi.fn(),
+}));
+
+import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
+import { downloadFromSandbox } from "../download";
+import { buildSandboxTarArgv, exportSandboxSessions, parseSessionIndex } from "./export";
+
+const captureMock = captureOpenshell as unknown as ReturnType<typeof vi.fn>;
+const runMock = runOpenshell as unknown as ReturnType<typeof vi.fn>;
+const downloadMock = downloadFromSandbox as unknown as ReturnType<typeof vi.fn>;
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  captureMock.mockReset();
+  runMock.mockReset();
+  downloadMock.mockReset();
+  downloadMock.mockResolvedValue({ sandboxPath: "", hostDest: "" });
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  consoleLogSpy.mockRestore();
+});
+
+describe("buildSandboxTarArgv", () => {
+  it("tars the whole agent sessions dir and excludes trajectory by default", () => {
+    expect(
+      buildSandboxTarArgv({
+        sourceDir: "/sandbox/.openclaw/agents/main/sessions",
+        tarballRemote: "/tmp/x.tgz",
+        resolvedFiles: null,
+        includeTrajectory: false,
+      }),
+    ).toEqual([
+      "tar",
+      "-czf",
+      "/tmp/x.tgz",
+      "-C",
+      "/sandbox/.openclaw/agents/main/sessions",
+      "--exclude=*.trajectory.jsonl",
+      ".",
+    ]);
+  });
+
+  it("keeps trajectory files when includeTrajectory=true and no key filter", () => {
+    expect(
+      buildSandboxTarArgv({
+        sourceDir: "/sandbox/.openclaw/agents/main/sessions",
+        tarballRemote: "/tmp/x.tgz",
+        resolvedFiles: null,
+        includeTrajectory: true,
+      }),
+    ).toEqual(["tar", "-czf", "/tmp/x.tgz", "-C", "/sandbox/.openclaw/agents/main/sessions", "."]);
+  });
+
+  it("passes resolved files verbatim when keys filter the bundle", () => {
+    expect(
+      buildSandboxTarArgv({
+        sourceDir: "/sandbox/.openclaw/agents/main/sessions",
+        tarballRemote: "/tmp/x.tgz",
+        resolvedFiles: ["sid-1.jsonl", "sid-2.jsonl"],
+        includeTrajectory: false,
+      }),
+    ).toEqual([
+      "tar",
+      "-czf",
+      "/tmp/x.tgz",
+      "-C",
+      "/sandbox/.openclaw/agents/main/sessions",
+      "sid-1.jsonl",
+      "sid-2.jsonl",
+    ]);
+  });
+});
+
+describe("parseSessionIndex", () => {
+  it("accepts a plain JSON array of entries", () => {
+    const output = '[{"key":"agent:main:main","sessionId":"sid-1"}]';
+    expect(parseSessionIndex(output)).toEqual([{ key: "agent:main:main", sessionId: "sid-1" }]);
+  });
+
+  it("accepts an object wrapper with a sessions array", () => {
+    const output = '{"sessions":[{"key":"agent:main:main","sessionId":"sid-1"}]}';
+    expect(parseSessionIndex(output)).toEqual([{ key: "agent:main:main", sessionId: "sid-1" }]);
+  });
+
+  it("treats id as an alias for sessionId", () => {
+    const output = '[{"key":"agent:main:main","id":"sid-1"}]';
+    expect(parseSessionIndex(output)).toEqual([{ key: "agent:main:main", sessionId: "sid-1" }]);
+  });
+
+  it("tolerates log noise preceding a single-line JSON payload", () => {
+    const output = 'warning: deprecation\n[{"key":"agent:main:main","sessionId":"sid-1"}]';
+    expect(parseSessionIndex(output)).toEqual([{ key: "agent:main:main", sessionId: "sid-1" }]);
+  });
+
+  it("returns empty when the output cannot be parsed", () => {
+    expect(parseSessionIndex("hello world")).toEqual([]);
+  });
+});
+
+describe("exportSandboxSessions", () => {
+  function makeCapture(output: string, status = 0) {
+    return { status, output, error: undefined as Error | undefined };
+  }
+
+  it("tars all sessions when no keys are supplied and downloads via the wrapper", async () => {
+    const result = await exportSandboxSessions({
+      sandboxName: "alpha",
+      out: "./out.tgz",
+    });
+
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(runMock).toHaveBeenCalledTimes(2);
+    const tarCall = runMock.mock.calls[0]?.[0] as string[];
+    expect(tarCall.slice(0, 5)).toEqual(["sandbox", "exec", "--name", "alpha", "--"]);
+    expect(tarCall).toContain("--exclude=*.trajectory.jsonl");
+    expect(tarCall.at(-1)).toBe(".");
+
+    expect(downloadMock).toHaveBeenCalledTimes(1);
+    expect(downloadMock.mock.calls[0]?.[0]).toMatchObject({
+      sandboxName: "alpha",
+      hostDest: "./out.tgz",
+    });
+    expect(result.selectedKeys).toBe("all");
+    expect(result.resolvedFiles).toBe("all");
+    expect(result.agent).toBe("main");
+  });
+
+  it("resolves canonical keys to filenames via openclaw sessions list", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-1" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-2" },
+        ]),
+      ),
+    );
+
+    const result = await exportSandboxSessions({
+      sandboxName: "alpha",
+      keys: ["agent:main:telegram:t-1"],
+      out: "./out.tgz",
+      includeTrajectory: true,
+    });
+
+    const tarCall = runMock.mock.calls[0]?.[0] as string[];
+    expect(tarCall).toContain("sid-2.jsonl");
+    expect(tarCall).toContain("sid-2.trajectory.jsonl");
+    expect(tarCall).not.toContain("sid-1.jsonl");
+    expect(result.selectedKeys).toEqual(["agent:main:telegram:t-1"]);
+    expect(result.resolvedFiles).toEqual(["sid-2.jsonl", "sid-2.trajectory.jsonl"]);
+  });
+
+  it("treats alias keys under the --agent flag as canonical", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(JSON.stringify([{ key: "agent:work:telegram:t-1", sessionId: "sid-9" }])),
+    );
+
+    await exportSandboxSessions({
+      sandboxName: "alpha",
+      agent: "work",
+      keys: ["telegram:t-1"],
+      out: "./out.tgz",
+    });
+
+    const captureCall = captureMock.mock.calls[0]?.[0] as string[];
+    expect(captureCall).toContain("--agent");
+    expect(captureCall).toContain("work");
+    const tarCall = runMock.mock.calls[0]?.[0] as string[];
+    expect(tarCall).toContain("sid-9.jsonl");
+  });
+
+  it("refuses canonical keys whose agent disagrees with --agent", async () => {
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        agent: "work",
+        keys: ["agent:main:main"],
+      }),
+    ).rejects.toThrow(/scoped to agent 'main', not 'work'/);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to tar when a requested key cannot be found in the index", async () => {
+    captureMock.mockReturnValueOnce(makeCapture(JSON.stringify([])));
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        keys: ["agent:main:main"],
+      }),
+    ).rejects.toThrow(/no entries found in agent 'main'/);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it("cleans up the staging tarball after the host download succeeds", async () => {
+    await exportSandboxSessions({
+      sandboxName: "alpha",
+      out: "./out.tgz",
+    });
+    const cleanupCall = runMock.mock.calls.at(-1);
+    expect(cleanupCall?.[0]).toContain("rm");
+    expect(cleanupCall?.[0]).toContain("-f");
+    expect(cleanupCall?.[1]).toMatchObject({ ignoreError: true });
+  });
+
+  it("emits a JSON manifest when --json is set", async () => {
+    await exportSandboxSessions({
+      sandboxName: "alpha",
+      out: "./out.tgz",
+      json: true,
+    });
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    const printed = consoleLogSpy.mock.calls[0]?.[0] as string;
+    expect(JSON.parse(printed)).toMatchObject({
+      sandboxName: "alpha",
+      agent: "main",
+      selectedKeys: "all",
+      hostDest: "./out.tgz",
+    });
+  });
+});

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -95,6 +95,11 @@ describe("parseSessionIndex", () => {
   it("returns null when the output is non-empty but no JSON shape is recognised", () => {
     expect(parseSessionIndex("hello world")).toBeNull();
   });
+
+  it("returns null when the array is non-empty but every entry uses unknown field names (schema drift)", () => {
+    const output = JSON.stringify([{ alias: "agent:main:main", uuid: "sid-1" }]);
+    expect(parseSessionIndex(output)).toBeNull();
+  });
 });
 
 describe("exportSandboxSessions", () => {
@@ -134,7 +139,10 @@ describe("exportSandboxSessions", () => {
     expect(downloadCall.at(-1)).toBe("./out.tgz");
 
     expect(result.selectedKeys).toBe("all");
+    expect(result.resolvedSessionIds).toEqual(["sid-a", "sid-b"]);
     expect(result.resolvedFiles).toEqual(["sid-a.jsonl", "sid-b.jsonl"]);
+    expect(result.hostDest).toBe("./out.tgz");
+    expect(result.bundleBytes).toBeNull();
   });
 
   it("dedupes resolved session ids when the same session is referenced by both alias and canonical key", async () => {
@@ -153,6 +161,7 @@ describe("exportSandboxSessions", () => {
       out: "./out.tgz",
     });
 
+    expect(result.resolvedSessionIds).toEqual(["sid-a"]);
     expect(result.resolvedFiles).toEqual(["sid-a.jsonl"]);
   });
 
@@ -307,7 +316,7 @@ describe("exportSandboxSessions", () => {
     expect(cleanupCall?.[1]).toMatchObject({ ignoreError: true });
   });
 
-  it("emits a JSON manifest when --json is set", async () => {
+  it("emits a JSON manifest with resolved session ids, files, host path, and bundle size when --json is set", async () => {
     captureMock.mockReturnValueOnce(
       makeCapture(JSON.stringify([{ key: "agent:main:main", sessionId: "sid-a" }])),
     );
@@ -318,12 +327,15 @@ describe("exportSandboxSessions", () => {
     });
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);
     const printed = consoleLogSpy.mock.calls[0]?.[0] as string;
-    expect(JSON.parse(printed)).toMatchObject({
+    const parsed = JSON.parse(printed);
+    expect(parsed).toMatchObject({
       sandboxName: "alpha",
       agent: "main",
       selectedKeys: "all",
+      resolvedSessionIds: ["sid-a"],
       resolvedFiles: ["sid-a.jsonl"],
       hostDest: "./out.tgz",
     });
+    expect(parsed).toHaveProperty("bundleBytes");
   });
 });

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -7,22 +7,16 @@ vi.mock("../gateway-state", () => ({
   ensureLiveSandboxOrExit: vi.fn(async () => undefined),
 }));
 
-vi.mock("../download", () => ({
-  downloadFromSandbox: vi.fn(async () => ({ sandboxPath: "", hostDest: "" })),
-}));
-
 vi.mock("../../../adapters/openshell/runtime", () => ({
   captureOpenshell: vi.fn(),
   runOpenshell: vi.fn(),
 }));
 
 import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
-import { downloadFromSandbox } from "../download";
 import { buildSandboxTarArgv, exportSandboxSessions, parseSessionIndex } from "./export";
 
 const captureMock = captureOpenshell as unknown as ReturnType<typeof vi.fn>;
 const runMock = runOpenshell as unknown as ReturnType<typeof vi.fn>;
-const downloadMock = downloadFromSandbox as unknown as ReturnType<typeof vi.fn>;
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -30,8 +24,7 @@ let consoleLogSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   captureMock.mockReset();
   runMock.mockReset();
-  downloadMock.mockReset();
-  downloadMock.mockResolvedValue({ sandboxPath: "", hostDest: "" });
+  runMock.mockReturnValue({ status: 0, stdout: "", stderr: "" });
   consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
 });
@@ -43,6 +36,10 @@ afterEach(() => {
 
 function makeCapture(output: string, status = 0) {
   return { status, output, error: undefined as Error | undefined };
+}
+
+function makeRun(status: number) {
+  return { status, stdout: "", stderr: "" };
 }
 
 describe("buildSandboxTarArgv", () => {
@@ -87,8 +84,16 @@ describe("parseSessionIndex", () => {
     expect(parseSessionIndex(output)).toEqual([{ key: "agent:main:main", sessionId: "sid-1" }]);
   });
 
-  it("returns empty when the output cannot be parsed", () => {
-    expect(parseSessionIndex("hello world")).toEqual([]);
+  it("returns [] when the upstream emits an empty index (empty array)", () => {
+    expect(parseSessionIndex("[]")).toEqual([]);
+  });
+
+  it("returns [] when the upstream emits no output at all", () => {
+    expect(parseSessionIndex("")).toEqual([]);
+  });
+
+  it("returns null when the output is non-empty but no JSON shape is recognised", () => {
+    expect(parseSessionIndex("hello world")).toBeNull();
   });
 });
 
@@ -124,11 +129,15 @@ describe("exportSandboxSessions", () => {
     expect(shellCommand).toMatch(/&& chmod 600 /);
     expect(shellCommand).not.toMatch(/sid-a\.trajectory\.jsonl/);
 
+    const downloadCall = runMock.mock.calls[1]?.[0] as string[];
+    expect(downloadCall.slice(0, 3)).toEqual(["sandbox", "download", "alpha"]);
+    expect(downloadCall.at(-1)).toBe("./out.tgz");
+
     expect(result.selectedKeys).toBe("all");
     expect(result.resolvedFiles).toEqual(["sid-a.jsonl", "sid-b.jsonl"]);
   });
 
-  it("includes trajectory files for every session when --include-trajectory is set and no keys filter", async () => {
+  it("dedupes resolved session ids when the same session is referenced by both alias and canonical key", async () => {
     captureMock.mockReturnValueOnce(
       makeCapture(
         JSON.stringify([
@@ -140,16 +149,11 @@ describe("exportSandboxSessions", () => {
 
     const result = await exportSandboxSessions({
       sandboxName: "alpha",
+      keys: ["agent:main:main", "main"],
       out: "./out.tgz",
-      includeTrajectory: true,
     });
 
-    expect(result.resolvedFiles).toEqual([
-      "sid-a.jsonl",
-      "sid-a.trajectory.jsonl",
-      "sid-b.jsonl",
-      "sid-b.trajectory.jsonl",
-    ]);
+    expect(result.resolvedFiles).toEqual(["sid-a.jsonl"]);
   });
 
   it("resolves canonical keys to filenames via openclaw sessions list", async () => {
@@ -229,6 +233,17 @@ describe("exportSandboxSessions", () => {
     expect(runMock).not.toHaveBeenCalled();
   });
 
+  it("refuses to export when sessions list emits an unrecognised payload (does not silently fall back to no-sessions)", async () => {
+    captureMock.mockReturnValueOnce(makeCapture("upstream changed contract\n<not json>"));
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        out: "./out.tgz",
+      }),
+    ).rejects.toThrow(/Could not parse `openclaw sessions list/);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
   it("refuses to tar when a resolved session id starts with '-' (would be interpreted as a tar option)", async () => {
     captureMock.mockReturnValueOnce(
       makeCapture(
@@ -258,17 +273,34 @@ describe("exportSandboxSessions", () => {
     expect(cleanupCall?.[1]).toMatchObject({ ignoreError: true });
   });
 
-  it("still cleans up the staging tarball when the host download throws", async () => {
+  it("still cleans up the staging tarball when the in-sandbox tar exits non-zero", async () => {
     captureMock.mockReturnValueOnce(
       makeCapture(JSON.stringify([{ key: "agent:main:main", sessionId: "sid-a" }])),
     );
-    downloadMock.mockRejectedValueOnce(new Error("openshell download exited 1"));
+    runMock.mockReturnValueOnce(makeRun(1));
     await expect(
       exportSandboxSessions({
         sandboxName: "alpha",
         out: "./out.tgz",
       }),
-    ).rejects.toThrow(/openshell download exited 1/);
+    ).rejects.toThrow(/Failed to tar sessions/);
+    const cleanupCall = runMock.mock.calls.at(-1);
+    expect(cleanupCall?.[0]).toContain("rm");
+    expect(cleanupCall?.[0]).toContain("-f");
+    expect(cleanupCall?.[1]).toMatchObject({ ignoreError: true });
+  });
+
+  it("still cleans up the staging tarball when the host download exits non-zero", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(JSON.stringify([{ key: "agent:main:main", sessionId: "sid-a" }])),
+    );
+    runMock.mockReturnValueOnce(makeRun(0)).mockReturnValueOnce(makeRun(1));
+    await expect(
+      exportSandboxSessions({
+        sandboxName: "alpha",
+        out: "./out.tgz",
+      }),
+    ).rejects.toThrow(/Failed to download/);
     const cleanupCall = runMock.mock.calls.at(-1);
     expect(cleanupCall?.[0]).toContain("rm");
     expect(cleanupCall?.[0]).toContain("-f");

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../gateway-state", () => ({
@@ -113,10 +115,17 @@ describe("exportSandboxSessions", () => {
       ),
     );
 
+    const chmodSpy = vi.spyOn(fs, "chmodSync").mockImplementation(() => {});
+
     const result = await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
     });
+
+    // Session JSONL can contain pasted secrets, so the downloaded host bundle
+    // must be locked down to owner-only, not just the in-sandbox staging copy.
+    expect(chmodSpy).toHaveBeenCalledWith("./out.tgz", 0o600);
+    chmodSpy.mockRestore();
 
     expect(captureMock).toHaveBeenCalledTimes(1);
     const captureCall = captureMock.mock.calls[0]?.[0] as string[];

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -120,6 +120,7 @@ describe("exportSandboxSessions", () => {
     const result = await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
+      format: "tar",
     });
 
     // Session JSONL can contain pasted secrets, so the downloaded host bundle
@@ -154,6 +155,67 @@ describe("exportSandboxSessions", () => {
     expect(result.bundleBytes).toBeNull();
   });
 
+  it("writes a browsable directory of session files by default (dir format, no tar staging)", async () => {
+    captureMock.mockReturnValueOnce(
+      makeCapture(
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-a" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-b" },
+        ]),
+      ),
+    );
+
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
+    const chmodSpy = vi.spyOn(fs, "chmodSync").mockImplementation(() => {});
+    const statSpy = vi
+      .spyOn(fs, "statSync")
+      .mockReturnValue({ size: 42 } as unknown as ReturnType<typeof fs.statSync>);
+
+    const result = await exportSandboxSessions({
+      sandboxName: "alpha",
+      out: "./sessions-alpha",
+    });
+
+    // dir is the default: no in-sandbox tar/staging, just a per-file download
+    // straight into the host directory.
+    expect(mkdirSpy).toHaveBeenCalledWith("./sessions-alpha", { recursive: true });
+    const shellCalls = runMock.mock.calls.filter((c) => (c[0] as string[]).includes("sh"));
+    expect(shellCalls).toHaveLength(0);
+    const downloadCalls = runMock.mock.calls.filter((c) => (c[0] as string[])[1] === "download");
+    expect(downloadCalls).toHaveLength(2);
+    expect(downloadCalls[0]?.[0]).toEqual([
+      "sandbox",
+      "download",
+      "alpha",
+      "/sandbox/.openclaw/agents/main/sessions/sid-a.jsonl",
+      "sessions-alpha/sid-a.jsonl",
+    ]);
+    // Each downloaded file is locked to owner-only (session JSONL may hold secrets).
+    expect(chmodSpy).toHaveBeenCalledWith("sessions-alpha/sid-a.jsonl", 0o600);
+
+    expect(result.format).toBe("dir");
+    expect(result.hostDest).toBe("./sessions-alpha");
+    expect(result.bundleBytes).toBeNull();
+    expect(result.sessions).toEqual([
+      {
+        key: "agent:main:main",
+        sessionId: "sid-a",
+        path: "sessions-alpha/sid-a.jsonl",
+        sizeBytes: 42,
+      },
+      {
+        key: "agent:main:telegram:t-1",
+        sessionId: "sid-b",
+        path: "sessions-alpha/sid-b.jsonl",
+        sizeBytes: 42,
+      },
+    ]);
+
+    mkdirSpy.mockRestore();
+    chmodSpy.mockRestore();
+    statSpy.mockRestore();
+  });
+
   it("dedupes resolved session ids when the same session is referenced by both alias and canonical key", async () => {
     captureMock.mockReturnValueOnce(
       makeCapture(
@@ -168,6 +230,7 @@ describe("exportSandboxSessions", () => {
       sandboxName: "alpha",
       keys: ["agent:main:main", "main"],
       out: "./out.tgz",
+      format: "tar",
     });
 
     expect(result.resolvedSessionIds).toEqual(["sid-a"]);
@@ -188,6 +251,7 @@ describe("exportSandboxSessions", () => {
       sandboxName: "alpha",
       keys: ["agent:main:telegram:t-1"],
       out: "./out.tgz",
+      format: "tar",
       includeTrajectory: true,
     });
 
@@ -209,6 +273,7 @@ describe("exportSandboxSessions", () => {
       agent: "work",
       keys: ["telegram:t-1"],
       out: "./out.tgz",
+      format: "tar",
     });
 
     const captureCall = captureMock.mock.calls[0]?.[0] as string[];
@@ -246,6 +311,7 @@ describe("exportSandboxSessions", () => {
       exportSandboxSessions({
         sandboxName: "alpha",
         out: "./out.tgz",
+        format: "tar",
       }),
     ).rejects.toThrow(/agent 'main' has no sessions to bundle/);
     expect(runMock).not.toHaveBeenCalled();
@@ -257,6 +323,7 @@ describe("exportSandboxSessions", () => {
       exportSandboxSessions({
         sandboxName: "alpha",
         out: "./out.tgz",
+        format: "tar",
       }),
     ).rejects.toThrow(/Could not parse `openclaw sessions list/);
     expect(runMock).not.toHaveBeenCalled();
@@ -284,6 +351,7 @@ describe("exportSandboxSessions", () => {
     await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
+      format: "tar",
     });
     const cleanupCall = runMock.mock.calls.at(-1);
     expect(cleanupCall?.[0]).toContain("rm");
@@ -300,6 +368,7 @@ describe("exportSandboxSessions", () => {
       exportSandboxSessions({
         sandboxName: "alpha",
         out: "./out.tgz",
+        format: "tar",
       }),
     ).rejects.toThrow(/Failed to tar sessions/);
     const cleanupCall = runMock.mock.calls.at(-1);
@@ -317,6 +386,7 @@ describe("exportSandboxSessions", () => {
       exportSandboxSessions({
         sandboxName: "alpha",
         out: "./out.tgz",
+        format: "tar",
       }),
     ).rejects.toThrow(/Failed to download/);
     const cleanupCall = runMock.mock.calls.at(-1);
@@ -332,6 +402,7 @@ describe("exportSandboxSessions", () => {
     await exportSandboxSessions({
       sandboxName: "alpha",
       out: "./out.tgz",
+      format: "tar",
       json: true,
     });
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -1,6 +1,44 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Scope boundary for `nemoclaw <name> sessions export`:
+//
+//   - Invalid state addressed: extracting OpenClaw's per-agent session JSONL
+//     out of a running sandbox to the host today requires a two-hop
+//     `docker exec kubectl cp` + `docker cp` workaround that bakes in-sandbox
+//     paths and TLS quirks into every consumer (see issue #3979). This module
+//     wraps that flow.
+//   - Source boundary:
+//       * NemoClaw side (this file): validate the requested agent/keys,
+//         resolve canonical keys to session ids via the in-sandbox
+//         `openclaw sessions list --json`, build the in-sandbox tar command,
+//         download the resulting tarball via `openshell sandbox download`,
+//         and best-effort clean up the staging artifact afterwards.
+//       * OpenClaw side (upstream `openclaw` npm package): owns the on-disk
+//         session store under `/sandbox/.openclaw/agents/<id>/sessions/` and
+//         the `sessions.list` index contract. NemoClaw never edits that
+//         store and only reads it through the upstream CLI; renaming a key,
+//         changing the per-session filename layout, or normalising the
+//         `sessions list --json` shape are upstream concerns.
+//   - Source-fix constraint: NemoClaw cannot bypass the two-hop transport
+//     without reaching into the cluster container's file system, which
+//     would violate the sandbox isolation. The wrapper therefore stays a
+//     pure orchestrator over `openshell sandbox exec/download` and
+//     `openclaw sessions list`.
+//   - Regression-test coverage:
+//       * Host-side: `src/lib/actions/sandbox/sessions/export.test.ts`
+//         covers tar argv construction, index parser shape tolerance, key
+//         canonicalisation, agent-scope refusal, leading-dash session id
+//         rejection, download-failure cleanup, and JSON manifest shape.
+//       * E2E (stub openshell): `test/sandbox-sessions-export-cli.test.ts`
+//         exercises the full CLI through dispatch with a fake openshell
+//         binary, proving the `exec tar`, `download`, and `exec rm` wire
+//         calls happen in the expected order.
+//   - Removal condition: the source-boundary comment can be removed when
+//     OpenClaw exposes a stable `sessions.export` RPC that returns a
+//     ready-to-download bundle path, removing NemoClaw's need to compose
+//     the tar command and re-resolve key -> session-id host-side.
+
 import { randomBytes } from "node:crypto";
 
 import { CLI_NAME } from "../../../cli/branding";
@@ -37,7 +75,10 @@ interface SessionIndexEntry {
   sessionId: string;
 }
 
-const SAFE_TOKEN_RE = /^[A-Za-z0-9._-]+$/;
+// Session ids must start with an alphanumeric character so they can never be
+// interpreted as a tar option (`--checkpoint-action=...`, etc.) when appended
+// to the argv. Hyphens and underscores remain permitted as inner characters.
+const SAFE_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 export async function exportSandboxSessions(
   opts: SessionsExportOptions,
@@ -63,20 +104,35 @@ export async function exportSandboxSessions(
     includeTrajectory: opts.includeTrajectory ?? false,
   });
 
-  runOpenshell(["sandbox", "exec", "--name", opts.sandboxName, "--", ...tarArgv]);
-
   const hostDest = resolveHostDestination(opts.out, opts.sandboxName, agent);
-  await downloadFromSandbox({
-    sandboxName: opts.sandboxName,
-    sandboxPath: tarballRemote,
-    hostDest,
-    allowNonReadyPhase: true,
-  });
 
-  runOpenshell(["sandbox", "exec", "--name", opts.sandboxName, "--", "rm", "-f", tarballRemote], {
-    ignoreError: true,
-    stdio: "ignore",
-  });
+  try {
+    runOpenshell([
+      "sandbox",
+      "exec",
+      "--name",
+      opts.sandboxName,
+      "--",
+      "sh",
+      "-c",
+      buildShellInvocation(tarArgv, tarballRemote),
+    ]);
+
+    await downloadFromSandbox({
+      sandboxName: opts.sandboxName,
+      sandboxPath: tarballRemote,
+      hostDest,
+      allowNonReadyPhase: true,
+    });
+  } finally {
+    // Best-effort cleanup of the in-sandbox staging tarball. Runs even when
+    // tar/download fail so a partial export cannot leave a world-readable
+    // bundle of session JSONL in the sandbox's /tmp.
+    runOpenshell(["sandbox", "exec", "--name", opts.sandboxName, "--", "rm", "-f", tarballRemote], {
+      ignoreError: true,
+      stdio: "ignore",
+    });
+  }
 
   const result: SessionsExportResult = {
     sandboxName: opts.sandboxName,
@@ -106,14 +162,32 @@ export function buildSandboxTarArgv(input: {
   resolvedFiles: string[] | null;
   includeTrajectory: boolean;
 }): string[] {
+  // `--` separates tar options from operands so any future file name that
+  // happens to start with `-` (even though SAFE_TOKEN_RE forbids that today)
+  // cannot be reinterpreted as a tar option.
   const argv: string[] = ["tar", "-czf", input.tarballRemote, "-C", input.sourceDir];
   if (input.resolvedFiles && input.resolvedFiles.length > 0) {
-    for (const file of input.resolvedFiles) argv.push(file);
+    argv.push("--");
+    for (const file of input.resolvedFiles) argv.push(`./${file}`);
     return argv;
   }
   if (!input.includeTrajectory) argv.push("--exclude=*.trajectory.jsonl");
-  argv.push(".");
+  argv.push("--", "./");
   return argv;
+}
+
+function buildShellInvocation(tarArgv: readonly string[], tarballRemote: string): string {
+  // umask 077 restricts the staging tarball (mode 600) so a concurrent
+  // sandbox user cannot read another agent's session JSONL out of /tmp
+  // between the tar step and the download step.
+  const quoted = tarArgv.map(shellQuote).join(" ");
+  const quotedTarball = shellQuote(tarballRemote);
+  return `umask 077 && ${quoted} && chmod 600 ${quotedTarball}`;
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9._\/=:@%+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function resolveAgentId(opts: SessionsExportOptions): string {
@@ -157,7 +231,7 @@ function resolveSelectedFiles(
     }
     if (!SAFE_TOKEN_RE.test(sessionId)) {
       throw new Error(
-        `Refusing to tar: session id '${sessionId}' resolved for key '${key}' contains unsafe characters.`,
+        `Refusing to tar: session id '${sessionId}' resolved for key '${key}' contains unsafe characters or starts with '-'.`,
       );
     }
     files.push(`${sessionId}.jsonl`);
@@ -201,6 +275,29 @@ function readSessionIndex(sandboxName: string, agent: string): SessionIndexEntry
   return parseSessionIndex(result.output);
 }
 
+// Tolerant parsing of `openclaw sessions list --json`.
+//
+//   - Invalid state addressed: the upstream OpenClaw CLI has historically
+//     emitted the session index either as a plain JSON array, wrapped in
+//     `{sessions:[...]}` / `{entries:[...]}` / `{items:[...]}`, with
+//     `sessionId` or `id` as the file-name field, and prefixed with Node
+//     experimental-feature warnings. Each shape variant is enough to break a
+//     strict parser and abort the export.
+//   - Source boundary: NemoClaw must accept the upstream-of-the-day shape
+//     read-only. The upstream-pinned contract is captured in
+//     `agents/openclaw/manifest.yaml -> expected_version`; this code does not
+//     hard-code the literal so the manifest stays the single source of
+//     truth.
+//   - Source-fix constraint: tightening the parser to one shape would
+//     regress against any in-the-wild OpenClaw build that still emits a
+//     legacy shape, and NemoClaw cannot rev the upstream CLI from this side.
+//   - Regression-test coverage: `export.test.ts > parseSessionIndex` covers
+//     each accepted shape plus the log-noise prefix; CLI-level coverage in
+//     `test/sandbox-sessions-export-cli.test.ts` exercises the array and
+//     wrapped-object forms via the stub openshell.
+//   - Removal condition: once OpenClaw documents a single stable JSON
+//     contract for `sessions list --json` in its release notes, this
+//     parser can collapse to the strict shape and the alias map can drop.
 export function parseSessionIndex(output: string): SessionIndexEntry[] {
   const trimmed = output.trim();
   if (!trimmed) return [];

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomBytes } from "node:crypto";
+
+import { CLI_NAME } from "../../../cli/branding";
+import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
+import { downloadFromSandbox } from "../download";
+import { ensureLiveSandboxOrExit } from "../gateway-state";
+import {
+  DEFAULT_AGENT_ID,
+  parseAgentIdFromSessionKey,
+  validateAgentId,
+  validateSessionKey,
+} from "./paths";
+
+export interface SessionsExportOptions {
+  sandboxName: string;
+  agent?: string;
+  keys?: readonly string[];
+  out?: string;
+  includeTrajectory?: boolean;
+  json?: boolean;
+}
+
+export interface SessionsExportResult {
+  sandboxName: string;
+  agent: string;
+  selectedKeys: string[] | "all";
+  resolvedFiles: string[] | "all";
+  tarballRemote: string;
+  hostDest: string;
+}
+
+interface SessionIndexEntry {
+  key: string;
+  sessionId: string;
+}
+
+const SAFE_TOKEN_RE = /^[A-Za-z0-9._-]+$/;
+
+export async function exportSandboxSessions(
+  opts: SessionsExportOptions,
+): Promise<SessionsExportResult> {
+  const agent = resolveAgentId(opts);
+  const trimmedKeys = (opts.keys ?? []).map((value) => validateSessionKey(value));
+  enforceAgentScope(agent, trimmedKeys);
+
+  await ensureLiveSandboxOrExit(opts.sandboxName, { allowNonReadyPhase: true });
+
+  const sourceDir = `/sandbox/.openclaw/agents/${agent}/sessions`;
+  const tarballRemote = stagingTarballPath(agent);
+
+  const resolvedFiles =
+    trimmedKeys.length > 0
+      ? resolveSelectedFiles(opts.sandboxName, agent, trimmedKeys, opts.includeTrajectory ?? false)
+      : null;
+
+  const tarArgv = buildSandboxTarArgv({
+    sourceDir,
+    tarballRemote,
+    resolvedFiles,
+    includeTrajectory: opts.includeTrajectory ?? false,
+  });
+
+  runOpenshell(["sandbox", "exec", "--name", opts.sandboxName, "--", ...tarArgv]);
+
+  const hostDest = resolveHostDestination(opts.out, opts.sandboxName, agent);
+  await downloadFromSandbox({
+    sandboxName: opts.sandboxName,
+    sandboxPath: tarballRemote,
+    hostDest,
+    allowNonReadyPhase: true,
+  });
+
+  runOpenshell(["sandbox", "exec", "--name", opts.sandboxName, "--", "rm", "-f", tarballRemote], {
+    ignoreError: true,
+    stdio: "ignore",
+  });
+
+  const result: SessionsExportResult = {
+    sandboxName: opts.sandboxName,
+    agent,
+    selectedKeys: trimmedKeys.length > 0 ? trimmedKeys : "all",
+    resolvedFiles: resolvedFiles ?? "all",
+    tarballRemote,
+    hostDest,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(result));
+  } else {
+    const scope =
+      trimmedKeys.length > 0
+        ? `${trimmedKeys.length} key(s) on agent '${agent}'`
+        : `all sessions for agent '${agent}'`;
+    console.error(`  Exported ${scope} to ${hostDest}`);
+  }
+
+  return result;
+}
+
+export function buildSandboxTarArgv(input: {
+  sourceDir: string;
+  tarballRemote: string;
+  resolvedFiles: string[] | null;
+  includeTrajectory: boolean;
+}): string[] {
+  const argv: string[] = ["tar", "-czf", input.tarballRemote, "-C", input.sourceDir];
+  if (input.resolvedFiles && input.resolvedFiles.length > 0) {
+    for (const file of input.resolvedFiles) argv.push(file);
+    return argv;
+  }
+  if (!input.includeTrajectory) argv.push("--exclude=*.trajectory.jsonl");
+  argv.push(".");
+  return argv;
+}
+
+function resolveAgentId(opts: SessionsExportOptions): string {
+  if (opts.agent) return validateAgentId(opts.agent);
+  for (const key of opts.keys ?? []) {
+    const trimmed = key.trim();
+    const parsed = parseAgentIdFromSessionKey(trimmed);
+    if (parsed) return validateAgentId(parsed);
+  }
+  return DEFAULT_AGENT_ID;
+}
+
+function enforceAgentScope(agent: string, keys: readonly string[]): void {
+  for (const key of keys) {
+    const parsed = parseAgentIdFromSessionKey(key);
+    if (parsed && parsed !== agent) {
+      throw new Error(
+        `Refusing to export: session key '${key}' is scoped to agent '${parsed}', not '${agent}'.`,
+      );
+    }
+  }
+}
+
+function resolveSelectedFiles(
+  sandboxName: string,
+  agent: string,
+  keys: readonly string[],
+  includeTrajectory: boolean,
+): string[] {
+  const index = readSessionIndex(sandboxName, agent);
+  const byKey = new Map<string, string>();
+  for (const entry of index) byKey.set(entry.key, entry.sessionId);
+
+  const missing: string[] = [];
+  const files: string[] = [];
+  for (const key of keys) {
+    const sessionId = byKey.get(key) ?? byKey.get(normaliseToCanonical(agent, key)) ?? null;
+    if (!sessionId) {
+      missing.push(key);
+      continue;
+    }
+    if (!SAFE_TOKEN_RE.test(sessionId)) {
+      throw new Error(
+        `Refusing to tar: session id '${sessionId}' resolved for key '${key}' contains unsafe characters.`,
+      );
+    }
+    files.push(`${sessionId}.jsonl`);
+    if (includeTrajectory) files.push(`${sessionId}.trajectory.jsonl`);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Refusing to export: no entries found in agent '${agent}' for key(s): ${missing.join(", ")}.`,
+    );
+  }
+  return files;
+}
+
+function normaliseToCanonical(agent: string, key: string): string {
+  if (key.startsWith("agent:")) return key;
+  return `agent:${agent}:${key}`;
+}
+
+function readSessionIndex(sandboxName: string, agent: string): SessionIndexEntry[] {
+  const result = captureOpenshell(
+    [
+      "sandbox",
+      "exec",
+      "--name",
+      sandboxName,
+      "--",
+      "openclaw",
+      "sessions",
+      "list",
+      "--agent",
+      agent,
+      "--json",
+    ],
+    { ignoreError: true },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to list sessions in sandbox '${sandboxName}' for agent '${agent}' (exit ${result.status}). Verify the sandbox is live with \`${CLI_NAME} ${sandboxName} status\`.`,
+    );
+  }
+  return parseSessionIndex(result.output);
+}
+
+export function parseSessionIndex(output: string): SessionIndexEntry[] {
+  const trimmed = output.trim();
+  if (!trimmed) return [];
+  const lines = trimmed.split(/\r?\n/);
+  const candidates: string[] = [];
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const candidate = lines[index]?.trim();
+    if (candidate && (candidate.startsWith("[") || candidate.startsWith("{"))) {
+      candidates.push(candidate);
+    }
+  }
+  candidates.push(trimmed);
+  for (const candidate of candidates) {
+    const entries = tryExtractIndex(candidate);
+    if (entries) return entries;
+  }
+  return [];
+}
+
+function tryExtractIndex(text: string): SessionIndexEntry[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const array = pickIndexArray(parsed);
+  if (!array) return null;
+  const entries: SessionIndexEntry[] = [];
+  for (const entry of array) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const key = typeof obj.key === "string" ? obj.key : null;
+    const sessionId =
+      typeof obj.sessionId === "string"
+        ? obj.sessionId
+        : typeof obj.id === "string"
+          ? obj.id
+          : null;
+    if (key && sessionId) entries.push({ key, sessionId });
+  }
+  return entries;
+}
+
+function pickIndexArray(parsed: unknown): unknown[] | null {
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed && typeof parsed === "object") {
+    const obj = parsed as Record<string, unknown>;
+    if (Array.isArray(obj.sessions)) return obj.sessions;
+    if (Array.isArray(obj.entries)) return obj.entries;
+    if (Array.isArray(obj.items)) return obj.items;
+  }
+  return null;
+}
+
+function stagingTarballPath(agent: string): string {
+  const suffix = randomBytes(6).toString("hex");
+  return `/tmp/sessions-export-${agent}-${suffix}.tgz`;
+}
+
+function resolveHostDestination(
+  out: string | undefined,
+  sandboxName: string,
+  agent: string,
+): string {
+  if (out && out.trim()) return out.trim();
+  return `./sessions-${sandboxName}-${agent}.tgz`;
+}

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -65,7 +65,7 @@ export interface SessionsExportResult {
   sandboxName: string;
   agent: string;
   selectedKeys: string[] | "all";
-  resolvedFiles: string[] | "all";
+  resolvedFiles: string[];
   tarballRemote: string;
   hostDest: string;
 }
@@ -92,16 +92,26 @@ export async function exportSandboxSessions(
   const sourceDir = `/sandbox/.openclaw/agents/${agent}/sessions`;
   const tarballRemote = stagingTarballPath(agent);
 
-  const resolvedFiles =
-    trimmedKeys.length > 0
-      ? resolveSelectedFiles(opts.sandboxName, agent, trimmedKeys, opts.includeTrajectory ?? false)
-      : null;
+  // Always enumerate sessions through the in-sandbox `openclaw sessions list`
+  // index, even with no key filter, so the tarball contains exactly the
+  // matching `<sessionId>.jsonl` (+ optional trajectory) files and never
+  // picks up `sessions.json`, stale `.jsonl.lock` files, or other store
+  // bookkeeping.
+  const resolvedFiles = resolveSelectedFiles(
+    opts.sandboxName,
+    agent,
+    trimmedKeys,
+    opts.includeTrajectory ?? false,
+  );
+
+  if (resolvedFiles.length === 0) {
+    throw new Error(`Refusing to export: agent '${agent}' has no sessions to bundle.`);
+  }
 
   const tarArgv = buildSandboxTarArgv({
     sourceDir,
     tarballRemote,
     resolvedFiles,
-    includeTrajectory: opts.includeTrajectory ?? false,
   });
 
   const hostDest = resolveHostDestination(opts.out, opts.sandboxName, agent);
@@ -138,7 +148,7 @@ export async function exportSandboxSessions(
     sandboxName: opts.sandboxName,
     agent,
     selectedKeys: trimmedKeys.length > 0 ? trimmedKeys : "all",
-    resolvedFiles: resolvedFiles ?? "all",
+    resolvedFiles,
     tarballRemote,
     hostDest,
   };
@@ -149,7 +159,7 @@ export async function exportSandboxSessions(
     const scope =
       trimmedKeys.length > 0
         ? `${trimmedKeys.length} key(s) on agent '${agent}'`
-        : `all sessions for agent '${agent}'`;
+        : `all sessions for agent '${agent}' (${resolvedFiles.length} file(s))`;
     console.error(`  Exported ${scope} to ${hostDest}`);
   }
 
@@ -159,20 +169,13 @@ export async function exportSandboxSessions(
 export function buildSandboxTarArgv(input: {
   sourceDir: string;
   tarballRemote: string;
-  resolvedFiles: string[] | null;
-  includeTrajectory: boolean;
+  resolvedFiles: readonly string[];
 }): string[] {
-  // `--` separates tar options from operands so any future file name that
-  // happens to start with `-` (even though SAFE_TOKEN_RE forbids that today)
-  // cannot be reinterpreted as a tar option.
-  const argv: string[] = ["tar", "-czf", input.tarballRemote, "-C", input.sourceDir];
-  if (input.resolvedFiles && input.resolvedFiles.length > 0) {
-    argv.push("--");
-    for (const file of input.resolvedFiles) argv.push(`./${file}`);
-    return argv;
-  }
-  if (!input.includeTrajectory) argv.push("--exclude=*.trajectory.jsonl");
-  argv.push("--", "./");
+  // `--` separates tar options from operands so any file name that happens
+  // to start with `-` (even though SAFE_TOKEN_RE forbids that today) cannot
+  // be reinterpreted as a tar option.
+  const argv: string[] = ["tar", "-czf", input.tarballRemote, "-C", input.sourceDir, "--"];
+  for (const file of input.resolvedFiles) argv.push(`./${file}`);
   return argv;
 }
 
@@ -221,14 +224,28 @@ function resolveSelectedFiles(
   const byKey = new Map<string, string>();
   for (const entry of index) byKey.set(entry.key, entry.sessionId);
 
-  const missing: string[] = [];
-  const files: string[] = [];
-  for (const key of keys) {
-    const sessionId = byKey.get(key) ?? byKey.get(normaliseToCanonical(agent, key)) ?? null;
-    if (!sessionId) {
-      missing.push(key);
-      continue;
+  const entries: { key: string; sessionId: string }[] = [];
+  if (keys.length === 0) {
+    for (const entry of index) entries.push(entry);
+  } else {
+    const missing: string[] = [];
+    for (const key of keys) {
+      const sessionId = byKey.get(key) ?? byKey.get(normaliseToCanonical(agent, key)) ?? null;
+      if (!sessionId) {
+        missing.push(key);
+        continue;
+      }
+      entries.push({ key, sessionId });
     }
+    if (missing.length > 0) {
+      throw new Error(
+        `Refusing to export: no entries found in agent '${agent}' for key(s): ${missing.join(", ")}.`,
+      );
+    }
+  }
+
+  const files: string[] = [];
+  for (const { key, sessionId } of entries) {
     if (!SAFE_TOKEN_RE.test(sessionId)) {
       throw new Error(
         `Refusing to tar: session id '${sessionId}' resolved for key '${key}' contains unsafe characters or starts with '-'.`,
@@ -236,11 +253,6 @@ function resolveSelectedFiles(
     }
     files.push(`${sessionId}.jsonl`);
     if (includeTrajectory) files.push(`${sessionId}.trajectory.jsonl`);
-  }
-  if (missing.length > 0) {
-    throw new Error(
-      `Refusing to export: no entries found in agent '${agent}' for key(s): ${missing.join(", ")}.`,
-    );
   }
   return files;
 }

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -6,8 +6,7 @@
 //   - Invalid state addressed: extracting OpenClaw's per-agent session JSONL
 //     out of a running sandbox to the host today requires a two-hop
 //     `docker exec kubectl cp` + `docker cp` workaround that bakes in-sandbox
-//     paths and TLS quirks into every consumer (see issue #3979). This module
-//     wraps that flow.
+//     paths and TLS quirks into every consumer. This module wraps that flow.
 //   - Source boundary:
 //       * NemoClaw side (this file): validate the requested agent/keys,
 //         resolve canonical keys to session ids via the in-sandbox
@@ -43,7 +42,6 @@ import { randomBytes } from "node:crypto";
 
 import { CLI_NAME } from "../../../cli/branding";
 import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
-import { downloadFromSandbox } from "../download";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
 import {
   DEFAULT_AGENT_ID,
@@ -117,23 +115,38 @@ export async function exportSandboxSessions(
   const hostDest = resolveHostDestination(opts.out, opts.sandboxName, agent);
 
   try {
-    runOpenshell([
-      "sandbox",
-      "exec",
-      "--name",
-      opts.sandboxName,
-      "--",
-      "sh",
-      "-c",
-      buildShellInvocation(tarArgv, tarballRemote),
-    ]);
+    // Use ignoreError so the underlying spawn helper does not call
+    // process.exit on a non-zero tar/download status. Without that, the
+    // finally cleanup below would never run and the staged session JSONL
+    // would survive in the sandbox's /tmp.
+    const tarResult = runOpenshell(
+      [
+        "sandbox",
+        "exec",
+        "--name",
+        opts.sandboxName,
+        "--",
+        "sh",
+        "-c",
+        buildShellInvocation(tarArgv, tarballRemote),
+      ],
+      { ignoreError: true, stdio: "inherit" },
+    );
+    if (tarResult.status !== 0) {
+      throw new Error(
+        `Failed to tar sessions for agent '${agent}' in sandbox '${opts.sandboxName}' (exit ${tarResult.status}).`,
+      );
+    }
 
-    await downloadFromSandbox({
-      sandboxName: opts.sandboxName,
-      sandboxPath: tarballRemote,
-      hostDest,
-      allowNonReadyPhase: true,
-    });
+    const downloadResult = runOpenshell(
+      ["sandbox", "download", opts.sandboxName, tarballRemote, hostDest],
+      { ignoreError: true, stdio: "inherit" },
+    );
+    if (downloadResult.status !== 0) {
+      throw new Error(
+        `Failed to download '${tarballRemote}' from sandbox '${opts.sandboxName}' (exit ${downloadResult.status}).`,
+      );
+    }
   } finally {
     // Best-effort cleanup of the in-sandbox staging tarball. Runs even when
     // tar/download fail so a partial export cannot leave a world-readable
@@ -244,6 +257,7 @@ function resolveSelectedFiles(
     }
   }
 
+  const seen = new Set<string>();
   const files: string[] = [];
   for (const { key, sessionId } of entries) {
     if (!SAFE_TOKEN_RE.test(sessionId)) {
@@ -251,6 +265,8 @@ function resolveSelectedFiles(
         `Refusing to tar: session id '${sessionId}' resolved for key '${key}' contains unsafe characters or starts with '-'.`,
       );
     }
+    if (seen.has(sessionId)) continue;
+    seen.add(sessionId);
     files.push(`${sessionId}.jsonl`);
     if (includeTrajectory) files.push(`${sessionId}.trajectory.jsonl`);
   }
@@ -284,7 +300,13 @@ function readSessionIndex(sandboxName: string, agent: string): SessionIndexEntry
       `Failed to list sessions in sandbox '${sandboxName}' for agent '${agent}' (exit ${result.status}). Verify the sandbox is live with \`${CLI_NAME} ${sandboxName} status\`.`,
     );
   }
-  return parseSessionIndex(result.output);
+  const parsed = parseSessionIndex(result.output);
+  if (parsed === null) {
+    throw new Error(
+      `Could not parse \`openclaw sessions list --agent ${agent} --json\` output as a session index. Check the OpenClaw version pinned in agents/openclaw/manifest.yaml.`,
+    );
+  }
+  return parsed;
 }
 
 // Tolerant parsing of `openclaw sessions list --json`.
@@ -310,7 +332,7 @@ function readSessionIndex(sandboxName: string, agent: string): SessionIndexEntry
 //   - Removal condition: once OpenClaw documents a single stable JSON
 //     contract for `sessions list --json` in its release notes, this
 //     parser can collapse to the strict shape and the alias map can drop.
-export function parseSessionIndex(output: string): SessionIndexEntry[] {
+export function parseSessionIndex(output: string): SessionIndexEntry[] | null {
   const trimmed = output.trim();
   if (!trimmed) return [];
   const lines = trimmed.split(/\r?\n/);
@@ -326,7 +348,11 @@ export function parseSessionIndex(output: string): SessionIndexEntry[] {
     const entries = tryExtractIndex(candidate);
     if (entries) return entries;
   }
-  return [];
+  // Non-empty output, but no JSON-shaped candidate parsed into a recognised
+  // session index. Distinguish this from the empty-string case so callers
+  // can surface a parse error instead of silently treating it as "no
+  // sessions" — the latter would mask an upstream contract drift.
+  return null;
 }
 
 function tryExtractIndex(text: string): SessionIndexEntry[] | null {

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -12,7 +12,7 @@
 //         resolve canonical keys to session ids via the in-sandbox
 //         `openclaw sessions list --json`, build the in-sandbox tar command,
 //         download the resulting tarball via `openshell sandbox download`,
-//         and best-effort clean up the staging artifact afterwards.
+//         and best-effort clean up the staging artefact afterwards.
 //       * OpenClaw side (upstream `openclaw` npm package): owns the on-disk
 //         session store under `/sandbox/.openclaw/agents/<id>/sessions/` and
 //         the `sessions.list` index contract. NemoClaw never edits that
@@ -39,6 +39,7 @@
 //     the tar command and re-resolve key -> session-id host-side.
 
 import { randomBytes } from "node:crypto";
+import fs from "node:fs";
 
 import { CLI_NAME } from "../../../cli/branding";
 import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
@@ -63,9 +64,11 @@ export interface SessionsExportResult {
   sandboxName: string;
   agent: string;
   selectedKeys: string[] | "all";
+  resolvedSessionIds: string[];
   resolvedFiles: string[];
   tarballRemote: string;
   hostDest: string;
+  bundleBytes: number | null;
 }
 
 interface SessionIndexEntry {
@@ -95,7 +98,7 @@ export async function exportSandboxSessions(
   // matching `<sessionId>.jsonl` (+ optional trajectory) files and never
   // picks up `sessions.json`, stale `.jsonl.lock` files, or other store
   // bookkeeping.
-  const resolvedFiles = resolveSelectedFiles(
+  const { sessionIds: resolvedSessionIds, files: resolvedFiles } = resolveSelectedFiles(
     opts.sandboxName,
     agent,
     trimmedKeys,
@@ -157,23 +160,33 @@ export async function exportSandboxSessions(
     });
   }
 
+  let bundleBytes: number | null = null;
+  try {
+    bundleBytes = fs.statSync(hostDest).size;
+  } catch {
+    bundleBytes = null;
+  }
+
   const result: SessionsExportResult = {
     sandboxName: opts.sandboxName,
     agent,
     selectedKeys: trimmedKeys.length > 0 ? trimmedKeys : "all",
+    resolvedSessionIds,
     resolvedFiles,
     tarballRemote,
     hostDest,
+    bundleBytes,
   };
 
   if (opts.json) {
     console.log(JSON.stringify(result));
   } else {
+    const sizeNote = bundleBytes !== null ? ` (${bundleBytes} byte(s))` : "";
     const scope =
       trimmedKeys.length > 0
         ? `${trimmedKeys.length} key(s) on agent '${agent}'`
-        : `all sessions for agent '${agent}' (${resolvedFiles.length} file(s))`;
-    console.error(`  Exported ${scope} to ${hostDest}`);
+        : `all sessions for agent '${agent}' (${resolvedSessionIds.length} session(s))`;
+    console.error(`  Exported ${scope} to ${hostDest}${sizeNote}`);
   }
 
   return result;
@@ -232,7 +245,7 @@ function resolveSelectedFiles(
   agent: string,
   keys: readonly string[],
   includeTrajectory: boolean,
-): string[] {
+): { sessionIds: string[]; files: string[] } {
   const index = readSessionIndex(sandboxName, agent);
   const byKey = new Map<string, string>();
   for (const entry of index) byKey.set(entry.key, entry.sessionId);
@@ -258,6 +271,7 @@ function resolveSelectedFiles(
   }
 
   const seen = new Set<string>();
+  const sessionIds: string[] = [];
   const files: string[] = [];
   for (const { key, sessionId } of entries) {
     if (!SAFE_TOKEN_RE.test(sessionId)) {
@@ -267,10 +281,11 @@ function resolveSelectedFiles(
     }
     if (seen.has(sessionId)) continue;
     seen.add(sessionId);
+    sessionIds.push(sessionId);
     files.push(`${sessionId}.jsonl`);
     if (includeTrajectory) files.push(`${sessionId}.trajectory.jsonl`);
   }
-  return files;
+  return { sessionIds, files };
 }
 
 function normaliseToCanonical(agent: string, key: string): string {
@@ -364,6 +379,8 @@ function tryExtractIndex(text: string): SessionIndexEntry[] | null {
   }
   const array = pickIndexArray(parsed);
   if (!array) return null;
+  // Legitimate empty index — upstream said no sessions.
+  if (array.length === 0) return [];
   const entries: SessionIndexEntry[] = [];
   for (const entry of array) {
     if (!entry || typeof entry !== "object") continue;
@@ -377,6 +394,10 @@ function tryExtractIndex(text: string): SessionIndexEntry[] | null {
           : null;
     if (key && sessionId) entries.push({ key, sessionId });
   }
+  // Non-empty upstream array yielded zero recognised entries — schema drift.
+  // Return null so the caller surfaces a parse error instead of silently
+  // treating it as "no sessions".
+  if (entries.length === 0) return null;
   return entries;
 }
 

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -40,6 +40,7 @@
 
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
 import { CLI_NAME } from "../../../cli/branding";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
@@ -50,24 +51,38 @@ import {
   validateSessionKey,
 } from "./paths";
 
+export type SessionsExportFormat = "dir" | "tar";
+
 export interface SessionsExportOptions {
   sandboxName: string;
   agent?: string;
   keys?: readonly string[];
   out?: string;
+  format?: SessionsExportFormat;
   includeTrajectory?: boolean;
   json?: boolean;
+}
+
+export interface SessionExportEntry {
+  key: string;
+  sessionId: string;
+  // Host path to the session's `<sessionId>.jsonl` in `dir` format; null in
+  // `tar` format (the file lives inside the bundle).
+  path: string | null;
+  sizeBytes: number | null;
 }
 
 export interface SessionsExportResult {
   sandboxName: string;
   agent: string;
+  format: SessionsExportFormat;
   selectedKeys: string[] | "all";
   resolvedSessionIds: string[];
   resolvedFiles: string[];
-  tarballRemote: string;
   hostDest: string;
+  // Tarball size in `tar` format; null in `dir` format.
   bundleBytes: number | null;
+  sessions: SessionExportEntry[];
 }
 
 interface SessionIndexEntry {
@@ -89,104 +104,136 @@ export async function exportSandboxSessions(
 
   await ensureLiveSandboxOrExit(opts.sandboxName, { allowNonReadyPhase: true });
 
+  const format: SessionsExportFormat = opts.format === "tar" ? "tar" : "dir";
   const sourceDir = `/sandbox/.openclaw/agents/${agent}/sessions`;
-  const tarballRemote = stagingTarballPath(agent);
 
   // Always enumerate sessions through the in-sandbox `openclaw sessions list`
-  // index, even with no key filter, so the tarball contains exactly the
+  // index, even with no key filter, so the export contains exactly the
   // matching `<sessionId>.jsonl` (+ optional trajectory) files and never
   // picks up `sessions.json`, stale `.jsonl.lock` files, or other store
   // bookkeeping.
-  const { sessionIds: resolvedSessionIds, files: resolvedFiles } = resolveSelectedFiles(
-    opts.sandboxName,
-    agent,
-    trimmedKeys,
-    opts.includeTrajectory ?? false,
-  );
+  const {
+    sessionIds: resolvedSessionIds,
+    files: resolvedFiles,
+    sessions,
+  } = resolveSelectedFiles(opts.sandboxName, agent, trimmedKeys, opts.includeTrajectory ?? false);
 
   if (resolvedFiles.length === 0) {
     throw new Error(`Refusing to export: agent '${agent}' has no sessions to bundle.`);
   }
 
-  const tarArgv = buildSandboxTarArgv({
-    sourceDir,
-    tarballRemote,
-    resolvedFiles,
-  });
-
-  const hostDest = resolveHostDestination(opts.out, opts.sandboxName, agent);
-
-  try {
-    // Use ignoreError so the underlying spawn helper does not call
-    // process.exit on a non-zero tar/download status. Without that, the
-    // finally cleanup below would never run and the staged session JSONL
-    // would survive in the sandbox's /tmp.
-    const tarResult = runOpenshell(
-      [
-        "sandbox",
-        "exec",
-        "--name",
-        opts.sandboxName,
-        "--",
-        "sh",
-        "-c",
-        buildShellInvocation(tarArgv, tarballRemote),
-      ],
-      { ignoreError: true, stdio: "inherit" },
-    );
-    if (tarResult.status !== 0) {
-      throw new Error(
-        `Failed to tar sessions for agent '${agent}' in sandbox '${opts.sandboxName}' (exit ${tarResult.status}).`,
-      );
-    }
-
-    const downloadResult = runOpenshell(
-      ["sandbox", "download", opts.sandboxName, tarballRemote, hostDest],
-      { ignoreError: true, stdio: "inherit" },
-    );
-    if (downloadResult.status !== 0) {
-      throw new Error(
-        `Failed to download '${tarballRemote}' from sandbox '${opts.sandboxName}' (exit ${downloadResult.status}).`,
-      );
-    }
-  } finally {
-    // Best-effort cleanup of the in-sandbox staging tarball. Runs even when
-    // tar/download fail so a partial export cannot leave a world-readable
-    // bundle of session JSONL in the sandbox's /tmp.
-    runOpenshell(["sandbox", "exec", "--name", opts.sandboxName, "--", "rm", "-f", tarballRemote], {
-      ignoreError: true,
-      stdio: "ignore",
-    });
-  }
-
-  // Harden the downloaded bundle: session JSONL captures user prompts and tool
-  // I/O, which routinely contain pasted secrets (API keys, tokens). The
-  // in-sandbox staging tarball is created 0600, but the host copy lands with
-  // the caller's umask, so restrict it to owner-only here too.
-  try {
-    fs.chmodSync(hostDest, 0o600);
-  } catch {
-    console.error(
-      `  Warning: could not restrict permissions on ${hostDest}; treat it as sensitive — it may contain session secrets.`,
-    );
-  }
+  const hostDest = resolveHostDestination(opts.out, opts.sandboxName, agent, format);
 
   let bundleBytes: number | null = null;
-  try {
-    bundleBytes = fs.statSync(hostDest).size;
-  } catch {
-    bundleBytes = null;
+  let exported: SessionExportEntry[];
+
+  if (format === "tar") {
+    const tarballRemote = stagingTarballPath(agent);
+    const tarArgv = buildSandboxTarArgv({ sourceDir, tarballRemote, resolvedFiles });
+    try {
+      // Use ignoreError so the underlying spawn helper does not call
+      // process.exit on a non-zero tar/download status. Without that, the
+      // finally cleanup below would never run and the staged session JSONL
+      // would survive in the sandbox's /tmp.
+      const tarResult = runOpenshell(
+        [
+          "sandbox",
+          "exec",
+          "--name",
+          opts.sandboxName,
+          "--",
+          "sh",
+          "-c",
+          buildShellInvocation(tarArgv, tarballRemote),
+        ],
+        { ignoreError: true, stdio: "inherit" },
+      );
+      if (tarResult.status !== 0) {
+        throw new Error(
+          `Failed to tar sessions for agent '${agent}' in sandbox '${opts.sandboxName}' (exit ${tarResult.status}).`,
+        );
+      }
+
+      const downloadResult = runOpenshell(
+        ["sandbox", "download", opts.sandboxName, tarballRemote, hostDest],
+        { ignoreError: true, stdio: "inherit" },
+      );
+      if (downloadResult.status !== 0) {
+        throw new Error(
+          `Failed to download '${tarballRemote}' from sandbox '${opts.sandboxName}' (exit ${downloadResult.status}).`,
+        );
+      }
+    } finally {
+      // Best-effort cleanup of the in-sandbox staging tarball. Runs even when
+      // tar/download fail so a partial export cannot leave a world-readable
+      // bundle of session JSONL in the sandbox's /tmp.
+      runOpenshell(
+        ["sandbox", "exec", "--name", opts.sandboxName, "--", "rm", "-f", tarballRemote],
+        { ignoreError: true, stdio: "ignore" },
+      );
+    }
+
+    // Session JSONL captures user prompts and tool I/O, which routinely contain
+    // pasted secrets. The host tarball lands with the caller's umask, so
+    // restrict it to owner-only (the in-sandbox staging copy is already 0600).
+    hardenPermissions(hostDest);
+    try {
+      bundleBytes = fs.statSync(hostDest).size;
+    } catch {
+      bundleBytes = null;
+    }
+    // Per-session files live inside the tarball, so the manifest carries ids only.
+    exported = sessions.map((entry) => ({
+      key: entry.key,
+      sessionId: entry.sessionId,
+      path: null,
+      sizeBytes: null,
+    }));
+  } else {
+    // dir format (the #3979 default): copy each resolved session file straight
+    // onto the host into a browsable directory. No /tmp staging tarball, so
+    // there is no world-readable staging window to clean up.
+    try {
+      fs.mkdirSync(hostDest, { recursive: true });
+    } catch (err) {
+      throw new Error(`Failed to create export directory '${hostDest}': ${(err as Error).message}`);
+    }
+    for (const file of resolvedFiles) {
+      const localPath = path.join(hostDest, file);
+      const downloadResult = runOpenshell(
+        ["sandbox", "download", opts.sandboxName, `${sourceDir}/${file}`, localPath],
+        { ignoreError: true, stdio: "inherit" },
+      );
+      if (downloadResult.status !== 0) {
+        throw new Error(
+          `Failed to download '${file}' from sandbox '${opts.sandboxName}' (exit ${downloadResult.status}).`,
+        );
+      }
+      // Session JSONL can contain pasted secrets — restrict each file to owner-only.
+      hardenPermissions(localPath);
+    }
+    exported = sessions.map((entry) => {
+      const localPath = path.join(hostDest, `${entry.sessionId}.jsonl`);
+      let sizeBytes: number | null = null;
+      try {
+        sizeBytes = fs.statSync(localPath).size;
+      } catch {
+        sizeBytes = null;
+      }
+      return { key: entry.key, sessionId: entry.sessionId, path: localPath, sizeBytes };
+    });
   }
 
   const result: SessionsExportResult = {
     sandboxName: opts.sandboxName,
     agent,
+    format,
     selectedKeys: trimmedKeys.length > 0 ? trimmedKeys : "all",
     resolvedSessionIds,
     resolvedFiles,
-    tarballRemote,
     hostDest,
     bundleBytes,
+    sessions: exported,
   };
 
   if (opts.json) {
@@ -201,6 +248,19 @@ export async function exportSandboxSessions(
   }
 
   return result;
+}
+
+// Restrict a freshly written host artefact to owner-only (0600). Best-effort:
+// session JSONL can contain pasted secrets, but a chmod failure (e.g. an exotic
+// host filesystem) should warn rather than abort an otherwise-successful export.
+function hardenPermissions(target: string): void {
+  try {
+    fs.chmodSync(target, 0o600);
+  } catch {
+    console.error(
+      `  Warning: could not restrict permissions on ${target}; treat it as sensitive — it may contain session secrets.`,
+    );
+  }
 }
 
 export function buildSandboxTarArgv(input: {
@@ -256,7 +316,7 @@ function resolveSelectedFiles(
   agent: string,
   keys: readonly string[],
   includeTrajectory: boolean,
-): { sessionIds: string[]; files: string[] } {
+): { sessionIds: string[]; files: string[]; sessions: SessionIndexEntry[] } {
   const index = readSessionIndex(sandboxName, agent);
   const byKey = new Map<string, string>();
   for (const entry of index) byKey.set(entry.key, entry.sessionId);
@@ -284,6 +344,7 @@ function resolveSelectedFiles(
   const seen = new Set<string>();
   const sessionIds: string[] = [];
   const files: string[] = [];
+  const sessions: SessionIndexEntry[] = [];
   for (const { key, sessionId } of entries) {
     if (!SAFE_TOKEN_RE.test(sessionId)) {
       throw new Error(
@@ -293,10 +354,11 @@ function resolveSelectedFiles(
     if (seen.has(sessionId)) continue;
     seen.add(sessionId);
     sessionIds.push(sessionId);
+    sessions.push({ key, sessionId });
     files.push(`${sessionId}.jsonl`);
     if (includeTrajectory) files.push(`${sessionId}.trajectory.jsonl`);
   }
-  return { sessionIds, files };
+  return { sessionIds, files, sessions };
 }
 
 function normaliseToCanonical(agent: string, key: string): string {
@@ -432,7 +494,10 @@ function resolveHostDestination(
   out: string | undefined,
   sandboxName: string,
   agent: string,
+  format: SessionsExportFormat,
 ): string {
   if (out && out.trim()) return out.trim();
-  return `./sessions-${sandboxName}-${agent}.tgz`;
+  // dir is the #3979 default: a browsable `./sessions-<sandbox>/` tree. tar
+  // keeps the single-bundle name for share/upload cases.
+  return format === "tar" ? `./sessions-${sandboxName}-${agent}.tgz` : `./sessions-${sandboxName}/`;
 }

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -40,9 +40,8 @@
 
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
-
-import { CLI_NAME } from "../../../cli/branding";
 import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
+import { CLI_NAME } from "../../../cli/branding";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
 import {
   DEFAULT_AGENT_ID,
@@ -158,6 +157,18 @@ export async function exportSandboxSessions(
       ignoreError: true,
       stdio: "ignore",
     });
+  }
+
+  // Harden the downloaded bundle: session JSONL captures user prompts and tool
+  // I/O, which routinely contain pasted secrets (API keys, tokens). The
+  // in-sandbox staging tarball is created 0600, but the host copy lands with
+  // the caller's umask, so restrict it to owner-only here too.
+  try {
+    fs.chmodSync(hostDest, 0o600);
+  } catch {
+    console.error(
+      `  Warning: could not restrict permissions on ${hostDest}; treat it as sensitive — it may contain session secrets.`,
+    );
   }
 
   let bundleBytes: number | null = null;

--- a/src/lib/actions/sandbox/upload.test.ts
+++ b/src/lib/actions/sandbox/upload.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./gateway-state", () => ({
+  ensureLiveSandboxOrExit: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../adapters/openshell/runtime", () => ({
+  runOpenshell: vi.fn(),
+}));
+
+import { runOpenshell } from "../../adapters/openshell/runtime";
+import { ensureLiveSandboxOrExit } from "./gateway-state";
+import { uploadToSandbox } from "./upload";
+
+const runMock = runOpenshell as unknown as ReturnType<typeof vi.fn>;
+const ensureMock = ensureLiveSandboxOrExit as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  runMock.mockReset();
+  ensureMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("uploadToSandbox", () => {
+  it("forwards verbatim args to `openshell sandbox upload` after a live-sandbox check", async () => {
+    const result = await uploadToSandbox({
+      sandboxName: "alpha",
+      hostPath: "./SOUL.md",
+      sandboxDest: "/sandbox/.openclaw/workspace/SOUL.md",
+    });
+
+    expect(ensureMock).toHaveBeenCalledWith("alpha", { allowNonReadyPhase: true });
+    expect(runMock).toHaveBeenCalledWith(
+      ["sandbox", "upload", "alpha", "./SOUL.md", "/sandbox/.openclaw/workspace/SOUL.md"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    expect(result).toEqual({
+      hostPath: "./SOUL.md",
+      sandboxDest: "/sandbox/.openclaw/workspace/SOUL.md",
+    });
+  });
+
+  it("defaults the sandbox destination to /sandbox/ when omitted", async () => {
+    await uploadToSandbox({ sandboxName: "alpha", hostPath: "./x" });
+    const args = runMock.mock.calls[0]?.[0];
+    expect(args?.at(-1)).toBe("/sandbox/");
+  });
+
+  it("throws (does not exit) when no host path is given", async () => {
+    await expect(uploadToSandbox({ sandboxName: "alpha", hostPath: "" })).rejects.toThrow(
+      /No host path provided/,
+    );
+    expect(ensureMock).not.toHaveBeenCalled();
+    expect(runMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/sandbox/upload.ts
+++ b/src/lib/actions/sandbox/upload.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runOpenshell } from "../../adapters/openshell/runtime";
+import { CLI_NAME } from "../../cli/branding";
+import { ensureLiveSandboxOrExit } from "./gateway-state";
+
+export interface SandboxUploadOptions {
+  sandboxName: string;
+  hostPath: string;
+  sandboxDest?: string;
+  allowNonReadyPhase?: boolean;
+}
+
+export interface SandboxUploadResult {
+  hostPath: string;
+  sandboxDest: string;
+}
+
+export async function uploadToSandbox(opts: SandboxUploadOptions): Promise<SandboxUploadResult> {
+  const hostPath = (opts.hostPath ?? "").trim();
+  if (!hostPath) {
+    throw new Error(
+      `No host path provided; usage: ${CLI_NAME} ${opts.sandboxName} upload <host-path> [sandbox-dest]`,
+    );
+  }
+  const sandboxDest = (opts.sandboxDest ?? "").trim() || "/sandbox/";
+
+  await ensureLiveSandboxOrExit(opts.sandboxName, {
+    allowNonReadyPhase: opts.allowNonReadyPhase ?? true,
+  });
+
+  runOpenshell(["sandbox", "upload", opts.sandboxName, hostPath, sandboxDest], {
+    stdio: "inherit",
+  });
+
+  return { hostPath, sandboxDest };
+}

--- a/src/lib/cli/command-registry.test.ts
+++ b/src/lib/cli/command-registry.test.ts
@@ -55,11 +55,12 @@ describe("command-registry", () => {
   });
 
   describe("sandboxCommands()", () => {
-    it("should return exactly 44 entries", () => {
-      // 38 visible + 6 hidden (shields×3 + config get/set/rotate-token).
-      // 38 visible includes the sessions group (root + list + reset + delete)
-      // and the agents trio (add + delete + list).
-      expect(sandboxCommands()).toHaveLength(44);
+    it("should return exactly 47 entries", () => {
+      // 41 visible + 6 hidden (shields×3 + config get/set/rotate-token).
+      // 41 visible includes the sessions group (root + list + reset + delete +
+      // export), the agents trio (add + delete + list), and the download +
+      // upload host-side openshell wrappers.
+      expect(sandboxCommands()).toHaveLength(47);
     });
 
     it("every entry has scope sandbox", () => {
@@ -213,14 +214,15 @@ describe("command-registry", () => {
   });
 
   describe("sandboxActionTokens()", () => {
-    it("returns exactly 26 unique action tokens including empty string", () => {
+    it("returns exactly 28 unique action tokens including empty string", () => {
       const tokens = sandboxActionTokens();
-      expect(tokens).toHaveLength(26);
+      expect(tokens).toHaveLength(28);
       // Must contain every first-level sandbox action plus the empty default action.
       const expected = new Set([
         "agents",
         "connect",
         "dashboard-url",
+        "download",
         "exec",
         "status",
         "doctor",
@@ -243,6 +245,7 @@ describe("command-registry", () => {
         "config",
         "channels",
         "gateway-token",
+        "upload",
         "",
       ]);
       expect(new Set(tokens)).toEqual(expected);

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -227,6 +227,14 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       flags: "[--yes|-y|--force] [--cleanup-gateway|--no-cleanup-gateway]",
     },
   ],
+  "sandbox:download": [
+    {
+      group: "Sandbox Management",
+      order: 4.6,
+      description: "Download a file or directory from the sandbox to the host",
+      flags: "<sandbox-path> [host-dest]",
+    },
+  ],
   "sandbox:doctor": [
     {
       group: "Sandbox Management",
@@ -240,6 +248,14 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       group: "Sandbox Management",
       order: 4.5,
       flags: "[--workdir <dir>] [--tty|--no-tty] [--timeout <s>] -- <cmd> [args...]",
+    },
+  ],
+  "sandbox:upload": [
+    {
+      group: "Sandbox Management",
+      order: 4.7,
+      description: "Upload a file or directory from the host into the sandbox",
+      flags: "<host-path> [sandbox-dest]",
     },
   ],
   "sandbox:gateway:token": [

--- a/src/lib/cli/public-display-sessions.ts
+++ b/src/lib/cli/public-display-sessions.ts
@@ -36,4 +36,12 @@ export const SANDBOX_SESSIONS_DISPLAY_LAYOUT: Record<string, readonly PublicDisp
       description: "Delete a session entry via the OpenClaw gateway",
     },
   ],
+  "sandbox:sessions:export": [
+    {
+      group: "Sandbox Management",
+      order: 17.4,
+      flags: "[keys...] [--agent <id>] [--out <path>] [--include-trajectory] [--json]",
+      description: "Export OpenClaw session JSONL out of a running sandbox",
+    },
+  ],
 };

--- a/test/sandbox-download-upload-cli.test.ts
+++ b/test/sandbox-download-upload-cli.test.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runWithEnv, writeSandboxRegistry } from "./cli/helpers";
+
+function buildStubOpenshell(home: string, logFile: string): string {
+  const localBin = path.join(home, "bin");
+  fs.mkdirSync(localBin, { recursive: true });
+  fs.writeFileSync(
+    path.join(localBin, "openshell"),
+    [
+      "#!/usr/bin/env bash",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(logFile)}`,
+      'case "$*" in',
+      '  "sandbox list"*) printf "alpha Ready\\n"; exit 0 ;;',
+      '  "sandbox get alpha"*) printf "Name: alpha\\nPhase: Ready\\nPolicy:\\n"; exit 0 ;;',
+      '  "gateway info -g nemoclaw"*) printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+      "  *) exit 0 ;;",
+      "esac",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return localBin;
+}
+
+describe("sandbox download/upload CLI wrappers", () => {
+  it("forwards `<name> download <sandbox-path> [host-dest]` to openshell", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-download-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog);
+
+      const result = runWithEnv("alpha download /sandbox/.openclaw/workspace/SOUL.md ./out 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8");
+      expect(calls).toMatch(
+        /sandbox download alpha \/sandbox\/\.openclaw\/workspace\/SOUL\.md \.\/out/,
+      );
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults the host destination to '.' when omitted", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-download-default-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog);
+
+      const result = runWithEnv("alpha download /sandbox/.openclaw/x 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8");
+      expect(calls).toMatch(/sandbox download alpha \/sandbox\/\.openclaw\/x \./);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("forwards `<name> upload <host-path> [sandbox-dest]` to openshell", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-upload-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog);
+
+      const result = runWithEnv(
+        "alpha upload ./SOUL.md /sandbox/.openclaw/workspace/SOUL.md 2>&1",
+        {
+          HOME: home,
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+        },
+      );
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8");
+      expect(calls).toMatch(
+        /sandbox upload alpha \.\/SOUL\.md \/sandbox\/\.openclaw\/workspace\/SOUL\.md/,
+      );
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults the sandbox destination to /sandbox/ when omitted", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-upload-default-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog);
+
+      const result = runWithEnv("alpha upload ./x 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8");
+      expect(calls).toMatch(/sandbox upload alpha \.\/x \/sandbox\//);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/sandbox-sessions-export-cli.test.ts
+++ b/test/sandbox-sessions-export-cli.test.ts
@@ -78,9 +78,11 @@ describe("sandbox sessions export CLI", () => {
         sandboxName: "alpha",
         agent: "main",
         selectedKeys: "all",
+        resolvedSessionIds: ["sid-a", "sid-b"],
         resolvedFiles: ["sid-a.jsonl", "sid-b.jsonl"],
         hostDest: out,
       });
+      expect(manifest).toHaveProperty("bundleBytes");
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/test/sandbox-sessions-export-cli.test.ts
+++ b/test/sandbox-sessions-export-cli.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runWithEnv, writeSandboxRegistry } from "./cli/helpers";
+
+function buildStubOpenshell(home: string, logFile: string, sessionListJson: string): string {
+  const localBin = path.join(home, "bin");
+  fs.mkdirSync(localBin, { recursive: true });
+  fs.writeFileSync(
+    path.join(localBin, "openshell"),
+    [
+      "#!/usr/bin/env bash",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(logFile)}`,
+      'case "$*" in',
+      '  "sandbox list"*) printf "alpha Ready\\n"; exit 0 ;;',
+      '  "sandbox get alpha"*) printf "Name: alpha\\nPhase: Ready\\nPolicy:\\n"; exit 0 ;;',
+      '  "gateway info -g nemoclaw"*) printf "Gateway: nemoclaw\\n"; exit 0 ;;',
+      '  *"openclaw sessions list"*)',
+      `    printf '%s\\n' ${JSON.stringify(sessionListJson)}`,
+      "    exit 0 ;;",
+      '  *"sandbox exec --name alpha -- tar"*) exit 0 ;;',
+      '  "sandbox download"*) exit 0 ;;',
+      '  *"sandbox exec --name alpha -- rm"*) exit 0 ;;',
+      "  *) exit 0 ;;",
+      "esac",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return localBin;
+}
+
+describe("sandbox sessions export CLI", () => {
+  it("tars the whole agent sessions dir, downloads, and cleans up when no keys are supplied", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-all-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog, "[]");
+
+      const out = path.join(home, "bundle.tgz");
+      const result = runWithEnv(`alpha sessions export --out ${out} --json 2>&1`, {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8").split("\n");
+      const tarLine = calls.find((line) => line.includes("-- tar -czf"));
+      const downloadLine = calls.find((line) => line.startsWith("sandbox download"));
+      const cleanupLine = calls.find((line) => line.includes("-- rm -f"));
+      expect(tarLine).toBeDefined();
+      expect(tarLine).toContain("/sandbox/.openclaw/agents/main/sessions");
+      expect(tarLine).toContain("--exclude=*.trajectory.jsonl");
+      expect(downloadLine).toContain("alpha");
+      expect(downloadLine).toContain(out);
+      expect(cleanupLine).toBeDefined();
+      expect(cleanupLine).toContain("/tmp/sessions-export-main-");
+
+      const manifest = JSON.parse(result.out.trim().split("\n").at(-1) as string);
+      expect(manifest).toMatchObject({
+        sandboxName: "alpha",
+        agent: "main",
+        selectedKeys: "all",
+        resolvedFiles: "all",
+        hostDest: out,
+      });
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves canonical keys to session-id files via openclaw sessions list and tars only those files", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-keys-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(
+        home,
+        openshellLog,
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-a" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-b" },
+        ]),
+      );
+
+      const out = path.join(home, "bundle.tgz");
+      const result = runWithEnv(
+        `alpha sessions export agent:main:telegram:t-1 --out ${out} --include-trajectory --json 2>&1`,
+        {
+          HOME: home,
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+        },
+      );
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8").split("\n");
+      const tarLine = calls.find((line) => line.includes("-- tar -czf"));
+      expect(tarLine).toBeDefined();
+      expect(tarLine).toContain("sid-b.jsonl");
+      expect(tarLine).toContain("sid-b.trajectory.jsonl");
+      expect(tarLine).not.toContain("sid-a.jsonl");
+      expect(tarLine).not.toContain("--exclude=*.trajectory.jsonl");
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an alias key under --agent as canonical when invoking openclaw sessions list", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-agent-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(
+        home,
+        openshellLog,
+        JSON.stringify([{ key: "agent:work:telegram:t-1", sessionId: "sid-x" }]),
+      );
+
+      const out = path.join(home, "bundle.tgz");
+      const result = runWithEnv(
+        `alpha sessions export telegram:t-1 --agent work --out ${out} --json 2>&1`,
+        {
+          HOME: home,
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+        },
+      );
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8");
+      expect(calls).toMatch(/openclaw sessions list --agent work --json/);
+      expect(calls).toMatch(/sid-x\.jsonl/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to export when a canonical key disagrees with the --agent flag (no exec is issued)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-mismatch-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog, "[]");
+
+      const result = runWithEnv("alpha sessions export agent:main:main --agent work 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(1);
+      expect(result.out).toMatch(/scoped to agent 'main', not 'work'/);
+
+      const calls = fs.existsSync(openshellLog) ? fs.readFileSync(openshellLog, "utf8") : "";
+      expect(calls).not.toMatch(/-- tar/);
+      expect(calls).not.toMatch(/sandbox download/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/sandbox-sessions-export-cli.test.ts
+++ b/test/sandbox-sessions-export-cli.test.ts
@@ -23,7 +23,7 @@ function buildStubOpenshell(home: string, logFile: string, sessionListJson: stri
       '  *"openclaw sessions list"*)',
       `    printf '%s\\n' ${JSON.stringify(sessionListJson)}`,
       "    exit 0 ;;",
-      '  *"sandbox exec --name alpha -- tar"*) exit 0 ;;',
+      '  *"sandbox exec --name alpha -- sh -c"*) exit 0 ;;',
       '  "sandbox download"*) exit 0 ;;',
       '  *"sandbox exec --name alpha -- rm"*) exit 0 ;;',
       "  *) exit 0 ;;",
@@ -50,12 +50,13 @@ describe("sandbox sessions export CLI", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8").split("\n");
-      const tarLine = calls.find((line) => line.includes("-- tar -czf"));
+      const tarLine = calls.find((line) => line.includes("-- sh -c") && line.includes("umask 077"));
       const downloadLine = calls.find((line) => line.startsWith("sandbox download"));
       const cleanupLine = calls.find((line) => line.includes("-- rm -f"));
       expect(tarLine).toBeDefined();
       expect(tarLine).toContain("/sandbox/.openclaw/agents/main/sessions");
       expect(tarLine).toContain("--exclude=*.trajectory.jsonl");
+      expect(tarLine).toContain("chmod 600");
       expect(downloadLine).toContain("alpha");
       expect(downloadLine).toContain(out);
       expect(cleanupLine).toBeDefined();
@@ -99,10 +100,10 @@ describe("sandbox sessions export CLI", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8").split("\n");
-      const tarLine = calls.find((line) => line.includes("-- tar -czf"));
+      const tarLine = calls.find((line) => line.includes("-- sh -c") && line.includes("umask 077"));
       expect(tarLine).toBeDefined();
-      expect(tarLine).toContain("sid-b.jsonl");
-      expect(tarLine).toContain("sid-b.trajectory.jsonl");
+      expect(tarLine).toContain("./sid-b.jsonl");
+      expect(tarLine).toContain("./sid-b.trajectory.jsonl");
       expect(tarLine).not.toContain("sid-a.jsonl");
       expect(tarLine).not.toContain("--exclude=*.trajectory.jsonl");
     } finally {
@@ -133,7 +134,7 @@ describe("sandbox sessions export CLI", () => {
 
       const calls = fs.readFileSync(openshellLog, "utf8");
       expect(calls).toMatch(/openclaw sessions list --agent work --json/);
-      expect(calls).toMatch(/sid-x\.jsonl/);
+      expect(calls).toMatch(/\.\/sid-x\.jsonl/);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
@@ -154,7 +155,29 @@ describe("sandbox sessions export CLI", () => {
       expect(result.out).toMatch(/scoped to agent 'main', not 'work'/);
 
       const calls = fs.existsSync(openshellLog) ? fs.readFileSync(openshellLog, "utf8") : "";
-      expect(calls).not.toMatch(/-- tar/);
+      expect(calls).not.toMatch(/-- sh -c/);
+      expect(calls).not.toMatch(/sandbox download/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects positional keys that start with '-' instead of silently exporting all sessions", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-stray-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog, "[]");
+
+      const result = runWithEnv("alpha sessions export -foo --json 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).not.toBe(0);
+      expect(result.out).toMatch(/Unknown flag or option-shaped key|Nonexistent flag/i);
+
+      const calls = fs.existsSync(openshellLog) ? fs.readFileSync(openshellLog, "utf8") : "";
+      expect(calls).not.toMatch(/-- sh -c/);
       expect(calls).not.toMatch(/sandbox download/);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });

--- a/test/sandbox-sessions-export-cli.test.ts
+++ b/test/sandbox-sessions-export-cli.test.ts
@@ -35,12 +35,19 @@ function buildStubOpenshell(home: string, logFile: string, sessionListJson: stri
 }
 
 describe("sandbox sessions export CLI", () => {
-  it("tars the whole agent sessions dir, downloads, and cleans up when no keys are supplied", () => {
+  it("enumerates every session via openclaw sessions list when no keys are supplied and tars only the resolved files", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-all-"));
     try {
       writeSandboxRegistry(home);
       const openshellLog = path.join(home, "openshell-calls.log");
-      const localBin = buildStubOpenshell(home, openshellLog, "[]");
+      const localBin = buildStubOpenshell(
+        home,
+        openshellLog,
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-a" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-b" },
+        ]),
+      );
 
       const out = path.join(home, "bundle.tgz");
       const result = runWithEnv(`alpha sessions export --out ${out} --json 2>&1`, {
@@ -50,12 +57,16 @@ describe("sandbox sessions export CLI", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8").split("\n");
+      const listLine = calls.find((line) => line.includes("openclaw sessions list"));
       const tarLine = calls.find((line) => line.includes("-- sh -c") && line.includes("umask 077"));
       const downloadLine = calls.find((line) => line.startsWith("sandbox download"));
       const cleanupLine = calls.find((line) => line.includes("-- rm -f"));
+      expect(listLine).toBeDefined();
       expect(tarLine).toBeDefined();
       expect(tarLine).toContain("/sandbox/.openclaw/agents/main/sessions");
-      expect(tarLine).toContain("--exclude=*.trajectory.jsonl");
+      expect(tarLine).toContain("./sid-a.jsonl");
+      expect(tarLine).toContain("./sid-b.jsonl");
+      expect(tarLine).not.toContain("trajectory.jsonl");
       expect(tarLine).toContain("chmod 600");
       expect(downloadLine).toContain("alpha");
       expect(downloadLine).toContain(out);
@@ -67,7 +78,7 @@ describe("sandbox sessions export CLI", () => {
         sandboxName: "alpha",
         agent: "main",
         selectedKeys: "all",
-        resolvedFiles: "all",
+        resolvedFiles: ["sid-a.jsonl", "sid-b.jsonl"],
         hostDest: out,
       });
     } finally {
@@ -105,7 +116,6 @@ describe("sandbox sessions export CLI", () => {
       expect(tarLine).toContain("./sid-b.jsonl");
       expect(tarLine).toContain("./sid-b.trajectory.jsonl");
       expect(tarLine).not.toContain("sid-a.jsonl");
-      expect(tarLine).not.toContain("--exclude=*.trajectory.jsonl");
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
@@ -153,6 +163,28 @@ describe("sandbox sessions export CLI", () => {
       });
       expect(result.code).toBe(1);
       expect(result.out).toMatch(/scoped to agent 'main', not 'work'/);
+
+      const calls = fs.existsSync(openshellLog) ? fs.readFileSync(openshellLog, "utf8") : "";
+      expect(calls).not.toMatch(/-- sh -c/);
+      expect(calls).not.toMatch(/sandbox download/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to export when the agent has no sessions to bundle", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-empty-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(home, openshellLog, "[]");
+
+      const result = runWithEnv("alpha sessions export 2>&1", {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(1);
+      expect(result.out).toMatch(/agent 'main' has no sessions to bundle/);
 
       const calls = fs.existsSync(openshellLog) ? fs.readFileSync(openshellLog, "utf8") : "";
       expect(calls).not.toMatch(/-- sh -c/);

--- a/test/sandbox-sessions-export-cli.test.ts
+++ b/test/sandbox-sessions-export-cli.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
 import { runWithEnv, writeSandboxRegistry } from "./cli/helpers";
 
@@ -24,7 +24,10 @@ function buildStubOpenshell(home: string, logFile: string, sessionListJson: stri
       `    printf '%s\\n' ${JSON.stringify(sessionListJson)}`,
       "    exit 0 ;;",
       '  *"sandbox exec --name alpha -- sh -c"*) exit 0 ;;',
-      '  "sandbox download"*) exit 0 ;;',
+      '  "sandbox download"*)',
+      // Create the destination so the host-side chmod/stat succeed (mirrors a
+      // real download); the last positional arg is the host path.
+      '    dest="${@: -1}"; printf "session-data" > "$dest" 2>/dev/null || true; exit 0 ;;',
       '  *"sandbox exec --name alpha -- rm"*) exit 0 ;;',
       "  *) exit 0 ;;",
       "esac",
@@ -50,7 +53,7 @@ describe("sandbox sessions export CLI", () => {
       );
 
       const out = path.join(home, "bundle.tgz");
-      const result = runWithEnv(`alpha sessions export --out ${out} --json 2>&1`, {
+      const result = runWithEnv(`alpha sessions export --format tar --out ${out} --json 2>&1`, {
         HOME: home,
         PATH: `${localBin}:${process.env.PATH || ""}`,
       });
@@ -88,6 +91,49 @@ describe("sandbox sessions export CLI", () => {
     }
   });
 
+  it("writes a browsable directory of session files by default (dir format, no tar/staging)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-dir-"));
+    try {
+      writeSandboxRegistry(home);
+      const openshellLog = path.join(home, "openshell-calls.log");
+      const localBin = buildStubOpenshell(
+        home,
+        openshellLog,
+        JSON.stringify([
+          { key: "agent:main:main", sessionId: "sid-a" },
+          { key: "agent:main:telegram:t-1", sessionId: "sid-b" },
+        ]),
+      );
+
+      const outDir = path.join(home, "sessions-alpha");
+      const result = runWithEnv(`alpha sessions export --out ${outDir} --json 2>&1`, {
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+      });
+      expect(result.code).toBe(0);
+
+      const calls = fs.readFileSync(openshellLog, "utf8").split("\n");
+      // dir is the default: no in-sandbox tar (umask 077) and no /tmp staging cleanup.
+      expect(calls.some((line) => line.includes("umask 077"))).toBe(false);
+      expect(calls.some((line) => line.includes("-- rm -f"))).toBe(false);
+      const downloadLines = calls.filter((line) => line.startsWith("sandbox download"));
+      expect(downloadLines).toHaveLength(2);
+      expect(downloadLines[0]).toContain("/sandbox/.openclaw/agents/main/sessions/sid-a.jsonl");
+      expect(downloadLines[0]).toContain(path.join(outDir, "sid-a.jsonl"));
+
+      const manifest = JSON.parse(result.out.trim().split("\n").at(-1) as string);
+      expect(manifest).toMatchObject({
+        format: "dir",
+        hostDest: outDir,
+        resolvedSessionIds: ["sid-a", "sid-b"],
+      });
+      expect(manifest.sessions).toHaveLength(2);
+      expect(manifest.sessions[0]).toMatchObject({ key: "agent:main:main", sessionId: "sid-a" });
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("resolves canonical keys to session-id files via openclaw sessions list and tars only those files", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sessions-export-keys-"));
     try {
@@ -104,7 +150,7 @@ describe("sandbox sessions export CLI", () => {
 
       const out = path.join(home, "bundle.tgz");
       const result = runWithEnv(
-        `alpha sessions export agent:main:telegram:t-1 --out ${out} --include-trajectory --json 2>&1`,
+        `alpha sessions export agent:main:telegram:t-1 --format tar --out ${out} --include-trajectory --json 2>&1`,
         {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,
@@ -136,7 +182,7 @@ describe("sandbox sessions export CLI", () => {
 
       const out = path.join(home, "bundle.tgz");
       const result = runWithEnv(
-        `alpha sessions export telegram:t-1 --agent work --out ${out} --json 2>&1`,
+        `alpha sessions export telegram:t-1 --agent work --format tar --out ${out} --json 2>&1`,
         {
           HOME: home,
           PATH: `${localBin}:${process.env.PATH || ""}`,


### PR DESCRIPTION
## Summary

Adds `nemoclaw <name> sessions export` — a host-side wrapper that tars OpenClaw's per-agent session store inside the sandbox and downloads the bundle to the host via the OpenShell transport, removing the two-hop `docker exec kubectl cp` workaround called out in #3979. The same change ships the generic `sandbox download` and `sandbox upload` host-side wrappers around `openshell sandbox download`/`upload` that the export pipeline reuses.

## Related Issue

Resolves #3979

## Changes

- `nemoclaw <name> sessions export [keys...] [--agent <id>] [--out <path>] [--include-trajectory] [--json]`: positional varargs select sessions; none means every session for the agent; canonical (`agent:<id>:<rest>`) or alias keys are both accepted, with `--agent` scoping aliases and refusing canonical/`--agent` mismatches. Trajectory files are excluded by default.
- `nemoclaw <name> download <sandbox-path> [host-dest]`: thin host-side wrapper around `openshell sandbox download` with a live-sandbox readiness check.
- `nemoclaw <name> upload <host-path> [sandbox-dest]`: symmetric wrapper around `openshell sandbox upload`.
- Export always enumerates the index through `openclaw sessions list --agent <id> --json` and tars only the matching `<sessionId>.jsonl` (+ optional trajectory) files; the bundle never picks up `sessions.json`, stale `.jsonl.lock` files, or other store bookkeeping.
- Tar + download run with `ignoreError` so a non-zero status throws a host-side error instead of `process.exit`, letting the `finally` cleanup remove the staging tarball even when the export fails partway. The staging tarball itself is created behind `umask 077 && tar … && chmod 600` to harden the in-sandbox `/tmp` artefact.
- `parseSessionIndex` distinguishes an empty upstream index from an unparsable one and surfaces a parse error instead of silently treating an unrecognised payload as "no sessions".
- Resolved session ids are deduplicated by session id so the same session is never tarred twice when both alias and canonical keys are supplied.
- Reference docs (`docs/reference/commands.mdx` + the Hermes mirror) cover the new `sessions export`, `download`, and `upload` commands.
- Public display layout entries for `sandbox:download`, `sandbox:upload`, and `sandbox:sessions:export`; registry counts updated.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sandbox:download, sandbox:upload, and sandbox:sessions:export commands to copy files and export session JSONL from running sandboxes; supports defaults (host dest=".", sandbox dest="/sandbox/"), --format (dir|tar), --out, --include-trajectory, and --json manifest output.

* **Tests**
  * Added comprehensive unit and CLI tests covering argument forwarding, defaults, validation, session-key resolution, tar staging, download/upload flows, permission hardening (0600), cleanup, and error cases (including rejected flag-like keys).

* **Documentation**
  * Added command reference docs describing usage, flags, defaults, safety checks, and export behavior.

* **Chores**
  * Updated CLI display layout and command-registry tests to include the new commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->