### PR TITLE
ci(test): ratchet test conditional growth

### DIFF
--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -256,7 +256,7 @@ jobs:
           set -euo pipefail
 
           node <<'NODE'
-          const TEST_FILE_RE = /^(test|src|nemoclaw\/src)\/.*\.(test|spec)\.(?:[cm]?[jt]s|[jt]sx)$/;
+          const TEST_FILE_RE = /^(test|src|nemoclaw\/src)\/.*\.(test|spec)\.(?:[cm]?[jt]s)$/;
           const { BASE_SHA, GH_TOKEN, HEAD_REPO, HEAD_SHA, PR_NUMBER, REPO } = process.env;
           const headers = { Authorization: `Bearer ${GH_TOKEN}`, "X-GitHub-Api-Version": "2022-11-28" };
 

--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -289,6 +289,12 @@ jobs:
             return Buffer.from(body.content.replace(/\s/g, ""), "base64").toString("utf8");
           }
 
+          function assertRepositoryName(repo, label) {
+            if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo ?? "")) {
+              throw new Error(`${label} must be an owner/name repository name`);
+            }
+          }
+
           function stripTriviaAndLiterals(text) {
             let output = "";
             let index = 0;
@@ -418,6 +424,9 @@ jobs:
             const changedTests = files.filter(({ filename, previous_filename }) => (
               TEST_FILE_RE.test(filename) || TEST_FILE_RE.test(previous_filename ?? "")
             ));
+            assertRepositoryName(REPO, "REPO");
+            assertRepositoryName(HEAD_REPO, "HEAD_REPO");
+
             const details = [];
             let baseTotal = 0;
             let headTotal = 0;
@@ -434,8 +443,9 @@ jobs:
               }
             }
 
-            if (headTotal > baseTotal) {
-              console.error(`FAIL: changed test files add ${headTotal - baseTotal} net if statement(s).`);
+            if (details.length > 0) {
+              console.error("FAIL: changed test files add if statements.");
+              console.error(`Changed test files contain ${headTotal} if statement(s) at PR head vs ${baseTotal} at base.`);
               console.error("");
               console.error("Test bodies should stay linear. Split conditional behavior into separate test cases, use it.skipIf/it.runIf for platform or environment gates, or move non-asserting setup branches into named helpers.");
               console.error("");

--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -456,7 +456,7 @@ jobs:
           }
 
           function countIfStatements(text) {
-            return stripTriviaAndLiterals(text).match(/\bif\b/g)?.length ?? 0;
+            return stripTriviaAndLiterals(text).match(/\bif\s*\(/g)?.length ?? 0;
           }
 
           async function countAt(repo, ref, file) {

--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -243,3 +243,214 @@ jobs:
             process.exit(1);
           });
           NODE
+
+      - name: Require changed test files not to add if statements
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          node <<'NODE'
+          const TEST_FILE_RE = /^(test|src|nemoclaw\/src)\/.*\.(test|spec)\.(?:[cm]?[jt]s|[jt]sx)$/;
+          const { BASE_SHA, GH_TOKEN, HEAD_REPO, HEAD_SHA, PR_NUMBER, REPO } = process.env;
+          const headers = { Authorization: `Bearer ${GH_TOKEN}`, "X-GitHub-Api-Version": "2022-11-28" };
+
+          async function getJson(url) {
+            const response = await fetch(url, { headers });
+            if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
+            return response.json();
+          }
+
+          async function getPullFiles() {
+            const files = [];
+            for (let page = 1; ; page += 1) {
+              const batch = await getJson(`https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}`);
+              files.push(...batch);
+              if (batch.length < 100) return files;
+            }
+          }
+
+          async function getContent(repo, ref, file) {
+            if (!file) return null;
+            const encodedPath = file.split("/").map(encodeURIComponent).join("/");
+            const url = `https://api.github.com/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`;
+            const response = await fetch(url, { headers });
+            if (response.status === 404) return null;
+            if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
+            const body = await response.json();
+            if (body.type !== "file" || body.encoding !== "base64" || typeof body.content !== "string") {
+              throw new Error(`Could not decode file contents for ${file}`);
+            }
+            return Buffer.from(body.content.replace(/\s/g, ""), "base64").toString("utf8");
+          }
+
+          function stripTriviaAndLiterals(text) {
+            let output = "";
+            let index = 0;
+            let previousToken = "";
+            let identifierBuffer = "";
+            let lastIdentifier = "";
+
+            function finalizeIdentifier() {
+              if (identifierBuffer !== "") {
+                lastIdentifier = identifierBuffer;
+                identifierBuffer = "";
+              }
+            }
+
+            function appendCode(char) {
+              output += char;
+              if (/[A-Za-z0-9_$]/.test(char)) {
+                identifierBuffer += char;
+              } else {
+                finalizeIdentifier();
+              }
+              if (/\S/.test(char)) previousToken = char;
+            }
+
+            function consumeQuoted(quote) {
+              output += " ";
+              index += 1;
+              while (index < text.length) {
+                const char = text[index];
+                if (char === "\\") {
+                  index += 2;
+                } else if (char === quote) {
+                  index += 1;
+                  return;
+                } else {
+                  index += 1;
+                }
+              }
+            }
+
+            function consumeTemplate() {
+              output += " ";
+              index += 1;
+              while (index < text.length) {
+                const char = text[index];
+                if (char === "\\") {
+                  index += 2;
+                } else if (char === "`") {
+                  index += 1;
+                  return;
+                } else {
+                  index += 1;
+                }
+              }
+            }
+
+            function regexCanStart() {
+              const expressionKeyword = identifierBuffer || lastIdentifier;
+              return (
+                previousToken === "" ||
+                /[({[=,:;!&|?+\-*~^%<>]/.test(previousToken) ||
+                /^(?:return|throw|case|delete|void|typeof|yield|await|else|do)$/.test(expressionKeyword)
+              );
+            }
+
+            function consumeRegex() {
+              output += " ";
+              index += 1;
+              let inCharacterClass = false;
+              while (index < text.length) {
+                const char = text[index];
+                if (char === "\\") {
+                  index += 2;
+                } else if (char === "[") {
+                  inCharacterClass = true;
+                  index += 1;
+                } else if (char === "]") {
+                  inCharacterClass = false;
+                  index += 1;
+                } else if (char === "/" && !inCharacterClass) {
+                  index += 1;
+                  while (/[a-z]/i.test(text[index] ?? "")) index += 1;
+                  return;
+                } else {
+                  index += 1;
+                }
+              }
+            }
+
+            while (index < text.length) {
+              const char = text[index];
+              const next = text[index + 1];
+              if (char === "/" && next === "/") {
+                output += " ";
+                index += 2;
+                while (index < text.length && !/[\r\n]/.test(text[index])) index += 1;
+              } else if (char === "/" && next === "*") {
+                output += " ";
+                index += 2;
+                while (index < text.length && !(text[index] === "*" && text[index + 1] === "/")) index += 1;
+                index = Math.min(index + 2, text.length);
+              } else if (char === '"' || char === "'") {
+                consumeQuoted(char);
+              } else if (char === "`") {
+                consumeTemplate();
+              } else if (char === "/" && regexCanStart()) {
+                consumeRegex();
+              } else {
+                appendCode(char);
+                index += 1;
+              }
+            }
+            return output;
+          }
+
+          function countIfStatements(text) {
+            return stripTriviaAndLiterals(text).match(/\bif\b/g)?.length ?? 0;
+          }
+
+          async function countAt(repo, ref, file) {
+            const text = await getContent(repo, ref, file);
+            return text === null ? 0 : countIfStatements(text);
+          }
+
+          async function main() {
+            const files = await getPullFiles();
+            const changedTests = files.filter(({ filename, previous_filename }) => (
+              TEST_FILE_RE.test(filename) || TEST_FILE_RE.test(previous_filename ?? "")
+            ));
+            const details = [];
+            let baseTotal = 0;
+            let headTotal = 0;
+
+            for (const file of changedTests) {
+              const basePath = TEST_FILE_RE.test(file.previous_filename ?? "") ? file.previous_filename : file.filename;
+              const headPath = file.status === "removed" || !TEST_FILE_RE.test(file.filename) ? null : file.filename;
+              const baseCount = await countAt(REPO, BASE_SHA, basePath);
+              const headCount = await countAt(HEAD_REPO, HEAD_SHA, headPath);
+              baseTotal += baseCount;
+              headTotal += headCount;
+              if (headCount > baseCount) {
+                details.push(`${headPath ?? file.filename}: ${headCount} if statement(s), up from ${baseCount}`);
+              }
+            }
+
+            if (headTotal > baseTotal) {
+              console.error(`FAIL: changed test files add ${headTotal - baseTotal} net if statement(s).`);
+              console.error("");
+              console.error("Test bodies should stay linear. Split conditional behavior into separate test cases, use it.skipIf/it.runIf for platform or environment gates, or move non-asserting setup branches into named helpers.");
+              console.error("");
+              console.error("Files with increased if counts:");
+              for (const detail of details) console.error(`- ${detail}`);
+              console.error("");
+              console.error("Run locally: npm run test-conditionals:scan -- --top 25");
+              process.exit(1);
+            }
+
+            console.log(`PASS: changed test files did not add if statements (${headTotal} at PR head vs ${baseTotal} at base).`);
+          }
+
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE

--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -340,12 +340,57 @@ jobs:
               index += 1;
               while (index < text.length) {
                 const char = text[index];
+                const next = text[index + 1];
                 if (char === "\\") {
                   index += 2;
                 } else if (char === "`") {
                   index += 1;
                   return;
+                } else if (char === "$" && next === "{") {
+                  output += " ";
+                  index += 2;
+                  consumeTemplateExpression();
                 } else {
+                  index += 1;
+                }
+              }
+            }
+
+            function consumeTemplateExpression() {
+              let depth = 1;
+              while (index < text.length && depth > 0) {
+                const char = text[index];
+                const next = text[index + 1];
+                if (char === "/" && next === "/") {
+                  output += " ";
+                  index += 2;
+                  while (index < text.length && !/[\r\n]/.test(text[index])) index += 1;
+                } else if (char === "/" && next === "*") {
+                  output += " ";
+                  index += 2;
+                  while (index < text.length && !(text[index] === "*" && text[index + 1] === "/")) index += 1;
+                  index = Math.min(index + 2, text.length);
+                } else if (char === '"' || char === "'") {
+                  consumeQuoted(char);
+                } else if (char === "`") {
+                  consumeTemplate();
+                } else if (char === "/" && regexCanStart()) {
+                  consumeRegex();
+                } else if (char === "{") {
+                  depth += 1;
+                  appendCode(char);
+                  index += 1;
+                } else if (char === "}") {
+                  depth -= 1;
+                  if (depth === 0) {
+                    output += " ";
+                    index += 1;
+                  } else {
+                    appendCode(char);
+                    index += 1;
+                  }
+                } else {
+                  appendCode(char);
                   index += 1;
                 }
               }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "source-shape:scan": "tsx scripts/find-source-shape-tests.ts --metrics",
     "source-shape:check": "tsx scripts/find-source-shape-tests.ts --check",
     "test-size:check": "tsx scripts/check-test-file-size-budget.ts",
+    "test-conditionals:scan": "tsx scripts/find-test-conditionals.ts",
     "bump:version": "tsx scripts/bump-version.ts",
     "release:plan": "tsx scripts/release-plan.ts",
     "release:cut": "bash scripts/release-cut-tag.sh",

--- a/scripts/find-test-conditionals.ts
+++ b/scripts/find-test-conditionals.ts
@@ -112,7 +112,8 @@ function* walkFiles(dir: string): Generator<string> {
 
 function scriptKindFor(filePath: string): ts.ScriptKind {
   if (/\.tsx$/i.test(filePath)) return ts.ScriptKind.TSX;
-  if (/\.[cm]?jsx?$/i.test(filePath)) return ts.ScriptKind.JS;
+  if (/\.jsx$/i.test(filePath)) return ts.ScriptKind.JSX;
+  if (/\.[cm]?js$/i.test(filePath)) return ts.ScriptKind.JS;
   return ts.ScriptKind.TS;
 }
 

--- a/scripts/find-test-conditionals.ts
+++ b/scripts/find-test-conditionals.ts
@@ -68,7 +68,7 @@ type CliOptions = {
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_SCAN_ROOTS = Object.freeze(["test", "src", "nemoclaw/src"]);
-const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]s|[jt]sx)$/;
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]s)$/;
 const HIGH_SCORE_THRESHOLD = 8;
 const TEST_CALL_NAMES = new Set(["it", "test"]);
 const HOOK_CALL_NAMES = new Set(["beforeEach", "afterEach", "beforeAll", "afterAll"]);
@@ -111,10 +111,7 @@ function* walkFiles(dir: string): Generator<string> {
 }
 
 function scriptKindFor(filePath: string): ts.ScriptKind {
-  if (/\.tsx$/i.test(filePath)) return ts.ScriptKind.TSX;
-  if (/\.jsx$/i.test(filePath)) return ts.ScriptKind.JSX;
-  if (/\.[cm]?js$/i.test(filePath)) return ts.ScriptKind.JS;
-  return ts.ScriptKind.TS;
+  return /\.[cm]?js$/i.test(filePath) ? ts.ScriptKind.JS : ts.ScriptKind.TS;
 }
 
 function normalizeWhitespace(text: string): string {

--- a/scripts/find-test-conditionals.ts
+++ b/scripts/find-test-conditionals.ts
@@ -1,0 +1,609 @@
+#!/usr/bin/env -S npx tsx
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Finds `if` statements in test files. Branching inside tests often hides two
+// test paths in one case, makes failures environment-dependent, or lets missing
+// fixtures silently skip assertions.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+export type TestConditionalContextKind = "test" | "hook" | "suite" | "helper" | "top-level";
+
+export type TestConditionalOccurrence = {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly condition: string;
+  readonly contextKind: TestConditionalContextKind;
+  readonly contextName: string | null;
+  readonly score: number;
+  readonly reasons: readonly string[];
+  readonly hasElse: boolean;
+  readonly containsAssertion: boolean;
+  readonly containsControlFlow: boolean;
+  readonly inLoop: boolean;
+  readonly nestedDepth: number;
+  readonly branchLines: number;
+  readonly branchStatementCount: number;
+};
+
+export type TestConditionalFileSummary = {
+  readonly file: string;
+  readonly count: number;
+  readonly score: number;
+  readonly testBodyCount: number;
+  readonly assertionBranchCount: number;
+  readonly maxScore: number;
+};
+
+export type TestConditionalReport = {
+  readonly summary: {
+    readonly scannedFiles: number;
+    readonly filesWithConditionals: number;
+    readonly conditionalCount: number;
+    readonly testBodyConditionalCount: number;
+    readonly assertionBranchCount: number;
+    readonly highScoreCount: number;
+  };
+  readonly files: readonly TestConditionalFileSummary[];
+  readonly occurrences: readonly TestConditionalOccurrence[];
+};
+
+type CallbackContext = {
+  readonly kind: TestConditionalContextKind;
+  readonly name: string | null;
+};
+
+type CliOptions = {
+  readonly json: boolean;
+  readonly top: number;
+  readonly minScore: number;
+  readonly roots: readonly string[];
+};
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_SCAN_ROOTS = Object.freeze(["test", "src", "nemoclaw/src"]);
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]s|[jt]sx)$/;
+const HIGH_SCORE_THRESHOLD = 8;
+const TEST_CALL_NAMES = new Set(["it", "test"]);
+const HOOK_CALL_NAMES = new Set(["beforeEach", "afterEach", "beforeAll", "afterAll"]);
+const SUITE_CALL_NAMES = new Set(["describe"]);
+const ASSERTION_CALL_NAMES = new Set(["expect", "assert"]);
+const SKIP_DIRS = new Set([
+  ".git",
+  ".venv",
+  "coverage",
+  "dist",
+  "docs/_build",
+  "nemoclaw/dist",
+  "nemoclaw/node_modules",
+  "node_modules",
+]);
+
+function toRepoPath(absPath: string): string {
+  return path.relative(REPO_ROOT, absPath).split(path.sep).join("/");
+}
+
+function isSkipped(absPath: string): boolean {
+  const rel = toRepoPath(absPath);
+  return [...SKIP_DIRS].some((skipDir) => rel === skipDir || rel.startsWith(`${skipDir}/`));
+}
+
+function* walkFiles(dir: string): Generator<string> {
+  if (!existsSync(dir) || isSkipped(dir)) return;
+
+  for (const entry of readdirSync(dir)) {
+    const absPath = path.join(dir, entry);
+    if (isSkipped(absPath)) continue;
+
+    const stats = statSync(absPath);
+    if (stats.isDirectory()) {
+      yield* walkFiles(absPath);
+    } else if (stats.isFile() && TEST_FILE_PATTERN.test(entry)) {
+      yield absPath;
+    }
+  }
+}
+
+function scriptKindFor(filePath: string): ts.ScriptKind {
+  if (/\.tsx$/i.test(filePath)) return ts.ScriptKind.TSX;
+  if (/\.[cm]?jsx?$/i.test(filePath)) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function truncate(text: string, maxLength = 140): string {
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function getLine(sourceFile: ts.SourceFile, position: number): number {
+  return sourceFile.getLineAndCharacterOfPosition(position).line + 1;
+}
+
+function getLineColumn(
+  sourceFile: ts.SourceFile,
+  position: number,
+): { line: number; column: number } {
+  const location = sourceFile.getLineAndCharacterOfPosition(position);
+  return { line: location.line + 1, column: location.character + 1 };
+}
+
+function expressionName(expression: ts.Expression): string | null {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  return null;
+}
+
+function isNamedCall(expression: ts.Expression, names: ReadonlySet<string>): boolean {
+  const name = expressionName(expression);
+  return name !== null && names.has(name);
+}
+
+function rootCallName(expression: ts.Expression): string | null {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return rootCallName(expression.expression);
+  if (ts.isCallExpression(expression)) return rootCallName(expression.expression);
+  return null;
+}
+
+function firstStringArgument(call: ts.CallExpression): string | null {
+  const first = call.arguments[0];
+  if (first === undefined) return null;
+  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) return first.text;
+  return null;
+}
+
+function callbackContextForFunction(node: ts.Node): CallbackContext | null {
+  const parent = node.parent;
+  if (!ts.isCallExpression(parent)) return null;
+
+  const rootName = rootCallName(parent.expression);
+  if (rootName !== null && TEST_CALL_NAMES.has(rootName)) {
+    return { kind: "test", name: firstStringArgument(parent) };
+  }
+  if (rootName !== null && HOOK_CALL_NAMES.has(rootName)) {
+    return { kind: "hook", name: rootName };
+  }
+  if (rootName !== null && SUITE_CALL_NAMES.has(rootName)) {
+    return { kind: "suite", name: firstStringArgument(parent) };
+  }
+  return null;
+}
+
+function isFunctionLikeNode(node: ts.Node): node is ts.FunctionLikeDeclaration {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  );
+}
+
+function descendantMatches(node: ts.Node, predicate: (child: ts.Node) => boolean): boolean {
+  let found = false;
+
+  function visit(child: ts.Node): void {
+    if (found) return;
+    if (predicate(child)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(child, visit);
+  }
+
+  ts.forEachChild(node, visit);
+  return found;
+}
+
+function descendantStatementCount(node: ts.Statement | undefined): number {
+  if (node === undefined) return 0;
+  let count = 0;
+
+  function visit(child: ts.Node): void {
+    if (ts.isStatement(child)) count += 1;
+    ts.forEachChild(child, visit);
+  }
+
+  visit(node);
+  return count;
+}
+
+function nearestContext(contexts: readonly CallbackContext[]): CallbackContext | null {
+  return contexts.at(-1) ?? null;
+}
+
+function classifyContext(
+  contexts: readonly CallbackContext[],
+  functionDepth: number,
+): CallbackContext {
+  const context = nearestContext(contexts);
+  if (context !== null) return context;
+  if (functionDepth > 0) return { kind: "helper", name: null };
+  return { kind: "top-level", name: null };
+}
+
+function hasAncestor(node: ts.Node, predicate: (ancestor: ts.Node) => boolean): boolean {
+  let parent = node.parent;
+  while (parent !== undefined) {
+    if (predicate(parent)) return true;
+    parent = parent.parent;
+  }
+  return false;
+}
+
+function countIfAncestors(node: ts.Node): number {
+  let depth = 0;
+  let parent = node.parent;
+  while (parent !== undefined) {
+    if (ts.isIfStatement(parent)) depth += 1;
+    parent = parent.parent;
+  }
+  return depth;
+}
+
+function isLoop(node: ts.Node): boolean {
+  return (
+    ts.isForStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForOfStatement(node) ||
+    ts.isWhileStatement(node) ||
+    ts.isDoStatement(node)
+  );
+}
+
+function computeScore(input: {
+  readonly contextKind: TestConditionalContextKind;
+  readonly hasElse: boolean;
+  readonly containsAssertion: boolean;
+  readonly containsControlFlow: boolean;
+  readonly inLoop: boolean;
+  readonly nestedDepth: number;
+  readonly branchLines: number;
+  readonly branchStatementCount: number;
+  readonly condition: string;
+}): { score: number; reasons: string[] } {
+  let score = 1;
+  const reasons: string[] = [];
+
+  if (input.contextKind === "test") {
+    score += 4;
+    reasons.push("inside test body");
+  } else if (input.contextKind === "hook") {
+    score += 3;
+    reasons.push("inside test hook");
+  } else if (input.contextKind === "suite") {
+    score += 2;
+    reasons.push("inside describe callback");
+  } else if (input.contextKind === "helper") {
+    score += 1;
+    reasons.push("inside test helper");
+  }
+
+  if (input.containsAssertion) {
+    score += 4;
+    reasons.push("branches assertions");
+  }
+  if (input.containsControlFlow) {
+    score += 2;
+    reasons.push("branches return/throw/break/continue");
+  }
+  if (input.hasElse) {
+    score += 1;
+    reasons.push("has else branch");
+  }
+  if (input.inLoop) {
+    score += 2;
+    reasons.push("inside loop");
+  }
+  if (input.nestedDepth > 0) {
+    score += input.nestedDepth * 2;
+    reasons.push(`nested ${input.nestedDepth} level(s)`);
+  }
+  if (input.branchStatementCount >= 8) {
+    score += 2;
+    reasons.push(`${input.branchStatementCount} branch statements`);
+  }
+  if (input.branchLines >= 50) {
+    score += 5;
+    reasons.push(`${input.branchLines} branch lines`);
+  } else if (input.branchLines >= 20) {
+    score += 2;
+    reasons.push(`${input.branchLines} branch lines`);
+  }
+  if (
+    /\b(?:process\.env|process\.platform|os\.platform|CI|BREV|SKIP|RUN_E2E)\b/.test(input.condition)
+  ) {
+    score += 1;
+    reasons.push("environment-sensitive condition");
+  }
+
+  return { score, reasons };
+}
+
+function scanIfStatement(
+  node: ts.IfStatement,
+  sourceFile: ts.SourceFile,
+  contexts: readonly CallbackContext[],
+  functionDepth: number,
+  file: string,
+): TestConditionalOccurrence {
+  const start = node.getStart(sourceFile);
+  const end = node.getEnd();
+  const branchLines = Math.max(1, getLine(sourceFile, end) - getLine(sourceFile, start) + 1);
+  const condition = truncate(normalizeWhitespace(node.expression.getText(sourceFile)));
+  const containsAssertion =
+    descendantMatches(
+      node.thenStatement,
+      (child) => ts.isCallExpression(child) && isNamedCall(child.expression, ASSERTION_CALL_NAMES),
+    ) ||
+    (node.elseStatement !== undefined &&
+      descendantMatches(
+        node.elseStatement,
+        (child) =>
+          ts.isCallExpression(child) && isNamedCall(child.expression, ASSERTION_CALL_NAMES),
+      ));
+  const containsControlFlow = descendantMatches(
+    node,
+    (child) =>
+      ts.isReturnStatement(child) ||
+      ts.isThrowStatement(child) ||
+      ts.isBreakStatement(child) ||
+      ts.isContinueStatement(child),
+  );
+  const context = classifyContext(contexts, functionDepth);
+  const branchStatementCount =
+    descendantStatementCount(node.thenStatement) + descendantStatementCount(node.elseStatement);
+  const input = {
+    contextKind: context.kind,
+    hasElse: node.elseStatement !== undefined,
+    containsAssertion,
+    containsControlFlow,
+    inLoop: hasAncestor(node, isLoop),
+    nestedDepth: countIfAncestors(node),
+    branchLines,
+    branchStatementCount,
+    condition,
+  };
+  const { score, reasons } = computeScore(input);
+  const { line, column } = getLineColumn(sourceFile, start);
+
+  return {
+    file,
+    line,
+    column,
+    condition,
+    contextKind: context.kind,
+    contextName: context.name,
+    score,
+    reasons,
+    hasElse: input.hasElse,
+    containsAssertion,
+    containsControlFlow,
+    inLoop: input.inLoop,
+    nestedDepth: input.nestedDepth,
+    branchLines,
+    branchStatementCount,
+  };
+}
+
+export function scanTextForTestConditionals(
+  file: string,
+  sourceText: string,
+): TestConditionalOccurrence[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(file),
+  );
+  const occurrences: TestConditionalOccurrence[] = [];
+  const contexts: CallbackContext[] = [];
+  let functionDepth = 0;
+
+  function visit(node: ts.Node): void {
+    let pushedContext = false;
+    let enteredFunction = false;
+
+    if (isFunctionLikeNode(node)) {
+      functionDepth += 1;
+      enteredFunction = true;
+      const context = callbackContextForFunction(node);
+      if (context !== null) {
+        contexts.push(context);
+        pushedContext = true;
+      }
+    }
+
+    if (ts.isIfStatement(node)) {
+      occurrences.push(scanIfStatement(node, sourceFile, contexts, functionDepth, file));
+    }
+
+    ts.forEachChild(node, visit);
+
+    if (pushedContext) contexts.pop();
+    if (enteredFunction) functionDepth -= 1;
+  }
+
+  visit(sourceFile);
+  return occurrences;
+}
+
+function summarizeFiles(
+  occurrences: readonly TestConditionalOccurrence[],
+): TestConditionalFileSummary[] {
+  const summaries = new Map<string, TestConditionalFileSummary>();
+
+  for (const occurrence of occurrences) {
+    const previous = summaries.get(occurrence.file) ?? {
+      file: occurrence.file,
+      count: 0,
+      score: 0,
+      testBodyCount: 0,
+      assertionBranchCount: 0,
+      maxScore: 0,
+    };
+    summaries.set(occurrence.file, {
+      file: occurrence.file,
+      count: previous.count + 1,
+      score: previous.score + occurrence.score,
+      testBodyCount: previous.testBodyCount + (occurrence.contextKind === "test" ? 1 : 0),
+      assertionBranchCount: previous.assertionBranchCount + (occurrence.containsAssertion ? 1 : 0),
+      maxScore: Math.max(previous.maxScore, occurrence.score),
+    });
+  }
+
+  return [...summaries.values()].sort(
+    (a, b) => b.score - a.score || b.count - a.count || a.file.localeCompare(b.file),
+  );
+}
+
+export function collectTestConditionals(roots = DEFAULT_SCAN_ROOTS): TestConditionalReport {
+  const absFiles = roots.flatMap((root) => [...walkFiles(path.join(REPO_ROOT, root))]);
+  const occurrences = absFiles
+    .flatMap((absPath) =>
+      scanTextForTestConditionals(toRepoPath(absPath), readFileSync(absPath, "utf-8")),
+    )
+    .sort((a, b) => b.score - a.score || a.file.localeCompare(b.file) || a.line - b.line);
+  const files = summarizeFiles(occurrences);
+
+  return {
+    summary: {
+      scannedFiles: absFiles.length,
+      filesWithConditionals: files.length,
+      conditionalCount: occurrences.length,
+      testBodyConditionalCount: occurrences.filter((entry) => entry.contextKind === "test").length,
+      assertionBranchCount: occurrences.filter((entry) => entry.containsAssertion).length,
+      highScoreCount: occurrences.filter((entry) => entry.score >= HIGH_SCORE_THRESHOLD).length,
+    },
+    files,
+    occurrences,
+  };
+}
+
+function formatContext(occurrence: TestConditionalOccurrence): string {
+  const name = occurrence.contextName === null ? "" : `: ${occurrence.contextName}`;
+  return `${occurrence.contextKind}${name}`;
+}
+
+function formatOccurrence(occurrence: TestConditionalOccurrence): string {
+  const reasons = occurrence.reasons.length > 0 ? occurrence.reasons.join(", ") : "plain branch";
+  return [
+    `- ${occurrence.file}:${occurrence.line}:${occurrence.column}`,
+    `score=${occurrence.score}`,
+    `[${formatContext(occurrence)}]`,
+    `if (${occurrence.condition})`,
+    `— ${reasons}`,
+  ].join(" ");
+}
+
+export function formatReport(
+  report: TestConditionalReport,
+  options: Pick<CliOptions, "top">,
+): string {
+  const lines = [
+    `Scanned ${report.summary.scannedFiles} test files; found ${report.summary.conditionalCount} if statement(s) in ${report.summary.filesWithConditionals} file(s).`,
+    `${report.summary.testBodyConditionalCount} are inside test bodies; ${report.summary.assertionBranchCount} branch assertions; ${report.summary.highScoreCount} score >= ${HIGH_SCORE_THRESHOLD}.`,
+    "",
+    "Top files by conditional score:",
+  ];
+
+  for (const file of report.files.slice(0, options.top)) {
+    lines.push(
+      `- ${file.file}: score=${file.score}, ifs=${file.count}, test-body=${file.testBodyCount}, assertion-branches=${file.assertionBranchCount}, max=${file.maxScore}`,
+    );
+  }
+
+  lines.push("", "Most egregious if statements:");
+  for (const occurrence of report.occurrences.slice(0, options.top)) {
+    lines.push(formatOccurrence(occurrence));
+  }
+
+  return lines.join("\n");
+}
+
+function parsePositiveInt(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const roots: string[] = [];
+  let json = false;
+  let top = 20;
+  let minScore = 1;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--top") {
+      top = parsePositiveInt(argv[++index] ?? "", "--top");
+    } else if (arg === "--min-score") {
+      minScore = parsePositiveInt(argv[++index] ?? "", "--min-score");
+    } else if (arg === "--root") {
+      roots.push(argv[++index] ?? "");
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        `Usage: tsx scripts/find-test-conditionals.ts [--top N] [--min-score N] [--root PATH] [--json]\n\nScans test/spec files under test, src, and nemoclaw/src by default.`,
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (roots.some((root) => root.trim() === "")) throw new Error("--root requires a path");
+  return { json, top, minScore, roots: roots.length > 0 ? roots : DEFAULT_SCAN_ROOTS };
+}
+
+function filterReport(report: TestConditionalReport, minScore: number): TestConditionalReport {
+  if (minScore <= 1) return report;
+  const occurrences = report.occurrences.filter((entry) => entry.score >= minScore);
+  const files = summarizeFiles(occurrences);
+  return {
+    summary: {
+      ...report.summary,
+      filesWithConditionals: files.length,
+      conditionalCount: occurrences.length,
+      testBodyConditionalCount: occurrences.filter((entry) => entry.contextKind === "test").length,
+      assertionBranchCount: occurrences.filter((entry) => entry.containsAssertion).length,
+      highScoreCount: occurrences.filter((entry) => entry.score >= HIGH_SCORE_THRESHOLD).length,
+    },
+    files,
+    occurrences,
+  };
+}
+
+function main(): void {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const report = filterReport(collectTestConditionals(options.roots), options.minScore);
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log(formatReport(report, options));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  main();
+}

--- a/test/codebase-growth-guardrails-conditionals.test.ts
+++ b/test/codebase-growth-guardrails-conditionals.test.ts
@@ -8,6 +8,8 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { scanTextForTestConditionals } from "../scripts/find-test-conditionals";
+
 const WORKFLOW_PATH = ".github/workflows/codebase-growth-guardrails.yaml";
 const STEP_NAME = "Require changed test files not to add if statements";
 const NODE_MARKER = "node <<'NODE'\n";
@@ -43,6 +45,13 @@ function extractConditionalsNodeScript(): string {
     .replaceAll("\n          ", "\n");
 }
 
+function extractWorkflowCounterScript(): string {
+  const script = extractConditionalsNodeScript();
+  const counterStart = script.indexOf("function stripTriviaAndLiterals(text)");
+  const counterEnd = script.indexOf("async function countAt", counterStart);
+  return script.slice(counterStart, counterEnd);
+}
+
 function encodeContent(text: string): string {
   return Buffer.from(text, "utf8").toString("base64");
 }
@@ -55,6 +64,20 @@ function contentsUrl(content: MockContent): string {
 
 function pullFilesUrl(): string {
   return `https://api.github.com/repos/${ENV.REPO}/pulls/${ENV.PR_NUMBER}/files?per_page=100&page=1`;
+}
+
+function astIfCount(sourceText: string): number {
+  return scanTextForTestConditionals("test/virtual-workflow-parity.test.ts", sourceText).length;
+}
+
+function workflowIfCount(sourceText: string): number {
+  const script = `${extractWorkflowCounterScript()}\nconsole.log(countIfStatements(process.argv[1]));\n`;
+  const result = spawnSync(process.execPath, ["-e", script, sourceText], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return Number(result.stdout.trim());
 }
 
 function runWorkflowConditionalsGuard(input: {
@@ -103,6 +126,35 @@ function runWorkflowConditionalsGuard(input: {
 }
 
 describe("codebase growth guardrail test conditionals step", () => {
+  it.each([
+    {
+      name: "comments and strings",
+      source: [
+        "// if (commented) return;",
+        "const text = 'if (string)';",
+        "expect(text).toContain('if');",
+      ].join("\n"),
+    },
+    {
+      name: "regex literals",
+      source: "expect(/if \\(regex\\)/.test('if (regex)')).toBe(true);",
+    },
+    {
+      name: "real branches and else-if chains",
+      source: "if (first) run(); else if (second) recover();",
+    },
+    {
+      name: "nested template interpolation",
+      source: 'const value = `${`${(() => { if (flag) return "yes"; return "no"; })()}`}`;',
+    },
+    {
+      name: "non-statement property tokens",
+      source: "const obj = { if: true }; expect(obj.if).toBe(true); type Shape = { if: boolean };",
+    },
+  ])("matches local scanner count for $name", ({ source }) => {
+    expect(workflowIfCount(source)).toBe(astIfCount(source));
+  });
+
   it("fails a per-file increase even when another changed test removes an if", () => {
     const result = runWorkflowConditionalsGuard({
       files: [{ filename: "test/add.test.ts" }, { filename: "test/remove.test.ts" }],
@@ -142,6 +194,34 @@ describe("codebase growth guardrail test conditionals step", () => {
           repo: ENV.HEAD_REPO,
           ref: ENV.HEAD_SHA,
           text: "const obj = { if: true }; expect(obj.if).toBe(true); type Shape = { if: boolean };",
+        },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("PASS");
+  });
+
+  it("ignores removed files and files renamed out of test patterns", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [
+        { filename: "test/removed.test.ts", status: "removed" },
+        {
+          filename: "src/helper.ts",
+          previous_filename: "test/renamed-out.test.ts",
+          status: "renamed",
+        },
+      ],
+      contents: [
+        {
+          file: "test/removed.test.ts",
+          ref: ENV.BASE_SHA,
+          text: "if (flag) expect(flag).toBe(true);",
+        },
+        {
+          file: "test/renamed-out.test.ts",
+          ref: ENV.BASE_SHA,
+          text: "if (flag) expect(flag).toBe(true);",
         },
       ],
     });

--- a/test/codebase-growth-guardrails-conditionals.test.ts
+++ b/test/codebase-growth-guardrails-conditionals.test.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WORKFLOW_PATH = ".github/workflows/codebase-growth-guardrails.yaml";
+const STEP_NAME = "Require changed test files not to add if statements";
+const NODE_MARKER = "node <<'NODE'\n";
+const NODE_END_MARKER = "\n          NODE";
+const ENV = {
+  BASE_SHA: "base-sha",
+  GH_TOKEN: "test-token",
+  HEAD_REPO: "fork/repo",
+  HEAD_SHA: "head-sha",
+  PR_NUMBER: "123",
+  REPO: "NVIDIA/NemoClaw",
+};
+
+type MockFile = {
+  readonly filename: string;
+  readonly previous_filename?: string;
+  readonly status?: string;
+};
+
+type MockContent = {
+  readonly repo?: string;
+  readonly ref: string;
+  readonly file: string;
+  readonly text: string;
+};
+
+function extractConditionalsNodeScript(): string {
+  const workflow = fs.readFileSync(WORKFLOW_PATH, "utf8");
+  const step = workflow.slice(workflow.indexOf(STEP_NAME));
+  const nodeStart = step.indexOf(NODE_MARKER) + NODE_MARKER.length;
+  return step
+    .slice(nodeStart, step.indexOf(NODE_END_MARKER, nodeStart))
+    .replaceAll("\n          ", "\n");
+}
+
+function encodeContent(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+function contentsUrl(content: MockContent): string {
+  const repo = content.repo ?? ENV.REPO;
+  const encodedPath = content.file.split("/").map(encodeURIComponent).join("/");
+  return `https://api.github.com/repos/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(content.ref)}`;
+}
+
+function pullFilesUrl(): string {
+  return `https://api.github.com/repos/${ENV.REPO}/pulls/${ENV.PR_NUMBER}/files?per_page=100&page=1`;
+}
+
+function runWorkflowConditionalsGuard(input: {
+  readonly files: readonly MockFile[];
+  readonly contents: readonly MockContent[];
+}): ReturnType<typeof spawnSync> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-growth-conditionals-"));
+  const scriptPath = path.join(tmpDir, "guardrail.cjs");
+  const responses = new Map<string, unknown>([
+    [pullFilesUrl(), input.files],
+    ...input.contents.map(
+      (content) =>
+        [
+          contentsUrl(content),
+          {
+            content: encodeContent(content.text),
+            encoding: "base64",
+            type: "file",
+          },
+        ] as const,
+    ),
+  ]);
+  const wrapper = [
+    `const responses = new Map(${JSON.stringify([...responses])});`,
+    "global.fetch = async (url) => {",
+    "  const body = responses.get(String(url));",
+    "  return {",
+    "    ok: body !== undefined,",
+    "    status: body === undefined ? 404 : 200,",
+    "    json: async () => body ?? {},",
+    "  };",
+    "};",
+    extractConditionalsNodeScript(),
+  ].join("\n");
+
+  fs.writeFileSync(scriptPath, wrapper);
+  try {
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, ...ENV },
+    });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("codebase growth guardrail test conditionals step", () => {
+  it("fails a per-file increase even when another changed test removes an if", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [{ filename: "test/add.test.ts" }, { filename: "test/remove.test.ts" }],
+      contents: [
+        { file: "test/add.test.ts", ref: ENV.BASE_SHA, text: "expect(true).toBe(true);" },
+        {
+          file: "test/add.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "if (flag) expect(flag).toBe(true);",
+        },
+        {
+          file: "test/remove.test.ts",
+          ref: ENV.BASE_SHA,
+          text: "if (flag) expect(flag).toBe(true);",
+        },
+        {
+          file: "test/remove.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "expect(true).toBe(true);",
+        },
+      ],
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("test/add.test.ts");
+  });
+
+  it("does not count non-statement if property tokens", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [{ filename: "test/non-statement.test.ts" }],
+      contents: [
+        { file: "test/non-statement.test.ts", ref: ENV.BASE_SHA, text: "" },
+        {
+          file: "test/non-statement.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: "const obj = { if: true }; expect(obj.if).toBe(true); type Shape = { if: boolean };",
+        },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("PASS");
+  });
+
+  it("counts executable if statements inside template interpolation", () => {
+    const result = runWorkflowConditionalsGuard({
+      files: [{ filename: "test/template.test.ts" }],
+      contents: [
+        { file: "test/template.test.ts", ref: ENV.BASE_SHA, text: "" },
+        {
+          file: "test/template.test.ts",
+          repo: ENV.HEAD_REPO,
+          ref: ENV.HEAD_SHA,
+          text: 'const value = `${(() => { if (flag) return "enabled"; return "disabled"; })()}`;',
+        },
+      ],
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("test/template.test.ts");
+  });
+});

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -8,14 +8,13 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
-
-import { testTimeoutOptions } from "../../helpers/timeouts";
 import {
   evaluateE2eVitestWorkflowDispatchSelectors,
   readFreeStandingJobsInventory,
   validateE2eVitestScenariosWorkflowBoundary,
   validateFreeStandingWorkflowInventory,
 } from "../../../tools/e2e-scenarios/workflow-boundary.mts";
+import { testTimeoutOptions } from "../../helpers/timeouts";
 
 function readWorkflow(): Record<string, unknown> {
   return YAML.parse(
@@ -565,7 +564,7 @@ describe("e2e-vitest-scenarios workflow boundary", () => {
     },
   );
 
-  it("derives the free-standing inventory from workflow job metadata", () => {
+  it("derives the free-standing inventory from workflow job metadata", { timeout: 60_000 }, () => {
     const inventory = readFreeStandingJobsInventory();
     expect(validateFreeStandingWorkflowInventory()).toEqual([]);
     expect(inventory.allowedJobs).toContain("openshell-version-pin-vitest");

--- a/test/test-conditionals-scanner.test.ts
+++ b/test/test-conditionals-scanner.test.ts
@@ -32,6 +32,29 @@ describe("test conditional scanner", () => {
     });
   });
 
+  it("detects executable if statements inside template interpolation", () => {
+    const occurrences = scanTextForTestConditionals(
+      "test/virtual-template-conditionals.test.ts",
+      [
+        'import { expect, it } from "vitest";',
+        'it("branches in interpolation", () => {',
+        "  const value = `${(() => {",
+        '    if (process.env.FLAG) return "enabled";',
+        '    return "disabled";',
+        "  })()}`;",
+        '  expect(value).toBeTypeOf("string");',
+        "});",
+      ].join("\n"),
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]).toMatchObject({
+      contextKind: "test",
+      contextName: "branches in interpolation",
+      containsControlFlow: true,
+    });
+  });
+
   it("parses JSX test files with JSX script kind", () => {
     const occurrences = scanTextForTestConditionals(
       "test/virtual-jsx-conditionals.test.jsx",

--- a/test/test-conditionals-scanner.test.ts
+++ b/test/test-conditionals-scanner.test.ts
@@ -32,6 +32,31 @@ describe("test conditional scanner", () => {
     });
   });
 
+  it("parses JSX test files with JSX script kind", () => {
+    const occurrences = scanTextForTestConditionals(
+      "test/virtual-jsx-conditionals.test.jsx",
+      `
+        import { expect, it } from "vitest";
+
+        const Component = () => <div data-testid="ok" />;
+
+        it("branches after jsx", () => {
+          const node = <Component />;
+          if (node) {
+            expect(node).toBeTruthy();
+          }
+        });
+      `,
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]).toMatchObject({
+      contextKind: "test",
+      contextName: "branches after jsx",
+      containsAssertion: true,
+    });
+  });
+
   it("scores assertion branches in test bodies above helper guard clauses", () => {
     const occurrences = scanTextForTestConditionals(
       "test/virtual-conditionals.test.ts",

--- a/test/test-conditionals-scanner.test.ts
+++ b/test/test-conditionals-scanner.test.ts
@@ -55,31 +55,6 @@ describe("test conditional scanner", () => {
     });
   });
 
-  it("parses JSX test files with JSX script kind", () => {
-    const occurrences = scanTextForTestConditionals(
-      "test/virtual-jsx-conditionals.test.jsx",
-      `
-        import { expect, it } from "vitest";
-
-        const Component = () => <div data-testid="ok" />;
-
-        it("branches after jsx", () => {
-          const node = <Component />;
-          if (node) {
-            expect(node).toBeTruthy();
-          }
-        });
-      `,
-    );
-
-    expect(occurrences).toHaveLength(1);
-    expect(occurrences[0]).toMatchObject({
-      contextKind: "test",
-      contextName: "branches after jsx",
-      containsAssertion: true,
-    });
-  });
-
   it("scores assertion branches in test bodies above helper guard clauses", () => {
     const occurrences = scanTextForTestConditionals(
       "test/virtual-conditionals.test.ts",

--- a/test/test-conditionals-scanner.test.ts
+++ b/test/test-conditionals-scanner.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { scanTextForTestConditionals } from "../scripts/find-test-conditionals";
+
+describe("test conditional scanner", () => {
+  it("detects real if statements without matching strings or comments", () => {
+    const occurrences = scanTextForTestConditionals(
+      "test/virtual-conditionals.test.ts",
+      `
+        import { expect, it } from "vitest";
+
+        // if (commentedOut) expect(false).toBe(true);
+        const fixture = "if (insideString) expect(false).toBe(true)";
+
+        it("branches", () => {
+          if (fixture.length > 0) {
+            expect(fixture).toContain("if");
+          }
+        });
+      `,
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]).toMatchObject({
+      line: 8,
+      contextKind: "test",
+      contextName: "branches",
+      containsAssertion: true,
+    });
+  });
+
+  it("scores assertion branches in test bodies above helper guard clauses", () => {
+    const occurrences = scanTextForTestConditionals(
+      "test/virtual-conditionals.test.ts",
+      `
+        import { expect, it } from "vitest";
+
+        function maybeNormalize(value?: string) {
+          if (value === undefined) return "fallback";
+          return value;
+        }
+
+        it("branches assertions", () => {
+          const value = maybeNormalize("hello");
+          if (value === "hello") {
+            expect(value).toBe("hello");
+          } else {
+            expect(value).toBe("fallback");
+          }
+        });
+      `,
+    );
+
+    const [testBranch, helperGuard] = occurrences.sort((a, b) => b.score - a.score);
+
+    expect(testBranch).toMatchObject({
+      contextKind: "test",
+      containsAssertion: true,
+      hasElse: true,
+    });
+    expect(helperGuard).toMatchObject({
+      contextKind: "helper",
+      containsControlFlow: true,
+    });
+    expect(testBranch.score).toBeGreaterThan(helperGuard.score);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a local test-conditional scanner and hooks a net-new `if` ratchet into the existing codebase growth guardrail workflow. This keeps current test branching debt visible while blocking changed test files from adding more conditional complexity.

## Changes
- Add `scripts/find-test-conditionals.ts` to report and score `if` statements in test/spec files.
- Add `npm run test-conditionals:scan` and focused scanner unit coverage.
- Extend `.github/workflows/codebase-growth-guardrails.yaml` with a data-only pull_request_target check that rejects net-new `if` statements in changed test files.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a CI guardrail that compares conditional `if` usage in changed test/spec files between the PR base and head, failing the build if it increases.
  * Introduced a new local scanner to analyze test/spec code for conditional patterns, returning ranked results in JSON or readable text with filtering.
  * Added an npm script to run the new scanner.
* **Tests**
  * Added unit tests to verify detection within test bodies, correct handling of comments/strings, template cases, and result prioritization.
  * Updated an e2e scenario test to set an explicit timeout and adjust import ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->