### PR TITLE
policy: allow Hermes inference audio endpoints

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -67,6 +67,8 @@ network_policies:
           - allow: { method: POST, path: "/v1/chat/completions" }
           - allow: { method: POST, path: "/v1/messages" }
           - allow: { method: POST, path: "/v1/responses" }
+          - allow: { method: POST, path: "/v1/audio/transcriptions" }
+          - allow: { method: POST, path: "/v1/audio/speech" }
           - allow: { method: POST, path: "/v1/completions" }
           - allow: { method: POST, path: "/v1/embeddings" }
           - allow: { method: GET, path: "/v1/models" }

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -511,6 +511,10 @@ describe("permissive sandbox policy", () => {
 describe("Hermes sandbox policy", () => {
   const policy = loadYaml<SandboxPolicy>(HERMES_POLICY_PATH);
 
+  /**
+   * Verifies that Hermes managed inference keeps the same narrow allowlist
+   * shape as OpenClaw while including every sandbox-routed inference endpoint.
+   */
   function expectManagedInferenceSecurityShape(): void {
     const np = policy.network_policies ?? {};
     const managedInference = np.managed_inference;

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -534,6 +534,8 @@ describe("Hermes sandbox policy", () => {
       { allow: { method: "POST", path: "/v1/chat/completions" } },
       { allow: { method: "POST", path: "/v1/messages" } },
       { allow: { method: "POST", path: "/v1/responses" } },
+      { allow: { method: "POST", path: "/v1/audio/transcriptions" } },
+      { allow: { method: "POST", path: "/v1/audio/speech" } },
       { allow: { method: "POST", path: "/v1/completions" } },
       { allow: { method: "POST", path: "/v1/embeddings" } },
       { allow: { method: "GET", path: "/v1/models" } },


### PR DESCRIPTION
## Summary

- Allows Hermes managed `inference.local` policy to call `POST /v1/audio/transcriptions` and `POST /v1/audio/speech`.
- Updates the Hermes policy shape regression test so speech endpoints stay in the allowlist.

## Scope note

This is the NemoClaw-side policy prerequisite for #1520. The actual `inference.local` proxy route owner is OpenShell, so this PR does not by itself add gateway routing for speech bodies. OpenClaw policy already permits `POST /**` for managed inference; Hermes had the narrow allowlist that would block these endpoints once OpenShell supports them.

## Validation

- `NODE_PATH=/Users/holim/code/NemoClaw/node_modules /Users/holim/code/NemoClaw/node_modules/.bin/vitest run test/validate-blueprint.test.ts`
- `git diff --check`

Refs #1520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded network access for the REST API by adding explicit permission for additional `POST` egress requests to `/v1/audio/transcriptions` and `/v1/audio/speech`.

* **Tests**
  * Updated sandbox policy validation tests to match the tightened allowlist shape, including the newly allowed audio endpoint rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->