### PR TITLE
onboard: opt-in arbitrary extra placeholder credential keys

### DIFF
--- a/src/lib/onboard/extra-placeholder-keys.test.ts
+++ b/src/lib/onboard/extra-placeholder-keys.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   appendExtraPlaceholderKeysEnvArg,
   canonicalPlaceholderKeys,
+  EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY_ENV,
   EXTRA_PLACEHOLDER_KEYS_ENV,
   EXTRA_PLACEHOLDER_KEYS_MAX,
   extraPlaceholderProviderSlug,
@@ -102,9 +103,29 @@ describe("parseExtraPlaceholderKeys", () => {
       EXTRA_PLACEHOLDER_KEYS_ENV,
     ]) {
       expect(result.warnings).toContain(
-        `${EXTRA_PLACEHOLDER_KEYS_ENV}: ignoring "${blocked}" — must extend a canonical channel envKey (e.g. TELEGRAM_BOT_TOKEN_AGENT_A); arbitrary host secrets such as GITHUB_TOKEN are refused so they cannot leak into the sandbox provider gateway`,
+        `${EXTRA_PLACEHOLDER_KEYS_ENV}: ignoring "${blocked}" — must extend a canonical channel envKey (e.g. TELEGRAM_BOT_TOKEN_AGENT_A); arbitrary host secrets such as GITHUB_TOKEN are refused unless ${EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY_ENV}=1`,
       );
     }
+  });
+
+  it("accepts arbitrary host secret env names when allowArbitrary is opted in", () => {
+    // With the explicit opt-in, keys that do not extend a canonical channel envKey are accepted
+    // (the operator is responsible for a matching egress credential-rewrite preset). The format
+    // regex and canonical-collision checks still apply, so a token equal to a canonical envKey is
+    // still refused even under the opt-in.
+    const result = parseExtraPlaceholderKeys(
+      ["GITHUB_TOKEN", "SNOWFLAKE_MCP_BEARER", "lower_case", "SLACK_BOT_TOKEN"].join(" "),
+      CANONICAL_ENVKEYS_FIXTURE,
+      true,
+    );
+    expect(result.keys).toEqual(["GITHUB_TOKEN", "SNOWFLAKE_MCP_BEARER"]);
+    // Still rejects the non-matching pattern and the exact canonical-key collision.
+    expect(result.warnings).toContain(
+      `${EXTRA_PLACEHOLDER_KEYS_ENV}: ignoring "lower_case" — must match /^[A-Z][A-Z0-9_]{0,127}$/`,
+    );
+    expect(result.warnings).toContain(
+      `${EXTRA_PLACEHOLDER_KEYS_ENV}: ignoring "SLACK_BOT_TOKEN" — collides with a canonical channel envKey`,
+    );
   });
 
   it("dedupes repeated tokens without emitting a warning", () => {

--- a/src/lib/onboard/extra-placeholder-keys.ts
+++ b/src/lib/onboard/extra-placeholder-keys.ts
@@ -18,6 +18,14 @@ export const EXTRA_PLACEHOLDER_KEY_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
 
 export const EXTRA_PLACEHOLDER_KEYS_MAX = 32;
 
+// Opt-in: allow credential keys that do NOT extend a canonical channel envKey (e.g. a custom MCP
+// bearer such as SNOWFLAKE_MCP_BEARER, or GITHUB_TOKEN). The safe default still refuses arbitrary
+// keys; set this to "1" only when a matching egress credential-rewrite policy preset exists for the
+// target host. As with channel tokens, the real value never enters the sandbox — only the
+// `openshell:resolve:env:<KEY>` placeholder does, resolved at the egress boundary.
+export const EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY_ENV =
+  "NEMOCLAW_EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY";
+
 export interface ExtraPlaceholderKeysResult {
   readonly keys: readonly string[];
   readonly warnings: readonly string[];
@@ -45,6 +53,7 @@ function findExtendedCanonicalPrefix(
 export function parseExtraPlaceholderKeys(
   raw: string | undefined | null,
   canonicalKeys: ReadonlySet<string> = new Set(),
+  allowArbitrary = false,
 ): ExtraPlaceholderKeysResult {
   if (!raw || !raw.trim()) {
     return { keys: [], warnings: [] };
@@ -66,9 +75,9 @@ export function parseExtraPlaceholderKeys(
       );
       continue;
     }
-    if (!findExtendedCanonicalPrefix(candidate, canonicalKeys)) {
+    if (!allowArbitrary && !findExtendedCanonicalPrefix(candidate, canonicalKeys)) {
       warnings.push(
-        `${EXTRA_PLACEHOLDER_KEYS_ENV}: ignoring "${candidate}" — must extend a canonical channel envKey (e.g. TELEGRAM_BOT_TOKEN_AGENT_A); arbitrary host secrets such as GITHUB_TOKEN are refused so they cannot leak into the sandbox provider gateway`,
+        `${EXTRA_PLACEHOLDER_KEYS_ENV}: ignoring "${candidate}" — must extend a canonical channel envKey (e.g. TELEGRAM_BOT_TOKEN_AGENT_A); arbitrary host secrets such as GITHUB_TOKEN are refused unless ${EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY_ENV}=1`,
       );
       continue;
     }
@@ -94,9 +103,11 @@ export function registerExtraPlaceholderProviders(
   messagingTokenDefs: MessagingTokenDefShape[],
   log: (message: string) => void = (m) => console.warn(`  ${m}`),
 ): string[] {
+  const allowArbitrary = process.env[EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY_ENV] === "1";
   const parsed = parseExtraPlaceholderKeys(
     process.env[EXTRA_PLACEHOLDER_KEYS_ENV],
     canonicalPlaceholderKeys(),
+    allowArbitrary,
   );
   for (const warning of parsed.warnings) log(warning);
   for (const envKey of parsed.keys) {


### PR DESCRIPTION
## Problem

`NEMOCLAW_EXTRA_PLACEHOLDER_KEYS` only accepts keys that **extend a canonical channel envKey prefix** (`SLACK_BOT_TOKEN_*`, `TELEGRAM_BOT_TOKEN_*`, …). It deliberately **refuses arbitrary host secret names** like `GITHUB_TOKEN` or a custom MCP bearer (`parseExtraPlaceholderKeys` → `findExtendedCanonicalPrefix`).

That's a sensible default, but it blocks a legitimate use case: integrating a **read-only MCP server** or a **git host** that authenticates with a bearer/token. Those credentials should be injected the same way channel tokens are — as a `openshell:resolve:env:<KEY>` **placeholder** in the sandbox, with the real value held host-side and rewritten at the egress boundary via a matching credential-rewrite policy preset. Today the only workaround is to abuse a canonical prefix (e.g. naming an MCP bearer `SLACK_BOT_TOKEN_MYMCP`), which is opaque and misleading.

## Change

Add an explicit opt-in env flag **`NEMOCLAW_EXTRA_PLACEHOLDER_KEYS_ALLOW_ARBITRARY=1`** that relaxes **only** the canonical-prefix requirement in `parseExtraPlaceholderKeys`.

- Default (flag unset) behaviour is **unchanged** — arbitrary keys are still refused.
- The format regex (`/^[A-Z][A-Z0-9_]{0,127}$/`), the canonical-collision check, dedup, and the `EXTRA_PLACEHOLDER_KEYS_MAX` cap **all still apply** even with the opt-in.
- As with channel tokens, the **real secret never enters the sandbox** — only the `openshell:resolve:env:<KEY>` placeholder does; the operator is responsible for a matching egress credential-rewrite preset for the target host.

The refusal warning now points operators at the flag instead of being a dead end.

## Tests

- Updated the existing "refuses arbitrary host secret env names" test for the new warning text.
- Added a test asserting that with `allowArbitrary=true`, arbitrary keys are accepted while the format and canonical-collision checks still reject malformed / colliding tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an opt-in toggle to allow arbitrary environment variable names as extra placeholder keys, expanding configuration flexibility.

* **Tests**
  * Updated test coverage for the new opt-in validation behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->