### PR TITLE
docs: refresh v0.0.63 release docs

### DIFF
--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -36,6 +36,34 @@ Ignore comment lines (starting with `#`) and inline comments (everything after `
 
 Keep the loaded skip list in memory for use throughout the skill execution and the whole documentation process.
 
+## Step 0.5: Find Release Announcement Notes
+
+When the user asks for release-prep or post-release docs for a specific version `n` (for example `0.0.63`), find the NemoClaw GitHub discussion announcement for that release before drafting release notes.
+Use the announcement as source context alongside the commit scan, especially for release themes, PR grouping, contributor thanks, and maintainer wording.
+
+Search recent discussions and select the announcement whose title or body references `v<n>` or `NemoClaw v<n>`:
+
+```bash
+gh api graphql -f owner=NVIDIA -f name=NemoClaw -f query='
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    discussions(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        url
+        body
+        createdAt
+        category { name }
+      }
+    }
+  }
+}'
+```
+
+Prefer discussions in the `Announcements` category. If the discussion body is unavailable through `gh api`, use the GitHub discussion URL supplied by the user or fetch the discussion page content through the available tools.
+If no matching discussion exists, continue from the commit scan and report the missing announcement in the final summary.
+
 ## Step 1: Identify Relevant Commits
 
 Determine the commit range. The user may provide one explicitly (e.g., "since v0.1.0" or "last 30 commits"). If not, default to commits since the head of the main branch.
@@ -174,7 +202,7 @@ Skip this step when the user only asked for ordinary doc catch-up and no release
 
 If the user invoked this skill for release prep, finish the release-specific doc work before verification:
 
-1. Determine the release label from the release version requested by the user. Release labels use `vX.Y.Z` format. For example, release `0.0.37` uses label `v0.0.37`. If the user did not provide a release version, ask for it before opening the release-prep PR.
+1. Determine the documented release version `n` from the user's request. For post-release documentation refreshes, label the PR with the next patch release label, not the documented release label. Release labels use `vX.Y.Z` format. For example, a docs refresh for release `0.0.63` uses label `v0.0.64`. Increment only the patch component; if the version is nonstandard or pre-release, ask before choosing a label. If the user did not provide a release version, ask for it before opening the release-prep PR.
 2. Refresh the NemoClaw user skills:
 
    ```bash
@@ -208,8 +236,8 @@ Commit changes and open a pull request with a concise summary of the doc updates
 - #<doc-impacting-PR-number> -> `docs/path.mdx`: Description of the doc change reflecting the source code changes in the PR.
 ```
 
-Apply the `area: docs`, `area: skills`, and corresponding release labels so reviewers can identify doc-only changes for the target release and generated skill updates.
-When creating the PR with `gh pr create`, pass all labels, for example `--label "area: docs" --label "area: skills" --label v0.0.37`.
+Apply the `area: docs`, `area: skills`, and next-patch release label so reviewers can identify doc-only changes for the next train and generated skill updates.
+When creating the PR with `gh pr create`, pass all labels, for example a post-release docs refresh for `0.0.63` uses `--label "area: docs" --label "area: skills" --label v0.0.64`.
 If the release label does not exist, report that instead of substituting another label.
 
 ## Tips
@@ -228,15 +256,17 @@ User says: "Catch up the docs for everything merged since v0.1.0."
 2. Filter to `feat`, `fix`, `refactor`, `perf` commits touching user-facing code.
 3. Map each to a doc page.
 4. Read the commit diffs and current doc pages.
-5. Draft doc updates reflecting the source code changes in the commits following the style guide.
-6. **Release prep only:** Determine the release label from the user-requested release version.
-7. **Release prep only:** Run `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx`. Do not update root `skills/`.
-8. Present the summary.
-9. Build with `npm run docs` to verify.
-10. **Release prep only:** Commit changes and open a pull request with the `area: docs`, `area: skills`, and corresponding `vX.Y.Z` release labels. Include a concise summary of the doc updates and a source summary that links each identified merged PR to its matching doc page. Include the PR number, affected doc page, links, and description of the doc change in this shape:
+5. For release-specific docs, find the matching GitHub discussion announcement and use it as source context.
+6. Draft doc updates reflecting the source code changes in the commits following the style guide.
+7. **Release prep only:** Determine the next-patch release label from the user-requested documented release version.
+   For a post-release docs refresh for `0.0.63`, use label `v0.0.64`.
+8. **Release prep only:** Run `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx`. Do not update root `skills/`.
+9. Present the summary.
+10. Build with `npm run docs` to verify.
+11. **Release prep only:** Commit changes and open a pull request with the `area: docs`, `area: skills`, and next-patch release label. Include a concise summary of the doc updates and a source summary that links each identified merged PR to its matching doc page. Include the PR number, affected doc page, links, and description of the doc change in this shape:
 
    ```markdown
    - #<doc-impacting-PR-number> -> `docs/path.mdx`: Description of the doc change reflecting the source code changes in the PR.
    ```
 
-   If the release label does not exist, report that the PR was created without the release label or that PR creation failed because the label was missing.
+   If the next-patch release label does not exist, report that the PR was created without the release label or that PR creation failed because the label was missing.

--- a/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/SKILL.md
@@ -205,6 +205,9 @@ For the full compatible-endpoint prompt flow, non-interactive variables, API-pat
 
 NemoClaw can use an already-running vLLM server on `localhost:8000`, start managed vLLM on supported NVIDIA GPU hosts, or manage a local NIM container when `NEMOCLAW_EXPERIMENTAL=1` is set.
 Managed vLLM records the model returned by `/v1/models` and uses runtime metadata such as `max_model_len` when available.
+In interactive managed vLLM setup, the wizard lists validated model choices for your host profile before it pulls weights.
+Press **Enter** to accept the profile default, or choose a numbered model from the list.
+For scripted runs, set `NEMOCLAW_VLLM_MODEL=<slug>` to choose a registry model without prompting.
 If the host reboots and the `nemoclaw-vllm` container is stopped, NemoClaw restarts the managed vLLM container during recovery instead of requiring a fresh onboarding run.
 NIM uses the same chat-completions API path restriction as vLLM.
 

--- a/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
+++ b/.agents/skills/nemoclaw-user-configure-inference/references/inference-options.md
@@ -296,6 +296,8 @@ If vLLM is already running, NemoClaw detects the running model and validates the
 When vLLM exposes runtime metadata such as `max_model_len`, NemoClaw uses that value for the `contextWindow` baked into `openclaw.json` unless you set `NEMOCLAW_CONTEXT_WINDOW` yourself.
 If vLLM is not running and your host matches a DGX Spark or DGX Station managed profile, NemoClaw shows the **Install vLLM** or **Start vLLM** entry by default.
 Generic Linux NVIDIA GPU hosts still require `NEMOCLAW_EXPERIMENTAL=1` or `NEMOCLAW_PROVIDER=install-vllm` before the managed entry appears.
+In interactive runs, the managed vLLM path lists the supported registry models for your host profile before it pulls weights.
+Press **Enter** to use the default model, or choose a numbered entry to serve another validated model with its matching `vllm serve` flags.
 NemoClaw pulls the vLLM image, downloads model weights into `~/.cache/huggingface`, starts the `nemoclaw-vllm` container on `localhost:8000`, streams Hugging Face download progress, and polls `/v1/models` until the model is ready.
 Managed DGX Spark and DGX Station profiles use the stable NGC `nvcr.io/nvidia/vllm:26.05.post1-py3` container image.
 If Docker pull output stops making progress, a watchdog stops the stalled pull instead of failing slow but active downloads on a fixed wall-clock timeout.
@@ -327,6 +329,7 @@ NEMOCLAW_PROVIDER=vllm \
 
 Install or start managed vLLM when NemoClaw detects a supported profile.
 On DGX Spark and DGX Station, `NEMOCLAW_PROVIDER=install-vllm` is enough for non-interactive runs; add `NEMOCLAW_EXPERIMENTAL=1` on generic Linux NVIDIA GPU hosts.
+Non-interactive runs use the profile default unless you set `NEMOCLAW_VLLM_MODEL`.
 
 ```bash
 NEMOCLAW_PROVIDER=install-vllm \
@@ -338,8 +341,8 @@ Start vLLM with the model you want before onboarding if you manage the server yo
 
 ### Override the Managed-vLLM Model
 
-Managed vLLM serves the profile default unless you select a different registry entry.
-Export `NEMOCLAW_VLLM_MODEL=<slug>` before invoking the installer to choose a different model from the registry.
+Managed vLLM serves the profile default unless you choose a different registry entry in the interactive picker or set an override for automation.
+Export `NEMOCLAW_VLLM_MODEL=<slug>` before invoking the installer to choose a different model without prompting.
 NemoClaw uses the matching `vllm serve` flags, including the reasoning parser, tool-call parser, and `--max-model-len`.
 Recognized slugs are:
 

--- a/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
+++ b/.agents/skills/nemoclaw-user-configure-security/references/best-practices.md
@@ -2,7 +2,7 @@
 
 import { AgentOnly } from "../_components/AgentGuide";
 
-NemoClaw ships with deny-by-default security controls across four layers: network, filesystem, process, and inference.
+NemoClaw ships with deny-by-default security controls across five layers: network, filesystem, process, gateway authentication, and inference.
 You can tune every control, but each change shifts the risk profile.
 This page documents each configurable control, its default, what it protects, the concrete risk of relaxing it, and a recommendation for common use cases.
 
@@ -10,7 +10,7 @@ For background on how the layers fit together, refer to How It Works (use the `n
 
 ## Protection Layers at a Glance
 
-NemoClaw enforces security at four layers.
+NemoClaw enforces security at five layers.
 NemoClaw locks some controls when it creates the sandbox and requires a restart to change them.
 You can hot-reload others while the sandbox runs.
 
@@ -36,6 +36,7 @@ flowchart TB
             subgraph GW["Gateway: the gatekeeper"]
                 direction LR
                 NET["🌐 Network Layer<br/>Controls where the agent can connect"]
+                AUTH["🔐 Gateway Authentication Layer<br/>Controls which devices and clients can reach the gateway"]
                 INF["🧠 Inference Layer<br/>Controls which AI models the agent can use"]
             end
         end
@@ -54,7 +55,7 @@ flowchart TB
     classDef operator fill:#fff,stroke:#76b900,color:#1a1a1a,stroke-width:2px,font-weight:bold
 
     class AGENT agent
-    class PROC,FS locked
+    class PROC,FS,AUTH locked
     class NET,INF hot
     class OUTSIDE external
     class YOU operator
@@ -70,6 +71,7 @@ flowchart TB
 | Network | Unauthorized outbound connections and data exfiltration. | OpenShell gateway | Yes. Use `openshell policy set` or operator approval. |
 | Filesystem | System binary tampering, credential theft, config manipulation. | Landlock LSM + container mounts | Landlock layout: no. Requires sandbox re-creation. Use host-side NemoClaw commands for durable config changes. |
 | Process | Privilege escalation, fork bombs, syscall abuse. | Container runtime (Docker/K8s `securityContext`) | No. Requires sandbox re-creation. |
+| Gateway Authentication | Unauthorized devices or clients reaching the gateway and its dashboard. | OpenShell gateway | No. Set at image build / onboarding time. |
 | Inference | Credential exposure, unauthorized model access, cost overruns. | OpenShell gateway | Yes. Use the NemoClaw inference switching command. |
 
 ## Network Controls
@@ -276,7 +278,7 @@ This is opt-in because such hosts are common (many cloud VMs, Docker Desktop, WS
 The check covers the agent process tree only — a `nemoclaw connect` shell is spawned by the container runtime outside that tree and is not affected (tracked in [NVIDIA/OpenShell#1452](https://github.com/NVIDIA/OpenShell/issues/1452)).
 
 <AgentOnly variant="openclaw">
-For additional protection, pass `--cap-drop=ALL` with `docker run` or Compose. Refer to Sandbox Hardening.
+For additional protection, pass `--cap-drop=ALL` with `docker run` or Compose. Refer to Sandbox Hardening (use the `nemoclaw-user-deploy-remote` skill).
 </AgentOnly>
 
 | Aspect | Detail |
@@ -594,7 +596,7 @@ The following patterns weaken security without providing meaningful benefit.
 - Customize the Network Policy (use the `nemoclaw-user-manage-policy` skill) for static and dynamic policy changes.
 - Approve or Deny Network Requests (use the `nemoclaw-user-manage-policy` skill) for the operator approval flow.
 <AgentOnly variant="openclaw">
-- Sandbox Hardening for container-level security measures.
+- Sandbox Hardening (use the `nemoclaw-user-deploy-remote` skill) for container-level security measures.
 </AgentOnly>
 - Inference Options (use the `nemoclaw-user-configure-inference` skill) for provider configuration details.
 - How It Works (use the `nemoclaw-user-overview` skill) for the protection layer architecture.

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/SKILL.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/SKILL.md
@@ -217,7 +217,7 @@ The standard installer follows the admin-promoted `lkg` release tag by default.
 If you need a specific release, set `NEMOCLAW_INSTALL_TAG` on the `bash` side of the install pipeline.
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=v0.0.56 bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=v0.0.63 bash
 nemoclaw upgrade-sandboxes --check
 ```
 
@@ -231,6 +231,8 @@ nemoclaw upgrade-sandboxes --check
 ```
 
 Each rebuild destroys the old container and creates a new one, while preserving the manifest-defined workspace or agent state that NemoClaw knows how to snapshot.
+`upgrade-sandboxes --check` can report a sandbox as stale because the running agent version is behind, because the managed NemoClaw image fingerprint differs from the current CLI, or both.
+Custom-image sandboxes created with `--from <Dockerfile>` are not marked stale solely by image fingerprint, so an upgrade check does not accidentally replace them with the default image.
 Runtime changes outside those state paths, such as packages installed manually in the running container, are not preserved.
 For the full state-preservation contract, snapshot restore behavior, and manual backup workflow, refer to [Backup and Restore](references/backup-restore.md).
 For command flags, refer to `nemoclaw update` (use the `nemoclaw-user-reference` skill), `nemoclaw upgrade-sandboxes` (use the `nemoclaw-user-reference` skill), and `nemoclaw <name> rebuild` (use the `nemoclaw-user-reference` skill).

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/backup-restore.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/backup-restore.md
@@ -68,6 +68,9 @@ nemoclaw my-assistant snapshot restore before-upgrade --to my-assistant-clone --
 The `nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
 Snapshot restore performs a targeted repair for legacy `.openclaw-data` symlinks that older images created.
 NemoClaw rejects unsafe symlinks and hard links inside sandbox state during backup creation before they can enter a snapshot.
+Snapshots also preserve user-owned `openclaw.json` settings.
+During rebuild or restore, NemoClaw merges those restored settings with the freshly generated runtime config so current provider placeholders, messaging enablement, and gateway state win over stale snapshot values.
+If the restored config cannot be parsed or applied safely, NemoClaw stops the restore instead of replacing the generated config with an unsafe fallback.
 
 </AgentOnly>
 <AgentOnly variant="hermes">

--- a/.agents/skills/nemoclaw-user-manage-sandboxes/references/messaging-channels.md
+++ b/.agents/skills/nemoclaw-user-manage-sandboxes/references/messaging-channels.md
@@ -69,14 +69,21 @@ Set `DISCORD_USER_ID` to restrict access to one user; otherwise, any member of t
 Slack uses Socket Mode and requires two tokens.
 Use `SLACK_BOT_TOKEN` for the bot user OAuth token (`xoxb-...`) and `SLACK_APP_TOKEN` for the app-level Socket Mode token (`xapp-...`).
 NemoClaw validates both tokens before it saves Slack credentials or enables the channel.
+This validation calls the live Slack API (`auth.test` and `apps.connections.open`), so the tokens must belong to a real Slack app.
+If Slack rejects the tokens (for example, `invalid_auth` for placeholder or fake values), NemoClaw skips the Slack channel.
+Because the `slack` network policy preset is only applied for channels that are actually enabled, a skipped Slack channel also means the `slack` preset is not applied, so it does not appear as applied (`●`) in `nemoclaw <name> policy-list`.
+To exercise Slack channel setup and the `slack` policy preset with placeholder tokens in a restricted network or hermetic test environment, set `NEMOCLAW_SKIP_SLACK_AUTH_VALIDATION=1` to skip the live credential probes; Slack token format checks still apply.
 Set `SLACK_ALLOWED_USERS` to comma-separated Slack member IDs to authorize those users for DMs and for channel `@mention` events in channels where the Slack app is present.
 Set `SLACK_ALLOWED_CHANNELS` to comma-separated Slack channel IDs to restrict channel `@mention` handling to those channels.
 When both Slack allowlists are set, NemoClaw requires the mention to come from one of the allowed channels and one of the allowed members.
 Channel messages still require an explicit bot mention.
 When a Slack channel `@mention` is denied by these allowlists, NemoClaw sends a denial notice back to the sender instead of dropping the message silently.
 During sandbox startup, NemoClaw normalizes OpenShell credential placeholders into the environment shape expected by the Slack runtime, so post-rebuild Slack starts use the gateway-managed tokens instead of literal placeholder strings.
+Slack Socket Mode allows one active connection per app-level token.
+If another sandbox on the same gateway already uses the same Slack app token, onboarding and `channels add slack` warn before continuing in interactive mode and abort in non-interactive mode.
+Use `--force` only when you intentionally want to move the Slack Socket Mode session to the new sandbox.
 
-WeChat (experimental) delivers messages over Tencent's iLink gateway through the upstream `@tencent-weixin/openclaw-weixin` plugin baked into the sandbox base image and the built-in Hermes iLink WeChat adapter.
+WeChat (experimental) delivers messages over Tencent's iLink gateway through the upstream `@tencent-weixin/openclaw-weixin` plugin installed into WeChat-enabled OpenClaw sandbox images and the built-in Hermes iLink WeChat adapter.
 The supported mode in this release is **personal WeChat** (`bot_type=3`).
 WeChat Official Account and WeCom/Enterprise WeChat are not wired up.
 
@@ -283,6 +290,7 @@ For example, two Telegram sandboxes can DM the same `TELEGRAM_ALLOWED_IDS` accou
 For WeChat, each sandbox must own a distinct iLink `accountId` (bot identity).
 Running two sandboxes against the same WeChat account causes one of them to lose messages.
 If you enable a messaging channel and another sandbox already uses the same token, onboarding prompts you to confirm before continuing in interactive mode and exits non-zero in non-interactive mode.
+For Slack, NemoClaw checks both the bot token and the Socket Mode app token so duplicate Socket Mode sessions do not compete silently.
 If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning.
 Re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
 `nemoclaw status` reports cross-sandbox overlaps so you can resolve duplicates before messages start dropping.

--- a/.agents/skills/nemoclaw-user-overview/references/release-notes.md
+++ b/.agents/skills/nemoclaw-user-overview/references/release-notes.md
@@ -14,7 +14,6 @@ NemoClaw v0.0.63 improves sandbox recovery, OpenClaw configuration restore safet
 - Snapshot-backed rebuilds preserve OpenClaw configuration more safely. Rebuilds now carry forward user-owned `openclaw.json` settings, merge restored config with freshly generated runtime state, and fail when restored config cannot be applied safely. For more information, refer to Backup and Restore (use the `nemoclaw-user-manage-sandboxes` skill).
 - Onboarding diagnoses host setup and local inference issues earlier. The installer reports unusual Docker daemon access when a Linux user is outside the `docker` group, host DNS blocks are caught before NVIDIA provider validation, Ollama auth-proxy port conflicts recover during startup, and managed vLLM offers an interactive model picker for supported host profiles. For more information, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill).
 - Messaging and Hermes startup paths enforce clearer runtime boundaries. Slack setup validates Socket Mode credentials and warns or blocks duplicate Slack Socket Mode sandboxes on a shared gateway, while Hermes direct gateway launch keeps environment-secret protections active and handles wrapped gateway arguments. For more information, refer to Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill).
-- Release validation continues moving onboarding and E2E coverage into typed, targeted Vitest slices, including resume, Docker-unreachable gateway startup, version-pin, docs validation, and migration-retirement coverage.
 
 ## v0.0.62
 

--- a/.agents/skills/nemoclaw-user-overview/references/release-notes.md
+++ b/.agents/skills/nemoclaw-user-overview/references/release-notes.md
@@ -6,6 +6,16 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.63
+
+NemoClaw v0.0.63 improves sandbox recovery, OpenClaw configuration restore safety, local inference onboarding, messaging safeguards, and release validation:
+
+- Sandbox lifecycle commands preserve and recover more state. `rebuild --yes` can recreate a locally registered sandbox that is missing from a healthy gateway, Docker-driver sandboxes can restart from OpenShell container labels after a host reboot, and `upgrade-sandboxes` detects recorded NemoClaw image drift even when the agent version itself matches. For more information, refer to Manage Sandbox Lifecycle (use the `nemoclaw-user-manage-sandboxes` skill).
+- Snapshot-backed rebuilds preserve OpenClaw configuration more safely. Rebuilds now carry forward user-owned `openclaw.json` settings, merge restored config with freshly generated runtime state, and fail when restored config cannot be applied safely. For more information, refer to Backup and Restore (use the `nemoclaw-user-manage-sandboxes` skill).
+- Onboarding diagnoses host setup and local inference issues earlier. The installer reports unusual Docker daemon access when a Linux user is outside the `docker` group, host DNS blocks are caught before NVIDIA provider validation, Ollama auth-proxy port conflicts recover during startup, and managed vLLM offers an interactive model picker for supported host profiles. For more information, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill).
+- Messaging and Hermes startup paths enforce clearer runtime boundaries. Slack setup validates Socket Mode credentials and warns or blocks duplicate Slack Socket Mode sandboxes on a shared gateway, while Hermes direct gateway launch keeps environment-secret protections active and handles wrapped gateway arguments. For more information, refer to Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill).
+- Release validation continues moving onboarding and E2E coverage into typed, targeted Vitest slices, including resume, Docker-unreachable gateway startup, version-pin, docs validation, and migration-retirement coverage.
+
 ## v0.0.62
 
 NemoClaw v0.0.62 improves onboarding reliability for GPU sandboxes, local inference, gateway pairing, Hermes configuration, and release validation:
@@ -34,7 +44,7 @@ NemoClaw v0.0.61 improves sandbox network visibility, onboarding recovery, Herme
 - Onboarding and rebuild paths recover more reliably across host and provider drift. ARM64 image-tar upload failures receive a clear classification with an image-reference workaround, rebuild detaches sandbox providers before delete, rebuilt resume snapshots keep session state, and messaging selector key sequences work during onboarding. For more information, refer to NemoClaw CLI Commands Reference (use the `nemoclaw-user-reference` skill).
 - Local inference and Hermes setup cover more restart and configuration edge cases. Managed inference hostnames bypass host proxies, managed vLLM restarts after host reboot, DGX Station managed vLLM defaults to `Qwen/Qwen3.6-27B-FP8`, Hermes rejects dashboard port collisions during configuration, and Hermes recovery enforces the environment-secret boundary. For more information, refer to Use a Local Inference Server (use the `nemoclaw-user-configure-inference` skill).
 - Messaging setup gives clearer feedback and stores more deterministic state. Slack now notifies the sender when a channel `@mention` is denied, operator-supplied placeholder keys can be registered during onboarding, `messagingPlan` persists into resume state, and channel conflict detection now uses the manifest-plan architecture. For more information, refer to Messaging Channels (use the `nemoclaw-user-manage-sandboxes` skill).
-- Release validation now uses real shell assertions in the e2e scenario runner, includes an opt-in live scenario project, shards CLI coverage, adds a docs-only PR fast path, and trims slow CLI subprocess coverage.
+- Release validation now runs real shell-boundary assertions through Vitest E2E support, includes an opt-in live scenario project, shards CLI coverage, adds a docs-only PR fast path, and trims slow CLI subprocess coverage.
 
 ## v0.0.60
 
@@ -197,7 +207,7 @@ NemoClaw v0.0.48 improves onboarding, sandbox builds, local inference, messaging
 
 NemoClaw v0.0.47 focused on release hardening and validation coverage:
 
-- The scenario E2E framework gained baseline onboarding coverage for CLI setup, OpenShell gateway creation, sandbox state, inference routing, and smoke tests.
+- The Vitest E2E fixture layer gained baseline onboarding coverage for CLI setup, OpenShell gateway creation, sandbox state, inference routing, and smoke tests.
 - Messaging provider scenarios now validate provider attachment, placeholder configuration, secret-leak prevention, bridge reachability, Discord gateway routing, Slack provider state, Telegram injection safety, and token-rotation isolation.
 - CLI command registration was refactored so public display defaults stay consistent across sandbox channel, host, log, policy, skill, and snapshot commands.
 - PR review advisor automation was added for maintainers, with deterministic GitHub context gathering and structured review comments.

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -1289,7 +1289,7 @@ NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` fr
 Sandboxes that match the current digest are left alone.
 NemoClaw also checks the build fingerprint recorded on each managed sandbox image.
 A sandbox needs upgrade when its agent version is stale, when its recorded NemoClaw image fingerprint differs from the running CLI, or both.
-Custom-image sandboxes created with `--from <Dockerfile>` are not classified by image drift because rebuilding them onto the default image would drop the custom image.
+Custom Dockerfile sandboxes are not classified by image drift because rebuilding them onto the default image would drop the custom image.
 Legacy sandboxes without a recorded fingerprint opt into this check after their next rebuild.
 
 ```bash

--- a/.agents/skills/nemoclaw-user-reference/references/commands.md
+++ b/.agents/skills/nemoclaw-user-reference/references/commands.md
@@ -741,6 +741,15 @@ The token is written to stdout with no surrounding text.
 A one-line security warning is written to stderr; pass `--quiet` (or `-q`) to suppress it.
 The command exits non-zero with a diagnostic on stderr when the sandbox is not registered or when the token cannot be retrieved (for example, if the sandbox is not running).
 
+The token also authenticates the Control UI config endpoint served by the gateway on the forwarded dashboard port.
+There is no `controlui.bootstrap.config.json` path; the supported endpoint is `/__openclaw/control-ui-config.json`, and it requires the token (unauthenticated requests return `401` with a JSON body):
+
+```bash
+TOKEN=$(nemoclaw my-assistant gateway-token --quiet)
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:18789/__openclaw/control-ui-config.json"
+```
+
 **Warning:**
 
 Treat the gateway token like a password.
@@ -1278,6 +1287,10 @@ When the command is running from a source checkout, it reports that state and do
 Rebuild sandboxes whose base image is older than the one currently pinned by NemoClaw.
 NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` from the registry, then compares it against the digest each sandbox was created with.
 Sandboxes that match the current digest are left alone.
+NemoClaw also checks the build fingerprint recorded on each managed sandbox image.
+A sandbox needs upgrade when its agent version is stale, when its recorded NemoClaw image fingerprint differs from the running CLI, or both.
+Custom-image sandboxes created with `--from <Dockerfile>` are not classified by image drift because rebuilding them onto the default image would drop the custom image.
+Legacy sandboxes without a recorded fingerprint opt into this check after their next rebuild.
 
 ```bash
 nemoclaw upgrade-sandboxes [--check] [--auto] [--yes|-y]

--- a/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
+++ b/.agents/skills/nemoclaw-user-reference/references/troubleshooting.md
@@ -88,6 +88,20 @@ newgrp docker
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
+### Installer reports Docker access outside the docker group
+
+On Linux, the installer may report that Docker is reachable even though your user is not in the `docker` group.
+This means the host grants Docker daemon access through another path, such as a custom `DOCKER_HOST`, socket ACL, or managed runtime policy.
+NemoClaw can continue when `docker info` works, but the diagnostic explains why a negative Docker-permission test will not reproduce on that host.
+
+Check the Docker access path before relying on the host as a clean permission baseline:
+
+```bash
+id -nG
+echo "${DOCKER_HOST:-}"
+docker info
+```
+
 ### macOS first-run failures
 
 The two most common first-run failures on macOS are missing developer tools and Docker connection errors.
@@ -150,6 +164,21 @@ docker run --rm busybox nslookup example.com
 ```
 
 When the lookup returns an answer, retry onboarding.
+
+### Host DNS resolution is blocked before provider validation
+
+NemoClaw also checks that the host process can resolve the provider host before it starts NVIDIA provider validation.
+A firewall rule that blocks host DNS traffic on port `53` can make later validation fail with `curl: (6) Could not resolve host: integrate.api.nvidia.com` even when container DNS probes look healthy.
+Current onboarding stops earlier with a host DNS diagnostic and remediation hints.
+
+Verify host DNS outside NemoClaw:
+
+```bash
+node -e 'require("node:dns").resolve4("integrate.api.nvidia.com", (err, addrs) => { if (err) { console.error(err); process.exit(1); } console.log(addrs.join(",")); })'
+```
+
+Fix the host firewall, VPN, or DNS policy so the host can resolve the provider endpoint, then rerun onboarding.
+If you intentionally use a non-NVIDIA provider and need to bypass only this preflight, set `NEMOCLAW_SKIP_HOST_DNS_PREFLIGHT=1`.
 
 ### Port already in use
 
@@ -530,6 +559,8 @@ Follow these steps to reconnect.
    ```
 
    Wait a few seconds, then re-check with `openshell sandbox list`.
+   On Docker-driver hosts, NemoClaw also looks for OpenShell-labeled sandbox containers when the gateway is healthy but reports the sandbox as missing.
+   It can start a stopped labeled container, or restore the latest GPU-backup sibling container name and start it.
 
 1. Reconnect.
 
@@ -555,9 +586,10 @@ Follow these steps to reconnect.
 
 **If the sandbox does not recover:**
 
-If the sandbox remains missing after restarting the gateway, run `nemoclaw onboard` to recreate it.
-The wizard prompts for confirmation before destroying an existing sandbox. If you confirm, it **destroys and recreates** the sandbox. Workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
-Back up your workspace first by following the instructions at Back Up and Restore (use the `nemoclaw-user-manage-sandboxes` skill).
+If the sandbox remains missing after restarting the gateway, run `nemoclaw <name> rebuild --yes` while the local registry entry still exists.
+The rebuild path uses the recorded sandbox metadata and the snapshot flow to preserve supported workspace and agent state.
+If the sandbox was intentionally deleted and you want a clean setup instead, run `nemoclaw <name> destroy` to remove the stale local entry, then run `nemoclaw onboard`.
+Create a snapshot first when the sandbox is reachable enough to back up state. For details, refer to Back Up and Restore (use the `nemoclaw-user-manage-sandboxes` skill).
 
 ### Sandbox is running an outdated agent version
 
@@ -1113,6 +1145,47 @@ CHAT_UI_URL=http://127.0.0.1:19000 nemoclaw onboard
 
 If you need to run multiple sandboxes at different ports at the same time, see
 [Running multiple sandboxes simultaneously](#running-multiple-sandboxes-simultaneously).
+
+### Control UI config endpoint returns 404 or non-JSON
+
+The Control UI loads its runtime configuration from a gateway endpoint, not from a static
+`controlui.bootstrap.config.json` file. No `controlui.bootstrap.config.json` path is served,
+so requesting it returns `HTTP 404 Not Found` with a short plain-text body, and piping that
+response to `jq` fails with a parse error such as `Invalid numeric literal`.
+
+<AgentOnly variant="openclaw">
+
+The supported Control UI config endpoint is `/__openclaw/control-ui-config.json`, served by
+the OpenClaw gateway on the forwarded dashboard port. It is gated by the gateway auth token:
+
+- An unauthenticated request returns `HTTP 401 Unauthorized` with a JSON body
+  (`{"error":{"message":"Unauthorized","type":"unauthorized"}}`), which is already valid JSON.
+- An authenticated request returns `HTTP 200 OK` with the Control UI config as JSON.
+
+Resolve the forwarded dashboard port, then authenticate with the gateway token from
+`nemoclaw <name> gateway-token`:
+
+```bash
+openshell forward list                       # note the dashboard PORT for the sandbox
+export DASH_PORT=<port>
+TOKEN=$(nemoclaw <name> gateway-token --quiet)
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:${DASH_PORT}/__openclaw/control-ui-config.json" | jq empty \
+  && echo "Control UI config is valid JSON"
+```
+
+The token is sensitive; treat it like a password and do not log, share, or commit it. For
+browser access, use the tokenized URL from `nemoclaw <name> dashboard-url` instead of
+calling the config endpoint directly.
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+Hermes manages its own dashboard sessions and does not expose an OpenClaw gateway auth token
+or a `/__openclaw/control-ui-config.json` endpoint. Use `nemohermes <name> status` to see the
+dashboard and API endpoints for a Hermes sandbox.
+
+</AgentOnly>
 
 ### Ollama auth proxy did not start
 

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -15,6 +15,15 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.63
+
+NemoClaw v0.0.63 improves sandbox recovery, OpenClaw configuration restore safety, local inference onboarding, messaging safeguards, and release validation:
+
+- Sandbox lifecycle commands preserve and recover more state. `rebuild --yes` can recreate a locally registered sandbox that is missing from a healthy gateway, Docker-driver sandboxes can restart from OpenShell container labels after a host reboot, and `upgrade-sandboxes` detects recorded NemoClaw image drift even when the agent version itself matches. For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle).
+- Snapshot-backed rebuilds preserve OpenClaw configuration more safely. Rebuilds now carry forward user-owned `openclaw.json` settings, merge restored config with freshly generated runtime state, and fail when restored config cannot be applied safely. For more information, refer to [Backup and Restore](../manage-sandboxes/backup-restore).
+- Onboarding diagnoses host setup and local inference issues earlier. The installer reports unusual Docker daemon access when a Linux user is outside the `docker` group, host DNS blocks are caught before NVIDIA provider validation, Ollama auth-proxy port conflicts recover during startup, and managed vLLM offers an interactive model picker for supported host profiles. For more information, refer to [Use a Local Inference Server](../inference/use-local-inference).
+- Messaging and Hermes startup paths enforce clearer runtime boundaries. Slack setup validates Socket Mode credentials and warns or blocks duplicate Slack Socket Mode sandboxes on a shared gateway, while Hermes direct gateway launch keeps environment-secret protections active and handles wrapped gateway arguments. For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels).
+
 ## v0.0.62
 
 NemoClaw v0.0.62 improves onboarding reliability for GPU sandboxes, local inference, gateway pairing, Hermes configuration, and release validation:

--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -307,6 +307,8 @@ If vLLM is already running, NemoClaw detects the running model and validates the
 When vLLM exposes runtime metadata such as `max_model_len`, NemoClaw uses that value for the `contextWindow` baked into `openclaw.json` unless you set `NEMOCLAW_CONTEXT_WINDOW` yourself.
 If vLLM is not running and your host matches a DGX Spark or DGX Station managed profile, NemoClaw shows the **Install vLLM** or **Start vLLM** entry by default.
 Generic Linux NVIDIA GPU hosts still require `NEMOCLAW_EXPERIMENTAL=1` or `NEMOCLAW_PROVIDER=install-vllm` before the managed entry appears.
+In interactive runs, the managed vLLM path lists the supported registry models for your host profile before it pulls weights.
+Press **Enter** to use the default model, or choose a numbered entry to serve another validated model with its matching `vllm serve` flags.
 NemoClaw pulls the vLLM image, downloads model weights into `~/.cache/huggingface`, starts the `nemoclaw-vllm` container on `localhost:8000`, streams Hugging Face download progress, and polls `/v1/models` until the model is ready.
 Managed DGX Spark and DGX Station profiles use the stable NGC `nvcr.io/nvidia/vllm:26.05.post1-py3` container image.
 If Docker pull output stops making progress, a watchdog stops the stalled pull instead of failing slow but active downloads on a fixed wall-clock timeout.
@@ -338,6 +340,7 @@ NEMOCLAW_PROVIDER=vllm \
 
 Install or start managed vLLM when NemoClaw detects a supported profile.
 On DGX Spark and DGX Station, `NEMOCLAW_PROVIDER=install-vllm` is enough for non-interactive runs; add `NEMOCLAW_EXPERIMENTAL=1` on generic Linux NVIDIA GPU hosts.
+Non-interactive runs use the profile default unless you set `NEMOCLAW_VLLM_MODEL`.
 
 ```bash
 NEMOCLAW_PROVIDER=install-vllm \
@@ -349,8 +352,8 @@ Start vLLM with the model you want before onboarding if you manage the server yo
 
 ### Override the Managed-vLLM Model
 
-Managed vLLM serves the profile default unless you select a different registry entry.
-Export `NEMOCLAW_VLLM_MODEL=<slug>` before invoking the installer to choose a different model from the registry.
+Managed vLLM serves the profile default unless you choose a different registry entry in the interactive picker or set an override for automation.
+Export `NEMOCLAW_VLLM_MODEL=<slug>` before invoking the installer to choose a different model without prompting.
 NemoClaw uses the matching `vllm serve` flags, including the reasoning parser, tool-call parser, and `--max-model-len`.
 Recognized slugs are:
 

--- a/docs/inference/use-local-inference.mdx
+++ b/docs/inference/use-local-inference.mdx
@@ -208,6 +208,9 @@ For the full compatible-endpoint prompt flow, non-interactive variables, API-pat
 
 NemoClaw can use an already-running vLLM server on `localhost:8000`, start managed vLLM on supported NVIDIA GPU hosts, or manage a local NIM container when `NEMOCLAW_EXPERIMENTAL=1` is set.
 Managed vLLM records the model returned by `/v1/models` and uses runtime metadata such as `max_model_len` when available.
+In interactive managed vLLM setup, the wizard lists validated model choices for your host profile before it pulls weights.
+Press **Enter** to accept the profile default, or choose a numbered model from the list.
+For scripted runs, set `NEMOCLAW_VLLM_MODEL=<slug>` to choose a registry model without prompting.
 If the host reboots and the `nemoclaw-vllm` container is stopped, NemoClaw restarts the managed vLLM container during recovery instead of requiring a fresh onboarding run.
 NIM uses the same chat-completions API path restriction as vLLM.
 

--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -79,6 +79,9 @@ $$nemoclaw my-assistant snapshot restore before-upgrade --to my-assistant-clone 
 The `$$nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
 Snapshot restore performs a targeted repair for legacy `.openclaw-data` symlinks that older images created.
 NemoClaw rejects unsafe symlinks and hard links inside sandbox state during backup creation before they can enter a snapshot.
+Snapshots also preserve user-owned `openclaw.json` settings.
+During rebuild or restore, NemoClaw merges those restored settings with the freshly generated runtime config so current provider placeholders, messaging enablement, and gateway state win over stale snapshot values.
+If the restored config cannot be parsed or applied safely, NemoClaw stops the restore instead of replacing the generated config with an unsafe fallback.
 
 </AgentOnly>
 <AgentOnly variant="hermes">

--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -222,7 +222,7 @@ The standard installer follows the admin-promoted `lkg` release tag by default.
 If you need a specific release, set `NEMOCLAW_INSTALL_TAG` on the `bash` side of the install pipeline.
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=v0.0.56 bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_INSTALL_TAG=v0.0.63 bash
 $$nemoclaw upgrade-sandboxes --check
 ```
 
@@ -236,6 +236,8 @@ $$nemoclaw upgrade-sandboxes --check
 ```
 
 Each rebuild destroys the old container and creates a new one, while preserving the manifest-defined workspace or agent state that NemoClaw knows how to snapshot.
+`upgrade-sandboxes --check` can report a sandbox as stale because the running agent version is behind, because the managed NemoClaw image fingerprint differs from the current CLI, or both.
+Custom-image sandboxes created with `--from <Dockerfile>` are not marked stale solely by image fingerprint, so an upgrade check does not accidentally replace them with the default image.
 Runtime changes outside those state paths, such as packages installed manually in the running container, are not preserved.
 For the full state-preservation contract, snapshot restore behavior, and manual backup workflow, refer to [Backup and Restore](backup-restore).
 For command flags, refer to [`$$nemoclaw update`](../reference/commands#$$nemoclaw-update), [`$$nemoclaw upgrade-sandboxes`](../reference/commands#$$nemoclaw-upgrade-sandboxes), and [`$$nemoclaw <name> rebuild`](../reference/commands#$$nemoclaw-name-rebuild).

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -90,6 +90,9 @@ When both Slack allowlists are set, NemoClaw requires the mention to come from o
 Channel messages still require an explicit bot mention.
 When a Slack channel `@mention` is denied by these allowlists, NemoClaw sends a denial notice back to the sender instead of dropping the message silently.
 During sandbox startup, NemoClaw normalizes OpenShell credential placeholders into the environment shape expected by the Slack runtime, so post-rebuild Slack starts use the gateway-managed tokens instead of literal placeholder strings.
+Slack Socket Mode allows one active connection per app-level token.
+If another sandbox on the same gateway already uses the same Slack app token, onboarding and `channels add slack` warn before continuing in interactive mode and abort in non-interactive mode.
+Use `--force` only when you intentionally want to move the Slack Socket Mode session to the new sandbox.
 
 WeChat (experimental) delivers messages over Tencent's iLink gateway through the upstream `@tencent-weixin/openclaw-weixin` plugin installed into WeChat-enabled OpenClaw sandbox images and the built-in Hermes iLink WeChat adapter.
 The supported mode in this release is **personal WeChat** (`bot_type=3`).
@@ -298,6 +301,7 @@ For example, two Telegram sandboxes can DM the same `TELEGRAM_ALLOWED_IDS` accou
 For WeChat, each sandbox must own a distinct iLink `accountId` (bot identity).
 Running two sandboxes against the same WeChat account causes one of them to lose messages.
 If you enable a messaging channel and another sandbox already uses the same token, onboarding prompts you to confirm before continuing in interactive mode and exits non-zero in non-interactive mode.
+For Slack, NemoClaw checks both the bot token and the Socket Mode app token so duplicate Socket Mode sessions do not compete silently.
 If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning.
 Re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
 `$$nemoclaw status` reports cross-sandbox overlaps so you can resolve duplicates before messages start dropping.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1086,6 +1086,10 @@ When the command is running from a source checkout, it reports that state and do
 Rebuild sandboxes whose base image is older than the one currently pinned by NemoClaw.
 NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` from the registry, then compares it against the digest each sandbox was created with.
 Sandboxes that match the current digest are left alone.
+NemoClaw also checks the build fingerprint recorded on each managed sandbox image.
+A sandbox needs upgrade when its agent version is stale, when its recorded NemoClaw image fingerprint differs from the running CLI, or both.
+Custom-image sandboxes created with `--from <Dockerfile>` are not classified by image drift because rebuilding them onto the default image would drop the custom image.
+Legacy sandboxes without a recorded fingerprint opt into this check after their next rebuild.
 
 ```bash
 nemohermes upgrade-sandboxes [--check] [--auto] [--yes|-y]

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1088,7 +1088,7 @@ NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` fr
 Sandboxes that match the current digest are left alone.
 NemoClaw also checks the build fingerprint recorded on each managed sandbox image.
 A sandbox needs upgrade when its agent version is stale, when its recorded NemoClaw image fingerprint differs from the running CLI, or both.
-Custom-image sandboxes created with `--from <Dockerfile>` are not classified by image drift because rebuilding them onto the default image would drop the custom image.
+Custom Dockerfile sandboxes are not classified by image drift because rebuilding them onto the default image would drop the custom image.
 Legacy sandboxes without a recorded fingerprint opt into this check after their next rebuild.
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1314,7 +1314,7 @@ NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` fr
 Sandboxes that match the current digest are left alone.
 NemoClaw also checks the build fingerprint recorded on each managed sandbox image.
 A sandbox needs upgrade when its agent version is stale, when its recorded NemoClaw image fingerprint differs from the running CLI, or both.
-Custom-image sandboxes created with `--from <Dockerfile>` are not classified by image drift because rebuilding them onto the default image would drop the custom image.
+Custom Dockerfile sandboxes are not classified by image drift because rebuilding them onto the default image would drop the custom image.
 Legacy sandboxes without a recorded fingerprint opt into this check after their next rebuild.
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1312,6 +1312,10 @@ When the command is running from a source checkout, it reports that state and do
 Rebuild sandboxes whose base image is older than the one currently pinned by NemoClaw.
 NemoClaw resolves the digest of `ghcr.io/nvidia/nemoclaw/sandbox-base:latest` from the registry, then compares it against the digest each sandbox was created with.
 Sandboxes that match the current digest are left alone.
+NemoClaw also checks the build fingerprint recorded on each managed sandbox image.
+A sandbox needs upgrade when its agent version is stale, when its recorded NemoClaw image fingerprint differs from the running CLI, or both.
+Custom-image sandboxes created with `--from <Dockerfile>` are not classified by image drift because rebuilding them onto the default image would drop the custom image.
+Legacy sandboxes without a recorded fingerprint opt into this check after their next rebuild.
 
 ```bash
 $$nemoclaw upgrade-sandboxes [--check] [--auto] [--yes|-y]

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -102,6 +102,20 @@ newgrp docker
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
+### Installer reports Docker access outside the docker group
+
+On Linux, the installer may report that Docker is reachable even though your user is not in the `docker` group.
+This means the host grants Docker daemon access through another path, such as a custom `DOCKER_HOST`, socket ACL, or managed runtime policy.
+NemoClaw can continue when `docker info` works, but the diagnostic explains why a negative Docker-permission test will not reproduce on that host.
+
+Check the Docker access path before relying on the host as a clean permission baseline:
+
+```bash
+id -nG
+echo "${DOCKER_HOST:-}"
+docker info
+```
+
 ### macOS first-run failures
 
 The two most common first-run failures on macOS are missing developer tools and Docker connection errors.
@@ -164,6 +178,21 @@ docker run --rm busybox nslookup example.com
 ```
 
 When the lookup returns an answer, retry onboarding.
+
+### Host DNS resolution is blocked before provider validation
+
+NemoClaw also checks that the host process can resolve the provider host before it starts NVIDIA provider validation.
+A firewall rule that blocks host DNS traffic on port `53` can make later validation fail with `curl: (6) Could not resolve host: integrate.api.nvidia.com` even when container DNS probes look healthy.
+Current onboarding stops earlier with a host DNS diagnostic and remediation hints.
+
+Verify host DNS outside NemoClaw:
+
+```bash
+node -e 'require("node:dns").resolve4("integrate.api.nvidia.com", (err, addrs) => { if (err) { console.error(err); process.exit(1); } console.log(addrs.join(",")); })'
+```
+
+Fix the host firewall, VPN, or DNS policy so the host can resolve the provider endpoint, then rerun onboarding.
+If you intentionally use a non-NVIDIA provider and need to bypass only this preflight, set `NEMOCLAW_SKIP_HOST_DNS_PREFLIGHT=1`.
 
 ### Port already in use
 
@@ -544,6 +573,8 @@ Follow these steps to reconnect.
    ```
 
    Wait a few seconds, then re-check with `openshell sandbox list`.
+   On Docker-driver hosts, NemoClaw also looks for OpenShell-labeled sandbox containers when the gateway is healthy but reports the sandbox as missing.
+   It can start a stopped labeled container, or restore the latest GPU-backup sibling container name and start it.
 
 1. Reconnect.
 
@@ -569,9 +600,10 @@ Follow these steps to reconnect.
 
 <Warning title="If the sandbox does not recover">
 
-If the sandbox remains missing after restarting the gateway, run `$$nemoclaw onboard` to recreate it.
-The wizard prompts for confirmation before destroying an existing sandbox. If you confirm, it **destroys and recreates** the sandbox. Workspace files (SOUL.md, USER.md, IDENTITY.md, AGENTS.md, MEMORY.md, and daily memory notes) are lost.
-Back up your workspace first by following the instructions at [Back Up and Restore](../manage-sandboxes/backup-restore).
+If the sandbox remains missing after restarting the gateway, run `$$nemoclaw <name> rebuild --yes` while the local registry entry still exists.
+The rebuild path uses the recorded sandbox metadata and the snapshot flow to preserve supported workspace and agent state.
+If the sandbox was intentionally deleted and you want a clean setup instead, run `$$nemoclaw <name> destroy` to remove the stale local entry, then run `$$nemoclaw onboard`.
+Create a snapshot first when the sandbox is reachable enough to back up state. For details, refer to [Back Up and Restore](../manage-sandboxes/backup-restore).
 </Warning>
 
 ### Sandbox is running an outdated agent version


### PR DESCRIPTION
## Summary
- Add the v0.0.63 release-note section using the published development note as source context.
- Update source docs for sandbox recovery, OpenClaw config restore safety, managed vLLM selection, Slack Socket Mode conflict handling, and host diagnostics.
- Refresh generated `nemoclaw-user-*` skills from the updated Fern MDX docs.
- Update the release-doc refresh skill so post-release docs for version `n` look up the matching announcement discussion and use the `n+1` patch release label.
- Fix CLI/docs parity by avoiding a `--from <Dockerfile>` flag mention inside the `upgrade-sandboxes` command section.

## Source summary
- #5034 -> `docs/reference/troubleshooting.mdx`, `docs/about/release-notes.mdx`: Document safer stale-sandbox recovery through `rebuild --yes` before recreating from scratch.
- #5091 -> `docs/reference/troubleshooting.mdx`, `docs/about/release-notes.mdx`: Document Docker-driver post-reboot recovery from OpenShell container labels.
- #5101, #5174, #5177 -> `docs/manage-sandboxes/backup-restore.mdx`, `docs/about/release-notes.mdx`: Document OpenClaw `openclaw.json` preservation, merge behavior, and fail-safe restore handling.
- #5102 -> `docs/reference/commands.mdx`, `docs/reference/commands-nemohermes.mdx`, `docs/manage-sandboxes/lifecycle.mdx`, `docs/about/release-notes.mdx`: Document `upgrade-sandboxes` image-fingerprint drift detection.
- #4201 -> `docs/reference/troubleshooting.mdx`, `docs/about/release-notes.mdx`: Document the installer diagnostic for unexpected Docker daemon access outside the `docker` group.
- #5038 -> `docs/inference/inference-options.mdx`, `docs/inference/use-local-inference.mdx`, `docs/about/release-notes.mdx`: Document the interactive managed-vLLM model picker and non-interactive override behavior.
- #5040, #5041 -> `docs/reference/troubleshooting.mdx`, `docs/about/release-notes.mdx`: Document Ollama auth-proxy recovery and host DNS preflight diagnostics.
- #4986, #5039 -> `docs/manage-sandboxes/messaging-channels.mdx`, `docs/about/release-notes.mdx`: Document Slack validation and duplicate Slack Socket Mode sandbox handling.
- #4981, #5168 -> `docs/about/release-notes.mdx`: Capture Hermes gateway secret-guard and wrapped-argv startup hardening in the release surface.
- Follow-up -> `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`: Record the post-release docs workflow, discussion-announcement lookup, and next-patch release label rule.
- Follow-up -> `docs/reference/commands.mdx`, `docs/reference/commands-nemohermes.mdx`: Reword custom Dockerfile sandbox text so CLI parity does not treat `--from` as an `upgrade-sandboxes` flag.

## Verification
- `python3 scripts/docs-to-skills.py docs/ .agents/skills/ --prefix nemoclaw-user --doc-platform fern-mdx`
- `npm run docs`
- `npm run build:cli`
- `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli`
- Skip-term scan for `docs/.docs-skip` blocked terms across generated user skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local inference setup with interactive model selection prompts and environment variable overrides
  * Improved sandbox upgrade detection using build fingerprints and version checks
  * Clarified configuration restore behavior preserving user settings during rebuild/restore
  * Added gateway authentication as fifth security layer
  * Expanded Slack messaging validation with live credential checking
  * Enhanced troubleshooting guidance for Docker access, DNS issues, and sandbox recovery
  * Updated release notes for v0.0.63 featuring sandbox recovery and inference improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->