### PR TITLE
fix(e2e): add gateway connectivity retry before recovery approve

### DIFF
--- a/test/e2e/test-issue-4462-scope-upgrade-approval.sh
+++ b/test/e2e/test-issue-4462-scope-upgrade-approval.sh
@@ -602,6 +602,23 @@ exit 0
   if [ -n "$pending_after" ]; then
     pass "legacy gateway-pinned approve leaves the CLI scope-upgrade request pending"
     recovery_request_id="$pending_after"
+    # Wait for the gateway WebSocket to stabilise after the legacy approve
+    # failure — the failed request can leave the connection transiently
+    # unreachable, causing an immediate recovery approve to fail with
+    # "gateway connect failed".
+    local gw_ready=0
+    for _gw_attempt in 1 2 3 4 5; do
+      if device_state_json >/dev/null 2>&1; then
+        gw_ready=1
+        break
+      fi
+      info "gateway not yet reachable (attempt ${_gw_attempt}/5), waiting 2 s …"
+      sleep 2
+    done
+    if [ "$gw_ready" -eq 0 ]; then
+      fail "gateway did not become reachable within 10 s after legacy approve failure"
+      return 1
+    fi
     approve_request "$recovery_request_id" "recovery after legacy characterization" 1 || return 1
     pass "fixed devices approve path recovers the pending legacy request"
     return 0


### PR DESCRIPTION
## Summary

**✨ [AI-generated PR]**

The issue-4462-gateway-pinned-approval-characterization-e2e nightly job fails intermittently because the gateway WebSocket is transiently unreachable after the legacy approve characterization step deliberately provokes a failure. The recovery openclaw devices approve fires immediately without waiting, hitting gateway connect failed.

This PR adds a short polling loop (5 attempts x 2 s) that waits for device_state_json to succeed before issuing the recovery approve, giving the gateway time to stabilise.

## Root Cause

Between the June 12 and June 13 nightlies, commits b747bfa and 09a5c69 hardened the recovery proxy-env sourcing path. The legacy approve's failed WebSocket request leaves the gateway briefly unstable; the test's recovery approve fires instantly without any backoff. This is a test-side timing issue, not a product bug.

## Changes

- test/e2e/test-issue-4462-scope-upgrade-approval.sh: Insert a gateway-readiness polling loop in legacy_gateway_pinned_approval_characterization() before the recovery approve_request call.

## Nightly Run

- **Failing run:** https://github.com/NVIDIA/NemoClaw/actions/runs/27450816965
- **Failing job:** issue-4462-gateway-pinned-approval-characterization-e2e / run
- **Error:** FAIL: recovery after legacy characterization: openclaw devices approve failed... gateway connect failed: G
- **Classification:** infra_flake — transient gateway unreachability after deliberate failure

## Test Plan

- [ ] Re-run issue-4462-gateway-pinned-approval-characterization-e2e E2E job with this fix
- [ ] Verify the retry loop logs gateway not yet reachable on transient failures
- [ ] Confirm the recovery approve succeeds after the retry

Signed-off-by: Hung Le <hple@nvidia.com>

Fixes #5377