### PR TITLE
chore(lint): ratchet cognitive complexity

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -86,7 +86,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 254
+            "maxAllowedComplexity": 255
           }
         }
       },
@@ -96,21 +96,6 @@
     }
   },
   "overrides": [
-    {
-      "includes": ["src/lib/onboard.ts"],
-      "linter": {
-        "rules": {
-          "complexity": {
-            "noExcessiveCognitiveComplexity": {
-              "level": "error",
-              "options": {
-                "maxAllowedComplexity": 255
-              }
-            }
-          }
-        }
-      }
-    },
     {
       "includes": [
         "bin/**/*.js",

--- a/biome.json
+++ b/biome.json
@@ -82,6 +82,14 @@
     "enabled": true,
     "rules": {
       "recommended": false,
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 255
+          }
+        }
+      },
       "correctness": {
         "noUndeclaredVariables": "error"
       }

--- a/biome.json
+++ b/biome.json
@@ -86,7 +86,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 255
+            "maxAllowedComplexity": 254
           }
         }
       },
@@ -96,6 +96,21 @@
     }
   },
   "overrides": [
+    {
+      "includes": ["src/lib/onboard.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": {
+              "level": "error",
+              "options": {
+                "maxAllowedComplexity": 255
+              }
+            }
+          }
+        }
+      }
+    },
     {
       "includes": [
         "bin/**/*.js",


### PR DESCRIPTION
## Summary
Enable Biome's cognitive complexity lint rule as an error at the current maximum observed threshold. This starts the ratchet without requiring refactors or introducing per-file exceptions in the PR.

## Changes
- Added `complexity/noExcessiveCognitiveComplexity` to `biome.json` with `maxAllowedComplexity: 255`.
- Keeps the current tree passing while preventing future functions from exceeding the existing top score.
- Avoids scoped overrides or ignore comments so the lint ratchet starts from a single global baseline.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
Targeted validation run before commit:
- `npx @biomejs/biome lint --only=complexity/noExcessiveCognitiveComplexity --max-diagnostics=none .`
- `npx @biomejs/biome lint biome.json`
- `npx @biomejs/biome format biome.json`

- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the linter configuration to enforce stricter cognitive complexity checks, reporting excessive complexity as an error to help keep code easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->