### PR TITLE
fix(cli): recover live sandboxes in list when local registry is empty

### DIFF
--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -21,6 +21,7 @@ type RunnerOptions = {
   stdio?: StdioOptions;
   input?: string;
   ignoreError?: boolean;
+  includeStderr?: boolean;
   timeout?: number;
 };
 
@@ -55,6 +56,7 @@ export function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
     cwd: ROOT,
     env: opts.env,
     ignoreError: opts.ignoreError,
+    includeStderr: opts.includeStderr,
     timeout: opts.timeout,
     errorLine: console.error,
     exit: (code: number) => process.exit(code),

--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -27,6 +27,7 @@ type RunnerOptions = {
 
 let openshellBin: string | null = null;
 
+/** Resolve and cache the OpenShell binary path, exiting if it is not installed. */
 export function getOpenshellBinary(): string {
   if (!openshellBin) {
     openshellBin = resolveOpenshell();
@@ -38,6 +39,7 @@ export function getOpenshellBinary(): string {
   return openshellBin;
 }
 
+/** Run an OpenShell command, inheriting stdio (no output capture). */
 export function runOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   return runOpenshellCommand(getOpenshellBinary(), args, {
     cwd: ROOT,
@@ -68,6 +70,7 @@ export function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   });
 }
 
+/** Capture the SSH config OpenShell emits for a sandbox. */
 export function captureSandboxSshConfig(sandboxName: string, opts: RunnerOptions = {}) {
   return captureSandboxSshConfigCommand(getOpenshellBinary(), sandboxName, {
     cwd: ROOT,
@@ -79,12 +82,14 @@ export function captureSandboxSshConfig(sandboxName: string, opts: RunnerOptions
   });
 }
 
+/** Resolve the status-probe timeout (ms) from env, falling back to the default. */
 export function getStatusProbeTimeoutMs(): number {
   const raw = process.env.NEMOCLAW_STATUS_PROBE_TIMEOUT_MS;
   const parsed = raw ? Number(raw) : NaN;
   return Number.isFinite(parsed) && parsed > 0 ? parsed : OPENSHELL_PROBE_TIMEOUT_MS;
 }
 
+/** Async variant of {@link captureOpenshell} for status probes, with a kill grace period. */
 export function captureOpenshellForStatus(args: CommandArgs, opts: RunnerOptions = {}) {
   return captureOpenshellCommandAsync(getOpenshellBinary(), args, {
     cwd: ROOT,
@@ -95,10 +100,12 @@ export function captureOpenshellForStatus(args: CommandArgs, opts: RunnerOptions
   });
 }
 
+/** Whether a captured command result represents an ETIMEDOUT spawn timeout. */
 export function isCommandTimeout(result: { error?: Error }) {
   return (result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT";
 }
 
+/** Return the installed OpenShell version, or null when it cannot be determined. */
 export function getInstalledOpenshellVersionOrNull(opts: { timeout?: number } = {}): string | null {
   return getInstalledOpenshellVersion(getOpenshellBinary(), {
     cwd: ROOT,

--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -51,6 +51,11 @@ export function runOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   });
 }
 
+/**
+ * Run an OpenShell command and capture its output. `includeStderr` keeps stderr
+ * in the captured output even when `ignoreError` is set (needed for probes that
+ * must stay non-fatal yet still read status text OpenShell writes to stderr).
+ */
 export function captureOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
   return captureOpenshellCommand(getOpenshellBinary(), args, {
     cwd: ROOT,

--- a/src/lib/gateway-runtime-action.test.ts
+++ b/src/lib/gateway-runtime-action.test.ts
@@ -78,20 +78,27 @@ describe("gateway-runtime-action per-sandbox gateway routing", () => {
       expect(result.activeGateway).toBe("nemoclaw");
     });
 
-    it("keeps probes fatal (no ignoreError) by default", () => {
+    it("keeps probes fatal by default, but still captures stderr (ignoreError falsy)", () => {
       captureSpy.mockReturnValue({ status: 0, output: "Status: Connected\nGateway: nemoclaw\n" });
 
       gatewayRuntime.getNamedGatewayLifecycleState("nemoclaw");
 
       for (const [, opts] of captureSpy.mock.calls) {
+        // Default path is fatal (no ignoreError). stderr is still captured here
+        // because captureOpenshell includes stderr whenever ignoreError is falsy,
+        // so the `Status:`/`Gateway:` lines (written to stderr) are not dropped.
         expect(opts?.ignoreError).not.toBe(true);
+        expect(opts?.includeStderr).not.toBe(true);
       }
     });
 
-    it("makes probes non-fatal when ignoreProbeErrors is set (#5714)", () => {
+    it("makes probes non-fatal AND keeps includeStderr in lockstep when ignoreProbeErrors is set (#5714)", () => {
       // Plain `nemoclaw list` recovery must not be killed by a hung gateway:
       // both lifecycle probes must run with ignoreError so an ETIMEDOUT is
-      // swallowed instead of triggering captureOpenshell's process.exit.
+      // swallowed instead of triggering captureOpenshell's process.exit. Because
+      // ignoreError would otherwise drop stderr (where OpenShell writes the
+      // Status:/Gateway: lines), includeStderr MUST stay true in lockstep, or
+      // the healthy/connected classification silently breaks.
       captureSpy.mockReturnValue({ status: 0, output: "Status: Connected\nGateway: nemoclaw\n" });
 
       gatewayRuntime.getNamedGatewayLifecycleState("nemoclaw", { ignoreProbeErrors: true });
@@ -99,6 +106,7 @@ describe("gateway-runtime-action per-sandbox gateway routing", () => {
       expect(captureSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
       for (const [, opts] of captureSpy.mock.calls) {
         expect(opts?.ignoreError).toBe(true);
+        expect(opts?.includeStderr).toBe(true);
       }
     });
   });

--- a/src/lib/gateway-runtime-action.test.ts
+++ b/src/lib/gateway-runtime-action.test.ts
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 type GatewayRuntimeModule = typeof import("../../dist/lib/gateway-runtime-action");
 
@@ -76,6 +76,30 @@ describe("gateway-runtime-action per-sandbox gateway routing", () => {
 
       expect(result.state).toBe("connected_other");
       expect(result.activeGateway).toBe("nemoclaw");
+    });
+
+    it("keeps probes fatal (no ignoreError) by default", () => {
+      captureSpy.mockReturnValue({ status: 0, output: "Status: Connected\nGateway: nemoclaw\n" });
+
+      gatewayRuntime.getNamedGatewayLifecycleState("nemoclaw");
+
+      for (const [, opts] of captureSpy.mock.calls) {
+        expect(opts?.ignoreError).not.toBe(true);
+      }
+    });
+
+    it("makes probes non-fatal when ignoreProbeErrors is set (#5714)", () => {
+      // Plain `nemoclaw list` recovery must not be killed by a hung gateway:
+      // both lifecycle probes must run with ignoreError so an ETIMEDOUT is
+      // swallowed instead of triggering captureOpenshell's process.exit.
+      captureSpy.mockReturnValue({ status: 0, output: "Status: Connected\nGateway: nemoclaw\n" });
+
+      gatewayRuntime.getNamedGatewayLifecycleState("nemoclaw", { ignoreProbeErrors: true });
+
+      expect(captureSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+      for (const [, opts] of captureSpy.mock.calls) {
+        expect(opts?.ignoreError).toBe(true);
+      }
     });
   });
 

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -17,10 +17,12 @@ import {
 import { GATEWAY_PORT } from "./core/ports";
 import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
 
+/** Whether `gateway info` output names the given NemoClaw gateway. */
 function hasNamedGateway(output = "", gatewayName = "nemoclaw"): boolean {
   return stripAnsi(output).includes(`Gateway: ${gatewayName}`);
 }
 
+/** Parse the active gateway name from `openshell status` output, or null. */
 function getActiveGatewayName(output = ""): string | null {
   const match = stripAnsi(output).match(/^\s*Gateway:\s+(.+?)\s*$/m);
   return match ? match[1].trim() : null;

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -7,14 +7,15 @@ const { startGatewayForRecovery } = require("./onboard") as {
     gatewayPort?: number;
   }) => Promise<void>;
 };
+
+import { stripAnsi } from "./adapters/openshell/client";
+import { captureOpenshell, runOpenshell } from "./adapters/openshell/runtime";
 import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "./adapters/openshell/timeouts";
-import { stripAnsi } from "./adapters/openshell/client";
-import { captureOpenshell, runOpenshell } from "./adapters/openshell/runtime";
-import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
 import { GATEWAY_PORT } from "./core/ports";
+import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
 
 function hasNamedGateway(output = "", gatewayName = "nemoclaw"): boolean {
   return stripAnsi(output).includes(`Gateway: ${gatewayName}`);
@@ -27,10 +28,26 @@ function getActiveGatewayName(output = ""): string | null {
 
 export function getNamedGatewayLifecycleState(
   gatewayName: string = resolveGatewayName(GATEWAY_PORT),
+  opts: { ignoreProbeErrors?: boolean } = {},
 ) {
-  const status = captureOpenshell(["status"], { timeout: OPENSHELL_PROBE_TIMEOUT_MS });
+  // #5714: callers that must stay non-fatal (e.g. plain `nemoclaw list`
+  // recovery) opt into `ignoreProbeErrors` so a hung/timed-out `openshell
+  // status` returns a not-healthy classification instead of `process.exit`ing
+  // via captureOpenshell's default error handling. Other callers keep the
+  // existing fatal behavior by default.
+  const ignoreError = opts.ignoreProbeErrors === true;
+  // When ignoring probe errors we must still capture stderr — OpenShell writes
+  // the `Status:`/`Gateway:` lines there, and `ignoreError` would otherwise
+  // drop stderr and break the healthy/connected classification.
+  const status = captureOpenshell(["status"], {
+    timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+    ignoreError,
+    includeStderr: ignoreError,
+  });
   const gatewayInfo = captureOpenshell(["gateway", "info", "-g", gatewayName], {
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+    ignoreError,
+    includeStderr: ignoreError,
   });
   const cleanStatus = stripAnsi(status.output);
   const activeGateway = getActiveGatewayName(status.output);

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -26,6 +26,13 @@ function getActiveGatewayName(output = ""): string | null {
   return match ? match[1].trim() : null;
 }
 
+/**
+ * Classify the lifecycle state of the named gateway (healthy_named,
+ * named_unreachable, named_unhealthy, connected_other, or missing_named) from
+ * `openshell status` and `gateway info`. Pass `ignoreProbeErrors` to keep the
+ * probes non-fatal so a hung/timed-out gateway is classified rather than
+ * exiting the process.
+ */
 export function getNamedGatewayLifecycleState(
   gatewayName: string = resolveGatewayName(GATEWAY_PORT),
   opts: { ignoreProbeErrors?: boolean } = {},

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -156,11 +156,17 @@ describe("inventory commands", () => {
     });
   });
 
-  it("renders a gateway-recovered row with unknown agent/GPU instead of OpenClaw/CPU defaults (#5714)", async () => {
+  it("renders a gateway-recovered row with the trusted live phase but unknown agent/GPU (#5714)", async () => {
     const inventory = await getSandboxInventory({
       recoverRegistryEntries: async () => ({
         sandboxes: [
-          { name: "dcode-station", model: null, provider: null, recoveredFromGateway: true },
+          {
+            name: "dcode-station",
+            model: null,
+            provider: null,
+            recoveredFromGateway: true,
+            livePhase: "Ready",
+          },
         ],
         defaultSandbox: null,
         recoveredFromSession: false,
@@ -170,12 +176,20 @@ describe("inventory commands", () => {
       loadLastSession: () => null,
     });
 
+    expect(inventory.sandboxes[0]).toMatchObject({
+      recoveredFromGateway: true,
+      livePhase: "Ready",
+    });
+
     const lines: string[] = [];
     renderSandboxInventoryText(inventory, (m = "") => lines.push(m), null);
     const body = lines.join("\n");
     expect(body).toContain("Recovered 1 sandbox");
     expect(body).toContain("agent: unknown");
     expect(body).toContain("GPU: unknown");
+    // Trusted PHASE from `openshell sandbox list` is surfaced so list agrees
+    // with `nemoclaw <name> status` (the reporter's Ready expectation).
+    expect(body).toContain("phase: Ready");
     expect(body).not.toContain("CPU sandbox");
     expect(body).not.toContain("agent: openclaw");
   });

--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -7,6 +7,7 @@ import {
   getSandboxInventory,
   getStatusReport,
   listSandboxesCommand,
+  renderSandboxInventoryText,
   type SandboxEntry,
   showStatusCommand,
 } from "./index";
@@ -132,6 +133,51 @@ describe("inventory commands", () => {
       ],
     });
     expect(getLiveInference).not.toHaveBeenCalled();
+  });
+
+  it("shows agent as 'unknown' for a gateway-recovered sandbox (#5714), not the OpenClaw default", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          { name: "dcode-station", model: null, provider: null, recoveredFromGateway: true },
+        ],
+        defaultSandbox: null,
+        recoveredFromSession: false,
+        recoveredFromGateway: 1,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    expect(inventory.sandboxes[0]).toMatchObject({
+      name: "dcode-station",
+      agent: "unknown",
+      recoveredFromGateway: true,
+    });
+  });
+
+  it("renders a gateway-recovered row with unknown agent/GPU instead of OpenClaw/CPU defaults (#5714)", async () => {
+    const inventory = await getSandboxInventory({
+      recoverRegistryEntries: async () => ({
+        sandboxes: [
+          { name: "dcode-station", model: null, provider: null, recoveredFromGateway: true },
+        ],
+        defaultSandbox: null,
+        recoveredFromSession: false,
+        recoveredFromGateway: 1,
+      }),
+      getLiveInference: () => null,
+      loadLastSession: () => null,
+    });
+
+    const lines: string[] = [];
+    renderSandboxInventoryText(inventory, (m = "") => lines.push(m), null);
+    const body = lines.join("\n");
+    expect(body).toContain("Recovered 1 sandbox");
+    expect(body).toContain("agent: unknown");
+    expect(body).toContain("GPU: unknown");
+    expect(body).not.toContain("CPU sandbox");
+    expect(body).not.toContain("agent: openclaw");
   });
 
   it("normalizes invalid configured inference fields out of inventory rows", async () => {

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -23,10 +23,14 @@ export interface SandboxEntry {
   messaging?: SandboxMessagingState | null;
   agent?: string | null;
   dashboardPort?: number | null;
-  // #5714: display-only marker for a sandbox recovered directly from the live
-  // gateway whose agent is genuinely unknown (the gateway sandbox list does not
-  // expose it). Lets the renderer show "unknown" instead of the OpenClaw default.
+  // #5714: display-only markers for a sandbox recovered directly from the live
+  // gateway. `recoveredFromGateway` flags that agent/GPU are genuinely unknown
+  // (the gateway sandbox list does not expose them) so the renderer shows
+  // "unknown" instead of the OpenClaw/CPU default; `livePhase` carries the
+  // trusted PHASE column (e.g. Ready) from `openshell sandbox list`. Neither is
+  // part of the durable registry type — they ride only on ephemeral list rows.
   recoveredFromGateway?: boolean;
+  livePhase?: string | null;
 }
 
 export interface MessagingBridgeHealth {
@@ -78,7 +82,9 @@ export interface SandboxInventoryRow {
   // #5714: row recovered display-only from the live gateway. Its agent/GPU/
   // inference state is unknown (the gateway sandbox list does not expose it),
   // so the renderer shows "unknown" rather than asserting OpenClaw/CPU defaults.
+  // `livePhase` is the trusted PHASE (e.g. Ready) carried from the sandbox list.
   recoveredFromGateway?: boolean;
+  livePhase?: string | null;
 }
 
 export interface SandboxInventoryResult {
@@ -215,6 +221,7 @@ function buildSandboxInventoryRow(
     activeSessionCount,
     connected: activeSessionCount !== null && activeSessionCount > 0,
     ...(sandbox.recoveredFromGateway ? { recoveredFromGateway: true } : {}),
+    ...(sandbox.recoveredFromGateway ? { livePhase: sandbox.livePhase ?? null } : {}),
   };
 }
 
@@ -318,9 +325,13 @@ export function renderSandboxInventoryText(
     const presets = sandbox.policies.length > 0 ? sandbox.policies.join(", ") : "none";
     const connected = sandbox.connected ? " ●" : "";
     const agent = sandbox.agent || "openclaw";
+    // #5714: for a gateway-recovered row, surface the trusted live PHASE
+    // (e.g. Ready) from `openshell sandbox list` so `list` agrees with
+    // `nemoclaw <name> status`; normal registry rows have no live phase.
+    const phase = sandbox.recoveredFromGateway ? `  phase: ${sandbox.livePhase || "unknown"}` : "";
     log(`    ${sandbox.name}${def}${connected}`);
     log(
-      `      agent: ${agent}  model: ${model}  provider: ${provider}  ${gpu}  policies: ${presets}`,
+      `      agent: ${agent}  model: ${model}  provider: ${provider}  ${gpu}${phase}  policies: ${presets}`,
     );
     if (modelDrifted || providerDrifted) {
       const parts: string[] = [];

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -176,6 +176,11 @@ function safeStatusString(value: string | null | undefined): string | null {
   return redactFull(value);
 }
 
+/**
+ * Project a stored or recovered {@link SandboxEntry} into a display row,
+ * resolving inference/GPU fields and marking gateway-recovered rows so unknown
+ * agent/GPU state renders as "unknown" rather than OpenClaw/CPU defaults.
+ */
 function buildSandboxInventoryRow(
   sandbox: SandboxEntry,
   defaultSandbox: string | null,

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -23,6 +23,10 @@ export interface SandboxEntry {
   messaging?: SandboxMessagingState | null;
   agent?: string | null;
   dashboardPort?: number | null;
+  // #5714: display-only marker for a sandbox recovered directly from the live
+  // gateway whose agent is genuinely unknown (the gateway sandbox list does not
+  // expose it). Lets the renderer show "unknown" instead of the OpenClaw default.
+  recoveredFromGateway?: boolean;
 }
 
 export interface MessagingBridgeHealth {
@@ -71,6 +75,10 @@ export interface SandboxInventoryRow {
   isDefault: boolean;
   activeSessionCount: number | null;
   connected: boolean;
+  // #5714: row recovered display-only from the live gateway. Its agent/GPU/
+  // inference state is unknown (the gateway sandbox list does not expose it),
+  // so the renderer shows "unknown" rather than asserting OpenClaw/CPU defaults.
+  recoveredFromGateway?: boolean;
 }
 
 export interface SandboxInventoryResult {
@@ -192,11 +200,16 @@ function buildSandboxInventoryRow(
     openshellDriver: safeStatusString(sandbox.openshellDriver || null),
     openshellVersion: safeStatusString(sandbox.openshellVersion || null),
     policies: Array.isArray(sandbox.policies) ? sandbox.policies : [],
-    agent: sandbox.agent || null,
+    // #5714: a sandbox recovered display-only from the live gateway has an
+    // unknown agent (the gateway sandbox list does not expose it). Surface
+    // "unknown" instead of letting the renderer's `|| "openclaw"` default
+    // misrepresent a Deep Agents/Hermes sandbox as OpenClaw.
+    agent: sandbox.agent || (sandbox.recoveredFromGateway ? "unknown" : null),
     ...(sandbox.dashboardPort != null ? { dashboardPort: sandbox.dashboardPort } : {}),
     isDefault: sandbox.name === defaultSandbox,
     activeSessionCount,
     connected: activeSessionCount !== null && activeSessionCount > 0,
+    ...(sandbox.recoveredFromGateway ? { recoveredFromGateway: true } : {}),
   };
 }
 
@@ -289,7 +302,14 @@ export function renderSandboxInventoryText(
       liveInference.provider &&
       liveInference.provider !== sandbox.provider
     );
-    const gpu = sandbox.sandboxGpuEnabled ? "sandbox GPU" : "CPU sandbox";
+    // #5714: a gateway-recovered row's GPU state is unknown — the gateway
+    // sandbox list does not expose it — so don't assert "CPU sandbox" (which
+    // would mislead DGX users whose GPU sandbox's registry entry was lost).
+    const gpu = sandbox.recoveredFromGateway
+      ? "GPU: unknown"
+      : sandbox.sandboxGpuEnabled
+        ? "sandbox GPU"
+        : "CPU sandbox";
     const presets = sandbox.policies.length > 0 ? sandbox.policies.join(", ") : "none";
     const connected = sandbox.connected ? " ●" : "";
     const agent = sandbox.agent || "openclaw";

--- a/src/lib/registry-recovery-action.test.ts
+++ b/src/lib/registry-recovery-action.test.ts
@@ -39,6 +39,7 @@ vi.mock("./adapters/openshell/resolve.js", () => ({
 
 vi.mock("./gateway-runtime-action.js", () => ({
   recoverNamedGatewayRuntime: vi.fn(),
+  getNamedGatewayLifecycleState: vi.fn(() => ({ state: "missing_named" })),
 }));
 
 vi.mock("./adapters/openshell/runtime.js", () => ({
@@ -50,7 +51,7 @@ vi.mock("./state/onboard-session.js", () => ({
 }));
 
 vi.mock("./runtime-recovery.js", () => ({
-  parseLiveSandboxNames: () => new Set<string>(),
+  parseLiveSandboxNames: vi.fn(() => new Set<string>()),
 }));
 
 vi.mock("./runner.js", () => ({
@@ -62,7 +63,14 @@ vi.mock("./runner.js", () => ({
   },
 }));
 
+import { resolveOpenshell } from "./adapters/openshell/resolve.js";
+import { captureOpenshell } from "./adapters/openshell/runtime.js";
+import {
+  getNamedGatewayLifecycleState,
+  recoverNamedGatewayRuntime,
+} from "./gateway-runtime-action.js";
 import { recoverRegistryEntries } from "./registry-recovery-action.js";
+import { parseLiveSandboxNames } from "./runtime-recovery.js";
 import { loadSession } from "./state/onboard-session.js";
 
 describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
@@ -215,5 +223,137 @@ describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
 
     expect(mockRegistryState.sandboxes["alpha"]).toBeDefined();
     expect(result.sandboxes.find((s) => s.name === "alpha")).toBeDefined();
+  });
+});
+
+describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistryState.sandboxes = {};
+    mockRegistryState.defaultSandbox = null;
+    vi.mocked(loadSession).mockReturnValue(null);
+    vi.mocked(resolveOpenshell).mockReturnValue("/usr/bin/openshell");
+    vi.mocked(captureOpenshell).mockReturnValue({ output: "", status: 0 } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set<string>());
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "missing_named" } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("recovers live gateway sandboxes for display when the registry is empty and unseeded", async () => {
+    // Reporter case: `nemoclaw list` ran with an empty/lost local registry and
+    // no onboard session, while the gateway was connected and the live sandbox
+    // existed (`status` reported Ready). list must rediscover it for display.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(1);
+    const recovered = result.sandboxes.find((s) => s.name === "dcode-station");
+    expect(recovered).toBeDefined();
+    // Minimal safe entry: no invented agent/model/provider metadata.
+    expect(recovered?.model).toBeNull();
+    expect(recovered?.provider).toBeNull();
+    expect(recovered?.agent).toBeUndefined();
+  });
+
+  it("does NOT persist unseeded gateway recoveries to the on-disk registry (#5714 agent safety)", async () => {
+    // `openshell sandbox list` does not expose the agent type, so persisting a
+    // recovered entry would default agent to "openclaw" everywhere downstream
+    // and permanently misclassify a Deep Agents/Hermes sandbox. Recovery is
+    // display-only: the on-disk registry must stay empty.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    await recoverRegistryEntries();
+
+    expect(mockRegistryState.sandboxes["dcode-station"]).toBeUndefined();
+  });
+
+  it("recovers via a NemoClaw per-port gateway when it is the active gateway", async () => {
+    // A non-default NEMOCLAW_GATEWAY_PORT runs `nemoclaw-<port>`; that is still
+    // a NemoClaw-managed gateway, so connected_other against it is trustworthy.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({
+      state: "connected_other",
+      activeGateway: "nemoclaw-8092",
+    } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(1);
+    expect(result.sandboxes.find((s) => s.name === "dcode-station")).toBeDefined();
+  });
+
+  it("ignores a failed `sandbox list` probe instead of parsing error text as names", async () => {
+    // A non-zero `openshell sandbox list` may print free-form error text; its
+    // first token must never be surfaced as a recovered sandbox.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(captureOpenshell).mockReturnValue({
+      output: "transport error: connection reset",
+      status: 1,
+    } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["transport"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
+  });
+
+  it("does NOT recover from a foreign (non-NemoClaw) active gateway", async () => {
+    // `openshell sandbox list` is scoped to the active gateway; if that gateway
+    // is not NemoClaw-managed, its sandboxes must not be surfaced as recovered
+    // NemoClaw entries.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({
+      state: "connected_other",
+      activeGateway: "some-other-project",
+    } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["foreign-sbox"]));
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
+  });
+
+  it("inspects the gateway read-only (never mutates gateway state) when unseeded", async () => {
+    // A plain `nemoclaw list` must never select/start a gateway as a side
+    // effect of listing: it inspects the lifecycle directly and never calls
+    // the mutating recoverNamedGatewayRuntime path.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    await recoverRegistryEntries();
+
+    expect(getNamedGatewayLifecycleState).toHaveBeenCalledWith(undefined, {
+      ignoreProbeErrors: true,
+    });
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the empty registry when no gateway is connected", async () => {
+    // Read-only inspection: gateway is not connected, so no live names are
+    // written. list stays empty instead of starting a gateway.
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "missing_named" } as never);
+
+    const result = await recoverRegistryEntries();
+
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+  });
+
+  it("does not probe the gateway when OpenShell is not installed", async () => {
+    vi.mocked(resolveOpenshell).mockReturnValue(null);
+
+    const result = await recoverRegistryEntries();
+
+    expect(getNamedGatewayLifecycleState).not.toHaveBeenCalled();
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+    expect(result.sandboxes).toEqual([]);
   });
 });

--- a/src/lib/registry-recovery-action.test.ts
+++ b/src/lib/registry-recovery-action.test.ts
@@ -258,6 +258,42 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     expect(recovered?.model).toBeNull();
     expect(recovered?.provider).toBeNull();
     expect(recovered?.agent).toBeUndefined();
+    // Marked recovered-from-gateway so the inventory renderer shows unknown
+    // agent/GPU instead of OpenClaw/CPU defaults (consumed by buildSandboxInventoryRow).
+    expect(recovered?.recoveredFromGateway).toBe(true);
+  });
+
+  it("treats an incomplete (phantom) session as unseeded — stays in read-only/display-only path", async () => {
+    // PRA-2: a session that recorded sandboxName but whose sandbox step never
+    // completed is a phantom (#2753). It must NOT count as a recovery seed,
+    // otherwise an empty registry + phantom session would take the mutating,
+    // persisting seeded path. Recovery must stay read-only/display-only.
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "phantom",
+      provider: "nvidia",
+      model: "nemotron",
+      policyPresets: [],
+      nimContainer: null,
+      steps: {
+        sandbox: { status: "pending", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+
+    const result = await recoverRegistryEntries();
+
+    // Read-only path: never invokes the mutating gateway recovery, inspects
+    // lifecycle directly, and surfaces the live sandbox display-only.
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+    expect(getNamedGatewayLifecycleState).toHaveBeenCalledWith(undefined, {
+      ignoreProbeErrors: true,
+    });
+    const recovered = result.sandboxes.find((s) => s.name === "dcode-station");
+    expect(recovered?.recoveredFromGateway).toBe(true);
+    // Nothing persisted — neither the phantom session sandbox nor the recovered one.
+    expect(mockRegistryState.sandboxes["dcode-station"]).toBeUndefined();
+    expect(mockRegistryState.sandboxes["phantom"]).toBeUndefined();
   });
 
   it("does NOT persist unseeded gateway recoveries to the on-disk registry (#5714 agent safety)", async () => {
@@ -273,9 +309,12 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     expect(mockRegistryState.sandboxes["dcode-station"]).toBeUndefined();
   });
 
-  it("recovers via a NemoClaw per-port gateway when it is the active gateway", async () => {
-    // A non-default NEMOCLAW_GATEWAY_PORT runs `nemoclaw-<port>`; that is still
-    // a NemoClaw-managed gateway, so connected_other against it is trustworthy.
+  it("does NOT recover when a different NemoClaw gateway is active (connected_other)", async () => {
+    // The active gateway differs from the one this process resolves (e.g. active
+    // `nemoclaw-8092` while `list` targets the default `nemoclaw`). `sandbox
+    // list` may be scoped to the active gateway and a follow-up `<name> status`
+    // resolves the target gateway, so advertising the other gateway's sandboxes
+    // would be unactionable — read-only recovery requires healthy_named only.
     vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({
       state: "connected_other",
       activeGateway: "nemoclaw-8092",
@@ -284,8 +323,8 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
 
     const result = await recoverRegistryEntries();
 
-    expect(result.recoveredFromGateway).toBe(1);
-    expect(result.sandboxes.find((s) => s.name === "dcode-station")).toBeDefined();
+    expect(result.recoveredFromGateway).toBe(0);
+    expect(result.sandboxes).toEqual([]);
   });
 
   it("ignores a failed `sandbox list` probe instead of parsing error text as names", async () => {

--- a/src/lib/registry-recovery-action.test.ts
+++ b/src/lib/registry-recovery-action.test.ts
@@ -51,7 +51,7 @@ vi.mock("./state/onboard-session.js", () => ({
 }));
 
 vi.mock("./runtime-recovery.js", () => ({
-  parseLiveSandboxNames: vi.fn(() => new Set<string>()),
+  parseLiveSandboxEntries: vi.fn(() => [] as Array<{ name: string; phase: string | null }>),
 }));
 
 vi.mock("./runner.js", () => ({
@@ -70,7 +70,7 @@ import {
   recoverNamedGatewayRuntime,
 } from "./gateway-runtime-action.js";
 import { recoverRegistryEntries } from "./registry-recovery-action.js";
-import { parseLiveSandboxNames } from "./runtime-recovery.js";
+import { parseLiveSandboxEntries } from "./runtime-recovery.js";
 import { loadSession } from "./state/onboard-session.js";
 
 describe("recoverRegistryEntries (#2753 seed-time guard)", () => {
@@ -234,7 +234,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     vi.mocked(loadSession).mockReturnValue(null);
     vi.mocked(resolveOpenshell).mockReturnValue("/usr/bin/openshell");
     vi.mocked(captureOpenshell).mockReturnValue({ output: "", status: 0 } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set<string>());
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([]);
     vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "missing_named" } as never);
   });
 
@@ -242,17 +242,26 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     vi.restoreAllMocks();
   });
 
-  it("recovers live gateway sandboxes for display when the registry is empty and unseeded", async () => {
-    // Reporter case: `nemoclaw list` ran with an empty/lost local registry and
-    // no onboard session, while the gateway was connected and the live sandbox
-    // existed (`status` reported Ready). list must rediscover it for display.
+  it("list displays recovered sandbox Ready phase and authoritative agent when available, otherwise documents unknown fallback", async () => {
+    // Reporter case (#5714): `nemoclaw list` ran with an empty/lost local
+    // registry and no onboard session while the gateway was connected and the
+    // live sandbox existed (`status` reported Ready). list must rediscover it
+    // for display, carrying the TRUSTED live PHASE (Ready) from the gateway
+    // sandbox list, but leaving agent/model/provider unknown — the gateway list
+    // is not an authoritative agent source; the real agent is reconciled by a
+    // follow-up `nemoclaw <name> status`.
     vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "dcode-station", phase: "Ready" }]);
 
     const result = await recoverRegistryEntries();
 
     expect(result.recoveredFromGateway).toBe(1);
-    const recovered = result.sandboxes.find((s) => s.name === "dcode-station");
+    const recovered = result.sandboxes.find((s) => s.name === "dcode-station") as
+      | ((typeof result.sandboxes)[number] & {
+          recoveredFromGateway?: boolean;
+          livePhase?: string | null;
+        })
+      | undefined;
     expect(recovered).toBeDefined();
     // Minimal safe entry: no invented agent/model/provider metadata.
     expect(recovered?.model).toBeNull();
@@ -261,6 +270,8 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     // Marked recovered-from-gateway so the inventory renderer shows unknown
     // agent/GPU instead of OpenClaw/CPU defaults (consumed by buildSandboxInventoryRow).
     expect(recovered?.recoveredFromGateway).toBe(true);
+    // Trusted live PHASE is carried for display so list agrees with status.
+    expect(recovered?.livePhase).toBe("Ready");
   });
 
   it("treats an incomplete (phantom) session as unseeded — stays in read-only/display-only path", async () => {
@@ -279,7 +290,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
       },
     } as never);
     vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "dcode-station", phase: "Ready" }]);
 
     const result = await recoverRegistryEntries();
 
@@ -289,11 +300,51 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     expect(getNamedGatewayLifecycleState).toHaveBeenCalledWith(undefined, {
       ignoreProbeErrors: true,
     });
-    const recovered = result.sandboxes.find((s) => s.name === "dcode-station");
+    const recovered = result.sandboxes.find((s) => s.name === "dcode-station") as
+      | { recoveredFromGateway?: boolean }
+      | undefined;
     expect(recovered?.recoveredFromGateway).toBe(true);
     // Nothing persisted — neither the phantom session sandbox nor the recovered one.
     expect(mockRegistryState.sandboxes["dcode-station"]).toBeUndefined();
     expect(mockRegistryState.sandboxes["phantom"]).toBeUndefined();
+  });
+
+  it("incomplete session with existing registry entries does not trigger mutating gateway recovery solely because the phantom session name is missing", async () => {
+    // PRA-5: with an existing registry entry plus an incomplete (phantom)
+    // session naming a DIFFERENT, missing sandbox, recovery must not flip on and
+    // call the mutating gateway recovery (select/start). `shouldRecoverRegistryEntries`
+    // must treat the phantom session as not-a-seed (isSessionSandboxConfirmed),
+    // so `missingSessionSandbox` stays false and no recovery runs.
+    mockRegistryState.sandboxes["beta"] = {
+      name: "beta",
+      provider: "nvidia",
+      model: "nemotron",
+      gpuEnabled: false,
+      policies: [],
+      nimContainer: null,
+      agent: "openclaw",
+    };
+    vi.mocked(loadSession).mockReturnValue({
+      sandboxName: "phantom",
+      provider: "nvidia",
+      model: "nemotron",
+      policyPresets: [],
+      nimContainer: null,
+      steps: {
+        sandbox: { status: "pending", startedAt: null, completedAt: null, error: null },
+      },
+    } as never);
+    vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "live-x", phase: "Ready" }]);
+
+    const result = await recoverRegistryEntries();
+
+    // No mutating recovery, no read-only gateway inspection — recovery never ran.
+    expect(recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+    expect(getNamedGatewayLifecycleState).not.toHaveBeenCalled();
+    // Existing entry preserved; nothing new surfaced or persisted.
+    expect(result.sandboxes.map((s) => s.name)).toEqual(["beta"]);
+    expect(result.recoveredFromGateway).toBe(0);
   });
 
   it("does NOT persist unseeded gateway recoveries to the on-disk registry (#5714 agent safety)", async () => {
@@ -302,7 +353,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     // and permanently misclassify a Deep Agents/Hermes sandbox. Recovery is
     // display-only: the on-disk registry must stay empty.
     vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "dcode-station", phase: "Ready" }]);
 
     await recoverRegistryEntries();
 
@@ -319,7 +370,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
       state: "connected_other",
       activeGateway: "nemoclaw-8092",
     } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "dcode-station", phase: "Ready" }]);
 
     const result = await recoverRegistryEntries();
 
@@ -335,7 +386,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
       output: "transport error: connection reset",
       status: 1,
     } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["transport"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "transport", phase: null }]);
 
     const result = await recoverRegistryEntries();
 
@@ -351,7 +402,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
       state: "connected_other",
       activeGateway: "some-other-project",
     } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["foreign-sbox"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "foreign-sbox", phase: "Ready" }]);
 
     const result = await recoverRegistryEntries();
 
@@ -364,7 +415,7 @@ describe("recoverRegistryEntries (#5714 empty-registry live gateway recovery)", 
     // effect of listing: it inspects the lifecycle directly and never calls
     // the mutating recoverNamedGatewayRuntime path.
     vi.mocked(getNamedGatewayLifecycleState).mockReturnValue({ state: "healthy_named" } as never);
-    vi.mocked(parseLiveSandboxNames).mockReturnValue(new Set(["dcode-station"]));
+    vi.mocked(parseLiveSandboxEntries).mockReturnValue([{ name: "dcode-station", phase: "Ready" }]);
 
     await recoverRegistryEntries();
 

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -8,7 +8,6 @@ import {
   getNamedGatewayLifecycleState,
   recoverNamedGatewayRuntime,
 } from "./gateway-runtime-action";
-import { resolveGatewayPortFromName } from "./onboard/gateway-binding";
 import { validateName } from "./runner";
 import { parseLiveSandboxNames } from "./runtime-recovery";
 import * as onboardSession from "./state/onboard-session";
@@ -175,22 +174,18 @@ function seedRecoveryMetadata(
  */
 function canInspectLiveGatewayReadOnly(): boolean {
   // #5714: unseeded `nemoclaw list` recovery must never mutate gateway state
-  // (no select/start). Probes are non-fatal so a hung gateway falls back to the
-  // empty registry instead of exiting the process.
+  // (no select/start). Require `healthy_named` — the active gateway IS the
+  // NemoClaw gateway this process resolves/targets. We deliberately do NOT
+  // recover from a `connected_other` gateway (a different active gateway,
+  // whether a NemoClaw per-port gateway or a foreign one): `openshell sandbox
+  // list` may be scoped to the active gateway, and a follow-up `nemoclaw <name>
+  // status` resolves the same target gateway as this `list` — so recovering
+  // only from `healthy_named` keeps `list` and follow-up commands consistent
+  // and never advertises a sandbox the next command cannot act on. Probes are
+  // non-fatal so a hung gateway falls back to the empty registry instead of
+  // exiting the process.
   const lifecycle = getNamedGatewayLifecycleState(undefined, { ignoreProbeErrors: true });
-  // The target NemoClaw gateway is healthy — trust its sandbox list.
-  if (lifecycle.state === "healthy_named") {
-    return true;
-  }
-  // A different gateway is active. `openshell sandbox list` is scoped to the
-  // active gateway, so only trust it when that gateway is still NemoClaw-managed
-  // (the bare `nemoclaw` or a per-port `nemoclaw-<port>` from a non-default
-  // NEMOCLAW_GATEWAY_PORT). Never list a foreign OpenShell gateway's sandboxes
-  // as recovered NemoClaw entries.
-  if (lifecycle.state === "connected_other") {
-    return resolveGatewayPortFromName(lifecycle.activeGateway ?? "") !== null;
-  }
-  return false;
+  return lifecycle.state === "healthy_named";
 }
 
 /**
@@ -325,14 +320,20 @@ export async function recoverRegistryEntries({
 
   const seeded = seedRecoveryMetadata(current, session, requestedSandboxName);
   // A seed is any signal that the user expects a specific sandbox to exist:
-  // existing registry entries, a recorded onboard session, or an explicit
+  // existing registry entries, a *confirmed* onboard session, or an explicit
   // requested name. With a seed we allow active gateway recovery (which may
-  // select/start the named gateway). Without one — the #5714 empty-registry
-  // `list` case — restrict recovery to a read-only inspection of any connected
-  // gateway so plain `nemoclaw list` never mutates gateway state as a side
-  // effect of listing.
+  // select/start the named gateway) and persist recovered entries. Without one
+  // — the #5714 empty-registry `list` case — restrict recovery to a read-only
+  // inspection of any connected gateway so plain `nemoclaw list` never mutates
+  // gateway state or persists entries as a side effect of listing.
+  //
+  // An *incomplete* session (sandboxName recorded but the sandbox step never
+  // completed) is a phantom from an interrupted onboard (#2753); it must NOT
+  // count as a seed, otherwise an empty registry + phantom session would take
+  // the mutating/persisting seeded path instead of the safe display-only one.
+  const hasConfirmedSession = isSessionSandboxConfirmed(session) && Boolean(session?.sandboxName);
   const hasRecoverySeed =
-    current.sandboxes.length > 0 || Boolean(session?.sandboxName) || Boolean(requestedSandboxName);
+    current.sandboxes.length > 0 || hasConfirmedSession || Boolean(requestedSandboxName);
   const gateway = await recoverRegistryFromLiveGateway(seeded.metadataByName, {
     readOnly: !hasRecoverySeed,
   });

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -9,10 +9,23 @@ import {
   recoverNamedGatewayRuntime,
 } from "./gateway-runtime-action";
 import { validateName } from "./runner";
-import { parseLiveSandboxNames } from "./runtime-recovery";
+import { parseLiveSandboxEntries } from "./runtime-recovery";
 import * as onboardSession from "./state/onboard-session";
 import type { SandboxEntry } from "./state/registry";
 import * as registry from "./state/registry";
+
+/**
+ * #5714: a sandbox surfaced display-only by unseeded `nemoclaw list` recovery.
+ * These transient markers (`recoveredFromGateway`, `livePhase`) are deliberately
+ * NOT part of the durable {@link SandboxEntry} persistence contract — they live
+ * only on the in-memory list result so they can never be written to
+ * sandboxes.json — and let the renderer show the live phase while marking
+ * agent/GPU unknown (the gateway list is not a trusted source for those).
+ */
+export type RecoveredSandboxEntry = SandboxEntry & {
+  recoveredFromGateway: true;
+  livePhase: string | null;
+};
 
 type Session = ReturnType<typeof onboardSession.loadSession>;
 
@@ -88,7 +101,13 @@ function shouldRecoverRegistryEntries(
   requestedSandboxName: string | null,
 ) {
   const sessionSandboxName = session?.sandboxName ?? null;
-  const hasSessionSandbox = Boolean(sessionSandboxName);
+  // #5714/PRA-5: only a *confirmed* session sandbox counts here. An incomplete
+  // (phantom) onboard session must not make `missingSessionSandbox` true, or it
+  // would flip `shouldRecover` on and drive the mutating seeded gateway recovery
+  // (select/start) during a plain `nemoclaw list` even when the registry already
+  // has entries. Applied consistently with the `hasRecoverySeed` check in
+  // recoverRegistryEntries.
+  const hasSessionSandbox = isSessionSandboxConfirmed(session) && Boolean(sessionSandboxName);
   const missingSessionSandbox =
     hasSessionSandbox && !current.sandboxes.some((sandbox) => sandbox.name === sessionSandboxName);
   const missingRequestedSandbox =
@@ -209,7 +228,7 @@ interface LiveGatewayRecovery {
    * #5714: live sandboxes surfaced for display only (unseeded `list` recovery)
    * that were NOT persisted to the on-disk registry. Empty for the seeded path.
    */
-  ephemeralSandboxes: SandboxEntry[];
+  ephemeralSandboxes: RecoveredSandboxEntry[];
 }
 
 /**
@@ -233,19 +252,19 @@ async function recoverRegistryFromLiveGateway(
   }
 
   let recoveredFromGateway = 0;
-  const ephemeralSandboxes: SandboxEntry[] = [];
+  const ephemeralSandboxes: RecoveredSandboxEntry[] = [];
   const liveList = captureOpenshell(["sandbox", "list"], {
     ignoreError: true,
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
   });
   // Only trust the output of a clean `sandbox list`. On a non-zero/failed probe
   // (timeout, transport error) OpenShell may print free-form text whose first
-  // token parseLiveSandboxNames would otherwise mistake for a sandbox name.
+  // token parseLiveSandboxEntries would otherwise mistake for a sandbox name.
   if (liveList.status !== 0) {
     return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
   }
-  const liveNames = Array.from<string>(parseLiveSandboxNames(liveList.output));
-  for (const name of liveNames) {
+  const liveEntries = parseLiveSandboxEntries(liveList.output);
+  for (const { name, phase } of liveEntries) {
     const metadata = metadataByName.get(name) || undefined;
     if (readOnly) {
       // Unseeded recovery: surface the live sandbox for THIS `list` only and do
@@ -253,9 +272,10 @@ async function recoverRegistryFromLiveGateway(
       // — not the agent or gateway binding — so a persisted entry would default
       // `agent` to "openclaw" everywhere downstream (state dirs, connect,
       // rebuild, doctor), permanently misclassifying a Deep Agents/Hermes
-      // sandbox after registry loss. Display-only recovery fixes the
-      // discoverability mismatch without writing unsafe durable metadata;
-      // follow-up named commands reconcile the real agent via the gateway.
+      // sandbox after registry loss. We DO carry the trusted live PHASE so the
+      // row can show e.g. Ready (#5714 acceptance), but agent stays unknown
+      // because the gateway list is not an authoritative agent source; the
+      // real agent is reconciled by a follow-up `nemoclaw <name> status`.
       let validName: string;
       try {
         validName = validateName(name, "sandbox name");
@@ -265,6 +285,7 @@ async function recoverRegistryFromLiveGateway(
       ephemeralSandboxes.push({
         ...buildRecoveredSandboxEntry(validName, metadata),
         recoveredFromGateway: true,
+        livePhase: phase,
       });
       recoveredFromGateway += 1;
       continue;

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -1,15 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { recoverNamedGatewayRuntime } from "./gateway-runtime-action";
-import * as onboardSession from "./state/onboard-session";
-import { OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
-import { captureOpenshell } from "./adapters/openshell/runtime";
-import * as registry from "./state/registry";
-import type { SandboxEntry } from "./state/registry";
 import { resolveOpenshell } from "./adapters/openshell/resolve";
-import { parseLiveSandboxNames } from "./runtime-recovery";
+import { captureOpenshell } from "./adapters/openshell/runtime";
+import { OPENSHELL_PROBE_TIMEOUT_MS } from "./adapters/openshell/timeouts";
+import {
+  getNamedGatewayLifecycleState,
+  recoverNamedGatewayRuntime,
+} from "./gateway-runtime-action";
+import { resolveGatewayPortFromName } from "./onboard/gateway-binding";
 import { validateName } from "./runner";
+import { parseLiveSandboxNames } from "./runtime-recovery";
+import * as onboardSession from "./state/onboard-session";
+import type { SandboxEntry } from "./state/registry";
+import * as registry from "./state/registry";
 
 type Session = ReturnType<typeof onboardSession.loadSession>;
 
@@ -79,9 +83,15 @@ function shouldRecoverRegistryEntries(
     current.sandboxes.length > 0 || hasSessionSandbox || Boolean(requestedSandboxName);
   return {
     missingRequestedSandbox,
+    // #5714: an empty local registry must always attempt recovery, even with
+    // no session/requested-name seed. The reporter's `nemoclaw list` printed
+    // "No sandboxes registered" while the live gateway/container were healthy
+    // and `nemoclaw <name> status` reported Ready. Probing the live gateway
+    // (bounded, read-only when unseeded — see recoverRegistryEntries) lets the
+    // documented discovery command rediscover a sandbox the local registry lost.
     shouldRecover:
-      hasRecoverySeed &&
-      (current.sandboxes.length === 0 || missingRequestedSandbox || missingSessionSandbox),
+      current.sandboxes.length === 0 ||
+      (hasRecoverySeed && (missingRequestedSandbox || missingSessionSandbox)),
   };
 }
 
@@ -136,34 +146,100 @@ function seedRecoveryMetadata(
   return { metadataByName, recoveredFromSession };
 }
 
-async function recoverRegistryFromLiveGateway(
-  metadataByName: Map<string, RecoveredSandboxMetadata>,
-) {
-  if (!resolveOpenshell()) {
-    return 0;
+function canInspectLiveGatewayReadOnly(): boolean {
+  // #5714: unseeded `nemoclaw list` recovery must never mutate gateway state
+  // (no select/start). Probes are non-fatal so a hung gateway falls back to the
+  // empty registry instead of exiting the process.
+  const lifecycle = getNamedGatewayLifecycleState(undefined, { ignoreProbeErrors: true });
+  // The target NemoClaw gateway is healthy — trust its sandbox list.
+  if (lifecycle.state === "healthy_named") {
+    return true;
   }
+  // A different gateway is active. `openshell sandbox list` is scoped to the
+  // active gateway, so only trust it when that gateway is still NemoClaw-managed
+  // (the bare `nemoclaw` or a per-port `nemoclaw-<port>` from a non-default
+  // NEMOCLAW_GATEWAY_PORT). Never list a foreign OpenShell gateway's sandboxes
+  // as recovered NemoClaw entries.
+  if (lifecycle.state === "connected_other") {
+    return resolveGatewayPortFromName(lifecycle.activeGateway ?? "") !== null;
+  }
+  return false;
+}
+
+async function canInspectLiveGatewayViaRecovery(): Promise<boolean> {
   const recovery = await recoverNamedGatewayRuntime();
-  const canInspectLiveGateway =
+  return (
     recovery.recovered ||
     recovery.before?.state === "healthy_named" ||
-    recovery.after?.state === "healthy_named";
+    recovery.after?.state === "healthy_named"
+  );
+}
+
+interface LiveGatewayRecovery {
+  recoveredFromGateway: number;
+  /**
+   * #5714: live sandboxes surfaced for display only (unseeded `list` recovery)
+   * that were NOT persisted to the on-disk registry. Empty for the seeded path.
+   */
+  ephemeralSandboxes: SandboxEntry[];
+}
+
+async function recoverRegistryFromLiveGateway(
+  metadataByName: Map<string, RecoveredSandboxMetadata>,
+  { readOnly = false }: { readOnly?: boolean } = {},
+): Promise<LiveGatewayRecovery> {
+  if (!resolveOpenshell()) {
+    return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
+  }
+  const canInspectLiveGateway = readOnly
+    ? canInspectLiveGatewayReadOnly()
+    : await canInspectLiveGatewayViaRecovery();
   if (!canInspectLiveGateway) {
-    return 0;
+    return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
   }
 
   let recoveredFromGateway = 0;
+  const ephemeralSandboxes: SandboxEntry[] = [];
   const liveList = captureOpenshell(["sandbox", "list"], {
     ignoreError: true,
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
   });
+  // Only trust the output of a clean `sandbox list`. On a non-zero/failed probe
+  // (timeout, transport error) OpenShell may print free-form text whose first
+  // token parseLiveSandboxNames would otherwise mistake for a sandbox name.
+  if (liveList.status !== 0) {
+    return { recoveredFromGateway: 0, ephemeralSandboxes: [] };
+  }
   const liveNames = Array.from<string>(parseLiveSandboxNames(liveList.output));
   for (const name of liveNames) {
     const metadata = metadataByName.get(name) || undefined;
+    if (readOnly) {
+      // Unseeded recovery: surface the live sandbox for THIS `list` only and do
+      // not persist it. `openshell sandbox list` exposes only NAME/CREATED/PHASE
+      // — not the agent or gateway binding — so a persisted entry would default
+      // `agent` to "openclaw" everywhere downstream (state dirs, connect,
+      // rebuild, doctor), permanently misclassifying a Deep Agents/Hermes
+      // sandbox after registry loss. Display-only recovery fixes the
+      // discoverability mismatch without writing unsafe durable metadata;
+      // follow-up named commands reconcile the real agent via the gateway.
+      let validName: string;
+      try {
+        validName = validateName(name, "sandbox name");
+      } catch {
+        continue;
+      }
+      ephemeralSandboxes.push({
+        ...buildRecoveredSandboxEntry(validName, metadata),
+        recoveredFromGateway: true,
+      });
+      recoveredFromGateway += 1;
+      continue;
+    }
     if (upsertRecoveredSandbox(name, metadata)) {
       recoveredFromGateway += 1;
     }
   }
-  return recoveredFromGateway;
+  return { recoveredFromGateway, ephemeralSandboxes };
 }
 
 function applyRecoveredDefault(
@@ -196,15 +272,31 @@ export async function recoverRegistryEntries({
   }
 
   const seeded = seedRecoveryMetadata(current, session, requestedSandboxName);
-  const shouldProbeLiveGateway =
+  // A seed is any signal that the user expects a specific sandbox to exist:
+  // existing registry entries, a recorded onboard session, or an explicit
+  // requested name. With a seed we allow active gateway recovery (which may
+  // select/start the named gateway). Without one — the #5714 empty-registry
+  // `list` case — restrict recovery to a read-only inspection of any connected
+  // gateway so plain `nemoclaw list` never mutates gateway state as a side
+  // effect of listing.
+  const hasRecoverySeed =
     current.sandboxes.length > 0 || Boolean(session?.sandboxName) || Boolean(requestedSandboxName);
-  const recoveredFromGateway = shouldProbeLiveGateway
-    ? await recoverRegistryFromLiveGateway(seeded.metadataByName)
-    : 0;
+  const gateway = await recoverRegistryFromLiveGateway(seeded.metadataByName, {
+    readOnly: !hasRecoverySeed,
+  });
   const recovered = applyRecoveredDefault(current.defaultSandbox, requestedSandboxName, session);
+  // Merge display-only (ephemeral) live-gateway sandboxes that were not
+  // persisted (#5714 unseeded recovery), skipping any that a concurrent path
+  // may already have registered.
+  const persistedNames = new Set(recovered.sandboxes.map((sandbox) => sandbox.name));
+  const sandboxes = [
+    ...recovered.sandboxes,
+    ...gateway.ephemeralSandboxes.filter((sandbox) => !persistedNames.has(sandbox.name)),
+  ];
   return {
     ...recovered,
+    sandboxes,
     recoveredFromSession: seeded.recoveredFromSession,
-    recoveredFromGateway,
+    recoveredFromGateway: gateway.recoveredFromGateway,
   };
 }

--- a/src/lib/registry-recovery-action.ts
+++ b/src/lib/registry-recovery-action.ts
@@ -23,6 +23,11 @@ type RecoveredSandboxMetadata = Partial<
   policyPresets?: string[] | null;
 };
 
+/**
+ * Build a minimal-safe registry entry for a recovered sandbox from whatever
+ * metadata is known, asserting `agent` only when the seed actually provides it
+ * so recovery never clobbers a persisted agent or invents one.
+ */
 function buildRecoveredSandboxEntry(
   name: string,
   metadata: RecoveredSandboxMetadata = {},
@@ -50,6 +55,11 @@ function buildRecoveredSandboxEntry(
   return entry;
 }
 
+/**
+ * Persist a recovered sandbox into the registry, registering a new entry or
+ * merging into an existing one. Returns true only when a new entry was created.
+ * Invalid sandbox names are skipped (returns false).
+ */
 function upsertRecoveredSandbox(name: string, metadata: RecoveredSandboxMetadata = {}) {
   let validName;
   try {
@@ -67,6 +77,12 @@ function upsertRecoveredSandbox(name: string, metadata: RecoveredSandboxMetadata
   return true;
 }
 
+/**
+ * Decide whether registry recovery should run and whether the requested
+ * sandbox is missing from the on-disk registry. Recovery is attempted whenever
+ * the registry is empty (the #5714 unseeded `list` case) or a seed (session or
+ * requested name) points at a sandbox the registry does not yet contain.
+ */
 function shouldRecoverRegistryEntries(
   current: { sandboxes: Array<{ name: string }>; defaultSandbox?: string | null },
   session: Session | null,
@@ -106,6 +122,11 @@ function isSessionSandboxConfirmed(session: Session | null): boolean {
   return session.steps?.sandbox?.status === "complete";
 }
 
+/**
+ * Build the name→metadata seed map used to enrich gateway-recovered entries,
+ * and recover a confirmed onboard-session sandbox into the registry when it is
+ * missing. Returns the seed map and whether a session sandbox was recovered.
+ */
 function seedRecoveryMetadata(
   current: { sandboxes: SandboxEntry[] },
   session: Session | null,
@@ -146,6 +167,12 @@ function seedRecoveryMetadata(
   return { metadataByName, recoveredFromSession };
 }
 
+/**
+ * Decide whether the unseeded (#5714) `nemoclaw list` recovery may read the
+ * live `openshell sandbox list` without mutating gateway state. Returns true
+ * only when OpenShell is connected to a NemoClaw-managed gateway (the bare
+ * `nemoclaw` or a per-port `nemoclaw-<port>`), never a foreign gateway.
+ */
 function canInspectLiveGatewayReadOnly(): boolean {
   // #5714: unseeded `nemoclaw list` recovery must never mutate gateway state
   // (no select/start). Probes are non-fatal so a hung gateway falls back to the
@@ -166,6 +193,12 @@ function canInspectLiveGatewayReadOnly(): boolean {
   return false;
 }
 
+/**
+ * Decide whether the seeded recovery path may read the live sandbox list,
+ * actively recovering the named NemoClaw gateway (select/start) first when
+ * needed. Used when an existing entry, onboard session, or requested name
+ * signals a specific sandbox the user expects to exist.
+ */
 async function canInspectLiveGatewayViaRecovery(): Promise<boolean> {
   const recovery = await recoverNamedGatewayRuntime();
   return (
@@ -184,6 +217,12 @@ interface LiveGatewayRecovery {
   ephemeralSandboxes: SandboxEntry[];
 }
 
+/**
+ * Inspect the live OpenShell gateway and recover its sandboxes. In `readOnly`
+ * mode (unseeded #5714 `list`) recovered sandboxes are returned as display-only
+ * `ephemeralSandboxes` and never persisted; otherwise they are upserted into
+ * the on-disk registry. Returns the recovered count and any ephemeral entries.
+ */
 async function recoverRegistryFromLiveGateway(
   metadataByName: Map<string, RecoveredSandboxMetadata>,
   { readOnly = false }: { readOnly?: boolean } = {},
@@ -242,6 +281,11 @@ async function recoverRegistryFromLiveGateway(
   return { recoveredFromGateway, ephemeralSandboxes };
 }
 
+/**
+ * Set the registry default to the requested name (or the session sandbox when
+ * no default exists) once it is present in the registry, then return the
+ * refreshed registry listing.
+ */
 function applyRecoveredDefault(
   currentDefaultSandbox: string | null,
   requestedSandboxName: string | null,
@@ -259,6 +303,14 @@ function applyRecoveredDefault(
   return registry.listSandboxes();
 }
 
+/**
+ * Reconcile the local sandbox registry against the onboard session and the live
+ * OpenShell gateway. With a seed (existing entry, session, or requested name)
+ * it actively recovers and persists entries; for an empty registry with no seed
+ * (#5714) it performs a bounded, read-only gateway inspection and returns the
+ * live sandboxes as display-only entries without persisting them. Returns the
+ * registry listing plus `recoveredFromSession`/`recoveredFromGateway` markers.
+ */
 export async function recoverRegistryEntries({
   requestedSandboxName = null,
 }: {

--- a/src/lib/runtime-recovery.test.ts
+++ b/src/lib/runtime-recovery.test.ts
@@ -4,9 +4,59 @@
 import { describe, expect, it } from "vitest";
 
 // Import from compiled dist/ for correct coverage attribution.
-import { parseLiveSandboxNames, parseReadySandboxNames } from "../../dist/lib/runtime-recovery";
+import {
+  parseLiveSandboxEntries,
+  parseLiveSandboxNames,
+  parseReadySandboxNames,
+} from "../../dist/lib/runtime-recovery";
 
 describe("runtime recovery helpers", () => {
+  it("parses name + live PHASE pairs regardless of column layout (#5714)", () => {
+    // Trailing-phase (real `NAME CREATED PHASE`), header skipped, and a compact
+    // age-suffixed layout (`NAME PHASE 2m ago`) must all yield the phase.
+    expect(
+      parseLiveSandboxEntries(
+        [
+          "NAME              CREATED              PHASE",
+          "dcode-station     2026-06-25 09:40:49  Ready",
+          "beta              2026-06-25 10:01:00  Provisioning",
+          "gamma             Error                2m ago",
+          "compact           Running",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { name: "dcode-station", phase: "Ready" },
+      { name: "beta", phase: "Provisioning" },
+      { name: "gamma", phase: "Error" },
+      { name: "compact", phase: "Running" },
+    ]);
+  });
+
+  it("preserves terminal/transient phases, not just ready/running (#5714)", () => {
+    expect(
+      parseLiveSandboxEntries(
+        [
+          "alpha   2026-06-25 09:40:49  Failed",
+          "beta    2026-06-25 09:41:00  CrashLoopBackOff",
+          "gamma   2026-06-25 09:42:00  Creating",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { name: "alpha", phase: "Failed" },
+      { name: "beta", phase: "CrashLoopBackOff" },
+      { name: "gamma", phase: "Creating" },
+    ]);
+  });
+
+  it("returns a null phase when no known phase token is present", () => {
+    expect(parseLiveSandboxEntries("solo")).toEqual([{ name: "solo", phase: null }]);
+  });
+
+  it("skips headers and error lines when parsing live entries", () => {
+    expect(parseLiveSandboxEntries("No sandboxes found.")).toEqual([]);
+    expect(parseLiveSandboxEntries("Error: boom")).toEqual([]);
+  });
+
   it("parses live sandbox names from openshell sandbox list output", () => {
     expect(
       Array.from(

--- a/src/lib/runtime-recovery.ts
+++ b/src/lib/runtime-recovery.ts
@@ -29,15 +29,18 @@ const LIVE_SANDBOX_DISPLAY_PHASES = new Set([
   "Unknown",
 ]);
 
+/** Strip ANSI color escape sequences from CLI output. */
 function stripAnsi(text: string | null | undefined): string {
   return String(text || "").replace(ANSI_RE, "");
 }
 
+/** Detect an OpenShell protobuf/wire schema-mismatch error in command output. */
 export function isOpenShellProtobufSchemaMismatch(output = ""): boolean {
   const clean = stripAnsi(output);
   return /invalid wire type/i.test(clean) || /proto(?:buf)?(?: decode| schema| wire)/i.test(clean);
 }
 
+/** Whether a `sandbox list` line is a header/empty/error row rather than a sandbox. */
 function isNonSandboxRow(line: string, firstCol: string): boolean {
   if (firstCol === "NAME") return true;
   if (line === "No sandboxes found" || line === "No sandboxes found.") return true;
@@ -46,6 +49,7 @@ function isNonSandboxRow(line: string, firstCol: string): boolean {
   return false;
 }
 
+/** Extract the phase token from a `sandbox list` row's columns (compact or trailing). */
 function parseSandboxListPhase(cols: string[]): string | null {
   const compactPhase = cols[1];
   if (cols.length <= 3 && SANDBOX_PHASES.has(compactPhase)) return compactPhase;
@@ -53,6 +57,7 @@ function parseSandboxListPhase(cols: string[]): string | null {
   return trailingPhase && SANDBOX_PHASES.has(trailingPhase) ? trailingPhase : null;
 }
 
+/** Parse the set of all live sandbox names from `openshell sandbox list` output. */
 export function parseLiveSandboxNames(listOutput = ""): Set<string> {
   const clean = stripAnsi(listOutput);
   const names = new Set<string>();
@@ -98,6 +103,7 @@ export function parseLiveSandboxEntries(listOutput = ""): LiveSandboxEntry[] {
   return entries;
 }
 
+/** Parse the set of sandbox names in a Ready/Running phase from `sandbox list` output. */
 export function parseReadySandboxNames(listOutput = ""): Set<string> {
   const clean = stripAnsi(listOutput);
   const names = new Set<string>();

--- a/src/lib/runtime-recovery.ts
+++ b/src/lib/runtime-recovery.ts
@@ -8,6 +8,26 @@
 
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 const SANDBOX_PHASES = new Set(["Ready", "Running", "NotReady", "Provisioning", "Error"]);
+// Broader phase vocabulary for surfacing the live PHASE on #5714 recovered list
+// rows. Unions the lifecycle phases above with the terminal/failure phases used
+// elsewhere (see state/gateway.ts TERMINAL_SANDBOX_PHASES) plus common
+// transient phases, so a recovered row reports the real phase (e.g. Failed,
+// CrashLoopBackOff, Creating) instead of "unknown". Kept separate from
+// SANDBOX_PHASES so parseReadySandboxNames' Ready/Running gate is unchanged.
+const LIVE_SANDBOX_DISPLAY_PHASES = new Set([
+  "Ready",
+  "Running",
+  "NotReady",
+  "Provisioning",
+  "Creating",
+  "Pending",
+  "Terminating",
+  "Error",
+  "Failed",
+  "CrashLoopBackOff",
+  "ImagePullBackOff",
+  "Unknown",
+]);
 
 function stripAnsi(text: string | null | undefined): string {
   return String(text || "").replace(ANSI_RE, "");
@@ -45,6 +65,37 @@ export function parseLiveSandboxNames(listOutput = ""): Set<string> {
     names.add(cols[0]);
   }
   return names;
+}
+
+export interface LiveSandboxEntry {
+  name: string;
+  phase: string | null;
+}
+
+/**
+ * Parse `openshell sandbox list` rows into name + live PHASE pairs, skipping
+ * headers and status/error lines. Used by #5714 list recovery to surface the
+ * live phase (e.g. Ready) of a rediscovered sandbox without trusting the list
+ * output for any other (e.g. agent) metadata it does not contain.
+ */
+export function parseLiveSandboxEntries(listOutput = ""): LiveSandboxEntry[] {
+  const clean = stripAnsi(listOutput);
+  const entries: LiveSandboxEntry[] = [];
+  for (const rawLine of clean.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const cols = line.split(/\s+/);
+    if (!cols[0]) continue;
+    if (isNonSandboxRow(line, cols[0])) continue;
+    // Scan every column after the name for a known phase token so we read the
+    // phase regardless of column layout — trailing (`NAME CREATED PHASE`),
+    // compact (`NAME PHASE`), or with an age suffix (`NAME PHASE 2m ago`). The
+    // first column is the name and is never a phase. Uses the broader display
+    // vocabulary so terminal/transient phases (Failed, Creating, …) are kept.
+    const phase = cols.slice(1).find((col) => LIVE_SANDBOX_DISPLAY_PHASES.has(col)) ?? null;
+    entries.push({ name: cols[0], phase });
+  }
+  return entries;
 }
 
 export function parseReadySandboxNames(listOutput = ""): Set<string> {

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -107,16 +107,6 @@ export interface SandboxEntry {
   // different NEMOCLAW_GATEWAY_PORT no longer recreates/kills the first (#4422).
   gatewayName?: string | null;
   gatewayPort?: number | null;
-  // Transient, display-only marker for a sandbox surfaced by #5714 unseeded
-  // `nemoclaw list` recovery directly from the live gateway. The recovery path
-  // that sets it only ever pushes such entries into the in-memory list result
-  // (ephemeralSandboxes) and never routes them through registerSandbox/
-  // updateSandbox, so it is never written to sandboxes.json. (registerSandbox
-  // also writes an explicit field allowlist that omits it; updateSandbox does
-  // not, so callers must not pass a flagged entry to updateSandbox.) It signals
-  // that fields like `agent` are genuinely unknown rather than defaults so the
-  // renderer does not present a recovered Deep Agents/Hermes sandbox as OpenClaw.
-  recoveredFromGateway?: boolean;
 }
 
 export interface SandboxRegistry {
@@ -387,12 +377,24 @@ function normalizeSandboxEntryForRuntime(entry: SandboxEntry): SandboxEntry {
 }
 
 function serializeSandboxEntryForDisk(entry: SandboxEntry): SandboxEntry {
-  const messaging = serializeSandboxMessagingStateForDisk(entry.messaging);
+  // #5714: defensively drop transient, display-only recovery markers so they
+  // can never reach sandboxes.json even if a caller force-passed one through
+  // updateSandbox(). These are not part of the durable SandboxEntry type; they
+  // live only on the ephemeral list-recovery rows.
+  const {
+    recoveredFromGateway: _recovered,
+    livePhase: _phase,
+    ...durable
+  } = entry as SandboxEntry & {
+    recoveredFromGateway?: boolean;
+    livePhase?: string | null;
+  };
+  const messaging = serializeSandboxMessagingStateForDisk(durable.messaging);
   if (!messaging) {
-    const { messaging: _messaging, ...rest } = entry;
+    const { messaging: _messaging, ...rest } = durable;
     return rest;
   }
-  return { ...entry, messaging };
+  return { ...durable, messaging };
 }
 
 export function getSandbox(name: string): SandboxEntry | null {

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -376,6 +376,11 @@ function normalizeSandboxEntryForRuntime(entry: SandboxEntry): SandboxEntry {
   return { ...entry, messaging };
 }
 
+/**
+ * Prepare a sandbox entry for persistence: normalize messaging state and drop
+ * transient #5714 display-only markers (`recoveredFromGateway`, `livePhase`)
+ * that must never reach sandboxes.json.
+ */
 function serializeSandboxEntryForDisk(entry: SandboxEntry): SandboxEntry {
   // #5714: defensively drop transient, display-only recovery markers so they
   // can never reach sandboxes.json even if a caller force-passed one through

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -107,6 +107,16 @@ export interface SandboxEntry {
   // different NEMOCLAW_GATEWAY_PORT no longer recreates/kills the first (#4422).
   gatewayName?: string | null;
   gatewayPort?: number | null;
+  // Transient, display-only marker for a sandbox surfaced by #5714 unseeded
+  // `nemoclaw list` recovery directly from the live gateway. The recovery path
+  // that sets it only ever pushes such entries into the in-memory list result
+  // (ephemeralSandboxes) and never routes them through registerSandbox/
+  // updateSandbox, so it is never written to sandboxes.json. (registerSandbox
+  // also writes an explicit field allowlist that omits it; updateSandbox does
+  // not, so callers must not pass a flagged entry to updateSandbox.) It signals
+  // that fields like `agent` are genuinely unknown rather than defaults so the
+  // renderer does not present a recovered Deep Agents/Hermes sandbox as OpenClaw.
+  recoveredFromGateway?: boolean;
 }
 
 export interface SandboxRegistry {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -104,6 +104,23 @@ describe("registry", () => {
     expect(registry.getSandbox("first").gatewayPort).toBe(8080);
   });
 
+  it("registry serialization and update strip recoveredFromGateway display marker (#5714)", () => {
+    // The transient #5714 display markers must never reach sandboxes.json even
+    // if a caller force-passes one through updateSandbox(). They are not part of
+    // the durable SandboxEntry type; serializeSandboxEntryForDisk strips them.
+    registry.registerSandbox({ name: "alpha", model: "m", provider: "p" });
+    registry.updateSandbox("alpha", {
+      policies: ["npm"],
+      recoveredFromGateway: true,
+      livePhase: "Ready",
+    });
+
+    const data = JSON.parse(fs.readFileSync(regFile, "utf-8"));
+    expect(data.sandboxes.alpha.policies).toEqual(["npm"]);
+    expect(data.sandboxes.alpha.recoveredFromGateway).toBeUndefined();
+    expect(data.sandboxes.alpha.livePhase).toBeUndefined();
+  });
+
   it("normalizes configured inference fields into a discriminated view", () => {
     const configured = { name: "alpha", provider: "nvidia-prod", model: "nvidia/test" };
     const missingProvider = { name: "beta", provider: null, model: "nvidia/test" };


### PR DESCRIPTION
## Summary

`nemoclaw list` printed "No sandboxes registered" while the live OpenShell gateway and container were healthy and `nemoclaw <name> status` reported `Phase: Ready` (reported on DGX Station with a Deep Agents sandbox). The `list` recovery path required a *seed* — an existing registry entry, an onboard session, or an explicit requested name — before it would probe the gateway. After a local registry loss with no seed, it trusted the empty registry and reported nothing, even though the named-status path could find and reconcile the same sandbox.

## Related Issue

Fixes #5714

## Changes

- **Widen list recovery for an empty registry.** `recoverRegistryEntries` now attempts recovery whenever the local registry is empty, even with no session/requested-name seed.
- **Bounded, read-only, non-mutating gateway inspection for the unseeded case.** Plain `nemoclaw list` never selects or starts a gateway. It inspects the live sandbox list only when OpenShell is connected to a **NemoClaw-managed** gateway (`nemoclaw` or a per-port `nemoclaw-<port>`) — never a foreign OpenShell gateway. Gateway probes are non-fatal (`ignoreProbeErrors`), so a hung/timed-out gateway falls back to the empty registry instead of exiting the process, and recovery is gated on a clean (`status === 0`) `sandbox list` so error text is never parsed as a sandbox name.
- **Display-only recovery — recovered entries are NOT persisted.** The global `openshell sandbox list` exposes only NAME/CREATED/PHASE, not the agent or gateway binding. Persisting a recovered entry would default `agent` to `openclaw` everywhere downstream (state dirs, connect, rebuild, doctor) and permanently misclassify a Deep Agents/Hermes sandbox. Recovered sandboxes are surfaced for the current `list` only; follow-up named commands reconcile the real agent via the gateway.
- **Honest rendering.** Recovered rows show `agent`/`model`/`provider`/`GPU` as `unknown` rather than inventing OpenClaw/CPU defaults.
- `getNamedGatewayLifecycleState` gains an opt-in `ignoreProbeErrors` (default keeps existing fatal behavior); `captureOpenshell` forwards `includeStderr` so non-fatal probes still capture the gateway status text.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Verification

Verified end-to-end through the real worktree CLI (`node ./bin/nemoclaw.js …`) against a live OpenShell gateway. The local registry was emptied and the onboard session removed to simulate the reporter's registry loss; the on-disk registry is checked after each run.

**1. Pre-fix (reporter mismatch) — `list` blind while a Ready sandbox is live:**

```console
$ node ./bin/nemoclaw.js list

  No sandboxes registered. Run `nemoclaw onboard` to get started.

$ node ./bin/nemoclaw.js sbox-4778 status
  Sandbox: sbox-4778
    Model:    nvidia/nemotron-3-super-120b-a12b
    Provider: nvidia-prod
    ...
  Phase: Ready
# docker ps -a → openshell-sbox-4778-… Up   (container healthy, gateway Connected)
```

**2. Post-fix — `list` rediscovers the live sandboxes (display-only, registry stays empty):**

```console
$ node ./bin/nemoclaw.js list

  Recovered 5 sandbox entries from the live OpenShell gateway.

  Sandboxes:
    probe3014x
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    e2e-5468-ollama
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    issue4538-fix
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    sbox-4778
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none
    dcode5744
      agent: unknown  model: unknown  provider: unknown  GPU: unknown  policies: none

$ node -e 'console.log(Object.keys(require(process.env.HOME+"/.nemoclaw/sandboxes.json").sandboxes))'
[]        # recovered for display only — NOT persisted (agent is unknowable from the gateway list)
```

(Recovery was also re-verified while OpenShell was connected to a NemoClaw per-port gateway `nemoclaw-8092` — `connected_other` to a NemoClaw-managed name still recovers; a foreign gateway name does not.)

**3. Post-fix graceful degradation — gateway unreachable, empty registry → no crash, no bogus names:**

```console
$ node ./bin/nemoclaw.js list      # gateway down: Connection refused on :8080
                                   # `openshell sandbox list` → transport error
  No sandboxes registered. Run `nemoclaw onboard` to get started.
$ echo $?
0
```

Targeted + adjacent unit tests pass (registry-recovery, gateway-runtime, inventory, openshell adapter, repro-2666, gateway/connect drift; ~290 tests), `npm run typecheck:cli` clean, Biome clean; `nemoclaw-start` (126) passes with the `nemoclaw/` subproject deps installed.

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recovery for empty registries with unseeded sessions via bounded, read-only ephemeral results.
  * Inventory rendering now supports gateway-recovered sandboxes (uses `unknown` agent/GPU and shows `phase` when available).
  * Added live sandbox phase parsing with `parseLiveSandboxEntries`.
* **Bug Fixes**
  * Added stderr retention for lifecycle/probe classification (`includeStderr`) when probe errors are ignored.
  * Prevented transient recovery/display markers (`recoveredFromGateway`, `livePhase`) from persisting to disk.
* **Tests**
  * Added cases for unseeded vs seeded recovery, probe option behavior, and phase parsing variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Supersedes #5771 (reopened from NVIDIA/NemoClaw branch so trusted advisor workflows can run).
