### PR TITLE
fix: address issue #5254

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -788,6 +788,25 @@ hermes() {
       return 1
       ;;
   esac
+  # NemoClaw#5254: in this Hermes build, a one-shot prompt (-z) starts a NEW
+  # session even when --resume <id> is given, so the turn is never appended to
+  # the resumed session's history. Warn (without blocking) so multi-turn
+  # scripts do not silently fragment across session IDs.
+  _nc_has_resume=""
+  _nc_has_oneshot=""
+  for _nc_arg in "$@"; do
+    case "$_nc_arg" in
+      --resume|--resume=*) _nc_has_resume=1 ;;
+      -z) _nc_has_oneshot=1 ;;
+    esac
+  done
+  if [ -n "$_nc_has_resume" ] && [ -n "$_nc_has_oneshot" ]; then
+    echo "Warning: 'hermes --resume <id> -z ...' starts a NEW session instead of appending to <id>." >&2
+    echo "         The one-shot turn will not be added to the resumed session's history," >&2
+    echo "         and 'hermes sessions list' will show it under a different session ID." >&2
+    echo "         To continue an existing session, run 'hermes --resume <id>' interactively (omit -z)." >&2
+  fi
+  unset _nc_has_resume _nc_has_oneshot _nc_arg
   command hermes "$@"
 }
 # nemoclaw-configure-guard end

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1009,6 +1009,10 @@ nemohermes my-assistant sessions
 nemohermes my-assistant sessions --all-agents --json
 ```
 
+<Note>
+Inside the sandbox, a one-shot Hermes prompt (`hermes --resume <id> -z "..."`) starts a **new** session in this build instead of appending the turn to `<id>`; the follow-up shows up under a different session ID in `hermes sessions list`. To continue an existing session, run `hermes --resume <id>` interactively (omit `-z`). The in-sandbox shell prints this warning when it detects the `--resume … -z` combination.
+</Note>
+
 ### `nemohermes <name> sessions list`
 
 Pass-through to `openclaw sessions list` inside the sandbox.

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 const START_SCRIPT = path.join(import.meta.dirname, "..", "agents", "hermes", "start.sh");
@@ -617,6 +617,65 @@ function runRuntimeShellEnvBootstrap() {
   }
 }
 
+// Build the sourced proxy env file (which defines the `hermes()` configure
+// guard), then run `hermes <args>` against a PATH-resolved stub so we can assert
+// the guard's behavior without a real Hermes binary.
+function runConfigureGuard(hermesArgs: string[]) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-guard-"));
+  const envFile = path.join(tmpDir, "nemoclaw-proxy-env.sh");
+  const caFile = path.join(tmpDir, "proxy ca.pem");
+  const hermesHome = path.join(tmpDir, ".hermes");
+  const scriptPath = path.join(tmpDir, "run.sh");
+  const stubDir = path.join(tmpDir, "bin");
+  const stub = path.join(stubDir, "hermes");
+
+  fs.mkdirSync(hermesHome, { recursive: true });
+  fs.mkdirSync(stubDir, { recursive: true });
+  fs.writeFileSync(caFile, "ca");
+  // `command hermes "$@"` inside the guard resolves to this stub via PATH.
+  fs.writeFileSync(stub, "#!/usr/bin/env bash\necho HERMES_STUB_RAN\n", { mode: 0o755 });
+
+  const src = fs.readFileSync(START_SCRIPT, "utf-8");
+  fs.writeFileSync(
+    scriptPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'emit_sandbox_sourced_file() { cat >"$1"; chmod 444 "$1"; }',
+      `_PROXY_ENV_FILE=${shellQuote(envFile)}`,
+      `_PROXY_URL=${shellQuote("http://10.200.0.1:3128")}`,
+      `_NO_PROXY_VAL=${shellQuote("localhost,127.0.0.1,::1,10.200.0.1")}`,
+      `HERMES_DIR=${shellQuote(hermesHome)}`,
+      `SSL_CERT_FILE=${shellQuote(caFile)}`,
+      "CURL_CA_BUNDLE=",
+      "REQUESTS_CA_BUNDLE=",
+      "GIT_SSL_CAINFO=",
+      extractRuntimeShellEnvBlock(src),
+      "write_runtime_shell_env",
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+
+  try {
+    const gen = spawnSync("bash", [scriptPath], {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: process.env,
+    });
+    if (gen.status !== 0) {
+      throw new Error(`runtime shell env bootstrap failed: ${gen.stderr}`);
+    }
+    const quotedArgs = hermesArgs.map(shellQuote).join(" ");
+    return spawnSync("bash", ["-c", `. ${shellQuote(envFile)}; hermes ${quotedArgs}`], {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: { ...process.env, PATH: `${stubDir}:/usr/bin:/bin` },
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
 describe("agents/hermes/start.sh runtime shell env", () => {
   it("puts the Hermes configure guard in the sourced proxy env file", () => {
     const run = runRuntimeShellEnvBootstrap();
@@ -638,6 +697,29 @@ describe("agents/hermes/start.sh runtime shell env", () => {
     expect(run.guardResult.stderr).toContain(
       "Error: 'hermes setup' cannot modify config inside the sandbox.",
     );
+  });
+
+  it("warns that --resume with a one-shot (-z) prompt does not append to the session (NemoClaw#5254)", () => {
+    // Both flags present: the one-shot would fragment history into a new
+    // session, so the guard must warn while still running the real command.
+    const resumeOneShot = runConfigureGuard([
+      "--resume",
+      "20260611_201639_8d0b6d",
+      "-z",
+      "Now repeat what I just asked you",
+    ]);
+    expect(resumeOneShot.stderr).toContain("starts a NEW session instead of appending to <id>");
+    expect(resumeOneShot.stdout).toContain("HERMES_STUB_RAN");
+
+    // Interactive resume (no -z) is the supported path and must stay quiet.
+    const interactiveResume = runConfigureGuard(["--resume", "20260611_201639_8d0b6d"]);
+    expect(interactiveResume.stderr).not.toContain("starts a NEW session");
+    expect(interactiveResume.stdout).toContain("HERMES_STUB_RAN");
+
+    // A bare one-shot (no --resume) must not warn either.
+    const bareOneShot = runConfigureGuard(["-z", "say hello"]);
+    expect(bareOneShot.stderr).not.toContain("starts a NEW session");
+    expect(bareOneShot.stdout).toContain("HERMES_STUB_RAN");
   });
 });
 


### PR DESCRIPTION
## Summary
Issue #5254: `hermes --resume <sessionId> -z "<prompt>"` starts a new session instead of appending to the existing one. Root-cause investigation showed the one-shot session-append behavior is owned by the third-party Hermes Agent binary (v0.14.0), which is NOT vendored in this repo — NemoClaw's only runtime levers over Hermes are the generated config.yaml (no session-resume key), the pass-through hermes-wrapper.sh, the start.sh entrypoint, and the Python plugin (no session-resolution hook). Following the debugging guidance for externally-rooted causes, the fix adds handling at the layer NemoClaw owns: the existing `hermes()` configure-guard shell function in agents/hermes/start.sh (the repo's established pattern for Hermes CLI/UX guards, e.g. setup/doctor) now detects the `--resume <id>` + `-z` one-shot combination and prints a non-blocking warning to stderr explaining the turn will NOT be appended to the resumed session and that the supported way to continue a session is interactive `hermes --resume <id>` (omit -z). The command still runs (no behavior break). Docs note added to commands-nemohermes.mdx.

## Related Issue
Fixes #5254

## Changes
- Automated Claude Code fix selected by `auto_fix/auto_fix_recent_issues.py`.
- See the commits on this branch for the exact file-level changes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [ ] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details reported by Claude Code:
- bash -n agents/hermes/start.sh (syntax check) — OK
- npx vitest run test/hermes-start.test.ts — 35 tests passed (includes new NemoClaw#5254 guard test asserting: warning fires for `--resume <id> -z ...`, stays silent for interactive `--resume <id>` and for bare `-z`, and the real hermes still executes in all cases via a PATH-resolved stub)
- npx biome check --write test/hermes-start.test.ts — formatted, no remaining lint errors
- `bash -n agents/hermes/start.sh`
- `npx vitest run test/hermes-start.test.ts`
- `npx biome check --write test/hermes-start.test.ts`

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning message when combining `--resume` with one-shot mode (`-z`), informing users that a new session will be created rather than continuing the existing one.

* **Documentation**
  * Updated documentation to clarify session resume behavior with one-shot prompts.

* **Tests**
  * Added tests for resume and one-shot mode interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->