### PR TITLE
chore(pr-template): add quality gate checklist

### DIFF
--- a/.agents/skills/nemoclaw-contributor-create-pr/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-create-pr/SKILL.md
@@ -190,8 +190,8 @@ Use the exact template structure below. Fill in each section based on the diff (
 - [ ] Docs updated for user-facing behavior changes
 - [ ] Docs not applicable — justification:
 - [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
-- [ ] Sensitive-path review or waiver recorded — reviewer/justification:
-- [ ] Non-success, skipped, or missing CI check accepted — check name and waiver/follow-up issue:
+- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
+- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:
 
 ## Verification
 <!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
@@ -218,7 +218,7 @@ Follow these rules when filling in the template:
 - **Related Issue:** Include `Fixes #NNN` or `Closes #NNN` if an issue exists. Remove the section entirely if there is no related issue.
 - **Changes:** Bullet list of key changes. Be specific — reference file names, commands, or behaviors that changed.
 - **Type of Change:** Check exactly one box. Use `[x]` for checked, `[ ]` for unchecked.
-- **Quality Gates:** Check every line that applies to the diff. If tests/docs are not needed or existing coverage is sufficient, include the justification. If sensitive paths changed or a non-success CI check is accepted, record the reviewer, waiver, or follow-up issue.
+- **Quality Gates:** Check every line that applies to the diff. If tests/docs are not needed or existing coverage is sufficient, include the justification. If sensitive paths changed or a non-success CI check is accepted, record the authorized reviewer, maintainer-approved waiver, approval link, or follow-up issue.
 - **Verification:** Check only the boxes for steps you actually ran and confirmed passing, or for Git hooks that passed during normal commit and push. Do not check boxes for steps you skipped or did not verify. The DCO declaration and GitHub verification checkbox is mandatory before PR creation because Step 4 must pass first. For doc-only changes, `npm test` is not required; leave it unchecked unless you ran it.
 - **DCO Sign-Off:** Replace `{name}` and `{email}` with values from `git config user.name` and `git config user.email`.
 

--- a/.agents/skills/nemoclaw-contributor-create-pr/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-create-pr/SKILL.md
@@ -182,15 +182,25 @@ Use the exact template structure below. Fill in each section based on the diff (
 - [ ] Doc only (prose changes, no code sample modifications)
 - [ ] Doc only (includes code sample changes)
 
+## Quality Gates
+<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
+- [ ] Tests added or updated for changed behavior
+- [ ] Existing tests cover changed behavior — justification:
+- [ ] Tests not applicable — justification:
+- [ ] Docs updated for user-facing behavior changes
+- [ ] Docs not applicable — justification:
+- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
+- [ ] Sensitive-path review or waiver recorded — reviewer/justification:
+- [ ] Non-success, skipped, or missing CI check accepted — check name and waiver/follow-up issue:
+
 ## Verification
 <!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
 - [ ] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
 - [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
 - [ ] Targeted tests pass for changed behavior
 - [ ] Full `npm test` passes (broad runtime changes only)
-- [ ] Tests added or updated for new or changed behavior
+- [ ] Quality Gates section completed with required justifications or waivers
 - [ ] No secrets, API keys, or credentials committed
-- [ ] Docs updated for user-facing behavior changes
 - [ ] `npm run docs` builds without warnings (doc changes only)
 - [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
 - [ ] New doc pages include SPDX header and frontmatter (new pages only)
@@ -208,6 +218,7 @@ Follow these rules when filling in the template:
 - **Related Issue:** Include `Fixes #NNN` or `Closes #NNN` if an issue exists. Remove the section entirely if there is no related issue.
 - **Changes:** Bullet list of key changes. Be specific — reference file names, commands, or behaviors that changed.
 - **Type of Change:** Check exactly one box. Use `[x]` for checked, `[ ]` for unchecked.
+- **Quality Gates:** Check every line that applies to the diff. If tests/docs are not needed or existing coverage is sufficient, include the justification. If sensitive paths changed or a non-success CI check is accepted, record the reviewer, waiver, or follow-up issue.
 - **Verification:** Check only the boxes for steps you actually ran and confirmed passing, or for Git hooks that passed during normal commit and push. Do not check boxes for steps you skipped or did not verify. The DCO declaration and GitHub verification checkbox is mandatory before PR creation because Step 4 must pass first. For doc-only changes, `npm test` is not required; leave it unchecked unless you ran it.
 - **DCO Sign-Off:** Replace `{name}` and `{email}` with values from `git config user.name` and `git config user.email`.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,15 +15,25 @@
 - [ ] Doc only (prose changes, no code sample modifications)
 - [ ] Doc only (includes code sample changes)
 
+## Quality Gates
+<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
+- [ ] Tests added or updated for changed behavior
+- [ ] Existing tests cover changed behavior — justification:
+- [ ] Tests not applicable — justification:
+- [ ] Docs updated for user-facing behavior changes
+- [ ] Docs not applicable — justification:
+- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
+- [ ] Sensitive-path review or waiver recorded — reviewer/justification:
+- [ ] Non-success, skipped, or missing CI check accepted — check name and waiver/follow-up issue:
+
 ## Verification
 <!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
 - [ ] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
 - [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
 - [ ] Targeted tests pass for changed behavior
 - [ ] Full `npm test` passes (broad runtime changes only)
-- [ ] Tests added or updated for new or changed behavior
+- [ ] Quality Gates section completed with required justifications or waivers
 - [ ] No secrets, API keys, or credentials committed
-- [ ] Docs updated for user-facing behavior changes
 - [ ] `npm run docs` builds without warnings (doc changes only)
 - [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
 - [ ] New doc pages include SPDX header and frontmatter (new pages only)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,8 @@
 - [ ] Docs updated for user-facing behavior changes
 - [ ] Docs not applicable — justification:
 - [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
-- [ ] Sensitive-path review or waiver recorded — reviewer/justification:
-- [ ] Non-success, skipped, or missing CI check accepted — check name and waiver/follow-up issue:
+- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
+- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:
 
 ## Verification
 <!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->


### PR DESCRIPTION
## Summary
Adds an explicit Quality Gates section to the PR template so contributors record test, docs, sensitive-path, and CI-waiver decisions before merge. Updates the PR creation skill to keep automated PR bodies aligned with the template.

## Changes
- Add Quality Gates checklist entries to `.github/PULL_REQUEST_TEMPLATE.md` for tests, docs, sensitive paths, and non-success CI waivers.
- Replace duplicate test/docs verification checkboxes with a single Quality Gates completion checkbox.
- Update `.agents/skills/nemoclaw-contributor-create-pr/SKILL.md` so contributor agents use the new template and filling guidance.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: PR template and contributor-skill prose only; no runtime behavior changes.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: process/template-only change, not product user-facing documentation.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review or waiver recorded — reviewer/justification:
- [ ] Non-success, skipped, or missing CI check accepted — check name and waiver/follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pull request checklist to add a new **Quality Gates** section for test coverage/waivers, documentation update status, and sensitive-path/security review with required justifications.
  * Reworked the **Verification** section to be shorter, focusing on commit verification, checks executed (hook/targeted and optional full test runs), and confirmation that **Quality Gates** and “no secrets” requirements were satisfied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->