### PR TITLE
test(connect): guard auto-pair timeout budget invariant

### DIFF
--- a/src/lib/actions/sandbox/connect-autopair-budget.test.ts
+++ b/src/lib/actions/sandbox/connect-autopair-budget.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+  CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S,
+  CONNECT_AUTO_PAIR_LIST_TIMEOUT_S,
+  CONNECT_AUTO_PAIR_MAX_APPROVALS,
+  CONNECT_AUTO_PAIR_TIMEOUT_MS,
+} from "./connect-autopair-budget";
+
+// Worst-case time the in-sandbox script can legitimately spend inside the outer
+// spawnSync timer: one `devices list` plus up to MAX_APPROVALS `devices approve`
+// calls, each at its full budget. Expressed in ms to compare against the outer cap.
+const innerWorstCaseMs =
+  (CONNECT_AUTO_PAIR_LIST_TIMEOUT_S +
+    CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S * CONNECT_AUTO_PAIR_MAX_APPROVALS) *
+  1000;
+
+describe("connect auto-pair budget", () => {
+  it("keeps the outer spawnSync cap above the worst-case inner runtime", () => {
+    // If this ever inverts, a legitimately slow approve is SIGKILLed mid-loop,
+    // stranding the allowlisted request (the regression #4504 guarded against).
+    expect(CONNECT_AUTO_PAIR_TIMEOUT_MS).toBeGreaterThan(innerWorstCaseMs);
+  });
+
+  it("leaves headroom for shell/python startup before the inner loop begins", () => {
+    // The outer timer starts at `sh` spawn, before proxy env is sourced and
+    // python3 launches. The module documents 5 seconds of slack for that startup.
+    expect(CONNECT_AUTO_PAIR_TIMEOUT_MS - innerWorstCaseMs).toBeGreaterThanOrEqual(5000);
+  });
+
+  it("uses positive, whole-number budgets", () => {
+    for (const value of [
+      CONNECT_AUTO_PAIR_MAX_APPROVALS,
+      CONNECT_AUTO_PAIR_LIST_TIMEOUT_S,
+      CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S,
+      CONNECT_AUTO_PAIR_TIMEOUT_MS,
+    ]) {
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/actions/sandbox/connect-autopair-budget.test.ts
+++ b/src/lib/actions/sandbox/connect-autopair-budget.test.ts
@@ -19,8 +19,8 @@ const innerWorstCaseMs =
 
 describe("connect auto-pair budget", () => {
   it("keeps the outer spawnSync cap above the worst-case inner runtime", () => {
-    // If this ever inverts, a legitimately slow approve is SIGKILLed mid-loop,
-    // stranding the allowlisted request (the regression #4504 guarded against).
+    // If this ever inverts, the outer timeout can terminate a legitimately slow
+    // approve mid-loop, stranding the allowlisted request (#4504).
     expect(CONNECT_AUTO_PAIR_TIMEOUT_MS).toBeGreaterThan(innerWorstCaseMs);
   });
 

--- a/src/lib/actions/sandbox/connect-autopair-budget.ts
+++ b/src/lib/actions/sandbox/connect-autopair-budget.ts
@@ -21,6 +21,6 @@ export const CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S = 10;
 // (CONNECT_AUTO_PAIR_LIST_TIMEOUT_S + CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S ×
 // CONNECT_AUTO_PAIR_MAX_APPROVALS) PLUS shell/python startup, since the outer
 // timer starts at `sh` spawn before the proxy env is sourced and python3
-// launches; the 5s slack means a legitimate slow approve is never SIGKILLed
-// mid-loop, which would strand the allowlisted request.
+// launches; the 5s slack prevents the outer timeout from terminating a
+// legitimate slow approve mid-loop, which would strand the allowlisted request.
 export const CONNECT_AUTO_PAIR_TIMEOUT_MS = 20_000;


### PR DESCRIPTION
## Summary
Adds a regression test for the connect-time auto-pair timeout budget. The `connect-autopair-budget.ts` module was deliberately written as a dependency-free leaf "so tests can import and assert the invariant on the real values," but no such test existed. This locks in the safety invariant the module documents, with no production behavior changes.

## Changes
- Add `src/lib/actions/sandbox/connect-autopair-budget.test.ts`:
  - Asserts the outer `spawnSync` cap (`CONNECT_AUTO_PAIR_TIMEOUT_MS`) stays above the worst-case inner runtime (`LIST_TIMEOUT_S + APPROVE_TIMEOUT_S × MAX_APPROVALS`), so a slow approve is never terminated mid-loop and the allowlisted request is not stranded (regression #4504).
  - Asserts the documented 5-second startup headroom is preserved.
  - Sanity-checks the budgets are positive whole numbers.
- Clarify timeout comments to describe the outer timeout terminating the approve process without naming an incorrect signal.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Atulya Singh <atulyarajsingh@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for auto-pair budget timeout validation, ensuring proper timeout management and system resource allocation with appropriate headroom for initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


