### PR TITLE
fix(onboard): skip CDI GPU mode on Docker Desktop WSL (#5512)

### DIFF
--- a/src/lib/onboard/docker-gpu-patch-wsl.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-wsl.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { shouldApplyDockerGpuPatch } from "../../../dist/lib/onboard/docker-gpu-patch";
+import {
+  buildDockerGpuModeCandidates,
+  shouldApplyDockerGpuPatch,
+} from "../../../dist/lib/onboard/docker-gpu-patch";
 
 describe("shouldApplyDockerGpuPatch on Docker Desktop WSL", () => {
   it("ignores NEMOCLAW_DOCKER_GPU_PATCH=0 on Docker Desktop WSL where the patch is required", () => {
@@ -51,5 +54,28 @@ describe("shouldApplyDockerGpuPatch on Docker Desktop WSL", () => {
         },
       ),
     ).toBe(true);
+  });
+});
+
+describe("buildDockerGpuModeCandidates on Docker Desktop WSL (#5512)", () => {
+  it("skips the CDI mode on Docker Desktop WSL even when CDI is advertised", () => {
+    // Docker Desktop WSL advertises CDI dirs but has no usable nvidia.com/gpu
+    // spec, so CDI fails the real recreate; the patch must use --gpus instead.
+    const modes = buildDockerGpuModeCandidates("all", {
+      cdiAvailable: true,
+      dockerDesktopWsl: true,
+    });
+    expect(modes.map((mode) => mode.kind)).not.toContain("cdi");
+    expect(modes[0]?.kind).toBe("gpus");
+    expect(modes[0]?.args).toEqual(["--gpus", "all"]);
+  });
+
+  it("keeps CDI first on a non-Docker-Desktop-WSL host that advertises CDI", () => {
+    const modes = buildDockerGpuModeCandidates("all", {
+      cdiAvailable: true,
+      dockerDesktopWsl: false,
+    });
+    expect(modes[0]?.kind).toBe("cdi");
+    expect(modes[0]?.args).toEqual(["--device", "nvidia.com/gpu=all"]);
   });
 });

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -496,7 +496,11 @@ export function buildDockerGpuMode(
 
 export function buildDockerGpuModeCandidates(
   device?: string | null,
-  options: { cdiAvailable?: boolean; backend?: DockerGpuPatchBackend } = {},
+  options: {
+    cdiAvailable?: boolean;
+    backend?: DockerGpuPatchBackend;
+    dockerDesktopWsl?: boolean;
+  } = {},
 ): DockerGpuPatchMode[] {
   if (options.backend === "jetson") {
     return [buildDockerGpuMode("nvidia-runtime", device, { backend: "jetson" })];
@@ -510,8 +514,16 @@ export function buildDockerGpuModeCandidates(
   // gateway wiring and the supervisor never reconnects (#4948). Keep --gpus
   // and the NVIDIA runtime as fallbacks until OpenShell exposes an
   // authoritative GPU mode contract that can replace CDI-spec probing.
+  //
+  // #5512: Docker Desktop WSL advertises CDI spec directories (so cdiAvailable
+  // is true) while the WSL distro has no usable nvidia.com/gpu spec. There the
+  // CDI mode passes the create-only probe but fails the real recreate with
+  // "unresolvable CDI devices nvidia.com/gpu=all", so skip CDI and use the
+  // --gpus compatibility path that preflight already commits to on this runtime.
   const candidates: DockerGpuPatchMode[] = [];
-  if (options.cdiAvailable) candidates.push(buildDockerGpuMode("cdi", device));
+  if (options.cdiAvailable && !options.dockerDesktopWsl) {
+    candidates.push(buildDockerGpuMode("cdi", device));
+  }
   candidates.push(buildDockerGpuMode("gpus", device), buildDockerGpuMode("nvidia-runtime", device));
   return candidates;
 }
@@ -949,7 +961,12 @@ function probeDockerGpuMode(
 }
 
 export function selectDockerGpuPatchMode(
-  options: { image: string; device?: string | null; backend?: DockerGpuPatchBackend },
+  options: {
+    image: string;
+    device?: string | null;
+    backend?: DockerGpuPatchBackend;
+    dockerDesktopWsl?: boolean;
+  },
   deps: DockerGpuPatchDeps = {},
 ): { mode: DockerGpuPatchMode | null; attempts: DockerGpuPatchModeAttempt[] } {
   const cdiAvailable = options.backend === "jetson" ? false : dockerReportsNvidiaCdiDevices(deps);
@@ -957,6 +974,7 @@ export function selectDockerGpuPatchMode(
   for (const mode of buildDockerGpuModeCandidates(options.device, {
     cdiAvailable,
     backend: options.backend,
+    dockerDesktopWsl: options.dockerDesktopWsl,
   })) {
     const result = probeDockerGpuMode(mode, options.image, deps);
     const attempt = { mode, ok: result.ok, error: result.error };
@@ -1014,6 +1032,7 @@ export function recreateOpenShellDockerSandboxWithGpu(
     waitForSupervisor?: boolean;
     openshellSandboxCommand?: readonly string[] | null;
     backend?: DockerGpuPatchBackend;
+    dockerDesktopWsl?: boolean;
   },
   deps: DockerGpuPatchDeps = {},
 ): DockerGpuPatchResult {
@@ -1037,7 +1056,12 @@ export function recreateOpenShellDockerSandboxWithGpu(
     if (!image) throw new Error("OpenShell sandbox container inspect did not include an image.");
 
     const selection = selectDockerGpuPatchMode(
-      { image, device: options.gpuDevice, backend: options.backend },
+      {
+        image,
+        device: options.gpuDevice,
+        backend: options.backend,
+        dockerDesktopWsl: options.dockerDesktopWsl,
+      },
       deps,
     );
     context.modeAttempts = selection.attempts;
@@ -1184,6 +1208,7 @@ export function applyDockerGpuPatchOrExit(
     // /dev/nvmap group access.
     backend?: DockerGpuPatchBackend;
     openshellSandboxCommand?: readonly string[] | null;
+    dockerDesktopWsl?: boolean;
   },
   deps: Pick<DockerGpuPatchDeps, "runOpenshell" | "runCaptureOpenshell" | "sleep">,
 ): DockerGpuPatchResult {

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -62,6 +62,12 @@ type DockerGpuSandboxCreatePatchOptions = {
   openshellSandboxCommand?: readonly string[] | null;
   timeoutSecs: number;
   backend?: DockerGpuPatchBackend;
+  /**
+   * Whether the host is Docker Desktop WSL. Defaults to the cached
+   * `isDockerDesktopWslRuntime()` probe. When true, the GPU patch skips the CDI
+   * mode (unusable on this runtime) and uses `--gpus` instead (#5512).
+   */
+  dockerDesktopWsl?: boolean;
   deps: DockerGpuSandboxCreateDeps;
   /**
    * Test seams. The production composition uses the canonical
@@ -136,6 +142,7 @@ export function createDockerGpuSandboxCreatePatch(
     openshellSandboxCommand: options.openshellSandboxCommand ?? null,
     timeoutSecs: options.timeoutSecs,
     backend: options.backend,
+    dockerDesktopWsl: options.dockerDesktopWsl ?? isDockerDesktopWslRuntime(),
   };
 
   return {


### PR DESCRIPTION
## Summary

On Docker Desktop + WSL2 with an NVIDIA GPU, onboard's `[6/8]` Docker GPU patch recreates the sandbox container with `--device nvidia.com/gpu=all` (CDI syntax) and fails:

```
CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all
```

even though preflight already logs that it will use the `--gpus` compatibility path. The only workaround today is `--no-gpu` / `NEMOCLAW_SANDBOX_GPU=0`, which disables GPU entirely.

## Root cause

Docker Desktop advertises CDI spec **directories**, so `dockerReportsNvidiaCdiDevices()` returns true and `buildDockerGpuModeCandidates()` offers CDI as the first candidate. The create-only probe (`docker create … true`) passes, but the real recreate fails because the WSL distro exposes **no usable `nvidia.com/gpu` spec**. The Docker Desktop WSL status was detected at preflight but never reached the mode selector — `selectDockerGpuPatchMode` only received `{image, device, backend}`.

PR #5198 (which closed #5180) added the CDI-injection failure classification, the `--no-gpu` recovery hint, and the warning that `NEMOCLAW_DOCKER_GPU_PATCH=0` is ignored on this runtime — but it did not change mode selection. This is the unaddressed root cause.

## Fix

Thread the existing Docker Desktop WSL detection (`isDockerDesktopWslRuntime()`, already used to gate the patch) through `selectDockerGpuPatchMode` into `buildDockerGpuModeCandidates`, and skip the CDI candidate when on Docker Desktop WSL so the patch uses `--gpus all` — the path preflight already commits to.

- Native Docker-CDI hosts are **unaffected**: they still prefer CDI, preserving the gateway supervisor-wiring contract from #4948.
- The flag is resolved via the cached detector in `docker-gpu-sandbox-create.ts`, so no change to `onboard.ts` and no extra `docker info` calls.

## Testing

- New unit tests in `docker-gpu-patch-wsl.test.ts`: CDI is skipped (first candidate is `--gpus all`) when `dockerDesktopWsl` is true even with CDI advertised, and CDI is still preferred otherwise.
- `tsc -p tsconfig.src.json` clean; GPU-patch suites pass (remaining failures are pre-existing Windows-only `/etc/cdi` path tests, identical on `main`).

## Notes / follow-up

- This step is only reached after the `[2/8]` gateway-bind issue (#5513, fix in #5534).
- Separate latent bug still open: on an **early** patch failure the original sandbox is already renamed to `*-nemoclaw-gpu-backup-<timestamp>` before container creation, and only the new container is removed — leaving an orphan backup. Happy to follow up with a focused PR for that cleanup.

Fixes #5512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU configuration for Docker Desktop on Windows Subsystem for Linux (WSL). The system now properly detects WSL runtime environments and automatically selects GPU acceleration modes that work reliably on Docker Desktop WSL, avoiding GPU modes that may not be available or incompatible within that specific environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Abhimanyu Kumar <abhimanyukumar7290@gmail.com>
