### PR TITLE
chore(lint): lower cognitive complexity ratchet to 184

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -86,7 +86,7 @@
         "noExcessiveCognitiveComplexity": {
           "level": "error",
           "options": {
-            "maxAllowedComplexity": 185
+            "maxAllowedComplexity": 184
           }
         }
       },


### PR DESCRIPTION
## Summary
Continue the stacked cognitive-complexity ratchet by lowering the threshold from 185 to 184. The previous stack step brought all remaining offenders to 184 or below, so this PR only tightens the Biome configuration.

## Changes
- Lowered `complexity/noExcessiveCognitiveComplexity` from `185` to `184` in `biome.json`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- `npx @biomejs/biome lint --only=complexity/noExcessiveCognitiveComplexity --max-diagnostics=none .`

- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Tests added or updated for new or changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>