### PR TITLE
ci(pr-limit): exempt jyaunches maintainer

### DIFF
--- a/.github/workflows/pr-limit.yaml
+++ b/.github/workflows/pr-limit.yaml
@@ -28,7 +28,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Core maintainers are exempt from the PR limit.
-          EXEMPT="ericksoa kjw3 jacobtomlinson cv"
+          EXEMPT="ericksoa kjw3 jacobtomlinson cv jyaunches"
           for user in $EXEMPT; do
             if [ "$AUTHOR" = "$user" ]; then
               echo "Author $AUTHOR is a core maintainer — exempt from PR limit"


### PR DESCRIPTION
## Summary
- add @jyaunches to the core maintainer exemption list used by the PR limit workflow

## Root cause
- the workflow uses a hard-coded allowlist instead of checking repository maintainer/admin permissions
- @cv is exempt because they are listed; @jyaunches has admin permission but was omitted

## Validation
- git diff --check
- pre-commit hooks during commit passed for YAML and secret checks

This should prevent the workflow from closing maintainer PRs by @jyaunches above the 10-open-PR contributor limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal process configuration.

*Note: This release includes no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->