### PR TITLE
fix(e2e): restore macOS Docker VM compat comment after onboard refactor

### DIFF
--- a/src/lib/onboard/sandbox-dockerfile-patch-flow.ts
+++ b/src/lib/onboard/sandbox-dockerfile-patch-flow.ts
@@ -145,6 +145,8 @@ export async function prepareSandboxDockerfilePatch({
     preferredInferenceApi,
     webSearchConfig,
     resolved ? resolved.ref : null,
+    // Docker-on-Colima uses normal container ownership; keep the old VM chmod
+    // compatibility path disabled unless a future VM-specific flow opts in.
     false,
     null,
     hermesToolGateways,

--- a/test/e2e/test-openshell-gateway-upgrade.sh
+++ b/test/e2e/test-openshell-gateway-upgrade.sh
@@ -450,7 +450,7 @@ exercise_macos_docker_rootfs_permission_regression() {
     || fail "Dockerfile is missing the macOS VM rootfs compatibility ARG"
   grep -Fq "ARG NEMOCLAW_DARWIN_VM_COMPAT=\${sanitizeDockerArg(darwinVmCompat ? \"1\" : \"0\")}" src/lib/onboard/dockerfile-patch.ts \
     || fail "Dockerfile patch helper does not patch the macOS VM rootfs compatibility ARG"
-  grep -Fq "Docker-on-Colima uses normal container ownership" src/lib/onboard.ts \
+  grep -Fq "Docker-on-Colima uses normal container ownership" src/lib/onboard/sandbox-dockerfile-patch-flow.ts \
     || fail "onboard does not keep macOS Docker sandbox builds out of the VM rootfs compatibility path"
   grep -q "chmod -R a+rwX /sandbox/.openclaw" Dockerfile \
     || fail "Dockerfile does not relax OpenClaw state permissions for macOS VM rootfs remapping"


### PR DESCRIPTION
Fixes #5261

**✨ [AI-generated PR]**

## Summary

Commit `27ae4c3` ("refactor(onboard): extract dockerfile patch flow") moved `patchStagedDockerfile()` from `onboard.ts` to `sandbox-dockerfile-patch-flow.ts` but dropped the design-intent comment that documents why `darwinVmCompat=false` for Docker builds. The `openshell-gateway-upgrade-e2e` test greps for this comment in `onboard.ts` as a design guard. This PR restores the comment in the new file and updates the test to grep the correct path.

## Related Issue
<!-- Linked after issue creation -->

## Changes

- **`src/lib/onboard/sandbox-dockerfile-patch-flow.ts`**: Restore the `// Docker-on-Colima uses normal container ownership` comment above the `false` (darwinVmCompat) argument on line 148.
- **`test/e2e/test-openshell-gateway-upgrade.sh`**: Update the grep target from `src/lib/onboard.ts` to `src/lib/onboard/sandbox-dockerfile-patch-flow.ts`.

## Validation

Custom-e2e validation was not run — the available token lacks the `workflow` scope required to push `.github/workflows/custom-e2e.yaml`. The fix is a mechanical comment restoration + grep path update with no behavioral change. Manual validation: run `openshell-gateway-upgrade-e2e` on this branch.

- Original failing run: [27386272836](https://github.com/NVIDIA/NemoClaw/actions/runs/27386272836) on `a3ae21b6eed8399099fd390bd45ad43e78218258`
- Targeted job: `openshell-gateway-upgrade-e2e (#80933852535)`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure
- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>