### PR TITLE
fix(ci): route advisors to inference API

### DIFF
--- a/.github/workflows/e2e-advisor.yaml
+++ b/.github/workflows/e2e-advisor.yaml
@@ -163,8 +163,6 @@ jobs:
           E2E_ADVISOR_RUN_ANALYSIS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_analysis == false && '0' || '1' }}
           # Preferred E2E advisor secret.
           E2E_ADVISOR_API_KEY: ${{ secrets.PI_E2E_ADVISOR_API_KEY }}
-          # Optional local-provider-compatible fallback for future upstream/external-advisor use.
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd "$ADVISOR_WORKDIR"
           node --experimental-strip-types "$ADVISOR_DIR/tools/e2e-advisor/analyze.mts" \
@@ -183,8 +181,6 @@ jobs:
           # Reuse the shared E2E advisor secret. The scenario advisor is a
           # separate prompt/agent but uses the same model and credential.
           E2E_ADVISOR_API_KEY: ${{ secrets.PI_E2E_ADVISOR_API_KEY }}
-          # Optional local-provider-compatible fallback for future upstream/external-advisor use.
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd "$ADVISOR_WORKDIR"
           node --experimental-strip-types "$ADVISOR_DIR/tools/e2e-advisor/scenarios.mts" \

--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -140,8 +140,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.target_pr }}
           PR_REVIEW_ADVISOR_RUN_ANALYSIS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_analysis == false && '0' || '1' }}
           GH_TOKEN: ${{ github.token }}
-          PR_REVIEW_ADVISOR_API_KEY: ${{ secrets.PR_REVIEW_ADVISOR_API_KEY || secrets.PI_PR_REVIEW_ADVISOR_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PR_REVIEW_ADVISOR_API_KEY: ${{ secrets.PR_REVIEW_ADVISOR_API_KEY }}
         run: |
           cd "$ADVISOR_WORKDIR"
           if [ ! -f "$ADVISOR_DIR/tools/pr-review-advisor/analyze.mts" ]; then

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -7,6 +7,12 @@ import Ajv2020 from "ajv/dist/2020.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { githubGraphql } from "../tools/advisors/github.mts";
 import {
+  ADVISOR_OPENAI_COMPATIBLE_BASE_URL,
+  DEFAULT_ADVISOR_MODEL,
+  DEFAULT_ADVISOR_PROVIDER,
+  openAiAdvisorProviderConfig,
+} from "../tools/advisors/session.mts";
+import {
   buildPromptTurns,
   buildSystemPrompt,
   classifyMonolithDelta,
@@ -128,6 +134,34 @@ describe("PR review advisor", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  it("configures the advisor through the hosted OpenAI-compatible service", () => {
+    const config = openAiAdvisorProviderConfig("PR_REVIEW_ADVISOR_API_KEY") as {
+      apiKey: string;
+      baseUrl: string;
+      models: Array<{
+        id: string;
+        compat?: Record<string, unknown>;
+        reasoning: boolean;
+      }>;
+    };
+
+    expect(DEFAULT_ADVISOR_PROVIDER).toBe("openai");
+    expect(DEFAULT_ADVISOR_MODEL).toBe("openai/openai/gpt-5.5");
+    expect(config.apiKey).toBe("PR_REVIEW_ADVISOR_API_KEY");
+    expect(config.baseUrl).toBe(ADVISOR_OPENAI_COMPATIBLE_BASE_URL);
+    expect(config.models[0]?.id).toBe(DEFAULT_ADVISOR_MODEL);
+    expect(config.models[0]?.reasoning).toBe(false);
+    expect(config.models[0]?.compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+      supportsStrictMode: false,
+      supportsUsageInStreaming: false,
+      maxTokensField: "max_tokens",
+    });
+  });
+
   it("normalizes advisor output into the schema-owned metadata", () => {
     const result = normalizeReviewResult(validResult(), metadata());
 
@@ -662,6 +696,13 @@ jobs:
           ref: refs/pull/\${{ github.event.pull_request.head.sha }}/merge
           path: pr-workdir
           persist-credentials: false
+      - name: Run PR review advisor
+        env:
+          PR_REVIEW_ADVISOR_API_KEY: \${{ secrets.PR_REVIEW_ADVISOR_API_KEY || secrets.PI_PR_REVIEW_ADVISOR_API_KEY }}
+          OPENAI_API_KEY: \${{ secrets.OPENAI_API_KEY }}
+        run: |
+          cd "$ADVISOR_WORKDIR"
+          node "$ADVISOR_DIR/tools/pr-review-advisor/analyze.mts" --schema "$ADVISOR_DIR/tools/pr-review-advisor/schema.json"
 `,
     );
 
@@ -674,6 +715,8 @@ jobs:
           "workflow permissions.contents must be read",
           "review job must not be globally continue-on-error",
           "PR checkout must use the pull request head SHA as inert analysis data",
+          "Run PR review advisor must receive PR_REVIEW_ADVISOR_API_KEY only from secrets.PR_REVIEW_ADVISOR_API_KEY",
+          "Run PR review advisor must not receive OPENAI_API_KEY",
         ]),
       );
       expect(errors.some((error) => error.includes("full commit SHA"))).toBe(true);

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -16,17 +16,20 @@ import {
 
 export const DEFAULT_ADVISOR_PROVIDER = "openai";
 export const DEFAULT_ADVISOR_MODEL = "openai/openai/gpt-5.5";
+export const ADVISOR_OPENAI_COMPATIBLE_BASE_URL = "https://inference-api.nvidia.com/v1";
 export const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"];
 
 const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 
 type AdvisorProviderConfig = Parameters<ModelRegistry["registerProvider"]>[1];
+type AdvisorModelConfig = NonNullable<AdvisorProviderConfig["models"]>[number];
 
 export type RunAdvisorResult = {
   /** Assistant text from the final turn. For single-turn callers, this is the full response. */
   text: string;
   raw: string;
   turnTexts: string[];
+  turnErrors: string[];
 };
 
 export type AdvisorPromptTurn = {
@@ -53,9 +56,16 @@ export type RunReadOnlyAdvisorOptions = {
 export function openAiAdvisorProviderConfig(credentialEnv: string): AdvisorProviderConfig {
   return {
     api: "openai-completions",
-    baseUrl: "https://integrate.api.nvidia.com/v1",
+    baseUrl: ADVISOR_OPENAI_COMPATIBLE_BASE_URL,
     models: [
-      advisorModel(DEFAULT_ADVISOR_MODEL, "GPT-5.5", 256000, 32768, true, ["text", "image"]),
+      advisorModel(DEFAULT_ADVISOR_MODEL, "GPT-5.5", 256000, 32768, false, ["text", "image"], {
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        supportsStore: false,
+        supportsStrictMode: false,
+        supportsUsageInStreaming: false,
+        maxTokensField: "max_tokens",
+      }),
     ],
     ["api" + "Key"]: credentialEnv,
   } as AdvisorProviderConfig;
@@ -68,8 +78,9 @@ export function advisorModel(
   maxTokens: number,
   reasoning: boolean,
   input: ("text" | "image")[],
-): NonNullable<AdvisorProviderConfig["models"]>[number] {
-  return { id, name, reasoning, input, cost: ZERO_COST, contextWindow, maxTokens };
+  compat?: AdvisorModelConfig["compat"],
+): AdvisorModelConfig {
+  return { id, name, reasoning, input, cost: ZERO_COST, contextWindow, maxTokens, compat };
 }
 
 export async function runReadOnlyAdvisor(
@@ -81,7 +92,9 @@ export async function runReadOnlyAdvisor(
   const { authStorage, modelRegistry } = prepareAdvisorConfig(provider, options.credentialEnv);
   const model = modelRegistry.find(provider, modelId);
   if (!model || !modelRegistry.hasConfiguredAuth(model)) {
-    throw new Error(`Could not configure advisor model ${modelId}`);
+    throw new Error(
+      `Could not configure advisor model ${provider}/${modelId}; set ${options.credentialEnv}`,
+    );
   }
 
   const settingsManager = SettingsManager.inMemory({
@@ -119,6 +132,7 @@ export async function runReadOnlyAdvisor(
   const rawHeader = [
     modelFallbackMessage ? `[${options.logPrefix}] ${modelFallbackMessage}` : undefined,
     `[${options.logPrefix}] model=${model.provider}/${model.id}`,
+    `[${options.logPrefix}] base_url=${model.baseUrl}`,
     `[${options.logPrefix}] tools=${READ_ONLY_TOOLS.join(",")}`,
     `[${options.logPrefix}] prompt_turns=${promptTurns.length}`,
     "--- ASSISTANT TEXT ---",
@@ -126,13 +140,36 @@ export async function runReadOnlyAdvisor(
 
   const raw = new CappedBuffer(options.maxCaptureBytes, `${rawHeader.join("\n")}\n`);
   const turnTextBuffers: CappedBuffer[] = [];
+  const turnErrors: string[] = [];
   let currentTurnText: CappedBuffer | undefined;
   let currentTurnName = "";
+  let currentTurnError: string | undefined;
+
+  const captureTurnError = (source: string, message: string | undefined): void => {
+    const normalized = normalizeProviderError(message);
+    if (!normalized) return;
+    currentTurnError ||= normalized;
+    raw.append(`\n[${options.logPrefix}] ${source}: ${normalized}\n`);
+  };
 
   const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
-    if (event.type === "message_update" && event.assistantMessageEvent.type === "text_delta") {
-      currentTurnText?.append(event.assistantMessageEvent.delta);
-      raw.append(event.assistantMessageEvent.delta);
+    if (event.type === "message_update") {
+      if (event.assistantMessageEvent.type === "text_delta") {
+        currentTurnText?.append(event.assistantMessageEvent.delta);
+        raw.append(event.assistantMessageEvent.delta);
+        return;
+      }
+      if (event.assistantMessageEvent.type === "error") {
+        captureTurnError(
+          "assistant_stream_error",
+          event.assistantMessageEvent.error.errorMessage || event.assistantMessageEvent.reason,
+        );
+        return;
+      }
+      return;
+    }
+    if (event.type === "message_end") {
+      captureTurnError("assistant_message_error", assistantMessageError(event.message));
       return;
     }
     if (event.type === "tool_execution_start") {
@@ -179,6 +216,7 @@ export async function runReadOnlyAdvisor(
     for (const [index, turn] of promptTurns.entries()) {
       currentTurnName = turn.name;
       currentTurnText = new CappedBuffer(options.maxCaptureBytes);
+      currentTurnError = undefined;
       turnTextBuffers.push(currentTurnText);
       const turnIndex = `${index + 1}/${promptTurns.length}`;
       raw.append(`\n[${options.logPrefix}] user_turn_start ${turnIndex} ${turn.name}\n`);
@@ -188,6 +226,9 @@ export async function runReadOnlyAdvisor(
       raw.append(
         `\n[${options.logPrefix}] user_turn_end ${turnIndex} ${turn.name} textBytes=${turnTextBytes}\n`,
       );
+      if (currentTurnError) {
+        turnErrors.push(`${turn.name}: ${currentTurnError}`);
+      }
       currentTurnText = undefined;
       currentTurnName = "";
     }
@@ -220,7 +261,28 @@ export async function runReadOnlyAdvisor(
   if (truncationNotes.length > 0) raw.appendFooter(`\n${truncationNotes.join("\n")}\n`);
 
   const turnTexts = turnTextBuffers.map((buffer) => buffer.toString());
-  return { text: turnTexts.at(-1) || "", raw: raw.toStringWithTrailingNewline(), turnTexts };
+  return {
+    text: turnTexts.at(-1) || "",
+    raw: raw.toStringWithTrailingNewline(),
+    turnTexts,
+    turnErrors,
+  };
+}
+
+function assistantMessageError(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") return undefined;
+  const record = message as { role?: unknown; stopReason?: unknown; errorMessage?: unknown };
+  if (record.role !== "assistant") return undefined;
+  if (record.stopReason !== "error" && record.stopReason !== "aborted") return undefined;
+  return typeof record.errorMessage === "string" && record.errorMessage.trim()
+    ? record.errorMessage
+    : String(record.stopReason);
+}
+
+function normalizeProviderError(message: string | undefined): string | undefined {
+  if (!message) return undefined;
+  const normalized = message.trim().replace(/\s+/g, " ");
+  return normalized || undefined;
 }
 
 function normalizePromptTurns(promptTurns: AdvisorPromptTurn[]): AdvisorPromptTurn[] {
@@ -291,7 +353,7 @@ function prepareAdvisorConfig(
 ): { authStorage: AuthStorage; modelRegistry: ModelRegistry } {
   const authStorage = AuthStorage.inMemory();
   const modelRegistry = ModelRegistry.inMemory(authStorage);
-  const credential = process.env[credentialEnv] || process.env.OPENAI_API_KEY;
+  const credential = process.env[credentialEnv]?.trim();
   if (credential) {
     authStorage.setRuntimeApiKey(provider, credential);
     modelRegistry.registerProvider(provider, openAiAdvisorProviderConfig(credentialEnv));

--- a/tools/e2e-advisor/README.md
+++ b/tools/e2e-advisor/README.md
@@ -44,7 +44,8 @@ Configure this repository secret for E2E recommendations:
 
 - `PI_E2E_ADVISOR_API_KEY`
 
-The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model and also accepts `OPENAI_API_KEY` for local runs.
+The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model through the
+OpenAI-compatible `https://inference-api.nvidia.com/v1` service.
 
 If advisor credentials are unavailable, the advisor writes a low-confidence unavailable result instead of
 making deterministic recommendations.
@@ -78,7 +79,8 @@ node --experimental-strip-types tools/e2e-advisor/analyze.mts \
   --out-dir artifacts/e2e-advisor
 ```
 
-Set `E2E_ADVISOR_API_KEY` or `OPENAI_API_KEY` locally, or configure the repository `PI_E2E_ADVISOR_API_KEY` secret. Run `npm install` first so the Pi SDK dependency is available.
+Set `E2E_ADVISOR_API_KEY` locally, or configure the repository `PI_E2E_ADVISOR_API_KEY`
+secret. Run `npm install` first so the Pi SDK dependency is available.
 
 ## Output contract
 

--- a/tools/e2e-advisor/analyze.mts
+++ b/tools/e2e-advisor/analyze.mts
@@ -158,6 +158,10 @@ async function main(): Promise<void> {
         "utf8",
       )}`,
     );
+    if (sdkResult.turnErrors.length > 0) {
+      writeFailure(`Advisor SDK provider error: ${sdkResult.turnErrors.join("; ")}`);
+      process.exit(1);
+    }
   } catch (error: unknown) {
     const reason = error instanceof Error ? error.message : String(error);
     fs.writeFileSync(artifacts.raw, `Advisor SDK execution failed: ${reason}\n`);

--- a/tools/e2e-advisor/scenarios.mts
+++ b/tools/e2e-advisor/scenarios.mts
@@ -199,6 +199,10 @@ async function main(): Promise<void> {
         "utf8",
       )}`,
     );
+    if (sdkResult.turnErrors.length > 0) {
+      writeFailure(`Scenario advisor SDK provider error: ${sdkResult.turnErrors.join("; ")}`);
+      process.exit(1);
+    }
   } catch (error: unknown) {
     const reason = error instanceof Error ? error.message : String(error);
     fs.writeFileSync(artifacts.raw, `Scenario advisor SDK execution failed: ${reason}\n`);

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -52,9 +52,8 @@ Configure this repository secret for review analysis:
 
 - `PR_REVIEW_ADVISOR_API_KEY`
 
-The workflow also accepts the legacy `PI_PR_REVIEW_ADVISOR_API_KEY` secret as a
-fallback. The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model and
-also accepts `OPENAI_API_KEY` for local runs.
+The analyzer uses the fixed `openai/openai/gpt-5.5` advisor model through the
+OpenAI-compatible `https://inference-api.nvidia.com/v1` service.
 
 If advisor credentials are unavailable, the advisor writes a low-confidence unavailable result
 instead of failing closed without artifacts.
@@ -90,7 +89,7 @@ node --experimental-strip-types tools/pr-review-advisor/analyze.mts \
   --out-dir artifacts/pr-review-advisor
 ```
 
-Set `PR_REVIEW_ADVISOR_API_KEY` or `OPENAI_API_KEY` locally, or configure the repository
+Set `PR_REVIEW_ADVISOR_API_KEY` locally, or configure the repository
 `PR_REVIEW_ADVISOR_API_KEY` secret. Run `npm install` first so the Pi SDK dependency is
 available.
 

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -329,6 +329,10 @@ async function main(): Promise<void> {
     });
     fs.writeFileSync(artifacts.raw, sdkResult.raw);
     logProgress(`PR review advisor conversation finished: turns=${sdkResult.turnTexts.length}`);
+    if (sdkResult.turnErrors.length > 0) {
+      writeFailure(`PR review advisor SDK provider error: ${sdkResult.turnErrors.join("; ")}`);
+      process.exit(1);
+    }
   } catch (error: unknown) {
     const reason = error instanceof Error ? error.message : String(error);
     fs.writeFileSync(artifacts.raw, `PR review advisor SDK execution failed: ${reason}\n`);

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -141,6 +141,20 @@ export function validatePrReviewAdvisorWorkflowBoundary(
   requireRunContains(errors, analyze, 'cd "$ADVISOR_WORKDIR"');
   requireRunContains(errors, analyze, "$ADVISOR_DIR/tools/pr-review-advisor/analyze.mts");
   requireRunContains(errors, analyze, "$ADVISOR_DIR/tools/pr-review-advisor/schema.json");
+  if (analyze) {
+    const analyzeEnv = asRecord(analyze.env);
+    if (
+      stringValue(analyzeEnv.PR_REVIEW_ADVISOR_API_KEY).trim() !==
+      "${{ secrets.PR_REVIEW_ADVISOR_API_KEY }}"
+    ) {
+      errors.push(
+        "Run PR review advisor must receive PR_REVIEW_ADVISOR_API_KEY only from secrets.PR_REVIEW_ADVISOR_API_KEY",
+      );
+    }
+    if (Object.hasOwn(analyzeEnv, "OPENAI_API_KEY")) {
+      errors.push("Run PR review advisor must not receive OPENAI_API_KEY");
+    }
+  }
 
   const comment = requireStep(errors, steps, "Post PR review advisor comment");
   requireRunContains(errors, comment, "$ADVISOR_DIR/tools/pr-review-advisor/comment.mts");


### PR DESCRIPTION
## Summary
Route the PR and E2E advisor SDK configuration to the hosted OpenAI-compatible `inference-api.nvidia.com` service so the injected advisor secrets are used against the intended endpoint. The advisor wrappers now surface provider errors in artifacts/comments instead of collapsing empty SDK output into a JSON parse failure.

## Changes
- Point the shared advisor provider config at `https://inference-api.nvidia.com/v1` with conservative OpenAI-compatible request flags.
- Remove stale `PI_PR_REVIEW_ADVISOR_API_KEY` and `OPENAI_API_KEY` advisor fallbacks from workflows and docs.
- Capture assistant provider errors from the Pi SDK session stream and report them through PR/E2E advisor failure artifacts.
- Extend PR advisor workflow-boundary coverage for the single-secret contract and update advisor README guidance.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting in advisor tools; errors occurring during advisor turns are now properly captured and reported.

* **Documentation**
  * Updated setup instructions to reflect current credential configuration requirements for advisor tools.
  * Clarified advisor model and endpoint configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->