### PR TITLE
docs: add v0.0.66 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -15,6 +15,26 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.66
+
+NemoClaw v0.0.66 improves gateway serving, OpenClaw agent workflows, messaging defaults, local inference setup, and release validation:
+
+- Gateway and recovery paths now fail more clearly while preserving sandbox boundaries.
+  NemoClaw pins OpenClaw gateway hot reload behavior, watches for sustained serving state, auto-detects resumable onboarding sessions, reuses gateway-held NVIDIA credentials during non-interactive recreate flows, enforces the Hermes environment-secret boundary during recovery probes, and hardens temporary-file creation in sandbox helper paths.
+  For more information, refer to [Troubleshooting](../reference/troubleshooting), [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), [Credential Storage](../security/credential-storage), and [Security Best Practices](../security/best-practices).
+- OpenClaw sandboxes gained new agent workflows.
+  The release adds the LangChain Deep Agents Code harness, `agents.yaml` declarative multi-agent manifests, live `agents apply` reconciliation, and the non-interactive `$$nemoclaw <name> agent` passthrough command for automation that needs direct OpenClaw agent access.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](../get-started/quickstart-langchain-deepagents-code), [Declarative Multi-Agent Manifest](../inference/declarative-agents-manifest), and [NemoClaw CLI Commands Reference](../reference/commands).
+- Messaging setup has clearer OpenClaw Telegram group defaults.
+  NemoClaw records explicit channel defaults during onboarding, defaults OpenClaw Telegram group access to `TELEGRAM_GROUP_POLICY=open`, and lets operators choose `allowlist` or `disabled` when they need stricter group behavior.
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels).
+- Day-two CLI operations validate local and sandbox paths earlier.
+  `$$nemoclaw <name> exec --workdir <dir>` checks that the sandbox directory exists before running the inner command, and `download`, `upload`, and `sessions export` resolve relative host paths from the caller's current working directory.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands) and [Workspace Files](../manage-sandboxes/workspace-files).
+- Local inference setup avoids more misleading failures.
+  NemoClaw skips false-negative host verification for local providers when the sandbox-routed endpoint is the source of truth, keeps the first Local Ollama TUI turn under OpenClaw's compaction budget, and refreshes the DGX Spark Qwen3.6 managed-vLLM recipe to match current model-card guidance.
+  For more information, refer to [Use a Local Inference Server](../inference/use-local-inference) and [NemoClaw Inference Options](../inference/inference-options).
+
 ## v0.0.65
 
 NemoClaw v0.0.65 improves gateway recovery, sandbox state restore, local inference setup, and messaging activation:


### PR DESCRIPTION
## Summary
Adds the NemoClaw v0.0.66 release notes to the published docs so the release page reflects the shipped announcement themes and links readers to deeper workflow documentation.

## Related Issue
None.

## Changes
- Adds a new `v0.0.66` section to `docs/about/release-notes.mdx`.
- Links release-note bullets to the relevant troubleshooting, lifecycle, security, agent, messaging, CLI, workspace, and inference docs.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>