### PR TITLE
fix compatible endpoint reasoning mode

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3968,7 +3968,6 @@ async function setupNim(
   let preferredInferenceApi: string | null = null;
   let allowToolsIncompatible = false;
   let skipHostInferenceSmoke = false;
-
   const providerHostState = detectInferenceProviderHostState({
     gpu,
     experimental: EXPERIMENTAL,
@@ -3996,7 +3995,6 @@ async function setupNim(
     ? getNonInteractiveModel(requestedProvider || "build")
     : null;
   const agentProviderOptions = getAgentInferenceProviderOptions(agent);
-
   // Model Router: complexity-based routing via blueprint config.
   const blueprintRouterCfg = loadBlueprintProfile("routed");
   const { options, hermesProviderAvailable } = buildInferenceProviderMenu({

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3651,6 +3651,7 @@ async function handleNimLocalSelection(
   return "selected";
 }
 
+/** Handles hosted and compatible remote provider selection, credentials, model prompts, and validation. */
 async function handleRemoteProviderSelection(
   args: RemoteProviderSelectionArgs,
   state: SetupNimSelectionState,
@@ -3939,6 +3940,7 @@ async function handleRemoteProviderSelection(
   return "selected";
 }
 
+/** Configures the selected inference provider and returns the sandbox-facing model route state. */
 async function setupNim(
   gpu: ReturnType<typeof nim.detectGpu>,
   sandboxName: string | null = null,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3651,7 +3651,6 @@ async function handleNimLocalSelection(
   return "selected";
 }
 
-/** Handles hosted and compatible remote provider selection, credentials, model prompts, and validation. */
 async function handleRemoteProviderSelection(
   args: RemoteProviderSelectionArgs,
   state: SetupNimSelectionState,
@@ -3940,7 +3939,6 @@ async function handleRemoteProviderSelection(
   return "selected";
 }
 
-/** Configures the selected inference provider and returns the sandbox-facing model route state. */
 async function setupNim(
   gpu: ReturnType<typeof nim.detectGpu>,
   sandboxName: string | null = null,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3661,7 +3661,6 @@ async function handleRemoteProviderSelection(
   state.credentialEnv = remoteConfig.credentialEnv;
   state.endpointUrl = remoteConfig.endpointUrl;
   state.preferredInferenceApi = null;
-
   if (selected.key === "custom" || selected.key === "anthropicCompatible") {
     const kind = selected.key === "custom" ? "openai" : "anthropic";
     const _envUrl = (process.env.NEMOCLAW_ENDPOINT_URL || "").trim();
@@ -3702,7 +3701,6 @@ async function handleRemoteProviderSelection(
       );
     }
   }
-
   if (selected.key === "hermesProvider") {
     const selectedHermesAuthMethod = await promptHermesAuthMethod();
     if (isBackToSelection(selectedHermesAuthMethod)) {
@@ -3740,7 +3738,6 @@ async function handleRemoteProviderSelection(
       recordedHermesToolGateways,
       { prompt, note, isNonInteractive },
     );
-
     const defaultModel =
       requestedModel || (recoveredFromSandbox && recoveredModel) || remoteConfig.defaultModel;
     if (isNonInteractive()) {
@@ -3893,18 +3890,25 @@ async function handleRemoteProviderSelection(
         console.log("");
         return "retry-selection";
       }
-
       const validationResult = await validateSelectedRemoteModel({
         selected,
         remoteConfig,
         state,
         selectedCredentialEnv,
       });
-      if (validationResult === "selected") break;
+      if (validationResult === "selected") {
+        if (selected.key === "custom") {
+          await require("./onboard/reasoning-mode").configureCustomOpenAiReasoningModeOrExit({
+            isNonInteractive,
+            promptYesNoOrDefault,
+            note,
+          });
+        }
+        break;
+      }
       if (validationResult === "retry-selection") return "retry-selection";
     }
   }
-
   if (selected.key === "build") {
     const buildModel = requireValue(
       isBackToSelection(state.model) ? null : state.model,
@@ -3931,7 +3935,6 @@ async function handleRemoteProviderSelection(
     if (buildValidation.retrySelection) return "retry-selection";
     state.preferredInferenceApi = buildValidation.preferredInferenceApi;
   }
-
   console.log(`  Using ${remoteConfig.label} with model: ${state.model}`);
   return "selected";
 }
@@ -3953,7 +3956,6 @@ async function setupNim(
   skipHostInferenceSmoke: boolean;
 }> {
   step(3, 8, "Configuring inference provider");
-
   let model: string | typeof BACK_TO_SELECTION | null = null;
   let provider: string = REMOTE_PROVIDER_CONFIG.build.providerName;
   let nimContainer: string | null = null;

--- a/src/lib/onboard/compatible-endpoint-smoke.test.ts
+++ b/src/lib/onboard/compatible-endpoint-smoke.test.ts
@@ -171,6 +171,32 @@ JSON
     expect(fs.readFileSync(callFile, "utf-8")).toBe("2");
   });
 
+  it("reports reasoning-only terminal responses with the Option 3 reasoning knob", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-compat-smoke-reasoning-only-"));
+    const model = "reasoning/provider-model";
+    const configPath = writeSmokeConfig(tmpDir, model);
+    const { binDir, callFile } = writeFakeCurl(
+      tmpDir,
+      String.raw`
+cat <<'JSON'
+{"id":"chatcmpl-123","choices":[{"index":0,"message":{"role":"assistant","content":"","reasoning_content":"PONG"},"finish_reason":"stop"}]}
+JSON
+`,
+    );
+    const script = buildCompatibleEndpointSandboxSmokeScript(model, {
+      configPath,
+      initialMaxTokens: 64,
+      retryMaxTokens: 128,
+    });
+
+    const result = runSmokeScript(script, tmpDir, binDir);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("returned non-empty reasoning_content");
+    expect(result.stderr).toContain("NEMOCLAW_REASONING=true");
+    expect(fs.readFileSync(callFile, "utf-8")).toBe("1");
+  });
+
   it("wraps the script as a base64 decoded temporary shell command", () => {
     const command = buildCompatibleEndpointSandboxSmokeCommand("nvidia/model");
 

--- a/src/lib/onboard/compatible-endpoint-smoke.ts
+++ b/src/lib/onboard/compatible-endpoint-smoke.ts
@@ -306,6 +306,13 @@ if not isinstance(content, str) or not content.strip():
             file=sys.stderr,
         )
         sys.exit(1)
+    if isinstance(reasoning_content, str) and reasoning_content.strip():
+        print(
+            "inference.local reached the model, but the %s smoke attempt returned non-empty reasoning_content with empty choices[0].message.content (finish_reason=%r). If this OpenAI-compatible model is reasoning-only, enable reasoning mode during Option 3 onboarding or set NEMOCLAW_REASONING=true before rerunning onboarding: %s"
+            % (attempt, finish_reason, json.dumps(data)[:1000]),
+            file=sys.stderr,
+        )
+        sys.exit(1)
     print(
         "inference.local response did not contain non-empty choices[0].message.content (finish_reason=%r): %s"
         % (finish_reason, json.dumps(data)[:1000]),

--- a/src/lib/onboard/reasoning-mode.test.ts
+++ b/src/lib/onboard/reasoning-mode.test.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { configureCustomOpenAiReasoningMode, normalizeReasoningMode } from "./reasoning-mode";
+
+describe("OpenAI-compatible reasoning mode onboarding", () => {
+  it("normalizes valid NEMOCLAW_REASONING values", () => {
+    expect(normalizeReasoningMode("true")).toBe("true");
+    expect(normalizeReasoningMode(" FALSE ")).toBe("false");
+    expect(normalizeReasoningMode("yes")).toBe(null);
+  });
+
+  it("uses an existing non-interactive NEMOCLAW_REASONING override without prompting", async () => {
+    const env = { NEMOCLAW_REASONING: " TRUE " } as NodeJS.ProcessEnv;
+    const promptYesNoOrDefault = vi.fn();
+    const note = vi.fn();
+
+    await configureCustomOpenAiReasoningMode({
+      env,
+      isNonInteractive: () => true,
+      promptYesNoOrDefault,
+      note,
+    });
+
+    expect(env.NEMOCLAW_REASONING).toBe("true");
+    expect(promptYesNoOrDefault).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(
+      "  [non-interactive] OpenAI-compatible reasoning mode -> true",
+    );
+  });
+
+  it("prompts Option 3 users and writes NEMOCLAW_REASONING", async () => {
+    const env = {} as NodeJS.ProcessEnv;
+    const promptYesNoOrDefault = vi.fn(async () => true);
+    const note = vi.fn();
+
+    await configureCustomOpenAiReasoningMode({
+      env,
+      isNonInteractive: () => false,
+      promptYesNoOrDefault,
+      note,
+    });
+
+    expect(promptYesNoOrDefault).toHaveBeenCalledWith(
+      "  Enable reasoning mode for this OpenAI-compatible model?",
+      "NEMOCLAW_REASONING",
+      false,
+    );
+    expect(env.NEMOCLAW_REASONING).toBe("true");
+    expect(note).toHaveBeenCalledWith("  OpenAI-compatible reasoning mode enabled.");
+  });
+
+  it("rejects invalid NEMOCLAW_REASONING values with an actionable error", async () => {
+    await expect(
+      configureCustomOpenAiReasoningMode({
+        env: { NEMOCLAW_REASONING: "maybe" } as NodeJS.ProcessEnv,
+        isNonInteractive: () => true,
+        promptYesNoOrDefault: vi.fn(),
+      }),
+    ).rejects.toThrow('NEMOCLAW_REASONING must be "true" or "false"');
+  });
+});

--- a/src/lib/onboard/reasoning-mode.ts
+++ b/src/lib/onboard/reasoning-mode.ts
@@ -13,8 +13,8 @@ export type ReasoningModeDeps = {
 };
 
 export type ReasoningModeExitDeps = ReasoningModeDeps & {
-  error: (message: string) => void;
-  exit: (code: number) => never;
+  error?: (message: string) => void;
+  exit?: (code: number) => never;
 };
 
 const REASONING_ENV = "NEMOCLAW_REASONING";
@@ -35,7 +35,9 @@ export async function configureCustomOpenAiReasoningMode(deps: ReasoningModeDeps
   if (existing) {
     const normalized = normalizeReasoningMode(existing);
     if (!normalized) {
-      throw new Error(`${REASONING_ENV} must be "true" or "false" for OpenAI-compatible endpoints.`);
+      throw new Error(
+        `${REASONING_ENV} must be "true" or "false" for OpenAI-compatible endpoints.`,
+      );
     }
     env[REASONING_ENV] = normalized;
     if (deps.isNonInteractive()) {
@@ -62,7 +64,9 @@ export async function configureCustomOpenAiReasoningModeOrExit(
   try {
     await configureCustomOpenAiReasoningMode(deps);
   } catch (err) {
-    deps.error(`  ${err instanceof Error ? err.message : String(err)}`);
-    deps.exit(1);
+    const error = deps.error ?? console.error;
+    const exit = deps.exit ?? process.exit;
+    error(`  ${err instanceof Error ? err.message : String(err)}`);
+    exit(1);
   }
 }

--- a/src/lib/onboard/reasoning-mode.ts
+++ b/src/lib/onboard/reasoning-mode.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type ReasoningModeDeps = {
+  env?: NodeJS.ProcessEnv;
+  isNonInteractive: () => boolean;
+  promptYesNoOrDefault: (
+    question: string,
+    envVar: string | null,
+    defaultIsYes: boolean,
+  ) => Promise<boolean>;
+  note?: (message: string) => void;
+};
+
+export type ReasoningModeExitDeps = ReasoningModeDeps & {
+  error: (message: string) => void;
+  exit: (code: number) => never;
+};
+
+const REASONING_ENV = "NEMOCLAW_REASONING";
+
+export function normalizeReasoningMode(value: string | undefined): "true" | "false" | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "true" || normalized === "false") return normalized;
+  return null;
+}
+
+export async function configureCustomOpenAiReasoningMode(deps: ReasoningModeDeps): Promise<void> {
+  const env = deps.env || process.env;
+  const existing = String(env[REASONING_ENV] ?? "").trim();
+  if (existing) {
+    const normalized = normalizeReasoningMode(existing);
+    if (!normalized) {
+      throw new Error(`${REASONING_ENV} must be "true" or "false" for OpenAI-compatible endpoints.`);
+    }
+    env[REASONING_ENV] = normalized;
+    if (deps.isNonInteractive()) {
+      deps.note?.(`  [non-interactive] OpenAI-compatible reasoning mode -> ${normalized}`);
+    }
+    return;
+  }
+
+  const enabled = await deps.promptYesNoOrDefault(
+    "  Enable reasoning mode for this OpenAI-compatible model?",
+    REASONING_ENV,
+    false,
+  );
+  env[REASONING_ENV] = enabled ? "true" : "false";
+  if (enabled) {
+    deps.note?.("  OpenAI-compatible reasoning mode enabled.");
+  }
+}
+
+export async function configureCustomOpenAiReasoningModeOrExit(
+  deps: ReasoningModeExitDeps,
+): Promise<void> {
+  try {
+    await configureCustomOpenAiReasoningMode(deps);
+  } catch (err) {
+    deps.error(`  ${err instanceof Error ? err.message : String(err)}`);
+    deps.exit(1);
+  }
+}

--- a/src/lib/onboard/reasoning-mode.ts
+++ b/src/lib/onboard/reasoning-mode.ts
@@ -19,6 +19,7 @@ export type ReasoningModeExitDeps = ReasoningModeDeps & {
 
 const REASONING_ENV = "NEMOCLAW_REASONING";
 
+/** Normalizes the reasoning-mode environment value accepted by Option 3 onboarding. */
 export function normalizeReasoningMode(value: string | undefined): "true" | "false" | null {
   const normalized = String(value ?? "")
     .trim()
@@ -27,6 +28,7 @@ export function normalizeReasoningMode(value: string | undefined): "true" | "fal
   return null;
 }
 
+/** Resolves and records whether an OpenAI-compatible endpoint should use reasoning mode. */
 export async function configureCustomOpenAiReasoningMode(deps: ReasoningModeDeps): Promise<void> {
   const env = deps.env || process.env;
   const existing = String(env[REASONING_ENV] ?? "").trim();
@@ -53,6 +55,7 @@ export async function configureCustomOpenAiReasoningMode(deps: ReasoningModeDeps
   }
 }
 
+/** Applies reasoning-mode configuration and exits through the onboarding error path on invalid input. */
 export async function configureCustomOpenAiReasoningModeOrExit(
   deps: ReasoningModeExitDeps,
 ): Promise<void> {

--- a/test/onboard-compatible-reasoning-mode.test.ts
+++ b/test/onboard-compatible-reasoning-mode.test.ts
@@ -39,10 +39,7 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift ;;
   esac
 done
-if [ "\${NEMOCLAW_REASONING:-}" != "true" ]; then
-  body='{"error":{"message":"reasoning mode was not set before validation"}}'
-  status="400"
-elif echo "$url" | grep -q '/responses$'; then
+if echo "$url" | grep -q '/responses$'; then
   body='{"id":"resp_123","output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}]}'
   status="200"
 elif echo "$url" | grep -q '/chat/completions$'; then

--- a/test/onboard-compatible-reasoning-mode.test.ts
+++ b/test/onboard-compatible-reasoning-mode.test.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+describe("custom OpenAI-compatible reasoning mode onboarding", () => {
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt("lets Other OpenAI-compatible endpoint users enable reasoning mode", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-onboard-custom-openai-reasoning-"),
+    );
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "custom-openai-reasoning-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const credentialsPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "credentials", "store.js"),
+    );
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='{"error":{"message":"bad request"}}'
+status="400"
+outfile=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    -d) shift 2 ;;
+    *) url="$1"; shift ;;
+  esac
+done
+if [ "\${NEMOCLAW_REASONING:-}" != "true" ]; then
+  body='{"error":{"message":"reasoning mode was not set before validation"}}'
+  status="400"
+elif echo "$url" | grep -q '/responses$'; then
+  body='{"id":"resp_123","output":[{"type":"message","content":[{"type":"output_text","text":"OK"}]}]}'
+  status="200"
+elif echo "$url" | grep -q '/chat/completions$'; then
+  body='{"id":"chatcmpl-123","choices":[{"message":{"content":"OK"}}]}'
+  status="200"
+fi
+printf '%s' "$body" > "$outfile"
+printf '%s' "$status"
+`,
+      { mode: 0o755 },
+    );
+
+    fs.writeFileSync(
+      scriptPath,
+      String.raw`
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+
+const answers = ["3", "https://proxy.example.com/v1", "reasoning-model", "y"];
+const messages = [];
+
+credentials.prompt = async (message) => {
+  messages.push(message);
+  return answers.shift() || "";
+};
+runner.runCapture = () => "";
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  process.env.COMPATIBLE_API_KEY = "proxy-key";
+  delete process.env.NEMOCLAW_REASONING;
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim(null);
+    originalLog(JSON.stringify({ result, messages, lines, reasoning: process.env.NEMOCLAW_REASONING || null }));
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`,
+    );
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.result.provider, "compatible-endpoint");
+    assert.equal(payload.result.model, "reasoning-model");
+    assert.equal(payload.result.preferredInferenceApi, "openai-completions");
+    assert.equal(payload.reasoning, "true");
+    assert.ok(
+      payload.messages.some((message: string) =>
+        /Enable reasoning mode for this OpenAI-compatible model/.test(message),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Option 3 OpenAI-compatible reasoning-mode configuration through `NEMOCLAW_REASONING`.
- Prompts interactive custom endpoint users before sandbox creation and validates existing non-interactive env overrides.
- Makes compatible-endpoint sandbox smoke failures actionable when the response has non-empty `reasoning_content` but empty `choices[0].message.content`.
- Adds focused tests for env normalization, interactive selection, and reasoning-only smoke responses.

## Validation

- `NODE_PATH=/Users/holim/code/NemoClaw/node_modules /Users/holim/code/NemoClaw/node_modules/.bin/vitest run src/lib/onboard/reasoning-mode.test.ts src/lib/onboard/compatible-endpoint-smoke.test.ts test/onboard-compatible-reasoning-mode.test.ts`
- `NODE_PATH=/Users/holim/code/NemoClaw/node_modules /Users/holim/code/NemoClaw/node_modules/.bin/tsc -p tsconfig.src.json --noEmit`
- `git diff --check`

Fixes #3279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added onboarding support for “reasoning mode” for OpenAI-compatible endpoints, including an interactive option that persists `NEMOCLAW_REASONING` as `"true"`/`"false"`, with input normalization and clear prompts.

* **Bug Fixes**
  * Enhanced compatible-endpoint smoke checks to fail fast when responses contain only reasoning (empty message content), with guidance to enable reasoning mode (or set `NEMOCLAW_REASONING=true`).

* **Tests**
  * Expanded smoke and onboarding coverage for reasoning-mode behavior, including POSIX OpenAI-compatible integration tests plus unit checks for normalization and invalid env handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->