### PR TITLE
test(shields): cover up and down flow outcomes

### DIFF
--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+const requireDist = createRequire(import.meta.url);
+const shieldsModulePath = "../../../dist/lib/shields/index.js";
+
+type ShieldsHarness = {
+  logSpy: MockInstance;
+  shieldsDown: typeof import("../../../dist/lib/shields/index.js").shieldsDown;
+  shieldsUp: typeof import("../../../dist/lib/shields/index.js").shieldsUp;
+  isShieldsDown: typeof import("../../../dist/lib/shields/index.js").isShieldsDown;
+};
+
+let tmpDir: string;
+
+function createHarness(): ShieldsHarness {
+  delete require.cache[requireDist.resolve(shieldsModulePath)];
+  delete require.cache[requireDist.resolve("../../../dist/lib/sandbox/privileged-exec.js")];
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+  const runner = requireDist("../../../dist/lib/runner.js");
+  const policy = requireDist("../../../dist/lib/policy/index.js");
+  const sandboxConfig = requireDist("../../../dist/lib/sandbox/config.js");
+  const registry = requireDist("../../../dist/lib/state/registry.js");
+  const privilegedExec = requireDist("../../../dist/lib/sandbox/privileged-exec.js");
+  const dockerExec = requireDist("../../../dist/lib/adapters/docker/exec.js");
+  const audit = requireDist("../../../dist/lib/shields/audit.js");
+
+  vi.spyOn(runner, "validateName").mockImplementation((name: unknown) => String(name));
+  vi.spyOn(runner, "runCapture").mockReturnValue("version: 1\nnetwork_policies:\n  test: {}\n");
+  vi.spyOn(runner, "run").mockReturnValue({ status: 0 });
+  vi.spyOn(policy, "buildPolicyGetCommand").mockReturnValue(["openshell", "policy", "get"]);
+  vi.spyOn(policy, "buildPolicySetCommand").mockReturnValue(["openshell", "policy", "set"]);
+  vi.spyOn(policy, "parseCurrentPolicy").mockImplementation((raw: unknown) => String(raw));
+  vi.spyOn(policy, "resolvePermissivePolicyPath").mockReturnValue(
+    path.join(tmpDir, "permissive.yaml"),
+  );
+  fs.writeFileSync(path.join(tmpDir, "permissive.yaml"), "version: 1\nnetwork_policies: {}\n");
+  vi.spyOn(sandboxConfig, "resolveAgentConfig").mockReturnValue({
+    agentName: "openclaw",
+    configDir: "/sandbox/.openclaw",
+    configFile: "openclaw.json",
+    configPath: "/sandbox/.openclaw/openclaw.json",
+    format: "json",
+  });
+  vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "openclaw", openshellDriver: "docker" });
+  vi.spyOn(registry, "listSandboxes").mockReturnValue({ sandboxes: [{ name: "openclaw" }] });
+  vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockImplementation(
+    (_sandboxName: unknown, cmd: unknown) => [
+      "exec",
+      "--user",
+      "root",
+      "openshell-openclaw",
+      ...(Array.isArray(cmd) ? cmd.map(String) : []),
+    ],
+  );
+  vi.spyOn(dockerExec, "dockerExecFileSync").mockImplementation((argv: unknown) => {
+    const args = Array.isArray(argv) ? argv.map(String) : [];
+    if (args.includes("sha256sum")) return "a".repeat(64) + "  /sandbox/.openclaw/openclaw.json\n";
+    if (args.includes("stat")) {
+      return args.at(-1) === "/sandbox/.openclaw"
+        ? "2770 sandbox:sandbox\n"
+        : "660 sandbox:sandbox\n";
+    }
+    return "";
+  });
+  vi.spyOn(audit, "appendAuditEntry").mockImplementation(() => undefined);
+
+  const shields = requireDist(shieldsModulePath);
+  logSpy.mockClear();
+  return {
+    logSpy,
+    shieldsDown: shields.shieldsDown,
+    shieldsUp: shields.shieldsUp,
+    isShieldsDown: shields.isShieldsDown,
+  };
+}
+
+describe("shields command flow", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "shields-flow-"));
+    vi.stubEnv("HOME", tmpDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete require.cache[requireDist.resolve(shieldsModulePath)];
+  });
+
+  it("shieldsDown captures policy, unlocks config, saves state, and skips timer on request", () => {
+    const harness = createHarness();
+
+    harness.shieldsDown("openclaw", {
+      timeout: "5m",
+      reason: "coverage",
+      skipTimer: true,
+      throwOnError: true,
+    });
+
+    const statePath = path.join(tmpDir, ".nemoclaw", "state", "shields-openclaw.json");
+    const state = JSON.parse(fs.readFileSync(statePath, "utf-8"));
+    expect(state).toMatchObject({
+      shieldsDown: true,
+      shieldsDownTimeout: 300,
+      shieldsDownReason: "coverage",
+      shieldsDownPolicy: "permissive",
+    });
+    expect(fs.existsSync(state.shieldsPolicySnapshotPath)).toBe(true);
+    expect(harness.isShieldsDown("openclaw")).toBe(true);
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
+      "Config unlocked for openclaw (no auto-lockdown timer",
+    );
+  });
+
+  it("shieldsUp refuses to mark lockdown active when the saved restrictive policy snapshot is missing", () => {
+    const harness = createHarness();
+    const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, "shields-openclaw.json"),
+      JSON.stringify({
+        shieldsDown: true,
+        shieldsDownAt: new Date(Date.now() - 120_000).toISOString(),
+        shieldsDownTimeout: 300,
+        shieldsDownReason: "coverage",
+        shieldsDownPolicy: "permissive",
+        shieldsPolicySnapshotPath: path.join(stateDir, "missing-snapshot.yaml"),
+      }),
+    );
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      "Saved policy snapshot is missing",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused shields command flow coverage for shields-down state capture and shields-up fail-closed behavior. The tests exercise the policy snapshot, mutable config unlock, state persistence, no-timer path, and missing restrictive snapshot guard.

## Changes
- Added `src/lib/shields/flow.test.ts` with a dist-style harness for shields commands.
- Covered `shieldsDown` capturing the current policy, applying permissive mode, unlocking config, saving state, and skipping the auto-lock timer.
- Covered `shieldsUp` refusing to mark lockdown active when the saved restrictive policy snapshot is missing.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
  - `npx vitest run src/lib/shields/flow.test.ts --project cli`
  - `npm run typecheck:cli`
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: commit and push hooks were skipped for this test-only branch because the broad local hook suite has unrelated pre-existing CLI failures in this checkout; targeted tests and CLI typecheck passed.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive end-to-end test suite for the shields command flow with detailed verification of state capture, persistence, configuration unlocking, and policy snapshot handling. The suite includes mock stubs for various components and proper cleanup procedures to ensure reliable test execution and environment restoration between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->