### PR TITLE
fix(ci): bucket cancelled jobs in Selective E2E Results comment

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -2486,13 +2486,21 @@ jobs:
             const passed = ran.filter(([, v]) => v.result === 'success');
             const failed = ran.filter(([, v]) => v.result === 'failure');
             const skipped = reportedEntries.filter(([, v]) => v.result === 'skipped');
+            // Cancelled jobs (e.g. cancel-in-progress superseding an older run)
+            // are neither success, failure, nor skipped. Without a bucket for
+            // them they slipped through the status tally and the comment fell
+            // through to the default "✅ All requested jobs passed" — masking
+            // the fact that the run produced no signal at all.
+            const cancelled = ran.filter(([, v]) => v.result === 'cancelled');
 
             const status =
               failed.length > 0 || missingRequested.length > 0
                 ? '❌ Some jobs failed'
-                : skipped.length > 0 && passed.length === 0
-                  ? '⚠️ No requested jobs ran'
-                  : '✅ All requested jobs passed';
+                : cancelled.length > 0 && passed.length === 0
+                  ? '⚠️ Run cancelled — no signal'
+                  : skipped.length > 0 && passed.length === 0
+                    ? '⚠️ No requested jobs ran'
+                    : '✅ All requested jobs passed';
 
             const body = [
               `### Selective E2E Results — ${status}`,
@@ -2501,7 +2509,7 @@ jobs:
               `**Target ref:** \`${displayRef}\``,
               targetRef ? `**Workflow ref:** \`${workflowBranch}\`` : undefined,
               requestedJobs ? `**Requested jobs:** \`${requestedJobs}\`` : '**Requested jobs:** all (no filter)',
-              `**Summary:** ${passed.length} passed, ${failed.length} failed, ${skipped.length} skipped`,
+              `**Summary:** ${passed.length} passed, ${failed.length} failed, ${cancelled.length} cancelled, ${skipped.length} skipped`,
               '',
               '| Job | Result |',
               '|-----|--------|',


### PR DESCRIPTION
## Summary

The "Selective E2E Results" comment posted by `.github/workflows/nightly-e2e.yaml` bucketed job results into `passed` / `failed` / `skipped` but never accounted for `cancelled`. A job ending in `cancelled` (e.g. when `cancel-in-progress` kills a stale run) slipped past all three tallies and fell through to the default `"✅ All requested jobs passed"` status, with the summary line reading `"0 passed, 0 failed, 0 skipped"` — masking that the run produced no signal at all.

## Repro (in the wild)

PR #5085 commit `026802ba8`:

```text
### Selective E2E Results — ✅ All requested jobs passed
Run: 27305033204
Requested jobs: agent-turn-latency-e2e,cloud-inference-e2e
Summary: 0 passed, 0 failed, 0 skipped

| Job                    | Result        |
|------------------------|---------------|
| agent-turn-latency-e2e | ⚠️ cancelled |
| cloud-inference-e2e    | ⚠️ cancelled |
```

Both requested jobs were cancelled (cancel-in-progress superseding the older run) yet the headline read green. Same pattern earlier on #4610.

## Root

`.github/workflows/nightly-e2e.yaml:2486-2495` (pre-fix):

```js
const passed  = ran.filter(([, v]) => v.result === 'success');
const failed  = ran.filter(([, v]) => v.result === 'failure');
const skipped = reportedEntries.filter(([, v]) => v.result === 'skipped');

const status =
  failed.length > 0 || missingRequested.length > 0 ? '❌ Some jobs failed'
  : skipped.length > 0 && passed.length === 0    ? '⚠️ No requested jobs ran'
  :                                                  '✅ All requested jobs passed';
```

A `cancelled` job is `!== 'success'`, `!== 'failure'`, `!== 'skipped'` — falls through to the default.

## Changes

- Add a `cancelled` bucket derived from `ran` the same way the others are.
- Insert a status branch between the failure case and the no-ran case: when cancelled jobs are present and nothing passed, surface `⚠️ Run cancelled — no signal` instead of falsely claiming success.
- Include cancelled count in the summary line so the bucket is visible even when the other states are zero.

Successful, failed, and skipped runs continue to render exactly as before — only the cancelled case changes from "false green" to "honest yellow."

cc @jyaunches (flagged this earlier in slack)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved nightly e2e test reporting in PR comments to better distinguish cancelled jobs from other outcomes. PR comments now display cancelled job counts and provide clearer status messaging when test runs are cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->