### PR TITLE
fix(sandbox): tolerate brave provider profile re-import in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -709,7 +709,12 @@ RUN set -eu; \
     fi; \
     if [ "$NEMOCLAW_WEB_SEARCH_ENABLED" = "1" ]; then \
         openclaw plugins install "npm:@openclaw/brave-plugin@${OPENCLAW_VERSION}" --pin; \
-        BRAVE_API_KEY=openshell:resolve:env:BRAVE_API_KEY openclaw doctor --fix --non-interactive; \
+        if ! brave_doctor_out=$(BRAVE_API_KEY=openshell:resolve:env:BRAVE_API_KEY openclaw doctor --fix --non-interactive 2>&1); then \
+            printf '%s\n' "$brave_doctor_out" >&2; \
+            printf '%s' "$brave_doctor_out" | grep -qi "already exists" || exit 1; \
+        else \
+            printf '%s\n' "$brave_doctor_out"; \
+        fi; \
     elif [ "$NEMOCLAW_OPENCLAW_OTEL" = "1" ]; then \
         openclaw doctor --fix --non-interactive; \
     fi


### PR DESCRIPTION
## Summary
`openclaw plugins install brave-plugin` now imports the brave provider profile as
a side effect. The subsequent `openclaw doctor --fix --non-interactive` tries to
import it again, exits non-zero with "custom provider profile 'brave' already
exists", and kills the Docker build under `set -eu`.

The fix mirrors the tolerance already present in the host-side TypeScript
(`brave-provider-profile.ts:80`): capture doctor's output, and if the only
failure is "already exists", treat it as success. Any other non-zero exit still
propagates as a real build failure.

## Related Issue
Fixes #5367

## Changes
- `Dockerfile`: wrap `openclaw doctor --fix` in the Brave path with an
  `if ! var=$(cmd 2>&1)` guard that passes through "already exists" and fails
  hard on all other non-zero exits

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates

## Verification
- [x] No secrets, API keys, or credentials committed
- [x] Git hooks passed during commit and push

---
Signed-off-by: ShauryaaSharma <shauryasofficial27@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the setup build process by capturing diagnostic output and using smarter success/failure handling during optional component checks. If a resource already exists, the build now proceeds without failing, while genuine errors still stop the build. This results in clearer logs and more reliable initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->