### PR TITLE
feat(cli): report nullable union hotspots

### DIFF
--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -200,6 +200,7 @@ type RawFileData = PatternCounts & {
   weakExportCount: number;
   importSpecifiers: string[];
   importBindings: RawImportBinding[];
+  reExportBindings: RawImportBinding[];
   noCheck: boolean;
   functions: RawFunctionData[];
   nullableUnions: NullableUnionOccurrence[];
@@ -956,6 +957,39 @@ function collectImportBindings(sourceFile: ts.SourceFile): RawImportBinding[] {
   return bindings;
 }
 
+function collectReExportBindings(sourceFile: ts.SourceFile): RawImportBinding[] {
+  const bindings: RawImportBinding[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isExportDeclaration(statement) ||
+      !statement.moduleSpecifier ||
+      !ts.isStringLiteralLike(statement.moduleSpecifier)
+    ) {
+      continue;
+    }
+    const specifier = statement.moduleSpecifier.text;
+    if (!specifier.startsWith(".")) {
+      continue;
+    }
+
+    const exportClause = statement.exportClause;
+    if (!exportClause || !ts.isNamedExports(exportClause)) {
+      continue;
+    }
+
+    for (const element of exportClause.elements) {
+      bindings.push({
+        specifier,
+        importedName: element.propertyName?.text ?? element.name.text,
+        localName: element.name.text,
+      });
+    }
+  }
+
+  return bindings;
+}
+
 function resolveLocalImport(
   project: ProjectInfo,
   fromFile: string,
@@ -1296,6 +1330,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
     weakExportCount,
     importSpecifiers: collectImportSpecifiers(sourceFile),
     importBindings: collectImportBindings(sourceFile),
+    reExportBindings: collectReExportBindings(sourceFile),
     noCheck,
     functions,
     nullableUnions,
@@ -1324,6 +1359,7 @@ function buildNullableUnionReport(
   rawFiles: readonly RawFileData[],
   fanInByFile: ReadonlyMap<string, number>,
   importBindingsByFile: ReadonlyMap<string, ReadonlyMap<string, readonly RawImportBinding[]>>,
+  reExportBindingsByFile: ReadonlyMap<string, ReadonlyMap<string, readonly RawImportBinding[]>>,
 ): NullableUnionReport {
   const byType = new Map<
     string,
@@ -1369,32 +1405,76 @@ function buildNullableUnionReport(
     }
   }
 
+  function exportedNamesByModuleForCandidate(
+    candidateAbsPath: string,
+    candidateName: string,
+  ): Map<string, Set<string>> {
+    const namesByModule = new Map<string, Set<string>>();
+    const addName = (modulePath: string, exportedName: string): boolean => {
+      const names = namesByModule.get(modulePath) ?? new Set<string>();
+      const initialSize = names.size;
+      names.add(exportedName);
+      namesByModule.set(modulePath, names);
+      return names.size !== initialSize;
+    };
+
+    addName(candidateAbsPath, candidateName);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [reExporterPath, reExportsBySource] of reExportBindingsByFile.entries()) {
+        for (const [sourcePath, bindings] of reExportsBySource.entries()) {
+          const sourceNames = namesByModule.get(sourcePath);
+          if (!sourceNames) {
+            continue;
+          }
+          for (const binding of bindings) {
+            if (sourceNames.has(binding.importedName)) {
+              changed = addName(reExporterPath, binding.localName) || changed;
+            }
+          }
+        }
+      }
+    }
+
+    return namesByModule;
+  }
+
   const exportedTypes = rawFiles
     .flatMap((file) => file.exportedNullableTypes)
     .map(({ absPath, ...candidate }): NullableExportedTypeFanout => {
       let referenceCount = 0;
       let referencingFileCount = 0;
+      const exportedNamesByModule = exportedNamesByModuleForCandidate(absPath, candidate.name);
       for (const file of rawFiles) {
         if (file.absPath === absPath) {
           continue;
         }
-        const importedBindings = importBindingsByFile.get(file.absPath)?.get(absPath) ?? [];
-        const localNames = new Set(
-          importedBindings
-            .filter((binding) => binding.importedName === candidate.name)
-            .map((binding) => binding.localName),
-        );
-        const namespaceNames = new Set(
-          importedBindings
-            .filter((binding) => binding.importedName === "*")
-            .map((binding) => binding.localName),
-        );
-        if (localNames.size === 0 && namespaceNames.size === 0) {
+        const importedBindingsByModule = importBindingsByFile.get(file.absPath);
+        if (!importedBindingsByModule) {
+          continue;
+        }
+        const localNames = new Set<string>();
+        const namespaceExports = new Map<string, ReadonlySet<string>>();
+        for (const [modulePath, importedBindings] of importedBindingsByModule.entries()) {
+          const exportedNames = exportedNamesByModule.get(modulePath);
+          if (!exportedNames) {
+            continue;
+          }
+          for (const binding of importedBindings) {
+            if (binding.importedName === "*") {
+              namespaceExports.set(binding.localName, exportedNames);
+            } else if (exportedNames.has(binding.importedName)) {
+              localNames.add(binding.localName);
+            }
+          }
+        }
+        if (localNames.size === 0 && namespaceExports.size === 0) {
           continue;
         }
         const fileReferenceCount = file.typeReferences.filter((reference) => {
           if (reference.qualifier) {
-            return reference.name === candidate.name && namespaceNames.has(reference.qualifier);
+            return namespaceExports.get(reference.qualifier)?.has(reference.name) ?? false;
           }
           return localNames.has(reference.name);
         }).length;
@@ -1585,10 +1665,12 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
   const importersByFile = new Map<string, Set<string>>();
   const importsFromFile = new Map<string, Set<string>>();
   const importBindingsByFile = new Map<string, Map<string, RawImportBinding[]>>();
+  const reExportBindingsByFile = new Map<string, Map<string, RawImportBinding[]>>();
   for (const file of rawFiles) {
     importersByFile.set(file.absPath, new Set());
     importsFromFile.set(file.absPath, new Set());
     importBindingsByFile.set(file.absPath, new Map());
+    reExportBindingsByFile.set(file.absPath, new Map());
   }
 
   for (const file of rawFiles) {
@@ -1604,6 +1686,10 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
       importBindingsByFile.get(file.absPath),
       `Missing import binding map for analyzed file ${file.absPath}`,
     );
+    const resolvedReExports = requireDefined(
+      reExportBindingsByFile.get(file.absPath),
+      `Missing re-export binding map for analyzed file ${file.absPath}`,
+    );
 
     for (const specifier of file.importSpecifiers) {
       const resolved = resolveLocalImport(project, file.absPath, specifier, analyzedFiles);
@@ -1615,6 +1701,15 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
       const bindings = file.importBindings.filter((binding) => binding.specifier === specifier);
       if (bindings.length > 0) {
         resolvedBindings.set(resolved, [...(resolvedBindings.get(resolved) ?? []), ...bindings]);
+      }
+      const reExportBindings = file.reExportBindings.filter(
+        (binding) => binding.specifier === specifier,
+      );
+      if (reExportBindings.length > 0) {
+        resolvedReExports.set(resolved, [
+          ...(resolvedReExports.get(resolved) ?? []),
+          ...reExportBindings,
+        ]);
       }
     }
   }
@@ -1648,7 +1743,12 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
     });
 
   const fanInByFile = new Map(files.map((file) => [file.filePath, file.fanIn]));
-  const nullableUnions = buildNullableUnionReport(rawFiles, fanInByFile, importBindingsByFile);
+  const nullableUnions = buildNullableUnionReport(
+    rawFiles,
+    fanInByFile,
+    importBindingsByFile,
+    reExportBindingsByFile,
+  );
   const functions: FunctionHotspot[] = rawFiles
     .flatMap((file) => file.functions)
     .map((fn) => {

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -180,6 +180,12 @@ type RawNullableExportedType = {
   nullableTypes: string[];
 };
 
+type RawImportBinding = {
+  specifier: string;
+  importedName: string;
+  localName: string;
+};
+
 type RawFileData = PatternCounts & {
   absPath: string;
   filePath: string;
@@ -188,6 +194,7 @@ type RawFileData = PatternCounts & {
   exportCount: number;
   weakExportCount: number;
   importSpecifiers: string[];
+  importBindings: RawImportBinding[];
   noCheck: boolean;
   functions: RawFunctionData[];
   nullableUnions: NullableUnionOccurrence[];
@@ -885,6 +892,46 @@ function collectImportSpecifiers(sourceFile: ts.SourceFile): string[] {
   return [...specifiers];
 }
 
+function collectImportBindings(sourceFile: ts.SourceFile): RawImportBinding[] {
+  const bindings: RawImportBinding[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteralLike(statement.moduleSpecifier)) {
+      continue;
+    }
+    const specifier = statement.moduleSpecifier.text;
+    if (!specifier.startsWith(".")) {
+      continue;
+    }
+
+    const importClause = statement.importClause;
+    if (!importClause) {
+      continue;
+    }
+
+    if (importClause.name) {
+      bindings.push({
+        specifier,
+        importedName: "default",
+        localName: importClause.name.text,
+      });
+    }
+
+    const namedBindings = importClause.namedBindings;
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        bindings.push({
+          specifier,
+          importedName: element.propertyName?.text ?? element.name.text,
+          localName: element.name.text,
+        });
+      }
+    }
+  }
+
+  return bindings;
+}
+
 function resolveLocalImport(
   project: ProjectInfo,
   fromFile: string,
@@ -1224,6 +1271,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
     exportCount: countExports(sourceFile),
     weakExportCount,
     importSpecifiers: collectImportSpecifiers(sourceFile),
+    importBindings: collectImportBindings(sourceFile),
     noCheck,
     functions,
     nullableUnions,
@@ -1248,7 +1296,7 @@ function countByValue(values: readonly string[]): Array<{ type: string; count: n
 function buildNullableUnionReport(
   rawFiles: readonly RawFileData[],
   fanInByFile: ReadonlyMap<string, number>,
-  importsFromFile: ReadonlyMap<string, ReadonlySet<string>>,
+  importBindingsByFile: ReadonlyMap<string, ReadonlyMap<string, readonly RawImportBinding[]>>,
 ): NullableUnionReport {
   const byType = new Map<
     string,
@@ -1300,11 +1348,19 @@ function buildNullableUnionReport(
       let referenceCount = 0;
       let referencingFileCount = 0;
       for (const file of rawFiles) {
-        if (file.absPath === absPath || !importsFromFile.get(file.absPath)?.has(absPath)) {
+        if (file.absPath === absPath) {
           continue;
         }
-        const fileReferenceCount = file.typeReferenceNames.filter(
-          (typeName) => typeName === candidate.name,
+        const localNames = new Set(
+          (importBindingsByFile.get(file.absPath)?.get(absPath) ?? [])
+            .filter((binding) => binding.importedName === candidate.name)
+            .map((binding) => binding.localName),
+        );
+        if (localNames.size === 0) {
+          continue;
+        }
+        const fileReferenceCount = file.typeReferenceNames.filter((typeName) =>
+          localNames.has(typeName),
         ).length;
         if (fileReferenceCount > 0) {
           referenceCount += fileReferenceCount;
@@ -1492,9 +1548,11 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
 
   const importersByFile = new Map<string, Set<string>>();
   const importsFromFile = new Map<string, Set<string>>();
+  const importBindingsByFile = new Map<string, Map<string, RawImportBinding[]>>();
   for (const file of rawFiles) {
     importersByFile.set(file.absPath, new Set());
     importsFromFile.set(file.absPath, new Set());
+    importBindingsByFile.set(file.absPath, new Map());
   }
 
   for (const file of rawFiles) {
@@ -1506,6 +1564,10 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
       importsFromFile.get(file.absPath),
       `Missing import set for analyzed file ${file.absPath}`,
     );
+    const resolvedBindings = requireDefined(
+      importBindingsByFile.get(file.absPath),
+      `Missing import binding map for analyzed file ${file.absPath}`,
+    );
 
     for (const specifier of file.importSpecifiers) {
       const resolved = resolveLocalImport(project, file.absPath, specifier, analyzedFiles);
@@ -1514,6 +1576,10 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
       }
       resolvedImports.add(resolved);
       importersByFile.get(resolved)?.add(file.absPath);
+      const bindings = file.importBindings.filter((binding) => binding.specifier === specifier);
+      if (bindings.length > 0) {
+        resolvedBindings.set(resolved, [...(resolvedBindings.get(resolved) ?? []), ...bindings]);
+      }
     }
   }
 
@@ -1546,7 +1612,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
     });
 
   const fanInByFile = new Map(files.map((file) => [file.filePath, file.fanIn]));
-  const nullableUnions = buildNullableUnionReport(rawFiles, fanInByFile, importsFromFile);
+  const nullableUnions = buildNullableUnionReport(rawFiles, fanInByFile, importBindingsByFile);
   const functions: FunctionHotspot[] = rawFiles
     .flatMap((file) => file.functions)
     .map((fn) => {

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -186,6 +186,11 @@ type RawImportBinding = {
   localName: string;
 };
 
+type RawTypeReference = {
+  name: string;
+  qualifier: string | null;
+};
+
 type RawFileData = PatternCounts & {
   absPath: string;
   filePath: string;
@@ -199,7 +204,7 @@ type RawFileData = PatternCounts & {
   functions: RawFunctionData[];
   nullableUnions: NullableUnionOccurrence[];
   exportedNullableTypes: RawNullableExportedType[];
-  typeReferenceNames: string[];
+  typeReferences: RawTypeReference[];
 };
 
 type CommentDirectiveOccurrence = {
@@ -613,8 +618,19 @@ function collectNullableUnionTypes(node: ts.Node, sourceFile: ts.SourceFile): st
   return types;
 }
 
-function getTypeReferenceName(node: ts.TypeReferenceNode): string {
-  return ts.isIdentifier(node.typeName) ? node.typeName.text : node.typeName.right.text;
+function getEntityNameParts(name: ts.EntityName): string[] {
+  if (ts.isIdentifier(name)) {
+    return [name.text];
+  }
+  return [...getEntityNameParts(name.left), name.right.text];
+}
+
+function getTypeReference(node: ts.TypeReferenceNode): RawTypeReference {
+  const parts = getEntityNameParts(node.typeName);
+  return {
+    name: requireDefined(parts[parts.length - 1], "Type reference name is missing"),
+    qualifier: parts.length > 1 ? parts.slice(0, -1).join(".") : null,
+  };
 }
 
 function buildTypeAliasMap(sourceFile: ts.SourceFile): Map<string, ts.TypeNode> {
@@ -918,6 +934,14 @@ function collectImportBindings(sourceFile: ts.SourceFile): RawImportBinding[] {
     }
 
     const namedBindings = importClause.namedBindings;
+    if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+      bindings.push({
+        specifier,
+        importedName: "*",
+        localName: namedBindings.name.text,
+      });
+    }
+
     if (namedBindings && ts.isNamedImports(namedBindings)) {
       for (const element of namedBindings.elements) {
         bindings.push({
@@ -1169,7 +1193,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
   const functionStack: RawFunctionData[] = [];
   const nullableUnions: NullableUnionOccurrence[] = [];
   const exportedNullableTypes: RawNullableExportedType[] = [];
-  const typeReferenceNames: string[] = [];
+  const typeReferences: RawTypeReference[] = [];
 
   addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(directiveOccurrences));
 
@@ -1236,7 +1260,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
     }
 
     if (ts.isTypeReferenceNode(node)) {
-      typeReferenceNames.push(getTypeReferenceName(node));
+      typeReferences.push(getTypeReference(node));
       if (isDirectRecordStringUnknown(node, aliases)) {
         applyPattern("recordStringUnknownCount");
       }
@@ -1276,7 +1300,10 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
     functions,
     nullableUnions,
     exportedNullableTypes,
-    typeReferenceNames: typeReferenceNames.sort(),
+    typeReferences: typeReferences.sort((left, right) => {
+      if (left.name !== right.name) return left.name.localeCompare(right.name);
+      return (left.qualifier ?? "").localeCompare(right.qualifier ?? "");
+    }),
   };
 }
 
@@ -1351,17 +1378,26 @@ function buildNullableUnionReport(
         if (file.absPath === absPath) {
           continue;
         }
+        const importedBindings = importBindingsByFile.get(file.absPath)?.get(absPath) ?? [];
         const localNames = new Set(
-          (importBindingsByFile.get(file.absPath)?.get(absPath) ?? [])
+          importedBindings
             .filter((binding) => binding.importedName === candidate.name)
             .map((binding) => binding.localName),
         );
-        if (localNames.size === 0) {
+        const namespaceNames = new Set(
+          importedBindings
+            .filter((binding) => binding.importedName === "*")
+            .map((binding) => binding.localName),
+        );
+        if (localNames.size === 0 && namespaceNames.size === 0) {
           continue;
         }
-        const fileReferenceCount = file.typeReferenceNames.filter((typeName) =>
-          localNames.has(typeName),
-        ).length;
+        const fileReferenceCount = file.typeReferences.filter((reference) => {
+          if (reference.qualifier) {
+            return reference.name === candidate.name && namespaceNames.has(reference.qualifier);
+          }
+          return localNames.has(reference.name);
+        }).length;
         if (fileReferenceCount > 0) {
           referenceCount += fileReferenceCount;
           referencingFileCount += 1;

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -174,6 +174,7 @@ type RawFunctionData = PatternCounts & {
 type RawNullableExportedType = {
   name: string;
   declarationKind: "interface" | "type";
+  absPath: string;
   filePath: string;
   line: number;
   nullableTypes: string[];
@@ -191,6 +192,7 @@ type RawFileData = PatternCounts & {
   functions: RawFunctionData[];
   nullableUnions: NullableUnionOccurrence[];
   exportedNullableTypes: RawNullableExportedType[];
+  typeReferenceNames: string[];
 };
 
 type CommentDirectiveOccurrence = {
@@ -254,10 +256,6 @@ function countNonEmptyLines(text: string): number {
 function countMatches(text: string, re: RegExp): number {
   const matches = text.match(re);
   return matches ? matches.length : 0;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function collectDirectiveCommentOccurrences(text: string): CommentDirectiveOccurrence[] {
@@ -606,6 +604,10 @@ function collectNullableUnionTypes(node: ts.Node, sourceFile: ts.SourceFile): st
 
   visit(node);
   return types;
+}
+
+function getTypeReferenceName(node: ts.TypeReferenceNode): string {
+  return ts.isIdentifier(node.typeName) ? node.typeName.text : node.typeName.right.text;
 }
 
 function buildTypeAliasMap(sourceFile: ts.SourceFile): Map<string, ts.TypeNode> {
@@ -1120,6 +1122,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
   const functionStack: RawFunctionData[] = [];
   const nullableUnions: NullableUnionOccurrence[] = [];
   const exportedNullableTypes: RawNullableExportedType[] = [];
+  const typeReferenceNames: string[] = [];
 
   addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(directiveOccurrences));
 
@@ -1156,6 +1159,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
         exportedNullableTypes.push({
           name: node.name.text,
           declarationKind: ts.isInterfaceDeclaration(node) ? "interface" : "type",
+          absPath,
           filePath: toPosixRelative(rootDir, absPath),
           line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
           nullableTypes,
@@ -1184,8 +1188,11 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
       applyPattern("nonNullAssertionCount");
     }
 
-    if (ts.isTypeReferenceNode(node) && isDirectRecordStringUnknown(node, aliases)) {
-      applyPattern("recordStringUnknownCount");
+    if (ts.isTypeReferenceNode(node)) {
+      typeReferenceNames.push(getTypeReferenceName(node));
+      if (isDirectRecordStringUnknown(node, aliases)) {
+        applyPattern("recordStringUnknownCount");
+      }
     }
 
     if (ts.isCallExpression(node) && isParserBoundaryCall(node)) {
@@ -1221,6 +1228,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
     functions,
     nullableUnions,
     exportedNullableTypes,
+    typeReferenceNames: typeReferenceNames.sort(),
   };
 }
 
@@ -1240,6 +1248,7 @@ function countByValue(values: readonly string[]): Array<{ type: string; count: n
 function buildNullableUnionReport(
   rawFiles: readonly RawFileData[],
   fanInByFile: ReadonlyMap<string, number>,
+  importsFromFile: ReadonlyMap<string, ReadonlySet<string>>,
 ): NullableUnionReport {
   const byType = new Map<
     string,
@@ -1285,19 +1294,20 @@ function buildNullableUnionReport(
     }
   }
 
-  const sourceTextByFile = new Map(
-    rawFiles.map((file) => [file.filePath, fs.readFileSync(file.absPath, "utf8")]),
-  );
   const exportedTypes = rawFiles
     .flatMap((file) => file.exportedNullableTypes)
-    .map((candidate): NullableExportedTypeFanout => {
-      const referencePattern = new RegExp(`\\b${escapeRegExp(candidate.name)}\\b`, "g");
+    .map(({ absPath, ...candidate }): NullableExportedTypeFanout => {
       let referenceCount = 0;
       let referencingFileCount = 0;
-      for (const sourceText of sourceTextByFile.values()) {
-        const matches = sourceText.match(referencePattern);
-        if (matches) {
-          referenceCount += matches.length;
+      for (const file of rawFiles) {
+        if (file.absPath === absPath || !importsFromFile.get(file.absPath)?.has(absPath)) {
+          continue;
+        }
+        const fileReferenceCount = file.typeReferenceNames.filter(
+          (typeName) => typeName === candidate.name,
+        ).length;
+        if (fileReferenceCount > 0) {
+          referenceCount += fileReferenceCount;
           referencingFileCount += 1;
         }
       }
@@ -1536,7 +1546,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
     });
 
   const fanInByFile = new Map(files.map((file) => [file.filePath, file.fanIn]));
-  const nullableUnions = buildNullableUnionReport(rawFiles, fanInByFile);
+  const nullableUnions = buildNullableUnionReport(rawFiles, fanInByFile, importsFromFile);
   const functions: FunctionHotspot[] = rawFiles
     .flatMap((file) => file.functions)
     .map((fn) => {

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -974,7 +974,11 @@ function collectReExportBindings(sourceFile: ts.SourceFile): RawImportBinding[] 
     }
 
     const exportClause = statement.exportClause;
-    if (!exportClause || !ts.isNamedExports(exportClause)) {
+    if (!exportClause) {
+      bindings.push({ specifier, importedName: "*", localName: "*" });
+      continue;
+    }
+    if (!ts.isNamedExports(exportClause)) {
       continue;
     }
 
@@ -988,6 +992,25 @@ function collectReExportBindings(sourceFile: ts.SourceFile): RawImportBinding[] 
   }
 
   return bindings;
+}
+
+function collectLocalNamedExportNames(sourceFile: ts.SourceFile): Map<string, string[]> {
+  const names = new Map<string, string[]>();
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportDeclaration(statement) && !statement.moduleSpecifier) {
+      const exportClause = statement.exportClause;
+      if (!exportClause || !ts.isNamedExports(exportClause)) {
+        continue;
+      }
+      for (const element of exportClause.elements) {
+        const localName = element.propertyName?.text ?? element.name.text;
+        names.set(localName, [...(names.get(localName) ?? []), element.name.text]);
+      }
+    }
+  }
+
+  return names;
 }
 
 function resolveLocalImport(
@@ -1228,6 +1251,7 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
   const nullableUnions: NullableUnionOccurrence[] = [];
   const exportedNullableTypes: RawNullableExportedType[] = [];
   const typeReferences: RawTypeReference[] = [];
+  const localNamedExportNames = collectLocalNamedExportNames(sourceFile);
 
   addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(directiveOccurrences));
 
@@ -1255,20 +1279,23 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
       return;
     }
 
-    if (
-      (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
-      hasExportModifier(node)
-    ) {
+    if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
+      const exportedNames = new Set<string>(localNamedExportNames.get(node.name.text));
+      if (hasExportModifier(node)) {
+        exportedNames.add(node.name.text);
+      }
       const nullableTypes = collectNullableUnionTypes(node, sourceFile);
-      if (nullableTypes.length > 0) {
-        exportedNullableTypes.push({
-          name: node.name.text,
-          declarationKind: ts.isInterfaceDeclaration(node) ? "interface" : "type",
-          absPath,
-          filePath: toPosixRelative(rootDir, absPath),
-          line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
-          nullableTypes,
-        });
+      if (exportedNames.size > 0 && nullableTypes.length > 0) {
+        for (const exportedName of exportedNames) {
+          exportedNullableTypes.push({
+            name: exportedName,
+            declarationKind: ts.isInterfaceDeclaration(node) ? "interface" : "type",
+            absPath,
+            filePath: toPosixRelative(rootDir, absPath),
+            line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+            nullableTypes,
+          });
+        }
       }
     }
 
@@ -1429,7 +1456,11 @@ function buildNullableUnionReport(
             continue;
           }
           for (const binding of bindings) {
-            if (sourceNames.has(binding.importedName)) {
+            if (binding.importedName === "*") {
+              for (const sourceName of sourceNames) {
+                changed = addName(reExporterPath, sourceName) || changed;
+              }
+            } else if (sourceNames.has(binding.importedName)) {
               changed = addName(reExporterPath, binding.localName) || changed;
             }
           }

--- a/scripts/type-safety-hotspots.ts
+++ b/scripts/type-safety-hotspots.ts
@@ -27,6 +27,7 @@ type PatternCounts = {
   nonNullAssertionCount: number;
   parserBoundaryCount: number;
   tsDirectiveCount: number;
+  nullableUnionCount: number;
 };
 
 export type FileHotspot = PatternCounts & {
@@ -61,6 +62,57 @@ export type FunctionHotspot = PatternCounts & {
   reasons: string[];
 };
 
+export type NullableUnionOccurrence = {
+  filePath: string;
+  line: number;
+  column: number;
+  kind: "property" | "parameter" | "return" | "variable" | "type-alias" | "other";
+  name: string | null;
+  containerName: string | null;
+  type: string;
+  nonNullType: string;
+};
+
+export type NullableUnionTypeHotspot = {
+  type: string;
+  nonNullType: string;
+  totalCount: number;
+  fileCount: number;
+  fanout: number;
+  files: Array<{
+    filePath: string;
+    count: number;
+    fanIn: number;
+    examples: NullableUnionOccurrence[];
+  }>;
+};
+
+export type NullableUnionFileHotspot = {
+  filePath: string;
+  count: number;
+  fanIn: number;
+  topTypes: Array<{ type: string; count: number }>;
+};
+
+export type NullableExportedTypeFanout = {
+  name: string;
+  declarationKind: "interface" | "type";
+  filePath: string;
+  line: number;
+  nullableUnionCount: number;
+  nullableTypes: Array<{ type: string; count: number }>;
+  referenceCount: number;
+  referencingFileCount: number;
+  fanout: number;
+};
+
+export type NullableUnionReport = {
+  totalCount: number;
+  byType: NullableUnionTypeHotspot[];
+  byFile: NullableUnionFileHotspot[];
+  exportedTypes: NullableExportedTypeFanout[];
+};
+
 type ThemeSummary = {
   id: string;
   title: string;
@@ -82,6 +134,7 @@ export type HotspotReport = {
   summary: ReportSummary;
   files: FileHotspot[];
   functions: FunctionHotspot[];
+  nullableUnions: NullableUnionReport;
   themes: ThemeSummary[];
   scoring: {
     description: string;
@@ -118,6 +171,14 @@ type RawFunctionData = PatternCounts & {
   noCheck: boolean;
 };
 
+type RawNullableExportedType = {
+  name: string;
+  declarationKind: "interface" | "type";
+  filePath: string;
+  line: number;
+  nullableTypes: string[];
+};
+
 type RawFileData = PatternCounts & {
   absPath: string;
   filePath: string;
@@ -128,6 +189,8 @@ type RawFileData = PatternCounts & {
   importSpecifiers: string[];
   noCheck: boolean;
   functions: RawFunctionData[];
+  nullableUnions: NullableUnionOccurrence[];
+  exportedNullableTypes: RawNullableExportedType[];
 };
 
 type CommentDirectiveOccurrence = {
@@ -153,6 +216,7 @@ function createPatternCounts(): PatternCounts {
     nonNullAssertionCount: 0,
     parserBoundaryCount: 0,
     tsDirectiveCount: 0,
+    nullableUnionCount: 0,
   };
 }
 
@@ -190,6 +254,10 @@ function countNonEmptyLines(text: string): number {
 function countMatches(text: string, re: RegExp): number {
   const matches = text.match(re);
   return matches ? matches.length : 0;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function collectDirectiveCommentOccurrences(text: string): CommentDirectiveOccurrence[] {
@@ -423,6 +491,121 @@ function isNodeExported(node: ReportableFunctionNode): boolean {
   }
 
   return false;
+}
+
+function isNullTypeNode(node: ts.TypeNode): boolean {
+  return (
+    node.kind === ts.SyntaxKind.NullKeyword ||
+    (ts.isLiteralTypeNode(node) && node.literal.kind === ts.SyntaxKind.NullKeyword)
+  );
+}
+
+function normalizeTypeText(node: ts.TypeNode, sourceFile: ts.SourceFile): string {
+  return node.getText(sourceFile).replace(/\s+/g, " ").trim();
+}
+
+function normalizeNullableUnionType(
+  node: ts.UnionTypeNode,
+  sourceFile: ts.SourceFile,
+): { type: string; nonNullType: string } {
+  const nonNullParts = node.types
+    .filter((part) => !isNullTypeNode(part))
+    .map((part) => normalizeTypeText(part, sourceFile))
+    .sort((left, right) => left.localeCompare(right));
+  const nonNullType = nonNullParts.join(" | ");
+  return {
+    type: [...nonNullParts, "null"].join(" | "),
+    nonNullType,
+  };
+}
+
+function nullableUnionType(node: ts.Node, sourceFile: ts.SourceFile): string | null {
+  if (!ts.isUnionTypeNode(node) || !node.types.some(isNullTypeNode)) {
+    return null;
+  }
+  return normalizeNullableUnionType(node, sourceFile).type;
+}
+
+function getContainerName(node: ts.Node): string | null {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isInterfaceDeclaration(current) || ts.isTypeAliasDeclaration(current)) {
+      return current.name.text;
+    }
+    if (ts.isClassDeclaration(current)) {
+      return current.name?.text ?? null;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function getNullableUnionKindAndName(
+  node: ts.UnionTypeNode,
+): Pick<NullableUnionOccurrence, "kind" | "name" | "containerName"> {
+  const parent = node.parent;
+
+  if (ts.isPropertySignature(parent) || ts.isPropertyDeclaration(parent)) {
+    return {
+      kind: "property",
+      name: getPropertyNameText(parent.name),
+      containerName: getContainerName(parent.parent),
+    };
+  }
+
+  if (ts.isParameter(parent)) {
+    return {
+      kind: "parameter",
+      name: getPropertyNameText(parent.name),
+      containerName: isReportableFunction(parent.parent)
+        ? getFunctionDisplayName(parent.parent)
+        : null,
+    };
+  }
+
+  if (ts.isVariableDeclaration(parent)) {
+    return { kind: "variable", name: getPropertyNameText(parent.name), containerName: null };
+  }
+
+  if (ts.isTypeAliasDeclaration(parent)) {
+    return { kind: "type-alias", name: parent.name.text, containerName: null };
+  }
+
+  if (isReportableFunction(parent) && parent.type === node) {
+    return { kind: "return", name: "return", containerName: getFunctionDisplayName(parent) };
+  }
+
+  return { kind: "other", name: null, containerName: getContainerName(parent) };
+}
+
+function createNullableUnionOccurrence(
+  node: ts.UnionTypeNode,
+  sourceFile: ts.SourceFile,
+  filePath: string,
+): NullableUnionOccurrence {
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return {
+    filePath,
+    line: position.line + 1,
+    column: position.character + 1,
+    ...getNullableUnionKindAndName(node),
+    ...normalizeNullableUnionType(node, sourceFile),
+  };
+}
+
+function collectNullableUnionTypes(node: ts.Node, sourceFile: ts.SourceFile): string[] {
+  const types: string[] = [];
+
+  function visit(current: ts.Node): void {
+    const type = nullableUnionType(current, sourceFile);
+    if (type) {
+      types.push(type);
+    }
+    ts.forEachChild(current, visit);
+  }
+
+  visit(node);
+  return types;
 }
 
 function buildTypeAliasMap(sourceFile: ts.SourceFile): Map<string, ts.TypeNode> {
@@ -829,6 +1012,12 @@ function buildFileReasons(file: RawFileData, fanIn: number): string[] {
   if (file.recordStringUnknownCount > 0) {
     appendReason(reasons, `${String(file.recordStringUnknownCount)} Record<string, unknown>`);
   }
+  if (file.nullableUnionCount > 0) {
+    appendReason(
+      reasons,
+      `${String(file.nullableUnionCount)} nullable ${pluralize(file.nullableUnionCount, "union")}`,
+    );
+  }
   if (file.typeAssertionCount > 0) {
     appendReason(
       reasons,
@@ -878,6 +1067,12 @@ function buildFunctionReasons(fn: RawFunctionData, fileFanIn: number): string[] 
   if (fn.recordStringUnknownCount > 0) {
     appendReason(reasons, `${String(fn.recordStringUnknownCount)} Record<string, unknown>`);
   }
+  if (fn.nullableUnionCount > 0) {
+    appendReason(
+      reasons,
+      `${String(fn.nullableUnionCount)} nullable ${pluralize(fn.nullableUnionCount, "union")}`,
+    );
+  }
   if (fn.typeAssertionCount > 0) {
     appendReason(
       reasons,
@@ -923,6 +1118,8 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
   const fileMetrics = createPatternCounts();
   const functions: RawFunctionData[] = [];
   const functionStack: RawFunctionData[] = [];
+  const nullableUnions: NullableUnionOccurrence[] = [];
+  const exportedNullableTypes: RawNullableExportedType[] = [];
 
   addPattern(fileMetrics, "tsDirectiveCount", countDirectiveComments(directiveOccurrences));
 
@@ -948,6 +1145,29 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
       ts.forEachChild(node, visit);
       functionStack.pop();
       return;
+    }
+
+    if (
+      (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
+      hasExportModifier(node)
+    ) {
+      const nullableTypes = collectNullableUnionTypes(node, sourceFile);
+      if (nullableTypes.length > 0) {
+        exportedNullableTypes.push({
+          name: node.name.text,
+          declarationKind: ts.isInterfaceDeclaration(node) ? "interface" : "type",
+          filePath: toPosixRelative(rootDir, absPath),
+          line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+          nullableTypes,
+        });
+      }
+    }
+
+    if (ts.isUnionTypeNode(node) && node.types.some(isNullTypeNode)) {
+      nullableUnions.push(
+        createNullableUnionOccurrence(node, sourceFile, toPosixRelative(rootDir, absPath)),
+      );
+      applyPattern("nullableUnionCount");
     }
 
     if (node.kind === ts.SyntaxKind.AnyKeyword) {
@@ -999,6 +1219,148 @@ function analyzeFile(absPath: string, rootDir: string, project: ProjectInfo): Ra
     importSpecifiers: collectImportSpecifiers(sourceFile),
     noCheck,
     functions,
+    nullableUnions,
+    exportedNullableTypes,
+  };
+}
+
+function countByValue(values: readonly string[]): Array<{ type: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([type, count]) => ({ type, count }))
+    .sort((left, right) => {
+      if (right.count !== left.count) return right.count - left.count;
+      return left.type.localeCompare(right.type);
+    });
+}
+
+function buildNullableUnionReport(
+  rawFiles: readonly RawFileData[],
+  fanInByFile: ReadonlyMap<string, number>,
+): NullableUnionReport {
+  const byType = new Map<
+    string,
+    {
+      nonNullType: string;
+      totalCount: number;
+      files: Map<string, { count: number; fanIn: number; examples: NullableUnionOccurrence[] }>;
+    }
+  >();
+  const byFile = new Map<string, { count: number; fanIn: number; types: string[] }>();
+
+  for (const file of rawFiles) {
+    for (const occurrence of file.nullableUnions) {
+      const typeEntry = byType.get(occurrence.type) ?? {
+        nonNullType: occurrence.nonNullType,
+        totalCount: 0,
+        files: new Map<
+          string,
+          { count: number; fanIn: number; examples: NullableUnionOccurrence[] }
+        >(),
+      };
+      typeEntry.totalCount += 1;
+      const typeFileEntry = typeEntry.files.get(file.filePath) ?? {
+        count: 0,
+        fanIn: fanInByFile.get(file.filePath) ?? 0,
+        examples: [],
+      };
+      typeFileEntry.count += 1;
+      if (typeFileEntry.examples.length < 3) {
+        typeFileEntry.examples.push(occurrence);
+      }
+      typeEntry.files.set(file.filePath, typeFileEntry);
+      byType.set(occurrence.type, typeEntry);
+
+      const fileEntry = byFile.get(file.filePath) ?? {
+        count: 0,
+        fanIn: fanInByFile.get(file.filePath) ?? 0,
+        types: [],
+      };
+      fileEntry.count += 1;
+      fileEntry.types.push(occurrence.type);
+      byFile.set(file.filePath, fileEntry);
+    }
+  }
+
+  const sourceTextByFile = new Map(
+    rawFiles.map((file) => [file.filePath, fs.readFileSync(file.absPath, "utf8")]),
+  );
+  const exportedTypes = rawFiles
+    .flatMap((file) => file.exportedNullableTypes)
+    .map((candidate): NullableExportedTypeFanout => {
+      const referencePattern = new RegExp(`\\b${escapeRegExp(candidate.name)}\\b`, "g");
+      let referenceCount = 0;
+      let referencingFileCount = 0;
+      for (const sourceText of sourceTextByFile.values()) {
+        const matches = sourceText.match(referencePattern);
+        if (matches) {
+          referenceCount += matches.length;
+          referencingFileCount += 1;
+        }
+      }
+      return {
+        ...candidate,
+        nullableUnionCount: candidate.nullableTypes.length,
+        nullableTypes: countByValue(candidate.nullableTypes),
+        referenceCount,
+        referencingFileCount,
+        fanout: referencingFileCount,
+      };
+    })
+    .sort((left, right) => {
+      if (right.fanout !== left.fanout) return right.fanout - left.fanout;
+      if (right.referenceCount !== left.referenceCount)
+        return right.referenceCount - left.referenceCount;
+      if (right.nullableUnionCount !== left.nullableUnionCount) {
+        return right.nullableUnionCount - left.nullableUnionCount;
+      }
+      return left.name.localeCompare(right.name);
+    });
+
+  return {
+    totalCount: rawFiles.reduce((count, file) => count + file.nullableUnionCount, 0),
+    byType: [...byType.entries()]
+      .map(([type, entry]): NullableUnionTypeHotspot => {
+        const files = [...entry.files.entries()]
+          .map(([filePath, fileEntry]) => ({ filePath, ...fileEntry }))
+          .sort((left, right) => {
+            if (right.count !== left.count) return right.count - left.count;
+            if (right.fanIn !== left.fanIn) return right.fanIn - left.fanIn;
+            return left.filePath.localeCompare(right.filePath);
+          });
+        return {
+          type,
+          nonNullType: entry.nonNullType,
+          totalCount: entry.totalCount,
+          fileCount: entry.files.size,
+          fanout: files.reduce((sum, file) => sum + file.fanIn, 0),
+          files,
+        };
+      })
+      .sort((left, right) => {
+        if (right.totalCount !== left.totalCount) return right.totalCount - left.totalCount;
+        if (right.fileCount !== left.fileCount) return right.fileCount - left.fileCount;
+        if (right.fanout !== left.fanout) return right.fanout - left.fanout;
+        return left.type.localeCompare(right.type);
+      }),
+    byFile: [...byFile.entries()]
+      .map(
+        ([filePath, entry]): NullableUnionFileHotspot => ({
+          filePath,
+          count: entry.count,
+          fanIn: entry.fanIn,
+          topTypes: countByValue(entry.types).slice(0, 5),
+        }),
+      )
+      .sort((left, right) => {
+        if (right.count !== left.count) return right.count - left.count;
+        if (right.fanIn !== left.fanIn) return right.fanIn - left.fanIn;
+        return left.filePath.localeCompare(right.filePath);
+      }),
+    exportedTypes,
   };
 }
 
@@ -1045,6 +1407,26 @@ function buildThemes(files: FileHotspot[], summary: ReportSummary): ThemeSummary
       detail: `${String(summary.weakExportCount)} exported functions still rely on weak signatures.`,
       count: summary.weakExportCount,
       examples: exportExamples,
+    });
+  }
+
+  const nullableExamples = files
+    .filter((file) => file.nullableUnionCount > 0)
+    .sort((left, right) => {
+      if (right.nullableUnionCount !== left.nullableUnionCount) {
+        return right.nullableUnionCount - left.nullableUnionCount;
+      }
+      return left.filePath.localeCompare(right.filePath);
+    })
+    .slice(0, 3)
+    .map((file) => file.filePath);
+  if (summary.nullableUnionCount > 0) {
+    themes.push({
+      id: "nullable-unions",
+      title: "Keep nullable unions at boundaries",
+      detail: `${String(summary.nullableUnionCount)} nullable unions show where raw state can become constrained internal types.`,
+      count: summary.nullableUnionCount,
+      examples: nullableExamples,
     });
   }
 
@@ -1154,6 +1536,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
     });
 
   const fanInByFile = new Map(files.map((file) => [file.filePath, file.fanIn]));
+  const nullableUnions = buildNullableUnionReport(rawFiles, fanInByFile);
   const functions: FunctionHotspot[] = rawFiles
     .flatMap((file) => file.functions)
     .map((fn) => {
@@ -1196,6 +1579,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
       acc.nonNullAssertionCount += file.nonNullAssertionCount;
       acc.parserBoundaryCount += file.parserBoundaryCount;
       acc.tsDirectiveCount += file.tsDirectiveCount;
+      acc.nullableUnionCount += file.nullableUnionCount;
       return acc;
     },
     {
@@ -1213,6 +1597,7 @@ export function analyzeTypeSafetyHotspots(options: AnalyzeOptions = {}): Hotspot
     summary,
     files,
     functions,
+    nullableUnions,
     themes: buildThemes(files, summary),
     scoring: {
       description:
@@ -1276,7 +1661,9 @@ export function renderTextReport(
       report.summary.noCheckFileCount === 1 ? "" : "s"
     }, ${String(report.summary.typeAssertionCount)} casts, ${String(
       report.summary.recordStringUnknownCount,
-    )} Record<string, unknown>, ${String(report.summary.parserBoundaryCount)} parse boundaries.`,
+    )} Record<string, unknown>, ${String(report.summary.parserBoundaryCount)} parse boundaries, ${String(
+      report.summary.nullableUnionCount,
+    )} nullable unions.`,
   );
   lines.push(`Heuristic: ${report.scoring.description}`);
 
@@ -1320,6 +1707,69 @@ export function renderTextReport(
         )}`,
       );
       lines.push(`   ${fn.reasons.join("; ")}`);
+    });
+  }
+
+  lines.push("");
+  lines.push("Top nullable union types");
+  const topNullableTypes = report.nullableUnions.byType.slice(0, Math.min(options.topFiles, 10));
+  if (topNullableTypes.length === 0) {
+    lines.push("- No nullable unions found.");
+  } else {
+    topNullableTypes.forEach((entry, index) => {
+      lines.push(
+        `${String(index + 1)}. ${entry.type} — ${String(entry.totalCount)} occurrence${
+          entry.totalCount === 1 ? "" : "s"
+        } in ${String(entry.fileCount)} file${entry.fileCount === 1 ? "" : "s"}, aggregate fan-in ${String(
+          entry.fanout,
+        )}`,
+      );
+      const fileSummary = entry.files
+        .slice(0, 3)
+        .map((file) => `${file.filePath} (${String(file.count)}, fan-in ${String(file.fanIn)})`)
+        .join("; ");
+      lines.push(`   ${fileSummary}`);
+    });
+  }
+
+  lines.push("");
+  lines.push("Top nullable union files");
+  const topNullableFiles = report.nullableUnions.byFile.slice(0, Math.min(options.topFiles, 10));
+  if (topNullableFiles.length === 0) {
+    lines.push("- No files contain nullable unions.");
+  } else {
+    topNullableFiles.forEach((entry, index) => {
+      lines.push(
+        `${String(index + 1)}. ${entry.filePath} — ${String(entry.count)} nullable union${
+          entry.count === 1 ? "" : "s"
+        }, fan-in ${String(entry.fanIn)}`,
+      );
+      lines.push(
+        `   ${entry.topTypes.map((type) => `${type.type} (${String(type.count)})`).join("; ")}`,
+      );
+    });
+  }
+
+  lines.push("");
+  lines.push("Exported nullable types by fanout");
+  const topExportedNullableTypes = report.nullableUnions.exportedTypes.slice(
+    0,
+    Math.min(options.topFiles, 10),
+  );
+  if (topExportedNullableTypes.length === 0) {
+    lines.push("- No exported interfaces or type aliases contain nullable unions.");
+  } else {
+    topExportedNullableTypes.forEach((entry, index) => {
+      lines.push(
+        `${String(index + 1)}. ${entry.name} (${entry.filePath}:${String(entry.line)}) — ${String(
+          entry.nullableUnionCount,
+        )} nullable union${entry.nullableUnionCount === 1 ? "" : "s"}, referenced in ${String(
+          entry.referencingFileCount,
+        )} file${entry.referencingFileCount === 1 ? "" : "s"}`,
+      );
+      lines.push(
+        `   ${entry.nullableTypes.map((type) => `${type.type} (${String(type.count)})`).join("; ")}`,
+      );
     });
   }
 

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -197,6 +197,12 @@ export function readOwner(value: UserConfig | null): string | null {
   return value?.owner ?? null;
 }
 `,
+      "src/unrelated.ts": `export interface UserConfig {
+  owner: string | null;
+}
+
+const comment = "UserConfig in a string should not count as fanout";
+`,
     });
 
     const report = analyzeTypeSafetyHotspots({
@@ -214,14 +220,19 @@ export function readOwner(value: UserConfig | null): string | null {
       (entry) => entry.filePath === "src/config.ts",
     );
     const exportedConfig = report.nullableUnions.exportedTypes.find(
-      (entry) => entry.name === "UserConfig",
+      (entry) => entry.name === "UserConfig" && entry.filePath === "src/config.ts",
+    );
+    const unrelatedConfig = report.nullableUnions.exportedTypes.find(
+      (entry) => entry.name === "UserConfig" && entry.filePath === "src/unrelated.ts",
     );
 
     expect(report.summary.nullableUnionCount).toBeGreaterThanOrEqual(7);
     expect(stringNull?.totalCount).toBeGreaterThanOrEqual(4);
     expect(configFile?.count).toBeGreaterThanOrEqual(5);
     expect(exportedConfig?.nullableUnionCount).toBe(2);
-    expect(exportedConfig?.referencingFileCount).toBe(3);
+    expect(exportedConfig?.referencingFileCount).toBe(2);
+    expect(exportedConfig?.referenceCount).toBe(2);
+    expect(unrelatedConfig?.referencingFileCount).toBe(0);
     expect(report.themes.map((theme) => theme.id)).toContain("nullable-unions");
     expect(textReport).toContain("Top nullable union types");
     expect(textReport).toContain("Exported nullable types by fanout");

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -181,6 +181,10 @@ export const configB = normalizeConfig("{}");
   fallbackOwner?: string | null;
 }
 
+export interface OtherConfig {
+  id: string | null;
+}
+
 export type MaybeConfig = UserConfig | null;
 
 export function normalizeConfig(raw: UserConfig | null): string | null {
@@ -196,6 +200,19 @@ export const configA = null as UserConfig | null;
 export function readOwner(value: UserConfig | null): string | null {
   return value?.owner ?? null;
 }
+`,
+      "src/use-c.ts": `import type { MaybeConfig } from "./config";
+
+interface UserConfig {
+  shadow: string | null;
+}
+
+export const maybe = null as MaybeConfig;
+export const shadow = null as UserConfig | null;
+`,
+      "src/use-d.ts": `import type { UserConfig as ImportedConfig } from "./config";
+
+export const aliased = null as ImportedConfig | null;
 `,
       "src/unrelated.ts": `export interface UserConfig {
   owner: string | null;
@@ -230,8 +247,8 @@ const comment = "UserConfig in a string should not count as fanout";
     expect(stringNull?.totalCount).toBeGreaterThanOrEqual(4);
     expect(configFile?.count).toBeGreaterThanOrEqual(5);
     expect(exportedConfig?.nullableUnionCount).toBe(2);
-    expect(exportedConfig?.referencingFileCount).toBe(2);
-    expect(exportedConfig?.referenceCount).toBe(2);
+    expect(exportedConfig?.referencingFileCount).toBe(3);
+    expect(exportedConfig?.referenceCount).toBe(3);
     expect(unrelatedConfig?.referencingFileCount).toBe(0);
     expect(report.themes.map((theme) => theme.id)).toContain("nullable-unions");
     expect(textReport).toContain("Top nullable union types");

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -218,6 +218,16 @@ export const aliased = null as ImportedConfig | null;
 
 export const namespaced = null as Config.UserConfig | null;
 `,
+      "src/barrel.ts": `export type { UserConfig } from "./config";
+`,
+      "src/use-f.ts": `import type { UserConfig as BarrelConfig } from "./barrel";
+
+export const barreled = null as BarrelConfig | null;
+`,
+      "src/use-g.ts": `import type * as Barrel from "./barrel";
+
+export const namespacedBarrel = null as Barrel.UserConfig | null;
+`,
       "src/unrelated.ts": `export interface UserConfig {
   owner: string | null;
 }
@@ -251,8 +261,8 @@ const comment = "UserConfig in a string should not count as fanout";
     expect(stringNull?.totalCount).toBeGreaterThanOrEqual(4);
     expect(configFile?.count).toBeGreaterThanOrEqual(5);
     expect(exportedConfig?.nullableUnionCount).toBe(2);
-    expect(exportedConfig?.referencingFileCount).toBe(4);
-    expect(exportedConfig?.referenceCount).toBe(4);
+    expect(exportedConfig?.referencingFileCount).toBe(6);
+    expect(exportedConfig?.referenceCount).toBe(6);
     expect(unrelatedConfig?.referencingFileCount).toBe(0);
     expect(report.themes.map((theme) => theme.id)).toContain("nullable-unions");
     expect(textReport).toContain("Top nullable union types");

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -174,6 +174,59 @@ export const configB = normalizeConfig("{}");
     expect(textReport).toContain("normalizeConfig");
   });
 
+  it("reports nullable unions by type, file, and exported type fanout", () => {
+    const rootDir = makeProject({
+      "src/config.ts": `export interface UserConfig {
+  owner: string | null;
+  fallbackOwner?: string | null;
+}
+
+export type MaybeConfig = UserConfig | null;
+
+export function normalizeConfig(raw: UserConfig | null): string | null {
+  return raw?.owner ?? null;
+}
+`,
+      "src/use-a.ts": `import type { UserConfig } from "./config";
+
+export const configA = null as UserConfig | null;
+`,
+      "src/use-b.ts": `import type { UserConfig } from "./config";
+
+export function readOwner(value: UserConfig | null): string | null {
+  return value?.owner ?? null;
+}
+`,
+    });
+
+    const report = analyzeTypeSafetyHotspots({
+      rootDir,
+      projectPaths: ["tsconfig.json"],
+    });
+    const textReport = renderTextReport(report, {
+      topFiles: 5,
+      topFunctions: 5,
+      minScore: 1,
+    });
+
+    const stringNull = report.nullableUnions.byType.find((entry) => entry.type === "string | null");
+    const configFile = report.nullableUnions.byFile.find(
+      (entry) => entry.filePath === "src/config.ts",
+    );
+    const exportedConfig = report.nullableUnions.exportedTypes.find(
+      (entry) => entry.name === "UserConfig",
+    );
+
+    expect(report.summary.nullableUnionCount).toBeGreaterThanOrEqual(7);
+    expect(stringNull?.totalCount).toBeGreaterThanOrEqual(4);
+    expect(configFile?.count).toBeGreaterThanOrEqual(5);
+    expect(exportedConfig?.nullableUnionCount).toBe(2);
+    expect(exportedConfig?.referencingFileCount).toBe(3);
+    expect(report.themes.map((theme) => theme.id)).toContain("nullable-unions");
+    expect(textReport).toContain("Top nullable union types");
+    expect(textReport).toContain("Exported nullable types by fanout");
+  });
+
   it("rejects another flag in place of a --root value", () => {
     expect(() => parseArgs(["--root", "--json"])).toThrow(/Missing value for --root/);
   });

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -185,6 +185,11 @@ export interface OtherConfig {
   id: string | null;
 }
 
+interface HiddenConfig {
+  hidden: string | null;
+}
+export type { HiddenConfig };
+
 export type MaybeConfig = UserConfig | null;
 
 export function normalizeConfig(raw: UserConfig | null): string | null {
@@ -220,6 +225,8 @@ export const namespaced = null as Config.UserConfig | null;
 `,
       "src/barrel.ts": `export type { UserConfig } from "./config";
 `,
+      "src/star-barrel.ts": `export * from "./config";
+`,
       "src/use-f.ts": `import type { UserConfig as BarrelConfig } from "./barrel";
 
 export const barreled = null as BarrelConfig | null;
@@ -227,6 +234,14 @@ export const barreled = null as BarrelConfig | null;
       "src/use-g.ts": `import type * as Barrel from "./barrel";
 
 export const namespacedBarrel = null as Barrel.UserConfig | null;
+`,
+      "src/use-h.ts": `import type { UserConfig as StarConfig } from "./star-barrel";
+
+export const starBarreled = null as StarConfig | null;
+`,
+      "src/use-i.ts": `import type { HiddenConfig } from "./config";
+
+export const hidden = null as HiddenConfig | null;
 `,
       "src/unrelated.ts": `export interface UserConfig {
   owner: string | null;
@@ -256,14 +271,19 @@ const comment = "UserConfig in a string should not count as fanout";
     const unrelatedConfig = report.nullableUnions.exportedTypes.find(
       (entry) => entry.name === "UserConfig" && entry.filePath === "src/unrelated.ts",
     );
+    const hiddenConfig = report.nullableUnions.exportedTypes.find(
+      (entry) => entry.name === "HiddenConfig" && entry.filePath === "src/config.ts",
+    );
 
     expect(report.summary.nullableUnionCount).toBeGreaterThanOrEqual(7);
     expect(stringNull?.totalCount).toBeGreaterThanOrEqual(4);
     expect(configFile?.count).toBeGreaterThanOrEqual(5);
     expect(exportedConfig?.nullableUnionCount).toBe(2);
-    expect(exportedConfig?.referencingFileCount).toBe(6);
-    expect(exportedConfig?.referenceCount).toBe(6);
+    expect(exportedConfig?.referencingFileCount).toBe(7);
+    expect(exportedConfig?.referenceCount).toBe(7);
     expect(unrelatedConfig?.referencingFileCount).toBe(0);
+    expect(hiddenConfig?.nullableUnionCount).toBe(1);
+    expect(hiddenConfig?.referencingFileCount).toBe(1);
     expect(report.themes.map((theme) => theme.id)).toContain("nullable-unions");
     expect(textReport).toContain("Top nullable union types");
     expect(textReport).toContain("Exported nullable types by fanout");

--- a/test/type-safety-hotspots.test.ts
+++ b/test/type-safety-hotspots.test.ts
@@ -214,6 +214,10 @@ export const shadow = null as UserConfig | null;
 
 export const aliased = null as ImportedConfig | null;
 `,
+      "src/use-e.ts": `import type * as Config from "./config";
+
+export const namespaced = null as Config.UserConfig | null;
+`,
       "src/unrelated.ts": `export interface UserConfig {
   owner: string | null;
 }
@@ -247,8 +251,8 @@ const comment = "UserConfig in a string should not count as fanout";
     expect(stringNull?.totalCount).toBeGreaterThanOrEqual(4);
     expect(configFile?.count).toBeGreaterThanOrEqual(5);
     expect(exportedConfig?.nullableUnionCount).toBe(2);
-    expect(exportedConfig?.referencingFileCount).toBe(3);
-    expect(exportedConfig?.referenceCount).toBe(3);
+    expect(exportedConfig?.referencingFileCount).toBe(4);
+    expect(exportedConfig?.referenceCount).toBe(4);
     expect(unrelatedConfig?.referencingFileCount).toBe(0);
     expect(report.themes.map((theme) => theme.id)).toContain("nullable-unions");
     expect(textReport).toContain("Top nullable union types");


### PR DESCRIPTION
## Summary
Extend the type-safety hotspots tool so it reports nullable union hotspots alongside existing weak-type and parse-boundary findings. The report now ranks nullable unions by union shape, file concentration, and exported type fanout to support the nullability refactor tracked in #5518.

## Related Issue
Refs #5518

## Changes
- Add nullable-union counting to `scripts/type-safety-hotspots.ts` and include totals in the summary and repo-wide themes.
- Add a `nullableUnions` JSON report with `byType`, `byFile`, and `exportedTypes` rankings.
- Extend text output with sections for top nullable union types, files, and exported type fanout.
- Add coverage in `test/type-safety-hotspots.test.ts` for nullable type, file, and fanout reporting.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the type-safety hotspot report to detect nullable-union patterns and show canonical per-type and per-file hotspots, including contextual occurrence details.
  * Added repo-wide nullable-union aggregation and exported-type fan-out metrics to reveal how widely these patterns are referenced across modules/re-exports.
  * Introduced a new `nullable-unions` theme and added dedicated sections to the text report (including updated totals/summary lines).
* **Tests**
  * Added an end-to-end Vitest coverage case for multi-module nullable unions, re-exports (direct/star/barrel/alias), exported fan-out accuracy, and expected report sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->