### PR TITLE
test(e2e): update Discord proxy expectation

### DIFF
--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -1828,11 +1828,11 @@ print(account.get('token', ''))
     skip "M9: No Discord token to check"
   fi
 
-  # M9b: Discord Gateway WebSocket routing uses OpenClaw's managed proxy.
-  # Newer OpenClaw starts its own process-wide managed proxy from the top-level
-  # proxy config, so NemoClaw should not bake a Discord-only account.proxy or
-  # launch its temporary loopback helper. The fake Gateway proof in M13b-M13g
-  # exercises the same OpenShell relay path using the generated proxy config.
+  # M9b: Discord Gateway WebSocket routing uses the per-account proxy.
+  # OpenClaw's Discord gateway client only tunnels when the Discord account
+  # proxy is set, while the top-level managed proxy remains configured for the
+  # rest of the channel stack. The fake Gateway proof in M13b-M13g exercises
+  # the same OpenShell relay path using the generated managed proxy config.
   dc_proxy=$(echo "$channel_json" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
@@ -1849,10 +1849,10 @@ if proxy.get('enabled') is True:
     print(proxy.get('proxyUrl') or '')
 \"" 2>/dev/null || true)
   expected_managed_proxy="http://${NEMOCLAW_PROXY_HOST:-10.200.0.1}:${NEMOCLAW_PROXY_PORT:-3128}"
-  if [ -n "$dc_token" ] && [ -z "$dc_proxy" ] && [ "$managed_proxy_url" = "$expected_managed_proxy" ]; then
-    pass "M9b: Discord relies on OpenClaw managed proxy config, with no per-account loopback proxy"
+  if [ -n "$dc_token" ] && [ "$dc_proxy" = "$expected_managed_proxy" ] && [ "$managed_proxy_url" = "$expected_managed_proxy" ]; then
+    pass "M9b: Discord uses per-account proxy while OpenClaw managed proxy config remains set"
   elif [ -n "$dc_token" ]; then
-    fail "M9b: Discord proxy wiring wrong; expected account.proxy='' and proxy.proxyUrl='${expected_managed_proxy}' (account.proxy='${dc_proxy}', proxy.proxyUrl='${managed_proxy_url}')"
+    fail "M9b: Discord proxy wiring wrong; expected account.proxy='${expected_managed_proxy}' and proxy.proxyUrl='${expected_managed_proxy}' (account.proxy='${dc_proxy}', proxy.proxyUrl='${managed_proxy_url}')"
   else
     skip "M9b: No Discord channel config to check"
   fi


### PR DESCRIPTION
## Summary
Updates the messaging providers E2E M9b assertion so Discord now expects `channels.discord.accounts.default.proxy` to match the sandbox proxy while the top-level managed proxy remains configured. This aligns the test with the Discord proxy behavior restored by PR #5248 for issue #5075.

## Changes
- Updated `test/e2e/test-messaging-providers.sh` M9b comments and pass/fail messages to describe per-account Discord proxy routing.
- Changed the M9b assertion to require both `account.proxy` and `proxy.proxyUrl` to equal the expected sandbox proxy URL.
- Reviewed `docs/` and found no user-facing docs update needed because this is a stale E2E expectation change with no product behavior change.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- `bash -n test/e2e/test-messaging-providers.sh` passed.
- `shellcheck test/e2e/test-messaging-providers.sh` passed.
- `npx prek run --files test/e2e/test-messaging-providers.sh` passed.
- `npx vitest run --project cli test/discord-template-resolver-proxy.test.ts test/generate-openclaw-config.test.ts` passed.
- Docs review completed: no docs changes needed.
- Full `npx prek run --all-files` and `npm test` were attempted and fail in unrelated existing suites outside this change.

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Discord proxy configuration validation in end-to-end tests to reflect current proxy-wiring expectations during configuration patching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->