### PR TITLE
fix(connect): recover when active gateway has no spec for the sandbox

### DIFF
--- a/src/lib/actions/sandbox/gateway-state-drift.test.ts
+++ b/src/lib/actions/sandbox/gateway-state-drift.test.ts
@@ -209,6 +209,20 @@ describe("sandbox gateway state drift guard", () => {
     expect(lookup.output).toContain("sandbox has no spec");
   });
 
+  it("classifies the same gRPC reply as `missing` on the async status-probe path so the live `nemoclaw <sandbox> status` lookup goes through the named-gateway reconciler too", async () => {
+    detectPreflightIssueSpy.mockReturnValue(null);
+    captureOpenshellForStatusSpy.mockResolvedValue({
+      status: 1,
+      output:
+        'status: Internal, message: "sandbox has no spec", details: [], metadata: MetadataMap {}',
+    });
+
+    const lookup = await gatewayState.getSandboxGatewayStateForStatus("alpha");
+
+    expect(lookup.state).toBe("missing");
+    expect(lookup.output).toContain("sandbox has no spec");
+  });
+
   it("selects the sandbox's owning gateway and retries when the active gateway is a sibling that has no spec for it", () => {
     detectPreflightIssueSpy.mockReturnValue(null);
     getSandboxSpy.mockReturnValue({

--- a/src/lib/actions/sandbox/gateway-state-drift.test.ts
+++ b/src/lib/actions/sandbox/gateway-state-drift.test.ts
@@ -194,4 +194,53 @@ describe("sandbox gateway state drift guard", () => {
     );
     expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({ gatewayName: "nemoclaw-8090" });
   });
+
+  it("classifies the `sandbox has no spec` gRPC reply as a missing sandbox so the named-gateway reconciler can retry on the owning gateway", () => {
+    detectPreflightIssueSpy.mockReturnValue(null);
+    captureOpenshellSpy.mockReturnValue({
+      status: 1,
+      output:
+        'status: Internal, message: "sandbox has no spec", details: [], metadata: MetadataMap {}',
+    });
+
+    const lookup = gatewayState.getSandboxGatewayState("alpha");
+
+    expect(lookup.state).toBe("missing");
+    expect(lookup.output).toContain("sandbox has no spec");
+  });
+
+  it("selects the sandbox's owning gateway and retries when the active gateway is a sibling that has no spec for it", () => {
+    detectPreflightIssueSpy.mockReturnValue(null);
+    getSandboxSpy.mockReturnValue({
+      name: "instance-a",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+    });
+    getNamedGatewayLifecycleStateSpy.mockReturnValue({
+      state: "connected_other",
+      activeGateway: "nemoclaw-8081",
+      status: "Gateway: nemoclaw-8081\nStatus: Connected",
+    });
+    captureOpenshellSpy.mockReturnValueOnce({
+      status: 0,
+      output: "Sandbox:\n  Name: instance-a\n  Phase: Ready",
+    });
+
+    const retry = gatewayState.reconcileMissingAgainstNamedGateway("instance-a", {
+      state: "missing",
+      output: 'status: Internal, message: "sandbox has no spec"',
+    });
+
+    expect(retry).toEqual(
+      expect.objectContaining({
+        state: "present",
+        recoveredGateway: true,
+        recoveryVia: "select",
+      }),
+    );
+    expect(runOpenshellSpy).toHaveBeenCalledWith(
+      ["gateway", "select", "nemoclaw"],
+      expect.objectContaining({ ignoreError: true }),
+    );
+  });
 });

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -144,7 +144,13 @@ export function getSandboxGatewayState(sandboxName: string): SandboxGatewayState
     }
     return { state: "present", output };
   }
-  if (/\bNotFound\b|\bNot Found\b|sandbox not found/i.test(output)) {
+  // `sandbox has no spec` is the gRPC reply when the active OpenShell gateway
+  // is reachable but does not know about this sandbox — the multi-instance
+  // case where the active gateway is a sibling of the one the sandbox was
+  // onboarded against. Classify as `missing` so the named-gateway reconciler
+  // selects the sandbox's owning gateway and retries; without this the lookup
+  // would fall to `unknown_error` and exit with a hint instead of recovering.
+  if (/\bNotFound\b|\bNot Found\b|sandbox not found|sandbox has no spec/i.test(output)) {
     return { state: "missing", output };
   }
   if (
@@ -202,7 +208,7 @@ export async function getSandboxGatewayStateForStatus(
     }
     return { state: "present", output };
   }
-  if (/\bNotFound\b|\bNot Found\b|sandbox not found/i.test(output)) {
+  if (/\bNotFound\b|\bNot Found\b|sandbox not found|sandbox has no spec/i.test(output)) {
     return { state: "missing", output };
   }
   if (

--- a/src/lib/onboard/dashboard-port.ts
+++ b/src/lib/onboard/dashboard-port.ts
@@ -30,7 +30,7 @@ type SandboxRegistryEntry = {
   dashboardPort?: number | null;
 };
 
-type ListSandboxesFn = () => { sandboxes: SandboxRegistryEntry[] };
+export type ListSandboxesFn = () => { sandboxes: SandboxRegistryEntry[] };
 
 // Match the broader pattern used by onboard.ts (covers CSI, OSC, and Fe escapes)
 // so colorised `openshell forward list` output parses correctly.

--- a/src/lib/onboard/dashboard.ts
+++ b/src/lib/onboard/dashboard.ts
@@ -23,6 +23,7 @@ import {
   getOccupiedPorts,
   getRegistryOccupiedDashboardPorts,
   isLiveForwardStatus,
+  type ListSandboxesFn,
 } from "./dashboard-port";
 import { bestEffortForwardStop } from "./forward-cleanup";
 import {
@@ -52,6 +53,11 @@ export interface OnboardDashboardDeps {
   isWsl(): boolean;
   redact(value: unknown): string;
   sleep(seconds: number): void;
+  // Sandbox-registry lookup used by `ensureDashboardForward` for the
+  // cross-gateway dashboard port view. Tests inject a stub so the allocator
+  // never reads the runner's real `~/.nemoclaw/sandboxes.json`; production
+  // callers leave it unset and the helper falls back to the live registry.
+  listSandboxes?: ListSandboxesFn;
   printAgentDashboardUi(
     sandboxName: string,
     token: string | null,
@@ -255,7 +261,7 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
         preferredPort,
         existingForwards,
         undefined,
-        getRegistryOccupiedDashboardPorts(sandboxName),
+        getRegistryOccupiedDashboardPorts(sandboxName, deps.listSandboxes),
       );
     } catch (err) {
       if (!rollbackSandboxOnFailure) throw err;

--- a/test/onboard-dashboard.test.ts
+++ b/test/onboard-dashboard.test.ts
@@ -45,6 +45,7 @@ describe("onboard dashboard helpers", () => {
       redact: (value: unknown) => String(value),
       sleep: vi.fn(),
       printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
     });
 
     expect(helpers.ensureDashboardForward("my-sandbox", "http://127.0.0.1:18789")).toBe(18789);
@@ -87,6 +88,7 @@ describe("onboard dashboard helpers", () => {
       redact: (value: unknown) => String(value),
       sleep: vi.fn(),
       printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
     });
 
     expect(helpers.ensureDashboardForward("my-sandbox", "http://127.0.0.1:18789")).toBe(18789);
@@ -121,6 +123,7 @@ describe("onboard dashboard helpers", () => {
       redact: (value: unknown) => String(value),
       sleep: vi.fn(),
       printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
     });
 
     expect(
@@ -168,6 +171,7 @@ describe("onboard dashboard helpers", () => {
       redact: (value: unknown) => String(value),
       sleep: vi.fn(),
       printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
     });
 
     let output = "";
@@ -208,6 +212,7 @@ describe("onboard dashboard helpers", () => {
       redact: (value: unknown) => String(value),
       sleep: vi.fn(),
       printAgentDashboardUi: vi.fn(),
+      listSandboxes: () => ({ sandboxes: [] }),
     });
 
     let output = "";


### PR DESCRIPTION
## Summary
When a sandbox is onboarded against one NemoClaw gateway and the user later switches the active OpenShell gateway to a sibling instance, `nemoclaw <sandbox> connect` calls `openshell sandbox get <sandbox>` against the wrong gateway and receives the gRPC reply `sandbox has no spec`. The lookup currently falls through to the catch-all `unknown_error` bucket, so `getReconciledSandboxGatewayState` never attempts recovery and the user is told the sandbox could not be verified. Treat that reply as a missing-on-this-gateway signal, route it through the existing named-gateway reconciler, and let it `openshell gateway select` the sandbox's owning gateway and retry — so the connect proceeds without manual intervention.

## Changes
- `src/lib/actions/sandbox/gateway-state.ts` — extend the `missing` pattern in `getSandboxGatewayState` and `getSandboxGatewayStateForStatus` to cover `sandbox has no spec`. The reconciler already self-heals a `missing` lookup against the sandbox's recorded gateway, so this single classification change wires the existing recovery path to the multi-instance case without any new branch logic.
- `src/lib/onboard/dashboard.ts` — accept an optional `listSandboxes` dep on `OnboardDashboardDeps` and thread it through to `getRegistryOccupiedDashboardPorts` in `ensureDashboardForward`. Production callers keep the live-registry default; tests can inject a stub so the dashboard helpers do not read whatever sandboxes happen to live in the test runner's `~/.nemoclaw/sandboxes.json`.
- `src/lib/onboard/dashboard-port.ts` — re-export `ListSandboxesFn` so `dashboard.ts` (and any other consumer of the dep seam) can name the type without duplicating the shape.
- `test/onboard-dashboard.test.ts` — pass `listSandboxes: () => ({ sandboxes: [] })` into every `createOnboardDashboardHelpers` call so the existing port-allocation expectations stay independent of the runner's real registry.
- `src/lib/actions/sandbox/gateway-state-drift.test.ts` — two regression tests: (1) `getSandboxGatewayState` classifies the `sandbox has no spec` gRPC reply as `missing`; (2) `reconcileMissingAgainstNamedGateway` selects the sandbox's owning gateway and retries when the active gateway is a sibling that does not know about the sandbox.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox-state detection and recovery when a reachable gateway reports the sandbox as missing, enabling automatic gateway selection and recovery.

* **New Features**
  * Made the sandbox-listing hook injectable so registry reads can be provided or stubbed during allocation.

* **Tests**
  * Added tests covering sandbox state-drift scenarios and updated dashboard allocation tests to use the injectable listing hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->