### PR TITLE
refactor(registry): add normalized sandbox entry views

### DIFF
--- a/src/lib/state/registry-entry-view.ts
+++ b/src/lib/state/registry-entry-view.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SandboxEntry } from "./registry";
+
+export type SandboxEntryInference =
+  | { kind: "configured"; provider: string; model: string }
+  | { kind: "unconfigured" };
+
+export type SandboxGatewayBinding =
+  | { kind: "registered"; gatewayName: string; gatewayPort: number }
+  | { kind: "missing" };
+
+export interface NormalizedSandboxEntry {
+  name: string;
+  raw: SandboxEntry;
+  inference: SandboxEntryInference;
+  gateway: SandboxGatewayBinding;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isValidTcpPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+export function getSandboxEntryInference(entry: SandboxEntry): SandboxEntryInference {
+  return isNonEmptyString(entry.provider) && isNonEmptyString(entry.model)
+    ? { kind: "configured", provider: entry.provider, model: entry.model }
+    : { kind: "unconfigured" };
+}
+
+export function getSandboxEntryGatewayBinding(entry: SandboxEntry): SandboxGatewayBinding {
+  return isNonEmptyString(entry.gatewayName) && isValidTcpPort(entry.gatewayPort)
+    ? { kind: "registered", gatewayName: entry.gatewayName, gatewayPort: entry.gatewayPort }
+    : { kind: "missing" };
+}
+
+export function normalizeSandboxEntryView(entry: SandboxEntry): NormalizedSandboxEntry {
+  return {
+    name: entry.name,
+    raw: entry,
+    inference: getSandboxEntryInference(entry),
+    gateway: getSandboxEntryGatewayBinding(entry),
+  };
+}

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -6,6 +6,16 @@ import path from "node:path";
 import { isErrnoException } from "../core/errno";
 import { ensureConfigDir, readConfigFile, writeConfigFile } from "./config-io";
 import type { SandboxMessagingState } from "./registry-messaging";
+
+export {
+  getSandboxEntryGatewayBinding,
+  getSandboxEntryInference,
+  type NormalizedSandboxEntry,
+  normalizeSandboxEntryView,
+  type SandboxEntryInference,
+  type SandboxGatewayBinding,
+} from "./registry-entry-view";
+
 import {
   cloneSandboxMessagingState,
   getConfiguredMessagingChannels as getRegistryConfiguredMessagingChannels,
@@ -97,48 +107,9 @@ export interface SandboxEntry {
   gatewayPort?: number | null;
 }
 
-export type SandboxEntryInference =
-  | { kind: "configured"; provider: string; model: string }
-  | { kind: "unconfigured" };
-
-export type SandboxGatewayBinding =
-  | { kind: "registered"; gatewayName: string; gatewayPort: number }
-  | { kind: "missing" };
-
-export interface NormalizedSandboxEntry {
-  name: string;
-  raw: SandboxEntry;
-  inference: SandboxEntryInference;
-  gateway: SandboxGatewayBinding;
-}
-
 export interface SandboxRegistry {
   sandboxes: Record<string, SandboxEntry>;
   defaultSandbox: string | null;
-}
-
-export function getSandboxEntryInference(entry: SandboxEntry): SandboxEntryInference {
-  return typeof entry.provider === "string" && typeof entry.model === "string"
-    ? { kind: "configured", provider: entry.provider, model: entry.model }
-    : { kind: "unconfigured" };
-}
-
-export function getSandboxEntryGatewayBinding(entry: SandboxEntry): SandboxGatewayBinding {
-  return typeof entry.gatewayName === "string" &&
-    typeof entry.gatewayPort === "number" &&
-    Number.isInteger(entry.gatewayPort) &&
-    entry.gatewayPort > 0
-    ? { kind: "registered", gatewayName: entry.gatewayName, gatewayPort: entry.gatewayPort }
-    : { kind: "missing" };
-}
-
-export function normalizeSandboxEntryView(entry: SandboxEntry): NormalizedSandboxEntry {
-  return {
-    name: entry.name,
-    raw: entry,
-    inference: getSandboxEntryInference(entry),
-    gateway: getSandboxEntryGatewayBinding(entry),
-  };
 }
 
 export const REGISTRY_FILE = path.join(process.env.HOME || "/tmp", ".nemoclaw", "sandboxes.json");

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -5,14 +5,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { isErrnoException } from "../core/errno";
 import { ensureConfigDir, readConfigFile, writeConfigFile } from "./config-io";
+import type { SandboxMessagingState } from "./registry-messaging";
 import {
   cloneSandboxMessagingState,
-  serializeSandboxMessagingStateForDisk,
   getConfiguredMessagingChannels as getRegistryConfiguredMessagingChannels,
   getDisabledChannels as getRegistryDisabledChannels,
+  serializeSandboxMessagingStateForDisk,
   setChannelDisabled as setRegistryChannelDisabled,
 } from "./registry-messaging";
-import type { SandboxMessagingState } from "./registry-messaging";
+
 export {
   getActiveMessagingChannelsFromEntry,
   getConfiguredMessagingChannelsFromEntry,
@@ -96,9 +97,48 @@ export interface SandboxEntry {
   gatewayPort?: number | null;
 }
 
+export type SandboxEntryInference =
+  | { kind: "configured"; provider: string; model: string }
+  | { kind: "unconfigured" };
+
+export type SandboxGatewayBinding =
+  | { kind: "registered"; gatewayName: string; gatewayPort: number }
+  | { kind: "missing" };
+
+export interface NormalizedSandboxEntry {
+  name: string;
+  raw: SandboxEntry;
+  inference: SandboxEntryInference;
+  gateway: SandboxGatewayBinding;
+}
+
 export interface SandboxRegistry {
   sandboxes: Record<string, SandboxEntry>;
   defaultSandbox: string | null;
+}
+
+export function getSandboxEntryInference(entry: SandboxEntry): SandboxEntryInference {
+  return typeof entry.provider === "string" && typeof entry.model === "string"
+    ? { kind: "configured", provider: entry.provider, model: entry.model }
+    : { kind: "unconfigured" };
+}
+
+export function getSandboxEntryGatewayBinding(entry: SandboxEntry): SandboxGatewayBinding {
+  return typeof entry.gatewayName === "string" &&
+    typeof entry.gatewayPort === "number" &&
+    Number.isInteger(entry.gatewayPort) &&
+    entry.gatewayPort > 0
+    ? { kind: "registered", gatewayName: entry.gatewayName, gatewayPort: entry.gatewayPort }
+    : { kind: "missing" };
+}
+
+export function normalizeSandboxEntryView(entry: SandboxEntry): NormalizedSandboxEntry {
+  return {
+    name: entry.name,
+    raw: entry,
+    inference: getSandboxEntryInference(entry),
+    gateway: getSandboxEntryGatewayBinding(entry),
+  };
 }
 
 export const REGISTRY_FILE = path.join(process.env.HOME || "/tmp", ".nemoclaw", "sandboxes.json");
@@ -319,7 +359,10 @@ function normalizeRegistry(data: SandboxRegistry): SandboxRegistry {
   return {
     defaultSandbox: data.defaultSandbox ?? null,
     sandboxes: Object.fromEntries(
-      sandboxRegistryEntries(data).map(([name, entry]) => [name, normalizeSandboxEntry(entry)]),
+      sandboxRegistryEntries(data).map(([name, entry]) => [
+        name,
+        normalizeSandboxEntryForRuntime(entry),
+      ]),
     ),
   };
 }
@@ -351,7 +394,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function normalizeSandboxEntry(entry: SandboxEntry): SandboxEntry {
+function normalizeSandboxEntryForRuntime(entry: SandboxEntry): SandboxEntry {
   const messaging = cloneSandboxMessagingState(entry.messaging);
   if (!messaging) {
     const { messaging: _messaging, ...rest } = entry;

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -108,6 +108,8 @@ describe("registry", () => {
     const configured = { name: "alpha", provider: "nvidia-prod", model: "nvidia/test" };
     const missingProvider = { name: "beta", provider: null, model: "nvidia/test" };
     const missingModel = { name: "gamma", provider: "nvidia-prod", model: null };
+    const blankProvider = { name: "delta", provider: "", model: "nvidia/test" };
+    const blankModel = { name: "epsilon", provider: "nvidia-prod", model: "   " };
 
     expect(registry.getSandboxEntryInference(configured)).toEqual({
       kind: "configured",
@@ -116,6 +118,8 @@ describe("registry", () => {
     });
     expect(registry.getSandboxEntryInference(missingProvider)).toEqual({ kind: "unconfigured" });
     expect(registry.getSandboxEntryInference(missingModel)).toEqual({ kind: "unconfigured" });
+    expect(registry.getSandboxEntryInference(blankProvider)).toEqual({ kind: "unconfigured" });
+    expect(registry.getSandboxEntryInference(blankModel)).toEqual({ kind: "unconfigured" });
   });
 
   it("normalizes gateway binding fields into a discriminated view", () => {
@@ -139,6 +143,20 @@ describe("registry", () => {
         gatewayPort: 0,
       }),
     ).toEqual({ kind: "missing" });
+    expect(
+      registry.getSandboxEntryGatewayBinding({
+        name: "too-high-port",
+        gatewayName: "nemoclaw",
+        gatewayPort: 65536,
+      }),
+    ).toEqual({ kind: "missing" });
+    expect(
+      registry.getSandboxEntryGatewayBinding({
+        name: "blank-gateway",
+        gatewayName: "",
+        gatewayPort: 8080,
+      }),
+    ).toEqual({ kind: "missing" });
   });
 
   it("normalizes sandbox entries without mutating the raw registry entry", () => {
@@ -159,6 +177,19 @@ describe("registry", () => {
       gateway: { kind: "registered", gatewayName: "nemoclaw", gatewayPort: 8080 },
     });
     expect(normalized.raw).toBe(raw);
+  });
+
+  it("normalizes invalid typed fields to missing views", () => {
+    const normalized = registry.normalizeSandboxEntryView({
+      name: "invalid",
+      provider: "",
+      model: "nvidia/test",
+      gatewayName: "nemoclaw",
+      gatewayPort: 65536,
+    });
+
+    expect(normalized.inference).toEqual({ kind: "unconfigured" });
+    expect(normalized.gateway).toEqual({ kind: "missing" });
   });
 
   it("first registered becomes default", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach } from "vitest";
 import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
 import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
 
 // Use a temp dir so tests don't touch real ~/.nemoclaw.
 // HOME must be set before loading registry (it reads HOME at require time),
@@ -102,6 +102,63 @@ describe("registry", () => {
     // The second registration must not retarget the first sandbox's binding.
     expect(registry.getSandbox("first").gatewayName).toBe("nemoclaw");
     expect(registry.getSandbox("first").gatewayPort).toBe(8080);
+  });
+
+  it("normalizes configured inference fields into a discriminated view", () => {
+    const configured = { name: "alpha", provider: "nvidia-prod", model: "nvidia/test" };
+    const missingProvider = { name: "beta", provider: null, model: "nvidia/test" };
+    const missingModel = { name: "gamma", provider: "nvidia-prod", model: null };
+
+    expect(registry.getSandboxEntryInference(configured)).toEqual({
+      kind: "configured",
+      provider: "nvidia-prod",
+      model: "nvidia/test",
+    });
+    expect(registry.getSandboxEntryInference(missingProvider)).toEqual({ kind: "unconfigured" });
+    expect(registry.getSandboxEntryInference(missingModel)).toEqual({ kind: "unconfigured" });
+  });
+
+  it("normalizes gateway binding fields into a discriminated view", () => {
+    expect(
+      registry.getSandboxEntryGatewayBinding({
+        name: "alpha",
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+      }),
+    ).toEqual({ kind: "registered", gatewayName: "nemoclaw", gatewayPort: 8080 });
+    expect(
+      registry.getSandboxEntryGatewayBinding({ name: "missing-name", gatewayPort: 8080 }),
+    ).toEqual({ kind: "missing" });
+    expect(
+      registry.getSandboxEntryGatewayBinding({ name: "missing-port", gatewayName: "nemoclaw" }),
+    ).toEqual({ kind: "missing" });
+    expect(
+      registry.getSandboxEntryGatewayBinding({
+        name: "invalid-port",
+        gatewayName: "nemoclaw",
+        gatewayPort: 0,
+      }),
+    ).toEqual({ kind: "missing" });
+  });
+
+  it("normalizes sandbox entries without mutating the raw registry entry", () => {
+    const raw = {
+      name: "alpha",
+      provider: "nvidia-prod",
+      model: "nvidia/test",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+    };
+
+    const normalized = registry.normalizeSandboxEntryView(raw);
+
+    expect(normalized).toEqual({
+      name: "alpha",
+      raw,
+      inference: { kind: "configured", provider: "nvidia-prod", model: "nvidia/test" },
+      gateway: { kind: "registered", gatewayName: "nemoclaw", gatewayPort: 8080 },
+    });
+    expect(normalized.raw).toBe(raw);
   });
 
   it("first registered becomes default", () => {


### PR DESCRIPTION
## Summary
Continue the #5518 nullability cleanup by adding normalized views for high-fanout sandbox registry entries. This creates discriminated, non-null internal views for inference and gateway state while preserving the raw persisted `SandboxEntry` shape.

## Related Issue
Refs #5518

## Changes
- Add `SandboxEntryInference`, `SandboxGatewayBinding`, and `NormalizedSandboxEntry` view types.
- Add helpers to normalize provider/model and gateway binding fields into discriminated views.
- Rename the existing internal registry-entry messaging normalizer to avoid ambiguity with the new public view helper.
- Add registry tests for configured/unconfigured inference, registered/missing gateway bindings, and raw-entry preservation.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a normalized “view” layer for sandbox registry entries, including structured inference and gateway-binding sub-sections.
  * Introduced helpers to compute inference and gateway binding state, and to produce a normalized entry payload.
* **Tests**
  * Added coverage for configured vs unconfigured inference and registered vs missing/invalid gateway bindings, including validation of invalid inputs and preservation of the original raw entry reference.
* **Chores**
  * Reorganized import order in the registry test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->