### PR TITLE
fix(discord): stop emitting a non-loopback per-account proxy (#5544)

### DIFF
--- a/src/lib/messaging/channels/discord/template-resolver.ts
+++ b/src/lib/messaging/channels/discord/template-resolver.ts
@@ -8,15 +8,11 @@ import {
   nonEmptyArray,
   nonEmptyCsv,
   nonEmptyObject,
-  nonEmptyString,
   parseBoolean,
   parseList,
   resolvedRenderTemplateReference,
   stateValue,
 } from "../template-resolver-utils";
-
-const DEFAULT_PROXY_HOST = "10.200.0.1";
-const DEFAULT_PROXY_PORT = "3128";
 
 type DiscordGuildConfig = {
   readonly requireMention?: boolean;
@@ -27,8 +23,7 @@ export const resolveDiscordTemplateReference: BuiltInRenderTemplateResolver = (
   reference,
   context,
 ) => {
-  if (reference === "discordProxyUrl")
-    return resolvedRenderTemplateReference(proxyUrl(context.env));
+  if (reference === "discordProxyUrl") return resolvedRenderTemplateReference(undefined);
 
   switch (reference) {
     case "discord.guilds":
@@ -87,10 +82,4 @@ function discordRequireMention(context: RenderTemplateContext): boolean {
     if (typeof guild.requireMention === "boolean") return guild.requireMention;
   }
   return true;
-}
-
-function proxyUrl(env: RenderTemplateContext["env"]): string {
-  const host = nonEmptyString(env?.NEMOCLAW_PROXY_HOST) ?? DEFAULT_PROXY_HOST;
-  const port = nonEmptyString(env?.NEMOCLAW_PROXY_PORT) ?? DEFAULT_PROXY_PORT;
-  return `http://${host}:${port}`;
 }

--- a/test/discord-template-resolver-proxy.test.ts
+++ b/test/discord-template-resolver-proxy.test.ts
@@ -5,26 +5,29 @@ import { describe, expect, it } from "vitest";
 
 import { resolveDiscordTemplateReference } from "../dist/lib/messaging/channels/discord/template-resolver.js";
 
-// The Discord gateway client honors only the per-account proxy (it ignores the
-// managed env proxy), so channels.discord.accounts.default.proxy must resolve to
-// the sandbox proxy or the gateway WebSocket cannot egress the deny-by-default
-// network namespace. Telegram already resolves its proxy this way; #5075.
+// OpenClaw's Discord plugin validates channels.discord.accounts.default.proxy
+// and rejects any non-loopback host (validateDiscordProxyUrl: "Proxy URL must
+// target a loopback host"). The sandbox egress proxy (10.200.0.1:3128) is not
+// loopback, so a per-account proxy must NOT be emitted; Discord gateway/REST
+// egress is carried by the top-level managed proxy (proxy.loopbackMode:
+// "gateway-only") instead. discordProxyUrl therefore resolves to undefined so
+// the proxy field is dropped from the rendered config (#5544; reverts #5248).
 const ctx = (env: Record<string, string | undefined>) => ({ inputs: [], env });
 
 describe("discord template-resolver: discordProxyUrl", () => {
-  it("resolves discordProxyUrl to the default sandbox proxy (was previously undefined, #5075)", () => {
+  it("resolves to undefined so no per-account proxy is emitted (#5544)", () => {
     expect(resolveDiscordTemplateReference("discordProxyUrl", ctx({}))).toEqual({
       matched: true,
-      value: "http://10.200.0.1:3128",
+      value: undefined,
     });
   });
 
-  it("honors NEMOCLAW_PROXY_HOST / NEMOCLAW_PROXY_PORT overrides", () => {
+  it("stays undefined even when NEMOCLAW_PROXY_HOST / NEMOCLAW_PROXY_PORT are set", () => {
     expect(
       resolveDiscordTemplateReference(
         "discordProxyUrl",
         ctx({ NEMOCLAW_PROXY_HOST: "10.201.0.9", NEMOCLAW_PROXY_PORT: "43128" }),
       ),
-    ).toEqual({ matched: true, value: "http://10.201.0.9:43128" });
+    ).toEqual({ matched: true, value: undefined });
   });
 });

--- a/test/e2e-scenario/live/messaging-providers.test.ts
+++ b/test/e2e-scenario/live/messaging-providers.test.ts
@@ -433,6 +433,15 @@ process.exit(Array.isArray(channels) && channels.some((c) => c?.channelId === "w
     );
     check(discordToken.length > 0, "M8: Discord token present in openclaw.json");
     check(discordToken !== state.tokens.discord, "M9: Discord token is not the host token");
+    const expectedManagedProxy = `http://${state.env.NEMOCLAW_PROXY_HOST ?? "10.200.0.1"}:${state.env.NEMOCLAW_PROXY_PORT ?? "3128"}`;
+    const discordAccountProxy = accountString(discordAccount, "proxy");
+    const managedProxyUrl = typeof config.proxy?.proxyUrl === "string" ? config.proxy.proxyUrl : "";
+    check(
+      discordAccountProxy === "" &&
+        config.proxy?.enabled === true &&
+        managedProxyUrl === expectedManagedProxy,
+      `M9b: Discord relies on OpenClaw managed proxy config, with no per-account loopback proxy (account.proxy='${discordAccountProxy}', proxy.proxyUrl='${managedProxyUrl}')`,
+    );
     check(accountBool(telegramAccount, "enabled") === true, "M10: Telegram account is enabled");
     check(accountBool(discordAccount, "enabled") === true, "M11: Discord account is enabled");
     check(

--- a/test/e2e-scenario/live/messaging-providers.test.ts
+++ b/test/e2e-scenario/live/messaging-providers.test.ts
@@ -433,7 +433,9 @@ process.exit(Array.isArray(channels) && channels.some((c) => c?.channelId === "w
     );
     check(discordToken.length > 0, "M8: Discord token present in openclaw.json");
     check(discordToken !== state.tokens.discord, "M9: Discord token is not the host token");
-    const expectedManagedProxy = `http://${state.env.NEMOCLAW_PROXY_HOST ?? "10.200.0.1"}:${state.env.NEMOCLAW_PROXY_PORT ?? "3128"}`;
+    const expectedManagedProxyHost = nonEmpty(state.env.NEMOCLAW_PROXY_HOST) ?? "10.200.0.1";
+    const expectedManagedProxyPort = nonEmpty(state.env.NEMOCLAW_PROXY_PORT) ?? "3128";
+    const expectedManagedProxy = `http://${expectedManagedProxyHost}:${expectedManagedProxyPort}`;
     const discordAccountProxy = accountString(discordAccount, "proxy");
     const managedProxyUrl = typeof config.proxy?.proxyUrl === "string" ? config.proxy.proxyUrl : "";
     check(

--- a/test/e2e/test-messaging-providers.sh
+++ b/test/e2e/test-messaging-providers.sh
@@ -1830,11 +1830,13 @@ print(account.get('token', ''))
     skip "M9: No Discord token to check"
   fi
 
-  # M9b: Discord Gateway WebSocket routing uses the per-account proxy.
-  # OpenClaw's Discord gateway client only tunnels when the Discord account
-  # proxy is set, while the top-level managed proxy remains configured for the
-  # rest of the channel stack. The fake Gateway proof in M13b-M13g exercises
-  # the same OpenShell relay path using the generated managed proxy config.
+  # M9b: Discord Gateway WebSocket routing uses OpenClaw's managed proxy.
+  # OpenClaw's Discord plugin validates the per-account proxy and rejects any
+  # non-loopback host, so NemoClaw must not bake a Discord-only account.proxy
+  # (the sandbox egress proxy 10.200.0.1:3128 is not loopback). Discord
+  # gateway/REST egress is carried by the top-level managed proxy
+  # (proxy.loopbackMode "gateway-only"). The fake Gateway proof in M13b-M13g
+  # exercises the same OpenShell relay path using that managed proxy config.
   dc_proxy=$(echo "$channel_json" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
@@ -1851,10 +1853,10 @@ if proxy.get('enabled') is True:
     print(proxy.get('proxyUrl') or '')
 \"" 2>/dev/null || true)
   expected_managed_proxy="http://${NEMOCLAW_PROXY_HOST:-10.200.0.1}:${NEMOCLAW_PROXY_PORT:-3128}"
-  if [ -n "$dc_token" ] && [ "$dc_proxy" = "$expected_managed_proxy" ] && [ "$managed_proxy_url" = "$expected_managed_proxy" ]; then
-    pass "M9b: Discord uses per-account proxy while OpenClaw managed proxy config remains set"
+  if [ -n "$dc_token" ] && [ -z "$dc_proxy" ] && [ "$managed_proxy_url" = "$expected_managed_proxy" ]; then
+    pass "M9b: Discord relies on OpenClaw managed proxy config, with no per-account loopback proxy"
   elif [ -n "$dc_token" ]; then
-    fail "M9b: Discord proxy wiring wrong; expected account.proxy='${expected_managed_proxy}' and proxy.proxyUrl='${expected_managed_proxy}' (account.proxy='${dc_proxy}', proxy.proxyUrl='${managed_proxy_url}')"
+    fail "M9b: Discord proxy wiring wrong; expected account.proxy='' and proxy.proxyUrl='${expected_managed_proxy}' (account.proxy='${dc_proxy}', proxy.proxyUrl='${managed_proxy_url}')"
   else
     skip "M9b: No Discord channel config to check"
   fi

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -613,10 +613,10 @@ describe("generate-openclaw-config.mts: config generation", () => {
       "openshell:resolve:env:DISCORD_BOT_TOKEN",
     );
     expect(config.channels.telegram.accounts.default.proxy).toBe("http://10.200.0.1:3128");
-    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:3128");
+    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("#3894: routes Discord gateway traffic through the per-account proxy", () => {
+  it("#3894: routes Discord gateway traffic through OpenClaw's managed proxy", () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const config = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
@@ -633,10 +633,10 @@ describe("generate-openclaw-config.mts: config generation", () => {
       token: "openshell:resolve:env:DISCORD_BOT_TOKEN",
       enabled: true,
     });
-    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.201.0.9:43128");
+    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("writes the Discord account proxy alongside the managed proxy", () => {
+  it("does not write a Discord account proxy when the managed proxy is configured", () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const config = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
@@ -644,7 +644,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
 
     expect(config.proxy.proxyUrl).toBe("http://10.200.0.1:43128");
-    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:43128");
+    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
   it("can defer OpenClaw managed proxy config for build-time doctor", () => {
@@ -655,7 +655,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
 
     expect(config.proxy).toBeUndefined();
-    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:3128");
+    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
   it("ignores the OpenShell loopback proxy env var when using OpenClaw managed proxy", () => {
@@ -667,10 +667,10 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
 
     expect(config.proxy.proxyUrl).toBe("http://10.200.0.1:3128");
-    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.200.0.1:3128");
+    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("routes both Telegram and Discord through the per-account proxy", () => {
+  it("keeps Telegram on the OpenShell proxy while Discord relies on the managed proxy", () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
     const config = runConfigScript({
       NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
@@ -680,7 +680,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
 
     expect(config.proxy.proxyUrl).toBe("http://10.201.0.9:43128");
     expect(config.channels.telegram.accounts.default.proxy).toBe("http://10.201.0.9:43128");
-    expect(config.channels.discord.accounts.default.proxy).toBe("http://10.201.0.9:43128");
+    expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
   it("emits Bolt-shape placeholders for Slack so the SDK's prefix regex passes", () => {


### PR DESCRIPTION
## Summary
The Discord channel config emits a per-account proxy (`channels.discord.accounts.default.proxy = http://10.200.0.1:3128`) that OpenClaw's Discord plugin rejects by design. `extensions/discord/src/proxy-fetch.ts` `validateDiscordProxyUrl` throws `Proxy URL must target a loopback host` for any non-loopback host, and that validator runs on both the REST and gateway transports. The rejected proxy is dropped, so the Discord gateway WebSocket cannot egress the deny-by-default network namespace and never reaches READY. This restores reliance on the top-level managed proxy for Discord, the mechanism that originally addressed #5075 / #3894.

## Related Issue
Fixes #5544

## Changes
- Resolve `discordProxyUrl` back to `undefined` so the per-account proxy field is omitted from the rendered `openclaw.json`. Discord gateway and REST egress is carried by the top-level managed proxy (`proxy.loopbackMode: "gateway-only"`), which OpenClaw documents as the path for routing channel traffic through the operator proxy.
- Telegram keeps its per-account proxy: its Bot API transport honors a non-loopback proxy and has no loopback validator. Discord uniquely validates loopback, so mirroring Telegram was the wrong shape for Discord.
- Flip the `generate-openclaw-config` and discord template-resolver expectations back to asserting no per-account Discord proxy, and revert the messaging-providers `M9b` check to expect the managed proxy with no Discord `account.proxy`.
- Effectively reverts #5248 (and its #5391 test follow-up).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

Ran: `npx vitest run test/discord-template-resolver-proxy.test.ts test/generate-openclaw-config.test.ts` (130 passed), `npm run build:cli`, and `biome check` on the touched files (clean). The full-suite `test-cli`/`test-plugin` commit and push hooks were skipped because they trip on a pre-existing collection error in `test/ssrf-parity.test.ts` (0 tests collected) that also fails on a clean `main` checkout and is unrelated to this change. CI runs the full gate.

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Updated Discord messaging so `discordProxyUrl` is no longer emitted per account; Discord Gateway traffic is routed via the application’s managed proxy configuration for consistent behavior.

* **Tests**
  * Revised unit and end-to-end tests to assert Discord account `proxy` remains empty while the global managed proxy URL is used, including cases with proxy host/port environment overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->