### PR TITLE
docs: refresh release notes for v0.0.67

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -28,8 +28,6 @@ NemoClaw v0.0.67 improves onboarding recovery, messaging reliability, OpenClaw a
 - AI-agent documentation now uses one compact routing skill instead of generated page-copy skills.
   The `nemoclaw-user-guide` skill points agents to the docs MCP server, `llms.txt`, and canonical Markdown routes so the docs site remains the source of truth.
   For more information, refer to [Use NemoClaw Agent Prompts, Docs MCP Server, and Skills with Your AI Coding Agent](../resources/agent-skills).
-- Release validation coverage is more selective and easier to route.
-  Hermes secret-boundary and Jetson GPU scenarios moved from legacy shell coverage into live Vitest E2E paths, hosted-inference workflow key routing returned to the previous safe wiring after post-merge validation, and maintainer label taxonomy now includes `integration: dcode` for LangChain Deep Code work.
 
 ## v0.0.66
 

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -15,6 +15,22 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.67
+
+NemoClaw v0.0.67 improves onboarding recovery, messaging reliability, OpenClaw agent workflows, and AI-agent documentation routing:
+
+- Onboarding and OpenClaw agent operations recover more reliably after interrupted or scripted runs.
+  NemoClaw keeps repair backstops active when `onboard --resume` continues from later nonterminal onboarding phases, and `agents apply` removes orphan OpenClaw agents without forwarding a delete flag that the OpenClaw CLI rejects.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands).
+- Discord messaging now uses the managed proxy path that OpenClaw accepts.
+  NemoClaw no longer writes a non-loopback per-account Discord proxy, while Telegram keeps its per-account proxy behavior, and WhatsApp policy E2E checks avoid brittle shell-pipeline failures on large policy output.
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels).
+- AI-agent documentation now uses one compact routing skill instead of generated page-copy skills.
+  The `nemoclaw-user-guide` skill points agents to the docs MCP server, `llms.txt`, and canonical Markdown routes so the docs site remains the source of truth.
+  For more information, refer to [Use NemoClaw Agent Prompts, Docs MCP Server, and Skills with Your AI Coding Agent](../resources/agent-skills).
+- Release validation coverage is more selective and easier to route.
+  Hermes secret-boundary and Jetson GPU scenarios moved from legacy shell coverage into live Vitest E2E paths, hosted-inference workflow key routing returned to the previous safe wiring after post-merge validation, and maintainer label taxonomy now includes `integration: dcode` for LangChain Deep Code work.
+
 ## v0.0.66
 
 NemoClaw v0.0.66 improves gateway serving, OpenClaw agent workflows, messaging defaults, local inference setup, and release validation:

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -81,6 +81,7 @@ By default, NemoClaw configures the bot to reply only when mentioned.
 If `DISCORD_SERVER_ID` is set and `DISCORD_REQUIRE_MENTION` is unset, NemoClaw defaults `DISCORD_REQUIRE_MENTION` to `1`.
 Set `DISCORD_REQUIRE_MENTION=0` if you want it to reply to all messages in the configured server.
 Set `DISCORD_USER_ID` to restrict access to one user; otherwise, any member of the configured server can message the bot.
+NemoClaw routes Discord REST and gateway traffic through the top-level managed proxy and does not write a per-account Discord proxy, because OpenClaw accepts only loopback values for that field.
 
 Slack uses Socket Mode and requires two tokens.
 Use `SLACK_BOT_TOKEN` for the bot user OAuth token (`xoxb-...`) and `SLACK_APP_TOKEN` for the app-level Socket Mode token (`xapp-...`).

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -89,6 +89,7 @@ nemoclaw onboard --agent hermes [options]
 
 NemoClaw records onboarding progress so interrupted runs can continue.
 Use `--resume` to continue a resumable onboarding session with the provider, model, sandbox name, agent, and custom Dockerfile path recorded by the original run.
+During resume, NemoClaw reruns preflight, gateway, provider, and sandbox repair checks even when the saved session has already reached a later nonterminal onboarding phase.
 If the recorded session conflicts with flags you pass on the recovery run, NemoClaw exits and tells you to either rerun with the original settings or start over.
 
 Use `--fresh` to discard the saved onboarding session and start the wizard from the beginning.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -130,6 +130,7 @@ nemoclaw onboard --agent hermes [options]
 
 NemoClaw records onboarding progress so interrupted runs can continue.
 Use `--resume` to continue a resumable onboarding session with the provider, model, sandbox name, agent, and custom Dockerfile path recorded by the original run.
+During resume, NemoClaw reruns preflight, gateway, provider, and sandbox repair checks even when the saved session has already reached a later nonterminal onboarding phase.
 If the recorded session conflicts with flags you pass on the recovery run, NemoClaw exits and tells you to either rerun with the original settings or start over.
 
 Use `--fresh` to discard the saved onboarding session and start the wizard from the beginning.
@@ -1315,6 +1316,8 @@ $$nemoclaw my-assistant agents delete work --force --json
 Reconcile the live sandbox roster against a declarative [agents.yaml manifest](../inference/declarative-agents-manifest).
 The verb lists current agents via `openclaw agents list --json`, diffs them against the manifest, and adds missing secondaries or deletes orphan ones through `openclaw agents add|delete`.
 Per-agent `model`, `subagents.*`, `tools`, top-level `defaults`, and `main` overrides need a sandbox rebuild and are surfaced as warnings rather than silently dropped; rerun `$$nemoclaw onboard --agents <agents.yaml> --recreate-sandbox` to bake those fields.
+When the diff removes orphan agents, NemoClaw calls OpenClaw delete with `--force` only.
+`--non-interactive` controls the host-side `agents apply` prompt and is not forwarded to OpenClaw's delete command.
 
 ```bash
 $$nemoclaw my-assistant agents apply -f ./agents.yaml

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1316,7 +1316,7 @@ $$nemoclaw my-assistant agents delete work --force --json
 Reconcile the live sandbox roster against a declarative [agents.yaml manifest](../inference/declarative-agents-manifest).
 The verb lists current agents via `openclaw agents list --json`, diffs them against the manifest, and adds missing secondaries or deletes orphan ones through `openclaw agents add|delete`.
 Per-agent `model`, `subagents.*`, `tools`, top-level `defaults`, and `main` overrides need a sandbox rebuild and are surfaced as warnings rather than silently dropped; rerun `$$nemoclaw onboard --agents <agents.yaml> --recreate-sandbox` to bake those fields.
-When the diff removes orphan agents, NemoClaw calls OpenClaw delete with `--force` only.
+When the diff removes orphan agents, NemoClaw invokes OpenClaw's confirmation-skipping delete mode internally.
 `--non-interactive` controls the host-side `agents apply` prompt and is not forwarded to OpenClaw's delete command.
 
 ```bash


### PR DESCRIPTION
## Summary
Refresh the docs for the v0.0.67 release using the GitHub announcement and release-range commit scan.

## Changes
- Add v0.0.67 release notes for onboarding recovery, Discord proxy behavior, OpenClaw agent apply deletion, and compact AI-agent docs routing.
- Clarify `onboard --resume` repair checks in the OpenClaw and Hermes command references.
- Clarify Discord's managed proxy path and `agents apply` delete behavior in the relevant docs pages.

## Source Summary
- #5699 -> `docs/resources/agent-skills.mdx`, `docs/about/release-notes.mdx`: Reflects the compact `nemoclaw-user-guide` docs-routing skill and canonical MCP/Markdown docs entry points.
- #5571 -> `docs/manage-sandboxes/messaging-channels.mdx`, `docs/about/release-notes.mdx`: Documents Discord using the managed proxy path instead of a rejected per-account proxy.
- #5704 -> `docs/about/release-notes.mdx`: Captures the WhatsApp policy assertion hardening in the release note context.
- Follow-up commit `46ead831e` -> `docs/reference/commands.mdx`, `docs/reference/commands-nemohermes.mdx`, `docs/about/release-notes.mdx`: Documents resume repair checks across later nonterminal onboarding phases.
- Follow-up commit `ee0725a32` -> `docs/reference/commands.mdx`, `docs/about/release-notes.mdx`: Documents that `agents apply` uses OpenClaw's confirmation-skipping delete mode for orphan agents.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification run:
- `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli` passed.
- `npm run docs` passed with the pre-existing Fern light-mode accent contrast warning: `The contrast ratio between the accent color and the background color for light mode is 2.41:1. It should be at least 3:1.`

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.67 covering onboarding recovery, messaging reliability, OpenClaw agent workflows, and AI-agent documentation routing.
  * Clarified Discord channel requirements, including routing through the top-level managed proxy.
  * Updated onboarding resume guidance to note rerunning preflight, gateway, provider, and sandbox repair checks.
  * Refined CLI command reference details for orphan-agent deletion behavior and how interactive flags affect prompts vs. deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->