### PR TITLE
docs(get-started): remove duplicate H1 in LangChain quickstart

### DIFF
--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -14,7 +14,6 @@ status: published
 content:
   type: "get_started"
 ---
-# Quickstart with LangChain Deep Agents Code
 
 Use this guide when you want NemoClaw to build an OpenShell sandbox with the `dcode` terminal coding agent installed and configured for NemoClaw-managed inference.
 


### PR DESCRIPTION
## Summary

- Remove a duplicate body H1 from the LangChain Deep Agents Code quickstart.
- The page title is already provided by the MDX frontmatter.

## Verification

- `npm run docs`
- `npx prek run --from-ref upstream/main --to-ref HEAD`

Signed-off-by: Fredrik Bratten <fbratten@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the quickstart guide structure for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->