### PR TITLE
fix gpu toolkit cdi preflight detection

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1577,8 +1577,9 @@ function waitForSandboxReady(sandboxName: string, attempts = 10, delaySeconds = 
 
 // ── Step 1: Preflight ────────────────────────────────────────────
 
-// Keep the Docker CDI guard near preflight so resume hits the same early failure path.
-// Jetson/Tegra uses Docker's NVIDIA runtime backend and is exempt from CDI.
+/**
+ * Fails onboarding when Docker CDI injection is configured but the NVIDIA GPU spec is invalid.
+ */
 function assertCdiNvidiaGpuSpecPresent(
   host: ReturnType<typeof assessHost>,
   optedOutGpuPassthrough: boolean,
@@ -1601,11 +1602,9 @@ type PreflightOptions = Pick<
   optedOutGpuPassthrough?: boolean;
 };
 
-// Reject unsupported container runtimes (currently only Podman with the
-// Linux Docker-driver gateway) before any Docker-specific probes. Both
-// the fresh preflight and `--resume` backstop call this — if `docker`
-// resolves to Podman, surface the unsupported-runtime message instead of
-// running bridge/DNS diagnostics that would be misleading.
+/**
+ * Rejects unsupported runtimes before Docker-specific bridge, DNS, and CDI probes.
+ */
 function rejectUnsupportedContainerRuntime(host: ReturnType<typeof assessHost>): void {
   if (isLinuxDockerDriverGatewayEnabled() && host.runtime === "podman") {
     console.error(`  ✗ ${cliDisplayName()} onboarding now uses OpenShell's Docker driver.`);
@@ -1615,13 +1614,14 @@ function rejectUnsupportedContainerRuntime(host: ReturnType<typeof assessHost>):
   }
 }
 
+/**
+ * Runs host preflight and blocks early on Docker, GPU, CDI, and runtime problems.
+ */
 async function preflight(
   preflightOpts: PreflightOptions = {},
 ): Promise<ReturnType<typeof nim.detectGpu>> {
   step(1, 8, "Preflight checks");
-
   const host = assessHost();
-
   // Docker / runtime
   if (!host.dockerReachable) {
     console.error("  Docker is not reachable. Please fix Docker and try again.");
@@ -1640,12 +1640,11 @@ async function preflight(
     device: preflightOpts.sandboxGpuDevice ?? null,
   });
   exitOnSandboxGpuConfigErrors(sandboxGpuConfig);
-  const optedOutGpuPassthrough =
+  const explicitlyOptedOutGpuPassthrough =
     preflightOpts.optedOutGpuPassthrough === true ||
     preflightOpts.noGpu === true ||
-    !sandboxGpuConfig.sandboxGpuEnabled;
-  assertCdiNvidiaGpuSpecPresent(host, optedOutGpuPassthrough, sandboxGpuConfig.hostGpuPlatform);
-
+    sandboxGpuConfig.mode === "0";
+  assertCdiNvidiaGpuSpecPresent(host, explicitlyOptedOutGpuPassthrough, sandboxGpuConfig.hostGpuPlatform);
   assertDockerBridgeAndContainerDnsHealthy(host, isNonInteractive());
 
   if (host.runtime !== "unknown") {

--- a/src/lib/onboard/machine/handlers/preflight.test.ts
+++ b/src/lib/onboard/machine/handlers/preflight.test.ts
@@ -186,11 +186,33 @@ describe("handlePreflightState", () => {
     expect(harness.deps.startRecordedStep).not.toHaveBeenCalled();
     expect(harness.deps.assertCdiNvidiaGpuSpecPresent).toHaveBeenCalledWith(
       { cdiNvidiaGpuSpecMissing: false },
-      true,
+      false,
       undefined,
     );
     expect(harness.deps.validateSandboxGpuPreflight).toHaveBeenCalledOnce();
     expect(result.resumePreflight).toBe(true);
+  });
+
+  it("keeps CDI guard active on resume when auto mode disables GPU after failed detection", async () => {
+    const session = createSession();
+    session.steps.preflight.status = "complete";
+    session.gpuPassthrough = false;
+    const assertCdiNvidiaGpuSpecPresent = vi.fn();
+    const host = { cdiNvidiaGpuSpecMissing: true };
+    const harness = createDeps({
+      detectGpu: vi.fn(() => null),
+      getResumeSandboxGpuOverrides: vi.fn(() => ({ flag: null, device: null })),
+      resolveSandboxGpuConfig,
+      assessHost: () => host,
+      assertCdiNvidiaGpuSpecPresent,
+    });
+
+    await handlePreflightState({
+      ...baseOptions(harness.deps, session),
+      resume: true,
+    });
+
+    expect(assertCdiNvidiaGpuSpecPresent).toHaveBeenCalledWith(host, false, null);
   });
 
   it("passes host GPU platform into the resumed CDI guard", async () => {
@@ -220,7 +242,7 @@ describe("handlePreflightState", () => {
 
     expect(assertCdiNvidiaGpuSpecPresent).toHaveBeenCalledWith(
       { cdiNvidiaGpuSpecMissing: false },
-      true,
+      false,
       "jetson",
     );
   });

--- a/src/lib/onboard/machine/handlers/preflight.ts
+++ b/src/lib/onboard/machine/handlers/preflight.ts
@@ -93,10 +93,17 @@ export interface PreflightStateResult<Gpu, Config extends PreflightSandboxGpuCon
   stateResult: OnboardStateTransitionResult;
 }
 
+/**
+ * Checks whether the environment pins sandbox GPU mode or device selection.
+ */
 function envHasSandboxGpuOverride(env: NodeJS.ProcessEnv): boolean {
   return env.NEMOCLAW_SANDBOX_GPU !== undefined || env.NEMOCLAW_SANDBOX_GPU_DEVICE !== undefined;
 }
 
+/**
+ * Executes or revalidates the preflight state while preserving the user's
+ * effective sandbox GPU intent across fresh onboarding and resume.
+ */
 export async function handlePreflightState<
   Gpu,
   SandboxEntry,
@@ -143,9 +150,7 @@ export async function handlePreflightState<
     });
     deps.validateSandboxGpuPreflight(resumeSandboxGpuConfig);
     const resumeOptedOutGpuPassthrough =
-      noGpu ||
-      (!gpuRequested && session?.gpuPassthrough === false) ||
-      !resumeSandboxGpuConfig.sandboxGpuEnabled;
+      noGpu || effectiveSandboxGpuFlag === "disable" || resumeSandboxGpuConfig.mode === "0";
     const resumeHost = deps.assessHost();
     // Reject unsupported runtimes (Podman) BEFORE the CDI GPU-spec
     // backstop and the Docker-specific bridge/DNS probes so Podman

--- a/src/lib/onboard/preflight-cdi.test.ts
+++ b/src/lib/onboard/preflight-cdi.test.ts
@@ -8,6 +8,9 @@ import { assessHost, planHostRemediation } from "../../../dist/lib/onboard/prefl
 
 type HostAssessment = Parameters<typeof planHostRemediation>[0];
 
+/**
+ * Creates a Linux Docker host assessment with NVIDIA CDI defaults for focused overrides.
+ */
 function baseAssessment(overrides: Partial<HostAssessment> = {}): HostAssessment {
   return {
     platform: "linux",
@@ -38,6 +41,9 @@ function baseAssessment(overrides: Partial<HostAssessment> = {}): HostAssessment
   };
 }
 
+/**
+ * Emulates the systemctl/stat probes needed by CDI staleness remediation tests.
+ */
 function healthySystemctlAndStat(command: readonly string[]) {
   if (command[0] === "systemctl" && command[1] === "is-enabled") return "enabled";
   if (command[0] === "systemctl" && command[1] === "is-active") return "active";
@@ -65,6 +71,51 @@ describe("assessHost — CDI", () => {
 
     expect(result.dockerCdiSpecDirs).toEqual(["/etc/cdi", "/var/run/cdi"]);
     expect(result.cdiNvidiaGpuSpecMissing).toBe(true);
+  });
+
+  it("plans toolkit bootstrap when PCI detects NVIDIA hardware but nvidia-smi and nvidia-ctk are absent", () => {
+    const result = assessHost({
+      platform: "linux",
+      env: {},
+      release: "6.8.0-58-generic",
+      readFileImpl: (filePath: string) =>
+        filePath.endsWith("other.yaml")
+          ? "cdiVersion: 0.5.0\nkind: vendor.example/device\ndevices: []\n"
+          : "Linux version 6.8.0-58-generic",
+      readdirImpl: (dir: string) => (dir === "/etc/cdi" ? ["other.yaml"] : []),
+      runCaptureImpl: (command: readonly string[]) =>
+        new Map([
+          [["sh", "-c", 'command -v "$1"', "--", "apt-get"].join("\0"), "/usr/bin/apt-get"],
+          [
+            ["lspci", "-nn"].join("\0"),
+            "01:00.0 VGA compatible controller: NVIDIA Corporation GA102 [GeForce RTX 3090]\n",
+          ],
+          [["systemctl", "is-active", "docker"].join("\0"), "active"],
+          [["systemctl", "is-enabled", "docker"].join("\0"), "enabled"],
+        ]).get(command.join("\0")) ?? "",
+      dockerInfoOutput: JSON.stringify({
+        ServerVersion: "27.0",
+        OperatingSystem: "Ubuntu 24.04",
+        CDISpecDirs: ["/etc/cdi", "/var/run/cdi"],
+      }),
+      commandExistsImpl: (name: string) =>
+        name === "docker" || name === "lspci" || name === "systemctl",
+    });
+
+    expect(result.hasNvidiaGpu).toBe(true);
+    expect(result.nvidiaContainerToolkitInstalled).toBe(false);
+    expect(result.cdiNvidiaGpuSpecMissing).toBe(true);
+
+    const action = planHostRemediation(result).find(
+      (entry: { id: string }) => entry.id === "install_nvidia_container_toolkit",
+    );
+    expect(action).toBeTruthy();
+    expect(action?.blocking).toBe(true);
+    expect(action?.commands).toContain("sudo apt-get install -y nvidia-container-toolkit");
+    expect(action?.commands.some((command) => command.includes("nvidia-ctk cdi generate"))).toBe(
+      true,
+    );
+    expect(action?.commands.some((command) => command.includes("nvidia-ctk cdi list"))).toBe(true);
   });
 
   it("does not flag the host when an nvidia.com/gpu YAML spec is present", () => {

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -385,13 +385,37 @@ function isHeadlessLikely(env: NodeJS.ProcessEnv): boolean {
   return !env.DISPLAY && !env.WAYLAND_DISPLAY && !env.TERM_PROGRAM;
 }
 
-function detectNvidiaGpu(runCaptureImpl: RunCaptureFn): boolean {
-  if (!commandExists("nvidia-smi", runCaptureImpl)) {
-    return false;
+/**
+ * Detects NVIDIA hardware via nvidia-smi first, then Linux PCI data as a toolkit-free fallback.
+ */
+function detectNvidiaGpu(opts: {
+  platform: NodeJS.Platform | string;
+  isWsl: boolean;
+  runCaptureImpl: RunCaptureFn;
+  commandExistsImpl?: (commandName: string) => boolean;
+}): boolean {
+  const commandExistsImpl =
+    opts.commandExistsImpl ??
+    ((commandName: string) => commandExists(commandName, opts.runCaptureImpl));
+  if (commandExistsImpl("nvidia-smi")) {
+    const smiOutput = opts.runCaptureImpl(["nvidia-smi", "-L"], { ignoreError: true });
+    if (String(smiOutput || "").trim()) return true;
   }
-  return Boolean(String(runCaptureImpl(["nvidia-smi", "-L"], { ignoreError: true }) || "").trim());
+
+  if (opts.platform !== "linux" || opts.isWsl || !commandExistsImpl("lspci")) return false;
+  const pciOutput = opts.runCaptureImpl(["lspci", "-nn"], { ignoreError: true });
+  return String(pciOutput || "")
+    .split(/\r?\n/)
+    .some(
+      (line) =>
+        /nvidia/i.test(line) &&
+        /(vga compatible controller|3d controller|display controller)/i.test(line),
+    );
 }
 
+/**
+ * Detects the host package manager used for NVIDIA toolkit remediation commands.
+ */
 function detectPackageManager(runCaptureImpl: RunCaptureFn): PackageManager {
   if (commandExists("apt-get", runCaptureImpl)) return "apt";
   if (commandExists("dnf", runCaptureImpl)) return "dnf";
@@ -401,6 +425,9 @@ function detectPackageManager(runCaptureImpl: RunCaptureFn): PackageManager {
   return "unknown";
 }
 
+/**
+ * Normalizes systemctl active/enabled output into a tri-state service status.
+ */
 function parseSystemctlState(value = ""): boolean | null {
   const normalized = String(value || "")
     .trim()
@@ -447,6 +474,9 @@ export function buildContainerToolkitBootstrapCommands(
   ];
 }
 
+/**
+ * Builds the host capability snapshot used to plan preflight remediation.
+ */
 export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
   const platform = opts.platform ?? process.platform;
   const env = opts.env ?? process.env;
@@ -456,12 +486,33 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
       runCapture(command, { ignoreError: options?.ignoreError ?? false }));
   const readFileImpl = opts.readFileImpl ?? fs.readFileSync;
   const readdirImpl = opts.readdirImpl ?? ((dir: string) => fs.readdirSync(dir));
+  const shouldReadLinuxHostDetails = platform === "linux";
+  const release = opts.release ?? (shouldReadLinuxHostDetails ? os.release() : "");
+  const procVersion =
+    opts.procVersion ??
+    (shouldReadLinuxHostDetails
+      ? (() => {
+          try {
+            return readFileImpl("/proc/version", "utf-8");
+          } catch {
+            return "";
+          }
+        })()
+      : "");
+  const isWslHost = detectWsl({ platform, env, release, procVersion });
   const dockerInstalled =
     opts.commandExistsImpl?.("docker") ?? commandExists("docker", runCaptureImpl);
   const nodeInstalled = opts.commandExistsImpl?.("node") ?? commandExists("node", runCaptureImpl);
   const openshellInstalled =
     opts.commandExistsImpl?.("openshell") ?? commandExists("openshell", runCaptureImpl);
-  const hasNvidiaGpu = opts.gpuProbeImpl?.() ?? detectNvidiaGpu(runCaptureImpl);
+  const hasNvidiaGpu =
+    opts.gpuProbeImpl?.() ??
+    detectNvidiaGpu({
+      platform,
+      isWsl: isWslHost,
+      runCaptureImpl,
+      commandExistsImpl: opts.commandExistsImpl,
+    });
   const nvidiaContainerToolkitInstalled =
     opts.commandExistsImpl?.("nvidia-ctk") ?? commandExists("nvidia-ctk", runCaptureImpl);
   const packageManager = detectPackageManager(runCaptureImpl);
@@ -480,22 +531,10 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     dockerReachable = true;
     dockerRunning = true;
   }
-
-  const release = opts.release ?? os.release();
-  const procVersion =
-    opts.procVersion ??
-    (() => {
-      try {
-        return readFileImpl("/proc/version", "utf-8");
-      } catch {
-        return "";
-      }
-    })();
   let runtime = inferContainerRuntime(dockerInfoOutput);
   if (dockerReachable && runtime === "unknown" && platform === "linux") {
     runtime = "docker";
   }
-  const isWslHost = detectWsl({ platform, env, release, procVersion });
   const dockerCgroupVersion = dockerReachable
     ? parseDockerCgroupVersion(dockerInfoOutput)
     : "unknown";


### PR DESCRIPTION
## Summary

- Adds Linux `lspci` fallback GPU detection when `nvidia-smi` is unavailable, so preflight still recognizes NVIDIA PCI GPU hardware.
- Keeps the existing `install_nvidia_container_toolkit` remediation active for missing toolkit plus missing/invalid NVIDIA CDI spec.
- Treats CDI guard opt-out as explicit CPU/GPU-off intent rather than auto-disabled GPU detection state.
- Adds regression coverage for the exact issue path and the cached resume preflight guard.

## Validation

- `NODE_PATH=/Users/holim/code/NemoClaw/node_modules /Users/holim/code/NemoClaw/node_modules/.bin/vitest run src/lib/onboard/preflight-cdi.test.ts src/lib/onboard/machine/handlers/preflight.test.ts`
- `NODE_PATH=/Users/holim/code/NemoClaw/node_modules /Users/holim/code/NemoClaw/node_modules/.bin/tsc -p tsconfig.src.json --noEmit`
- `git diff --check`

Notes: #5489 currently has an assignee, so this PR is intentionally limited to the missing preflight detection/remediation path.

Fixes #5489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved NVIDIA GPU detection on Linux by trying `nvidia-smi` first and falling back to `lspci` when needed.
  * Refined preflight/resume GPU passthrough opt-out logic (including `noGpu` and sandbox GPU mode `0`) and updated CDI GPU spec guarding accordingly.
  * When Docker is reachable on Linux, runtime is now normalized to `docker` when it was previously unknown.

* **Tests**
  * Added/expanded CDI and preflight resume scenarios, including cases where `nvidia-ctk` is unavailable and expected blocking remediation/actions are verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->