### PR TITLE
test(e2e): restore messaging bash parity

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -4674,6 +4674,12 @@ jobs:
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_SANDBOX_NAME: "e2e-channels-add-remove"
       OPENSHELL_GATEWAY: "nemoclaw"
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
+      NEMOCLAW_PROVIDER: custom
+      NEMOCLAW_ENDPOINT_URL: https://inference-api.nvidia.com/v1
+      NEMOCLAW_MODEL: nvidia/nvidia/nemotron-3-ultra
+      NEMOCLAW_COMPAT_MODEL: nvidia/nvidia/nemotron-3-ultra
+      NEMOCLAW_PREFERRED_API: openai-completions
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -4733,6 +4739,7 @@ jobs:
         # channels remove cleanup.
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
           TELEGRAM_BOT_TOKEN: "test-fake-telegram-token-add-remove-e2e"
           TELEGRAM_ALLOWED_IDS: "123456789"
           TELEGRAM_REQUIRE_MENTION: "0"

--- a/src/lib/messaging/plan-validation.test.ts
+++ b/src/lib/messaging/plan-validation.test.ts
@@ -147,6 +147,87 @@ describe("parseSandboxMessagingPlan", () => {
     });
   });
 
+  it("keeps compact persisted plans free of derived workflow sections", () => {
+    const source = makePlan({
+      networkPolicy: {
+        presets: ["telegram"],
+        entries: [
+          {
+            channelId: "telegram",
+            presetName: "telegram",
+            policyKeys: ["telegram"],
+            source: "manifest",
+          },
+        ],
+      },
+      agentRender: [
+        {
+          channelId: "telegram",
+          agent: "openclaw",
+          target: "openclaw.json",
+          kind: "json-fragment",
+          path: "channels.telegram",
+          value: { enabled: true },
+          templateRefs: [],
+        },
+      ],
+      buildSteps: [
+        {
+          channelId: "telegram",
+          kind: "package-install",
+          outputId: "telegram-openclaw-plugin",
+          required: true,
+          value: "npm:@openclaw/telegram",
+        },
+      ],
+      runtimeSetup: {
+        nodePreloads: [],
+        envAliases: [],
+        secretScans: [
+          {
+            channelId: "telegram",
+            path: "/sandbox/.openclaw/openclaw.json",
+            pattern: "TELEGRAM_BOT_TOKEN",
+          },
+        ],
+      },
+      stateUpdates: [
+        {
+          channelId: "telegram",
+          kind: "persist-inputs",
+          stateKey: "allowedIds.telegram",
+          inputIds: ["allowedIds"],
+        },
+      ],
+      healthChecks: [
+        {
+          channelId: "telegram",
+          phase: "health-check",
+          requiredBefore: "lifecycle-success",
+          hookIds: ["telegram-openclaw-bridge-health"],
+        },
+      ],
+    });
+
+    const compact = compactSandboxMessagingPlanForPersistence(source);
+
+    expect(compact.networkPolicy).toEqual(source.networkPolicy);
+    expect(compact).not.toHaveProperty("agentRender");
+    expect(compact).not.toHaveProperty("buildSteps");
+    expect(compact).not.toHaveProperty("runtimeSetup");
+    expect(compact).not.toHaveProperty("stateUpdates");
+    expect(compact).not.toHaveProperty("healthChecks");
+    expect(compact.channels).toEqual([
+      {
+        channelId: "telegram",
+        active: true,
+        configured: true,
+        disabled: false,
+        inputs: [{ inputId: "allowedIds", value: "123" }],
+      },
+    ]);
+  });
+
   it("rejects mismatched selectors, duplicate channels, and unsupported channels", () => {
     expect(parseSandboxMessagingPlan(makePlan(), { sandboxName: "other" })).toBeNull();
     expect(parseSandboxMessagingPlan(makePlan(), { agent: "hermes" })).toBeNull();

--- a/test/e2e-scenario/live/channels-add-remove.test.ts
+++ b/test/e2e-scenario/live/channels-add-remove.test.ts
@@ -171,7 +171,14 @@ function expectHostTelegramPlan(expected: "active" | "removed", context: string)
       : {};
   const networkEntries = planArray(networkPolicy, "entries");
   const networkPresets = stringArray(networkPolicy.presets);
-  const agentRender = planArray(plan, "agentRender");
+
+  expect(Object.hasOwn(plan, "agentRender"), "messaging.plan.agentRender should not persist").toBe(
+    false,
+  );
+  expect(
+    channels.some((entry) => Object.hasOwn(entry, "hooks")),
+    "messaging.plan.channels hooks should not persist",
+  ).toBe(false);
 
   if (expected === "active") {
     expect(
@@ -194,10 +201,6 @@ function expectHostTelegramPlan(expected: "active" | "removed", context: string)
       ),
       `telegram TELEGRAM_BOT_TOKEN credential binding missing ${context}`,
     ).toBe(true);
-    expect(
-      agentRender.some((entry) => entry.channelId === "telegram" && entry.agent === "openclaw"),
-      `telegram openclaw agent render entry missing ${context}`,
-    ).toBe(true);
     expect(disabledChannels, `telegram unexpectedly disabled ${context}`).not.toContain("telegram");
     return;
   }
@@ -217,10 +220,6 @@ function expectHostTelegramPlan(expected: "active" | "removed", context: string)
   expect(
     credentialBindings.some((entry) => entry.channelId === "telegram"),
     `telegram credential binding still present ${context}`,
-  ).toBe(false);
-  expect(
-    agentRender.some((entry) => entry.channelId === "telegram"),
-    `telegram agent render entry still present ${context}`,
   ).toBe(false);
 }
 

--- a/test/e2e-scenario/live/messaging-providers-helpers.ts
+++ b/test/e2e-scenario/live/messaging-providers-helpers.ts
@@ -513,7 +513,8 @@ if env 2>/dev/null | grep -Fq "$token"; then echo FOUND; else echo ABSENT; fi`
         ? `token="$(printf '%s' ${shellQuote(tokenB64)} | base64 -d)"
 if cat /proc/[0-9]*/cmdline 2>/dev/null | tr '\\0' '\\n' | grep -Fq "$token"; then echo FOUND; else echo ABSENT; fi`
         : `token="$(printf '%s' ${shellQuote(tokenB64)} | base64 -d)"
-if grep -rIlm1 -F "$token" /sandbox /home /etc /tmp /var 2>/dev/null | head -1; then true; else echo ABSENT; fi`;
+match="$(grep -rIlm1 -F "$token" /sandbox /home /etc /tmp /var 2>/dev/null | head -1 || true)"
+if [ -n "$match" ]; then printf '%s\n' "$match"; else echo ABSENT; fi`;
   return sandboxOutput(sandbox, probe, artifactName, redactionValues);
 }
 

--- a/test/e2e-scenario/live/messaging-providers-helpers.ts
+++ b/test/e2e-scenario/live/messaging-providers-helpers.ts
@@ -798,12 +798,35 @@ function decodeFrame(buffer) {
     if (buffer.length < 4) return null;
     payloadLength = buffer.readUInt16BE(2);
     offset = 4;
+  } else if (payloadLength === 127) {
+    if (buffer.length < 10) return null;
+    payloadLength = Number(buffer.readBigUInt64BE(2));
+    offset = 10;
   }
   if (buffer.length < offset + payloadLength) return null;
   return { opcode, payload: buffer.slice(offset, offset + payloadLength), totalLength: offset + payloadLength };
 }
 
-const socket = net.createConnection({ host, port });
+function parseProxyTarget() {
+  const raw = process.env.HTTP_PROXY || process.env.http_proxy || "";
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("HTTP proxy for Discord Gateway proof is malformed");
+  }
+  if (parsed.protocol !== "http:") throw new Error("Discord Gateway proof only supports HTTP proxies");
+  const proxyPort = Number(parsed.port || "80");
+  if (!Number.isInteger(proxyPort) || proxyPort < 1 || proxyPort > 65535) throw new Error("HTTP proxy port for Discord Gateway proof is invalid");
+  if (parsed.hostname !== "10.200.0.1" || proxyPort !== 3128) throw new Error("unexpected HTTP proxy for Discord Gateway proof");
+  return { host: parsed.hostname, port: proxyPort };
+}
+
+const proxy = parseProxyTarget();
+const socket = proxy
+  ? net.createConnection({ host: proxy.host, port: proxy.port })
+  : net.createConnection({ host, port });
 const timer = setTimeout(() => {
   socket.destroy();
   finish("TIMEOUT");
@@ -811,11 +834,15 @@ const timer = setTimeout(() => {
 let handshake = Buffer.alloc(0);
 let framed = Buffer.alloc(0);
 let upgraded = false;
+let finished = false;
 
 socket.on("connect", () => {
   const key = crypto.randomBytes(16).toString("base64");
+  const requestTarget = proxy
+    ? \`http://\${host}:\${port}/gateway?v=10&encoding=json\`
+    : "/gateway?v=10&encoding=json";
   socket.write([
-    "GET /gateway?v=10&encoding=json HTTP/1.1",
+    \`GET \${requestTarget} HTTP/1.1\`,
     \`Host: \${host}:\${port}\`,
     "Upgrade: websocket",
     "Connection: Upgrade",
@@ -865,6 +892,7 @@ socket.on("data", (chunk) => {
     } else if (message.op === 11) {
       results.push("HEARTBEAT_ACK");
       clearTimeout(timer);
+      finished = true;
       socket.end();
       finish();
     }
@@ -872,7 +900,11 @@ socket.on("data", (chunk) => {
 });
 socket.on("error", (error) => {
   clearTimeout(timer);
-  finish(\`ERROR \${error.message}\`);
+  if (!finished) finish(\`ERROR \${error.message}\`);
+});
+socket.on("close", () => {
+  clearTimeout(timer);
+  if (!finished) finish("CLOSED");
 });
 `,
     {

--- a/test/e2e-scenario/live/messaging-providers.test.ts
+++ b/test/e2e-scenario/live/messaging-providers.test.ts
@@ -267,6 +267,26 @@ process.exit(Array.isArray(channels) && channels.some((c) => c?.channelId === "w
     );
     expectExitZero(whatsappRebuild, "M-WA4: rebuild completed after WhatsApp channel add");
 
+    const whatsappPolicyPost = await runHost(
+      host,
+      "openshell",
+      ["policy", "get", "--full", SANDBOX_NAME],
+      {
+        artifactName: "whatsapp-policy-post-rebuild-messaging-providers",
+        env: state.env,
+        redactionValues,
+        timeoutMs: 60_000,
+      },
+    );
+    const whatsappPolicyPostText = outputText(whatsappPolicyPost);
+    check(
+      whatsappPolicyPostText.includes("web.whatsapp.com") &&
+        whatsappPolicyPostText.includes("whatsapp.net") &&
+        whatsappPolicyPostText.includes("raw.githubusercontent.com") &&
+        /\/usr\/local\/bin\/node|\/usr\/bin\/node/.test(whatsappPolicyPostText),
+      "M-WA5: WhatsApp policy preset survived rebuild with Node binary scope",
+    );
+
     const providerList = await runHost(host, "openshell", ["provider", "list"], {
       artifactName: "provider-list-messaging-providers",
       env: state.env,
@@ -882,10 +902,16 @@ req.setTimeout(30000, () => { req.destroy(); console.log("TIMEOUT"); });
       fakeGateway.captureFile,
       (row) => row.event === "identify",
     );
+    const gatewayCaptureText = fs.existsSync(fakeGateway.captureFile)
+      ? fs.readFileSync(fakeGateway.captureFile, "utf8")
+      : "";
     check(
       gatewayIdentify?.tokenMatchesExpected === true &&
-        gatewayIdentify?.tokenLooksPlaceholder === false,
-      "M13f: fake Gateway received host-side Discord token after relay rewrite",
+        gatewayIdentify?.tokenLooksPlaceholder === false &&
+        !Object.prototype.hasOwnProperty.call(gatewayIdentify, "token") &&
+        !gatewayCaptureText.includes(state.tokens.discord) &&
+        !gatewayCaptureText.includes("openshell:resolve:env:"),
+      "M13f: fake Gateway proved placeholder-to-token rewrite without logging the raw token",
     );
 
     const gatewayPort = await sandboxOutput(

--- a/test/e2e-scenario/live/messaging-providers.test.ts
+++ b/test/e2e-scenario/live/messaging-providers.test.ts
@@ -902,9 +902,8 @@ req.setTimeout(30000, () => { req.destroy(); console.log("TIMEOUT"); });
       fakeGateway.captureFile,
       (row) => row.event === "identify",
     );
-    const gatewayCaptureText = fs.existsSync(fakeGateway.captureFile)
-      ? fs.readFileSync(fakeGateway.captureFile, "utf8")
-      : "";
+    check(fs.existsSync(fakeGateway.captureFile), "M13f: fake Gateway capture file exists");
+    const gatewayCaptureText = fs.readFileSync(fakeGateway.captureFile, "utf8");
     check(
       gatewayIdentify?.tokenMatchesExpected === true &&
         gatewayIdentify?.tokenLooksPlaceholder === false &&

--- a/test/e2e-scenario/live/messaging-providers.test.ts
+++ b/test/e2e-scenario/live/messaging-providers.test.ts
@@ -280,9 +280,9 @@ process.exit(Array.isArray(channels) && channels.some((c) => c?.channelId === "w
     );
     const whatsappPolicyPostText = outputText(whatsappPolicyPost);
     check(
-      whatsappPolicyPostText.includes("web.whatsapp.com") &&
-        whatsappPolicyPostText.includes("whatsapp.net") &&
-        whatsappPolicyPostText.includes("raw.githubusercontent.com") &&
+      policyTextHasHost(whatsappPolicyPostText, "web.whatsapp.com") &&
+        policyTextHasHost(whatsappPolicyPostText, "whatsapp.net") &&
+        policyTextHasHost(whatsappPolicyPostText, "raw.githubusercontent.com") &&
         /\/usr\/local\/bin\/node|\/usr\/bin\/node/.test(whatsappPolicyPostText),
       "M-WA5: WhatsApp policy preset survived rebuild with Node binary scope",
     );

--- a/test/e2e-scenario/live/openclaw-discord-pairing.test.ts
+++ b/test/e2e-scenario/live/openclaw-discord-pairing.test.ts
@@ -126,7 +126,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     expect(configSummary.token).toContain("openshell:resolve:env:");
     expect(configSummary.token).toContain("DISCORD_BOT_TOKEN");
     expect(configSummary.dmPolicy).not.toBe("allowlist");
-    expect(configSummary.accountProxy, "Discord account proxy").toMatch(/^http:\/\//);
+    expect(configSummary.accountProxy, "Discord account proxy").toBe("");
     expect(configSummary.managedProxy, "OpenClaw managed proxy").toMatch(/^http:\/\//);
 
     await assertOpenClawStateRoot(sandbox, SANDBOX_NAME, "discord", redactions);

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -5781,6 +5781,36 @@ function validateChannelsAddRemoveVitestJob(
       "channels-add-remove-vitest job must force OPENSHELL_GATEWAY=nemoclaw",
     );
   }
+  if (jobEnv.NEMOCLAW_E2E_USE_HOSTED_INFERENCE !== "1") {
+    errors.push(
+      "channels-add-remove-vitest job must enable hosted-compatible inference mode",
+    );
+  }
+  if (jobEnv.NEMOCLAW_PROVIDER !== "custom") {
+    errors.push(
+      "channels-add-remove-vitest job must route hosted inference through the custom provider",
+    );
+  }
+  if (jobEnv.NEMOCLAW_ENDPOINT_URL !== "https://inference-api.nvidia.com/v1") {
+    errors.push(
+      "channels-add-remove-vitest job must use the hosted compatible inference endpoint",
+    );
+  }
+  if (jobEnv.NEMOCLAW_MODEL !== "nvidia/nvidia/nemotron-3-ultra") {
+    errors.push(
+      "channels-add-remove-vitest job must use the hosted Inference Hub model id",
+    );
+  }
+  if (jobEnv.NEMOCLAW_COMPAT_MODEL !== "nvidia/nvidia/nemotron-3-ultra") {
+    errors.push(
+      "channels-add-remove-vitest job must set NEMOCLAW_COMPAT_MODEL to the hosted model id",
+    );
+  }
+  if (jobEnv.NEMOCLAW_PREFERRED_API !== "openai-completions") {
+    errors.push(
+      "channels-add-remove-vitest job must prefer openai-completions for hosted inference",
+    );
+  }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
     "DOCKERHUB_USERNAME",
@@ -5909,6 +5939,11 @@ function validateChannelsAddRemoveVitestJob(
   if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
     errors.push(
       "channels-add-remove-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+    );
+  }
+  if (runVitestEnv.COMPATIBLE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
+    errors.push(
+      "channels-add-remove-vitest step must stage NVIDIA_INFERENCE_API_KEY as COMPATIBLE_API_KEY",
     );
   }
   if (

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -5813,6 +5813,7 @@ function validateChannelsAddRemoveVitestJob(
   }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
+    "COMPATIBLE_API_KEY",
     "DOCKERHUB_USERNAME",
     "DOCKERHUB_TOKEN",
     "GITHUB_TOKEN",
@@ -5836,6 +5837,12 @@ function validateChannelsAddRemoveVitestJob(
         stepName,
         stepEnv,
         "NVIDIA_INFERENCE_API_KEY",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        stepName,
+        stepEnv,
+        "COMPATIBLE_API_KEY",
       );
     }
     if (step.name !== "Authenticate to Docker Hub") {


### PR DESCRIPTION
## Summary
Restore issue #5800 parity package `P0-C` for merged bash-suite messaging/Discord/WhatsApp deltas only.

## Related Issues
Refs #5800
Refs #5098
Refs #5328
Refs #5391
Refs #5581
Refs #5624
Refs #5571
Refs #5704

## Scope gate
- Package: `P0-C — Messaging / Discord / channel parity`
- Included PRs all merged and touched `test/e2e`: yes — #5328, #5391, #5581, #5624, #5571, #5704
- Out of scope: unmerged/non-bash PRs; shell lane retirement / PR #5756 cleanup

## Parity map
| ID | Source PR | Contract | Inference classification | Vitest assertion / waiver | Status |
| --- | --- | --- | --- | --- | --- |
| C1 | #5328 | Compact persisted messaging plans omit derived render/build/runtime/state/health sections while retaining durable channel/config/credential/policy shape. | `none` | `src/lib/messaging/plan-validation.test.ts`; `test/e2e-scenario/live/channels-add-remove.test.ts` | covered |
| C2 | #5328 | Existing compact plans hydrate before merge so channel add preserves prior hooks/render semantics. | `none` | existing `src/lib/messaging/applier/host-state-applier.test.ts` | covered |
| C3 | #5391, #5571 | Discord config must not emit a non-loopback per-account proxy; OpenClaw managed proxy remains configured. | `none` | `test/discord-template-resolver-proxy.test.ts`; `test/generate-openclaw-config.test.ts`; `test/e2e-scenario/live/messaging-providers.test.ts`; `test/e2e-scenario/live/openclaw-discord-pairing.test.ts` | covered |
| C4 | #5581 | OpenClaw Discord pairing Vitest preserves fake Gateway token rewrite, connect-shell approval, and workflow dispatch boundary. | `hermetic-default` | existing `test/e2e-scenario/live/openclaw-discord-pairing.test.ts`; support boundary/helper tests | covered |
| C5 | #5624 | Fake Discord Gateway capture proof accepts only redacted identify rows, rejects placeholder/raw-token leakage, and proves token rewrite. | `hermetic-default` | `test/e2e-scenario/live/messaging-providers.test.ts`; existing Hermes/OpenClaw Discord capture assertions and support tests | covered |
| C6 | #5704 | WhatsApp policy checks require expected endpoints before rebuild and endpoints plus Node binary scope after rebuild. | `none` | `test/e2e-scenario/live/messaging-providers.test.ts`; `test/policies.test.ts` | covered |

## Inference mode support
- Default mode for touched live targets: `none` for config/unit assertions; `hermetic-default` for fake Discord Gateway/live sandbox token-rewrite assertions.
- Real inference support preserved: not applicable to this package’s messaging/provider contracts; live sandbox targets still use existing `NVIDIA_INFERENCE_API_KEY` path where their broader scenario requires install/onboard.
- Modes validated in this PR: unit/support hermetic commands below; selective live E2E run `28194650942` passed `messaging-providers-vitest`, `channels-add-remove-vitest`, and `openclaw-discord-pairing-vitest` at `531acd9f8`. Follow-up head `46e004e3` only tightens local workflow-boundary assertions for `COMPATIBLE_API_KEY`.
- If not validated with real inference: package contracts are messaging/config/proxy/capture policy boundaries; `channels-add-remove-vitest` also passed the hosted-compatible workflow path after staging `NVIDIA_INFERENCE_API_KEY` as `COMPATIBLE_API_KEY`.

## Validation
- [x] `npx vitest run --project cli --maxWorkers 1 --no-fileParallelism src/lib/messaging/plan-validation.test.ts src/lib/messaging/applier/host-state-applier.test.ts test/discord-template-resolver-proxy.test.ts`
- [x] `npx vitest run --project e2e-vitest-support --maxWorkers 1 --no-fileParallelism test/e2e-scenario/support-tests/openclaw-discord-legacy-capture.test.ts test/e2e-scenario/support-tests/openclaw-discord-pairing-helpers.test.ts test/e2e-scenario/support-tests/openclaw-discord-workflow-boundary.test.ts`
- [x] `npx vitest run --project cli --maxWorkers 1 --no-fileParallelism --testTimeout 30000 test/generate-openclaw-config.test.ts -t "Discord|proxy|non-Slack"`
- [x] `npx vitest run --project cli --maxWorkers 1 --no-fileParallelism test/policies.test.ts -t "whatsapp"`
- [x] `npx vitest run --project e2e-vitest-support --maxWorkers 1 --no-fileParallelism test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts test/e2e-scenario/support-tests/openclaw-discord-workflow-boundary.test.ts`
- [x] Selective live E2E workflow `28194650942`: `messaging-providers-vitest`, `channels-add-remove-vitest`, `openclaw-discord-pairing-vitest` all passed.

## Follow-ups / waivers
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging plan persistence validation to ensure only required fields are stored; derived workflow sections and per-channel hook data are no longer persisted.
  * Strengthened live channel add/remove assertions to enforce `agentRender` and per-channel `hooks` absence.
  * Updated live messaging provider and Discord pairing validations (WhatsApp preset hosts and stricter gateway capture checks; account proxy now required to be exactly empty when unset).
* **Tests / CI**
  * Enhanced Vitest/e2e scenario test tooling and environment setup for hosted-compatible inference, including compatible API key staging and more robust Discord gateway capture/proxy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
