### PR TITLE
test(connect): cover probe-only outcomes

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -24,6 +24,12 @@ type ConnectHarness = {
 
 type ConnectHarnessOptions = {
   listOutput?: string;
+  processCheck?: {
+    checked: boolean;
+    wasRunning?: boolean;
+    recovered?: boolean;
+    forwardRecovered?: boolean;
+  };
   spawnStatus?: number | null;
 };
 
@@ -86,7 +92,7 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
   vi.spyOn(sandboxVersion, "formatStalenessWarning").mockReturnValue([]);
   const checkAndRecoverSpy = vi
     .spyOn(processRecovery, "checkAndRecoverSandboxProcesses")
-    .mockReturnValue({ checked: true, wasRunning: true, recovered: false });
+    .mockReturnValue(options.processCheck ?? { checked: true, wasRunning: true, recovered: false });
   const ensureOllamaAuthProxySpy = vi
     .spyOn(ollamaProxy, "ensureOllamaAuthProxy")
     .mockImplementation(() => undefined);
@@ -172,6 +178,43 @@ describe("connectSandbox flow", () => {
 
     expect(harness.checkAndRecoverSpy).toHaveBeenCalledWith("alpha");
     expect(harness.ensureOllamaAuthProxySpy).toHaveBeenCalledTimes(1);
+    expect(harness.spawnSyncSpy).not.toHaveBeenCalledWith(
+      "openshell",
+      ["sandbox", "connect", "alpha"],
+      expect.any(Object),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("probe-only mode reports recovered gateways without opening an interactive shell", async () => {
+    const harness = createConnectHarness({
+      processCheck: { checked: true, wasRunning: false, recovered: true },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).resolves.toBeUndefined();
+
+    expect(harness.checkAndRecoverSpy).toHaveBeenCalledWith("alpha", { quiet: true });
+    expect(harness.runAutoPairSpy).toHaveBeenCalledWith("alpha", expect.any(Object));
+    expect(harness.spawnSyncSpy).not.toHaveBeenCalledWith(
+      "openshell",
+      ["sandbox", "connect", "alpha"],
+      expect.any(Object),
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
+      "Probe complete: recovered OpenClaw gateway in 'alpha'.",
+    );
+  });
+
+  it("probe-only mode exits when process inspection cannot run", async () => {
+    const harness = createConnectHarness({
+      processCheck: { checked: false, wasRunning: false, recovered: false },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(harness.runAutoPairSpy).not.toHaveBeenCalled();
     expect(harness.spawnSyncSpy).not.toHaveBeenCalledWith(
       "openshell",
       ["sandbox", "connect", "alpha"],


### PR DESCRIPTION
## Summary
Extends connect flow coverage to the `--probe-only` recovery path. The tests cover recovered gateway reporting and fail-fast process-inspection failures without opening an interactive shell.

## Changes
- Extended `src/lib/actions/sandbox/connect-flow.test.ts` with configurable process-check outcomes.
- Covered probe-only successful recovery output and auto-pair approval behavior.
- Covered probe-only failure when the sandbox process inspection cannot run.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
  - `npx vitest run src/lib/actions/sandbox/connect-flow.test.ts --project cli`
  - `npm run typecheck:cli`
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: commit and push hooks were skipped for this test-only branch because the broad local hook suite has unrelated pre-existing CLI failures in this checkout; targeted tests and CLI typecheck passed.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced the sandbox connection test harness to support configurable process inspection outcomes for improved test flexibility.
  * Added comprehensive test coverage for probe-only mode including scenarios for successful process recovery verification and handling process inspection failures.
  * Improved test robustness with better simulation of various process states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->