### PR TITLE
refactor(cli): reuse shared shell quote helper

### DIFF
--- a/src/lib/channel-runtime-status.ts
+++ b/src/lib/channel-runtime-status.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { shellQuote } from "./core/shell-quote";
+
 /**
  * Probe the OpenClaw runtime channel registry from inside a sandbox.
  *
@@ -139,10 +141,6 @@ export function extractEnabledChannelsFromOpenclawConfig(json: unknown): string[
     }
   }
   return [...visible].sort();
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 // Sentinel header the gateway-log scan script always echoes when the log

--- a/src/lib/skill-remote.ts
+++ b/src/lib/skill-remote.ts
@@ -3,11 +3,8 @@
 
 import { spawnSync } from "node:child_process";
 
+import { shellQuote } from "./core/shell-quote";
 import type { SkillPaths } from "./skill-install";
-
-// Re-export shellQuote from runner.ts — a repo-wide test enforces
-// a single definition lives in runner.ts.
-const { shellQuote } = require("./runner");
 
 export { shellQuote };
 

--- a/test/e2e-scenario/fixtures/phases/state-validation.ts
+++ b/test/e2e-scenario/fixtures/phases/state-validation.ts
@@ -17,6 +17,7 @@ import {
 import type { ShellProbeResult } from "../shell-probe.ts";
 import { probesForState, requireExpectedState } from "../../scenarios/expected-states.ts";
 import type { ExpectedState, StateProbeId } from "../../scenarios/types.ts";
+import { shellQuote } from "../../../../src/lib/core/shell-quote";
 import type { NemoClawInstance } from "./onboarding.ts";
 
 // Mirror of `src/lib/state/registry.ts::REGISTRY_FILE`. The fixture
@@ -110,10 +111,6 @@ function gatewayBaseEndpoint(gatewayUrl: string): string {
 
 function resultHttpCode(result: ShellProbeResult): string {
   return result.stdout.trim();
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 function resultHasHttpCode(result: ShellProbeResult, allowedCodes: readonly string[]): boolean {

--- a/test/e2e-scenario/live/rebuild-openclaw.test.ts
+++ b/test/e2e-scenario/live/rebuild-openclaw.test.ts
@@ -12,6 +12,7 @@ import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { shellQuote } from "../../../src/lib/core/shell-quote";
 
 // Direct Vitest replacement coverage for test/e2e/test-rebuild-openclaw.sh.
 // The contract stays intentionally local to this live test: build an older
@@ -139,10 +140,6 @@ function cliEnv(apiKey: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEn
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
     ...extra,
   });
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 function openshellBestEffort(

--- a/test/e2e-scenario/live/skill-agent.test.ts
+++ b/test/e2e-scenario/live/skill-agent.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
+import { shellQuote } from "../../../src/lib/core/shell-quote";
 
 // Focused Vitest live replacement coverage for test/e2e/test-skill-agent-e2e.sh.
 // Keep this as a direct live test: the legacy contract is skill fixture
@@ -57,10 +58,6 @@ function resultText(result: { stdout: string; stderr: string }): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 function isExternalAgentVerificationFlake(text: string): boolean {

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
+import { shellQuote } from "../src/lib/core/shell-quote";
+
 const START_SCRIPT = path.join(import.meta.dirname, "..", "agents", "hermes", "start.sh");
 const SECRET_BOUNDARY_VALIDATOR_SCRIPT = path.join(
   import.meta.dirname,
@@ -15,10 +17,6 @@ const SECRET_BOUNDARY_VALIDATOR_SCRIPT = path.join(
   "hermes",
   "validate-env-secret-boundary.py",
 );
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
 
 function bashPrintfQ(value: string): string {
   const result = spawnSync("bash", ["-c", "printf '%q' \"$1\"", "bash-printf-q", value], {


### PR DESCRIPTION
## Summary
Centralizes shell quoting by reusing the existing `src/lib/core/shell-quote.ts` helper everywhere this branch touched. This removes duplicate local `shellQuote` implementations from runtime/status code and test fixtures.

## Changes
- Imported the shared `shellQuote` helper in channel runtime status probing and skill remote helpers.
- Removed local shell quote implementations from Hermes and live E2E tests.
- Updated the E2E state-validation fixture to use the shared helper so source and tests have one shell quoting definition.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shell quote utility function to a centralized module, improving code maintainability across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->