### PR TITLE
fix: address issue #5211

### DIFF
--- a/docs/deployment/brev-web-ui.mdx
+++ b/docs/deployment/brev-web-ui.mdx
@@ -17,6 +17,13 @@ Use this guide when you want to try NemoClaw without installing the CLI or using
 If you want to manage the remote host from a terminal, see [Deploy to a Remote GPU Instance](deploy-to-remote-gpu).
 </Note>
 
+<Warning>
+The Brev launchable in this guide deploys the **OpenClaw** runtime by default, and the **Launch** page reports `RUNTIME = OpenClaw`.
+The launchable selects the agent from the `NEMOCLAW_AGENT` environment variable, which defaults to `openclaw` when it is unset.
+To deploy Hermes (NemoHermes) instead, the launchable must run the installer with `NEMOCLAW_AGENT=hermes` set before onboarding.
+See [Deploy Hermes Instead of OpenClaw](#deploy-hermes-instead-of-openclaw).
+</Warning>
+
 ## What This Flow Creates
 
 The Brev web flow creates the following resources:
@@ -26,6 +33,23 @@ The Brev web flow creates the following resources:
 - A NemoClaw sandbox running OpenClaw.
 - Inference routing for the provider you select during setup.
 - A browser-accessible OpenClaw dashboard.
+
+## Deploy Hermes Instead of OpenClaw
+
+This launchable provisions the OpenClaw runtime by default.
+The deployed agent is selected from the `NEMOCLAW_AGENT` environment variable that the launchable passes to the installer:
+
+- When `NEMOCLAW_AGENT` is unset, the installer defaults to `openclaw`, and the **Launch** page shows `RUNTIME = OpenClaw`.
+- When `NEMOCLAW_AGENT=hermes`, the installer provisions the Hermes (NemoHermes) runtime, and the **Launch** page shows `RUNTIME = Hermes`.
+
+To deploy Hermes through the Brev web UI, the launchable's startup environment must export `NEMOCLAW_AGENT=hermes` so the installer selects Hermes, matching the documented Hermes installer entry point:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes bash
+```
+
+If a Hermes-targeted launchable does not set `NEMOCLAW_AGENT=hermes`, it silently falls back to the OpenClaw runtime even though Hermes was requested.
+For the terminal-driven Hermes flow, see the [Quickstart with Hermes](../get-started/quickstart-hermes).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Issue #5211: the 'NemoClaw for Hermes Agent' API Catalog Try Now flow deploys the OpenClaw runtime instead of Hermes. Root cause: the Hermes catalog card reuses the same Brev launchable (env-3Azt0aYgVNFEuz7opyx3gscmowS) that the repo documents as the OpenClaw web-UI launchable. NemoClaw selects the agent from the NEMOCLAW_AGENT env var (src/lib/agent/defs.ts resolveAgentName; scripts/install.sh:809), which defaults to 'openclaw' when unset, so a launchable that does not export NEMOCLAW_AGENT=hermes silently provisions OpenClaw and the Launch page reports RUNTIME=OpenClaw. The launchable definition itself lives on the Brev/build.nvidia.com platform (outside this repo); the repo's lever is its canonical Brev web-UI documentation, which previously described only the OpenClaw flow and gave no Hermes path. Fix: updated docs/deployment/brev-web-ui.mdx with a Warning callout and a new 'Deploy Hermes Instead of OpenClaw' section documenting that the launchable must export NEMOCLAW_AGENT=hermes to provision Hermes (RUNTIME=Hermes), and that without it the agent silently falls back to OpenClaw.

## Related Issue
Fixes #5211

## Changes
- Automated Claude Code fix selected by `auto_fix/auto_fix_recent_issues.py`.
- See the commits on this branch for the exact file-level changes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details reported by Claude Code:
- Traced agent resolution: resolveAgentName() in src/lib/agent/defs.ts and scripts/install.sh:809 default to openclaw only when NEMOCLAW_AGENT is unset; NEMOCLAW_AGENT takes precedence over saved session, confirming the code already honors NEMOCLAW_AGENT=hermes.
- Confirmed the OpenClaw web-UI doc (docs/deployment/brev-web-ui.mdx:53) hardcodes launchableID env-3Azt0aYgVNFEuz7opyx3gscmowS, the same launchable referenced by the Hermes API Catalog card in the issue.
- Verified the relative doc link target ../get-started/quickstart-hermes resolves to docs/get-started/quickstart-hermes.mdx.
- Ran npm run docs:check-agent-variants (exit 0); git status shows only docs/deployment/brev-web-ui.mdx changed.
- `grep -rn 'NEMOCLAW_AGENT' scripts/install.sh`
- `grep -rn 'launchableID' (docs/mdx/skills)`
- `npm run docs:check-agent-variants`
- `git status --porcelain`

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that OpenClaw is the default agent runtime and documented how to deploy Hermes instead using environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->