### PR TITLE
fix(install): surface silent OpenClaw runtime fallback in launchable deploys

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -473,6 +473,35 @@ print_cli_path_refresh_actions() {
   printf "  ${C_DIM}Or open a new terminal after updating your shell profile.${C_RESET}\n"
 }
 
+# Surface the silent agent fallback. When a non-interactive install (a Brev
+# launchable or other automated deploy) completes on the default OpenClaw
+# runtime *because* NEMOCLAW_AGENT was never set, say so loudly. A launchable
+# that meant to provision a different agent (for example Hermes) otherwise looks
+# identical to an OpenClaw deploy and the mistake is only visible from the live
+# page's RUNTIME field. (#5211)
+warn_default_agent_fallback() {
+  local resolved_agent="${1:-}"
+
+  # Only meaningful once a sandbox was actually provisioned.
+  [[ "${ONBOARD_RAN:-false}" == true ]] || return 0
+  # An explicit NEMOCLAW_AGENT (even =openclaw) is an intentional choice — stay
+  # quiet. The bug is the *unset* case falling back to openclaw.
+  [[ -z "${NEMOCLAW_AGENT:-}" ]] || return 0
+  # Only the default-to-openclaw outcome is worth flagging.
+  [[ "$resolved_agent" == "openclaw" || -z "$resolved_agent" ]] || return 0
+  # Interactive users who skipped NEMOCLAW_AGENT chose OpenClaw on purpose; the
+  # silent fallback only traps automated launchable deploys.
+  installer_non_interactive || return 0
+
+  printf "\n"
+  printf "  ${C_YELLOW}${C_BOLD}Note: deployed the default OpenClaw runtime (RUNTIME = OpenClaw).${C_RESET}\n"
+  printf "  ${C_YELLOW}NEMOCLAW_AGENT was not set, so the installer defaulted to OpenClaw.${C_RESET}\n"
+  printf "  ${C_DIM}If you intended a different agent (for example Hermes), the launchable${C_RESET}\n"
+  printf "  ${C_DIM}or environment must export NEMOCLAW_AGENT before install, for example:${C_RESET}\n"
+  printf "  %s\$%s curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_AGENT=hermes bash\n" \
+    "$C_GREEN" "$C_RESET"
+}
+
 print_done() {
   local elapsed=$((SECONDS - _INSTALL_START))
   local _needs_cli_refresh=false
@@ -499,6 +528,7 @@ print_done() {
       fi
       printf "  ${C_DIM}Use the Start chatting section above for browser and terminal options.${C_RESET}\n"
     fi
+    warn_default_agent_fallback "$agent_name"
   elif [[ "$NEMOCLAW_READY_NOW" == true ]]; then
     if [[ "$_needs_cli_refresh" == true ]]; then
       printf "  ${C_YELLOW}%s CLI is installed, but this shell needs PATH refresh before '%s' will run.${C_RESET}\n" "$_CLI_DISPLAY" "$_CLI_BIN"

--- a/test/install-default-agent-fallback.test.ts
+++ b/test/install-default-agent-fallback.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
+const INSTALLER_SOURCE = fs.readFileSync(INSTALLER_PAYLOAD, "utf-8");
+
+function extractShellFunctionBefore(name: string, nextName: string): string {
+  const start = INSTALLER_SOURCE.indexOf(`${name}() {`);
+  const end = INSTALLER_SOURCE.indexOf(`\n${nextName}() {`, start);
+  if (start === -1 || end === -1) {
+    throw new Error(`expected ${name} before ${nextName} in scripts/install.sh`);
+  }
+  return INSTALLER_SOURCE.slice(start, end).trimEnd();
+}
+
+const WARN_FUNCTION = extractShellFunctionBefore("warn_default_agent_fallback", "print_done");
+
+type Outcome = { status: number | null; stdout: string };
+
+function runWarn(opts: {
+  resolvedAgent: string;
+  env?: Record<string, string>;
+  onboardRan?: string;
+}): Outcome {
+  const onboardRan = opts.onboardRan ?? "true";
+  const snippet = `
+    set -euo pipefail
+    # Color codes are noise for assertions — blank them so we match on text.
+    C_YELLOW=""; C_BOLD=""; C_DIM=""; C_GREEN=""; C_RESET=""
+    ONBOARD_RAN="${onboardRan}"
+    installer_non_interactive() { [[ "\${NON_INTERACTIVE:-}" == "1" || "\${NEMOCLAW_NON_INTERACTIVE:-}" == "1" ]]; }
+    ${WARN_FUNCTION}
+    warn_default_agent_fallback "${opts.resolvedAgent}"
+  `;
+  const result = spawnSync("bash", ["-c", snippet], {
+    encoding: "utf-8",
+    env: { ...process.env, ...opts.env },
+  });
+  return { status: result.status, stdout: result.stdout };
+}
+
+describe("warn_default_agent_fallback (#5211)", () => {
+  it("warns when a non-interactive deploy silently defaults to openclaw", () => {
+    const { status, stdout } = runWarn({
+      resolvedAgent: "openclaw",
+      env: { NEMOCLAW_NON_INTERACTIVE: "1", NEMOCLAW_AGENT: "" },
+    });
+    expect(status).toBe(0);
+    expect(stdout).toContain("defaulted to OpenClaw");
+    expect(stdout).toContain("NEMOCLAW_AGENT=hermes");
+  });
+
+  it("stays quiet when NEMOCLAW_AGENT was explicitly set (intentional choice)", () => {
+    const { stdout } = runWarn({
+      resolvedAgent: "openclaw",
+      env: { NEMOCLAW_NON_INTERACTIVE: "1", NEMOCLAW_AGENT: "openclaw" },
+    });
+    expect(stdout).toBe("");
+  });
+
+  it("stays quiet for a non-default resolved agent (hermes deployed)", () => {
+    const { stdout } = runWarn({
+      resolvedAgent: "hermes",
+      env: { NEMOCLAW_NON_INTERACTIVE: "1", NEMOCLAW_AGENT: "" },
+    });
+    expect(stdout).toBe("");
+  });
+
+  it("stays quiet for interactive installs (openclaw chosen on purpose)", () => {
+    const { stdout } = runWarn({
+      resolvedAgent: "openclaw",
+      env: { NEMOCLAW_NON_INTERACTIVE: "", NON_INTERACTIVE: "", NEMOCLAW_AGENT: "" },
+    });
+    expect(stdout).toBe("");
+  });
+
+  it("stays quiet when onboarding did not run", () => {
+    const { stdout } = runWarn({
+      resolvedAgent: "openclaw",
+      onboardRan: "false",
+      env: { NEMOCLAW_NON_INTERACTIVE: "1", NEMOCLAW_AGENT: "" },
+    });
+    expect(stdout).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
The installer now prints a clear note when a non-interactive deploy (a Brev launchable or other automated install) completes on the **default OpenClaw runtime because `NEMOCLAW_AGENT` was never set**. This makes the deploy-time blind spot behind #5211 loud instead of silent.

## Related Issue
Relates to #5211

Note: this does **not** fully close #5211. The literal bug is platform-side — the *NemoClaw for Hermes Agent* API Catalog **Try Now** flow reuses the OpenClaw Brev launchable (`env-3Azt0aYgVNFEuz7opyx3gscmowS`), which boots the installer without exporting `NEMOCLAW_AGENT`, so the agent silently falls back to `openclaw` and `RUNTIME=OpenClaw`. The real fix is to make that launchable export `NEMOCLAW_AGENT=hermes` (tracked on the issue). This PR is the in-repo defensive guard that surfaces the misconfiguration at deploy time.

## Changes
- Add `warn_default_agent_fallback()` to `scripts/install.sh`. It prints a yellow note (deployed default OpenClaw + how to select another agent) **only when** all of: onboarding ran, `NEMOCLAW_AGENT` was unset, the resolved agent is the `openclaw` default, and the install is non-interactive. Interactive OpenClaw users and explicit selections stay quiet.
- Call the guard at the end of the onboarding-success branch of `print_done()`.
- Add `test/install-default-agent-fallback.test.ts` covering all five branches (warns on silent launchable fallback; quiet for explicit `NEMOCLAW_AGENT`, non-default resolved agent, interactive install, and onboarding-not-run).

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes on verification:
- prek hooks pass on the changed files; `bash -n scripts/install.sh` is clean.
- The new test passes (5/5).
- `npm test` was not checked off because the full suite has one pre-existing, environment-specific failure in `test/service-env.test.ts` (a `capsh` flag/version mismatch on the local host) that reproduces on `main` with these changes stashed and is unrelated to this PR.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Jason Ma <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation process now displays a prominent yellow warning in the completion message when the default OpenClaw runtime is automatically selected due to missing agent configuration.

* **Tests**
  * Added tests to verify warning display behavior for default agent fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->