### PR TITLE
test(e2e): avoid inference calls in hosted reachability probe

### DIFF
--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -28,6 +28,55 @@ function secrets(values: Record<string, string | undefined>) {
   };
 }
 
+type ProbeRunOptions = {
+  env?: Record<string, string>;
+  curlExitCode?: number;
+  curlStatus?: string;
+};
+
+function runHostedProbe(options: ProbeRunOptions = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hosted-probe-"));
+  const callsPath = path.join(tmpDir, "curl.calls");
+  const curlPath = path.join(tmpDir, "curl");
+  const scriptPath = path.join(tmpDir, "run-probe.sh");
+  const curlExitCode = options.curlExitCode ?? 0;
+  const curlStatus = options.curlStatus ?? "404";
+
+  fs.writeFileSync(
+    curlPath,
+    `#!/bin/sh
+for arg in "$@"; do
+  printf 'ARG:%s\n' "$arg" >> ${JSON.stringify(callsPath)}
+done
+printf %s ${JSON.stringify(curlStatus)}
+exit ${curlExitCode}
+`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+. ${JSON.stringify(COMPAT_HELPER)}
+nemoclaw_e2e_probe_hosted_inference
+`,
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync("bash", [scriptPath], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${tmpDir}:${process.env.PATH ?? ""}`,
+      NVIDIA_INFERENCE_API_KEY: "hosted-compatible-key",
+      ...options.env,
+    },
+  });
+  const calls = fs.existsSync(callsPath) ? fs.readFileSync(callsPath, "utf-8") : "";
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  return { result, calls };
+}
+
 describe("hosted inference E2E config", () => {
   it("uses NVIDIA_INFERENCE_API_KEY as the hosted compatible endpoint source secret", () => {
     const cfg = requireHostedInferenceConfig(
@@ -54,44 +103,48 @@ describe("hosted inference E2E config", () => {
     expect(cfg.credentialEnv).toBe("COMPATIBLE_API_KEY");
   });
 
-  it("uses a lightweight reachability probe instead of spending an inference request", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hosted-probe-"));
-    try {
-      const curlPath = path.join(tmpDir, "curl");
-      const callsPath = path.join(tmpDir, "curl.calls");
-      fs.writeFileSync(
-        curlPath,
-        `#!/bin/sh
-printf '%s\n' "$*" >> ${JSON.stringify(callsPath)}
-case "$*" in
-  *chat/completions*) exit 88 ;;
-esac
-printf '404'
-exit 0
-`,
-        { mode: 0o755 },
-      );
+  it("uses a lightweight compatible reachability probe without API or auth requests", () => {
+    const { result, calls } = runHostedProbe({
+      env: {
+        NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1",
+        NEMOCLAW_ENDPOINT_URL: "https://inference-api.nvidia.com/v1",
+      },
+    });
 
-      const result = spawnSync(
-        "bash",
-        [
-          "-c",
-          `set -euo pipefail
-export PATH=${JSON.stringify(`${tmpDir}:${process.env.PATH ?? ""}`)}
-export NVIDIA_INFERENCE_API_KEY=hosted-compatible-key
-export NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1
-. ${JSON.stringify(COMPAT_HELPER)}
-nemoclaw_e2e_probe_hosted_inference
-`,
-        ],
-        { encoding: "utf-8" },
-      );
+    expect(result.status).toBe(0);
+    expect(calls).toContain("ARG:https://inference-api.nvidia.com/v1");
+    expect(calls).not.toContain("chat/completions");
+    expect(calls).not.toContain("/models");
+    expect(calls).not.toContain("Authorization");
+    expect(calls).not.toContain("Bearer");
+  });
 
-      expect(result.status).toBe(0);
-      expect(fs.readFileSync(callsPath, "utf-8")).not.toContain("chat/completions");
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
+  it("uses a lightweight nvapi reachability probe without /models or auth", () => {
+    const { result, calls } = runHostedProbe({
+      env: {
+        NVIDIA_INFERENCE_API_KEY: "nvapi-test-key",
+        NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "",
+        NEMOCLAW_PROVIDER: "cloud",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(calls).toContain("ARG:https://inference-api.nvidia.com/v1");
+    expect(calls).not.toContain("/models");
+    expect(calls).not.toContain("Authorization");
+    expect(calls).not.toContain("Bearer");
+  });
+
+  it("fails hosted reachability when curl returns HTTP status 000", () => {
+    const { result } = runHostedProbe({ curlStatus: "000" });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("fails hosted reachability when curl exits nonzero", () => {
+    const { result } = runHostedProbe({ curlExitCode: 7, curlStatus: "" });
+
+    expect(result.status).not.toBe(0);
   });
 
   it("configures the custom provider route for inference-api.nvidia.com", () => {

--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -1,9 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+
+const COMPAT_HELPER = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "e2e",
+  "lib",
+  "ci-compatible-inference.sh",
+);
 
 function secrets(values: Record<string, string | undefined>) {
   return {
@@ -39,6 +52,46 @@ describe("hosted inference E2E config", () => {
 
     expect(cfg.apiKey).toBe("sk-compatible-key");
     expect(cfg.credentialEnv).toBe("COMPATIBLE_API_KEY");
+  });
+
+  it("uses a lightweight reachability probe instead of spending an inference request", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hosted-probe-"));
+    try {
+      const curlPath = path.join(tmpDir, "curl");
+      const callsPath = path.join(tmpDir, "curl.calls");
+      fs.writeFileSync(
+        curlPath,
+        `#!/bin/sh
+printf '%s\n' "$*" >> ${JSON.stringify(callsPath)}
+case "$*" in
+  *chat/completions*) exit 88 ;;
+esac
+printf '404'
+exit 0
+`,
+        { mode: 0o755 },
+      );
+
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail
+export PATH=${JSON.stringify(`${tmpDir}:${process.env.PATH ?? ""}`)}
+export NVIDIA_INFERENCE_API_KEY=hosted-compatible-key
+export NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1
+. ${JSON.stringify(COMPAT_HELPER)}
+nemoclaw_e2e_probe_hosted_inference
+`,
+        ],
+        { encoding: "utf-8" },
+      );
+
+      expect(result.status).toBe(0);
+      expect(fs.readFileSync(callsPath, "utf-8")).not.toContain("chat/completions");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("configures the custom provider route for inference-api.nvidia.com", () => {

--- a/test/e2e/lib/ci-compatible-inference.sh
+++ b/test/e2e/lib/ci-compatible-inference.sh
@@ -105,27 +105,16 @@ nemoclaw_e2e_hosted_inference_model() {
 }
 
 nemoclaw_e2e_probe_hosted_inference() {
-  local base_url key
+  local base_url status
   base_url="$(nemoclaw_e2e_hosted_inference_base_url)"
-  key="$(nemoclaw_e2e_hosted_inference_key)"
 
-  if nemoclaw_e2e_using_compatible_inference; then
-    local model payload
-    model="$(nemoclaw_e2e_hosted_inference_model)"
-    payload=$(
-      printf '{"model":"%s","messages":[{"role":"user","content":"Respond with OK."}],"temperature":0,"max_tokens":8}' "$model"
-    )
-    curl -sf --max-time 30 \
-      -X POST "${base_url}/chat/completions" \
-      -H "Authorization: Bearer $key" \
-      -H "Content-Type: application/json" \
-      -d "$payload" >/dev/null 2>&1
-    return $?
-  fi
-
-  curl -sf --max-time 10 \
-    -H "Authorization: Bearer $key" \
-    "${base_url}/models" >/dev/null 2>&1
+  # This preflight is a network/TLS reachability check only. Do not spend an
+  # inference request here: full parallel nightly runs can otherwise burn CI
+  # quota or trip HTTP 429 before the scenario reaches the behavior under test.
+  # Onboarding still performs the authenticated model/API validation with
+  # redaction and retries.
+  status=$(curl -sS --connect-timeout 10 --max-time 20 -o /dev/null -w "%{http_code}" "$base_url" 2>/dev/null) || return $?
+  [ -n "$status" ] && [ "$status" != "000" ]
 }
 
 nemoclaw_e2e_require_hosted_inference_key() {

--- a/test/e2e/lib/ci-compatible-inference.sh
+++ b/test/e2e/lib/ci-compatible-inference.sh
@@ -111,6 +111,9 @@ nemoclaw_e2e_probe_hosted_inference() {
   # This preflight is a network/TLS reachability check only. Do not spend an
   # inference request here: full parallel nightly runs can otherwise burn CI
   # quota or trip HTTP 429 before the scenario reaches the behavior under test.
+  # In compatible mode, NEMOCLAW_ENDPOINT_URL is a trusted repo-controlled CI
+  # input from nightly workflow env_json; this probe intentionally validates
+  # only TCP/TLS/HTTP reachability for that base URL, not provider semantics.
   # Onboarding still performs the authenticated model/API validation with
   # redaction and retries.
   status=$(curl -sS --connect-timeout 10 --max-time 20 -o /dev/null -w "%{http_code}" "$base_url" 2>/dev/null) || return $?


### PR DESCRIPTION
## Summary
Changes the hosted inference E2E preflight from an authenticated chat completion to a lightweight HTTP reachability probe. This avoids spending model requests and tripping HTTP 429 during full parallel nightly runs before the scenario reaches the behavior under test.

## Related Issue
Related to #5406 nightly follow-up.

## Changes
- Update `test/e2e/lib/ci-compatible-inference.sh` so `nemoclaw_e2e_probe_hosted_inference` checks network/TLS reachability only and accepts any non-000 HTTP response.
- Add support-test coverage proving the probe does not call `/chat/completions`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:
- `npx biome check --write test/e2e-scenario/support-tests/hosted-inference.test.ts`
- `bash -n test/e2e/lib/ci-compatible-inference.sh`
- `npx vitest run --project cli test/e2e-scenario/support-tests/hosted-inference.test.ts`

Docs review: no user-facing docs changes needed; this is E2E harness stabilization only.

Note: local broad hooks still fail in unrelated runtime recovery preload tests because temp preload files are seen as group-writable (`mode=664`), matching prior local hook failures. Targeted changed tests passed.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for hosted inference probe validation, including lightweight reachability assertions and negative cases when connectivity fails or the probe reports errors.

* **Refactor**
  * Updated the hosted inference probe to run a lightweight network/TLS connectivity check only, avoiding authenticated requests and preventing inference/auth-related endpoints from being called.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->