### PR TITLE
fix(sandbox): resolve host paths against caller cwd for download and upload

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1122,7 +1122,8 @@ Session JSONL can contain pasted secrets (API keys, tokens), so exported files a
 ### `nemohermes <name> download <sandbox-path> [host-dest]`
 
 Host-side wrapper around `openshell sandbox download` that adds a live-sandbox readiness check.
-The source path inside the sandbox and the host destination are forwarded to OpenShell verbatim, so the file-system semantics (single-file vs directory copy, trailing-slash handling, overwrite behaviour) follow the OpenShell transport.
+The sandbox source path is forwarded to OpenShell verbatim; a relative host destination is resolved against the caller's working directory before it reaches OpenShell, so the downloaded file lands where the user invoked the CLI from rather than inside the install directory.
+Absolute host destinations pass through unchanged, and the OpenShell transport keeps its file-system semantics (single-file vs directory copy, trailing-slash handling, overwrite behaviour).
 With no `host-dest` the destination defaults to the current directory.
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1378,7 +1378,8 @@ Session JSONL can contain pasted secrets (API keys, tokens), so exported files a
 ### `$$nemoclaw <name> download <sandbox-path> [host-dest]`
 
 Host-side wrapper around `openshell sandbox download` that adds a live-sandbox readiness check.
-The source path inside the sandbox and the host destination are forwarded to OpenShell verbatim, so the file-system semantics (single-file vs directory copy, trailing-slash handling, overwrite behaviour) follow the OpenShell transport.
+The sandbox source path is forwarded to OpenShell verbatim; a relative host destination is resolved against the caller's working directory before it reaches OpenShell, so the downloaded file lands where the user invoked the CLI from rather than inside the install directory.
+Absolute host destinations pass through unchanged, and the OpenShell transport keeps its file-system semantics (single-file vs directory copy, trailing-slash handling, overwrite behaviour).
 With no `host-dest` the destination defaults to the current directory.
 
 ```bash

--- a/src/commands/sandbox/download.ts
+++ b/src/commands/sandbox/download.ts
@@ -12,7 +12,7 @@ export default class SandboxDownloadCommand extends NemoClawCommand {
   static strict = true;
   static summary = "Download a file or directory from the sandbox to the host";
   static description =
-    "Thin host-side wrapper around `openshell sandbox download`. Validates that the sandbox is alive, then forwards the source and destination verbatim to the OpenShell transport so its file-system semantics (single-file vs. directory copy, trailing-slash handling, overwrite behaviour) stay the same.";
+    "Thin host-side wrapper around `openshell sandbox download`. Validates that the sandbox is alive, forwards the sandbox source path verbatim, and resolves a relative host destination against the caller's working directory before handing it to the OpenShell transport. Absolute host destinations pass through unchanged, and OpenShell's file-system semantics (single-file vs. directory copy, trailing-slash handling, overwrite behaviour) stay the same.";
   static usage = ["<name> <sandbox-path> [host-dest]"];
   static examples = [
     "<%= config.bin %> sandbox download alpha /sandbox/.openclaw/workspace/SOUL.md ./",

--- a/src/commands/sandbox/upload.ts
+++ b/src/commands/sandbox/upload.ts
@@ -12,7 +12,7 @@ export default class SandboxUploadCommand extends NemoClawCommand {
   static strict = true;
   static summary = "Upload a file or directory from the host into the sandbox";
   static description =
-    "Thin host-side wrapper around `openshell sandbox upload`. Validates that the sandbox is alive, then forwards the source and destination verbatim to the OpenShell transport so its file-system semantics (single-file vs. directory copy, trailing-slash handling, overwrite behaviour) stay the same.";
+    "Thin host-side wrapper around `openshell sandbox upload`. Validates that the sandbox is alive, resolves a relative host source path against the caller's working directory, and forwards the sandbox destination verbatim to the OpenShell transport. Absolute host source paths pass through unchanged, and OpenShell's file-system semantics (single-file vs. directory copy, trailing-slash handling, overwrite behaviour) stay the same.";
   static usage = ["<name> <host-path> [sandbox-dest]"];
   static examples = [
     "<%= config.bin %> sandbox upload alpha ./local-file /sandbox/",

--- a/src/lib/actions/sandbox/download.test.ts
+++ b/src/lib/actions/sandbox/download.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./gateway-state", () => ({
@@ -28,28 +29,51 @@ afterEach(() => {
 });
 
 describe("downloadFromSandbox", () => {
-  it("forwards verbatim args to `openshell sandbox download` after a live-sandbox check", async () => {
+  it("resolves a relative host destination against the caller cwd before forwarding to openshell", async () => {
     const result = await downloadFromSandbox({
       sandboxName: "alpha",
       sandboxPath: "/sandbox/.openclaw/workspace/SOUL.md",
       hostDest: "./out",
     });
 
+    const expectedHostDest = path.resolve(process.cwd(), "out");
     expect(ensureMock).toHaveBeenCalledWith("alpha", { allowNonReadyPhase: true });
     expect(runMock).toHaveBeenCalledWith(
-      ["sandbox", "download", "alpha", "/sandbox/.openclaw/workspace/SOUL.md", "./out"],
+      ["sandbox", "download", "alpha", "/sandbox/.openclaw/workspace/SOUL.md", expectedHostDest],
       expect.objectContaining({ stdio: "inherit" }),
     );
     expect(result).toEqual({
       sandboxPath: "/sandbox/.openclaw/workspace/SOUL.md",
-      hostDest: "./out",
+      hostDest: expectedHostDest,
     });
   });
 
-  it("defaults the host destination to the current directory when omitted", async () => {
+  it("defaults the host destination to the caller cwd when omitted", async () => {
     await downloadFromSandbox({ sandboxName: "alpha", sandboxPath: "/sandbox/x" });
     const args = runMock.mock.calls[0]?.[0];
-    expect(args?.at(-1)).toBe(".");
+    expect(args?.at(-1)).toBe(process.cwd());
+  });
+
+  it("forwards an absolute host destination unchanged", async () => {
+    await downloadFromSandbox({
+      sandboxName: "alpha",
+      sandboxPath: "/sandbox/x",
+      hostDest: "/tmp/dl-default",
+    });
+    const args = runMock.mock.calls[0]?.[0];
+    expect(args?.at(-1)).toBe("/tmp/dl-default");
+  });
+
+  it("preserves a trailing separator on a relative directory destination", async () => {
+    await downloadFromSandbox({
+      sandboxName: "alpha",
+      sandboxPath: "/sandbox/x",
+      hostDest: "./out/",
+    });
+    const args = runMock.mock.calls[0]?.[0];
+    const hostDest = args?.at(-1) as string;
+    expect(hostDest.endsWith(path.sep) || hostDest.endsWith("/")).toBe(true);
+    expect(hostDest.slice(0, -1)).toBe(path.resolve(process.cwd(), "out"));
   });
 
   it("throws (does not exit) when no sandbox path is given", async () => {

--- a/src/lib/actions/sandbox/download.ts
+++ b/src/lib/actions/sandbox/download.ts
@@ -4,6 +4,7 @@
 import { runOpenshell } from "../../adapters/openshell/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { ensureLiveSandboxOrExit } from "./gateway-state";
+import { resolveHostPathFromCwd } from "./host-path";
 
 export interface SandboxDownloadOptions {
   sandboxName: string;
@@ -26,7 +27,7 @@ export async function downloadFromSandbox(
       `No sandbox path provided; usage: ${CLI_NAME} ${opts.sandboxName} download <sandbox-path> [host-dest]`,
     );
   }
-  const hostDest = (opts.hostDest ?? "").trim() || ".";
+  const hostDest = resolveHostPathFromCwd((opts.hostDest ?? "").trim() || ".");
 
   await ensureLiveSandboxOrExit(opts.sandboxName, {
     allowNonReadyPhase: opts.allowNonReadyPhase ?? true,

--- a/src/lib/actions/sandbox/host-path.test.ts
+++ b/src/lib/actions/sandbox/host-path.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { resolveHostPathFromCwd } from "./host-path";
+
+describe("resolveHostPathFromCwd", () => {
+  it("resolves '.' to the current working directory", () => {
+    expect(resolveHostPathFromCwd(".")).toBe(process.cwd());
+  });
+
+  it("resolves a relative path against the current working directory", () => {
+    expect(resolveHostPathFromCwd("./out")).toBe(path.resolve(process.cwd(), "out"));
+    expect(resolveHostPathFromCwd("out/sub")).toBe(path.resolve(process.cwd(), "out", "sub"));
+    expect(resolveHostPathFromCwd("../sibling")).toBe(path.resolve(process.cwd(), "..", "sibling"));
+  });
+
+  it("returns absolute paths normalised but unmoved", () => {
+    expect(resolveHostPathFromCwd("/tmp/out")).toBe("/tmp/out");
+    expect(resolveHostPathFromCwd("/tmp//redundant/../out")).toBe("/tmp/out");
+  });
+
+  it("preserves a trailing separator on relative directory destinations", () => {
+    const resolved = resolveHostPathFromCwd("./out/");
+    expect(resolved.endsWith(path.sep) || resolved.endsWith("/")).toBe(true);
+    expect(resolved.slice(0, -1)).toBe(path.resolve(process.cwd(), "out"));
+  });
+
+  it("preserves a trailing separator on absolute directory destinations", () => {
+    expect(resolveHostPathFromCwd("/tmp/out/")).toBe(`/tmp/out${path.sep}`);
+  });
+
+  it("passes empty input through unchanged", () => {
+    expect(resolveHostPathFromCwd("")).toBe("");
+  });
+});

--- a/src/lib/actions/sandbox/host-path.ts
+++ b/src/lib/actions/sandbox/host-path.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+export function resolveHostPathFromCwd(input: string): string {
+  if (input.length === 0) return input;
+  const hasTrailingSeparator = input.length > 1 && /[/\\]$/.test(input);
+  const absolute = path.isAbsolute(input)
+    ? path.normalize(input)
+    : path.resolve(process.cwd(), input);
+  if (hasTrailingSeparator && !/[/\\]$/.test(absolute)) {
+    return `${absolute}${path.sep}`;
+  }
+  return absolute;
+}

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -124,8 +125,10 @@ describe("exportSandboxSessions", () => {
     });
 
     // Session JSONL can contain pasted secrets, so the downloaded host bundle
-    // must be locked down to owner-only, not just the in-sandbox staging copy.
-    expect(chmodSpy).toHaveBeenCalledWith("./out.tgz", 0o600);
+    // must be locked down to owner-only at the resolved host path, not at a
+    // path that drifts with the caller's cwd.
+    const expectedHostDest = path.resolve(process.cwd(), "out.tgz");
+    expect(chmodSpy).toHaveBeenCalledWith(expectedHostDest, 0o600);
     chmodSpy.mockRestore();
 
     expect(captureMock).toHaveBeenCalledTimes(1);
@@ -139,19 +142,28 @@ describe("exportSandboxSessions", () => {
     const tarCall = runMock.mock.calls[0]?.[0] as string[];
     expect(tarCall.slice(0, 7)).toEqual(["sandbox", "exec", "--name", "alpha", "--", "sh", "-c"]);
     const shellCommand = tarCall[7] as string;
-    expect(shellCommand).toMatch(/^umask 077 && tar -czf /);
+    // Staging directory inside /sandbox keeps openshell's workspace check happy
+    // and the umask + chmod chain seals the staging tarball to owner-only.
+    expect(shellCommand).toMatch(
+      /^umask 077 && mkdir -p \/sandbox\/\.nemoclaw-staging && chmod 700 \/sandbox\/\.nemoclaw-staging && tar -czf \/sandbox\/\.nemoclaw-staging\/sessions-export-main-[0-9a-f]+\.tgz/,
+    );
     expect(shellCommand).toMatch(/-- \.\/sid-a\.jsonl \.\/sid-b\.jsonl/);
-    expect(shellCommand).toMatch(/&& chmod 600 /);
+    expect(shellCommand).toMatch(
+      /&& chmod 600 \/sandbox\/\.nemoclaw-staging\/sessions-export-main-[0-9a-f]+\.tgz$/,
+    );
     expect(shellCommand).not.toMatch(/sid-a\.trajectory\.jsonl/);
 
     const downloadCall = runMock.mock.calls[1]?.[0] as string[];
     expect(downloadCall.slice(0, 3)).toEqual(["sandbox", "download", "alpha"]);
-    expect(downloadCall.at(-1)).toBe("./out.tgz");
+    expect(downloadCall[3]).toMatch(
+      /^\/sandbox\/\.nemoclaw-staging\/sessions-export-main-[0-9a-f]+\.tgz$/,
+    );
+    expect(downloadCall.at(-1)).toBe(expectedHostDest);
 
     expect(result.selectedKeys).toBe("all");
     expect(result.resolvedSessionIds).toEqual(["sid-a", "sid-b"]);
     expect(result.resolvedFiles).toEqual(["sid-a.jsonl", "sid-b.jsonl"]);
-    expect(result.hostDest).toBe("./out.tgz");
+    expect(result.hostDest).toBe(expectedHostDest);
     expect(result.bundleBytes).toBeNull();
   });
 
@@ -177,8 +189,13 @@ describe("exportSandboxSessions", () => {
     });
 
     // dir is the default: no in-sandbox tar/staging, just a per-file download
-    // straight into the host directory.
-    expect(mkdirSpy).toHaveBeenCalledWith("./sessions-alpha", { recursive: true });
+    // straight into the host directory. The host directory is resolved
+    // against process.cwd() so the chmod hardening hits the real file even
+    // though openshell runs with a different cwd.
+    const expectedDir = path.resolve(process.cwd(), "sessions-alpha");
+    const expectedSidA = path.join(expectedDir, "sid-a.jsonl");
+    const expectedSidB = path.join(expectedDir, "sid-b.jsonl");
+    expect(mkdirSpy).toHaveBeenCalledWith(expectedDir, { recursive: true });
     const shellCalls = runMock.mock.calls.filter((c) => (c[0] as string[]).includes("sh"));
     expect(shellCalls).toHaveLength(0);
     const downloadCalls = runMock.mock.calls.filter((c) => (c[0] as string[])[1] === "download");
@@ -188,25 +205,25 @@ describe("exportSandboxSessions", () => {
       "download",
       "alpha",
       "/sandbox/.openclaw/agents/main/sessions/sid-a.jsonl",
-      "sessions-alpha/sid-a.jsonl",
+      expectedSidA,
     ]);
     // Each downloaded file is locked to owner-only (session JSONL may hold secrets).
-    expect(chmodSpy).toHaveBeenCalledWith("sessions-alpha/sid-a.jsonl", 0o600);
+    expect(chmodSpy).toHaveBeenCalledWith(expectedSidA, 0o600);
 
     expect(result.format).toBe("dir");
-    expect(result.hostDest).toBe("./sessions-alpha");
+    expect(result.hostDest).toBe(expectedDir);
     expect(result.bundleBytes).toBeNull();
     expect(result.sessions).toEqual([
       {
         key: "agent:main:main",
         sessionId: "sid-a",
-        path: "sessions-alpha/sid-a.jsonl",
+        path: expectedSidA,
         sizeBytes: 42,
       },
       {
         key: "agent:main:telegram:t-1",
         sessionId: "sid-b",
-        path: "sessions-alpha/sid-b.jsonl",
+        path: expectedSidB,
         sizeBytes: 42,
       },
     ]);
@@ -414,7 +431,7 @@ describe("exportSandboxSessions", () => {
       selectedKeys: "all",
       resolvedSessionIds: ["sid-a"],
       resolvedFiles: ["sid-a.jsonl"],
-      hostDest: "./out.tgz",
+      hostDest: path.resolve(process.cwd(), "out.tgz"),
     });
     expect(parsed).toHaveProperty("bundleBytes");
   });

--- a/src/lib/actions/sandbox/sessions/export.test.ts
+++ b/src/lib/actions/sandbox/sessions/export.test.ts
@@ -207,8 +207,18 @@ describe("exportSandboxSessions", () => {
       "/sandbox/.openclaw/agents/main/sessions/sid-a.jsonl",
       expectedSidA,
     ]);
-    // Each downloaded file is locked to owner-only (session JSONL may hold secrets).
+    expect(downloadCalls[1]?.[0]).toEqual([
+      "sandbox",
+      "download",
+      "alpha",
+      "/sandbox/.openclaw/agents/main/sessions/sid-b.jsonl",
+      expectedSidB,
+    ]);
+    // Every downloaded session file is locked to owner-only — the bug observed
+    // in production was inconsistent perms across files in the same export
+    // run, so both files in this two-session fixture must see the chmod.
     expect(chmodSpy).toHaveBeenCalledWith(expectedSidA, 0o600);
+    expect(chmodSpy).toHaveBeenCalledWith(expectedSidB, 0o600);
 
     expect(result.format).toBe("dir");
     expect(result.hostDest).toBe(expectedDir);

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -143,7 +143,7 @@ export async function exportSandboxSessions(
       // Use ignoreError so the underlying spawn helper does not call
       // process.exit on a non-zero tar/download status. Without that, the
       // finally cleanup below would never run and the staged session JSONL
-      // would survive in the sandbox's /tmp.
+      // would survive in the in-sandbox staging directory.
       const tarResult = runOpenshell(
         [
           "sandbox",
@@ -174,8 +174,8 @@ export async function exportSandboxSessions(
       }
     } finally {
       // Best-effort cleanup of the in-sandbox staging tarball. Runs even when
-      // tar/download fail so a partial export cannot leave a world-readable
-      // bundle of session JSONL in the sandbox's /tmp.
+      // tar/download fail so a partial export cannot leave a bundle of session
+      // JSONL behind in the in-sandbox staging directory.
       runOpenshell(
         ["sandbox", "exec", "--name", opts.sandboxName, "--", "rm", "-f", tarballRemote],
         { ignoreError: true, stdio: "ignore" },
@@ -199,9 +199,9 @@ export async function exportSandboxSessions(
       sizeBytes: null,
     }));
   } else {
-    // dir format (the #3979 default): copy each resolved session file straight
-    // onto the host into a browsable directory. No /tmp staging tarball, so
-    // there is no world-readable staging window to clean up.
+    // dir format default: copy each resolved session file straight onto the
+    // host into a browsable directory. No in-sandbox staging tarball, so
+    // there is no staging window to clean up.
     try {
       fs.mkdirSync(hostDest, { recursive: true });
     } catch (err) {

--- a/src/lib/actions/sandbox/sessions/export.ts
+++ b/src/lib/actions/sandbox/sessions/export.ts
@@ -44,6 +44,7 @@ import path from "node:path";
 import { captureOpenshell, runOpenshell } from "../../../adapters/openshell/runtime";
 import { CLI_NAME } from "../../../cli/branding";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
+import { resolveHostPathFromCwd } from "../host-path";
 import {
   DEFAULT_AGENT_ID,
   parseAgentIdFromSessionKey,
@@ -94,6 +95,14 @@ interface SessionIndexEntry {
 // interpreted as a tar option (`--checkpoint-action=...`, etc.) when appended
 // to the argv. Hyphens and underscores remain permitted as inner characters.
 const SAFE_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+// In-sandbox staging directory for the transient tar bundle. Must live inside
+// the `/sandbox` workspace because `openshell sandbox download` refuses any
+// source path outside it; using the sandbox's `/tmp` (the previous choice)
+// trips that check and aborts the export with a misleading "outside the
+// sandbox workspace" error. The hidden `.nemoclaw-staging` prefix keeps the
+// directory clearly NemoClaw-owned and separate from OpenClaw's own store.
+const STAGING_DIR_IN_SANDBOX = "/sandbox/.nemoclaw-staging";
 
 export async function exportSandboxSessions(
   opts: SessionsExportOptions,
@@ -278,11 +287,14 @@ export function buildSandboxTarArgv(input: {
 
 function buildShellInvocation(tarArgv: readonly string[], tarballRemote: string): string {
   // umask 077 restricts the staging tarball (mode 600) so a concurrent
-  // sandbox user cannot read another agent's session JSONL out of /tmp
-  // between the tar step and the download step.
+  // sandbox user cannot read another agent's session JSONL between the tar
+  // step and the download step. The mkdir + chmod 700 pair guarantees the
+  // staging directory itself is owner-only even if a previous run (or an
+  // unrelated tool) created it with a broader mode.
   const quoted = tarArgv.map(shellQuote).join(" ");
   const quotedTarball = shellQuote(tarballRemote);
-  return `umask 077 && ${quoted} && chmod 600 ${quotedTarball}`;
+  const quotedStagingDir = shellQuote(STAGING_DIR_IN_SANDBOX);
+  return `umask 077 && mkdir -p ${quotedStagingDir} && chmod 700 ${quotedStagingDir} && ${quoted} && chmod 600 ${quotedTarball}`;
 }
 
 function shellQuote(value: string): string {
@@ -487,7 +499,7 @@ function pickIndexArray(parsed: unknown): unknown[] | null {
 
 function stagingTarballPath(agent: string): string {
   const suffix = randomBytes(6).toString("hex");
-  return `/tmp/sessions-export-${agent}-${suffix}.tgz`;
+  return `${STAGING_DIR_IN_SANDBOX}/sessions-export-${agent}-${suffix}.tgz`;
 }
 
 function resolveHostDestination(
@@ -496,8 +508,13 @@ function resolveHostDestination(
   agent: string,
   format: SessionsExportFormat,
 ): string {
-  if (out && out.trim()) return out.trim();
-  // dir is the #3979 default: a browsable `./sessions-<sandbox>/` tree. tar
-  // keeps the single-bundle name for share/upload cases.
-  return format === "tar" ? `./sessions-${sandboxName}-${agent}.tgz` : `./sessions-${sandboxName}/`;
+  if (out && out.trim()) return resolveHostPathFromCwd(out.trim());
+  // dir is the default: a browsable `sessions-<sandbox>/` tree. tar keeps the
+  // single-bundle name for share/upload cases. Both defaults are resolved
+  // against the caller's process.cwd() so the host artefact lands where the
+  // user invoked the CLI from, not inside the install directory that
+  // `runOpenshell` pins as the child's cwd.
+  const fallback =
+    format === "tar" ? `sessions-${sandboxName}-${agent}.tgz` : `sessions-${sandboxName}/`;
+  return resolveHostPathFromCwd(fallback);
 }

--- a/src/lib/actions/sandbox/upload.test.ts
+++ b/src/lib/actions/sandbox/upload.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./gateway-state", () => ({
@@ -28,20 +29,21 @@ afterEach(() => {
 });
 
 describe("uploadToSandbox", () => {
-  it("forwards verbatim args to `openshell sandbox upload` after a live-sandbox check", async () => {
+  it("resolves a relative host path against the caller cwd before forwarding to openshell", async () => {
     const result = await uploadToSandbox({
       sandboxName: "alpha",
       hostPath: "./SOUL.md",
       sandboxDest: "/sandbox/.openclaw/workspace/SOUL.md",
     });
 
+    const expectedHostPath = path.resolve(process.cwd(), "SOUL.md");
     expect(ensureMock).toHaveBeenCalledWith("alpha", { allowNonReadyPhase: true });
     expect(runMock).toHaveBeenCalledWith(
-      ["sandbox", "upload", "alpha", "./SOUL.md", "/sandbox/.openclaw/workspace/SOUL.md"],
+      ["sandbox", "upload", "alpha", expectedHostPath, "/sandbox/.openclaw/workspace/SOUL.md"],
       expect.objectContaining({ stdio: "inherit" }),
     );
     expect(result).toEqual({
-      hostPath: "./SOUL.md",
+      hostPath: expectedHostPath,
       sandboxDest: "/sandbox/.openclaw/workspace/SOUL.md",
     });
   });
@@ -50,6 +52,28 @@ describe("uploadToSandbox", () => {
     await uploadToSandbox({ sandboxName: "alpha", hostPath: "./x" });
     const args = runMock.mock.calls[0]?.[0];
     expect(args?.at(-1)).toBe("/sandbox/");
+  });
+
+  it("forwards an absolute host path unchanged", async () => {
+    await uploadToSandbox({
+      sandboxName: "alpha",
+      hostPath: "/etc/hosts",
+      sandboxDest: "/sandbox/etc/",
+    });
+    const args = runMock.mock.calls[0]?.[0];
+    expect(args?.[3]).toBe("/etc/hosts");
+  });
+
+  it("preserves a trailing separator on a relative host directory source", async () => {
+    await uploadToSandbox({
+      sandboxName: "alpha",
+      hostPath: "./src/",
+      sandboxDest: "/sandbox/work/",
+    });
+    const args = runMock.mock.calls[0]?.[0];
+    const hostPath = args?.[3] as string;
+    expect(hostPath.endsWith(path.sep) || hostPath.endsWith("/")).toBe(true);
+    expect(hostPath.slice(0, -1)).toBe(path.resolve(process.cwd(), "src"));
   });
 
   it("throws (does not exit) when no host path is given", async () => {

--- a/src/lib/actions/sandbox/upload.ts
+++ b/src/lib/actions/sandbox/upload.ts
@@ -4,6 +4,7 @@
 import { runOpenshell } from "../../adapters/openshell/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { ensureLiveSandboxOrExit } from "./gateway-state";
+import { resolveHostPathFromCwd } from "./host-path";
 
 export interface SandboxUploadOptions {
   sandboxName: string;
@@ -18,12 +19,13 @@ export interface SandboxUploadResult {
 }
 
 export async function uploadToSandbox(opts: SandboxUploadOptions): Promise<SandboxUploadResult> {
-  const hostPath = (opts.hostPath ?? "").trim();
-  if (!hostPath) {
+  const trimmedHostPath = (opts.hostPath ?? "").trim();
+  if (!trimmedHostPath) {
     throw new Error(
       `No host path provided; usage: ${CLI_NAME} ${opts.sandboxName} upload <host-path> [sandbox-dest]`,
     );
   }
+  const hostPath = resolveHostPathFromCwd(trimmedHostPath);
   const sandboxDest = (opts.sandboxDest ?? "").trim() || "/sandbox/";
 
   await ensureLiveSandboxOrExit(opts.sandboxName, {

--- a/test/sandbox-download-upload-cli.test.ts
+++ b/test/sandbox-download-upload-cli.test.ts
@@ -29,7 +29,7 @@ function buildStubOpenshell(home: string, logFile: string): string {
 }
 
 describe("sandbox download/upload CLI wrappers", () => {
-  it("forwards `<name> download <sandbox-path> [host-dest]` to openshell", () => {
+  it("forwards `<name> download <sandbox-path> [host-dest]` to openshell with the host-dest resolved against the caller cwd", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-download-"));
     try {
       writeSandboxRegistry(home);
@@ -43,15 +43,16 @@ describe("sandbox download/upload CLI wrappers", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8");
-      expect(calls).toMatch(
-        /sandbox download alpha \/sandbox\/\.openclaw\/workspace\/SOUL\.md \.\/out/,
+      const expectedHostDest = path.resolve(process.cwd(), "out");
+      expect(calls).toContain(
+        `sandbox download alpha /sandbox/.openclaw/workspace/SOUL.md ${expectedHostDest}`,
       );
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("defaults the host destination to '.' when omitted", () => {
+  it("defaults the host destination to the caller cwd when omitted", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-download-default-"));
     try {
       writeSandboxRegistry(home);
@@ -65,13 +66,13 @@ describe("sandbox download/upload CLI wrappers", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8");
-      expect(calls).toMatch(/sandbox download alpha \/sandbox\/\.openclaw\/x \./);
+      expect(calls).toContain(`sandbox download alpha /sandbox/.openclaw/x ${process.cwd()}`);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("forwards `<name> upload <host-path> [sandbox-dest]` to openshell", () => {
+  it("forwards `<name> upload <host-path> [sandbox-dest]` to openshell with the host-path resolved against the caller cwd", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-upload-"));
     try {
       writeSandboxRegistry(home);
@@ -88,15 +89,16 @@ describe("sandbox download/upload CLI wrappers", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8");
-      expect(calls).toMatch(
-        /sandbox upload alpha \.\/SOUL\.md \/sandbox\/\.openclaw\/workspace\/SOUL\.md/,
+      const expectedHostPath = path.resolve(process.cwd(), "SOUL.md");
+      expect(calls).toContain(
+        `sandbox upload alpha ${expectedHostPath} /sandbox/.openclaw/workspace/SOUL.md`,
       );
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("defaults the sandbox destination to /sandbox/ when omitted", () => {
+  it("defaults the sandbox destination to /sandbox/ when omitted and still resolves the host path against the caller cwd", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-upload-default-"));
     try {
       writeSandboxRegistry(home);
@@ -110,7 +112,8 @@ describe("sandbox download/upload CLI wrappers", () => {
       expect(result.code).toBe(0);
 
       const calls = fs.readFileSync(openshellLog, "utf8");
-      expect(calls).toMatch(/sandbox upload alpha \.\/x \/sandbox\//);
+      const expectedHostPath = path.resolve(process.cwd(), "x");
+      expect(calls).toContain(`sandbox upload alpha ${expectedHostPath} /sandbox/`);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/test/sandbox-sessions-export-cli.test.ts
+++ b/test/sandbox-sessions-export-cli.test.ts
@@ -74,7 +74,7 @@ describe("sandbox sessions export CLI", () => {
       expect(downloadLine).toContain("alpha");
       expect(downloadLine).toContain(out);
       expect(cleanupLine).toBeDefined();
-      expect(cleanupLine).toContain("/tmp/sessions-export-main-");
+      expect(cleanupLine).toContain("/sandbox/.nemoclaw-staging/sessions-export-main-");
 
       const manifest = JSON.parse(result.out.trim().split("\n").at(-1) as string);
       expect(manifest).toMatchObject({


### PR DESCRIPTION
## Summary
- Host path resolution for `sandbox download`, `sandbox upload`, and `sessions export` no longer drifts to the install directory because `runOpenshell` spawns openshell with `cwd: ROOT`. User-supplied and default host paths are now absolutised against `process.cwd()` before reaching openshell.
- `sessions export --format tar` now stages its in-sandbox bundle inside `/sandbox/.nemoclaw-staging/` (mode 700) instead of the sandbox's `/tmp`, so `openshell sandbox download` no longer rejects the source as outside the workspace.

## Related Issues
Fixes #5502
Fixes #5503
Fixes #5504

## Changes
- New `src/lib/actions/sandbox/host-path.ts` (`resolveHostPathFromCwd`) preserves trailing-slash directory semantics; applied in `downloadFromSandbox`, `uploadToSandbox`, and `exportSandboxSessions`.
- `sessions export` tar staging moved from `/tmp/sessions-export-…` to `/sandbox/.nemoclaw-staging/sessions-export-…`; the shell invocation now `mkdir -p`s the staging directory under `umask 077` and clamps it to mode 700.
- Action-level unit tests and CLI integration tests updated to assert on the resolved absolute host paths and the new staging location. Helper covered with focused unit tests (`.`, relative, absolute, normalisation, trailing slash, empty).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relative host paths in `sandbox download` and `sandbox upload` now resolve against the caller's current working directory, ensuring downloads and uploads land where users expect.
  * Absolute paths pass through unchanged.

* **Documentation**
  * Clarified path resolution behavior in download and upload command documentation and help text.

* **Bug Fixes**
  * Improved path handling consistency for session exports using internal staging directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->