### PR TITLE
fix(onboard): refresh stale reused messaging plan from env inputs

### DIFF
--- a/src/lib/onboard/machine/handlers/sandbox.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.test.ts
@@ -1,12 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SandboxMessagingPlan } from "../../../messaging/manifest";
 import { hashCredential } from "../../../security/credential-hash";
 import { createSession, type Session, type SessionUpdates } from "../../../state/onboard-session";
+import { detectMessagingChannelsFromEnv } from "../../messaging-channel-setup";
 import { handleSandboxState, type SandboxStateOptions } from "./sandbox";
+
+vi.mock("../../messaging-channel-setup", () => ({
+  detectMessagingChannelsFromEnv: vi.fn(() => []),
+}));
+
+const detectMessagingChannelsFromEnvMock = vi.mocked(detectMessagingChannelsFromEnv);
 
 function makeMinimalPlan(
   sandboxName: string,
@@ -217,6 +224,10 @@ function baseOptions(
 }
 
 describe("handleSandboxState", () => {
+  beforeEach(() => {
+    detectMessagingChannelsFromEnvMock.mockReturnValue([]);
+  });
+
   it("creates a sandbox and records messaging/web search state", async () => {
     const { deps, calls } = createDeps({
       configureWebSearch: vi.fn(async () => ({ fetchEnabled: true as const })),
@@ -623,6 +634,78 @@ describe("handleSandboxState", () => {
     expect(writePlanToEnv).not.toHaveBeenCalled();
     expect((calls.createSandbox.mock.calls[0] as unknown[])[6]).toEqual([]);
     expect(getSession().messagingPlan).toBeNull();
+  });
+
+  it("refreshes a reused empty registry messaging plan when env supplies new channel inputs", async () => {
+    // Reporter scenario (#5680): a fresh non-interactive onboard targets an
+    // existing sandbox whose registry messaging plan has no active channels, but
+    // the process now exports TELEGRAM_BOT_TOKEN. The empty plan must not be
+    // accepted as authoritative; messaging setup must run so the Telegram
+    // reachability check executes instead of being silently bypassed.
+    detectMessagingChannelsFromEnvMock.mockReturnValue(["telegram"]);
+    // Reused registry plan has no ACTIVE channels but records a previously
+    // configured in-sandbox-QR channel (whatsapp, disabled) with no host token.
+    // The rebuild must seed `existing` from this authoritative registry plan,
+    // not from the session plan, so whatsapp is preserved across the refresh.
+    const registryPlan = makeMinimalPlan("my-assistant", "openclaw", ["whatsapp"], ["whatsapp"]);
+    const refreshedPlan = makeMinimalPlan("my-assistant", "openclaw", ["telegram"], ["telegram"]);
+    const session = createSession({
+      sandboxName: "my-assistant",
+      // A divergent/stale session plan that must NOT be used as the seed source.
+      messagingPlan: makeMinimalPlan("my-assistant", "openclaw", ["slack"]),
+    });
+    const writePlanToEnv = vi.fn();
+    const readMessagingPlanFromEnv = vi
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValue(refreshedPlan);
+    const { deps, calls, getSession } = createDeps({
+      getRecordedMessagingChannelsForResume: vi.fn(() => null),
+      writePlanToEnv,
+      readMessagingPlanFromEnv,
+      getRegistrySandboxMessagingPlan: () => registryPlan,
+    });
+    // Fake-token rejection disables Telegram, so no channel survives setup.
+    calls.setupMessaging.mockResolvedValue([]);
+
+    const result = await handleSandboxState({
+      ...baseOptions(deps, session),
+      sandboxName: "my-assistant",
+    });
+
+    expect(calls.setupMessaging).toHaveBeenCalledWith(null, ["whatsapp"], "my-assistant");
+    expect(writePlanToEnv).not.toHaveBeenCalled();
+    expect(calls.note).toHaveBeenCalledWith(
+      "  [non-interactive] Detected messaging channel inputs for telegram; refreshing reused sandbox messaging plan.",
+    );
+    expect(result.selectedMessagingChannels).toEqual([]);
+    expect(getSession().messagingPlan).toEqual(refreshedPlan);
+  });
+
+  it("preserves an active registry channel without refresh when env adds a different channel", async () => {
+    // Regression guard: a reused plan with an active channel (slack) must not be
+    // rebuilt just because a new token (telegram) now appears in env. Rebuilding
+    // non-interactively would re-derive the plan from env and drop slack when
+    // its token is absent from this run, so active plans are preserved as-is.
+    detectMessagingChannelsFromEnvMock.mockReturnValue(["telegram"]);
+    const registryPlan = makeMinimalPlan("my-assistant", "openclaw", ["slack"]);
+    const session = createSession({ sandboxName: "my-assistant", messagingPlan: registryPlan });
+    const writePlanToEnv = vi.fn();
+    const { deps, calls } = createDeps({
+      getRecordedMessagingChannelsForResume: vi.fn(() => null),
+      writePlanToEnv,
+      readMessagingPlanFromEnv: () => null,
+      getRegistrySandboxMessagingPlan: () => registryPlan,
+    });
+
+    const result = await handleSandboxState({
+      ...baseOptions(deps, session),
+      sandboxName: "my-assistant",
+    });
+
+    expect(calls.setupMessaging).not.toHaveBeenCalled();
+    expect(writePlanToEnv).toHaveBeenCalledWith(registryPlan);
+    expect(result.selectedMessagingChannels).toEqual(["slack"]);
   });
 
   it("does not restore plan to env when registry has no entry", async () => {

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -5,6 +5,7 @@ import { isMessagingSupportedAgent, tryGetMessagingAgentId } from "../../../mess
 import type { MessagingAgentId, SandboxMessagingPlan } from "../../../messaging/manifest";
 import { hashCredential } from "../../../security/credential-hash";
 import type { Session, SessionUpdates } from "../../../state/onboard-session";
+import { detectMessagingChannelsFromEnv } from "../../messaging-channel-setup";
 import { getActiveChannelsFromPlan, getChannelsFromPlan } from "../../messaging-plan-session";
 import { withSandboxPhaseTrace } from "../../tracing";
 import { branchTo, type OnboardStateTransitionResult } from "../result";
@@ -439,7 +440,59 @@ export async function handleSandboxState<
     } else if (envMessagingPlan) {
       reuseMessagingPlan(envMessagingPlan, false);
     } else if (registryMessagingPlan) {
-      reuseMessagingPlan(registryMessagingPlan, true);
+      // Honor newly supplied messaging env inputs when the reused registry plan
+      // has no active channels for the current agent (the reporter's empty/stale
+      // "Messaging: none" case). Rebuild via setupMessagingChannels so newly
+      // supplied channels (e.g. Telegram via TELEGRAM_BOT_TOKEN) are discovered
+      // and run their reachability checks instead of being silently bypassed
+      // (#5680). When the reused plan already has active channels, preserve it
+      // as-is so we never drop an existing channel whose token is absent from
+      // this run's env. The explicit env-staged branch above stays authoritative.
+      const registryActiveChannels = filterChannelNamesForCurrentAgent(
+        getActiveChannelsFromPlan(registryMessagingPlan) ?? [],
+        agent,
+      );
+      const envDetectedChannels = filterChannelNamesForCurrentAgent(
+        detectMessagingChannelsFromEnv(
+          agent as Parameters<typeof detectMessagingChannelsFromEnv>[0],
+        ),
+        agent,
+      );
+      if (registryActiveChannels.length === 0 && envDetectedChannels.length > 0) {
+        deps.note(
+          `  [non-interactive] Detected messaging channel inputs for ${envDetectedChannels.join(", ")}; refreshing reused sandbox messaging plan.`,
+        );
+        // Seed previously-configured channels from the authoritative reused
+        // registry plan, not session?.messagingPlan (which may be null or stale
+        // on a fresh non-interactive run). This preserves channels configured on
+        // the sandbox whose inputs aren't re-derivable from env this run — e.g.
+        // an in-sandbox-QR channel like WhatsApp that has no host-side token.
+        const existingChannels =
+          getChannelsFromPlan(registryMessagingPlan) ?? getChannelsFromPlan(session?.messagingPlan);
+        const existing = existingChannels
+          ? filterChannelNamesForCurrentAgent(existingChannels, agent)
+          : existingChannels;
+        selectedMessagingChannels = await deps.setupMessagingChannels(agent, existing, sandboxName);
+        selectedMessagingChannels = filterChannelNamesForCurrentAgent(
+          selectedMessagingChannels,
+          agent,
+        );
+        messagingPlan = deps.readMessagingPlanFromEnv();
+        if (messagingPlan) {
+          const filtered = filterMessagingPlanForCurrentAgent(messagingPlan, agent);
+          if (!filtered) {
+            deps.clearPlanEnv();
+            messagingPlan = null;
+            selectedMessagingChannels = [];
+          } else if (filtered !== messagingPlan) {
+            messagingPlan = filtered;
+            selectedMessagingChannels = getActiveChannelsFromPlan(messagingPlan) ?? [];
+            deps.writePlanToEnv(filtered);
+          }
+        }
+      } else {
+        reuseMessagingPlan(registryMessagingPlan, true);
+      }
     } else {
       const existingChannels = getChannelsFromPlan(session?.messagingPlan);
       const existing = existingChannels

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -8,7 +8,11 @@ import { createBuiltInChannelManifestRegistry, MessagingSetupApplier } from "../
 import { MESSAGING_SETUP_APPLIER_ENV_KEY } from "../messaging/applier/types";
 import { validateSlackCredentials } from "../messaging/channels/slack/hooks/credential-validation";
 import { runWechatHostQrLogin } from "../messaging/channels/wechat/login";
-import { setupMessagingChannels, setupSelectedMessagingChannels } from "./messaging-channel-setup";
+import {
+  detectMessagingChannelsFromEnv,
+  setupMessagingChannels,
+  setupSelectedMessagingChannels,
+} from "./messaging-channel-setup";
 
 vi.mock("../credentials/store", () => ({
   getCredential: vi.fn(() => null),
@@ -567,5 +571,45 @@ describe("setupMessagingChannels", () => {
     const output = logs.join("\n");
     expect(output).toContain("token_revoked");
     expect(output).toContain("slack — already configured");
+  });
+});
+
+describe("detectMessagingChannelsFromEnv", () => {
+  function clearMessagingEnv(): void {
+    const envKeys = manifestRegistry
+      .listAvailable({ agent: "openclaw", supportedChannelIds: null })
+      .flatMap((manifest) => manifest.inputs)
+      .map((input) => input.envKey)
+      .filter((envKey): envKey is string => Boolean(envKey));
+    for (const envKey of envKeys) delete process.env[envKey];
+    delete process.env.NEMOCLAW_POLICY_PRESETS;
+  }
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.clearAllMocks();
+    vi.mocked(getCredential).mockReturnValue(null);
+    clearMessagingEnv();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("returns no telegram channel when no messaging env inputs are present", () => {
+    expect(detectMessagingChannelsFromEnv(null)).not.toContain("telegram");
+  });
+
+  it("detects telegram when TELEGRAM_BOT_TOKEN is supplied", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-token";
+
+    expect(detectMessagingChannelsFromEnv(null)).toContain("telegram");
+  });
+
+  it("does not select telegram from NEMOCLAW_POLICY_PRESETS alone", () => {
+    process.env.NEMOCLAW_POLICY_PRESETS = "telegram";
+
+    expect(detectMessagingChannelsFromEnv(null)).not.toContain("telegram");
   });
 });

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -55,6 +55,24 @@ const getMessagingInputValue = (input: ChannelInputSpec): string | null => {
   return normalizeCredentialValue(process.env[input.envKey]) || null;
 };
 
+/**
+ * Detect which built-in messaging channels currently have complete required
+ * inputs in the process environment, using the same manifest input rules as
+ * {@link setupMessagingChannels}. Pure and side-effect free: it only reads env
+ * via the manifest input resolvers so callers can compare current env inputs
+ * against a reused/stale sandbox messaging plan before treating that plan as
+ * authoritative. NEMOCLAW_POLICY_PRESETS is intentionally ignored — policy
+ * presets are not messaging channel selection.
+ */
+export function detectMessagingChannelsFromEnv(agent: AgentDefinition | null = null): string[] {
+  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const availabilityContext = getMessagingManifestAvailabilityContext(agent);
+  const availableChannels = manifestRegistry.listAvailable(availabilityContext);
+  return availableChannels
+    .filter((manifest) => hasMessagingManifestRequiredInputs(manifest, getMessagingInputValue))
+    .map((manifest) => manifest.id);
+}
+
 export async function setupMessagingChannels(
   agent: AgentDefinition | null = null,
   existingChannels: string[] | null = null,


### PR DESCRIPTION
## Summary

Non-interactive `nemoclaw onboard` reusing an existing sandbox whose stored messaging plan has **zero active channels** (the reporter's empty/stale `Messaging: none` state) silently refreshed credential hashes and skipped messaging channel setup. Newly supplied messaging env inputs (e.g. `TELEGRAM_BOT_TOKEN`) were never discovered, so the Telegram `getMe` reachability probe was bypassed even with `NEMOCLAW_SKIP_TELEGRAM_REACHABILITY` unset. This fix makes the reused-sandbox path honor fresh messaging env inputs so the reachability probe runs.

## Related Issue

Fixes #5680

## Changes

- `src/lib/onboard/machine/handlers/sandbox.ts`: in the reused-`registryMessagingPlan` branch, when the plan has **no active channels** but this run supplies complete messaging env inputs, rebuild the plan via `setupMessagingChannels` (which runs channel reachability checks) instead of silently refreshing hashes. Plans that already have active channels are preserved as-is, so an existing channel is never dropped when its token is absent from this run. The explicit env-staged plan branch above stays authoritative for rebuild/resume.
- `src/lib/onboard/messaging-channel-setup.ts`: add `detectMessagingChannelsFromEnv`, a pure, side-effect-free probe that reports which built-in channels currently have complete required inputs, reusing the same manifest input rules as `setupMessagingChannels`. `NEMOCLAW_POLICY_PRESETS` is intentionally ignored — policy presets are not messaging channel selection.
- Tests for both the rebuild path and the preserve-active-channel regression guard, plus unit coverage of `detectMessagingChannelsFromEnv` (including that `NEMOCLAW_POLICY_PRESETS=telegram` alone does not select messaging).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push
- [x] Targeted tests pass for changed behavior (`sandbox.test.ts`, `messaging-channel-setup.test.ts` — 39 tests)
- [x] Full `npm test` (cli project) passes — 8126 passed, 18 skipped
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs reviewed — no user-facing doc changes required (internal onboarding state-machine correctness fix; no new flags/env/API)

### End-to-end verification (real worktree CLI vs live OpenShell 0.0.44 sandbox)

Built the worktree CLI (`npm run build:cli`) and drove real `node ./bin/nemoclaw.js onboard` commands against a live OpenShell 0.0.44 Docker-driver sandbox (CPU host, hosted NVIDIA Endpoints inference). Created the reporter's buggy state — a sandbox `compat-tg-5680` whose registry messaging plan is non-null with **zero active channels** (telegram configured-but-disabled) — then ran the reporter workflow with a fake `TELEGRAM_BOT_TOKEN` and `NEMOCLAW_SKIP_TELEGRAM_REACHABILITY` unset.

Exact command (same for both builds):

```bash
export NVIDIA_INFERENCE_API_KEY=...                 # hosted inference
export TELEGRAM_BOT_TOKEN="123456789:AAFfake-token-for-5680-e2e-reproduction-xyz"
export TELEGRAM_ALLOWED_IDS="123456789"
export NEMOCLAW_POLICY_PRESETS="telegram"
export NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1
export NEMOCLAW_SANDBOX_NAME=compat-tg-5680
unset NEMOCLAW_SKIP_TELEGRAM_REACHABILITY
node ./bin/nemoclaw.js onboard --non-interactive --no-gpu --no-sandbox-gpu --yes-i-accept-third-party-software
```

**Unpatched build (bug reproduced — probe silently bypassed):**

```text
  Messaging:     none
  [non-interactive] Sandbox 'compat-tg-5680' exists and is ready — reusing it
  [non-interactive] Applying policy presets: telegram
```

(No `[5/8] Messaging channels`, no reachability output — matches the reporter's exact observation.)

**Patched build (fixed — messaging setup + reachability probe run):**

```text
  Messaging:     none
  [non-interactive] Detected messaging channel inputs for telegram; refreshing reused sandbox messaging plan.
  [5/8] Messaging channels
  [non-interactive] Messaging channel inputs detected: telegram
  Telegram integration will be disabled for this enrollment run because api.telegram.org is unreachable.
  [non-interactive] Sandbox 'compat-tg-5680' exists and is ready — reusing it
```

The patched run discovers the env-supplied Telegram input on the reused sandbox and runs the `getMe` reachability probe, emitting reachability diagnostics instead of silently skipping. (This E2E host's egress to `api.telegram.org` is firewall-blocked, so the probe reports "unreachable" rather than a token rejection — both prove the probe executed rather than being bypassed; on a host that can reach Telegram a fake token yields the `Telegram bot token was rejected.` log.) The test sandbox was destroyed after verification.

---

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messaging channel setup now automatically detects which channels are available from current environment settings, and can restore or refresh the active messaging plan during sandbox resume.

* **Bug Fixes**
  * Fixed sandbox resume to preserve an existing active messaging plan when environment changes don’t affect the active channel.
  * Fixed cases where an empty reused messaging plan is correctly refreshed once messaging credentials (e.g., Telegram token) become available later, ensuring messaging setup runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->