### PR TITLE
chore(policy): add Deep Code integration label

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
@@ -538,6 +538,7 @@
       ],
       "values": [
         "integration: brave",
+        "integration: dcode",
         "integration: discord",
         "integration: hermes",
         "integration: openclaw",
@@ -552,6 +553,12 @@
           "description": "Brave integration behavior.",
           "positive_signals": ["Brave", "browser integration", "Brave-specific channel or app behavior"],
           "negative_signals": ["generic browser issue without Brave evidence"]
+        },
+        {
+          "name": "integration: dcode",
+          "description": "LangChain Deep Code integration behavior.",
+          "positive_signals": ["LangChain Deep Code", "Deep Code", "langchain-deepagents-code", "dcode", "agents/langchain-deepagents-code"],
+          "negative_signals": ["generic LangChain issue without Deep Code evidence", "generic coding-agent issue without LangChain Deep Code evidence"]
         },
         {
           "name": "integration: discord",

--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
@@ -150,11 +150,12 @@ Integration labels apply when a recurring external app, channel, tool, or agent 
 
 Use `area: integrations` for integration subsystem work, and add `integration:*` when a listed integration is named or clearly implicated. Use `area: messaging` when delivery, channel lifecycle, manifests, or bridge messages are the affected subsystem; combine it with `integration:*` when the messaging issue is specific to a listed integration.
 
-Specific integration labels are routing labels. If the title, body, linked issue, test name, file path, or PR prefix names `Hermes`, `OpenClaw`, `Discord`, `Slack`, `Telegram`, `WeChat`, `WhatsApp`, or `Brave` as the affected subject, include the corresponding `integration:*` label. Do not replace the specific label with only `area: integrations`.
+Specific integration labels are routing labels. If the title, body, linked issue, test name, file path, or PR prefix names `Hermes`, `OpenClaw`, `LangChain Deep Code`, `Deep Code`, `Discord`, `Slack`, `Telegram`, `WeChat`, `WhatsApp`, or `Brave` as the affected subject, include the corresponding `integration:*` label. Do not replace the specific label with only `area: integrations`.
 
 | Label | Description |
 |---|---|
 | `integration: brave` | Brave integration behavior. |
+| `integration: dcode` | LangChain Deep Code integration behavior. |
 | `integration: discord` | Discord bridge or channel lifecycle. |
 | `integration: hermes` | Hermes startup, plugin, sandbox, TUI, or Hermes model/tool-call behavior. |
 | `integration: openclaw` | OpenClaw runtime, TUI, e2e tests, stubs, plugins, configuration, or bridge. |

--- a/.agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/triage-instructions.md
@@ -22,7 +22,7 @@ These instructions are for agents and skills that evaluate NemoClaw issues and P
 
 1. Classify the issue using native GitHub Issue Type: `Bug`, `Enhancement`, `Task`, `Documentation`, `Epic`, or `Initiative`.
 2. Add area labels only when the affected surface is clear.
-3. Add platform, provider, or integration labels only with explicit evidence. When a listed integration is named as the affected subject, include the matching `integration:*` label rather than only the broad `area: integrations` label.
+3. Add platform, provider, or integration labels only with explicit evidence. When a listed integration is named as the affected subject, include the matching `integration:*` label rather than only the broad `area: integrations` label. Use `integration: dcode` for LangChain Deep Code, Deep Code, `langchain-deepagents-code`, or `dcode` evidence.
 4. Add `needs:*` only when an immediate blocking action queue is needed. Do not add `needs: triage` during normal triage.
 5. Recommend Project Priority from impact evidence, not user urgency language.
 6. Recommend Project Status separately from labels.

--- a/.agents/skills/nemoclaw-maintainer-triage/references/triage-instructions.md
+++ b/.agents/skills/nemoclaw-maintainer-triage/references/triage-instructions.md
@@ -108,6 +108,7 @@ Use these descriptions to match labels to issue/PR content:
 - `Platform: ARM64`: Issue specific to ARM64 / aarch64 architecture
 - `Integration: Slack`: Issue or feature involving the Slack integration or Slack bridge
 - `Integration: Discord`: Issue or feature involving the Discord integration
+- `integration: dcode`: Issue or feature involving LangChain Deep Code, Deep Code, `langchain-deepagents-code`, or `dcode`
 - `Integration: Telegram`: Issue or feature involving the Telegram integration
 - `Integration: GitHub`: Issue or feature involving GitHub-specific behavior (not the repo itself)
 - `Provider: NVIDIA`: Issue or feature specific to NVIDIA inference endpoints or NIM


### PR DESCRIPTION
## Summary
Adds `integration: dcode` as the canonical routing label for LangChain Deep Code integration work. This keeps maintainer policy and triage guidance aligned with the live GitHub label rename.

## Related Issue
Related to #5665

## Changes
- Add `integration: dcode` to the human-readable and machine-readable label taxonomy.
- Define LangChain Deep Code routing signals, including `Deep Code`, `langchain-deepagents-code`, and `dcode`.
- Update canonical and runtime triage instructions to recommend `integration: dcode` for Deep Code evidence.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Will Curran <wcurran@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new `integration: dcode` label to identify and route LangChain Deep Code-related issues and pull requests for improved classification and tracking.

* **Documentation**
  * Updated label taxonomy references and triage instructions to define the new integration label, clarifying when and how to apply it based on issue signals and keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->