### PR TITLE
test(e2e): document platform parity coverage for WSL GPU Spark

### DIFF
--- a/src/lib/onboard/docker-gpu-patch-mode-selection.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-mode-selection.test.ts
@@ -42,6 +42,40 @@ function inspectFixture(): DockerContainerInspect {
 }
 
 describe("docker-gpu-patch CDI-first mode selection (#4948)", () => {
+  it("keeps Docker Desktop WSL on the compatibility selector path instead of trusting host-visible CDI", () => {
+    // #5512: Docker Desktop WSL may expose CDI spec directories while the WSL
+    // distro cannot resolve a usable nvidia.com/gpu spec. The patch must stay
+    // enabled, the OpenShell create --gpu flag must stay suppressed, and mode
+    // probing must still fall back to Docker's --gpus compatibility path if a
+    // speculative CDI probe fails.
+    expect(buildDockerGpuModeCandidates("all", { cdiAvailable: true }).map((m) => m.kind)).toEqual([
+      "cdi",
+      "gpus",
+      "nvidia-runtime",
+    ]);
+
+    const dockerRun = vi.fn((args: readonly string[]) =>
+      args.includes("--device")
+        ? {
+            status: 1,
+            stderr: "CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all",
+          }
+        : { status: 0, stdout: "probe-id" },
+    );
+    const selected = selectDockerGpuPatchMode(
+      { image: "openshell/sandbox:abc" },
+      { ...cdiHostDeps(), dockerRun },
+    );
+
+    expect(selected.mode?.kind).toBe("gpus");
+    expect(selected.mode?.label).toBe("--gpus all");
+    expect(selected.attempts.map((attempt) => [attempt.mode.kind, attempt.ok])).toEqual([
+      ["cdi", false],
+      ["gpus", true],
+    ]);
+    expect(selected.attempts[0]?.error).toContain("unresolvable CDI devices");
+  });
+
   it("prefers CDI over --gpus when the host advertises an NVIDIA CDI spec", () => {
     // Repro for #4948: on a Docker-CDI GPU host (e.g. Ubuntu 24.04 with
     // /etc/cdi/nvidia.yaml), `docker create --gpus all` is *accepted* so the

--- a/src/lib/onboard/docker-gpu-patch.test.ts
+++ b/src/lib/onboard/docker-gpu-patch.test.ts
@@ -796,18 +796,18 @@ describe("docker-gpu-patch sandbox DNS fallback (#3579)", () => {
   });
 
   it("keeps the DGX Spark DNS workaround diagnostic-only unless the host exposes an upstream resolver", () => {
+    const loopbackFiles: Record<string, string> = {
+      "/etc/resolv.conf": "nameserver 127.0.0.53\n",
+      "/run/systemd/resolve/resolv.conf": "nameserver 8.8.8.8\n",
+    };
+    const sparkFiles: Record<string, string> = {
+      "/etc/resolv.conf": "nameserver 10.18.1.96\n",
+    };
     const loopbackOnly = detectSandboxFallbackDns({
-      readFile: (p: string): string | null => {
-        if (p === "/etc/resolv.conf") return "nameserver 127.0.0.53\n";
-        if (p === "/run/systemd/resolve/resolv.conf") return "nameserver 8.8.8.8\n";
-        return null;
-      },
+      readFile: (p: string): string | null => loopbackFiles[p] ?? null,
     });
     const sparkManagedDns = detectSandboxFallbackDns({
-      readFile: (p: string): string | null => {
-        if (p === "/etc/resolv.conf") return "nameserver 10.18.1.96\n";
-        return null;
-      },
+      readFile: (p: string): string | null => sparkFiles[p] ?? null,
     });
 
     expect(loopbackOnly).toBe("8.8.8.8");

--- a/src/lib/onboard/docker-gpu-patch.test.ts
+++ b/src/lib/onboard/docker-gpu-patch.test.ts
@@ -794,6 +794,37 @@ describe("docker-gpu-patch sandbox DNS fallback (#3579)", () => {
     expect(args).not.toEqual(expect.arrayContaining(["--network", "host"]));
     expect(args).toEqual(expect.arrayContaining(["--dns", "8.8.8.8"]));
   });
+
+  it("keeps the DGX Spark DNS workaround diagnostic-only unless the host exposes an upstream resolver", () => {
+    const loopbackOnly = detectSandboxFallbackDns({
+      readFile: (p: string): string | null => {
+        if (p === "/etc/resolv.conf") return "nameserver 127.0.0.53\n";
+        if (p === "/run/systemd/resolve/resolv.conf") return "nameserver 8.8.8.8\n";
+        return null;
+      },
+    });
+    const sparkManagedDns = detectSandboxFallbackDns({
+      readFile: (p: string): string | null => {
+        if (p === "/etc/resolv.conf") return "nameserver 10.18.1.96\n";
+        return null;
+      },
+    });
+
+    expect(loopbackOnly).toBe("8.8.8.8");
+    expect(sparkManagedDns).toBeNull();
+
+    const inspect = inspectFixture();
+    const preservedArgs = buildDockerGpuCloneRunArgs(inspect, buildDockerGpuMode("gpus"), {
+      sandboxFallbackDns: sparkManagedDns,
+    });
+    expect(preservedArgs).not.toEqual(expect.arrayContaining(["--dns"]));
+    expect(preservedArgs).not.toEqual(expect.arrayContaining(["--network", "host"]));
+
+    const patchedArgs = buildDockerGpuCloneRunArgs(inspect, buildDockerGpuMode("gpus"), {
+      sandboxFallbackDns: loopbackOnly,
+    });
+    expect(patchedArgs).toEqual(expect.arrayContaining(["--dns", "8.8.8.8"]));
+  });
 });
 
 // Jetson `/dev/nvmap` group-permission propagation (#4231). The reporter's

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -467,6 +467,26 @@ describe("formatSandboxBridgeUnreachableMessage", () => {
     expect(msg).toContain("host-gateway");
     expect(msg).not.toContain("ufw allow");
   });
+
+  it("keeps Docker Desktop WSL host-gateway failures retryable instead of suggesting UFW", () => {
+    const msg = formatSandboxBridgeUnreachableMessage(
+      {
+        ok: false,
+        reason: "tcp_failed",
+        routeKind: "host_gateway",
+        networkName: "openshell-docker",
+        subnet: "172.19.0.0/16",
+        detail: "sandbox container could not reach host.openshell.internal:8080",
+      },
+      8080,
+      { isWsl: true },
+    );
+
+    expect(msg).toContain("host-gateway");
+    expect(msg).toContain("Restart Docker and the OpenShell gateway");
+    expect(msg).not.toContain("ufw allow");
+    expect(msg).not.toContain("127.0.0.1");
+  });
 });
 
 describe("tryAutoApplyUfwRule (#4265)", () => {

--- a/src/lib/onboard/preflight-cdi.test.ts
+++ b/src/lib/onboard/preflight-cdi.test.ts
@@ -340,4 +340,22 @@ describe("planHostRemediation — CDI", () => {
       ),
     ).toBe(true);
   });
+
+  it("still blocks with install_nvidia_container_toolkit when nvidia-smi is unavailable but PCI GPU context exists", () => {
+    const actions = planHostRemediation(
+      baseAssessment({
+        cdiNvidiaGpuSpecMissing: true,
+        hasNvidiaGpu: true,
+        nvidiaContainerToolkitInstalled: false,
+      }),
+    );
+
+    const actionIds = actions.map((entry) => entry.id);
+    expect(actionIds.indexOf("install_nvidia_container_toolkit")).toBeGreaterThanOrEqual(0);
+    expect(actionIds).not.toContain("generate_nvidia_cdi_spec");
+    const toolkitAction = actions.find((entry) => entry.id === "install_nvidia_container_toolkit");
+    expect(toolkitAction?.blocking).toBe(true);
+    expect(toolkitAction?.commands.join("\n")).toContain("nvidia-container-toolkit");
+    expect(toolkitAction?.commands.join("\n")).toContain("nvidia-ctk cdi generate");
+  });
 });

--- a/test/e2e-scenario/support-tests/platform-parity-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/platform-parity-workflow-boundary.test.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateE2eVitestWorkflowDispatchSelectors,
+  readFreeStandingJobsInventory,
+  validateE2eVitestScenariosWorkflowBoundary,
+} from "../../../tools/e2e-scenarios/workflow-boundary.mts";
+import { canonicalScenarios } from "../scenarios/scenarios/baseline.ts";
+
+function scenarioById(id: string) {
+  const scenario = canonicalScenarios().find((entry) => entry.id === id);
+  if (!scenario) throw new Error(`missing scenario ${id}`);
+  return scenario;
+}
+
+describe("P0-E platform parity workflow coverage", () => {
+  it("keeps the WSL platform scenario on a Windows WSL runner boundary", () => {
+    const wsl = scenarioById("wsl-repo-cloud-openclaw");
+
+    expect(wsl.environment).toMatchObject({
+      platform: "wsl-local",
+      runtime: "docker-running",
+      onboarding: "cloud-openclaw",
+    });
+    expect(wsl.runnerRequirements).toEqual(expect.arrayContaining(["windows-latest", "wsl2"]));
+    expect(wsl.suiteIds).toContain("platform-wsl");
+    expect(wsl.requiredSecrets).toContain("NVIDIA_INFERENCE_API_KEY");
+
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "wsl-repo-cloud-openclaw" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: true,
+      registryScenarios: ["wsl-repo-cloud-openclaw"],
+      selectedFreeStandingJobs: [],
+    });
+  });
+
+  it("keeps GPU, Spark, and Jetson platform selectors explicit and routable", () => {
+    expect(validateE2eVitestScenariosWorkflowBoundary()).toEqual([]);
+
+    const inventory = readFreeStandingJobsInventory();
+    expect(inventory.scenarioToJob.get("gpu-e2e")).toBe("gpu-e2e-vitest");
+    expect(inventory.scenarioToJob.get("gpu-double-onboard")).toBe("gpu-double-onboard-vitest");
+    expect(inventory.scenarioToJob.get("spark-install")).toBe("spark-install-vitest");
+    expect(inventory.scenarioToJob.get("jetson-nvmap-gpu")).toBe("jetson-nvmap-gpu-vitest");
+
+    expect(evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "gpu-e2e" })).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["gpu-e2e-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "gpu-double-onboard" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["gpu-double-onboard-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "spark-install" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["spark-install-vitest"],
+      registryScenarios: [],
+    });
+
+    // Jetson/Tegra hardware is still an explicit-only route; do not imply the
+    // default full-suite dispatch proved /dev/nvmap group behavior.
+    expect(evaluateE2eVitestWorkflowDispatchSelectors({}).selectedFreeStandingJobs).not.toContain(
+      "jetson-nvmap-gpu-vitest",
+    );
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "jetson-nvmap-gpu" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["jetson-nvmap-gpu-vitest"],
+      registryScenarios: [],
+    });
+  });
+});

--- a/test/e2e-scenario/support-tests/platform-parity-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/platform-parity-workflow-boundary.test.ts
@@ -10,15 +10,10 @@ import {
 } from "../../../tools/e2e-scenarios/workflow-boundary.mts";
 import { canonicalScenarios } from "../scenarios/scenarios/baseline.ts";
 
-function scenarioById(id: string) {
-  const scenario = canonicalScenarios().find((entry) => entry.id === id);
-  if (!scenario) throw new Error(`missing scenario ${id}`);
-  return scenario;
-}
-
 describe("P0-E platform parity workflow coverage", () => {
   it("keeps the WSL platform scenario on a Windows WSL runner boundary", () => {
-    const wsl = scenarioById("wsl-repo-cloud-openclaw");
+    const wsl = canonicalScenarios().find((entry) => entry.id === "wsl-repo-cloud-openclaw");
+    expect(wsl).toBeDefined();
 
     expect(wsl.environment).toMatchObject({
       platform: "wsl-local",


### PR DESCRIPTION
## Summary
Restore issue #5800 parity package `P0-E` by documenting and pinning platform-aware Vitest coverage for WSL GPU, Docker Desktop gateway, Linux GPU toolkit preflight, DGX Spark DNS, and platform workflow routing.

## Related Issues
Refs #5800
Refs #5098
Refs #5513 / #5536 / #5754
Refs #5512 / #5537 / #5538 / #5541
Refs #5489 / #5500 / #5529
Refs #5520 / #5539

## Package scope
- Package: `P0-E — WSL/GPU/Spark platform parity or waiver package`
- Covers: WSL gateway host-gateway diagnostics, WSL GPU CDI-to-`--gpus` compatibility fallback, missing toolkit remediation when `nvidia-smi` is unavailable but GPU context exists, DGX Spark DNS diagnostic-only behavior, and workflow selector boundaries for WSL/GPU/Spark/Jetson platform routes.
- Out of scope: shell lane retirement / PR #5756 cleanup; production platform fixes from still-open source PRs.

## Parity map
| ID | Source PR/issue | Contract | Inference classification | Vitest assertion / waiver | Status |
| --- | --- | --- | --- | --- | --- |
| E1 | #5513 / #5536 / #5754 | Docker Desktop WSL host-gateway probe failures must not be misreported as Linux bridge/UFW failures. | `none` | `src/lib/onboard/gateway-sandbox-reachability.test.ts` asserts host-gateway WSL message is retryable and has no UFW/127.0.0.1 guidance. | covered |
| E2 | #5512 / #5537 / #5538 | Docker Desktop WSL may advertise CDI dirs but still needs Docker `--gpus` compatibility fallback when CDI injection is unresolvable. | `none` | `src/lib/onboard/docker-gpu-patch-mode-selection.test.ts` asserts CDI probe failure falls through to `--gpus all`; existing create-plan tests keep the GPU patch enabled and suppress direct OpenShell `--gpu`. | covered |
| E3 | #5512 / #5541 | GPU recreate rollback/backup behavior is platform-sensitive and must not strand `*-nemoclaw-gpu-backup-*`. | `none` | Existing `src/lib/onboard/docker-gpu-patch-rollback.test.ts` and `src/lib/onboard/docker-gpu-sandbox-create.test.ts` cover deferred rollback/finalize behavior; no new assertion needed. | covered |
| E4 | #5489 / #5500 / #5529 | Linux preflight must still block with `install_nvidia_container_toolkit` when `nvidia-smi` is unavailable but GPU/CDI context requires toolkit repair. | `none` | `src/lib/onboard/preflight-cdi.test.ts` asserts blocking toolkit action and `nvidia-ctk cdi generate` remediation. | covered |
| E5 | #5520 / #5539 | DGX Spark DNS behavior is diagnostic-only unless host loopback resolver fallback provides an upstream; do not force host networking. | `none` | `src/lib/onboard/docker-gpu-patch.test.ts` asserts loopback resolver injects `--dns`, Spark-managed non-loopback DNS stays preserved, and no `--network host` is implied. | covered |
| E6 | #5512 / #5513 / #5520 platform runner validation | WSL/GPU/Spark/Jetson selectors remain explicit and routable without claiming ubuntu-latest proves platform-only hardware behavior. | `none` | `test/e2e-scenario/support-tests/platform-parity-workflow-boundary.test.ts` asserts WSL registry routing and GPU/Spark/Jetson free-standing selector mappings; Jetson remains explicit-only. | covered |
| E7 | #5512 / #5513 / #5520 live hardware proof | Real Windows Docker Desktop WSL GPU and DGX Spark DNS behavior cannot be proven on ubuntu-latest. | `none` | Waiver/follow-up: keep source platform issues open for NV QA/platform-owner validation; this PR pins the unit/workflow contracts that can run in normal CI. | waived/follow-up |

## Inference mode support
- Default mode for touched live targets: `none` (support/unit/workflow-boundary only; no live inference target edited).
- Real inference support preserved: not applicable.
- Modes validated in this PR: not applicable.
- If not validated with real inference: package is platform routing/GPU/network setup; inference is incidental and not part of these assertions.

## Validation
- [x] `npm run build:cli`
- [x] `npx vitest run src/lib/onboard/gateway-sandbox-reachability.test.ts src/lib/onboard/docker-gpu-patch-mode-selection.test.ts src/lib/onboard/preflight-cdi.test.ts src/lib/onboard/docker-gpu-patch.test.ts test/e2e-scenario/support-tests/platform-parity-workflow-boundary.test.ts --reporter=default`
- [x] `git diff --check`
- [ ] hosted/public selective E2E workflow: not required; platform-only live proof remains in source issues/explicit selectors.

## Follow-ups / waivers
- Live Windows Docker Desktop WSL GPU validation remains tied to #5512/#5513 and explicit WSL/GPU selectors.
- Live DGX Spark DNS validation remains tied to #5520/#5539; this PR preserves diagnostic-only behavior instead of asserting Spark hardware from ubuntu-latest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for GPU setup selection, including fallback behavior when CDI probing fails.
  * Expanded DNS-related checks to keep network settings consistent in loopback-only environments.
  * Improved gateway reachability messaging checks for WSL scenarios.
  * Added remediation coverage for NVIDIA toolkit installation and CDI guidance.
  * Extended end-to-end workflow boundary validation across platform and GPU/Spark/Jetson scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->