### PR TITLE
fix(cli): auto-recover non-interactive onboard when no sandbox recorded

### DIFF
--- a/src/lib/onboard/session-bootstrap.test.ts
+++ b/src/lib/onboard/session-bootstrap.test.ts
@@ -190,29 +190,55 @@ describe("prepareOnboardSession", () => {
     expect(deps.updateSession).not.toHaveBeenCalled();
   });
 
-  it("rejects non-interactive resume when no sandbox name can be recovered", async () => {
-    const { deps } = createDeps(createSession({ sandboxName: null }));
-
-    await expect(
-      prepareOnboardSession(
-        {
-          resume: true,
-          fresh: false,
-          requestedFromDockerfile: null,
-          requestedSandboxName: null,
-          cannotPrompt: true,
-          nonInteractive: true,
-        },
-        deps,
-      ),
-    ).rejects.toThrow(ExitError);
-
-    expect(deps.error).toHaveBeenCalledWith(
-      "  Cannot resume non-interactive onboard: the previous run was interrupted before sandbox creation completed,",
+  it("auto-recovers a non-interactive resume when no sandbox name was recorded", async () => {
+    // The previous run was interrupted before sandbox creation, so the
+    // in_progress session has no sandbox to resume. Non-interactive onboard
+    // must auto-recover by starting fresh instead of aborting (#5626).
+    const { deps, getSession } = createDeps(
+      createSession({ sessionId: "stale-session", sandboxName: null }),
     );
-    expect(deps.error).toHaveBeenCalledWith(
-      "  so no sandbox name was recorded. Re-run with --name <sandbox> (or set NEMOCLAW_SANDBOX_NAME).",
+
+    const result = await prepareOnboardSession(
+      {
+        resume: true,
+        fresh: false,
+        requestedFromDockerfile: null,
+        requestedSandboxName: null,
+        cannotPrompt: true,
+        nonInteractive: true,
+      },
+      deps,
     );
-    expect(deps.exitProcess).toHaveBeenCalledTimes(1);
+
+    expect(deps.exitProcess).not.toHaveBeenCalled();
+    expect(deps.clearSession).toHaveBeenCalledTimes(1);
+    expect(result.session?.mode).toBe("non-interactive");
+    expect(result.session?.sessionId).not.toBe("stale-session");
+    expect(getSession()?.sessionId).not.toBe("stale-session");
+    expect(deps.error).toHaveBeenCalledWith(
+      "  Interrupted onboarding session has no sandbox recorded yet; starting a fresh onboard.",
+    );
+  });
+
+  it("still resumes a non-interactive session when a sandbox name was requested", async () => {
+    // A recoverable name (here via --name / NEMOCLAW_SANDBOX_NAME) must still
+    // resume the existing session rather than be discarded.
+    const { deps } = createDeps(createSession({ sessionId: "keep-session", sandboxName: null }));
+
+    const result = await prepareOnboardSession(
+      {
+        resume: true,
+        fresh: false,
+        requestedFromDockerfile: null,
+        requestedSandboxName: "my-box",
+        cannotPrompt: true,
+        nonInteractive: true,
+      },
+      deps,
+    );
+
+    expect(deps.exitProcess).not.toHaveBeenCalled();
+    expect(deps.clearSession).not.toHaveBeenCalled();
+    expect(result.session?.status).toBe("in_progress");
   });
 });

--- a/src/lib/onboard/session-bootstrap.ts
+++ b/src/lib/onboard/session-bootstrap.ts
@@ -112,23 +112,12 @@ async function exitForResumeConflicts(
   deps.exitProcess(1);
 }
 
-function assertRecoverableResumeSandboxName(
+function recoverableResumeSandboxName(
   session: Session | null,
   input: OnboardSessionBootstrapInput,
-  deps: OnboardSessionBootstrapDeps,
-): void {
+): string | null {
   const sandboxStepCompleted = session?.steps?.sandbox?.status === "complete";
-  const recoveredSandboxName =
-    input.requestedSandboxName || (sandboxStepCompleted ? session?.sandboxName || null : null);
-  if (input.cannotPrompt && !recoveredSandboxName) {
-    deps.error(
-      "  Cannot resume non-interactive onboard: the previous run was interrupted before sandbox creation completed,",
-    );
-    deps.error(
-      "  so no sandbox name was recorded. Re-run with --name <sandbox> (or set NEMOCLAW_SANDBOX_NAME).",
-    );
-    deps.exitProcess(1);
-  }
+  return input.requestedSandboxName || (sandboxStepCompleted ? session?.sandboxName || null : null);
 }
 
 async function prepareResumeSession(
@@ -157,6 +146,18 @@ async function prepareResumeSession(
     await exitForResumeConflicts(resumeConflicts, deps);
   }
 
+  // A non-interactive resume with no recoverable sandbox name means the
+  // previous run was interrupted before sandbox creation completed, so there
+  // is nothing to resume and no TTY to prompt for a name. Rather than aborting
+  // (which left curl|bash installs with no recovery path, #5626), auto-recover
+  // by discarding the stale session and starting a fresh onboard.
+  if (input.cannotPrompt && !recoverableResumeSandboxName(session, input)) {
+    deps.error(
+      "  Interrupted onboarding session has no sandbox recorded yet; starting a fresh onboard.",
+    );
+    return prepareFreshSession({ ...input, fresh: true }, deps);
+  }
+
   deps.updateSession((current: Session) => {
     deps.repairResumeMachineSnapshot(current);
     current.mode = mode(input.nonInteractive);
@@ -165,7 +166,6 @@ async function prepareResumeSession(
     return current;
   });
   session = deps.loadSession();
-  assertRecoverableResumeSandboxName(session, input, deps);
   return { session, fromDockerfile };
 }
 


### PR DESCRIPTION
## Summary
When a previous onboarding run was interrupted before sandbox creation completed, the saved session has no sandbox name. `install.sh` auto-attaches `--resume` for any `in_progress` session, so a non-interactive `nemoclaw onboard` then aborted with exit 1 and left `curl|bash` installs with no recovery path. This change treats that state as recoverable by discarding the stale session and starting a fresh onboard.

## Related Issue
Fixes #5626
<!-- #5627 is a duplicate of #5626 (identical report); this fix covers both. -->

## Changes
- `src/lib/onboard/session-bootstrap.ts`: in non-interactive resume with no recoverable sandbox name (interrupted before sandbox creation), discard the stale session and fall back to a fresh onboard instead of calling `exitProcess(1)`. Replaced the `assertRecoverableResumeSandboxName` abort helper with a pure `recoverableResumeSandboxName` check. Interactive resume and resumes with a requested/recorded sandbox name (`--name` / `NEMOCLAW_SANDBOX_NAME`) are unchanged.
- `src/lib/onboard/session-bootstrap.test.ts`: replaced the test asserting the old abort with one asserting auto-recovery (clears the stale session, starts fresh, emits an explanatory message), plus a test confirming a requested sandbox name still resumes.

## Type of Change
- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off required by CI. Run: git config user.name && git config user.email -->
Signed-off-by: Jason Ma <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session recovery to automatically initialize a fresh session when non-interactive resume fails, preventing errors.

* **Tests**
  * Updated test expectations for session bootstrap behavior and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->