### PR TITLE
test(channels): cover remove and stop dry-run flows

### DIFF
--- a/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+const requireDist = createRequire(import.meta.url);
+const policyChannelModulePath = "../../../../dist/lib/actions/sandbox/policy-channel.js";
+
+type PolicyChannelModule = typeof import("../../../../dist/lib/actions/sandbox/policy-channel");
+
+describe("policy channel remove/enable flows", () => {
+  let exitSpy: MockInstance;
+  let logSpy: MockInstance;
+
+  beforeEach(() => {
+    delete require.cache[requireDist.resolve(policyChannelModulePath)];
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete require.cache[requireDist.resolve(policyChannelModulePath)];
+  });
+
+  it("reports remove usage and exits before touching channel state when no channel is supplied", async () => {
+    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
+
+    await expect(policyChannel.removeSandboxChannel("alpha", {})).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("supports a remove dry run without gateway, registry, or rebuild side effects", async () => {
+    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
+
+    await expect(
+      policyChannel.removeSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+    ).resolves.toBeUndefined();
+
+    expect(logSpy.mock.calls.flat().join("\n")).toContain(
+      "--dry-run: would remove channel 'telegram' for 'alpha'.",
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("supports stop dry runs for configured channels", async () => {
+    const registry = requireDist("../../../../dist/lib/state/registry.js");
+    vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "alpha" });
+    vi.spyOn(registry, "getConfiguredMessagingChannelsFromEntry").mockReturnValue(["telegram"]);
+    vi.spyOn(registry, "getDisabledChannels").mockReturnValue([]);
+    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
+
+    await expect(
+      policyChannel.stopSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+    ).resolves.toBeUndefined();
+
+    expect(logSpy.mock.calls.flat().join("\n")).toContain(
+      "--dry-run: would stop channel 'telegram' for 'alpha'.",
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused coverage for channel remove and stop command guardrails. The tests exercise usage errors and dry-run behavior without mutating gateway or registry state.

## Changes
- Added `src/lib/actions/sandbox/policy-channel-remove-flow.test.ts`.
- Covered `channels remove` with missing channel arguments.
- Covered `channels remove --dry-run` and `channels stop --dry-run` output and no-exit behavior.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
  - `npx vitest run src/lib/actions/sandbox/policy-channel-remove-flow.test.ts --project cli`
  - `npm run typecheck:cli`
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: commit and push hooks were skipped for this test-only branch because the broad local hook suite has unrelated pre-existing CLI failures in this checkout; targeted tests and CLI typecheck passed.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for sandbox policy channel removal and disable flows, ensuring proper error handling and dry-run behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->