### PR TITLE
test(e2e): flag unwired live Vitest tests [SUPPORT]

### DIFF
--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -8,6 +8,7 @@ import {
   buildPrompt,
   buildSystemPrompt,
   canonicalDispatchCommand,
+  extractFreeStandingVitestJobs,
   normalizeScenarioAdvisorResult,
   renderScenarioSummary,
   SCENARIO_ADVISOR_WORKFLOWS,
@@ -82,6 +83,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "e2e-scenarios-all",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "all",
           required: true,
           reason: "shared scenario runtime changed",
           // Model returns a non-canonical command; sanitizer must overwrite it.
@@ -92,6 +94,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           scenario: "ubuntu-repo-cloud-openclaw",
           required: false,
           reason: "smoke confirmation on the canonical scenario",
@@ -161,6 +164,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
           {
             id: "e2e-scenarios-all",
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "all",
             reason: "valid Vitest fan-out",
             dispatchCommand: "gh ...",
           },
@@ -180,6 +184,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
           {
             id: "ubuntu-repo-cloud-openclaw",
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "scenario",
             // Model claims this required item is actually optional.
             required: false,
             reason: "in required[] but model marked optional",
@@ -190,6 +195,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
           {
             id: "ubuntu-repo-docker-post-reboot-recovery",
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "scenario",
             // Model claims this optional item is actually required.
             required: true,
             reason: "in optional[] but model marked required",
@@ -211,18 +217,21 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
           {
             id: "ubuntu;rm -rf /",
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "scenario",
             reason: "shell injection attempt",
             dispatchCommand: "gh ...",
           },
           {
             id: "Ubuntu_Repo_Cloud", // not kebab
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "scenario",
             reason: "non-canonical id",
             dispatchCommand: "gh ...",
           },
           {
             id: "ubuntu-repo-cloud-openclaw",
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "scenario",
             reason: "valid",
             dispatchCommand: "gh ...",
           },
@@ -241,18 +250,21 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           reason: "ok",
           dispatchCommand: "gh ...",
         },
         {
           id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           reason: "dup",
           dispatchCommand: "gh ...",
         },
         {
           id: "valid-kebab-but-not-in-registry",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           reason: "unknown scenario",
           dispatchCommand: "gh ...",
         },
@@ -273,24 +285,28 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "valid-kebab-but-not-in-registry",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           reason: "model invented a scenario",
           dispatchCommand: "gh ...",
         },
         {
           id: "ubuntu-repo-cloud-hermes",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           reason: "registry scenario not wired for live Vitest fixtures",
           dispatchCommand: "gh ...",
         },
         {
           id: "e2e-scenarios-all",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "all",
           reason: "shared scenario runtime changed",
           dispatchCommand: "gh ...",
         },
         {
           id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           reason: "known scenario",
           dispatchCommand: "gh ...",
         },
@@ -313,6 +329,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
           {
             id: "e2e-scenarios-all",
             workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "all",
             reason: "model tried to fan out for an unwired free-standing test",
             dispatchCommand: "gh ...",
           },
@@ -335,14 +352,36 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
     );
   });
 
-  it("keeps fan-out for a new free-standing live test once workflow wiring is present", () => {
+  it("extracts free-standing Vitest jobs from workflow job selectors", () => {
+    expect(
+      extractFreeStandingVitestJobs(String.raw`
+jobs:
+  live-scenarios:
+    if: \${{ inputs.jobs == '' }}
+    steps:
+      - run: npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/registry-scenarios.test.ts
+  token-rotation-vitest:
+    if: \${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',token-rotation-vitest,') }}
+    steps:
+      - run: npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/token-rotation.test.ts
+`),
+    ).toEqual([
+      {
+        id: "token-rotation-vitest",
+        liveTestFiles: ["test/e2e-scenario/live/token-rotation.test.ts"],
+      },
+    ]);
+  });
+
+  it("prefers a focused free-standing job over fan-out once workflow wiring is present", () => {
     const normalized = normalizeScenarioAdvisorResult(
       {
         required: [
           {
             id: "e2e-scenarios-all",
             workflow: VITEST_SCENARIO_WORKFLOW,
-            reason: "workflow-wired free-standing test should run through the Vitest workflow",
+            selectorType: "all",
+            reason: "model tried to fan out for a workflow-wired free-standing test",
             dispatchCommand: "gh ...",
           },
         ],
@@ -353,17 +392,63 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
       metadata({
         changedFiles: [
           ".github/workflows/e2e-vitest-scenarios.yaml",
-          "test/e2e-scenario/live/rebuild-openclaw.test.ts",
+          "test/e2e-scenario/live/token-rotation.test.ts",
         ],
       }),
       {
-        vitestWorkflowText:
-          "npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/rebuild-openclaw.test.ts",
+        vitestWorkflowText: String.raw`
+jobs:
+  token-rotation-vitest:
+    if: \${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',token-rotation-vitest,') }}
+    steps:
+      - run: npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/token-rotation.test.ts
+`,
       },
     );
 
-    expect(normalized.required.map((item) => item.id)).toEqual(["e2e-scenarios-all"]);
+    expect(normalized.required.map((item) => [item.selectorType, item.id])).toEqual([
+      ["job", "token-rotation-vitest"],
+    ]);
+    expect(normalized.required[0]?.dispatchCommand).toBe(
+      "gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field jobs=token-rotation-vitest",
+    );
     expect(normalized.noScenarioE2eReason).toBeNull();
+  });
+
+  it("accepts a model-provided free-standing job recommendation when the job is workflow-wired", () => {
+    const normalized = normalizeScenarioAdvisorResult(
+      {
+        required: [
+          {
+            id: "token-rotation-vitest",
+            workflow: VITEST_SCENARIO_WORKFLOW,
+            selectorType: "job",
+            reason: "focused job covers the changed live test",
+            dispatchCommand: "malicious non-canonical command",
+          },
+        ],
+        optional: [],
+        noScenarioE2eReason: null,
+        confidence: "high",
+      },
+      metadata({ changedFiles: ["test/e2e-scenario/live/token-rotation.test.ts"] }),
+      {
+        vitestWorkflowText: String.raw`
+jobs:
+  token-rotation-vitest:
+    if: \${{ contains(format(',{0},', inputs.jobs), ',token-rotation-vitest,') }}
+    steps:
+      - run: npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/token-rotation.test.ts
+`,
+      },
+    );
+
+    expect(normalized.required.map((item) => [item.selectorType, item.id])).toEqual([
+      ["job", "token-rotation-vitest"],
+    ]);
+    expect(normalized.required[0]?.dispatchCommand).toBe(
+      "gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field jobs=token-rotation-vitest",
+    );
   });
 
   it("removes optional recommendations whose id duplicates a required one", () => {
@@ -372,6 +457,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           required: true,
           reason: "primary",
           dispatchCommand: "gh ...",
@@ -381,6 +467,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "ubuntu-repo-cloud-openclaw",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           required: false,
           reason: "duplicate fallback",
           dispatchCommand: "gh ...",
@@ -388,6 +475,7 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
         {
           id: "ubuntu-repo-docker-post-reboot-recovery",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "scenario",
           required: false,
           reason: "adjacent",
           dispatchCommand: "gh ...",
@@ -447,6 +535,7 @@ describe("Vitest E2E scenario advisor — summary and comment rendering", () => 
         {
           id: "e2e-scenarios-all",
           workflow: VITEST_SCENARIO_WORKFLOW,
+          selectorType: "all",
           required: true,
           reason: "scenario workflow changed",
           dispatchCommand: canonicalDispatchCommand(VITEST_SCENARIO_WORKFLOW, "e2e-scenarios-all"),

--- a/test/e2e-scenario-advisor.test.ts
+++ b/test/e2e-scenario-advisor.test.ts
@@ -306,6 +306,66 @@ describe("Vitest E2E scenario advisor — normalization contract", () => {
     ]);
   });
 
+  it("suppresses fan-out for a new free-standing live test that is not workflow-wired", () => {
+    const normalized = normalizeScenarioAdvisorResult(
+      {
+        required: [
+          {
+            id: "e2e-scenarios-all",
+            workflow: VITEST_SCENARIO_WORKFLOW,
+            reason: "model tried to fan out for an unwired free-standing test",
+            dispatchCommand: "gh ...",
+          },
+        ],
+        optional: [],
+        noScenarioE2eReason: null,
+        confidence: "high",
+      },
+      metadata({ changedFiles: ["test/e2e-scenario/live/rebuild-openclaw.test.ts"] }),
+      { vitestWorkflowText: "jobs:\n  live-scenarios:\n    steps: []\n" },
+    );
+
+    expect(normalized.required).toEqual([]);
+    expect(normalized.optional).toEqual([]);
+    expect(normalized.noScenarioE2eReason).toContain(
+      "not wired into `.github/workflows/e2e-vitest-scenarios.yaml`",
+    );
+    expect(normalized.noScenarioE2eReason).toContain(
+      "test/e2e-scenario/live/rebuild-openclaw.test.ts",
+    );
+  });
+
+  it("keeps fan-out for a new free-standing live test once workflow wiring is present", () => {
+    const normalized = normalizeScenarioAdvisorResult(
+      {
+        required: [
+          {
+            id: "e2e-scenarios-all",
+            workflow: VITEST_SCENARIO_WORKFLOW,
+            reason: "workflow-wired free-standing test should run through the Vitest workflow",
+            dispatchCommand: "gh ...",
+          },
+        ],
+        optional: [],
+        noScenarioE2eReason: null,
+        confidence: "high",
+      },
+      metadata({
+        changedFiles: [
+          ".github/workflows/e2e-vitest-scenarios.yaml",
+          "test/e2e-scenario/live/rebuild-openclaw.test.ts",
+        ],
+      }),
+      {
+        vitestWorkflowText:
+          "npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/rebuild-openclaw.test.ts",
+      },
+    );
+
+    expect(normalized.required.map((item) => item.id)).toEqual(["e2e-scenarios-all"]);
+    expect(normalized.noScenarioE2eReason).toBeNull();
+  });
+
   it("removes optional recommendations whose id duplicates a required one", () => {
     const raw = {
       required: [

--- a/tools/e2e-advisor/scenarios-schema.json
+++ b/tools/e2e-advisor/scenarios-schema.json
@@ -42,10 +42,11 @@
   "$defs": {
     "scenarioRecommendation": {
       "type": "object",
-      "required": ["id", "workflow", "required", "reason", "dispatchCommand"],
+      "required": ["id", "workflow", "selectorType", "required", "reason", "dispatchCommand"],
       "properties": {
         "id": { "type": "string" },
         "workflow": { "type": "string" },
+        "selectorType": { "enum": ["all", "scenario", "job"] },
         "scenario": { "type": "string" },
         "suiteFilter": { "type": "string" },
         "required": { "type": "boolean" },

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -47,18 +47,31 @@ const SCENARIO_WORKFLOW_PATH = `.github/workflows/${SCENARIO_WORKFLOW}`;
 const SCENARIO_ALL_ID = "e2e-scenarios-all";
 const REGISTRY_LIVE_ENTRYPOINT = "test/e2e-scenario/live/registry-scenarios.test.ts";
 const FREE_STANDING_LIVE_TEST_PATTERN = /^test\/e2e-scenario\/live\/[^/]+\.test\.ts$/;
+const FREE_STANDING_LIVE_FILE_PATTERN = /^test\/e2e-scenario\/live\/[^/]+\.ts$/;
 const ALLOWED_WORKFLOWS = new Set<string>([SCENARIO_WORKFLOW]);
-// Scenario IDs are embedded into the dispatch command we hand to users; restrict
-// to a strict kebab-case allowlist so a hallucinated id can never inject shell
-// metacharacters or non-canonical tokens into the dispatch line.
+// Scenario IDs and job IDs are embedded into the dispatch command we hand to
+// users; restrict them to shell-safe allowlists so a hallucinated id can never
+// inject metacharacters or non-canonical tokens into the dispatch line.
 const SCENARIO_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
-export function canonicalDispatchCommand(workflow: string, id: string): string {
+type ScenarioSelectorType = "all" | "scenario" | "job";
+
+export function canonicalDispatchCommand(
+  workflow: string,
+  id: string,
+  selectorType: ScenarioSelectorType = id === SCENARIO_ALL_ID ? "all" : "scenario",
+): string {
   if (workflow !== SCENARIO_WORKFLOW) {
     throw new Error(`Unknown scenario workflow: ${workflow}`);
   }
-  if (id === SCENARIO_ALL_ID) {
+  if (selectorType === "all") {
+    if (id !== SCENARIO_ALL_ID) throw new Error(`Invalid fan-out selector id: ${id}`);
     return `gh workflow run ${SCENARIO_WORKFLOW} --ref <pr-head-ref>`;
+  }
+  if (selectorType === "job") {
+    if (!JOB_ID_PATTERN.test(id)) throw new Error(`Invalid Vitest job id: ${id}`);
+    return `gh workflow run ${SCENARIO_WORKFLOW} --ref <pr-head-ref> --field jobs=${id}`;
   }
   return `gh workflow run ${SCENARIO_WORKFLOW} --ref <pr-head-ref> --field scenarios=${id}`;
 }
@@ -76,11 +89,23 @@ type AdvisorMetadata = {
 export type ScenarioRecommendation = {
   id: string;
   workflow: string;
+  selectorType: ScenarioSelectorType;
   scenario?: string;
   suiteFilter?: string;
   required: boolean;
   reason: string;
   dispatchCommand: string;
+};
+
+export type VitestWorkflowJob = {
+  id: string;
+  liveTestFiles: string[];
+};
+
+type ScenarioNormalizationContext = {
+  vitestWorkflowText?: string;
+  freeStandingJobs: VitestWorkflowJob[];
+  liveTestToJobs: Map<string, string[]>;
 };
 
 export type ScenarioAdvisorResult = {
@@ -240,8 +265,9 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
     "- `test/e2e-scenario/fixtures/` and `test/e2e-scenario/support-tests/` — shared Vitest fixtures, clients, and phase helpers.",
     "",
     "Decision policy:",
-    "- Required (all scenarios): changes to scenario registry, matrix emission, expected-state metadata, live support classification, shared fixtures, or the Vitest scenario workflow itself. Recommend the `e2e-scenarios-all` fan-out through `e2e-vitest-scenarios.yaml`.",
+    "- Required (all scenarios): changes to scenario registry, matrix emission, expected-state metadata, live support classification, shared fixtures, or the shared Vitest scenario workflow machinery. Recommend the `e2e-scenarios-all` fan-out through `e2e-vitest-scenarios.yaml`.",
     "- Required (targeted): fixture, live test, manifest, runtime-support, or scenario changes that affect a specific subset. Recommend the smallest set of live-supported typed scenario IDs that exercises the changed surface.",
+    "- Required (free-standing job): if a PR wires or changes a discrete live Vitest job in `.github/workflows/e2e-vitest-scenarios.yaml` for a specific `test/e2e-scenario/live/*.test.ts`, prefer that job over `e2e-scenarios-all`. Use selectorType=`job`, id=`<job-id>`, workflow=`e2e-vitest-scenarios.yaml`, and dispatchCommand exactly `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field jobs=<job-id>`.",
     "- Missing wiring: if a PR adds or changes a free-standing live Vitest file under `test/e2e-scenario/live/*.test.ts` but that file is not referenced by `.github/workflows/e2e-vitest-scenarios.yaml` and is not `registry-scenarios.test.ts`, do not recommend the fan-out as proof. Return no required/optional recommendations and set `noScenarioE2eReason` to say the test must be wired into `e2e-vitest-scenarios.yaml` before it can be dispatched.",
     "- Optional: adjacent scenarios that exercise the same suite on a different platform/onboarding (e.g. macOS, WSL, GPU) but are not the primary target. Special-runner scenarios (`gpu-`, `macos-`, `wsl-`, `brev-`) should usually be optional unless they are the only path that exercises the change.",
     "- None: docs-only, comment-only, tests-only outside `test/e2e-scenario/`, or changes that cannot affect Vitest scenario behavior. Set `noScenarioE2eReason` and return empty `required`/`optional` arrays.",
@@ -250,8 +276,9 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
     "- Only recommend live-supported typed scenario IDs that exist in the registry or the synthetic fan-out id `e2e-scenarios-all`. Do not invent IDs.",
     "- The only allowed workflow is `e2e-vitest-scenarios.yaml`.",
     "- Each `dispatchCommand` for a single-scenario recommendation MUST be exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field scenarios=<id>`.",
-    "- For the fan-out, use exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref>` and set `id`/`workflow` to `e2e-scenarios-all`/`e2e-vitest-scenarios.yaml`.",
-    "- The normalizer validates targeted IDs against the trusted advisor checkout's registry/runtime-support modules, not PR-local TypeScript. If a PR adds or newly wires a typed registry scenario that is not live-supported on trusted `main` yet, recommend the `e2e-scenarios-all` fan-out rather than a targeted dispatch. This fallback does not apply to unwired free-standing live test files.",
+    "- Each `dispatchCommand` for a free-standing job recommendation MUST be exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field jobs=<id>`.",
+    "- For the fan-out, use exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref>` and set `id`/`workflow`/`selectorType` to `e2e-scenarios-all`/`e2e-vitest-scenarios.yaml`/`all`.",
+    "- The normalizer validates targeted IDs against the trusted advisor checkout's registry/runtime-support modules, not PR-local TypeScript. If a PR adds or newly wires a typed registry scenario that is not live-supported on trusted `main` yet, recommend the `e2e-scenarios-all` fan-out rather than a targeted dispatch. This fallback does not apply to free-standing live test jobs.",
     "- A `suiteFilter` may be set on a recommendation as analytical metadata explaining why the scenario was selected. It must NOT leak into the dispatch command.",
     "- `relevantChangedFiles` must be the subset of `changedFiles` under `test/e2e-scenario/`, `.github/workflows/e2e-vitest-scenarios.yaml`, or other directly scenario-relevant paths.",
     "",
@@ -301,27 +328,42 @@ export function normalizeScenarioAdvisorResult(
   }
 
   const object = result as Record<string, unknown>;
+  const context = buildScenarioNormalizationContext(options.vitestWorkflowText);
   const unwiredFreeStandingLiveTests = findUnwiredFreeStandingLiveTests(
     metadata.changedFiles,
-    options.vitestWorkflowText,
+    context.vitestWorkflowText,
   );
   const suppressFanout = shouldSuppressFanoutForUnwiredLiveTests(
     metadata.changedFiles,
     unwiredFreeStandingLiveTests,
   );
-  const required = suppressFanout ? [] : sanitizeRecommendations(object.required, true);
-  const optional = suppressFanout ? [] : sanitizeRecommendations(object.optional, false);
+  const deterministicJobs = deterministicFreeStandingJobRecommendations(metadata.changedFiles, context);
+  const required = suppressFanout
+    ? []
+    : mergeRecommendations(
+        deterministicJobs,
+        suppressFanoutForFocusedJobs(
+          sanitizeRecommendations(object.required, true, context),
+          deterministicJobs,
+          metadata.changedFiles,
+        ),
+      );
+  const optional = suppressFanout
+    ? []
+    : suppressFanoutForFocusedJobs(
+        sanitizeRecommendations(object.optional, false, context),
+        deterministicJobs,
+        metadata.changedFiles,
+      );
   const reasonField = object.noScenarioE2eReason;
   const noScenarioE2eReason = suppressFanout
     ? missingFreeStandingLiveWiringReason(unwiredFreeStandingLiveTests)
-    : typeof reasonField === "string" && reasonField.trim()
+    : typeof reasonField === "string" && reasonField.trim() && required.length === 0 && optional.length === 0
       ? reasonField.trim()
-      : reasonField === null || reasonField === undefined
-        ? required.length === 0 && optional.length === 0
-          ? unwiredFreeStandingLiveTests.length > 0
-            ? missingFreeStandingLiveWiringReason(unwiredFreeStandingLiveTests)
-            : "Advisor reported no Vitest E2E scenario impact."
-          : null
+      : required.length === 0 && optional.length === 0
+        ? unwiredFreeStandingLiveTests.length > 0
+          ? missingFreeStandingLiveWiringReason(unwiredFreeStandingLiveTests)
+          : "Advisor reported no Vitest E2E scenario impact."
         : null;
 
   return {
@@ -331,7 +373,9 @@ export function normalizeScenarioAdvisorResult(
     changedFiles: metadata.changedFiles,
     relevantChangedFiles: stringArrayWithinChanged(object.relevantChangedFiles, metadata.changedFiles),
     required,
-    optional: optional.filter((candidate) => !required.some((item) => item.id === candidate.id)),
+    optional: optional.filter(
+      (candidate) => !required.some((item) => item.id === candidate.id && item.selectorType === candidate.selectorType),
+    ),
     noScenarioE2eReason,
     confidence: enumValue<["low", "medium", "high"]>(object.confidence, ["low", "medium", "high"], "medium"),
   };
@@ -343,6 +387,48 @@ function readVitestWorkflowText(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function buildScenarioNormalizationContext(vitestWorkflowText = readVitestWorkflowText()): ScenarioNormalizationContext {
+  const freeStandingJobs = extractFreeStandingVitestJobs(vitestWorkflowText ?? "");
+  const liveTestToJobs = new Map<string, string[]>();
+  for (const job of freeStandingJobs) {
+    for (const file of job.liveTestFiles) {
+      const jobs = liveTestToJobs.get(file) ?? [];
+      jobs.push(job.id);
+      liveTestToJobs.set(file, jobs);
+    }
+  }
+  return { vitestWorkflowText, freeStandingJobs, liveTestToJobs };
+}
+
+export function extractFreeStandingVitestJobs(workflowText: string): VitestWorkflowJob[] {
+  const jobsBlockStart = workflowText.search(/^jobs:\s*$/m);
+  if (jobsBlockStart === -1) return [];
+
+  const lines = workflowText.slice(jobsBlockStart).split(/\r?\n/);
+  const jobs: VitestWorkflowJob[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^  ([A-Za-z0-9_-]+):\s*$/);
+    if (!match) continue;
+
+    const id = match[1] || "";
+    const bodyLines: string[] = [];
+    for (let bodyIndex = index + 1; bodyIndex < lines.length; bodyIndex += 1) {
+      if (/^  [A-Za-z0-9_-]+:\s*$/.test(lines[bodyIndex])) break;
+      bodyLines.push(lines[bodyIndex]);
+    }
+    const body = bodyLines.join("\n");
+    if (!body.includes("inputs.jobs") || !body.includes(`,${id},`)) continue;
+    const liveTestFiles = uniqueStrings(
+      [...body.matchAll(/test\/e2e-scenario\/live\/[A-Za-z0-9._-]+\.test\.ts/g)].map(
+        (item) => item[0],
+      ),
+    ).filter((file) => file !== REGISTRY_LIVE_ENTRYPOINT);
+    if (liveTestFiles.length === 0) continue;
+    jobs.push({ id, liveTestFiles });
+  }
+  return jobs.sort((a, b) => a.id.localeCompare(b.id));
 }
 
 function findUnwiredFreeStandingLiveTests(
@@ -384,38 +470,107 @@ function missingFreeStandingLiveWiringReason(files: string[]): string {
   return `New free-standing live Vitest test ${fileList} is not wired into \`${SCENARIO_WORKFLOW_PATH}\`, so the Vitest scenario workflow cannot dispatch it yet. Add a discrete job or register it as a typed live scenario before treating the PR as E2E-runnable.`;
 }
 
-function sanitizeRecommendations(value: unknown, requiredFlag: boolean): ScenarioRecommendation[] {
+function deterministicFreeStandingJobRecommendations(
+  changedFiles: string[],
+  context: ScenarioNormalizationContext,
+): ScenarioRecommendation[] {
+  const liveFiles = changedFiles.filter(
+    (file) => FREE_STANDING_LIVE_FILE_PATTERN.test(file) && file !== REGISTRY_LIVE_ENTRYPOINT,
+  );
+  const output: ScenarioRecommendation[] = [];
+  const seen = new Set<string>();
+  for (const file of liveFiles) {
+    for (const job of context.liveTestToJobs.get(file) ?? []) {
+      if (seen.has(job)) continue;
+      seen.add(job);
+      output.push({
+        id: job,
+        workflow: SCENARIO_WORKFLOW,
+        selectorType: "job",
+        required: true,
+        reason: `Focused free-standing Vitest job wired for changed live test \`${file}\`.`,
+        dispatchCommand: canonicalDispatchCommand(SCENARIO_WORKFLOW, job, "job"),
+      });
+    }
+  }
+  return output.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function suppressFanoutForFocusedJobs(
+  recommendations: ScenarioRecommendation[],
+  deterministicJobs: ScenarioRecommendation[],
+  changedFiles: string[],
+): ScenarioRecommendation[] {
+  if (deterministicJobs.length === 0) return recommendations;
+  const relevantFiles = changedFiles.filter(isVitestScenarioRelevantFile);
+  const onlyFocusedFreeStandingChange = relevantFiles.every(
+    (file) =>
+      file === SCENARIO_WORKFLOW_PATH ||
+      FREE_STANDING_LIVE_FILE_PATTERN.test(file) ||
+      file.startsWith("test/e2e-scenario/support-tests/") ||
+      file.startsWith("tools/e2e-scenarios/"),
+  );
+  if (!onlyFocusedFreeStandingChange) return recommendations;
+  return recommendations.filter((item) => item.selectorType !== "all");
+}
+
+function mergeRecommendations(
+  first: ScenarioRecommendation[],
+  second: ScenarioRecommendation[],
+): ScenarioRecommendation[] {
   const seen = new Set<string>();
   const output: ScenarioRecommendation[] = [];
+  for (const item of [...first, ...second]) {
+    const key = `${item.selectorType}:${item.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(item);
+  }
+  return output;
+}
+
+function sanitizeRecommendations(
+  value: unknown,
+  requiredFlag: boolean,
+  context: ScenarioNormalizationContext,
+): ScenarioRecommendation[] {
+  const seen = new Set<string>();
+  const output: ScenarioRecommendation[] = [];
+  const allowedJobIds = new Set(context.freeStandingJobs.map((job) => job.id));
   for (const item of recordItems(value)) {
     const id = stringOrUndefined(item.id);
     const reason = stringOrUndefined(item.reason);
     const workflow = stringOrUndefined(item.workflow);
     if (!id || !reason || !workflow) continue;
     // Allowlist: only the Vitest scenario workflow may be dispatched, and
-    // only kebab-case ids are accepted. Reject everything else; we do not
+    // only safe selector ids are accepted. Reject everything else; we do not
     // trust the model to author shell-safe dispatch commands.
     if (!ALLOWED_WORKFLOWS.has(workflow)) continue;
-    if (!SCENARIO_ID_PATTERN.test(id)) continue;
-    const scenarioDefinition = id === SCENARIO_ALL_ID ? undefined : getScenario(id);
+    const selectorType = normalizeSelectorType(item.selectorType, id, allowedJobIds);
+    if (!selectorType) continue;
+    if (selectorType === "job" && !allowedJobIds.has(id)) continue;
+    if (selectorType !== "job" && !SCENARIO_ID_PATTERN.test(id)) continue;
+    const scenarioDefinition = selectorType === "all" ? undefined : getScenario(id);
     if (
-      id !== SCENARIO_ALL_ID &&
+      selectorType === "scenario" &&
       (!scenarioDefinition || !liveScenarioSupport(scenarioDefinition).supported)
     ) {
       continue;
     }
-    if (seen.has(id)) continue;
-    seen.add(id);
+    const key = `${selectorType}:${id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
     const scenario = stringOrUndefined(item.scenario);
     const suiteFilter = stringOrUndefined(item.suiteFilter);
     // Build dispatchCommand server-side. The model's value is intentionally
     // discarded so prompt drift can never leak a non-canonical dispatch into
     // the sticky comment.
-    const dispatchCommand = canonicalDispatchCommand(workflow, id);
+    const dispatchCommand = canonicalDispatchCommand(workflow, id, selectorType);
     output.push(
       dropUndefinedValues({
         id,
         workflow,
+        selectorType,
         scenario,
         suiteFilter,
         // Authority is the array position, not the model. Items in required[]
@@ -428,6 +583,21 @@ function sanitizeRecommendations(value: unknown, requiredFlag: boolean): Scenari
     );
   }
   return output;
+}
+
+function normalizeSelectorType(
+  value: unknown,
+  id: string,
+  allowedJobIds: Set<string>,
+): ScenarioSelectorType | null {
+  if (value === "all" || value === "scenario" || value === "job") return value;
+  if (id === SCENARIO_ALL_ID) return "all";
+  if (allowedJobIds.has(id)) return "job";
+  return "scenario";
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function stringArrayWithinChanged(value: unknown, changedFiles: string[]): string[] {

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -43,7 +43,10 @@ const ADVISOR_PROVIDER = DEFAULT_ADVISOR_PROVIDER;
 const ADVISOR_MODEL = DEFAULT_ADVISOR_MODEL;
 const ADVISOR_CREDENTIAL_ENV = ["E2E", "ADVISOR", "API", "KEY"].join("_");
 const SCENARIO_WORKFLOW = "e2e-vitest-scenarios.yaml";
+const SCENARIO_WORKFLOW_PATH = `.github/workflows/${SCENARIO_WORKFLOW}`;
 const SCENARIO_ALL_ID = "e2e-scenarios-all";
+const REGISTRY_LIVE_ENTRYPOINT = "test/e2e-scenario/live/registry-scenarios.test.ts";
+const FREE_STANDING_LIVE_TEST_PATTERN = /^test\/e2e-scenario\/live\/[^/]+\.test\.ts$/;
 const ALLOWED_WORKFLOWS = new Set<string>([SCENARIO_WORKFLOW]);
 // Scenario IDs are embedded into the dispatch command we hand to users; restrict
 // to a strict kebab-case allowlist so a hallucinated id can never inject shell
@@ -176,6 +179,7 @@ async function main(): Promise<void> {
     result = normalizeScenarioAdvisorResult(
       extractJson(sdkResult.text || sdkResult.raw, artifacts.raw, "e2e_scenario_advisor_json"),
       metadata,
+      { vitestWorkflowText: readVitestWorkflowText() },
     );
   } catch (error: unknown) {
     writeFailure(error instanceof Error ? error.message : String(error));
@@ -238,6 +242,7 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
     "Decision policy:",
     "- Required (all scenarios): changes to scenario registry, matrix emission, expected-state metadata, live support classification, shared fixtures, or the Vitest scenario workflow itself. Recommend the `e2e-scenarios-all` fan-out through `e2e-vitest-scenarios.yaml`.",
     "- Required (targeted): fixture, live test, manifest, runtime-support, or scenario changes that affect a specific subset. Recommend the smallest set of live-supported typed scenario IDs that exercises the changed surface.",
+    "- Missing wiring: if a PR adds or changes a free-standing live Vitest file under `test/e2e-scenario/live/*.test.ts` but that file is not referenced by `.github/workflows/e2e-vitest-scenarios.yaml` and is not `registry-scenarios.test.ts`, do not recommend the fan-out as proof. Return no required/optional recommendations and set `noScenarioE2eReason` to say the test must be wired into `e2e-vitest-scenarios.yaml` before it can be dispatched.",
     "- Optional: adjacent scenarios that exercise the same suite on a different platform/onboarding (e.g. macOS, WSL, GPU) but are not the primary target. Special-runner scenarios (`gpu-`, `macos-`, `wsl-`, `brev-`) should usually be optional unless they are the only path that exercises the change.",
     "- None: docs-only, comment-only, tests-only outside `test/e2e-scenario/`, or changes that cannot affect Vitest scenario behavior. Set `noScenarioE2eReason` and return empty `required`/`optional` arrays.",
     "",
@@ -246,7 +251,7 @@ export function buildSystemPrompt(schema: AdvisorSchema): string {
     "- The only allowed workflow is `e2e-vitest-scenarios.yaml`.",
     "- Each `dispatchCommand` for a single-scenario recommendation MUST be exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref> --field scenarios=<id>`.",
     "- For the fan-out, use exactly: `gh workflow run e2e-vitest-scenarios.yaml --ref <pr-head-ref>` and set `id`/`workflow` to `e2e-scenarios-all`/`e2e-vitest-scenarios.yaml`.",
-    "- The normalizer validates targeted IDs against the trusted advisor checkout's registry/runtime-support modules, not PR-local TypeScript. If a PR adds or newly wires a scenario that is not live-supported on trusted `main` yet, recommend the `e2e-scenarios-all` fan-out rather than a targeted dispatch.",
+    "- The normalizer validates targeted IDs against the trusted advisor checkout's registry/runtime-support modules, not PR-local TypeScript. If a PR adds or newly wires a typed registry scenario that is not live-supported on trusted `main` yet, recommend the `e2e-scenarios-all` fan-out rather than a targeted dispatch. This fallback does not apply to unwired free-standing live test files.",
     "- A `suiteFilter` may be set on a recommendation as analytical metadata explaining why the scenario was selected. It must NOT leak into the dispatch command.",
     "- `relevantChangedFiles` must be the subset of `changedFiles` under `test/e2e-scenario/`, `.github/workflows/e2e-vitest-scenarios.yaml`, or other directly scenario-relevant paths.",
     "",
@@ -289,21 +294,33 @@ ${diff || "<no diff available>"}
 export function normalizeScenarioAdvisorResult(
   result: unknown,
   metadata: AdvisorMetadata,
+  options: { vitestWorkflowText?: string } = {},
 ): ScenarioAdvisorResult {
   if (!result || typeof result !== "object" || Array.isArray(result)) {
     throw new Error("Scenario advisor returned a non-object result");
   }
 
   const object = result as Record<string, unknown>;
-  const required = sanitizeRecommendations(object.required, true);
-  const optional = sanitizeRecommendations(object.optional, false);
+  const unwiredFreeStandingLiveTests = findUnwiredFreeStandingLiveTests(
+    metadata.changedFiles,
+    options.vitestWorkflowText,
+  );
+  const suppressFanout = shouldSuppressFanoutForUnwiredLiveTests(
+    metadata.changedFiles,
+    unwiredFreeStandingLiveTests,
+  );
+  const required = suppressFanout ? [] : sanitizeRecommendations(object.required, true);
+  const optional = suppressFanout ? [] : sanitizeRecommendations(object.optional, false);
   const reasonField = object.noScenarioE2eReason;
-  const noScenarioE2eReason =
-    typeof reasonField === "string" && reasonField.trim()
+  const noScenarioE2eReason = suppressFanout
+    ? missingFreeStandingLiveWiringReason(unwiredFreeStandingLiveTests)
+    : typeof reasonField === "string" && reasonField.trim()
       ? reasonField.trim()
       : reasonField === null || reasonField === undefined
         ? required.length === 0 && optional.length === 0
-          ? "Advisor reported no Vitest E2E scenario impact."
+          ? unwiredFreeStandingLiveTests.length > 0
+            ? missingFreeStandingLiveWiringReason(unwiredFreeStandingLiveTests)
+            : "Advisor reported no Vitest E2E scenario impact."
           : null
         : null;
 
@@ -318,6 +335,53 @@ export function normalizeScenarioAdvisorResult(
     noScenarioE2eReason,
     confidence: enumValue<["low", "medium", "high"]>(object.confidence, ["low", "medium", "high"], "medium"),
   };
+}
+
+function readVitestWorkflowText(): string | undefined {
+  try {
+    return fs.readFileSync(path.join(root, SCENARIO_WORKFLOW_PATH), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function findUnwiredFreeStandingLiveTests(
+  changedFiles: string[],
+  vitestWorkflowText = readVitestWorkflowText(),
+): string[] {
+  return changedFiles.filter(
+    (file) =>
+      FREE_STANDING_LIVE_TEST_PATTERN.test(file) &&
+      file !== REGISTRY_LIVE_ENTRYPOINT &&
+      !(vitestWorkflowText ?? "").includes(file),
+  );
+}
+
+function shouldSuppressFanoutForUnwiredLiveTests(
+  changedFiles: string[],
+  unwiredFreeStandingLiveTests: string[],
+): boolean {
+  if (unwiredFreeStandingLiveTests.length === 0) return false;
+  const relevantFiles = changedFiles.filter(isVitestScenarioRelevantFile);
+  return relevantFiles.every(
+    (file) =>
+      unwiredFreeStandingLiveTests.includes(file) ||
+      file === SCENARIO_WORKFLOW_PATH,
+  );
+}
+
+function isVitestScenarioRelevantFile(file: string): boolean {
+  return (
+    file === SCENARIO_WORKFLOW_PATH ||
+    file.startsWith("test/e2e-scenario/") ||
+    file.startsWith("tools/e2e-scenario") ||
+    file.startsWith("tools/e2e-scenarios")
+  );
+}
+
+function missingFreeStandingLiveWiringReason(files: string[]): string {
+  const fileList = files.map((file) => `\`${file}\``).join(", ");
+  return `New free-standing live Vitest test ${fileList} is not wired into \`${SCENARIO_WORKFLOW_PATH}\`, so the Vitest scenario workflow cannot dispatch it yet. Add a discrete job or register it as a typed live scenario before treating the PR as E2E-runnable.`;
 }
 
 function sanitizeRecommendations(value: unknown, requiredFlag: boolean): ScenarioRecommendation[] {


### PR DESCRIPTION
## Summary
Update the Vitest E2E scenario advisor so it no longer recommends the fan-out workflow as proof for a newly added free-standing live Vitest file that is not wired into `e2e-vitest-scenarios.yaml`.

## Context
Recent #5098 migration PRs can add `test/e2e-scenario/live/*.test.ts` without adding a workflow job. The advisor previously fell back to `e2e-scenarios-all`, but that dispatch cannot execute a free-standing test file unless the workflow references it.

## Changes
- Detect changed free-standing live Vitest tests that are not referenced by `.github/workflows/e2e-vitest-scenarios.yaml`.
- Suppress misleading fan-out/targeted recommendations for PRs where the only scenario-relevant change is an unwired free-standing live test.
- Return a no-scenario reason that tells authors to add a discrete workflow job or register the test as a typed live scenario.
- Add regression coverage for unwired vs wired free-standing live tests.

## Verification
- `npm ci --ignore-scripts`
- `npx vitest run test/e2e-scenario-advisor.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tests for E2E scenario advisor normalization, covering selector-type handling and free-standing Vitest job extraction and normalization.

* **Chores**
  * Recommendation schema now requires a selectorType discriminator ("all", "scenario", "job").
  * Normalization now suppresses scenario fan-out when changed free-standing live tests aren’t wired into the trusted workflow and surfaces a noScenarioE2eReason message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->