### PR TITLE
fix(onboard): detach terminal agent create stream on ready

### DIFF
--- a/agents/langchain-deepagents-code/start.sh
+++ b/agents/langchain-deepagents-code/start.sh
@@ -129,7 +129,8 @@ prepare_runtime_env
 # phase, which breaks the Docker GPU-patch supervisor reconnect and leaves GPU
 # posture unreliable (#5717). Idle forever instead so the sandbox stays Ready.
 if [ "$#" -eq 0 ]; then
-  exec sleep infinity
+  printf '%s\n' 'Setting up NemoClaw Deep Agents Code runtime...'
+  exec tail -f /dev/null
 fi
 
 exec "$@"

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3068,7 +3068,6 @@ async function createSandbox(
     failureCheck: dockerGpuCreatePatch.createFailureMessage,
     traceEvent: onboardTracing.addTraceEvent,
   });
-
   if (initialSandboxPolicy.cleanup && initialSandboxPolicy.cleanup()) {
     process.removeListener("exit", initialSandboxPolicy.cleanup);
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3064,6 +3064,7 @@ async function createSandbox(
       dockerGpuCreatePatch.maybeApplyDuringCreate();
       return false;
     },
+    readyCheckOutputPatterns: agentDefs.isTerminalAgent(agent) ? [] : undefined,
     failureCheck: dockerGpuCreatePatch.createFailureMessage,
     traceEvent: onboardTracing.addTraceEvent,
   });

--- a/test/dcode-start-keepalive.test.ts
+++ b/test/dcode-start-keepalive.test.ts
@@ -44,6 +44,7 @@ describe("Deep Agents Code sandbox entrypoint keep-alive (#5717)", () => {
     // A self-exiting entrypoint would return status 0 with no signal.
     expect(result.signal).toBe("SIGTERM");
     expect(result.status).toBeNull();
+    expect(result.stdout).toContain("Setting up NemoClaw Deep Agents Code runtime...");
   });
 
   it("execs an explicitly supplied command instead of idling", () => {

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -59,6 +59,14 @@ describe("LangChain Deep Agents Code image contracts", () => {
     );
   });
 
+  it("prints NemoClaw setup output before idling as a terminal runtime", () => {
+    const startScript = readAgentFile("start.sh");
+
+    expect(startScript).toContain("Setting up NemoClaw Deep Agents Code runtime");
+    expect(startScript).toContain("exec tail -f /dev/null");
+    expect(startScript).not.toContain("exec sleep infinity");
+  });
+
   it("does not serialize provider or optional service secrets into the shell env file", () => {
     const startScript = readAgentFile("start.sh");
 

--- a/test/onboard-terminal-dashboard.test.ts
+++ b/test/onboard-terminal-dashboard.test.ts
@@ -18,7 +18,11 @@ function writeExecutable(target: string, contents: string) {
 }
 
 function parseStdoutJson<T>(stdout: string): T {
-  const line = stdout.trim().split("\n").pop();
+  const line = stdout
+    .trim()
+    .split("\n")
+    .reverse()
+    .find((candidate) => candidate.startsWith("{") && candidate.endsWith("}"));
   assert.ok(line, `expected JSON payload in stdout:\n${stdout}`);
   return JSON.parse(line);
 }
@@ -55,6 +59,7 @@ const sandboxName = "deepagents-box";
 const commands = [];
 const registerCalls = [];
 const updateCalls = [];
+const keepAlive = setInterval(() => {}, 1000);
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 
 agentOnboard.createAgentSandbox = () => {
@@ -104,11 +109,11 @@ childProcess.spawn = (...args) => {
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   child.unref = () => {};
+  child.kill = () => true;
   child.pid = 4242;
   commands.push({ command: _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]), env: args[2]?.env || null });
   process.nextTick(() => {
     child.stdout.emit("data", Buffer.from("Created sandbox: " + sandboxName + "\n"));
-    child.emit("close", 0);
   });
   return child;
 };
@@ -122,7 +127,9 @@ const agent = agentDefs.loadAgent("langchain-deepagents-code");
   process.env.NEMOCLAW_DASHBOARD_PORT = "19000";
   const resultName = await createSandbox(null, "gpt-5.4", "nvidia-prod", null, sandboxName, null, null, null, agent);
   console.log(JSON.stringify({ resultName, commands, registerCalls, updateCalls }));
+  clearInterval(keepAlive);
 })().catch((error) => {
+  clearInterval(keepAlive);
   console.error(error);
   process.exit(1);
 });
@@ -137,7 +144,9 @@ const agent = agentDefs.loadAgent("langchain-deepagents-code");
       HOME: tmpDir,
       PATH: `${fakeBin}:${process.env.PATH || ""}`,
       NEMOCLAW_NON_INTERACTIVE: "1",
+      OPENSHELL_DRIVERS: scenario === "create" ? "vm" : "docker",
     },
+    timeout: 15000,
   });
   assert.equal(result.status, 0, result.stderr);
   return parseStdoutJson<{


### PR DESCRIPTION
## Summary
Terminal-runtime sandboxes now continue onboarding once OpenShell reports Ready, even when the VM create stream does not emit gateway-style startup output. This fixes DeepAgents Code onboarding hanging on macOS VM-driver hosts after the sandbox is already Ready.

## Bugs
LangChain hang at sandbox build MacOS
```
  Sandbox reported Ready; waiting for startup command output before detaching.
  Still waiting for sandbox to become ready... (30s elapsed)
  Still waiting for sandbox to become ready... (45s elapsed)
  Still waiting for sandbox to become ready... (60s elapsed)
  Still waiting for sandbox to become ready... (75s elapsed)
  Still waiting for sandbox to become ready... (90s elapsed)
  Still waiting for sandbox to become ready... (105s elapsed)
  Still waiting for sandbox to become ready... (120s elapsed)
  Still waiting for sandbox to become ready... (135s elapsed)
  Still waiting for sandbox to become ready... (150s elapsed)
  Still waiting for sandbox to become ready... (165s elapsed)
  Still waiting for sandbox to become ready... (180s elapsed)
  Still waiting for sandbox to become ready... (195s elapsed)
  Still waiting for sandbox to become ready... (210s elapsed)
```
## Related Issue
Fixes #5766

## Changes
- Disable the create-stream startup-output guard for terminal agents while preserving the OpenShell Ready check.
- Keep the DeepAgents Code entrypoint alive with a portable `tail -f /dev/null` idle path and emit a setup marker.
- Extend terminal-agent onboarding and DeepAgents entrypoint tests to cover VM-driver Ready detachment without startup output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup behavior for idle runtimes: when launched without a command, it now prints a clearer runtime setup message before idling.
* **Bug Fixes**
  * Enhanced sandbox onboarding for terminal-based flows by adjusting how “ready” is detected during sandbox creation.
  * Updated and expanded test coverage to validate the new startup message, idle behavior, and readiness parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->