### PR TITLE
test(core): add isRecord unit tests for json-types

### DIFF
--- a/src/lib/core/json-types.test.ts
+++ b/src/lib/core/json-types.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { isRecord } from "./json-types";
+
+describe("isRecord", () => {
+  it("returns true for a plain object", () => {
+    expect(isRecord({ key: "value" })).toBe(true);
+  });
+
+  it("returns true for an empty object", () => {
+    expect(isRecord({})).toBe(true);
+  });
+
+  it("returns true for a nested object", () => {
+    expect(isRecord({ a: { b: 1 } })).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isRecord(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isRecord(undefined)).toBe(false);
+  });
+
+  it("returns false for an array", () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isRecord("hello")).toBe(false);
+  });
+
+  it("returns false for a number", () => {
+    expect(isRecord(42)).toBe(false);
+  });
+
+  it("returns false for a boolean", () => {
+    expect(isRecord(true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a focused unit-test suite for the `isRecord` type guard in `src/lib/core/json-types.ts`, which previously had no co-located test. This raises coverage on a shared utility used across CLI data boundaries (onboard, policies, agent-onboard) with no production code changes.

## Changes
- Add `src/lib/core/json-types.test.ts` with Vitest cases for `isRecord`:
  - returns `true` for plain, empty, and nested objects
  - returns `false` for `null`, `undefined`, arrays, strings, numbers, and booleans

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Atulya Singh <atulyarajsingh@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for record validation logic, verifying correct behavior with various input types including objects, null, undefined, arrays, and primitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->