### PR TITLE
docs: add quickstart starter prompt CTA

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -11,6 +11,8 @@ content:
 skill:
   priority: 10
 ---
+import { StarterPromptButton } from "../_components/StarterPromptButton";
+
 Follow these steps to get started with NemoClaw and your first sandboxed OpenClaw agent.
 
 <Note>
@@ -22,6 +24,13 @@ NemoClaw ships user skills for AI coding assistants.
 Load them when you want your assistant to walk through installation, inference choices, policy approvals, monitoring, or troubleshooting with NemoClaw-specific guidance.
 Refer to [Agent Skills](../resources/agent-skills).
 </Tip>
+
+<Tip title="Use an AI coding assistant">
+If you want Cursor, Claude Code, Codex, Copilot, or another coding assistant to guide the setup, copy the starter prompt below and paste it into your assistant.
+The prompt tells the assistant to collect choices before running commands, use non-interactive setup when possible, and load NemoClaw Agent Skills when available.
+</Tip>
+
+<StarterPromptButton />
 
 ## Install NemoClaw and Onboard an OpenClaw Agent
 


### PR DESCRIPTION
## Summary
- add the existing Copy Starter Prompt CTA to the OpenClaw quickstart
- explain when to paste the starter prompt into Cursor, Claude Code, Codex, Copilot, or another coding assistant
- keep the command-first install path available below the assistant-guided path

Part of #5048

## Testing
- `NODE_PATH=/workspace/openclaw/projects/nemoclaw/upstream/node_modules PATH=/workspace/openclaw/projects/nemoclaw/upstream/node_modules/.bin:$PATH npm run docs`
- `git -c gpg.ssh.allowedSignersFile=/workspace/openclaw/projects/nemoclaw/upstream/.git/info/allowed_signers verify-commit HEAD`

Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart guide with enhanced presentation of AI coding assistant tips using an interactive button for easy access to starter prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->