### PR TITLE
fix(plugin): route registration banner to stderr

### DIFF
--- a/nemoclaw/src/index.ts
+++ b/nemoclaw/src/index.ts
@@ -437,9 +437,9 @@ export default function register(api: OpenClawPluginApi): void {
     "  Slash:     /nemoclaw",
   ];
 
-  api.logger.info("");
+  process.stderr.write("\n");
   for (const line of renderBox(bannerLines)) {
-    api.logger.info(line);
+    process.stderr.write(`${line}\n`);
   }
-  api.logger.info("");
+  process.stderr.write("\n");
 }

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./index.js";
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -81,6 +81,10 @@ describe("plugin registration", () => {
     mockStderrWrite();
     mockMissingOpenClawConfig();
     mockedLoadOnboardConfig.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("registers a slash command", () => {
@@ -210,6 +214,10 @@ describe("before_tool_call secret scanner hook (#1233)", () => {
     mockStderrWrite();
     mockMissingOpenClawConfig();
     mockedLoadOnboardConfig.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   function getHookHandler(api: OpenClawPluginApi) {

--- a/nemoclaw/src/register.test.ts
+++ b/nemoclaw/src/register.test.ts
@@ -32,6 +32,17 @@ const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedLoadOnboardConfig = vi.mocked(loadOnboardConfig);
 const originalReadFileSync = (await vi.importActual<typeof import("node:fs")>("node:fs"))
   .readFileSync;
+let stderrWrite: ReturnType<typeof vi.spyOn>;
+
+function mockStderrWrite(): void {
+  stderrWrite = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((() => true) as typeof process.stderr.write);
+}
+
+function stderrOutput(): string {
+  return stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
+}
 
 function mockMissingOpenClawConfig(): void {
   mockedReadFileSync.mockReset();
@@ -67,6 +78,7 @@ function createMockApi(): OpenClawPluginApi {
 describe("plugin registration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStderrWrite();
     mockMissingOpenClawConfig();
     mockedLoadOnboardConfig.mockReturnValue(null);
   });
@@ -140,8 +152,15 @@ describe("plugin registration", () => {
     expect(providerArg.models?.chat).toEqual([
       expect.objectContaining({ id: "inference/nvidia/live-model", label: "nvidia/live-model" }),
     ]);
-    const logLines = vi.mocked(api.logger.info).mock.calls.map(([message]) => message);
-    expect(logLines.some((line) => line.includes("Model:     nvidia/live-model"))).toBe(true);
+    expect(stderrOutput()).toContain("Model:     nvidia/live-model");
+  });
+
+  it("writes the registration banner to stderr instead of plugin info logs", () => {
+    const api = createMockApi();
+    register(api);
+
+    expect(stderrOutput()).toContain("NemoClaw registered");
+    expect(api.logger.info).not.toHaveBeenCalled();
   });
 
   it("falls back to onboard config when openclaw.json has no primary model", () => {
@@ -178,18 +197,17 @@ describe("plugin registration", () => {
       expect.objectContaining({ id: "nvidia/nemotron-3-nano-30b-a3b" }),
     ]);
 
-    const logLines = vi.mocked(api.logger.info).mock.calls.map(([message]) => message);
-    expect(logLines.some((line) => line.includes("Endpoint:  build.nvidia.com"))).toBe(true);
-    expect(logLines.some((line) => line.includes("Provider:  NVIDIA Endpoints"))).toBe(true);
-    expect(
-      logLines.some((line) => line.includes("Model:     nvidia/nemotron-3-super-120b-a12b")),
-    ).toBe(true);
+    const stderr = stderrOutput();
+    expect(stderr).toContain("Endpoint:  build.nvidia.com");
+    expect(stderr).toContain("Provider:  NVIDIA Endpoints");
+    expect(stderr).toContain("Model:     nvidia/nemotron-3-super-120b-a12b");
   });
 });
 
 describe("before_tool_call secret scanner hook (#1233)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStderrWrite();
     mockMissingOpenClawConfig();
     mockedLoadOnboardConfig.mockReturnValue(null);
   });


### PR DESCRIPTION
## Summary
Routes the NemoClaw plugin registration banner directly to stderr instead of `api.logger.info`, so non-JSON `nemoclaw <sandbox> agent` passthrough stdout remains reserved for the agent reply.

## Related Issue
Fixes #5654

## Changes
- Writes the registration banner with `process.stderr.write`.
- Updates plugin registration tests to capture stderr.
- Adds a regression assertion that the banner no longer uses `api.logger.info`.

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

Targeted checks run:
- `cd nemoclaw && npm test -- src/register.test.ts`
- `cd nemoclaw && npm run lint -- src/index.ts src/register.test.ts`
- `cd nemoclaw && npm run build`

## Checklist

### General

- [x] I have read and followed the contributing guide.
- [ ] I have read and followed the style guide. (for doc-only changes)

### Code Changes

- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [x] Doc pages updated for any user-facing behavior changes, or no doc update needed because this restores the expected stdout/stderr contract.

Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the plugin startup banner to write directly to standard error, improving reliability of banner rendering across environments.

* **Tests**
  * Revised registration-banner tests to validate output captured from standard error instead of logger calls, including coverage for model selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->