### PR TITLE
fix(inference): force completions API for providers without /v1/responses

### DIFF
--- a/src/lib/inference/config.ts
+++ b/src/lib/inference/config.ts
@@ -6,6 +6,7 @@
  * inference output parsing. All functions are pure.
  */
 
+import { shouldSkipResponsesProbe } from "../validation";
 import { DEFAULT_OLLAMA_MODEL } from "./local";
 
 export const INFERENCE_ROUTE_URL = "https://inference.local/v1";
@@ -186,6 +187,15 @@ export function getSandboxInferenceConfig(
   let primaryModelRef: string;
   let inferenceBaseUrl = INFERENCE_ROUTE_URL;
   let inferenceApi = preferredInferenceApi || "openai-completions";
+  // Providers without a /v1/responses endpoint must never be configured with the
+  // Responses API. On a provider switch the runtime API resolves to null and the
+  // caller falls back to the persisted (shared "inference") provider api, which
+  // can carry a prior provider's "openai-responses" over to e.g. nvidia-prod and
+  // 404 every request. Force completions here, mirroring how anthropic-prod
+  // forces anthropic-messages below.
+  if (provider && shouldSkipResponsesProbe(provider)) {
+    inferenceApi = "openai-completions";
+  }
   let inferenceCompat: Record<string, unknown> | null = null;
 
   switch (provider) {

--- a/test/inference-config-responses-api.test.ts
+++ b/test/inference-config-responses-api.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { getSandboxInferenceConfig } from "../dist/lib/inference/config.js";
+
+// Providers in shouldSkipResponsesProbe (nvidia-prod, nvidia-nim, gemini-api) do
+// not expose /v1/responses. On a provider switch the runtime API resolves to null
+// and the caller falls back to the persisted shared "inference" provider api, which
+// can carry a prior provider's "openai-responses" over. getSandboxInferenceConfig
+// must force completions for these providers so the route does not 404 every turn.
+describe("getSandboxInferenceConfig: Responses API guard for no-/responses providers", () => {
+  it("forces openai-completions for nvidia-prod even when a stale openai-responses api carries over", () => {
+    const cfg = getSandboxInferenceConfig(
+      "meta/llama-3.1-8b-instruct",
+      "nvidia-prod",
+      "openai-responses",
+    );
+    expect(cfg.inferenceApi).toBe("openai-completions");
+  });
+
+  it("forces openai-completions for nvidia-nim and gemini-api with a stale openai-responses api", () => {
+    expect(getSandboxInferenceConfig("m", "nvidia-nim", "openai-responses").inferenceApi).toBe(
+      "openai-completions",
+    );
+    expect(getSandboxInferenceConfig("m", "gemini-api", "openai-responses").inferenceApi).toBe(
+      "openai-completions",
+    );
+  });
+
+  it("still honors openai-responses for a compatible-endpoint that supports it", () => {
+    expect(
+      getSandboxInferenceConfig("m", "compatible-endpoint", "openai-responses").inferenceApi,
+    ).toBe("openai-responses");
+  });
+
+  it("leaves anthropic-prod on anthropic-messages regardless of the passed api", () => {
+    expect(getSandboxInferenceConfig("m", "anthropic-prod", "openai-responses").inferenceApi).toBe(
+      "anthropic-messages",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Switching a sandbox to `nvidia-prod` / `nvidia-nim` / `gemini-api` from a different provider could configure `api: "openai-responses"` and 404 every request, because those providers do not expose `/v1/responses`. The switch path runs no validation probe, so it failed silently on the first turn.

On a provider switch, `resolveRuntimeInferenceApi` returns `null` (its session and config branches are gated on `currentProvider === provider`), so `runInferenceSet` falls back to `getPreferredInferenceApi(config)`, which reads the persisted shared `"inference"` provider api. A prior compatible-endpoint validated as `openai-responses` is still recorded there and gets carried into the switch. `getSandboxInferenceConfig` did not reset `inferenceApi` for these providers (unlike `anthropic-prod`, which forces `anthropic-messages`), so `buildProviderConfig` wrote a Responses API the endpoint does not expose.

## Related Issue

Closes #5239.

## Changes

- `src/lib/inference/config.ts`: in `getSandboxInferenceConfig`, force `inferenceApi = "openai-completions"` when `shouldSkipResponsesProbe(provider)` is true (the canonical no-`/responses` set: `nvidia-prod`, `nvidia-nim`, `gemini-api`), mirroring how `anthropic-prod` forces `anthropic-messages`.
- `test/inference-config-responses-api.test.ts`: cover that the three no-responses providers force completions even with a stale `openai-responses` carryover, that a compatible-endpoint still honors `openai-responses`, and that `anthropic-prod` stays on `anthropic-messages`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- `npx vitest run --project cli test/inference-config-responses-api.test.ts test/onboard-model-router.test.ts test/nemotron-inference-fix.test.ts` — 15/15 pass
- `npm run typecheck:cli` and `npm run build:cli` — clean

Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider configuration handling to ensure proper endpoint selection across different providers, enhancing stability and consistency in inference API behavior.

* **Tests**
  * Added comprehensive test coverage for provider-specific API endpoint configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->