### PR TITLE
refactor(onboard): make session null updates explicit

### DIFF
--- a/src/lib/state/onboard-session.test.ts
+++ b/src/lib/state/onboard-session.test.ts
@@ -16,11 +16,28 @@ type OnboardMachineEventsModule = typeof import("../../../dist/lib/onboard/machi
 type OnboardMachineEvent = import("../../../dist/lib/onboard/machine/events").OnboardMachineEvent;
 type LoadedSession = NonNullable<ReturnType<OnboardSessionModule["loadSession"]>>;
 type DebugSummary = NonNullable<ReturnType<OnboardSessionModule["summarizeForDebug"]>>;
+type NullableSessionUpdateKey =
+  import("../../../dist/lib/state/onboard-session").NullableSessionUpdateKey;
 type MessagingPlan = NonNullable<LoadedSession["messagingPlan"]>;
 type MessagingChannelId = MessagingPlan["channels"][number]["channelId"];
 let session: OnboardSessionModule;
 let machineEvents: OnboardMachineEventsModule;
 let tmpDir: string;
+
+const _nullableSessionUpdateKeyAcceptsNullableFields: Record<
+  Extract<"model" | "credentialEnv" | "webSearchConfig", NullableSessionUpdateKey>,
+  true
+> = {
+  model: true,
+  credentialEnv: true,
+  webSearchConfig: true,
+};
+const _nullableSessionUpdateKeyRejectsNonNullableFields: Record<
+  Extract<"status" | "gpuPassthrough" | "metadata", NullableSessionUpdateKey>,
+  never
+> = {};
+void _nullableSessionUpdateKeyAcceptsNullableFields;
+void _nullableSessionUpdateKeyRejectsNonNullableFields;
 
 function requireLoadedSession(
   loaded: ReturnType<OnboardSessionModule["loadSession"]>,

--- a/src/lib/state/onboard-session.test.ts
+++ b/src/lib/state/onboard-session.test.ts
@@ -515,6 +515,49 @@ describe("onboard session", () => {
     expect(loaded.hermesAuthMethod).toBeNull();
   });
 
+  it("classifies nullable string update intent explicitly", () => {
+    const unchanged = session.getNullableStringUpdateIntent(undefined);
+    const malformed = session.getNullableStringUpdateIntent(42);
+    const clear = session.getNullableStringUpdateIntent(null);
+    const normalizedClear = session.getNullableStringUpdateIntent(
+      "https://secret.example",
+      () => null,
+    );
+    const set = session.getNullableStringUpdateIntent("model");
+
+    expect(unchanged).toEqual({ kind: "unchanged" });
+    expect(malformed).toEqual({ kind: "unchanged" });
+    expect(clear).toEqual({ kind: "clear" });
+    expect(normalizedClear).toEqual({ kind: "clear" });
+    expect(set).toEqual({ kind: "set", value: "model" });
+    expect(session.hasSessionUpdateValue(unchanged)).toBe(false);
+    expect(session.hasSessionUpdateValue(clear)).toBe(true);
+    expect(session.isSessionUpdateClear(clear)).toBe(true);
+    expect(session.isSessionUpdateClear(set)).toBe(false);
+  });
+
+  it("applies nullable session update intent to safe updates", () => {
+    const safe: Partial<LoadedSession> = {};
+
+    session.applyNullableSessionUpdate(
+      safe,
+      "model",
+      session.getNullableStringUpdateIntent("model-a"),
+    );
+    session.applyNullableSessionUpdate(
+      safe,
+      "credentialEnv",
+      session.getNullableStringUpdateIntent(null),
+    );
+    session.applyNullableSessionUpdate(
+      safe,
+      "provider",
+      session.getNullableStringUpdateIntent(undefined),
+    );
+
+    expect(safe).toEqual({ model: "model-a", credentialEnv: null });
+  });
+
   it("accepts null as an explicit clear for every nullable string field", () => {
     // All six nullable fields that travel through filterSafeUpdates must
     // support the null-clear contract. If any regresses to the old

--- a/src/lib/state/onboard-session.ts
+++ b/src/lib/state/onboard-session.ts
@@ -868,6 +868,14 @@ export type NullableSessionUpdateIntent<T> =
   | { kind: "clear" }
   | { kind: "set"; value: T };
 
+export type NullableSessionUpdateKey = {
+  [K in keyof Session]-?: null extends Session[K] ? K : never;
+}[keyof Session];
+
+type NullableStringSessionUpdateKey = {
+  [K in NullableSessionUpdateKey]-?: NonNullable<Session[K]> extends string ? K : never;
+}[NullableSessionUpdateKey];
+
 function sessionUpdateUnchanged<T>(): NullableSessionUpdateIntent<T> {
   return { kind: "unchanged" };
 }
@@ -900,7 +908,7 @@ export function isSessionUpdateClear<T>(intent: NullableSessionUpdateIntent<T>):
   return intent.kind === "clear";
 }
 
-export function applyNullableSessionUpdate<K extends keyof Session>(
+export function applyNullableSessionUpdate<K extends NullableSessionUpdateKey>(
   safe: Partial<Session>,
   key: K,
   intent: NullableSessionUpdateIntent<NonNullable<Session[K]>>,
@@ -924,7 +932,7 @@ export function applyNullableSessionUpdate<K extends keyof Session>(
 // (credentialEnv=null) silently dropped the clear and left the stale value
 // on disk. The rebuild preflight then demanded a credential the current
 // sandbox does not actually need.
-function assignNullableString<K extends keyof Session>(
+function assignNullableString<K extends NullableStringSessionUpdateKey>(
   safe: Partial<Session>,
   key: K,
   value: unknown,

--- a/src/lib/state/onboard-session.ts
+++ b/src/lib/state/onboard-session.ts
@@ -863,6 +863,56 @@ export function releaseOnboardLock(): void {
 
 // ── Step management ──────────────────────────────────────────────
 
+export type NullableSessionUpdateIntent<T> =
+  | { kind: "unchanged" }
+  | { kind: "clear" }
+  | { kind: "set"; value: T };
+
+function sessionUpdateUnchanged<T>(): NullableSessionUpdateIntent<T> {
+  return { kind: "unchanged" };
+}
+
+function sessionUpdateClear<T>(): NullableSessionUpdateIntent<T> {
+  return { kind: "clear" };
+}
+
+function sessionUpdateSet<T>(value: T): NullableSessionUpdateIntent<T> {
+  return { kind: "set", value };
+}
+
+export function getNullableStringUpdateIntent(
+  value: unknown,
+  normalize?: (v: string) => string | null,
+): NullableSessionUpdateIntent<string> {
+  if (value === undefined) return sessionUpdateUnchanged();
+  if (value === null) return sessionUpdateClear();
+  if (typeof value !== "string") return sessionUpdateUnchanged();
+
+  const normalized = normalize ? normalize(value) : value;
+  return normalized === null ? sessionUpdateClear() : sessionUpdateSet(normalized);
+}
+
+export function hasSessionUpdateValue<T>(intent: NullableSessionUpdateIntent<T>): boolean {
+  return intent.kind !== "unchanged";
+}
+
+export function isSessionUpdateClear<T>(intent: NullableSessionUpdateIntent<T>): boolean {
+  return intent.kind === "clear";
+}
+
+export function applyNullableSessionUpdate<K extends keyof Session>(
+  safe: Partial<Session>,
+  key: K,
+  intent: NullableSessionUpdateIntent<NonNullable<Session[K]>>,
+): void {
+  if (intent.kind === "unchanged") return;
+  if (intent.kind === "clear") {
+    (safe as Record<K, Session[K] | null>)[key] = null as Session[K] & null;
+    return;
+  }
+  (safe as Record<K, Session[K]>)[key] = intent.value as Session[K];
+}
+
 // Apply an explicit-clear-aware update for a nullable session field.
 //
 //   value === "string"  → assign (after optional normalizer)
@@ -880,21 +930,13 @@ function assignNullableString<K extends keyof Session>(
   value: unknown,
   normalize?: (v: string) => string | null,
 ): void {
-  if (value === undefined) return;
-  if (value === null) {
-    (safe as Record<K, Session[K] | null>)[key] = null as Session[K] & null;
-    return;
-  }
-  if (typeof value === "string") {
-    const normalized = normalize ? normalize(value) : value;
-    if (normalized === null) {
-      // A normalizer that returned null means the input was unredactable;
-      // treat the same as an explicit clear rather than dropping silently.
-      (safe as Record<K, Session[K] | null>)[key] = null as Session[K] & null;
-      return;
-    }
-    (safe as Record<K, Session[K]>)[key] = normalized as Session[K];
-  }
+  applyNullableSessionUpdate(
+    safe,
+    key,
+    getNullableStringUpdateIntent(value, normalize) as NullableSessionUpdateIntent<
+      NonNullable<Session[K]>
+    >,
+  );
   // Non-string, non-null, non-undefined values are silently dropped —
   // matches the pre-#2625 behavior for malformed input (e.g. numbers via
   // JSON re-entry).


### PR DESCRIPTION
## Summary
Continue the #5518 nullability cleanup by making onboard session update null semantics explicit. Nullable string session fields now pass through a small update-intent model, preserving the existing `undefined` means unchanged and `null` means clear contract while making that behavior testable and reusable.

## Related Issue
Refs #5518

## Changes
- Add `NullableSessionUpdateIntent` with `unchanged`, `clear`, and `set` states.
- Add helpers to classify nullable string updates and apply nullable session updates.
- Route nullable string filtering in `filterSafeUpdates` through the explicit intent helpers.
- Add tests for update intent classification, clear detection, and safe update application.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added compile-time type assertions and strengthened runtime checks for nullable session field update behavior, including handling of unchanged values, explicit clears (including normalized-to-null cases), and explicit sets.

* **Refactor**
  * Introduced an intent-based mechanism for updating nullable session fields during persistence preparation, replacing prior branching logic while preserving existing behaviors for `undefined` (unchanged) and `null`-driven clears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->