### PR TITLE
fix(sandbox): stop openclaw doctor tightening mutable config perms (#4538, #4859)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,9 +93,11 @@ RUN npm ci --omit=dev
 COPY scripts/patch-openclaw-tool-catalog.js /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js
 COPY scripts/patch-openclaw-chat-send.js /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js
 COPY scripts/patch-openclaw-slack-deny-feedback.mts /usr/local/lib/nemoclaw/patch-openclaw-slack-deny-feedback.mts
+COPY scripts/patch-openclaw-doctor-mutable-perms.mts /usr/local/lib/nemoclaw/patch-openclaw-doctor-mutable-perms.mts
 RUN chmod 755 /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.js \
         /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js \
-        /usr/local/lib/nemoclaw/patch-openclaw-slack-deny-feedback.mts
+        /usr/local/lib/nemoclaw/patch-openclaw-slack-deny-feedback.mts \
+        /usr/local/lib/nemoclaw/patch-openclaw-doctor-mutable-perms.mts
 
 # Upgrade OpenClaw if the base image is stale.
 #
@@ -504,6 +506,23 @@ RUN set -eu; \
 # and openclaw/openclaw#50298, or when NemoClaw no longer ships OpenClaw 2026.5.x.
 # hadolint ignore=DL3059
 RUN node /usr/local/lib/nemoclaw/patch-openclaw-chat-send.js \
+    /usr/local/lib/node_modules/openclaw/dist
+
+# Patch OpenClaw's `doctor` state-integrity check so it stops reporting and
+# tightening NemoClaw's mutable-config contract (NVIDIA/NemoClaw #4538, #4859).
+#
+# OpenClaw doctor flags /sandbox/.openclaw (2770) and openclaw.json (660) as
+# "permissions are too open" and, with --fix, tightens them to single-user
+# 700/600 — durably breaking the group-shared contract the gateway UID needs to
+# persist config writes. The patch narrows doctor's over-open test to OTHER
+# (world) bits only when running inside an OpenShell sandbox (OPENSHELL_SANDBOX
+# is set — OpenShell injects the sandbox name there, verified on 0.0.44), so
+# group bits (the gateway's shared access) are tolerated while genuinely
+# world-accessible modes are still caught. Out-of-sandbox behavior is unchanged.
+# The script fails closed if the pinned doctor state-integrity shape changes.
+# See the script header for details.
+# hadolint ignore=DL3059
+RUN node --experimental-strip-types /usr/local/lib/nemoclaw/patch-openclaw-doctor-mutable-perms.mts \
     /usr/local/lib/node_modules/openclaw/dist
 
 # Patch OpenClaw's pinned 2026.5.27 compiled selection runtime to expose a

--- a/scripts/patch-openclaw-doctor-mutable-perms.mts
+++ b/scripts/patch-openclaw-doctor-mutable-perms.mts
@@ -44,9 +44,10 @@
  *
  * The patch classifies the compiled OpenClaw dist by content signature, requires
  * exactly the two reviewed `(stat.mode & 63) !== 0` permission gates in the
- * doctor state-integrity module, and fails loudly when the shape is unrecognized
- * rather than silently leaving the sandbox unpatched. It is idempotent and a
- * no-op when no matching module is present.
+ * doctor state-integrity module, and fails loudly (non-zero) when the shape is
+ * unrecognized OR no module is found — rather than silently leaving the sandbox
+ * unpatched, since the doctor module is core OpenClaw and always present where
+ * this runs. It is idempotent across re-runs.
  *
  * Removal criteria: drop when OpenClaw's doctor recognizes a group-shared state
  * layout (or exposes config to opt out of the 700/600 enforcement), so the
@@ -153,11 +154,17 @@ function patchDoctorModule(file: string): boolean {
 
 const modules = locateDoctorModules(dirs);
 if (modules.length === 0) {
-  console.log(
-    `INFO: no OpenClaw doctor state-integrity module found under ${dirs.join(", ")}; ` +
-      "skipping mutable-perms doctor patch",
+  // Fail closed. The doctor state-integrity module is core OpenClaw and is
+  // always present wherever this patch runs (the OpenClaw runtime dist). An
+  // absent module means the dist shape/path drifted, so a silent no-op would
+  // ship an image whose `doctor --fix` resumes tightening the NemoClaw mutable
+  // contract back to 700/600 (#4538, #4859) — the exact regression this patch
+  // prevents. Stop the build and force a re-review instead, matching the
+  // fetch-guard patches' "fail on unknown OpenClaw dist shape" stance.
+  fail(
+    `no OpenClaw doctor state-integrity module found under ${dirs.join(", ")}; ` +
+      "the OpenClaw dist shape may have drifted — re-review this patch for the new layout",
   );
-  process.exit(0);
 }
 
 const patchedFiles: string[] = [];

--- a/scripts/patch-openclaw-doctor-mutable-perms.mts
+++ b/scripts/patch-openclaw-doctor-mutable-perms.mts
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * NemoClaw compatibility shim for OpenClaw's `doctor` state-integrity check
+ * (NVIDIA/NemoClaw #4538, #4859).
+ *
+ * OpenClaw's doctor enforces a single-user 700/600 state layout: it flags the
+ * state directory and openclaw.json as "too open" whenever ANY group OR other
+ * permission bit is set (`(stat.mode & 63) !== 0`, where 63 === 0o77), and with
+ * `--fix` it tightens them to 700/600.
+ *
+ * NemoClaw's mutable-config contract is the opposite by design: the gateway runs
+ * under a distinct UID that shares the `sandbox` group (Dockerfile.base
+ * `usermod -aG sandbox gateway`), so /sandbox/.openclaw must stay setgid +
+ * group-writable (2770) and openclaw.json group-writable (660) or the gateway
+ * UID EACCESes on every control-UI config write. A raw in-sandbox
+ * `openclaw doctor --fix` tightens 2770/660 back to 700/600, durably breaking
+ * that contract (the regression QA reopened in #4538 and #4859), and prints
+ * scary "permissions are too open" / "Tightened permissions ... to 700/600"
+ * messages that misrepresent the intended contract as a misconfiguration.
+ *
+ * This patch narrows doctor's over-open test to OTHER (world) bits only when the
+ * process runs inside an OpenShell sandbox (OPENSHELL_SANDBOX is set):
+ *
+ *     (stat.mode & 63) !== 0
+ *   → (stat.mode & (process.env.OPENSHELL_SANDBOX ? 7 : 63)) !== 0
+ *
+ * where 7 === 0o7 (other-rwx). Group bits (the gateway's shared access) are then
+ * tolerated, so the NemoClaw 2770/660 contract is neither flagged nor tightened,
+ * while genuinely world-accessible modes (e.g. 0o2777 / 0o664) are still caught
+ * and repaired. Out-of-sandbox behavior (no OPENSHELL_SANDBOX) is byte-identical
+ * to upstream. OpenShell injects OPENSHELL_SANDBOX at sandbox runtime; an
+ * image-level ENV does not survive (it is stripped by OpenShell), which is why
+ * the bypass keys on the runtime env var rather than a build-time flag.
+ *
+ * NOTE on the gate: OpenShell injects the sandbox NAME into OPENSHELL_SANDBOX
+ * (e.g. `OPENSHELL_SANDBOX=my-sandbox`), verified against OpenShell 0.0.44 — it
+ * is NOT the literal "1". The bypass therefore keys on the var being non-empty
+ * ("inside any OpenShell sandbox") rather than `=== "1"`, so it actually fires in
+ * the sandbox runtime where the reporter runs `openclaw doctor`. The var is unset
+ * outside an OpenShell sandbox, so upstream behavior is preserved there.
+ *
+ * The patch classifies the compiled OpenClaw dist by content signature, requires
+ * exactly the two reviewed `(stat.mode & 63) !== 0` permission gates in the
+ * doctor state-integrity module, and fails loudly when the shape is unrecognized
+ * rather than silently leaving the sandbox unpatched. It is idempotent and a
+ * no-op when no matching module is present.
+ *
+ * Removal criteria: drop when OpenClaw's doctor recognizes a group-shared state
+ * layout (or exposes config to opt out of the 700/600 enforcement), so the
+ * NemoClaw mutable contract is no longer reported and tightened.
+ *
+ * Usage: patch-openclaw-doctor-mutable-perms.mts <openclaw-dist-dir> [<dir>...]
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const STATE_DIR_SIGNATURE = "State directory permissions are too open";
+const CONFIG_SIGNATURE = "Config file is group/world readable";
+const PERM_GATE = "(stat.mode & 63) !== 0";
+const PATCHED_GATE = "(stat.mode & (process.env.OPENSHELL_SANDBOX ? 7 : 63)) !== 0";
+const PATCH_MARKER = "nemoclaw: tolerate group-shared mutable config perms";
+const EXPECTED_GATES = 2;
+
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+  console.error("Usage: patch-openclaw-doctor-mutable-perms.mts <openclaw-dist-dir> [<dir>...]");
+  process.exit(2);
+}
+
+function fail(message: string): never {
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+}
+
+function listJsFiles(dir: string): string[] {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+    .map((entry) => join(dir, entry.name));
+}
+
+// Locate the compiled doctor state-integrity module(s): the file owns both the
+// state-dir and config-file permission warnings. The hashed filename drifts
+// between bundles, so classify by content rather than by name.
+function locateDoctorModules(searchDirs: string[]): string[] {
+  const found = new Set<string>();
+  for (const dir of searchDirs) {
+    if (!existsSync(dir)) continue;
+    for (const file of listJsFiles(dir)) {
+      const source = readFileSync(file, "utf8");
+      if (source.includes(STATE_DIR_SIGNATURE) && source.includes(CONFIG_SIGNATURE)) {
+        found.add(file);
+      }
+    }
+  }
+  return [...found];
+}
+
+function patchDoctorModule(file: string): boolean {
+  const source = readFileSync(file, "utf8");
+
+  if (source.includes(PATCH_MARKER)) {
+    // Already patched (idempotent re-run). Confirm no unpatched gate slipped
+    // back in alongside the patched ones.
+    if (source.includes(PERM_GATE)) {
+      fail(
+        `doctor state-integrity module ${file} is partially patched (found an unpatched ` +
+          `'${PERM_GATE}' gate alongside the NemoClaw marker); inspect the dist and re-review this patch`,
+      );
+    }
+    return false;
+  }
+
+  // Shape gate: both the over-open checks must be present in the reviewed
+  // `(stat.mode & 63) !== 0` form. Anything else means OpenClaw reworked the
+  // permission logic and the rewrite must be re-reviewed.
+  const gateCount = source.split(PERM_GATE).length - 1;
+  if (gateCount !== EXPECTED_GATES) {
+    fail(
+      `doctor state-integrity module ${file} has ${gateCount} '${PERM_GATE}' permission gates ` +
+        `(expected exactly ${EXPECTED_GATES}); refusing ambiguous rewrite — re-review this patch for the new OpenClaw layout`,
+    );
+  }
+
+  const patched = source.replaceAll(
+    PERM_GATE,
+    `${PATCHED_GATE} /* ${PATCH_MARKER} (#4538, #4859) */`,
+  );
+
+  const patchedCount = patched.split(PATCHED_GATE).length - 1;
+  if (patchedCount !== EXPECTED_GATES) {
+    fail(
+      `doctor state-integrity patch verification failed for ${file}: expected ${EXPECTED_GATES} ` +
+        `patched permission gates, found ${patchedCount}`,
+    );
+  }
+  if (patched.includes(PERM_GATE)) {
+    fail(`doctor state-integrity patch left an unpatched permission gate in ${file}`);
+  }
+
+  writeFileSync(file, patched);
+  return true;
+}
+
+const modules = locateDoctorModules(dirs);
+if (modules.length === 0) {
+  console.log(
+    `INFO: no OpenClaw doctor state-integrity module found under ${dirs.join(", ")}; ` +
+      "skipping mutable-perms doctor patch",
+  );
+  process.exit(0);
+}
+
+const patchedFiles: string[] = [];
+for (const file of modules) {
+  const changed = patchDoctorModule(file);
+  const verified = readFileSync(file, "utf8");
+  if (!verified.includes(PATCH_MARKER)) {
+    fail(`doctor mutable-perms patch did not apply in ${file}`);
+  }
+  if (changed) patchedFiles.push(file);
+}
+
+if (patchedFiles.length > 0) {
+  console.log(
+    `INFO: patched OpenClaw doctor mutable-perms gate in ${patchedFiles
+      .map((file) => relative(process.cwd(), file))
+      .join(", ")}`,
+  );
+} else {
+  console.log("INFO: OpenClaw doctor mutable-perms patch already present; nothing to do");
+}

--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -165,6 +165,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "scripts", "patch-openclaw-slack-deny-feedback.mts"),
     path.join(stagedScriptsDir, "patch-openclaw-slack-deny-feedback.mts"),
   );
+  fs.copyFileSync(
+    path.join(rootDir, "scripts", "patch-openclaw-doctor-mutable-perms.mts"),
+    path.join(stagedScriptsDir, "patch-openclaw-doctor-mutable-perms.mts"),
+  );
 
   return { buildCtx, stagedDockerfile };
 }

--- a/test/openclaw-doctor-mutable-perms-patch.test.ts
+++ b/test/openclaw-doctor-mutable-perms-patch.test.ts
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const PATCH_SCRIPT = path.join(
+  import.meta.dirname,
+  "..",
+  "scripts",
+  "patch-openclaw-doctor-mutable-perms.mts",
+);
+
+// Minimal stand-in for the compiled OpenClaw doctor state-integrity module: the
+// two permission gates use the exact `(stat.mode & 63) !== 0` form the patch
+// rewrites, alongside the two warning signatures the patch keys on. dirTooOpen /
+// fileTooOpen are exported so the patched behavior can be exercised directly.
+function doctorModuleSource(
+  options: { gateCount?: number; withSignatures?: boolean } = {},
+): string {
+  const gateCount = options.gateCount ?? 2;
+  const withSignatures = options.withSignatures ?? true;
+  const lines = [
+    "function dirTooOpen(stat) {",
+    "\tif ((stat.mode & 63) !== 0) {",
+    withSignatures
+      ? "\t\twarnings.push(`- State directory permissions are too open (${displayStateDir}). Recommend chmod 700.`);"
+      : "\t\twarnings.push(`- State directory needs review.`);",
+    "\t\treturn true;",
+    "\t}",
+    "\treturn false;",
+    "}",
+    "function fileTooOpen(stat) {",
+    // The second gate is only emitted when gateCount === 2.
+    gateCount >= 2 ? "\tif ((stat.mode & 63) !== 0) {" : "\tif ((stat.mode & 7) !== 0) {",
+    withSignatures
+      ? "\t\twarnings.push(`- Config file is group/world readable (${displayConfigPath}). Recommend chmod 600.`);"
+      : "\t\twarnings.push(`- Config file needs review.`);",
+    "\t\treturn true;",
+    "\t}",
+    "\treturn false;",
+    "}",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function writeDoctorDist(
+  root: string,
+  options: { gateCount?: number; withSignatures?: boolean } = {},
+): string {
+  const distDir = path.join(root, "dist");
+  fs.mkdirSync(distDir, { recursive: true });
+  const file = path.join(distDir, "doctor-state-integrity-FIXTURE.js");
+  fs.writeFileSync(file, doctorModuleSource(options));
+  return file;
+}
+
+function runPatch(...dirs: string[]) {
+  return spawnSync(process.execPath, ["--experimental-strip-types", PATCH_SCRIPT, ...dirs], {
+    encoding: "utf-8",
+    timeout: 10000,
+  });
+}
+
+// Evaluate the patched dir/file "too open" predicates under a chosen
+// OPENSHELL_SANDBOX value and a mode, mirroring how the real doctor calls them.
+function evalGate(
+  patchedSource: string,
+  fn: "dirTooOpen" | "fileTooOpen",
+  mode: number,
+  openshellSandbox: string | undefined,
+): boolean {
+  const sandbox: Record<string, unknown> = {
+    warnings: [] as string[],
+    displayStateDir: "/sandbox/.openclaw",
+    displayConfigPath: "/sandbox/.openclaw/openclaw.json",
+    process: { env: openshellSandbox === undefined ? {} : { OPENSHELL_SANDBOX: openshellSandbox } },
+  };
+  return vm.runInNewContext(`${patchedSource}\n${fn}({ mode: ${mode} });`, sandbox) as boolean;
+}
+
+describe("OpenClaw doctor mutable-perms patch", () => {
+  it("tolerates the NemoClaw 2770/660 contract inside a sandbox while still flagging world bits", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-doctor-perms-"));
+    const file = writeDoctorDist(tmp);
+    try {
+      const patch = runPatch(path.join(tmp, "dist"));
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      expect(patch.stdout).toContain("patched OpenClaw doctor mutable-perms gate");
+
+      const patched = fs.readFileSync(file, "utf-8");
+      // Both gates rewritten to the sandbox-aware mask; no raw `& 63` gate remains.
+      expect(patched.match(/process\.env\.OPENSHELL_SANDBOX \? 7 : 63/g)).toHaveLength(2);
+      expect(patched).not.toContain("(stat.mode & 63) !== 0");
+      expect(patched).toContain("nemoclaw: tolerate group-shared mutable config perms");
+
+      const NAME = "my-sandbox"; // OpenShell injects the sandbox NAME, not "1".
+      // Inside a sandbox: the mutable contract (2770 dir / 660 file → group bits
+      // only) is NOT flagged.
+      expect(evalGate(patched, "dirTooOpen", 0o2770, NAME)).toBe(false);
+      expect(evalGate(patched, "fileTooOpen", 0o660, NAME)).toBe(false);
+      // Inside a sandbox: genuinely world-accessible modes ARE still flagged.
+      expect(evalGate(patched, "dirTooOpen", 0o2777, NAME)).toBe(true);
+      expect(evalGate(patched, "fileTooOpen", 0o664, NAME)).toBe(true);
+      // Outside a sandbox (unset): upstream behavior — group bits flagged.
+      expect(evalGate(patched, "dirTooOpen", 0o2770, undefined)).toBe(true);
+      expect(evalGate(patched, "fileTooOpen", 0o660, undefined)).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("is idempotent across repeated runs", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-doctor-perms-idem-"));
+    const file = writeDoctorDist(tmp);
+    try {
+      expect(runPatch(path.join(tmp, "dist")).status).toBe(0);
+      const rerun = runPatch(path.join(tmp, "dist"));
+      expect(rerun.status, `${rerun.stdout}${rerun.stderr}`).toBe(0);
+      expect(rerun.stdout).toContain("already present");
+      const patched = fs.readFileSync(file, "utf-8");
+      expect(patched.match(/process\.env\.OPENSHELL_SANDBOX \? 7 : 63/g)).toHaveLength(2);
+      expect(patched.match(/nemoclaw: tolerate group-shared mutable config perms/g)).toHaveLength(
+        2,
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when no doctor state-integrity module is present", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-doctor-perms-none-"));
+    fs.mkdirSync(path.join(tmp, "dist"), { recursive: true });
+    fs.writeFileSync(path.join(tmp, "dist", "unrelated.js"), "export const x = 1;\n");
+    try {
+      const patch = runPatch(path.join(tmp, "dist"));
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      expect(patch.stdout).toContain("no OpenClaw doctor state-integrity module found");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("fails loudly when the permission-gate shape changes (wrong gate count)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-doctor-perms-shape-"));
+    // Only one `(stat.mode & 63) !== 0` gate — refuse the ambiguous rewrite.
+    writeDoctorDist(tmp, { gateCount: 1 });
+    try {
+      const patch = runPatch(path.join(tmp, "dist"));
+      expect(patch.status).toBe(1);
+      expect(patch.stderr).toContain("expected exactly 2");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/openclaw-doctor-mutable-perms-patch.test.ts
+++ b/test/openclaw-doctor-mutable-perms-patch.test.ts
@@ -133,14 +133,17 @@ describe("OpenClaw doctor mutable-perms patch", () => {
     }
   });
 
-  it("is a no-op when no doctor state-integrity module is present", () => {
+  it("fails closed when no doctor state-integrity module is present (dist drift)", () => {
+    // The doctor module is core OpenClaw and always present where this patch
+    // runs; an absent module means dist drift, so a silent no-op would ship an
+    // unpatched image. Fail closed instead.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-doctor-perms-none-"));
     fs.mkdirSync(path.join(tmp, "dist"), { recursive: true });
     fs.writeFileSync(path.join(tmp, "dist", "unrelated.js"), "export const x = 1;\n");
     try {
       const patch = runPatch(path.join(tmp, "dist"));
-      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
-      expect(patch.stdout).toContain("no OpenClaw doctor state-integrity module found");
+      expect(patch.status).toBe(1);
+      expect(patch.stderr).toContain("no OpenClaw doctor state-integrity module found");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -85,6 +85,7 @@ describe("sandbox build context staging", () => {
     writeFixture(path.join("scripts", "patch-openclaw-tool-catalog.js"));
     writeFixture(path.join("scripts", "patch-openclaw-chat-send.js"));
     writeFixture(path.join("scripts", "patch-openclaw-slack-deny-feedback.mts"));
+    writeFixture(path.join("scripts", "patch-openclaw-doctor-mutable-perms.mts"));
   }
 
   function expectDockerfileScriptCopiesExist(buildCtx: string, stagedDockerfile: string) {


### PR DESCRIPTION
## Summary

`openclaw doctor --fix`, run inside a NemoClaw mutable sandbox, tightens the
group-writable OpenClaw config contract (`/sandbox/.openclaw` 2770 / `openclaw.json`
660) back to single-user 700/600, durably breaking the gateway UID's ability to
persist control-UI config writes — and prints scary "permissions are too open" /
"Tightened permissions" output. This patches OpenClaw's `doctor` at the source so
it tolerates the intended group-shared perms inside an OpenShell sandbox while
still catching genuinely world-accessible modes.

## Related Issue

Fixes #4538
Fixes #4859

## Changes

- **New `scripts/patch-openclaw-doctor-mutable-perms.mts`** — build-time patch that
  narrows OpenClaw doctor's over-open test from group+other bits (`stat.mode & 63`)
  to OTHER (world) bits only (`stat.mode & 7`) when running inside an OpenShell
  sandbox (`OPENSHELL_SANDBOX` set). Group bits — the gateway's intended shared
  access — are tolerated, so the 2770/660 contract is neither warned about nor
  tightened; world-accessible modes (e.g. 2777/664) are still flagged/repaired.
  Out-of-sandbox behavior is byte-identical to upstream. Classifies the compiled
  doctor state-integrity module by content signature, requires exactly the two
  reviewed permission gates, fails closed on shape drift, and is idempotent.
- **`Dockerfile`** — COPY + chmod + `RUN node --experimental-strip-types` the new
  patch against `/usr/local/lib/node_modules/openclaw/dist`, alongside the existing
  OpenClaw patches.
- **`src/lib/sandbox/build-context.ts`** — stage the new patch script into the
  optimized sandbox build context (so onboard's image build can COPY it).
- **Tests** — `test/openclaw-doctor-mutable-perms-patch.test.ts` (behavioral:
  tolerates 2770/660 in-sandbox, still flags world bits, upstream behavior when
  unset, idempotent, fails loud on shape drift) and a build-context staging
  assertion.

### Why a source patch (vs the #5017 guard alone)

PR #5017's always-on `openclaw()` shell guard only restores 2770/660 *after* doctor
exits — the warning/tighten still runs, and any path that bypasses the connect-shell
guard (stale image, raw `command openclaw`, the macOS reporter flow in #4859) leaves
the tree durably locked at 700/600. Fixing doctor at the OpenClaw source makes the
contract hold regardless of host OS or whether the guard is loaded, resolving both
the All-Platforms #4538 and the macOS #4859 reports with one image-level fix. The
#5017 guard is kept as defense-in-depth for sandboxes built before this patch.

### Note on the `OPENSHELL_SANDBOX` gate

The gate keys on `OPENSHELL_SANDBOX` being non-empty rather than `=== "1"`: OpenShell
injects the sandbox **name** into that variable (e.g. `OPENSHELL_SANDBOX=my-sandbox`),
verified against OpenShell 0.0.44 — it is not the literal `"1"`. A non-empty check
("inside any OpenShell sandbox") is what actually fires in the runtime where the
reporter runs `openclaw doctor`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] `npm test` passes (643 files, 7929 tests)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

### E2E (real onboarded sandbox, patched image, OpenClaw 2026.5.27)

| Scenario | doctor exit | scary messages | bashrc EACCES | final perms |
|---|---|---|---|---|
| connect-shell `openclaw doctor --fix` (#4538) | 0 | 0 | 0 | `2770/660` |
| raw `command openclaw doctor --fix`, guard bypassed (#4859 path) | 0 | 0 | — | `2770/660` |
| unpatched baseline | 1 | 4 | 1 | `700/600` |

Built the sandbox image through `nemoclaw onboard` (which stages the worktree
Dockerfile), confirmed the patch is baked into the image's doctor module, then ran
the exact reporter workflow (`stat` → `openclaw doctor --fix` → `stat`) through a
real login shell and through a raw guard-bypassing shell.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox-aware permission handling: runtime relaxes group/shared checks when detected in a sandbox, preserving stricter checks otherwise.

* **Tests**
  * End-to-end tests added to validate patch behavior, idempotency, sandbox vs non-sandbox outcomes, and failure on unexpected module shapes.

* **Chores**
  * Build now stages and applies the permission compatibility patch automatically and fails fast if the expected distribution shape is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->