### PR TITLE
test(e2e): migrate OpenClaw Discord pairing to Vitest

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -4133,6 +4133,83 @@ jobs:
           docker logout docker.io || true
           rm -rf "${DOCKER_CONFIG}"
 
+  openclaw-discord-pairing-vitest:
+    needs: generate-matrix
+    if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',openclaw-discord-pairing-vitest,') || contains(format(',{0},', inputs.scenarios), ',openclaw-discord-pairing,') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      FREE_STANDING_VITEST_JOB: "1"
+      FREE_STANDING_SCENARIO_ID: "openclaw-discord-pairing"
+      DOCKER_CONFIG: ${{ github.workspace }}/.docker-config-openclaw-discord-pairing
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/openclaw-discord-pairing
+      NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
+      NEMOCLAW_RUN_E2E_SCENARIOS: "1"
+      NEMOCLAW_NON_INTERACTIVE: "1"
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_SANDBOX_NAME: "e2e-openclaw-discord-pairing"
+      OPENSHELL_GATEWAY: "nemoclaw"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
+            exit 0
+          fi
+          mkdir -p "${DOCKER_CONFIG}"
+          chmod 700 "${DOCKER_CONFIG}"
+          echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin || echo "::warning::Docker Hub login failed; continuing with anonymous pulls."
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Run OpenClaw Discord pairing live test
+        # Migrated from test/e2e/test-openclaw-discord-pairing.sh. Preserves
+        # fake Discord Gateway token rewrite and connect-shell pairing approval.
+        env:
+          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          DISCORD_BOT_TOKEN: test-fake-discord-pairing-e2e
+        run: |
+          set -euo pipefail
+          npx vitest run --project e2e-scenarios-live \
+            test/e2e-scenario/live/openclaw-discord-pairing.test.ts \
+            --silent=false --reporter=default
+
+      - name: Upload OpenClaw Discord pairing artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-vitest-scenarios-openclaw-discord-pairing
+          path: e2e-artifacts/vitest/openclaw-discord-pairing/
+          include-hidden-files: false
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        run: |
+          set -euo pipefail
+          docker logout docker.io || true
+          rm -rf "${DOCKER_CONFIG}"
+
   issue-2478-crash-loop-recovery-vitest:
     needs: generate-matrix
     if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',issue-2478-crash-loop-recovery-vitest,') || contains(format(',{0},', inputs.scenarios), ',issue-2478-crash-loop-recovery,') }}
@@ -4304,6 +4381,7 @@ jobs:
         device-auth-health-vitest,
         channels-add-remove-vitest,
         telegram-injection-vitest,
+        openclaw-discord-pairing-vitest,
       ]
     if: ${{ always() && github.event_name == 'workflow_dispatch' }}
     permissions:

--- a/test/e2e-scenario/live/openclaw-discord-pairing.test.ts
+++ b/test/e2e-scenario/live/openclaw-discord-pairing.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Live Vitest replacement for test/e2e/test-openclaw-discord-pairing.sh. */
+
+import fs from "node:fs";
+
+import { expect, test } from "../fixtures/e2e-test.ts";
+import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
+import {
+  applyFakePolicy,
+  approveAndAssertPairing,
+  assertOpenClawStateRoot,
+  cleanupPairingSandbox,
+  DISCORD_DM_CHANNEL,
+  extractPairingCode,
+  issuePairingRequest,
+  PAIRING_USER,
+  pairingEnv,
+  pairingRedactions,
+  runDiscordGatewayProof,
+  startFakeDiscordGateway,
+  writePairingArtifacts,
+} from "./openclaw-pairing-helpers.ts";
+import {
+  dockerInfo,
+  expectExitZero,
+  expectSandboxReady,
+  installSandbox,
+  resultText,
+  sandboxSh,
+} from "./phase6-messaging-helpers.ts";
+
+const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-openclaw-discord-pairing";
+const DISCORD_TOKEN = process.env.DISCORD_BOT_TOKEN ?? "test-fake-discord-pairing-e2e";
+const LIVE_TIMEOUT_MS = 55 * 60_000;
+
+function assertDiscordGatewayCapture(captureFile: string): void {
+  const rows = fs
+    .readFileSync(captureFile, "utf8")
+    .trim()
+    .split(/\n+/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  const identify = rows.filter((row) => row.event === "identify").at(-1);
+  expect(identify, "fake Discord Gateway did not capture IDENTIFY").toBeTruthy();
+  expect(identify?.tokenMatchesExpected, "Discord token rewrite").toBe(true);
+  expect(identify?.tokenLooksPlaceholder, "Discord placeholder leaked").toBe(false);
+}
+
+test.skipIf(!shouldRunLiveE2EScenarios())(
+  "OpenClaw Discord pairing request is shared with connect-shell approval",
+  { timeout: LIVE_TIMEOUT_MS },
+  async ({ artifacts, cleanup, host, sandbox, secrets, skip }) => {
+    const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
+    const env = pairingEnv({
+      sandboxName: SANDBOX_NAME,
+      apiKey,
+      channel: "discord",
+      discordToken: DISCORD_TOKEN,
+    });
+    const redactions = pairingRedactions({ apiKey, discordToken: DISCORD_TOKEN });
+
+    await artifacts.writeJson("scenario.json", {
+      id: "openclaw-discord-pairing",
+      legacySource: "test/e2e/test-openclaw-discord-pairing.sh",
+      boundary:
+        "install.sh Discord OpenClaw sandbox + fake Discord Gateway token rewrite + runtime pairing request + connect-shell approval",
+      sandboxName: SANDBOX_NAME,
+      pairingUser: PAIRING_USER.discord,
+      dmChannel: DISCORD_DM_CHANNEL,
+    });
+
+    cleanup.add(`destroy Discord pairing sandbox ${SANDBOX_NAME}`, () =>
+      cleanupPairingSandbox(host, SANDBOX_NAME, env, redactions, "cleanup-discord-pairing"),
+    );
+    await cleanupPairingSandbox(host, SANDBOX_NAME, env, redactions, "preclean-discord-pairing");
+
+    const docker = await dockerInfo(host, env);
+    expect(docker.exitCode, resultText(docker)).toBe(0);
+
+    try {
+      const install = await installSandbox(host, env, redactions, "install-discord-pairing");
+      expectExitZero(install, "install.sh --non-interactive with Discord");
+    } catch (error) {
+      if (String(error).includes("NVIDIA_ENDPOINT_RATE_LIMIT")) {
+        skip("NVIDIA endpoint validation was rate-limited before Discord pairing assertions ran");
+        return;
+      }
+      throw error;
+    }
+    await expectSandboxReady(host, SANDBOX_NAME, env, redactions, "sandbox-list-discord-pairing");
+
+    const provider = await host.command(
+      "openshell",
+      ["provider", "get", `${SANDBOX_NAME}-discord-bridge`],
+      {
+        artifactName: "provider-get-discord-pairing",
+        env,
+        redactionValues: redactions,
+        timeoutMs: 60_000,
+      },
+    );
+    expectExitZero(provider, "Discord provider exists");
+
+    const config = await sandboxSh(
+      sandbox,
+      SANDBOX_NAME,
+      `python3 - <<'PY'\nimport json\ncfg=json.load(open('/sandbox/.openclaw/openclaw.json'))\naccount=(cfg.get('channels',{}).get('discord',{}).get('accounts',{}).get('default') or {})\nprint(json.dumps({'token': account.get('token',''), 'dmPolicy': account.get('dmPolicy',''), 'allowFrom': account.get('allowFrom', [])}))\nPY`,
+      { artifactName: "discord-openclaw-config", redactionValues: redactions },
+    );
+    expectExitZero(config, "Discord OpenClaw config");
+    expect(config.stdout).toContain("openshell:resolve:env:");
+    expect(config.stdout).toContain("DISCORD_BOT_TOKEN");
+    expect(config.stdout).not.toContain('"dmPolicy": "allowlist"');
+
+    await assertOpenClawStateRoot(sandbox, SANDBOX_NAME, "discord", redactions);
+
+    const fakeGateway = await startFakeDiscordGateway(
+      host,
+      cleanup,
+      env,
+      DISCORD_TOKEN,
+      redactions,
+    );
+    await applyFakePolicy({
+      host,
+      sandboxName: SANDBOX_NAME,
+      api: fakeGateway,
+      protocol: "websocket",
+      rewrite: "websocket-credential-rewrite",
+      env,
+      redactions,
+      artifactName: "apply-discord-gateway-policy",
+    });
+    const gatewayProof = await runDiscordGatewayProof({
+      sandbox,
+      sandboxName: SANDBOX_NAME,
+      port: fakeGateway.port,
+      redactions,
+    });
+    expectExitZero(gatewayProof, "Discord Gateway protocol proof");
+    expect(resultText(gatewayProof)).toContain("UPGRADE");
+    expect(resultText(gatewayProof)).toContain("HELLO");
+    expect(resultText(gatewayProof)).toContain("IDENTIFY_SENT_PLACEHOLDER");
+    expect(resultText(gatewayProof)).toContain("READY");
+    expect(resultText(gatewayProof)).toContain("HEARTBEAT_ACK");
+    assertDiscordGatewayCapture(fakeGateway.captureFile);
+
+    const issue = await issuePairingRequest({
+      sandbox,
+      sandboxName: SANDBOX_NAME,
+      channel: "discord",
+      redactions,
+    });
+    expectExitZero(issue, "Discord pairing request creation");
+    const code = extractPairingCode(resultText(issue), "DISCORD_PAIRING_E2E_RESULT");
+    await writePairingArtifacts(artifacts, "discord", { code, user: PAIRING_USER.discord });
+
+    await approveAndAssertPairing({
+      sandbox,
+      sandboxName: SANDBOX_NAME,
+      channel: "discord",
+      code,
+      redactions,
+    });
+  },
+);

--- a/test/e2e-scenario/live/openclaw-pairing-helpers.ts
+++ b/test/e2e-scenario/live/openclaw-pairing-helpers.ts
@@ -1,0 +1,659 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ArtifactSink } from "../fixtures/artifacts.ts";
+import type { CleanupRegistry } from "../fixtures/cleanup.ts";
+import type { HostCliClient } from "../fixtures/clients/host.ts";
+import type { SandboxClient } from "../fixtures/clients/sandbox.ts";
+import { expect } from "../fixtures/e2e-test.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { type FakeDockerApi, startFakeDockerApi } from "./messaging-providers-helpers.ts";
+import {
+  bestEffort,
+  cleanupSandbox,
+  expectExitZero,
+  phase6Env,
+  REPO_ROOT,
+  resultText,
+  sandboxEncodedSh,
+  sandboxNode,
+  sandboxSh,
+} from "./phase6-messaging-helpers.ts";
+
+export type PairingChannel = "slack" | "discord";
+
+export const PAIRING_USER = {
+  slack: process.env.NEMOCLAW_SLACK_PAIRING_USER ?? "U3730E2E",
+  discord: process.env.NEMOCLAW_DISCORD_PAIRING_USER ?? "1005536447329222676",
+};
+
+export const DISCORD_DM_CHANNEL = process.env.NEMOCLAW_DISCORD_DM_CHANNEL ?? "1199988877766655554";
+
+export function pairingEnv(options: {
+  sandboxName: string;
+  apiKey: string;
+  channel: PairingChannel;
+  slackBot?: string;
+  slackApp?: string;
+  discordToken?: string;
+}): NodeJS.ProcessEnv {
+  const extra: NodeJS.ProcessEnv =
+    options.channel === "slack"
+      ? {
+          SLACK_BOT_TOKEN: options.slackBot ?? "xoxb-fake-slack-pairing-e2e",
+          SLACK_APP_TOKEN: options.slackApp ?? "xapp-fake-slack-pairing-e2e",
+          NEMOCLAW_SKIP_SLACK_AUTH_VALIDATION: "1",
+        }
+      : {
+          DISCORD_BOT_TOKEN: options.discordToken ?? "test-fake-discord-pairing-e2e",
+        };
+  return phase6Env({
+    sandboxName: options.sandboxName,
+    agent: "openclaw",
+    apiKey: options.apiKey,
+    extra,
+  });
+}
+
+export function pairingRedactions(options: {
+  apiKey: string;
+  slackBot?: string;
+  slackApp?: string;
+  discordToken?: string;
+}): string[] {
+  return [options.apiKey, options.slackBot, options.slackApp, options.discordToken].filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+}
+
+export async function cleanupPairingSandbox(
+  host: HostCliClient,
+  sandboxName: string,
+  env: NodeJS.ProcessEnv,
+  redactions: string[],
+  prefix: string,
+): Promise<void> {
+  await cleanupSandbox(host, sandboxName, env, redactions, prefix);
+  await bestEffort(() =>
+    host.command("openshell", ["gateway", "destroy", "-g", "nemoclaw"], {
+      artifactName: `${prefix}-openshell-gateway-destroy`,
+      env,
+      redactionValues: redactions,
+      timeoutMs: 120_000,
+    }),
+  );
+}
+
+export async function premergeSlackPolicyIfNeeded(cleanup: CleanupRegistry): Promise<void> {
+  const basePolicy = path.join(
+    REPO_ROOT,
+    "nemoclaw-blueprint",
+    "policies",
+    "openclaw-sandbox.yaml",
+  );
+  const original = fs.readFileSync(basePolicy, "utf8");
+  if (original.includes("api.slack.com")) return;
+  fs.appendFileSync(
+    basePolicy,
+    `
+
+  # Slack - pre-merged for OpenClaw Slack pairing Vitest E2E (#3730)
+  slack:
+    name: slack
+    endpoints:
+      - host: slack.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: api.slack.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: hooks.slack.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: POST, path: "/**" }
+      - host: wss-primary.slack.com
+        port: 443
+        protocol: websocket
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: WEBSOCKET_TEXT, path: "/**" }
+      - host: wss-backup.slack.com
+        port: 443
+        protocol: websocket
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+          - allow: { method: WEBSOCKET_TEXT, path: "/**" }
+    binaries:
+      - { path: /usr/local/bin/node }
+      - { path: /usr/bin/node }
+`,
+  );
+  cleanup.add("restore Slack pairing base policy pre-merge", async () => {
+    fs.writeFileSync(basePolicy, original);
+  });
+}
+
+export async function startFakeDiscordGateway(
+  host: HostCliClient,
+  cleanup: CleanupRegistry,
+  env: NodeJS.ProcessEnv,
+  token: string,
+  redactions: string[],
+): Promise<FakeDockerApi> {
+  return startFakeDockerApi(host, cleanup.add.bind(cleanup), {
+    kind: "discord-gateway",
+    imageScript: "fake-discord-gateway.cjs",
+    containerPrefix: "nemoclaw-fake-discord-pairing",
+    portEnv: "FAKE_DISCORD_GATEWAY_PORT",
+    portFileEnv: "FAKE_DISCORD_GATEWAY_PORT_FILE",
+    captureFileEnv: "FAKE_DISCORD_GATEWAY_CAPTURE_FILE",
+    expectedEnv: { FAKE_DISCORD_GATEWAY_EXPECTED_TOKEN: token },
+    env,
+    redactionValues: redactions,
+  });
+}
+
+export async function startFakeSlackApi(
+  host: HostCliClient,
+  cleanup: CleanupRegistry,
+  env: NodeJS.ProcessEnv,
+  botToken: string,
+  appToken: string,
+  redactions: string[],
+): Promise<FakeDockerApi> {
+  return startFakeDockerApi(host, cleanup.add.bind(cleanup), {
+    kind: "slack",
+    imageScript: "fake-slack-api.cjs",
+    containerPrefix: "nemoclaw-fake-slack-pairing",
+    portEnv: "FAKE_SLACK_API_PORT",
+    portFileEnv: "FAKE_SLACK_API_PORT_FILE",
+    captureFileEnv: "FAKE_SLACK_API_CAPTURE_FILE",
+    expectedEnv: {
+      FAKE_SLACK_API_EXPECTED_BOT_TOKEN: botToken,
+      FAKE_SLACK_API_EXPECTED_APP_TOKEN: appToken,
+      FAKE_SLACK_API_SOCKET_USER_ID: PAIRING_USER.slack,
+    },
+    env,
+    redactionValues: redactions,
+  });
+}
+
+export async function applyFakePolicy(options: {
+  host: HostCliClient;
+  sandboxName: string;
+  api: FakeDockerApi;
+  protocol: "rest" | "websocket";
+  rewrite: "request-body-credential-rewrite" | "websocket-credential-rewrite";
+  env: NodeJS.ProcessEnv;
+  redactions: string[];
+  artifactName: string;
+}): Promise<void> {
+  const methods = options.protocol === "rest" ? ["GET", "POST"] : ["GET", "WEBSOCKET_TEXT"];
+  const args = [
+    "policy",
+    "update",
+    options.sandboxName,
+    "--add-endpoint",
+    `host.openshell.internal:${options.api.port}:read-write:${options.protocol}:enforce:${options.rewrite},allowed-ip=10.0.0.0/8,allowed-ip=172.16.0.0/12,allowed-ip=192.168.0.0/16`,
+  ];
+  for (const method of methods)
+    args.push("--add-allow", `host.openshell.internal:${options.api.port}:${method}:/**`);
+  args.push("--binary", "/usr/local/bin/node", "--binary", "/usr/bin/node", "--wait");
+  const result = await options.host.command("openshell", args, {
+    artifactName: options.artifactName,
+    env: options.env,
+    redactionValues: options.redactions,
+    timeoutMs: 120_000,
+  });
+  expectExitZero(result, options.artifactName);
+}
+
+export async function assertOpenClawStateRoot(
+  sandbox: SandboxClient,
+  sandboxName: string,
+  channel: PairingChannel,
+  redactions: string[],
+): Promise<void> {
+  const env = await sandboxSh(
+    sandbox,
+    sandboxName,
+    'printf "OPENCLAW_HOME=%s\\nOPENCLAW_STATE_DIR=%s\\nOPENCLAW_CONFIG_PATH=%s\\nOPENCLAW_OAUTH_DIR=%s\\n" "$OPENCLAW_HOME" "$OPENCLAW_STATE_DIR" "$OPENCLAW_CONFIG_PATH" "$OPENCLAW_OAUTH_DIR"',
+    { artifactName: `${channel}-openclaw-state-env`, redactionValues: redactions },
+  );
+  expectExitZero(env, "OpenClaw state env");
+  expect(resultText(env)).toContain("OPENCLAW_HOME=/sandbox");
+  expect(resultText(env)).toContain("OPENCLAW_STATE_DIR=/sandbox/.openclaw");
+  expect(resultText(env)).toContain("OPENCLAW_CONFIG_PATH=/sandbox/.openclaw/openclaw.json");
+  expect(resultText(env)).toContain("OPENCLAW_OAUTH_DIR=/sandbox/.openclaw/credentials");
+
+  const list = await sandboxSh(
+    sandbox,
+    sandboxName,
+    `openclaw pairing list ${channel} --json 2>&1`,
+    {
+      artifactName: `${channel}-initial-pairing-list`,
+      redactionValues: redactions,
+    },
+  );
+  expectExitZero(list, `openclaw pairing list ${channel}`);
+  expect(resultText(list)).toMatch(new RegExp(`"channel"\\s*:\\s*"${channel}"`));
+}
+
+const LOAD_CONVERSATION_RUNTIME_SOURCE = String.raw`
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+function findOpenClawPackageRootFromBinary() {
+  let binary = "";
+  try { binary = execFileSync("sh", ["-lc", "command -v openclaw"], { encoding: "utf8" }).trim(); } catch { return null; }
+  if (!binary) return null;
+  let current = "";
+  try { current = fs.realpathSync(binary); } catch { return null; }
+  if (fs.statSync(current).isFile()) current = path.dirname(current);
+  for (let depth = 0; depth < 8; depth += 1) {
+    const manifest = path.join(current, "package.json");
+    if (fs.existsSync(manifest)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(manifest, "utf8"));
+        if (pkg?.name === "openclaw") return current;
+      } catch {}
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+async function loadConversationRuntime() {
+  const candidates = [];
+  const binaryRoot = findOpenClawPackageRootFromBinary();
+  if (binaryRoot) candidates.push(binaryRoot);
+  try {
+    const globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
+    if (globalRoot) candidates.push(path.join(globalRoot, "openclaw"));
+  } catch {}
+  candidates.push("/usr/local/lib/node_modules/openclaw", "/usr/lib/node_modules/openclaw");
+  for (const root of [...new Set(candidates)]) {
+    const runtime = path.join(root, "dist/plugin-sdk/conversation-runtime.js");
+    if (fs.existsSync(runtime)) return import(pathToFileURL(runtime).href);
+  }
+  throw new Error("OpenClaw conversation runtime not found; checked: " + candidates.join(", "));
+}
+`;
+
+export const DISCORD_PAIRING_SCRIPT = String.raw`
+set -eu
+set -a
+[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh
+set +a
+discord_pairing_user="$1"
+discord_dm_channel="$2"
+: "\${OPENCLAW_HOME:?OPENCLAW_HOME missing}"
+: "\${OPENCLAW_STATE_DIR:?OPENCLAW_STATE_DIR missing}"
+: "\${OPENCLAW_CONFIG_PATH:?OPENCLAW_CONFIG_PATH missing}"
+: "\${OPENCLAW_OAUTH_DIR:?OPENCLAW_OAUTH_DIR missing}"
+exec env HOME=/sandbox OPENCLAW_HOME="$OPENCLAW_HOME" OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" OPENCLAW_CONFIG_PATH="$OPENCLAW_CONFIG_PATH" OPENCLAW_OAUTH_DIR="$OPENCLAW_OAUTH_DIR" HTTP_PROXY="\${HTTP_PROXY:-}" HTTPS_PROXY="\${HTTPS_PROXY:-}" http_proxy="\${http_proxy:-}" https_proxy="\${https_proxy:-}" NO_PROXY="\${NO_PROXY:-}" no_proxy="\${no_proxy:-}" NODE_OPTIONS="\${NODE_OPTIONS:-}" DISCORD_PAIRING_USER="$discord_pairing_user" DISCORD_DM_CHANNEL="$discord_dm_channel" node --input-type=module <<'NODE'
+__LOAD_CONVERSATION_RUNTIME_SOURCE__
+const { issuePairingChallenge, upsertChannelPairingRequest } = await loadConversationRuntime();
+const senderId = process.env.DISCORD_PAIRING_USER;
+const channelId = process.env.DISCORD_DM_CHANNEL;
+let replyText = "";
+const result = await issuePairingChallenge({
+  channel: "discord",
+  senderId,
+  senderIdLine: "Discord user id: " + senderId,
+  meta: { accountId: "default", channelId, isDirectMessage: true },
+  upsertPairingRequest: async ({ id, meta }) => upsertChannelPairingRequest({ channel: "discord", id, accountId: "default", meta }),
+  sendPairingReply: async (text) => { replyText = text; },
+});
+if (!result.created || !result.code) throw new Error("pairing challenge was not created: " + JSON.stringify(result));
+console.log("DISCORD_PAIRING_E2E_RESULT " + JSON.stringify({ code: result.code, senderId, channelId, replyText }));
+NODE
+`.replace("__LOAD_CONVERSATION_RUNTIME_SOURCE__", LOAD_CONVERSATION_RUNTIME_SOURCE);
+
+export const SLACK_PAIRING_SCRIPT = String.raw`
+set -eu
+set -a
+[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh
+set +a
+fake_slack_api_port="$1"
+slack_pairing_user="$2"
+: "\${OPENCLAW_HOME:?OPENCLAW_HOME missing}"
+: "\${OPENCLAW_STATE_DIR:?OPENCLAW_STATE_DIR missing}"
+: "\${OPENCLAW_CONFIG_PATH:?OPENCLAW_CONFIG_PATH missing}"
+: "\${OPENCLAW_OAUTH_DIR:?OPENCLAW_OAUTH_DIR missing}"
+exec env HOME=/sandbox OPENCLAW_HOME="$OPENCLAW_HOME" OPENCLAW_STATE_DIR="$OPENCLAW_STATE_DIR" OPENCLAW_CONFIG_PATH="$OPENCLAW_CONFIG_PATH" OPENCLAW_OAUTH_DIR="$OPENCLAW_OAUTH_DIR" HTTP_PROXY="\${HTTP_PROXY:-}" HTTPS_PROXY="\${HTTPS_PROXY:-}" http_proxy="\${http_proxy:-}" https_proxy="\${https_proxy:-}" NO_PROXY="\${NO_PROXY:-}" no_proxy="\${no_proxy:-}" NODE_OPTIONS="\${NODE_OPTIONS:-}" FAKE_SLACK_API_HOST="host.openshell.internal" FAKE_SLACK_API_PORT="$fake_slack_api_port" SLACK_PAIRING_USER="$slack_pairing_user" node --input-type=module <<'NODE'
+__LOAD_CONVERSATION_RUNTIME_SOURCE__
+import crypto from "node:crypto";
+import http from "node:http";
+import net from "node:net";
+
+function parseProxyTarget() {
+  const raw = process.env.HTTP_PROXY || process.env.http_proxy || "";
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "http:" ? { host: parsed.hostname, port: Number(parsed.port || "80") } : null;
+  } catch {
+    return null;
+  }
+}
+function encodeClientText(payload) {
+  const body = Buffer.from(payload, "utf8");
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.alloc(body.length);
+  for (let i = 0; i < body.length; i += 1) masked[i] = body[i] ^ mask[i % 4];
+  if (body.length < 126) return Buffer.concat([Buffer.from([0x81, 0x80 | body.length]), mask, masked]);
+  const header = Buffer.alloc(4);
+  header[0] = 0x81;
+  header[1] = 0x80 | 126;
+  header.writeUInt16BE(body.length, 2);
+  return Buffer.concat([header, mask, masked]);
+}
+function decodeServerFrame(buffer) {
+  if (buffer.length < 2) return null;
+  const opcode = buffer[0] & 0x0f;
+  let payloadLength = buffer[1] & 0x7f;
+  let offset = 2;
+  if (payloadLength === 126) {
+    if (buffer.length < 4) return null;
+    payloadLength = buffer.readUInt16BE(2);
+    offset = 4;
+  } else if (payloadLength === 127) {
+    if (buffer.length < 10) return null;
+    payloadLength = Number(buffer.readBigUInt64BE(2));
+    offset = 10;
+  }
+  if (buffer.length < offset + payloadLength) return null;
+  return { opcode, payload: buffer.slice(offset, offset + payloadLength), totalLength: offset + payloadLength };
+}
+function receiveSlackSocketEvent() {
+  const host = "host.openshell.internal";
+  const port = Number(process.env.FAKE_SLACK_API_PORT);
+  const proxy = parseProxyTarget();
+  return new Promise((resolve, reject) => {
+    const socket = proxy ? net.createConnection({ host: proxy.host, port: proxy.port }) : net.createConnection({ host, port });
+    const timer = setTimeout(() => { socket.destroy(); reject(new Error("timed out waiting for fake Slack Socket Mode event")); }, 30000);
+    let handshake = Buffer.alloc(0);
+    let framed = Buffer.alloc(0);
+    let upgraded = false;
+    socket.on("connect", () => {
+      const key = crypto.randomBytes(16).toString("base64");
+      const requestTarget = proxy ? "http://" + host + ":" + port + "/socket-mode" : "/socket-mode";
+      socket.write([
+        "GET " + requestTarget + " HTTP/1.1",
+        "Host: " + host + ":" + port,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        "Sec-WebSocket-Key: " + key,
+        "Sec-WebSocket-Version: 13",
+        "\r\n",
+      ].join("\r\n"));
+    });
+    socket.on("data", (chunk) => {
+      if (!upgraded) {
+        handshake = Buffer.concat([handshake, chunk]);
+        const end = handshake.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        const statusLine = handshake.slice(0, end).toString("latin1").split("\r\n")[0] || "";
+        if (!statusLine.includes("101")) {
+          clearTimeout(timer);
+          socket.destroy();
+          reject(new Error("fake Slack websocket upgrade failed: " + statusLine));
+          return;
+        }
+        upgraded = true;
+        framed = Buffer.concat([framed, handshake.slice(end + 4)]);
+        socket.write(encodeClientText(JSON.stringify({ type: "socket_mode_client_hello", token: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN" })));
+      } else {
+        framed = Buffer.concat([framed, chunk]);
+      }
+      while (framed.length > 0) {
+        const frame = decodeServerFrame(framed);
+        if (!frame) break;
+        framed = framed.slice(frame.totalLength);
+        if (frame.opcode !== 1) continue;
+        const envelope = JSON.parse(frame.payload.toString("utf8"));
+        socket.write(encodeClientText(JSON.stringify({ envelope_id: envelope.envelope_id })));
+        clearTimeout(timer);
+        socket.end();
+        socket.destroy();
+        resolve(envelope);
+        return;
+      }
+    });
+    socket.on("error", (error) => { clearTimeout(timer); reject(error); });
+  });
+}
+function postPairingReply(text, channel) {
+  const host = "host.openshell.internal";
+  const port = Number(process.env.FAKE_SLACK_API_PORT);
+  const token = "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN";
+  const data = new URLSearchParams({ token, channel, text }).toString();
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: host,
+      port,
+      path: "/api/chat.postMessage",
+      method: "POST",
+      headers: {
+        Authorization: "Bearer " + token,
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": Buffer.byteLength(data),
+      },
+      timeout: 30000,
+    }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => { body += chunk; });
+      res.on("end", () => {
+        if (res.statusCode !== 200) reject(new Error("chat.postMessage failed: " + res.statusCode + " " + body.slice(0, 200)));
+        else resolve(body);
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("chat.postMessage timed out")));
+    req.write(data);
+    req.end();
+  });
+}
+const { issuePairingChallenge, upsertChannelPairingRequest } = await loadConversationRuntime();
+const envelope = await receiveSlackSocketEvent();
+const event = envelope?.payload?.event;
+if (!event || event.type !== "message" || !event.user || !event.channel) throw new Error("unexpected fake Slack envelope: " + JSON.stringify(envelope).slice(0, 400));
+if (event.user !== process.env.SLACK_PAIRING_USER) throw new Error("unexpected fake Slack user: " + event.user);
+const result = await issuePairingChallenge({
+  channel: "slack",
+  senderId: event.user,
+  senderIdLine: "Slack user ID: " + event.user,
+  meta: { accountId: "default", channelId: event.channel, teamId: envelope.payload?.team_id || "" },
+  upsertPairingRequest: async ({ id, meta }) => upsertChannelPairingRequest({ channel: "slack", id, accountId: "default", meta }),
+  sendPairingReply: async (text) => { await postPairingReply(text, event.channel); },
+});
+if (!result.created || !result.code) throw new Error("pairing challenge was not created: " + JSON.stringify(result));
+console.log("PAIRING_E2E_RESULT " + JSON.stringify({ code: result.code, senderId: event.user, channelId: event.channel }));
+NODE
+`.replace("__LOAD_CONVERSATION_RUNTIME_SOURCE__", LOAD_CONVERSATION_RUNTIME_SOURCE);
+
+export function extractPairingCode(output: string, marker: string): string {
+  const line = output.split(/\r?\n/).find((candidate) => candidate.startsWith(`${marker} `));
+  if (!line) throw new Error(`missing ${marker} line: ${output.slice(0, 500)}`);
+  const data = JSON.parse(line.slice(marker.length + 1)) as { code?: string };
+  if (!data.code) throw new Error(`missing pairing code in ${line}`);
+  return data.code;
+}
+
+export async function issuePairingRequest(options: {
+  sandbox: SandboxClient;
+  sandboxName: string;
+  channel: PairingChannel;
+  redactions: string[];
+  fakeSlackPort?: string;
+}): Promise<ShellProbeResult> {
+  return sandboxEncodedSh(
+    options.sandbox,
+    options.sandboxName,
+    options.channel === "slack" ? SLACK_PAIRING_SCRIPT : DISCORD_PAIRING_SCRIPT,
+    options.channel === "slack"
+      ? [options.fakeSlackPort ?? "", PAIRING_USER.slack]
+      : [PAIRING_USER.discord, DISCORD_DM_CHANNEL],
+    {
+      artifactName: `${options.channel}-issue-pairing-request`,
+      redactionValues: options.redactions,
+      timeoutMs: 120_000,
+    },
+  );
+}
+
+export async function approveAndAssertPairing(options: {
+  sandbox: SandboxClient;
+  sandboxName: string;
+  channel: PairingChannel;
+  code: string;
+  redactions: string[];
+}): Promise<void> {
+  const user = PAIRING_USER[options.channel];
+  const pending = await sandboxSh(
+    options.sandbox,
+    options.sandboxName,
+    `test -f /sandbox/.openclaw/credentials/${options.channel}-pairing.json && grep -F ${JSON.stringify(options.code)} /sandbox/.openclaw/credentials/${options.channel}-pairing.json && grep -F ${JSON.stringify(user)} /sandbox/.openclaw/credentials/${options.channel}-pairing.json`,
+    { artifactName: `${options.channel}-pending-file`, redactionValues: options.redactions },
+  );
+  expectExitZero(pending, `${options.channel} pending file`);
+
+  const list = await sandboxSh(
+    options.sandbox,
+    options.sandboxName,
+    `openclaw pairing list ${options.channel} --json 2>&1`,
+    {
+      artifactName: `${options.channel}-pairing-list-before-approve`,
+      redactionValues: options.redactions,
+    },
+  );
+  expectExitZero(list, `${options.channel} pairing list before approval`);
+  if (!resultText(list).includes(options.code) || !resultText(list).includes(user)) {
+    throw new Error(`${options.channel} pairing list did not include pending request`);
+  }
+
+  const approve = await sandboxSh(
+    options.sandbox,
+    options.sandboxName,
+    `openclaw pairing approve ${options.channel} ${JSON.stringify(options.code)} 2>&1`,
+    { artifactName: `${options.channel}-pairing-approve`, redactionValues: options.redactions },
+  );
+  expectExitZero(approve, `${options.channel} pairing approve`);
+  if (!resultText(approve).includes("Approved") || !resultText(approve).includes(user)) {
+    throw new Error(`${options.channel} approve output did not include Approved and user`);
+  }
+
+  const after = await sandboxSh(
+    options.sandbox,
+    options.sandboxName,
+    `openclaw pairing list ${options.channel} --json 2>&1`,
+    {
+      artifactName: `${options.channel}-pairing-list-after-approve`,
+      redactionValues: options.redactions,
+    },
+  );
+  expectExitZero(after, `${options.channel} pairing list after approval`);
+  if (resultText(after).includes(options.code)) {
+    throw new Error(`${options.channel} approved pairing code still pending`);
+  }
+
+  const allow = await sandboxSh(
+    options.sandbox,
+    options.sandboxName,
+    `test -f /sandbox/.openclaw/credentials/${options.channel}-default-allowFrom.json && grep -F ${JSON.stringify(user)} /sandbox/.openclaw/credentials/${options.channel}-default-allowFrom.json`,
+    { artifactName: `${options.channel}-allow-from`, redactionValues: options.redactions },
+  );
+  expectExitZero(allow, `${options.channel} allowFrom file`);
+
+  const repeat = await sandboxSh(
+    options.sandbox,
+    options.sandboxName,
+    `openclaw pairing approve ${options.channel} ${JSON.stringify(options.code)} 2>&1`,
+    { artifactName: `${options.channel}-repeat-approve`, redactionValues: options.redactions },
+  );
+  if (repeat.exitCode === 0 || !resultText(repeat).includes("No pending pairing request found")) {
+    throw new Error(
+      `${options.channel} repeat approval did not fail closed: ${resultText(repeat)}`,
+    );
+  }
+}
+
+export async function runDiscordGatewayProof(options: {
+  sandbox: SandboxClient;
+  sandboxName: string;
+  port: string;
+  redactions: string[];
+}): Promise<ShellProbeResult> {
+  const source =
+    String.raw`
+import crypto from "node:crypto";
+import net from "node:net";
+const host = "host.openshell.internal";
+const port = Number(process.env.FAKE_DISCORD_GATEWAY_PORT);
+const identifyToken = "openshell:resolve:env:DISCORD_BOT_TOKEN";
+const results = [];
+function finish(message) { if (message) results.push(message); console.log(results.join("\n")); process.exit(0); }
+function encodeClientText(payload) { const body = Buffer.from(payload, "utf8"); const mask = crypto.randomBytes(4); const masked = Buffer.alloc(body.length); for (let i = 0; i < body.length; i += 1) masked[i] = body[i] ^ mask[i % 4]; return Buffer.concat([Buffer.from([0x81, 0x80 | body.length]), mask, masked]); }
+function encodeClientClose(code) { const body = Buffer.alloc(2); body.writeUInt16BE(code, 0); const mask = crypto.randomBytes(4); for (let i = 0; i < body.length; i += 1) body[i] ^= mask[i % 4]; return Buffer.concat([Buffer.from([0x88, 0x80 | 2]), mask, body]); }
+function decodeFrame(buffer) { if (buffer.length < 2) return null; const opcode = buffer[0] & 0x0f; let payloadLength = buffer[1] & 0x7f; let offset = 2; if (payloadLength === 126) { if (buffer.length < 4) return null; payloadLength = buffer.readUInt16BE(2); offset = 4; } if (buffer.length < offset + payloadLength) return null; return { opcode, payload: buffer.slice(offset, offset + payloadLength), totalLength: offset + payloadLength }; }
+const socket = net.createConnection({ host, port });
+const timer = setTimeout(() => { socket.destroy(); finish("TIMEOUT"); }, 20000);
+let handshake = Buffer.alloc(0), framed = Buffer.alloc(0), upgraded = false;
+socket.on("connect", () => { const key = crypto.randomBytes(16).toString("base64"); socket.write([` +
+    "`GET /gateway?v=10&encoding=json HTTP/1.1`" +
+    `, ` +
+    "`Host: ${host}:${port}`" +
+    `, "Upgrade: websocket", "Connection: Upgrade", ` +
+    "`Sec-WebSocket-Key: ${key}`" +
+    `, "Sec-WebSocket-Version: 13", "\r\n"].join("\r\n")); });
+socket.on("data", (chunk) => {
+  if (!upgraded) { handshake = Buffer.concat([handshake, chunk]); const end = handshake.indexOf("\r\n\r\n"); if (end === -1) return; const statusLine = handshake.slice(0, end).toString("latin1").split("\r\n")[0] || ""; if (!statusLine.includes("101")) { clearTimeout(timer); finish(` +
+    "`HTTP_${statusLine}`" +
+    `); } upgraded = true; results.push("UPGRADE"); framed = Buffer.concat([framed, handshake.slice(end + 4)]); } else framed = Buffer.concat([framed, chunk]);
+  while (framed.length > 0) { const frame = decodeFrame(framed); if (!frame) break; framed = framed.slice(frame.totalLength); if (frame.opcode === 1) { const message = JSON.parse(frame.payload.toString("utf8")); if (message.op === 10) { results.push("HELLO"); socket.write(encodeClientText(JSON.stringify({ op: 2, d: { token: identifyToken, intents: 0, properties: { os: "linux", browser: "nemoclaw-e2e", device: "nemoclaw-e2e" } } }))); results.push("IDENTIFY_SENT_PLACEHOLDER"); } else if (message.op === 0 && message.t === "READY") { results.push("READY"); socket.write(encodeClientText(JSON.stringify({ op: 1, d: message.s ?? null }))); } else if (message.op === 11) { results.push("HEARTBEAT_ACK"); socket.write(encodeClientClose(1000)); clearTimeout(timer); finish(); } } }
+});
+socket.on("error", (error) => { clearTimeout(timer); finish(` +
+    "`ERROR:${error.message}`" +
+    `); });
+`;
+  return sandboxNode(
+    options.sandbox,
+    options.sandboxName,
+    source,
+    { FAKE_DISCORD_GATEWAY_PORT: options.port },
+    {
+      artifactName: "discord-gateway-proof",
+      redactionValues: options.redactions,
+      timeoutMs: 60_000,
+    },
+  );
+}
+
+export async function writePairingArtifacts(
+  artifacts: ArtifactSink,
+  channel: PairingChannel,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await artifacts.writeJson(`${channel}-pairing-result.json`, data);
+}


### PR DESCRIPTION
## Summary
Migrates the OpenClaw Discord pairing E2E into live Vitest coverage. The replacement keeps the real install/OpenShell sandbox boundary, hermetic fake Discord Gateway token rewrite, runtime pairing request creation, and connect-shell approval flow.

## Related Issue
Refs #5098

## Changes
- Add `test/e2e-scenario/live/openclaw-discord-pairing.test.ts` as Vitest coverage for `test/e2e/test-openclaw-discord-pairing.sh`.
- Add `test/e2e-scenario/live/openclaw-pairing-helpers.ts` for shared fake Slack/Discord provider and pairing assertions.
- Wire `openclaw-discord-pairing-vitest` into `.github/workflows/e2e-vitest-scenarios.yaml`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>