### PR TITLE
fix(messaging): refresh stale messaging render plans

### DIFF
--- a/src/lib/messaging/compiler/workflow-planner.test.ts
+++ b/src/lib/messaging/compiler/workflow-planner.test.ts
@@ -446,6 +446,55 @@ describe("MessagingWorkflowPlanner", () => {
     ]);
   });
 
+  it("refreshes missing manifest render entries from stale rebuild plans", async () => {
+    const existingPlan = await planner().buildPlan({
+      sandboxName: "demo",
+      agent: "hermes",
+      workflow: "onboard",
+      isInteractive: false,
+      configuredChannels: ["discord"],
+      credentialAvailability: {
+        DISCORD_BOT_TOKEN: true,
+      },
+    });
+    const stalePlan = {
+      ...existingPlan,
+      credentialBindings: existingPlan.credentialBindings.map((binding) => ({
+        ...binding,
+        credentialHash: "hash-discord-token",
+      })),
+      agentRender: [],
+      buildSteps: [],
+    };
+
+    const plan = await planner().buildRebuildPlanFromSandboxEntry({
+      sandboxName: "demo",
+      agent: "hermes",
+      sandboxEntry: {
+        name: "demo",
+        agent: "hermes",
+        messaging: { schemaVersion: 1, plan: stalePlan },
+      },
+      supportedChannelIds: ["discord"],
+    });
+
+    expect(plan?.workflow).toBe("rebuild");
+    expect(
+      plan?.credentialBindings.find((binding) => binding.providerEnvKey === "DISCORD_BOT_TOKEN")
+        ?.credentialHash,
+    ).toBe("hash-discord-token");
+    const discordEnvRender = plan?.agentRender.find(
+      (entry) =>
+        entry.channelId === "discord" &&
+        entry.kind === "env-lines" &&
+        entry.target === "~/.hermes/.env",
+    );
+    expect(discordEnvRender).toMatchObject({
+      kind: "env-lines",
+      lines: expect.arrayContaining(["DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN"]),
+    });
+  });
+
   it("adds one manifest channel into an existing sandbox entry plan", async () => {
     const existingPlan = await planner().buildPlan({
       sandboxName: "demo",

--- a/src/lib/messaging/compiler/workflow-planner.ts
+++ b/src/lib/messaging/compiler/workflow-planner.ts
@@ -101,10 +101,33 @@ export class MessagingWorkflowPlanner {
   ): Promise<SandboxMessagingPlan | null> {
     const existingPlan = readSandboxEntryPlan(context);
     if (existingPlan) {
-      return setPlanDisabledChannels(
+      const normalizedPlan = setPlanDisabledChannels(
         existingPlan,
         disabledChannelsFromSandboxEntry(context.sandboxEntry, existingPlan),
         "rebuild",
+      );
+      if (!planMissingActiveChannelRender(normalizedPlan)) return normalizedPlan;
+
+      const configuredChannels = uniqueChannels(
+        normalizedPlan.channels.map((channel) => channel.channelId),
+      );
+      const refreshedPlan = await this.buildPlan({
+        sandboxName: context.sandboxName,
+        agent: context.agent,
+        workflow: "rebuild",
+        isInteractive: false,
+        configuredChannels,
+        disabledChannels: normalizedPlan.disabledChannels,
+        supportedChannelIds: context.supportedChannelIds,
+        credentialAvailability: mergeAvailability(
+          credentialAvailabilityFromPlan(normalizedPlan),
+          this.credentialAvailabilityFromSandboxEntry(context.sandboxEntry, configuredChannels),
+          context.credentialAvailability,
+        ),
+      });
+      return mergeSandboxMessagingPlans(
+        normalizedPlan,
+        preserveCredentialBindingHashes(normalizedPlan, refreshedPlan),
       );
     }
     return null;
@@ -351,6 +374,39 @@ function setPlanDisabledChannels(
     channels,
     disabledChannels,
   });
+}
+
+function preserveCredentialBindingHashes(
+  existing: SandboxMessagingPlan,
+  incoming: SandboxMessagingPlan,
+): SandboxMessagingPlan {
+  const existingHashes = new Map(
+    existing.credentialBindings
+      .filter((binding) => binding.credentialHash)
+      .map((binding) => [credentialBindingKey(binding), binding.credentialHash] as const),
+  );
+  if (existingHashes.size === 0) return incoming;
+
+  return clonePlan({
+    ...incoming,
+    credentialBindings: incoming.credentialBindings.map((binding) => ({
+      ...binding,
+      credentialHash: binding.credentialHash ?? existingHashes.get(credentialBindingKey(binding)),
+    })),
+  });
+}
+
+function credentialBindingKey(
+  binding: Pick<SandboxMessagingPlan["credentialBindings"][number], "channelId" | "providerEnvKey">,
+): string {
+  return binding.channelId + "\0" + binding.providerEnvKey;
+}
+
+function planMissingActiveChannelRender(plan: SandboxMessagingPlan): boolean {
+  const renderedChannels = new Set(plan.agentRender.map((entry) => entry.channelId));
+  return plan.channels.some(
+    (channel) => channel.active && !channel.disabled && !renderedChannels.has(channel.channelId),
+  );
 }
 
 function removePlanChannel(


### PR DESCRIPTION
## Summary
Refresh rebuild messaging plans when a stored sandbox plan has active channels but no agent render entries. This fixes stale Hermes Discord rebuild state without hand-populating compiled render fixtures in the e2e test.

# Fix
Closes #5263 

## Changes
- Rebuild manifest-derived render entries for existing rebuild plans that are missing active channel render output.
- Preserve existing credential hashes when refreshed credential bindings are merged back into the stored plan.
- Add a regression test for stale Hermes Discord rebuild plans with empty `agentRender`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Targeted checks run before PR creation:
- `npx @biomejs/biome check --write src/lib/messaging/compiler/workflow-planner.ts src/lib/messaging/compiler/workflow-planner.test.ts` passes
- `npx vitest run src/lib/messaging/compiler/workflow-planner.test.ts test/messaging-build-applier.test.ts` passes

Full `npx prek -a` was started but did not complete before interruption; it remains pending.

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebuild plan handling to regenerate missing manifest entries that become stale, ensuring channel configurations are properly restored
  * Enhanced credential binding preservation during rebuild operations, ensuring authentication details remain intact across configuration updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->