### PR TITLE
docs: list nemoclaw user agent skills

### DIFF
--- a/docs/resources/agent-skills.mdx
+++ b/docs/resources/agent-skills.mdx
@@ -51,6 +51,7 @@ The following user skills ship with NemoClaw.
 | Skill | Summary |
 |-------|---------|
 | `nemoclaw-user-overview` | What NemoClaw is, ecosystem placement (OpenClaw + OpenShell + NemoClaw), how it works internally, and release notes. |
+| `nemoclaw-user-agent-skills` | Clone, update, and use NemoClaw's agent skills, including this page and the skills directory layout. |
 | `nemoclaw-user-get-started` | Install NemoClaw, launch a sandbox, and run the first agent prompt. |
 | `nemoclaw-user-configure-inference` | Choose inference providers during onboarding, switch models without restarting, and set up local inference servers (Ollama, vLLM, TensorRT-LLM, NIM). |
 | `nemoclaw-user-manage-policy` | Approve or deny blocked egress requests in the TUI and customize the sandbox network policy (add, remove, or modify allowed endpoints). |
@@ -77,6 +78,7 @@ Examples of questions your assistant can answer with these skills:
 | "What security controls can I configure?" | `nemoclaw-user-configure-security` |
 | "Back up my agent workspace files." | `nemoclaw-user-manage-sandboxes` |
 | "What CLI commands are available?" | `nemoclaw-user-reference` |
+| "What NemoClaw skills are available for my coding assistant?" | `nemoclaw-user-agent-skills` |
 
 You can also reference a skill directly by name if you know which one you need.
 


### PR DESCRIPTION
## Summary
Adds the missing `nemoclaw-user-agent-skills` entry to the Agent Skills documentation so the page lists all user skills shipped under `.agents/skills`.

## Related Issue
Fixes #5083

## Replacement PR
Replaces #5398 with a clean one-commit branch because the original PR history contained an unverified commit.

## Changes
- Added `nemoclaw-user-agent-skills` to the Available Skills table.
- Added an example question that maps to `nemoclaw-user-agent-skills`.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] DCO trailer is present on the commit.
- [x] GitHub reports the commit signature as verified.
- [x] No secrets, API keys, or credentials committed.
- [x] Docs updated for user-facing behavior changes.
- [ ] `npm run docs` builds without warnings (doc changes only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Expanded skills documentation with information on NemoClaw's agent skills, including setup guidance and example question mappings for coding assistant integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: RlxChap2 <mmah02778@gmail.com>

