### PR TITLE
test(e2e): migrate test-spark-install.sh to vitest

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -4879,7 +4879,9 @@ jobs:
       NEMOCLAW_RUN_E2E_SCENARIOS: "1"
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_FRESH: "1"
       NEMOCLAW_SANDBOX_NAME: "e2e-spark-install-vitest"
+      NEMOCLAW_PROVIDER: "cloud"
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -4901,8 +4903,7 @@ jobs:
         # install.sh/public curl|bash boundary, install-log retention, PATH
         # refresh, and post-install nemoclaw/openshell/--help checks.
         env:
-          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
-          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           set -euo pipefail
           npx vitest run --project e2e-scenarios-live \

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -2659,7 +2659,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-
   cloud-onboard-vitest:
     needs: generate-matrix
     if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',cloud-onboard-vitest,') || contains(format(',{0},', inputs.scenarios), ',cloud-onboard,') }}
@@ -4867,6 +4866,58 @@ jobs:
           docker logout docker.io || true
           rm -rf "${DOCKER_CONFIG}"
 
+  spark-install-vitest:
+    needs: generate-matrix
+    if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',spark-install-vitest,') || contains(format(',{0},', inputs.scenarios), ',spark-install,') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      FREE_STANDING_VITEST_JOB: "1"
+      FREE_STANDING_SCENARIO_ID: "spark-install"
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/spark-install
+      NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
+      NEMOCLAW_RUN_E2E_SCENARIOS: "1"
+      NEMOCLAW_NON_INTERACTIVE: "1"
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_SANDBOX_NAME: "e2e-spark-install-vitest"
+      OPENSHELL_GATEWAY: "nemoclaw"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run Spark install live test
+        # Migrated from test/e2e/test-spark-install.sh. This preserves the
+        # Linux + Docker prerequisite gate, the plain non-interactive
+        # install.sh/public curl|bash boundary, install-log retention, PATH
+        # refresh, and post-install nemoclaw/openshell/--help checks.
+        env:
+          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+        run: |
+          set -euo pipefail
+          npx vitest run --project e2e-scenarios-live \
+            test/e2e-scenario/live/spark-install.test.ts \
+            --silent=false --reporter=default
+
+      - name: Upload Spark install artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-vitest-scenarios-spark-install
+          path: e2e-artifacts/vitest/spark-install/
+          include-hidden-files: false
+          if-no-files-found: ignore
+          retention-days: 14
 
   # ── PR result comment (mirrors nightly-e2e.yaml's report-to-pr) ───────────
   # Posts a results table on the open PR for the dispatching branch (or the
@@ -4942,6 +4993,7 @@ jobs:
         openclaw-discord-pairing-vitest,
         openclaw-slack-pairing-vitest,
         channels-stop-start-vitest,
+        spark-install-vitest,
       ]
     if: ${{ always() && github.event_name == 'workflow_dispatch' }}
     permissions:

--- a/test/e2e-scenario/live/spark-install-helpers.ts
+++ b/test/e2e-scenario/live/spark-install-helpers.ts
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import { resultText } from "../fixtures/clients/command.ts";
+import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
+import { redactString } from "../fixtures/redaction.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+
+export const DEFAULT_SPARK_INSTALL_SANDBOX_NAME = "e2e-spark-install-vitest";
+export const DEFAULT_INSTALL_URL = "https://www.nvidia.com/nemoclaw.sh";
+
+export type InstallerInvocation = {
+  mode: "local" | "public";
+  script: string;
+  installUrl?: string;
+};
+
+type InstallerInvocationOptions = {
+  repoRoot: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function requireSparkInstallContract(
+  condition: boolean,
+  message: string,
+): void {
+  condition || fail(message);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+export function assertSparkInstallSandboxName(name: string): string {
+  validateSandboxName(name);
+  requireSparkInstallContract(
+    name.startsWith("e2e-spark-install-"),
+    `spark install sandbox must use the e2e-spark-install- prefix: ${name}`,
+  );
+  return name;
+}
+
+export function assertRequiredInstallerEnv(env: NodeJS.ProcessEnv): void {
+  requireSparkInstallContract(
+    env.NEMOCLAW_NON_INTERACTIVE === "1",
+    "NEMOCLAW_NON_INTERACTIVE=1 is required for the Spark install migration",
+  );
+  requireSparkInstallContract(
+    env.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE === "1",
+    "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 is required for the Spark install migration",
+  );
+}
+
+export function validatePublicInstallUrl(raw: string): string {
+  const url = new URL(raw);
+  const hostname = url.hostname.toLowerCase();
+  requireSparkInstallContract(
+    url.protocol === "https:",
+    "public installer URL must use https",
+  );
+  requireSparkInstallContract(
+    url.username === "" && url.password === "",
+    "public installer URL must not include credentials",
+  );
+  requireSparkInstallContract(
+    hostname === "www.nvidia.com",
+    `public installer URL host is not allowed: ${url.hostname}`,
+  );
+  requireSparkInstallContract(
+    url.pathname === "/nemoclaw.sh",
+    `public installer URL path is not allowed: ${url.pathname}`,
+  );
+  requireSparkInstallContract(
+    url.search === "" && url.hash === "",
+    "public installer URL must not include query or fragment data",
+  );
+  return url.toString();
+}
+
+export function buildInstallerInvocation({
+  repoRoot,
+  env = process.env,
+}: InstallerInvocationOptions): InstallerInvocation {
+  return env.NEMOCLAW_E2E_PUBLIC_INSTALL === "1"
+    ? (() => {
+        const installUrl = validatePublicInstallUrl(
+          env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL,
+        );
+        return {
+          mode: "public" as const,
+          installUrl,
+          script: [
+            "set -euo pipefail",
+            "&&",
+            `curl -fsSL ${shellQuote(installUrl)}`,
+            "|",
+            "NEMOCLAW_NON_INTERACTIVE=1",
+            "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+            "bash",
+          ].join(" "),
+        };
+      })()
+    : {
+        mode: "local",
+        script: [
+          `cd ${shellQuote(repoRoot)}`,
+          "&&",
+          "NEMOCLAW_NON_INTERACTIVE=1",
+          "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+          "bash install.sh --non-interactive",
+        ].join(" "),
+      };
+}
+
+export function writeRedactedInstallLog(
+  file: string,
+  result: Pick<ShellProbeResult, "stdout" | "stderr">,
+  redactionValues: readonly string[] = [],
+): void {
+  fs.writeFileSync(file, redactString(resultText(result), redactionValues));
+}
+
+export function logTail(
+  file: string,
+  lineCount = 80,
+  redactionValues: readonly string[] = [],
+): string {
+  const lines = fs.existsSync(file)
+    ? fs.readFileSync(file, "utf8").split(/\r?\n/)
+    : [];
+  return redactString(lines.slice(-lineCount).join("\n"), redactionValues);
+}
+
+export function exitDetail(
+  result: Pick<ShellProbeResult, "stdout" | "stderr">,
+  installLog?: string,
+  redactionValues: readonly string[] = [],
+): string {
+  return [
+    redactString(resultText(result), redactionValues),
+    installLog
+      ? `--- install log tail (${installLog}) ---\n${logTail(installLog, 80, redactionValues)}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/test/e2e-scenario/live/spark-install-helpers.ts
+++ b/test/e2e-scenario/live/spark-install-helpers.ts
@@ -26,10 +26,7 @@ function fail(message: string): never {
   throw new Error(message);
 }
 
-function requireSparkInstallContract(
-  condition: boolean,
-  message: string,
-): void {
+function requireSparkInstallContract(condition: boolean, message: string): void {
   condition || fail(message);
 }
 
@@ -60,10 +57,7 @@ export function assertRequiredInstallerEnv(env: NodeJS.ProcessEnv): void {
 export function validatePublicInstallUrl(raw: string): string {
   const url = new URL(raw);
   const hostname = url.hostname.toLowerCase();
-  requireSparkInstallContract(
-    url.protocol === "https:",
-    "public installer URL must use https",
-  );
+  requireSparkInstallContract(url.protocol === "https:", "public installer URL must use https");
   requireSparkInstallContract(
     url.username === "" && url.password === "",
     "public installer URL must not include credentials",
@@ -131,9 +125,7 @@ export function logTail(
   lineCount = 80,
   redactionValues: readonly string[] = [],
 ): string {
-  const lines = fs.existsSync(file)
-    ? fs.readFileSync(file, "utf8").split(/\r?\n/)
-    : [];
+  const lines = fs.existsSync(file) ? fs.readFileSync(file, "utf8").split(/\r?\n/) : [];
   return redactString(lines.slice(-lineCount).join("\n"), redactionValues);
 }
 

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Live Vitest replacement for test/e2e/test-spark-install.sh. */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import type { HostCliClient } from "../fixtures/clients/host.ts";
+import { resultText } from "../fixtures/clients/command.ts";
+import { expect, test } from "../fixtures/e2e-test.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-spark-install-vitest";
+const DEFAULT_INSTALL_URL = "https://www.nvidia.com/nemoclaw.sh";
+const LIVE_TIMEOUT_MS = 40 * 60_000;
+const INSTALL_TIMEOUT_MS = 30 * 60_000;
+const liveTest =
+  shouldRunLiveE2EScenarios() ||
+  process.env.CI === "true" ||
+  process.env.NEMOCLAW_RUN_INSTALLER_TESTS === "1"
+    ? test
+    : test.skip;
+
+type InstallerInvocation = {
+  mode: "local" | "public";
+  script: string;
+  installUrl?: string;
+};
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    ...buildAvailabilityProbeEnv(),
+    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+    NEMOCLAW_NON_INTERACTIVE: "1",
+    NEMOCLAW_RECREATE_SANDBOX: "1",
+    NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+    OPENSHELL_GATEWAY: "nemoclaw",
+    ...extra,
+  };
+}
+
+function buildInstallerInvocation(installLog: string): InstallerInvocation {
+  if (process.env.NEMOCLAW_E2E_PUBLIC_INSTALL === "1") {
+    const installUrl = process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL;
+    return {
+      mode: "public",
+      installUrl,
+      script: [
+        `curl -fsSL ${shellQuote(installUrl)}`,
+        "|",
+        "NEMOCLAW_NON_INTERACTIVE=1",
+        "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+        `bash > ${shellQuote(installLog)} 2>&1`,
+      ].join(" "),
+    };
+  }
+
+  return {
+    mode: "local",
+    script: [
+      `cd ${shellQuote(REPO_ROOT)}`,
+      "&&",
+      "NEMOCLAW_NON_INTERACTIVE=1",
+      "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+      `bash install.sh --non-interactive > ${shellQuote(installLog)} 2>&1`,
+    ].join(" "),
+  };
+}
+
+function sourceInstalledPathProbe(): string {
+  return [
+    'if [ -f "$HOME/.bashrc" ]; then source "$HOME/.bashrc" 2>/dev/null || true; fi',
+    'export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"',
+    'if [ -s "$NVM_DIR/nvm.sh" ]; then . "$NVM_DIR/nvm.sh"; fi',
+    'if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then export PATH="$HOME/.local/bin:$PATH"; fi',
+    "command -v nemoclaw",
+    "command -v openshell",
+    "nemoclaw --help >/dev/null",
+  ].join("; ");
+}
+
+async function bestEffortCleanup(host: HostCliClient): Promise<void> {
+  const cleanup = [
+    `if command -v nemoclaw >/dev/null 2>&1; then nemoclaw ${shellQuote(SANDBOX_NAME)} destroy --yes >/dev/null 2>&1 || true; fi`,
+    `if command -v openshell >/dev/null 2>&1; then openshell sandbox delete ${shellQuote(SANDBOX_NAME)} >/dev/null 2>&1 || true; fi`,
+    "if command -v openshell >/dev/null 2>&1; then openshell gateway destroy -g nemoclaw >/dev/null 2>&1 || true; fi",
+  ].join("\n");
+  await host.command("bash", ["-lc", cleanup], {
+    artifactName: "cleanup-spark-install-state",
+    env: env(),
+    timeoutMs: 120_000,
+  });
+}
+
+function logTail(file: string, lineCount = 80): string {
+  if (!fs.existsSync(file)) return "";
+  const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+  return lines.slice(-lineCount).join("\n");
+}
+
+function exitDetail(result: ShellProbeResult, installLog?: string): string {
+  return [
+    resultText(result),
+    installLog ? `--- install log tail (${installLog}) ---\n${logTail(installLog)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+liveTest(
+  "spark install path: standard non-interactive install leaves NemoClaw and OpenShell usable",
+  { timeout: LIVE_TIMEOUT_MS },
+  async ({ artifacts, cleanup, host, secrets, skip }) => {
+    await artifacts.writeJson("scenario.json", {
+      id: "spark-install",
+      legacySource: "test/e2e/test-spark-install.sh",
+      sandboxName: SANDBOX_NAME,
+      contracts: [
+        "Linux + Docker prerequisite gate",
+        "NEMOCLAW_NON_INTERACTIVE=1 and NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 are required for the install",
+        "standard installer path runs without Spark-specific setup",
+        "optional NEMOCLAW_E2E_PUBLIC_INSTALL=1 curl|bash path is selected by the same env gate",
+        "install log is retained",
+        "nemoclaw and openshell are on PATH after profile refresh",
+        "nemoclaw --help exits 0",
+      ],
+    });
+
+    if (process.platform !== "linux") {
+      skip(
+        "DGX Spark install smoke is Linux-only; the workflow job runs on a Linux Docker runner.",
+      );
+    }
+    expect(process.platform).toBe("linux");
+
+    expect(fs.existsSync(path.join(REPO_ROOT, "install.sh")), "repo install.sh must exist").toBe(
+      true,
+    );
+
+    const docker = await host.command("docker", ["info"], {
+      artifactName: "phase-0-docker-info",
+      env: env(),
+      timeoutMs: 30_000,
+    });
+    expect(docker.exitCode, resultText(docker)).toBe(0);
+
+    expect(process.env.NEMOCLAW_NON_INTERACTIVE ?? "1").toBe("1");
+    expect(process.env.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE ?? "1").toBe("1");
+
+    const hosted = requireHostedInferenceConfig(secrets, process.env, {
+      model: "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    });
+    const redactionValues = [hosted.apiKey];
+    cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () => bestEffortCleanup(host));
+    await bestEffortCleanup(host);
+
+    const installLog = process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
+    const installer = buildInstallerInvocation(installLog);
+    await artifacts.writeJson("installer.json", {
+      mode: installer.mode,
+      installUrl: installer.installUrl,
+      installLog,
+    });
+    expect(installer.script).toContain("NEMOCLAW_NON_INTERACTIVE=1");
+    expect(installer.script).toContain("NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    if (installer.mode === "local") {
+      expect(installer.script).toContain("bash install.sh --non-interactive");
+      expect(installer.script).not.toContain("setup-spark");
+    } else {
+      expect(installer.script).toContain("curl -fsSL");
+      expect(installer.installUrl).toBe(
+        process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL,
+      );
+    }
+
+    const install = await host.command("bash", ["-lc", installer.script], {
+      artifactName: `phase-1-${installer.mode}-install`,
+      cwd: REPO_ROOT,
+      env: env({
+        ...hosted.env,
+        NVIDIA_INFERENCE_API_KEY: hosted.apiKey,
+      }),
+      redactionValues,
+      timeoutMs: INSTALL_TIMEOUT_MS,
+    });
+    expect(install.exitCode, exitDetail(install, installLog)).toBe(0);
+    expect(fs.existsSync(installLog), `${installLog} should be written`).toBe(true);
+
+    const installedCommands = await host.command("bash", ["-lc", sourceInstalledPathProbe()], {
+      artifactName: "phase-2-installed-cli-path-probe",
+      env: env(),
+      timeoutMs: 60_000,
+    });
+    expect(installedCommands.exitCode, resultText(installedCommands)).toBe(0);
+    expect(installedCommands.stdout).toContain("nemoclaw");
+    expect(installedCommands.stdout).toContain("openshell");
+  },
+);

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -4,34 +4,36 @@
 /** Live Vitest replacement for test/e2e/test-spark-install.sh. */
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { resultText } from "../fixtures/clients/command.ts";
+import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
-import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
-import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import {
+  shouldRunInstallerIntegration,
+  shouldRunLiveE2EScenarios,
+} from "../fixtures/live-project-gate.ts";
+import {
+  assertRequiredInstallerEnv,
+  assertSparkInstallSandboxName,
+  buildInstallerInvocation,
+  DEFAULT_INSTALL_URL,
+  DEFAULT_SPARK_INSTALL_SANDBOX_NAME,
+  exitDetail,
+  writeRedactedInstallLog,
+} from "./spark-install-helpers.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
-const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-spark-install-vitest";
-const DEFAULT_INSTALL_URL = "https://www.nvidia.com/nemoclaw.sh";
+const SANDBOX_NAME = assertSparkInstallSandboxName(
+  process.env.NEMOCLAW_SANDBOX_NAME ?? DEFAULT_SPARK_INSTALL_SANDBOX_NAME,
+);
 const LIVE_TIMEOUT_MS = 40 * 60_000;
 const INSTALL_TIMEOUT_MS = 30 * 60_000;
 const liveTest =
-  process.platform === "linux" &&
-  (shouldRunLiveE2EScenarios() ||
-    process.env.CI === "true" ||
-    process.env.NEMOCLAW_RUN_INSTALLER_TESTS === "1")
+  process.platform === "linux" && (shouldRunLiveE2EScenarios() || shouldRunInstallerIntegration())
     ? test
     : test.skip;
-
-type InstallerInvocation = {
-  mode: "local" | "public";
-  script: string;
-  installUrl?: string;
-};
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
@@ -49,32 +51,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
-}
-
-function buildInstallerInvocation(installLog: string): InstallerInvocation {
-  const installUrl = process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL;
-  return process.env.NEMOCLAW_E2E_PUBLIC_INSTALL === "1"
-    ? {
-        mode: "public",
-        installUrl,
-        script: [
-          `curl -fsSL ${shellQuote(installUrl)}`,
-          "|",
-          "NEMOCLAW_NON_INTERACTIVE=1",
-          "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
-          `bash > ${shellQuote(installLog)} 2>&1`,
-        ].join(" "),
-      }
-    : {
-        mode: "local",
-        script: [
-          `cd ${shellQuote(REPO_ROOT)}`,
-          "&&",
-          "NEMOCLAW_NON_INTERACTIVE=1",
-          "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
-          `bash install.sh --non-interactive > ${shellQuote(installLog)} 2>&1`,
-        ].join(" "),
-      };
 }
 
 function sourceInstalledPathProbe(): string {
@@ -100,20 +76,6 @@ async function bestEffortCleanup(host: HostCliClient): Promise<void> {
     env: env(),
     timeoutMs: 120_000,
   });
-}
-
-function logTail(file: string, lineCount = 80): string {
-  const lines = fs.existsSync(file) ? fs.readFileSync(file, "utf8").split(/\r?\n/) : [];
-  return lines.slice(-lineCount).join("\n");
-}
-
-function exitDetail(result: ShellProbeResult, installLog?: string): string {
-  return [
-    resultText(result),
-    installLog ? `--- install log tail (${installLog}) ---\n${logTail(installLog)}` : "",
-  ]
-    .filter(Boolean)
-    .join("\n");
 }
 
 liveTest(
@@ -148,8 +110,7 @@ liveTest(
     });
     expect(docker.exitCode, resultText(docker)).toBe(0);
 
-    expect(process.env.NEMOCLAW_NON_INTERACTIVE ?? "1").toBe("1");
-    expect(process.env.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE ?? "1").toBe("1");
+    assertRequiredInstallerEnv(process.env);
 
     const apiKey = secrets.required("NVIDIA_API_KEY");
     const redactionValues = [apiKey];
@@ -158,7 +119,10 @@ liveTest(
 
     const installLog = process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
     fs.mkdirSync(path.dirname(installLog), { recursive: true });
-    const installer = buildInstallerInvocation(installLog);
+    const installer = buildInstallerInvocation({
+      repoRoot: REPO_ROOT,
+      env: process.env,
+    });
     await artifacts.writeJson("installer.json", {
       mode: installer.mode,
       installUrl: installer.installUrl,
@@ -170,9 +134,7 @@ liveTest(
       installer.mode === "local"
         ? installer.script.includes("bash install.sh --non-interactive") &&
             !installer.script.includes("setup-spark")
-        : installer.script.includes("curl -fsSL") &&
-            installer.installUrl ===
-              (process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL),
+        : installer.script.includes("curl -fsSL") && installer.installUrl === DEFAULT_INSTALL_URL,
     ).toBe(true);
 
     const install = await host.command("bash", ["-lc", installer.script], {
@@ -184,7 +146,8 @@ liveTest(
       redactionValues,
       timeoutMs: INSTALL_TIMEOUT_MS,
     });
-    expect(install.exitCode, exitDetail(install, installLog)).toBe(0);
+    writeRedactedInstallLog(installLog, install, redactionValues);
+    expect(install.exitCode, exitDetail(install, installLog, redactionValues)).toBe(0);
     expect(fs.existsSync(installLog), `${installLog} should be written`).toBe(true);
 
     const installedCommands = await host.command("bash", ["-lc", sourceInstalledPathProbe()], {

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -15,8 +15,7 @@ import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
-const SANDBOX_NAME =
-  process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-spark-install-vitest";
+const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-spark-install-vitest";
 const DEFAULT_INSTALL_URL = "https://www.nvidia.com/nemoclaw.sh";
 const LIVE_TIMEOUT_MS = 40 * 60_000;
 const INSTALL_TIMEOUT_MS = 30 * 60_000;
@@ -53,8 +52,7 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 }
 
 function buildInstallerInvocation(installLog: string): InstallerInvocation {
-  const installUrl =
-    process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL;
+  const installUrl = process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL;
   return process.env.NEMOCLAW_E2E_PUBLIC_INSTALL === "1"
     ? {
         mode: "public",
@@ -105,18 +103,14 @@ async function bestEffortCleanup(host: HostCliClient): Promise<void> {
 }
 
 function logTail(file: string, lineCount = 80): string {
-  const lines = fs.existsSync(file)
-    ? fs.readFileSync(file, "utf8").split(/\r?\n/)
-    : [];
+  const lines = fs.existsSync(file) ? fs.readFileSync(file, "utf8").split(/\r?\n/) : [];
   return lines.slice(-lineCount).join("\n");
 }
 
 function exitDetail(result: ShellProbeResult, installLog?: string): string {
   return [
     resultText(result),
-    installLog
-      ? `--- install log tail (${installLog}) ---\n${logTail(installLog)}`
-      : "",
+    installLog ? `--- install log tail (${installLog}) ---\n${logTail(installLog)}` : "",
   ]
     .filter(Boolean)
     .join("\n");
@@ -143,10 +137,9 @@ liveTest(
 
     expect(process.platform).toBe("linux");
 
-    expect(
-      fs.existsSync(path.join(REPO_ROOT, "install.sh")),
-      "repo install.sh must exist",
-    ).toBe(true);
+    expect(fs.existsSync(path.join(REPO_ROOT, "install.sh")), "repo install.sh must exist").toBe(
+      true,
+    );
 
     const docker = await host.command("docker", ["info"], {
       artifactName: "phase-0-docker-info",
@@ -160,13 +153,10 @@ liveTest(
 
     const apiKey = secrets.required("NVIDIA_API_KEY");
     const redactionValues = [apiKey];
-    cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () =>
-      bestEffortCleanup(host),
-    );
+    cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () => bestEffortCleanup(host));
     await bestEffortCleanup(host);
 
-    const installLog =
-      process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
+    const installLog = process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
     fs.mkdirSync(path.dirname(installLog), { recursive: true });
     const installer = buildInstallerInvocation(installLog);
     await artifacts.writeJson("installer.json", {
@@ -175,9 +165,7 @@ liveTest(
       installLog,
     });
     expect(installer.script).toContain("NEMOCLAW_NON_INTERACTIVE=1");
-    expect(installer.script).toContain(
-      "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
-    );
+    expect(installer.script).toContain("NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
     expect(
       installer.mode === "local"
         ? installer.script.includes("bash install.sh --non-interactive") &&
@@ -197,19 +185,13 @@ liveTest(
       timeoutMs: INSTALL_TIMEOUT_MS,
     });
     expect(install.exitCode, exitDetail(install, installLog)).toBe(0);
-    expect(fs.existsSync(installLog), `${installLog} should be written`).toBe(
-      true,
-    );
+    expect(fs.existsSync(installLog), `${installLog} should be written`).toBe(true);
 
-    const installedCommands = await host.command(
-      "bash",
-      ["-lc", sourceInstalledPathProbe()],
-      {
-        artifactName: "phase-2-installed-cli-path-probe",
-        env: env(),
-        timeoutMs: 60_000,
-      },
-    );
+    const installedCommands = await host.command("bash", ["-lc", sourceInstalledPathProbe()], {
+      artifactName: "phase-2-installed-cli-path-probe",
+      env: env(),
+      timeoutMs: 60_000,
+    });
     expect(installedCommands.exitCode, resultText(installedCommands)).toBe(0);
     expect(installedCommands.stdout).toContain("nemoclaw");
     expect(installedCommands.stdout).toContain("openshell");

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -11,7 +11,6 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { resultText } from "../fixtures/clients/command.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
-import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
@@ -44,8 +43,10 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     ...buildAvailabilityProbeEnv(),
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
+    NEMOCLAW_FRESH: "1",
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+    NEMOCLAW_PROVIDER: "cloud",
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
@@ -157,10 +158,8 @@ liveTest(
     expect(process.env.NEMOCLAW_NON_INTERACTIVE ?? "1").toBe("1");
     expect(process.env.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE ?? "1").toBe("1");
 
-    const hosted = requireHostedInferenceConfig(secrets, process.env, {
-      model: "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-    });
-    const redactionValues = [hosted.apiKey];
+    const apiKey = secrets.required("NVIDIA_API_KEY");
+    const redactionValues = [apiKey];
     cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () =>
       bestEffortCleanup(host),
     );
@@ -192,8 +191,7 @@ liveTest(
       artifactName: `phase-1-${installer.mode}-install`,
       cwd: REPO_ROOT,
       env: env({
-        ...hosted.env,
-        NVIDIA_INFERENCE_API_KEY: hosted.apiKey,
+        NVIDIA_API_KEY: apiKey,
       }),
       redactionValues,
       timeoutMs: INSTALL_TIMEOUT_MS,

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -168,6 +168,7 @@ liveTest(
 
     const installLog =
       process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
+    fs.mkdirSync(path.dirname(installLog), { recursive: true });
     const installer = buildInstallerInvocation(installLog);
     await artifacts.writeJson("installer.json", {
       mode: installer.mode,

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -16,14 +16,16 @@ import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
-const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-spark-install-vitest";
+const SANDBOX_NAME =
+  process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-spark-install-vitest";
 const DEFAULT_INSTALL_URL = "https://www.nvidia.com/nemoclaw.sh";
 const LIVE_TIMEOUT_MS = 40 * 60_000;
 const INSTALL_TIMEOUT_MS = 30 * 60_000;
 const liveTest =
-  shouldRunLiveE2EScenarios() ||
-  process.env.CI === "true" ||
-  process.env.NEMOCLAW_RUN_INSTALLER_TESTS === "1"
+  process.platform === "linux" &&
+  (shouldRunLiveE2EScenarios() ||
+    process.env.CI === "true" ||
+    process.env.NEMOCLAW_RUN_INSTALLER_TESTS === "1")
     ? test
     : test.skip;
 
@@ -50,31 +52,30 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 }
 
 function buildInstallerInvocation(installLog: string): InstallerInvocation {
-  if (process.env.NEMOCLAW_E2E_PUBLIC_INSTALL === "1") {
-    const installUrl = process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL;
-    return {
-      mode: "public",
-      installUrl,
-      script: [
-        `curl -fsSL ${shellQuote(installUrl)}`,
-        "|",
-        "NEMOCLAW_NON_INTERACTIVE=1",
-        "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
-        `bash > ${shellQuote(installLog)} 2>&1`,
-      ].join(" "),
-    };
-  }
-
-  return {
-    mode: "local",
-    script: [
-      `cd ${shellQuote(REPO_ROOT)}`,
-      "&&",
-      "NEMOCLAW_NON_INTERACTIVE=1",
-      "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
-      `bash install.sh --non-interactive > ${shellQuote(installLog)} 2>&1`,
-    ].join(" "),
-  };
+  const installUrl =
+    process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL;
+  return process.env.NEMOCLAW_E2E_PUBLIC_INSTALL === "1"
+    ? {
+        mode: "public",
+        installUrl,
+        script: [
+          `curl -fsSL ${shellQuote(installUrl)}`,
+          "|",
+          "NEMOCLAW_NON_INTERACTIVE=1",
+          "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+          `bash > ${shellQuote(installLog)} 2>&1`,
+        ].join(" "),
+      }
+    : {
+        mode: "local",
+        script: [
+          `cd ${shellQuote(REPO_ROOT)}`,
+          "&&",
+          "NEMOCLAW_NON_INTERACTIVE=1",
+          "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+          `bash install.sh --non-interactive > ${shellQuote(installLog)} 2>&1`,
+        ].join(" "),
+      };
 }
 
 function sourceInstalledPathProbe(): string {
@@ -103,15 +104,18 @@ async function bestEffortCleanup(host: HostCliClient): Promise<void> {
 }
 
 function logTail(file: string, lineCount = 80): string {
-  if (!fs.existsSync(file)) return "";
-  const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+  const lines = fs.existsSync(file)
+    ? fs.readFileSync(file, "utf8").split(/\r?\n/)
+    : [];
   return lines.slice(-lineCount).join("\n");
 }
 
 function exitDetail(result: ShellProbeResult, installLog?: string): string {
   return [
     resultText(result),
-    installLog ? `--- install log tail (${installLog}) ---\n${logTail(installLog)}` : "",
+    installLog
+      ? `--- install log tail (${installLog}) ---\n${logTail(installLog)}`
+      : "",
   ]
     .filter(Boolean)
     .join("\n");
@@ -120,7 +124,7 @@ function exitDetail(result: ShellProbeResult, installLog?: string): string {
 liveTest(
   "spark install path: standard non-interactive install leaves NemoClaw and OpenShell usable",
   { timeout: LIVE_TIMEOUT_MS },
-  async ({ artifacts, cleanup, host, secrets, skip }) => {
+  async ({ artifacts, cleanup, host, secrets }) => {
     await artifacts.writeJson("scenario.json", {
       id: "spark-install",
       legacySource: "test/e2e/test-spark-install.sh",
@@ -136,16 +140,12 @@ liveTest(
       ],
     });
 
-    if (process.platform !== "linux") {
-      skip(
-        "DGX Spark install smoke is Linux-only; the workflow job runs on a Linux Docker runner.",
-      );
-    }
     expect(process.platform).toBe("linux");
 
-    expect(fs.existsSync(path.join(REPO_ROOT, "install.sh")), "repo install.sh must exist").toBe(
-      true,
-    );
+    expect(
+      fs.existsSync(path.join(REPO_ROOT, "install.sh")),
+      "repo install.sh must exist",
+    ).toBe(true);
 
     const docker = await host.command("docker", ["info"], {
       artifactName: "phase-0-docker-info",
@@ -161,10 +161,13 @@ liveTest(
       model: "nvidia/llama-3.3-nemotron-super-49b-v1.5",
     });
     const redactionValues = [hosted.apiKey];
-    cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () => bestEffortCleanup(host));
+    cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () =>
+      bestEffortCleanup(host),
+    );
     await bestEffortCleanup(host);
 
-    const installLog = process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
+    const installLog =
+      process.env.INSTALL_LOG ?? artifacts.pathFor("logs/install.log");
     const installer = buildInstallerInvocation(installLog);
     await artifacts.writeJson("installer.json", {
       mode: installer.mode,
@@ -172,16 +175,17 @@ liveTest(
       installLog,
     });
     expect(installer.script).toContain("NEMOCLAW_NON_INTERACTIVE=1");
-    expect(installer.script).toContain("NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
-    if (installer.mode === "local") {
-      expect(installer.script).toContain("bash install.sh --non-interactive");
-      expect(installer.script).not.toContain("setup-spark");
-    } else {
-      expect(installer.script).toContain("curl -fsSL");
-      expect(installer.installUrl).toBe(
-        process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL,
-      );
-    }
+    expect(installer.script).toContain(
+      "NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
+    expect(
+      installer.mode === "local"
+        ? installer.script.includes("bash install.sh --non-interactive") &&
+            !installer.script.includes("setup-spark")
+        : installer.script.includes("curl -fsSL") &&
+            installer.installUrl ===
+              (process.env.NEMOCLAW_INSTALL_SCRIPT_URL ?? DEFAULT_INSTALL_URL),
+    ).toBe(true);
 
     const install = await host.command("bash", ["-lc", installer.script], {
       artifactName: `phase-1-${installer.mode}-install`,
@@ -194,13 +198,19 @@ liveTest(
       timeoutMs: INSTALL_TIMEOUT_MS,
     });
     expect(install.exitCode, exitDetail(install, installLog)).toBe(0);
-    expect(fs.existsSync(installLog), `${installLog} should be written`).toBe(true);
+    expect(fs.existsSync(installLog), `${installLog} should be written`).toBe(
+      true,
+    );
 
-    const installedCommands = await host.command("bash", ["-lc", sourceInstalledPathProbe()], {
-      artifactName: "phase-2-installed-cli-path-probe",
-      env: env(),
-      timeoutMs: 60_000,
-    });
+    const installedCommands = await host.command(
+      "bash",
+      ["-lc", sourceInstalledPathProbe()],
+      {
+        artifactName: "phase-2-installed-cli-path-probe",
+        env: env(),
+        timeoutMs: 60_000,
+      },
+    );
     expect(installedCommands.exitCode, resultText(installedCommands)).toBe(0);
     expect(installedCommands.stdout).toContain("nemoclaw");
     expect(installedCommands.stdout).toContain("openshell");

--- a/test/e2e-scenario/support-tests/spark-install-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/spark-install-helpers.test.ts
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertRequiredInstallerEnv,
+  assertSparkInstallSandboxName,
+  buildInstallerInvocation,
+  DEFAULT_INSTALL_URL,
+  exitDetail,
+  writeRedactedInstallLog,
+} from "../live/spark-install-helpers.ts";
+
+const SENTINEL = "sentinel-nvidia-api-key";
+const RESULT_WITH_SECRET = {
+  stdout: `install stdout ${SENTINEL}`,
+  stderr: `install stderr ${SENTINEL}`,
+};
+
+describe("spark install live test helpers", () => {
+  it("writes and reports only redacted install logs", () => {
+    const tmp = fs.mkdtempSync(
+      path.join(os.tmpdir(), "spark-install-helpers-"),
+    );
+    const installLog = path.join(tmp, "install.log");
+
+    try {
+      writeRedactedInstallLog(installLog, RESULT_WITH_SECRET, [SENTINEL]);
+      const log = fs.readFileSync(installLog, "utf8");
+      const detail = exitDetail(RESULT_WITH_SECRET, installLog, [SENTINEL]);
+
+      expect(log).toContain("[REDACTED]");
+      expect(log).not.toContain(SENTINEL);
+      expect(detail).toContain("[REDACTED]");
+      expect(detail).not.toContain(SENTINEL);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects public installer URL overrides outside the documented origin", () => {
+    const unsafeUrls = [
+      "http://www.nvidia.com/nemoclaw.sh",
+      "file:///tmp/nemoclaw.sh",
+      "https://user:pass@www.nvidia.com/nemoclaw.sh",
+      "https://localhost/nemoclaw.sh",
+      "https://127.0.0.1/nemoclaw.sh",
+      "https://10.0.0.1/nemoclaw.sh",
+      "https://example.com/nemoclaw.sh",
+      "https://www.nvidia.com/other.sh",
+      "https://www.nvidia.com/nemoclaw.sh?token=leak",
+    ];
+
+    for (const installUrl of unsafeUrls) {
+      expect(() =>
+        buildInstallerInvocation({
+          repoRoot: "/repo",
+          env: {
+            NEMOCLAW_E2E_PUBLIC_INSTALL: "1",
+            NEMOCLAW_INSTALL_SCRIPT_URL: installUrl,
+          },
+        }),
+      ).toThrow();
+    }
+  });
+
+  it("keeps public curl-pipe mode on the allowlisted installer and enables pipefail", () => {
+    const invocation = buildInstallerInvocation({
+      repoRoot: "/repo",
+      env: {
+        NEMOCLAW_E2E_PUBLIC_INSTALL: "1",
+        NEMOCLAW_INSTALL_SCRIPT_URL: DEFAULT_INSTALL_URL,
+      },
+    });
+
+    expect(invocation.mode).toBe("public");
+    expect(invocation.installUrl).toBe(DEFAULT_INSTALL_URL);
+    expect(invocation.script).toContain("set -euo pipefail && curl -fsSL");
+    expect(invocation.script).toContain("| NEMOCLAW_NON_INTERACTIVE=1");
+  });
+
+  it("rejects non-test-owned sandbox names before destructive cleanup can use them", () => {
+    expect(assertSparkInstallSandboxName("e2e-spark-install-vitest")).toBe(
+      "e2e-spark-install-vitest",
+    );
+    expect(assertSparkInstallSandboxName("e2e-spark-install-local-1")).toBe(
+      "e2e-spark-install-local-1",
+    );
+    expect(() => assertSparkInstallSandboxName("personal-dev")).toThrow(
+      /e2e-spark-install-/,
+    );
+    expect(() => assertSparkInstallSandboxName("bad name")).toThrow(
+      /sandbox name is invalid/,
+    );
+  });
+
+  it("requires the real non-interactive installer environment", () => {
+    expect(() =>
+      assertRequiredInstallerEnv({
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertRequiredInstallerEnv({ NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1" }),
+    ).toThrow(/NEMOCLAW_NON_INTERACTIVE=1/);
+    expect(() =>
+      assertRequiredInstallerEnv({ NEMOCLAW_NON_INTERACTIVE: "1" }),
+    ).toThrow(/NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1/);
+  });
+});

--- a/test/e2e-scenario/support-tests/spark-install-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/spark-install-helpers.test.ts
@@ -24,9 +24,7 @@ const RESULT_WITH_SECRET = {
 
 describe("spark install live test helpers", () => {
   it("writes and reports only redacted install logs", () => {
-    const tmp = fs.mkdtempSync(
-      path.join(os.tmpdir(), "spark-install-helpers-"),
-    );
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "spark-install-helpers-"));
     const installLog = path.join(tmp, "install.log");
 
     try {
@@ -91,12 +89,8 @@ describe("spark install live test helpers", () => {
     expect(assertSparkInstallSandboxName("e2e-spark-install-local-1")).toBe(
       "e2e-spark-install-local-1",
     );
-    expect(() => assertSparkInstallSandboxName("personal-dev")).toThrow(
-      /e2e-spark-install-/,
-    );
-    expect(() => assertSparkInstallSandboxName("bad name")).toThrow(
-      /sandbox name is invalid/,
-    );
+    expect(() => assertSparkInstallSandboxName("personal-dev")).toThrow(/e2e-spark-install-/);
+    expect(() => assertSparkInstallSandboxName("bad name")).toThrow(/sandbox name is invalid/);
   });
 
   it("requires the real non-interactive installer environment", () => {
@@ -106,11 +100,11 @@ describe("spark install live test helpers", () => {
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
       }),
     ).not.toThrow();
-    expect(() =>
-      assertRequiredInstallerEnv({ NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1" }),
-    ).toThrow(/NEMOCLAW_NON_INTERACTIVE=1/);
-    expect(() =>
-      assertRequiredInstallerEnv({ NEMOCLAW_NON_INTERACTIVE: "1" }),
-    ).toThrow(/NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1/);
+    expect(() => assertRequiredInstallerEnv({ NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1" })).toThrow(
+      /NEMOCLAW_NON_INTERACTIVE=1/,
+    );
+    expect(() => assertRequiredInstallerEnv({ NEMOCLAW_NON_INTERACTIVE: "1" })).toThrow(
+      /NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1/,
+    );
   });
 });

--- a/test/e2e-scenario/support-tests/spark-install-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/spark-install-helpers.test.ts
@@ -67,6 +67,17 @@ describe("spark install live test helpers", () => {
     }
   });
 
+  it("defaults public curl-pipe mode to the allowlisted installer URL", () => {
+    const invocation = buildInstallerInvocation({
+      repoRoot: "/repo",
+      env: { NEMOCLAW_E2E_PUBLIC_INSTALL: "1" },
+    });
+
+    expect(invocation.mode).toBe("public");
+    expect(invocation.installUrl).toBe(DEFAULT_INSTALL_URL);
+    expect(invocation.script).toContain(`curl -fsSL '${DEFAULT_INSTALL_URL}'`);
+  });
+
   it("keeps public curl-pipe mode on the allowlisted installer and enables pipefail", () => {
     const invocation = buildInstallerInvocation({
       repoRoot: "/repo",

--- a/test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts
@@ -57,9 +57,13 @@ describe("spark install workflow boundary", () => {
     };
     const job = workflow.jobs["spark-install-vitest"];
     expect(job).toBeDefined();
+    job["runs-on" as keyof typeof job] = "self-hosted" as never;
     job["timeout-minutes" as keyof typeof job] = 30 as never;
     job.env = {
       ...job.env,
+      E2E_ARTIFACT_DIR: "tmp/spark-install",
+      NEMOCLAW_CLI_BIN: "/usr/bin/nemoclaw",
+      NEMOCLAW_RUN_E2E_SCENARIOS: "0",
       NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}",
       NEMOCLAW_NON_INTERACTIVE: "0",
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "0",
@@ -109,7 +113,11 @@ describe("spark install workflow boundary", () => {
     try {
       expect(validateE2eVitestScenariosWorkflowBoundary(workflowPath)).toEqual(
         expect.arrayContaining([
+          "spark-install-vitest job must run on ubuntu-latest",
           "spark-install-vitest job must keep a 45 minute timeout",
+          "spark-install-vitest job must write artifacts under e2e-artifacts/vitest/spark-install",
+          "spark-install-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+          "spark-install-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
           "spark-install-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
           "spark-install-vitest job must accept third-party software non-interactively",
           "spark-install-vitest job must set NEMOCLAW_FRESH=1",

--- a/test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts
@@ -83,24 +83,18 @@ describe("spark install workflow boundary", () => {
     expect(setupNode).toBeDefined();
     setupNode!.uses = "actions/setup-node@v6";
 
-    const install = job.steps.find(
-      (step) => step.name === "Install root dependencies",
-    );
+    const install = job.steps.find((step) => step.name === "Install root dependencies");
     expect(install).toBeDefined();
     install!.env = { NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}" };
     install!.run = "npm install";
 
-    const runSpark = job.steps.find(
-      (step) => step.name === "Run Spark install live test",
-    );
+    const runSpark = job.steps.find((step) => step.name === "Run Spark install live test");
     expect(runSpark).toBeDefined();
     runSpark!.env = {};
     runSpark!.run =
       "npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/other.test.ts";
 
-    const upload = job.steps.find(
-      (step) => step.name === "Upload Spark install artifacts",
-    );
+    const upload = job.steps.find((step) => step.name === "Upload Spark install artifacts");
     expect(upload).toBeDefined();
     upload!.with = {
       ...(upload!.with as Record<string, unknown>),

--- a/test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import {
+  evaluateE2eVitestWorkflowDispatchSelectors,
+  validateE2eVitestScenariosWorkflowBoundary,
+} from "../../../tools/e2e-scenarios/workflow-boundary.mts";
+
+function readWorkflow(): Record<string, unknown> {
+  return YAML.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/e2e-vitest-scenarios.yaml"),
+      "utf-8",
+    ),
+  ) as Record<string, unknown>;
+}
+
+describe("spark install workflow boundary", () => {
+  it("maps the Spark install selector to its free-standing Vitest job", () => {
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({
+        scenarios: "spark-install",
+      }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["spark-install-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({
+        jobs: "spark-install-vitest",
+      }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["spark-install-vitest"],
+      registryScenarios: [],
+    });
+  });
+
+  it("rejects Spark install trusted-boundary drift", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-vitest-workflow-"));
+    const workflowPath = path.join(tmp, "workflow.yaml");
+    const workflow = readWorkflow() as {
+      jobs: Record<
+        string,
+        { env?: Record<string, unknown>; steps: Array<Record<string, unknown>> }
+      >;
+    };
+    const job = workflow.jobs["spark-install-vitest"];
+    expect(job).toBeDefined();
+    job["timeout-minutes" as keyof typeof job] = 30 as never;
+    job.env = {
+      ...job.env,
+      NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}",
+      NEMOCLAW_NON_INTERACTIVE: "0",
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "0",
+      NEMOCLAW_FRESH: "0",
+      NEMOCLAW_SANDBOX_NAME: "personal-dev",
+      NEMOCLAW_PROVIDER: "custom",
+      OPENSHELL_GATEWAY: "shared",
+    };
+
+    const checkout = job.steps.find((step) =>
+      String(step.uses ?? "").startsWith("actions/checkout@"),
+    );
+    expect(checkout).toBeDefined();
+    checkout!.uses = "actions/checkout@v6";
+    checkout!.with = {
+      ...(checkout!.with as Record<string, unknown>),
+      "persist-credentials": true,
+    };
+
+    const setupNode = job.steps.find((step) => step.name === "Set up Node");
+    expect(setupNode).toBeDefined();
+    setupNode!.uses = "actions/setup-node@v6";
+
+    const install = job.steps.find(
+      (step) => step.name === "Install root dependencies",
+    );
+    expect(install).toBeDefined();
+    install!.env = { NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}" };
+    install!.run = "npm install";
+
+    const runSpark = job.steps.find(
+      (step) => step.name === "Run Spark install live test",
+    );
+    expect(runSpark).toBeDefined();
+    runSpark!.env = {};
+    runSpark!.run =
+      "npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/other.test.ts";
+
+    const upload = job.steps.find(
+      (step) => step.name === "Upload Spark install artifacts",
+    );
+    expect(upload).toBeDefined();
+    upload!.with = {
+      ...(upload!.with as Record<string, unknown>),
+      name: "spark-install-artifacts",
+      path: "e2e-artifacts/vitest/",
+      "include-hidden-files": true,
+      "if-no-files-found": "error",
+      "retention-days": 1,
+    };
+    fs.writeFileSync(workflowPath, YAML.stringify(workflow));
+
+    try {
+      expect(validateE2eVitestScenariosWorkflowBoundary(workflowPath)).toEqual(
+        expect.arrayContaining([
+          "spark-install-vitest job must keep a 45 minute timeout",
+          "spark-install-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+          "spark-install-vitest job must accept third-party software non-interactively",
+          "spark-install-vitest job must set NEMOCLAW_FRESH=1",
+          "spark-install-vitest job must use the stable e2e-spark-install-vitest sandbox name",
+          "spark-install-vitest job must use the cloud provider",
+          "spark-install-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+          "spark-install-vitest job env must not include NVIDIA_API_KEY",
+          "spark-install-vitest checkout action must be pinned to a full commit SHA",
+          "spark-install-vitest checkout step must set persist-credentials=false",
+          "spark-install-vitest setup-node action must be pinned to a full commit SHA",
+          "spark-install-vitest step 'Install root dependencies' env must not include NVIDIA_API_KEY",
+          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
+          "spark-install-vitest Vitest step must receive NVIDIA_API_KEY from secrets",
+          "step 'Run Spark install live test' run script must include set -euo pipefail",
+          "step 'Run Spark install live test' run script must include test/e2e-scenario/live/spark-install.test.ts",
+          "spark-install-vitest artifact upload name must be stable",
+          "artifact upload path must include e2e-artifacts/vitest/spark-install/",
+          "spark-install-vitest artifact upload must set include-hidden-files: false",
+          "spark-install-vitest artifact upload must ignore missing fixture artifacts",
+          "spark-install-vitest artifact upload retention-days must be 14",
+        ]),
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -84,7 +84,9 @@ function deriveFreeStandingJobsInventoryFromJobs(jobs: WorkflowRecord): {
     if (!hasJobMarker && !hasScenarioMarker) continue;
 
     if (!SELECTOR_ID_PATTERN.test(jobId)) {
-      errors.push(`free-standing workflow metadata contains invalid job id: ${jobId}`);
+      errors.push(
+        `free-standing workflow metadata contains invalid job id: ${jobId}`,
+      );
     }
     if (!hasJobMarker) {
       errors.push(
@@ -102,7 +104,9 @@ function deriveFreeStandingJobsInventoryFromJobs(jobs: WorkflowRecord): {
 
     const scenario = env[FREE_STANDING_SCENARIO_MARKER];
     if (typeof scenario !== "string" || !SELECTOR_ID_PATTERN.test(scenario)) {
-      errors.push(`${jobId} job ${FREE_STANDING_SCENARIO_MARKER} must be a selector id`);
+      errors.push(
+        `${jobId} job ${FREE_STANDING_SCENARIO_MARKER} must be a selector id`,
+      );
       continue;
     }
     freeStandingScenarios.push(scenario);
@@ -110,13 +114,17 @@ function deriveFreeStandingJobsInventoryFromJobs(jobs: WorkflowRecord): {
   }
 
   if (allowedJobs.length === 0) {
-    errors.push("free-standing workflow metadata must declare at least one job");
+    errors.push(
+      "free-standing workflow metadata must declare at least one job",
+    );
   }
   for (const duplicate of findDuplicates(allowedJobs)) {
     errors.push(`free-standing workflow metadata repeats job id: ${duplicate}`);
   }
   for (const duplicate of findDuplicates(freeStandingScenarios)) {
-    errors.push(`free-standing workflow metadata repeats scenario id: ${duplicate}`);
+    errors.push(
+      `free-standing workflow metadata repeats scenario id: ${duplicate}`,
+    );
   }
 
   return {
@@ -129,7 +137,10 @@ function deriveFreeStandingJobsInventoryFromJobs(jobs: WorkflowRecord): {
   };
 }
 
-const freeStandingJobsInventoryCache = new Map<string, CachedFreeStandingJobsInventory>();
+const freeStandingJobsInventoryCache = new Map<
+  string,
+  CachedFreeStandingJobsInventory
+>();
 
 function readWorkflowRecord(workflowPath: string): WorkflowRecord {
   return asRecord(YAML.parse(readFileSync(workflowPath, "utf-8")));
@@ -149,7 +160,8 @@ export function validateFreeStandingWorkflowInventory(
   workflowPath = DEFAULT_VITEST_WORKFLOW_PATH,
 ): string[] {
   const workflow = readWorkflowRecord(workflowPath);
-  return deriveFreeStandingJobsInventoryFromJobs(asRecord(workflow.jobs)).errors;
+  return deriveFreeStandingJobsInventoryFromJobs(asRecord(workflow.jobs))
+    .errors;
 }
 
 export function readFreeStandingJobsInventory(
@@ -157,14 +169,22 @@ export function readFreeStandingJobsInventory(
 ): FreeStandingJobsInventory {
   const stats = statSync(workflowPath);
   const cached = freeStandingJobsInventoryCache.get(workflowPath);
-  if (cached && cached.mtimeMs === stats.mtimeMs && cached.size === stats.size) {
+  if (
+    cached &&
+    cached.mtimeMs === stats.mtimeMs &&
+    cached.size === stats.size
+  ) {
     return cloneFreeStandingJobsInventory(cached.inventory);
   }
 
   const workflow = readWorkflowRecord(workflowPath);
-  const { errors, inventory } = deriveFreeStandingJobsInventoryFromJobs(asRecord(workflow.jobs));
+  const { errors, inventory } = deriveFreeStandingJobsInventoryFromJobs(
+    asRecord(workflow.jobs),
+  );
   if (errors.length > 0) {
-    throw new Error(`Invalid free-standing workflow inventory:\n${errors.join("\n")}`);
+    throw new Error(
+      `Invalid free-standing workflow inventory:\n${errors.join("\n")}`,
+    );
   }
   freeStandingJobsInventoryCache.set(workflowPath, {
     mtimeMs: stats.mtimeMs,
@@ -288,12 +308,20 @@ export function evaluateE2eVitestWorkflowDispatchSelectors(input: {
   };
 }
 
-function namedStep(steps: readonly WorkflowStep[], name: string): WorkflowStep | undefined {
+function namedStep(
+  steps: readonly WorkflowStep[],
+  name: string,
+): WorkflowStep | undefined {
   return steps.find((step) => step.name === name);
 }
 
-function requireInput(errors: string[], inputs: WorkflowRecord, name: string): void {
-  if (!Object.hasOwn(inputs, name)) errors.push(`workflow_dispatch missing input: ${name}`);
+function requireInput(
+  errors: string[],
+  inputs: WorkflowRecord,
+  name: string,
+): void {
+  if (!Object.hasOwn(inputs, name))
+    errors.push(`workflow_dispatch missing input: ${name}`);
 }
 
 function requireStep(
@@ -324,7 +352,9 @@ function requireRunContains(
 ): void {
   if (!step) return;
   if (!stringValue(step.run).includes(expected)) {
-    errors.push(`step '${step.name ?? "<unnamed>"}' run script must include ${expected}`);
+    errors.push(
+      `step '${step.name ?? "<unnamed>"}' run script must include ${expected}`,
+    );
   }
 }
 
@@ -335,11 +365,17 @@ function requireRunDoesNotContain(
 ): void {
   if (!step) return;
   if (stringValue(step.run).includes(forbidden)) {
-    errors.push(`step '${step.name ?? "<unnamed>"}' run script must not include ${forbidden}`);
+    errors.push(
+      `step '${step.name ?? "<unnamed>"}' run script must not include ${forbidden}`,
+    );
   }
 }
 
-function requireUploadPathContains(errors: string[], uploadPath: string, expected: string): void {
+function requireUploadPathContains(
+  errors: string[],
+  uploadPath: string,
+  expected: string,
+): void {
   if (!uploadPath.includes(expected)) {
     errors.push(`artifact upload path must include ${expected}`);
   }
@@ -356,16 +392,28 @@ function requireEnvDoesNotExposeSecret(
   }
 }
 
-function requireWorkflowDispatch(errors: string[], triggers: WorkflowRecord): WorkflowRecord {
+function requireWorkflowDispatch(
+  errors: string[],
+  triggers: WorkflowRecord,
+): WorkflowRecord {
   const workflowDispatch = asRecord(triggers.workflow_dispatch);
   if (Object.keys(workflowDispatch).length === 0)
     errors.push("workflow must support workflow_dispatch");
   return workflowDispatch;
 }
 
-function rejectAutomaticTriggers(errors: string[], triggers: WorkflowRecord): void {
-  for (const unsafe of ["push", "pull_request", "pull_request_target", "schedule"]) {
-    if (Object.hasOwn(triggers, unsafe)) errors.push(`workflow must not run on ${unsafe}`);
+function rejectAutomaticTriggers(
+  errors: string[],
+  triggers: WorkflowRecord,
+): void {
+  for (const unsafe of [
+    "push",
+    "pull_request",
+    "pull_request_target",
+    "schedule",
+  ]) {
+    if (Object.hasOwn(triggers, unsafe))
+      errors.push(`workflow must not run on ${unsafe}`);
   }
 }
 
@@ -384,7 +432,8 @@ function requireNoDispatchInputInterpolation(
   errors: string[],
   steps: readonly WorkflowStep[],
 ): void {
-  const expressionPattern = /\$\{\{\s*(?:inputs|github\.event\.inputs)\s*(?:\.|\[)/;
+  const expressionPattern =
+    /\$\{\{\s*(?:inputs|github\.event\.inputs)\s*(?:\.|\[)/;
   for (const step of steps) {
     if (expressionPattern.test(stringValue(step.run))) {
       errors.push(
@@ -430,7 +479,12 @@ function validateFreeStandingInventoryBoundary(
     if (Object.keys(job).length === 0) continue;
 
     if (!FREE_STANDING_SELECTOR_SPECIAL_CASES.has(jobName)) {
-      validateFreeStandingJobSelector(errors, jobs, jobName, scenarioByJob.get(jobName));
+      validateFreeStandingJobSelector(
+        errors,
+        jobs,
+        jobName,
+        scenarioByJob.get(jobName),
+      );
     }
 
     const jobEnv = asRecord(job.env);
@@ -442,7 +496,11 @@ function validateFreeStandingInventoryBoundary(
     requireNoDispatchInputInterpolation(errors, steps);
     for (const step of steps) {
       if (step.uses) {
-        requireFullShaAction(errors, step, `${jobName} step '${step.name ?? step.uses}'`);
+        requireFullShaAction(
+          errors,
+          step,
+          `${jobName} step '${step.name ?? step.uses}'`,
+        );
       }
       if (/\$\{\{\s*secrets\./.test(stringValue(step.run))) {
         errors.push(
@@ -469,7 +527,9 @@ function validateFreeStandingInventoryCoverage(
   }
   for (const [scenario, jobId] of inventory.scenarioToJob) {
     if (!inventory.allowedJobs.includes(jobId)) {
-      errors.push(`free-standing inventory maps ${scenario} to unknown job ${jobId}`);
+      errors.push(
+        `free-standing inventory maps ${scenario} to unknown job ${jobId}`,
+      );
       continue;
     }
     const job = asRecord(jobs[jobId]);
@@ -487,7 +547,10 @@ function validateFreeStandingInventoryCoverage(
   }
 }
 
-function validateOpenShellVersionPinVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateOpenShellVersionPinVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "openshell-version-pin-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -498,14 +561,22 @@ function validateOpenShellVersionPinVitestJob(errors: string[], jobs: WorkflowRe
   if (job["runs-on"] !== "ubuntu-latest") {
     errors.push("openshell-version-pin-vitest job must run on ubuntu-latest");
   }
-  validateFreeStandingJobSelector(errors, jobs, jobName, "openshell-version-pin");
+  validateFreeStandingJobSelector(
+    errors,
+    jobs,
+    jobName,
+    "openshell-version-pin",
+  );
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("openshell-version-pin-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "openshell-version-pin-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/openshell-version-pin"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/openshell-version-pin"
   ) {
     errors.push(
       "openshell-version-pin-vitest job must write artifacts under e2e-artifacts/vitest/openshell-version-pin",
@@ -529,16 +600,30 @@ function validateOpenShellVersionPinVitestJob(errors: string[], jobs: WorkflowRe
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("openshell-version-pin-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "openshell-version-pin-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("openshell-version-pin-vitest job missing checkout step");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "openshell-version-pin-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("openshell-version-pin-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "openshell-version-pin-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("openshell-version-pin-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "openshell-version-pin-vitest setup-node");
+  if (!setupNode)
+    errors.push("openshell-version-pin-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "openshell-version-pin-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -546,20 +631,52 @@ function validateOpenShellVersionPinVitestJob(errors: string[], jobs: WorkflowRe
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run OpenShell version-pin live test");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/openshell-version-pin.test.ts");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run OpenShell version-pin live test",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/openshell-version-pin.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload OpenShell version-pin artifacts");
-  requireFullShaAction(errors, upload, "openshell-version-pin-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload OpenShell version-pin artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "openshell-version-pin-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-openshell-version-pin") {
-    errors.push("openshell-version-pin-vitest artifact upload name must be stable");
+    errors.push(
+      "openshell-version-pin-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/openshell-version-pin/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/openshell-version-pin/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
     errors.push(
       "openshell-version-pin-vitest artifact upload must set include-hidden-files: false",
@@ -571,11 +688,16 @@ function validateOpenShellVersionPinVitestJob(errors: string[], jobs: WorkflowRe
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("openshell-version-pin-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "openshell-version-pin-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateSkillAgentVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateSkillAgentVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "skill-agent-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -592,13 +714,18 @@ function validateSkillAgentVitestJob(errors: string[], jobs: WorkflowRecord): vo
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
     errors.push("skill-agent-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/skill-agent") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/skill-agent"
+  ) {
     errors.push(
       "skill-agent-vitest job must write artifacts under e2e-artifacts/vitest/skill-agent",
     );
   }
   if (!stringValue(jobEnv.NEMOCLAW_CLI_BIN).includes("bin/nemoclaw.js")) {
-    errors.push("skill-agent-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "skill-agent-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -620,15 +747,20 @@ function validateSkillAgentVitestJob(errors: string[], jobs: WorkflowRecord): vo
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("skill-agent-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "skill-agent-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("skill-agent-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "skill-agent-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("skill-agent-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("skill-agent-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "skill-agent-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -637,30 +769,70 @@ function validateSkillAgentVitestJob(errors: string[], jobs: WorkflowRecord): vo
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell CLI",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run skill-agent live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run skill-agent live test",
+  );
   const runEnv = asRecord(runVitest?.env);
-  if (runEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push("skill-agent-vitest run step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+  if (
+    runEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      "skill-agent-vitest run step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
   }
   requireRunContains(
     errors,
     runVitest,
     'export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"',
   );
-  requireRunContains(errors, runVitest, 'OPENSHELL_BIN="$(command -v openshell)"');
+  requireRunContains(
+    errors,
+    runVitest,
+    'OPENSHELL_BIN="$(command -v openshell)"',
+  );
   requireRunContains(errors, runVitest, "export OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/skill-agent.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/skill-agent.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload skill-agent artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload skill-agent artifacts",
+  );
   requireFullShaAction(errors, upload, "skill-agent-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-skill-agent") {
@@ -687,17 +859,24 @@ function validateSkillAgentVitestJob(errors: string[], jobs: WorkflowRecord): vo
     }
   }
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("skill-agent-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "skill-agent-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("skill-agent-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "skill-agent-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
     errors.push("skill-agent-vitest artifact upload retention-days must be 14");
   }
 }
 
-function validateNetworkPolicyVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateNetworkPolicyVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "network-policy-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -718,18 +897,27 @@ function validateNetworkPolicyVitestJob(errors: string[], jobs: WorkflowRecord):
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("network-policy-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "network-policy-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/network-policy") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/network-policy"
+  ) {
     errors.push(
       "network-policy-vitest job must write artifacts under e2e-artifacts/vitest/network-policy",
     );
   }
   if (!stringValue(jobEnv.NEMOCLAW_CLI_BIN).includes("bin/nemoclaw.js")) {
-    errors.push("network-policy-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "network-policy-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("network-policy-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "network-policy-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
@@ -737,7 +925,12 @@ function validateNetworkPolicyVitestJob(errors: string[], jobs: WorkflowRecord):
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "network-policy-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "network-policy-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -775,15 +968,20 @@ function validateNetworkPolicyVitestJob(errors: string[], jobs: WorkflowRecord):
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("network-policy-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "network-policy-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("network-policy-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "network-policy-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("network-policy-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("network-policy-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "network-policy-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -792,53 +990,102 @@ function validateNetworkPolicyVitestJob(errors: string[], jobs: WorkflowRecord):
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
   if (namedStep(steps, "Authenticate to Docker Hub")) {
-    errors.push("network-policy-vitest must not include unused Docker Hub authentication");
+    errors.push(
+      "network-policy-vitest must not include unused Docker Hub authentication",
+    );
   }
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_INFERENCE_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run network-policy live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run network-policy live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "network-policy-vitest Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/network-policy.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/network-policy.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload network-policy artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload network-policy artifacts",
+  );
   requireFullShaAction(errors, upload, "network-policy-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-network-policy") {
     errors.push("network-policy-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/network-policy/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/network-policy/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("network-policy-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "network-policy-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("network-policy-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "network-policy-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("network-policy-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "network-policy-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateCommonEgressAgentVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateCommonEgressAgentVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "common-egress-agent-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -851,34 +1098,49 @@ function validateCommonEgressAgentVitestJob(errors: string[], jobs: WorkflowReco
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, "common-egress-agent");
   if (job["timeout-minutes"] !== 120) {
-    errors.push("common-egress-agent-vitest job must keep the legacy 120 minute timeout");
+    errors.push(
+      "common-egress-agent-vitest job must keep the legacy 120 minute timeout",
+    );
   }
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("common-egress-agent-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "common-egress-agent-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/common-egress-agent"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/common-egress-agent"
   ) {
     errors.push(
       "common-egress-agent-vitest job must write artifacts under e2e-artifacts/vitest/common-egress-agent",
     );
   }
   if (!stringValue(jobEnv.NEMOCLAW_CLI_BIN).includes("bin/nemoclaw.js")) {
-    errors.push("common-egress-agent-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "common-egress-agent-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
-    errors.push("common-egress-agent-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+    errors.push(
+      "common-egress-agent-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("common-egress-agent-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    errors.push(
+      "common-egress-agent-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_RECREATE_SANDBOX !== "1") {
-    errors.push("common-egress-agent-vitest job must set NEMOCLAW_RECREATE_SANDBOX=1");
+    errors.push(
+      "common-egress-agent-vitest job must set NEMOCLAW_RECREATE_SANDBOX=1",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("common-egress-agent-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "common-egress-agent-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   for (const secret of [
     "NVIDIA_API_KEY",
@@ -886,7 +1148,12 @@ function validateCommonEgressAgentVitestJob(errors: string[], jobs: WorkflowReco
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "common-egress-agent-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "common-egress-agent-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -902,7 +1169,11 @@ function validateCommonEgressAgentVitestJob(errors: string[], jobs: WorkflowReco
         "NVIDIA_API_KEY",
       );
     }
-    for (const secret of ["DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN", "GITHUB_TOKEN"]) {
+    for (const secret of [
+      "DOCKERHUB_USERNAME",
+      "DOCKERHUB_TOKEN",
+      "GITHUB_TOKEN",
+    ]) {
       requireEnvDoesNotExposeSecret(
         errors,
         `common-egress-agent-vitest step '${stepName}'`,
@@ -912,16 +1183,26 @@ function validateCommonEgressAgentVitestJob(errors: string[], jobs: WorkflowReco
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("common-egress-agent-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("common-egress-agent-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "common-egress-agent-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("common-egress-agent-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "common-egress-agent-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("common-egress-agent-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "common-egress-agent-vitest setup-node");
+  if (!setupNode)
+    errors.push("common-egress-agent-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "common-egress-agent-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -929,48 +1210,100 @@ function validateCommonEgressAgentVitestJob(errors: string[], jobs: WorkflowReco
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run common-egress agent live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run common-egress agent live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
-    errors.push("common-egress-agent-vitest step must receive NVIDIA_API_KEY from secrets");
+    errors.push(
+      "common-egress-agent-vitest step must receive NVIDIA_API_KEY from secrets",
+    );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/common-egress-agent.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/common-egress-agent.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload common-egress agent artifacts");
-  requireFullShaAction(errors, upload, "common-egress-agent-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload common-egress agent artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "common-egress-agent-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-common-egress-agent") {
-    errors.push("common-egress-agent-vitest artifact upload name must be stable");
+    errors.push(
+      "common-egress-agent-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/common-egress-agent/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/common-egress-agent/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("common-egress-agent-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "common-egress-agent-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("common-egress-agent-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "common-egress-agent-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("common-egress-agent-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "common-egress-agent-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateShieldsConfigVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateShieldsConfigVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "shields-config-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -983,28 +1316,43 @@ function validateShieldsConfigVitestJob(errors: string[], jobs: WorkflowRecord):
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, "shields-config");
   if (job["timeout-minutes"] !== 45) {
-    errors.push("shields-config-vitest job must keep the legacy 45 minute timeout");
+    errors.push(
+      "shields-config-vitest job must keep the legacy 45 minute timeout",
+    );
   }
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("shields-config-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "shields-config-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/shields-config") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/shields-config"
+  ) {
     errors.push(
       "shields-config-vitest job must write artifacts under e2e-artifacts/vitest/shields-config",
     );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("shields-config-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "shields-config-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
-    errors.push("shields-config-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+    errors.push(
+      "shields-config-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("shields-config-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    errors.push(
+      "shields-config-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-shields") {
-    errors.push("shields-config-vitest job must set NEMOCLAW_SANDBOX_NAME=e2e-shields");
+    errors.push(
+      "shields-config-vitest job must set NEMOCLAW_SANDBOX_NAME=e2e-shields",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -1012,8 +1360,18 @@ function validateShieldsConfigVitestJob(errors: string[], jobs: WorkflowRecord):
     jobEnv,
     "NVIDIA_INFERENCE_API_KEY",
   );
-  requireEnvDoesNotExposeSecret(errors, "shields-config-vitest job", jobEnv, "DOCKERHUB_USERNAME");
-  requireEnvDoesNotExposeSecret(errors, "shields-config-vitest job", jobEnv, "DOCKERHUB_TOKEN");
+  requireEnvDoesNotExposeSecret(
+    errors,
+    "shields-config-vitest job",
+    jobEnv,
+    "DOCKERHUB_USERNAME",
+  );
+  requireEnvDoesNotExposeSecret(
+    errors,
+    "shields-config-vitest job",
+    jobEnv,
+    "DOCKERHUB_TOKEN",
+  );
 
   const steps = asSteps(job.steps);
   requireNoDispatchInputInterpolation(errors, steps);
@@ -1044,14 +1402,23 @@ function validateShieldsConfigVitestJob(errors: string[], jobs: WorkflowRecord):
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("shields-config-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "shields-config-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("shields-config-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "shields-config-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -1059,12 +1426,15 @@ function validateShieldsConfigVitestJob(errors: string[], jobs: WorkflowRecord):
     );
   }
   if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("shields-config-vitest Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
+    errors.push(
+      "shields-config-vitest Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
+    );
   }
   requireRunContains(errors, dockerHubAuth, "docker login docker.io");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("shields-config-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("shields-config-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "shields-config-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -1073,37 +1443,81 @@ function validateShieldsConfigVitestJob(errors: string[], jobs: WorkflowRecord):
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run shields-config live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run shields-config live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push("shields-config-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      "shields-config-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/shields-config.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/shields-config.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload shields-config artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload shields-config artifacts",
+  );
   requireFullShaAction(errors, upload, "shields-config-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-shields-config") {
     errors.push("shields-config-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/shields-config/");
-  requireUploadPathContains(errors, uploadPath, "/tmp/nemoclaw-e2e-shields-install.log");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/shields-config/",
+  );
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "/tmp/nemoclaw-e2e-shields-install.log",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("shields-config-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "shields-config-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("shields-config-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "shields-config-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("shields-config-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "shields-config-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateRebuildOpenClawVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateRebuildOpenClawVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "rebuild-openclaw-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -1116,19 +1530,28 @@ function validateRebuildOpenClawVitestJob(errors: string[], jobs: WorkflowRecord
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, "rebuild-openclaw");
   if (job["timeout-minutes"] !== 130) {
-    errors.push("rebuild-openclaw-vitest job must keep the legacy 130 minute timeout");
+    errors.push(
+      "rebuild-openclaw-vitest job must keep the legacy 130 minute timeout",
+    );
   }
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("rebuild-openclaw-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "rebuild-openclaw-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/rebuild-openclaw") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/rebuild-openclaw"
+  ) {
     errors.push(
       "rebuild-openclaw-vitest job must write artifacts under e2e-artifacts/vitest/rebuild-openclaw",
     );
   }
   if (!stringValue(jobEnv.NEMOCLAW_CLI_BIN).includes("bin/nemoclaw.js")) {
-    errors.push("rebuild-openclaw-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "rebuild-openclaw-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -1150,14 +1573,24 @@ function validateRebuildOpenClawVitestJob(errors: string[], jobs: WorkflowRecord
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("rebuild-openclaw-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("rebuild-openclaw-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "rebuild-openclaw-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("rebuild-openclaw-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "rebuild-openclaw-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -1172,7 +1605,8 @@ function validateRebuildOpenClawVitestJob(errors: string[], jobs: WorkflowRecord
   requireRunContains(errors, dockerHubAuth, "docker login docker.io");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("rebuild-openclaw-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("rebuild-openclaw-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "rebuild-openclaw-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -1181,50 +1615,100 @@ function validateRebuildOpenClawVitestJob(errors: string[], jobs: WorkflowRecord
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
   requireEnvDoesNotExposeSecret(
     errors,
     "rebuild-openclaw-vitest step 'Install OpenShell'",
     asRecord(installOpenShell?.env),
     "GITHUB_TOKEN",
   );
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_INFERENCE_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run OpenClaw rebuild live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run OpenClaw rebuild live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push("rebuild-openclaw-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      "rebuild-openclaw-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/rebuild-openclaw.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/rebuild-openclaw.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload OpenClaw rebuild artifacts");
-  requireFullShaAction(errors, upload, "rebuild-openclaw-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload OpenClaw rebuild artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "rebuild-openclaw-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-rebuild-openclaw") {
     errors.push("rebuild-openclaw-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/rebuild-openclaw/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/rebuild-openclaw/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("rebuild-openclaw-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "rebuild-openclaw-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("rebuild-openclaw-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "rebuild-openclaw-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("rebuild-openclaw-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "rebuild-openclaw-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
@@ -1233,8 +1717,12 @@ function validateRebuildHermesVitestJob(
   jobs: WorkflowRecord,
   options: { staleBase: boolean },
 ): void {
-  const jobName = options.staleBase ? "rebuild-hermes-stale-base-vitest" : "rebuild-hermes-vitest";
-  const scenarioName = options.staleBase ? "rebuild-hermes-stale-base" : "rebuild-hermes";
+  const jobName = options.staleBase
+    ? "rebuild-hermes-stale-base-vitest"
+    : "rebuild-hermes-vitest";
+  const scenarioName = options.staleBase
+    ? "rebuild-hermes-stale-base"
+    : "rebuild-hermes";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
     errors.push(`workflow missing ${jobName} job`);
@@ -1262,7 +1750,9 @@ function validateRebuildHermesVitestJob(
     errors.push(`${jobName} job must set NEMOCLAW_AGENT=hermes`);
   }
   if (jobEnv.NEMOCLAW_PROVIDER !== "custom") {
-    errors.push(`${jobName} job must use the hosted compatible endpoint provider`);
+    errors.push(
+      `${jobName} job must use the hosted compatible endpoint provider`,
+    );
   }
   if (jobEnv.NEMOCLAW_ENDPOINT_URL !== "https://inference-api.nvidia.com/v1") {
     errors.push(`${jobName} job must target hosted CI inference endpoint`);
@@ -1278,13 +1768,19 @@ function validateRebuildHermesVitestJob(
   }
   if (options.staleBase) {
     if (jobEnv.NEMOCLAW_HERMES_STALE_BASE_REBUILD_E2E !== "1") {
-      errors.push(`${jobName} job must enable NEMOCLAW_HERMES_STALE_BASE_REBUILD_E2E=1`);
+      errors.push(
+        `${jobName} job must enable NEMOCLAW_HERMES_STALE_BASE_REBUILD_E2E=1`,
+      );
     }
     if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-rebuild-hermes-base") {
-      errors.push(`${jobName} job must set NEMOCLAW_SANDBOX_NAME=e2e-rebuild-hermes-base`);
+      errors.push(
+        `${jobName} job must set NEMOCLAW_SANDBOX_NAME=e2e-rebuild-hermes-base`,
+      );
     }
   } else if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-rebuild-hermes") {
-    errors.push(`${jobName} job must set NEMOCLAW_SANDBOX_NAME=e2e-rebuild-hermes`);
+    errors.push(
+      `${jobName} job must set NEMOCLAW_SANDBOX_NAME=e2e-rebuild-hermes`,
+    );
   }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
@@ -1301,30 +1797,56 @@ function validateRebuildHermesVitestJob(
     const stepName = `${jobName} step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (!step.name?.startsWith("Run Hermes")) {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push(`${jobName} job missing checkout step`);
   requireFullShaAction(errors, checkout, `${jobName} checkout`);
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push(`${jobName} checkout step must set persist-credentials=false`);
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(`${jobName} Docker Hub auth must receive DOCKERHUB_USERNAME from secrets`);
+    errors.push(
+      `${jobName} Docker Hub auth must receive DOCKERHUB_USERNAME from secrets`,
+    );
   }
   if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(`${jobName} Docker Hub auth must receive DOCKERHUB_TOKEN from secrets`);
+    errors.push(
+      `${jobName} Docker Hub auth must receive DOCKERHUB_TOKEN from secrets`,
+    );
   }
   requireRunContains(errors, dockerHubAuth, "docker login docker.io");
   requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
@@ -1339,20 +1861,39 @@ function validateRebuildHermesVitestJob(
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const runVitest = requireJobStep(
     errors,
     jobName,
     steps,
-    options.staleBase ? "Run Hermes stale-base rebuild live test" : "Run Hermes rebuild live test",
+    options.staleBase
+      ? "Run Hermes stale-base rebuild live test"
+      : "Run Hermes rebuild live test",
   );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push(`${jobName} step must receive NVIDIA_INFERENCE_API_KEY from secrets`);
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      `${jobName} step must receive NVIDIA_INFERENCE_API_KEY from secrets`,
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/rebuild-hermes.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/rebuild-hermes.test.ts",
+  );
 
   const upload = requireJobStep(
     errors,
@@ -1379,17 +1920,24 @@ function validateRebuildHermesVitestJob(
       : "e2e-artifacts/vitest/rebuild-hermes/",
   );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push(`${jobName} artifact upload must set include-hidden-files: false`);
+    errors.push(
+      `${jobName} artifact upload must set include-hidden-files: false`,
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push(`${jobName} artifact upload must ignore missing fixture artifacts`);
+    errors.push(
+      `${jobName} artifact upload must ignore missing fixture artifacts`,
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
     errors.push(`${jobName} artifact upload retention-days must be 14`);
   }
 }
 
-function validateSandboxRebuildVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateSandboxRebuildVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "sandbox-rebuild-vitest";
   const scenarioName = "sandbox-rebuild";
   const job = asRecord(jobs[jobName]);
@@ -1403,22 +1951,33 @@ function validateSandboxRebuildVitestJob(errors: string[], jobs: WorkflowRecord)
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
   if (job["timeout-minutes"] !== 90) {
-    errors.push("sandbox-rebuild-vitest job must keep the legacy 90 minute timeout");
+    errors.push(
+      "sandbox-rebuild-vitest job must keep the legacy 90 minute timeout",
+    );
   }
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("sandbox-rebuild-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "sandbox-rebuild-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/sandbox-rebuild") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/sandbox-rebuild"
+  ) {
     errors.push(
       "sandbox-rebuild-vitest job must write artifacts under e2e-artifacts/vitest/sandbox-rebuild",
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("sandbox-rebuild-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "sandbox-rebuild-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("sandbox-rebuild-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "sandbox-rebuild-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
@@ -1426,7 +1985,12 @@ function validateSandboxRebuildVitestJob(errors: string[], jobs: WorkflowRecord)
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "sandbox-rebuild-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "sandbox-rebuild-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -1435,24 +1999,49 @@ function validateSandboxRebuildVitestJob(errors: string[], jobs: WorkflowRecord)
     const stepName = `sandbox-rebuild-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run sandbox rebuild live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("sandbox-rebuild-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("sandbox-rebuild-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "sandbox-rebuild-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("sandbox-rebuild-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "sandbox-rebuild-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -1460,13 +2049,16 @@ function validateSandboxRebuildVitestJob(errors: string[], jobs: WorkflowRecord)
     );
   }
   if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("sandbox-rebuild-vitest Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
+    errors.push(
+      "sandbox-rebuild-vitest Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
+    );
   }
   requireRunContains(errors, dockerHubAuth, "docker login docker.io");
   requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("sandbox-rebuild-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("sandbox-rebuild-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "sandbox-rebuild-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -1475,48 +2067,101 @@ function validateSandboxRebuildVitestJob(errors: string[], jobs: WorkflowRecord)
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_INFERENCE_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run sandbox rebuild live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run sandbox rebuild live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push("sandbox-rebuild-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      "sandbox-rebuild-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/sandbox-rebuild.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/sandbox-rebuild.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload sandbox rebuild artifacts");
-  requireFullShaAction(errors, upload, "sandbox-rebuild-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload sandbox rebuild artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "sandbox-rebuild-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-sandbox-rebuild") {
     errors.push("sandbox-rebuild-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/sandbox-rebuild/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/sandbox-rebuild/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("sandbox-rebuild-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "sandbox-rebuild-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("sandbox-rebuild-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "sandbox-rebuild-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("sandbox-rebuild-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "sandbox-rebuild-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateStateBackupRestoreVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "state-backup-restore-vitest";
   const scenarioName = "state-backup-restore";
   const job = asRecord(jobs[jobName]);
@@ -1530,33 +2175,48 @@ function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRec
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
   if (job["timeout-minutes"] !== 60) {
-    errors.push("state-backup-restore-vitest job must keep the legacy 60 minute timeout");
+    errors.push(
+      "state-backup-restore-vitest job must keep the legacy 60 minute timeout",
+    );
   }
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("state-backup-restore-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "state-backup-restore-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/state-backup-restore"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/state-backup-restore"
   ) {
     errors.push(
       "state-backup-restore-vitest job must write artifacts under e2e-artifacts/vitest/state-backup-restore",
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("state-backup-restore-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "state-backup-restore-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("state-backup-restore-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "state-backup-restore-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
-    errors.push("state-backup-restore-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+    errors.push(
+      "state-backup-restore-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("state-backup-restore-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    errors.push(
+      "state-backup-restore-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-state-backup") {
-    errors.push("state-backup-restore-vitest job must set NEMOCLAW_SANDBOX_NAME=e2e-state-backup");
+    errors.push(
+      "state-backup-restore-vitest job must set NEMOCLAW_SANDBOX_NAME=e2e-state-backup",
+    );
   }
   for (const secret of [
     "NVIDIA_API_KEY",
@@ -1564,7 +2224,12 @@ function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRec
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "state-backup-restore-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "state-backup-restore-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -1573,24 +2238,53 @@ function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRec
     const stepName = `state-backup-restore-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run state backup restore live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("state-backup-restore-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "state-backup-restore-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("state-backup-restore-vitest job missing checkout step");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "state-backup-restore-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("state-backup-restore-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "state-backup-restore-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -1606,8 +2300,13 @@ function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRec
   requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("state-backup-restore-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "state-backup-restore-vitest setup-node");
+  if (!setupNode)
+    errors.push("state-backup-restore-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "state-backup-restore-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -1615,38 +2314,83 @@ function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRec
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run state backup restore live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run state backup restore live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
-    errors.push("state-backup-restore-vitest step must receive NVIDIA_API_KEY from secrets");
+    errors.push(
+      "state-backup-restore-vitest step must receive NVIDIA_API_KEY from secrets",
+    );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/state-backup-restore.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/state-backup-restore.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload state backup restore artifacts");
-  requireFullShaAction(errors, upload, "state-backup-restore-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload state backup restore artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "state-backup-restore-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-state-backup-restore") {
-    errors.push("state-backup-restore-vitest artifact upload name must be stable");
+    errors.push(
+      "state-backup-restore-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/state-backup-restore/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/state-backup-restore/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("state-backup-restore-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "state-backup-restore-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
     errors.push(
@@ -1654,11 +2398,16 @@ function validateStateBackupRestoreVitestJob(errors: string[], jobs: WorkflowRec
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("state-backup-restore-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "state-backup-restore-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateUpgradeStaleSandboxVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "upgrade-stale-sandbox-vitest";
   const scenarioName = "upgrade-stale-sandbox";
   const job = asRecord(jobs[jobName]);
@@ -1672,25 +2421,34 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
   if (job["timeout-minutes"] !== 55) {
-    errors.push("upgrade-stale-sandbox-vitest job must keep the legacy 55 minute timeout");
+    errors.push(
+      "upgrade-stale-sandbox-vitest job must keep the legacy 55 minute timeout",
+    );
   }
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("upgrade-stale-sandbox-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "upgrade-stale-sandbox-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/upgrade-stale-sandbox"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/upgrade-stale-sandbox"
   ) {
     errors.push(
       "upgrade-stale-sandbox-vitest job must write artifacts under e2e-artifacts/vitest/upgrade-stale-sandbox",
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("upgrade-stale-sandbox-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "upgrade-stale-sandbox-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("upgrade-stale-sandbox-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "upgrade-stale-sandbox-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-upgrade-stale") {
     errors.push(
@@ -1698,10 +2456,20 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
     );
   }
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("upgrade-stale-sandbox-vitest job must not set DOCKER_CONFIG at job level");
+    errors.push(
+      "upgrade-stale-sandbox-vitest job must not set DOCKER_CONFIG at job level",
+    );
   }
-  for (const secret of ["NVIDIA_INFERENCE_API_KEY", ...COMMON_SECRET_ENV_NAMES]) {
-    requireEnvDoesNotExposeSecret(errors, "upgrade-stale-sandbox-vitest job", jobEnv, secret);
+  for (const secret of [
+    "NVIDIA_INFERENCE_API_KEY",
+    ...COMMON_SECRET_ENV_NAMES,
+  ]) {
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "upgrade-stale-sandbox-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -1710,22 +2478,51 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
     const stepName = `upgrade-stale-sandbox-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run upgrade stale sandbox live Vitest test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("upgrade-stale-sandbox-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "upgrade-stale-sandbox-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("upgrade-stale-sandbox-vitest job missing checkout step");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "upgrade-stale-sandbox-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("upgrade-stale-sandbox-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "upgrade-stale-sandbox-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const configureDockerAuth = requireJobStep(
@@ -1740,7 +2537,12 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
     'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-upgrade-stale-sandbox" >> "$GITHUB_ENV"',
   );
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -1758,8 +2560,13 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
   requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("upgrade-stale-sandbox-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "upgrade-stale-sandbox-vitest setup-node");
+  if (!setupNode)
+    errors.push("upgrade-stale-sandbox-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "upgrade-stale-sandbox-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -1767,13 +2574,26 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell CLI",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
@@ -1788,23 +2608,49 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
     "Run upgrade stale sandbox live Vitest test",
   );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "upgrade-stale-sandbox-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/upgrade-stale-sandbox.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/upgrade-stale-sandbox.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload upgrade stale sandbox artifacts");
-  requireFullShaAction(errors, upload, "upgrade-stale-sandbox-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload upgrade stale sandbox artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "upgrade-stale-sandbox-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-upgrade-stale-sandbox") {
-    errors.push("upgrade-stale-sandbox-vitest artifact upload name must be stable");
+    errors.push(
+      "upgrade-stale-sandbox-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/upgrade-stale-sandbox/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/upgrade-stale-sandbox/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
     errors.push(
       "upgrade-stale-sandbox-vitest artifact upload must set include-hidden-files: false",
@@ -1816,15 +2662,25 @@ function validateUpgradeStaleSandboxVitestJob(errors: string[], jobs: WorkflowRe
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("upgrade-stale-sandbox-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "upgrade-stale-sandbox-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
-function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateTokenRotationVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "token-rotation-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -1837,19 +2693,28 @@ function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord):
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, "token-rotation");
   if (job["timeout-minutes"] !== 45) {
-    errors.push("token-rotation-vitest job must keep the legacy 45 minute timeout");
+    errors.push(
+      "token-rotation-vitest job must keep the legacy 45 minute timeout",
+    );
   }
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("token-rotation-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "token-rotation-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/token-rotation") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/token-rotation"
+  ) {
     errors.push(
       "token-rotation-vitest job must write artifacts under e2e-artifacts/vitest/token-rotation",
     );
   }
   if (!stringValue(jobEnv.NEMOCLAW_CLI_BIN).includes("bin/nemoclaw.js")) {
-    errors.push("token-rotation-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "token-rotation-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -1871,14 +2736,23 @@ function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord):
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("token-rotation-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "token-rotation-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("token-rotation-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "token-rotation-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -1886,12 +2760,15 @@ function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord):
     );
   }
   if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("token-rotation-vitest Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
+    errors.push(
+      "token-rotation-vitest Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
+    );
   }
   requireRunContains(errors, dockerHubAuth, "docker login docker.io");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("token-rotation-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("token-rotation-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "token-rotation-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -1900,12 +2777,21 @@ function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord):
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run token rotation live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run token rotation live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   requireEnvDoesNotExposeSecret(
     errors,
@@ -1914,7 +2800,9 @@ function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord):
     "NVIDIA_INFERENCE_API_KEY",
   );
   if (runVitestEnv.GITHUB_TOKEN !== "${{ github.token }}") {
-    errors.push("token-rotation-vitest step must receive GITHUB_TOKEN from github.token");
+    errors.push(
+      "token-rotation-vitest step must receive GITHUB_TOKEN from github.token",
+    );
   }
   for (const tokenName of [
     "TELEGRAM_BOT_TOKEN_A",
@@ -1935,25 +2823,48 @@ function validateTokenRotationVitestJob(errors: string[], jobs: WorkflowRecord):
       errors.push(`token-rotation-vitest step must set ${tokenName}`);
     }
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/token-rotation.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/token-rotation.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload token rotation artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload token rotation artifacts",
+  );
   requireFullShaAction(errors, upload, "token-rotation-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-token-rotation") {
     errors.push("token-rotation-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/token-rotation/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/token-rotation/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("token-rotation-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "token-rotation-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("token-rotation-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "token-rotation-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("token-rotation-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "token-rotation-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
@@ -1969,11 +2880,20 @@ function validateMessagingCompatibleEndpointVitestJob(
   }
 
   if (job["runs-on"] !== "ubuntu-latest") {
-    errors.push("messaging-compatible-endpoint-vitest job must run on ubuntu-latest");
+    errors.push(
+      "messaging-compatible-endpoint-vitest job must run on ubuntu-latest",
+    );
   }
-  validateFreeStandingJobSelector(errors, jobs, jobName, "messaging-compatible-endpoint");
+  validateFreeStandingJobSelector(
+    errors,
+    jobs,
+    jobName,
+    "messaging-compatible-endpoint",
+  );
   if (job["timeout-minutes"] !== 45) {
-    errors.push("messaging-compatible-endpoint-vitest job must keep the legacy 45 minute timeout");
+    errors.push(
+      "messaging-compatible-endpoint-vitest job must keep the legacy 45 minute timeout",
+    );
   }
 
   const jobEnv = asRecord(job.env);
@@ -1991,13 +2911,19 @@ function validateMessagingCompatibleEndpointVitestJob(
     );
   }
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("messaging-compatible-endpoint-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "messaging-compatible-endpoint-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-msg-compat") {
-    errors.push("messaging-compatible-endpoint-vitest job must pin the legacy sandbox name");
+    errors.push(
+      "messaging-compatible-endpoint-vitest job must pin the legacy sandbox name",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("messaging-compatible-endpoint-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "messaging-compatible-endpoint-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -2054,9 +2980,18 @@ function validateMessagingCompatibleEndpointVitestJob(
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("messaging-compatible-endpoint-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "messaging-compatible-endpoint-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push(
+      "messaging-compatible-endpoint-vitest job missing checkout step",
+    );
+  requireFullShaAction(
+    errors,
+    checkout,
+    "messaging-compatible-endpoint-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push(
       "messaging-compatible-endpoint-vitest checkout step must set persist-credentials=false",
@@ -2064,8 +2999,15 @@ function validateMessagingCompatibleEndpointVitestJob(
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("messaging-compatible-endpoint-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "messaging-compatible-endpoint-vitest setup-node");
+  if (!setupNode)
+    errors.push(
+      "messaging-compatible-endpoint-vitest job missing step: Set up Node",
+    );
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "messaging-compatible-endpoint-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -2073,7 +3015,11 @@ function validateMessagingCompatibleEndpointVitestJob(
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
@@ -2097,12 +3043,20 @@ function validateMessagingCompatibleEndpointVitestJob(
     );
   }
   if (runVitestEnv.TELEGRAM_BOT_TOKEN !== "test-fake-telegram-token-e2e") {
-    errors.push("messaging-compatible-endpoint-vitest step must set a fake Telegram token");
+    errors.push(
+      "messaging-compatible-endpoint-vitest step must set a fake Telegram token",
+    );
   }
   if (runVitestEnv.TELEGRAM_ALLOWED_IDS !== "123456789") {
-    errors.push("messaging-compatible-endpoint-vitest step must set fake Telegram allowed ids");
+    errors.push(
+      "messaging-compatible-endpoint-vitest step must set fake Telegram allowed ids",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
   requireRunContains(
     errors,
     runVitest,
@@ -2115,10 +3069,18 @@ function validateMessagingCompatibleEndpointVitestJob(
     steps,
     "Upload messaging compatible endpoint artifacts",
   );
-  requireFullShaAction(errors, upload, "messaging-compatible-endpoint-vitest upload-artifact");
+  requireFullShaAction(
+    errors,
+    upload,
+    "messaging-compatible-endpoint-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
-  if (uploadWith.name !== "e2e-vitest-scenarios-messaging-compatible-endpoint") {
-    errors.push("messaging-compatible-endpoint-vitest artifact upload name must be stable");
+  if (
+    uploadWith.name !== "e2e-vitest-scenarios-messaging-compatible-endpoint"
+  ) {
+    errors.push(
+      "messaging-compatible-endpoint-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
   requireUploadPathContains(
@@ -2137,11 +3099,16 @@ function validateMessagingCompatibleEndpointVitestJob(
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("messaging-compatible-endpoint-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "messaging-compatible-endpoint-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateOnboardNegativePathsVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateOnboardNegativePathsVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "onboard-negative-paths-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -2152,11 +3119,18 @@ function validateOnboardNegativePathsVitestJob(errors: string[], jobs: WorkflowR
   if (job["runs-on"] !== "ubuntu-latest") {
     errors.push("onboard-negative-paths-vitest job must run on ubuntu-latest");
   }
-  validateFreeStandingJobSelector(errors, jobs, jobName, "onboard-negative-paths");
+  validateFreeStandingJobSelector(
+    errors,
+    jobs,
+    jobName,
+    "onboard-negative-paths",
+  );
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("onboard-negative-paths-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "onboard-negative-paths-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
     jobEnv.E2E_ARTIFACT_DIR !==
@@ -2184,16 +3158,30 @@ function validateOnboardNegativePathsVitestJob(errors: string[], jobs: WorkflowR
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("onboard-negative-paths-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "onboard-negative-paths-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("onboard-negative-paths-vitest job missing checkout step");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "onboard-negative-paths-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("onboard-negative-paths-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "onboard-negative-paths-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("onboard-negative-paths-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "onboard-negative-paths-vitest setup-node");
+  if (!setupNode)
+    errors.push("onboard-negative-paths-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "onboard-negative-paths-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -2201,23 +3189,55 @@ function validateOnboardNegativePathsVitestJob(errors: string[], jobs: WorkflowR
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run onboard negative-paths live test");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/onboard-negative-paths.test.ts");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run onboard negative-paths live test",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/onboard-negative-paths.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload onboard negative-paths artifacts");
-  requireFullShaAction(errors, upload, "onboard-negative-paths-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload onboard negative-paths artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "onboard-negative-paths-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-onboard-negative-paths") {
-    errors.push("onboard-negative-paths-vitest artifact upload name must be stable");
+    errors.push(
+      "onboard-negative-paths-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/onboard-negative-paths/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/onboard-negative-paths/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
     errors.push(
       "onboard-negative-paths-vitest artifact upload must set include-hidden-files: false",
@@ -2229,11 +3249,16 @@ function validateOnboardNegativePathsVitestJob(errors: string[], jobs: WorkflowR
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("onboard-negative-paths-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "onboard-negative-paths-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateCloudInferenceVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateCloudInferenceVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "cloud-inference-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -2250,24 +3275,40 @@ function validateCloudInferenceVitestJob(errors: string[], jobs: WorkflowRecord)
   }
 
   const jobEnv = asRecord(job.env);
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/cloud-inference") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/cloud-inference"
+  ) {
     errors.push(
       "cloud-inference-vitest job must write artifacts under e2e-artifacts/vitest/cloud-inference",
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("cloud-inference-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "cloud-inference-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("cloud-inference-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "cloud-inference-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-cloud-inference") {
-    errors.push("cloud-inference-vitest job must set NEMOCLAW_SANDBOX_NAME=e2e-cloud-inference");
+    errors.push(
+      "cloud-inference-vitest job must set NEMOCLAW_SANDBOX_NAME=e2e-cloud-inference",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("cloud-inference-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "cloud-inference-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
-  requireEnvDoesNotExposeSecret(errors, "cloud-inference-vitest job", jobEnv, "NVIDIA_API_KEY");
+  requireEnvDoesNotExposeSecret(
+    errors,
+    "cloud-inference-vitest job",
+    jobEnv,
+    "NVIDIA_API_KEY",
+  );
 
   const steps = asSteps(job.steps);
   requireNoDispatchInputInterpolation(errors, steps);
@@ -2282,15 +3323,21 @@ function validateCloudInferenceVitestJob(errors: string[], jobs: WorkflowRecord)
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("cloud-inference-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("cloud-inference-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "cloud-inference-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("cloud-inference-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "cloud-inference-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("cloud-inference-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("cloud-inference-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "cloud-inference-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -2299,48 +3346,96 @@ function validateCloudInferenceVitestJob(errors: string[], jobs: WorkflowRecord)
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run cloud inference live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run cloud inference live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
-    errors.push("cloud-inference-vitest run step must receive NVIDIA_API_KEY from secrets");
+    errors.push(
+      "cloud-inference-vitest run step must receive NVIDIA_API_KEY from secrets",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/cloud-inference.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/cloud-inference.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload cloud inference artifacts");
-  requireFullShaAction(errors, upload, "cloud-inference-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload cloud inference artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "cloud-inference-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-cloud-inference") {
     errors.push("cloud-inference-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/cloud-inference/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/cloud-inference/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("cloud-inference-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "cloud-inference-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("cloud-inference-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "cloud-inference-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("cloud-inference-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "cloud-inference-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function requireNoDockerHubAuthInRun(errors: string[], owner: string, runScript: string): void {
+function requireNoDockerHubAuthInRun(
+  errors: string[],
+  owner: string,
+  runScript: string,
+): void {
   if (!runScript) return;
   const usesDockerLogin = /\bdocker\s+login\b/i.test(runScript);
-  const referencesSecret = /\bsecrets\.[A-Za-z0-9_]+\b|\$\{\{\s*secrets\.[^}]+\}\}/.test(runScript);
+  const referencesSecret =
+    /\bsecrets\.[A-Za-z0-9_]+\b|\$\{\{\s*secrets\.[^}]+\}\}/.test(runScript);
   if (usesDockerLogin || referencesSecret) {
-    errors.push(`${owner} run script must not use docker login or inline secret interpolation`);
+    errors.push(
+      `${owner} run script must not use docker login or inline secret interpolation`,
+    );
   }
 }
 
-function validateDoubleOnboardVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateDoubleOnboardVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "double-onboard-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -2355,12 +3450,19 @@ function validateDoubleOnboardVitestJob(errors: string[], jobs: WorkflowRecord):
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("double-onboard-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "double-onboard-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("double-onboard-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "double-onboard-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/double-onboard") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/double-onboard"
+  ) {
     errors.push(
       "double-onboard-vitest job must write artifacts under e2e-artifacts/vitest/double-onboard",
     );
@@ -2371,7 +3473,12 @@ function validateDoubleOnboardVitestJob(errors: string[], jobs: WorkflowRecord):
     jobEnv,
     "NVIDIA_INFERENCE_API_KEY",
   );
-  requireEnvDoesNotExposeSecret(errors, "double-onboard-vitest job", jobEnv, "DOCKERHUB_TOKEN");
+  requireEnvDoesNotExposeSecret(
+    errors,
+    "double-onboard-vitest job",
+    jobEnv,
+    "DOCKERHUB_TOKEN",
+  );
 
   const steps = asSteps(job.steps);
   requireNoDispatchInputInterpolation(errors, steps);
@@ -2392,28 +3499,42 @@ function validateDoubleOnboardVitestJob(errors: string[], jobs: WorkflowRecord):
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("double-onboard-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "double-onboard-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("double-onboard-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "double-onboard-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "double-onboard-vitest Docker login step must read DOCKERHUB_USERNAME from secrets",
     );
   }
   if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("double-onboard-vitest Docker login step must read DOCKERHUB_TOKEN from secrets");
+    errors.push(
+      "double-onboard-vitest Docker login step must read DOCKERHUB_TOKEN from secrets",
+    );
   }
   requireRunContains(errors, dockerLogin, "docker login docker.io");
   requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("double-onboard-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("double-onboard-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "double-onboard-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -2422,38 +3543,78 @@ function validateDoubleOnboardVitestJob(errors: string[], jobs: WorkflowRecord):
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installTools = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
+  const installTools = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell CLI",
+  );
   requireRunContains(errors, installTools, "bash scripts/install-openshell.sh");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run double-onboard live Vitest test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run double-onboard live Vitest test",
+  );
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/double-onboard.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/double-onboard.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload double-onboard Vitest artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload double-onboard Vitest artifacts",
+  );
   requireFullShaAction(errors, upload, "double-onboard-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-double-onboard") {
     errors.push("double-onboard-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/double-onboard/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/double-onboard/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("double-onboard-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "double-onboard-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("double-onboard-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "double-onboard-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("double-onboard-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "double-onboard-vitest artifact upload retention-days must be 14",
+    );
   }
 }
-function validateRuntimeOverridesVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateRuntimeOverridesVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "runtime-overrides-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -2468,10 +3629,13 @@ function validateRuntimeOverridesVitestJob(errors: string[], jobs: WorkflowRecor
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("runtime-overrides-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "runtime-overrides-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/runtime-overrides"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/runtime-overrides"
   ) {
     errors.push(
       "runtime-overrides-vitest job must write artifacts under e2e-artifacts/vitest/runtime-overrides",
@@ -2489,29 +3653,54 @@ function validateRuntimeOverridesVitestJob(errors: string[], jobs: WorkflowRecor
     jobEnv,
     "DOCKERHUB_USERNAME",
   );
-  requireEnvDoesNotExposeSecret(errors, "runtime-overrides-vitest job", jobEnv, "DOCKERHUB_TOKEN");
+  requireEnvDoesNotExposeSecret(
+    errors,
+    "runtime-overrides-vitest job",
+    jobEnv,
+    "DOCKERHUB_TOKEN",
+  );
 
   const steps = asSteps(job.steps);
   requireNoDispatchInputInterpolation(errors, steps);
   for (const step of steps) {
     const stepName = `runtime-overrides-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
+    requireEnvDoesNotExposeSecret(
+      errors,
+      stepName,
+      stepEnv,
+      "NVIDIA_INFERENCE_API_KEY",
+    );
+    requireEnvDoesNotExposeSecret(
+      errors,
+      stepName,
+      stepEnv,
+      "DOCKERHUB_USERNAME",
+    );
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
     requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("runtime-overrides-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("runtime-overrides-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "runtime-overrides-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("runtime-overrides-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "runtime-overrides-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("runtime-overrides-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "runtime-overrides-vitest setup-node");
+  if (!setupNode)
+    errors.push("runtime-overrides-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "runtime-overrides-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -2519,32 +3708,71 @@ function validateRuntimeOverridesVitestJob(errors: string[], jobs: WorkflowRecor
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run runtime overrides live test");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/runtime-overrides.test.ts");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run runtime overrides live test",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/runtime-overrides.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload runtime overrides artifacts");
-  requireFullShaAction(errors, upload, "runtime-overrides-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload runtime overrides artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "runtime-overrides-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-runtime-overrides") {
     errors.push("runtime-overrides-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/runtime-overrides/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/runtime-overrides/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("runtime-overrides-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "runtime-overrides-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("runtime-overrides-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "runtime-overrides-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("runtime-overrides-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "runtime-overrides-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateHermesE2EVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateHermesE2EVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "hermes-e2e-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -2556,13 +3784,21 @@ function validateHermesE2EVitestJob(errors: string[], jobs: WorkflowRecord): voi
     errors.push("hermes-e2e-vitest job must run on ubuntu-latest");
   }
   if (job.needs !== "generate-matrix") {
-    errors.push("hermes-e2e-vitest job must depend on generate-matrix validation");
+    errors.push(
+      "hermes-e2e-vitest job must depend on generate-matrix validation",
+    );
   }
-  if (job.if !== "${{ needs.generate-matrix.outputs.hermes_selected == 'true' }}") {
-    errors.push("hermes-e2e-vitest job must use validated hermes_selected output");
+  if (
+    job.if !== "${{ needs.generate-matrix.outputs.hermes_selected == 'true' }}"
+  ) {
+    errors.push(
+      "hermes-e2e-vitest job must use validated hermes_selected output",
+    );
   }
   if (stringValue(job.if).includes("inputs.scenarios")) {
-    errors.push("hermes-e2e-vitest job must not inspect raw workflow dispatch scenarios");
+    errors.push(
+      "hermes-e2e-vitest job must not inspect raw workflow dispatch scenarios",
+    );
   }
 
   const jobEnv = asRecord(job.env);
@@ -2570,10 +3806,17 @@ function validateHermesE2EVitestJob(errors: string[], jobs: WorkflowRecord): voi
     errors.push("hermes-e2e-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("hermes-e2e-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "hermes-e2e-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/hermes-e2e") {
-    errors.push("hermes-e2e-vitest job must write artifacts under e2e-artifacts/vitest/hermes-e2e");
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/hermes-e2e"
+  ) {
+    errors.push(
+      "hermes-e2e-vitest job must write artifacts under e2e-artifacts/vitest/hermes-e2e",
+    );
   }
   if (jobEnv.NEMOCLAW_AGENT !== "hermes") {
     errors.push("hermes-e2e-vitest job must set NEMOCLAW_AGENT=hermes");
@@ -2582,7 +3825,9 @@ function validateHermesE2EVitestJob(errors: string[], jobs: WorkflowRecord): voi
     errors.push("hermes-e2e-vitest job must pin the CI-safe Hermes model");
   }
   if (jobEnv.NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS !== "60") {
-    errors.push("hermes-e2e-vitest job must give hosted endpoint validation a CI-safe timeout");
+    errors.push(
+      "hermes-e2e-vitest job must give hosted endpoint validation a CI-safe timeout",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -2604,15 +3849,20 @@ function validateHermesE2EVitestJob(errors: string[], jobs: WorkflowRecord): voi
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("hermes-e2e-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "hermes-e2e-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("hermes-e2e-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "hermes-e2e-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("hermes-e2e-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("hermes-e2e-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "hermes-e2e-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -2621,40 +3871,78 @@ function validateHermesE2EVitestJob(errors: string[], jobs: WorkflowRecord): voi
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run Hermes live Vitest test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run Hermes live Vitest test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push("hermes-e2e-vitest Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      "hermes-e2e-vitest Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/hermes-e2e.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/hermes-e2e.test.ts",
+  );
   requireRunDoesNotContain(errors, runVitest, "${{ inputs.");
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload Hermes live Vitest artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload Hermes live Vitest artifacts",
+  );
   requireFullShaAction(errors, upload, "hermes-e2e-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-hermes-e2e") {
     errors.push("hermes-e2e-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/hermes-e2e/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/hermes-e2e/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("hermes-e2e-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "hermes-e2e-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("hermes-e2e-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "hermes-e2e-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
     errors.push("hermes-e2e-vitest artifact upload retention-days must be 14");
   }
 }
 
-function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateHermesRootEntrypointSmokeVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "hermes-root-entrypoint-smoke-vitest";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
@@ -2663,10 +3951,14 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
   }
 
   if (job["runs-on"] !== "ubuntu-latest") {
-    errors.push("hermes-root-entrypoint-smoke-vitest job must run on ubuntu-latest");
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest job must run on ubuntu-latest",
+    );
   }
   if (job.needs !== "generate-matrix") {
-    errors.push("hermes-root-entrypoint-smoke-vitest job must depend on generate-matrix");
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest job must depend on generate-matrix",
+    );
   }
   const expectedIf =
     "${{ needs.generate-matrix.result == 'success' && ((inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',hermes-root-entrypoint-smoke-vitest,') || contains(format(',{0},', inputs.scenarios), ',hermes-root-entrypoint-smoke,')) }}";
@@ -2676,12 +3968,16 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
     );
   }
   if (job["timeout-minutes"] !== 45) {
-    errors.push("hermes-root-entrypoint-smoke-vitest job must keep the 45 minute timeout");
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest job must keep the 45 minute timeout",
+    );
   }
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("hermes-root-entrypoint-smoke-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
     jobEnv.E2E_ARTIFACT_DIR !==
@@ -2746,9 +4042,18 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("hermes-root-entrypoint-smoke-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "hermes-root-entrypoint-smoke-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest job missing checkout step",
+    );
+  requireFullShaAction(
+    errors,
+    checkout,
+    "hermes-root-entrypoint-smoke-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push(
       "hermes-root-entrypoint-smoke-vitest checkout step must set persist-credentials=false",
@@ -2756,8 +4061,15 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("hermes-root-entrypoint-smoke-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "hermes-root-entrypoint-smoke-vitest setup-node");
+  if (!setupNode)
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest job missing step: Set up Node",
+    );
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "hermes-root-entrypoint-smoke-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -2765,7 +4077,11 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const runVitest = requireJobStep(
     errors,
@@ -2773,7 +4089,11 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
     steps,
     "Run Hermes root entrypoint smoke live test",
   );
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
   requireRunContains(
     errors,
     runVitest,
@@ -2787,10 +4107,16 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
     steps,
     "Upload Hermes root entrypoint smoke artifacts",
   );
-  requireFullShaAction(errors, upload, "hermes-root-entrypoint-smoke-vitest upload-artifact");
+  requireFullShaAction(
+    errors,
+    upload,
+    "hermes-root-entrypoint-smoke-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-hermes-root-entrypoint-smoke") {
-    errors.push("hermes-root-entrypoint-smoke-vitest artifact upload name must be stable");
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
   requireUploadPathContains(
@@ -2809,11 +4135,16 @@ function validateHermesRootEntrypointSmokeVitestJob(errors: string[], jobs: Work
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("hermes-root-entrypoint-smoke-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "hermes-root-entrypoint-smoke-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateDiagnosticsVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "diagnostics-vitest";
   const scenarioName = "diagnostics";
   const job = asRecord(jobs[jobName]);
@@ -2832,15 +4163,22 @@ function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): v
 
   const jobEnv = asRecord(job.env);
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("diagnostics-vitest job must not expose Docker auth to branch-controlled steps");
+    errors.push(
+      "diagnostics-vitest job must not expose Docker auth to branch-controlled steps",
+    );
   }
-  if (jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/diagnostics") {
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/diagnostics"
+  ) {
     errors.push(
       "diagnostics-vitest job must write artifacts under e2e-artifacts/vitest/diagnostics",
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("diagnostics-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "diagnostics-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
     errors.push("diagnostics-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
@@ -2849,10 +4187,14 @@ function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): v
     errors.push("diagnostics-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("diagnostics-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    errors.push(
+      "diagnostics-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-diag") {
-    errors.push("diagnostics-vitest job must use the stable e2e-diag sandbox name");
+    errors.push(
+      "diagnostics-vitest job must use the stable e2e-diag sandbox name",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
     errors.push("diagnostics-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
@@ -2863,7 +4205,12 @@ function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): v
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "diagnostics-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "diagnostics-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -2872,9 +4219,19 @@ function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): v
     const stepName = `diagnostics-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run diagnostics live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
+    requireEnvDoesNotExposeSecret(
+      errors,
+      stepName,
+      stepEnv,
+      "DOCKERHUB_USERNAME",
+    );
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
     requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
@@ -2886,15 +4243,20 @@ function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): v
     );
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("diagnostics-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "diagnostics-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("diagnostics-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "diagnostics-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("diagnostics-vitest job missing step: Set up Node");
+  if (!setupNode)
+    errors.push("diagnostics-vitest job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "diagnostics-vitest setup-node");
 
   const installRootDependencies = requireJobStep(
@@ -2903,40 +4265,259 @@ function validateDiagnosticsVitestJob(errors: string[], jobs: WorkflowRecord): v
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run diagnostics live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run diagnostics live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
-    errors.push("diagnostics-vitest Vitest step must receive NVIDIA_API_KEY from secrets");
+    errors.push(
+      "diagnostics-vitest Vitest step must receive NVIDIA_API_KEY from secrets",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/diagnostics.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/diagnostics.test.ts",
+  );
   requireRunDoesNotContain(errors, runVitest, "${{ inputs.");
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload diagnostics artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload diagnostics artifacts",
+  );
   requireFullShaAction(errors, upload, "diagnostics-vitest upload-artifact");
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-diagnostics") {
     errors.push("diagnostics-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/diagnostics/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/diagnostics/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("diagnostics-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "diagnostics-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("diagnostics-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "diagnostics-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
     errors.push("diagnostics-vitest artifact upload retention-days must be 14");
   }
 }
 
-function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateSparkInstallVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
+  const jobName = "spark-install-vitest";
+  const scenarioName = "spark-install";
+  const job = asRecord(jobs[jobName]);
+  if (Object.keys(job).length === 0) {
+    errors.push("workflow missing spark-install-vitest job");
+    return;
+  }
+
+  if (job["runs-on"] !== "ubuntu-latest") {
+    errors.push("spark-install-vitest job must run on ubuntu-latest");
+  }
+  if (job["timeout-minutes"] !== 45) {
+    errors.push("spark-install-vitest job must keep a 45 minute timeout");
+  }
+  validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
+
+  const jobEnv = asRecord(job.env);
+  if (
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/spark-install"
+  ) {
+    errors.push(
+      "spark-install-vitest job must write artifacts under e2e-artifacts/vitest/spark-install",
+    );
+  }
+  if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
+    errors.push(
+      "spark-install-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
+  }
+  if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
+    errors.push(
+      "spark-install-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
+  }
+  if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
+    errors.push("spark-install-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+  }
+  if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
+    errors.push(
+      "spark-install-vitest job must accept third-party software non-interactively",
+    );
+  }
+  if (jobEnv.NEMOCLAW_FRESH !== "1") {
+    errors.push("spark-install-vitest job must set NEMOCLAW_FRESH=1");
+  }
+  if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-spark-install-vitest") {
+    errors.push(
+      "spark-install-vitest job must use the stable e2e-spark-install-vitest sandbox name",
+    );
+  }
+  if (jobEnv.NEMOCLAW_PROVIDER !== "cloud") {
+    errors.push("spark-install-vitest job must use the cloud provider");
+  }
+  if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
+    errors.push(
+      "spark-install-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
+  }
+  for (const secret of COMMON_SECRET_ENV_NAMES) {
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "spark-install-vitest job",
+      jobEnv,
+      secret,
+    );
+  }
+
+  const steps = asSteps(job.steps);
+  requireNoDispatchInputInterpolation(errors, steps);
+  for (const step of steps) {
+    const stepName = `spark-install-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
+    const stepEnv = asRecord(step.env);
+    if (step.name !== "Run Spark install live test") {
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
+    }
+    requireEnvDoesNotExposeSecret(
+      errors,
+      stepName,
+      stepEnv,
+      "DOCKERHUB_USERNAME",
+    );
+    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
+  }
+
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout) {
+    errors.push("spark-install-vitest job missing checkout step");
+  }
+  requireFullShaAction(errors, checkout, "spark-install-vitest checkout");
+  if (asRecord(checkout?.with)["persist-credentials"] !== false) {
+    errors.push(
+      "spark-install-vitest checkout step must set persist-credentials=false",
+    );
+  }
+
+  const setupNode = namedStep(steps, "Set up Node");
+  if (!setupNode) {
+    errors.push("spark-install-vitest job missing step: Set up Node");
+  }
+  requireFullShaAction(errors, setupNode, "spark-install-vitest setup-node");
+
+  const installRootDependencies = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install root dependencies",
+  );
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
+
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run Spark install live test",
+  );
+  const runVitestEnv = asRecord(runVitest?.env);
+  if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
+    errors.push(
+      "spark-install-vitest Vitest step must receive NVIDIA_API_KEY from secrets",
+    );
+  }
+  requireRunContains(errors, runVitest, "set -euo pipefail");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/spark-install.test.ts",
+  );
+
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload Spark install artifacts",
+  );
+  requireFullShaAction(errors, upload, "spark-install-vitest upload-artifact");
+  const uploadWith = asRecord(upload?.with);
+  if (uploadWith.name !== "e2e-vitest-scenarios-spark-install") {
+    errors.push("spark-install-vitest artifact upload name must be stable");
+  }
+  const uploadPath = stringValue(uploadWith.path);
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/spark-install/",
+  );
+  if (uploadWith["include-hidden-files"] !== false) {
+    errors.push(
+      "spark-install-vitest artifact upload must set include-hidden-files: false",
+    );
+  }
+  if (uploadWith["if-no-files-found"] !== "ignore") {
+    errors.push(
+      "spark-install-vitest artifact upload must ignore missing fixture artifacts",
+    );
+  }
+  if (uploadWith["retention-days"] !== 14) {
+    errors.push(
+      "spark-install-vitest artifact upload retention-days must be 14",
+    );
+  }
+}
+
+function validateSnapshotCommandsVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "snapshot-commands-vitest";
   const scenarioName = "snapshot-commands";
   const job = asRecord(jobs[jobName]);
@@ -2955,29 +4536,42 @@ function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecor
 
   const jobEnv = asRecord(job.env);
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("snapshot-commands-vitest job must not set DOCKER_CONFIG at job level");
+    errors.push(
+      "snapshot-commands-vitest job must not set DOCKER_CONFIG at job level",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/snapshot-commands"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/snapshot-commands"
   ) {
     errors.push(
       "snapshot-commands-vitest job must write artifacts under e2e-artifacts/vitest/snapshot-commands",
     );
   }
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("snapshot-commands-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "snapshot-commands-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
-    errors.push("snapshot-commands-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+    errors.push(
+      "snapshot-commands-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("snapshot-commands-vitest job must accept third-party software non-interactively");
+    errors.push(
+      "snapshot-commands-vitest job must accept third-party software non-interactively",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-snapshot") {
-    errors.push("snapshot-commands-vitest job must use the stable e2e-snapshot sandbox name");
+    errors.push(
+      "snapshot-commands-vitest job must use the stable e2e-snapshot sandbox name",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("snapshot-commands-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "snapshot-commands-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   for (const secret of [
     "NVIDIA_API_KEY",
@@ -2985,7 +4579,12 @@ function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecor
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "snapshot-commands-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "snapshot-commands-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -2994,23 +4593,42 @@ function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecor
     const stepName = `snapshot-commands-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run snapshot commands live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) {
     errors.push("snapshot-commands-vitest job missing checkout step");
   }
   requireFullShaAction(errors, checkout, "snapshot-commands-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("snapshot-commands-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "snapshot-commands-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const configureDockerAuth = requireJobStep(
@@ -3026,9 +4644,16 @@ function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecor
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "snapshot-commands-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -3048,7 +4673,11 @@ function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecor
   if (!setupNode) {
     errors.push("snapshot-commands-vitest job missing step: Set up Node");
   }
-  requireFullShaAction(errors, setupNode, "snapshot-commands-vitest setup-node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "snapshot-commands-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -3056,35 +4685,78 @@ function validateSnapshotCommandsVitestJob(errors: string[], jobs: WorkflowRecor
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run snapshot commands live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run snapshot commands live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
-    errors.push("snapshot-commands-vitest Vitest step must receive NVIDIA_API_KEY from secrets");
+    errors.push(
+      "snapshot-commands-vitest Vitest step must receive NVIDIA_API_KEY from secrets",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/snapshot-commands.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/snapshot-commands.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload snapshot commands artifacts");
-  requireFullShaAction(errors, upload, "snapshot-commands-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload snapshot commands artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "snapshot-commands-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-snapshot-commands") {
     errors.push("snapshot-commands-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/snapshot-commands/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/snapshot-commands/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("snapshot-commands-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "snapshot-commands-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("snapshot-commands-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "snapshot-commands-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("snapshot-commands-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "snapshot-commands-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
     errors.push("snapshot-commands-vitest Docker auth cleanup must always run");
   }
@@ -3100,12 +4772,16 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
   const scenarioName = "model-router-provider-routed-inference";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
-    errors.push("workflow missing model-router-provider-routed-inference-vitest job");
+    errors.push(
+      "workflow missing model-router-provider-routed-inference-vitest job",
+    );
     return;
   }
 
   if (job["runs-on"] !== "ubuntu-latest") {
-    errors.push("model-router-provider-routed-inference-vitest job must run on ubuntu-latest");
+    errors.push(
+      "model-router-provider-routed-inference-vitest job must run on ubuntu-latest",
+    );
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
 
@@ -3158,21 +4834,44 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     const stepName = `model-router-provider-routed-inference-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run Model Router provider-routed inference live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) {
-    errors.push("model-router-provider-routed-inference-vitest job missing checkout step");
+    errors.push(
+      "model-router-provider-routed-inference-vitest job missing checkout step",
+    );
   }
-  requireFullShaAction(errors, checkout, "model-router-provider-routed-inference-vitest checkout");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "model-router-provider-routed-inference-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push(
       "model-router-provider-routed-inference-vitest checkout step must set persist-credentials=false",
@@ -3192,9 +4891,16 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "model-router-provider-routed-inference-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -3212,7 +4918,9 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
-    errors.push("model-router-provider-routed-inference-vitest job missing step: Set up Node");
+    errors.push(
+      "model-router-provider-routed-inference-vitest job missing step: Set up Node",
+    );
   }
   requireFullShaAction(
     errors,
@@ -3226,7 +4934,11 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
@@ -3238,12 +4950,19 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     "Run Model Router provider-routed inference live test",
   );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "model-router-provider-routed-inference-vitest Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
   requireRunContains(
     errors,
     runVitest,
@@ -3262,7 +4981,10 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     "model-router-provider-routed-inference-vitest upload-artifact",
   );
   const uploadWith = asRecord(upload?.with);
-  if (uploadWith.name !== "e2e-vitest-scenarios-model-router-provider-routed-inference") {
+  if (
+    uploadWith.name !==
+    "e2e-vitest-scenarios-model-router-provider-routed-inference"
+  ) {
     errors.push(
       "model-router-provider-routed-inference-vitest artifact upload name must be stable",
     );
@@ -3289,7 +5011,12 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
     errors.push(
       "model-router-provider-routed-inference-vitest Docker auth cleanup must always run",
@@ -3305,7 +5032,10 @@ function runContainsCloudflaredAptInstall(run: string): boolean {
   );
 }
 
-function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateTunnelLifecycleVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "tunnel-lifecycle-vitest";
   const scenarioName = "tunnel-lifecycle";
   const job = asRecord(jobs[jobName]);
@@ -3324,19 +5054,29 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
 
   const jobEnv = asRecord(job.env);
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("tunnel-lifecycle-vitest job must not set DOCKER_CONFIG at job level");
+    errors.push(
+      "tunnel-lifecycle-vitest job must not set DOCKER_CONFIG at job level",
+    );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("tunnel-lifecycle-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "tunnel-lifecycle-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.FREE_STANDING_VITEST_JOB !== "1") {
-    errors.push("tunnel-lifecycle-vitest job must set FREE_STANDING_VITEST_JOB=1");
+    errors.push(
+      "tunnel-lifecycle-vitest job must set FREE_STANDING_VITEST_JOB=1",
+    );
   }
   if (jobEnv.FREE_STANDING_SCENARIO_ID !== scenarioName) {
-    errors.push(`tunnel-lifecycle-vitest job must set FREE_STANDING_SCENARIO_ID=${scenarioName}`);
+    errors.push(
+      `tunnel-lifecycle-vitest job must set FREE_STANDING_SCENARIO_ID=${scenarioName}`,
+    );
   }
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("tunnel-lifecycle-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "tunnel-lifecycle-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   requireEnvDoesNotExposeSecret(
     errors,
@@ -3352,23 +5092,47 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
     const stepEnv = asRecord(step.env);
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
     if (step.name !== "Run tunnel lifecycle live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) {
     errors.push("tunnel-lifecycle-vitest job missing checkout step");
   }
   requireFullShaAction(errors, checkout, "tunnel-lifecycle-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("tunnel-lifecycle-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "tunnel-lifecycle-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const configureDockerAuth = requireJobStep(
@@ -3383,11 +5147,22 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
     'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-tunnel-lifecycle" >> "$GITHUB_ENV"',
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
+  requireRunDoesNotContain(
+    errors,
+    configureDockerAuth,
+    "${{ github.workspace }}",
+  );
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "tunnel-lifecycle-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -3415,7 +5190,11 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
@@ -3440,13 +5219,25 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
     "NVIDIA_API_KEY",
   );
   requireRunContains(errors, cloudflaredPrereq, "cloudflared --version");
-  requireRunContains(errors, cloudflaredPrereq, "test/e2e/lib/cloudflared-version-resolver.sh");
+  requireRunContains(
+    errors,
+    cloudflaredPrereq,
+    "test/e2e/lib/cloudflared-version-resolver.sh",
+  );
   requireRunContains(errors, cloudflaredPrereq, "sudo apt-get install -y");
   requireRunContains(errors, cloudflaredPrereq, "cloudflared=${cf_version}");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run tunnel lifecycle live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run tunnel lifecycle live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "tunnel-lifecycle-vitest Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
@@ -3456,28 +5247,60 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
       "tunnel-lifecycle-vitest Vitest step must not run cloudflared APT installation with NVIDIA_INFERENCE_API_KEY in scope",
     );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/tunnel-lifecycle.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/tunnel-lifecycle.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload tunnel lifecycle artifacts");
-  requireFullShaAction(errors, upload, "tunnel-lifecycle-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload tunnel lifecycle artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "tunnel-lifecycle-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-tunnel-lifecycle") {
     errors.push("tunnel-lifecycle-vitest artifact upload name must be stable");
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/tunnel-lifecycle/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/tunnel-lifecycle/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("tunnel-lifecycle-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "tunnel-lifecycle-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("tunnel-lifecycle-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "tunnel-lifecycle-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("tunnel-lifecycle-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "tunnel-lifecycle-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
     errors.push("tunnel-lifecycle-vitest Docker auth cleanup must always run");
   }
@@ -3485,7 +5308,10 @@ function validateTunnelLifecycleVitestJob(errors: string[], jobs: WorkflowRecord
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
-function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateIssue2478CrashLoopRecoveryVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "issue-2478-crash-loop-recovery-vitest";
   const scenarioName = "issue-2478-crash-loop-recovery";
   const job = asRecord(jobs[jobName]);
@@ -3495,10 +5321,14 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
   }
 
   if (job["runs-on"] !== "ubuntu-latest") {
-    errors.push("issue-2478-crash-loop-recovery-vitest job must run on ubuntu-latest");
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest job must run on ubuntu-latest",
+    );
   }
   if (job["timeout-minutes"] !== 30) {
-    errors.push("issue-2478-crash-loop-recovery-vitest job must keep the 30 minute timeout");
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest job must keep the 30 minute timeout",
+    );
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
 
@@ -3511,7 +5341,8 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
   const expectedEnv: Record<string, string> = {
     FREE_STANDING_VITEST_JOB: "1",
     FREE_STANDING_SCENARIO_ID: scenarioName,
-    E2E_ARTIFACT_DIR: "${{ github.workspace }}/e2e-artifacts/vitest/issue-2478-crash-loop-recovery",
+    E2E_ARTIFACT_DIR:
+      "${{ github.workspace }}/e2e-artifacts/vitest/issue-2478-crash-loop-recovery",
     NEMOCLAW_CLI_BIN: "${{ github.workspace }}/bin/nemoclaw.js",
     NEMOCLAW_RUN_E2E_SCENARIOS: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
@@ -3521,10 +5352,15 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
   };
   for (const [key, value] of Object.entries(expectedEnv)) {
     if (jobEnv[key] !== value) {
-      errors.push(`issue-2478-crash-loop-recovery-vitest job env ${key} must be ${value}`);
+      errors.push(
+        `issue-2478-crash-loop-recovery-vitest job env ${key} must be ${value}`,
+      );
     }
   }
-  for (const secret of ["NVIDIA_INFERENCE_API_KEY", ...COMMON_SECRET_ENV_NAMES]) {
+  for (const secret of [
+    "NVIDIA_INFERENCE_API_KEY",
+    ...COMMON_SECRET_ENV_NAMES,
+  ]) {
     requireEnvDoesNotExposeSecret(
       errors,
       "issue-2478-crash-loop-recovery-vitest job",
@@ -3538,21 +5374,44 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
   for (const step of steps) {
     const stepName = `issue-2478-crash-loop-recovery-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
+    requireEnvDoesNotExposeSecret(
+      errors,
+      stepName,
+      stepEnv,
+      "NVIDIA_INFERENCE_API_KEY",
+    );
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) {
-    errors.push("issue-2478-crash-loop-recovery-vitest job missing checkout step");
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest job missing checkout step",
+    );
   }
-  requireFullShaAction(errors, checkout, "issue-2478-crash-loop-recovery-vitest checkout");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "issue-2478-crash-loop-recovery-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push(
       "issue-2478-crash-loop-recovery-vitest checkout step must set persist-credentials=false",
@@ -3571,11 +5430,22 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
     'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-issue-2478-crash-loop-recovery" >> "$GITHUB_ENV"',
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
+  requireRunDoesNotContain(
+    errors,
+    configureDockerAuth,
+    "${{ github.workspace }}",
+  );
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "issue-2478-crash-loop-recovery-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -3593,9 +5463,15 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
-    errors.push("issue-2478-crash-loop-recovery-vitest job missing step: Set up Node");
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest job missing step: Set up Node",
+    );
   }
-  requireFullShaAction(errors, setupNode, "issue-2478-crash-loop-recovery-vitest setup-node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "issue-2478-crash-loop-recovery-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -3603,13 +5479,26 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell CLI",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
 
   const runVitest = requireJobStep(
     errors,
@@ -3624,7 +5513,11 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
     runVitestEnv,
     "NVIDIA_INFERENCE_API_KEY",
   );
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
   requireRunContains(
     errors,
     runVitest,
@@ -3637,10 +5530,18 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
     steps,
     "Upload issue #2478 crash-loop recovery artifacts",
   );
-  requireFullShaAction(errors, upload, "issue-2478-crash-loop-recovery-vitest upload-artifact");
+  requireFullShaAction(
+    errors,
+    upload,
+    "issue-2478-crash-loop-recovery-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
-  if (uploadWith.name !== "e2e-vitest-scenarios-issue-2478-crash-loop-recovery") {
-    errors.push("issue-2478-crash-loop-recovery-vitest artifact upload name must be stable");
+  if (
+    uploadWith.name !== "e2e-vitest-scenarios-issue-2478-crash-loop-recovery"
+  ) {
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
   requireUploadPathContains(
@@ -3659,18 +5560,30 @@ function validateIssue2478CrashLoopRecoveryVitestJob(errors: string[], jobs: Wor
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("issue-2478-crash-loop-recovery-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
-    errors.push("issue-2478-crash-loop-recovery-vitest Docker auth cleanup must always run");
+    errors.push(
+      "issue-2478-crash-loop-recovery-vitest Docker auth cleanup must always run",
+    );
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
-function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateChannelsAddRemoveVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "channels-add-remove-vitest";
   const scenarioName = "channels-add-remove";
   const job = asRecord(jobs[jobName]);
@@ -3684,21 +5597,28 @@ function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowReco
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
   if (job["timeout-minutes"] !== 75) {
-    errors.push("channels-add-remove-vitest job must keep the legacy 75 minute timeout");
+    errors.push(
+      "channels-add-remove-vitest job must keep the legacy 75 minute timeout",
+    );
   }
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("channels-add-remove-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "channels-add-remove-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
-    jobEnv.E2E_ARTIFACT_DIR !== "${{ github.workspace }}/e2e-artifacts/vitest/channels-add-remove"
+    jobEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/channels-add-remove"
   ) {
     errors.push(
       "channels-add-remove-vitest job must write artifacts under e2e-artifacts/vitest/channels-add-remove",
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("channels-add-remove-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "channels-add-remove-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
   if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-channels-add-remove") {
     errors.push(
@@ -3706,13 +5626,19 @@ function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowReco
     );
   }
   if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
-    errors.push("channels-add-remove-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+    errors.push(
+      "channels-add-remove-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("channels-add-remove-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    errors.push(
+      "channels-add-remove-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("channels-add-remove-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "channels-add-remove-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   for (const secret of [
     "NVIDIA_API_KEY",
@@ -3720,7 +5646,12 @@ function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowReco
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "channels-add-remove-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "channels-add-remove-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -3729,24 +5660,49 @@ function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowReco
     const stepName = `channels-add-remove-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run channels add/remove live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("channels-add-remove-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("channels-add-remove-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "channels-add-remove-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("channels-add-remove-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "channels-add-remove-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -3762,8 +5718,13 @@ function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowReco
   requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("channels-add-remove-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "channels-add-remove-vitest setup-node");
+  if (!setupNode)
+    errors.push("channels-add-remove-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "channels-add-remove-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -3771,57 +5732,118 @@ function validateChannelsAddRemoveVitestJob(errors: string[], jobs: WorkflowReco
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run channels add/remove live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run channels add/remove live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
-    errors.push("channels-add-remove-vitest step must receive NVIDIA_API_KEY from secrets");
+    errors.push(
+      "channels-add-remove-vitest step must receive NVIDIA_API_KEY from secrets",
+    );
   }
-  if (runVitestEnv.TELEGRAM_BOT_TOKEN !== "test-fake-telegram-token-add-remove-e2e") {
-    errors.push("channels-add-remove-vitest step must set the fake Telegram token");
+  if (
+    runVitestEnv.TELEGRAM_BOT_TOKEN !==
+    "test-fake-telegram-token-add-remove-e2e"
+  ) {
+    errors.push(
+      "channels-add-remove-vitest step must set the fake Telegram token",
+    );
   }
   if (runVitestEnv.TELEGRAM_ALLOWED_IDS !== "123456789") {
-    errors.push("channels-add-remove-vitest step must set TELEGRAM_ALLOWED_IDS");
+    errors.push(
+      "channels-add-remove-vitest step must set TELEGRAM_ALLOWED_IDS",
+    );
   }
   if (runVitestEnv.TELEGRAM_REQUIRE_MENTION !== "0") {
-    errors.push("channels-add-remove-vitest step must set TELEGRAM_REQUIRE_MENTION");
+    errors.push(
+      "channels-add-remove-vitest step must set TELEGRAM_REQUIRE_MENTION",
+    );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/channels-add-remove.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/channels-add-remove.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload channels add/remove artifacts");
-  requireFullShaAction(errors, upload, "channels-add-remove-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload channels add/remove artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "channels-add-remove-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   if (uploadWith.name !== "e2e-vitest-scenarios-channels-add-remove") {
-    errors.push("channels-add-remove-vitest artifact upload name must be stable");
+    errors.push(
+      "channels-add-remove-vitest artifact upload name must be stable",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/channels-add-remove/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/channels-add-remove/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("channels-add-remove-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "channels-add-remove-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("channels-add-remove-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "channels-add-remove-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("channels-add-remove-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "channels-add-remove-vitest artifact upload retention-days must be 14",
+    );
   }
 }
 
-function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateOpenClawDiscordPairingVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "openclaw-discord-pairing-vitest";
   const scenarioName = "openclaw-discord-pairing";
   const job = asRecord(jobs[jobName]);
@@ -3831,19 +5853,34 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
   }
 
   if (job["runs-on"] !== "ubuntu-latest") {
-    errors.push("openclaw-discord-pairing-vitest job must run on ubuntu-latest");
+    errors.push(
+      "openclaw-discord-pairing-vitest job must run on ubuntu-latest",
+    );
   }
   if (job["timeout-minutes"] !== 60) {
-    errors.push("openclaw-discord-pairing-vitest job must keep the 60 minute timeout");
+    errors.push(
+      "openclaw-discord-pairing-vitest job must keep the 60 minute timeout",
+    );
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
 
   const jobEnv = asRecord(job.env);
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("openclaw-discord-pairing-vitest job must not set DOCKER_CONFIG at job level");
+    errors.push(
+      "openclaw-discord-pairing-vitest job must not set DOCKER_CONFIG at job level",
+    );
   }
-  for (const secret of ["NVIDIA_INFERENCE_API_KEY", "NVIDIA_API_KEY", ...COMMON_SECRET_ENV_NAMES]) {
-    requireEnvDoesNotExposeSecret(errors, "openclaw-discord-pairing-vitest job", jobEnv, secret);
+  for (const secret of [
+    "NVIDIA_INFERENCE_API_KEY",
+    "NVIDIA_API_KEY",
+    ...COMMON_SECRET_ENV_NAMES,
+  ]) {
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "openclaw-discord-pairing-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -3852,27 +5889,58 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
     const stepName = `openclaw-discord-pairing-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run OpenClaw Discord pairing live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("openclaw-discord-pairing-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "openclaw-discord-pairing-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("openclaw-discord-pairing-vitest job missing checkout step");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "openclaw-discord-pairing-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("openclaw-discord-pairing-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "openclaw-discord-pairing-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("openclaw-discord-pairing-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "openclaw-discord-pairing-vitest setup-node");
+  if (!setupNode)
+    errors.push(
+      "openclaw-discord-pairing-vitest job missing step: Set up Node",
+    );
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "openclaw-discord-pairing-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -3880,7 +5948,11 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
@@ -3897,11 +5969,22 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
     'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-discord-pairing" >> "$GITHUB_ENV"',
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
+  requireRunDoesNotContain(
+    errors,
+    configureDockerAuth,
+    "${{ github.workspace }}",
+  );
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "openclaw-discord-pairing-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -3916,8 +5999,17 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
   requireRunContains(errors, dockerLogin, "docker login docker.io");
   requireRunContains(errors, dockerLogin, "--password-stdin");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell CLI",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
@@ -3932,16 +6024,29 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
     "Run OpenClaw Discord pairing live test",
   );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "openclaw-discord-pairing-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
   if (runVitestEnv.DISCORD_BOT_TOKEN !== "test-fake-discord-pairing-e2e") {
-    errors.push("openclaw-discord-pairing-vitest step must use fake Discord token");
+    errors.push(
+      "openclaw-discord-pairing-vitest step must use fake Discord token",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/openclaw-discord-pairing.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/openclaw-discord-pairing.test.ts",
+  );
 
   const upload = requireJobStep(
     errors,
@@ -3949,10 +6054,18 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
     steps,
     "Upload OpenClaw Discord pairing artifacts",
   );
-  requireFullShaAction(errors, upload, "openclaw-discord-pairing-vitest upload-artifact");
+  requireFullShaAction(
+    errors,
+    upload,
+    "openclaw-discord-pairing-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/openclaw-discord-pairing/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/openclaw-discord-pairing/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
     errors.push(
       "openclaw-discord-pairing-vitest artifact upload must set include-hidden-files: false",
@@ -3964,18 +6077,30 @@ function validateOpenClawDiscordPairingVitestJob(errors: string[], jobs: Workflo
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("openclaw-discord-pairing-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "openclaw-discord-pairing-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
-    errors.push("openclaw-discord-pairing-vitest Docker auth cleanup must always run");
+    errors.push(
+      "openclaw-discord-pairing-vitest Docker auth cleanup must always run",
+    );
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
-function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateOpenClawSlackPairingVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "openclaw-slack-pairing-vitest";
   const scenarioName = "openclaw-slack-pairing";
   const job = asRecord(jobs[jobName]);
@@ -3988,16 +6113,29 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
     errors.push("openclaw-slack-pairing-vitest job must run on ubuntu-latest");
   }
   if (job["timeout-minutes"] !== 60) {
-    errors.push("openclaw-slack-pairing-vitest job must keep the 60 minute timeout");
+    errors.push(
+      "openclaw-slack-pairing-vitest job must keep the 60 minute timeout",
+    );
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
 
   const jobEnv = asRecord(job.env);
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("openclaw-slack-pairing-vitest job must not set DOCKER_CONFIG at job level");
+    errors.push(
+      "openclaw-slack-pairing-vitest job must not set DOCKER_CONFIG at job level",
+    );
   }
-  for (const secret of ["NVIDIA_INFERENCE_API_KEY", "NVIDIA_API_KEY", ...COMMON_SECRET_ENV_NAMES]) {
-    requireEnvDoesNotExposeSecret(errors, "openclaw-slack-pairing-vitest job", jobEnv, secret);
+  for (const secret of [
+    "NVIDIA_INFERENCE_API_KEY",
+    "NVIDIA_API_KEY",
+    ...COMMON_SECRET_ENV_NAMES,
+  ]) {
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "openclaw-slack-pairing-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -4006,27 +6144,56 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
     const stepName = `openclaw-slack-pairing-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run OpenClaw Slack pairing live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("openclaw-slack-pairing-vitest job missing checkout step");
-  requireFullShaAction(errors, checkout, "openclaw-slack-pairing-vitest checkout");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("openclaw-slack-pairing-vitest job missing checkout step");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "openclaw-slack-pairing-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("openclaw-slack-pairing-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "openclaw-slack-pairing-vitest checkout step must set persist-credentials=false",
+    );
   }
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("openclaw-slack-pairing-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "openclaw-slack-pairing-vitest setup-node");
+  if (!setupNode)
+    errors.push("openclaw-slack-pairing-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "openclaw-slack-pairing-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -4034,7 +6201,11 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
@@ -4051,11 +6222,22 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
     'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-slack-pairing" >> "$GITHUB_ENV"',
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
+  requireRunDoesNotContain(
+    errors,
+    configureDockerAuth,
+    "${{ github.workspace }}",
+  );
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "openclaw-slack-pairing-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -4070,8 +6252,17 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
   requireRunContains(errors, dockerLogin, "docker login docker.io");
   requireRunContains(errors, dockerLogin, "--password-stdin");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell CLI",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
@@ -4079,27 +6270,60 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
   requireRunContains(errors, installOpenShell, "-u NVIDIA_INFERENCE_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run OpenClaw Slack pairing live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run OpenClaw Slack pairing live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "openclaw-slack-pairing-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
   if (runVitestEnv.SLACK_BOT_TOKEN !== "xoxb-fake-slack-pairing-e2e") {
-    errors.push("openclaw-slack-pairing-vitest step must use fake Slack bot token");
+    errors.push(
+      "openclaw-slack-pairing-vitest step must use fake Slack bot token",
+    );
   }
   if (runVitestEnv.SLACK_APP_TOKEN !== "xapp-fake-slack-pairing-e2e") {
-    errors.push("openclaw-slack-pairing-vitest step must use fake Slack app token");
+    errors.push(
+      "openclaw-slack-pairing-vitest step must use fake Slack app token",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/openclaw-slack-pairing.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/openclaw-slack-pairing.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload OpenClaw Slack pairing artifacts");
-  requireFullShaAction(errors, upload, "openclaw-slack-pairing-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload OpenClaw Slack pairing artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "openclaw-slack-pairing-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/openclaw-slack-pairing/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/openclaw-slack-pairing/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
     errors.push(
       "openclaw-slack-pairing-vitest artifact upload must set include-hidden-files: false",
@@ -4111,18 +6335,30 @@ function validateOpenClawSlackPairingVitestJob(errors: string[], jobs: WorkflowR
     );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("openclaw-slack-pairing-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "openclaw-slack-pairing-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
-    errors.push("openclaw-slack-pairing-vitest Docker auth cleanup must always run");
+    errors.push(
+      "openclaw-slack-pairing-vitest Docker auth cleanup must always run",
+    );
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
-function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateChannelsStopStartVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "channels-stop-start-vitest";
   const scenarioName = "channels-stop-start";
   const job = asRecord(jobs[jobName]);
@@ -4136,20 +6372,29 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
   if (job["timeout-minutes"] !== 90) {
-    errors.push("channels-stop-start-vitest job must keep the 90 minute timeout");
+    errors.push(
+      "channels-stop-start-vitest job must keep the 90 minute timeout",
+    );
   }
   const strategy = asRecord(job.strategy);
   if (strategy["fail-fast"] !== false) {
     errors.push("channels-stop-start-vitest strategy.fail-fast must be false");
   }
   const matrix = asRecord(strategy.matrix);
-  if (!Array.isArray(matrix.agent) || matrix.agent.join(",") !== "openclaw,hermes") {
-    errors.push("channels-stop-start-vitest matrix.agent must be openclaw,hermes");
+  if (
+    !Array.isArray(matrix.agent) ||
+    matrix.agent.join(",") !== "openclaw,hermes"
+  ) {
+    errors.push(
+      "channels-stop-start-vitest matrix.agent must be openclaw,hermes",
+    );
   }
 
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
-    errors.push("channels-stop-start-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+    errors.push(
+      "channels-stop-start-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1",
+    );
   }
   if (
     jobEnv.E2E_ARTIFACT_DIR !==
@@ -4160,15 +6405,22 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     );
   }
   if (jobEnv.NEMOCLAW_CLI_BIN !== "${{ github.workspace }}/bin/nemoclaw.js") {
-    errors.push("channels-stop-start-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "channels-stop-start-vitest job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
-  if (jobEnv.NEMOCLAW_SANDBOX_NAME !== "e2e-channels-stop-start-${{ matrix.agent }}") {
+  if (
+    jobEnv.NEMOCLAW_SANDBOX_NAME !==
+    "e2e-channels-stop-start-${{ matrix.agent }}"
+  ) {
     errors.push(
       "channels-stop-start-vitest job must derive NEMOCLAW_SANDBOX_NAME from matrix.agent with the e2e-channels-stop-start- prefix",
     );
   }
   if (jobEnv.NEMOCLAW_AGENT !== "${{ matrix.agent }}") {
-    errors.push("channels-stop-start-vitest job must pass matrix.agent through NEMOCLAW_AGENT");
+    errors.push(
+      "channels-stop-start-vitest job must pass matrix.agent through NEMOCLAW_AGENT",
+    );
   }
   if (jobEnv.NEMOCLAW_CHANNELS_STOP_START_AGENT !== "${{ matrix.agent }}") {
     errors.push(
@@ -4176,19 +6428,27 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     );
   }
   if (jobEnv.NEMOCLAW_NON_INTERACTIVE !== "1") {
-    errors.push("channels-stop-start-vitest job must set NEMOCLAW_NON_INTERACTIVE=1");
+    errors.push(
+      "channels-stop-start-vitest job must set NEMOCLAW_NON_INTERACTIVE=1",
+    );
   }
   if (jobEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE !== "1") {
-    errors.push("channels-stop-start-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1");
+    errors.push(
+      "channels-stop-start-vitest job must set NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1",
+    );
   }
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
-    errors.push("channels-stop-start-vitest job must force OPENSHELL_GATEWAY=nemoclaw");
+    errors.push(
+      "channels-stop-start-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
+    );
   }
   if (
     jobEnv.DOCKER_CONFIG !==
     "${{ github.workspace }}/.docker-config-channels-stop-start-${{ matrix.agent }}"
   ) {
-    errors.push("channels-stop-start-vitest job must isolate Docker auth by matrix agent");
+    errors.push(
+      "channels-stop-start-vitest job must isolate Docker auth by matrix agent",
+    );
   }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
@@ -4197,7 +6457,12 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
   ]) {
-    requireEnvDoesNotExposeSecret(errors, "channels-stop-start-vitest job", jobEnv, secret);
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "channels-stop-start-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -4206,25 +6471,55 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     const stepName = `channels-stop-start-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run channels stop/start live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
-  if (!checkout) errors.push("channels-stop-start-vitest job missing checkout step");
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (!checkout)
+    errors.push("channels-stop-start-vitest job missing checkout step");
   requireFullShaAction(errors, checkout, "channels-stop-start-vitest checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
-    errors.push("channels-stop-start-vitest checkout step must set persist-credentials=false");
+    errors.push(
+      "channels-stop-start-vitest checkout step must set persist-credentials=false",
+    );
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerHubAuth = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerHubEnv = asRecord(dockerHubAuth?.env);
   if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
     errors.push(
@@ -4243,8 +6538,13 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
   requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("channels-stop-start-vitest job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "channels-stop-start-vitest setup-node");
+  if (!setupNode)
+    errors.push("channels-stop-start-vitest job missing step: Set up Node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "channels-stop-start-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -4252,20 +6552,38 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
   requireRunContains(errors, installOpenShell, "-u NVIDIA_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run channels stop/start live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run channels stop/start live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
   requireEnvDoesNotExposeSecret(
     errors,
@@ -4273,37 +6591,85 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     runVitestEnv,
     "NVIDIA_API_KEY",
   );
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "channels-stop-start-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
   if (
-    runVitestEnv.TELEGRAM_BOT_TOKEN !== "test-fake-telegram-token-stop-start-${{ matrix.agent }}"
+    runVitestEnv.TELEGRAM_BOT_TOKEN !==
+    "test-fake-telegram-token-stop-start-${{ matrix.agent }}"
   ) {
-    errors.push("channels-stop-start-vitest step must set the fake Telegram token");
+    errors.push(
+      "channels-stop-start-vitest step must set the fake Telegram token",
+    );
   }
-  if (runVitestEnv.DISCORD_BOT_TOKEN !== "test-fake-discord-token-stop-start-${{ matrix.agent }}") {
-    errors.push("channels-stop-start-vitest step must set the fake Discord token");
+  if (
+    runVitestEnv.DISCORD_BOT_TOKEN !==
+    "test-fake-discord-token-stop-start-${{ matrix.agent }}"
+  ) {
+    errors.push(
+      "channels-stop-start-vitest step must set the fake Discord token",
+    );
   }
-  if (runVitestEnv.SLACK_BOT_TOKEN !== "xoxb-fake-slack-token-stop-start-${{ matrix.agent }}") {
-    errors.push("channels-stop-start-vitest step must set the fake Slack bot token");
+  if (
+    runVitestEnv.SLACK_BOT_TOKEN !==
+    "xoxb-fake-slack-token-stop-start-${{ matrix.agent }}"
+  ) {
+    errors.push(
+      "channels-stop-start-vitest step must set the fake Slack bot token",
+    );
   }
-  if (runVitestEnv.SLACK_APP_TOKEN !== "xapp-fake-slack-token-stop-start-${{ matrix.agent }}") {
-    errors.push("channels-stop-start-vitest step must set the fake Slack app token");
+  if (
+    runVitestEnv.SLACK_APP_TOKEN !==
+    "xapp-fake-slack-token-stop-start-${{ matrix.agent }}"
+  ) {
+    errors.push(
+      "channels-stop-start-vitest step must set the fake Slack app token",
+    );
   }
-  if (runVitestEnv.WECHAT_BOT_TOKEN !== "test-fake-wechat-token-stop-start-${{ matrix.agent }}") {
-    errors.push("channels-stop-start-vitest step must set the fake WeChat token");
+  if (
+    runVitestEnv.WECHAT_BOT_TOKEN !==
+    "test-fake-wechat-token-stop-start-${{ matrix.agent }}"
+  ) {
+    errors.push(
+      "channels-stop-start-vitest step must set the fake WeChat token",
+    );
   }
   requireRunContains(errors, runVitest, "OPENSHELL_BIN");
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/channels-stop-start.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/channels-stop-start.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload channels stop/start artifacts");
-  requireFullShaAction(errors, upload, "channels-stop-start-vitest upload-artifact");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload channels stop/start artifacts",
+  );
+  requireFullShaAction(
+    errors,
+    upload,
+    "channels-stop-start-vitest upload-artifact",
+  );
   const uploadWith = asRecord(upload?.with);
-  if (uploadWith.name !== "e2e-vitest-scenarios-channels-stop-start-${{ matrix.agent }}") {
-    errors.push("channels-stop-start-vitest artifact upload name must include matrix.agent");
+  if (
+    uploadWith.name !==
+    "e2e-vitest-scenarios-channels-stop-start-${{ matrix.agent }}"
+  ) {
+    errors.push(
+      "channels-stop-start-vitest artifact upload name must include matrix.agent",
+    );
   }
   const uploadPath = stringValue(uploadWith.path);
   requireUploadPathContains(
@@ -4312,24 +6678,40 @@ function validateChannelsStopStartVitestJob(errors: string[], jobs: WorkflowReco
     "e2e-artifacts/vitest/channels-stop-start/${{ matrix.agent }}/",
   );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("channels-stop-start-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "channels-stop-start-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("channels-stop-start-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "channels-stop-start-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("channels-stop-start-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "channels-stop-start-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
-    errors.push("channels-stop-start-vitest Docker auth cleanup must always run");
+    errors.push(
+      "channels-stop-start-vitest Docker auth cleanup must always run",
+    );
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
-function validateTelegramInjectionVitestJob(errors: string[], jobs: WorkflowRecord): void {
+function validateTelegramInjectionVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
   const jobName = "telegram-injection-vitest";
   const scenarioName = "telegram-injection";
   const job = asRecord(jobs[jobName]);
@@ -4342,16 +6724,29 @@ function validateTelegramInjectionVitestJob(errors: string[], jobs: WorkflowReco
     errors.push("telegram-injection-vitest job must run on ubuntu-latest");
   }
   if (job["timeout-minutes"] !== 45) {
-    errors.push("telegram-injection-vitest job must keep the 45 minute timeout");
+    errors.push(
+      "telegram-injection-vitest job must keep the 45 minute timeout",
+    );
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
 
   const jobEnv = asRecord(job.env);
   if ("DOCKER_CONFIG" in jobEnv) {
-    errors.push("telegram-injection-vitest job must not set DOCKER_CONFIG at job level");
+    errors.push(
+      "telegram-injection-vitest job must not set DOCKER_CONFIG at job level",
+    );
   }
-  for (const secret of ["NVIDIA_INFERENCE_API_KEY", "NVIDIA_API_KEY", ...COMMON_SECRET_ENV_NAMES]) {
-    requireEnvDoesNotExposeSecret(errors, "telegram-injection-vitest job", jobEnv, secret);
+  for (const secret of [
+    "NVIDIA_INFERENCE_API_KEY",
+    "NVIDIA_API_KEY",
+    ...COMMON_SECRET_ENV_NAMES,
+  ]) {
+    requireEnvDoesNotExposeSecret(
+      errors,
+      "telegram-injection-vitest job",
+      jobEnv,
+      secret,
+    );
   }
 
   const steps = asSteps(job.steps);
@@ -4360,12 +6755,32 @@ function validateTelegramInjectionVitestJob(errors: string[], jobs: WorkflowReco
     const stepName = `telegram-injection-vitest step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     if (step.name !== "Run Telegram injection live test") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_INFERENCE_API_KEY",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "NVIDIA_API_KEY",
+      );
     }
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
@@ -4383,11 +6798,22 @@ function validateTelegramInjectionVitestJob(errors: string[], jobs: WorkflowReco
     'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-telegram-injection" >> "$GITHUB_ENV"',
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
+  requireRunDoesNotContain(
+    errors,
+    configureDockerAuth,
+    "${{ github.workspace }}",
+  );
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "telegram-injection-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -4402,8 +6828,17 @@ function validateTelegramInjectionVitestJob(errors: string[], jobs: WorkflowReco
   requireRunContains(errors, dockerLogin, "docker login docker.io");
   requireRunContains(errors, dockerLogin, "--password-stdin");
 
-  const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
-  requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
+  const installOpenShell = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install OpenShell",
+  );
+  requireRunContains(
+    errors,
+    installOpenShell,
+    "bash scripts/install-openshell.sh",
+  );
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_USERNAME");
   requireRunContains(errors, installOpenShell, "-u DOCKERHUB_TOKEN");
@@ -4411,33 +6846,71 @@ function validateTelegramInjectionVitestJob(errors: string[], jobs: WorkflowReco
   requireRunContains(errors, installOpenShell, "-u NVIDIA_INFERENCE_API_KEY");
   requireRunContains(errors, installOpenShell, "-u GITHUB_TOKEN");
 
-  const runVitest = requireJobStep(errors, jobName, steps, "Run Telegram injection live test");
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Run Telegram injection live test",
+  );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
     errors.push(
       "telegram-injection-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
     );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/telegram-injection.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/telegram-injection.test.ts",
+  );
 
-  const upload = requireJobStep(errors, jobName, steps, "Upload Telegram injection artifacts");
+  const upload = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Upload Telegram injection artifacts",
+  );
   const uploadWith = asRecord(upload?.with);
   const uploadPath = stringValue(uploadWith.path);
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/telegram-injection/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/telegram-injection/",
+  );
   if (uploadWith["include-hidden-files"] !== false) {
-    errors.push("telegram-injection-vitest artifact upload must set include-hidden-files: false");
+    errors.push(
+      "telegram-injection-vitest artifact upload must set include-hidden-files: false",
+    );
   }
   if (uploadWith["if-no-files-found"] !== "ignore") {
-    errors.push("telegram-injection-vitest artifact upload must ignore missing fixture artifacts");
+    errors.push(
+      "telegram-injection-vitest artifact upload must ignore missing fixture artifacts",
+    );
   }
   if (uploadWith["retention-days"] !== 14) {
-    errors.push("telegram-injection-vitest artifact upload retention-days must be 14");
+    errors.push(
+      "telegram-injection-vitest artifact upload retention-days must be 14",
+    );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
-    errors.push("telegram-injection-vitest Docker auth cleanup must always run");
+    errors.push(
+      "telegram-injection-vitest Docker auth cleanup must always run",
+    );
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
@@ -4451,25 +6924,38 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
   const scenarioName = "bedrock-runtime-compatible-anthropic";
   const job = asRecord(jobs[jobName]);
   if (Object.keys(job).length === 0) {
-    errors.push("workflow missing bedrock-runtime-compatible-anthropic-vitest job");
+    errors.push(
+      "workflow missing bedrock-runtime-compatible-anthropic-vitest job",
+    );
     return;
   }
 
   if (job["runs-on"] !== "ubuntu-latest") {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest job must run on ubuntu-latest");
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest job must run on ubuntu-latest",
+    );
   }
   if (job["timeout-minutes"] !== 60) {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest timeout-minutes must be 60");
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest timeout-minutes must be 60",
+    );
   }
   validateFreeStandingJobSelector(errors, jobs, jobName, scenarioName);
 
   const strategy = asRecord(job.strategy);
   if (strategy["fail-fast"] !== false) {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest strategy.fail-fast must be false");
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest strategy.fail-fast must be false",
+    );
   }
   const matrix = asRecord(strategy.matrix);
-  if (!Array.isArray(matrix.agent) || matrix.agent.join(",") !== "openclaw,hermes") {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest matrix.agent must be openclaw,hermes");
+  if (
+    !Array.isArray(matrix.agent) ||
+    matrix.agent.join(",") !== "openclaw,hermes"
+  ) {
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest matrix.agent must be openclaw,hermes",
+    );
   }
 
   const jobEnv = asRecord(job.env);
@@ -4548,17 +7034,35 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_API_KEY");
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
     if (step.name !== "Authenticate to Docker Hub") {
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
       requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest job missing checkout step");
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest job missing checkout step",
+    );
   }
-  requireFullShaAction(errors, checkout, "bedrock-runtime-compatible-anthropic-vitest checkout");
+  requireFullShaAction(
+    errors,
+    checkout,
+    "bedrock-runtime-compatible-anthropic-vitest checkout",
+  );
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push(
       "bedrock-runtime-compatible-anthropic-vitest checkout step must set persist-credentials=false",
@@ -4578,9 +7082,16 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
   );
   requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
 
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
+  const dockerLogin = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Authenticate to Docker Hub",
+  );
   const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
+  if (
+    dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}"
+  ) {
     errors.push(
       "bedrock-runtime-compatible-anthropic-vitest Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
     );
@@ -4598,9 +7109,15 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest job missing step: Set up Node");
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest job missing step: Set up Node",
+    );
   }
-  requireFullShaAction(errors, setupNode, "bedrock-runtime-compatible-anthropic-vitest setup-node");
+  requireFullShaAction(
+    errors,
+    setupNode,
+    "bedrock-runtime-compatible-anthropic-vitest setup-node",
+  );
 
   const installRootDependencies = requireJobStep(
     errors,
@@ -4608,7 +7125,11 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
     steps,
     "Install root dependencies",
   );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
+  requireRunContains(
+    errors,
+    installRootDependencies,
+    "npm ci --ignore-scripts",
+  );
 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
@@ -4619,7 +7140,11 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
     steps,
     "Run Bedrock Runtime compatible Anthropic live test",
   );
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
   requireRunContains(
     errors,
     runVitest,
@@ -4669,9 +7194,16 @@ function validateBedrockRuntimeCompatibleAnthropicVitestJob(
     );
   }
 
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
+  const cleanup = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Clean up Docker auth",
+  );
   if (cleanup?.if !== "always()") {
-    errors.push("bedrock-runtime-compatible-anthropic-vitest Docker auth cleanup must always run");
+    errors.push(
+      "bedrock-runtime-compatible-anthropic-vitest Docker auth cleanup must always run",
+    );
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
@@ -4695,7 +7227,8 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   }
 
   const permissions = asRecord(workflow.permissions);
-  if (permissions.contents !== "read") errors.push("workflow permissions.contents must be read");
+  if (permissions.contents !== "read")
+    errors.push("workflow permissions.contents must be read");
 
   const jobs = asRecord(workflow.jobs);
   const { errors: inventoryErrors, inventory: freeStandingInventory } =
@@ -4703,7 +7236,8 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   errors.push(...inventoryErrors);
   validateFreeStandingInventoryBoundary(errors, jobs, freeStandingInventory);
   const generateMatrix = asRecord(jobs["generate-matrix"]);
-  if (Object.keys(generateMatrix).length === 0) errors.push("workflow missing generate-matrix job");
+  if (Object.keys(generateMatrix).length === 0)
+    errors.push("workflow missing generate-matrix job");
   if (generateMatrix["runs-on"] !== "ubuntu-latest") {
     errors.push("generate-matrix job must run on ubuntu-latest");
   }
@@ -4711,7 +7245,10 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   if (generateOutputs.matrix !== "${{ steps.matrix.outputs.matrix }}") {
     errors.push("generate-matrix job must expose matrix output");
   }
-  if (generateOutputs.hermes_selected !== "${{ steps.matrix.outputs.hermes_selected }}") {
+  if (
+    generateOutputs.hermes_selected !==
+    "${{ steps.matrix.outputs.hermes_selected }}"
+  ) {
     errors.push("generate-matrix job must expose hermes_selected output");
   }
   const generateSteps = asSteps(generateMatrix.steps);
@@ -4719,21 +7256,31 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   const generateCheckout = generateSteps.find((step) =>
     stringValue(step.uses).startsWith("actions/checkout@"),
   );
-  if (!generateCheckout) errors.push("generate-matrix job missing checkout step");
+  if (!generateCheckout)
+    errors.push("generate-matrix job missing checkout step");
   requireFullShaAction(errors, generateCheckout, "generate-matrix checkout");
   if (asRecord(generateCheckout?.with)["persist-credentials"] !== false) {
-    errors.push("generate-matrix checkout step must set persist-credentials=false");
+    errors.push(
+      "generate-matrix checkout step must set persist-credentials=false",
+    );
   }
   const generateSetupNode = namedStep(generateSteps, "Set up Node");
-  if (!generateSetupNode) errors.push("generate-matrix job missing step: Set up Node");
+  if (!generateSetupNode)
+    errors.push("generate-matrix job missing step: Set up Node");
   requireFullShaAction(errors, generateSetupNode, "generate-matrix setup-node");
-  const generate = requireStep(errors, generateSteps, "Generate Vitest scenario matrix");
+  const generate = requireStep(
+    errors,
+    generateSteps,
+    "Generate Vitest scenario matrix",
+  );
   const generateEnv = asRecord(generate?.env);
   if (generateEnv.JOBS !== "${{ inputs.jobs }}") {
     errors.push("matrix generation step must pass jobs through JOBS env");
   }
   if (generateEnv.SCENARIOS !== "${{ inputs.scenarios }}") {
-    errors.push("matrix generation step must pass scenarios through SCENARIOS env");
+    errors.push(
+      "matrix generation step must pass scenarios through SCENARIOS env",
+    );
   }
   requireRunContains(errors, generate, FREE_STANDING_WORKFLOW_INVENTORY_SCRIPT);
   requireRunContains(
@@ -4746,18 +7293,42 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     generate,
     "free_standing_scenarios_csv must match scenario mapping keys",
   );
-  requireRunContains(errors, generate, "Free-standing scenario maps to unknown job");
-  requireRunContains(errors, generate, "Use either scenarios or jobs, not both");
+  requireRunContains(
+    errors,
+    generate,
+    "Free-standing scenario maps to unknown job",
+  );
+  requireRunContains(
+    errors,
+    generate,
+    "Use either scenarios or jobs, not both",
+  );
   requireRunContains(errors, generate, "Unknown free-standing Vitest job");
   requireRunContains(errors, generate, 'matrix="[]"');
-  requireRunContains(errors, generate, "npx tsx test/e2e-scenario/scenarios/run.ts");
+  requireRunContains(
+    errors,
+    generate,
+    "npx tsx test/e2e-scenario/scenarios/run.ts",
+  );
   requireRunContains(errors, generate, "--emit-live-matrix");
   requireRunContains(errors, generate, "--scenarios");
   requireRunContains(errors, generate, "^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$");
-  requireRunContains(errors, generate, "Invalid scenario input; use comma-separated scenario ids");
-  requireRunContains(errors, generate, "Invalid jobs input; use comma-separated job ids");
+  requireRunContains(
+    errors,
+    generate,
+    "Invalid scenario input; use comma-separated scenario ids",
+  );
+  requireRunContains(
+    errors,
+    generate,
+    "Invalid jobs input; use comma-separated job ids",
+  );
   requireRunDoesNotContain(errors, generate, "Invalid jobs input: ${JOBS}");
-  requireRunDoesNotContain(errors, generate, "Invalid scenario input: ${SCENARIOS}");
+  requireRunDoesNotContain(
+    errors,
+    generate,
+    "Invalid scenario input: ${SCENARIOS}",
+  );
   requireRunDoesNotContain(errors, generate, "^[A-Za-z0-9._-]+");
   requireRunContains(errors, generate, "hermes_selected=false");
   requireRunContains(errors, generate, "hermes_selected=true");
@@ -4770,7 +7341,8 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   requireRunContains(errors, generate, "| Scenario | Runner | Label |");
 
   const liveScenarios = asRecord(jobs["live-scenarios"]);
-  if (Object.keys(liveScenarios).length === 0) errors.push("workflow missing live-scenarios job");
+  if (Object.keys(liveScenarios).length === 0)
+    errors.push("workflow missing live-scenarios job");
   if (liveScenarios["runs-on"] !== "${{ matrix.runner }}") {
     errors.push("live-scenarios job must run on the matrix runner");
   }
@@ -4778,17 +7350,24 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     errors.push("live-scenarios job must depend on generate-matrix");
   }
   if (
-    liveScenarios.if !== "${{ inputs.jobs == '' && needs.generate-matrix.outputs.matrix != '[]' }}"
+    liveScenarios.if !==
+    "${{ inputs.jobs == '' && needs.generate-matrix.outputs.matrix != '[]' }}"
   ) {
-    errors.push("live-scenarios job must not run when a free-standing jobs selector is supplied");
+    errors.push(
+      "live-scenarios job must not run when a free-standing jobs selector is supplied",
+    );
   }
   const strategy = asRecord(liveScenarios.strategy);
   if (strategy["fail-fast"] !== false) {
     errors.push("live-scenarios strategy.fail-fast must be false");
   }
   const matrix = asRecord(strategy.matrix);
-  if (matrix.include !== "${{ fromJSON(needs.generate-matrix.outputs.matrix) }}") {
-    errors.push("live-scenarios matrix.include must come from generate-matrix output");
+  if (
+    matrix.include !== "${{ fromJSON(needs.generate-matrix.outputs.matrix) }}"
+  ) {
+    errors.push(
+      "live-scenarios matrix.include must come from generate-matrix output",
+    );
   }
 
   const jobEnv = asRecord(liveScenarios.env);
@@ -4796,15 +7375,26 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     errors.push("live-scenarios job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
   }
   if (!stringValue(jobEnv.E2E_ARTIFACT_DIR).includes("e2e-artifacts/vitest")) {
-    errors.push("live-scenarios job must write artifacts under e2e-artifacts/vitest");
+    errors.push(
+      "live-scenarios job must write artifacts under e2e-artifacts/vitest",
+    );
   }
   if (stringValue(jobEnv.E2E_ARTIFACT_DIR).includes("${{ matrix.id }}")) {
-    errors.push("live-scenarios job E2E_ARTIFACT_DIR must be the Vitest artifact parent");
+    errors.push(
+      "live-scenarios job E2E_ARTIFACT_DIR must be the Vitest artifact parent",
+    );
   }
   if (!stringValue(jobEnv.NEMOCLAW_CLI_BIN).includes("bin/nemoclaw.js")) {
-    errors.push("live-scenarios job must point NEMOCLAW_CLI_BIN at the repo CLI");
+    errors.push(
+      "live-scenarios job must point NEMOCLAW_CLI_BIN at the repo CLI",
+    );
   }
-  requireEnvDoesNotExposeSecret(errors, "live-scenarios job", jobEnv, "NVIDIA_INFERENCE_API_KEY");
+  requireEnvDoesNotExposeSecret(
+    errors,
+    "live-scenarios job",
+    jobEnv,
+    "NVIDIA_INFERENCE_API_KEY",
+  );
 
   const steps = asSteps(liveScenarios.steps);
   requireNoDispatchInputInterpolation(errors, steps);
@@ -4819,7 +7409,9 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     }
   }
 
-  const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
+  const checkout = steps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
   if (!checkout) errors.push("live-scenarios job missing checkout step");
   requireFullShaAction(errors, checkout, "checkout");
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
@@ -4838,11 +7430,24 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   if (runVitestEnv.SCENARIO_ID !== "${{ matrix.id }}") {
     errors.push("Vitest step must pass matrix.id through SCENARIO_ID env");
   }
-  if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
-    errors.push("Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+  if (
+    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
+    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+  ) {
+    errors.push(
+      "Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
   }
-  requireRunContains(errors, runVitest, "npx vitest run --project e2e-scenarios-live");
-  requireRunContains(errors, runVitest, "test/e2e-scenario/live/registry-scenarios.test.ts");
+  requireRunContains(
+    errors,
+    runVitest,
+    "npx vitest run --project e2e-scenarios-live",
+  );
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/e2e-scenario/live/registry-scenarios.test.ts",
+  );
   requireRunContains(errors, runVitest, '"^${SCENARIO_ID}$"');
 
   const summary = requireStep(errors, steps, "Summarize artifacts");
@@ -4851,7 +7456,9 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     errors.push("summary step must pass matrix.id through SCENARIO_ID env");
   }
   if (summaryEnv.SCENARIO_LABEL !== "${{ matrix.label }}") {
-    errors.push("summary step must pass matrix.label through SCENARIO_LABEL env");
+    errors.push(
+      "summary step must pass matrix.label through SCENARIO_LABEL env",
+    );
   }
   requireRunContains(errors, summary, "run-plan.json");
   requireRunContains(
@@ -4859,7 +7466,11 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     summary,
     'Path(os.environ["E2E_ARTIFACT_DIR"]) / os.environ["SCENARIO_ID"]',
   );
-  requireRunContains(errors, summary, "| Scenario | Manifest | Expected state | Suites | Phases |");
+  requireRunContains(
+    errors,
+    summary,
+    "| Scenario | Manifest | Expected state | Suites | Phases |",
+  );
   requireRunContains(errors, summary, "SCENARIO_ID");
 
   const upload = requireStep(errors, steps, "Upload Vitest E2E artifacts");
@@ -4899,12 +7510,26 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     uploadPath,
     "e2e-artifacts/vitest/${{ matrix.id }}/state-validation.result.json",
   );
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/${{ matrix.id }}/actions/");
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/${{ matrix.id }}/logs/");
-  requireUploadPathContains(errors, uploadPath, "e2e-artifacts/vitest/${{ matrix.id }}/shell/");
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/${{ matrix.id }}/actions/",
+  );
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/${{ matrix.id }}/logs/",
+  );
+  requireUploadPathContains(
+    errors,
+    uploadPath,
+    "e2e-artifacts/vitest/${{ matrix.id }}/shell/",
+  );
   for (const line of uploadPath.split("\n")) {
     if (line.trim() === "e2e-artifacts/vitest/${{ matrix.id }}/") {
-      errors.push("artifact upload path must not list the whole matrix artifact directory");
+      errors.push(
+        "artifact upload path must not list the whole matrix artifact directory",
+      );
     }
   }
   if (uploadWith["include-hidden-files"] !== false) {
@@ -4927,7 +7552,12 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     "sessions-agents-cli-vitest",
     "sessions-agents-cli",
   );
-  validateFreeStandingJobSelector(errors, jobs, "inference-routing-vitest", "inference-routing");
+  validateFreeStandingJobSelector(
+    errors,
+    jobs,
+    "inference-routing-vitest",
+    "inference-routing",
+  );
   validateCloudInferenceVitestJob(errors, jobs);
   validateRuntimeOverridesVitestJob(errors, jobs);
   validateDoubleOnboardVitestJob(errors, jobs);
@@ -4960,6 +7590,7 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   validateDiagnosticsVitestJob(errors, jobs);
   validateModelRouterProviderRoutedInferenceVitestJob(errors, jobs);
   validateSnapshotCommandsVitestJob(errors, jobs);
+  validateSparkInstallVitestJob(errors, jobs);
   validateFreeStandingJobSelector(
     errors,
     jobs,
@@ -5006,9 +7637,15 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   } else {
     const needs = Array.isArray(reportToPr.needs) ? reportToPr.needs : [];
     for (const required of ["generate-matrix", "live-scenarios"]) {
-      if (!needs.includes(required)) errors.push(`report-to-pr job must wait for ${required}`);
+      if (!needs.includes(required))
+        errors.push(`report-to-pr job must wait for ${required}`);
     }
-    validateFreeStandingInventoryCoverage(errors, jobs, needs, freeStandingInventory);
+    validateFreeStandingInventoryCoverage(
+      errors,
+      jobs,
+      needs,
+      freeStandingInventory,
+    );
     const reportSteps = asSteps(reportToPr.steps);
     const report = requireJobStep(
       errors,
@@ -5021,12 +7658,18 @@ export function validateE2eVitestScenariosWorkflowBoundary(
       errors.push("report-to-pr step must pass jobs through JOBS env");
     }
     if (reportEnv.JOB_PR_NUMBER !== "${{ inputs.pr_number }}") {
-      errors.push("report-to-pr step must pass pr_number through JOB_PR_NUMBER env");
+      errors.push(
+        "report-to-pr step must pass pr_number through JOB_PR_NUMBER env",
+      );
     }
     if (reportEnv.JOB_SCENARIOS !== "${{ inputs.scenarios }}") {
-      errors.push("report-to-pr step must pass scenarios through JOB_SCENARIOS env");
+      errors.push(
+        "report-to-pr step must pass scenarios through JOB_SCENARIOS env",
+      );
     }
-    const reportScript = stringValue(asRecord(report?.with).script ?? report?.run);
+    const reportScript = stringValue(
+      asRecord(report?.with).script ?? report?.run,
+    );
     if (!reportScript.includes("process.env.JOBS")) {
       errors.push(
         "step 'Post Vitest scenario results to PR' run script must include process.env.JOBS",
@@ -5063,7 +7706,9 @@ export function validateE2eVitestScenariosWorkflowBoundary(
       );
     }
     if (!reportScript.includes("cancelled")) {
-      errors.push("step 'Post Vitest scenario results to PR' run script must count cancelled jobs");
+      errors.push(
+        "step 'Post Vitest scenario results to PR' run script must count cancelled jobs",
+      );
     }
     if (!reportScript.includes("**Requested jobs:**")) {
       errors.push(
@@ -5075,7 +7720,10 @@ export function validateE2eVitestScenariosWorkflowBoundary(
         "step 'Post Vitest scenario results to PR' run script must include **Requested scenarios:**",
       );
     }
-    for (const forbidden of ["toJSON(inputs.pr_number)", "toJSON(inputs.scenarios)"]) {
+    for (const forbidden of [
+      "toJSON(inputs.pr_number)",
+      "toJSON(inputs.scenarios)",
+    ]) {
       if (reportScript.includes(forbidden)) {
         errors.push(
           `step 'Post Vitest scenario results to PR' run script must not include ${forbidden}`,


### PR DESCRIPTION
## Summary
Migrate `test/e2e/test-spark-install.sh` with the simplest equivalent live Vitest coverage.

## Related Issues
Refs #5098

## Assertion parity
| ID | Legacy assertion/check | Replacement Vitest assertion | Boundary preserved | Status |
| --- | --- | --- | --- | --- |
| A1 | Repo root resolves to `/workspace` or script-relative checkout with `install.sh`; otherwise exits 1 | `test/e2e-scenario/live/spark-install.test.ts` asserts `REPO_ROOT/install.sh` exists and runs from that root | Real repository checkout + installer file | `covered` |
| A2 | Host must be Linux | Test gates on `process.platform === "linux"`; workflow job runs on `ubuntu-latest` | Real host platform | `covered` |
| A3 | `docker info` must exit 0 | `host.command("docker", ["info"])` and `expect(exitCode).toBe(0)` | Real Docker daemon | `covered` |
| A4 | `NEMOCLAW_NON_INTERACTIVE=1` is required | Test/workflow set and assert `NEMOCLAW_NON_INTERACTIVE=1`; installer command prefixes it | Real env + shell command | `covered` |
| A5 | `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` is required | Test/workflow set and assert `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1`; installer command prefixes it | Real env + shell command | `covered` |
| A6 | Generic installer flow without Spark-specific setup | Local path runs `bash install.sh --non-interactive` and asserts the command does not include `setup-spark` | Real installer path | `covered` |
| A7 | Optional `NEMOCLAW_E2E_PUBLIC_INSTALL=1` uses `curl -fsSL $NEMOCLAW_INSTALL_SCRIPT_URL \\| ... bash` | `buildInstallerInvocation()` selects/asserts the curl-pipe command and URL/default when that env is set | Real curl-pipe command when selected | `covered` |
| A8 | Install exits 0; failures include last 80 log lines | `expect(install.exitCode).toBe(0)` with `exitDetail(..., installLog)` tailing the log | Real bash process, log file, exit status | `covered` |
| A9 | After `.bashrc`/`nvm.sh`/`~/.local/bin` refresh, `command -v nemoclaw` succeeds | `sourceInstalledPathProbe()` runs same refresh and asserts exit 0/stdout contains `nemoclaw` | Real shell profile/PATH behavior | `covered` |
| A10 | After same refresh, `command -v openshell` succeeds | Same probe asserts exit 0/stdout contains `openshell` | Real installed OpenShell on PATH | `covered` |
| A11 | `nemoclaw --help` exits 0 | Same probe runs `nemoclaw --help >/dev/null` and asserts exit 0 | Real installed CLI invocation | `covered` |
| A12 | Summary/log path are emitted | Fixture writes `scenario.json`, `installer.json`, shell artifacts, and workflow uploads `e2e-artifacts/vitest/spark-install/` | Deterministic Vitest artifacts | `stronger` |

All legacy assertions are covered or intentionally stronger in Vitest. No row is `missing`, `partial`, or `candidate only`.

## Contract mapping
- Legacy assertion family: Spark-class Linux host can use the standard NemoClaw installer with no Spark-specific setup.
  - Replacement: `test/e2e-scenario/live/spark-install.test.ts` covers A1-A12.
  - Boundary preserved: real Linux host, Docker daemon, `bash install.sh --non-interactive`, optional `curl -fsSL ... | bash`, install log file, profile/PATH refresh, real `nemoclaw` and `openshell` commands.

## Simplicity check
- Test shape: simple live Vitest test.
- Original runner/lane: unwired/manual legacy script; documented prereq is Linux + Docker (DGX Spark or similar).
- Replacement runner: `e2e-vitest-scenarios.yaml` job `spark-install-vitest` on `ubuntu-latest` with Docker.
- New shared helpers: none; one-off helpers are local to the test.
- New framework/registry/ledger: **none**
- Workflow changes: add selective free-standing Vitest job; legacy shell deletion/workflow retirement deferred to #5098 Phase 11.
- Selective dispatch: `gh workflow run e2e-vitest-scenarios.yaml --repo NVIDIA/NemoClaw --ref e2e-migrate-test-spark-install -f jobs=spark-install-vitest -f pr_number=<PR>`

## Pre-push parity gate
- Legacy script: `test/e2e/test-spark-install.sh`
- Assertion rows inventoried: `12`
- Covered/stronger rows: `12`
- Missing/partial/candidate-only rows: `0`
- Direct reference only rows: `0`
- Runner/resource boundary matched: `yes — Linux + Docker manual legacy contract mapped to ubuntu-latest + Docker selective Vitest job`

## Advisor follow-up
- PRA-3/PRA-T1: installer stdout/stderr now stay in `host.command` redaction and retained `install.log` is written through `writeRedactedInstallLog`; helper test proves sentinel API key redaction in both retained log and failure detail.
- PRA-4/PRA-8/PRA-T2/PRA-T3: public curl-pipe mode now only accepts `https://www.nvidia.com/nemoclaw.sh` and enables `set -euo pipefail`.
- PRA-5/PRA-T4: sandbox name is validated and must use the `e2e-spark-install-` test-owned prefix before cleanup/install.
- PRA-6/PRA-T6/PRA-T7: test now asserts the actual required non-interactive env values without defaults.
- PRA-9: reused `shouldRunInstallerIntegration()` and removed unused import.

## Verification
- `NEMOCLAW_RUN_E2E_SCENARIOS=1 npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/spark-install.test.ts --reporter=default` (skips on local macOS)
- `npx tsx -e "import { validateE2eVitestScenariosWorkflowBoundary } from './tools/e2e-scenarios/workflow-boundary.mts'; const errors = validateE2eVitestScenariosWorkflowBoundary(); console.log(errors.join('\\n')); process.exit(errors.length ? 1 : 0);"`
- `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts --reporter=default`
- `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/spark-install-helpers.test.ts --reporter=default`
- `npm run build:cli`
- `git diff --check`
- `npx prek run --all-files --stage pre-push --skip tsc-plugin --skip tsc-js --skip tsc-cli --skip version-tag-sync --skip test-cli --skip test-plugin --skip source-shape-test-budget --skip test-file-size-budget --skip test-skills-yaml`
- PR: https://github.com/NVIDIA/NemoClaw/pull/5608
- Same-runner selective run: https://github.com/NVIDIA/NemoClaw/actions/runs/27986019551 (`queued`, validates hardening commit `fad3eaf32`)
- Previous same-runner selective run: https://github.com/NVIDIA/NemoClaw/actions/runs/27983972303 (`success`, `spark-install-vitest` passed on `ubuntu-latest` + Docker)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a new live end-to-end Spark installer scenario that validates installer preconditions, runs the install in a sandboxed flow, and verifies post-install CLI availability.
  * Introduced helper utilities and tests to ensure safe installer invocation, strict environment/URL rules, and redacted logging for sensitive output.

* **CI/CD Updates**
  * Expanded the end-to-end workflow to run the new live Spark installer scenario and publish its Vitest artifacts.
  * Updated pull request reporting so the scenario’s results are included in the PR summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

