### PR TITLE
docs(inference): add model task-fit guidance

### DIFF
--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -74,6 +74,24 @@ The managed install/start vLLM entry appears by default on DGX Spark and DGX Sta
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to [Use a Local Inference Server](use-local-inference). |
 | Model Router | Starts a host-side router on port `4000`, registers it as an OpenAI-compatible provider, and keeps the sandbox pointed at `inference.local`. Set `NEMOCLAW_PROVIDER=routed` for non-interactive setup. | The router pool defines the model names. |
 
+## Choosing a Model for Your Task
+
+The tables above list *where* inference runs.
+Use the guidance below to choose *which* kind of model fits your workload, then tune the model metadata NemoClaw bakes into the sandbox.
+
+| Your task | Recommended option | Why | Where to configure |
+|---|---|---|---|
+| Tool-heavy or agentic work (several tools, long instructions, multi-turn dispatch) | A managed Nemotron model, or a local server with a tool-call parser such as vLLM | Agent loops need the server to return structured `tool_calls`, not a JSON-looking string in normal assistant text. | [Tool-Calling Reliability](tool-calling-reliability) |
+| Cost-sensitive or mixed workload | Model Router | The router picks the lowest-cost model whose predicted quality stays within the configured `tolerance` threshold. | [Model Router](#model-router) |
+| Long-context prompts | A provider and model that support a large context window | NemoClaw bakes the context window into the sandbox; local vLLM auto-detects `max_model_len` when you do not set one. | Set `NEMOCLAW_CONTEXT_WINDOW`; see [Switch Inference Models](switch-inference-providers#tune-model-metadata) |
+| Multimodal (image input) | A model that accepts image input through your provider | Declare image support so NemoClaw configures the sandbox for multimodal inputs. | Set `NEMOCLAW_INFERENCE_INPUTS=text,image`; see [Switch Inference Models](switch-inference-providers#tune-model-metadata) |
+| Local, offline, or privacy-sensitive | Local Ollama or managed vLLM | Local routes keep inference on the host and do not forward your provider API key into the sandbox. | [Use a Local Inference Server](use-local-inference) |
+
+<Note>
+Relative latency and price depend on the provider, region, and model revision, so this page does not rank models on those axes.
+Use the Model Router when you want NemoClaw to balance quality against cost automatically, and check your provider's catalog for current per-model pricing and context limits.
+</Note>
+
 ## Choosing the Right Option for Nemotron
 
 NVIDIA Nemotron models expose OpenAI-compatible APIs across every supported deployment surface, so two onboarding options can route to Nemotron.

--- a/test/repro-4755-model-task-fit.test.ts
+++ b/test/repro-4755-model-task-fit.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression test for issue #4755:
+ *   inference-options page lacks per-model task-fit guidance, so a reader
+ *   trying to "pick the right model for my use case" has no basis for the
+ *   decision (JTBD-4).
+ *
+ * Locks in a repo-grounded "Choosing a Model for Your Task" section that maps
+ * a use case to a recommended option, a grounded rationale, and where to
+ * configure it. Every row cites an existing page/section or NEMOCLAW_* knob,
+ * so this test also guards against the cited links/knobs drifting away.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const PAGE_PATH = path.join(REPO_ROOT, "docs", "inference", "inference-options.mdx");
+const page = fs.readFileSync(PAGE_PATH, "utf8");
+
+describe("inference-options model task-fit guidance (#4755)", () => {
+  it("adds the task-fit section before the Nemotron routing section", () => {
+    const taskFit = page.indexOf("## Choosing a Model for Your Task");
+    const nemotron = page.indexOf("## Choosing the Right Option for Nemotron");
+    expect(taskFit).toBeGreaterThan(-1);
+    expect(nemotron).toBeGreaterThan(-1);
+    expect(taskFit).toBeLessThan(nemotron);
+  });
+
+  it("documents the task-fit table header", () => {
+    expect(page).toContain("| Your task | Recommended option | Why | Where to configure |");
+  });
+
+  it.each([
+    "Tool-heavy or agentic work",
+    "Cost-sensitive or mixed workload",
+    "Long-context prompts",
+    "Multimodal (image input)",
+    "Local, offline, or privacy-sensitive",
+  ])("covers the %s use case", (useCase) => {
+    expect(page).toContain(useCase);
+  });
+
+  it.each([
+    "NEMOCLAW_CONTEXT_WINDOW",
+    "NEMOCLAW_INFERENCE_INPUTS=text,image",
+  ])("grounds configuration in %s", (knob) => {
+    expect(page).toContain(knob);
+  });
+
+  it.each([
+    "(tool-calling-reliability)",
+    "(#model-router)",
+    "(switch-inference-providers#tune-model-metadata)",
+    "(use-local-inference)",
+  ])("cites the %s link", (link) => {
+    expect(page).toContain(link);
+  });
+
+  it("does not assert relative latency or price rankings", () => {
+    const section = page.slice(
+      page.indexOf("## Choosing a Model for Your Task"),
+      page.indexOf("## Choosing the Right Option for Nemotron"),
+    );
+    expect(section).toMatch(/does not rank models on those axes/);
+  });
+});


### PR DESCRIPTION
## Summary
The Inference Options page compares providers and hosts but never maps a model to a task type, so a reader trying to pick the right model for their use case (JTBD-4) has no basis for the decision. This adds a repo-grounded "Choosing a Model for Your Task" section so readers can match a workload to an inference option.

## Related Issue
Fixes #4755

## Changes
- Add a "Choosing a Model for Your Task" section to `docs/inference/inference-options.mdx`, placed between the provider tables and the Nemotron routing section, with a use-case table covering tool-heavy/agentic work, cost-sensitive/mixed workloads, long-context prompts, multimodal (image input), and local/offline use.
- Ground every row in existing material: Tool-Calling Reliability, the Model Router `tolerance` mechanism, `NEMOCLAW_CONTEXT_WINDOW`, `NEMOCLAW_INFERENCE_INPUTS`, and the local-inference guide. A short note states that relative latency and price are intentionally not ranked, since those are not repo-owned facts and vary by provider/region/revision.
- Add `test/repro-4755-model-task-fit.test.ts` (the doc-validation test requested in the issue): asserts the section, each use-case row, the cited `NEMOCLAW_*` knobs, and the internal links are present and that the section precedes the Nemotron section.
- Verification run manually (prek hooks were not installed in this environment): `vitest run test/repro-4755-model-task-fit.test.ts` (14/14), `npm run docs` (0 errors; the only 2 warnings are pre-existing global ones — Fern redirects-auth and theme accent-contrast — not introduced by this change), `biome check` (clean), and `npm run typecheck:cli` (0 errors).

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Choosing a Model for Your Task” section with a workload-to-recommendation guide, including guidance for tool-heavy/agentic work, cost-sensitive use cases, long-context prompts, multimodal image input, and local/offline/privacy-sensitive scenarios.
  * Clarified that latency and price aren’t ranked, and recommended automated quality-vs-cost balancing.

* **Tests**
  * Added a regression test to confirm the section’s placement, expected table/content, anchor links, and that it does not claim latency/price ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->