### PR TITLE
fix(cli): recover live sandboxes in list when local registry is empty

### DIFF
--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -21,6 +21,7 @@ type RunnerOptions = {
   stdio?: StdioOptions;
   input?: string;
   ignoreError?: boolean;
+  includeStderr?: boolean;
   timeout?: number;
 };
 
@@ -55,6 +56,7 @@ export function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
     cwd: ROOT,
     env: opts.env,
     ignoreError: opts.ignoreError,
+    includeStderr: opts.includeStderr,
     timeout: opts.timeout,
     errorLine: console.error,
     exit: (code: number) => process.exit(code),

--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -27,6 +27,7 @@ type RunnerOptions = {
 
 let openshellBin: string | null = null;
 
+/** Resolve and cache the OpenShell binary path, exiting if it is not installed. */
 export function getOpenshellBinary(): string {
   if (!openshellBin) {
     openshellBin = resolveOpenshell();
@@ -38,6 +39,7 @@ export function getOpenshellBinary(): string {
   return openshellBin;
 }
 
+/** Run an OpenShell command, inheriting stdio (no output capture). */
 export function runOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   return runOpenshellCommand(getOpenshellBinary(), args, {
     cwd: ROOT,
@@ -68,6 +70,7 @@ export function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   });
 }
 
+/** Capture the SSH config OpenShell emits for a sandbox. */
 export function captureSandboxSshConfig(sandboxName: string, opts: RunnerOptions = {}) {
   return captureSandboxSshConfigCommand(getOpenshellBinary(), sandboxName, {
     cwd: ROOT,
@@ -79,12 +82,14 @@ export function captureSandboxSshConfig(sandboxName: string, opts: RunnerOptions
   });
 }
 
+/** Resolve the status-probe timeout (ms) from env, falling back to the default. */
 export function getStatusProbeTimeoutMs(): number {
   const raw = process.env.NEMOCLAW_STATUS_PROBE_TIMEOUT_MS;
   const parsed = raw ? Number(raw) : NaN;
   return Number.isFinite(parsed) && parsed > 0 ? parsed : OPENSHELL_PROBE_TIMEOUT_MS;
 }
 
+/** Async variant of {@link captureOpenshell} for status probes, with a kill grace period. */
 export function captureOpenshellForStatus(args: CommandArgs, opts: RunnerOptions = {}) {
   return captureOpenshellCommandAsync(getOpenshellBinary(), args, {
     cwd: ROOT,
@@ -95,10 +100,12 @@ export function captureOpenshellForStatus(args: CommandArgs, opts: RunnerOptions
   });
 }
 
+/** Whether a captured command result represents an ETIMEDOUT spawn timeout. */
 export function isCommandTimeout(result: { error?: Error }) {
   return (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
 }
 
+/** Return the installed OpenShell version, or null when it cannot be determined. */
 export function getInstalledOpenshellVersionOrNull(opts: { timeout?: number } = {}): string | null {
   return getInstalledOpenshellVersion(getOpenshellBinary(), {
     cwd: ROOT,

--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -51,6 +51,11 @@ export function runOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   });
 }
 
+/**
+ * Run an OpenShell command and capture its output. `includeStderr` keeps stderr
+ * in the captured output even when `ignoreError` is set (needed for probes that
+ * must stay non-fatal yet still read status text OpenShell writes to stderr).
+ */
 export function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   return captureOpenshellCommand(getOpenshellBinary(), args, {
     cwd: ROOT,

--- a/src/lib/gateway-runtime-action.test.ts
+++ b/src/lib/gateway-runtime-action.test.ts
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 type GatewayRuntimeModule = typeof import("../../dist/lib/gateway-runtime-action");
 
@@ -76,6 +76,30 @@ describe("gateway-runtime-action per-sandbox gateway routing", () => {
 
       expect(result.state).toBe("connected_other");
       expect(result.activeGateway).toBe("nemoclaw");
+    });
+
+    it("keeps probes fatal (no ignoreError) by default", () => {
+      captureSpy.mockReturnValue({ status: 0, output: "Status: Connected\nGateway: nemoclaw\n" });
+
+      gatewayRuntime.getNamedGatewayLifecycleState("nemoclaw");
+
+      for (const [, opts] of captureSpy.mock.calls) {
+        expect(opts?.ignoreError).not.toBe(true);
+      }
+    });
+
+    it("makes probes non-fatal when ignoreProbeErrors is set (#5714)", () => {
+      // Plain `nemoclaw list` recovery must not be killed by a hung gateway:
+      // both lifecycle probes must run with ignoreError so an ETIMEDOUT is
+      // swallowed instead of triggering captureOpenshell's process.exit.
+      captureSpy.mockReturnValue({ status: 0, output: "Status: Connected\nGateway: nemoclaw\n" });
+
+      gatewayRuntime.getNamedGatewayLifecycleState("nemoclaw", { ignoreProbeErrors: true });
+
+      expect(captureSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+      for (const [, opts] of captureSpy.mock.calls) {
+        expect(opts?.ignoreError).toBe(true);
+      }
     });
   });
 

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -17,10 +17,12 @@ import {
 import { GATEWAY_PORT } from "./core/ports";
 import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
 
+/** Whether `gateway info` output names the given NemoClaw gateway. */
 function hasNamedGateway(output = "", gatewayName = "nemoclaw"): boolean {
   return stripAnsi(output).includes(`Gateway: ${gatewayName}`);
 }
 
+/** Parse the active gateway name from `openshell status` output, or null. */
 function getActiveGatewayName(output = ""): string | null {
   const match = stripAnsi(output).match(/^\s*Gateway:\s+(.+?)\s*$/m);
   return match ? match[1].trim() : null;

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -7,14 +7,15 @@ const { startGatewayForRecovery } = require("./onboard") as {
     gatewayPort?: number;
   }) => Promise<void>;
 };
+
+import { stripAnsi } from "./adapters/openshell/client";
+import { captureOpenshell, runOpenshell } from "./adapters/openshell/runtime";
 import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "./adapters/openshell/timeouts";
-import { stripAnsi } from "./adapters/openshell/client";
-import { captureOpenshell, runOpenshell } from "./adapters/openshell/runtime";
-import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
 import { GATEWAY_PORT } from "./core/ports";
+import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
 
 function hasNamedGateway(output = "", gatewayName = "nemoclaw"): boolean {
   return stripAnsi(output).includes(`Gateway: ${gatewayName}`);
@@ -27,10 +28,26 @@ function getActiveGatewayName(output = ""): string | null {
 
 export function getNamedGatewayLifecycleState(
   gatewayName: string = resolveGatewayName(GATEWAY_PORT),
+  opts: { ignoreProbeErrors?: boolean } = {},
 ) {
-  const status = captureOpenshell(["status"], { timeout: OPENSHELL_PROBE_TIMEOUT_MS });
+  // #5714: callers that must stay non-fatal (e.g. plain `nemoclaw list`
+  // recovery) opt into `ignoreProbeErrors` so a hung/timed-out `openshell
+  // status` returns a not-healthy classification instead of `process.exit`ing
+  // via captureOpenshell's default error handling. Other callers keep the
+  // existing fatal behavior by default.
+  const ignoreError = opts.ignoreProbeErrors === true;
+  // When ignoring probe errors we must still capture stderr — OpenShell writes
+  // the `Status:`/`Gateway:` lines there, and `ignoreError` would otherwise
+  // drop stderr and break the healthy/connected classification.
+  const status = captureOpenshell(["status"], {
+    timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+    ignoreError,
+    includeStderr: ignoreError,
+  });
   const gatewayInfo = captureOpenshell(["gateway", "info", "-g", gatewayName], {
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+    ignoreError,
+    includeStderr: ignoreError,
   });
   const cleanStatus = stripAnsi(status.output);
   const activeGateway = getActiveGatewayName(status.output);

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -26,6 +26,13 @@ function getActiveGatewayName(output = ""): string | null {
   return match ? match[1].trim() : null;
 }
 
+/**
+ * Classify the lifecycle state of the named gateway (healthy_named,
+ * named_unreachable, named_unhealthy, connected_other, or missing_named) from
+ * `openshell status` and `gateway info`. Pass `ignoreProbeErrors` to keep the
+ * probes non-fatal so a hung/timed-out gateway is classified rather than
+ * exiting the process.
+ */
 export function getNamedGatewayLifecycleState(
   gatewayName: string = resolveGatewayName(GATEWAY_PORT),
   opts: { ignoreProbeErrors?: boolean } = {},

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -7,6 +7,7 @@ import {
   getSandboxInventory,
   getStatusReport,
   listSandboxesCommand,
+  renderSandboxInventoryText,
   type SandboxEntry,
   showStatusCommand,
 } from "./index";
@@ -132,6 +133,51 @@ describe("inventory commands", () => {
       ],
     });
     expect(getLiveInference).not.toHaveBeenCalled();
+  });
+
+  it("shows agent as 'unknown' for a gateway-recovered sandbox (#5714), not the OpenClaw default", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          { name: "dcode-station", model: null, provider: null, recoveredFromGateway: true },
+        ],
+        defaultSandbox: null,
+        recoveredFromSession: false,
+        recoveredFromGateway: 1,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    expect(inventory.sandboxes[0]).toMatchObject({
+      name: "dcode-station",
+      agent: "unknown",
+      recoveredFromGateway: true,
+    });
+  });
+
+  it("renders a gateway-recovered row with unknown agent/GPU instead of OpenClaw/CPU defaults (#5714)", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          { name: "dcode-station", model: null, provider: null, recoveredFromGateway: true },
+        ],
+        defaultSandbox: null,
+        recoveredFromSession: false,
+        recoveredFromGateway: 1,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    const lines: string[] = [];
+    renderSandboxInventoryText(inventory, (m = "") => lines.push(m), null);
+    const body = lines.join("\n");
+    expect(body).toContain("Recovered 1 sandbox");
+    expect(body).toContain("agent: unknown");
+    expect(body).toContain("GPU: unknown");
+    expect(body).not.toContain("CPU sandbox");
+    expect(body).not.toContain("agent: openclaw");
   });
 
   it("normalizes invalid configured inference fields out of inventory rows", async () => {

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -176,6 +176,11 @@ function safeStatusString(value: string | null | undefined): string | null {
   return redactFull(value);
 }
 
+/**
+ * Project a stored or recovered {@link SandboxEntry} into a display row,
+ * resolving inference/GPU fields and marking gateway-recovered rows so unknown
+ * agent/GPU state renders as "unknown" rather than OpenClaw/CPU defaults.
+ */
 function buildSandboxInventoryRow(
   sandbox: SandboxEntry,
   defaultSandbox: string | null,

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -23,6 +23,10 @@ export interface SandboxEntry {
   messaging?: SandboxMessagingState | null;
   agent?: string | null;
   dashboardPort?: number | null;
+  // #5714: display-only marker for a sandbox recovered directly from the live
+  // gateway whose agent is genuinely unknown (the gateway sandbox list does not
+  // expose it). Lets the renderer show "unknown" instead of the OpenClaw default.
+  recoveredFromGateway?: boolean;
 }
 
 export interface MessagingBridgeHealth {
@@ -71,6 +75,10 @@ export interface SandboxInventoryRow {
   isDefault: boolean;
   activeSessionCount: number | null;
   connected: boolean;
+  // #5714: row recovered display-only from the live gateway. Its agent/GPU/
+  // inference state is unknown (the gateway sandbox list does not expose it),
+  // so the renderer shows "unknown" rather than asserting OpenClaw/CPU defaults.
+  recoveredFromGateway?: boolean;
 }
 
 export interface SandboxInventoryResult {
@@ -192,11 +200,16 @@ function buildSandboxInventoryRow(
     openshellDriver: safeStatusString(sandbox.openshellDriver || null),
     openshellVersion: safeStatusString(sandbox.openshellVersion || null),
     policies: Array.isArray(sandbox.policies) ? sandbox.policies : [],
-    agent: sandbox.agent || null,
+    // #5714: a sandbox recovered display-only from the live gateway has an
+    // unknown agent (the gateway sandbox list does not expose it). Surface
+    // "unknown" instead of letting the renderer's `|| "openclaw"` default
+    // misrepresent a Deep Agents/Hermes sandbox as OpenClaw.
+    agent: sandbox.agent || (sandbox.recoveredFromGateway ? "unknown" : null),
     ...(sandbox.dashboardPort != null ? { dashboardPort: sandbox.dashboardPort } : {}),
     isDefault: sandbox.name === defaultSandbox,
     activeSessionCount,
     connected: activeSessionCount !== null && activeSessionCount > 0,
+    ...(sandbox.recoveredFromGateway ? { recoveredFromGateway: true } : {}),
   };
 }
 
@@ -289,7 +302,14 @@ export function renderSandboxInventoryText(
       liveInference.provider &&
       liveInference.provider !== sandbox.provider
     );
-    const gpu = sandbox.sandboxGpuEnabled ? "sandbox GPU" : "CPU sandbox";
+    // #5714: a gateway-recovered row's GPU state is unknown — the gateway
+    // sandbox list does not expose it — so don't assert "CPU sandbox" (which
+    // would mislead DGX users whose GPU sandbox's registry entry was lost).
+    const gpu = sandbox.recoveredFromGateway
+      ? "GPU: unknown"
+      : sandbox.sandboxGpuEnabled
+        ? "sandbox GPU"
+        : "CPU sandbox";
     const presets = sandbox.policies.length > 0 ? sandbox.policies.join(", ") : "none";
     const connected = sandbox.connected ? " ●" : "";
     const agent = sandbox.agent || "openclaw";

--- a/src/lib/registry-recovery-action.test.ts
+++ b/src/lib/registry-recovery-action.test.ts
@@ -39,6 +39,7 @@ vi.mock("./adapters/openshell/resolve.js", () => ({
 
 vi.mock("./gateway-runtime-action.js", () => ({
   recoverNamedGatewayRuntime: vi.fn(),
+  getNamedGatewayLifecycleState: vi.fn(() => ({ state: "missing_named" })),
 }));
 
 vi.mock("./adapters/openshell/runtime.js", () => ({
@@ -50,7 +51,7 @@ vi.mock("./state/onboard-session.js", () => ({
 }));
 
 vi.mock("./runtime-recovery.js", () => ({
-  parseLiveSandboxNames: () => new Set<string>(),
+  parseLiveSandboxNames: vi.fn(() => new Set<string>()),
 }));
 
 vi.mock("./runner.js", () => ({
@@ -62,7 +63,14 @@ vi.mock("./runner.js", () => ({
   },
 }));
 
+import { resolveOpenshell } from "./adapters/openshell/resolve.js";
+import { captureOpenshell } from "./adapters/openshell/runtime.js";
+import {
+  getNamedGatewayLifecycleState,
+  recoverNamedGatewayRuntime,
+} from "./gateway-runtime-action.js";
 import { recoverRegistryEntries } from "./registry-recovery-action.js";
+import { parseLiveSandboxNames } from "./runtime-recovery.js";
 import { loadSession } from "./state/onboard-session.js";
 
 describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
@@ -215,5 +223,137 @@ describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
 
     expect(mockRegistryState.sandboxes["alpha"]).toBeDefined();
     expect(result.sandboxes.find((s) => s.name === "alpha")).toBeDefined();
+  });
+});
+
+describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistryState.sandboxes = {};
+    mockRegistryState.defaultSandbox = null;
+    vi.mocked(loadSession).mockReturnValue(null);
+    vi.mocked(resolveOpenshell).mockReturnValue("/usr/bin/openshell");
+    vi.mocked(captureOpenshell).mockReturnValue({ output: "", status: 0 } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set<string>());
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "missing_named" } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("recovers live gateway sandboxes for display when the registry is empty and unseeded", async () => {
+    // Reporter case: `nemoclaw list` ran with an empty/lost local registry and
+    // no onboard session, while the gateway was connected and the live sandbox
+    // existed (`status` reported Ready). list must rediscover it for display.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(1);
+    const recovered = result.sandboxes.find((s) => s.name === "dcode-station");
+    expect(recovered).toBeDefined();
+    // Minimal safe entry: no invented agent/model/provider metadata.
+    expect(recovered?.model).toBeNull();
+    expect(recovered?.provider).toBeNull();
+    expect(recovered?.agent).toBeUndefined();
+  });
+
+  it("does NOT persist unseeded gateway recoveries to the on-disk registry (#5714 agent safety)", async () => {
+    // `openshell sandbox list` does not expose the agent type, so persisting a
+    // recovered entry would default agent to "openclaw" everywhere downstream
+    // and permanently misclassify a Deep Agents/Hermes sandbox. Recovery is
+    // display-only: the on-disk registry must stay empty.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    await recoverRegistryEntries();
+
+    expect(mockRegistryState.sandboxes["dcode-station"]).toBeUndefined();
+  });
+
+  it("recovers via a NemoClaw per-port gateway when it is the active gateway", async () => {
+    // A non-default NEMOCLAW_GATEWAY_PORT runs `nemoclaw-<port>`; that is still
+    // a NemoClaw-managed gateway, so connected_other against it is trustworthy.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({
+      state: "connected_other",
+      activeGateway: "nemoclaw-8092",
+    } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(1);
+    expect(result.sandboxes.find((s) => s.name === "dcode-station")).toBeDefined();
+  });
+
+  it("ignores a failed `sandbox list` probe instead of parsing error text as names", async () => {
+    // A non-zero `openshell sandbox list` may print free-form error text; its
+    // first token must never be surfaced as a recovered sandbox.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(captureOpenshell).mockReturnValue({
+      output: "transport error: connection reset",
+      status: 1,
+    } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["transport"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
+  });
+
+  it("does NOT recover from a foreign (non-NemoClaw) active gateway", async () => {
+    // `openshell sandbox list` is scoped to the active gateway; if that gateway
+    // is not NemoClaw-managed, its sandboxes must not be surfaced as recovered
+    // NemoClaw entries.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({
+      state: "connected_other",
+      activeGateway: "some-other-project",
+    } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["foreign-sbox"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
+  });
+
+  it("inspects the gateway read-only (never mutates gateway state) when unseeded", async () => {
+    // A plain `nemoclaw list` must never select/start a gateway as a side
+    // effect of listing: it inspects the lifecycle directly and never calls
+    // the mutating recoverNamedGatewayRuntime path.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    await recoverRegistryEntries();
+
+    expect(getNamedGatewayLifecycleState).toHaveBeenCalledWith(undefined, {
+      ignoreProbeErrors: true,
+    });
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the empty registry when no gateway is connected", async () => {
+    // Read-only inspection: gateway is not connected, so no live names are
+    // written. list stays empty instead of starting a gateway.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "missing_named" } as never);
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+  });
+
+  it("does not probe the gateway when OpenShell is not installed", async () => {
+    vi.mocked(resolveOpenshell).mockReturnValue(null);
+
+    const result = await recoverRegistryEntries();
+
+    expect(getNamedGatewayLifecycleState).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+    expect(result.sandboxes).toEqual([]);
   });
 });

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -1,15 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { recoverNamedGatewayRuntime } from "./gateway-runtime-action";
-import * as onboardSession from "./state/onboard-session";
-import { OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
-import { captureOpenshell } from "./adapters/openshell/runtime";
-import * as registry from "./state/registry";
-import type { SandboxEntry } from "./state/registry";
 import { resolveOpenshell } from "./adapters/openshell/resolve";
-import { parseLiveSandboxNames } from "./runtime-recovery";
+import { captureOpenshell } from "./adapters/openshell/runtime";
+import { OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
+import {
+  getNamedGatewayLifecycleState,
+  recoverNamedGatewayRuntime,
+} from "./gateway-runtime-action";
+import { resolveGatewayPortFromName } from "./onboard/gateway-binding";
 import { validateName } from "./runner";
+import { parseLiveSandboxNames } from "./runtime-recovery";
+import * as onboardSession from "./state/onboard-session";
+import type { SandboxEntry } from "./state/registry";
+import * as registry from "./state/registry";
 
 type Session = ReturnType<typeof onboardSession.loadSession>;
 
@@ -79,9 +83,15 @@ function shouldRecoverRegistryEntries(
     current.sandboxes.length > 0 || hasSessionSandbox || Boolean(requestedSandboxName);
   return {
     missingRequestedSandbox,
+    // #5714: an empty local registry must always attempt recovery, even with
+    // no session/requested-name seed. The reporter's `nemoclaw list` printed
+    // "No sandboxes registered" while the live gateway/container were healthy
+    // and `nemoclaw <name> status` reported Ready. Probing the live gateway
+    // (bounded, read-only when unseeded — see recoverRegistryEntries) lets the
+    // documented discovery command rediscover a sandbox the local registry lost.
     shouldRecover:
-      hasRecoverySeed &&
-      (current.sandboxes.length === 0 || missingRequestedSandbox || missingSessionSandbox),
+      current.sandboxes.length === 0 ||
+      (hasRecoverySeed && (missingRequestedSandbox || missingSessionSandbox)),
   };
 }
 
@@ -136,34 +146,100 @@ function seedRecoveryMetadata(
   return { metadataByName, recoveredFromSession };
 }
 
-async function recoverRegistryFromLiveGateway(
-  metadataByName: Map<string, RecoveredSandboxMetadata>,
-) {
-  if (!resolveOpenshell()) {
-    return 0;
+function canInspectLiveGatewayReadOnly(): boolean {
+  // #5714: unseeded `nemoclaw list` recovery must never mutate gateway state
+  // (no select/start). Probes are non-fatal so a hung gateway falls back to the
+  // empty registry instead of exiting the process.
+  const lifecycle = getNamedGatewayLifecycleState(undefined, { ignoreProbeErrors: true });
+  // The target NemoClaw gateway is healthy — trust its sandbox list.
+  if (lifecycle.state === "healthy_named") {
+    return true;
   }
+  // A different gateway is active. `openshell sandbox list` is scoped to the
+  // active gateway, so only trust it when that gateway is still NemoClaw-managed
+  // (the bare `nemoclaw` or a per-port `nemoclaw-<port>` from a non-default
+  // NEMOCLAW_GATEWAY_PORT). Never list a foreign OpenShell gateway's sandboxes
+  // as recovered NemoClaw entries.
+  if (lifecycle.state === "connected_other") {
+    return resolveGatewayPortFromName(lifecycle.activeGateway ?? "") !== null;
+  }
+  return false;
+}
+
+async function canInspectLiveGatewayViaRecovery(): Promise<boolean> {
   const recovery = await recoverNamedGatewayRuntime();
-  const canInspectLiveGateway =
+  return (
     recovery.recovered ||
     recovery.before?.state === "healthy_named" ||
-    recovery.after?.state === "healthy_named";
+    recovery.after?.state === "healthy_named"
+  );
+}
+
+interface LiveGatewayRecovery {
+  recoveredFromGateway: number;
+  /**
+   * #5714: live sandboxes surfaced for display only (unseeded `list` recovery)
+   * that were NOT persisted to the on-disk registry. Empty for the seeded path.
+   */
+  ephemeralSandboxes: SandboxEntry[];
+}
+
+async function recoverRegistryFromLiveGateway(
+  metadataByName: Map<string, RecoveredSandboxMetadata>,
+  { readOnly = false }: { readOnly?: boolean } = {},
+): Promise<LiveGatewayRecovery> {
+  if (!resolveOpenshell()) {
+    return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
+  }
+  const canInspectLiveGateway = readOnly
+    ? canInspectLiveGatewayReadOnly()
+    : await canInspectLiveGatewayViaRecovery();
   if (!canInspectLiveGateway) {
-    return 0;
+    return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
   }
 
   let recoveredFromGateway = 0;
+  const ephemeralSandboxes: SandboxEntry[] = [];
   const liveList = captureOpenshell(["sandbox", "list"], {
     ignoreError: true,
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
   });
+  // Only trust the output of a clean `sandbox list`. On a non-zero/failed probe
+  // (timeout, transport error) OpenShell may print free-form text whose first
+  // token parseLiveSandboxNames would otherwise mistake for a sandbox name.
+  if (liveList.status !== 0) {
+    return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
+  }
   const liveNames = Array.from<string>(parseLiveSandboxNames(liveList.output));
   for (const name of liveNames) {
     const metadata = metadataByName.get(name) || undefined;
+    if (readOnly) {
+      // Unseeded recovery: surface the live sandbox for THIS `list` only and do
+      // not persist it. `openshell sandbox list` exposes only NAME/CREATED/PHASE
+      // — not the agent or gateway binding — so a persisted entry would default
+      // `agent` to "openclaw" everywhere downstream (state dirs, connect,
+      // rebuild, doctor), permanently misclassifying a Deep Agents/Hermes
+      // sandbox after registry loss. Display-only recovery fixes the
+      // discoverability mismatch without writing unsafe durable metadata;
+      // follow-up named commands reconcile the real agent via the gateway.
+      let validName: string;
+      try {
+        validName = validateName(name, "sandbox name");
+      } catch {
+        continue;
+      }
+      ephemeralSandboxes.push({
+        ...buildRecoveredSandboxEntry(validName, metadata),
+        recoveredFromGateway: true,
+      });
+      recoveredFromGateway += 1;
+      continue;
+    }
     if (upsertRecoveredSandbox(name, metadata)) {
       recoveredFromGateway += 1;
     }
   }
-  return recoveredFromGateway;
+  return { recoveredFromGateway, ephemeralSandboxes };
 }
 
 function applyRecoveredDefault(
@@ -196,15 +272,31 @@ export async function recoverRegistryEntries({
   }
 
   const seeded = seedRecoveryMetadata(current, session, requestedSandboxName);
-  const shouldProbeLiveGateway =
+  // A seed is any signal that the user expects a specific sandbox to exist:
+  // existing registry entries, a recorded onboard session, or an explicit
+  // requested name. With a seed we allow active gateway recovery (which may
+  // select/start the named gateway). Without one — the #5714 empty-registry
+  // `list` case — restrict recovery to a read-only inspection of any connected
+  // gateway so plain `nemoclaw list` never mutates gateway state as a side
+  // effect of listing.
+  const hasRecoverySeed =
     current.sandboxes.length > 0 || Boolean(session?.sandboxName) || Boolean(requestedSandboxName);
-  const recoveredFromGateway = shouldProbeLiveGateway
-    ? await recoverRegistryFromLiveGateway(seeded.metadataByName)
-    : 0;
+  const gateway = await recoverRegistryFromLiveGateway(seeded.metadataByName, {
+    readOnly: !hasRecoverySeed,
+  });
   const recovered = applyRecoveredDefault(current.defaultSandbox, requestedSandboxName, session);
+  // Merge display-only (ephemeral) live-gateway sandboxes that were not
+  // persisted (#5714 unseeded recovery), skipping any that a concurrent path
+  // may already have registered.
+  const persistedNames = new Set(recovered.sandboxes.map((sandbox) => sandbox.name));
+  const sandboxes = [
+    ...recovered.sandboxes,
+    ...gateway.ephemeralSandboxes.filter((sandbox) => !persistedNames.has(sandbox.name)),
+  ];
   return {
     ...recovered,
+    sandboxes,
     recoveredFromSession: seeded.recoveredFromSession,
-    recoveredFromGateway,
+    recoveredFromGateway: gateway.recoveredFromGateway,
   };
 }

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -23,6 +23,11 @@ type RecoveredSandboxMetadata = Partial<
   policyPresets?: string[] | null;
 };
 
+/**
+ * Build a minimal-safe registry entry for a recovered sandbox from whatever
+ * metadata is known, asserting `agent` only when the seed actually provides it
+ * so recovery never clobbers a persisted agent or invents one.
+ */
 function buildRecoveredSandboxEntry(
   name: string,
   metadata: RecoveredSandboxMetadata = {},
@@ -50,6 +55,11 @@ function buildRecoveredSandboxEntry(
   return entry;
 }
 
+/**
+ * Persist a recovered sandbox into the registry, registering a new entry or
+ * merging into an existing one. Returns true only when a new entry was created.
+ * Invalid sandbox names are skipped (returns false).
+ */
 function upsertRecoveredSandbox(name: string, metadata: RecoveredSandboxMetadata = {}) {
   let validName;
   try {
@@ -67,6 +77,12 @@ function upsertRecoveredSandbox(name: string, metadata: RecoveredSandboxMetadata
   return true;
 }
 
+/**
+ * Decide whether registry recovery should run and whether the requested
+ * sandbox is missing from the on-disk registry. Recovery is attempted whenever
+ * the registry is empty (the #5714 unseeded `list` case) or a seed (session or
+ * requested name) points at a sandbox the registry does not yet contain.
+ */
 function shouldRecoverRegistryEntries(
   current: { sandboxes: Array<{ name: string }>; defaultSandbox?: string | null },
   session: Session | null,
@@ -106,6 +122,11 @@ function isSessionSandboxConfirmed(session: Session | null): boolean {
   return session.steps?.sandbox?.status === "complete";
 }
 
+/**
+ * Build the name→metadata seed map used to enrich gateway-recovered entries,
+ * and recover a confirmed onboard-session sandbox into the registry when it is
+ * missing. Returns the seed map and whether a session sandbox was recovered.
+ */
 function seedRecoveryMetadata(
   current: { sandboxes: SandboxEntry[] },
   session: Session | null,
@@ -146,6 +167,12 @@ function seedRecoveryMetadata(
   return { metadataByName, recoveredFromSession };
 }
 
+/**
+ * Decide whether the unseeded (#5714) `nemoclaw list` recovery may read the
+ * live `openshell sandbox list` without mutating gateway state. Returns true
+ * only when OpenShell is connected to a NemoClaw-managed gateway (the bare
+ * `nemoclaw` or a per-port `nemoclaw-<port>`), never a foreign gateway.
+ */
 function canInspectLiveGatewayReadOnly(): boolean {
   // #5714: unseeded `nemoclaw list` recovery must never mutate gateway state
   // (no select/start). Probes are non-fatal so a hung gateway falls back to the
@@ -166,6 +193,12 @@ function canInspectLiveGatewayReadOnly(): boolean {
   return false;
 }
 
+/**
+ * Decide whether the seeded recovery path may read the live sandbox list,
+ * actively recovering the named NemoClaw gateway (select/start) first when
+ * needed. Used when an existing entry, onboard session, or requested name
+ * signals a specific sandbox the user expects to exist.
+ */
 async function canInspectLiveGatewayViaRecovery(): Promise<boolean> {
   const recovery = await recoverNamedGatewayRuntime();
   return (
@@ -184,6 +217,12 @@ interface LiveGatewayRecovery {
   ephemeralSandboxes: SandboxEntry[];
 }
 
+/**
+ * Inspect the live OpenShell gateway and recover its sandboxes. In `readOnly`
+ * mode (unseeded #5714 `list`) recovered sandboxes are returned as display-only
+ * `ephemeralSandboxes` and never persisted; otherwise they are upserted into
+ * the on-disk registry. Returns the recovered count and any ephemeral entries.
+ */
 async function recoverRegistryFromLiveGateway(
   metadataByName: Map<string, RecoveredSandboxMetadata>,
   { readOnly = false }: { readOnly?: boolean } = {},
@@ -242,6 +281,11 @@ async function recoverRegistryFromLiveGateway(
   return { recoveredFromGateway, ephemeralSandboxes };
 }
 
+/**
+ * Set the registry default to the requested name (or the session sandbox when
+ * no default exists) once it is present in the registry, then return the
+ * refreshed registry listing.
+ */
 function applyRecoveredDefault(
   currentDefaultSandbox: string | null,
   requestedSandboxName: string | null,
@@ -259,6 +303,14 @@ function applyRecoveredDefault(
   return registry.listSandboxes();
 }
 
+/**
+ * Reconcile the local sandbox registry against the onboard session and the live
+ * OpenShell gateway. With a seed (existing entry, session, or requested name)
+ * it actively recovers and persists entries; for an empty registry with no seed
+ * (#5714) it performs a bounded, read-only gateway inspection and returns the
+ * live sandboxes as display-only entries without persisting them. Returns the
+ * registry listing plus `recoveredFromSession`/`recoveredFromGateway` markers.
+ */
 export async function recoverRegistryEntries({
   requestedSandboxName = null,
 }: {

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -107,6 +107,16 @@ export interface SandboxEntry {
   // different NEMOCLAW_GATEWAY_PORT no longer recreates/kills the first (#4422).
   gatewayName?: string | null;
   gatewayPort?: number | null;
+  // Transient, display-only marker for a sandbox surfaced by #5714 unseeded
+  // `nemoclaw list` recovery directly from the live gateway. The recovery path
+  // that sets it only ever pushes such entries into the in-memory list result
+  // (ephemeralSandboxes) and never routes them through registerSandbox/
+  // updateSandbox, so it is never written to sandboxes.json. (registerSandbox
+  // also writes an explicit field allowlist that omits it; updateSandbox does
+  // not, so callers must not pass a flagged entry to updateSandbox.) It signals
+  // that fields like `agent` are genuinely unknown rather than defaults so the
+  // renderer does not present a recovered Deep Agents/Hermes sandbox as OpenClaw.
+  recoveredFromGateway?: boolean;
 }
 
 export interface SandboxRegistry {


### PR DESCRIPTION
## Summary

`nemoclaw list` printed "No sandboxes registered" while the live OpenShell gateway and container were healthy and `nemoclaw <name> status` reported `Phase: Ready` (reported on DGX Station with a Deep Agents sandbox). The `list` recovery path required a *seed* — an existing registry entry, an onboard session, or an explicit requested name — before it would probe the gateway. After a local registry loss with no seed, it trusted the empty registry and reported nothing, even though the named-status path could find and reconcile the same sandbox.

## Related Issue

Fixes #5714

## Changes

- **Widen list recovery for an empty registry.** `recoverRegistryEntries` now attempts recovery whenever the local registry is empty, even with no session/requested-name seed.
- **Bounded, read-only, non-mutating gateway inspection for the unseeded case.** Plain `nemoclaw list` never selects or starts a gateway. It inspects the live sandbox list only when OpenShell is connected to a **NemoClaw-managed** gateway (`nemoclaw` or a per-port `nemoclaw-<port>`) — never a foreign OpenShell gateway. Gateway probes are non-fatal (`ignoreProbeErrors`), so a hung/timed-out gateway falls back to the empty registry instead of exiting the process, and recovery is gated on a clean (`status === 0`) `sandbox list` so error text is never parsed as a sandbox name.
- **Display-only recovery — recovered entries are NOT persisted.** The global `openshell sandbox list` exposes only NAME/CREATED/PHASE, not the agent or gateway binding. Persisting a recovered entry would default `agent` to `openclaw` everywhere downstream (state dirs, connect, rebuild, doctor) and permanently misclassify a Deep Agents/Hermes sandbox. Recovered sandboxes are surfaced for the current `list` only; follow-up named commands reconcile the real agent via the gateway.
- **Honest rendering.** Recovered rows show `agent`/`model`/`provider`/`GPU` as `unknown` rather than inventing OpenClaw/CPU defaults.
- `getNamedGatewayLifecycleState` gains an opt-in `ignoreProbeErrors` (default keeps existing fatal behavior); `captureOpenshell` forwards `includeStderr` so non-fatal probes still capture the gateway status text.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

Verified end-to-end through the real worktree CLI (`node ./bin/nemoclaw.js …`) against a live OpenShell gateway. The local registry was emptied and the onboard session removed to simulate the reporter's registry loss; the on-disk registry is checked after each run.

**1. Pre-fix (reporter mismatch) — `list` blind while a Ready sandbox is live:**

```console
$ node ./bin/nemoclaw.js list

  No sandboxes registered. Run `nemoclaw onboard` to get started.

$ node ./bin/nemoclaw.js sbox-4778 status
  Sandbox: sbox-4778
    Model:    nvidia/nemotron-3-super-120b-a12b
    Provider: nvidia-prod
    ...
  Phase: Ready
# docker ps -a → openshell-sbox-4778-… Up   (container healthy, gateway Connected)
```

**2. Post-fix — `list` rediscovers the live sandboxes (display-only, registry stays empty):**

```console
$ node ./bin/nemoclaw.js list

  Recovered 5 sandbox entries from the live OpenShell gateway.

  Sandboxes:
    probe3014x
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    e2e-5468-ollama
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    issue4538-fix
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    sbox-4778
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    dcode5744
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none

$ node -e 'console.log(Object.keys(require(process.env.HOME+"/.nemoclaw/sandboxes.json").sandboxes))'
[]        # recovered for display only — NOT persisted (agent is unknowable from the gateway list)
```

(Recovery was also re-verified while OpenShell was connected to a NemoClaw per-port gateway `nemoclaw-8092` — `connected_other` to a NemoClaw-managed name still recovers; a foreign gateway name does not.)

**3. Post-fix graceful degradation — gateway unreachable, empty registry → no crash, no bogus names:**

```console
$ node ./bin/nemoclaw.js list      # gateway down: Connection refused on :8080
                                   # `openshell sandbox list` → transport error
  No sandboxes registered. Run `nemoclaw onboard` to get started.
$ echo $?
0
```

Targeted + adjacent unit tests pass (registry-recovery, gateway-runtime, inventory, openshell adapter, repro-2666, gateway/connect drift; ~290 tests), `npm run typecheck:cli` clean, Biome clean; `nemoclaw-start` (126) passes with the `nemoclaw/` subproject deps installed.

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to include standard error in captured command output.
  * Enhanced gateway recovery to support unseeded “read-only” live inspection, showing recovered sandboxes as transient display-only entries.
  * Inventory rendering now marks recovered sandboxes with `agent: unknown` and `GPU: unknown` when applicable.

* **Bug Fixes**
  * Gateway lifecycle probe failures can be handled without aborting recovery (including optional stderr-aware handling).
  * Live gateway inspection avoids listing unrelated/foreign gateways, skips when OpenShell isn’t available, and prevents error text from being interpreted as sandbox names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->