### PR TITLE
fix(onboard): restore pre-patch sandbox when GPU recreate fails early (#5512)

### DIFF
--- a/src/lib/onboard/docker-gpu-patch-finalize.ts
+++ b/src/lib/onboard/docker-gpu-patch-finalize.ts
@@ -85,6 +85,22 @@ export function rollbackToBackupContainer(
   return isZeroStatus(started);
 }
 
+/**
+ * Roll back a Docker GPU patch that failed *before* the supervisor wait — e.g.
+ * the recreate `docker run` itself failed after the original sandbox was already
+ * renamed to the backup. Restores the pre-patch sandbox so onboarding never
+ * leaves an orphaned `*-nemoclaw-gpu-backup-*` container (which otherwise
+ * collides on the next retry) (#5512). Accepts raw deps so the real
+ * `docker start`/`docker rename` defaults are resolved even when the caller's
+ * deps only carry the recreate subset.
+ */
+export function rollbackDockerGpuPatchOnRecreateFailure(
+  refs: { newContainerId: string; backupContainerName: string; originalName: string },
+  deps: DockerGpuPatchDeps = {},
+): boolean {
+  return rollbackToBackupContainer(refs, resolveRollbackDeps(deps));
+}
+
 export type DockerGpuPatchFinalizeOptions = {
   result: DockerGpuPatchResult;
   supervisorReady: boolean;

--- a/src/lib/onboard/docker-gpu-patch-rollback.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-rollback.test.ts
@@ -148,6 +148,11 @@ describe("recreateOpenShellDockerSandboxWithGpu rollback path", () => {
       "openshell-alpha",
       expect.objectContaining({ ignoreError: true }),
     );
+    // The failed recreate container (named originalName by `docker run --name`) is removed.
+    expect(dockerRm).toHaveBeenCalledWith(
+      "openshell-alpha",
+      expect.objectContaining({ ignoreError: true }),
+    );
     // The backup is renamed back, never left as an orphaned container.
     expect(
       dockerRm.mock.calls.some((call) => String(call[0]).includes("nemoclaw-gpu-backup")),

--- a/src/lib/onboard/docker-gpu-patch-rollback.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-rollback.test.ts
@@ -106,12 +106,14 @@ describe("recreateOpenShellDockerSandboxWithGpu rollback path", () => {
   });
 
   it("restores the pre-patch sandbox when the recreate run fails before the supervisor wait (#5512)", () => {
-    const dockerCapture = vi.fn((args: readonly string[]) => {
-      if (args[0] === "ps") return "old-container-id\n";
-      if (args[0] === "inspect") return JSON.stringify([inspectFixture()]);
-      if (args[0] === "info") return "";
-      return "";
-    });
+    const captureResponses: Record<string, string> = {
+      ps: "old-container-id\n",
+      inspect: JSON.stringify([inspectFixture()]),
+      info: "",
+    };
+    const dockerCapture = vi.fn(
+      (args: readonly string[]) => captureResponses[String(args[0])] ?? "",
+    );
     const dockerRun = vi.fn(() => ({ status: 0, stdout: "probe-id\n" }));
     // The recreate `docker run` fails after the original was renamed aside.
     const dockerRunDetached = vi.fn(() => ({ status: 1, stderr: "docker: boom" }));

--- a/src/lib/onboard/docker-gpu-patch-rollback.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-rollback.test.ts
@@ -105,6 +105,55 @@ describe("recreateOpenShellDockerSandboxWithGpu rollback path", () => {
     ).toBe(false);
   });
 
+  it("restores the pre-patch sandbox when the recreate run fails before the supervisor wait (#5512)", () => {
+    const dockerCapture = vi.fn((args: readonly string[]) => {
+      if (args[0] === "ps") return "old-container-id\n";
+      if (args[0] === "inspect") return JSON.stringify([inspectFixture()]);
+      if (args[0] === "info") return "";
+      return "";
+    });
+    const dockerRun = vi.fn(() => ({ status: 0, stdout: "probe-id\n" }));
+    // The recreate `docker run` fails after the original was renamed aside.
+    const dockerRunDetached = vi.fn(() => ({ status: 1, stderr: "docker: boom" }));
+    const dockerRename = vi.fn((_old: string, _next: string) => ({ status: 0 }));
+    const dockerStop = vi.fn(() => ({ status: 0 }));
+    const dockerStart = vi.fn(() => ({ status: 0 }));
+    const dockerRm = vi.fn((_name: string) => ({ status: 0 }));
+    const runCaptureOpenshell = vi.fn(() => "");
+
+    expect(() =>
+      recreateOpenShellDockerSandboxWithGpu(
+        { sandboxName: "alpha", timeoutSecs: 1 },
+        {
+          dockerCapture,
+          dockerRun,
+          dockerRunDetached,
+          dockerRename,
+          dockerStop,
+          dockerStart,
+          dockerRm,
+          runCaptureOpenshell,
+          sleep: vi.fn(),
+          now: () => new Date("2026-05-12T00:00:00Z"),
+        },
+      ),
+    ).toThrow(/Could not start GPU-enabled sandbox container/);
+
+    // The original sandbox is restored from the backup (rename backup -> original, then start).
+    const restoreRename = dockerRename.mock.calls.find(
+      (call) => String(call[0]).includes("nemoclaw-gpu-backup") && call[1] === "openshell-alpha",
+    );
+    expect(restoreRename).toBeDefined();
+    expect(dockerStart).toHaveBeenCalledWith(
+      "openshell-alpha",
+      expect.objectContaining({ ignoreError: true }),
+    );
+    // The backup is renamed back, never left as an orphaned container.
+    expect(
+      dockerRm.mock.calls.some((call) => String(call[0]).includes("nemoclaw-gpu-backup")),
+    ).toBe(false);
+  });
+
   it("reports rollback failure when restoring the backup container fails", () => {
     const dockerCapture = vi.fn((args: readonly string[]) => {
       if (args[0] === "ps") return "old-container-id\n";

--- a/src/lib/onboard/docker-gpu-patch-rollback.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-rollback.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type DockerContainerInspect,
+  getDockerGpuPatchFailureContext,
   recreateOpenShellDockerSandboxWithGpu,
 } from "../../../dist/lib/onboard/docker-gpu-patch";
 
@@ -159,6 +160,103 @@ describe("recreateOpenShellDockerSandboxWithGpu rollback path", () => {
     expect(
       dockerRm.mock.calls.some((call) => String(call[0]).includes("nemoclaw-gpu-backup")),
     ).toBe(false);
+  });
+
+  it("reports early recreate rollback failure when backup rename back fails (#5512)", () => {
+    const captureResponses: Record<string, string> = {
+      ps: "old-container-id\n",
+      inspect: JSON.stringify([inspectFixture()]),
+      info: "",
+    };
+    const dockerCapture = vi.fn(
+      (args: readonly string[]) => captureResponses[String(args[0])] ?? "",
+    );
+    const dockerRun = vi.fn(() => ({ status: 0, stdout: "probe-id\n" }));
+    const dockerRunDetached = vi.fn(() => ({ status: 1, stderr: "docker: boom" }));
+    const dockerRename = vi.fn((oldName: string) =>
+      String(oldName).includes("nemoclaw-gpu-backup")
+        ? { status: 1, stderr: "rename failed" }
+        : { status: 0 },
+    );
+    const dockerStop = vi.fn(() => ({ status: 0 }));
+    const dockerStart = vi.fn(() => ({ status: 0 }));
+    const dockerRm = vi.fn((_name: string) => ({ status: 0 }));
+    const runCaptureOpenshell = vi.fn(() => "");
+
+    let thrown: unknown;
+    try {
+      recreateOpenShellDockerSandboxWithGpu(
+        { sandboxName: "alpha", timeoutSecs: 1 },
+        {
+          dockerCapture,
+          dockerRun,
+          dockerRunDetached,
+          dockerRename,
+          dockerStop,
+          dockerStart,
+          dockerRm,
+          runCaptureOpenshell,
+          sleep: vi.fn(),
+          now: () => new Date("2026-05-12T00:00:00Z"),
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(String((thrown as Error).message)).toMatch(
+      /rollback failed; pre-patch sandbox was NOT restored/,
+    );
+    expect(getDockerGpuPatchFailureContext(thrown)?.rolledBack).toBe(false);
+    expect(dockerStart).not.toHaveBeenCalled();
+  });
+
+  it("reports early recreate rollback failure when restored original start fails (#5512)", () => {
+    const captureResponses: Record<string, string> = {
+      ps: "old-container-id\n",
+      inspect: JSON.stringify([inspectFixture()]),
+      info: "",
+    };
+    const dockerCapture = vi.fn(
+      (args: readonly string[]) => captureResponses[String(args[0])] ?? "",
+    );
+    const dockerRun = vi.fn(() => ({ status: 0, stdout: "probe-id\n" }));
+    const dockerRunDetached = vi.fn(() => ({ status: 1, stderr: "docker: boom" }));
+    const dockerRename = vi.fn((_old: string, _next: string) => ({ status: 0 }));
+    const dockerStop = vi.fn(() => ({ status: 0 }));
+    const dockerStart = vi.fn(() => ({ status: 1, stderr: "container start failed" }));
+    const dockerRm = vi.fn((_name: string) => ({ status: 0 }));
+    const runCaptureOpenshell = vi.fn(() => "");
+
+    let thrown: unknown;
+    try {
+      recreateOpenShellDockerSandboxWithGpu(
+        { sandboxName: "alpha", timeoutSecs: 1 },
+        {
+          dockerCapture,
+          dockerRun,
+          dockerRunDetached,
+          dockerRename,
+          dockerStop,
+          dockerStart,
+          dockerRm,
+          runCaptureOpenshell,
+          sleep: vi.fn(),
+          now: () => new Date("2026-05-12T00:00:00Z"),
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(String((thrown as Error).message)).toMatch(
+      /rollback failed; pre-patch sandbox was NOT restored/,
+    );
+    expect(getDockerGpuPatchFailureContext(thrown)?.rolledBack).toBe(false);
+    expect(dockerStart).toHaveBeenCalledWith(
+      "openshell-alpha",
+      expect.objectContaining({ ignoreError: true }),
+    );
   });
 
   it("reports rollback failure when restoring the backup container fails", () => {

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -14,7 +14,10 @@ import {
   dockerRunDetached,
   dockerStop,
 } from "../adapters/docker";
-import { reconcileSupervisorReconnect } from "./docker-gpu-patch-finalize";
+import {
+  reconcileSupervisorReconnect,
+  rollbackDockerGpuPatchOnRecreateFailure,
+} from "./docker-gpu-patch-finalize";
 import {
   DOCKER_GPU_SUPERVISOR_RECONNECT_ERROR_DEBOUNCE_ENV,
   DOCKER_GPU_SUPERVISOR_RECONNECT_TIMEOUT_ENV,
@@ -1101,10 +1104,15 @@ export function recreateOpenShellDockerSandboxWithGpu(
       timeout: DOCKER_GPU_PATCH_TIMEOUT_MS,
     });
     if (!isZeroStatus(runResult)) {
-      d.dockerRm(originalName, {
-        ignoreError: true,
-        timeout: DOCKER_GPU_PATCH_TIMEOUT_MS,
-      });
+      // #5512: the recreate failed after the original was renamed aside. Restore
+      // the pre-patch sandbox (remove the failed new container, rename the backup
+      // back, and start it) instead of leaving an orphaned
+      // `*-nemoclaw-gpu-backup-*` container and a sandbox with no live original
+      // behind — which otherwise collides on the next retry.
+      context.rolledBack = rollbackDockerGpuPatchOnRecreateFailure(
+        { newContainerId: originalName, backupContainerName, originalName },
+        deps,
+      );
       throw new Error(`Could not start GPU-enabled sandbox container: ${resultText(runResult)}`);
     }
 

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -1110,6 +1110,7 @@ export function recreateOpenShellDockerSandboxWithGpu(
       // `*-nemoclaw-gpu-backup-*` container and a sandbox with no live original
       // behind — which otherwise collides on the next retry.
       context.rolledBack = rollbackDockerGpuPatchOnRecreateFailure(
+        // newContainerId is originalName: the recreate `docker run` used `--name originalName`.
         { newContainerId: originalName, backupContainerName, originalName },
         deps,
       );

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -1114,7 +1114,13 @@ export function recreateOpenShellDockerSandboxWithGpu(
         { newContainerId: originalName, backupContainerName, originalName },
         deps,
       );
-      throw new Error(`Could not start GPU-enabled sandbox container: ${resultText(runResult)}`);
+      throw new Error(
+        `Could not start GPU-enabled sandbox container: ${resultText(runResult)}; ${
+          context.rolledBack
+            ? "pre-patch sandbox restored"
+            : "rollback failed; pre-patch sandbox was NOT restored"
+        }`,
+      );
     }
 
     const stdoutId = String(runResult.stdout || "").trim();


### PR DESCRIPTION
## Summary

Follow-up to #5537 addressing the orphan-backup symptom in #5512. When the Docker GPU patch's recreate `docker run` fails **after** the original sandbox was already renamed to `*-nemoclaw-gpu-backup-<timestamp>`, the early-failure path removed only the failed *new* container and left the backup orphaned — stranding the sandbox with no live original, and colliding with `*-nemoclaw-gpu-backup-*` on the next retry (as reported in #5512).

The supervisor-reconnect failure path already rolls back to the backup; this path didn't.

## Fix

Reuse the existing rollback primitive (`rollbackToBackupContainer`) on the early-failure path: remove the failed new container, rename the backup back to the original name, and start it — restoring the pre-patch sandbox instead of leaking a backup container.

- Adds `rollbackDockerGpuPatchOnRecreateFailure(refs, deps)` to `docker-gpu-patch-finalize.ts`, which resolves the real `docker start` / `docker rename` defaults (the recreate call path only carries a deps subset, so `dockerStart` would otherwise be unset).
- Records `context.rolledBack` for failure diagnostics, matching the reconnect-failure path.
- No `onboard.ts` change; all edits are under `src/lib/onboard/`.

## Testing

- New composed test in `docker-gpu-patch-rollback.test.ts`: when `dockerRunDetached` fails, the backup is renamed back to the original and started, and is never left as an orphaned container.
- `tsc -p tsconfig.src.json` clean; rollback / finalize / sandbox-create suites pass (18/18).

## Relationship to the WSL Docker Desktop chain

- #5534 — gateway bind at `[2/8]`
- #5536 — gateway cleanup on probe failure
- #5537 — skip CDI GPU mode at `[6/8]` (makes the patch succeed on Docker Desktop WSL, so this early-failure path is no longer hit there)
- this PR — restore the pre-patch sandbox for any *other* early GPU-recreate failure

Refs #5512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for Docker GPU patch recreation failures: if the GPU-enabled recreate step fails after the original container is renamed, the system now performs a reliable rollback to the pre-patch sandbox state and cleans up the failed recreate attempt.

* **Tests**
  * Added a rollback-path test for a recreate-phase `docker run --detach` failure, verifying restoration of the original container name, restart behavior, and correct cleanup (including ignoring the failed recreated container).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Abhimanyu Kumar <abhimanyukumar7290@gmail.com>
