### PR TITLE
feat(advisor): add simplification review signals

### DIFF
--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -522,6 +522,60 @@ diff --git a/test/example.test.ts b/test/example.test.ts
     );
   });
 
+  it("detects large TypeScript simplification signals with safe file reads", () => {
+    const largePath = path.join(ROOT, "tools", "pr-review-advisor", ".tmp-large-test.ts");
+    const smallPath = path.join(ROOT, "tools", "pr-review-advisor", ".tmp-small-test.ts");
+    fs.writeFileSync(
+      largePath,
+      `${Array.from({ length: 501 }, (_, index) => `line${index}`).join("\n")}\n`,
+    );
+    fs.writeFileSync(smallPath, "const small = true;\n");
+    try {
+      const signals = detectSimplificationSignals(
+        [path.relative(ROOT, largePath), path.relative(ROOT, smallPath)],
+        "",
+      );
+
+      expect(signals).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "large_file_growth",
+            file: path.relative(ROOT, largePath),
+          }),
+        ]),
+      );
+      expect(signals.some((signal) => signal.file === path.relative(ROOT, smallPath))).toBe(false);
+    } finally {
+      fs.rmSync(largePath, { force: true });
+      fs.rmSync(smallPath, { force: true });
+    }
+  });
+
+  it("skips symlinked large-file simplification candidates", () => {
+    const linkPath = path.join(ROOT, "tools", "pr-review-advisor", ".tmp-large-link.mts");
+    const outside = fs.mkdtempSync(path.join(ROOT, "..", ".tmp-large-outside-"));
+    const outsideFile = path.join(outside, "outside.mts");
+    fs.writeFileSync(
+      outsideFile,
+      `${Array.from({ length: 501 }, (_, index) => `secret${index}`).join("\n")}\n`,
+    );
+    try {
+      fs.symlinkSync(outsideFile, linkPath);
+    } catch {
+      fs.rmSync(outside, { recursive: true, force: true });
+      return;
+    }
+
+    try {
+      const signals = detectSimplificationSignals([path.relative(ROOT, linkPath)], "");
+
+      expect(signals).toEqual([]);
+    } finally {
+      fs.rmSync(linkPath, { force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   it("detects localized patch signals from added diff lines", () => {
     const signals =
       detectLocalizedPatchSignals(`diff --git a/src/lib/example.ts b/src/lib/example.ts

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -21,6 +21,7 @@ import {
   collectStaticTestInventory,
   collectTrustedPreviousAdvisorReview,
   detectLocalizedPatchSignals,
+  detectSimplificationSignals,
   extractPreviousAdvisorReview,
   normalizeReviewResult,
   readTrustedSecurityReviewSkill,
@@ -54,6 +55,7 @@ function metadata(overrides: Partial<ReviewMetadata> = {}): ReviewMetadata {
       nearbyTestNames: [],
       candidateExistingCoverage: [],
     },
+    simplificationSignals: [],
     previousAdvisorReview: null,
     workflowSignals: [],
     localizedPatchSignals: [],
@@ -271,6 +273,8 @@ describe("PR review advisor", () => {
     expect(prompt).toContain("Vitest E2E suite simplicity");
     expect(prompt).toContain("Test follow-ups to resolve or justify");
     expect(prompt).toContain("Every finding must be probe-shaped");
+    expect(prompt).toContain("Simplification review");
+    expect(prompt).toContain("delete, stdlib, native, yagni, or shrink");
     expect(prompt).not.toContain("Consider writing more tests for");
     expect(prompt).toContain("take a closer architecture look for new systems");
     expect(prompt).toContain("Favor focused Vitest tests and local test helpers");
@@ -329,9 +333,11 @@ describe("PR review advisor", () => {
     expect(turns[1]?.syntheticToolResults?.[0]?.toolName).toBe("pr_review_security_context");
     expect(turns[2]?.prompt).toContain("source-of-truth questions");
     expect(turns[2]?.prompt).toContain("staticTestInventory");
+    expect(turns[2]?.prompt).toContain("simplificationSignals");
     expect(turns[2]?.prompt).not.toContain("localizedPatchSignals");
     expect(turns[2]?.syntheticToolResults?.[0]?.content).toContain("localizedPatchSignals");
     expect(turns[2]?.syntheticToolResults?.[0]?.content).toContain("staticTestInventory");
+    expect(turns[2]?.syntheticToolResults?.[0]?.content).toContain("simplificationSignals");
     expect(turns[3]?.prompt).toContain("<pr_review_advisor_json>");
     expect(turns[3]?.syntheticToolResults?.map((result) => result.toolName)).toEqual([
       "pr_review_exact_metadata",
@@ -485,6 +491,35 @@ describe("PR review advisor", () => {
       fs.rmSync(tmp, { recursive: true, force: true });
       fs.rmSync(outside, { recursive: true, force: true });
     }
+  });
+
+  it("detects simplification signals from added diff lines", () => {
+    const signals = detectSimplificationSignals(
+      ["src/lib/example.ts", "test/example.test.ts"],
+      `diff --git a/src/lib/example.ts b/src/lib/example.ts
+@@ -1,2 +1,7 @@
++import moment from "moment";
++interface ExampleFactory {
++const value = process.env.NEMOCLAW_EXAMPLE_MODE;
++const wrapper = wrapClient(client);
+diff --git a/test/example.test.ts b/test/example.test.ts
+@@ -1,2 +1,4 @@
++const matrix = new ScenarioRegistry();
+`,
+    );
+
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "new_dependency",
+          evidence: expect.stringContaining("moment"),
+        }),
+        expect.objectContaining({ kind: "single_use_abstraction" }),
+        expect.objectContaining({ kind: "single_use_config" }),
+        expect.objectContaining({ kind: "wrapper" }),
+        expect.objectContaining({ kind: "test_over_scaffold" }),
+      ]),
+    );
   });
 
   it("detects localized patch signals from added diff lines", () => {
@@ -1015,6 +1050,46 @@ describe("PR review advisor", () => {
     );
     expect(followUp).toContain("<summary>Review findings by urgency:");
     expect(followUp).toContain("<summary>Since last review details</summary>");
+  });
+
+  it("renders simplification opportunities without weakening safety boundaries", () => {
+    const result = normalizeReviewResult(
+      validResult({
+        findings: [
+          {
+            severity: "suggestion",
+            category: "architecture",
+            file: "src/lib/example.ts",
+            line: 12,
+            title: "Replace custom date formatter",
+            description: "The new formatter duplicates platform behavior.",
+            impact: "Less custom date code reduces maintenance.",
+            recommendation: "Use Intl.DateTimeFormat and keep validation unchanged.",
+            verificationHint: "Compare output with existing date-format test cases.",
+            missingRegressionTest: "Existing date-format test cases should still pass.",
+            evidence: "Diff adds a formatter branch for locale output.",
+            simplification: {
+              tag: "native",
+              cut: "custom date formatter helper",
+              replacement: "Intl.DateTimeFormat",
+              estimatedNetLines: -18,
+              safetyBoundary: "Keep input validation and timezone test coverage.",
+            },
+          },
+        ],
+      }),
+      metadata(),
+    );
+
+    const comment = buildComment({ summary: renderSummary(result), result });
+
+    expect(result.findings[0]?.simplification).toMatchObject({ tag: "native" });
+    expect(comment).toContain(
+      "<summary>Simplification opportunities: 1 possible cut, net -18 lines possible</summary>",
+    );
+    expect(comment).toContain("**native** (src/lib/example.ts:12): custom date formatter helper");
+    expect(comment).toContain("Replacement: Intl.DateTimeFormat");
+    expect(comment).toContain("Safety boundary: Keep input validation and timezone test coverage.");
   });
 
   it("renders suggestion findings as in-scope current-review work", () => {

--- a/test/pr-review-advisor.test.ts
+++ b/test/pr-review-advisor.test.ts
@@ -539,7 +539,7 @@ diff --git a/test/example.test.ts b/test/example.test.ts
       expect(signals).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            kind: "large_file_growth",
+            kind: "large_file_hotspot",
             file: path.relative(ROOT, largePath),
           }),
         ]),

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -16,6 +16,7 @@ It complements the existing PR surfaces by keeping a NemoClaw maintainer code-re
 - codebase drift, monolith growth, and architecture guardrails;
 - source-of-truth review for fallback, recovery, tolerant parsing, monkeypatching, and other localized workaround behavior;
 - static test-inventory context from changed test files and nearby test names;
+- simplification review for safe delete/stdlib/native/YAGNI/shrink opportunities;
 - correctness and test-quality checks that CI cannot prove.
 
 It intentionally does not report GitHub mergeability, branch protection, CI status, reviewer state, CodeRabbit state, or E2E pass/fail status; those are handled elsewhere in the PR UI.
@@ -87,7 +88,7 @@ If present, this token is used for sticky PR comments. Otherwise the workflow fa
 - `retry-prompts/` — retry synthesis prompt and synthetic tool results when the first output is malformed or low quality.
 - `context/drift-context.json` — deterministic drift, overlap, monolith, and previous-review context.
 - `context/security-context.json` — deterministic security-risk context.
-- `context/validation-context.json` — deterministic acceptance, source-of-truth, and static test-inventory context.
+- `context/validation-context.json` — deterministic acceptance, source-of-truth, static test-inventory, and simplification-signal context.
 - `context/pr.diff` — truncated PR diff used by the advisor.
 - `context/previous-advisor-review.md` — previous sticky PR Review Advisor comment when one exists and its hidden run/comment metadata validates.
 - `pr-review-advisor-raw-output.txt` — raw multi-turn advisor transcript and diagnostics.
@@ -117,7 +118,9 @@ available.
 `tools/pr-review-advisor/schema.json` defines the normalized JSON result shape used for the PR
 comment and future reporting work. Findings include probe-shaped fields for impact, verification
 hints, and missing regression-test guidance so agents know what to check rather than treating findings
-as generic commentary. The advisor is intentionally advisory: every result includes limitations and
+as generic commentary. Findings can also include safe simplification metadata with delete, stdlib,
+native, YAGNI, or shrink tags; those suggestions must keep validation, security, data-loss prevention,
+and required tests intact. The advisor is intentionally advisory: every result includes limitations and
 requires human maintainer review. The PR comment deliberately frames suggestions as current-review
 improvements when they touch changed code; agents should not automatically defer them to a future PR
 without maintainer rationale or a linked follow-up.

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -241,7 +241,7 @@ export type SimplificationSignal = {
     | "single_use_abstraction"
     | "single_use_config"
     | "wrapper"
-    | "large_file_growth"
+    | "large_file_hotspot"
     | "test_over_scaffold";
   evidence: string;
   reviewRule: string;
@@ -964,10 +964,10 @@ function computeSimpleLargeFileDeltas(changedFiles: Set<string>): Simplification
         {
           file,
           line: null,
-          kind: "large_file_growth" as const,
+          kind: "large_file_hotspot" as const,
           evidence: `${file} is ${lines} lines after this change.`,
           reviewRule:
-            "When a large hotspot grows, ask whether a cohesive helper can be extracted or whether the growth is justified by security/context coupling.",
+            "When a large hotspot is touched, ask whether a cohesive helper can be extracted or whether the edit is justified by security/context coupling.",
         },
       ];
     })

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -93,6 +93,7 @@ const SOURCE_OF_TRUTH_STATUSES = [
   "needs_followup",
   "missing",
 ] as const;
+const SIMPLIFICATION_TAGS = ["delete", "stdlib", "native", "yagni", "shrink"] as const;
 
 type Confidence = (typeof CONFIDENCES)[number];
 type SummaryRecommendation = (typeof SUMMARY_RECOMMENDATIONS)[number];
@@ -101,6 +102,7 @@ type TestDepthVerdict = (typeof TEST_DEPTH_VERDICTS)[number];
 type AcceptanceStatus = (typeof ACCEPTANCE_STATUSES)[number];
 type SecurityVerdict = (typeof SECURITY_VERDICTS)[number];
 type SourceOfTruthStatus = (typeof SOURCE_OF_TRUTH_STATUSES)[number];
+type SimplificationTag = (typeof SIMPLIFICATION_TAGS)[number];
 
 type ArtifactPaths = {
   promptDir: string;
@@ -135,6 +137,15 @@ type Finding = {
   verificationHint: string;
   missingRegressionTest: string;
   evidence: string;
+  simplification?: SimplificationFinding;
+};
+
+type SimplificationFinding = {
+  tag: SimplificationTag;
+  cut: string;
+  replacement: string;
+  estimatedNetLines: number | null;
+  safetyBoundary: string;
 };
 
 type AcceptanceCoverage = {
@@ -199,6 +210,7 @@ export type DeterministicReviewContext = {
   riskyAreas: string[];
   testDepth: ReviewAdvisorResult["testDepth"];
   staticTestInventory: StaticTestInventory;
+  simplificationSignals: SimplificationSignal[];
   workflowSignals: string[];
   localizedPatchSignals: LocalizedPatchSignal[];
   monolithDeltas: MonolithDelta[];
@@ -217,6 +229,20 @@ type LocalizedPatchSignal = {
   file: string | null;
   line: number | null;
   kind: string;
+  evidence: string;
+  reviewRule: string;
+};
+
+export type SimplificationSignal = {
+  file: string | null;
+  line: number | null;
+  kind:
+    | "new_dependency"
+    | "single_use_abstraction"
+    | "single_use_config"
+    | "wrapper"
+    | "large_file_growth"
+    | "test_over_scaffold";
   evidence: string;
   reviewRule: string;
 };
@@ -624,6 +650,7 @@ async function collectDeterministicContext(options: {
     riskyAreas,
     testDepth,
     staticTestInventory,
+    simplificationSignals: detectSimplificationSignals(options.changedFiles, options.diff),
     previousAdvisorReview: github?.previousAdvisorReview || null,
     workflowSignals: detectWorkflowSignals(options.changedFiles, options.diff),
     localizedPatchSignals: detectLocalizedPatchSignals(options.diff),
@@ -821,6 +848,129 @@ function detectWorkflowSignals(changedFiles: string[], diff: string): string[] {
       "PR-controlled text may be interpolated into workflow expressions; verify shell safety.",
     );
   return signals;
+}
+
+export function detectSimplificationSignals(
+  changedFiles: string[],
+  diff: string,
+): SimplificationSignal[] {
+  const signals: SimplificationSignal[] = [];
+  let file: string | null = null;
+  let nextLine: number | null = null;
+  const changedFileSet = new Set(changedFiles);
+
+  for (const rawLine of diff.split("\n")) {
+    const fileMatch = rawLine.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (fileMatch) {
+      file = fileMatch[2] || fileMatch[1] || null;
+      nextLine = null;
+      continue;
+    }
+    const hunkMatch = rawLine.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      nextLine = Number.parseInt(hunkMatch[1] || "", 10);
+      if (!Number.isFinite(nextLine)) nextLine = null;
+      continue;
+    }
+    if (rawLine === "+++" || rawLine.startsWith("+++ ")) continue;
+    if (rawLine.startsWith("+")) {
+      const content = rawLine.slice(1).trim();
+      if (content) {
+        const signal = simplificationSignalForAddedLine(file, nextLine, content);
+        if (signal) signals.push(signal);
+      }
+      if (nextLine !== null) nextLine += 1;
+      if (signals.length >= 60) break;
+      continue;
+    }
+    if (rawLine.startsWith(" ") && nextLine !== null) nextLine += 1;
+  }
+
+  for (const delta of computeSimpleLargeFileDeltas(changedFileSet)) {
+    signals.push(delta);
+    if (signals.length >= 60) break;
+  }
+
+  return signals.slice(0, 60);
+}
+
+function simplificationSignalForAddedLine(
+  file: string | null,
+  line: number | null,
+  content: string,
+): SimplificationSignal | null {
+  const makeSignal = (
+    kind: SimplificationSignal["kind"],
+    reviewRule: string,
+  ): SimplificationSignal => ({ file, line, kind, evidence: content.slice(0, 220), reviewRule });
+
+  if (
+    /^(import|const|let|var)\b.*(?:\bfrom\s+["']|\brequire\(["'])(?:lodash|moment|date-fns|axios|uuid|chalk|commander|yargs)/.test(
+      content,
+    )
+  ) {
+    return makeSignal(
+      "new_dependency",
+      "Ask whether Node.js, TypeScript, browser, shell, or an already-installed dependency covers this before accepting another dependency.",
+    );
+  }
+  if (
+    /\b(?:interface|abstract\s+class|class)\s+\w*(?:Factory|Provider|Adapter|Strategy|Registry|Manager|Builder)\b/.test(
+      content,
+    )
+  ) {
+    return makeSignal(
+      "single_use_abstraction",
+      "Flag YAGNI when an abstraction has one implementation or one caller; inline until a second real variant exists.",
+    );
+  }
+  if (
+    /\b(?:process\.env\.[A-Z0-9_]+|[A-Z0-9_]+_ENABLED|ENABLE_[A-Z0-9_]+|DEFAULT_[A-Z0-9_]+)\b/.test(
+      content,
+    )
+  ) {
+    return makeSignal(
+      "single_use_config",
+      "Check whether this config knob is actually set by users/CI or whether a constant would be clearer until a second value exists.",
+    );
+  }
+  if (/\b(?:wrap|wrapper|proxy|adapter|facade|delegate)\b/i.test(content)) {
+    return makeSignal(
+      "wrapper",
+      "Check whether this wrapper adds policy/validation; if not, call the underlying API directly.",
+    );
+  }
+  if (
+    /\b(?:matrix|registry|framework|orchestrator|plugin)\b/i.test(content) &&
+    /\b(?:test|spec|fixture|scenario)\b/i.test(file || "")
+  ) {
+    return makeSignal(
+      "test_over_scaffold",
+      "Prefer one direct behavior test over a framework or registry when there is only one scenario.",
+    );
+  }
+  return null;
+}
+
+function computeSimpleLargeFileDeltas(changedFiles: Set<string>): SimplificationSignal[] {
+  return [...changedFiles]
+    .filter((file) => /^(tools\/pr-review-advisor|src|nemoclaw\/src)\/.*\.mts?$/.test(file))
+    .flatMap((file) => {
+      if (!fs.existsSync(file)) return [];
+      const lines = countLines(fs.readFileSync(file, "utf8"));
+      if (lines < 500) return [];
+      return [
+        {
+          file,
+          line: null,
+          kind: "large_file_growth" as const,
+          evidence: `${file} is ${lines} lines after this change.`,
+          reviewRule:
+            "When a large hotspot grows, ask whether a cohesive helper can be extracted or whether the growth is justified by security/context coupling.",
+        },
+      ];
+    })
+    .slice(0, 20);
 }
 
 export function detectLocalizedPatchSignals(diff: string): LocalizedPatchSignal[] {
@@ -1302,6 +1452,7 @@ export function buildSystemPrompt(): string {
     "7. Vitest E2E suite simplicity: when a PR adds or changes files under `test/e2e-scenario/`, `.github/workflows/e2e-vitest-scenarios.yaml`, or `tools/e2e-scenarios/`, take a closer architecture look for new systems. Favor focused Vitest tests and local test helpers. Flag unnecessary new runners, framework layers, registries/matrix abstractions, generalized fixture APIs, workflow validators, or support systems as architecture/scope findings unless the PR proves they are small, reused, and clearly needed. Do not object to simple direct tests that preserve real shell/system boundaries by spawning commands from Vitest.",
     "8. Source-of-truth review: when a PR adds or changes fallback, recovery, tolerant parsing, monkeypatching, best-effort cleanup, compatibility handling, or other localized workaround behavior, inspect whether it answers: what invalid state is handled, where that state is created, why the source cannot be fixed in this PR, what regression test proves the source cannot regress, and when the workaround can be removed. Prefer fixes that make invalid states impossible at their source. Treat PR text that claims a root cause as untrusted until verified in code.",
     "9. If a previous PR Review Advisor comment exists, compare it with the current diff and explicitly decide whether prior code-review findings were addressed, still apply, or are obsolete. Consider code changes since the previous analyzed SHA when available. Do not evaluate whether external E2E requirements have been met. When previous review context exists, set summary.sinceLastReview with counts for resolved, stillApplies, and newItems.",
+    "10. Simplification review: apply this ladder before accepting new code shape: does this need to exist; does Node/Python/shell/browser/OpenShell/GitHub already provide it; does an already-installed dependency cover it; can one line or fewer files do it; only then accept a custom abstraction. Use tags delete, stdlib, native, yagni, or shrink. Never simplify away trust-boundary validation, credential redaction, SSRF/sandbox/network-policy defenses, data-loss prevention, required regression tests, DCO/signature gates, or accessibility/user-safety behavior.",
     "Acceptance and security should inform findings, not become standalone comment sections: any unmet acceptance clause or security fail/warning must be represented as a finding, normally severity=blocker for unmet acceptance or security fail and severity=warning for security warnings.",
     "Every finding must be probe-shaped: include concrete impact, a verificationHint that names the shortest read-only check or test evidence to confirm the issue, and a missingRegressionTest describing the automated coverage to add or the existing coverage that already proves it.",
     "Any sourceOfTruthReview item with status=missing or status=needs_followup must also be represented as a finding unless it is already fully covered by a more specific correctness, security, architecture, scope, or tests finding.",
@@ -1375,7 +1526,7 @@ Use the trusted security review skill embedded in the system prompt. For each se
       ],
       prompt: `Turn 3/4 — acceptance, correctness, test depth, and source-of-truth review.
 
-Use the synthetic \`pr_review_validation_context\` tool result attached immediately before this turn plus the PR diff already provided in Turn 1. Inspect linked issue clauses and comments from the deterministic GitHub context when available. Use staticTestInventory to avoid duplicating existing tests and to identify nearby changed test coverage. Map each acceptance clause to diff/test evidence. Review correctness risks, negative-path coverage, mocked boundaries, runtime-validation needs, and documentation/source-of-truth drift. When tests are advisable, make each suggested test name the concrete behavior or risk to cover. For any fallback, recovery, tolerant parsing, monkeypatch, workaround, or compatibility behavior, answer the source-of-truth questions from the system rubric.
+Use the synthetic \`pr_review_validation_context\` tool result attached immediately before this turn plus the PR diff already provided in Turn 1. Inspect linked issue clauses and comments from the deterministic GitHub context when available. Use staticTestInventory to avoid duplicating existing tests and to identify nearby changed test coverage. Use simplificationSignals to look for safe opportunities to delete, use stdlib/native/platform features, remove YAGNI abstractions, or shrink changed code without weakening security or correctness boundaries. Map each acceptance clause to diff/test evidence. Review correctness risks, negative-path coverage, mocked boundaries, runtime-validation needs, and documentation/source-of-truth drift. When tests are advisable, make each suggested test name the concrete behavior or risk to cover. For any fallback, recovery, tolerant parsing, monkeypatch, workaround, or compatibility behavior, answer the source-of-truth questions from the system rubric.
 
 Do not produce final JSON yet; reply with concise working notes only.
 `,
@@ -1398,7 +1549,7 @@ Do not produce final JSON yet; reply with concise working notes only.
       ],
       prompt: `Turn 4/4 — synthesize the final advisor result.
 
-Return the final NemoClaw PR Review Advisor JSON only. Use your prior working notes, but keep the output focused on actionable current-review findings. Any unmet acceptance clause or security fail/warning must be represented as a finding. Any sourceOfTruthReview item with status=missing or status=needs_followup must also be represented as a finding unless already covered by a more specific finding. For every finding, populate impact, verificationHint, and missingRegressionTest with concrete, non-placeholder text. For suggestion-severity findings, recommend current-PR action when the improvement is local to changed code; recommend future follow-up only when the evidence shows it is genuinely out of scope.
+Return the final NemoClaw PR Review Advisor JSON only. Use your prior working notes, but keep the output focused on actionable current-review findings. Any unmet acceptance clause or security fail/warning must be represented as a finding. Any sourceOfTruthReview item with status=missing or status=needs_followup must also be represented as a finding unless already covered by a more specific finding. For every finding, populate impact, verificationHint, and missingRegressionTest with concrete, non-placeholder text. For safe simplification findings, populate simplification with a tag, what to cut, the replacement, estimated net line delta when clear, and the safety boundary that must remain. For suggestion-severity findings, recommend current-PR action when the improvement is local to changed code; recommend future follow-up only when the evidence shows it is genuinely out of scope.
 
 Set the fields exactly as specified in the synthetic \`pr_review_exact_metadata\` tool result attached immediately before this turn.
 
@@ -1495,6 +1646,7 @@ function buildValidationTurnContext(context: DeterministicReviewContext): Record
   return {
     testDepth: context.testDepth,
     staticTestInventory: context.staticTestInventory,
+    simplificationSignals: context.simplificationSignals,
     localizedPatchSignals: context.localizedPatchSignals,
     previousAdvisorReview: context.previousAdvisorReview,
     pullRequest: context.github?.pullRequest ?? null,
@@ -1653,8 +1805,27 @@ function sanitizeFindings(value: unknown): Finding[] {
         "No regression test recommendation provided.",
       ),
       evidence: stringOrDefault(item.evidence, "No evidence provided."),
+      simplification: sanitizeSimplification(item.simplification),
     }))
     .slice(0, 50);
+}
+
+function sanitizeSimplification(value: unknown): SimplificationFinding | undefined {
+  if (!isRecord(value)) return undefined;
+  const tag = enumValue(value.tag, SIMPLIFICATION_TAGS, "shrink");
+  return {
+    tag,
+    cut: stringOrDefault(value.cut, "Unspecified code to simplify."),
+    replacement: stringOrDefault(value.replacement, "Use the simpler existing path."),
+    estimatedNetLines:
+      typeof value.estimatedNetLines === "number" && Number.isInteger(value.estimatedNetLines)
+        ? value.estimatedNetLines
+        : null,
+    safetyBoundary: stringOrDefault(
+      value.safetyBoundary,
+      "Do not remove validation, security, data-loss prevention, or required test coverage.",
+    ),
+  };
 }
 
 function sanitizeAcceptanceCoverage(value: unknown): AcceptanceCoverage[] {

--- a/tools/pr-review-advisor/analyze.mts
+++ b/tools/pr-review-advisor/analyze.mts
@@ -954,10 +954,11 @@ function simplificationSignalForAddedLine(
 
 function computeSimpleLargeFileDeltas(changedFiles: Set<string>): SimplificationSignal[] {
   return [...changedFiles]
-    .filter((file) => /^(tools\/pr-review-advisor|src|nemoclaw\/src)\/.*\.mts?$/.test(file))
+    .filter((file) => /^(tools\/pr-review-advisor|src|nemoclaw\/src)\/.*\.(?:ts|mts)$/.test(file))
     .flatMap((file) => {
-      if (!fs.existsSync(file)) return [];
-      const lines = countLines(fs.readFileSync(file, "utf8"));
+      const text = readChangedRegularFilePrefix(file, 200000);
+      if (text === null) return [];
+      const lines = countLines(text);
       if (lines < 500) return [];
       return [
         {

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -34,6 +34,13 @@ type ReviewAdvisorResult = {
     verificationHint?: string;
     missingRegressionTest?: string;
     evidence?: string;
+    simplification?: {
+      tag?: string;
+      cut?: string;
+      replacement?: string;
+      estimatedNetLines?: number | null;
+      safetyBoundary?: string;
+    };
   }>;
   acceptanceCoverage?: Array<{
     clause?: string;
@@ -152,6 +159,7 @@ export function buildComment({
     result?.findings?.filter((finding) => finding.severity === "suggestion").length ?? 0;
   const secondary = buildSecondarySummary(result);
   const findingsDetails = renderFindingsDetails(result);
+  const simplificationDetails = renderSimplificationDetails(result);
   const testingFollowupsDetails = renderTestingFollowupsDetails(result);
   const previousReviewDetails = renderPreviousReviewDetails(result);
   const details = runUrl ? `\n[Workflow run details](${runUrl})` : "";
@@ -163,7 +171,7 @@ ${hiddenMetadata}## PR Review Advisor
 **Review posture:** ${posture}
 **Action expectation:** Address required items before merge. Resolve or explicitly justify warnings. Treat suggestions as current-PR improvements when they touch changed code; defer only with maintainer rationale or a linked follow-up.
 **Findings:** ${countLabel(blockerCount, "required fix", "required fixes")}, ${countLabel(warningCount, "item to resolve/justify", "items to resolve/justify")}, ${countLabel(suggestionCount, "in-scope improvement", "in-scope improvements")}
-${secondary}${findingsDetails}${testingFollowupsDetails}${previousReviewDetails}${details}
+${secondary}${findingsDetails}${simplificationDetails}${testingFollowupsDetails}${previousReviewDetails}${details}
 
 This is an automated, non-binding review; it still expects maintainers and agents to respond to each finding. A human maintainer must make the final merge decision.
 
@@ -263,6 +271,42 @@ function renderFindingsDetails(result?: ReviewAdvisorResult): string {
     lines.push("");
   }
   lines.push("</details>", "");
+  return `${lines.join("\n")}\n`;
+}
+
+function renderSimplificationDetails(result?: ReviewAdvisorResult): string {
+  const findings = result?.findings?.filter((finding) => finding.simplification) || [];
+  if (findings.length === 0) return "";
+  const netLines = findings.reduce((total, finding) => {
+    const value = finding.simplification?.estimatedNetLines;
+    return typeof value === "number" && Number.isFinite(value) ? total + value : total;
+  }, 0);
+  const netLabel = netLines < 0 ? `, net ${netLines} lines possible` : "";
+  const lines: string[] = [
+    "",
+    "<details>",
+    `<summary>Simplification opportunities: ${countLabel(findings.length, "possible cut", "possible cuts")}${netLabel}</summary>`,
+    "",
+    "_These are safe simplification checks only. Do not remove validation, security controls, data-loss prevention, or required tests._",
+  ];
+  for (const finding of findings.slice(0, 12)) {
+    const item = finding.simplification;
+    if (!item) continue;
+    const location = formatFindingLocation(finding);
+    lines.push(
+      `- **${escapeCommentText(item.tag || "shrink")}**${location}: ${escapeCommentText(item.cut || finding.title || "Review simplification")}`,
+    );
+    lines.push(
+      `  - Replacement: ${escapeCommentText(item.replacement || "Use the simpler existing path.")}`,
+    );
+    if (typeof item.estimatedNetLines === "number") {
+      lines.push(`  - Net: ${item.estimatedNetLines} lines`);
+    }
+    lines.push(
+      `  - Safety boundary: ${escapeCommentText(item.safetyBoundary || "Keep validation, security, data-loss prevention, and required tests.")}`,
+    );
+  }
+  lines.push("", "</details>", "");
   return `${lines.join("\n")}\n`;
 }
 

--- a/tools/pr-review-advisor/schema.json
+++ b/tools/pr-review-advisor/schema.json
@@ -193,7 +193,20 @@
         "recommendation": { "type": "string" },
         "verificationHint": { "type": "string" },
         "missingRegressionTest": { "type": "string" },
-        "evidence": { "type": "string" }
+        "evidence": { "type": "string" },
+        "simplification": { "$ref": "#/$defs/simplification" }
+      },
+      "additionalProperties": false
+    },
+    "simplification": {
+      "type": "object",
+      "required": ["tag", "cut", "replacement", "estimatedNetLines", "safetyBoundary"],
+      "properties": {
+        "tag": { "enum": ["delete", "stdlib", "native", "yagni", "shrink"] },
+        "cut": { "type": "string" },
+        "replacement": { "type": "string" },
+        "estimatedNetLines": { "type": ["integer", "null"] },
+        "safetyBoundary": { "type": "string" }
       },
       "additionalProperties": false
     }


### PR DESCRIPTION
## Summary
Adds a simplification review lane to the PR Review Advisor so it can surface safe delete, stdlib, native, YAGNI, and shrink opportunities alongside correctness/security findings. The advisor now receives deterministic simplification signals, can emit structured simplification metadata on findings, and renders a collapsed simplification section in sticky comments.

## Changes
- Add deterministic simplification signal detection for new dependencies, single-use abstractions/config, wrappers, test over-scaffolding, and large advisor/source hotspots.
- Add prompt guidance for a safe simplification ladder that preserves security, validation, data-loss prevention, and required tests.
- Extend finding schema/normalization with optional simplification metadata: tag, cut, replacement, estimated net lines, and safety boundary.
- Render simplification opportunities in a dedicated collapsed sticky-comment section.
- Update tests and the PR Review Advisor README for simplification signals and output contract behavior.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “simplification review” that identifies safe cleanup/optimization opportunities (e.g., safe delete, YAGNI/shrink, stdlib/native) and includes safety boundary guidance.
  * Review outputs now render a **“Simplification opportunities”** section with tag, cut/replacement guidance, optional estimated net line impact, and preserved safety-boundary text.

* **Documentation**
  * Updated PR Review Advisor documentation and output contract to describe the new simplification-signal and “safe simplification” metadata expectations.

* **Tests**
  * Expanded end-to-end and unit coverage for simplification signal detection (including large-file growth and symlink skip cases) plus verification of rendered comment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->