### PR TITLE
test(e2e): migrate cloud onboard flow to Vitest

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -1784,6 +1784,72 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+
+  cloud-onboard-vitest:
+    needs: generate-matrix
+    if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',cloud-onboard-vitest,') || contains(format(',{0},', inputs.scenarios), ',cloud-onboard,') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    env:
+      FREE_STANDING_VITEST_JOB: "1"
+      FREE_STANDING_SCENARIO_ID: "cloud-onboard"
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/cloud-onboard
+      NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
+      NEMOCLAW_RUN_E2E_SCENARIOS: "1"
+      NEMOCLAW_NON_INTERACTIVE: "1"
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_SANDBOX_NAME: "e2e-cloud-onboard-vitest"
+      NEMOCLAW_PUBLIC_INSTALL_REF: "${{ github.sha }}"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Install OpenShell CLI
+        run: bash scripts/install-openshell.sh
+
+      - name: Run cloud-onboard live Vitest test
+        env:
+          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
+          if command -v openshell >/dev/null 2>&1; then
+            OPENSHELL_BIN="$(command -v openshell)"
+          elif [ -x "$HOME/.local/bin/openshell" ]; then
+            OPENSHELL_BIN="$HOME/.local/bin/openshell"
+          else
+            echo "::error::OpenShell CLI not found after install"
+            exit 1
+          fi
+          export OPENSHELL_BIN
+          "$OPENSHELL_BIN" --version
+          npx vitest run --project e2e-scenarios-live \
+            test/e2e-scenario/live/cloud-onboard.test.ts \
+            --silent=false --reporter=default
+
+      - name: Upload cloud-onboard artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-vitest-scenarios-cloud-onboard
+          path: e2e-artifacts/vitest/cloud-onboard/
+          include-hidden-files: false
+          if-no-files-found: ignore
+          retention-days: 14
+
   token-rotation-vitest:
     needs: generate-matrix
     if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',token-rotation-vitest,') || contains(format(',{0},', inputs.scenarios), ',token-rotation,') }}
@@ -2986,6 +3052,7 @@ jobs:
         messaging-providers-vitest,
         launchable-smoke-vitest,
         double-onboard-vitest,
+        cloud-onboard-vitest,
         model-router-provider-routed-inference-vitest,
         sandbox-survival-vitest,
         gateway-drift-preflight-vitest,

--- a/test/e2e-scenario/live/cloud-onboard.test.ts
+++ b/test/e2e-scenario/live/cloud-onboard.test.ts
@@ -42,25 +42,32 @@ function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string
   return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
-async function cleanup(host: HostCliClient, sandbox: SandboxClient): Promise<void> {
-  await host
-    .command(
-      "bash",
-      [path.join(REPO_ROOT, "test/e2e/e2e-cloud-experimental/cleanup.sh"), "--verify"],
-      {
-        artifactName: "cleanup-cloud-experimental",
-        env: env(),
-        timeoutMs: 180_000,
-      },
-    )
-    .catch(() => undefined);
-  await sandbox
-    .openshell(["gateway", "destroy", "-g", "nemoclaw"], {
-      artifactName: "cleanup-openshell-gateway-destroy",
-      env: env(),
-      timeoutMs: 60_000,
-    })
-    .catch(() => undefined);
+async function cleanup(
+  host: HostCliClient,
+  sandbox: SandboxClient,
+  options: { verify: boolean; label: string },
+): Promise<void> {
+  const args = [path.join(REPO_ROOT, "test/e2e/e2e-cloud-experimental/cleanup.sh")];
+  if (options.verify) args.push("--verify");
+  const cleanupResult = await host.command("bash", args, {
+    artifactName: `${options.label}-cloud-experimental-cleanup`,
+    env: env(),
+    timeoutMs: 180_000,
+  });
+  if (options.verify) {
+    expect(cleanupResult.exitCode, resultText(cleanupResult)).toBe(0);
+  }
+
+  const gatewayDestroy = await sandbox.openshell(["gateway", "destroy", "-g", "nemoclaw"], {
+    artifactName: `${options.label}-openshell-gateway-destroy`,
+    env: env(),
+    timeoutMs: 60_000,
+  });
+  if (options.verify && gatewayDestroy.exitCode !== 0) {
+    expect(resultText(gatewayDestroy)).toMatch(
+      /unrecognized subcommand|not found|No active gateway/i,
+    );
+  }
 }
 
 function publicInstallRef(): string {
@@ -104,8 +111,10 @@ liveTest(
       skip(`Docker is required: ${resultText(docker)}`);
     }
 
-    cleanupRegistry.add("remove cloud-onboard sandbox", () => cleanup(host, sandbox));
-    await cleanup(host, sandbox);
+    cleanupRegistry.add("remove cloud-onboard sandbox", () =>
+      cleanup(host, sandbox, { label: "cleanup", verify: true }),
+    );
+    await cleanup(host, sandbox, { label: "pre-cleanup", verify: false });
 
     const install = await host.command(
       "bash",
@@ -169,7 +178,7 @@ liveTest(
       expect(result.exitCode, `${scriptName}: ${resultText(result)}`).toBe(0);
     }
 
-    await cleanup(host, sandbox);
+    await cleanup(host, sandbox, { label: "final-cleanup", verify: true });
     await artifacts.writeJson("scenario-result.json", { id: "cloud-onboard", status: "passed" });
   },
 );

--- a/test/e2e-scenario/live/cloud-onboard.test.ts
+++ b/test/e2e-scenario/live/cloud-onboard.test.ts
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Live Vitest replacement for test/e2e/test-cloud-onboard-e2e.sh. */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { type HostCliClient } from "../fixtures/clients/host.ts";
+import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
+import { expect, test } from "../fixtures/e2e-test.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-cloud-onboard-vitest";
+const CHECKS_DIR = path.join(REPO_ROOT, "test/e2e/e2e-cloud-experimental/checks");
+const LIVE_TIMEOUT_MS = 60 * 60_000;
+const liveTest = shouldRunLiveE2EScenarios() ? test : test.skip;
+
+validateSandboxName(SANDBOX_NAME);
+
+function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    ...buildAvailabilityProbeEnv(),
+    PATH: `${os.homedir()}/.local/bin:${os.homedir()}/.npm-global/bin:${process.env.PATH ?? ""}`,
+    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+    NEMOCLAW_NON_INTERACTIVE: "1",
+    NEMOCLAW_RECREATE_SANDBOX: "1",
+    NEMOCLAW_POLICY_MODE: "custom",
+    NEMOCLAW_POLICY_PRESETS: "npm,pypi",
+    NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+    OPENSHELL_GATEWAY: "nemoclaw",
+    ...extra,
+  };
+}
+
+function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
+  return [result.stdout, result.stderr].filter(Boolean).join("\n");
+}
+
+async function cleanup(host: HostCliClient, sandbox: SandboxClient): Promise<void> {
+  await host
+    .command(
+      "bash",
+      [path.join(REPO_ROOT, "test/e2e/e2e-cloud-experimental/cleanup.sh"), "--verify"],
+      {
+        artifactName: "cleanup-cloud-experimental",
+        env: env(),
+        timeoutMs: 180_000,
+      },
+    )
+    .catch(() => undefined);
+  await sandbox
+    .openshell(["gateway", "destroy", "-g", "nemoclaw"], {
+      artifactName: "cleanup-openshell-gateway-destroy",
+      env: env(),
+      timeoutMs: 60_000,
+    })
+    .catch(() => undefined);
+}
+
+function publicInstallRef(): string {
+  return process.env.NEMOCLAW_PUBLIC_INSTALL_REF || process.env.GITHUB_SHA || "main";
+}
+
+liveTest(
+  "cloud onboard: public installer creates healthy sandbox with security checks",
+  { timeout: LIVE_TIMEOUT_MS },
+  async ({ artifacts, cleanup: cleanupRegistry, host, sandbox, secrets, skip }) => {
+    const hosted = requireHostedInferenceConfig(secrets);
+    const ref = publicInstallRef();
+    const installUrl =
+      process.env.NEMOCLAW_INSTALL_SCRIPT_URL ??
+      `https://raw.githubusercontent.com/NVIDIA/NemoClaw/${ref}/install.sh`;
+    const installCwd = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-public-install-"));
+    const redactionValues = [hosted.apiKey];
+
+    await artifacts.writeJson("scenario.json", {
+      id: "cloud-onboard",
+      legacySource: "test/e2e/test-cloud-onboard-e2e.sh",
+      sandboxName: SANDBOX_NAME,
+      installUrl,
+      installRef: ref,
+      checksDir: CHECKS_DIR,
+      contracts: [
+        "public curl installer uses GitHub clone path for the requested ref",
+        "sandbox appears healthy after cloud onboarding",
+        "cloud split checks cover inference.local, security leak checks, and Landlock/read-only behavior",
+        "cleanup verifies sandbox removal",
+      ],
+    });
+
+    const docker = await host.command("docker", ["info"], {
+      artifactName: "phase-0-docker-info",
+      env: env(),
+      timeoutMs: 30_000,
+    });
+    if (docker.exitCode !== 0) {
+      if (process.env.GITHUB_ACTIONS === "true") throw new Error(resultText(docker));
+      skip(`Docker is required: ${resultText(docker)}`);
+    }
+
+    cleanupRegistry.add("remove cloud-onboard sandbox", () => cleanup(host, sandbox));
+    await cleanup(host, sandbox);
+
+    const install = await host.command(
+      "bash",
+      ["-lc", `cd '${installCwd}' && curl -fsSL '${installUrl}' | bash`],
+      {
+        artifactName: "phase-1-public-install",
+        env: env({
+          ...hosted.env,
+          NVIDIA_INFERENCE_API_KEY: hosted.apiKey,
+          NEMOCLAW_INSTALL_REF: ref,
+          NEMOCLAW_INSTALL_TAG: ref,
+          NEMOCLAW_INSTALL_SCRIPT_URL: installUrl,
+        }),
+        redactionValues,
+        timeoutMs: 25 * 60_000,
+      },
+    );
+    expect(install.exitCode, resultText(install)).toBe(0);
+    expect(resultText(install)).toContain("Installing NemoClaw from GitHub");
+    expect(resultText(install)).toContain("Cloning NemoClaw source");
+    if (ref !== "main") expect(resultText(install)).toContain(`Resolved install ref: ${ref}`);
+
+    const cliProbe = await host.command(
+      "bash",
+      [
+        "-lc",
+        'export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"; command -v nemoclaw; command -v openshell; nemoclaw --help >/dev/null',
+      ],
+      { artifactName: "phase-2-cli-path-probe", env: env(), timeoutMs: 60_000 },
+    );
+    expect(cliProbe.exitCode, resultText(cliProbe)).toBe(0);
+
+    const list = await host.command("bash", ["-lc", "nemoclaw list"], {
+      artifactName: "phase-2-nemoclaw-list",
+      env: env(),
+      timeoutMs: 60_000,
+    });
+    expect(list.exitCode, resultText(list)).toBe(0);
+    expect(list.stdout).toContain(SANDBOX_NAME);
+
+    const checkScripts = fs
+      .readdirSync(CHECKS_DIR)
+      .filter((name) => name.endsWith(".sh"))
+      .sort();
+    expect(checkScripts.length).toBeGreaterThan(0);
+    for (const scriptName of checkScripts) {
+      const result = await host.command("bash", [path.join(CHECKS_DIR, scriptName)], {
+        artifactName: `phase-3-check-${scriptName.replace(/\.sh$/, "")}`,
+        cwd: REPO_ROOT,
+        env: env({
+          ...hosted.env,
+          CLOUD_EXPERIMENTAL_MODEL: hosted.model,
+          COMPATIBLE_API_KEY: hosted.apiKey,
+          NEMOCLAW_E2E_CLOUD_API_KEY_ENV: "COMPATIBLE_API_KEY",
+          REPO: REPO_ROOT,
+          SANDBOX_NAME,
+        }),
+        redactionValues,
+        timeoutMs: 180_000,
+      });
+      expect(result.exitCode, `${scriptName}: ${resultText(result)}`).toBe(0);
+    }
+
+    await cleanup(host, sandbox);
+    await artifacts.writeJson("scenario-result.json", { id: "cloud-onboard", status: "passed" });
+  },
+);


### PR DESCRIPTION
## Summary
Migrate `test-cloud-onboard-e2e.sh` into the live Vitest E2E system. Adds `test/e2e-scenario/live/cloud-onboard.test.ts` and `cloud-onboard-vitest` workflow wiring. The Vitest test drives the public curl installer from the requested Git ref, verifies the installed CLI/OpenShell path, then runs the split cloud check scripts for inference.local, security, and Landlock/read-only behavior before cleanup.

## Related Issue
Refs #5098

## Changes
- Adds or wires the free-standing live Vitest scenario `cloud-onboard`.
- Adds selective workflow dispatch via `cloud-onboard-vitest` in `.github/workflows/e2e-vitest-scenarios.yaml`.
- Preserves the legacy system boundaries from `test-cloud-onboard-e2e.sh` while leaving legacy shell retirement to #5098 Phase 11.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted local checks run while preparing these branches:
- `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts --silent=false --reporter=default`
- `npm run typecheck:cli` for branches adding new TypeScript tests
- `git diff --check`

Selective same-runner dispatch: https://github.com/NVIDIA/NemoClaw/actions/runs/27638941300 — passed after merge-from-main refresh

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end live scenario that provisions a cloud onboarding environment and verifies the onboarding workflow, including installer/CLI availability and configuration/validation checks.

* **CI / Automation**
  * Extended the CI pipeline with a dedicated job to run the cloud onboarding scenario and upload its test artifacts.
  * Updated pull request scenario reporting so the cloud onboarding results are included in the published results table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->