### PR TITLE
docs: clarify network approval prerequisites

### DIFF
--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -18,6 +18,7 @@ OpenShell intercepts these requests and presents them in the TUI for operator ap
 
 - A running NemoClaw sandbox.
 - The OpenShell CLI on your `PATH`.
+- A local NemoClaw source checkout if you plan to run the walkthrough script.
 
 ## Open the TUI
 
@@ -27,11 +28,14 @@ Start the OpenShell terminal UI to monitor sandbox activity:
 openshell term
 ```
 
-For a remote sandbox, pass the instance name:
+For a remote sandbox, connect to the host that owns the sandbox:
 
 ```bash
-ssh my-gpu-box 'cd ~/nemoclaw && . .env && openshell term'
+SANDBOX_HOST=your-sandbox-host
+ssh "$SANDBOX_HOST" 'cd ~/nemoclaw && . .env && openshell term'
 ```
+
+Replace `your-sandbox-host` with the SSH host or alias where your NemoClaw sandbox is running before you run the command.
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.
 
@@ -47,6 +51,7 @@ The blocked request includes the following details:
 ## Approve or Deny the Request
 
 The TUI presents an approval prompt for each blocked request.
+Select the sandbox that shows the blocked request, then follow the prompt in the TUI to approve or deny it.
 
 - **Approve** the request to add the endpoint to the running policy for the current session.
 - **Deny** the request to keep the endpoint blocked.
@@ -56,6 +61,14 @@ They are not persisted to the baseline policy file.
 To keep an endpoint allowed after a restart, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](customize-network-policy).
 
 ## Run the Walkthrough
+
+The walkthrough script lives in the NemoClaw source repository.
+If you installed NemoClaw from the installer and do not have a source checkout, clone the repository first:
+
+```bash
+git clone https://github.com/NVIDIA/NemoClaw.git
+cd NemoClaw
+```
 
 From the NemoClaw repository root, run the walkthrough script after you have onboarded at least one sandbox and it is reachable:
 

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -51,7 +51,8 @@ The blocked request includes the following details:
 ## Approve or Deny the Request
 
 The TUI presents an approval prompt for each blocked request.
-Select the sandbox that shows the blocked request, then follow the prompt in the TUI to approve or deny it.
+Select the sandbox that shows the blocked request.
+Then follow the prompt in the TUI to approve or deny it.
 
 - **Approve** the request to add the endpoint to the running policy for the current session.
 - **Deny** the request to keep the endpoint blocked.
@@ -70,7 +71,8 @@ git clone https://github.com/NVIDIA/NemoClaw.git
 cd NemoClaw
 ```
 
-From the NemoClaw repository root, run the walkthrough script after you have onboarded at least one sandbox and it is reachable:
+From the NemoClaw repository root, run the walkthrough script.
+Ensure at least one sandbox is onboarded and reachable before running it:
 
 ```bash
 ./scripts/walkthrough.sh


### PR DESCRIPTION
## Summary
Clarifies the network approval walkthrough prerequisites and remote sandbox command so the examples are safer to copy and run. This covers the verified placeholder/source-checkout parts of #5082 without adding unverified TUI keybinding details.

## Related Issue
Addresses part of #5082

## Changes
- Add a source-checkout prerequisite for running `scripts/walkthrough.sh`.
- Replace the literal remote-host placeholder with a `SANDBOX_HOST` variable before the `ssh` command.
- Clarify that the remote host should be the host that owns the running sandbox.
- Add basic TUI guidance to select the sandbox with the blocked request and follow the approval prompt.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification run:
- `npx prek run --from-ref origin/main --to-ref HEAD`
- `npm run docs` (passed with 0 errors; Fern reported existing warnings/upgrade notice)

---
Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added prerequisites for the network request approval walkthrough
  * Revised TUI startup instructions with environment variable configuration and an SSH command
  * Enhanced operator guidance with explicit instructions to select the sandbox showing the blocked request before responding in the TUI
  * Expanded the walkthrough with cloning and directory navigation steps for setups without an existing source checkout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->