### PR TITLE
fix(onboard): surface network-policy hint when OpenClaw plugin install fails during sandbox build

### DIFF
--- a/src/lib/build-context.test.ts
+++ b/src/lib/build-context.test.ts
@@ -203,6 +203,25 @@ describe("printSandboxCreateRecoveryHints", () => {
     expect(out).toContain("NEMOCLAW_SANDBOX_GPU=0");
     expect(out).toContain("onboard --resume --no-gpu");
   });
+
+  it("prints plugin-install network-policy guidance when the Docker build fails at the OpenClaw plugin install step", () => {
+    const output = [
+      "npm error code ENOTFOUND",
+      "npm error network request to https://registry.npmjs.org/@openclaw%2Fbrave-plugin failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org",
+      "Docker stream error: The command '/bin/bash -o pipefail -c set -eu;",
+      '  openclaw plugins install "npm:@openclaw/brave-plugin@2026.5.27" --pin;',
+      "fi' returned a non-zero code: 1",
+    ].join("\n");
+    printSandboxCreateRecoveryHints(output);
+
+    const out = stderr();
+    expect(out).toContain("OpenClaw plugin-install step");
+    expect(out).toContain("ClawHub");
+    expect(out).toContain("npm registry");
+    expect(out).toContain("network policy");
+    expect(out).toContain("NEMOCLAW_WEB_SEARCH_ENABLED=0");
+    expect(out).toContain("onboard --resume");
+  });
 });
 
 describe("reconstructImageRefCreateCommand", () => {

--- a/src/lib/build-context.ts
+++ b/src/lib/build-context.ts
@@ -218,6 +218,21 @@ export function printSandboxCreateRecoveryHints(
     console.error(`  Recovery: ${CLI_NAME} onboard --resume --no-gpu`);
     return;
   }
+  if (failure.kind === "plugin_install_network_denied") {
+    console.error("  Hint: The sandbox Docker build failed at the OpenClaw plugin-install step.");
+    console.error(
+      "        Could not reach ClawHub or the npm registry — your sandbox network policy",
+    );
+    console.error(
+      "        may be blocking outbound plugin-install access. Check whether an active",
+    );
+    console.error("        preset allows egress to the npm registry and ClawHub, or disable the");
+    console.error(
+      "        feature that requires this plugin (e.g. NEMOCLAW_WEB_SEARCH_ENABLED=0).",
+    );
+    console.error(`  Recovery: ${CLI_NAME} onboard --resume`);
+    return;
+  }
   console.error(`  Recovery: ${CLI_NAME} onboard --resume`);
   console.error(`  Or:      ${CLI_NAME} onboard`);
 }

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -289,6 +289,29 @@ describe("classifySandboxCreateFailure", () => {
     ).toBe("unknown");
     expect(classifySandboxCreateFailure("HTTP 404: model not found").kind).toBe("unknown");
   });
+
+  it("detects plugin install failure from the npm:@openclaw/ package spec in the failed command", () => {
+    const output = [
+      "Docker stream error: The command '/bin/bash -o pipefail -c set -eu;",
+      '  openclaw plugins install "npm:@openclaw/brave-plugin@2026.5.27" --pin;',
+      "  BRAVE_API_KEY=openshell:resolve:env:BRAVE_API_KEY openclaw doctor --fix --non-interactive;",
+      "fi' returned a non-zero code: 1",
+    ].join("\n");
+    const result = classifySandboxCreateFailure(output);
+    expect(result.kind).toBe("plugin_install_network_denied");
+    expect(result.uploadedToGateway).toBe(false);
+  });
+
+  it("detects plugin install failure from the openclaw plugins install command text", () => {
+    const output =
+      "The command '...openclaw plugins install npm:@openclaw/diagnostics-otel@2026.5.27 --pin...' returned a non-zero code: 1";
+    expect(classifySandboxCreateFailure(output).kind).toBe("plugin_install_network_denied");
+  });
+
+  it("does NOT classify unrelated failures as plugin_install_network_denied", () => {
+    expect(classifySandboxCreateFailure("npm install failed with ENOENT").kind).toBe("unknown");
+    expect(classifySandboxCreateFailure("openclaw doctor --fix failed").kind).toBe("unknown");
+  });
 });
 
 describe("planSandboxCreateRecovery", () => {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -312,6 +312,18 @@ describe("classifySandboxCreateFailure", () => {
     expect(classifySandboxCreateFailure("npm install failed with ENOENT").kind).toBe("unknown");
     expect(classifySandboxCreateFailure("openclaw doctor --fix failed").kind).toBe("unknown");
   });
+
+  it("does NOT classify as plugin_install_network_denied when plugin install step succeeded and a later step failed", () => {
+    const output = [
+      "Step 3/10 : RUN openclaw plugins install npm:@openclaw/brave-plugin@2026.5.27 --pin",
+      " ---> Running in abc123",
+      " ---> def456",
+      "Step 4/10 : RUN fail-step",
+      " ---> Running in xyz789",
+      "The command '/bin/sh -c fail-step' returned a non-zero code: 1",
+    ].join("\n");
+    expect(classifySandboxCreateFailure(output).kind).toBe("unknown");
+  });
 });
 
 describe("planSandboxCreateRecovery", () => {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -290,8 +290,11 @@ describe("classifySandboxCreateFailure", () => {
     expect(classifySandboxCreateFailure("HTTP 404: model not found").kind).toBe("unknown");
   });
 
-  it("detects plugin install failure from the npm:@openclaw/ package spec in the failed command", () => {
+  it("detects plugin install network denial from ENOTFOUND against the npm registry", () => {
     const output = [
+      "npm error code ENOTFOUND",
+      "npm error errno ENOTFOUND",
+      "npm error network request to https://registry.npmjs.org/@openclaw%2Fbrave-plugin failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org",
       "Docker stream error: The command '/bin/bash -o pipefail -c set -eu;",
       '  openclaw plugins install "npm:@openclaw/brave-plugin@2026.5.27" --pin;',
       "  BRAVE_API_KEY=openshell:resolve:env:BRAVE_API_KEY openclaw doctor --fix --non-interactive;",
@@ -302,15 +305,28 @@ describe("classifySandboxCreateFailure", () => {
     expect(result.uploadedToGateway).toBe(false);
   });
 
-  it("detects plugin install failure from the openclaw plugins install command text", () => {
-    const output =
-      "The command '...openclaw plugins install npm:@openclaw/diagnostics-otel@2026.5.27 --pin...' returned a non-zero code: 1";
+  it("detects plugin install network denial from ECONNREFUSED against ClawHub", () => {
+    const output = [
+      "npm error code ECONNREFUSED",
+      "npm error network request to https://registry.clawhub.io/@openclaw%2Fdiagnostics-otel failed, reason: connect ECONNREFUSED 34.120.54.1:443",
+      "The command '...openclaw plugins install npm:@openclaw/diagnostics-otel@2026.5.27 --pin...' returned a non-zero code: 1",
+    ].join("\n");
     expect(classifySandboxCreateFailure(output).kind).toBe("plugin_install_network_denied");
   });
 
   it("does NOT classify unrelated failures as plugin_install_network_denied", () => {
     expect(classifySandboxCreateFailure("npm install failed with ENOENT").kind).toBe("unknown");
     expect(classifySandboxCreateFailure("openclaw doctor --fix failed").kind).toBe("unknown");
+  });
+
+  it("does NOT classify as plugin_install_network_denied when plugin install fails for a non-network reason", () => {
+    const output = [
+      "npm error code E404",
+      "npm error 404 Not Found - GET https://registry.npmjs.org/@openclaw%2Fmissing-plugin",
+      "npm error 404 '@openclaw/missing-plugin@0.0.0' is not in the npm registry",
+      "The command '/bin/bash -c openclaw plugins install npm:@openclaw/missing-plugin@0.0.0 --pin' returned a non-zero code: 1",
+    ].join("\n");
+    expect(classifySandboxCreateFailure(output).kind).toBe("unknown");
   });
 
   it("does NOT classify as plugin_install_network_denied when plugin install step succeeded and a later step failed", () => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -20,6 +20,7 @@ export interface SandboxCreateFailure {
     | "sandbox_create_incomplete"
     | "tls_cert_mismatch"
     | "gpu_cdi_injection_failed"
+    | "plugin_install_network_denied"
     | "unknown";
   uploadedToGateway: boolean;
 }
@@ -133,6 +134,13 @@ export function classifySandboxCreateFailure(output = ""): SandboxCreateFailure 
     /nvidia\.com\/gpu[^\n]*(CDI device injection failed|unresolvable CDI devices?)/i.test(text)
   ) {
     return { kind: "gpu_cdi_injection_failed", uploadedToGateway };
+  }
+  // The Docker build RUN step that runs `openclaw plugins install` embeds the
+  // command text in its failure message. Match it so the hint can surface the
+  // likely cause (network policy blocking npm/ClawHub egress) instead of the
+  // generic recovery line. See #4127 / follow-up from #4125.
+  if (/openclaw plugins install|npm:@openclaw\//i.test(text)) {
+    return { kind: "plugin_install_network_denied", uploadedToGateway };
   }
   if (/Created sandbox:/i.test(text)) {
     return { kind: "sandbox_create_incomplete", uploadedToGateway: true };

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -136,10 +136,17 @@ export function classifySandboxCreateFailure(output = ""): SandboxCreateFailure 
     return { kind: "gpu_cdi_injection_failed", uploadedToGateway };
   }
   // The Docker build RUN step that runs `openclaw plugins install` embeds the
-  // command text in its failure message. Match it so the hint can surface the
-  // likely cause (network policy blocking npm/ClawHub egress) instead of the
-  // generic recovery line. See #4127 / follow-up from #4125.
-  if (/openclaw plugins install|npm:@openclaw\//i.test(text)) {
+  // command text in its failure message. Anchor to the Docker error block
+  // (The command '...' returned a non-zero code) so a step-header occurrence
+  // of the command — when the plugin step itself succeeded and a later step
+  // failed — does not fire the wrong hint. [^']* matches newlines in JS
+  // character classes, so multi-line command text is handled correctly.
+  // See #4127 / follow-up from #4125.
+  if (
+    /The command '[^']*(?:openclaw plugins install|npm:@openclaw\/)[^']*'\s*returned a non-zero code/i.test(
+      text,
+    )
+  ) {
     return { kind: "plugin_install_network_denied", uploadedToGateway };
   }
   if (/Created sandbox:/i.test(text)) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -135,15 +135,17 @@ export function classifySandboxCreateFailure(output = ""): SandboxCreateFailure 
   ) {
     return { kind: "gpu_cdi_injection_failed", uploadedToGateway };
   }
-  // The Docker build RUN step that runs `openclaw plugins install` embeds the
-  // command text in its failure message. Anchor to the Docker error block
-  // (The command '...' returned a non-zero code) so a step-header occurrence
-  // of the command — when the plugin step itself succeeded and a later step
-  // failed — does not fire the wrong hint. [^']* matches newlines in JS
-  // character classes, so multi-line command text is handled correctly.
-  // See #4127 / follow-up from #4125.
+  // Require BOTH the failed Docker command block containing the plugin-install
+  // step AND a network/egress reachability error so that non-network failures
+  // (package-not-found, version conflicts, auth errors) fall through to the
+  // generic recovery rather than showing a misleading network-policy hint.
+  // [^']* matches newlines in JS character classes, so multi-line command text
+  // is handled correctly. See #4127 / follow-up from #4125.
   if (
     /The command '[^']*(?:openclaw plugins install|npm:@openclaw\/)[^']*'\s*returned a non-zero code/i.test(
+      text,
+    ) &&
+    /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|ESOCKETTIMEDOUT|network request.*failed|getaddrinfo|fetch failed|socket hang up|network timeout/i.test(
       text,
     )
   ) {


### PR DESCRIPTION
## Summary

When `openshell sandbox create` runs and the Docker build fails at the `openclaw plugins install` RUN step, NemoClaw previously fell through to the generic "Recovery: nemoclaw onboard --resume" message with no indication of _why_ the build failed. Users had to scroll through the raw Docker output to find the actual error.

This PR adds a new `plugin_install_network_denied` failure kind to `classifySandboxCreateFailure()` and a targeted hint in `printSandboxCreateRecoveryHints()` that:

- Names the failing step (OpenClaw plugin-install)
- Points to the most likely cause (sandbox network policy blocking npm/ClawHub egress)
- Suggests two remedies: relax the preset that requires egress, or disable the feature that triggers the install (e.g. `NEMOCLAW_WEB_SEARCH_ENABLED=0`)
- Continues to surface `nemoclaw onboard --resume` as the recovery path

Pattern matching is done against the error text OpenShell/Docker echo verbatim from the failed RUN step, which embeds the command (`openclaw plugins install`) and the package spec (`npm:@openclaw/…`). Unrelated `npm install` or `openclaw doctor` failures are not matched — confirmed by regression test.

## Changes

- `src/lib/validation.ts`: add `"plugin_install_network_denied"` to the `SandboxCreateFailure.kind` union; add classifier case before the `sandbox_create_incomplete` check
- `src/lib/build-context.ts`: add targeted hint handler in `printSandboxCreateRecoveryHints()`
- `src/lib/validation.test.ts`: three new unit tests — two positive (npm spec, command text) and one negative (unrelated failures must not match)

## Test plan

- [x] `npx vitest run --project cli src/lib/validation.test.ts` — all three new tests pass; existing suite clean
- [x] `npm run typecheck:cli` — clean
- [x] `npx @biomejs/biome lint src/lib/validation.ts src/lib/build-context.ts` — clean
- [x] Verified new tests were RED on unmodified `main` (stash confirm) and GREEN after the fix

Fixes #4127

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox creation failure detection to recognize when OpenClaw plugin installation fails due to restricted outbound network access.
  * Added targeted recovery console guidance for this scenario, including resuming via the appropriate resume command.
* **Tests**
  * Expanded classification test coverage for the new network-denied plugin-install failure case, including regression checks to avoid incorrect categorization for unrelated or later-stage failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->