### PR TITLE
fix(docs): correct in-sandbox OpenClaw config path in runtime controls

### DIFF
--- a/docs/manage-sandboxes/runtime-controls.mdx
+++ b/docs/manage-sandboxes/runtime-controls.mdx
@@ -41,7 +41,7 @@ The table below maps each commonly changed item to the layer that owns it and th
 | Agents allow-list (`agents.list` in `openclaw.json`) | Runtime. OpenClaw hot-reloads on config change | Prefer agent or NemoClaw commands that keep host and sandbox state aligned |
 | `openclaw.json` keys (general: model, agents.list, web.backend, channel config, and so on) | Mixed. Individual keys still follow the rebuild rules in the rows above, such as provider switch requiring rebuild even after editing the JSON. | Prefer NemoClaw host commands so the host registry and rebuilt image stay aligned |
 
-If a row above conflicts with what you observe, the runtime source of truth inside the sandbox is `/opt/nemoclaw/openclaw.json`; the host registry caches metadata but the image and OpenClaw read from the in-sandbox file.
+If a row above conflicts with what you observe, the runtime source of truth inside the sandbox is `/sandbox/.openclaw/openclaw.json`; the host registry caches metadata but the image and OpenClaw read from the in-sandbox file.
 
 </AgentOnly>
 <AgentOnly variant="hermes">

--- a/test/repro-runtime-controls-config-path.test.ts
+++ b/test/repro-runtime-controls-config-path.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// Regression: docs/manage-sandboxes/runtime-controls.mdx told users the OpenClaw
+// "runtime source of truth inside the sandbox" was /opt/nemoclaw/openclaw.json,
+// but that directory holds the NemoClaw plugin (installed via
+// `openclaw plugins install /opt/nemoclaw`), not the config. OpenClaw reads its
+// config from /sandbox/.openclaw/openclaw.json — the path the Dockerfile writes
+// and that src/lib/channel-runtime-status.ts calls "the same file OpenClaw
+// parses at startup." The Hermes sibling row already used the correct
+// /sandbox/.hermes paths.
+const REPO_ROOT = path.dirname(import.meta.dirname);
+const DOC = path.join(REPO_ROOT, "docs", "manage-sandboxes", "runtime-controls.mdx");
+const text = fs.readFileSync(DOC, "utf-8");
+
+describe("runtime-controls.mdx in-sandbox config path", () => {
+  it("points OpenClaw at the real in-sandbox config path", () => {
+    expect(text).not.toMatch(/\/opt\/nemoclaw\/openclaw\.json/);
+    expect(text).toContain("/sandbox/.openclaw/openclaw.json");
+  });
+
+  it("keeps the correct Hermes runtime source-of-truth paths", () => {
+    expect(text).toContain("/sandbox/.hermes/config.yaml");
+    expect(text).toContain("/sandbox/.hermes/.env");
+  });
+});


### PR DESCRIPTION
## Summary

The Runtime Controls page tells users the OpenClaw "runtime source of truth inside the sandbox" is `/opt/nemoclaw/openclaw.json`. That directory holds the **NemoClaw plugin**, not the agent config — so a user following the doc to inspect or reconcile config would look in the wrong place. OpenClaw reads its config from `/sandbox/.openclaw/openclaw.json`. This corrects the path.

## Related Issue

None — found during a documentation correctness sweep. (No tracking issue filed.)

## Changes

- `docs/manage-sandboxes/runtime-controls.mdx`: fix the OpenClaw "runtime source of truth" path from `/opt/nemoclaw/openclaw.json` to `/sandbox/.openclaw/openclaw.json`. The Hermes sibling row a few lines below already uses the correct `/sandbox/.hermes/config.yaml` + `/sandbox/.hermes/.env` paths.
- `test/repro-runtime-controls-config-path.test.ts`: add a regression test asserting the corrected OpenClaw path (and the existing Hermes paths), mirroring the existing docs-regression pattern in `test/repro-5088-best-practices-layers.test.ts`.

Evidence the corrected path is the real one:

- `Dockerfile` installs the NemoClaw plugin at `/opt/nemoclaw` (`openclaw plugins install /opt/nemoclaw`) and writes the agent config to `/sandbox/.openclaw/openclaw.json`.
- `src/lib/channel-runtime-status.ts` reads `/sandbox/.openclaw/openclaw.json` and documents it as "the same file OpenClaw parses at startup."

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

(One-word prose correction; plus an additive docs-regression guard test. No runtime code or code samples changed.)

## Verification

- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Notes: the new regression test passes (`vitest run test/repro-runtime-controls-config-path.test.ts` → 2 passed). The full `npm test` and `npm run docs` boxes are left unchecked because this is a prose-only change with no link or structural impact; the targeted regression test is the proof.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NemoClaw runtime controls documentation to reference the correct in-sandbox OpenClaw “source of truth” path (`/sandbox/.openclaw/openclaw.json`) instead of the prior `/opt/...` location.

* **Tests**
  * Added a regression test that validates the documentation no longer references the old OpenClaw path and continues to confirm the expected Hermes runtime “source of truth” paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->