### PR TITLE
refactor(inventory): use normalized sandbox views

### DIFF
--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -134,6 +134,64 @@ describe("inventory commands", () => {
     expect(getLiveInference).not.toHaveBeenCalled();
   });
 
+  it("normalizes invalid configured inference fields out of inventory rows", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          { name: "blank-provider", provider: "", model: "nvidia/test" },
+          { name: "blank-model", provider: "nvidia-prod", model: "   " },
+          { name: "configured", provider: "nvidia-prod", model: "nvidia/test" },
+        ],
+        defaultSandbox: "blank-provider",
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    expect(inventory.sandboxes).toMatchObject([
+      { name: "blank-provider", provider: null, model: "nvidia/test" },
+      { name: "blank-model", provider: "nvidia-prod", model: null },
+      { name: "configured", provider: "nvidia-prod", model: "nvidia/test" },
+    ]);
+  });
+
+  it("normalizes invalid configured inference fields out of status rows", () => {
+    const report = getStatusReport({
+      listSandboxes: () => ({
+        sandboxes: [
+          { name: "blank-provider", provider: "", model: "nvidia/test" },
+          { name: "blank-model", provider: "nvidia-prod", model: "   " },
+          { name: "configured", provider: "nvidia-prod", model: "nvidia/test" },
+        ],
+        defaultSandbox: "blank-provider",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+    });
+
+    expect(report.sandboxes).toMatchObject([
+      { name: "blank-provider", provider: null, model: "nvidia/test" },
+      { name: "blank-model", provider: "nvidia-prod", model: null },
+      { name: "configured", provider: "nvidia-prod", model: "nvidia/test" },
+    ]);
+  });
+
+  it("omits invalid configured inference fields from status text", () => {
+    const lines: string[] = [];
+    showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", provider: "", model: "   " }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => null,
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("    alpha *");
+    expect(lines.some((line) => line.includes("Inference:"))).toBe(false);
+  });
+
   it("prints the empty-state onboarding hint when no sandboxes exist", async () => {
     const lines: string[] = [];
     await listSandboxesCommand({

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -5,7 +5,7 @@ import { CLI_NAME } from "../cli/branding";
 import type { GatewayInference } from "../inference/config";
 import { getActiveChannelIdsFromPlan } from "../messaging/plan-validation";
 import { redactFull } from "../security/redact";
-import { normalizeSandboxEntryView, type SandboxMessagingState } from "../state/registry";
+import { getSandboxEntryDisplayInference, type SandboxMessagingState } from "../state/registry";
 import { resolveDefaultSandboxName } from "../tunnel/service-command";
 
 export interface SandboxEntry {
@@ -167,27 +167,6 @@ function safeStatusString(value: string | null | undefined): string | null {
   return redactFull(value);
 }
 
-function nonEmptyInventoryString(value: string | null | undefined): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
-}
-
-function getInventoryInferenceFields(sandbox: SandboxEntry): {
-  provider: string | null;
-  model: string | null;
-} {
-  const normalized = normalizeSandboxEntryView(sandbox);
-  if (normalized.inference.kind === "configured") {
-    return {
-      provider: normalized.inference.provider,
-      model: normalized.inference.model,
-    };
-  }
-  return {
-    provider: nonEmptyInventoryString(sandbox.provider),
-    model: nonEmptyInventoryString(sandbox.model),
-  };
-}
-
 function buildSandboxInventoryRow(
   sandbox: SandboxEntry,
   defaultSandbox: string | null,
@@ -198,7 +177,7 @@ function buildSandboxInventoryRow(
     typeof sandbox.sandboxGpuEnabled === "boolean"
       ? sandbox.sandboxGpuEnabled
       : sandbox.gpuEnabled === true;
-  const inference = getInventoryInferenceFields(sandbox);
+  const inference = getSandboxEntryDisplayInference(sandbox);
 
   return {
     name: sandbox.name,
@@ -347,7 +326,7 @@ function buildStatusSandboxRow(
   const isDefault = sandbox.name === defaultSandbox;
   const liveModel = isDefault ? liveInference?.model : null;
   const liveProvider = isDefault ? liveInference?.provider : null;
-  const inference = getInventoryInferenceFields(sandbox);
+  const inference = getSandboxEntryDisplayInference(sandbox);
   const dashboardPort =
     typeof sandbox.dashboardPort === "number" && Number.isFinite(sandbox.dashboardPort)
       ? sandbox.dashboardPort
@@ -448,7 +427,7 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       // agrees with `openshell inference get` (#2369).
       const liveModel = isDefault && live ? live.model : null;
       const liveProvider = isDefault && live ? live.provider : null;
-      const inference = getInventoryInferenceFields(sb);
+      const inference = getSandboxEntryDisplayInference(sb);
       const model = liveModel || inference.model;
       const provider = liveProvider || inference.provider;
       const portSuffix = sb.dashboardPort != null ? ` :${sb.dashboardPort}` : "";

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -5,7 +5,7 @@ import { CLI_NAME } from "../cli/branding";
 import type { GatewayInference } from "../inference/config";
 import { getActiveChannelIdsFromPlan } from "../messaging/plan-validation";
 import { redactFull } from "../security/redact";
-import type { SandboxMessagingState } from "../state/registry";
+import { normalizeSandboxEntryView, type SandboxMessagingState } from "../state/registry";
 import { resolveDefaultSandboxName } from "../tunnel/service-command";
 
 export interface SandboxEntry {
@@ -167,6 +167,27 @@ function safeStatusString(value: string | null | undefined): string | null {
   return redactFull(value);
 }
 
+function nonEmptyInventoryString(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function getInventoryInferenceFields(sandbox: SandboxEntry): {
+  provider: string | null;
+  model: string | null;
+} {
+  const normalized = normalizeSandboxEntryView(sandbox);
+  if (normalized.inference.kind === "configured") {
+    return {
+      provider: normalized.inference.provider,
+      model: normalized.inference.model,
+    };
+  }
+  return {
+    provider: nonEmptyInventoryString(sandbox.provider),
+    model: nonEmptyInventoryString(sandbox.model),
+  };
+}
+
 function buildSandboxInventoryRow(
   sandbox: SandboxEntry,
   defaultSandbox: string | null,
@@ -177,11 +198,12 @@ function buildSandboxInventoryRow(
     typeof sandbox.sandboxGpuEnabled === "boolean"
       ? sandbox.sandboxGpuEnabled
       : sandbox.gpuEnabled === true;
+  const inference = getInventoryInferenceFields(sandbox);
 
   return {
     name: sandbox.name,
-    model: sandbox.model || null,
-    provider: sandbox.provider || null,
+    model: inference.model,
+    provider: inference.provider,
     gpuEnabled: sandbox.gpuEnabled === true,
     hostGpuDetected: sandbox.hostGpuDetected === true,
     sandboxGpuEnabled,
@@ -325,6 +347,7 @@ function buildStatusSandboxRow(
   const isDefault = sandbox.name === defaultSandbox;
   const liveModel = isDefault ? liveInference?.model : null;
   const liveProvider = isDefault ? liveInference?.provider : null;
+  const inference = getInventoryInferenceFields(sandbox);
   const dashboardPort =
     typeof sandbox.dashboardPort === "number" && Number.isFinite(sandbox.dashboardPort)
       ? sandbox.dashboardPort
@@ -335,8 +358,8 @@ function buildStatusSandboxRow(
       : sandbox.gpuEnabled === true;
   return {
     name: safeStatusString(sandbox.name) || sandbox.name,
-    model: safeStatusString(liveModel || sandbox.model || null),
-    provider: safeStatusString(liveProvider || sandbox.provider || null),
+    model: safeStatusString(liveModel || inference.model),
+    provider: safeStatusString(liveProvider || inference.provider),
     gpuEnabled: sandbox.gpuEnabled === true,
     hostGpuDetected: sandbox.hostGpuDetected === true,
     sandboxGpuEnabled,
@@ -425,12 +448,13 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       // agrees with `openshell inference get` (#2369).
       const liveModel = isDefault && live ? live.model : null;
       const liveProvider = isDefault && live ? live.provider : null;
-      const model = liveModel || sb.model;
-      const provider = liveProvider || sb.provider;
+      const inference = getInventoryInferenceFields(sb);
+      const model = liveModel || inference.model;
+      const provider = liveProvider || inference.provider;
       const portSuffix = sb.dashboardPort != null ? ` :${sb.dashboardPort}` : "";
       log(`    ${sb.name}${def}${model ? ` (${model})` : ""}${portSuffix}`);
-      if (isDefault && liveModel && liveModel !== sb.model) {
-        log(`      (onboarded: ${sb.model || "unknown"})`);
+      if (isDefault && liveModel && liveModel !== inference.model) {
+        log(`      (onboarded: ${inference.model || "unknown"})`);
       }
       // #2604: surface the configured Inference (provider/model) and
       // Connected (active-session count) as labeled fields. Bare

--- a/src/lib/state/registry-entry-view.ts
+++ b/src/lib/state/registry-entry-view.ts
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SandboxEntry } from "./registry";
+export interface SandboxEntryViewInput {
+  name: string;
+  provider?: string | null;
+  model?: string | null;
+  gatewayName?: string | null;
+  gatewayPort?: number | null;
+}
 
 export type SandboxEntryInference =
   | { kind: "configured"; provider: string; model: string }
@@ -11,9 +17,11 @@ export type SandboxGatewayBinding =
   | { kind: "registered"; gatewayName: string; gatewayPort: number }
   | { kind: "missing" };
 
-export interface NormalizedSandboxEntry {
+export interface NormalizedSandboxEntry<
+  Entry extends SandboxEntryViewInput = SandboxEntryViewInput,
+> {
   name: string;
-  raw: SandboxEntry;
+  raw: Entry;
   inference: SandboxEntryInference;
   gateway: SandboxGatewayBinding;
 }
@@ -26,19 +34,21 @@ function isValidTcpPort(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
 }
 
-export function getSandboxEntryInference(entry: SandboxEntry): SandboxEntryInference {
+export function getSandboxEntryInference(entry: SandboxEntryViewInput): SandboxEntryInference {
   return isNonEmptyString(entry.provider) && isNonEmptyString(entry.model)
     ? { kind: "configured", provider: entry.provider, model: entry.model }
     : { kind: "unconfigured" };
 }
 
-export function getSandboxEntryGatewayBinding(entry: SandboxEntry): SandboxGatewayBinding {
+export function getSandboxEntryGatewayBinding(entry: SandboxEntryViewInput): SandboxGatewayBinding {
   return isNonEmptyString(entry.gatewayName) && isValidTcpPort(entry.gatewayPort)
     ? { kind: "registered", gatewayName: entry.gatewayName, gatewayPort: entry.gatewayPort }
     : { kind: "missing" };
 }
 
-export function normalizeSandboxEntryView(entry: SandboxEntry): NormalizedSandboxEntry {
+export function normalizeSandboxEntryView<Entry extends SandboxEntryViewInput>(
+  entry: Entry,
+): NormalizedSandboxEntry<Entry> {
   return {
     name: entry.name,
     raw: entry,

--- a/src/lib/state/registry-entry-view.ts
+++ b/src/lib/state/registry-entry-view.ts
@@ -13,6 +13,11 @@ export type SandboxEntryInference =
   | { kind: "configured"; provider: string; model: string }
   | { kind: "unconfigured" };
 
+export type SandboxEntryDisplayInference = {
+  provider: string | null;
+  model: string | null;
+};
+
 export type SandboxGatewayBinding =
   | { kind: "registered"; gatewayName: string; gatewayPort: number }
   | { kind: "missing" };
@@ -30,6 +35,10 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function optionalDisplayString(value: string | null | undefined): string | null {
+  return isNonEmptyString(value) ? value : null;
+}
+
 function isValidTcpPort(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
 }
@@ -44,6 +53,18 @@ export function getSandboxEntryGatewayBinding(entry: SandboxEntryViewInput): San
   return isNonEmptyString(entry.gatewayName) && isValidTcpPort(entry.gatewayPort)
     ? { kind: "registered", gatewayName: entry.gatewayName, gatewayPort: entry.gatewayPort }
     : { kind: "missing" };
+}
+
+export function getSandboxEntryDisplayInference(
+  entry: SandboxEntryViewInput,
+): SandboxEntryDisplayInference {
+  const inference = getSandboxEntryInference(entry);
+  return inference.kind === "configured"
+    ? { provider: inference.provider, model: inference.model }
+    : {
+        provider: optionalDisplayString(entry.provider),
+        model: optionalDisplayString(entry.model),
+      };
 }
 
 export function normalizeSandboxEntryView<Entry extends SandboxEntryViewInput>(

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -8,10 +8,12 @@ import { ensureConfigDir, readConfigFile, writeConfigFile } from "./config-io";
 import type { SandboxMessagingState } from "./registry-messaging";
 
 export {
+  getSandboxEntryDisplayInference,
   getSandboxEntryGatewayBinding,
   getSandboxEntryInference,
   type NormalizedSandboxEntry,
   normalizeSandboxEntryView,
+  type SandboxEntryDisplayInference,
   type SandboxEntryInference,
   type SandboxGatewayBinding,
 } from "./registry-entry-view";


### PR DESCRIPTION
## Summary
Continue the #5518 nullability cleanup by moving inventory/status reporting onto the normalized sandbox-entry view helpers. Inventory now uses the registry view layer for configured inference state while preserving legacy model-only display behavior.

## Related Issue
Refs #5518

## Changes
- Use `normalizeSandboxEntryView` when building sandbox inventory and status rows.
- Add a small inventory inference-field adapter that filters empty strings while preserving valid single-field model/provider display semantics.
- Generalize `registry-entry-view.ts` so normalized views can accept registry-compatible entry shapes outside `state/registry.ts`.
- Add inventory tests for blank provider/model fields in structured inventory, JSON status, and text status output.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI output to normalize invalid inference configuration: empty/whitespace provider and model values are now treated as missing and omitted from `nemoclaw list`/`nemoclaw status`.
  * Updated status display and drift detection to compare against the normalized (display) inference values.

* **Tests**
  * Added Vitest cases covering normalization of invalid inference fields for inventory/status rows and ensuring “Inference:” text is omitted when provider/model are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->