### PR TITLE
docs: fix QA-reported command drift

### DIFF
--- a/docs/.docs-skip
+++ b/docs/.docs-skip
@@ -29,20 +29,9 @@
 
 skip-features:
   - "openclaw-sandbox-permissive.yaml"   # permissive policy file, experimental
-  - "shields and config commands"        # experimental sandbox-mgmt commands (#1976), not advertised
-  - "src/lib/shields.ts"                 # shields implementation, experimental
-  - "src/lib/shields-timer.ts"           # shields auto-restore timer, experimental
-  - "src/lib/shields-audit.ts"           # shields audit trail, experimental
-  - "src/lib/sandbox-config.ts"          # config get, experimental
-  - "test/shields"                       # shields tests, experimental
-  - "test/e2e/test-shields-config.sh"    # shields/config E2E, experimental
-  - "shields-status"                     # plugin shields-status command, experimental
   - "config-show"                        # plugin config-show command, experimental
 
 skip-terms:
   - "permissive mode"                    # do not reference this concept in docs
-  - "shields down"                       # experimental shields command, not advertised
-  - "shields up"                         # experimental shields command, not advertised
-  - "shields status"                     # experimental shields command, not advertised
   - "config rotate-token"                # experimental config command, not advertised
   - "rotate-token"                       # experimental config command, not advertised

--- a/docs/deployment/deploy-to-remote-gpu.mdx
+++ b/docs/deployment/deploy-to-remote-gpu.mdx
@@ -16,19 +16,56 @@ The preferred path is to provision the VM, run the standard NemoClaw installer o
 
 ## Prerequisites
 
-- The [Brev CLI](https://brev.nvidia.com) installed and authenticated.
+- Access to a remote GPU VM that can run Docker and the NVIDIA Container Toolkit.
+- The [Brev CLI](https://brev.nvidia.com) installed and authenticated if you provision the VM with Brev.
 - A provider credential for the inference backend you want to use during onboarding.
 - `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` exported when your remote vLLM or Hugging Face workflow needs access to gated models.
 - NemoClaw installed locally if you plan to use the deprecated `nemoclaw deploy` wrapper. Otherwise, install NemoClaw directly on the remote host after provisioning it.
 
-## Deploy the Instance
+## Preferred Deployment Path
+
+Provision the remote GPU VM first, then run the normal installer and onboard flow on that VM.
+For Brev, `<instance-name>` is the instance name and SSH alias created by the Brev CLI.
+For another cloud provider, replace the provisioning and SSH commands with that provider's console or CLI workflow.
+
+```bash
+# On your local machine
+brev create <instance-name> --gpu <gpu-type>
+brev ssh <instance-name>
+```
+
+If `brev` is missing or unauthenticated, install or log in to the Brev CLI first, or provision the VM through your cloud console and connect with `ssh <user>@<host>`.
+
+Run the installer on the remote VM:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+Set any remote-only environment variables on the VM before onboarding.
+For example, set the browser origin if you will open the dashboard through a Brev public URL, and raise the first-run readiness budget on cold cloud hosts:
+
+```bash
+export CHAT_UI_URL="https://openclaw0-<id>.brevlab.com"
+export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
+nemoclaw onboard
+```
+
+After successful onboarding, you should see output that reports a ready sandbox and the next command to connect:
+
+```text
+✓ Sandbox '<name>' is ready
+Next: nemoclaw <name> connect
+```
+
+## Legacy Brev Compatibility
 
 <Warning>
 The `nemoclaw deploy` command is deprecated.
 Prefer provisioning the remote host separately, then running the standard NemoClaw installer and `nemoclaw onboard` on that host.
 </Warning>
 
-Create a Brev instance and run the legacy compatibility flow:
+Use the legacy compatibility wrapper only when you need the older Brev-specific bootstrap flow:
 
 ```bash
 nemoclaw deploy <instance-name>
@@ -51,38 +88,40 @@ If you export `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN`, the wrapper forwards those
 
 ## Connect to the Remote Sandbox
 
-After deployment finishes, the deploy command opens an interactive shell inside the remote sandbox.
-To reconnect after closing the session, run the command again:
+After onboarding finishes, run the host CLI on the remote VM:
 
 ```bash
-nemoclaw deploy <instance-name>
+nemoclaw <name> connect
 ```
+
+If you used the deprecated Brev compatibility wrapper, the wrapper opens an interactive shell inside the remote sandbox.
+To reconnect through that legacy flow, run `nemoclaw deploy <instance-name>` again.
 
 ## Monitor the Remote Sandbox
 
-SSH to the instance and run the OpenShell TUI to monitor activity and approve network requests:
+SSH to the instance and run the OpenShell TUI on the remote VM to monitor activity and approve network requests:
 
 ```bash
-ssh <instance-name> 'cd ~/nemoclaw && set -a && . .env && set +a && openshell term'
+ssh <instance-name> 'openshell term'
 ```
 
 ## Verify Inference
 
-Run a test agent prompt inside the remote sandbox:
+Run a test agent prompt from the remote VM host:
 
 ```bash
-openclaw agent --agent main -m "Hello from the remote sandbox" --session-id test
+nemoclaw <name> exec -- openclaw agent --agent main -m "Hello from the remote sandbox" --session-id test
 ```
 
 ## Remote Dashboard Access
 
 The NemoClaw dashboard validates the browser origin against an allowlist baked into the sandbox image at build time.
 By default, the allowlist only contains `http://127.0.0.1:18789`.
-When you access the dashboard from a remote browser, for example through a Brev public URL or an SSH port-forward, set `CHAT_UI_URL` to the origin the browser uses before running setup:
+When you access the dashboard from a remote browser, for example through a Brev public URL or an SSH port-forward, set `CHAT_UI_URL` to the origin the browser uses before running `nemoclaw onboard` on the remote VM:
 
 ```bash
 export CHAT_UI_URL="https://openclaw0-<id>.brevlab.com"
-nemoclaw deploy <instance-name>
+nemoclaw onboard
 ```
 
 For SSH port-forwarding, the origin is typically the default `http://127.0.0.1:18789`, so you do not need extra configuration.
@@ -134,9 +173,11 @@ Changing the proxy after onboarding requires re-running `nemoclaw onboard`.
 
 ## GPU Configuration
 
-The deploy script uses the `NEMOCLAW_GPU` environment variable to select the GPU type.
+The deprecated Brev compatibility wrapper uses the `NEMOCLAW_GPU` environment variable to select the GPU type.
 The default value is `a2-highgpu-1g:nvidia-tesla-a100:1`.
-Set this variable before running `nemoclaw deploy` to use a different GPU configuration:
+That value is specific to GCP-backed Brev instances.
+Other Brev providers or cloud consoles use different GPU type strings.
+Set this variable before running the deprecated wrapper to use a different GPU configuration:
 
 ```bash
 export NEMOCLAW_GPU="a2-highgpu-1g:nvidia-tesla-a100:2"

--- a/docs/inference/set-up-sub-agent.mdx
+++ b/docs/inference/set-up-sub-agent.mdx
@@ -24,7 +24,7 @@ When adapting an OpenClaw sub-agent setup, use these paths inside the sandbox:
 | Path | Purpose |
 |---|---|
 | `/sandbox/.openclaw/openclaw.json` | OpenClaw config, including `models.providers`, `agents.defaults`, and `agents.list`. |
-| `/sandbox/.openclaw/.config-hash` | Hash for `openclaw.json`. Keep it in sync after manual config edits; it becomes a startup-enforced trust anchor only after the file is root-owned and read-only. |
+| `/sandbox/.openclaw/.config-hash` | Hash for `openclaw.json`. Keep it in sync after manual config edits so OpenClaw can detect the updated config. |
 | `/sandbox/.openclaw/agents/<agent-id>/agent/auth-profiles.json` | Per-agent provider credentials. Use this when a sub-agent calls an auxiliary provider directly. |
 | `/sandbox/.openclaw/workspace/` | Writable shared workspace path for files the primary agent passes to the sub-agent. |
 | `/tmp/gateway.log` | OpenClaw gateway log. Use it to confirm config reloads and diagnose sub-agent failures. |
@@ -52,26 +52,30 @@ The primary orchestration model remains responsible for conversation, planning, 
 ## Update the Sandbox Config
 
 Fetch the current OpenClaw config from the sandbox, patch it with your auxiliary provider and `agents.list` changes, then upload it back.
+On Docker-driver sandboxes, run these commands from the host that owns the sandbox containers.
+The container name includes a runtime suffix, so discover it from the OpenShell sandbox label:
 
 ```bash
 export SANDBOX=my-assistant
-export DOCKER_CTR=openshell-cluster-nemoclaw
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- cat /sandbox/.openclaw/openclaw.json > /tmp/openclaw.json
+export SANDBOX_CTR=$(docker ps --filter "label=openshell.ai/sandbox-name=$SANDBOX" --format "{{.Names}}" | sed -n '1p')
+docker exec --user root "$SANDBOX_CTR" cat /sandbox/.openclaw/openclaw.json > /tmp/openclaw.json
 ```
 
 Create `/tmp/openclaw.updated.json` with the OpenClaw sub-agent config.
 For the Omni example, the demo provides `vlm-demo/vlm-subagent/openclaw-patch.py`.
 
 Upload the patched config and refresh the hash.
-In the default mutable state, this keeps the local hash consistent but does not make it tamper-proof; lock the config root-owned and read-only afterward if the sandbox should enforce config integrity at startup.
+In the default mutable state, this keeps the local hash consistent but does not make it tamper-proof.
+Use NemoClaw runtime controls when the sandbox needs a hardened config posture after the manual edit.
 
 ```bash
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 644 /sandbox/.openclaw/openclaw.json
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 644 /sandbox/.openclaw/.config-hash
-cat /tmp/openclaw.updated.json | docker exec -i "$DOCKER_CTR" kubectl exec -i -n openshell "$SANDBOX" -c agent -- sh -c 'cat > /sandbox/.openclaw/openclaw.json'
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- /bin/bash -c "cd /sandbox/.openclaw && sha256sum openclaw.json > .config-hash"
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 444 /sandbox/.openclaw/openclaw.json
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chmod 444 /sandbox/.openclaw/.config-hash
+docker exec --user root "$SANDBOX_CTR" chmod 644 /sandbox/.openclaw/openclaw.json
+docker exec --user root "$SANDBOX_CTR" chmod 644 /sandbox/.openclaw/.config-hash
+docker exec --user root -i "$SANDBOX_CTR" sh -c 'cat > /sandbox/.openclaw/openclaw.json' < /tmp/openclaw.updated.json
+docker exec --user root "$SANDBOX_CTR" /bin/bash -c "cd /sandbox/.openclaw && sha256sum openclaw.json > .config-hash"
+docker exec --user root "$SANDBOX_CTR" chown sandbox:sandbox /sandbox/.openclaw/openclaw.json /sandbox/.openclaw/.config-hash
+docker exec --user root "$SANDBOX_CTR" chmod 444 /sandbox/.openclaw/openclaw.json
+docker exec --user root "$SANDBOX_CTR" chmod 444 /sandbox/.openclaw/.config-hash
 ```
 
 Check `/tmp/gateway.log` after upload and confirm the gateway hot-reloaded the provider or `agents.list` change.
@@ -89,7 +93,7 @@ Use the same provider ID that appears in `models.providers`, such as `nvidia-omn
 After uploading the auth profile, make sure the sandbox user owns the sub-agent directory:
 
 ```bash
-docker exec "$DOCKER_CTR" kubectl exec -n openshell "$SANDBOX" -c agent -- chown -R sandbox:sandbox /sandbox/.openclaw/agents/vision-operator
+docker exec --user root "$SANDBOX_CTR" chown -R sandbox:sandbox /sandbox/.openclaw/agents/vision-operator
 ```
 
 ## Allow Auxiliary Provider Egress

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -181,16 +181,9 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_NON_INTERACTIVE=1 NEMOC
 
 If the installer cannot prompt for the notice in a terminal and no explicit acceptance is set, it exits before installing Node.js or the NemoClaw CLI.
 
-To enable Brave Search in non-interactive mode, set:
-
-```bash
-BRAVE_API_KEY=... \
-  nemohermes onboard --non-interactive
-```
-
-`BRAVE_API_KEY` enables Brave Search in non-interactive mode and also enables `web_fetch`.
-If Brave Search key validation fails in non-interactive mode, onboarding prints a warning, skips web search setup, and continues with the rest of the sandbox setup.
-After fixing the key, re-enable web search with `nemohermes config web-search`.
+Hermes does not use NemoClaw's OpenClaw Brave Search setup.
+If you authenticate Hermes through Nous Portal OAuth, the wizard can prompt for managed Nous tool gateways such as web search.
+API-key mode is inference-only and does not enable managed tool gateways.
 
 The wizard prompts for a sandbox name.
 Names must be 1 to 63 characters, lowercase, start with a letter, contain only letters, numbers, and internal hyphens, and end with a letter or number.
@@ -425,6 +418,40 @@ The exit code is the remote command's exit code.
 | `--workdir <dir>` | Working directory inside the sandbox |
 | `--tty` / `--no-tty` | Allocate a pseudo-terminal; defaults to auto-detection (on when stdin and stdout are terminals) |
 | `--timeout <seconds>` | Timeout in seconds (`0` means no timeout) |
+
+### `nemohermes <name> config get`
+
+Read the sanitized agent configuration from a sandbox.
+The output removes credential-bearing sections such as the OpenClaw gateway token before printing.
+Use `--key` to read one dotpath and `--format` to choose JSON or YAML output.
+
+```bash
+nemohermes my-assistant config get
+nemohermes my-assistant config get --key model --format yaml
+```
+
+| Flag | Description |
+|------|-------------|
+| `--key <dotpath>` | Print one value from the sanitized config |
+| `--format json|yaml` | Output format. Defaults to JSON |
+
+### `nemohermes <name> shields`
+
+Manage the sandbox config lockdown posture from the host.
+Use `shields status` to inspect the current state, `shields up` to lock the sandbox config and restore the captured restrictive policy, and `shields down` to temporarily unlock the config for maintenance.
+For the full mutability matrix, see [Runtime Controls](../manage-sandboxes/runtime-controls).
+
+```bash
+nemohermes my-assistant shields status
+nemohermes my-assistant shields up
+nemohermes my-assistant shields down --timeout 5m --reason "maintenance"
+```
+
+| Subcommand | Description |
+|------|-------------|
+| `shields status` | Show whether lockdown is configured, active, temporarily unlocked, or in error |
+| `shields up` | Lock the sandbox config and restore the saved restrictive policy |
+| `shields down` | Temporarily unlock the sandbox config. Supports `--timeout`, `--reason`, and `--policy` |
 
 ### `nemohermes <name> recover`
 
@@ -1335,7 +1362,7 @@ nemohermes status --json
 
 When at least one sandbox is registered and the named NemoClaw gateway is unreachable, unhealthy, or attached to a different sandbox, the command prints a `gateway: down [state] (reason)` line between the sandbox list and the host-service list.
 The command classifies the failing layer when possible: the named gateway port is not accepting connections, the named gateway is running but not Connected, the active OpenShell gateway points at a different name, or the named gateway is not configured at all.
-It then suggests `openshell gateway start --name nemoclaw` or `nemohermes onboard --resume` to recover.
+It then suggests `nemohermes onboard --resume` or equivalent managed-gateway recovery guidance.
 It exits with code `1` so shell scripts and CI can detect the degraded state from `$?`.
 For `--json`, the structured output includes `gatewayHealth`, and the exit code is set after the report is generated.
 A clean machine with no registered sandboxes keeps the legacy `0` exit because no gateway is expected to be configured yet.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -419,7 +419,11 @@ The exit code is the remote command's exit code.
 | `--tty` / `--no-tty` | Allocate a pseudo-terminal; defaults to auto-detection (on when stdin and stdout are terminals) |
 | `--timeout <seconds>` | Timeout in seconds (`0` means no timeout) |
 
-### `nemohermes <name> config get`
+### Advanced Sandbox Maintenance Commands
+
+The following commands are available for targeted host-side maintenance, but they are not part of the top-level public command list.
+
+#### `nemohermes <name> config get`
 
 Read the sanitized agent configuration from a sandbox.
 The output removes credential-bearing sections such as the OpenClaw gateway token before printing.
@@ -435,7 +439,7 @@ nemohermes my-assistant config get --key model --format yaml
 | `--key <dotpath>` | Print one value from the sanitized config |
 | `--format json|yaml` | Output format. Defaults to JSON |
 
-### `nemohermes <name> shields`
+#### `nemohermes <name> shields`
 
 Manage the sandbox config lockdown posture from the host.
 Use `shields status` to inspect the current state, `shields up` to lock the sandbox config and restore the captured restrictive policy, and `shields down` to temporarily unlock the config for maintenance.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -517,7 +517,11 @@ The exit code is the remote command's exit code.
 | `--tty` / `--no-tty` | Allocate a pseudo-terminal; defaults to auto-detection (on when stdin and stdout are terminals) |
 | `--timeout <seconds>` | Timeout in seconds (`0` means no timeout) |
 
-### `$$nemoclaw <name> config get`
+### Advanced Sandbox Maintenance Commands
+
+The following commands are available for targeted host-side maintenance, but they are not part of the top-level public command list.
+
+#### `$$nemoclaw <name> config get`
 
 Read the sanitized agent configuration from a sandbox.
 The output removes credential-bearing sections such as the OpenClaw gateway token before printing.
@@ -533,7 +537,7 @@ $$nemoclaw my-assistant config get --key model --format yaml
 | `--key <dotpath>` | Print one value from the sanitized config |
 | `--format json|yaml` | Output format. Defaults to JSON |
 
-### `$$nemoclaw <name> shields`
+#### `$$nemoclaw <name> shields`
 
 Manage the sandbox config lockdown posture from the host.
 Use `shields status` to inspect the current state, `shields up` to lock the sandbox config and restore the captured restrictive policy, and `shields down` to temporarily unlock the config for maintenance.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -233,6 +233,8 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_NON_INTERACTIVE=1 NEMOC
 
 If the installer cannot prompt for the notice in a terminal and no explicit acceptance is set, it exits before installing Node.js or the NemoClaw CLI.
 
+<AgentOnly variant="openclaw">
+
 To enable Brave Search in non-interactive mode, set:
 
 ```bash
@@ -242,7 +244,17 @@ BRAVE_API_KEY=... \
 
 `BRAVE_API_KEY` enables Brave Search in non-interactive mode and also enables `web_fetch`.
 If Brave Search key validation fails in non-interactive mode, onboarding prints a warning, skips web search setup, and continues with the rest of the sandbox setup.
-After fixing the key, re-enable web search with `$$nemoclaw config web-search`.
+After fixing the key, rerun onboarding with `BRAVE_API_KEY` set so NemoClaw can validate the key, register the Brave Search provider, and apply the `brave` policy preset.
+If the sandbox already exists without web search, accept the recreate prompt or pass `--recreate-sandbox`.
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+Hermes does not use NemoClaw's OpenClaw Brave Search setup.
+If you authenticate Hermes through Nous Portal OAuth, the wizard can prompt for managed Nous tool gateways such as web search.
+API-key mode is inference-only and does not enable managed tool gateways.
+
+</AgentOnly>
 
 The wizard prompts for a sandbox name.
 Names must be 1 to 63 characters, lowercase, start with a letter, contain only letters, numbers, and internal hyphens, and end with a letter or number.
@@ -504,6 +516,40 @@ The exit code is the remote command's exit code.
 | `--workdir <dir>` | Working directory inside the sandbox |
 | `--tty` / `--no-tty` | Allocate a pseudo-terminal; defaults to auto-detection (on when stdin and stdout are terminals) |
 | `--timeout <seconds>` | Timeout in seconds (`0` means no timeout) |
+
+### `$$nemoclaw <name> config get`
+
+Read the sanitized agent configuration from a sandbox.
+The output removes credential-bearing sections such as the OpenClaw gateway token before printing.
+Use `--key` to read one dotpath and `--format` to choose JSON or YAML output.
+
+```bash
+$$nemoclaw my-assistant config get
+$$nemoclaw my-assistant config get --key model --format yaml
+```
+
+| Flag | Description |
+|------|-------------|
+| `--key <dotpath>` | Print one value from the sanitized config |
+| `--format json|yaml` | Output format. Defaults to JSON |
+
+### `$$nemoclaw <name> shields`
+
+Manage the sandbox config lockdown posture from the host.
+Use `shields status` to inspect the current state, `shields up` to lock the sandbox config and restore the captured restrictive policy, and `shields down` to temporarily unlock the config for maintenance.
+For the full mutability matrix, see [Runtime Controls](../manage-sandboxes/runtime-controls).
+
+```bash
+$$nemoclaw my-assistant shields status
+$$nemoclaw my-assistant shields up
+$$nemoclaw my-assistant shields down --timeout 5m --reason "maintenance"
+```
+
+| Subcommand | Description |
+|------|-------------|
+| `shields status` | Show whether lockdown is configured, active, temporarily unlocked, or in error |
+| `shields up` | Lock the sandbox config and restore the saved restrictive policy |
+| `shields down` | Temporarily unlock the sandbox config. Supports `--timeout`, `--reason`, and `--policy` |
 
 ### `$$nemoclaw <name> recover`
 
@@ -1570,7 +1616,7 @@ $$nemoclaw status --json
 
 When at least one sandbox is registered and the named NemoClaw gateway is unreachable, unhealthy, or attached to a different sandbox, the command prints a `gateway: down [state] (reason)` line between the sandbox list and the host-service list.
 The command classifies the failing layer when possible: the named gateway port is not accepting connections, the named gateway is running but not Connected, the active OpenShell gateway points at a different name, or the named gateway is not configured at all.
-It then suggests `openshell gateway start --name nemoclaw` or `$$nemoclaw onboard --resume` to recover.
+It then suggests `$$nemoclaw onboard --resume` or equivalent managed-gateway recovery guidance.
 It exits with code `1` so shell scripts and CI can detect the degraded state from `$?`.
 For `--json`, the structured output includes `gatewayHealth`, and the exit code is set after the report is generated.
 A clean machine with no registered sandboxes keeps the legacy `0` exit because no gateway is expected to be configured yet.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -354,10 +354,9 @@ $$nemoclaw onboard
 `$$nemoclaw <name> connect` checks the OpenShell gateway before it tries dashboard forwarding, SSH, or inference repair.
 If the gateway is not reachable, the command exits early and prints recovery guidance.
 
-Start the gateway or resume onboarding, then retry:
+Resume onboarding so NemoClaw recreates or reconnects the managed gateway, then retry:
 
 ```bash
-openshell gateway start --name nemoclaw
 $$nemoclaw onboard --resume
 $$nemoclaw <name> connect
 ```
@@ -535,12 +534,12 @@ Follow these steps to reconnect.
 
    If the sandbox shows `Ready`, skip to step 4.
 
-1. Restart the gateway (if needed).
+1. Recover the managed gateway (if needed).
 
-   If the sandbox is not listed or the command fails, restart the OpenShell gateway:
+   If the sandbox is not listed or the command fails, let NemoClaw recover the managed gateway and sandbox registration:
 
    ```bash
-   openshell gateway start --name nemoclaw
+   $$nemoclaw onboard --resume
    ```
 
    Wait a few seconds, then re-check with `openshell sandbox list`.
@@ -631,11 +630,11 @@ $$nemoclaw <name> rebuild
 
 ### Sandbox creation reports a TLS certificate mismatch
 
-If sandbox creation reports a TLS or certificate mismatch, the OpenShell gateway certificate may have changed since the CLI last trusted it.
-Refresh the gateway trust and then resume onboarding:
+If sandbox creation reports a TLS or certificate mismatch, the OpenShell gateway certificate may have changed since the CLI last registered it.
+Remove the stale local gateway registration and then resume onboarding so NemoClaw refreshes the registration:
 
 ```bash
-openshell gateway trust -g nemoclaw
+openshell gateway remove nemoclaw
 $$nemoclaw onboard --resume
 ```
 


### PR DESCRIPTION
## Summary
Fixes QA-reported documentation drift in the remote GPU deployment, sub-agent setup, command reference, and troubleshooting pages. The updates replace deprecated or removed command paths with the current installer, Docker-driver, and NemoClaw-managed recovery flows.

## Related Issue
Fixes #5084
Fixes #3720
Fixes #3685
Fixes #3686

## Changes
- Reworked the remote GPU deployment page to lead with the preferred installer plus `nemoclaw onboard` flow and scope `nemoclaw deploy` as legacy Brev compatibility.
- Replaced stale `kubectl exec` sub-agent setup examples with Docker-driver sandbox container commands and current config ownership guidance.
- Removed invalid `openshell gateway start`, `openshell gateway trust`, and `config web-search` references from troubleshooting and command references.
- Added `config get` and `shields` command reference coverage for NemoClaw and NemoHermes, and removed stale docs-skip entries that blocked those shipped commands.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes:
- `npm run docs` passed with 0 errors and one pre-existing Fern contrast warning: light-mode accent color contrast ratio is 2.41:1 and should be at least 3:1.
- `npx prek run --all-files` was attempted. Formatting, lint, secrets, markdownlint, docs-to-skills, and staged-file commit hooks passed, but the full all-files run failed in unrelated CLI test timeouts and one signal assertion outside this docs change.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated remote GPU deployment guide with current installer and onboarding workflows
  * Added documentation for advanced sandbox maintenance commands (`config get`, `shields` controls)
  * Revised sub-agent setup instructions for Docker-based sandbox configuration
  * Improved troubleshooting guidance for gateway connectivity and sandbox creation issues
  * Updated documentation skip list to reflect current feature coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->