### PR TITLE
fix(state): preserve reporter-owned model metadata on openclaw.json rebuild restore

### DIFF
--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -97,6 +97,91 @@ describe("mergeOpenClawRestoredConfig", () => {
     });
   });
 
+  it("restores reporter-owned model metadata while keeping fresh provider routing (#5202)", () => {
+    // Reporter scenario: same provider id and same model id after rebuild, but
+    // the freshly generated v0.0.63 model block resets the user's tuning. The
+    // merge must keep fresh runtime routing/credentials while restoring the
+    // backed-up non-secret model metadata.
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        models: {
+          mode: "merge",
+          providers: {
+            inference: {
+              baseUrl: "http://127.0.0.1:8789/v1",
+              apiKey: "unused",
+              api: "chat-completions",
+              models: [
+                {
+                  compat: { supportsUsageInStreaming: true, toolCallStyle: "openai" },
+                  id: "moonshotai/kimi-k2",
+                  name: "stale-display-name",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 0.2 },
+                  contextWindow: 131072,
+                  maxTokens: 32768,
+                },
+              ],
+            },
+          },
+        },
+        mcp: { servers: { filesystem: { command: "npx", args: ["-y", "fs-server", "/work"] } } },
+      },
+      {
+        models: {
+          mode: "merge",
+          providers: {
+            inference: {
+              baseUrl: "http://127.0.0.1:9999/v1",
+              apiKey: "unused",
+              api: "chat-completions",
+              models: [
+                {
+                  id: "moonshotai/kimi-k2",
+                  name: "fresh-display-name",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 131072,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+        gateway: { auth: { token: "fresh-token" } },
+      },
+    );
+
+    const provider = (
+      merged as {
+        models: { providers: { inference: Record<string, unknown> } };
+      }
+    ).models.providers.inference;
+    // Runtime-owned provider routing/credentials win from the fresh rebuild.
+    expect(provider.baseUrl).toBe("http://127.0.0.1:9999/v1");
+    expect(provider.apiKey).toBe("unused");
+    expect(provider.api).toBe("chat-completions");
+
+    const model = (provider.models as Record<string, unknown>[])[0];
+    // Routing identity (id/name) stays fresh; tuning metadata is restored.
+    expect(model.id).toBe("moonshotai/kimi-k2");
+    expect(model.name).toBe("fresh-display-name");
+    expect(model.reasoning).toBe(true);
+    expect(model.cost).toEqual({ input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 0.2 });
+    expect(model.maxTokens).toBe(32768);
+    expect(model.compat).toEqual({ supportsUsageInStreaming: true, toolCallStyle: "openai" });
+    expect(model.input).toEqual(["text", "image"]);
+    expect(model.contextWindow).toBe(131072);
+
+    // Fresh runtime gateway is preserved; durable user mcp.servers survives.
+    expect((merged as { gateway: unknown }).gateway).toEqual({ auth: { token: "fresh-token" } });
+    expect(
+      (merged as { mcp: { servers: Record<string, unknown> } }).mcp.servers.filesystem,
+    ).toEqual({ command: "npx", args: ["-y", "fs-server", "/work"] });
+  });
+
   it("keeps current provider and plugin entries for matching keys", () => {
     const merged = mergeOpenClawRestoredConfig(
       {

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -17,14 +17,24 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
   /** NemoClaw-managed channels reflect current add/remove/start/stop state. */
   managedChannels: ["discord", "slack", "telegram", "whatsapp", "wechat", "openclaw-weixin"],
   /** Current generated entries win by id; backup-only user entries are kept. */
-  currentGeneratedEntryMaps: ["models.providers", "plugins.entries"],
+  currentGeneratedEntryMaps: ["plugins.entries"],
+  /**
+   * Provider entries are reconciled by id: the fresh rebuild owns routing and
+   * credential fields, while backed-up non-secret model tuning is restored.
+   */
+  providerRuntimeOwnedFields: ["baseUrl", "api", "apiKey"],
+  /** A model entry's routing identity is owned by the fresh rebuild. */
+  modelRuntimeOwnedFields: ["id", "name"],
   /** Durable user-owned top-level sections are inherited from the backup. */
-  backupDurableSections: ["mcpServers", "customAgents", "agents"],
+  backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
 } as const;
 
 const MANAGED_OPENCLAW_CHANNELS = new Set<string>(
   OPENCLAW_CONFIG_RESTORE_OWNERSHIP.managedChannels,
 );
+
+const PROVIDER_RUNTIME_OWNED_FIELDS = OPENCLAW_CONFIG_RESTORE_OWNERSHIP.providerRuntimeOwnedFields;
+const MODEL_RUNTIME_OWNED_FIELDS = OPENCLAW_CONFIG_RESTORE_OWNERSHIP.modelRuntimeOwnedFields;
 
 function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
   return isRecord(value);
@@ -97,12 +107,115 @@ function mergeOpenClawEntryMap(
   };
 }
 
+function modelEntryId(entry: unknown): string | null {
+  if (isPlainJsonObject(entry) && typeof entry.id === "string") return entry.id;
+  return null;
+}
+
+function restoreRuntimeOwnedFields(
+  merged: Record<string, unknown>,
+  current: Record<string, unknown>,
+  ownedFields: readonly string[],
+): void {
+  for (const field of ownedFields) {
+    if (field in current) merged[field] = cloneJson(current[field]);
+    else delete merged[field];
+  }
+}
+
+/**
+ * Reconcile one model entry whose id matches across backup and current.
+ *
+ * The fresh rebuild owns the model's routing identity (`id`/`name`); the
+ * backup restores the user's non-secret tuning (`reasoning`, `cost`,
+ * `contextWindow`, `maxTokens`, `compat`, `input`, …) that the regenerated
+ * defaults would otherwise reset (issue #5202).
+ */
+function mergeOpenClawModelEntry(
+  backupModel: Record<string, unknown>,
+  currentModel: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = mergeJsonObjects(currentModel, backupModel);
+  restoreRuntimeOwnedFields(merged, currentModel, MODEL_RUNTIME_OWNED_FIELDS);
+  return merged;
+}
+
+/**
+ * Merge a provider's `models` array. The fresh rebuild defines the model set
+ * and order; for each fresh model with an id present in the backup, the
+ * backed-up tuning is restored. Backup-only and id-less stale models are not
+ * resurrected so rebuild's regenerated routing stays authoritative.
+ */
+function mergeOpenClawModelArray(backupModels: unknown, currentModels: unknown): unknown {
+  if (!Array.isArray(currentModels)) return cloneJson(backupModels ?? currentModels);
+
+  const backupById = new Map<string, Record<string, unknown>>();
+  if (Array.isArray(backupModels)) {
+    for (const entry of backupModels) {
+      const id = modelEntryId(entry);
+      if (id && isPlainJsonObject(entry) && !backupById.has(id)) backupById.set(id, entry);
+    }
+  }
+
+  return currentModels.map((entry) => {
+    const id = modelEntryId(entry);
+    const backupMatch = id ? backupById.get(id) : undefined;
+    if (backupMatch && isPlainJsonObject(entry)) return mergeOpenClawModelEntry(backupMatch, entry);
+    return cloneJson(entry);
+  });
+}
+
+/**
+ * Reconcile one provider entry whose id matches across backup and current.
+ * Runtime-owned routing/credential fields stay fresh; backed-up non-secret
+ * config (including per-model tuning) is restored.
+ */
+function mergeOpenClawProviderEntry(
+  backupProvider: Record<string, unknown>,
+  currentProvider: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = mergeJsonObjects(currentProvider, backupProvider);
+  restoreRuntimeOwnedFields(merged, currentProvider, PROVIDER_RUNTIME_OWNED_FIELDS);
+  if ("models" in currentProvider || "models" in backupProvider) {
+    merged.models = mergeOpenClawModelArray(backupProvider.models, currentProvider.models);
+  }
+  return merged;
+}
+
+/**
+ * Merge `models.providers`. Backup-only providers are inherited; fresh-only
+ * providers win as generated; matching providers are reconciled by ownership
+ * so the fresh rebuild keeps routing/credentials while the backup restores
+ * user-owned non-secret model metadata (issue #5202).
+ */
+function mergeOpenClawProviderMap(
+  backupProviders: unknown,
+  currentProviders: unknown,
+): Record<string, unknown> | undefined {
+  if (!isPlainJsonObject(backupProviders) && !isPlainJsonObject(currentProviders)) return undefined;
+  const backup = isPlainJsonObject(backupProviders) ? backupProviders : {};
+  const current = isPlainJsonObject(currentProviders) ? currentProviders : {};
+
+  const merged: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(backup)) {
+    merged[key] = cloneJson(value);
+  }
+  for (const [key, value] of Object.entries(current)) {
+    const backupEntry = backup[key];
+    merged[key] =
+      isPlainJsonObject(backupEntry) && isPlainJsonObject(value)
+        ? mergeOpenClawProviderEntry(backupEntry, value)
+        : cloneJson(value);
+  }
+  return merged;
+}
+
 function mergeOpenClawModels(backupModels: unknown, currentModels: unknown): unknown {
   if (!isPlainJsonObject(backupModels)) return cloneJson(currentModels);
   if (!isPlainJsonObject(currentModels)) return cloneJson(backupModels);
 
   const merged = mergeJsonObjects(currentModels, backupModels);
-  const providers = mergeOpenClawEntryMap(backupModels.providers, currentModels.providers);
+  const providers = mergeOpenClawProviderMap(backupModels.providers, currentModels.providers);
   if (providers) merged.providers = providers;
   return merged;
 }

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -884,7 +884,7 @@ function backupStateFile(
   return "backed_up";
 }
 
-function buildStateFileRestoreCommand(
+export function buildStateFileRestoreCommand(
   dir: string,
   spec: StateFileSpec,
   refreshOpenClawConfigHash = false,
@@ -913,11 +913,34 @@ function buildStateFileRestoreCommand(
     '[ ! -L "$dst" ] || { echo "refusing symlinked state target: $dst" >&2; exit 11; }',
     'mkdir -p "$parent"',
     'tmp="$(mktemp "${parent}/.nemoclaw-restore.XXXXXX")"',
-    "trap 'rm -f \"$tmp\"' EXIT",
+    'trap \'rm -f "$tmp" "${anchor_tmp:-}"\' EXIT',
     'cat > "$tmp"',
     'chmod 640 "$tmp"',
-    'mv -f "$tmp" "$dst"',
   ];
+
+  if (refreshOpenClawConfigHash) {
+    // OpenClaw guards openclaw.json with a `.last-good` recovery anchor: on its
+    // config-integrity check it archives any live config that differs from
+    // `.last-good` as `openclaw.json.clobbered.*` and reverts to `.last-good`.
+    // The rebuild restore writes the merged user config directly, so without
+    // refreshing the anchor OpenClaw reverts the restored config back to the
+    // freshly generated baseline captured at first boot (issue #5202). Refresh
+    // the anchor from the staged temp BEFORE swapping the live file so the
+    // integrity watcher never observes a config that disagrees with it. Stage
+    // through a temp + atomic rename and fail closed (before the live swap) so
+    // a partial/failed anchor write never leaves a stale recovery target that
+    // would let OpenClaw revert the restored config.
+    steps.push(
+      'last_good="${dst}.last-good"',
+      '[ ! -L "$last_good" ] || { echo "refusing symlinked last-good target: $last_good" >&2; exit 13; }',
+      'anchor_tmp="$(mktemp "${parent}/.nemoclaw-lastgood.XXXXXX")" || { echo "failed to stage last-good anchor" >&2; exit 14; }',
+      'cat "$tmp" > "$anchor_tmp" || { echo "failed to write last-good anchor" >&2; exit 14; }',
+      'chmod 660 "$anchor_tmp" 2>/dev/null || true',
+      'mv -f "$anchor_tmp" "$last_good" || { echo "failed to install last-good anchor" >&2; exit 14; }',
+    );
+  }
+
+  steps.push('mv -f "$tmp" "$dst"');
 
   if (refreshOpenClawConfigHash) {
     steps.push(

--- a/test/openclaw-config-snapshot.test.ts
+++ b/test/openclaw-config-snapshot.test.ts
@@ -76,7 +76,13 @@ if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
 }
 if (cmd.includes(".nemoclaw-restore") && cmd.includes("openclaw.json")) {
   const configPath = path.join(dir, "openclaw.json");
-  fs.writeFileSync(configPath, readStdin());
+  const restored = readStdin();
+  // Mirror the real restore command: the OpenClaw .last-good recovery anchor is
+  // refreshed from the staged temp BEFORE the live config is swapped (#5202).
+  if (cmd.includes("last-good")) {
+    fs.writeFileSync(path.join(dir, "openclaw.json.last-good"), restored);
+  }
+  fs.writeFileSync(configPath, restored);
   if (cmd.includes("sha256sum") && cmd.includes(".config-hash")) {
     const digest = require("crypto").createHash("sha256").update(fs.readFileSync(configPath)).digest("hex");
     fs.writeFileSync(path.join(dir, ".config-hash"), digest + "  openclaw.json\\n");
@@ -361,6 +367,15 @@ describe("OpenClaw durable config file (#5027)", () => {
         args: ["-y", "fs-server", "/work"],
       });
       expect(after.mcp.servers.github.env.GITHUB_TOKEN).toBe("[STRIPPED_BY_MIGRATION]");
+
+      // OpenClaw's .last-good recovery anchor is refreshed to the restored
+      // config so its integrity check does not revert the merge (#5202).
+      const lastGood = JSON.parse(
+        fs.readFileSync(path.join(openclawDir, "openclaw.json.last-good"), "utf-8"),
+      );
+      expect(lastGood.models.providers.inference.models[0].reasoning).toBe(true);
+      expect(lastGood.models.providers.inference.models[0].maxTokens).toBe(32768);
+      expect(lastGood.mcp.servers.filesystem.command).toBe("npx");
     } finally {
       if (oldOpenshell === undefined) {
         delete process.env.NEMOCLAW_OPENSHELL_BIN;

--- a/test/openclaw-config-snapshot.test.ts
+++ b/test/openclaw-config-snapshot.test.ts
@@ -30,6 +30,64 @@ function writeExecutable(filePath: string, source: string): void {
   fs.writeFileSync(filePath, source, { mode: 0o755 });
 }
 
+/**
+ * Write fake `openshell` and `ssh` executables that mirror the backup/restore
+ * SSH contract against a local sandbox-root directory, so backupSandboxState /
+ * restoreSandboxState exercise the real code path without a live sandbox.
+ */
+function writeFakeSandboxBins(binDir: string, fakeRoot: string): void {
+  writeExecutable(
+    path.join(binDir, "openshell"),
+    `#!/bin/sh
+if [ "$1" = "sandbox" ] && [ "$2" = "get" ]; then
+  printf '{"name":"%s"}\n' "\${3:-alpha}"
+  exit 0
+fi
+if [ "$1" = "sandbox" ] && [ "$2" = "ssh-config" ]; then
+  printf 'Host openshell-alpha\n  HostName 127.0.0.1\n  User sandbox\n'
+  exit 0
+fi
+exit 0
+`,
+  );
+
+  writeExecutable(
+    path.join(binDir, "ssh"),
+    `#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const dir = path.join(${JSON.stringify(fakeRoot)}, ".openclaw");
+const cmd = process.argv[process.argv.length - 1] || "";
+function readStdin() {
+  const chunks = [];
+  for (;;) {
+    const buf = Buffer.alloc(65536);
+    let n = 0;
+    try { n = fs.readSync(0, buf, 0, buf.length, null); } catch { break; }
+    if (n === 0) break;
+    chunks.push(buf.subarray(0, n));
+  }
+  return Buffer.concat(chunks);
+}
+if (cmd.includes("[ -d ")) { process.exit(0); }
+if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
+  process.stdout.write(fs.readFileSync(path.join(dir, "openclaw.json")));
+  process.exit(0);
+}
+if (cmd.includes(".nemoclaw-restore") && cmd.includes("openclaw.json")) {
+  const configPath = path.join(dir, "openclaw.json");
+  fs.writeFileSync(configPath, readStdin());
+  if (cmd.includes("sha256sum") && cmd.includes(".config-hash")) {
+    const digest = require("crypto").createHash("sha256").update(fs.readFileSync(configPath)).digest("hex");
+    fs.writeFileSync(path.join(dir, ".config-hash"), digest + "  openclaw.json\\n");
+  }
+  process.exit(0);
+}
+process.exit(0);
+`,
+  );
+}
+
 function writeOpenClawRegistry(sandboxName: string): void {
   fs.mkdirSync(path.join(TMP_HOME, ".nemoclaw"), { recursive: true });
   fs.writeFileSync(
@@ -95,56 +153,7 @@ describe("OpenClaw durable config file (#5027)", () => {
       };
       fs.writeFileSync(path.join(openclawDir, "openclaw.json"), JSON.stringify(original, null, 2));
 
-      writeExecutable(
-        path.join(binDir, "openshell"),
-        `#!/bin/sh
-if [ "$1" = "sandbox" ] && [ "$2" = "get" ]; then
-  printf '{"name":"%s"}\n' "\${3:-alpha}"
-  exit 0
-fi
-if [ "$1" = "sandbox" ] && [ "$2" = "ssh-config" ]; then
-  printf 'Host openshell-alpha\n  HostName 127.0.0.1\n  User sandbox\n'
-  exit 0
-fi
-exit 0
-`,
-      );
-
-      writeExecutable(
-        path.join(binDir, "ssh"),
-        `#!/usr/bin/env node
-const fs = require("fs");
-const path = require("path");
-const dir = path.join(${JSON.stringify(fakeRoot)}, ".openclaw");
-const cmd = process.argv[process.argv.length - 1] || "";
-function readStdin() {
-  const chunks = [];
-  for (;;) {
-    const buf = Buffer.alloc(65536);
-    let n = 0;
-    try { n = fs.readSync(0, buf, 0, buf.length, null); } catch { break; }
-    if (n === 0) break;
-    chunks.push(buf.subarray(0, n));
-  }
-  return Buffer.concat(chunks);
-}
-if (cmd.includes("[ -d ")) { process.exit(0); }
-if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
-  process.stdout.write(fs.readFileSync(path.join(dir, "openclaw.json")));
-  process.exit(0);
-}
-if (cmd.includes(".nemoclaw-restore") && cmd.includes("openclaw.json")) {
-  const configPath = path.join(dir, "openclaw.json");
-  fs.writeFileSync(configPath, readStdin());
-  if (cmd.includes("sha256sum") && cmd.includes(".config-hash")) {
-    const digest = require("crypto").createHash("sha256").update(fs.readFileSync(configPath)).digest("hex");
-    fs.writeFileSync(path.join(dir, ".config-hash"), digest + "  openclaw.json\\n");
-  }
-  process.exit(0);
-}
-process.exit(0);
-`,
-      );
+      writeFakeSandboxBins(binDir, fakeRoot);
 
       writeOpenClawRegistry("alpha");
       // writeOpenClawRegistry records agent:null → defaults to openclaw.
@@ -217,6 +226,141 @@ process.exit(0);
       expect(fs.readFileSync(path.join(openclawDir, ".config-hash"), "utf-8")).toBe(
         `${expectedHash}  openclaw.json\n`,
       );
+    } finally {
+      if (oldOpenshell === undefined) {
+        delete process.env.NEMOCLAW_OPENSHELL_BIN;
+      } else {
+        process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
+      }
+      process.env.PATH = oldPath;
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  }, 15000);
+
+  it("preserves reporter-owned model metadata and mcp.servers across rebuild (#5202)", async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-snapshot-5202-"));
+    const oldPath = process.env.PATH;
+    const oldOpenshell = process.env.NEMOCLAW_OPENSHELL_BIN;
+    try {
+      const binDir = path.join(fixture, "bin");
+      const fakeRoot = path.join(fixture, "sandbox-root");
+      const openclawDir = path.join(fakeRoot, ".openclaw");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(openclawDir, { recursive: true });
+
+      // Reporter-shaped v0.0.62 config: a tuned inference provider model plus
+      // top-level mcp.servers, a real inline MCP secret, and a runtime gateway.
+      const original = {
+        models: {
+          mode: "merge",
+          providers: {
+            inference: {
+              baseUrl: "http://127.0.0.1:8789/v1",
+              apiKey: "unused",
+              api: "chat-completions",
+              models: [
+                {
+                  compat: { supportsUsageInStreaming: true, toolCallStyle: "openai" },
+                  id: "moonshotai/kimi-k2",
+                  name: "stale-display-name",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 0.2 },
+                  contextWindow: 131072,
+                  maxTokens: 32768,
+                },
+              ],
+            },
+          },
+        },
+        mcp: {
+          servers: {
+            filesystem: { command: "npx", args: ["-y", "fs-server", "/work"] },
+            github: {
+              command: "npx",
+              env: { GITHUB_TOKEN: "ghp_raw_secret", NODE_ENV: "production" },
+            },
+          },
+        },
+        gateway: { port: 18789, authToken: "gw-token" },
+      };
+      fs.writeFileSync(path.join(openclawDir, "openclaw.json"), JSON.stringify(original, null, 2));
+
+      writeFakeSandboxBins(binDir, fakeRoot);
+      writeOpenClawRegistry("alpha");
+
+      process.env.NEMOCLAW_OPENSHELL_BIN = path.join(binDir, "openshell");
+      process.env.PATH = `${binDir}:${oldPath || ""}`;
+
+      const backup = sandboxState.backupSandboxState("alpha");
+      expect(backup.success).toBe(true);
+
+      // Local backup keeps non-secret tuning + mcp.servers; secrets are stripped.
+      const backedUp = JSON.parse(
+        fs.readFileSync(path.join(backup.manifest!.backupPath, "openclaw.json"), "utf-8"),
+      );
+      expect(backedUp.models.providers.inference.models[0].reasoning).toBe(true);
+      expect(backedUp.mcp.servers.filesystem.command).toBe("npx");
+      expect(backedUp.mcp.servers.github.env.GITHUB_TOKEN).toBe("[STRIPPED_BY_MIGRATION]");
+      expect(backedUp.mcp.servers.github.env.NODE_ENV).toBe("production");
+      expect(backedUp.gateway).toBeUndefined();
+
+      // Fresh v0.0.63 rebuild output: same provider/model id, reset tuning, a
+      // fresh runtime gateway and a fresh base URL.
+      fs.writeFileSync(
+        path.join(openclawDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            models: {
+              mode: "merge",
+              providers: {
+                inference: {
+                  baseUrl: "http://127.0.0.1:9999/v1",
+                  apiKey: "unused",
+                  api: "chat-completions",
+                  models: [
+                    {
+                      id: "moonshotai/kimi-k2",
+                      name: "fresh-display-name",
+                      reasoning: false,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 131072,
+                      maxTokens: 4096,
+                    },
+                  ],
+                },
+              },
+            },
+            gateway: { auth: { token: "fresh-runtime-token" } },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const restore = sandboxState.restoreSandboxState("alpha", backup.manifest!.backupPath);
+      expect(restore.success).toBe(true);
+
+      const after = JSON.parse(fs.readFileSync(path.join(openclawDir, "openclaw.json"), "utf-8"));
+      const model = after.models.providers.inference.models[0];
+      // Reporter-owned tuning is restored.
+      expect(model.reasoning).toBe(true);
+      expect(model.cost).toEqual({ input: 0.5, output: 1.5, cacheRead: 0.1, cacheWrite: 0.2 });
+      expect(model.maxTokens).toBe(32768);
+      expect(model.compat).toEqual({ supportsUsageInStreaming: true, toolCallStyle: "openai" });
+      expect(model.input).toEqual(["text", "image"]);
+      // Fresh runtime routing/credentials win.
+      expect(model.id).toBe("moonshotai/kimi-k2");
+      expect(model.name).toBe("fresh-display-name");
+      expect(after.models.providers.inference.baseUrl).toBe("http://127.0.0.1:9999/v1");
+      expect(after.gateway.auth.token).toBe("fresh-runtime-token");
+      // Durable mcp.servers survives; the raw MCP secret never returns.
+      expect(after.mcp.servers.filesystem).toEqual({
+        command: "npx",
+        args: ["-y", "fs-server", "/work"],
+      });
+      expect(after.mcp.servers.github.env.GITHUB_TOKEN).toBe("[STRIPPED_BY_MIGRATION]");
     } finally {
       if (oldOpenshell === undefined) {
         delete process.env.NEMOCLAW_OPENSHELL_BIN;

--- a/test/state-file-restore-command.test.ts
+++ b/test/state-file-restore-command.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const sandboxState = (await import(
+  pathToFileURL(path.join(REPO_ROOT, "dist", "lib", "state", "sandbox.js")).href
+)) as typeof import("../dist/lib/state/sandbox.js");
+
+const spec = { path: "openclaw.json", strategy: "copy" } as const;
+
+describe("buildStateFileRestoreCommand (#5202)", () => {
+  it("refreshes the OpenClaw .last-good anchor before swapping the live config", () => {
+    const cmd = sandboxState.buildStateFileRestoreCommand("/sandbox/.openclaw", spec, true);
+
+    // The anchor write targets openclaw.json.last-good and rejects symlinks.
+    expect(cmd).toContain('last_good="${dst}.last-good"');
+    expect(cmd).toContain("refusing symlinked last-good target");
+
+    // The anchor is staged through a temp and installed via atomic rename, and
+    // fails closed (exit 14) so a partial write never reaches .last-good.
+    expect(cmd).toContain(".nemoclaw-lastgood.XXXXXX");
+    expect(cmd).toContain('mv -f "$anchor_tmp" "$last_good"');
+    expect(cmd).toContain("exit 14");
+
+    // Anchor must be installed BEFORE the live file is swapped, so OpenClaw's
+    // integrity watcher never observes a config that disagrees with .last-good.
+    const anchorIdx = cmd.indexOf('mv -f "$anchor_tmp" "$last_good"');
+    const swapIdx = cmd.indexOf('mv -f "$tmp" "$dst"');
+    expect(anchorIdx).toBeGreaterThanOrEqual(0);
+    expect(swapIdx).toBeGreaterThan(anchorIdx);
+
+    // The .config-hash is still refreshed after the swap.
+    expect(cmd).toContain("sha256sum");
+  });
+
+  it("does not touch the .last-good anchor for non-OpenClaw state restores", () => {
+    const cmd = sandboxState.buildStateFileRestoreCommand("/sandbox/.openclaw", spec, false);
+    expect(cmd).not.toContain("last-good");
+    expect(cmd).not.toContain("sha256sum");
+    expect(cmd).toContain('mv -f "$tmp" "$dst"');
+  });
+});


### PR DESCRIPTION
## Summary

After a NemoClaw upgrade + `nemoclaw <name> rebuild`, an OpenClaw sandbox's reporter-tuned `openclaw.json` model metadata reset to regenerated defaults. Fixing this required two layers: (1) the rebuild restore merge replaced matching `models.providers` entries wholesale, and (2) even after a correct merge, OpenClaw's own config-integrity protection reverted the restored config to its `.last-good` baseline. This PR fixes both, verified end-to-end through the real `nemoclaw` CLI on a live sandbox.

## Related Issue

Fixes #5202

## Changes

- `src/lib/state/openclaw-config-merge.ts`: reconcile matching `models.providers` entries by ownership instead of replacing them wholesale. The fresh rebuild keeps runtime-owned routing/credentials (`baseUrl`, `api`, `apiKey`) and a model's identity (`id`, `name`); the backup restores user-owned non-secret tuning (`reasoning`, `cost`, `contextWindow`, `maxTokens`, `compat`, `input`). Fresh rebuild stays authoritative for the provider/model set and order; backup-only/id-less stale models are not resurrected; backup-only providers are inherited. No raw secrets restored.
- `src/lib/state/sandbox.ts`: `buildStateFileRestoreCommand` now refreshes OpenClaw's `.last-good` recovery anchor for the `openclaw.json` merge restore — staged through a temp + atomic rename and failing closed **before** the live config is swapped. Without this, OpenClaw archives the restored config as `openclaw.json.clobbered.<ts>` and reverts to the freshly generated baseline.
- Tests: reporter-shaped unit regression (`openclaw-config-merge.test.ts`), a command-string unit test for the anchor refresh + ordering + fail-closed (`state-file-restore-command.test.ts`), and an extended backup/restore integration test through the real `backupSandboxState()`/`restoreSandboxState()` path asserting both the merged metadata, `mcp.servers` retention, and the `.last-good` anchor (`openclaw-config-snapshot.test.ts`).

## Notes on `mcp.servers`

The reporter also saw `mcp.servers` become `{}`. The fresh generated config emits no `mcp` section, so the backed-up `mcp` survives the generic object merge — confirmed live (fresh in-sandbox config showed `mcp: null`) and locked in by the tests. The merge layer needed no change for it; the `.last-good` revert was what dropped it end-to-end, which layer 2 fixes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] Reporter-workflow E2E on a live OpenClaw sandbox via the worktree CLI (no mocks):
  - `node ./bin/nemoclaw.js onboard --non-interactive --yes --no-gpu --name i5202e2e` — created a real OpenClaw sandbox (cloud inference, no GPU).
  - `node ./bin/nemoclaw.js i5202e2e exec -- ...` — tuned the in-sandbox `/sandbox/.openclaw/openclaw.json` to the reporter state (`reasoning:true`, custom `cost`, `maxTokens:32768`, `compat`, `mcp.servers.filesystem`).
  - `node ./bin/nemoclaw.js i5202e2e rebuild --yes` — the user-facing operation under test (backup → recreate → restore-merge → `.last-good` refresh).
  - Post-rebuild inspection of `/sandbox/.openclaw/openclaw.json`: kept `reasoning:true`, `maxTokens:32768`, `cost {0.5,1.5,0.1,0.2}`, `compat`, `input ["text","image"]`, `mcp.servers.filesystem`; runtime fields fresh (`baseUrl https://inference.local/v1`, `apiKey unused`, fresh `id`/`name`); **zero `openclaw.json.clobbered.*` files**. Survived a subsequent container restart (OpenClaw integrity check re-ran). Reproduced cleanly across two consecutive fixed rebuilds.
- [x] Pre-fix, the same workflow showed the bug: restored config reverted to `reasoning:false`/`maxTokens:4096`/no `compat`/no `mcp`, with the correctly-merged config archived as `openclaw.json.clobbered.*` — proving the merge worked but OpenClaw reverted it.
- [x] `npx vitest run` on the affected unit + integration tests — passing.
- [x] `tsc -p tsconfig.cli.json` typecheck passes.
- [x] `npx @biomejs/biome check` clean on changed files.
- [x] `codex review --uncommitted` clean.
- [x] Tests added for new/changed behavior.
- [x] No secrets, API keys, or credentials committed; only the already-sanitized backup is merged.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore behavior to keep user-provided model tuning/metadata and durable server settings across rebuilds while ensuring fresh runtime credentials and routing take precedence; backup/restore now strips secrets but preserves non-sensitive config.
* **Tests**
  * Added coverage validating config merge, durable server preservation, reporter-owned metadata restoration, and atomic state-file restore behavior (.last-good anchor).
* **Chores**
  * Exposed state-restore command builder for safer restore orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->