### PR TITLE
test(e2e): tolerate Kimi final punctuation

### DIFF
--- a/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
@@ -337,8 +337,10 @@ for token in ['abandoned','want me to continue']:
 if data.get('promptErrorSource') is not None: errors.append('promptErrorSource set')
 for field in ['aborted','externalAbort','timedOut','idleTimedOut','timedOutDuringCompaction']:
     if data.get(field): errors.append(f'{field}={data.get(field)!r}')
+def normalize_final_text(value):
+    return value.strip().removesuffix('.') if isinstance(value, str) else value
 final_texts=data.get('assistantTexts') or []
-if not final_texts or final_texts[-1] != 'hostname, date, and uptime completed successfully.': errors.append('final text mismatch')
+if not final_texts or normalize_final_text(final_texts[-1]) != 'hostname, date, and uptime completed successfully': errors.append('final text mismatch')
 roles=[m.get('role') for m in messages]
 if not ('toolResult' in roles and roles[-1]=='assistant'): errors.append('final assistant not after tool result')
 print(json.dumps({'errors':errors,'source':source,'toolMetas':metas,'roles':roles}, indent=2))

--- a/test/e2e/test-kimi-inference-compat.sh
+++ b/test/e2e/test-kimi-inference-compat.sh
@@ -575,7 +575,7 @@ PY
     return
   fi
 
-  if [ "$final_text" = "hostname, date, and uptime completed successfully." ]; then
+  if [ "${final_text%.}" = "hostname, date, and uptime completed successfully" ]; then
     pass "K4: OpenClaw agent returned the expected final text"
   else
     pass "K4: OpenClaw agent command completed; trajectory acceptance validates final tool results"
@@ -710,8 +710,14 @@ if "abandoned" in raw.lower():
     errors.append("trajectory/session contains 'abandoned'")
 if "want me to continue" in raw.lower():
     errors.append("trajectory/session contains 'want me to continue'")
+def normalize_final_text(value):
+    if not isinstance(value, str):
+        return value
+    return value.strip().removesuffix(".")
+
 final_texts = artifact_data.get("assistantTexts") or []
-if not final_texts or final_texts[-1] != "hostname, date, and uptime completed successfully.":
+expected_final_text = "hostname, date, and uptime completed successfully"
+if not final_texts or normalize_final_text(final_texts[-1]) != expected_final_text:
     errors.append("final assistant text is %r" % (final_texts[-1] if final_texts else None))
 if not tool_result_indices or not assistant_indices or max(assistant_indices) <= max(tool_result_indices):
     errors.append("final assistant response did not occur after all tool results")


### PR DESCRIPTION
## Summary
Relax the Kimi E2E final-answer assertion so the trajectory acceptance tolerates a missing trailing period while still requiring the expected sentence. This keeps the test focused on the tool-call split and successful final response instead of brittle punctuation from the hosted model.

## Changes
- Normalize final assistant text in `test/e2e/test-kimi-inference-compat.sh` before comparing the expected Kimi completion sentence.
- Apply the same normalization in the migrated Vitest helper `test/e2e-scenario/live/kimi-inference-compat-helpers.ts`.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved tolerance in AI inference compatibility test assertions by normalizing whitespace and handling optional trailing punctuation when comparing final assistant text outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->