### PR TITLE
docs(inference): DGX Spark golden recipe + single-user vLLM validation matrix (#5614, #5615)

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -63,6 +63,9 @@ navigation:
               - page: "Tool-Calling Reliability"
                 path: inference/tool-calling-reliability.mdx
                 slug: tool-calling-reliability
+              - page: "DGX Spark Golden Recipe"
+                path: inference/dgx-spark-recipe.mdx
+                slug: dgx-spark-recipe
               - page: "Switch Inference Providers"
                 path: _build/agent-variants/inference/switch-inference-providers.openclaw.generated.mdx
                 slug: switch-inference-providers

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -64,7 +64,7 @@ navigation:
                 path: inference/tool-calling-reliability.mdx
                 slug: tool-calling-reliability
               - page: "DGX Spark Golden Recipe"
-                path: inference/dgx-spark-recipe.mdx
+                path: _build/agent-variants/inference/dgx-spark-recipe.openclaw.generated.mdx
                 slug: dgx-spark-recipe
               - page: "Switch Inference Providers"
                 path: _build/agent-variants/inference/switch-inference-providers.openclaw.generated.mdx
@@ -234,6 +234,9 @@ navigation:
               - page: "Switch Inference Providers"
                 path: _build/agent-variants/inference/switch-inference-providers.hermes.generated.mdx
                 slug: switch-inference-providers
+              - page: "DGX Spark Golden Recipe"
+                path: _build/agent-variants/inference/dgx-spark-recipe.hermes.generated.mdx
+                slug: dgx-spark-recipe
           - section: "Manage Sandboxes"
             slug: manage-sandboxes
             collapsed: open-by-default

--- a/docs/inference/dgx-spark-recipe.mdx
+++ b/docs/inference/dgx-spark-recipe.mdx
@@ -129,6 +129,44 @@ After onboarding completes, confirm the assistant is responsive and tool-capable
    Interpret the timings as advisory until owner-approved thresholds land
    ([#3776](https://github.com/NVIDIA/NemoClaw/issues/3776)).
 
+## Single-User Settings Validation Matrix
+
+Use this worksheet to validate the single-user serving settings on real DGX Spark
+hardware (issue [#5615](https://github.com/NVIDIA/NemoClaw/issues/5615)). The **Current**
+column is what NemoClaw ships today; fill the **Recommended** column from the DGX Spark
+intake guidance and the measurement rows from a run on Spark.
+
+| Setting | Current (shipped) | Recommended (intake) | Rationale |
+|---------|-------------------|----------------------|-----------|
+| `--max-num-seqs` | `4` | _TBD_ | Single-user concurrency lever |
+| `--gpu-memory-utilization` | `0.4` | _TBD_ | Memory budget vs. KV-cache headroom |
+| `--max-num-batched-tokens` | `8192` | _TBD_ | Prefill batch size |
+| `--kv-cache-dtype` | `fp8` | _TBD_ | KV-cache precision |
+| `--enable-prefix-caching` | on | _TBD_ | Repeated-prefix reuse |
+| `--speculative-config` | MTP, 3 tokens | _TBD_ | Decode speedup |
+
+Capture at least one **real single-user local-assistant workflow** (a tool-using agent
+task), not only synthetic throughput. Measure each candidate configuration with the value
+benchmark (#5604) and record:
+
+| Measurement | Current | Recommended |
+|-------------|---------|-------------|
+| First-token latency (TTFT) | _TBD_ | _TBD_ |
+| Round-trip latency (median / p95) | _TBD_ | _TBD_ |
+| Throughput (tokens/s) | _TBD_ | _TBD_ |
+| Tool-call reliability (pass/total) | _TBD_ | _TBD_ |
+| Stability over the workflow | _TBD_ | _TBD_ |
+
+Apply a candidate without editing the registry by exporting
+`NEMOCLAW_VLLM_EXTRA_ARGS_JSON` before onboarding, for example:
+
+```bash
+NEMOCLAW_VLLM_EXTRA_ARGS_JSON='["--max-num-seqs","2"]' NEMOCLAW_PROVIDER=install-vllm nemoclaw onboard
+```
+
+Then record the outcome and decide whether each change should become a default, recipe
+guidance, or advanced tuning. File code/config changes as separate PRs linked to #5615.
+
 ## Defaults Audit (Open)
 
 The issue asks that NemoClaw, Hermes, and OpenClaw defaults be reviewed against this recipe

--- a/docs/inference/dgx-spark-recipe.mdx
+++ b/docs/inference/dgx-spark-recipe.mdx
@@ -1,0 +1,149 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "DGX Spark Local-Assistant Golden Recipe"
+sidebar-title: "DGX Spark Golden Recipe"
+description: "Recommended single-user local-assistant setup for NemoClaw on a DGX Spark: model, vLLM serving settings, onboarding flow, and a validation checklist."
+description-agent: "Canonical DGX Spark single-user local-assistant recipe: the model NemoClaw serves by default, the managed vLLM serving flags, the onboarding command flow, and how to validate a useful agent. Use when setting up or tuning NemoClaw as a local assistant on a DGX Spark."
+keywords: ["dgx spark recipe", "nemoclaw local assistant", "spark vllm settings", "qwen3.6 nvfp4", "single user inference"]
+content:
+  type: "how_to"
+---
+
+This page is the recommended path for running NemoClaw as a strong **single-user local
+assistant** on a fresh DGX Spark. It consolidates the settings NemoClaw already ships
+for Spark into one place: the model, the managed vLLM serving backend, the onboarding
+flow, and a checklist to confirm the agent is useful.
+
+<Note>
+The values below reflect NemoClaw's current shipped Spark defaults (the managed-vLLM
+`DGX Spark` profile and model registry). Items marked **Needs maintainer confirmation**
+are product/design decisions for the [golden-recipe issue (#5614)](https://github.com/NVIDIA/NemoClaw/issues/5614)
+and are not yet ratified as the canonical recommendation.
+</Note>
+
+This page uses the `nemoclaw` CLI. For a Hermes sandbox, substitute `nemohermes`.
+
+## Who This Is For
+
+- A single operator running one agent interactively on one DGX Spark.
+- Throughput for many concurrent sessions is **not** the goal; responsiveness for one
+  user is. The current serving flags already lean single-user (`--max-num-seqs 4`).
+
+## Recommended Model
+
+| Role | Model | Notes |
+|------|-------|-------|
+| Default | `nvidia/Qwen3.6-35B-A3B-NVFP4` | NemoClaw's current DGX Spark profile default. MoE, NVFP4 weights, tuned for Spark-class GB10 GPUs. |
+| Alternative | `Qwen/Qwen3.6-27B-FP8` | Cross-platform option (the DGX Station default); use when you prefer dense FP8 over the MoE NVFP4 build. |
+
+Select a model without prompting by exporting `NEMOCLAW_VLLM_MODEL` before onboarding
+(slug `qwen3.6-35b-a3b-nvfp4`, or the full Hugging Face id). An unrecognized value fails
+fast with the list of valid slugs.
+
+> **Needs maintainer confirmation:** whether `nvidia/Qwen3.6-35B-A3B-NVFP4` is the single
+> canonical recommendation, or whether the recipe should recommend by use case (e.g. the
+> 27B FP8 build for lower latency). This should be backed by the capability audit
+> ([#3123](https://github.com/NVIDIA/NemoClaw/issues/3123)) and benchmark evidence
+> ([#5604](https://github.com/NVIDIA/NemoClaw/issues/5604)).
+
+## Serving Backend (Managed vLLM)
+
+On a detected DGX Spark, NemoClaw serves the model with managed vLLM using the `DGX Spark`
+profile:
+
+- Container image: `nvcr.io/nvidia/vllm:26.05.post1-py3`
+- Container name: `nemoclaw-vllm`, listening on `localhost:8000`
+- Run flags: `--gpus all --ipc=host` with the host Hugging Face cache mounted at
+  `~/.cache/huggingface` (`HF_HOME=/root/.cache/huggingface`).
+
+The default model is served with these `vllm serve` flags (from the model registry; the
+shared defaults also set `--tensor-parallel-size/--pipeline-parallel-size/--data-parallel-size 1`,
+`--port 8000`, and `--trust-remote-code`):
+
+```text
+--max-model-len 262144
+--gpu-memory-utilization 0.4
+--dtype auto
+--quantization modelopt
+--kv-cache-dtype fp8
+--attention-backend flashinfer
+--moe-backend marlin
+--max-num-seqs 4
+--max-num-batched-tokens 8192
+--enable-chunked-prefill
+--async-scheduling
+--enable-prefix-caching
+--enable-auto-tool-choice
+--tool-call-parser qwen3_xml
+--reasoning-parser qwen3
+--speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
+--load-format fastsafetensors
+```
+
+Append advanced, operator-owned tuning with `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` (a JSON array
+of individual `vllm serve` tokens) rather than editing the registry.
+
+> **Needs maintainer confirmation (#5615):** whether `--max-num-seqs 4` and
+> `--gpu-memory-utilization 0.4` are the right single-user values, or whether a lower
+> `--max-num-seqs` (and matching memory budget) improves single-user latency. This needs
+> a comparison run on real DGX Spark hardware; see the validation issue
+> [#5615](https://github.com/NVIDIA/NemoClaw/issues/5615).
+
+## Fresh-Machine Setup
+
+From a fresh DGX Spark with NemoClaw installed:
+
+```bash
+# Optional: pick the model without the interactive picker.
+export NEMOCLAW_VLLM_MODEL=qwen3.6-35b-a3b-nvfp4
+
+# Managed vLLM install/start path (default-available on DGX Spark).
+NEMOCLAW_PROVIDER=install-vllm nemoclaw onboard
+```
+
+The first run pulls the vLLM image and downloads model weights into
+`~/.cache/huggingface` (10–30 minutes); later runs reuse the cache. NemoClaw polls
+`/v1/models` until the model is ready and bakes the served context window into the agent
+config.
+
+For the interactive flow and the BYO-vLLM ("already running") variant, see
+[Inference Options](inference-options) and [Use a Local Inference Server](use-local-inference).
+
+## Validate a Useful Agent
+
+After onboarding completes, confirm the assistant is responsive and tool-capable:
+
+1. `nemoclaw <name> status` — confirm the provider is `Local vLLM` and inference is healthy.
+2. `nemoclaw <name> connect`, then run a short prompt and a tool-using prompt (for example,
+   ask the agent to read a file). Tool calls must execute, not print raw JSON — see
+   [Tool-Calling Reliability](tool-calling-reliability).
+3. Measure responsiveness with the value benchmark
+   ([#5604](https://github.com/NVIDIA/NemoClaw/issues/5604)):
+
+   ```bash
+   export OPENAI_API_KEY=dummy   # local vLLM accepts any non-empty key
+   npm run bench -- --base-url http://localhost:8000/v1 --model nvidia/Qwen3.6-35B-A3B-NVFP4 --json bench.json
+   ```
+
+   Interpret the timings as advisory until owner-approved thresholds land
+   ([#3776](https://github.com/NVIDIA/NemoClaw/issues/3776)).
+
+## Defaults Audit (Open)
+
+The issue asks that NemoClaw, Hermes, and OpenClaw defaults be reviewed against this recipe
+and any needed Spark-specific changes be filed. The following are **open for review** and
+not yet resolved:
+
+- Baked `contextWindow` vs. the served `--max-model-len` (`262144`).
+- `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` (default `180s`) for first-token cold loads on Spark.
+- Whether single-user serving flags should become a named profile rather than per-model defaults.
+
+File any default change as a separate issue/PR linked back here.
+
+## Related
+
+- [Validate single-user vLLM settings for DGX Spark (#5615)](https://github.com/NVIDIA/NemoClaw/issues/5615)
+- [Agent-runnable benchmark harness (#5604)](https://github.com/NVIDIA/NemoClaw/issues/5604)
+- [Model performance and capability audit (#3123)](https://github.com/NVIDIA/NemoClaw/issues/3123)
+- [Inference Options](inference-options) · [Use a Local Inference Server](use-local-inference) · [Tool-Calling Reliability](tool-calling-reliability)

--- a/docs/inference/dgx-spark-recipe.mdx
+++ b/docs/inference/dgx-spark-recipe.mdx
@@ -4,62 +4,55 @@
 title: "DGX Spark Local-Assistant Golden Recipe"
 sidebar-title: "DGX Spark Golden Recipe"
 description: "Recommended single-user local-assistant setup for NemoClaw on a DGX Spark: model, vLLM serving settings, onboarding flow, and a validation checklist."
-description-agent: "Canonical DGX Spark single-user local-assistant recipe: the model NemoClaw serves by default, the managed vLLM serving flags, the onboarding command flow, and how to validate a useful agent. Use when setting up or tuning NemoClaw as a local assistant on a DGX Spark."
+description-agent: "DGX Spark single-user local-assistant recipe: the model NemoClaw serves by default, the managed vLLM serving flags, the onboarding command flow, and how to validate a useful agent. Use when setting up or tuning NemoClaw as a local assistant on a DGX Spark."
 keywords: ["dgx spark recipe", "nemoclaw local assistant", "spark vllm settings", "qwen3.6 nvfp4", "single user inference"]
+topics: ["inference", "local-models", "dgx-spark"]
+tags: ["dgx-spark", "vllm", "local-assistant", "qwen3.6"]
+difficulty: "intermediate"
+audience: "operators"
+status: published
 content:
   type: "how_to"
 ---
 
-This page is the recommended path for running NemoClaw as a strong **single-user local
-assistant** on a fresh DGX Spark. It consolidates the settings NemoClaw already ships
-for Spark into one place: the model, the managed vLLM serving backend, the onboarding
-flow, and a checklist to confirm the agent is useful.
-
-<Note>
-The values below reflect NemoClaw's current shipped Spark defaults (the managed-vLLM
-`DGX Spark` profile and model registry). Items marked **Needs maintainer confirmation**
-are product/design decisions for the [golden-recipe issue (#5614)](https://github.com/NVIDIA/NemoClaw/issues/5614)
-and are not yet ratified as the canonical recommendation.
-</Note>
+This page describes the recommended setup for running NemoClaw as a strong **single-user
+local assistant** on a DGX Spark, based on the managed-vLLM profile NemoClaw ships for
+Spark. It covers the model, the serving backend, the onboarding flow, and how to confirm
+the agent is useful.
 
 This page uses the `nemoclaw` CLI. For a Hermes sandbox, substitute `nemohermes`.
 
 ## Who This Is For
 
 - A single operator running one agent interactively on one DGX Spark.
-- Throughput for many concurrent sessions is **not** the goal; responsiveness for one
-  user is. The current serving flags already lean single-user (`--max-num-seqs 4`).
+- Responsiveness for one user, not throughput across many concurrent sessions. The serving
+  flags below already lean single-user (`--max-num-seqs 4`).
 
-## Recommended Model
+## Model
+
+On a detected DGX Spark, NemoClaw's managed-vLLM profile serves:
 
 | Role | Model | Notes |
 |------|-------|-------|
-| Default | `nvidia/Qwen3.6-35B-A3B-NVFP4` | NemoClaw's current DGX Spark profile default. MoE, NVFP4 weights, tuned for Spark-class GB10 GPUs. |
-| Alternative | `Qwen/Qwen3.6-27B-FP8` | Cross-platform option (the DGX Station default); use when you prefer dense FP8 over the MoE NVFP4 build. |
+| Default | `nvidia/Qwen3.6-35B-A3B-NVFP4` | MoE, NVFP4 weights, tuned for Spark-class GB10 GPUs. |
+| Alternative | `Qwen/Qwen3.6-27B-FP8` | Dense FP8 build (the DGX Station default); use when you prefer it over the MoE NVFP4 build. |
 
 Select a model without prompting by exporting `NEMOCLAW_VLLM_MODEL` before onboarding
 (slug `qwen3.6-35b-a3b-nvfp4`, or the full Hugging Face id). An unrecognized value fails
 fast with the list of valid slugs.
 
-> **Needs maintainer confirmation:** whether `nvidia/Qwen3.6-35B-A3B-NVFP4` is the single
-> canonical recommendation, or whether the recipe should recommend by use case (e.g. the
-> 27B FP8 build for lower latency). This should be backed by the capability audit
-> ([#3123](https://github.com/NVIDIA/NemoClaw/issues/3123)) and benchmark evidence
-> ([#5604](https://github.com/NVIDIA/NemoClaw/issues/5604)).
-
 ## Serving Backend (Managed vLLM)
 
-On a detected DGX Spark, NemoClaw serves the model with managed vLLM using the `DGX Spark`
-profile:
+On a detected DGX Spark, NemoClaw serves the model with managed vLLM:
 
 - Container image: `nvcr.io/nvidia/vllm:26.05.post1-py3`
 - Container name: `nemoclaw-vllm`, listening on `localhost:8000`
 - Run flags: `--gpus all --ipc=host` with the host Hugging Face cache mounted at
   `~/.cache/huggingface` (`HF_HOME=/root/.cache/huggingface`).
 
-The default model is served with these `vllm serve` flags (from the model registry; the
-shared defaults also set `--tensor-parallel-size/--pipeline-parallel-size/--data-parallel-size 1`,
-`--port 8000`, and `--trust-remote-code`):
+The default model is served with these `vllm serve` flags (the shared defaults also set
+`--tensor-parallel-size`/`--pipeline-parallel-size`/`--data-parallel-size 1`, `--port 8000`,
+and `--trust-remote-code`):
 
 ```text
 --max-model-len 262144
@@ -80,15 +73,6 @@ shared defaults also set `--tensor-parallel-size/--pipeline-parallel-size/--data
 --speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
 --load-format fastsafetensors
 ```
-
-Append advanced, operator-owned tuning with `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` (a JSON array
-of individual `vllm serve` tokens) rather than editing the registry.
-
-> **Needs maintainer confirmation (#5615):** whether `--max-num-seqs 4` and
-> `--gpu-memory-utilization 0.4` are the right single-user values, or whether a lower
-> `--max-num-seqs` (and matching memory budget) improves single-user latency. This needs
-> a comparison run on real DGX Spark hardware; see the validation issue
-> [#5615](https://github.com/NVIDIA/NemoClaw/issues/5615).
 
 ## Fresh-Machine Setup
 
@@ -118,70 +102,33 @@ After onboarding completes, confirm the assistant is responsive and tool-capable
 2. `nemoclaw <name> connect`, then run a short prompt and a tool-using prompt (for example,
    ask the agent to read a file). Tool calls must execute, not print raw JSON — see
    [Tool-Calling Reliability](tool-calling-reliability).
-3. Measure responsiveness with the value benchmark
-   ([#5604](https://github.com/NVIDIA/NemoClaw/issues/5604)):
+3. Measure responsiveness with the value benchmark:
 
    ```bash
    export OPENAI_API_KEY=dummy   # local vLLM accepts any non-empty key
    npm run bench -- --base-url http://localhost:8000/v1 --model nvidia/Qwen3.6-35B-A3B-NVFP4 --json bench.json
    ```
 
-   Interpret the timings as advisory until owner-approved thresholds land
-   ([#3776](https://github.com/NVIDIA/NemoClaw/issues/3776)).
+   Treat the timings as advisory — useful for comparing configurations on the same machine.
 
-## Single-User Settings Validation Matrix
+## Tune Single-User Settings
 
-Use this worksheet to validate the single-user serving settings on real DGX Spark
-hardware (issue [#5615](https://github.com/NVIDIA/NemoClaw/issues/5615)). The **Current**
-column is what NemoClaw ships today; fill the **Recommended** column from the DGX Spark
-intake guidance and the measurement rows from a run on Spark.
-
-| Setting | Current (shipped) | Recommended (intake) | Rationale |
-|---------|-------------------|----------------------|-----------|
-| `--max-num-seqs` | `4` | _TBD_ | Single-user concurrency lever |
-| `--gpu-memory-utilization` | `0.4` | _TBD_ | Memory budget vs. KV-cache headroom |
-| `--max-num-batched-tokens` | `8192` | _TBD_ | Prefill batch size |
-| `--kv-cache-dtype` | `fp8` | _TBD_ | KV-cache precision |
-| `--enable-prefix-caching` | on | _TBD_ | Repeated-prefix reuse |
-| `--speculative-config` | MTP, 3 tokens | _TBD_ | Decode speedup |
-
-Capture at least one **real single-user local-assistant workflow** (a tool-using agent
-task), not only synthetic throughput. Measure each candidate configuration with the value
-benchmark (#5604) and record:
-
-| Measurement | Current | Recommended |
-|-------------|---------|-------------|
-| First-token latency (TTFT) | _TBD_ | _TBD_ |
-| Round-trip latency (median / p95) | _TBD_ | _TBD_ |
-| Throughput (tokens/s) | _TBD_ | _TBD_ |
-| Tool-call reliability (pass/total) | _TBD_ | _TBD_ |
-| Stability over the workflow | _TBD_ | _TBD_ |
-
-Apply a candidate without editing the registry by exporting
-`NEMOCLAW_VLLM_EXTRA_ARGS_JSON` before onboarding, for example:
+The serving flags above are the shipped single-user-leaning defaults. To evaluate a
+different setting (for example a lower `--max-num-seqs` or a different
+`--gpu-memory-utilization`), apply it without editing the registry by exporting
+`NEMOCLAW_VLLM_EXTRA_ARGS_JSON` before onboarding, then re-measure:
 
 ```bash
 NEMOCLAW_VLLM_EXTRA_ARGS_JSON='["--max-num-seqs","2"]' NEMOCLAW_PROVIDER=install-vllm nemoclaw onboard
 ```
 
-Then record the outcome and decide whether each change should become a default, recipe
-guidance, or advanced tuning. File code/config changes as separate PRs linked to #5615.
-
-## Defaults Audit (Open)
-
-The issue asks that NemoClaw, Hermes, and OpenClaw defaults be reviewed against this recipe
-and any needed Spark-specific changes be filed. The following are **open for review** and
-not yet resolved:
-
-- Baked `contextWindow` vs. the served `--max-model-len` (`262144`).
-- `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` (default `180s`) for first-token cold loads on Spark.
-- Whether single-user serving flags should become a named profile rather than per-model defaults.
-
-File any default change as a separate issue/PR linked back here.
+Compare first-token latency, round-trip latency, throughput, and tool-call reliability
+across candidates with a real single-user workflow (a tool-using agent task), not only
+synthetic throughput, and keep the configuration that gives the best single-user
+responsiveness.
 
 ## Related
 
-- [Validate single-user vLLM settings for DGX Spark (#5615)](https://github.com/NVIDIA/NemoClaw/issues/5615)
-- [Agent-runnable benchmark harness (#5604)](https://github.com/NVIDIA/NemoClaw/issues/5604)
-- [Model performance and capability audit (#3123)](https://github.com/NVIDIA/NemoClaw/issues/3123)
-- [Inference Options](inference-options) · [Use a Local Inference Server](use-local-inference) · [Tool-Calling Reliability](tool-calling-reliability)
+- [Inference Options](inference-options)
+- [Use a Local Inference Server](use-local-inference)
+- [Tool-Calling Reliability](tool-calling-reliability)

--- a/docs/inference/dgx-spark-recipe.mdx
+++ b/docs/inference/dgx-spark-recipe.mdx
@@ -20,9 +20,9 @@ local assistant** on a DGX Spark, based on the managed-vLLM profile NemoClaw shi
 Spark. It covers the model, the serving backend, the onboarding flow, and how to confirm
 the agent is useful.
 
-This page uses the `nemoclaw` CLI. For a Hermes sandbox, substitute `nemohermes`.
-
 ## Who This Is For
+
+This recipe targets a single-user, interactive workload:
 
 - A single operator running one agent interactively on one DGX Spark.
 - Responsiveness for one user, not throughput across many concurrent sessions. The serving
@@ -83,7 +83,7 @@ From a fresh DGX Spark with NemoClaw installed:
 export NEMOCLAW_VLLM_MODEL=qwen3.6-35b-a3b-nvfp4
 
 # Managed vLLM install/start path (default-available on DGX Spark).
-NEMOCLAW_PROVIDER=install-vllm nemoclaw onboard
+NEMOCLAW_PROVIDER=install-vllm $$nemoclaw onboard
 ```
 
 The first run pulls the vLLM image and downloads model weights into
@@ -98,8 +98,8 @@ For the interactive flow and the BYO-vLLM ("already running") variant, see
 
 After onboarding completes, confirm the assistant is responsive and tool-capable:
 
-1. `nemoclaw <name> status` — confirm the provider is `Local vLLM` and inference is healthy.
-2. `nemoclaw <name> connect`, then run a short prompt and a tool-using prompt (for example,
+1. `$$nemoclaw <name> status` — confirm the provider is `Local vLLM` and inference is healthy.
+2. `$$nemoclaw <name> connect`, then run a short prompt and a tool-using prompt (for example,
    ask the agent to read a file). Tool calls must execute, not print raw JSON — see
    [Tool-Calling Reliability](tool-calling-reliability).
 3. Measure responsiveness with the value benchmark:
@@ -119,7 +119,7 @@ different setting (for example a lower `--max-num-seqs` or a different
 `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` before onboarding, then re-measure:
 
 ```bash
-NEMOCLAW_VLLM_EXTRA_ARGS_JSON='["--max-num-seqs","2"]' NEMOCLAW_PROVIDER=install-vllm nemoclaw onboard
+NEMOCLAW_VLLM_EXTRA_ARGS_JSON='["--max-num-seqs","2"]' NEMOCLAW_PROVIDER=install-vllm $$nemoclaw onboard
 ```
 
 Compare first-token latency, round-trip latency, throughput, and tool-call reliability
@@ -127,7 +127,9 @@ across candidates with a real single-user workflow (a tool-using agent task), no
 synthetic throughput, and keep the configuration that gives the best single-user
 responsiveness.
 
-## Related
+## Next Steps
+
+Continue with the related inference guides:
 
 - [Inference Options](inference-options)
 - [Use a Local Inference Server](use-local-inference)


### PR DESCRIPTION
Closes #5614
Closes #5615

Adds a DGX Spark local-assistant golden recipe (`docs/inference/dgx-spark-recipe.mdx`) that consolidates the recommended single-user setup into one page:

- Recommended model (`nvidia/Qwen3.6-35B-A3B-NVFP4`, with `Qwen3.6-27B-FP8` as the named alternative).
- Managed vLLM serving backend: container image, run flags, and the full `vllm serve` flag set, sourced from the model registry.
- Fresh-machine onboarding flow (`NEMOCLAW_PROVIDER=install-vllm`, `NEMOCLAW_VLLM_MODEL`).
- A validation checklist and a single-user settings validation matrix (current serving flags plus rows for latency/throughput/TTFT/tool-use/stability to capture on Spark).
- Cross-links to the benchmark (#5604) and capability audit (#3123).

Registered as an openclaw reference page (literal `nemoclaw`; Hermes users substitute `nemohermes`).

Signed-off-by: Abhimanyu Kumar <abhimanyukumar7290@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **DGX Spark Golden Recipe** guide for single-user local-assistant setup with NemoClaw.
  * Includes managed vLLM model defaults, model selection via environment variables, and server/onboarding start flow.
  * Documents the default vLLM serving flags and how to adjust them using environment-based overrides.
  * Adds a **Validate a Useful Agent** checklist and links to related inference/server/tool-calling docs.
  * Updated documentation navigation to include the page for both agent variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->