### PR TITLE
docs(quickstart): keep sandbox name examples consistent

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -256,9 +256,10 @@ Treat the authenticated URL like a password.
 ### Chat with the Agent from the Terminal
 
 Connect to the sandbox and use the OpenClaw CLI.
+The example uses the same `my-gpt-claw` sandbox name from the review summary and install output; replace it with the sandbox name you entered during onboarding.
 
 ```bash
-nemoclaw my-assistant connect
+nemoclaw my-gpt-claw connect
 # inside the sandbox:
 openclaw tui
 ```

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -256,7 +256,7 @@ Treat the authenticated URL like a password.
 ### Chat with the Agent from the Terminal
 
 Connect to the sandbox and use the OpenClaw CLI.
-The example uses the same `my-gpt-claw` sandbox name from the review summary and install output; replace it with the sandbox name you entered during onboarding.
+Use the sandbox name you entered during onboarding; this example keeps using `my-gpt-claw` from the install output.
 
 ```bash
 nemoclaw my-gpt-claw connect


### PR DESCRIPTION
## Summary
Supersedes #5675 with the same docs-only fix rebuilt on GitHub Verified signed commits, because force-push is not allowed on the original PR branch. Keeps the OpenClaw quickstart sandbox name consistent by using `my-gpt-claw` in the terminal chat example, matching the install/onboarding output shown earlier on the page.

## Related Issue
Addresses #5631 item 2.

## Changes
- Adds a short note that `my-gpt-claw` is the example sandbox name and should be replaced with the user's own onboarding sandbox name.
- Updates the terminal `connect` example from `my-assistant` to `my-gpt-claw`.
- Replaces CodeRabbit-flagged “review summary” wording with user-facing onboarding/install terminology.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Validation run:
- `git diff --check`
- `npm run docs` completed with 0 errors and 2 Fern warnings reported without details by default.
- GitHub API reports both PR commits as verified with `reason: valid`.
- The CodeRabbit suggestion to use `$$nemoclaw` was checked and intentionally not applied because `npm run docs` rejects `$$nemoclaw` in `docs/get-started/quickstart.mdx`: this page is a non-shared nav page and must use the literal `nemoclaw` command.

---
Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Chat with the Agent from the Terminal” quickstart to use the onboarding sandbox name (`my-gpt-claw`) instead of the previous example.
  * Clarified that readers should substitute the sandbox name they selected during onboarding (not a fixed literal).
  * Refreshed the sample `nemoclaw ... connect` command to match the new naming guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->