### PR TITLE
fix(sandbox): preserve persisted agent through registry recovery

### DIFF
--- a/src/lib/registry-recovery-action.test.ts
+++ b/src/lib/registry-recovery-action.test.ts
@@ -123,6 +123,68 @@ describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
     expect(result.sandboxes).toEqual([]);
   });
 
+  it("preserves a persisted Hermes agent when the session re-seeds the same sandbox", async () => {
+    // A Hermes sandbox already in the registry must keep `agent: "hermes"`
+    // even when registry-recovery re-seeds from session metadata that has
+    // no agent field. Object.assign in updateSandbox would otherwise clobber
+    // the persisted agent to null, breaking rebuild-time agent resolution
+    // (state paths under /sandbox/.hermes-data versus /sandbox/.openclaw-data).
+    mockRegistryState.sandboxes["my-hermes"] = {
+      name: "my-hermes",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      gpuEnabled: false,
+      policies: ["npm", "pypi"],
+      nimContainer: null,
+      agent: "hermes",
+      agentVersion: "2026.5.16",
+    };
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "my-hermes",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      policyPresets: ["npm", "pypi"],
+      nimContainer: null,
+      agent: "hermes",
+      steps: {
+        sandbox: { status: "complete", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+
+    await recoverRegistryEntries();
+
+    expect(mockRegistryState.sandboxes["my-hermes"]?.agent).toBe("hermes");
+    expect(mockRegistryState.sandboxes["my-hermes"]?.agentVersion).toBe("2026.5.16");
+  });
+
+  it("does not clobber a persisted agent when session metadata omits it", async () => {
+    // Defensive: even if a stale session has no `agent` field at all (older
+    // session format), recovery must not overwrite the persisted agent.
+    mockRegistryState.sandboxes["my-hermes"] = {
+      name: "my-hermes",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      gpuEnabled: false,
+      policies: [],
+      nimContainer: null,
+      agent: "hermes",
+    };
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "my-hermes",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      policyPresets: [],
+      nimContainer: null,
+      steps: {
+        sandbox: { status: "complete", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+
+    await recoverRegistryEntries();
+
+    expect(mockRegistryState.sandboxes["my-hermes"]?.agent).toBe("hermes");
+  });
+
   it("does not evict a registered sandbox even when its session step is incomplete (avoids false positives)", async () => {
     // A user with a real registered sandbox alpha and a stale session that
     // happens to record alpha with an incomplete sandbox step (e.g. a

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -23,7 +23,7 @@ function buildRecoveredSandboxEntry(
   name: string,
   metadata: RecoveredSandboxMetadata = {},
 ): SandboxEntry {
-  return {
+  const entry: SandboxEntry = {
     name,
     model: metadata.model || null,
     provider: metadata.provider || null,
@@ -34,8 +34,16 @@ function buildRecoveredSandboxEntry(
         ? metadata.policyPresets
         : [],
     nimContainer: metadata.nimContainer || null,
-    agent: metadata.agent || null,
   };
+  // Only assert `agent` when recovery actually knows it. Object.assign in
+  // updateSandbox would otherwise overwrite a persisted agent (e.g. "hermes")
+  // with null whenever the recovery seed has no source of truth — the live
+  // OpenShell gateway does not surface NemoClaw's agent type, and a session
+  // sandbox seed never set this field, so the existing entry must win.
+  if (metadata.agent !== undefined && metadata.agent !== null) {
+    entry.agent = metadata.agent;
+  }
+  return entry;
 }
 
 function upsertRecoveredSandbox(name: string, metadata: RecoveredSandboxMetadata = {}) {
@@ -109,6 +117,7 @@ function seedRecoveryMetadata(
       provider: session.provider || null,
       nimContainer: session.nimContainer || null,
       policyPresets: session.policyPresets || null,
+      agent: session.agent || null,
     }),
   );
   const sessionSandboxMissing = !current.sandboxes.some(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Registry recovery silently rewrote a sandbox's persisted `agent` field to `null` whenever it had no source of truth for that field (the live OpenShell gateway does not expose the NemoClaw agent type, and the session-seeded path never read `session.agent`). A NemoHermes sandbox would therefore end up registered as `agent: null` after the first command that triggered recovery, which downstream agent-aware paths interpret as OpenClaw — `nemohermes list` showed `agent: openclaw`, status drifted to "Provisioning", and `rebuild` aborted in pre-rebuild backup because state paths under `/sandbox/.hermes-data` were probed against the OpenClaw manifest.

## Related Issue
Fixes #5327

## Changes
- `src/lib/registry-recovery-action.ts` — `buildRecoveredSandboxEntry` now omits `agent` from the returned entry unless `metadata.agent` is explicitly provided, so the `Object.assign` in `updateSandbox` can no longer clobber a persisted `agent: "hermes"` with `null`. The session-seed path also threads `session.agent` through, so a confirmed onboard session keeps the correct agent across recovery.
- `src/lib/registry-recovery-action.test.ts` — adds two regression tests: (a) a persisted Hermes agent is preserved when the session re-seeds with `agent: "hermes"`; (b) a persisted agent is still preserved when an older session format omits the `agent` field entirely.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved recovery mechanism to better preserve agent settings. The system now correctly maintains existing agent information during recovery operations and restores agent data when available from the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->