### PR TITLE
test(e2e): accept recovered proxy env

### DIFF
--- a/test/e2e/test-issue-2478-crash-loop-recovery.sh
+++ b/test/e2e/test-issue-2478-crash-loop-recovery.sh
@@ -534,18 +534,27 @@ fi
 # sandbox exec` does not pipe stdin from the caller through to the subshell,
 # so a `printf | sandbox_exec sh -c 'cat > file'` would leave an empty file.
 # Encoding into the command argv sidesteps the stdin gap entirely.
+#
+# After the #2701 fix, recovery may already have restored a minimal hardened
+# proxy-env from trusted preload sources. In that case the sandbox user cannot
+# necessarily overwrite the root-owned 0444 file with the original snapshot;
+# accept the recovered file if it still proves the guard chain is active. This
+# keeps the test focused on the user-visible contract instead of byte-identical
+# cleanup of an implementation detail.
 sandbox_exec sh -c "echo '$SNAPSHOT_B64' | base64 -d > /tmp/nemoclaw-proxy-env.sh && chmod 444 /tmp/nemoclaw-proxy-env.sh" >/dev/null
 
-# Verify restore is byte-identical to the snapshot.
 restored_size="$(sandbox_exec sh -c 'wc -c < /tmp/nemoclaw-proxy-env.sh' | tr -d '[:space:]')"
-if [ "$restored_size" != "$SNAPSHOT_SIZE" ]; then
-  fail "proxy-env.sh restore failed: expected $SNAPSHOT_SIZE bytes, got '${restored_size}'"
+if [ "$restored_size" = "$SNAPSHOT_SIZE" ]; then
+  info "proxy-env.sh restored from snapshot (${restored_size} bytes verified)"
+elif gateway_guards_active "$NEGATIVE_PID" 5; then
+  info "proxy-env.sh retained recovered guard env (${restored_size} bytes; original snapshot was ${SNAPSHOT_SIZE} bytes)"
+else
+  fail "proxy-env.sh restore failed and recovered guard env is not active: expected $SNAPSHOT_SIZE bytes, got '${restored_size}'"
   exit 1
 fi
-info "proxy-env.sh restored (${restored_size} bytes verified)"
 
-# Kill the guardless negative-case gateway, then trigger recovery to bring the
-# gateway back with guards intact from the restored env file.
+# Kill the current negative-case gateway, then trigger recovery to bring the
+# gateway back with guards intact from either the snapshot or recovered env file.
 sandbox_exec sh -c "pkill -9 -f '[o]penclaw' 2>/dev/null; sleep 2; pgrep -af '[o]penclaw' || echo ALL_DEAD" >/dev/null
 run_probe_only_or_fail "Guard restore recovery"
 SOAK_START_PID="$(wait_for_gateway_up 30)"


### PR DESCRIPTION
## Summary

Tests the hypothesis from nightly run 27435780434 that `issue-2478-crash-loop-recovery-e2e` is failing because PR #5321 now restores a minimal hardened `/tmp/nemoclaw-proxy-env.sh`, while the bash test still expects to overwrite it with the original byte-identical snapshot.

This keeps the #2701 contract assertion intact, but after the negative-case recovery it accepts either:

- byte-identical restoration of the original proxy env snapshot, or
- the already-recovered proxy env when `gateway_guards_active` proves the safety-net + ciao guards are active.

## Validation

- `bash -n test/e2e/test-issue-2478-crash-loop-recovery.sh`
- `git diff --check`
- pre-commit hooks on commit, including shellcheck

Selective nightly run will be dispatched for `issue-2478-crash-loop-recovery-e2e` against this branch.

Refs #2478 #2701 #5321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved crash loop recovery testing with more flexible validation logic. The test now better handles edge cases during recovery scenarios while maintaining verification of critical guard mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->