### PR TITLE
test(e2e): accept multiturn Kimi tool calls

### DIFF
--- a/test/e2e/test-kimi-inference-compat.sh
+++ b/test/e2e/test-kimi-inference-compat.sh
@@ -678,7 +678,9 @@ assistant_tool_messages = [
     and item.get("message", {}).get("role") == "assistant"
     and any(block.get("type") == "toolCall" for block in item.get("message", {}).get("content", []))
 ]
-source_calls = assistant_tool_messages[-1].get("content", []) if assistant_tool_messages else []
+source_calls = []
+for message in assistant_tool_messages:
+    source_calls.extend(message.get("content", []))
 source_commands = [block.get("arguments", {}).get("command") for block in source_calls]
 messages = [item.get("message", {}) for item in session if item.get("type") == "message"]
 tool_result_indices = [idx for idx, msg in enumerate(messages) if msg.get("role") == "toolResult"]


### PR DESCRIPTION
## Summary
Stabilizes the live Kimi inference compatibility E2E by accepting Kimi tool calls emitted across multiple assistant turns. The full nightly run showed Kimi successfully executing all three expected tools and producing the final answer, but the trajectory checker only inspected the last assistant tool-call message and failed when the model emitted one command per assistant turn.

## Related Issue
Related to #5401.

## Changes
- Flatten tool-call content from all assistant tool-call messages in `test/e2e/test-kimi-inference-compat.sh` before checking the expected `hostname`, `date`, `uptime` order.
- Preserve the existing checks that the trace artifacts contain exactly three `exec` tool metas, no combined semicolon command remains, final status is success, and the final assistant response follows all tool results.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:
- `bash -n test/e2e/test-kimi-inference-compat.sh`

Nightly evidence:
- Main full nightly run 27487294753 failed `kimi-inference-compat-e2e` only because `sourceAssistantCommands` was `['uptime']` while the same trajectory showed `toolMetasCount: 3`, command set `date/hostname/uptime`, final status `success`, and final assistant text was correct.

Docs review: no user-facing docs changes needed; this is E2E harness stabilization only.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test validation to comprehensively examine tool call handling across all assistant messages with tool call blocks, ensuring more thorough assertion checks for command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->