### PR TITLE
Fail closed on corrupt config JSON

### DIFF
--- a/src/lib/state/config-io.test.ts
+++ b/src/lib/state/config-io.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  ConfigCorruptError,
   ConfigPermissionError,
   ensureConfigDir,
   readConfigFile,
@@ -24,6 +25,17 @@ function makeTempDir(): string {
 function writeFileWithMode(filePath: string, contents: string, mode: number) {
   fs.writeFileSync(filePath, contents, { mode });
   fs.chmodSync(filePath, mode);
+}
+
+function readCorruptConfig<T>(filePath: string, fallback: T): ConfigCorruptError {
+  let thrown: unknown;
+  try {
+    readConfigFile(filePath, fallback);
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(ConfigCorruptError);
+  return thrown as ConfigCorruptError;
 }
 
 afterEach(() => {
@@ -92,11 +104,33 @@ describe("config-io", () => {
     expect(readConfigFile(file, { ok: true })).toEqual({ ok: true });
   });
 
-  it("returns the fallback when the config file is malformed", () => {
+  it("moves malformed JSON aside and fails with repair guidance", () => {
     const dir = makeTempDir();
     const file = path.join(dir, "config.json");
     fs.writeFileSync(file, "{not-json");
-    expect(readConfigFile(file, { ok: true })).toEqual({ ok: true });
+
+    const error = readCorruptConfig(file, { ok: true });
+
+    expect(error.message).toContain("Corrupt config file");
+    expect(error.message).toContain("falling back to defaults");
+    expect(error.corruptPath).toMatch(/config\.json\.corrupt\.\d{4}-\d{2}-\d{2}T/);
+    expect(fs.existsSync(file)).toBe(false);
+    expect(fs.readFileSync(error.corruptPath!, "utf8")).toBe("{not-json");
+  });
+
+  it("rethrows non-ENOENT read errors instead of returning the fallback", () => {
+    const dir = makeTempDir();
+    const file = path.join(dir, "config.json");
+    const originalRead = fs.readFileSync;
+    fs.readFileSync = () => {
+      throw Object.assign(new Error("storage unavailable"), { code: "EIO" });
+    };
+
+    try {
+      expect(() => readConfigFile(file, { ok: true })).toThrow("storage unavailable");
+    } finally {
+      fs.readFileSync = originalRead;
+    }
   });
 
   it("writes and reads JSON atomically", () => {
@@ -312,6 +346,26 @@ describe("config-io", () => {
       readConfigFile(target, null);
 
       expect(fs.statSync(sibling).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("does not return an empty sandbox registry fallback when sandboxes.json is corrupt", () => {
+    const fakeHome = makeTempDir();
+    withHome(fakeHome, () => {
+      const hostDir = path.join(fakeHome, ".nemoclaw");
+      fs.mkdirSync(hostDir, { mode: 0o700 });
+      const target = path.join(hostDir, "sandboxes.json");
+      fs.writeFileSync(target, '{"sandboxes":');
+
+      const error = readCorruptConfig(target, { sandboxes: {}, defaultSandbox: null });
+
+      expect(error.message).toContain("sandboxes.json");
+      expect(fs.existsSync(target)).toBe(false);
+      const corruptName = fs.readdirSync(hostDir).find((name) => {
+        return /^sandboxes\.json\.corrupt\.\d{4}-\d{2}-\d{2}T/.test(name);
+      });
+      expect(corruptName).toBeDefined();
+      expect(fs.readFileSync(path.join(hostDir, corruptName!), "utf8")).toBe('{"sandboxes":');
     });
   });
 

--- a/src/lib/state/config-io.ts
+++ b/src/lib/state/config-io.ts
@@ -43,7 +43,7 @@ function isMutableSandboxConfigPath(targetPath: string): boolean {
   );
 }
 
-function toError(error: Error | string | number | boolean | null | undefined): Error {
+function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
@@ -89,6 +89,51 @@ function buildRemediation(): string {
   ].join("\n");
 }
 
+function corruptConfigPath(filePath: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `${filePath}.corrupt.${timestamp}`;
+}
+
+function moveCorruptConfigFile(filePath: string): string {
+  const targetPath = corruptConfigPath(filePath);
+  fs.renameSync(filePath, targetPath);
+  return targetPath;
+}
+
+function buildCorruptRemediation(
+  filePath: string,
+  corruptPath: string | null,
+  moveError?: Error,
+): string {
+  const lines = [
+    "  NemoClaw stopped instead of falling back to defaults because this file is not valid JSON.",
+  ];
+
+  if (corruptPath) {
+    lines.push(
+      "",
+      "  The corrupt file was moved aside:",
+      `    ${corruptPath}`,
+      "",
+      "  Inspect the moved file, repair the JSON, then move it back if you want to keep the state:",
+      `    mv ${shellQuote(corruptPath)} ${shellQuote(filePath)}`,
+      "",
+      "  Remove the moved file only if you intentionally want to start with fresh defaults.",
+    );
+  } else {
+    lines.push(
+      "",
+      "  NemoClaw could not move the corrupt file aside automatically.",
+      `  Repair or move this file manually before retrying: ${filePath}`,
+    );
+    if (moveError) {
+      lines.push(`  Move failure: ${moveError.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
 export class ConfigPermissionError extends Error {
   code = "EACCES";
   configPath: string;
@@ -121,6 +166,27 @@ export class ConfigPermissionError extends Error {
     if (cause) {
       this.cause = cause;
     }
+  }
+}
+
+export class ConfigCorruptError extends Error {
+  code = "ECONFIGCORRUPT";
+  configPath: string;
+  filePath: string;
+  corruptPath: string | null;
+  remediation: string;
+  moveError?: Error;
+
+  constructor(filePath: string, corruptPath: string | null, cause: Error, moveError?: Error) {
+    const remediation = buildCorruptRemediation(filePath, corruptPath, moveError);
+    super(`Corrupt config file: ${filePath}\n\n${remediation}`);
+    this.name = "ConfigCorruptError";
+    this.configPath = filePath;
+    this.filePath = filePath;
+    this.corruptPath = corruptPath;
+    this.remediation = remediation;
+    this.cause = cause;
+    this.moveError = moveError;
   }
 }
 
@@ -266,31 +332,12 @@ export function readConfigFile<T>(filePath: string, fallback: T): T {
     if (error instanceof ConfigPermissionError) {
       throw error;
     }
-    // Directory doesn't exist and can't be created — fall through to let
-    // readFileSync produce the appropriate ENOENT / fallback path.
+    throw error;
   }
 
+  let rawContent: string;
   try {
-    const content = parseJson<T>(fs.readFileSync(filePath, "utf-8"));
-
-    // Heal file-level permission drift: tighten group/world bits. lstat
-    // (not stat) so we don't chmod through a symlink to a target outside
-    // the config dir. Skip mutable-sandbox OpenClaw config paths so a
-    // future caller reading openclaw.json doesn't accidentally tighten
-    // its 660 contract (#4538). Defensive duplicate of healRootLevelFiles
-    // for read paths whose dirname differs from what ensureConfigDir saw.
-    try {
-      if (!isMutableSandboxConfigPath(filePath)) {
-        const st = fs.lstatSync(filePath);
-        if (st.isFile() && (st.mode & 0o077) !== 0) {
-          fs.chmodSync(filePath, 0o600);
-        }
-      }
-    } catch {
-      // Best effort — don't fail the read if we can't heal permissions.
-    }
-
-    return content;
+    rawContent = fs.readFileSync(filePath, "utf-8");
   } catch (error) {
     const errnoError = error instanceof Error ? error : null;
     if (isPermissionError(errnoError)) {
@@ -303,8 +350,44 @@ export function readConfigFile<T>(filePath: string, fallback: T): T {
     if (isErrnoException(errnoError) && errnoError.code === "ENOENT") {
       return fallback;
     }
-    return fallback;
+    throw error;
   }
+
+  let content: T;
+  try {
+    content = parseJson<T>(rawContent);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      let corruptPath: string | null = null;
+      let moveError: Error | undefined;
+      try {
+        corruptPath = moveCorruptConfigFile(filePath);
+      } catch (moveFailure) {
+        moveError = toError(moveFailure);
+      }
+      throw new ConfigCorruptError(filePath, corruptPath, toError(error), moveError);
+    }
+    throw error;
+  }
+
+  // Heal file-level permission drift: tighten group/world bits. lstat
+  // (not stat) so we don't chmod through a symlink to a target outside
+  // the config dir. Skip mutable-sandbox OpenClaw config paths so a
+  // future caller reading openclaw.json doesn't accidentally tighten
+  // its 660 contract (#4538). Defensive duplicate of healRootLevelFiles
+  // for read paths whose dirname differs from what ensureConfigDir saw.
+  try {
+    if (!isMutableSandboxConfigPath(filePath)) {
+      const st = fs.lstatSync(filePath);
+      if (st.isFile() && (st.mode & 0o077) !== 0) {
+        fs.chmodSync(filePath, 0o600);
+      }
+    }
+  } catch {
+    // Best effort — don't fail the read if we can't heal permissions.
+  }
+
+  return content;
 }
 
 export function writeConfigFile(filePath: string, data: SerializableConfig): void {


### PR DESCRIPTION
## Summary
- fail closed when readConfigFile sees malformed JSON instead of returning fallback state
- move corrupt JSON to *.corrupt.<timestamp> before showing repair guidance
- keep first-run ENOENT fallback behavior and cover generic config plus sandboxes.json

## Why
A corrupt sandboxes.json could previously look like an empty registry. That hides state damage and can make later workflows behave as if no sandboxes exist.

## Validation
- npm run build:cli
- ./node_modules/.bin/vitest run src/lib/state/config-io.test.ts
- npm run typecheck:cli
- ./node_modules/.bin/biome format src/lib/state/config-io.ts src/lib/state/config-io.test.ts
- ./node_modules/.bin/biome lint src/lib/state/config-io.ts src/lib/state/config-io.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrupt config files are now automatically backed up with timestamps and generate helpful repair instructions
  * Non-permission file read errors now throw explicit errors with guidance instead of silently falling back to defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->