### PR TITLE
fix(e2e): relax Kimi K5 trajectory final-text exact match

### DIFF
--- a/test/e2e/test-kimi-inference-compat.sh
+++ b/test/e2e/test-kimi-inference-compat.sh
@@ -575,7 +575,11 @@ PY
     return
   fi
 
-  if [ "$final_text" = "hostname, date, and uptime completed successfully." ]; then
+  canonical_text="hostname, date, and uptime completed successfully."
+  # Strip trailing period for comparison — live Kimi may omit it (#5419 nightly)
+  final_text_normalized="${final_text%.}"
+  canonical_normalized="${canonical_text%.}"
+  if [ "$final_text_normalized" = "$canonical_normalized" ]; then
     pass "K4: OpenClaw agent returned the expected final text"
   else
     pass "K4: OpenClaw agent command completed; trajectory acceptance validates final tool results"
@@ -711,8 +715,10 @@ if "abandoned" in raw.lower():
 if "want me to continue" in raw.lower():
     errors.append("trajectory/session contains 'want me to continue'")
 final_texts = artifact_data.get("assistantTexts") or []
-if not final_texts or final_texts[-1] != "hostname, date, and uptime completed successfully.":
-    errors.append("final assistant text is %r" % (final_texts[-1] if final_texts else None))
+canonical = "hostname, date, and uptime completed successfully."
+last_text = final_texts[-1] if final_texts else None
+if not last_text or last_text.rstrip(".") != canonical.rstrip("."):
+    errors.append("final assistant text is %r" % last_text)
 if not tool_result_indices or not assistant_indices or max(assistant_indices) <= max(tool_result_indices):
     errors.append("final assistant response did not occur after all tool results")
 


### PR DESCRIPTION
## Summary

**✨ [AI-generated PR]**

Relax the Kimi K5 trajectory acceptance check to tolerate missing trailing periods in the assistant's final text. The live Kimi model (`moonshotai/kimi-k2.6`) returned `"hostname, date, and uptime completed successfully"` (no period) during the 2026-06-15 nightly, which is semantically correct but failed the exact-match assertion. The same tolerance is applied to the K4 inline check for consistency.

Fixes #5434

## Related Issue

Fixes #5434

## Changes

- `test/e2e/test-kimi-inference-compat.sh`:
  - **K4 check** (~line 578): compare final text after stripping trailing period (`${final_text%.}`)
  - **K5 trajectory acceptance** (~line 714): compare `last_text.rstrip(".")` against the canonical string stripped the same way, so punctuation-only variance no longer fails the check

## Validation

The fix targets the nightly `kimi-inference-compat-e2e` job. A `-custom-e2e` validation workflow could not be pushed because the PAT lacks `.github/workflows/` write permission. Reviewers should re-run the `kimi-inference-compat-e2e` job on this branch to validate.

- Fix branch: [`fix/nightly-e2e-kimi-k5-trajectory-text-f4f3c58`](https://github.com/NVIDIA/NemoClaw/tree/fix/nightly-e2e-kimi-k5-trajectory-text-f4f3c58) on `NVIDIA/NemoClaw`
- Targeted jobs: `kimi-inference-compat-e2e (#81327174808)`
- Original failing run: [27516931535](https://github.com/NVIDIA/NemoClaw/actions/runs/27516931535) on `f4f3c586bd809db5ea36d4a46efc5a8873923981`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `bash -n test/e2e/test-kimi-inference-compat.sh` passes (syntax check)
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes

## AI Disclosure

- [x] AI-assisted — tool: Claude Code (nemoclaw-diagnosis skill)

---

Signed-off-by: Hung Le <hple@nvidia.com>