### PR TITLE
Reject redirect-following curl probe flags

### DIFF
--- a/src/lib/adapters/http/curl-args.ts
+++ b/src/lib/adapters/http/curl-args.ts
@@ -41,12 +41,9 @@ const CURL_SAFE_FLAG_OPTIONS = new Set([
   "-sS",
   "-sf",
   "-f",
-  "-L",
-  "-sfL",
   "--fail",
   "--silent",
   "--show-error",
-  "--location",
   "--compressed",
   "--get",
 ]);

--- a/src/lib/adapters/http/probe.test.ts
+++ b/src/lib/adapters/http/probe.test.ts
@@ -222,6 +222,24 @@ describe("http-probe helpers", () => {
     expect(result.message).toContain("curl probe URL must use http or https");
   });
 
+  it.each([
+    ["-L", ["-L"]],
+    ["-sfL", ["-sfL"]],
+    ["--location", ["--location"]],
+  ])("rejects redirect-following curl option %s before spawning", (_label, args) => {
+    let spawned = false;
+    const result = runCurlProbe(["-sS", ...args, "https://example.test/models"], {
+      spawnSyncImpl: () => {
+        spawned = true;
+        throw new Error("should not spawn");
+      },
+    });
+
+    expect(spawned).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("curl probe option is not allowed");
+  });
+
   it("rejects curl probe request bodies that read from local files", () => {
     let spawned = false;
     const result = runCurlProbe(

--- a/src/lib/inference/ollama/model-size.test.ts
+++ b/src/lib/inference/ollama/model-size.test.ts
@@ -63,6 +63,8 @@ describe("probeRegistrySize", () => {
     probeRegistrySize("qwen3.5:9b", recorder.capture);
     const [argv] = recorder.calls;
     expect(argv[0]).toBe("curl");
+    expect(argv).toContain("-sf");
+    expect(argv).not.toContain("-sfL");
     expect(argv[argv.length - 1]).toBe(
       "https://registry.ollama.ai/v2/library/qwen3.5/manifests/9b",
     );

--- a/src/lib/inference/ollama/model-size.ts
+++ b/src/lib/inference/ollama/model-size.ts
@@ -45,7 +45,7 @@ export function probeRegistrySize(model: string, capture: CaptureFn = runCapture
     [
       "curl",
       ...buildValidatedCurlCommandArgs([
-        "-sfL",
+        "-sf",
         "--max-time",
         String(PROBE_TIMEOUT_SECONDS),
         "-H",


### PR DESCRIPTION
## Summary
- remove `-L`, `-sfL`, and `--location` from the shared curl probe allowlist
- stop the Ollama registry size probe from depending on `-sfL`
- add regression coverage that redirect-following flags are rejected before curl is spawned

## Why
The curl probe validator normalizes the initial URL, then lets curl execute the rebuilt argv. Allowing redirect-following flags means a URL that starts public can still be followed to loopback, link-local, or another private/internal target outside the validator's view. Default-denying redirects keeps the existing SSRF boundary honest until a redirect-aware validator exists.

## Validation
- `npm run build:cli`
- `./node_modules/.bin/vitest run src/lib/adapters/http/probe.test.ts src/lib/inference/ollama/model-size.test.ts`
- `npm run typecheck:cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated HTTP probing and Docker manifest fetching to disable redirect-following in curl operations.

* **Tests**
  * Added validation tests to ensure redirect-following curl options are properly rejected.
  * Enhanced test coverage for manifest probing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->