### PR TITLE
refactor(onboard): add refined flow context guards

### DIFF
--- a/src/lib/onboard/machine/core-flow-phases.ts
+++ b/src/lib/onboard/machine/core-flow-phases.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WebSearchConfig } from "../../inference/web-search";
-import type { OnboardFlowContext } from "./flow-context";
+import { assertProviderSelectedContext, type OnboardFlowContext } from "./flow-context";
 import { runCoreOnboardFlowSequence } from "./flow-slices";
 import {
   handleProviderInferenceState,
@@ -97,9 +97,7 @@ export function createCoreOnboardFlowPhases<
   const sandboxPhase: OnboardSequencePhase<Context> = {
     state: "sandbox",
     async run(context) {
-      if (!context.model || !context.provider || !context.sandboxGpuConfig) {
-        throw new Error("Onboarding state is incomplete before sandbox setup.");
-      }
+      assertProviderSelectedContext(context, "sandbox setup");
       const sandboxStateResult = await handleSandboxState({
         resume: context.resume,
         fresh: context.fresh,

--- a/src/lib/onboard/machine/final-flow-phases.ts
+++ b/src/lib/onboard/machine/final-flow-phases.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WebSearchConfig } from "../../inference/web-search";
-import type { OnboardFlowContext } from "./flow-context";
+import { assertSandboxCreatedContext, type OnboardFlowContext } from "./flow-context";
 import {
   createAgentSetupPhase,
   createFinalizationPhase,
@@ -38,15 +38,6 @@ export interface FinalOnboardFlowPhaseOptions<
   >["deps"];
 }
 
-function requireFinalContext<Context extends OnboardFlowContext>(
-  context: Context,
-  stepName: string,
-): asserts context is Context & { sandboxName: string; model: string; provider: string } {
-  if (!context.sandboxName || !context.model || !context.provider) {
-    throw new Error(`Onboarding state is incomplete before ${stepName}.`);
-  }
-}
-
 export function createFinalOnboardFlowPhases<
   Context extends OnboardFlowContext,
   VerifyChain = unknown,
@@ -57,7 +48,7 @@ export function createFinalOnboardFlowPhases<
   const createBranchPhase =
     options.branchState === "agent_setup" ? createAgentSetupPhase : createOpenclawSetupPhase;
   const branchSetupPhase = createBranchPhase<Context>(async (context) => {
-    requireFinalContext(context, "agent setup");
+    assertSandboxCreatedContext(context, "agent setup");
     const agentSetupResult = await handleAgentSetupState({
       agent: context.agent,
       sandboxName: context.sandboxName,
@@ -76,7 +67,7 @@ export function createFinalOnboardFlowPhases<
   });
 
   const policiesPhase = createPoliciesPhase<Context>(async (context) => {
-    requireFinalContext(context, "policies");
+    assertSandboxCreatedContext(context, "policies");
     const policiesResult = await handlePoliciesState({
       resume: context.resume,
       sandboxName: context.sandboxName,
@@ -101,7 +92,7 @@ export function createFinalOnboardFlowPhases<
   });
 
   const finalizationPhase = createFinalizationPhase<Context>(async (context) => {
-    requireFinalContext(context, "finalization");
+    assertSandboxCreatedContext(context, "finalization");
     const finalizationResult = await handleFinalizationState({
       sandboxName: context.sandboxName,
       model: context.model,

--- a/src/lib/onboard/machine/flow-context.test.ts
+++ b/src/lib/onboard/machine/flow-context.test.ts
@@ -4,12 +4,14 @@
 import { describe, expect, it } from "vitest";
 
 import { createSession } from "../../state/onboard-session";
-import { advanceTo } from "./result";
 import {
+  assertProviderSelectedContext,
+  assertSandboxCreatedContext,
   mergeOnboardFlowContext,
-  onboardFlowPhaseResult,
   type OnboardFlowContext,
+  onboardFlowPhaseResult,
 } from "./flow-context";
+import { advanceTo } from "./result";
 
 function baseContext(): OnboardFlowContext<null, { type: string }, { mode: string }> {
   return {
@@ -60,5 +62,42 @@ describe("onboard flow context helpers", () => {
 
     expect(result.context.provider).toBe("nvidia-prod");
     expect(result.result).toMatchObject({ next: "gateway", transitionKind: "advance" });
+  });
+
+  it("asserts provider-selected context before sandbox setup", () => {
+    const context = mergeOnboardFlowContext(baseContext(), {
+      provider: "nvidia-prod",
+      model: "model",
+    });
+
+    expect(() => assertProviderSelectedContext(context, "sandbox setup")).not.toThrow();
+  });
+
+  it("rejects missing provider-selected context fields", () => {
+    expect(() => assertProviderSelectedContext(baseContext(), "sandbox setup")).toThrow(
+      /Onboarding state is incomplete before sandbox setup\./,
+    );
+  });
+
+  it("asserts sandbox-created context before final phases", () => {
+    const context = mergeOnboardFlowContext(baseContext(), {
+      sandboxName: "my-assistant",
+      provider: "nvidia-prod",
+      model: "model",
+      sandboxGpuConfig: null,
+    });
+
+    expect(() => assertSandboxCreatedContext(context, "policies")).not.toThrow();
+  });
+
+  it("rejects missing sandbox name before final phases", () => {
+    const context = mergeOnboardFlowContext(baseContext(), {
+      provider: "nvidia-prod",
+      model: "model",
+    });
+
+    expect(() => assertSandboxCreatedContext(context, "policies")).toThrow(
+      /Onboarding state is incomplete before policies\./,
+    );
   });
 });

--- a/src/lib/onboard/machine/flow-context.ts
+++ b/src/lib/onboard/machine/flow-context.ts
@@ -30,9 +30,42 @@ export interface OnboardFlowContext<Agent = unknown, Gpu = unknown, SandboxGpuCo
   gpuPassthrough: boolean;
 }
 
+export type ProviderSelectedOnboardFlowContext<Context extends OnboardFlowContext> = Context & {
+  model: string;
+  provider: string;
+  sandboxGpuConfig: NonNullable<Context["sandboxGpuConfig"]>;
+};
+
+export type SandboxCreatedOnboardFlowContext<Context extends OnboardFlowContext> = Context & {
+  sandboxName: string;
+  model: string;
+  provider: string;
+};
+
+export type FinalOnboardFlowContext<Context extends OnboardFlowContext> =
+  SandboxCreatedOnboardFlowContext<Context>;
+
 export interface OnboardFlowPhaseResult<Context extends OnboardFlowContext = OnboardFlowContext> {
   context: Context;
   result: OnboardStateHandlerResult;
+}
+
+export function assertProviderSelectedContext<Context extends OnboardFlowContext>(
+  context: Context,
+  stepName: string,
+): asserts context is ProviderSelectedOnboardFlowContext<Context> {
+  if (!context.model || !context.provider || !context.sandboxGpuConfig) {
+    throw new Error(`Onboarding state is incomplete before ${stepName}.`);
+  }
+}
+
+export function assertSandboxCreatedContext<Context extends OnboardFlowContext>(
+  context: Context,
+  stepName: string,
+): asserts context is SandboxCreatedOnboardFlowContext<Context> {
+  if (!context.sandboxName || !context.model || !context.provider) {
+    throw new Error(`Onboarding state is incomplete before ${stepName}.`);
+  }
 }
 
 export function mergeOnboardFlowContext<Context extends OnboardFlowContext>(


### PR DESCRIPTION
## Summary
Add shared refined onboarding flow context types and assertion helpers for the first #5518 nullability cleanup. The core and final onboard phases now reuse those guards instead of carrying local ad hoc not-null checks.

## Related Issue
Refs #5518

## Changes
- Add `ProviderSelectedOnboardFlowContext`, `SandboxCreatedOnboardFlowContext`, and `FinalOnboardFlowContext` aliases in `src/lib/onboard/machine/flow-context.ts`.
- Add shared `assertProviderSelectedContext` and `assertSandboxCreatedContext` helpers to narrow phase context before dependent work runs.
- Replace local context completeness checks in core and final flow phases with the shared assertions.
- Add unit coverage for the new flow-context assertion helpers.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal onboarding validation logic to improve consistency and maintainability through centralized assertion helpers.

* **Tests**
  * Added comprehensive test coverage for onboarding milestone validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->