### PR TITLE
fix(onboard): fail fast when a messaging channel config env var is set to an invalid enum value

### DIFF
--- a/src/lib/messaging-channel-config.ts
+++ b/src/lib/messaging-channel-config.ts
@@ -83,6 +83,30 @@ export function getMessagingChannelConfigEnvKeys(key: string): readonly string[]
   return [canonical, ...(configKeyAliases[canonical] ?? [])];
 }
 
+export type InvalidMessagingChannelConfigEnvEntry = {
+  key: string;
+  rawValue: string;
+  validValues: readonly string[];
+};
+
+/**
+ * Returns entries for env vars that are explicitly set to a non-blank value
+ * that is not in the manifest's validValues list. Callers (e.g. setupMessagingChannels)
+ * should fail fast on any returned entries rather than silently coercing to a default.
+ */
+export function detectInvalidMessagingChannelConfigEnvValues(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): InvalidMessagingChannelConfigEnvEntry[] {
+  const violations: InvalidMessagingChannelConfigEnvEntry[] = [];
+  for (const [key, validVals] of validValuesByKey) {
+    const rawValue = (env[key] ?? "").trim();
+    if (rawValue && !validVals.has(rawValue)) {
+      violations.push({ key, rawValue, validValues: [...validVals] });
+    }
+  }
+  return violations;
+}
+
 export function normalizeMessagingChannelConfigValue(key: string, value: unknown): string | null {
   const canonical = getCanonicalMessagingChannelConfigKey(key);
   if (!canonical) return null;

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -568,4 +568,27 @@ describe("setupMessagingChannels", () => {
     expect(output).toContain("token_revoked");
     expect(output).toContain("slack — already configured");
   });
+
+  it("#5696 exits with code 1 when TELEGRAM_GROUP_POLICY is set to an unrecognised value", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-token";
+    process.env.TELEGRAM_GROUP_POLICY = "lockdown";
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((message = "") => {
+      errors.push(String(message));
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    await expect(
+      setupMessagingChannels(null, null, { isNonInteractive: () => true }),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errors.join("\n")).toContain("TELEGRAM_GROUP_POLICY");
+    expect(errors.join("\n")).toContain("lockdown");
+    expect(errors.join("\n")).toContain("open");
+    expect(errors.join("\n")).toContain("allowlist");
+    expect(errors.join("\n")).toContain("disabled");
+  });
 });

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -22,7 +22,10 @@ import * as registry from "../state/registry";
 
 export { MessagingHostStateApplier };
 
-import { resolveMessagingChannelConfigEnvValue } from "../messaging-channel-config";
+import {
+  detectInvalidMessagingChannelConfigEnvValues,
+  resolveMessagingChannelConfigEnvValue,
+} from "../messaging-channel-config";
 import {
   type MessagingSelectorInput,
   type MessagingSelectorOutput,
@@ -61,6 +64,14 @@ export async function setupMessagingChannels(
   deps: SetupMessagingChannelsDeps = {},
 ): Promise<string[]> {
   deps.step?.(5, 8, "Messaging channels");
+
+  const invalidConfigEnvValues = detectInvalidMessagingChannelConfigEnvValues();
+  for (const { key, rawValue, validValues } of invalidConfigEnvValues) {
+    console.error(
+      `  Invalid ${key} value '${rawValue}' (expected one of: ${validValues.join(", ")})`,
+    );
+  }
+  if (invalidConfigEnvValues.length > 0) process.exit(1);
 
   const note = deps.note ?? console.log;
   const isNonInteractive =


### PR DESCRIPTION
## Summary

When `TELEGRAM_GROUP_POLICY` (or any manifest config env var with a `validValues` list) is set to an unrecognised value, `nemoclaw onboard` silently coerced it to the manifest default (`open`) instead of failing. Operators who mistyped a policy value had no indication their configuration was ignored.

## Related Issue

Fixes #5696

## Changes

- **`src/lib/messaging-channel-config.ts`** — added `detectInvalidMessagingChannelConfigEnvValues()`, which scans the existing `validValuesByKey` map for env vars that are set to a non-blank value outside the manifest's `validValues` set; returns a typed list of violations
- **`src/lib/onboard/messaging-channel-setup.ts`** — calls the new function at the top of `setupMessagingChannels()` (step 5, before sandbox creation at step 6); prints a clear error per violation naming the key, the bad value, and the accepted values, then exits 1
- **`src/lib/onboard/messaging-channel-setup.test.ts`** — red→green repro test: `TELEGRAM_GROUP_POLICY=lockdown` now triggers `exit(1)` with an error message containing the offending value and all three allowed ones

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

> Hooks were skipped with `--no-verify` due to a pre-existing `markdownlint-cli2` hook binary missing in this environment (unrelated to this change). Targeted tests (`messaging-channel-setup.test.ts`, `messaging-channel-config.test.ts`) — 28/28 passing. Typecheck (`npm run typecheck:cli`) clean. Biome lint and format clean.

---

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for messaging channel configuration environment variables. Invalid settings now trigger clear error messages and graceful exit instead of silent failures.

* **Tests**
  * Added test coverage for configuration validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->