### PR TITLE
ci(workflows): normalize workflow display names

### DIFF
--- a/.github/workflows/brev-nightly-e2e.yaml
+++ b/.github/workflows/brev-nightly-e2e.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: brev-nightly-e2e
+name: E2E / Brev Nightly
 
 # Runs Brev launchable validation as a standalone nightly workflow while the
 # main nightly-e2e workflow remains isolated from Brev platform flakiness.

--- a/.github/workflows/release-latest-tag.yaml
+++ b/.github/workflows/release-latest-tag.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Release latest tag
+name: Release / Latest Tag
 
 on:
   push:

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Forwards `/nvskills-ci` PR comments and signature push events to the central
-# NVSkills CI service in NVIDIA/nvskills-ci. Mirrors
+# NVSkills CI service in NVIDIA/nvskills-ci. Adapted from
 # templates/team-request-workflow.yml from NVIDIA/nvskills-ci@main.
 #
 # Onboarding reference: NVIDIA/nvskills-ci/docs/team-onboarding.md
@@ -10,7 +10,7 @@
 #
 # Required repository secret: NVSKILLS_CI_DISPATCH_TOKEN
 
-name: Request NVSkills CI
+name: Automation / Request NVSkills CI
 
 on:
   issue_comment:


### PR DESCRIPTION
## Summary
Normalize GitHub Actions workflow display names so every workflow follows the repository's `Category / Name` naming structure. The NVSkills workflow keeps the required `request-nvskills-ci.yml` path and CODEOWNERS protection; investigation confirmed the central validator checks the workflow run path, not the display name.

## Changes
- Rename the Brev nightly workflow display name to `E2E / Brev Nightly`.
- Rename the latest-tag promotion workflow display name to `Release / Latest Tag`.
- Rename the NVSkills request workflow display name to `Automation / Request NVSkills CI` and adjust its source-template comment from `Mirrors` to `Adapted from`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Docs writer check found no user-facing docs changes were needed.

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow display names for improved organization and clarity within the CI/CD pipeline infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->