### PR TITLE
feat(inference): add native Google Gemini adapter for tool-calling

### DIFF
--- a/src/lib/inference/gemini-native-adapter-main.ts
+++ b/src/lib/inference/gemini-native-adapter-main.ts
@@ -10,8 +10,9 @@ import { createGeminiNativeAdapterServer } from "./gemini-native-adapter";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const token = process.env.GEMINI_ADAPTER_TOKEN;
-const port = Number(process.env.GEMINI_ADAPTER_PORT || "8801");
-const host = process.env.GEMINI_ADAPTER_HOST || "0.0.0.0";
+const rawPort = process.env.GEMINI_ADAPTER_PORT || "8801";
+const port = Number.parseInt(rawPort, 10);
+const host = process.env.GEMINI_ADAPTER_HOST || "127.0.0.1";
 
 if (!apiKey) {
   console.error("gemini-native-adapter: GEMINI_API_KEY is required");
@@ -19,6 +20,12 @@ if (!apiKey) {
 }
 if (!token) {
   console.error("gemini-native-adapter: GEMINI_ADAPTER_TOKEN is required");
+  process.exit(1);
+}
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error(
+    "gemini-native-adapter: GEMINI_ADAPTER_PORT must be an integer between 1 and 65535",
+  );
   process.exit(1);
 }
 

--- a/src/lib/inference/gemini-native-adapter-main.ts
+++ b/src/lib/inference/gemini-native-adapter-main.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Thin process entry point for the native Gemini adapter. All request/translation logic lives
+// in (and is tested through) `createGeminiNativeAdapterServer`; this file only reads config from
+// the environment and starts the server. The GEMINI_API_KEY and adapter token are read from the
+// environment and never logged.
+
+import { createGeminiNativeAdapterServer } from "./gemini-native-adapter";
+
+const apiKey = process.env.GEMINI_API_KEY;
+const token = process.env.GEMINI_ADAPTER_TOKEN;
+const port = Number(process.env.GEMINI_ADAPTER_PORT || "8801");
+const host = process.env.GEMINI_ADAPTER_HOST || "0.0.0.0";
+
+if (!apiKey) {
+  console.error("gemini-native-adapter: GEMINI_API_KEY is required");
+  process.exit(1);
+}
+if (!token) {
+  console.error("gemini-native-adapter: GEMINI_ADAPTER_TOKEN is required");
+  process.exit(1);
+}
+
+const server = createGeminiNativeAdapterServer({ apiKey, token });
+server.listen(port, host, () => {
+  // Never log the key or token — host:port only.
+  console.log(`gemini-native-adapter listening on ${host}:${port}`);
+});

--- a/src/lib/inference/gemini-native-adapter.test.ts
+++ b/src/lib/inference/gemini-native-adapter.test.ts
@@ -1,0 +1,414 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import http from "node:http";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __test,
+  AdapterHttpError,
+  createGeminiNativeAdapterServer,
+  type GeminiCaller,
+} from "./gemini-native-adapter";
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+  servers.length = 0;
+});
+
+function listen(server: http.Server): Promise<string> {
+  servers.push(server);
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as import("node:net").AddressInfo;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+const TOKEN = "local-token";
+const API_KEY = "test-gemini-key";
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" };
+}
+
+describe("Gemini native OpenAI adapter", () => {
+  it("converts a non-streaming functionCall response into OpenAI tool_calls", async () => {
+    const generate = vi.fn(async ({ model, body }: { model: string; body: unknown }) => {
+      expect(model).toBe("gemini-2.5-flash");
+      // The translation layer should have produced Gemini-shaped contents.
+      expect(body).toMatchObject({ contents: expect.any(Array) });
+      return {
+        status: 200,
+        json: {
+          candidates: [
+            {
+              content: {
+                role: "model",
+                parts: [
+                  {
+                    functionCall: { name: "get_weather", args: { city: "Seattle" } },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7, totalTokenCount: 12 },
+        },
+      };
+    });
+    const callGemini: GeminiCaller = {
+      generate,
+      stream: vi.fn(),
+      listModels: vi.fn(),
+    };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "gemini-2.5-flash",
+        messages: [{ role: "user", content: "weather in Seattle?" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "get_weather",
+              description: "Get weather",
+              parameters: { type: "object", properties: { city: { type: "string" } } },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.object).toBe("chat.completion");
+    expect(body.model).toBe("gemini-2.5-flash");
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+    expect(body.choices[0].message.tool_calls).toHaveLength(1);
+    expect(body.choices[0].message.tool_calls[0]).toMatchObject({
+      type: "function",
+      function: { name: "get_weather", arguments: '{"city":"Seattle"}' },
+    });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams Gemini chunks as OpenAI chat.completion.chunk events ending with [DONE]", async () => {
+    async function* geminiStream() {
+      yield {
+        candidates: [{ content: { role: "model", parts: [{ text: "Hello" }] } }],
+      };
+      yield {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ functionCall: { name: "get_weather", args: { city: "Seattle" } } }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      };
+    }
+    const stream = vi.fn(async ({ model }: { model: string }) => {
+      expect(model).toBe("gemini-2.5-flash");
+      return geminiStream();
+    });
+    const callGemini: GeminiCaller = {
+      generate: vi.fn(),
+      stream,
+      listModels: vi.fn(),
+    };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "gemini-2.5-flash",
+        stream: true,
+        messages: [{ role: "user", content: "weather in Seattle?" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    const text = await response.text();
+    const dataLines = text
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => line.slice("data: ".length));
+
+    expect(dataLines.at(-1)).toBe("[DONE]");
+
+    const events = dataLines
+      .filter((line) => line !== "[DONE]")
+      .map((line) => JSON.parse(line) as any);
+
+    expect(events.every((event) => event.object === "chat.completion.chunk")).toBe(true);
+    // First text delta carries the assistant role and the text.
+    expect(events[0].choices[0].delta.role).toBe("assistant");
+    expect(events[0].choices[0].delta.content).toBe("Hello");
+    // Tool call delta carries an indexed tool_call.
+    const toolEvent = events.find((event) => event.choices[0].delta.tool_calls);
+    expect(toolEvent.choices[0].delta.tool_calls[0]).toMatchObject({
+      index: 0,
+      type: "function",
+      function: { name: "get_weather", arguments: '{"city":"Seattle"}' },
+    });
+    expect(events.at(-1).choices[0].finish_reason).toBe("tool_calls");
+    expect(stream).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects requests without a valid bearer token and never calls upstream", async () => {
+    const generate = vi.fn();
+    const stream = vi.fn();
+    const listModels = vi.fn();
+    const callGemini: GeminiCaller = { generate, stream, listModels };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const missing = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gemini-2.5-flash", messages: [] }),
+    });
+    expect(missing.status).toBe(401);
+
+    const wrong = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { Authorization: "Bearer nope", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gemini-2.5-flash", messages: [] }),
+    });
+    expect(wrong.status).toBe(401);
+
+    expect(generate).not.toHaveBeenCalled();
+    expect(stream).not.toHaveBeenCalled();
+    expect(listModels).not.toHaveBeenCalled();
+  });
+
+  it("returns an OpenAI-shaped model list from /v1/models", async () => {
+    const listModels = vi.fn(async () => ({
+      status: 200,
+      json: {
+        models: [
+          { name: "models/gemini-2.5-flash", displayName: "Gemini 2.5 Flash" },
+          { name: "models/gemini-2.5-pro", displayName: "Gemini 2.5 Pro" },
+        ],
+      },
+    }));
+    const callGemini: GeminiCaller = {
+      generate: vi.fn(),
+      stream: vi.fn(),
+      listModels,
+    };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/models`, { headers: authHeaders() });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.object).toBe("list");
+    expect(body.data).toEqual([
+      { id: "gemini-2.5-flash", object: "model", owned_by: "google" },
+      { id: "gemini-2.5-pro", object: "model", owned_by: "google" },
+    ]);
+    expect(listModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("relays an upstream error status from generateContent", async () => {
+    const generate = vi.fn(async () => ({
+      status: 400,
+      json: {
+        error: {
+          code: 400,
+          message: "Invalid argument: tools[0].function.parameters",
+          status: "INVALID_ARGUMENT",
+        },
+      },
+    }));
+    const callGemini: GeminiCaller = {
+      generate,
+      stream: vi.fn(),
+      listModels: vi.fn(),
+    };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "gemini-2.5-flash",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as any;
+    expect(body.error).toBeDefined();
+    expect(body.error.message).toContain("Invalid argument");
+  });
+
+  it("returns 400 for malformed JSON request bodies", async () => {
+    const callGemini: GeminiCaller = {
+      generate: vi.fn(),
+      stream: vi.fn(),
+      listModels: vi.fn(),
+    };
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: "{ not json",
+    });
+    expect(response.status).toBe(400);
+    expect(callGemini.generate as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("returns a real error status (not 200 + SSE) when a streaming upstream fails before any bytes", async () => {
+    const stream = vi.fn(async () => {
+      throw new AdapterHttpError(429, "Resource exhausted", "rate_limited");
+    });
+    const callGemini: GeminiCaller = { generate: vi.fn(), stream, listModels: vi.fn() };
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "gemini-2.5-flash",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    const body = (await response.json()) as any;
+    expect(body.error).toBeDefined();
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const callGemini: GeminiCaller = {
+      generate: vi.fn(),
+      stream: vi.fn(),
+      listModels: vi.fn(),
+    };
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/nonsense`, { headers: authHeaders() });
+    expect(response.status).toBe(404);
+  });
+});
+
+// A stalled upstream connection (e.g. a stale keep-alive socket to Google) must never hang the
+// adapter. The default caller wraps each idempotent attempt in a single retry on transient
+// stalls/resets so one bad socket is recovered on a fresh one instead of freezing the request.
+describe("withUpstreamRetry", () => {
+  it("returns the result without retrying when the first attempt succeeds", async () => {
+    let calls = 0;
+    const result = await __test.withUpstreamRetry(
+      async () => {
+        calls++;
+        return "ok";
+      },
+      { isRetryable: () => true },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries once on a retryable error then succeeds", async () => {
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new AdapterHttpError(504, "Gemini upstream timed out", "upstream_timeout"),
+      )
+      .mockResolvedValueOnce("ok");
+    const result = await __test.withUpstreamRetry(attempt, {
+      isRetryable: __test.isRetryableUpstreamError,
+    });
+    expect(result).toBe("ok");
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the retry budget and throws the last error", async () => {
+    let calls = 0;
+    await expect(
+      __test.withUpstreamRetry(
+        async () => {
+          calls++;
+          throw new AdapterHttpError(504, "Gemini upstream timed out", "upstream_timeout");
+        },
+        { isRetryable: () => true },
+      ),
+    ).rejects.toBeInstanceOf(AdapterHttpError);
+    expect(calls).toBe(2);
+  });
+
+  it("does not retry a non-retryable error", async () => {
+    let calls = 0;
+    await expect(
+      __test.withUpstreamRetry(
+        async () => {
+          calls++;
+          throw new AdapterHttpError(400, "Invalid argument", "gemini_error");
+        },
+        { isRetryable: __test.isRetryableUpstreamError },
+      ),
+    ).rejects.toBeInstanceOf(AdapterHttpError);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("isRetryableUpstreamError", () => {
+  it("treats a 504 upstream timeout as retryable", () => {
+    expect(
+      __test.isRetryableUpstreamError(new AdapterHttpError(504, "timed out", "upstream_timeout")),
+    ).toBe(true);
+  });
+
+  it("treats a 4xx upstream error as non-retryable", () => {
+    expect(
+      __test.isRetryableUpstreamError(new AdapterHttpError(400, "bad request", "gemini_error")),
+    ).toBe(false);
+  });
+
+  it("treats socket reset/timeout codes as retryable", () => {
+    expect(__test.isRetryableUpstreamError({ code: "ECONNRESET" })).toBe(true);
+    expect(__test.isRetryableUpstreamError({ code: "ETIMEDOUT" })).toBe(true);
+    expect(__test.isRetryableUpstreamError({ code: "EPIPE" })).toBe(true);
+  });
+
+  it("treats an unknown error as non-retryable", () => {
+    expect(__test.isRetryableUpstreamError(new Error("boom"))).toBe(false);
+  });
+});

--- a/src/lib/inference/gemini-native-adapter.test.ts
+++ b/src/lib/inference/gemini-native-adapter.test.ts
@@ -110,6 +110,86 @@ describe("Gemini native OpenAI adapter", () => {
     expect(generate).toHaveBeenCalledTimes(1);
   });
 
+  it("does not abort the upstream call when the request body is fully read (client still connected)", async () => {
+    // Regression (2026-06-23): wiring the abort to the REQUEST stream's "close" event cancels every POST
+    // the moment its body finishes being read — `req` "close" fires on normal completion, not only on a
+    // client disconnect — so the upstream call runs on an already-aborted signal. A real upstream caller
+    // (https.request/fetch) rejects synchronously when handed an already-aborted signal; this mock does
+    // the same, so the test is RED against `req.on("close")` and GREEN against the `res`-keyed fix.
+    const generate = vi.fn(
+      async ({ signal }: { model: string; body: unknown; signal?: AbortSignal }) => {
+        // A real upstream caller (https.request/fetch) throws synchronously when handed an
+        // already-aborted signal. `throwIfAborted()` does exactly that with no branch: under the
+        // buggy `req.on("close")` wiring the signal is already aborted here → throws → 502 (RED);
+        // under the `res.on("close")` fix it is not aborted → resolves 200 (GREEN).
+        signal?.throwIfAborted();
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, 20);
+          signal?.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(new Error("upstream aborted mid-call"));
+          });
+        });
+        return {
+          status: 200,
+          json: {
+            candidates: [
+              { content: { role: "model", parts: [{ text: "ok" }] }, finishReason: "STOP" },
+            ],
+          },
+        };
+      },
+    );
+    const callGemini: GeminiCaller = { generate, stream: vi.fn(), listModels: vi.fn() };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "gemini-2.5-flash",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the in-flight upstream call when the client disconnects mid-request", async () => {
+    // Proves the fix's actual benefit (and guards against silently dropping cancellation): a genuine
+    // client disconnect — the response stream closes before we finish writing — cancels the upstream
+    // Gemini call. Fails when no abort is wired at all.
+    let upstreamSignal: AbortSignal | undefined;
+    const generate = vi.fn(({ signal }: { model: string; body: unknown; signal?: AbortSignal }) => {
+      upstreamSignal = signal;
+      // Settles only when the request is aborted (the disconnect path).
+      return new Promise<{ status: number; json: unknown }>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("upstream aborted")));
+      });
+    });
+    const callGemini: GeminiCaller = { generate, stream: vi.fn(), listModels: vi.fn() };
+
+    const server = createGeminiNativeAdapterServer({ apiKey: API_KEY, token: TOKEN, callGemini });
+    const baseUrl = await listen(server);
+
+    const clientAbort = new AbortController();
+    const pending = fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ model: "gemini-2.5-flash", messages: [{ role: "user", content: "hi" }] }),
+      signal: clientAbort.signal,
+    }).catch(() => undefined);
+
+    await vi.waitFor(() => expect(generate).toHaveBeenCalledTimes(1));
+    clientAbort.abort();
+
+    await vi.waitFor(() => expect(upstreamSignal?.aborted).toBe(true));
+    await pending;
+  });
+
   it("streams Gemini chunks as OpenAI chat.completion.chunk events ending with [DONE]", async () => {
     async function* geminiStream() {
       yield {

--- a/src/lib/inference/gemini-native-adapter.ts
+++ b/src/lib/inference/gemini-native-adapter.ts
@@ -234,6 +234,14 @@ export function createGeminiNativeAdapterServer(options: GeminiNativeAdapterOpti
 
   return http.createServer(async (req, res) => {
     const started = Date.now();
+    const abortController = new AbortController();
+    // Cancel the in-flight upstream call only on a genuine client disconnect — i.e. the response
+    // stream closed before we finished writing it. Keying off the *request* stream's "close" is
+    // wrong: it fires when the request body finishes being read (normal completion), which would
+    // abort every POST before its upstream call runs.
+    res.on("close", () => {
+      if (!res.writableEnded) abortController.abort();
+    });
     let model = "unknown";
     let operation = "unknown";
     try {
@@ -262,7 +270,7 @@ export function createGeminiNativeAdapterServer(options: GeminiNativeAdapterOpti
 
       if (req.method === "GET" && url.pathname === "/v1/models") {
         operation = "list_models";
-        const result = await callGemini.listModels({});
+        const result = await callGemini.listModels({ signal: abortController.signal });
         if (result.status >= 400) {
           relayUpstreamError(res, result);
           logAdapterEvent(logger, "request_failed", {
@@ -304,7 +312,11 @@ export function createGeminiNativeAdapterServer(options: GeminiNativeAdapterOpti
         // Establish the upstream stream BEFORE committing response headers: an upstream error
         // before any bytes (e.g. a 4xx) then surfaces as a proper error status via the catch
         // below, rather than a 200 with an SSE error event the client can't act on.
-        const chunks = await callGemini.stream({ model, body: geminiBody });
+        const chunks = await callGemini.stream({
+          model,
+          body: geminiBody,
+          signal: abortController.signal,
+        });
         res.writeHead(200, {
           "Content-Type": "text/event-stream",
           "Cache-Control": "no-cache",
@@ -330,7 +342,11 @@ export function createGeminiNativeAdapterServer(options: GeminiNativeAdapterOpti
       }
 
       operation = "generate_content";
-      const result = await callGemini.generate({ model, body: geminiBody });
+      const result = await callGemini.generate({
+        model,
+        body: geminiBody,
+        signal: abortController.signal,
+      });
       if (result.status >= 400) {
         relayUpstreamError(res, result);
         logAdapterEvent(logger, "request_failed", {

--- a/src/lib/inference/gemini-native-adapter.ts
+++ b/src/lib/inference/gemini-native-adapter.ts
@@ -1,0 +1,634 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+import http from "node:http";
+import https from "node:https";
+import path from "node:path";
+
+import { compactText } from "../core/url-utils";
+import {
+  buildGeminiRequest,
+  convertGeminiResponse,
+  createGeminiStreamConverter,
+  type GeminiGenerateContentRequest,
+} from "./gemini-native-translation";
+import {
+  appendLocalAdapterJsonLine,
+  DEFAULT_LOCAL_ADAPTER_STATE_DIR,
+  type JsonObject,
+  localAdapterTokenHash,
+} from "./local-adapter-lifecycle";
+
+export {
+  buildGeminiRequest,
+  convertGeminiResponse,
+  createGeminiStreamConverter,
+} from "./gemini-native-translation";
+
+/**
+ * Lightweight, transport-agnostic HTTP error carrying the status/code an HTTP handler should
+ * surface. Mirrors the Bedrock adapter's `AdapterHttpError` so error handling reads the same
+ * across native adapters.
+ */
+export class AdapterHttpError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, message: string, code = "bad_request") {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
+
+/** Result of a unary upstream call: the HTTP status Google returned plus the parsed JSON body. */
+export type GeminiCallResult = { status: number; json: unknown };
+
+/** Parameters for a single Gemini upstream invocation (the model rides in the URL path). */
+export type GeminiCallParams = {
+  model: string;
+  body: GeminiGenerateContentRequest;
+  signal?: AbortSignal;
+};
+
+/**
+ * Injectable upstream so tests can fake Google. The default implementation
+ * ({@link createDefaultGeminiCaller}) makes real HTTPS calls and holds the `GEMINI_API_KEY`.
+ */
+export type GeminiCaller = {
+  /** Unary `:generateContent`. */
+  generate(params: GeminiCallParams): Promise<GeminiCallResult>;
+  /** Streaming `:streamGenerateContent?alt=sse`, yielding PARSED Gemini chunk objects. */
+  stream(params: GeminiCallParams): Promise<AsyncIterable<unknown>>;
+  /** `GET /models` for the model-list route. */
+  listModels(options?: { signal?: AbortSignal }): Promise<GeminiCallResult>;
+};
+
+type AdapterLogFields = Record<string, string | number | boolean | null | undefined>;
+type AdapterLogger = (event: string, fields?: AdapterLogFields) => void;
+
+export type GeminiNativeAdapterOptions = {
+  /** GEMINI_API_KEY — held here and injected to Google as `x-goog-api-key`. Never logged. */
+  apiKey: string;
+  /** Local Bearer token the boundary must present on every route. */
+  token: string;
+  /** Injectable upstream; defaults to real HTTPS calls to Google. */
+  callGemini?: GeminiCaller;
+  /** Override Google's base URL (default {@link DEFAULT_GEMINI_BASE_URL}). */
+  baseUrl?: string;
+  logger?: AdapterLogger;
+};
+
+export const LOG_PATH = path.join(DEFAULT_LOCAL_ADAPTER_STATE_DIR, "gemini-native-adapter.log");
+
+function normalizeLogField(
+  value: string | number | boolean | null | undefined,
+): string | number | boolean | null {
+  if (value === undefined) return null;
+  if (typeof value === "string") return compactText(value).slice(0, 180);
+  return value;
+}
+
+function defaultAdapterLogger(event: string, fields: AdapterLogFields = {}): void {
+  try {
+    const payload: Record<string, string | number | boolean | null> = {
+      ts: new Date().toISOString(),
+      event: normalizeLogField(event) as string,
+    };
+    for (const [key, value] of Object.entries(fields)) {
+      payload[key] = normalizeLogField(value);
+    }
+    appendLocalAdapterJsonLine(LOG_PATH, payload);
+  } catch {
+    /* best-effort diagnostics only */
+  }
+}
+
+function logAdapterEvent(
+  logger: AdapterLogger,
+  event: string,
+  fields: AdapterLogFields = {},
+): void {
+  try {
+    logger(event, fields);
+  } catch {
+    /* best-effort diagnostics only */
+  }
+}
+
+function authMatches(actual: string | string[] | undefined, token: string): boolean {
+  const header = Array.isArray(actual) ? actual[0] : actual;
+  if (!header) return false;
+  const expected = Buffer.from(`Bearer ${token}`);
+  const received = Buffer.from(header);
+  return received.length === expected.length && crypto.timingSafeEqual(received, expected);
+}
+
+function adapterTokenHash(token: string): string {
+  return localAdapterTokenHash(token);
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function sendUnauthorized(res: http.ServerResponse): void {
+  sendJson(res, 401, {
+    error: { message: "Unauthorized", type: "unauthorized", code: "unauthorized" },
+  });
+}
+
+function safeErrorMessage(err: unknown): string {
+  if (err instanceof AdapterHttpError) return err.message;
+  if (err instanceof Error && err.message) return err.message;
+  return "Gemini request failed.";
+}
+
+function sendError(res: http.ServerResponse, err: unknown): void {
+  const status = err instanceof AdapterHttpError ? err.status : 502;
+  const code = err instanceof AdapterHttpError ? err.code : "gemini_error";
+  sendJson(res, status, {
+    error: {
+      message: compactText(safeErrorMessage(err)),
+      type: code,
+      code,
+    },
+  });
+}
+
+function parseJsonObject(raw: string, label: string): JsonObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new AdapterHttpError(400, `Invalid JSON in ${label}.`, "invalid_request");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new AdapterHttpError(400, `Expected a JSON object for ${label}.`, "invalid_request");
+  }
+  return parsed as JsonObject;
+}
+
+function readRequestJson(req: http.IncomingMessage): Promise<JsonObject> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new AdapterHttpError(413, "Request body is too large.", "request_too_large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      try {
+        resolve(parseJsonObject(Buffer.concat(chunks).toString("utf8"), "request body"));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function resolveModel(body: JsonObject): string {
+  return typeof body.model === "string" && body.model.trim() ? body.model.trim() : "unknown";
+}
+
+/**
+ * Map a Gemini `GET /models` response to the OpenAI `GET /v1/models` shape. Gemini reports model
+ * names as `models/<id>` (e.g. `models/gemini-2.5-flash`); we strip the `models/` prefix so the
+ * sandbox sees plain OpenAI model ids.
+ */
+function toOpenAiModelList(json: unknown): {
+  object: "list";
+  data: Array<{ id: string; object: "model"; owned_by: "google" }>;
+} {
+  const models =
+    json && typeof json === "object" && Array.isArray((json as JsonObject).models)
+      ? ((json as JsonObject).models as unknown[])
+      : [];
+  const data: Array<{ id: string; object: "model"; owned_by: "google" }> = [];
+  for (const entry of models) {
+    if (!entry || typeof entry !== "object") continue;
+    const name = (entry as JsonObject).name;
+    if (typeof name !== "string" || !name) continue;
+    const id = name.startsWith("models/") ? name.slice("models/".length) : name;
+    data.push({ id, object: "model", owned_by: "google" });
+  }
+  return { object: "list", data };
+}
+
+export function createGeminiNativeAdapterServer(options: GeminiNativeAdapterOptions): http.Server {
+  const logger = options.logger || defaultAdapterLogger;
+  const baseUrl = options.baseUrl || DEFAULT_GEMINI_BASE_URL;
+  const callGemini =
+    options.callGemini || createDefaultGeminiCaller({ apiKey: options.apiKey, baseUrl });
+
+  return http.createServer(async (req, res) => {
+    const started = Date.now();
+    let model = "unknown";
+    let operation = "unknown";
+    try {
+      const url = new URL(req.url || "/", "http://127.0.0.1");
+
+      if (req.method === "GET" && url.pathname === "/health") {
+        sendJson(res, 200, {
+          ok: true,
+          baseUrl,
+          tokenHash: adapterTokenHash(options.token),
+        });
+        return;
+      }
+
+      if (!authMatches(req.headers.authorization, options.token)) {
+        sendUnauthorized(res);
+        logAdapterEvent(logger, "request_rejected", {
+          method: req.method || "unknown",
+          path: url.pathname,
+          status: 401,
+          reason: "unauthorized",
+          durationMs: Date.now() - started,
+        });
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === "/v1/models") {
+        operation = "list_models";
+        const result = await callGemini.listModels({});
+        if (result.status >= 400) {
+          relayUpstreamError(res, result);
+          logAdapterEvent(logger, "request_failed", {
+            operation,
+            status: result.status,
+            durationMs: Date.now() - started,
+          });
+          return;
+        }
+        sendJson(res, 200, toOpenAiModelList(result.json));
+        logAdapterEvent(logger, "request_completed", {
+          operation,
+          status: 200,
+          durationMs: Date.now() - started,
+        });
+        return;
+      }
+
+      if (req.method !== "POST" || url.pathname !== "/v1/chat/completions") {
+        sendJson(res, 404, {
+          error: { message: "Not found", type: "not_found", code: "not_found" },
+        });
+        logAdapterEvent(logger, "request_rejected", {
+          method: req.method || "unknown",
+          path: url.pathname,
+          status: 404,
+          reason: "not_found",
+          durationMs: Date.now() - started,
+        });
+        return;
+      }
+
+      const body = await readRequestJson(req);
+      model = resolveModel(body);
+      const geminiBody = buildGeminiRequest(body);
+
+      if (body.stream === true) {
+        operation = "stream_generate_content";
+        // Establish the upstream stream BEFORE committing response headers: an upstream error
+        // before any bytes (e.g. a 4xx) then surfaces as a proper error status via the catch
+        // below, rather than a 200 with an SSE error event the client can't act on.
+        const chunks = await callGemini.stream({ model, body: geminiBody });
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+        const converter = createGeminiStreamConverter(model);
+        for await (const chunk of chunks) {
+          const openAiChunk = converter.convertChunk(chunk);
+          if (openAiChunk) {
+            res.write(`data: ${JSON.stringify(openAiChunk)}\n\n`);
+          }
+        }
+        res.write("data: [DONE]\n\n");
+        res.end();
+        logAdapterEvent(logger, "request_completed", {
+          operation,
+          model,
+          status: 200,
+          stream: true,
+          durationMs: Date.now() - started,
+        });
+        return;
+      }
+
+      operation = "generate_content";
+      const result = await callGemini.generate({ model, body: geminiBody });
+      if (result.status >= 400) {
+        relayUpstreamError(res, result);
+        logAdapterEvent(logger, "request_failed", {
+          operation,
+          model,
+          status: result.status,
+          durationMs: Date.now() - started,
+        });
+        return;
+      }
+      sendJson(res, 200, convertGeminiResponse(result.json, model));
+      logAdapterEvent(logger, "request_completed", {
+        operation,
+        model,
+        status: 200,
+        stream: false,
+        durationMs: Date.now() - started,
+      });
+    } catch (err) {
+      const status = err instanceof AdapterHttpError ? err.status : 502;
+      const code = err instanceof AdapterHttpError ? err.code : "gemini_error";
+      logAdapterEvent(logger, "request_failed", {
+        operation,
+        model,
+        status,
+        code,
+        durationMs: Date.now() - started,
+      });
+      if (!res.headersSent) {
+        sendError(res, err);
+      } else {
+        res.write(
+          `data: ${JSON.stringify({ error: { message: compactText(safeErrorMessage(err)) } })}\n\n`,
+        );
+        res.end();
+      }
+    }
+  });
+}
+
+/**
+ * Relay an upstream Gemini error to the caller with the same status. Gemini errors are shaped
+ * `{ error: { code, message, status } }`; we surface an OpenAI-shaped `{ error: { message, type,
+ * code } }` so the sandbox's OpenAI client can parse it, preserving Google's message.
+ */
+function relayUpstreamError(res: http.ServerResponse, result: GeminiCallResult): void {
+  const upstream =
+    result.json && typeof result.json === "object" ? (result.json as JsonObject) : {};
+  const upstreamError =
+    upstream.error && typeof upstream.error === "object"
+      ? (upstream.error as JsonObject)
+      : undefined;
+  const message =
+    upstreamError && typeof upstreamError.message === "string"
+      ? upstreamError.message
+      : `Gemini request failed with status ${result.status}.`;
+  const status =
+    upstreamError && typeof upstreamError.status === "string" ? upstreamError.status : undefined;
+  sendJson(res, result.status, {
+    error: {
+      message: compactText(message),
+      type: status || "gemini_error",
+      code: status || "gemini_error",
+    },
+  });
+}
+
+type ParsedHttpsResponse = { status: number; text: string };
+
+/** POST JSON to Google over HTTPS, buffering the whole response (for the unary routes). */
+function httpsJson(
+  urlString: string,
+  options: {
+    method: "GET" | "POST";
+    headers: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+    timeoutMs?: number;
+  },
+): Promise<ParsedHttpsResponse> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlString);
+    const req = https.request(
+      {
+        method: options.method,
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: `${url.pathname}${url.search}`,
+        headers: options.headers,
+        signal: options.signal,
+        agent: upstreamAgent,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          resolve({ status: res.statusCode || 502, text: Buffer.concat(chunks).toString("utf8") });
+        });
+        res.on("error", reject);
+      },
+    );
+    attachIdleTimeout(req, options.timeoutMs ?? UPSTREAM_IDLE_TIMEOUT_MS);
+    req.on("error", reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+function parseMaybeJson(text: string): unknown {
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: { message: compactText(text) || "Non-JSON upstream response." } };
+  }
+}
+
+/**
+ * Stream Gemini SSE (`?alt=sse`) over HTTPS, parsing `data: {...}` lines into objects and yielding
+ * them. Gemini's SSE frames are line-delimited `data:` events separated by blank lines; we split
+ * on newlines, parse each `data:` payload, and skip anything that is not valid JSON (keep-alives,
+ * partial frames stitched across chunk boundaries via the line buffer).
+ */
+async function* parseGeminiSse(res: http.IncomingMessage): AsyncGenerator<unknown> {
+  let buffer = "";
+  for await (const chunk of res) {
+    buffer += chunk.toString("utf8");
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = buffer.slice(0, newlineIndex).replace(/\r$/, "");
+      buffer = buffer.slice(newlineIndex + 1);
+      const parsed = parseSseDataLine(line);
+      if (parsed !== undefined) yield parsed;
+      newlineIndex = buffer.indexOf("\n");
+    }
+  }
+  const tail = parseSseDataLine(buffer.replace(/\r$/, ""));
+  if (tail !== undefined) yield tail;
+}
+
+function parseSseDataLine(line: string): unknown {
+  if (!line.startsWith("data:")) return undefined;
+  const payload = line.slice("data:".length).trim();
+  if (!payload || payload === "[DONE]") return undefined;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Idle (no-data) timeout for an upstream Gemini connection. Generous enough to never trip on a
+ * legitimately slow first byte from a thinking model, but bounded so a dead/stalled socket can
+ * never hang the request indefinitely. Tripping it surfaces a retryable 504.
+ */
+const UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
+
+/**
+ * Pooled keep-alive agent for upstream calls. Reusing an established TLS connection both lowers
+ * latency and avoids the per-call handshake that, on a flaky egress path, is itself an occasional
+ * source of connection-setup stalls. `timeout` prunes sockets that sit idle long enough to have
+ * gone stale, so a reused socket is rarely half-closed; the per-request idle timeout + retry are
+ * the backstop for the residual case.
+ */
+const upstreamAgent = new https.Agent({ keepAlive: true, timeout: 30_000, maxSockets: 64 });
+
+/** Arm a socket-inactivity timeout that destroys the request with a retryable 504 if it stalls. */
+function attachIdleTimeout(req: http.ClientRequest, timeoutMs: number): void {
+  req.setTimeout(timeoutMs, () => {
+    req.destroy(new AdapterHttpError(504, "Gemini upstream timed out.", "upstream_timeout"));
+  });
+}
+
+/** Whether an upstream failure is a transient stall/reset worth a single fresh-socket retry. */
+function isRetryableUpstreamError(err: unknown): boolean {
+  if (err instanceof AdapterHttpError) return err.status === 504;
+  const code = (err as { code?: unknown } | null)?.code;
+  return (
+    code === "ECONNRESET" || code === "ETIMEDOUT" || code === "ECONNREFUSED" || code === "EPIPE"
+  );
+}
+
+/**
+ * Run an idempotent upstream attempt with a bounded retry budget. Gemini reads are side-effect
+ * free, so a transient stall (e.g. a stale keep-alive socket) is recovered on a fresh connection
+ * rather than failing the caller. Non-retryable errors (4xx, unknown) propagate immediately.
+ */
+async function withUpstreamRetry<T>(
+  attempt: () => Promise<T>,
+  opts: { retries?: number; isRetryable: (err: unknown) => boolean },
+): Promise<T> {
+  const total = (opts.retries ?? 1) + 1;
+  let lastError: unknown;
+  for (let i = 0; i < total; i++) {
+    try {
+      return await attempt();
+    } catch (err) {
+      lastError = err;
+      if (i === total - 1 || !opts.isRetryable(err)) throw err;
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Default upstream that holds the real `GEMINI_API_KEY` and makes HTTPS calls to Google's native
+ * `generateContent`/`streamGenerateContent`/`models` endpoints. The key is injected only as the
+ * `x-goog-api-key` header and is never logged.
+ */
+export function createDefaultGeminiCaller(config: {
+  apiKey: string;
+  baseUrl?: string;
+}): GeminiCaller {
+  const baseUrl = (config.baseUrl || DEFAULT_GEMINI_BASE_URL).replace(/\/$/, "");
+  const jsonHeaders = (): Record<string, string> => ({
+    "content-type": "application/json",
+    "x-goog-api-key": config.apiKey,
+  });
+
+  return {
+    async generate({ model, body, signal }) {
+      const url = `${baseUrl}/models/${encodeURIComponent(model)}:generateContent`;
+      return withUpstreamRetry(
+        async () => {
+          const res = await httpsJson(url, {
+            method: "POST",
+            headers: jsonHeaders(),
+            body: JSON.stringify(body),
+            signal,
+          });
+          return { status: res.status, json: parseMaybeJson(res.text) };
+        },
+        { isRetryable: isRetryableUpstreamError },
+      );
+    },
+
+    async stream({ model, body, signal }) {
+      const url = `${baseUrl}/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse`;
+      const parsed = new URL(url);
+      const openStream = () =>
+        new Promise<AsyncIterable<unknown>>((resolve, reject) => {
+          const req = https.request(
+            {
+              method: "POST",
+              hostname: parsed.hostname,
+              port: parsed.port || 443,
+              path: `${parsed.pathname}${parsed.search}`,
+              headers: { ...jsonHeaders(), accept: "text/event-stream" },
+              signal,
+              agent: upstreamAgent,
+            },
+            (res) => {
+              if ((res.statusCode || 502) >= 400) {
+                const chunks: Buffer[] = [];
+                res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+                res.on("end", () => {
+                  const text = Buffer.concat(chunks).toString("utf8");
+                  const json = parseMaybeJson(text) as JsonObject;
+                  const message =
+                    json.error && typeof json.error === "object"
+                      ? compactText(String((json.error as JsonObject).message || ""))
+                      : `Gemini stream failed with status ${res.statusCode}.`;
+                  reject(new AdapterHttpError(res.statusCode || 502, message, "gemini_error"));
+                });
+                return;
+              }
+              resolve(parseGeminiSse(res));
+            },
+          );
+          attachIdleTimeout(req, UPSTREAM_IDLE_TIMEOUT_MS);
+          req.on("error", reject);
+          req.write(JSON.stringify(body));
+          req.end();
+        });
+      return withUpstreamRetry(openStream, { isRetryable: isRetryableUpstreamError });
+    },
+
+    async listModels({ signal } = {}) {
+      return withUpstreamRetry(
+        async () => {
+          const res = await httpsJson(`${baseUrl}/models`, {
+            method: "GET",
+            headers: jsonHeaders(),
+            signal,
+          });
+          return { status: res.status, json: parseMaybeJson(res.text) };
+        },
+        { isRetryable: isRetryableUpstreamError },
+      );
+    },
+  };
+}
+
+export const __test = {
+  toOpenAiModelList,
+  relayUpstreamError,
+  parseSseDataLine,
+  withUpstreamRetry,
+  isRetryableUpstreamError,
+};

--- a/src/lib/inference/gemini-native-translation.test.ts
+++ b/src/lib/inference/gemini-native-translation.test.ts
@@ -1,0 +1,367 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGeminiContents,
+  buildGeminiRequest,
+  convertGeminiResponse,
+  createGeminiStreamConverter,
+  decodeThoughtSignatureId,
+  encodeThoughtSignatureId,
+  sanitizeGeminiSchema,
+  toGeminiFunctionDeclarations,
+  toGeminiToolConfig,
+} from "./gemini-native-translation";
+
+describe("toGeminiFunctionDeclarations", () => {
+  it("extracts only name/description/parameters, dropping extra function-object fields that Gemini rejects", () => {
+    // Hermes emits OpenAI tool defs whose `function` object carries extra fields
+    // (e.g. `strict`). Gemini's functionDeclarations translator is strict and 400s on
+    // unknown fields ("Unknown name ... at tools[N].function"), unlike OpenAI/DeepInfra.
+    const openAiTools = [
+      {
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Get the weather for a location",
+          parameters: {
+            type: "object",
+            properties: { location: { type: "string" } },
+            required: ["location"],
+          },
+          strict: true,
+        },
+      },
+    ];
+
+    const declarations = toGeminiFunctionDeclarations(openAiTools);
+
+    expect(declarations).toEqual([
+      {
+        name: "get_weather",
+        description: "Get the weather for a location",
+        parameters: {
+          type: "object",
+          properties: { location: { type: "string" } },
+          required: ["location"],
+        },
+      },
+    ]);
+  });
+});
+
+describe("sanitizeGeminiSchema", () => {
+  it("recursively drops JSON-Schema keywords Gemini's schema object rejects, keeping allowlisted fields", () => {
+    // Gemini's parameters schema accepts only a subset of OpenAPI 3.0. Keywords like
+    // `$schema`, `additionalProperties`, `oneOf`, and vendor extras (`strict`) trip its
+    // validator; mature adapters (LiteLLM/ADK) filter to an allowlist, recursively.
+    const schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      additionalProperties: false,
+      strict: true,
+      properties: {
+        q: { type: "string", description: "query" },
+        nested: {
+          type: "object",
+          additionalProperties: true,
+          properties: { a: { type: "number", minimum: 0 } },
+        },
+      },
+      required: ["q"],
+    };
+
+    expect(sanitizeGeminiSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        q: { type: "string", description: "query" },
+        nested: {
+          type: "object",
+          properties: { a: { type: "number", minimum: 0 } },
+        },
+      },
+      required: ["q"],
+    });
+  });
+
+  it("rewrites oneOf to anyOf (Gemini supports anyOf, not oneOf)", () => {
+    expect(sanitizeGeminiSchema({ oneOf: [{ type: "string" }, { type: "integer" }] })).toEqual({
+      anyOf: [{ type: "string" }, { type: "integer" }],
+    });
+  });
+
+  it("converts const to a single-value enum (Gemini has no const)", () => {
+    expect(sanitizeGeminiSchema({ type: "string", const: "fixed" })).toEqual({
+      type: "string",
+      enum: ["fixed"],
+    });
+  });
+
+  it("collapses a nullable anyOf union to nullable + the single non-null member", () => {
+    expect(sanitizeGeminiSchema({ anyOf: [{ type: "string" }, { type: "null" }] })).toEqual({
+      type: "string",
+      nullable: true,
+    });
+  });
+});
+
+describe("createGeminiStreamConverter", () => {
+  it("converts a text stream chunk to an OpenAI delta chunk (role on the first chunk)", () => {
+    const converter = createGeminiStreamConverter("gemini-2.5-flash");
+    const chunk = converter.convertChunk({
+      candidates: [{ content: { parts: [{ text: "Hel" }] } }],
+    });
+    expect(chunk?.object).toBe("chat.completion.chunk");
+    expect(chunk?.choices[0].delta).toEqual({ role: "assistant", content: "Hel" });
+    expect(chunk?.choices[0].finish_reason).toBeNull();
+  });
+
+  it("emits tool_call deltas with incrementing index + encoded signature, then tool_calls finish_reason", () => {
+    const converter = createGeminiStreamConverter("gemini-3-flash-preview");
+    const first = converter.convertChunk({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: { name: "get_weather", args: { location: "Paris" } },
+                thoughtSignature: "SIG",
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const toolCall = first?.choices[0].delta.tool_calls?.[0];
+    expect(toolCall?.index).toBe(0);
+    expect(toolCall?.function).toEqual({ name: "get_weather", arguments: '{"location":"Paris"}' });
+    expect(decodeThoughtSignatureId(toolCall?.id ?? "").signature).toBe("SIG");
+
+    const final = converter.convertChunk({ candidates: [{ finishReason: "STOP" }] });
+    expect(final?.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("returns null for an empty chunk (no delta, no finish_reason)", () => {
+    const converter = createGeminiStreamConverter("gemini-2.5-flash");
+    expect(converter.convertChunk({ candidates: [{}] })).toBeNull();
+  });
+});
+
+describe("buildGeminiRequest", () => {
+  it("assembles contents, systemInstruction, sanitized functionDeclarations, toolConfig, and generationConfig", () => {
+    const req = buildGeminiRequest({
+      model: "gemini-2.5-flash",
+      messages: [
+        { role: "system", content: "You are Atlas." },
+        { role: "user", content: "weather?" },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "w",
+            parameters: {
+              type: "object",
+              additionalProperties: false,
+              properties: { location: { type: "string" } },
+              required: ["location"],
+            },
+            strict: true,
+          },
+        },
+      ],
+      tool_choice: "auto",
+      max_tokens: 256,
+      temperature: 0.5,
+    });
+    expect(req.systemInstruction).toEqual({ parts: [{ text: "You are Atlas." }] });
+    expect(req.contents).toEqual([{ role: "user", parts: [{ text: "weather?" }] }]);
+    expect(req.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "get_weather",
+            description: "w",
+            parameters: {
+              type: "object",
+              properties: { location: { type: "string" } },
+              required: ["location"],
+            },
+          },
+        ],
+      },
+    ]);
+    expect(req.toolConfig).toEqual({ functionCallingConfig: { mode: "AUTO" } });
+    expect(req.generationConfig).toEqual({ maxOutputTokens: 256, temperature: 0.5 });
+  });
+
+  it("omits tools, toolConfig, and generationConfig when absent", () => {
+    const req = buildGeminiRequest({ messages: [{ role: "user", content: "hi" }] });
+    expect(req.tools).toBeUndefined();
+    expect(req.toolConfig).toBeUndefined();
+    expect(req.generationConfig).toBeUndefined();
+  });
+});
+
+describe("convertGeminiResponse", () => {
+  it("converts a Gemini text response to an OpenAI assistant message", () => {
+    const out = convertGeminiResponse(
+      {
+        candidates: [
+          { content: { role: "model", parts: [{ text: "Hello!" }] }, finishReason: "STOP" },
+        ],
+        usageMetadata: { promptTokenCount: 3, candidatesTokenCount: 2, totalTokenCount: 5 },
+      },
+      "gemini-2.5-flash",
+    );
+    expect(out.object).toBe("chat.completion");
+    expect(out.model).toBe("gemini-2.5-flash");
+    expect(out.choices[0].message.content).toBe("Hello!");
+    expect(out.choices[0].message.tool_calls).toBeUndefined();
+    expect(out.choices[0].finish_reason).toBe("stop");
+    expect(out.usage).toEqual({ prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 });
+  });
+
+  it("converts a functionCall response to a tool_call (encoding thoughtSignature into the id, finish_reason=tool_calls)", () => {
+    const out = convertGeminiResponse(
+      {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [
+                {
+                  functionCall: { name: "get_weather", args: { location: "Paris" } },
+                  thoughtSignature: "SIG123",
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      },
+      "gemini-3-flash-preview",
+    );
+    expect(out.choices[0].message.content).toBeNull();
+    expect(out.choices[0].finish_reason).toBe("tool_calls");
+    const call = out.choices[0].message.tool_calls?.[0];
+    expect(call?.type).toBe("function");
+    expect(call?.function).toEqual({ name: "get_weather", arguments: '{"location":"Paris"}' });
+    expect(decodeThoughtSignatureId(call?.id ?? "").signature).toBe("SIG123");
+  });
+});
+
+describe("buildGeminiContents", () => {
+  it("maps user and assistant text messages to user/model role contents", () => {
+    const { contents, systemInstruction } = buildGeminiContents([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello there" },
+    ]);
+    expect(systemInstruction).toBeUndefined();
+    expect(contents).toEqual([
+      { role: "user", parts: [{ text: "hi" }] },
+      { role: "model", parts: [{ text: "hello there" }] },
+    ]);
+  });
+
+  it("lifts system/developer messages into systemInstruction (not contents)", () => {
+    const { contents, systemInstruction } = buildGeminiContents([
+      { role: "system", content: "You are Atlas." },
+      { role: "user", content: "hi" },
+    ]);
+    expect(systemInstruction).toEqual({ parts: [{ text: "You are Atlas." }] });
+    expect(contents).toEqual([{ role: "user", parts: [{ text: "hi" }] }]);
+  });
+
+  it("maps tool_calls to model functionCall parts (replaying thoughtSignature) and tool results to user functionResponse parts", () => {
+    const toolId = encodeThoughtSignatureId("call_1", "SIG123");
+    const { contents } = buildGeminiContents([
+      { role: "user", content: "weather in Paris?" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: toolId,
+            type: "function",
+            function: { name: "get_weather", arguments: '{"location":"Paris"}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: toolId, name: "get_weather", content: '{"temp":"15C"}' },
+    ]);
+    expect(contents).toEqual([
+      { role: "user", parts: [{ text: "weather in Paris?" }] },
+      {
+        role: "model",
+        parts: [
+          {
+            functionCall: { name: "get_weather", args: { location: "Paris" } },
+            thoughtSignature: "SIG123",
+          },
+        ],
+      },
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "get_weather", response: { temp: "15C" } } }],
+      },
+    ]);
+  });
+});
+
+describe("toGeminiToolConfig", () => {
+  it("maps the string tool_choice values to functionCallingConfig modes", () => {
+    expect(toGeminiToolConfig("auto")).toEqual({ functionCallingConfig: { mode: "AUTO" } });
+    expect(toGeminiToolConfig("required")).toEqual({ functionCallingConfig: { mode: "ANY" } });
+    expect(toGeminiToolConfig("none")).toEqual({ functionCallingConfig: { mode: "NONE" } });
+    expect(toGeminiToolConfig(undefined)).toBeUndefined();
+  });
+
+  it("restricts to a named function via ANY + allowedFunctionNames", () => {
+    expect(toGeminiToolConfig({ type: "function", function: { name: "get_weather" } })).toEqual({
+      functionCallingConfig: { mode: "ANY", allowedFunctionNames: ["get_weather"] },
+    });
+  });
+});
+
+describe("thoughtSignature round-trip via tool_call id", () => {
+  it("embeds a thoughtSignature in the id and decodes it back (Gemini-3 requires replay)", () => {
+    const encoded = encodeThoughtSignatureId("call_1", "Cg0KAxc=SIG+/value==");
+    expect(encoded).not.toBe("call_1");
+    expect(decodeThoughtSignatureId(encoded)).toEqual({
+      callId: "call_1",
+      signature: "Cg0KAxc=SIG+/value==",
+    });
+  });
+
+  it("passes an id through unchanged when there is no signature", () => {
+    expect(encodeThoughtSignatureId("call_1", undefined)).toBe("call_1");
+    expect(decodeThoughtSignatureId("call_1")).toEqual({ callId: "call_1" });
+  });
+});
+
+describe("sanitizeGeminiSchema $ref", () => {
+  it("dereferences $ref against root $defs and inlines the definition (dropping $defs)", () => {
+    const schema = {
+      $defs: { Loc: { type: "string", description: "a location" } },
+      type: "object",
+      properties: {
+        from: { $ref: "#/$defs/Loc" },
+        to: { $ref: "#/$defs/Loc" },
+      },
+      required: ["from"],
+    };
+    expect(sanitizeGeminiSchema(schema)).toEqual({
+      type: "object",
+      properties: {
+        from: { type: "string", description: "a location" },
+        to: { type: "string", description: "a location" },
+      },
+      required: ["from"],
+    });
+  });
+});

--- a/src/lib/inference/gemini-native-translation.ts
+++ b/src/lib/inference/gemini-native-translation.ts
@@ -175,11 +175,7 @@ export function decodeThoughtSignatureId(id: string): { callId: string; signatur
   if (markerIndex < 0) return { callId: id };
   const callId = id.slice(0, markerIndex);
   const encoded = id.slice(markerIndex + THOUGHT_SIGNATURE_MARKER.length);
-  try {
-    return { callId, signature: Buffer.from(encoded, "base64url").toString("utf8") };
-  } catch {
-    return { callId: id };
-  }
+  return { callId, signature: Buffer.from(encoded, "base64url").toString("utf8") };
 }
 
 export type GeminiToolConfig = {
@@ -291,7 +287,7 @@ export function buildGeminiContents(messages: unknown): GeminiContents {
         if (signature) part.thoughtSignature = signature;
         parts.push(part);
       }
-      contents.push({ role: "model", parts });
+      if (parts.length > 0) contents.push({ role: "model", parts });
     } else if (role === "tool" || role === "function") {
       const { callId } = decodeThoughtSignatureId(String(raw.tool_call_id || ""));
       const name =

--- a/src/lib/inference/gemini-native-translation.ts
+++ b/src/lib/inference/gemini-native-translation.ts
@@ -1,0 +1,556 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+
+export type GeminiFunctionDeclaration = {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+};
+
+/**
+ * Schema keywords Gemini's function-declaration / structured-output schema object
+ * recognizes (a subset of OpenAPI 3.0). Everything else (`$schema`, `additionalProperties`,
+ * `oneOf`/`allOf`/`not`, `$defs`, vendor extras like `strict`) trips Gemini's validator, so
+ * we filter to this allowlist — the same strategy LiteLLM (`filter_schema_fields`) and
+ * Google ADK (`_sanitize_schema_formats_for_gemini`) use.
+ */
+const ALLOWED_SCHEMA_FIELDS = new Set<string>([
+  "type",
+  "format",
+  "title",
+  "description",
+  "nullable",
+  "enum",
+  "items",
+  "properties",
+  "required",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+  "minProperties",
+  "maxProperties",
+  "minimum",
+  "maximum",
+  "pattern",
+  "example",
+  "default",
+  "anyOf",
+  "propertyOrdering",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveSchemaRef(
+  ref: string,
+  defs: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const match = ref.match(/^#\/(?:\$defs|definitions)\/(.+)$/);
+  if (!match) return null;
+  const target = defs[match[1]];
+  return isPlainObject(target) ? target : null;
+}
+
+/**
+ * Recursively filter a JSON-Schema down to the keywords Gemini accepts: dereference `$ref`
+ * against the root `$defs`/`definitions`, rewrite `oneOf`->`anyOf` and `const`->`enum`,
+ * collapse nullable `anyOf` unions to `nullable`, then drop everything outside the allowlist.
+ * Recurses through `properties`, `items`, and `anyOf`.
+ */
+export function sanitizeGeminiSchema(schema: unknown): unknown {
+  const defs: Record<string, unknown> = isPlainObject(schema)
+    ? {
+        ...(isPlainObject(schema.$defs) ? schema.$defs : {}),
+        ...(isPlainObject(schema.definitions) ? schema.definitions : {}),
+      }
+    : {};
+  return sanitizeSchemaNode(schema, defs);
+}
+
+function sanitizeSchemaNode(schema: unknown, defs: Record<string, unknown>): unknown {
+  if (Array.isArray(schema)) return schema.map((entry) => sanitizeSchemaNode(entry, defs));
+  if (!isPlainObject(schema)) return schema;
+
+  let node: Record<string, unknown> = { ...schema };
+
+  // Inline `$ref` (the node's own sibling keywords override the referenced definition).
+  if (typeof node.$ref === "string") {
+    const resolved = resolveSchemaRef(node.$ref, defs);
+    const { $ref: _ref, ...rest } = node;
+    node = resolved ? { ...resolved, ...rest } : rest;
+  }
+
+  // `oneOf` -> `anyOf`: Gemini supports `anyOf` but not `oneOf`/`allOf`/`not`.
+  if (Array.isArray(node.oneOf) && node.anyOf === undefined) {
+    node.anyOf = node.oneOf;
+    delete node.oneOf;
+  }
+  // `const` -> single-value `enum`: Gemini has no `const`.
+  if ("const" in node) {
+    node.enum = [node.const];
+    delete node.const;
+  }
+  // `anyOf` containing a `{type:"null"}` member -> `nullable: true` with the null member
+  // dropped; if a single non-null member remains, collapse the union into it (the shape
+  // most tool schemas actually want, e.g. an optional string).
+  if (Array.isArray(node.anyOf)) {
+    const members = node.anyOf as Array<Record<string, unknown>>;
+    const hasNull = members.some((member) => isPlainObject(member) && member.type === "null");
+    if (hasNull) {
+      const nonNull = members.filter(
+        (member) => !(isPlainObject(member) && member.type === "null"),
+      );
+      delete node.anyOf;
+      if (nonNull.length === 1) {
+        node = { ...nonNull[0], ...node };
+      } else {
+        node.anyOf = nonNull;
+      }
+      node.nullable = true;
+    }
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (!ALLOWED_SCHEMA_FIELDS.has(key)) continue;
+    if (key === "properties" && isPlainObject(value)) {
+      const properties: Record<string, unknown> = {};
+      for (const [propertyName, propertySchema] of Object.entries(value)) {
+        properties[propertyName] = sanitizeSchemaNode(propertySchema, defs);
+      }
+      output[key] = properties;
+    } else if (key === "items") {
+      output[key] = sanitizeSchemaNode(value, defs);
+    } else if (key === "anyOf" && Array.isArray(value)) {
+      output[key] = value.map((entry) => sanitizeSchemaNode(entry, defs));
+    } else {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+/**
+ * Convert OpenAI-style tool definitions into Gemini `functionDeclarations`.
+ *
+ * Gemini's function-declaration translator is strict and rejects unknown fields on the
+ * `function` object (`Unknown name ... at tools[N].function`), whereas OpenAI/DeepInfra
+ * ignore them. Hermes emits extra fields (e.g. `strict`), so we extract only the
+ * Gemini-recognized shape: `name`, `description`, `parameters`.
+ */
+export function toGeminiFunctionDeclarations(tools: unknown): GeminiFunctionDeclaration[] {
+  if (!Array.isArray(tools)) return [];
+  const declarations: GeminiFunctionDeclaration[] = [];
+  for (const tool of tools) {
+    const fn = (tool as { function?: Record<string, unknown> } | null)?.function;
+    if (!fn || typeof fn !== "object") continue;
+    const declaration: GeminiFunctionDeclaration = { name: String(fn.name) };
+    if (fn.description !== undefined) declaration.description = String(fn.description);
+    if (fn.parameters !== undefined) declaration.parameters = fn.parameters;
+    declarations.push(declaration);
+  }
+  return declarations;
+}
+
+const THOUGHT_SIGNATURE_MARKER = "__gemsig__";
+
+/**
+ * Embed a Gemini-3 `thoughtSignature` into the OpenAI `tool_call.id`. Hermes echoes the id
+ * back verbatim in conversation history, so encoding the signature here lets us recover and
+ * replay it on the next turn (Gemini-3 *requires and validates* the signature on every
+ * `functionCall` part) with no server-side state — restart-safe.
+ */
+export function encodeThoughtSignatureId(callId: string, signature: string | undefined): string {
+  if (!signature) return callId;
+  return `${callId}${THOUGHT_SIGNATURE_MARKER}${Buffer.from(signature, "utf8").toString("base64url")}`;
+}
+
+/** Inverse of {@link encodeThoughtSignatureId}: recover the original id + thoughtSignature. */
+export function decodeThoughtSignatureId(id: string): { callId: string; signature?: string } {
+  const markerIndex = id.indexOf(THOUGHT_SIGNATURE_MARKER);
+  if (markerIndex < 0) return { callId: id };
+  const callId = id.slice(0, markerIndex);
+  const encoded = id.slice(markerIndex + THOUGHT_SIGNATURE_MARKER.length);
+  try {
+    return { callId, signature: Buffer.from(encoded, "base64url").toString("utf8") };
+  } catch {
+    return { callId: id };
+  }
+}
+
+export type GeminiToolConfig = {
+  functionCallingConfig: { mode: string; allowedFunctionNames?: string[] };
+};
+
+/**
+ * Map an OpenAI `tool_choice` to Gemini's `toolConfig.functionCallingConfig`: `auto`->AUTO,
+ * `required`/`any`->ANY, `none`->NONE, and a named function -> ANY restricted to that name via
+ * `allowedFunctionNames` (which the OpenAI-compat shim has no equivalent for). Returns
+ * undefined to let Gemini apply its default.
+ */
+export function toGeminiToolConfig(toolChoice: unknown): GeminiToolConfig | undefined {
+  if (toolChoice === undefined || toolChoice === null) return undefined;
+  if (typeof toolChoice === "string") {
+    const mode =
+      toolChoice === "auto"
+        ? "AUTO"
+        : toolChoice === "none"
+          ? "NONE"
+          : toolChoice === "required" || toolChoice === "any"
+            ? "ANY"
+            : undefined;
+    return mode ? { functionCallingConfig: { mode } } : undefined;
+  }
+  if (isPlainObject(toolChoice)) {
+    const fn = toolChoice.function;
+    const name = isPlainObject(fn) ? fn.name : undefined;
+    if (typeof name === "string") {
+      return { functionCallingConfig: { mode: "ANY", allowedFunctionNames: [name] } };
+    }
+  }
+  return undefined;
+}
+
+type GeminiPart =
+  | { text: string }
+  | { functionCall: { name: string; args: unknown }; thoughtSignature?: string }
+  | { functionResponse: { name: string; response: unknown } };
+
+type GeminiContent = { role: "user" | "model"; parts: GeminiPart[] };
+
+export type GeminiContents = {
+  contents: GeminiContent[];
+  systemInstruction?: { parts: Array<{ text: string }> };
+};
+
+function textOfContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        isPlainObject(part) && part.type === "text" && typeof part.text === "string"
+          ? part.text
+          : "",
+      )
+      .join("");
+  }
+  return "";
+}
+
+function parseJsonOr(value: unknown, fallback: unknown): unknown {
+  if (typeof value !== "string" || value.trim() === "") return fallback;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Convert an OpenAI `messages` array into Gemini `contents` (+ `systemInstruction`):
+ * - system/developer -> `systemInstruction` (lifted out of `contents`)
+ * - user -> `{ role: "user", parts: [{ text }] }`
+ * - assistant -> `{ role: "model", parts }` with text and/or `functionCall` parts; the
+ *   `thoughtSignature` embedded in each `tool_call.id` is replayed onto the `functionCall`
+ *   (Gemini-3 requires it)
+ * - tool/function -> `{ role: "user", parts: [{ functionResponse }] }`
+ */
+export function buildGeminiContents(messages: unknown): GeminiContents {
+  const list = Array.isArray(messages) ? messages : [];
+  const contents: GeminiContent[] = [];
+  const systemParts: Array<{ text: string }> = [];
+  const toolNameById = new Map<string, string>();
+
+  for (const raw of list) {
+    if (!isPlainObject(raw)) continue;
+    const role = String(raw.role || "").toLowerCase();
+
+    if (role === "system" || role === "developer") {
+      const text = textOfContent(raw.content);
+      if (text) systemParts.push({ text });
+    } else if (role === "user") {
+      contents.push({ role: "user", parts: [{ text: textOfContent(raw.content) }] });
+    } else if (role === "assistant") {
+      const parts: GeminiPart[] = [];
+      const text = textOfContent(raw.content);
+      if (text) parts.push({ text });
+      const toolCalls = Array.isArray(raw.tool_calls) ? raw.tool_calls : [];
+      for (const call of toolCalls) {
+        if (!isPlainObject(call)) continue;
+        const fn = isPlainObject(call.function) ? call.function : {};
+        const name = String(fn.name || "");
+        const { callId, signature } = decodeThoughtSignatureId(String(call.id || ""));
+        toolNameById.set(callId, name);
+        const part: { functionCall: { name: string; args: unknown }; thoughtSignature?: string } = {
+          functionCall: { name, args: parseJsonOr(fn.arguments, {}) },
+        };
+        if (signature) part.thoughtSignature = signature;
+        parts.push(part);
+      }
+      contents.push({ role: "model", parts });
+    } else if (role === "tool" || role === "function") {
+      const { callId } = decodeThoughtSignatureId(String(raw.tool_call_id || ""));
+      const name =
+        typeof raw.name === "string" && raw.name ? raw.name : toolNameById.get(callId) || "";
+      const parsed = parseJsonOr(raw.content, {});
+      const response = isPlainObject(parsed) ? parsed : { result: parsed };
+      contents.push({ role: "user", parts: [{ functionResponse: { name, response } }] });
+    }
+  }
+
+  const result: GeminiContents = { contents };
+  if (systemParts.length > 0) result.systemInstruction = { parts: systemParts };
+  return result;
+}
+
+function mapGeminiFinishReason(reason: unknown): string {
+  switch (String(reason || "").toUpperCase()) {
+    case "STOP":
+      return "stop";
+    case "MAX_TOKENS":
+      return "length";
+    case "SAFETY":
+    case "RECITATION":
+    case "BLOCKLIST":
+    case "PROHIBITED_CONTENT":
+    case "SPII":
+      return "content_filter";
+    default:
+      return "stop";
+  }
+}
+
+export type OpenAiToolCall = {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+};
+
+export type OpenAiChatCompletion = {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: { role: "assistant"; content: string | null; tool_calls?: OpenAiToolCall[] };
+    finish_reason: string;
+  }>;
+  usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+};
+
+/**
+ * Convert a Gemini `generateContent` response into an OpenAI chat completion. `functionCall`
+ * parts become `tool_calls` (each `thoughtSignature` is encoded into the `tool_call.id` so it
+ * can be replayed next turn); `finish_reason` is `tool_calls` when any tool call is present,
+ * otherwise the mapped Gemini `finishReason`.
+ */
+export function convertGeminiResponse(response: unknown, model: string): OpenAiChatCompletion {
+  const resp = isPlainObject(response) ? response : {};
+  const candidates = Array.isArray(resp.candidates) ? resp.candidates : [];
+  const firstCandidate = isPlainObject(candidates[0]) ? candidates[0] : {};
+  const content = isPlainObject(firstCandidate.content) ? firstCandidate.content : {};
+  const parts = Array.isArray(content.parts) ? content.parts : [];
+
+  const textChunks: string[] = [];
+  const toolCalls: OpenAiToolCall[] = [];
+  for (const part of parts) {
+    if (!isPlainObject(part)) continue;
+    if (typeof part.text === "string") {
+      textChunks.push(part.text);
+    } else if (isPlainObject(part.functionCall)) {
+      const functionCall = part.functionCall;
+      const baseId = `gemini-call-${crypto.randomBytes(8).toString("hex")}`;
+      const signature =
+        typeof part.thoughtSignature === "string" ? part.thoughtSignature : undefined;
+      toolCalls.push({
+        id: encodeThoughtSignatureId(baseId, signature),
+        type: "function",
+        function: {
+          name: String(functionCall.name || ""),
+          arguments: JSON.stringify(functionCall.args ?? {}),
+        },
+      });
+    }
+  }
+
+  const usage = isPlainObject(resp.usageMetadata) ? resp.usageMetadata : {};
+  const message: OpenAiChatCompletion["choices"][number]["message"] = {
+    role: "assistant",
+    content: textChunks.length > 0 ? textChunks.join("") : null,
+  };
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+  return {
+    id: `chatcmpl-gemini-${crypto.randomBytes(12).toString("hex")}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason:
+          toolCalls.length > 0 ? "tool_calls" : mapGeminiFinishReason(firstCandidate.finishReason),
+      },
+    ],
+    usage: {
+      prompt_tokens: Number(usage.promptTokenCount || 0),
+      completion_tokens: Number(usage.candidatesTokenCount || 0),
+      total_tokens: Number(usage.totalTokenCount || 0),
+    },
+  };
+}
+
+export type GeminiGenerateContentRequest = {
+  contents: GeminiContent[];
+  systemInstruction?: { parts: Array<{ text: string }> };
+  tools?: Array<{ functionDeclarations: GeminiFunctionDeclaration[] }>;
+  toolConfig?: GeminiToolConfig;
+  generationConfig?: Record<string, unknown>;
+};
+
+/**
+ * Assemble a Gemini `generateContent` request body from an OpenAI chat-completion request:
+ * messages -> contents/systemInstruction, tools -> sanitized functionDeclarations, tool_choice
+ * -> toolConfig, and sampling params -> generationConfig. The `model` rides in the URL path, so
+ * it is not part of the returned body.
+ */
+export function buildGeminiRequest(request: unknown): GeminiGenerateContentRequest {
+  const req = isPlainObject(request) ? request : {};
+  const { contents, systemInstruction } = buildGeminiContents(req.messages);
+  const result: GeminiGenerateContentRequest = { contents };
+  if (systemInstruction) result.systemInstruction = systemInstruction;
+
+  const declarations = toGeminiFunctionDeclarations(req.tools).map((declaration) =>
+    declaration.parameters !== undefined
+      ? { ...declaration, parameters: sanitizeGeminiSchema(declaration.parameters) }
+      : declaration,
+  );
+  if (declarations.length > 0) {
+    result.tools = [{ functionDeclarations: declarations }];
+    const toolConfig = toGeminiToolConfig(req.tool_choice);
+    if (toolConfig) result.toolConfig = toolConfig;
+  }
+
+  const generationConfig: Record<string, unknown> = {};
+  const maxTokens = req.max_completion_tokens ?? req.max_tokens;
+  if (maxTokens !== undefined && maxTokens !== null) {
+    generationConfig.maxOutputTokens = Number(maxTokens);
+  }
+  if (req.temperature !== undefined && req.temperature !== null) {
+    generationConfig.temperature = Number(req.temperature);
+  }
+  if (req.top_p !== undefined && req.top_p !== null) {
+    generationConfig.topP = Number(req.top_p);
+  }
+  if (req.stop !== undefined && req.stop !== null) {
+    generationConfig.stopSequences = Array.isArray(req.stop) ? req.stop : [req.stop];
+  }
+  if (Object.keys(generationConfig).length > 0) result.generationConfig = generationConfig;
+
+  return result;
+}
+
+export type OpenAiStreamChunk = {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: "assistant";
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason: string | null;
+  }>;
+};
+
+/**
+ * Stateful converter from a Gemini `streamGenerateContent` stream to OpenAI
+ * `chat.completion.chunk` events. Maintains a stable id/created across the stream, assigns
+ * monotonically increasing `tool_calls[].index` (the field Gemini's OpenAI-compat shim omits —
+ * the original bug), encodes each `thoughtSignature` into the tool_call id, emits `role` on the
+ * first delta, and reports `tool_calls` finish_reason when any tool call was streamed.
+ */
+export function createGeminiStreamConverter(model: string): {
+  convertChunk(geminiChunk: unknown): OpenAiStreamChunk | null;
+} {
+  const id = `chatcmpl-gemini-${crypto.randomBytes(12).toString("hex")}`;
+  const created = Math.floor(Date.now() / 1000);
+  let toolIndex = 0;
+  let emittedToolCall = false;
+  let sentRole = false;
+
+  return {
+    convertChunk(geminiChunk: unknown): OpenAiStreamChunk | null {
+      const chunk = isPlainObject(geminiChunk) ? geminiChunk : {};
+      const candidates = Array.isArray(chunk.candidates) ? chunk.candidates : [];
+      const firstCandidate = isPlainObject(candidates[0]) ? candidates[0] : {};
+      const content = isPlainObject(firstCandidate.content) ? firstCandidate.content : {};
+      const parts = Array.isArray(content.parts) ? content.parts : [];
+
+      const delta: OpenAiStreamChunk["choices"][number]["delta"] = {};
+      const textChunks: string[] = [];
+      const toolCalls: NonNullable<OpenAiStreamChunk["choices"][number]["delta"]["tool_calls"]> =
+        [];
+      for (const part of parts) {
+        if (!isPlainObject(part)) continue;
+        if (typeof part.text === "string") {
+          textChunks.push(part.text);
+        } else if (isPlainObject(part.functionCall)) {
+          const functionCall = part.functionCall;
+          const baseId = `gemini-call-${crypto.randomBytes(8).toString("hex")}`;
+          const signature =
+            typeof part.thoughtSignature === "string" ? part.thoughtSignature : undefined;
+          toolCalls.push({
+            index: toolIndex++,
+            id: encodeThoughtSignatureId(baseId, signature),
+            type: "function",
+            function: {
+              name: String(functionCall.name || ""),
+              arguments: JSON.stringify(functionCall.args ?? {}),
+            },
+          });
+          emittedToolCall = true;
+        }
+      }
+      if (textChunks.length > 0) delta.content = textChunks.join("");
+      if (toolCalls.length > 0) delta.tool_calls = toolCalls;
+
+      const hasFinish =
+        firstCandidate.finishReason !== undefined && firstCandidate.finishReason !== null;
+      const finishReason = hasFinish
+        ? emittedToolCall
+          ? "tool_calls"
+          : mapGeminiFinishReason(firstCandidate.finishReason)
+        : null;
+
+      if (Object.keys(delta).length === 0 && finishReason === null) return null;
+
+      if (!sentRole && Object.keys(delta).length > 0) {
+        delta.role = "assistant";
+        sentRole = true;
+      }
+
+      return {
+        id,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Adds a native Google Gemini adapter that translates between OpenAI-style tool-calling and
Gemini's native `generateContent` API, so Hermes (and any OpenAI-compatible caller) can reliably
tool-call against Gemini models. Fixes the `HTTP 400 INVALID_ARGUMENT` failure where Gemini
rejects OpenAI-style tool schemas.

## Related Issue
Closes #4232

## Root cause & fix
Gemini's OpenAI-compatibility endpoint rejects OpenAI-style tool definitions (the `{type, function}`
wrapper and JSON-Schema fields outside its OpenAPI-3.0 subset), drops the streaming `tool_call.index`,
and loses the Gemini-3 `thoughtSignature` on replay — so multi-turn tool calls fail.

This adapter speaks Gemini's **native** API instead:
- **Schema translation** — strips the OpenAI tool wrapper and sanitizes JSON Schema to Gemini's
  accepted subset (deref `$ref`, `oneOf`→`anyOf`, `const`→`enum`, collapse nullable unions).
- **Stable streaming** — emits OpenAI chunks with a stable, monotonic `tool_call.index`.
- **thoughtSignature round-trip** — carries Gemini-3's signature through the `tool_call.id` so
  multi-turn tool chains replay and validate.

## Changes
- `gemini-native-translation.ts` — translation layer (schema sanitizer, tool_choice mapping,
  request/response/stream conversion, thoughtSignature round-trip) + unit tests.
- `gemini-native-adapter.ts` + `…-main.ts` — local OpenAI-compatible HTTP server
  (`/v1/chat/completions`, `/v1/models`) holding `GEMINI_API_KEY` server-side; constant-time bearer
  auth, SSE streaming, 2 MB body cap, upstream-error relay, and resilience against transient upstream
  stalls (pooled keep-alive agent + idle timeout + single retry) + unit tests.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)

## How it was tested
- **Unit tests** (no API key needed): `cd nemoclaw && npm test` — 36 tests covering schema
  sanitization, thoughtSignature round-trip, tool_choice, streaming/non-streaming conversion, and the
  adapter's HTTP/SSE/auth/error/retry paths.
- **Live validation** (with your own `GEMINI_API_KEY`): run the adapter, point an OpenAI-compatible
  client at it, issue a tool-calling request — it succeeds where the OpenAI-compat endpoint returns
  `400 INVALID_ARGUMENT`. Verified end-to-end through a real agent loop (single + multi-turn tool
  chains exercising thoughtSignature) on `gemini-2.5-flash` and `gemini-3.5-flash`.
- Environment: Debian 13, Node.js 22, Docker.

## Verification
- [x] PR description includes the DCO sign-off; every commit appears as `Verified`
- [x] Targeted tests pass for changed behavior
- [x] Tests added for new behavior
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Samuel Beguiristain <125210256+sambegui@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Gemini “native” adapter server with OpenAI-compatible `GET /health`, `GET /v1/models`, and `POST /v1/chat/completions`.
  * Supports unary responses and SSE streaming, including translation of Gemini function/tool calls into OpenAI tool calls.
  * Enforces Bearer auth on protected routes and returns OpenAI-shaped error responses; validates startup credentials and connection settings.

* **Tests**
  * Expanded coverage for translation, SSE forwarding, authentication, malformed input, retryability, and client disconnect/abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->