### PR TITLE
chore(biome): ratchet node import protocol diagnostics

### DIFF
--- a/ci/biome-diagnostic-budget.json
+++ b/ci/biome-diagnostic-budget.json
@@ -10,6 +10,11 @@
       "name": "import cycles",
       "selector": "noImportCycles",
       "maxDiagnostics": 14
+    },
+    {
+      "name": "Node.js builtin import protocol",
+      "selector": "useNodejsImportProtocol",
+      "maxDiagnostics": 79
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds Node.js builtin import protocol diagnostics to the Biome ratchet at the current baseline so new imports keep using the explicit `node:` protocol.

## Changes
- Add a `useNodejsImportProtocol` budget entry to `ci/biome-diagnostic-budget.json`.
- Set the current Node builtin import protocol baseline to 79 diagnostics.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
