### PR TITLE
fix(policy): drop github from Hermes baseline

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -90,21 +90,12 @@ network_policies:
       - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
 
-  github:
-    name: github
-    endpoints:
-      - host: github.com
-        port: 443
-        access: full
-      - host: api.github.com
-        port: 443
-        access: full
-    binaries:
-      # `gh` was historically whitelisted here, but the Hermes sandbox base
-      # image (agents/hermes/Dockerfile.base) only apt-installs `git`, not
-      # `gh`, so the entry was a phantom — see #2179.
-      - { path: /usr/bin/git }
-      - { path: /opt/hermes/.venv/bin/python }
+  # NOTE: github.com / api.github.com and the git binary used to
+  # live in this base policy and were therefore granted to every
+  # Hermes sandbox regardless of user opt-in. They have been moved
+  # into a discoverable preset (`presets/github.yaml`) so a sandbox
+  # only gets GitHub access when the user explicitly selects the
+  # `github` preset during onboard.
 
   # ── Nous Research — public metadata and agent updates ─────────
   # Nous Portal OAuth, managed inference, and managed tool gateway auth are

--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -12,6 +12,6 @@
     "test/onboard-messaging.test.ts": 2063,
     "test/onboard-selection.test.ts": 6891,
     "test/onboard.test.ts": 4774,
-    "test/policies.test.ts": 2763
+    "test/policies.test.ts": 2753
   }
 }

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1822,28 +1822,6 @@ exit 1
       }
     });
 
-    it("Hermes baseline does not bake in github access; it ships only via the opt-in preset", () => {
-      const parsed = parseRepoYaml("agents/hermes/policy-additions.yaml");
-      expect(parsed.network_policies?.github).toBeUndefined();
-      const baselineHosts = Object.values(
-        (parsed.network_policies ?? {}) as Record<string, { endpoints?: Array<{ host?: string }> }>,
-      ).flatMap((policy) => (policy.endpoints ?? []).map((endpoint) => endpoint.host));
-      expect(baselineHosts).not.toContain("github.com");
-      expect(baselineHosts).not.toContain("api.github.com");
-
-      const preset = parsePresetYaml("github");
-      const presetGithub = preset.network_policies?.github as
-        | { endpoints?: Array<{ host?: string }>; binaries?: Array<{ path?: string }> }
-        | undefined;
-      const presetHosts = (presetGithub?.endpoints ?? [])
-        .map((endpoint) => endpoint.host)
-        .sort();
-      expect(presetHosts).toEqual(["api.github.com", "github.com"]);
-      const presetBinaries = (presetGithub?.binaries ?? []).map((binary) => binary.path);
-      expect(presetBinaries).toContain("/usr/bin/git");
-      expect(presetBinaries).not.toContain("/usr/bin/gh");
-    });
-
     it("REST policy YAML avoids deprecated tls: terminate", () => {
       const agentsDir = path.join(REPO_ROOT, "agents");
       const agentPolicyFiles = fs.existsSync(agentsDir)

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -1822,14 +1822,26 @@ exit 1
       }
     });
 
-    it("Hermes GitHub policy does not whitelist the absent gh CLI (#2179)", () => {
+    it("Hermes baseline does not bake in github access; it ships only via the opt-in preset", () => {
       const parsed = parseRepoYaml("agents/hermes/policy-additions.yaml");
-      const githubPolicy = parsed.network_policies?.github as
-        | { binaries?: Array<{ path?: string }> }
+      expect(parsed.network_policies?.github).toBeUndefined();
+      const baselineHosts = Object.values(
+        (parsed.network_policies ?? {}) as Record<string, { endpoints?: Array<{ host?: string }> }>,
+      ).flatMap((policy) => (policy.endpoints ?? []).map((endpoint) => endpoint.host));
+      expect(baselineHosts).not.toContain("github.com");
+      expect(baselineHosts).not.toContain("api.github.com");
+
+      const preset = parsePresetYaml("github");
+      const presetGithub = preset.network_policies?.github as
+        | { endpoints?: Array<{ host?: string }>; binaries?: Array<{ path?: string }> }
         | undefined;
-      const binaries = (githubPolicy?.binaries ?? []).map((binary) => binary.path).sort();
-      expect(binaries).toEqual(["/opt/hermes/.venv/bin/python", "/usr/bin/git"]);
-      expect(binaries).not.toContain("/usr/bin/gh");
+      const presetHosts = (presetGithub?.endpoints ?? [])
+        .map((endpoint) => endpoint.host)
+        .sort();
+      expect(presetHosts).toEqual(["api.github.com", "github.com"]);
+      const presetBinaries = (presetGithub?.binaries ?? []).map((binary) => binary.path);
+      expect(presetBinaries).toContain("/usr/bin/git");
+      expect(presetBinaries).not.toContain("/usr/bin/gh");
     });
 
     it("REST policy YAML avoids deprecated tls: terminate", () => {

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -545,6 +545,14 @@ describe("Hermes sandbox policy", () => {
   it("regression #4230: managed_inference keeps a narrow inference API allowlist", () => {
     expectManagedInferenceSecurityShape();
   });
+
+  it("base policy does not silently grant GitHub access; only the opt-in preset does", () => {
+    const np = policy.network_policies ?? {};
+    expect("github" in np).toBe(false);
+    const hosts = Object.values(np).flatMap((entry) => (entry.endpoints ?? []).map((e) => e.host));
+    expect(hosts).not.toContain("github.com");
+    expect(hosts).not.toContain("api.github.com");
+  });
 });
 
 describe("github preset", () => {

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -546,12 +546,16 @@ describe("Hermes sandbox policy", () => {
     expectManagedInferenceSecurityShape();
   });
 
-  it("base policy does not silently grant GitHub access; only the opt-in preset does", () => {
+  function expectGithubBaselineAbsent(): void {
     const np = policy.network_policies ?? {};
     expect("github" in np).toBe(false);
     const hosts = Object.values(np).flatMap((entry) => (entry.endpoints ?? []).map((e) => e.host));
     expect(hosts).not.toContain("github.com");
     expect(hosts).not.toContain("api.github.com");
+  }
+
+  it("base policy does not silently grant GitHub access; only the opt-in preset does", () => {
+    expectGithubBaselineAbsent();
   });
 });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The Hermes baseline policy `agents/hermes/policy-additions.yaml` hardcoded a `github` `network_policies` block, so every Hermes sandbox received unscoped access to `github.com` and `api.github.com` regardless of which presets the user selected at onboard. The Balanced tier — which lists no `github` preset — therefore still surfaced `● github  (active on gateway, missing from local state)` in `policy-list`, contradicting the documented Hermes baseline. The block is now removed and `github` ships only via the discoverable opt-in preset that already exists for OpenClaw.

## Related Issue
Fixes #5251

## Changes
- `agents/hermes/policy-additions.yaml` — drop the `github` network policy stanza (hosts + binaries) and replace it with the same NOTE breadcrumb the OpenClaw baseline carries, so the opt-in path becomes the single source of truth.
- `test/validate-blueprint.test.ts` — add a regression asserting the Hermes baseline never re-declares `github` and that no other baseline entry references `github.com` / `api.github.com`; helper-wrapped to satisfy the source-shape budget.
- `test/policies.test.ts` — drop the now-obsolete phantom-`gh` shape assertion (the binary list it pinned no longer exists once the baseline block is gone).
- `ci/test-file-size-budget.json` — ratchet `test/policies.test.ts` from 2763 → 2753 after the obsolete test was removed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * GitHub access is no longer provided by default in the Hermes sandbox. Users can now opt-in to GitHub access through a dedicated preset.

* **Chores**
  * Updated internal validation and testing frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
