### PR TITLE
fix(rebuild): isolate ambient onboard env from sandbox recreate (#5735)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -507,7 +507,14 @@ print_done() {
   local _needs_cli_refresh=false
   needs_shell_reload && _needs_cli_refresh=true
 
-  info "=== Installation complete ==="
+  # #5735: do not claim a clean install when the post-onboard auto-upgrade of a
+  # pre-existing sandbox failed (it may have been destroyed before its recreate
+  # failed). Surface an explicit incomplete/recovery status instead.
+  if [[ "${_UPGRADE_SANDBOXES_FAILED:-false}" == true ]]; then
+    warn "=== Installation completed with warnings ==="
+  else
+    info "=== Installation complete ==="
+  fi
   printf "\n"
   printf "  ${C_GREEN}${C_BOLD}%s${C_RESET}  ${C_DIM}(%ss)${C_RESET}\n" "$_CLI_DISPLAY" "$elapsed"
   printf "\n"
@@ -551,6 +558,11 @@ print_done() {
     printf "  ${C_GREEN}${C_BOLD}To finish setup, run:${C_RESET}\n"
     print_cli_path_refresh_actions
     printf "  %s$%s %s onboard\n" "$C_GREEN" "$C_RESET" "$_CLI_BIN"
+  fi
+  if [[ "${_UPGRADE_SANDBOXES_FAILED:-false}" == true ]]; then
+    printf "\n"
+    printf "  ${C_YELLOW}${C_BOLD}Existing sandbox upgrade did not finish.${C_RESET}\n"
+    printf "  ${C_YELLOW}One or more pre-existing sandboxes failed to upgrade. See the messages above for the affected sandbox name, any preserved backup path, and recovery steps (${C_BOLD}%s onboard --resume${C_RESET}${C_YELLOW} / ${C_BOLD}%s <name> rebuild${C_RESET}${C_YELLOW}).${C_RESET}\n" "$_CLI_BIN" "$_CLI_BIN"
   fi
   printf "\n"
   printf "  ${C_BOLD}GitHub${C_RESET}  ${C_DIM}https://github.com/nvidia/nemoclaw${C_RESET}\n"
@@ -863,6 +875,10 @@ ONBOARD_RAN=false
 # auto-onboarding (#3276).
 _CLI_PATH=""
 _PREEXISTING_SANDBOX_COUNT=0
+# #5735: set when the post-onboard auto-upgrade of pre-existing sandboxes
+# reported a failure. A failed/destructive rebuild must not be reported as a
+# clean install, so print_done downgrades the final banner when this is true.
+_UPGRADE_SANDBOXES_FAILED=false
 
 # Compare two semver strings (major.minor.patch). Returns 0 if $1 >= $2.
 # Rejects prerelease suffixes (e.g. "22.16.0-rc.1") to avoid arithmetic errors.
@@ -2682,7 +2698,16 @@ main() {
       # Uses --auto so it runs non-interactively in piped/CI contexts.
       if [ "${_PREEXISTING_SANDBOX_COUNT:-0}" -gt 0 ] 2>/dev/null && [ -n "$_cli_runner" ]; then
         info "Checking for sandboxes that need upgrading…"
-        "$_cli_runner" upgrade-sandboxes --auto 2>&1 || warn "Sandbox upgrade check failed (non-fatal)."
+        # #5735: a non-zero exit here can mean an existing sandbox was rebuilt
+        # destructively and its recreate failed. Record it so print_done reports
+        # the install as incomplete with recovery guidance instead of a clean
+        # banner. The CLI already prints the affected sandbox name and the
+        # preserved backup path on failure.
+        if ! "$_cli_runner" upgrade-sandboxes --auto 2>&1; then
+          _UPGRADE_SANDBOXES_FAILED=true
+          warn "One or more existing sandboxes could not be upgraded automatically."
+          warn "Review the messages above — affected sandboxes may need '${_CLI_BIN} onboard --resume' or '${_CLI_BIN} <name> rebuild', and any backup path shown above can restore workspace state."
+        fi
       fi
       restore_onboard_forward_after_post_checks || error "Hermes host forward restore failed."
     elif [ "${NON_INTERACTIVE:-}" = "1" ]; then

--- a/src/lib/actions/sandbox/rebuild-env-isolation.test.ts
+++ b/src/lib/actions/sandbox/rebuild-env-isolation.test.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AMBIENT_RECREATE_ENV_VARS,
+  assessAmbientRecreateEnv,
+  isolateAmbientRecreateEnv,
+} from "../../../../dist/lib/actions/sandbox/rebuild-env-isolation.js";
+
+describe("assessAmbientRecreateEnv", () => {
+  it("reports no contamination when no ambient onboard env is set", () => {
+    const result = assessAmbientRecreateEnv("openclaw", {});
+    expect(result.presentVars).toEqual([]);
+    expect(result.agentMismatch).toBeNull();
+  });
+
+  it("flags an ambient NEMOCLAW_AGENT that differs from the registry agent", () => {
+    const result = assessAmbientRecreateEnv("openclaw", {
+      NEMOCLAW_AGENT: "langchain-deepagents-code",
+      NEMOCLAW_PROVIDER_KEY: "sk-bogus",
+    });
+    expect(result.presentVars).toEqual(["NEMOCLAW_AGENT", "NEMOCLAW_PROVIDER_KEY"]);
+    expect(result.agentMismatch).toEqual({
+      envAgent: "langchain-deepagents-code",
+      registryAgent: "openclaw",
+    });
+  });
+
+  it("treats a null registry agent as the default OpenClaw runtime", () => {
+    const result = assessAmbientRecreateEnv(null, { NEMOCLAW_AGENT: "hermes" });
+    expect(result.agentMismatch).toEqual({ envAgent: "hermes", registryAgent: "openclaw" });
+  });
+
+  it("does not flag a mismatch when ambient NEMOCLAW_AGENT matches the registry", () => {
+    const result = assessAmbientRecreateEnv("hermes", { NEMOCLAW_AGENT: "hermes" });
+    expect(result.agentMismatch).toBeNull();
+    expect(result.presentVars).toEqual(["NEMOCLAW_AGENT"]);
+  });
+
+  it("ignores empty/whitespace env values", () => {
+    const result = assessAmbientRecreateEnv("openclaw", {
+      NEMOCLAW_AGENT: "   ",
+      NEMOCLAW_MODEL: "",
+    });
+    expect(result.presentVars).toEqual([]);
+    expect(result.agentMismatch).toBeNull();
+  });
+});
+
+describe("isolateAmbientRecreateEnv", () => {
+  it("removes ambient selection vars and restores the originals (including unset)", () => {
+    const env: NodeJS.ProcessEnv = {
+      NEMOCLAW_AGENT: "langchain-deepagents-code",
+      NEMOCLAW_PROVIDER_KEY: "sk-bogus",
+      NEMOCLAW_MODEL: "some-model",
+      // not part of the selection set — must be left untouched
+      NVIDIA_API_KEY: "nvapi-keep-me",
+    };
+
+    const restore = isolateAmbientRecreateEnv(env);
+
+    for (const name of AMBIENT_RECREATE_ENV_VARS) {
+      expect(env[name]).toBeUndefined();
+    }
+    expect(env.NVIDIA_API_KEY).toBe("nvapi-keep-me");
+
+    restore();
+
+    expect(env.NEMOCLAW_AGENT).toBe("langchain-deepagents-code");
+    expect(env.NEMOCLAW_PROVIDER_KEY).toBe("sk-bogus");
+    expect(env.NEMOCLAW_MODEL).toBe("some-model");
+    expect(env.NVIDIA_API_KEY).toBe("nvapi-keep-me");
+    // A var that was never set stays unset after restore.
+    expect("NEMOCLAW_PROVIDER" in env).toBe(false);
+  });
+
+  it("is idempotent — a second restore call is a no-op", () => {
+    const env: NodeJS.ProcessEnv = { NEMOCLAW_AGENT: "hermes" };
+    const restore = isolateAmbientRecreateEnv(env);
+    restore();
+    env.NEMOCLAW_AGENT = "changed-after-restore";
+    restore();
+    expect(env.NEMOCLAW_AGENT).toBe("changed-after-restore");
+  });
+});

--- a/src/lib/actions/sandbox/rebuild-env-isolation.ts
+++ b/src/lib/actions/sandbox/rebuild-env-isolation.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// #5735: A rebuild recreates a sandbox from its persisted registry/session
+// config. Ambient onboarding-selection env vars left over from an *unrelated*
+// onboard (e.g. the installer's just-completed Deep Agents onboard right before
+// `upgrade-sandboxes --auto`) must never steer `onboard --resume` away from the
+// target sandbox's recorded agent/provider/model/credential. These are the env
+// vars that onboard's resume path reads to pick the agent, provider, model,
+// endpoint, and credential — isolating them during the recreate forces the
+// pinned session + gateway-registered provider to win.
+export const AMBIENT_RECREATE_ENV_VARS = [
+  "NEMOCLAW_AGENT",
+  "NEMOCLAW_PROVIDER",
+  "NEMOCLAW_PROVIDER_KEY",
+  "NEMOCLAW_ENDPOINT_URL",
+  "NEMOCLAW_MODEL",
+] as const;
+
+export interface AmbientRecreateEnvAssessment {
+  /** Ambient onboard-selection env vars currently set (non-empty). */
+  readonly presentVars: string[];
+  /**
+   * Set when ambient `NEMOCLAW_AGENT` would recreate the sandbox as a different
+   * agent than the registry records — the structural target change behind the
+   * reporter's destroyed-then-recreated-as-Deep-Agents failure.
+   */
+  readonly agentMismatch: { readonly envAgent: string; readonly registryAgent: string } | null;
+}
+
+/**
+ * Describe how the ambient process env would alter this sandbox's recreate,
+ * relative to its authoritative registry agent. Pure — does not mutate env.
+ */
+export function assessAmbientRecreateEnv(
+  registryAgent: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): AmbientRecreateEnvAssessment {
+  const presentVars = AMBIENT_RECREATE_ENV_VARS.filter(
+    (name) => typeof env[name] === "string" && env[name]?.trim() !== "",
+  );
+
+  // The registry's null agent is the default OpenClaw runtime.
+  const effectiveRegistryAgent = (registryAgent || "openclaw").trim();
+  const envAgent = (env.NEMOCLAW_AGENT || "").trim();
+  const agentMismatch =
+    envAgent && envAgent !== effectiveRegistryAgent
+      ? { envAgent, registryAgent: effectiveRegistryAgent }
+      : null;
+
+  return { presentVars: [...presentVars], agentMismatch };
+}
+
+/**
+ * Remove the ambient onboard-selection env vars so the immediate
+ * `onboard --resume` recreate cannot read a different onboard's values.
+ * Returns a restore function that puts the original values back (including
+ * re-deleting any var that was unset). Always pair with a `finally`.
+ */
+export function isolateAmbientRecreateEnv(env: NodeJS.ProcessEnv = process.env): () => void {
+  const saved = new Map<string, string | undefined>();
+  for (const name of AMBIENT_RECREATE_ENV_VARS) {
+    saved.set(name, env[name]);
+    delete env[name];
+  }
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    for (const [name, value] of saved) {
+      if (value === undefined) {
+        delete env[name];
+      } else {
+        env[name] = value;
+      }
+    }
+  };
+}

--- a/src/lib/actions/sandbox/rebuild-flow.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow.test.ts
@@ -46,6 +46,8 @@ type RebuildFlowOverrides = {
     failedFiles: string[];
   };
   buildMessagingRebuildPlan?: () => Promise<unknown> | unknown;
+  sandboxEntry?: Record<string, unknown>;
+  sessionSandboxName?: string;
 };
 
 type RebuildFlowHarness = {
@@ -188,6 +190,7 @@ function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): Rebuild
     .spyOn(onboardSession, "releaseOnboardLock")
     .mockImplementation(() => undefined);
   const markStepFailedSpy = installTerminalStepFailureMock(onboardSession, session);
+  session.sandboxName = overrides.sessionSandboxName ?? session.sandboxName;
   vi.spyOn(registry, "getSandbox").mockReturnValue({
     name: "alpha",
     provider: "ollama-local",
@@ -195,6 +198,7 @@ function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): Rebuild
     policies: ["npm"],
     agent: null,
     nimContainer: null,
+    ...(overrides.sandboxEntry ?? {}),
   });
   vi.spyOn(registry, "listSandboxes").mockReturnValue({ sandboxes: [] });
   const registryUpdateSpy = vi.spyOn(registry, "updateSandbox").mockImplementation(() => undefined);
@@ -484,6 +488,134 @@ describe("rebuildSandbox flow", () => {
     expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "throw");
     expect(harness.errorSpy).toHaveBeenCalledWith(expect.stringContaining("bad, throw"));
     expect(harness.relockSpy).toHaveBeenCalledWith("alpha", expect.any(Object), true, "nemoclaw");
+  });
+
+  it("isolates ambient onboard-selection env during recreate, then restores it (#5735)", async () => {
+    // Simulate an installer that just onboarded an unrelated Deep Agents
+    // sandbox and left its selection env in the process before
+    // `upgrade-sandboxes --auto` rebuilds an existing OpenClaw (registry agent
+    // null) sandbox.
+    process.env.NEMOCLAW_AGENT = "langchain-deepagents-code";
+    process.env.NEMOCLAW_PROVIDER_KEY = "sk-bogus-installer-key";
+
+    let envSeenInsideOnboard: {
+      agent: string | undefined;
+      providerKey: string | undefined;
+    } | null = null;
+
+    try {
+      const harness = createRebuildFlowHarness({
+        applyPreset: () => true,
+        onboard: () => {
+          // onboard --resume's agent/provider/credential resolution reads these
+          // directly from process.env; they must be gone during recreate so the
+          // pinned registry session wins.
+          envSeenInsideOnboard = {
+            agent: process.env.NEMOCLAW_AGENT,
+            providerKey: process.env.NEMOCLAW_PROVIDER_KEY,
+          };
+        },
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(envSeenInsideOnboard).toEqual({ agent: undefined, providerKey: undefined });
+      // The mismatch (env agent != registry agent) is surfaced before delete.
+      const logged = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(logged).toContain("Ignoring ambient NEMOCLAW_AGENT='langchain-deepagents-code'");
+      // The caller's env is left exactly as it was after the rebuild.
+      expect(process.env.NEMOCLAW_AGENT).toBe("langchain-deepagents-code");
+      expect(process.env.NEMOCLAW_PROVIDER_KEY).toBe("sk-bogus-installer-key");
+    } finally {
+      // Test-injected selection env — unset unconditionally so it cannot leak
+      // into other tests in this worker.
+      delete process.env.NEMOCLAW_AGENT;
+      delete process.env.NEMOCLAW_PROVIDER_KEY;
+    }
+  });
+
+  it("aborts before backup/delete when a custom-endpoint target has no matching session (#5735)", async () => {
+    // Installer flow: the loaded onboard session belongs to a different
+    // (just-created) sandbox, and the target uses a custom OpenAI-compatible
+    // provider whose base URL is only in its own session. Recreating it would
+    // either fail or reconfigure against the wrong endpoint after deletion — so
+    // rebuild must fail closed with the sandbox intact.
+    process.env.COMPATIBLE_API_KEY = "compat-key"; // pass credential preflight first
+    try {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider: "compatible-endpoint", model: "custom-model" },
+        sessionSandboxName: "some-other-sandbox",
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Cannot determine recreate endpoint");
+
+      const errors = harness.errorSpy.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(errors).toContain("cannot determine the inference endpoint");
+      expect(errors).toContain("Sandbox is untouched");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+      expect(harness.runOpenshellSpy).not.toHaveBeenCalledWith(
+        ["sandbox", "delete", "alpha"],
+        expect.anything(),
+      );
+      expect(harness.onboardSpy).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.COMPATIBLE_API_KEY;
+    }
+  });
+
+  it("rebuilds a known-remote target even when the session belongs to another sandbox (#5735)", async () => {
+    // The same non-matching-session scenario but with a provider that has a
+    // canonical endpoint (NVIDIA Endpoints): the endpoint is re-derivable from
+    // registry, so the rebuild proceeds (no abort) and pins it.
+    process.env.NVIDIA_INFERENCE_API_KEY = "nvapi-key"; // pass credential preflight
+    try {
+      const harness = createRebuildFlowHarness({
+        applyPreset: () => true,
+        sandboxEntry: { provider: "nvidia-prod", model: "nvidia/nemotron" },
+        sessionSandboxName: "some-other-sandbox",
+      });
+      // A stale endpoint carried over from the unrelated session must be
+      // repinned from the nvidia-prod canonical config, not reused as-is.
+      const staleEndpoint = "https://stale.example.test/v1";
+      harness.session.endpointUrl = staleEndpoint;
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.onboardSpy).toHaveBeenCalled();
+      expect(harness.session.endpointUrl).not.toBe(staleEndpoint);
+      expect(harness.runOpenshellSpy).toHaveBeenCalledWith(
+        ["sandbox", "delete", "alpha"],
+        expect.objectContaining({ ignoreError: true }),
+      );
+    } finally {
+      delete process.env.NVIDIA_INFERENCE_API_KEY;
+    }
+  });
+
+  it("does not abort a routed (nvidia-router) target with a non-matching session (#5735)", async () => {
+    // nvidia-router derives its endpoint from the blueprint, not the session, so
+    // the endpoint preflight must not treat it like a custom endpoint and abort.
+    const harness = createRebuildFlowHarness({
+      applyPreset: () => true,
+      sandboxEntry: { provider: "nvidia-router", model: "router-model" },
+      sessionSandboxName: "some-other-sandbox",
+    });
+
+    await expect(
+      harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.runOpenshellSpy).toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.objectContaining({ ignoreError: true }),
+    );
+    expect(harness.onboardSpy).toHaveBeenCalled();
   });
 
   it("marks recreate onboarding failures as terminal and preserves retry cleanup", async () => {

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -25,7 +25,10 @@ const hermesProviderAuth = require("../../hermes-provider-auth") as {
 const { LOCAL_INFERENCE_PROVIDERS, REMOTE_PROVIDER_CONFIG, providerExistsInGateway } =
   require("../../onboard/providers") as {
     LOCAL_INFERENCE_PROVIDERS: string[];
-    REMOTE_PROVIDER_CONFIG: Record<string, { providerName: string; credentialEnv: string | null }>;
+    REMOTE_PROVIDER_CONFIG: Record<
+      string,
+      { providerName: string; credentialEnv: string | null; endpointUrl?: string | null }
+    >;
     providerExistsInGateway: (name: string, runOpenshellFn: typeof runOpenshell) => boolean;
   };
 
@@ -74,6 +77,7 @@ import {
 import { removeSandboxRegistryEntry } from "./destroy";
 import { ensureMessagingHostForwardAfterRebuild } from "./messaging-host-forward-lifecycle";
 import { executeSandboxCommand } from "./process-recovery";
+import { assessAmbientRecreateEnv, isolateAmbientRecreateEnv } from "./rebuild-env-isolation";
 import {
   backupSandboxStateForRebuild,
   ensureRebuildAgentBaseImage,
@@ -144,6 +148,50 @@ function getRebuildCredentialEnvFromRegistry(provider: string | null | undefined
       ? REMOTE_PROVIDER_CONFIG.build
       : Object.values(REMOTE_PROVIDER_CONFIG).find((entry) => entry.providerName === provider);
   return remoteConfig?.credentialEnv || null;
+}
+
+// Providers whose inference base URL is supplied by the operator at onboard time
+// (modelMode "input") and recorded only in that sandbox's own onboard session —
+// there is no canonical or registry source to re-derive it from during a
+// rebuild. These are the only providers for which a non-matching session makes
+// the recreate endpoint unrecoverable. (#5735)
+const SESSION_ONLY_ENDPOINT_PROVIDER_NAMES = new Set(
+  [
+    REMOTE_PROVIDER_CONFIG.custom?.providerName,
+    REMOTE_PROVIDER_CONFIG.anthropicCompatible?.providerName,
+    // Stable fallbacks in case the config keys are renamed.
+    "compatible-endpoint",
+    "compatible-anthropic-endpoint",
+  ].filter((value): value is string => typeof value === "string" && value.length > 0),
+);
+
+/**
+ * Resolve the authoritative inference endpoint for a sandbox's recorded provider
+ * during rebuild (#5735). Returns `{ known: true, endpointUrl }` when the
+ * recreate endpoint can be re-derived without the target's own onboard session —
+ * a known remote provider with a canonical URL (e.g. nvidia-prod → NVIDIA
+ * Endpoints), a local or routed (blueprint-derived) provider (no static URL to
+ * pin), or any other provider that does not record a custom base URL. Returns
+ * `{ known: false }` only for custom OpenAI/Anthropic-compatible providers whose
+ * base URL lives solely in their own session — the caller must then refuse to
+ * destroy the sandbox from an unrelated session rather than guess the endpoint.
+ */
+function getRebuildEndpointFromRegistry(
+  provider: string | null | undefined,
+): { known: true; endpointUrl: string | null } | { known: false } {
+  if (!provider) return { known: true, endpointUrl: null };
+  if (isLocalInferenceProvider(provider)) return { known: true, endpointUrl: null };
+  // Custom OpenAI/Anthropic-compatible providers carry their base URL only in
+  // the session; without a matching session it cannot be recovered.
+  if (SESSION_ONLY_ENDPOINT_PROVIDER_NAMES.has(provider)) return { known: false };
+  const remoteConfig =
+    provider === "nvidia-nim"
+      ? REMOTE_PROVIDER_CONFIG.build
+      : Object.values(REMOTE_PROVIDER_CONFIG).find((entry) => entry.providerName === provider);
+  // Known remote provider with a canonical endpoint → pin it. Otherwise (routed
+  // inference, NIM, or any provider without a custom session-only URL) there is
+  // no static URL to pin; the resume path derives it, so leave it unpinned.
+  return { known: true, endpointUrl: remoteConfig?.endpointUrl || null };
 }
 
 function normalizeHermesRebuildAuthMethod(value: unknown): "oauth" | "api_key" | null {
@@ -632,6 +680,62 @@ export async function rebuildSandbox(
   // the sandbox still intact. See #2273.
   if (!preflightRebuildCredentials(sandboxName, sb, log, bail)) return;
 
+  // #5735: make the recreate config match registry reality *before* any
+  // destructive backup/delete. A rebuild always recreates the target from its
+  // recorded agent/provider/model, so surface (and, at recreate time, ignore)
+  // any ambient onboard-selection env that would otherwise steer the resume
+  // toward a different agent/provider — e.g. an installer's just-completed
+  // Deep Agents onboard env bleeding into `upgrade-sandboxes --auto`.
+  const ambientRecreateEnv = assessAmbientRecreateEnv(rebuildAgent);
+  if (ambientRecreateEnv.presentVars.length > 0) {
+    log(
+      `Ambient onboard-selection env present (${ambientRecreateEnv.presentVars.join(", ")}); will be isolated during recreate so '${sandboxName}' rebuilds from its registry config`,
+    );
+    if (ambientRecreateEnv.agentMismatch) {
+      console.log(
+        `  ${D}Ignoring ambient NEMOCLAW_AGENT='${ambientRecreateEnv.agentMismatch.envAgent}' — ` +
+          `rebuilding '${sandboxName}' as its recorded agent '${ambientRecreateEnv.agentMismatch.registryAgent}'.${R}`,
+      );
+    }
+  }
+
+  // #5735: when the loaded onboard session belongs to a *different* sandbox
+  // (e.g. an installer's just-completed onboard before `upgrade-sandboxes
+  // --auto`), the target's inference endpoint can only be re-derived for
+  // providers with a canonical endpoint (NVIDIA Endpoints, Anthropic, etc.) or
+  // local inference. For a custom OpenAI-compatible / router provider the base
+  // URL lives only in the target's own onboard session — which we don't have —
+  // so recreating would either fail or silently reconfigure the provider
+  // against the unrelated session's endpoint. Fail closed *before* any
+  // destructive backup/delete so the live sandbox stays intact.
+  const endpointPreflightSession = onboardSession.loadSession();
+  if (
+    endpointPreflightSession?.sandboxName !== sandboxName &&
+    sb.provider &&
+    !isLocalInferenceProvider(sb.provider) &&
+    sb.provider !== hermesProviderAuth.HERMES_PROVIDER_NAME &&
+    !getRebuildEndpointFromRegistry(sb.provider).known
+  ) {
+    console.error("");
+    console.error(
+      `  ${_RD}Rebuild preflight failed:${R} cannot determine the inference endpoint for provider '${sb.provider}'.`,
+    );
+    console.error(
+      `  The custom endpoint for '${sandboxName}' is recorded only in its own onboard session,`,
+    );
+    console.error(
+      `  but the current session belongs to '${endpointPreflightSession?.sandboxName ?? "(none)"}'.`,
+    );
+    console.error(`  Rebuild '${sandboxName}' directly so its session is loaded:`);
+    console.error(`    ${CLI_NAME} ${sandboxName} rebuild`);
+    console.error("");
+    console.error("  Sandbox is untouched — no data was lost.");
+    bail(
+      `Cannot determine recreate endpoint for provider '${sb.provider}' without a matching session`,
+    );
+    return;
+  }
+
   const rebuildMessagingPlan = await stageRebuildMessagingPlanOrBail(
     sandboxName,
     sb,
@@ -767,6 +871,23 @@ export async function rebuildSandbox(
       s.provider = sb.provider ?? null;
       s.model = sb.model ?? null;
       s.nimContainer = sb.nimContainer ?? null;
+      // #5735: pin the credential env name from the target registry provider so
+      // onboard --resume cannot recreate this sandbox with an unrelated onboard's
+      // provider credential.
+      s.credentialEnv = getRebuildCredentialEnvFromRegistry(sb.provider);
+      // When the loaded session belongs to a *different* sandbox (e.g. the
+      // installer's just-completed onboard), repin the endpoint from the target
+      // provider's canonical config so a stale endpoint cannot bleed in. Only do
+      // this for providers with a canonical/registry-derivable endpoint; for a
+      // custom OpenAI-compatible provider the base URL exists only in its own
+      // matching session, so clearing it here would strand the recreate after
+      // the delete — preserve whatever the session holds instead.
+      if (!sessionMatchesSandbox) {
+        const rebuildEndpoint = getRebuildEndpointFromRegistry(sb.provider);
+        if (rebuildEndpoint.known) {
+          s.endpointUrl = rebuildEndpoint.endpointUrl;
+        }
+      }
       return s;
     });
     process.env.NEMOCLAW_SANDBOX_NAME = sandboxName;
@@ -828,6 +949,14 @@ export async function rebuildSandbox(
       storedFromDockerfile,
       autoYes: skipConfirm || rebuildConfirmed,
     });
+    // #5735: isolate ambient onboard-selection env only for the duration of the
+    // recreate. The session was just pinned to the registry agent/provider/
+    // model/credential above, so removing NEMOCLAW_AGENT/PROVIDER/PROVIDER_KEY/
+    // ENDPOINT_URL/MODEL forces onboard --resume to recreate from that pinned
+    // config (and the already-registered gateway provider) instead of an
+    // unrelated onboard's values. Restored in finally so a bulk rebuild loop
+    // and the caller's process env are left untouched.
+    const restoreAmbientRecreateEnv = isolateAmbientRecreateEnv();
     try {
       await onboard(recreateOpts);
       log("onboard() returned successfully");
@@ -840,6 +969,7 @@ export async function rebuildSandbox(
       }
     } finally {
       process.exit = _savedExit;
+      restoreAmbientRecreateEnv();
     }
 
     if (!onboardFailed) {

--- a/test/install-upgrade-sandboxes-severity.test.ts
+++ b/test/install-upgrade-sandboxes-severity.test.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
+
+// Exercise print_done() directly with a controlled environment. The post-onboard
+// auto-upgrade of pre-existing sandboxes is destructive (it deletes a sandbox
+// before recreating it), so a failed auto-upgrade must not be reported as a
+// clean install (#5735).
+function runPrintDone(upgradeFailed: boolean): string {
+  const snippet = `
+    set -e
+    source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
+    # Minimal stubs so print_done runs in isolation.
+    info() { printf 'INFO:%s\\n' "$*"; }
+    warn() { printf 'WARN:%s\\n' "$*"; }
+    needs_shell_reload() { return 1; }
+    resolve_onboarded_agent() { printf 'openclaw'; }
+    warn_default_agent_fallback() { :; }
+    print_cli_path_refresh_actions() { :; }
+    _INSTALL_START=0
+    SECONDS=0
+    _CLI_DISPLAY="NemoClaw"
+    _CLI_BIN="nemoclaw"
+    ONBOARD_RAN=true
+    NEMOCLAW_READY_NOW=true
+    _UPGRADE_SANDBOXES_FAILED=${upgradeFailed ? "true" : "false"}
+    print_done
+  `;
+  const result = spawnSync("bash", ["-c", snippet], {
+    encoding: "utf-8",
+    // Neutralize ambient shell hooks (BASH_ENV/ENV) so an outer profile cannot
+    // run before the snippet and make this deterministic test flaky.
+    env: { ...process.env, BASH_ENV: "", ENV: "" },
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout;
+}
+
+describe("install.sh print_done — auto-upgrade severity (#5735)", () => {
+  it("prints a clean completion banner when no sandbox upgrade failed", () => {
+    const out = runPrintDone(false);
+    expect(out).toContain("=== Installation complete ===");
+    expect(out).not.toContain("Installation completed with warnings");
+    expect(out).not.toContain("Existing sandbox upgrade did not finish");
+  });
+
+  it("downgrades the banner and surfaces recovery guidance when an upgrade failed", () => {
+    const out = runPrintDone(true);
+    // No plain "Installation complete" success banner.
+    expect(out).not.toContain("=== Installation complete ===");
+    expect(out).toContain("Installation completed with warnings");
+    // Explicit incomplete status with recovery guidance for the operator.
+    expect(out).toContain("Existing sandbox upgrade did not finish");
+    expect(out).toContain("onboard --resume");
+    expect(out).toContain("rebuild");
+  });
+});


### PR DESCRIPTION
## Summary

The installer runs `upgrade-sandboxes --auto` immediately after onboarding. When the operator had exported a different agent/provider for that onboard (e.g. `NEMOCLAW_AGENT=langchain-deepagents-code` + `NEMOCLAW_PROVIDER_KEY=sk-...`), those ambient values leaked into every existing sandbox's rebuild: the old OpenClaw sandbox was backed up, **deleted, then recreated as the wrong agent (Deep Agents) with an invalid key** — destroying the sandbox before a failed/mismatched recreate, while the installer still printed a clean "Installation complete" banner. A rebuild must recreate a sandbox from its own recorded registry/session config, never from an unrelated onboard's ambient env.

## Related Issue

Fixes #5735

## Changes

- **Isolate ambient onboard-selection env during recreate** — `NEMOCLAW_AGENT`, `NEMOCLAW_PROVIDER`, `NEMOCLAW_PROVIDER_KEY`, `NEMOCLAW_ENDPOINT_URL`, `NEMOCLAW_MODEL` are removed for the duration of the `onboard --resume` recreate (restored in `finally`), so the registry-pinned session and the already-registered gateway provider win. New `rebuild-env-isolation.ts` helper.
- **Surface the agent mismatch before any destructive backup/delete.**
- **Pin authoritative resume fields** — `credentialEnv` from the target registry provider; repin the endpoint from the provider's canonical config when the loaded session belongs to a different sandbox.
- **Fail closed before delete** when a non-matching session targets a custom OpenAI/Anthropic-compatible provider whose base URL exists only in its own session (`nvidia-router` and known remotes stay registry/blueprint-derivable and are not aborted).
- **Installer severity** — a failed `upgrade-sandboxes --auto` no longer prints a clean completion banner; it reports "completed with warnings" plus the affected sandbox / backup path / recovery commands.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

**Real-CLI E2E (live gateway, isolated dedicated-port gateway + temp registry):** created a real OpenClaw `nvidia-prod` sandbox, marked it stale, exported the reporter's `NEMOCLAW_AGENT=langchain-deepagents-code` + `NEMOCLAW_PROVIDER_KEY=sk-...`, and ran `./bin/nemoclaw.js upgrade-sandboxes --auto`.
- **Pre-fix:** the OpenClaw sandbox was deleted and recreated as **Deep Agents** (registry `agent=langchain-deepagents-code`) with incomplete state restore — data loss.
- **Post-fix:** the same command logged *"Ignoring ambient NEMOCLAW_AGENT=… — rebuilding as its recorded agent 'openclaw'"* and rebuilt it as **OpenClaw**, staying `Ready`.

Targeted unit tests: `rebuild-env-isolation.test.ts`, `rebuild-flow.test.ts` (env isolation + custom-endpoint pre-delete abort + nvidia-router/known-remote proceed), `install-upgrade-sandboxes-severity.test.ts`, plus `repro-2201.test.ts` and the sandbox/onboard suites. `tsc -p tsconfig.cli.json` clean; reviewed with `codex review --uncommitted` (findings addressed).

---

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox rebuilds now isolate recreate-related ambient environment values and pin inference settings from the target registry to prevent recreation from being influenced by unrelated session data.
  * Installation output now reports whether the automatic post-onboarding sandbox upgrade finished successfully, with added recovery guidance when it didn’t.

* **Bug Fixes**
  * Rebuild now fails earlier for mismatched-session, custom-endpoint scenarios where the recreate endpoint can’t be determined from the registry.
  * Improved rebuild endpoint handling for remote/custom and routed inference targets.

* **Tests**
  * Added unit and flow coverage for environment isolation, endpoint/credential pinning behavior, and installation completion severity messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->