### PR TITLE
refactor(onboard): centralize flow context refinements

### DIFF
--- a/src/lib/onboard/machine/core-flow-phases.ts
+++ b/src/lib/onboard/machine/core-flow-phases.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WebSearchConfig } from "../../inference/web-search";
-import { assertProviderSelectedContext, type OnboardFlowContext } from "./flow-context";
+import {
+  assertProviderSelectedContext,
+  mergeProviderModelSelectedContext,
+  mergeSandboxCreatedContext,
+  type OnboardFlowContext,
+} from "./flow-context";
 import { runCoreOnboardFlowSequence } from "./flow-slices";
 import {
   handleProviderInferenceState,
@@ -75,8 +80,7 @@ export function createCoreOnboardFlowPhases<
       });
 
       return {
-        context: {
-          ...context,
+        context: mergeProviderModelSelectedContext(context, {
           session: providerInferenceResult.session,
           sandboxName: providerInferenceResult.sandboxName,
           model: providerInferenceResult.model,
@@ -88,7 +92,7 @@ export function createCoreOnboardFlowPhases<
           preferredInferenceApi: providerInferenceResult.preferredInferenceApi,
           nimContainer: providerInferenceResult.nimContainer,
           webSearchConfig: providerInferenceResult.webSearchConfig,
-        },
+        }),
         result: providerInferenceResult.stateResults,
       };
     },
@@ -121,14 +125,13 @@ export function createCoreOnboardFlowPhases<
       });
 
       return {
-        context: {
-          ...context,
+        context: mergeSandboxCreatedContext(context, {
           session: sandboxStateResult.session,
           sandboxName: sandboxStateResult.sandboxName,
-          webSearchConfig: sandboxStateResult.webSearchConfig ?? null,
+          webSearchConfig: sandboxStateResult.webSearchConfig,
           selectedMessagingChannels: sandboxStateResult.selectedMessagingChannels,
           webSearchSupported: sandboxStateResult.webSearchSupported,
-        },
+        }),
         result: sandboxStateResult.stateResult,
       };
     },

--- a/src/lib/onboard/machine/flow-context.test.ts
+++ b/src/lib/onboard/machine/flow-context.test.ts
@@ -8,6 +8,8 @@ import {
   assertProviderSelectedContext,
   assertSandboxCreatedContext,
   mergeOnboardFlowContext,
+  mergeProviderModelSelectedContext,
+  mergeSandboxCreatedContext,
   type OnboardFlowContext,
   onboardFlowPhaseResult,
 } from "./flow-context";
@@ -64,6 +66,29 @@ describe("onboard flow context helpers", () => {
     expect(result.result).toMatchObject({ next: "gateway", transitionKind: "advance" });
   });
 
+  it("merges provider/model-selected context updates", () => {
+    const context = mergeProviderModelSelectedContext(baseContext(), {
+      session: createSession(),
+      sandboxName: "my-assistant",
+      provider: "nvidia-prod",
+      model: "model",
+      endpointUrl: "https://example.test/v1",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      hermesAuthMethod: null,
+      hermesToolGateways: [],
+      preferredInferenceApi: "openai-responses",
+      nimContainer: null,
+      webSearchConfig: null,
+    });
+
+    expect(context).toMatchObject({
+      sandboxName: "my-assistant",
+      provider: "nvidia-prod",
+      model: "model",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+    });
+  });
+
   it("asserts provider-selected context before sandbox setup", () => {
     const context = mergeOnboardFlowContext(baseContext(), {
       provider: "nvidia-prod",
@@ -77,6 +102,35 @@ describe("onboard flow context helpers", () => {
     expect(() => assertProviderSelectedContext(baseContext(), "sandbox setup")).toThrow(
       /Onboarding state is incomplete before sandbox setup\./,
     );
+  });
+
+  it("merges sandbox-created context updates", () => {
+    const providerContext = mergeProviderModelSelectedContext(baseContext(), {
+      session: createSession(),
+      sandboxName: null,
+      provider: "nvidia-prod",
+      model: "model",
+      endpointUrl: null,
+      credentialEnv: null,
+      hermesAuthMethod: null,
+      hermesToolGateways: [],
+      preferredInferenceApi: null,
+      nimContainer: null,
+      webSearchConfig: null,
+    });
+    const context = mergeSandboxCreatedContext(providerContext, {
+      session: createSession(),
+      sandboxName: "my-assistant",
+      webSearchConfig: null,
+      selectedMessagingChannels: ["telegram"],
+      webSearchSupported: true,
+    });
+
+    expect(context).toMatchObject({
+      sandboxName: "my-assistant",
+      selectedMessagingChannels: ["telegram"],
+      webSearchSupported: true,
+    });
   });
 
   it("asserts sandbox-created context before final phases", () => {

--- a/src/lib/onboard/machine/flow-context.ts
+++ b/src/lib/onboard/machine/flow-context.ts
@@ -30,11 +30,16 @@ export interface OnboardFlowContext<Agent = unknown, Gpu = unknown, SandboxGpuCo
   gpuPassthrough: boolean;
 }
 
-export type ProviderSelectedOnboardFlowContext<Context extends OnboardFlowContext> = Context & {
-  model: string;
-  provider: string;
-  sandboxGpuConfig: NonNullable<Context["sandboxGpuConfig"]>;
-};
+export type ProviderModelSelectedOnboardFlowContext<Context extends OnboardFlowContext> =
+  Context & {
+    model: string;
+    provider: string;
+  };
+
+export type ProviderSelectedOnboardFlowContext<Context extends OnboardFlowContext> =
+  ProviderModelSelectedOnboardFlowContext<Context> & {
+    sandboxGpuConfig: NonNullable<Context["sandboxGpuConfig"]>;
+  };
 
 export type SandboxCreatedOnboardFlowContext<Context extends OnboardFlowContext> = Context & {
   sandboxName: string;
@@ -48,6 +53,28 @@ export type FinalOnboardFlowContext<Context extends OnboardFlowContext> =
 export interface OnboardFlowPhaseResult<Context extends OnboardFlowContext = OnboardFlowContext> {
   context: Context;
   result: OnboardStateHandlerResult;
+}
+
+export interface ProviderModelSelectedContextUpdate {
+  session: Session | null;
+  sandboxName: string | null;
+  model: string;
+  provider: string;
+  endpointUrl: string | null;
+  credentialEnv: string | null;
+  hermesAuthMethod: string | null;
+  hermesToolGateways: string[];
+  preferredInferenceApi: string | null;
+  nimContainer: string | null;
+  webSearchConfig: WebSearchConfig | null;
+}
+
+export interface SandboxCreatedContextUpdate {
+  session: Session | null;
+  sandboxName: string;
+  webSearchConfig: WebSearchConfig | null;
+  selectedMessagingChannels: string[];
+  webSearchSupported: boolean;
 }
 
 export function assertProviderSelectedContext<Context extends OnboardFlowContext>(
@@ -72,6 +99,20 @@ export function mergeOnboardFlowContext<Context extends OnboardFlowContext>(
   context: Context,
   patch: Partial<Context>,
 ): Context {
+  return { ...context, ...patch };
+}
+
+export function mergeProviderModelSelectedContext<Context extends OnboardFlowContext>(
+  context: Context,
+  patch: ProviderModelSelectedContextUpdate,
+): ProviderModelSelectedOnboardFlowContext<Context> {
+  return { ...context, ...patch };
+}
+
+export function mergeSandboxCreatedContext<Context extends OnboardFlowContext>(
+  context: ProviderModelSelectedOnboardFlowContext<Context>,
+  patch: SandboxCreatedContextUpdate,
+): SandboxCreatedOnboardFlowContext<Context> {
   return { ...context, ...patch };
 }
 


### PR DESCRIPTION
## Summary
Continue the #5518 onboarding nullability series by centralizing how core onboarding phases refine flow context after provider selection and sandbox creation. The provider and sandbox phases now use typed merge helpers instead of hand-built spread objects, so provider/model and sandbox-created state are captured as explicit refined context shapes.

## Related Issue
Refs #5518

## Changes
- Add `ProviderModelSelectedOnboardFlowContext` plus typed update shapes for provider/model-selected and sandbox-created context updates.
- Add `mergeProviderModelSelectedContext` and `mergeSandboxCreatedContext` helpers in `src/lib/onboard/machine/flow-context.ts`.
- Use the helpers in `src/lib/onboard/machine/core-flow-phases.ts` to build provider and sandbox phase context updates.
- Add unit coverage for the new context merge helpers.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved the onboarding flow's context management with specialized merge helpers for provider selection and sandbox configuration, enhancing code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for the new context merge helpers used during onboarding phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->