### PR TITLE
fix(cli): stabilize public dispatch on WSL

### DIFF
--- a/src/lib/cli/public-dispatch.ts
+++ b/src/lib/cli/public-dispatch.ts
@@ -17,11 +17,11 @@ const { help } = require("../actions/root-help");
 const { runOclifArgv, runOclifCommandById } = require("./oclif-runner");
 const {
   canonicalUsageList,
-  directGlobalCommandIds,
   globalCommandTokens,
   sandboxActionTokens,
 } = require("./command-registry");
 import { normalizeArgv, suggestCommand, type NormalizedSandboxArgv } from "./argv-normalizer";
+import { getRegisteredOclifCommandMetadata } from "./oclif-metadata";
 import {
   translatePublicGlobalArgv,
   translatePublicSandboxArgv,
@@ -169,21 +169,17 @@ function validSandboxActionsText(): string {
   return sandboxActionList().filter(Boolean).join(", ");
 }
 
-// Direct command-ID execution is a bounded fallback for leaf global commands.
-// With oclif flexible taxonomy enabled, native argv like `status bogus` can be
-// interpreted as command ID `status:bogus` instead of command `status` with an
-// unexpected positional arg `bogus`. Derive the leaf set from oclif metadata so
-// adding/removing global commands does not require maintaining a parallel list.
-const DIRECT_OCLIF_COMMAND_ID_GLOBALS = directGlobalCommandIds();
-
 function shouldExecuteViaNativeArgv(
   result: Extract<PublicTranslationResult, { kind: "nativeArgv" }>,
 ): boolean {
+  // Native argv remains useful for fabricated unknown child routes so oclif owns
+  // the unknown-command error. Exact public translations should run by command
+  // ID to avoid flexible-taxonomy reinterpreting positional args under WSL.
   const helpArgs =
     result.commandId === "sandbox:exec" ? argsBeforeSeparator(result.args) : result.args;
   if (hasHelpFlag(helpArgs)) return false;
-  if (DIRECT_OCLIF_COMMAND_ID_GLOBALS.has(result.commandId)) return false;
   if (result.commandId.startsWith("root:")) return false;
+  if (getRegisteredOclifCommandMetadata(result.commandId)) return false;
   return true;
 }
 function printDispatchUsageError(

--- a/test/cli-oclif-compatibility.test.ts
+++ b/test/cli-oclif-compatibility.test.ts
@@ -107,7 +107,7 @@ describe("oclif compatibility dispatch", () => {
     }
   });
 
-  it("hands public sandbox execution to oclif as native argv", async () => {
+  it("hands exact public sandbox execution to oclif by command id", async () => {
     const cliPath = require.resolve("../dist/nemoclaw.js");
     const registryPath = require.resolve("../dist/lib/state/registry.js");
     const registryRecoveryPath = require.resolve("../dist/lib/registry-recovery-action.js");
@@ -184,8 +184,20 @@ describe("oclif compatibility dispatch", () => {
       await dispatchCli(["alpha", "status"]);
 
       expect(validateName).toHaveBeenCalledWith("alpha", "sandbox name");
+      expect(runOclifCommandById).toHaveBeenCalledWith(
+        "sandbox:status",
+        ["alpha"],
+        expect.objectContaining({ rootDir: process.cwd() }),
+      );
+      expect(runOclifArgv).not.toHaveBeenCalled();
+
+      runOclifArgv.mockClear();
+      runOclifCommandById.mockClear();
+
+      await dispatchCli(["alpha", "channels", "bogus"]);
+
       expect(runOclifArgv).toHaveBeenCalledWith(
-        ["sandbox", "status", "alpha"],
+        ["sandbox", "channels", "bogus", "alpha"],
         expect.objectContaining({ rootDir: process.cwd() }),
       );
       expect(runOclifCommandById).not.toHaveBeenCalled();
@@ -280,11 +292,12 @@ describe("oclif compatibility dispatch", () => {
 
       expect(validateName).toHaveBeenCalledWith("alpha", "sandbox name");
       expect(recoverRegistryEntries).not.toHaveBeenCalled();
-      expect(runOclifArgv).toHaveBeenCalledWith(
-        ["sandbox", "exec", "alpha", "--", "grep", "--help"],
+      expect(runOclifCommandById).toHaveBeenCalledWith(
+        "sandbox:exec",
+        ["alpha", "--", "grep", "--help"],
         expect.objectContaining({ rootDir: process.cwd() }),
       );
-      expect(runOclifCommandById).not.toHaveBeenCalled();
+      expect(runOclifArgv).not.toHaveBeenCalled();
     } finally {
       if (priorDisableAutoDispatch === undefined) {
         delete process.env.NEMOCLAW_DISABLE_AUTO_DISPATCH;
@@ -301,7 +314,7 @@ describe("oclif compatibility dispatch", () => {
     }
   });
 
-  it("keeps simple global execution on direct command IDs to avoid flexible taxonomy overmatching", async () => {
+  it("keeps exact global execution on direct command IDs to avoid flexible taxonomy overmatching", async () => {
     const cliPath = require.resolve("../dist/nemoclaw.js");
     const runnerPath = require.resolve("../dist/lib/runner.js");
     const publicDispatchPath = require.resolve("../dist/lib/cli/public-dispatch.js");
@@ -340,6 +353,18 @@ describe("oclif compatibility dispatch", () => {
       expect(runOclifCommandById).toHaveBeenCalledWith(
         "status",
         ["bogus"],
+        expect.objectContaining({ rootDir: process.cwd() }),
+      );
+      expect(runOclifArgv).not.toHaveBeenCalled();
+
+      runOclifArgv.mockClear();
+      runOclifCommandById.mockClear();
+
+      await dispatchCli(["credentials", "reset", "--yes"]);
+
+      expect(runOclifCommandById).toHaveBeenCalledWith(
+        "credentials:reset",
+        ["--yes"],
         expect.objectContaining({ rootDir: process.cwd() }),
       );
       expect(runOclifArgv).not.toHaveBeenCalled();

--- a/test/cli/status-routing.test.ts
+++ b/test/cli/status-routing.test.ts
@@ -41,4 +41,14 @@ describe("CLI status routing", () => {
     expect(r.code).toBe(2);
     expect(r.out).toContain("Unexpected argument: bogus");
   });
+
+  it("sandbox-first status rejects unexpected positional arguments through command-id dispatch", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-extra-"));
+    writeSandboxRegistry(home);
+
+    const r = runWithEnv("alpha status extra", { HOME: home });
+
+    expect(r.code).toBe(2);
+    expect(r.out).toContain("Unexpected argument: extra");
+  });
 });

--- a/test/repro-4538-raw-doctor-perms.test.ts
+++ b/test/repro-4538-raw-doctor-perms.test.ts
@@ -65,6 +65,20 @@ function modeBits(filePath: string): number {
   return fs.statSync(filePath).mode & 0o7777;
 }
 
+// WSL CI can run these snippets as root; force restore-path cases to model a
+// mutable sandbox-owned config tree instead of the shields-up root-owned branch.
+function mutableSandboxOwnerStatShim(): string {
+  return [
+    "stat() {",
+    '  if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%U" ]; then',
+    '    printf "sandbox\\n";',
+    "    return 0;",
+    "  fi",
+    '  command stat "$@";',
+    "}",
+  ].join("\n");
+}
+
 function mkdtempOnPosixFs(prefix: string): string {
   const roots = process.platform === "linux" ? ["/tmp", os.tmpdir()] : [os.tmpdir()];
   let lastError: unknown = null;
@@ -109,6 +123,7 @@ describe("#4538 raw `openclaw doctor --fix` mutable-perm restore", () => {
           "-c",
           [
             "set -uo pipefail",
+            mutableSandboxOwnerStatShim(),
             extractShellFunctionFromSource(src, "_nemoclaw_restore_mutable_config_perms"),
             "_nemoclaw_restore_mutable_config_perms",
           ].join("\n"),
@@ -177,6 +192,7 @@ describe("#4538 raw `openclaw doctor --fix` mutable-perm restore", () => {
           "-c",
           [
             "set -uo pipefail",
+            mutableSandboxOwnerStatShim(),
             // Intercept `command openclaw ...` (the guard's terminal call) to
             // simulate `doctor --fix`: tighten perms, then exit nonzero — the
             // EACCES-on-.bashrc case the reporter hit.
@@ -226,6 +242,7 @@ describe("#4538 raw `openclaw doctor --fix` mutable-perm restore", () => {
           "-c",
           [
             "set -e",
+            mutableSandboxOwnerStatShim(),
             "command() {",
             '  if [ "${1:-}" = "openclaw" ]; then',
             '    chmod 700 "$OPENCLAW_STATE_DIR";',
@@ -270,6 +287,7 @@ describe("#4538 raw `openclaw doctor --fix` mutable-perm restore", () => {
           "-c",
           [
             "set -uo pipefail",
+            mutableSandboxOwnerStatShim(),
             extractShellFunctionFromSource(src, "_nemoclaw_restore_mutable_config_perms"),
             "_nemoclaw_restore_mutable_config_perms",
           ].join("\n"),

--- a/test/repro-4538-raw-doctor-perms.test.ts
+++ b/test/repro-4538-raw-doctor-perms.test.ts
@@ -70,7 +70,7 @@ function modeBits(filePath: string): number {
 function mutableSandboxOwnerStatShim(): string {
   return [
     "stat() {",
-    '  if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%U" ]; then',
+    '  if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%U" ] && [ "${3:-}" = "$OPENCLAW_STATE_DIR" ]; then',
     '    printf "sandbox\\n";',
     "    return 0;",
     "  fi",


### PR DESCRIPTION
## Summary
This PR stabilizes the platform Vitest WSL lane by dispatching exact translated public CLI routes through oclif command IDs instead of re-resolving them through native argv. It also makes the raw `openclaw doctor --fix` permission regression tests explicitly model a mutable sandbox-owned config tree when the CI WSL user is root.

## Related Issue
N/A

## Changes
- Route exact translated public CLI commands directly by registered oclif command ID, leaving native argv only for fabricated unknown child routes that need oclif-owned errors.
- Extend dispatch coverage for exact sandbox routes, nested global routes such as `credentials reset`, and unknown child-route fallback.
- Add a `stat` shim in the #4538 permission regression tests so restore-path cases do not accidentally hit the root-owned shields-up branch on WSL CI.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Command execution routing now uses registry metadata to determine dispatch paths.

* **Tests**
  * Enhanced permission-handling regression tests for sandbox configuration restoration.
  * Updated command-dispatch compatibility tests to assert command-id routing behavior.
  * Added a CLI status-routing test to reject unexpected positional arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->