### PR TITLE
docs: document custom build cold/warm cache and layer ordering

### DIFF
--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -66,6 +66,48 @@ nemoclaw onboard --from ./my-plugin-sandbox/Dockerfile
 
 If you need a second sandbox alongside an existing one, use a dedicated build directory and rerun onboarding with the sandbox name and ports you intend to use.
 
+## Build Performance
+
+Custom plugin images are normal Docker builds, so build time depends on the build context size and the Docker layer cache rather than on NemoClaw.
+
+Keep the build context small and dedicated.
+The Dockerfile's parent directory is staged as the build context before the Docker build starts, so a broad directory can make onboarding look stuck while Docker is only preparing context.
+A small build directory stages quickly:
+
+```text
+my-plugin-sandbox/        # fast: only what the image needs
+├── Dockerfile
+├── .dockerignore
+└── my-plugin/
+```
+
+A Dockerfile placed in a large tree stages slowly:
+
+```text
+~/                        # slow: stages the whole home directory
+├── Dockerfile
+├── Downloads/
+├── datasets/
+└── models/
+```
+
+Distinguish cold builds from warm rebuilds.
+The first build on a fresh host is a cold build that downloads the base image and package indexes, so it is the slowest run.
+Later warm rebuilds reuse cached layers when the base image and earlier layers are unchanged.
+
+Order Dockerfile instructions from least-changing to most-changing so warm rebuilds reuse cached dependency layers:
+
+1. Base image.
+2. System package installs.
+3. Dependency manifests such as `package.json`.
+4. Dependency install such as `npm ci`.
+5. Application source.
+
+Pin the base image to an explicit tag or release ref so warm rebuilds resolve the same cached base instead of pulling a new one.
+
+When a build feels slow, set `NEMOCLAW_TRACE=1` before onboarding to capture phase timings that separate context staging, Docker build, image upload, and sandbox readiness.
+For the full `--from` build-context rules and trace details, refer to [CLI Commands Reference](../reference/commands).
+
 ## Network Access
 
 Plugins still run inside the sandbox policy boundary.

--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -103,7 +103,7 @@ Order Dockerfile instructions from least-changing to most-changing so warm rebui
 4. Dependency install such as `npm ci`.
 5. Application source.
 
-Pin the base image to an explicit tag or release ref so warm rebuilds resolve the same cached base instead of pulling a new one.
+Pin the base image to an explicit tag or digest so warm rebuilds resolve the same cached base instead of pulling a new one.
 
 When a build feels slow, set `NEMOCLAW_TRACE=1` before onboarding to capture phase timings that separate context staging, Docker build, image upload, and sandbox readiness.
 For the full `--from` build-context rules and trace details, refer to [CLI Commands Reference](../reference/commands).

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -257,6 +257,7 @@ NemoClaw also applies additional secret-safety exclusions that override `.docker
 Without a `.dockerignore`, onboarding still skips common large or local-only directories (`node_modules`, `.git`, `.venv`, and `__pycache__`) while staging this context.
 Other build outputs such as `dist/`, `target/`, or `build/` are included unless your `.dockerignore` excludes them.
 If the staged context is larger than 100 MB, onboarding prints a warning before the Docker build starts.
+Move the Dockerfile into a smaller dedicated directory or add `.dockerignore` entries for generated artifacts to shrink the context.
 If the directory contains unreadable files (for example, Windows system files visible in WSL), onboarding exits with an error suggesting you move the Dockerfile to a dedicated directory.
 
 ```bash
@@ -274,6 +275,18 @@ build-dir/
 ├── Dockerfile
 └── files-used-by-COPY/
 ```
+
+For faster custom builds, plan for Docker cache behavior:
+
+- Treat the first build on a fresh host as a cold build.
+  Cold builds download the base image and package indexes, so they take longer than later warm rebuilds even when NemoClaw is healthy.
+- A warm rebuild reuses cached layers when the base image and earlier layers are unchanged, so it is much faster than the first build.
+- Order Dockerfile instructions from least-changing to most-changing: base image, system packages, dependency manifests, dependency install, then application source.
+  This lets warm rebuilds reuse cached dependency layers instead of reinstalling on every source change.
+- Pin the base image to an explicit tag or release ref so warm rebuilds resolve the same cached base instead of pulling a new one.
+
+To diagnose where a slow build spends time, set `NEMOCLAW_TRACE=1` and read the phase timings in [Onboard Profiling Traces](#onboard-profiling-traces).
+NemoClaw does not guarantee exact build timings.
 
 All NemoClaw build arguments (`NEMOCLAW_MODEL`, `NEMOCLAW_PROVIDER_KEY`, `NEMOCLAW_INFERENCE_BASE_URL`, etc.) are injected as `ARG` overrides at build time, so declare them in your Dockerfile if you need to reference them.
 

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -283,7 +283,7 @@ For faster custom builds, plan for Docker cache behavior:
 - A warm rebuild reuses cached layers when the base image and earlier layers are unchanged, so it is much faster than the first build.
 - Order Dockerfile instructions from least-changing to most-changing: base image, system packages, dependency manifests, dependency install, then application source.
   This lets warm rebuilds reuse cached dependency layers instead of reinstalling on every source change.
-- Pin the base image to an explicit tag or release ref so warm rebuilds resolve the same cached base instead of pulling a new one.
+- Pin the base image to an explicit tag or digest so warm rebuilds resolve the same cached base instead of pulling a new one.
 
 To diagnose where a slow build spends time, set `NEMOCLAW_TRACE=1` and read the phase timings in [Onboard Profiling Traces](#onboard-profiling-traces).
 NemoClaw does not guarantee exact build timings.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -341,6 +341,7 @@ NemoClaw also applies additional secret-safety exclusions that override `.docker
 Without a `.dockerignore`, onboarding still skips common large or local-only directories (`node_modules`, `.git`, `.venv`, and `__pycache__`) while staging this context.
 Other build outputs such as `dist/`, `target/`, or `build/` are included unless your `.dockerignore` excludes them.
 If the staged context is larger than 100 MB, onboarding prints a warning before the Docker build starts.
+Move the Dockerfile into a smaller dedicated directory or add `.dockerignore` entries for generated artifacts to shrink the context.
 If the directory contains unreadable files (for example, Windows system files visible in WSL), onboarding exits with an error suggesting you move the Dockerfile to a dedicated directory.
 
 ```bash
@@ -358,6 +359,18 @@ build-dir/
 ├── Dockerfile
 └── files-used-by-COPY/
 ```
+
+For faster custom builds, plan for Docker cache behavior:
+
+- Treat the first build on a fresh host as a cold build.
+  Cold builds download the base image and package indexes, so they take longer than later warm rebuilds even when NemoClaw is healthy.
+- A warm rebuild reuses cached layers when the base image and earlier layers are unchanged, so it is much faster than the first build.
+- Order Dockerfile instructions from least-changing to most-changing: base image, system packages, dependency manifests, dependency install, then application source.
+  This lets warm rebuilds reuse cached dependency layers instead of reinstalling on every source change.
+- Pin the base image to an explicit tag or release ref so warm rebuilds resolve the same cached base instead of pulling a new one.
+
+To diagnose where a slow build spends time, set `NEMOCLAW_TRACE=1` and read the phase timings in [Onboard Profiling Traces](#onboard-profiling-traces).
+NemoClaw does not guarantee exact build timings.
 
 All NemoClaw build arguments (`NEMOCLAW_MODEL`, `NEMOCLAW_PROVIDER_KEY`, `NEMOCLAW_INFERENCE_BASE_URL`, etc.) are injected as `ARG` overrides at build time, so declare them in your Dockerfile if you need to reference them.
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -367,7 +367,7 @@ For faster custom builds, plan for Docker cache behavior:
 - A warm rebuild reuses cached layers when the base image and earlier layers are unchanged, so it is much faster than the first build.
 - Order Dockerfile instructions from least-changing to most-changing: base image, system packages, dependency manifests, dependency install, then application source.
   This lets warm rebuilds reuse cached dependency layers instead of reinstalling on every source change.
-- Pin the base image to an explicit tag or release ref so warm rebuilds resolve the same cached base instead of pulling a new one.
+- Pin the base image to an explicit tag or digest so warm rebuilds resolve the same cached base instead of pulling a new one.
 
 To diagnose where a slow build spends time, set `NEMOCLAW_TRACE=1` and read the phase timings in [Onboard Profiling Traces](#onboard-profiling-traces).
 NemoClaw does not guarantee exact build timings.


### PR DESCRIPTION
## Summary
Adds the remaining Docker build performance guidance for custom sandbox images identified in #4683: the cold-build versus warm-rebuild distinction and Dockerfile layer ordering for cache reuse. These were the two gaps not yet covered on `main` after the `.dockerignore` support docs landed.

## Related Issue
Addresses #4683 (remaining gaps; issue stays open if maintainers want further consolidation).

## Changes
- Add a consolidated "Build Performance" section to `docs/deployment/install-openclaw-plugins.mdx` covering cold vs warm builds, layer ordering, base image pinning, and a practical fast-vs-slow build-directory example.
- Add cold/warm + layer-ordering + base-pinning guidance to the `--from <Dockerfile>` reference in `docs/reference/commands.mdx` and `docs/reference/commands-nemohermes.mdx`, with a pointer to the Onboard Profiling Traces section for diagnosis.
- Add remediation guidance for the >100 MB build-context warning in both reference files.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added build-performance guidance for onboarding via Docker: reduce build context, use .dockerignore or a smaller Dockerfile directory, pin base images, and order instructions to maximize layer cache reuse.
  * Added troubleshooting for cold vs warm builds and a note on capturing build-phase timings (profiling trace) for onboarding performance investigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->