### PR TITLE
fix(openclaw): declare Kimi store compatibility

### DIFF
--- a/nemoclaw-blueprint/model-specific-setup/openclaw/kimi-k2.6-managed-inference.json
+++ b/nemoclaw-blueprint/model-specific-setup/openclaw/kimi-k2.6-managed-inference.json
@@ -11,6 +11,7 @@
   },
   "effects": {
     "openclawCompat": {
+      "supportsStore": false,
       "requiresStringContent": true,
       "maxTokensField": "max_tokens",
       "requiresToolResultName": true

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -1272,8 +1272,8 @@ describe("generate-openclaw-config.mts: config generation", () => {
       NEMOCLAW_INFERENCE_API: "openai-completions",
       NEMOCLAW_INFERENCE_COMPAT_B64: Buffer.from("null").toString("base64"),
     });
-
     expect(config.models.providers.inference.models[0].compat).toEqual({
+      supportsStore: false,
       requiresStringContent: true,
       maxTokensField: "max_tokens",
       requiresToolResultName: true,


### PR DESCRIPTION
## Summary
Declares `supportsStore: false` in the OpenClaw Kimi K2.6 model-specific setup manifest so managed NVIDIA/Kimi routes get the same compatibility shape as the previous custom mock path. This fixes the live `kimi-inference-compat-e2e` K2 config assertion that failed after #5401 moved the scenario to public NVIDIA Endpoints.

## Related Issue
Related to #5401.

## Changes
- Add `supportsStore: false` to `nemoclaw-blueprint/model-specific-setup/openclaw/kimi-k2.6-managed-inference.json`.
- Update `test/generate-openclaw-config.test.ts` so registry-only Kimi compat includes the store flag.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:
- `npx biome check --write nemoclaw-blueprint/model-specific-setup/openclaw/kimi-k2.6-managed-inference.json test/generate-openclaw-config.test.ts`
- `npx vitest run --project cli test/generate-openclaw-config.test.ts test/validate-config-schemas.test.ts --testNamePattern "Kimi|model-specific|registry compat"`

Docs review: no user-facing docs changes needed; this only completes an existing model-specific OpenClaw compatibility manifest.

Note: local broad pre-commit/pre-push hooks currently fail in unrelated runtime recovery preload tests because temp preload files are seen as group-writable (`mode=664`), matching the existing local hook failure observed on #5401 follow-up work. Targeted changed tests passed.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model-specific configuration to disable store support

* **Tests**
  * Updated test case formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->