### PR TITLE
feat(skills/merge-gate): add PR Review Advisor as a hard gate in check-gates.ts

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
+++ b/.agents/skills/nemoclaw-maintainer-day/MERGE-GATE.md
@@ -9,7 +9,7 @@ For the full priority list see [PR-REVIEW-PRIORITIES.md](PR-REVIEW-PRIORITIES.md
 1. **CI green** — all required checks in `statusCheckRollup`.
 2. **No conflicts** — `mergeStateStatus` clean.
 3. **No major CodeRabbit** — ignore style nits; block on correctness/security bugs.
-4. **No unresolved actionable PR Review Advisor findings** — correctness, security, acceptance, and test-depth findings block until addressed or explicitly judged false-positive.
+4. **PR Review Advisor not blocked** — `check-gates.ts` now checks this automatically; `allPass` will be false if the latest advisor comment has `recommendation: blocked`. Correctness, security, acceptance, and test-depth findings block until addressed or explicitly judged false-positive.
 5. **Risky code tested** — see [RISKY-AREAS.md](RISKY-AREAS.md). Confirm tests exist (added or pre-existing).
 
 ## Step 1: Run the Gate Checker
@@ -18,7 +18,7 @@ For the full priority list see [PR-REVIEW-PRIORITIES.md](PR-REVIEW-PRIORITIES.md
 node --experimental-strip-types --no-warnings .agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts <pr-number>
 ```
 
-This checks the deterministic gates programmatically and returns structured JSON with `allPass` and per-gate `pass`/`details`. PR Review Advisor follow-up remains a manual review step; use [PR CI and Automated Review Follow-Up](../_shared/pr-follow-up.md) for the shared triage loop.
+This checks all gates programmatically and returns structured JSON with `allPass` and per-gate `pass`/`details`, including the PR Review Advisor status. Use [PR CI and Automated Review Follow-Up](../_shared/pr-follow-up.md) for the shared triage loop when individual findings need investigation.
 
 ## Step 2: Interpret Results
 
@@ -29,16 +29,16 @@ The script handles the deterministic checks. You handle judgment calls:
 - **CI failing but narrow:** Follow the salvage workflow in [SALVAGE-PR.md](SALVAGE-PR.md).
 - **CI pending:** Wait and re-check. Do not approve while checks are still running.
 - **CodeRabbit:** Script flags unresolved major/critical threads. Review the `snippet` to confirm it's a real issue vs style nit. If doubt, leave unapproved.
-- **PR Review Advisor:** Read the latest sticky advisor comment and apply [PR CI and Automated Review Follow-Up](../_shared/pr-follow-up.md). Valid correctness, security, acceptance-coverage, and test-depth findings block approval unless explicitly judged false-positive.
+- **PR Review Advisor blocked:** `gates.prAdvisor.pass` will be false and `allPass` false. Read the full advisor comment on the PR, apply [PR CI and Automated Review Follow-Up](../_shared/pr-follow-up.md), and do not approve until the required findings are addressed or explicitly judged false-positive by a maintainer.
 - **Tests:** If `riskyCodeTested.pass` is false, follow [TEST-GAPS.md](TEST-GAPS.md).
 
 ## Step 3: Approve or Report
 
-**Approve only when:** `allPass` is true, `mergeStateStatus` is not DIRTY, and the latest PR Review Advisor comment has no unresolved actionable findings. Approving a PR with conflicts is wasted effort — the rebase will invalidate the approval.
+**Approve only when:** `allPass` is true and `mergeStateStatus` is not DIRTY. `allPass` now includes the PR Review Advisor gate, so a blocked advisor comment alone prevents approval. Approving a PR with conflicts is wasted effort — the rebase will invalidate the approval.
 
 The correct sequence for a conflicted PR: **salvage (rebase) → CI green → approve → report ready for merge.**
 
-**All pass + no conflicts + no actionable PR Review Advisor findings:** Approve and summarize why.
+**All pass + no conflicts:** Approve and summarize why.
 
 **Any fail:**
 

--- a/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts
@@ -4,7 +4,7 @@
 /**
  * Deterministic merge-gate checker for a single NemoClaw PR.
  *
- * Checks all 4 required gates and outputs structured JSON.
+ * Checks all 5 required gates and outputs structured JSON.
  * Claude uses the output to decide: approve, route to salvage, or report blockers.
  *
  * Usage: node --experimental-strip-types --no-warnings .agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts <pr-number> [--repo OWNER/REPO]
@@ -36,6 +36,11 @@ interface CodeRabbitThread {
   resolved: boolean;
 }
 
+interface PrAdvisorGateResult extends GateResult {
+  recommendation?: string;
+  openRequired?: number;
+}
+
 interface GateOutput {
   pr: number;
   url: string;
@@ -50,6 +55,7 @@ interface GateOutput {
     conflicts: GateResult & { mergeStateStatus?: string };
     coderabbit: GateResult & { unresolvedThreads?: CodeRabbitThread[] };
     riskyCodeTested: GateResult & { riskyFiles?: string[]; hasTests?: boolean };
+    prAdvisor: PrAdvisorGateResult;
   };
 }
 
@@ -260,7 +266,66 @@ function checkCodeRabbit(
 }
 
 // ---------------------------------------------------------------------------
-// Gate 4: Risky code has tests
+// Gate 4: PR Review Advisor not blocked
+// ---------------------------------------------------------------------------
+
+// The PRA bot embeds machine-readable metadata in an HTML comment:
+// <!-- nemoclaw-pr-review-advisor -->
+// <!-- head_sha: ...; recommendation: blocked; ... -->
+const PRA_META_RE = /recommendation:\s*([a-z_]+)/i;
+const PRA_REQUIRED_RE = /\*\*Open items:\*\*[^|]*?(\d+)\s+required/;
+
+function checkPrAdvisor(repo: string, number: number): PrAdvisorGateResult {
+  const raw = run("gh", ["api", `repos/${repo}/issues/${number}/comments`, "--paginate"]);
+
+  if (!raw) {
+    // run() returns "" on API failure — fail closed, same as CodeRabbit gate
+    return { pass: false, details: "Could not fetch PR comments (API error — fail-closed)" };
+  }
+
+  let allComments: Array<{ body?: string }>;
+  try {
+    allComments = JSON.parse(raw) as Array<{ body?: string }>;
+  } catch {
+    return { pass: false, details: "Could not parse PR comments (invalid JSON — fail-closed)" };
+  }
+
+  const praComments = allComments.filter((c) =>
+    (c.body ?? "").includes("nemoclaw-pr-review-advisor"),
+  );
+  if (praComments.length === 0) {
+    return { pass: true, details: "No PR Review Advisor comment found" };
+  }
+
+  // Use the last PRA comment (most recent re-run)
+  const body = praComments[praComments.length - 1].body ?? "";
+
+  const metaMatch = PRA_META_RE.exec(body);
+  if (!metaMatch) {
+    return {
+      pass: true,
+      details: "PR Review Advisor comment found but no recommendation metadata",
+    };
+  }
+
+  const recommendation = metaMatch[1].toLowerCase();
+  if (recommendation !== "blocked") {
+    return { pass: true, details: `PR Review Advisor: ${recommendation}`, recommendation };
+  }
+
+  const requiredMatch = PRA_REQUIRED_RE.exec(body);
+  const openRequired = requiredMatch ? parseInt(requiredMatch[1], 10) : undefined;
+
+  return {
+    pass: false,
+    details: `PR Review Advisor: blocked${openRequired !== undefined ? ` (${openRequired} required item(s))` : ""}`,
+    recommendation,
+    openRequired,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gate 5: Risky code has tests
 // ---------------------------------------------------------------------------
 
 function checkRiskyCodeTested(
@@ -329,13 +394,14 @@ function main(): void {
   const conflicts = checkConflicts(prData.mergeStateStatus);
   const coderabbit = checkCodeRabbit(repo, prNumber);
   const riskyCodeTested = checkRiskyCodeTested(prData.files ?? []);
+  const prAdvisor = checkPrAdvisor(repo, prNumber);
 
   const output: GateOutput = {
     pr: prNumber,
     url: prData.url,
     title: prData.title,
-    allPass: ci.pass && conflicts.pass && coderabbit.pass && riskyCodeTested.pass,
-    gates: { ci, conflicts, coderabbit, riskyCodeTested },
+    allPass: ci.pass && conflicts.pass && coderabbit.pass && riskyCodeTested.pass && prAdvisor.pass,
+    gates: { ci, conflicts, coderabbit, riskyCodeTested, prAdvisor },
   };
 
   console.log(JSON.stringify(output, null, 2));

--- a/.agents/skills/nemoclaw-maintainer-day/scripts/triage.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/triage.ts
@@ -268,8 +268,10 @@ function classifyPr(pr: PrData): ClassifiedPr {
   const blocked = mergeState === "BLOCKED";
   if (blocked && !hasConflict) reasons.push("merge-blocked");
 
-  // Simple CodeRabbit heuristic: check labels for major findings
-  // (Full CodeRabbit check is in check-gates.ts via GraphQL)
+  // CodeRabbit and PR Review Advisor are not checked here — fetching per-PR
+  // comments/threads for every open PR would make triage too slow. Both are
+  // checked as hard gates in check-gates.ts. A PR may appear as merge-now
+  // here but still fail the gate — always run check-gates.ts before approving.
   const coderabbitMajor = false; // conservative — gate checker does the real check
 
   // Classify into buckets


### PR DESCRIPTION
## Summary

- Adds a fifth gate (`prAdvisor`) to `check-gates.ts` that fetches the PR Review Advisor sticky comment, parses the `recommendation:` field from its embedded HTML metadata, and sets `allPass: false` when the value is `blocked`
- Fails closed on API errors (empty response or invalid JSON) — consistent with how the CodeRabbit gate behaves
- Updates `triage.ts` with a comment making it explicit that CodeRabbit and PRA are both skipped there for performance, and that a `merge-now` bucket assignment does not mean `check-gates.ts` can be skipped
- Updates `MERGE-GATE.md`: removes the "manual review step" caveat, documents the gate as automated, and removes a wrong claim that the advisor link appears in `gates.prAdvisor.details`

## Motivation

PR #5526 was approved despite the PR Review Advisor posting a **Blocked** status with two required fixes. The advisor check was documented as "manual" in `MERGE-GATE.md`, making it easy to skip. Making it a programmatic gate means `allPass` will be `false` on any blocked advisor comment, preventing the approval flow from proceeding.

## Test evidence

```
$ node --experimental-strip-types --no-warnings .agents/skills/nemoclaw-maintainer-day/scripts/check-gates.ts 5526
{
  "prAdvisor": {
    "pass": false,
    "details": "PR Review Advisor: blocked (2 required item(s))",
    "recommendation": "blocked",
    "openRequired": 2
  },
  "allPass": false
}
```

A PR with no PRA comment returns `"pass": true, "details": "No PR Review Advisor comment found"`.

## Test plan

- [ ] Run `check-gates.ts` against a PR where the advisor is blocked — `prAdvisor.pass` should be `false` and `allPass` should be `false`
- [ ] Run `check-gates.ts` against a PR with no advisor comment — `prAdvisor.pass` should be `true`
- [ ] Run `check-gates.ts` against a PR where the advisor is `approved` — `prAdvisor.pass` should be `true`

Signed-off-by: Preksha Vyas <prekshiv@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the merge gate workflow to add an explicit “PR Review Advisor not blocked” check.
  * PRs are now blocked from approval when PR Review Advisor recommends “blocked,” even if other checks pass.
* **Documentation**
  * Refined PR triage guidance to clarify that PR Review Advisor enforcement happens in the merge gate step (not during early PR classification).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->