### PR TITLE
ci(e2e): retry live vitest failures

### DIFF
--- a/test/e2e-scenario/docs/README.md
+++ b/test/e2e-scenario/docs/README.md
@@ -84,7 +84,8 @@ NEMOCLAW_RUN_E2E_SCENARIOS=1 NEMOCLAW_E2E_RETRIES=2 npx vitest run --project e2e
 Live Vitest E2E projects retry failed tests automatically in CI. The default is
 2 retries after the first failure (3 total attempts). Local opt-in runs default
 to no full-test retry; set `NEMOCLAW_E2E_RETRIES=<count>` to override either
-local or CI behavior.
+local or CI behavior. Overrides are capped at 5 retries so a typo cannot create
+unbounded credentialed live infrastructure attempts.
 
 The retired `--emit-matrix`, direct `--scenarios` execution, and `--plan-only`
 paths must not be reintroduced.

--- a/test/e2e-scenario/docs/README.md
+++ b/test/e2e-scenario/docs/README.md
@@ -76,7 +76,15 @@ npx vitest run --project e2e-vitest-support --silent=false --reporter=default
 # Opt-in live Vitest scenarios
 npm run build:cli
 NEMOCLAW_RUN_E2E_SCENARIOS=1 npx vitest run --project e2e-scenarios-live --silent=false --reporter=default
+
+# Force two retries locally (three total attempts) for external-service flakes
+NEMOCLAW_RUN_E2E_SCENARIOS=1 NEMOCLAW_E2E_RETRIES=2 npx vitest run --project e2e-scenarios-live
 ```
+
+Live Vitest E2E projects retry failed tests automatically in CI. The default is
+2 retries after the first failure (3 total attempts). Local opt-in runs default
+to no full-test retry; set `NEMOCLAW_E2E_RETRIES=<count>` to override either
+local or CI behavior.
 
 The retired `--emit-matrix`, direct `--scenarios` execution, and `--plan-only`
 paths must not be reintroduced.

--- a/test/e2e-scenario/support-tests/e2e-live-project-config.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-live-project-config.test.ts
@@ -9,12 +9,14 @@ import {
   shouldRunLiveE2EScenarios,
 } from "../fixtures/live-project-gate.ts";
 import config from "../../../vitest.config.ts";
+import { resolveE2ERetryCount } from "../../helpers/e2e-retries.ts";
 import { readYaml, type WorkflowStep } from "../../helpers/e2e-workflow-contract.ts";
 
 interface ProjectConfig {
   test?: {
     name?: string;
     include?: string[];
+    retry?: number;
   };
 }
 
@@ -86,6 +88,26 @@ describe("gated E2E Vitest projects", () => {
     expect(shouldRunBranchValidationE2E({ BREV_API_TOKEN: "token" })).toBe(true);
     expect(shouldRunBranchValidationE2E({ NEMOCLAW_RUN_BRANCH_VALIDATION_E2E: "true" })).toBe(true);
     expect(shouldRunBranchValidationE2E({ NEMOCLAW_RUN_BRANCH_VALIDATION_E2E: "1" })).toBe(true);
+  });
+
+  it("configures automatic retries only for live E2E Vitest projects", () => {
+    const expectedRetries = resolveE2ERetryCount();
+
+    expect(projectConfig("cli").test?.retry).toBeUndefined();
+    expect(projectConfig("e2e-vitest-support").test?.retry).toBeUndefined();
+    expect(projectConfig("e2e-scenarios-live").test?.retry).toBe(expectedRetries);
+    expect(projectConfig("e2e-branch-validation").test?.retry).toBe(expectedRetries);
+  });
+
+  it("defaults live E2E retries to CI only and supports explicit overrides", () => {
+    expect(resolveE2ERetryCount({})).toBe(0);
+    expect(resolveE2ERetryCount({ CI: "0" })).toBe(0);
+    expect(resolveE2ERetryCount({ CI: "1" })).toBe(2);
+    expect(resolveE2ERetryCount({ CI: "true" })).toBe(2);
+    expect(resolveE2ERetryCount({ GITHUB_ACTIONS: "true" })).toBe(2);
+    expect(resolveE2ERetryCount({ CI: "1", NEMOCLAW_E2E_RETRIES: "0" })).toBe(0);
+    expect(resolveE2ERetryCount({ NEMOCLAW_E2E_RETRIES: "3" })).toBe(3);
+    expect(resolveE2ERetryCount({ CI: "1", NEMOCLAW_E2E_RETRIES: "invalid" })).toBe(2);
   });
 
   it("sets the branch-validation sentinel in the reusable workflow Vitest step", () => {

--- a/test/e2e-scenario/support-tests/e2e-live-project-config.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-live-project-config.test.ts
@@ -107,6 +107,11 @@ describe("gated E2E Vitest projects", () => {
     expect(resolveE2ERetryCount({ GITHUB_ACTIONS: "true" })).toBe(2);
     expect(resolveE2ERetryCount({ CI: "1", NEMOCLAW_E2E_RETRIES: "0" })).toBe(0);
     expect(resolveE2ERetryCount({ NEMOCLAW_E2E_RETRIES: "3" })).toBe(3);
+    expect(resolveE2ERetryCount({ NEMOCLAW_E2E_RETRIES: "5" })).toBe(5);
+    expect(resolveE2ERetryCount({ NEMOCLAW_E2E_RETRIES: "6" })).toBe(5);
+    expect(resolveE2ERetryCount({ NEMOCLAW_E2E_RETRIES: "999999" })).toBe(5);
+    expect(resolveE2ERetryCount({ CI: "1", NEMOCLAW_E2E_RETRIES: "-1" })).toBe(2);
+    expect(resolveE2ERetryCount({ CI: "1", NEMOCLAW_E2E_RETRIES: "1.5" })).toBe(2);
     expect(resolveE2ERetryCount({ CI: "1", NEMOCLAW_E2E_RETRIES: "invalid" })).toBe(2);
   });
 

--- a/test/helpers/e2e-retries.ts
+++ b/test/helpers/e2e-retries.ts
@@ -5,11 +5,12 @@ type Environment = Record<string, string | undefined>;
 
 const DEFAULT_CI_E2E_RETRIES = 2;
 const DEFAULT_LOCAL_E2E_RETRIES = 0;
+const MAX_E2E_RETRIES = 5;
 
 export function resolveE2ERetryCount(env: Environment = process.env): number {
   const override = env.NEMOCLAW_E2E_RETRIES?.trim();
   if (override && /^[0-9]+$/.test(override)) {
-    return Number.parseInt(override, 10);
+    return Math.min(Number.parseInt(override, 10), MAX_E2E_RETRIES);
   }
 
   const envIsCi = env.GITHUB_ACTIONS === "true" || env.CI === "true" || env.CI === "1";

--- a/test/helpers/e2e-retries.ts
+++ b/test/helpers/e2e-retries.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type Environment = Record<string, string | undefined>;
+
+const DEFAULT_CI_E2E_RETRIES = 2;
+const DEFAULT_LOCAL_E2E_RETRIES = 0;
+
+export function resolveE2ERetryCount(env: Environment = process.env): number {
+  const override = env.NEMOCLAW_E2E_RETRIES?.trim();
+  if (override && /^[0-9]+$/.test(override)) {
+    return Number.parseInt(override, 10);
+  }
+
+  const envIsCi = env.GITHUB_ACTIONS === "true" || env.CI === "true" || env.CI === "1";
+  return envIsCi ? DEFAULT_CI_E2E_RETRIES : DEFAULT_LOCAL_E2E_RETRIES;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ import {
   shouldRunInstallerIntegration,
   shouldRunLiveE2EScenarios,
 } from "./test/e2e-scenario/fixtures/live-project-gate.ts";
+import { resolveE2ERetryCount } from "./test/helpers/e2e-retries";
 import { testTimeout } from "./test/helpers/timeouts";
 
 const isGithubActions = process.env.GITHUB_ACTIONS === "true";
@@ -16,6 +17,7 @@ const LIVE_E2E_PROJECT_TIMEOUT_MS = 30 * 60 * 1000;
 const runInstallerIntegration = shouldRunInstallerIntegration();
 const runLiveE2EScenarios = shouldRunLiveE2EScenarios();
 const runBranchValidationE2E = shouldRunBranchValidationE2E();
+const e2eRetryCount = resolveE2ERetryCount();
 
 export default defineConfig({
   test: {
@@ -82,6 +84,10 @@ export default defineConfig({
         test: {
           name: "e2e-scenarios-live",
           testTimeout: testTimeout(LIVE_E2E_PROJECT_TIMEOUT_MS),
+          // Vitest counts retries after the initial failure. In CI the default
+          // value of 2 gives live E2Es up to three total attempts while keeping
+          // local opt-in runs single-shot unless NEMOCLAW_E2E_RETRIES is set.
+          retry: e2eRetryCount,
           include: runLiveE2EScenarios ? ["test/e2e-scenario/live/**/*.test.ts"] : [],
           // Live scenario tests are opt-in because they install, onboard, and
           // mutate real NemoClaw/OpenShell state. Run explicitly with:
@@ -91,6 +97,7 @@ export default defineConfig({
       {
         test: {
           name: "e2e-branch-validation",
+          retry: e2eRetryCount,
           include: runBranchValidationE2E ? ["test/e2e/brev-e2e.test.ts"] : [],
           // Branch validation E2E: rsyncs the branch over a Brev instance
           // provisioned from the published NemoClaw launchable image and


### PR DESCRIPTION
## Summary
Add automatic retries for live Vitest E2E projects so transient external-service failures get a bounded second chance in CI. The default is 2 retries in CI (3 total attempts), while local runs stay single-shot unless `NEMOCLAW_E2E_RETRIES` is set.

## Changes
- Add `resolveE2ERetryCount()` to centralize E2E retry defaults and overrides.
- Configure `e2e-scenarios-live` and `e2e-branch-validation` Vitest projects to use the resolved retry count.
- Add support tests for retry configuration and document the retry behavior in the E2E Vitest fixture guide.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Implemented configurable E2E retry behavior to improve reliability, including CI vs local defaults.
  * Added validation to ensure retry settings apply only to live E2E projects, with invalid overrides ignored and values clamped to a safe maximum.

* **Documentation**
  * Updated E2E scenario documentation to explain how to enable local retries for external-service flakiness using `NEMOCLAW_E2E_RETRIES` and how CI retry defaults work.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->