### PR TITLE
docs: point remaining "Quickstart with Hermes" links at the Hermes quickstart

### DIFF
--- a/docs/about/ecosystem-hermes.mdx
+++ b/docs/about/ecosystem-hermes.mdx
@@ -99,5 +99,5 @@ Use the following table to decide when to use NemoHermes versus OpenShell alone.
 - [Overview](overview) describes what NemoClaw is, including capabilities, benefits, and use cases.
 - [How It Works](how-it-works) describes how NemoClaw runs, the blueprint, sandbox creation, routing, and protection layers for Hermes.
 - [Architecture](../reference/architecture) shows the repository structure and technical diagrams.
-- [Quickstart with Hermes](../get-started/quickstart) installs NemoClaw and launches your first Hermes sandbox.
+- [Quickstart with Hermes](../get-started/quickstart-hermes) installs NemoClaw and launches your first Hermes sandbox.
 - [NemoClaw Community](https://github.com/NVIDIA/nemoclaw-community) collects community-driven examples, showcases, and integrations that demonstrate complete blueprint patterns.

--- a/docs/inference/use-local-inference.mdx
+++ b/docs/inference/use-local-inference.mdx
@@ -26,7 +26,7 @@ OpenShell intercepts inference traffic and forwards it to the local endpoint you
 - NemoClaw installed. Refer to the [Quickstart](../get-started/quickstart) if you have not installed yet.
 </AgentOnly>
 <AgentOnly variant="hermes">
-- NemoClaw installed. Refer to [Quickstart with Hermes](../get-started/quickstart) if you have not installed yet.
+- NemoClaw installed. Refer to [Quickstart with Hermes](../get-started/quickstart-hermes) if you have not installed yet.
 </AgentOnly>
 - A local model server running, or a supported Ollama, vLLM, or NIM setup that the NemoClaw onboard wizard can use, start, or install.
 
@@ -259,6 +259,6 @@ If the provider itself needs to change (for example, switching from vLLM to a cl
 
 - [Inference Options](inference-options) for the full list of providers available during onboarding.
 - [Switch Inference Models](switch-inference-providers) for runtime model switching.
-- [Quickstart with Hermes](../get-started/quickstart) for first-time installation.
+- [Quickstart with Hermes](../get-started/quickstart-hermes) for first-time installation.
 
 </AgentOnly>

--- a/docs/manage-sandboxes/lifecycle.mdx
+++ b/docs/manage-sandboxes/lifecycle.mdx
@@ -17,7 +17,7 @@ import { AgentOnly } from "../_components/AgentGuide";
 Use this guide after you finish the [OpenClaw quickstart](../get-started/quickstart).
 </AgentOnly>
 <AgentOnly variant="hermes">
-Use this guide after you finish [Quickstart with Hermes](../get-started/quickstart).
+Use this guide after you finish [Quickstart with Hermes](../get-started/quickstart-hermes).
 </AgentOnly>
 It covers day-two sandbox operations such as listing sandboxes, checking health, managing ports, rebuilding safely, upgrading, and uninstalling.
 <AgentOnly variant="openclaw">

--- a/test/repro-hermes-quickstart-links.test.ts
+++ b/test/repro-hermes-quickstart-links.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// Regression for the remaining "Quickstart with Hermes" links that pointed at
+// the OpenClaw quickstart source file (docs/get-started/quickstart.mdx) instead
+// of the Hermes quickstart (docs/get-started/quickstart-hermes.mdx). Fern
+// resolves relative `[](…)` links by source-file path (see merged #5099/#5088),
+// so these resolved to the wrong page. Each occurrence below sits in a
+// Hermes-only context (a variant="hermes" block or the Hermes ecosystem page),
+// while the sibling OpenClaw link correctly keeps ../get-started/quickstart.
+const REPO_ROOT = path.dirname(import.meta.dirname);
+const read = (...rel: string[]) =>
+  fs.readFileSync(path.join(REPO_ROOT, "docs", ...rel), "utf-8");
+
+const HERMES_WRONG = /\[Quickstart with Hermes\]\(\.\.\/get-started\/quickstart\)/;
+const HERMES_RIGHT = /\[Quickstart with Hermes\]\(\.\.\/get-started\/quickstart-hermes\)/;
+
+describe('"Quickstart with Hermes" links target the Hermes quickstart page', () => {
+  it("ecosystem-hermes.mdx", () => {
+    const text = read("about", "ecosystem-hermes.mdx");
+    expect(text).not.toMatch(HERMES_WRONG);
+    expect(text).toMatch(HERMES_RIGHT);
+  });
+
+  it("manage-sandboxes/lifecycle.mdx (keeps the OpenClaw quickstart link)", () => {
+    const text = read("manage-sandboxes", "lifecycle.mdx");
+    expect(text).not.toMatch(HERMES_WRONG);
+    expect(text).toMatch(HERMES_RIGHT);
+    expect(text).toMatch(/\[OpenClaw quickstart\]\(\.\.\/get-started\/quickstart\)/);
+  });
+
+  it("inference/use-local-inference.mdx (keeps the OpenClaw quickstart link)", () => {
+    const text = read("inference", "use-local-inference.mdx");
+    expect(text).not.toMatch(HERMES_WRONG);
+    expect(text).toMatch(HERMES_RIGHT);
+    expect(text).toMatch(/\[Quickstart\]\(\.\.\/get-started\/quickstart\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Three more documentation pages had a "Quickstart with Hermes" link pointing at the OpenClaw quickstart source file (`../get-started/quickstart`) instead of the Hermes quickstart (`../get-started/quickstart-hermes`). Fern resolves relative `[](…)` links by source-file path, so these resolved to the wrong page. Each occurrence is in a Hermes-only context; the sibling OpenClaw links are correct and left untouched.

This completes the broken-internal-link cleanup also addressed in #5392 (#5076) and #5393 (#5079, #5089), and follows the same approach as the earlier link sweep in #4665.

## Changes

- `docs/about/ecosystem-hermes.mdx` — Hermes ecosystem page.
- `docs/manage-sandboxes/lifecycle.mdx` — `variant="hermes"` block (the `variant="openclaw"` block keeps `../get-started/quickstart`).
- `docs/inference/use-local-inference.mdx` — two `variant="hermes"` blocks (OpenClaw blocks unchanged).
- Added `test/repro-hermes-quickstart-links.test.ts` asserting the corrected targets and that the OpenClaw links are preserved.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications) — plus a regression test under `test/`
- [ ] Doc only (includes code sample changes)

## Verification

- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verified locally: the Hermes quickstart target source file exists; `scripts/docs-to-skills.py … --dry-run` succeeds; the new regression test's assertions pass. The full `prek` / `npm test` / `npm run docs` suite was not run locally; leaving those for CI.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to ensure Hermes-related guides correctly reference the Hermes-specific quickstart page.

* **Tests**
  * Added regression test to validate Hermes quickstart links are properly configured in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->