### PR TITLE
fix(ci): align hosted nightly inference defaults

### DIFF
--- a/.github/workflows/e2e-script.yaml
+++ b/.github/workflows/e2e-script.yaml
@@ -229,8 +229,8 @@ jobs:
             printf 'NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1\n'
             printf 'NEMOCLAW_PROVIDER=custom\n'
             printf 'NEMOCLAW_ENDPOINT_URL=https://inference-api.nvidia.com/v1\n'
-            printf 'NEMOCLAW_MODEL=nvidia/nvidia/nemotron-3-super-v3\n'
-            printf 'NEMOCLAW_COMPAT_MODEL=nvidia/nvidia/nemotron-3-super-v3\n'
+            printf 'NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b\n'
+            printf 'NEMOCLAW_COMPAT_MODEL=nvidia/nemotron-3-super-120b-a12b\n'
             printf 'NEMOCLAW_PREFERRED_API=openai-completions\n'
             printf 'COMPATIBLE_API_KEY=%s\n' "${NVIDIA_INFERENCE_API_KEY}"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -990,8 +990,8 @@ jobs:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
         run: |
           set -euo pipefail

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -468,8 +468,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -544,8 +544,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_ISSUE_4434_LIVE: "1"
@@ -973,8 +973,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1271,8 +1271,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1578,8 +1578,8 @@ jobs:
           NVIDIA_INFERENCE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/credential-migration
@@ -1804,8 +1804,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1817,8 +1817,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1856,8 +1856,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1869,8 +1869,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1908,8 +1908,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1921,8 +1921,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1961,8 +1961,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -1974,8 +1974,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -2014,8 +2014,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -2028,8 +2028,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -2070,8 +2070,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -2084,8 +2084,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"
@@ -2164,8 +2164,8 @@ jobs:
           NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
           NEMOCLAW_PROVIDER: custom
           NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
-          NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-super-v3
-          NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-super-v3
+          NEMOCLAW_MODEL: nvidia/nemotron-3-super-120b-a12b
+          NEMOCLAW_COMPAT_MODEL: nvidia/nemotron-3-super-120b-a12b
           NEMOCLAW_PREFERRED_API: openai-completions
           COMPATIBLE_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
           NEMOCLAW_NON_INTERACTIVE: "1"

--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -112,7 +112,7 @@ models:
     api_base: "https://integrate.api.nvidia.com"
 
   - name: super
-    litellm_model: "openai/nvidia/nvidia/nemotron-3-super-v3"
+    litellm_model: "openai/nvidia/nemotron-3-super-120b-a12b"
     cost_per_m_input_tokens: 0.10
     api_base: "https://integrate.api.nvidia.com"
 ```

--- a/src/lib/onboard/providers.ts
+++ b/src/lib/onboard/providers.ts
@@ -26,7 +26,7 @@ const HERMES_INFERENCE_ENDPOINT_URL = "https://inference-api.nousresearch.com/v1
 const HOSTED_INFERENCE_SOURCE_ENV = "NVIDIA_INFERENCE_API_KEY";
 const HOSTED_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
 const HOSTED_INFERENCE_ENDPOINT_URL = "https://inference-api.nvidia.com/v1";
-const HOSTED_INFERENCE_MODEL = "nvidia/nvidia/nemotron-3-super-v3";
+const HOSTED_INFERENCE_MODEL = "nvidia/nemotron-3-super-120b-a12b";
 
 const REMOTE_PROVIDER_CONFIG = {
   build: {

--- a/test/e2e-scenario/fixtures/hosted-inference.ts
+++ b/test/e2e-scenario/fixtures/hosted-inference.ts
@@ -6,7 +6,7 @@ const HOSTED_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
 const HOSTED_INFERENCE_PROVIDER = "custom";
 const HOSTED_INFERENCE_PROVIDER_NAME = "compatible-endpoint";
 const DEFAULT_HOSTED_INFERENCE_BASE_URL = "https://inference-api.nvidia.com/v1";
-const DEFAULT_HOSTED_INFERENCE_MODEL = "nvidia/nvidia/nemotron-3-super-v3";
+const DEFAULT_HOSTED_INFERENCE_MODEL = "nvidia/nemotron-3-super-120b-a12b";
 
 export interface HostedInferenceSecrets {
   required(name: string): string;

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -545,8 +545,8 @@ describe("E2E reusable workflow contract", () => {
     expect(runStep?.env?.NVIDIA_INFERENCE_API_KEY).toBe(GUARDED_HOSTED_INFERENCE_SECRET);
     expect(runStep?.env?.NEMOCLAW_PROVIDER).toBe("custom");
     expect(runStep?.env?.NEMOCLAW_ENDPOINT_URL).toBe("https://inference-api.nvidia.com/v1");
-    expect(runStep?.env?.NEMOCLAW_MODEL).toBe("nvidia/nvidia/nemotron-3-super-v3");
-    expect(runStep?.env?.NEMOCLAW_COMPAT_MODEL).toBe("nvidia/nvidia/nemotron-3-super-v3");
+    expect(runStep?.env?.NEMOCLAW_MODEL).toBe("nvidia/nemotron-3-super-120b-a12b");
+    expect(runStep?.env?.NEMOCLAW_COMPAT_MODEL).toBe("nvidia/nemotron-3-super-120b-a12b");
     expect(runStep?.env?.NEMOCLAW_PREFERRED_API).toBe("openai-completions");
     expect(runStep?.env?.COMPATIBLE_API_KEY).toBe(GUARDED_HOSTED_INFERENCE_SECRET);
     expect(runStep?.env?.GITHUB_TOKEN).toBeUndefined();
@@ -904,14 +904,32 @@ describe("E2E reusable workflow contract", () => {
     expect(exportStep?.run).toContain("NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1");
     expect(exportStep?.run).toContain("NEMOCLAW_PROVIDER=custom");
     expect(exportStep?.run).toContain("NEMOCLAW_ENDPOINT_URL=https://inference-api.nvidia.com/v1");
-    expect(exportStep?.run).toContain("NEMOCLAW_MODEL=nvidia/nvidia/nemotron-3-super-v3");
-    expect(exportStep?.run).toContain("NEMOCLAW_COMPAT_MODEL=nvidia/nvidia/nemotron-3-super-v3");
+    expect(exportStep?.run).toContain("NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b");
+    expect(exportStep?.run).toContain("NEMOCLAW_COMPAT_MODEL=nvidia/nemotron-3-super-120b-a12b");
     expect(exportStep?.run).toContain("NEMOCLAW_PREFERRED_API=openai-completions");
     expect(exportStep?.run).toContain("COMPATIBLE_API_KEY=%s");
 
     expect(hostedJobs.length).toBeGreaterThan(20);
     for (const [name, job] of hostedJobs) {
       expect(job.with?.nvidia_secret_as_compatible_api_key, name).toBeUndefined();
+    }
+  });
+
+  it("keeps rebuild fixture registry inference aligned with the onboard session", () => {
+    const rebuildFixtures = [
+      "test/e2e/test-rebuild-openclaw.sh",
+      "test/e2e/test-rebuild-hermes.sh",
+      "test/e2e/test-upgrade-stale-sandbox.sh",
+    ];
+
+    for (const fixture of rebuildFixtures) {
+      const body = readFileSync(fixture, "utf8");
+      expect(body, fixture).toContain("provider = sess.get('provider')");
+      expect(body, fixture).toContain("model = (");
+      expect(body, fixture).toContain("'provider': provider");
+      expect(body, fixture).toContain("'model': model");
+      expect(body, fixture).not.toContain("'provider': 'nvidia-prod'");
+      expect(body, fixture).not.toContain("'model': 'nvidia/nemotron-3-super-120b-a12b'");
     }
   });
 
@@ -962,8 +980,8 @@ describe("E2E reusable workflow contract", () => {
       }
       expect(step.env?.NEMOCLAW_PROVIDER, jobName).toBe("custom");
       expect(step.env?.NEMOCLAW_ENDPOINT_URL, jobName).toBe("https://inference-api.nvidia.com/v1");
-      expect(step.env?.NEMOCLAW_MODEL, jobName).toBe("nvidia/nvidia/nemotron-3-super-v3");
-      expect(step.env?.NEMOCLAW_COMPAT_MODEL, jobName).toBe("nvidia/nvidia/nemotron-3-super-v3");
+      expect(step.env?.NEMOCLAW_MODEL, jobName).toBe("nvidia/nemotron-3-super-120b-a12b");
+      expect(step.env?.NEMOCLAW_COMPAT_MODEL, jobName).toBe("nvidia/nemotron-3-super-120b-a12b");
       expect(step.env?.NEMOCLAW_PREFERRED_API, jobName).toBe("openai-completions");
       expect(step.env?.COMPATIBLE_API_KEY, jobName).toBe(GUARDED_HOSTED_INFERENCE_SECRET);
     }

--- a/test/e2e/lib/ci-compatible-inference.sh
+++ b/test/e2e/lib/ci-compatible-inference.sh
@@ -7,7 +7,7 @@
 # at inference-api.nvidia.com. Keep this helper in test/e2e so the
 # product-facing provider/default endpoint remain unchanged.
 
-NEMOCLAW_E2E_COMPATIBLE_INFERENCE_MODEL_DEFAULT="nvidia/nvidia/nemotron-3-super-v3"
+NEMOCLAW_E2E_COMPATIBLE_INFERENCE_MODEL_DEFAULT="nvidia/nemotron-3-super-120b-a12b"
 NEMOCLAW_E2E_HOSTED_INFERENCE_PROVIDER_DEFAULT="compatible-endpoint"
 NEMOCLAW_E2E_NVIDIA_INFERENCE_MODEL_DEFAULT="nvidia/nemotron-3-super-120b-a12b"
 

--- a/test/e2e/test-rebuild-hermes.sh
+++ b/test/e2e/test-rebuild-hermes.sh
@@ -246,7 +246,24 @@ echo "$PRE_REBUILD_CONFIG" | grep -Fq "discord:" \
 
 # Register in NemoClaw registry
 python3 -c "
-import hashlib, json
+import hashlib, json, os
+sess_path = '${SESSION_FILE}'
+try:
+    with open(sess_path) as f:
+        sess = json.load(f)
+except Exception:
+    sess = {}
+provider = sess.get('provider') or (
+    'compatible-endpoint'
+    if os.environ.get('NEMOCLAW_ENDPOINT_URL') and os.environ.get('COMPATIBLE_API_KEY')
+    else 'nvidia-prod'
+)
+model = (
+    sess.get('model')
+    or os.environ.get('NEMOCLAW_MODEL')
+    or os.environ.get('NEMOCLAW_COMPAT_MODEL')
+    or 'nvidia/nemotron-3-super-120b-a12b'
+)
 credential_hash = hashlib.sha256('${DISCORD_FAKE_TOKEN}'.encode()).hexdigest()
 plan = {
     'schemaVersion': 1,
@@ -284,8 +301,8 @@ plan = {
 reg = {'sandboxes': {'${SANDBOX_NAME}': {
     'name': '${SANDBOX_NAME}',
     'createdAt': '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
-    'model': 'nvidia/nemotron-3-super-120b-a12b',
-    'provider': 'nvidia-prod',
+    'model': model,
+    'provider': provider,
     'gpuEnabled': False,
     'policies': [],
     'policyTier': None,
@@ -299,12 +316,6 @@ reg = {'sandboxes': {'${SANDBOX_NAME}': {
 with open('${REGISTRY_FILE}', 'w') as f:
     json.dump(reg, f, indent=2)
 
-sess_path = '${SESSION_FILE}'
-try:
-    with open(sess_path) as f:
-        sess = json.load(f)
-except Exception:
-    sess = {}
 sess['sandboxName'] = '${SANDBOX_NAME}'
 sess['agent'] = 'hermes'
 sess['status'] = 'complete'

--- a/test/e2e/test-rebuild-openclaw.sh
+++ b/test/e2e/test-rebuild-openclaw.sh
@@ -215,12 +215,29 @@ VERIFY=$(openshell sandbox exec --name "${SANDBOX_NAME}" -- cat "${MARKER_FILE}"
 
 # Register in NemoClaw registry with old version
 python3 -c "
-import json
+import json, os
+sess_path = '${SESSION_FILE}'
+try:
+    with open(sess_path) as f:
+        sess = json.load(f)
+except Exception:
+    sess = {}
+provider = sess.get('provider') or (
+    'compatible-endpoint'
+    if os.environ.get('NEMOCLAW_ENDPOINT_URL') and os.environ.get('COMPATIBLE_API_KEY')
+    else 'nvidia-prod'
+)
+model = (
+    sess.get('model')
+    or os.environ.get('NEMOCLAW_MODEL')
+    or os.environ.get('NEMOCLAW_COMPAT_MODEL')
+    or 'nvidia/nemotron-3-super-120b-a12b'
+)
 reg = {'sandboxes': {'${SANDBOX_NAME}': {
     'name': '${SANDBOX_NAME}',
     'createdAt': '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
-    'model': 'nvidia/nemotron-3-super-120b-a12b',
-    'provider': 'nvidia-prod',
+    'model': model,
+    'provider': provider,
     'gpuEnabled': False,
     'policies': ['npm', 'pypi'],
     'policyTier': None,
@@ -234,12 +251,6 @@ with open('${REGISTRY_FILE}', 'w') as f:
 # Mark preflight and gateway steps as complete so that rebuild's
 # onboard --resume skips them (the gateway is already running and
 # port 8080 is legitimately in use).
-sess_path = '${SESSION_FILE}'
-try:
-    with open(sess_path) as f:
-        sess = json.load(f)
-except Exception:
-    sess = {}
 sess['sandboxName'] = '${SANDBOX_NAME}'
 sess['status'] = 'complete'
 sess['resumable'] = True

--- a/test/e2e/test-upgrade-stale-sandbox.sh
+++ b/test/e2e/test-upgrade-stale-sandbox.sh
@@ -155,12 +155,29 @@ pass "Old sandbox created (OpenClaw ${OLD_OPENCLAW_VERSION})"
 info "Phase 4: Registering sandbox with old agentVersion..."
 
 python3 -c "
-import json
+import json, os
+sess_path = '${SESSION_FILE}'
+try:
+    with open(sess_path) as f:
+        sess = json.load(f)
+except Exception:
+    sess = {}
+provider = sess.get('provider') or (
+    'compatible-endpoint'
+    if os.environ.get('NEMOCLAW_ENDPOINT_URL') and os.environ.get('COMPATIBLE_API_KEY')
+    else 'nvidia-prod'
+)
+model = (
+    sess.get('model')
+    or os.environ.get('NEMOCLAW_MODEL')
+    or os.environ.get('NEMOCLAW_COMPAT_MODEL')
+    or 'nvidia/nemotron-3-super-120b-a12b'
+)
 reg = {'sandboxes': {'${SANDBOX_NAME}': {
     'name': '${SANDBOX_NAME}',
     'createdAt': '$(date -u +%Y-%m-%dT%H:%M:%SZ)',
-    'model': 'nvidia/nemotron-3-super-120b-a12b',
-    'provider': 'nvidia-prod',
+    'model': model,
+    'provider': provider,
     'gpuEnabled': False,
     'policies': [],
     'policyTier': None,
@@ -170,12 +187,6 @@ reg = {'sandboxes': {'${SANDBOX_NAME}': {
 with open('${REGISTRY_FILE}', 'w') as f:
     json.dump(reg, f, indent=2)
 
-sess_path = '${SESSION_FILE}'
-try:
-    with open(sess_path) as f:
-        sess = json.load(f)
-except Exception:
-    sess = {}
 sess['sandboxName'] = '${SANDBOX_NAME}'
 sess['status'] = 'complete'
 with open(sess_path, 'w') as f:


### PR DESCRIPTION
## Summary
Fixes the hosted nightly E2E inference defaults that were still pointing at a stale double-prefixed Nemotron model ID, and keeps rebuild fixture registry metadata aligned with the provider/model selected during onboarding. This should unblock the hosted validation failures plus the rebuild/upgrade resume failures where CI onboarded as `compatible-endpoint` but the fixture registry forced `nvidia-prod`.

## Changes
- Updated hosted CI/custom compatible inference defaults to `nvidia/nemotron-3-super-120b-a12b` across workflows, onboarding defaults, E2E fixtures, and docs.
- Changed rebuild/upgrade E2E fixture registry seeding to preserve the current onboard session provider/model before falling back to env/default values.
- Added workflow/script contract coverage so hosted model IDs and rebuild fixture provider/model alignment do not regress.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes:
- `npm run docs` passed with 0 errors; Fern reported 2 hidden warnings.
- `npx prek run --all-files` passed.
- `npm test -- test/e2e-script-workflow.test.ts test/e2e-scenario/support-tests/hosted-inference.test.ts src/lib/onboard/providers.test.ts` passed.
- `bash -n` passed for the changed rebuild/upgrade shell fixtures.
- `rg -n "nvidia/nvidia/nemotron-3-super-v3" .github src test tools docs || true` has no product/workflow/doc hits; the only remaining `nemotron-3-super-v3` reference is a regression assertion that rejects the old ID.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated hosted inference model configuration across CI/CD workflows

* **Documentation**
  * Updated Model Router configuration example

* **Refactor**
  * Refactored test scripts to dynamically derive model and provider configuration instead of using hardcoded values

* **Tests**
  * Updated E2E test expectations and hosted inference configuration to align with model changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->