### PR TITLE
docs(quickstart): keep sandbox name examples consistent

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -256,9 +256,10 @@ Treat the authenticated URL like a password.
 ### Chat with the Agent from the Terminal
 
 Connect to the sandbox and use the OpenClaw CLI.
+The example uses the same `my-gpt-claw` sandbox name from the review summary and install output; replace it with the sandbox name you entered during onboarding.
 
 ```bash
-nemoclaw my-assistant connect
+nemoclaw my-gpt-claw connect
 # inside the sandbox:
 openclaw tui
 ```


### PR DESCRIPTION
## Summary
Keeps the OpenClaw quickstart sandbox name consistent by using `my-gpt-claw` in the terminal chat example, matching the review summary and install output shown earlier on the page.

## Related Issue
Addresses #5631 item 2.

## Changes
- Adds a short note that `my-gpt-claw` is the example sandbox name and should be replaced with the user's own onboarding sandbox name.
- Updates the terminal `connect` example from `my-assistant` to `my-gpt-claw`.

## Type of Change
- [ ] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [x] Doc only. Prose changes without code sample modifications.
- [x] Doc only. Includes code sample changes.

## Testing
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

Targeted docs check run:
- `npm run docs` completed with 0 errors and 2 existing Fern warnings reported without details by default.

## Checklist

### General

- [x] I have read and followed the contributing guide.
- [x] I have read and followed the style guide. (for doc-only changes)

### Doc Changes

- [x] Follows the style guide.
- [x] Cross-references and links verified by `npm run docs`.

Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>