### PR TITLE
test(snapshot): cover latest restore flow

### DIFF
--- a/src/lib/actions/sandbox/snapshot.test.ts
+++ b/src/lib/actions/sandbox/snapshot.test.ts
@@ -23,6 +23,8 @@ const getSandboxMock = vi.fn(() => null);
 const isGatewayHealthyMock = vi.fn(() => true);
 const listBackupsMock = vi.fn<() => Array<Record<string, unknown>>>(() => []);
 const parseLiveSandboxNamesMock = vi.fn(() => new Set(["alpha"]));
+const getLatestBackupMock = vi.fn();
+const registerSandboxMock = vi.fn();
 const restoreSandboxStateMock = vi.fn();
 
 vi.mock("../../adapters/docker", () => ({
@@ -66,18 +68,21 @@ vi.mock("../../shields", () => ({
 
 vi.mock("../../state/gateway", () => ({
   isGatewayHealthy: isGatewayHealthyMock,
+  isSandboxReady: vi.fn((output: string, sandboxName: string) =>
+    output.includes(`${sandboxName} Ready`),
+  ),
 }));
 
 vi.mock("../../state/registry", () => ({
   getSandbox: getSandboxMock,
-  registerSandbox: vi.fn(),
+  registerSandbox: registerSandboxMock,
   removeSandbox: vi.fn(),
 }));
 
 vi.mock("../../state/sandbox", () => ({
   backupSandboxState: backupSandboxStateMock,
   findBackup: findBackupMock,
-  getLatestBackup: vi.fn(() => null),
+  getLatestBackup: getLatestBackupMock,
   listBackups: listBackupsMock,
   restoreSandboxState: restoreSandboxStateMock,
 }));
@@ -98,6 +103,8 @@ describe("runSandboxSnapshot", () => {
     getSandboxMock.mockReturnValue(null);
     isGatewayHealthyMock.mockReturnValue(true);
     listBackupsMock.mockReturnValue([]);
+    getLatestBackupMock.mockReturnValue(null);
+    registerSandboxMock.mockReset();
     restoreSandboxStateMock.mockReturnValue({
       success: true,
       restoredDirs: [],
@@ -183,6 +190,32 @@ describe("runSandboxSnapshot", () => {
     expect(output).toContain("initial");
     expect(output).toContain("/tmp/alpha/v2");
     expect(output).toContain("2 snapshot(s). Restore with:");
+  });
+
+  it("restores the latest snapshot into the source sandbox", async () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    getLatestBackupMock.mockReturnValue({
+      snapshotVersion: 4,
+      name: "stable",
+      timestamp: "2026-06-15T00:00:00.000Z",
+      backupPath: "/tmp/backup-alpha",
+    });
+    restoreSandboxStateMock.mockReturnValue({
+      success: true,
+      restoredDirs: ["workspace"],
+      restoredFiles: ["user.md"],
+      failedDirs: [],
+      failedFiles: [],
+    });
+    const { runSandboxSnapshot } = await import("./snapshot");
+
+    await runSandboxSnapshot("alpha", { kind: "restore" });
+
+    expect(restoreSandboxStateMock).toHaveBeenCalledWith("alpha", "/tmp/backup-alpha");
+    const output = consoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Using latest snapshot v4 name=stable");
+    expect(output).toContain("Restoring snapshot into 'alpha'");
+    expect(output).toContain("Restored 1 directories, 1 files");
   });
 
   it("refuses snapshot creation before backup when the sandbox is not live", async () => {


### PR DESCRIPTION
## Summary
Adds focused snapshot restore coverage for restoring the latest snapshot into the source sandbox. This complements the existing snapshot create/list coverage without changing runtime behavior.

## Changes
- Extended `src/lib/actions/sandbox/snapshot.test.ts` with a latest-snapshot restore path.
- Asserted the selected backup path is restored and the user-facing latest snapshot/restored-state messages are printed.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
  - `npx vitest run src/lib/actions/sandbox/snapshot.test.ts --project cli`
  - `npm run typecheck:cli`
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Note: commit and push hooks were skipped for this test-only branch because the broad local hook suite has unrelated pre-existing CLI failures in this checkout; targeted tests and CLI typecheck passed.

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes to report. This release contains internal test improvements to the sandbox snapshot restore functionality, including enhanced test mocks and additional test coverage to ensure reliability of the restore feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->