### PR TITLE
ci(e2e): route token rotation through compatible endpoint

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -956,6 +956,7 @@ jobs:
       - name: Run token rotation E2E test
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1"
           NEMOCLAW_NON_INTERACTIVE: "1"
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
           NEMOCLAW_POLICY_TIER: "open"

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -552,6 +552,18 @@ describe("E2E reusable workflow contract", () => {
     }
   });
 
+  it("routes legacy token rotation through the CI compatible inference endpoint", () => {
+    const runStep = nightlyWorkflow.jobs["token-rotation-e2e"].steps?.find(
+      (step) => step.name === "Run token rotation E2E test",
+    );
+    const script = readFileSync(new URL("./e2e/test-token-rotation.sh", import.meta.url), "utf8");
+
+    expect(runStep?.env?.NVIDIA_INFERENCE_API_KEY).toBe("${{ secrets.NVIDIA_INFERENCE_API_KEY }}");
+    expect(runStep?.env?.NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE).toBe("1");
+    expect(script).toContain("lib/ci-compatible-inference.sh");
+    expect(script).toContain("nemoclaw_e2e_configure_compatible_inference");
+  });
+
   it("keeps converted jobs dispatchable through the reusable workflow", () => {
     const cloudJob = nightlyWorkflow.jobs["cloud-e2e"];
 

--- a/test/e2e/test-token-rotation.sh
+++ b/test/e2e/test-token-rotation.sh
@@ -16,7 +16,7 @@
 #
 # Prerequisites:
 #   - Docker running
-#   - NVIDIA_INFERENCE_API_KEY set (or fake OpenAI endpoint)
+#   - NVIDIA_INFERENCE_API_KEY set (or CI-compatible inference env)
 #   - TELEGRAM_BOT_TOKEN_A and TELEGRAM_BOT_TOKEN_B set (can be fake)
 #   - DISCORD_BOT_TOKEN_A and DISCORD_BOT_TOKEN_B set (can be fake)
 #   - SLACK_BOT_TOKEN_A and SLACK_BOT_TOKEN_B set (can be fake; xoxb- prefix)
@@ -37,6 +37,8 @@ export NEMOCLAW_E2E_DEFAULT_TIMEOUT=2400
 SCRIPT_DIR_TIMEOUT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=test/e2e/e2e-timeout.sh
 source "${SCRIPT_DIR_TIMEOUT}/e2e-timeout.sh"
+# shellcheck source=test/e2e/lib/ci-compatible-inference.sh
+. "${SCRIPT_DIR_TIMEOUT}/lib/ci-compatible-inference.sh"
 
 PASS=0
 FAIL=0
@@ -94,6 +96,8 @@ fi
 SANDBOX_NAME="${NEMOCLAW_SANDBOX_NAME:-e2e-token-rotation}"
 REGISTRY="$HOME/.nemoclaw/sandboxes.json"
 INSTALL_LOG="/tmp/nemoclaw-e2e-install.log"
+
+nemoclaw_e2e_configure_compatible_inference
 
 # ── Prerequisite checks ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Route the legacy token-rotation nightly E2E through the CI-compatible inference setup so it can use the `NVIDIA_INFERENCE_API_KEY` secret with `https://inference-api.nvidia.com/v1`. This keeps public documentation and provider text unchanged while aligning this CI path with the endpoint that now works for nightly coverage.

## Changes
- Set `NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE=1` on the `token-rotation-e2e` nightly job.
- Source and invoke `test/e2e/lib/ci-compatible-inference.sh` from `test/e2e/test-token-rotation.sh`.
- Add workflow contract coverage to keep the token-rotation job wired to the compatible inference helper.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added verification test for nightly token rotation workflow configuration and CI environment setup.

* **Chores**
  * Updated end-to-end token rotation test to properly configure inference credentials for CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->