### PR TITLE
fix(e2e): support compatible credential migration

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -982,17 +982,16 @@ jobs:
 
       - name: Run credential migration live test
         # Migrated from test/e2e/test-credential-migration.sh. This live test
-        # stages the hosted inference credential through legacy credentials.json.
-        # CI uses the compatible-provider route so repository-scoped E2E
-        # credentials do not need an nvapi- prefix.
+        # stages NVIDIA_INFERENCE_API_KEY through legacy credentials.json as the
+        # custom provider's COMPATIBLE_API_KEY. The hosted service behind this
+        # repo-scoped secret is inference-api.nvidia.com, not Build/NVIDIA
+        # Endpoints, so the test must exercise the compatible-provider route.
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
-          NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
           NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
           NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
         run: |
           set -euo pipefail
           npx vitest run --project e2e-scenarios-live \

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -982,11 +982,17 @@ jobs:
 
       - name: Run credential migration live test
         # Migrated from test/e2e/test-credential-migration.sh. This live test
-        # needs NVIDIA_INFERENCE_API_KEY only as the staged legacy credential value; it
-        # preserves the default NVIDIA provider/key migration path while
-        # pinning a lower-quota catalog model in the test fixture.
+        # stages the hosted inference credential through legacy credentials.json.
+        # CI uses the compatible-provider route so repository-scoped E2E
+        # credentials do not need an nvapi- prefix.
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1"
+          NEMOCLAW_PROVIDER: custom
+          NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
+          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
         run: |
           set -euo pipefail
           npx vitest run --project e2e-scenarios-live \

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1544,11 +1544,19 @@ jobs:
 
       - name: Run credential migration Vitest test
         # Trusted-code boundary: this job runs the checked-out target ref with
-        # NVIDIA_INFERENCE_API_KEY because it validates live credential migration into the
-        # OpenShell gateway. Keep checkout credentials disabled, do not pass
-        # GITHUB_TOKEN, and rely on reviewed/maintainer-dispatched refs.
+        # the hosted inference credential because it validates live credential
+        # migration into the OpenShell gateway. CI uses the compatible-provider
+        # route so repository-scoped E2E credentials do not need an nvapi-
+        # prefix. Keep checkout credentials disabled, do not pass GITHUB_TOKEN,
+        # and rely on reviewed/maintainer-dispatched refs.
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1"
+          NEMOCLAW_PROVIDER: custom
+          NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
+          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/credential-migration
           NEMOCLAW_RUN_E2E_SCENARIOS: "1"
           NEMOCLAW_SANDBOX_NAME: "e2e-cred-migration"

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -1544,19 +1544,18 @@ jobs:
 
       - name: Run credential migration Vitest test
         # Trusted-code boundary: this job runs the checked-out target ref with
-        # the hosted inference credential because it validates live credential
-        # migration into the OpenShell gateway. CI uses the compatible-provider
-        # route so repository-scoped E2E credentials do not need an nvapi-
-        # prefix. Keep checkout credentials disabled, do not pass GITHUB_TOKEN,
-        # and rely on reviewed/maintainer-dispatched refs.
+        # NVIDIA_INFERENCE_API_KEY because it validates live credential
+        # migration into the OpenShell gateway. The hosted service behind this
+        # repo-scoped secret is inference-api.nvidia.com, not Build/NVIDIA
+        # Endpoints, so the test stages it as the custom provider's
+        # COMPATIBLE_API_KEY. Keep checkout credentials disabled, do not pass
+        # GITHUB_TOKEN, and rely on reviewed/maintainer-dispatched refs.
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
-          NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
           NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
           NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/credential-migration
           NEMOCLAW_RUN_E2E_SCENARIOS: "1"
           NEMOCLAW_SANDBOX_NAME: "e2e-cred-migration"

--- a/test/e2e-scenario/fixtures/hosted-inference.ts
+++ b/test/e2e-scenario/fixtures/hosted-inference.ts
@@ -6,18 +6,16 @@ const DEFAULT_COMPATIBLE_BASE_URL = "https://inference-api.nvidia.com/v1";
 const DEFAULT_COMPATIBLE_MODEL = "nvidia/nvidia/nemotron-3-super-v3";
 
 export interface HostedInferenceSecrets {
-  optional(name: string): string | undefined;
   required(name: string): string;
 }
 
 export interface HostedInferenceOptions {
-  nvidiaSecretName?: "NVIDIA_INFERENCE_API_KEY" | "NVIDIA_API_KEY";
   nvidiaModel?: string;
 }
 
 export interface HostedInferenceConfig {
   apiKey: string;
-  credentialEnv: "NVIDIA_INFERENCE_API_KEY" | "NVIDIA_API_KEY" | "COMPATIBLE_API_KEY";
+  credentialEnv: "NVIDIA_INFERENCE_API_KEY" | "COMPATIBLE_API_KEY";
   provider: "nvidia" | "compatible";
   providerName: "nvidia-prod" | "compatible-endpoint";
   env: NodeJS.ProcessEnv;
@@ -35,13 +33,8 @@ export function requireHostedInferenceConfig(
   env: NodeJS.ProcessEnv = process.env,
   options: HostedInferenceOptions = {},
 ): HostedInferenceConfig {
-  const nvidiaSecretName = options.nvidiaSecretName ?? "NVIDIA_INFERENCE_API_KEY";
-
   if (usingCiCompatibleInference(env)) {
-    const apiKey =
-      secrets.optional("COMPATIBLE_API_KEY") ??
-      secrets.optional("NVIDIA_INFERENCE_API_KEY") ??
-      secrets.required(nvidiaSecretName);
+    const apiKey = secrets.required("COMPATIBLE_API_KEY");
     const endpointUrl = env.NEMOCLAW_ENDPOINT_URL || DEFAULT_COMPATIBLE_BASE_URL;
     const model = env.NEMOCLAW_MODEL || env.NEMOCLAW_COMPAT_MODEL || DEFAULT_COMPATIBLE_MODEL;
     return {
@@ -62,25 +55,25 @@ export function requireHostedInferenceConfig(
     };
   }
 
-  const apiKey = secrets.required(nvidiaSecretName);
+  const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
   if (!apiKey.startsWith("nvapi-")) {
     throw new Error(
-      `${nvidiaSecretName} must start with nvapi- unless ${COMPATIBLE_INFERENCE_FLAG}=1 is set`,
+      `NVIDIA_INFERENCE_API_KEY must start with nvapi- unless ${COMPATIBLE_INFERENCE_FLAG}=1 is set`,
     );
   }
 
   const model = options.nvidiaModel ?? env.NEMOCLAW_MODEL ?? "";
   return {
     apiKey,
-    credentialEnv: nvidiaSecretName,
+    credentialEnv: "NVIDIA_INFERENCE_API_KEY",
     provider: "nvidia",
     providerName: "nvidia-prod",
     endpointUrl: DEFAULT_COMPATIBLE_BASE_URL,
     model,
     env: {
-      [nvidiaSecretName]: apiKey,
+      NVIDIA_INFERENCE_API_KEY: apiKey,
       ...(model ? { NEMOCLAW_MODEL: model } : {}),
     },
-    contractLabel: `${nvidiaSecretName} is present and nvapi-prefixed`,
+    contractLabel: "NVIDIA_INFERENCE_API_KEY is present and nvapi-prefixed",
   };
 }

--- a/test/e2e-scenario/fixtures/hosted-inference.ts
+++ b/test/e2e-scenario/fixtures/hosted-inference.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const COMPATIBLE_INFERENCE_FLAG = "NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE";
+const DEFAULT_COMPATIBLE_BASE_URL = "https://inference-api.nvidia.com/v1";
+const DEFAULT_COMPATIBLE_MODEL = "nvidia/nvidia/nemotron-3-super-v3";
+
+export interface HostedInferenceSecrets {
+  optional(name: string): string | undefined;
+  required(name: string): string;
+}
+
+export interface HostedInferenceOptions {
+  nvidiaSecretName?: "NVIDIA_INFERENCE_API_KEY" | "NVIDIA_API_KEY";
+  nvidiaModel?: string;
+}
+
+export interface HostedInferenceConfig {
+  apiKey: string;
+  credentialEnv: "NVIDIA_INFERENCE_API_KEY" | "NVIDIA_API_KEY" | "COMPATIBLE_API_KEY";
+  provider: "nvidia" | "compatible";
+  providerName: "nvidia-prod" | "compatible-endpoint";
+  env: NodeJS.ProcessEnv;
+  model: string;
+  endpointUrl: string;
+  contractLabel: string;
+}
+
+export function usingCiCompatibleInference(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[COMPATIBLE_INFERENCE_FLAG] === "1";
+}
+
+export function requireHostedInferenceConfig(
+  secrets: HostedInferenceSecrets,
+  env: NodeJS.ProcessEnv = process.env,
+  options: HostedInferenceOptions = {},
+): HostedInferenceConfig {
+  const nvidiaSecretName = options.nvidiaSecretName ?? "NVIDIA_INFERENCE_API_KEY";
+
+  if (usingCiCompatibleInference(env)) {
+    const apiKey =
+      secrets.optional("COMPATIBLE_API_KEY") ??
+      secrets.optional("NVIDIA_INFERENCE_API_KEY") ??
+      secrets.required(nvidiaSecretName);
+    const endpointUrl = env.NEMOCLAW_ENDPOINT_URL || DEFAULT_COMPATIBLE_BASE_URL;
+    const model = env.NEMOCLAW_MODEL || env.NEMOCLAW_COMPAT_MODEL || DEFAULT_COMPATIBLE_MODEL;
+    return {
+      apiKey,
+      credentialEnv: "COMPATIBLE_API_KEY",
+      provider: "compatible",
+      providerName: "compatible-endpoint",
+      endpointUrl,
+      model,
+      env: {
+        NEMOCLAW_PROVIDER: "custom",
+        NEMOCLAW_ENDPOINT_URL: endpointUrl,
+        NEMOCLAW_MODEL: model,
+        NEMOCLAW_COMPAT_MODEL: model,
+        COMPATIBLE_API_KEY: apiKey,
+      },
+      contractLabel: "CI compatible inference credential is present",
+    };
+  }
+
+  const apiKey = secrets.required(nvidiaSecretName);
+  if (!apiKey.startsWith("nvapi-")) {
+    throw new Error(
+      `${nvidiaSecretName} must start with nvapi- unless ${COMPATIBLE_INFERENCE_FLAG}=1 is set`,
+    );
+  }
+
+  const model = options.nvidiaModel ?? env.NEMOCLAW_MODEL ?? "";
+  return {
+    apiKey,
+    credentialEnv: nvidiaSecretName,
+    provider: "nvidia",
+    providerName: "nvidia-prod",
+    endpointUrl: DEFAULT_COMPATIBLE_BASE_URL,
+    model,
+    env: {
+      [nvidiaSecretName]: apiKey,
+      ...(model ? { NEMOCLAW_MODEL: model } : {}),
+    },
+    contractLabel: `${nvidiaSecretName} is present and nvapi-prefixed`,
+  };
+}

--- a/test/e2e-scenario/fixtures/hosted-inference.ts
+++ b/test/e2e-scenario/fixtures/hosted-inference.ts
@@ -1,31 +1,31 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const COMPATIBLE_INFERENCE_FLAG = "NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE";
-const DEFAULT_COMPATIBLE_BASE_URL = "https://inference-api.nvidia.com/v1";
-const DEFAULT_COMPATIBLE_MODEL = "nvidia/nvidia/nemotron-3-super-v3";
+const HOSTED_INFERENCE_SECRET = "NVIDIA_INFERENCE_API_KEY";
+const HOSTED_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
+const HOSTED_INFERENCE_PROVIDER = "custom";
+const HOSTED_INFERENCE_PROVIDER_NAME = "compatible-endpoint";
+const DEFAULT_HOSTED_INFERENCE_BASE_URL = "https://inference-api.nvidia.com/v1";
+const DEFAULT_HOSTED_INFERENCE_MODEL = "nvidia/nvidia/nemotron-3-super-v3";
 
 export interface HostedInferenceSecrets {
   required(name: string): string;
 }
 
 export interface HostedInferenceOptions {
-  nvidiaModel?: string;
+  model?: string;
 }
 
 export interface HostedInferenceConfig {
   apiKey: string;
-  credentialEnv: "NVIDIA_INFERENCE_API_KEY" | "COMPATIBLE_API_KEY";
-  provider: "nvidia" | "compatible";
-  providerName: "nvidia-prod" | "compatible-endpoint";
+  sourceSecretName: typeof HOSTED_INFERENCE_SECRET;
+  credentialEnv: typeof HOSTED_INFERENCE_CREDENTIAL_ENV;
+  provider: typeof HOSTED_INFERENCE_PROVIDER;
+  providerName: typeof HOSTED_INFERENCE_PROVIDER_NAME;
   env: NodeJS.ProcessEnv;
   model: string;
   endpointUrl: string;
   contractLabel: string;
-}
-
-export function usingCiCompatibleInference(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env[COMPATIBLE_INFERENCE_FLAG] === "1";
 }
 
 export function requireHostedInferenceConfig(
@@ -33,47 +33,28 @@ export function requireHostedInferenceConfig(
   env: NodeJS.ProcessEnv = process.env,
   options: HostedInferenceOptions = {},
 ): HostedInferenceConfig {
-  if (usingCiCompatibleInference(env)) {
-    const apiKey = secrets.required("COMPATIBLE_API_KEY");
-    const endpointUrl = env.NEMOCLAW_ENDPOINT_URL || DEFAULT_COMPATIBLE_BASE_URL;
-    const model = env.NEMOCLAW_MODEL || env.NEMOCLAW_COMPAT_MODEL || DEFAULT_COMPATIBLE_MODEL;
-    return {
-      apiKey,
-      credentialEnv: "COMPATIBLE_API_KEY",
-      provider: "compatible",
-      providerName: "compatible-endpoint",
-      endpointUrl,
-      model,
-      env: {
-        NEMOCLAW_PROVIDER: "custom",
-        NEMOCLAW_ENDPOINT_URL: endpointUrl,
-        NEMOCLAW_MODEL: model,
-        NEMOCLAW_COMPAT_MODEL: model,
-        COMPATIBLE_API_KEY: apiKey,
-      },
-      contractLabel: "CI compatible inference credential is present",
-    };
-  }
-
-  const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
-  if (!apiKey.startsWith("nvapi-")) {
-    throw new Error(
-      `NVIDIA_INFERENCE_API_KEY must start with nvapi- unless ${COMPATIBLE_INFERENCE_FLAG}=1 is set`,
-    );
-  }
-
-  const model = options.nvidiaModel ?? env.NEMOCLAW_MODEL ?? "";
+  const apiKey = secrets.required(HOSTED_INFERENCE_SECRET);
+  const endpointUrl = env.NEMOCLAW_ENDPOINT_URL || DEFAULT_HOSTED_INFERENCE_BASE_URL;
+  const model =
+    env.NEMOCLAW_MODEL ||
+    env.NEMOCLAW_COMPAT_MODEL ||
+    options.model ||
+    DEFAULT_HOSTED_INFERENCE_MODEL;
   return {
     apiKey,
-    credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-    provider: "nvidia",
-    providerName: "nvidia-prod",
-    endpointUrl: DEFAULT_COMPATIBLE_BASE_URL,
+    sourceSecretName: HOSTED_INFERENCE_SECRET,
+    credentialEnv: HOSTED_INFERENCE_CREDENTIAL_ENV,
+    provider: HOSTED_INFERENCE_PROVIDER,
+    providerName: HOSTED_INFERENCE_PROVIDER_NAME,
+    endpointUrl,
     model,
     env: {
-      NVIDIA_INFERENCE_API_KEY: apiKey,
-      ...(model ? { NEMOCLAW_MODEL: model } : {}),
+      NEMOCLAW_PROVIDER: HOSTED_INFERENCE_PROVIDER,
+      NEMOCLAW_ENDPOINT_URL: endpointUrl,
+      NEMOCLAW_MODEL: model,
+      NEMOCLAW_COMPAT_MODEL: model,
+      [HOSTED_INFERENCE_CREDENTIAL_ENV]: apiKey,
     },
-    contractLabel: "NVIDIA_INFERENCE_API_KEY is present and nvapi-prefixed",
+    contractLabel: "NVIDIA_INFERENCE_API_KEY is staged as the compatible endpoint credential",
   };
 }

--- a/test/e2e-scenario/live/credential-migration.test.ts
+++ b/test/e2e-scenario/live/credential-migration.test.ts
@@ -9,6 +9,7 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 
 // Migrated from test/e2e/test-credential-migration.sh. This is a focused live
@@ -17,10 +18,9 @@ import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 // a successful real onboard registers the migrated value with the OpenShell
 // gateway, the plaintext file is removed after success, credentials list reads
 // from the gateway, and secure unlink removes a planted symlink without touching
-// its target. The live onboard intentionally follows the legacy default NVIDIA
-// Endpoints path: NVIDIA_INFERENCE_API_KEY is present only in the legacy file, absent from
-// the onboard child env, and must migrate into the nvidia-prod gateway provider.
-// No registry, migration ledger, or shared helper is introduced.
+// its target. By default the live onboard follows the legacy NVIDIA Endpoints
+// path. When CI opts into the compatible-provider secret path, the same
+// migration contract runs against COMPATIBLE_API_KEY and compatible-endpoint.
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
@@ -107,7 +107,10 @@ async function cleanupCredentialMigrationState(host: HostCliClient, home: string
     host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "destroy", "--yes"], {
       artifactName: "cleanup-nemoclaw-destroy",
       env,
-      redactionValues: [process.env.NVIDIA_INFERENCE_API_KEY ?? ""],
+      redactionValues: [
+        process.env.NVIDIA_INFERENCE_API_KEY ?? "",
+        process.env.COMPATIBLE_API_KEY ?? "",
+      ],
       timeoutMs: 120_000,
     }),
   );
@@ -138,15 +141,18 @@ runCredentialMigrationTest(
   "credential migration stages legacy file into gateway and removes plaintext safely",
   { timeout: ONBOARD_TIMEOUT_MS + INSTALL_TIMEOUT_MS + 5 * 60_000 },
   async ({ artifacts, cleanup, host, secrets, skip }) => {
-    // Use the existing nightly secret as the legacy NVIDIA credential. The
-    // onboard child env below deliberately does not receive NVIDIA_INFERENCE_API_KEY, so
+    // Use the existing nightly secret as the legacy provider credential. The
+    // onboard child env below deliberately does not receive that credential, so
     // the only source is ~/.nemoclaw/credentials.json — matching the retired
     // shell lane's migration contract.
-    const migratedCredentialValue = secrets.required("NVIDIA_INFERENCE_API_KEY");
-    expect(
-      migratedCredentialValue.startsWith("nvapi-"),
-      "NVIDIA_INFERENCE_API_KEY must start with nvapi-",
-    ).toBe(true);
+    const hostedInference = requireHostedInferenceConfig(secrets, process.env, {
+      nvidiaModel: CREDENTIAL_MIGRATION_MODEL,
+    });
+    const migratedCredentialValue = hostedInference.apiKey;
+    const {
+      [hostedInference.credentialEnv]: _omittedCredential,
+      ...hostedInferenceEnvWithoutCredential
+    } = hostedInference.env;
     expect(fs.existsSync(CLI_ENTRYPOINT), "bin/nemoclaw.js missing").toBe(true);
     expect(
       fs.existsSync(DIST_CREDENTIAL_STORE),
@@ -183,8 +189,8 @@ runCredentialMigrationTest(
       sandboxName: SANDBOX_NAME,
       contracts: [
         "legacy credentials.json stages allowlisted provider keys into onboard env",
-        "successful default NVIDIA Endpoints onboard registers the migrated value with OpenShell gateway",
-        "onboard keeps the default NVIDIA provider/key/endpoint/policy path while pinning a low-quota catalog model",
+        `successful onboard registers the migrated value with the ${hostedInference.providerName} OpenShell gateway provider`,
+        `onboard uses the ${hostedInference.provider} provider/key/endpoint/policy path`,
         "successful onboard removes plaintext credentials.json",
         "tampered non-credential keys do not become gateway providers",
         "credentials list reads providers from the gateway, not disk",
@@ -201,7 +207,7 @@ runCredentialMigrationTest(
       legacyFile,
       JSON.stringify(
         {
-          NVIDIA_INFERENCE_API_KEY: migratedCredentialValue,
+          [hostedInference.credentialEnv]: migratedCredentialValue,
           OPENSHELL_GATEWAY: "evil-gw-from-tampered-file",
           NODE_OPTIONS: "--require=/tmp/evil.js",
         },
@@ -214,11 +220,9 @@ runCredentialMigrationTest(
     const onboard = await host.command("node", [CLI_ENTRYPOINT, "onboard", "--non-interactive"], {
       artifactName: "onboard-from-legacy-credentials",
       env: testEnv(home, {
+        ...hostedInferenceEnvWithoutCredential,
         NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
         NEMOCLAW_RECREATE_SANDBOX: "1",
-        // Keep the default NVIDIA provider/key/endpoint/policy path while
-        // avoiding the high-quota default Nemotron validation model.
-        NEMOCLAW_MODEL: CREDENTIAL_MIGRATION_MODEL,
       }),
       redactionValues: [migratedCredentialValue],
       timeoutMs: ONBOARD_TIMEOUT_MS,
@@ -247,9 +251,10 @@ runCredentialMigrationTest(
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter((line) => /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(line));
-    expect(providerNames, `expected migrated NVIDIA provider\n${providersText}`).toContain(
-      "nvidia-prod",
-    );
+    expect(
+      providerNames,
+      `expected migrated ${hostedInference.providerName} provider\n${providersText}`,
+    ).toContain(hostedInference.providerName);
     expect(providerNames).not.toContain("OPENSHELL_GATEWAY");
     expect(providerNames).not.toContain("NODE_OPTIONS");
 
@@ -292,7 +297,9 @@ runCredentialMigrationTest(
     await artifacts.writeJson("scenario-result.json", {
       id: "credential-migration",
       sandboxName: SANDBOX_NAME,
-      model: CREDENTIAL_MIGRATION_MODEL,
+      model: hostedInference.model || CREDENTIAL_MIGRATION_MODEL,
+      provider: hostedInference.providerName,
+      credentialEnv: hostedInference.credentialEnv,
       providerNames,
       assertions: {
         onboardSucceeded: onboard.exitCode === 0,
@@ -300,7 +307,7 @@ runCredentialMigrationTest(
           "Staged 1 legacy credential(s) for migration to the OpenShell gateway.",
         ),
         legacyFileRemovedAfterOnboard: !fs.existsSync(legacyFile),
-        migratedNvidiaProviderRegistered: providerNames.includes("nvidia-prod"),
+        migratedProviderRegistered: providerNames.includes(hostedInference.providerName),
         tamperedKeysExcluded:
           !providerNames.includes("OPENSHELL_GATEWAY") && !providerNames.includes("NODE_OPTIONS"),
         credentialsListReadsGateway: credentialsText.includes(

--- a/test/e2e-scenario/live/credential-migration.test.ts
+++ b/test/e2e-scenario/live/credential-migration.test.ts
@@ -18,9 +18,10 @@ import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 // a successful real onboard registers the migrated value with the OpenShell
 // gateway, the plaintext file is removed after success, credentials list reads
 // from the gateway, and secure unlink removes a planted symlink without touching
-// its target. By default the live onboard follows the legacy NVIDIA Endpoints
-// path. When CI opts into the compatible-provider secret path, the same
-// migration contract runs against COMPATIBLE_API_KEY and compatible-endpoint.
+// its target. The repository secret is named NVIDIA_INFERENCE_API_KEY, but the
+// hosted E2E service is the OpenAI-compatible inference-api.nvidia.com endpoint,
+// so the migration contract stages that value as COMPATIBLE_API_KEY and expects
+// the compatible-endpoint gateway provider.
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
@@ -146,7 +147,7 @@ runCredentialMigrationTest(
     // the only source is ~/.nemoclaw/credentials.json — matching the retired
     // shell lane's migration contract.
     const hostedInference = requireHostedInferenceConfig(secrets, process.env, {
-      nvidiaModel: CREDENTIAL_MIGRATION_MODEL,
+      model: CREDENTIAL_MIGRATION_MODEL,
     });
     const migratedCredentialValue = hostedInference.apiKey;
     const {
@@ -190,7 +191,8 @@ runCredentialMigrationTest(
       contracts: [
         "legacy credentials.json stages allowlisted provider keys into onboard env",
         `successful onboard registers the migrated value with the ${hostedInference.providerName} OpenShell gateway provider`,
-        `onboard uses the ${hostedInference.provider} provider/key/endpoint/policy path`,
+        `${hostedInference.sourceSecretName} is migrated into the ${hostedInference.credentialEnv} provider credential`,
+        `onboard uses the ${hostedInference.provider} provider and ${hostedInference.endpointUrl} endpoint path`,
         "successful onboard removes plaintext credentials.json",
         "tampered non-credential keys do not become gateway providers",
         "credentials list reads providers from the gateway, not disk",

--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -16,38 +16,43 @@ function secrets(values: Record<string, string | undefined>) {
 }
 
 describe("hosted inference E2E config", () => {
-  it("requires an nvapi-prefixed NVIDIA key by default", () => {
+  it("uses NVIDIA_INFERENCE_API_KEY as the hosted compatible endpoint source secret", () => {
     const cfg = requireHostedInferenceConfig(
-      secrets({ NVIDIA_INFERENCE_API_KEY: "nvapi-test-key" }),
+      secrets({ NVIDIA_INFERENCE_API_KEY: "repo-hosted-key" }),
       {},
     );
 
-    expect(cfg.provider).toBe("nvidia");
-    expect(cfg.credentialEnv).toBe("NVIDIA_INFERENCE_API_KEY");
-    expect(cfg.env.NVIDIA_INFERENCE_API_KEY).toBe("nvapi-test-key");
+    expect(cfg.sourceSecretName).toBe("NVIDIA_INFERENCE_API_KEY");
+    expect(cfg.provider).toBe("custom");
+    expect(cfg.providerName).toBe("compatible-endpoint");
+    expect(cfg.credentialEnv).toBe("COMPATIBLE_API_KEY");
+    expect(cfg.env.COMPATIBLE_API_KEY).toBe("repo-hosted-key");
   });
 
-  it("rejects a non-NVIDIA key unless the compatible-provider flag is set", () => {
-    expect(() =>
-      requireHostedInferenceConfig(secrets({ NVIDIA_INFERENCE_API_KEY: "sk-compatible-key" }), {}),
-    ).toThrow(/must start with nvapi-/);
-  });
-
-  it("accepts a compatible-provider credential when CI enables the compatibility flag", () => {
+  it("does not require an nvapi-prefixed source secret", () => {
     const cfg = requireHostedInferenceConfig(
       secrets({
-        COMPATIBLE_API_KEY: "sk-compatible-key",
+        NVIDIA_INFERENCE_API_KEY: "sk-compatible-key",
       }),
-      { NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" },
+      {},
     );
 
-    expect(cfg.provider).toBe("compatible");
+    expect(cfg.apiKey).toBe("sk-compatible-key");
     expect(cfg.credentialEnv).toBe("COMPATIBLE_API_KEY");
+  });
+
+  it("configures the custom provider route for inference-api.nvidia.com", () => {
+    const cfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "repo-hosted-key" }),
+      { NEMOCLAW_MODEL: "nvidia/custom-model" },
+    );
+
     expect(cfg.env).toMatchObject({
       NEMOCLAW_PROVIDER: "custom",
       NEMOCLAW_ENDPOINT_URL: "https://inference-api.nvidia.com/v1",
-      NEMOCLAW_MODEL: "nvidia/nvidia/nemotron-3-super-v3",
-      COMPATIBLE_API_KEY: "sk-compatible-key",
+      NEMOCLAW_MODEL: "nvidia/custom-model",
+      NEMOCLAW_COMPAT_MODEL: "nvidia/custom-model",
+      COMPATIBLE_API_KEY: "repo-hosted-key",
     });
   });
 });

--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -3,14 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  requireHostedInferenceConfig,
-  usingCiCompatibleInference,
-} from "../fixtures/hosted-inference.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 
 function secrets(values: Record<string, string | undefined>) {
   return {
-    optional: (name: string) => values[name],
     required: (name: string) => {
       const value = values[name];
       if (!value) throw new Error(`missing ${name}`);
@@ -41,7 +37,6 @@ describe("hosted inference E2E config", () => {
     const cfg = requireHostedInferenceConfig(
       secrets({
         COMPATIBLE_API_KEY: "sk-compatible-key",
-        NVIDIA_INFERENCE_API_KEY: "sk-compatible-key",
       }),
       { NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" },
     );
@@ -54,19 +49,5 @@ describe("hosted inference E2E config", () => {
       NEMOCLAW_MODEL: "nvidia/nvidia/nemotron-3-super-v3",
       COMPATIBLE_API_KEY: "sk-compatible-key",
     });
-  });
-
-  it("falls back to the configured NVIDIA secret name for reusable workflow compatibility", () => {
-    const cfg = requireHostedInferenceConfig(
-      secrets({ NVIDIA_API_KEY: "provider-key" }),
-      { NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" },
-      { nvidiaSecretName: "NVIDIA_API_KEY" },
-    );
-
-    expect(cfg.provider).toBe("compatible");
-    expect(cfg.apiKey).toBe("provider-key");
-    expect(usingCiCompatibleInference({ NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" })).toBe(
-      true,
-    );
   });
 });

--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  requireHostedInferenceConfig,
+  usingCiCompatibleInference,
+} from "../fixtures/hosted-inference.ts";
+
+function secrets(values: Record<string, string | undefined>) {
+  return {
+    optional: (name: string) => values[name],
+    required: (name: string) => {
+      const value = values[name];
+      if (!value) throw new Error(`missing ${name}`);
+      return value;
+    },
+  };
+}
+
+describe("hosted inference E2E config", () => {
+  it("requires an nvapi-prefixed NVIDIA key by default", () => {
+    const cfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "nvapi-test-key" }),
+      {},
+    );
+
+    expect(cfg.provider).toBe("nvidia");
+    expect(cfg.credentialEnv).toBe("NVIDIA_INFERENCE_API_KEY");
+    expect(cfg.env.NVIDIA_INFERENCE_API_KEY).toBe("nvapi-test-key");
+  });
+
+  it("rejects a non-NVIDIA key unless the compatible-provider flag is set", () => {
+    expect(() =>
+      requireHostedInferenceConfig(secrets({ NVIDIA_INFERENCE_API_KEY: "sk-compatible-key" }), {}),
+    ).toThrow(/must start with nvapi-/);
+  });
+
+  it("accepts a compatible-provider credential when CI enables the compatibility flag", () => {
+    const cfg = requireHostedInferenceConfig(
+      secrets({
+        COMPATIBLE_API_KEY: "sk-compatible-key",
+        NVIDIA_INFERENCE_API_KEY: "sk-compatible-key",
+      }),
+      { NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" },
+    );
+
+    expect(cfg.provider).toBe("compatible");
+    expect(cfg.credentialEnv).toBe("COMPATIBLE_API_KEY");
+    expect(cfg.env).toMatchObject({
+      NEMOCLAW_PROVIDER: "custom",
+      NEMOCLAW_ENDPOINT_URL: "https://inference-api.nvidia.com/v1",
+      NEMOCLAW_MODEL: "nvidia/nvidia/nemotron-3-super-v3",
+      COMPATIBLE_API_KEY: "sk-compatible-key",
+    });
+  });
+
+  it("falls back to the configured NVIDIA secret name for reusable workflow compatibility", () => {
+    const cfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_API_KEY: "provider-key" }),
+      { NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" },
+      { nvidiaSecretName: "NVIDIA_API_KEY" },
+    );
+
+    expect(cfg.provider).toBe("compatible");
+    expect(cfg.apiKey).toBe("provider-key");
+    expect(usingCiCompatibleInference({ NEMOCLAW_E2E_USE_NVIDIA_SECRET_AS_COMPATIBLE: "1" })).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Teach the migrated credential-migration Vitest E2E to treat the repository `NVIDIA_INFERENCE_API_KEY` secret as the hosted OpenAI-compatible service credential for `https://inference-api.nvidia.com/v1`. The test now migrates that source secret into the custom provider's `COMPATIBLE_API_KEY` credential instead of asserting an `nvapi-`/Build NVIDIA provider contract.

## Changes
- Add a hosted-inference E2E fixture that reads `NVIDIA_INFERENCE_API_KEY` as the source secret and configures the custom `compatible-endpoint` route.
- Update the live credential-migration test to stage the migrated credential as `COMPATIBLE_API_KEY` and assert the `compatible-endpoint` gateway provider.
- Wire the nightly and Vitest scenario credential-migration jobs to pass the hosted service endpoint/model while keeping `COMPATIBLE_API_KEY` out of workflow secrets/env.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added hosted-inference tests validating credential-to-environment mapping, compatibility mode, and model routing
  * Updated credential-migration E2E to compute provider/credential settings at runtime and record dynamic provider/model outcomes

* **Chores**
  * CI workflows updated to exercise an alternate compatible-provider routing and pass compatible endpoint, model, and credential variables for testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->