### PR TITLE
test(e2e): restore inference helper parity

### DIFF
--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -86,6 +86,7 @@ function parseKeyValueLines(stdout: string): Record<string, string> {
       .filter(Boolean)
       .map((line) => {
         const index = line.indexOf("=");
+        if (index < 0) throw new Error(`Expected key=value line, got: ${line}`);
         return [line.slice(0, index), line.slice(index + 1)];
       }),
   );
@@ -330,7 +331,9 @@ describe("hosted inference E2E config", () => {
         method: "POST",
       });
       expect(responses.status).toBe(200);
-      expect(await responses.text()).toContain("event: response.output_text.delta");
+      const responsesText = await responses.text();
+      expect(responsesText).toContain("event: response.output_text.delta");
+      expect(responsesText).toContain('data: {"delta":"RESP_OK"}');
 
       expect(fake.requests()).toEqual(
         expect.arrayContaining([

--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 
 const COMPAT_HELPER = path.join(
@@ -75,6 +76,58 @@ nemoclaw_e2e_probe_hosted_inference
   const calls = fs.existsSync(callsPath) ? fs.readFileSync(callsPath, "utf-8") : "";
   fs.rmSync(tmpDir, { recursive: true, force: true });
   return { result, calls };
+}
+
+function parseKeyValueLines(stdout: string): Record<string, string> {
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+}
+
+function runCompatibleConfigure(env: Record<string, string> = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-compatible-config-"));
+  const scriptPath = path.join(tmpDir, "configure.sh");
+  fs.writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+. ${JSON.stringify(COMPAT_HELPER)}
+if nemoclaw_e2e_using_compatible_inference; then
+  printf 'using=1\n'
+else
+  printf 'using=0\n'
+fi
+nemoclaw_e2e_configure_compatible_inference
+printf 'provider=%s\n' "\${NEMOCLAW_PROVIDER:-}"
+printf 'endpoint=%s\n' "\${NEMOCLAW_ENDPOINT_URL:-}"
+printf 'model=%s\n' "\${NEMOCLAW_MODEL:-}"
+printf 'compatModel=%s\n' "\${NEMOCLAW_COMPAT_MODEL:-}"
+printf 'preferredApi=%s\n' "\${NEMOCLAW_PREFERRED_API:-}"
+printf 'compatibleKey=%s\n' "\${COMPATIBLE_API_KEY:-}"
+printf 'route=%s\n' "$(nemoclaw_e2e_expected_route_provider)"
+printf 'modelFn=%s\n' "$(nemoclaw_e2e_hosted_inference_model)"
+`,
+    { mode: 0o755 },
+  );
+
+  const result = spawnSync("bash", [scriptPath], {
+    encoding: "utf-8",
+    env: {
+      HOME: process.env.HOME ?? "",
+      PATH: process.env.PATH ?? "",
+      NVIDIA_INFERENCE_API_KEY: "hosted-compatible-key",
+      ...env,
+    },
+  });
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  return { result, values: parseKeyValueLines(result.stdout) };
 }
 
 describe("hosted inference E2E config", () => {
@@ -163,5 +216,137 @@ describe("hosted inference E2E config", () => {
       NVIDIA_INFERENCE_API_KEY: "repo-hosted-key",
       COMPATIBLE_API_KEY: "repo-hosted-key",
     });
+  });
+
+  it("preserves hosted Inference Hub model IDs and model precedence", () => {
+    const defaultCfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "repo-hosted-key" }),
+      {},
+    );
+    const compatModelCfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "repo-hosted-key" }),
+      { NEMOCLAW_COMPAT_MODEL: "nvidia/nvidia/custom-compatible-model" },
+    );
+    const explicitModelCfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "repo-hosted-key" }),
+      {
+        NEMOCLAW_COMPAT_MODEL: "nvidia/nvidia/custom-compatible-model",
+        NEMOCLAW_MODEL: "nvidia/nvidia/explicit-model",
+      },
+      { model: "nvidia/nvidia/option-model" },
+    );
+
+    expect(defaultCfg.model).toBe("nvidia/nvidia/nemotron-3-ultra");
+    expect(defaultCfg.model).not.toContain("nvidia/nvidia/nvidia/");
+    expect(compatModelCfg.model).toBe("nvidia/nvidia/custom-compatible-model");
+    expect(explicitModelCfg.model).toBe("nvidia/nvidia/explicit-model");
+  });
+
+  it("stages hosted-compatible shell env without requiring an nvapi key", () => {
+    const { result, values } = runCompatibleConfigure({
+      NVIDIA_INFERENCE_API_KEY: "sk-compatible-hosted-key",
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(values).toMatchObject({
+      using: "1",
+      provider: "custom",
+      endpoint: "https://inference-api.nvidia.com/v1",
+      model: "nvidia/nvidia/nemotron-3-ultra",
+      compatModel: "nvidia/nvidia/nemotron-3-ultra",
+      preferredApi: "openai-completions",
+      compatibleKey: "sk-compatible-hosted-key",
+      route: "compatible-endpoint",
+      modelFn: "nvidia/nvidia/nemotron-3-ultra",
+    });
+  });
+
+  it("leaves public NVIDIA shell mode unstaged for nvapi keys", () => {
+    const { result, values } = runCompatibleConfigure({
+      NVIDIA_INFERENCE_API_KEY: "nvapi-public-key",
+      NEMOCLAW_PROVIDER: "cloud",
+      NEMOCLAW_MODEL: "nvidia/public-model",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(values).toMatchObject({
+      using: "0",
+      provider: "cloud",
+      model: "nvidia/public-model",
+      compatModel: "",
+      preferredApi: "",
+      compatibleKey: "",
+      route: "nvidia-prod",
+      modelFn: "nvidia/public-model",
+    });
+  });
+
+  it("serves fake OpenAI-compatible chat and responses contracts", async () => {
+    const fake = await startFakeOpenAiCompatibleServer({
+      apiKey: "fake-compatible-key",
+      chatContent: "CHAT_OK",
+      model: "nvidia/nvidia/fake-model",
+      requireAuth: true,
+      responseText: "RESP_OK",
+    });
+
+    try {
+      const models = await fetch(`${fake.baseUrl}/models`);
+      expect(models.status).toBe(200);
+      expect(await models.json()).toMatchObject({
+        data: [{ id: "nvidia/nvidia/fake-model" }],
+      });
+
+      const unauthenticatedChat = await fetch(`${fake.baseUrl}/chat/completions`, {
+        body: JSON.stringify({ messages: [], model: "nvidia/nvidia/fake-model" }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+      expect(unauthenticatedChat.status).toBe(401);
+
+      const chat = await fetch(`${fake.baseUrl}/chat/completions`, {
+        body: JSON.stringify({
+          messages: [{ content: "ping", role: "user" }],
+          model: "nvidia/nvidia/fake-model",
+        }),
+        headers: {
+          Authorization: "Bearer fake-compatible-key",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(chat.status).toBe(200);
+      expect(await chat.json()).toMatchObject({
+        choices: [{ message: { content: "CHAT_OK" } }],
+      });
+
+      const responses = await fetch(`${fake.baseUrl}/responses`, {
+        body: JSON.stringify({ input: "ping", model: "nvidia/nvidia/fake-model", stream: true }),
+        headers: {
+          Authorization: "Bearer fake-compatible-key",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(responses.status).toBe(200);
+      expect(await responses.text()).toContain("event: response.output_text.delta");
+
+      expect(fake.requests()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ method: "GET", path: "/v1/models" }),
+          expect.objectContaining({ auth: "missing", path: "/v1/chat/completions" }),
+          expect.objectContaining({
+            auth: "ok",
+            model: "nvidia/nvidia/fake-model",
+            path: "/v1/chat/completions",
+            stream: false,
+          }),
+          expect.objectContaining({ auth: "ok", path: "/v1/responses", stream: true }),
+        ]),
+      );
+    } finally {
+      await fake.close();
+    }
   });
 });

--- a/test/e2e-scenario/support-tests/hosted-inference.test.ts
+++ b/test/e2e-scenario/support-tests/hosted-inference.test.ts
@@ -85,9 +85,12 @@ function parseKeyValueLines(stdout: string): Record<string, string> {
       .split("\n")
       .filter(Boolean)
       .map((line) => {
-        const index = line.indexOf("=");
-        if (index < 0) throw new Error(`Expected key=value line, got: ${line}`);
-        return [line.slice(0, index), line.slice(index + 1)];
+        const match = line.match(/^([^=]*)=(.*)$/s);
+        return match
+          ? [match[1], match[2]]
+          : (() => {
+              throw new Error(`Expected key=value line, got: ${line}`);
+            })();
       }),
   );
 }


### PR DESCRIPTION
## Summary
Restore issue #5800 parity package `P0-A` for merged bash-suite inference-helper deltas only.

This is a focused support-test parity PR: the helper/product behavior already exists on `main`; this adds missing Vitest assertions so shell retirement keeps the hosted/hermetic inference contracts covered.

## Related Issues
Refs #5800
Refs #5098
Refs #5373
Refs #5374
Refs #5385
Refs #5395
Refs #5399
Refs #5400
Refs #5411
Refs #5751
Refs #5672
Refs #5757

## Scope gate
- Package: `P0-A — Hosted/hermetic inference helper parity`
- Included PRs all merged and touched `test/e2e`: yes
- Out of scope: unmerged/non-bash PRs; product cleanup; shell lane retirement / PR #5756 cleanup

## Parity map
| ID | Source PR | Contract | Inference classification | Vitest assertion / waiver | Status |
| --- | --- | --- | --- | --- | --- |
| A1 | #5373 | Fake OpenAI-compatible helper supports `/models`, chat completions, responses API, auth checking, and request capture. | `hermetic-default` | `test/e2e-scenario/support-tests/hosted-inference.test.ts` starts `startFakeOpenAiCompatibleServer` and asserts models/chat/responses/request log behavior. | covered |
| A2 | #5374, #5385, #5395 | Hosted CI inference stages `NVIDIA_INFERENCE_API_KEY` as `COMPATIBLE_API_KEY`, routes as `custom`/`compatible-endpoint`, and prefers `openai-completions`. | `hosted-compatible capable` | Existing workflow/helper assertions plus new shell helper staging assertion in `hosted-inference.test.ts`. | covered |
| A3 | #5399, #5751, #5672, #5757 | Hosted model default remains the Inference Hub provider/namespace/model ID `nvidia/nvidia/nemotron-3-ultra`; explicit `NEMOCLAW_MODEL` takes precedence over `NEMOCLAW_COMPAT_MODEL`, which takes precedence over helper options/default. | `hosted-compatible capable` | New `requireHostedInferenceConfig` model precedence/default assertion; existing workflow/model namespace tests remain green. | covered |
| A4 | #5400, #5411 | Hosted reachability probe is bounded and low-cost: no `/models`, chat completions, auth header, or bearer token spend. | `hosted-compatible capable` | Existing probe tests retained and revalidated. | covered |
| A5 | #5385 | Public NVIDIA/nvapi shell mode remains distinct from hosted-compatible mode and is not restaged as compatible inference. | `public-nvidia required` | New shell helper assertion checks `nvapi-*` + `cloud` keeps `nvidia-prod`, leaves `COMPATIBLE_API_KEY` unset. | covered |

## Inference mode support
- Default mode for touched live targets: none touched; this PR only changes support tests.
- Real inference support preserved: yes, by asserting hosted-compatible and public-NVIDIA helper boundaries without invoking real inference.
- Modes validated in this PR: hermetic fake endpoint and shell helper mocked hosted-compatible/public boundary.
- If not validated with real inference: not required; no live target or hosted secret path changed.

## Validation
- [x] `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/hosted-inference.test.ts`
- [x] `npx vitest run test/e2e-script-workflow.test.ts test/issue-5667-hosted-inference-model-namespace.test.ts src/lib/inference/onboard-probes.test.ts src/lib/onboard/providers.test.ts`
- [x] `git diff --check`
- [ ] hosted/public selective E2E workflow, if required by classification: not required; support-test-only PR, no live/workflow behavior changed.

## Follow-ups / waivers
- Pre-push full `Test (CLI)` / `Test (plugin)` hooks were not clean on local macOS after the commit: CLI run hit existing macOS/stat/OOM-style failures; plugin run could not import package `json5`. Focused target tests above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for hosted inference compatibility and model ID/model precedence behavior.
  * Added validations for environment variable staging rules and shell mode behavior across NVAPI key scenarios.
  * Introduced a fake OpenAI-compatible server and added contract checks for `/models`, auth-required flows, and streamed responses on chat/response endpoints, including cleanup after runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->