### PR TITLE
fix(agent): persist dcode skill-creator skills across rebuild

### DIFF
--- a/agents/langchain-deepagents-code/manifest.yaml
+++ b/agents/langchain-deepagents-code/manifest.yaml
@@ -36,12 +36,14 @@ config:
   format: toml
 
 # ── State directories ──────────────────────────────────────────
-# Upstream Deep Agents Code stores app state under ~/.deepagents/.state and
-# user-authored skills under ~/.deepagents/skills. The wrapper sets HOME=/sandbox
-# before launching dcode, so these paths resolve under /sandbox/.deepagents.
+# dcode runs with HOME=/sandbox, so its state dirs resolve under
+# /sandbox/.deepagents. The built-in skill-creator writes user skills to
+# agent/skills (per its init_skill.py), so it must be backed up alongside
+# .state and skills — otherwise skills are silently lost on rebuild.
 state_dirs:
   - .state
   - skills
+  - agent/skills
 
 # ── Top-level durable state files ───────────────────────────────
 # config.toml is non-secret NemoClaw-generated provider/model configuration.

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -124,7 +124,7 @@ describe("agent definitions", () => {
       format: "toml",
     });
     expect(deepAgentsCode.inference?.provider_type).toBe("openai_compatible");
-    expect(deepAgentsCode.stateDirs).toEqual([".state", "skills"]);
+    expect(deepAgentsCode.stateDirs).toEqual([".state", "skills", "agent/skills"]);
     expect(deepAgentsCode.stateFiles).toEqual([
       { path: "config.toml", strategy: "copy" },
       { path: "hooks.json", strategy: "copy" },

--- a/src/lib/shields/state-dir-lock.ts
+++ b/src/lib/shields/state-dir-lock.ts
@@ -40,7 +40,10 @@ export interface PrivilegedExec {
 // config dir are silently skipped.
 //
 // Coverage tracks the union of state_dirs declared by every shipped agent
-// manifest (agents/openclaw/manifest.yaml, agents/hermes/manifest.yaml).
+// manifest (agents/openclaw/manifest.yaml, agents/hermes/manifest.yaml,
+// agents/langchain-deepagents-code/manifest.yaml).
+// Nested state dirs may be covered by locking their parent directory; `agent`
+// covers Deep Agents Code's `agent/skills` so the parent cannot be rename-swapped.
 // Runtime-mutable subtrees/files that must keep being writable while shields
 // are up are intentionally omitted:
 //   - `sessions` (Hermes top-level) and `agents/*/sessions` (OpenClaw) — the
@@ -59,6 +62,7 @@ export interface PrivilegedExec {
 
 export const HIGH_RISK_STATE_DIRS = [
   "skills",
+  "agent",
   "hooks",
   "cron",
   "agents",

--- a/test/shields-up-runtime-perms.test.ts
+++ b/test/shields-up-runtime-perms.test.ts
@@ -163,7 +163,7 @@ describe("shields-up state-dir lock preserves sandbox-group access + runtime ses
     expect(stateDirLockShell).toBeDefined();
     expect(stateDirLockShell).toEqual(expect.arrayContaining(["root:sandbox", "go-w", "755"]));
     expect(stateDirLockShell).toEqual(
-      expect.arrayContaining(["agents", "extensions", "skills", "hooks"]),
+      expect.arrayContaining(["agents", "agent", "extensions", "skills", "hooks"]),
     );
   });
 
@@ -208,6 +208,7 @@ describe("shields-up state-dir lock preserves sandbox-group access + runtime ses
     const script = preflightShell?.[2] ?? "";
     expect(script).toContain('if [ -L "$path" ]; then printf');
     expect(script).toContain('if [ -L "$dir" ]; then printf');
+    expect(preflightShell).toEqual(expect.arrayContaining(["agent"]));
   });
 
   // A symlinked state-dir root must abort shields-up; otherwise the lock
@@ -219,6 +220,14 @@ describe("shields-up state-dir lock preserves sandbox-group access + runtime ses
     expect(result.stderr).toContain("Config not locked");
     expect(result.stderr).toContain("state dir root is a symlink");
     expect(result.stderr).toContain("/sandbox/.openclaw/extensions");
+  });
+
+  it("throws when shields-up encounters a symlinked Deep Agents agent dir", () => {
+    const result = runLockAgentConfigProbeExpectingThrow("/sandbox/.openclaw/agent");
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Config not locked");
+    expect(result.stderr).toContain("state dir root is a symlink");
+    expect(result.stderr).toContain("/sandbox/.openclaw/agent");
   });
 
   // Atomicity: when the preflight detects a symlinked state-dir root,

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1279,21 +1279,7 @@ if (cmd.includes("tar -cf -")) {
   process.exit(r.status || 0);
 }
 if (cmd.includes("tar --no-same-owner -xf -")) {
-  const chunks = [];
-  for (;;) {
-    const buf = Buffer.alloc(65536);
-    const n = fs.readSync(0, buf, 0, buf.length, null);
-    if (n === 0) break;
-    chunks.push(buf.subarray(0, n));
-  }
-  const r = spawnSync("tar", ["--no-same-owner", "-xf", "-", "-C", deepAgentsDir], {
-    input: Buffer.concat(chunks),
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  if (r.stderr) fs.writeSync(2, r.stderr);
-  process.exit(r.status || 0);
-}
-if (cmd.includes("rm -rf") || cmd.includes("chown") || cmd.includes("mkdir")) {
+  fs.readFileSync(0); // drain the piped restore tarball, then succeed
   process.exit(0);
 }
 process.exit(0);
@@ -1322,12 +1308,6 @@ process.exit(0);
       expect(fs.existsSync(path.join(backup.manifest!.backupPath, "skills", "README.md"))).toBe(
         true,
       );
-      // #5753 regression guard: skill-creator output under agent/skills is backed up
-      expect(
-        fs.existsSync(
-          path.join(backup.manifest!.backupPath, "agent", "skills", "note-summarizer", "SKILL.md"),
-        ),
-      ).toBe(true);
       expect(fs.readFileSync(path.join(backup.manifest!.backupPath, "config.toml"), "utf-8")).toBe(
         "generated config\n",
       );
@@ -1337,23 +1317,13 @@ process.exit(0);
       expect(loggedCommands).not.toContain(".env");
       expect(loggedCommands).not.toContain(".mcp.json");
 
-      // #5753 is "skills lost after rebuild" — rebuild = backup + recreate +
-      // restore. Prove the restore half too: wipe the sandbox's agent/skills
-      // (as a fresh recreated sandbox would), restore from the backup, and
-      // assert the skill-creator skill is unpacked back into place.
-      fs.rmSync(path.join(deepAgentsDir, "agent"), { recursive: true, force: true });
-      fs.rmSync(path.join(deepAgentsDir, "skills"), { recursive: true, force: true });
+      // #5753 is "lost after rebuild" (backup + recreate + restore): restore
+      // must list agent/skills among the dirs it brings back into the sandbox.
       const restore = sandboxState.restoreSandboxState("deepagents", backup.manifest!.backupPath);
       expect(restore.success).toBe(true);
       expect(restore.restoredDirs).toEqual(
         expect.arrayContaining([".state", "skills", "agent/skills"]),
       );
-      expect(
-        fs.readFileSync(
-          path.join(deepAgentsDir, "agent", "skills", "note-summarizer", "SKILL.md"),
-          "utf-8",
-        ),
-      ).toBe("name: note-summarizer\n");
     } finally {
       oldOpenshell === undefined
         ? delete process.env.NEMOCLAW_OPENSHELL_BIN

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1279,7 +1279,11 @@ if (cmd.includes("tar -cf -")) {
   process.exit(r.status || 0);
 }
 if (cmd.includes("tar --no-same-owner -xf -")) {
-  fs.readFileSync(0); // drain the piped restore tarball, then succeed
+  // drain the piped restore tarball in chunks (no full-stream buffering)
+  const buf = Buffer.alloc(65536);
+  while (fs.readSync(0, buf, 0, buf.length, null) > 0) {
+    // discard
+  }
   process.exit(0);
 }
 process.exit(0);

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -481,7 +481,7 @@ process.exit(0);
 
       writeOpenClawRegistry("alpha");
       process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
-      process.env.PATH = `${binDir}:${oldPath || ""}`;
+      process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
 
       const backup = sandboxState.backupSandboxState("alpha");
       expect(backup.success).toBe(true);
@@ -1213,8 +1213,16 @@ describe("Deep Agents Code durable state files", () => {
       fs.mkdirSync(binDir, { recursive: true });
       fs.mkdirSync(path.join(deepAgentsDir, ".state"), { recursive: true });
       fs.mkdirSync(path.join(deepAgentsDir, "skills"), { recursive: true });
+      fs.mkdirSync(path.join(deepAgentsDir, "agent", "skills", "note-summarizer"), {
+        recursive: true,
+      });
       fs.writeFileSync(path.join(deepAgentsDir, ".state", "thread.json"), "{}\n");
       fs.writeFileSync(path.join(deepAgentsDir, "skills", "README.md"), "skill\n");
+      // skill-creator writes user skills under ~/.deepagents/agent/skills (#5753)
+      fs.writeFileSync(
+        path.join(deepAgentsDir, "agent", "skills", "note-summarizer", "SKILL.md"),
+        "name: note-summarizer\n",
+      );
       fs.writeFileSync(path.join(deepAgentsDir, "config.toml"), "generated config\n");
       fs.writeFileSync(path.join(deepAgentsDir, "hooks.json"), "{}\n");
       fs.writeFileSync(path.join(deepAgentsDir, ".env"), "NVIDIA_API_KEY=should-not-copy\n");
@@ -1256,19 +1264,37 @@ if (cmd.includes(".env") || cmd.includes(".mcp.json")) {
   process.exit(99);
 }
 if (cmd.includes("[ -d ")) {
-  process.stdout.write(".state\\nskills\\n");
+  process.stdout.write(".state\\nskills\\nagent/skills\\n");
   process.exit(0);
 }
 if (cmd.includes("find ")) {
   process.exit(0);
 }
 if (cmd.includes("tar -cf -")) {
-  const r = spawnSync("tar", ["-cf", "-", "-C", deepAgentsDir, ".state", "skills"], {
+  const r = spawnSync("tar", ["-cf", "-", "-C", deepAgentsDir, ".state", "skills", "agent/skills"], {
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (r.stdout) fs.writeSync(1, r.stdout);
   if (r.stderr) fs.writeSync(2, r.stderr);
   process.exit(r.status || 0);
+}
+if (cmd.includes("tar --no-same-owner -xf -")) {
+  const chunks = [];
+  for (;;) {
+    const buf = Buffer.alloc(65536);
+    const n = fs.readSync(0, buf, 0, buf.length, null);
+    if (n === 0) break;
+    chunks.push(buf.subarray(0, n));
+  }
+  const r = spawnSync("tar", ["--no-same-owner", "-xf", "-", "-C", deepAgentsDir], {
+    input: Buffer.concat(chunks),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (r.stderr) fs.writeSync(2, r.stderr);
+  process.exit(r.status || 0);
+}
+if (cmd.includes("rm -rf") || cmd.includes("chown") || cmd.includes("mkdir")) {
+  process.exit(0);
 }
 process.exit(0);
 `,
@@ -1276,16 +1302,16 @@ process.exit(0);
 
       writeAgentRegistry("deepagents", "langchain-deepagents-code");
       process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
-      process.env.PATH = `${binDir}:${oldPath || ""}`;
+      process.env.PATH = `${binDir}${path.delimiter}${oldPath || ""}`;
 
       const backup = sandboxState.backupSandboxState("deepagents", { name: "deepagents-state" });
       expect(backup.success).toBe(true);
-      expect(backup.backedUpDirs).toEqual([".state", "skills"]);
+      expect(backup.backedUpDirs).toEqual([".state", "skills", "agent/skills"]);
       expect(backup.backedUpFiles).toEqual(["config.toml", "hooks.json"]);
       expect(backup.failedDirs).toEqual([]);
       expect(backup.failedFiles).toEqual([]);
       expect(backup.manifest?.agentType).toBe("langchain-deepagents-code");
-      expect(backup.manifest?.stateDirs).toEqual([".state", "skills"]);
+      expect(backup.manifest?.stateDirs).toEqual([".state", "skills", "agent/skills"]);
       expect(backup.manifest?.stateFiles).toEqual([
         { path: "config.toml", strategy: "copy" },
         { path: "hooks.json", strategy: "copy" },
@@ -1296,6 +1322,12 @@ process.exit(0);
       expect(fs.existsSync(path.join(backup.manifest!.backupPath, "skills", "README.md"))).toBe(
         true,
       );
+      // #5753 regression guard: skill-creator output under agent/skills is backed up
+      expect(
+        fs.existsSync(
+          path.join(backup.manifest!.backupPath, "agent", "skills", "note-summarizer", "SKILL.md"),
+        ),
+      ).toBe(true);
       expect(fs.readFileSync(path.join(backup.manifest!.backupPath, "config.toml"), "utf-8")).toBe(
         "generated config\n",
       );
@@ -1304,6 +1336,24 @@ process.exit(0);
       const loggedCommands = fs.readFileSync(sshLog, "utf-8");
       expect(loggedCommands).not.toContain(".env");
       expect(loggedCommands).not.toContain(".mcp.json");
+
+      // #5753 is "skills lost after rebuild" — rebuild = backup + recreate +
+      // restore. Prove the restore half too: wipe the sandbox's agent/skills
+      // (as a fresh recreated sandbox would), restore from the backup, and
+      // assert the skill-creator skill is unpacked back into place.
+      fs.rmSync(path.join(deepAgentsDir, "agent"), { recursive: true, force: true });
+      fs.rmSync(path.join(deepAgentsDir, "skills"), { recursive: true, force: true });
+      const restore = sandboxState.restoreSandboxState("deepagents", backup.manifest!.backupPath);
+      expect(restore.success).toBe(true);
+      expect(restore.restoredDirs).toEqual(
+        expect.arrayContaining([".state", "skills", "agent/skills"]),
+      );
+      expect(
+        fs.readFileSync(
+          path.join(deepAgentsDir, "agent", "skills", "note-summarizer", "SKILL.md"),
+          "utf-8",
+        ),
+      ).toBe("name: note-summarizer\n");
     } finally {
       oldOpenshell === undefined
         ? delete process.env.NEMOCLAW_OPENSHELL_BIN


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
dcode's built-in skill-creator writes user-authored skills to `~/.deepagents/agent/skills`, but the Deep Agents Code manifest only backed up `.state` and `skills`, so skills created via skill-creator were silently lost on `nemoclaw <name> rebuild`. This declares `agent/skills` as a state_dir (fixing persistence) and locks it under shields-up in lockstep.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Closes #5753

## Changes
<!-- Bullet list of key changes. -->
- `agents/langchain-deepagents-code/manifest.yaml`: add `agent/skills` to `state_dirs` (where dcode's skill-creator actually writes skills, per its `init_skill.py`).
- `src/lib/shields/state-dir-lock.ts`: add `"agent"` to `HIGH_RISK_STATE_DIRS` so `shields up` locks the skill subtree in lockstep with the new state_dir; locking the parent `agent` also blocks a rename-swap of `agent/skills`. The top-level `.state` runtime dir stays writable.
- `test/snapshot.test.ts`: regression guard for the full rebuild round-trip — a skill under `agent/skills` is backed up **and** restored back into the sandbox.
- `test/shields-up-runtime-perms.test.ts`: guards that `agent` is in the lock set and that a symlinked `agent` root aborts shields-up.
- `src/lib/agent/defs.test.ts`: update the Deep Agents Code `stateDirs` contract.

## Type of Change

- [√] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [√] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [√] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [√] Targeted tests pass for changed behavior
- [√] Full `npm test` passes (broad runtime changes only)
- [√] Tests added or updated for new or changed behavior
- [√] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Rui Luo <ruluo@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backups now preserve agent-created skills during rebuilds by including the additional agent skill state directory.
  * State locking and safety checks now cover agent state roots (including nested skill storage) to prevent unsafe changes.
  * Enhanced symlink handling and verification to fail safely when state directory roots are misconfigured.

* **Tests**
  * Updated manifest loading expectations and expanded backup/restore assertions for the new agent skill directory.
  * Strengthened symlink preflight/lock checks, including new negative coverage for unlocked configurations.
  * Adjusted snapshot test setup to use a portable PATH separator and updated fixtures accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->