### PR TITLE
docs: add Cursor Windows recovery guidance

### DIFF
--- a/docs/_components/StarterPromptButton.tsx
+++ b/docs/_components/StarterPromptButton.tsx
@@ -48,9 +48,11 @@ Use these Markdown documentation pages as the first sources:
 - Full Markdown documentation bundle: https://docs.nvidia.com/nemoclaw/llms-full.txt
 - OpenClaw home: https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/home.md
 - OpenClaw prerequisites: https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/get-started/prerequisites.md
+- OpenClaw Windows preparation: https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/get-started/windows-preparation.md
 - OpenClaw quickstart: https://docs.nvidia.com/nemoclaw/latest/user-guide/openclaw/get-started/quickstart.md
 - Hermes home: https://docs.nvidia.com/nemoclaw/latest/user-guide/hermes/home.md
 - Hermes prerequisites: https://docs.nvidia.com/nemoclaw/latest/user-guide/hermes/get-started/prerequisites.md
+- Hermes Windows preparation: https://docs.nvidia.com/nemoclaw/latest/user-guide/hermes/get-started/windows-preparation.md
 - Hermes quickstart: https://docs.nvidia.com/nemoclaw/latest/user-guide/hermes/get-started/quickstart.md
 
 ## Avoid Getting Stuck on Interactive NemoClaw Prompts
@@ -106,6 +108,20 @@ NEMOCLAW_PROVIDER=ollama NEMOCLAW_MODEL=<approved-model-or-omit-this-variable> N
 \`\`\`
 
 If non-interactive mode cannot cover a later prompt, stop before running the interactive command. Ask me one selection question, then choose either a supported non-interactive environment variable or a rerun plan. Do not leave a command waiting at \`Choose [1]:\`.
+
+## Recover from Cursor Windows Terminal Restrictions
+
+If I use Cursor on Windows and Cursor reports "Legacy Terminal Tool" is disabled, "Run Mode locked to Allowlist with Sandbox", or another message that blocks the command before it starts, treat that as a Cursor security restriction rather than a NemoClaw install failure.
+
+Explain the restriction in plain language and offer exactly two choices:
+
+- I can enable Cursor's terminal access and let you retry the approved command.
+- You can create a one-click Windows installer file for me and walk me through opening it.
+
+Before creating a one-click file, verify Docker Desktop is running or tell me to start it, because NemoClaw still needs Docker from WSL.
+If you create a file, use a temporary or clearly named local \`.bat\` file in my user profile, show me the file path, and include only the approved WSL command.
+After I run it, summarize the expected installer output and choose the next recovery step from the NemoClaw docs.
+Do not repeatedly retry blocked commands in Cursor after the same Run Mode message appears.
 
 ## Configure Messaging Channels after Non-Interactive Onboarding
 

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -76,6 +76,16 @@ If the bootstrap script reports that `winget.exe` is not available (common on Wi
 After you install Docker Desktop, rerun the bootstrap script.
 The script skips the install step after it detects Docker Desktop.
 
+## Recover from Cursor Terminal Restrictions
+
+Cursor can block the starter prompt before NemoClaw runs when Windows terminal automation is restricted.
+If Cursor reports that the Legacy Terminal Tool is disabled, or that Run Mode is locked to **Allowlist with Sandbox**, treat that as a Cursor security setting instead of a NemoClaw installer error.
+
+If your Cursor account allows it, enable the Legacy Terminal Tool in Cursor Settings, choose a Run Mode that permits the approved terminal command, then rerun the starter prompt.
+If those settings are locked by your account or organization, use the Windows bootstrap script above from PowerShell or ask Cursor to create a one-click `.bat` file that runs the approved WSL installer command.
+Before opening a one-click file, start Docker Desktop and wait until it is running.
+NemoClaw still needs Docker Desktop from WSL after Cursor hands off the installer command.
+
 The manual steps below describe the same Windows preparation pieces and are useful when you need to verify or repair WSL, Ubuntu, or Docker Desktop by hand.
 
 ## Enable WSL 2


### PR DESCRIPTION
## Summary
Adds a narrow Windows+Cursor recovery path for the starter prompt flow when Cursor blocks terminal automation before NemoClaw runs.

## Related Issue
Fixes #5326

## Changes
- Adds Windows preparation Markdown pages to the starter prompt source list.
- Adds starter-prompt guidance for Cursor Legacy Terminal Tool / Run Mode restrictions.
- Adds a Windows preparation recovery section that explains the Cursor restriction and the Docker Desktop prerequisite before one-click fallback files.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Commands run:
- `npx prek run --from-ref origin/main --to-ref HEAD`
- `npm run docs` — passed with 0 errors; Fern reported 2 existing warnings plus the Fern upgrade notice
- `npm test -- windows-preparation-doc-copy`

---
Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows troubleshooting guide for Cursor terminal restrictions
  * Provided recovery instructions with multiple resolution options
  * Updated Windows preparation documentation with setup guidance for supported agents
  * Documented step-by-step procedures to resolve terminal security restriction issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->