### PR TITLE
test(e2e): restore recovery kimi scope parity

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -920,7 +920,7 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_SANDBOX_NAME: "e2e-kimi-compat"
-      NEMOCLAW_E2E_INFERENCE_MODE: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && 'public-nvidia' || 'mock' }}
+      NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia"
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -939,7 +939,7 @@ jobs:
         run: bash scripts/install-openshell.sh
       - name: Run Kimi compatibility live Vitest test
         env:
-          NVIDIA_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_API_KEY || '' }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -920,6 +920,7 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_SANDBOX_NAME: "e2e-kimi-compat"
+      NEMOCLAW_E2E_INFERENCE_MODE: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && 'public-nvidia' || 'mock' }}
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -937,6 +938,8 @@ jobs:
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run Kimi compatibility live Vitest test
+        env:
+          NVIDIA_API_KEY: ${{ (github.event_name != 'workflow_dispatch' || inputs.target_ref == '') && secrets.NVIDIA_API_KEY || '' }}
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"

--- a/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
@@ -21,6 +21,26 @@ export const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-kimi-compa
 validateSandboxName(SANDBOX_NAME);
 export const KIMI_MODEL = process.env.NEMOCLAW_KIMI_MODEL ?? "moonshotai/kimi-k2.6";
 
+export type KimiInferenceMode = "mock" | "public-nvidia";
+
+export interface KimiEnvOptions {
+  mode?: KimiInferenceMode;
+  apiKey?: string;
+}
+
+export function resolveKimiInferenceMode(env: NodeJS.ProcessEnv = process.env): KimiInferenceMode {
+  if (env.NEMOCLAW_E2E_INFERENCE_MODE?.trim().toLowerCase() === "public-nvidia")
+    return "public-nvidia";
+  if (env.NEMOCLAW_KIMI_USE_MOCK === "0") return "public-nvidia";
+  return "mock";
+}
+
+export function requirePublicNvidiaApiKey(value: string): string {
+  if (!value.startsWith("nvapi-"))
+    throw new Error("NVIDIA_API_KEY must be a public NVIDIA Endpoints nvapi-* key");
+  return value;
+}
+
 export interface KimiRequest {
   path: string;
   model?: string;
@@ -35,10 +55,13 @@ export interface KimiMock {
   close(): Promise<void>;
 }
 
-export function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return {
+export function env(
+  extra: NodeJS.ProcessEnv = {},
+  options: KimiEnvOptions = {},
+): NodeJS.ProcessEnv {
+  const mode = options.mode ?? resolveKimiInferenceMode();
+  const common: NodeJS.ProcessEnv = {
     ...buildAvailabilityProbeEnv(),
-    COMPATIBLE_API_KEY: "test-kimi-key",
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_MODEL: KIMI_MODEL,
     NEMOCLAW_NON_INTERACTIVE: "1",
@@ -47,11 +70,27 @@ export function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     NEMOCLAW_POLICY_MODE: "skip",
     NEMOCLAW_POLICY_TIER: "restricted",
     NEMOCLAW_PREFERRED_API: "openai-completions",
-    NEMOCLAW_PROVIDER: "custom",
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
     NEMOCLAW_YES: "1",
     OPENSHELL_GATEWAY: process.env.OPENSHELL_GATEWAY ?? "nemoclaw",
+  };
+  if (mode === "public-nvidia") {
+    return {
+      ...common,
+      NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia",
+      NEMOCLAW_PROVIDER: "cloud",
+      ...(options.apiKey
+        ? { NVIDIA_API_KEY: options.apiKey, NVIDIA_INFERENCE_API_KEY: options.apiKey }
+        : {}),
+      ...extra,
+    };
+  }
+  return {
+    ...common,
+    COMPATIBLE_API_KEY: "test-kimi-key",
+    NEMOCLAW_E2E_INFERENCE_MODE: "mock",
+    NEMOCLAW_PROVIDER: "custom",
     ...extra,
   };
 }

--- a/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
@@ -26,6 +26,7 @@ export type KimiInferenceMode = "mock" | "public-nvidia";
 export interface KimiEnvOptions {
   mode?: KimiInferenceMode;
   apiKey?: string;
+  includeSecret?: boolean;
 }
 
 export function resolveKimiInferenceMode(env: NodeJS.ProcessEnv = process.env): KimiInferenceMode {
@@ -80,7 +81,7 @@ export function env(
       ...common,
       NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia",
       NEMOCLAW_PROVIDER: "cloud",
-      ...(options.apiKey
+      ...(options.includeSecret && options.apiKey
         ? { NVIDIA_API_KEY: options.apiKey, NVIDIA_INFERENCE_API_KEY: options.apiKey }
         : {}),
       ...extra,
@@ -138,7 +139,11 @@ export function kimiOnboardEnv(
   mode: KimiInferenceMode,
   apiKey: string | undefined,
 ): NodeJS.ProcessEnv {
-  return env(fake ? { NEMOCLAW_ENDPOINT_URL: fake.baseUrl } : {}, { mode, apiKey });
+  return env(fake ? { NEMOCLAW_ENDPOINT_URL: fake.baseUrl } : {}, {
+    mode,
+    apiKey,
+    includeSecret: true,
+  });
 }
 
 export async function assertKimiUpstreamTraffic(options: {
@@ -399,10 +404,7 @@ export function parseConfig(raw: string): {
 }
 
 export async function assertTrajectory(sandbox: SandboxClient): Promise<void> {
-  const trajectory = await sandbox.execShell(
-    SANDBOX_NAME,
-    trustedSandboxShellScript(String.raw`python3 - <<'PY'
-import json, pathlib, sys
+  const checkScript = String.raw`import json, pathlib, sys
 root=pathlib.Path('/sandbox/.openclaw')
 base=pathlib.Path('/sandbox/.openclaw/agents/main/sessions')
 session=base/'e2e-kimi-tools.jsonl'
@@ -441,8 +443,11 @@ if not final_texts or normalize_final_text(final_texts[-1]) != 'hostname, date, 
 roles=[m.get('role') for m in messages]
 if not ('toolResult' in roles and roles[-1]=='assistant'): errors.append('final assistant not after tool result')
 print(json.dumps({'errors':errors,'source':source,'toolMetas':metas,'roles':roles}, indent=2))
-sys.exit(1 if errors else 0)
-PY`),
+sys.exit(1 if errors else 0)`;
+  const encoded = Buffer.from(checkScript, "utf8").toString("base64");
+  const trajectory = await sandbox.execShell(
+    SANDBOX_NAME,
+    trustedSandboxShellScript(`python3 -c "$(printf %s '${encoded}' | base64 -d)"`),
     { artifactName: "kimi-trajectory-tool-splitting-check", env: env(), timeoutMs: 60_000 },
   );
   expect(trajectory.exitCode, resultText(trajectory)).toBe(0);

--- a/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
@@ -30,8 +30,8 @@ export interface KimiEnvOptions {
 }
 
 export function resolveKimiInferenceMode(env: NodeJS.ProcessEnv = process.env): KimiInferenceMode {
-  if (env.NEMOCLAW_E2E_INFERENCE_MODE?.trim().toLowerCase() === "public-nvidia")
-    return "public-nvidia";
+  const explicitMode = env.NEMOCLAW_E2E_INFERENCE_MODE?.trim().toLowerCase();
+  if (explicitMode === "public-nvidia" || explicitMode === "mock") return explicitMode;
   if (env.NEMOCLAW_KIMI_USE_MOCK === "0") return "public-nvidia";
   return "mock";
 }

--- a/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
@@ -116,6 +116,64 @@ export async function startKimiMock(): Promise<KimiMock> {
   };
 }
 
+export function kimiBoundary(mode: KimiInferenceMode): string {
+  return mode === "public-nvidia"
+    ? "source CLI onboard + public NVIDIA Kimi endpoint + OpenClaw config/plugin/inference route"
+    : "source CLI onboard + fake OpenAI-compatible Kimi endpoint + OpenClaw config/plugin/inference route";
+}
+
+export async function startKimiUpstream(mode: KimiInferenceMode): Promise<KimiMock | undefined> {
+  return mode === "mock" ? startKimiMock() : undefined;
+}
+
+export function maybeRegisterKimiMockCleanup(
+  cleanup: { add(name: string, fn: () => Promise<void>): void },
+  fake: KimiMock | undefined,
+): void {
+  if (fake) cleanup.add("close fake Kimi endpoint", () => fake.close());
+}
+
+export function kimiOnboardEnv(
+  fake: KimiMock | undefined,
+  mode: KimiInferenceMode,
+  apiKey: string | undefined,
+): NodeJS.ProcessEnv {
+  return env(fake ? { NEMOCLAW_ENDPOINT_URL: fake.baseUrl } : {}, { mode, apiKey });
+}
+
+export async function assertKimiUpstreamTraffic(options: {
+  fake: KimiMock | undefined;
+  host: HostCliClient;
+  mode: KimiInferenceMode;
+  apiKey: string | undefined;
+}): Promise<void> {
+  if (options.fake) {
+    expect(
+      options.fake.requests.some(
+        (request) =>
+          request.authOk &&
+          request.path.includes("/chat/completions") &&
+          request.model === KIMI_MODEL &&
+          request.hasTools,
+      ),
+    ).toBe(true);
+    expect(options.fake.requests.some((request) => request.authOk && request.hasToolResult)).toBe(
+      true,
+    );
+    return;
+  }
+
+  const route = await options.host.command("openshell", ["inference", "get", "-g", "nemoclaw"], {
+    artifactName: "public-nvidia-kimi-route",
+    env: env({}, { mode: options.mode, apiKey: options.apiKey }),
+    redactionValues: [options.apiKey ?? ""],
+    timeoutMs: 60_000,
+  });
+  expect(route.exitCode, resultText(route)).toBe(0);
+  expect(resultText(route)).toContain("nvidia-prod");
+  expect(resultText(route)).toContain(KIMI_MODEL);
+}
+
 function handleKimiRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,

--- a/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat-helpers.ts
@@ -29,9 +29,21 @@ export interface KimiEnvOptions {
   includeSecret?: boolean;
 }
 
+// Source-of-truth boundary for the Kimi public/mock split: trusted CI sets the
+// canonical NEMOCLAW_E2E_INFERENCE_MODE selector, local runs default to mock only
+// when the selector is absent, and unknown explicit values fail closed so a typo
+// cannot downgrade public-NVIDIA validation into hermetic mock coverage.
 export function resolveKimiInferenceMode(env: NodeJS.ProcessEnv = process.env): KimiInferenceMode {
-  const explicitMode = env.NEMOCLAW_E2E_INFERENCE_MODE?.trim().toLowerCase();
-  if (explicitMode === "public-nvidia" || explicitMode === "mock") return explicitMode;
+  if (env.NEMOCLAW_E2E_INFERENCE_MODE !== undefined) {
+    const explicitMode = env.NEMOCLAW_E2E_INFERENCE_MODE.trim().toLowerCase();
+    if (explicitMode === "public-nvidia" || explicitMode === "mock") return explicitMode;
+    throw new Error(
+      `NEMOCLAW_E2E_INFERENCE_MODE must be one of: mock, public-nvidia; got ${env.NEMOCLAW_E2E_INFERENCE_MODE}`,
+    );
+  }
+  // Temporary compatibility alias for legacy shell-lane invocations copied from
+  // test/e2e/test-kimi-inference-compat.sh. NEMOCLAW_E2E_INFERENCE_MODE is the
+  // canonical selector; remove this alias when the legacy shell lane retires.
   if (env.NEMOCLAW_KIMI_USE_MOCK === "0") return "public-nvidia";
   return "mock";
 }
@@ -144,6 +156,13 @@ export function kimiOnboardEnv(
     apiKey,
     includeSecret: true,
   });
+}
+
+export function kimiAgentEnv(mode: KimiInferenceMode): NodeJS.ProcessEnv {
+  // Onboard owns the only raw public NVIDIA key handoff. After that, the sandbox
+  // agent must use the configured nvidia-prod route rather than inheriting the
+  // repository secret in its process environment.
+  return env({}, { mode });
 }
 
 export async function assertKimiUpstreamTraffic(options: {

--- a/test/e2e-scenario/live/kimi-inference-compat.test.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat.test.ts
@@ -9,17 +9,21 @@ import { trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import {
+  assertKimiUpstreamTraffic,
   assertTrajectory,
   CLI,
   cleanupKimi,
   env,
   KIMI_MODEL,
+  kimiBoundary,
+  kimiOnboardEnv,
+  maybeRegisterKimiMockCleanup,
   parseConfig,
   REPO_ROOT,
   requirePublicNvidiaApiKey,
   resolveKimiInferenceMode,
   SANDBOX_NAME,
-  startKimiMock,
+  startKimiUpstream,
 } from "./kimi-inference-compat-helpers.ts";
 
 const TIMEOUT_MS = 40 * 60_000;
@@ -33,17 +37,14 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       mode === "public-nvidia"
         ? requirePublicNvidiaApiKey(secrets.required("NVIDIA_API_KEY"))
         : undefined;
-    const fake = mode === "mock" ? await startKimiMock() : undefined;
-    if (fake) cleanup.add("close fake Kimi endpoint", () => fake.close());
+    const fake = await startKimiUpstream(mode);
+    maybeRegisterKimiMockCleanup(cleanup, fake);
     cleanup.add("destroy Kimi sandbox", () => cleanupKimi(host, sandbox));
 
     await artifacts.writeJson("scenario.json", {
       id: "kimi-inference-compat",
       legacySource: "test/e2e/test-kimi-inference-compat.sh",
-      boundary:
-        mode === "public-nvidia"
-          ? "source CLI onboard + public NVIDIA Kimi endpoint + OpenClaw config/plugin/inference route"
-          : "source CLI onboard + fake OpenAI-compatible Kimi endpoint + OpenClaw config/plugin/inference route",
+      boundary: kimiBoundary(mode),
       inferenceClassification: "public-nvidia required with mock/hermetic fallback",
       inferenceMode: mode,
       sandboxName: SANDBOX_NAME,
@@ -65,7 +66,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       {
         artifactName: "onboard-kimi-compatible",
         cwd: REPO_ROOT,
-        env: env(fake ? { NEMOCLAW_ENDPOINT_URL: fake.baseUrl } : {}, { mode, apiKey }),
+        env: kimiOnboardEnv(fake, mode, apiKey),
         redactionValues: ["test-kimi-key", apiKey ?? ""],
         timeoutMs: 20 * 60_000,
       },
@@ -133,27 +134,6 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     );
     expect(toolAgent.exitCode, resultText(toolAgent)).toBe(0);
     await assertTrajectory(sandbox);
-    if (fake) {
-      expect(
-        fake.requests.some(
-          (request) =>
-            request.authOk &&
-            request.path.includes("/chat/completions") &&
-            request.model === KIMI_MODEL &&
-            request.hasTools,
-        ),
-      ).toBe(true);
-      expect(fake.requests.some((request) => request.authOk && request.hasToolResult)).toBe(true);
-    } else {
-      const route = await host.command("openshell", ["inference", "get", "-g", "nemoclaw"], {
-        artifactName: "public-nvidia-kimi-route",
-        env: env({}, { mode, apiKey }),
-        redactionValues: [apiKey ?? ""],
-        timeoutMs: 60_000,
-      });
-      expect(route.exitCode, resultText(route)).toBe(0);
-      expect(resultText(route)).toContain("nvidia-prod");
-      expect(resultText(route)).toContain(KIMI_MODEL);
-    }
+    await assertKimiUpstreamTraffic({ fake, host, mode, apiKey });
   },
 );

--- a/test/e2e-scenario/live/kimi-inference-compat.test.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat.test.ts
@@ -16,6 +16,8 @@ import {
   KIMI_MODEL,
   parseConfig,
   REPO_ROOT,
+  requirePublicNvidiaApiKey,
+  resolveKimiInferenceMode,
   SANDBOX_NAME,
   startKimiMock,
 } from "./kimi-inference-compat-helpers.ts";
@@ -25,16 +27,25 @@ const TIMEOUT_MS = 40 * 60_000;
 test.skipIf(!shouldRunLiveE2EScenarios())(
   "Kimi-compatible endpoint config enables plugin wiring and managed inference route",
   { timeout: TIMEOUT_MS },
-  async ({ artifacts, cleanup, host, sandbox }) => {
-    const fake = await startKimiMock();
-    cleanup.add("close fake Kimi endpoint", () => fake.close());
+  async ({ artifacts, cleanup, host, sandbox, secrets }) => {
+    const mode = resolveKimiInferenceMode();
+    const apiKey =
+      mode === "public-nvidia"
+        ? requirePublicNvidiaApiKey(secrets.required("NVIDIA_API_KEY"))
+        : undefined;
+    const fake = mode === "mock" ? await startKimiMock() : undefined;
+    if (fake) cleanup.add("close fake Kimi endpoint", () => fake.close());
     cleanup.add("destroy Kimi sandbox", () => cleanupKimi(host, sandbox));
 
     await artifacts.writeJson("scenario.json", {
       id: "kimi-inference-compat",
       legacySource: "test/e2e/test-kimi-inference-compat.sh",
       boundary:
-        "source CLI onboard + fake OpenAI-compatible Kimi endpoint + OpenClaw config/plugin/inference route",
+        mode === "public-nvidia"
+          ? "source CLI onboard + public NVIDIA Kimi endpoint + OpenClaw config/plugin/inference route"
+          : "source CLI onboard + fake OpenAI-compatible Kimi endpoint + OpenClaw config/plugin/inference route",
+      inferenceClassification: "public-nvidia required with mock/hermetic fallback",
+      inferenceMode: mode,
       sandboxName: SANDBOX_NAME,
       model: KIMI_MODEL,
     });
@@ -54,8 +65,8 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       {
         artifactName: "onboard-kimi-compatible",
         cwd: REPO_ROOT,
-        env: env({ NEMOCLAW_ENDPOINT_URL: fake.baseUrl }),
-        redactionValues: ["test-kimi-key"],
+        env: env(fake ? { NEMOCLAW_ENDPOINT_URL: fake.baseUrl } : {}, { mode, apiKey }),
+        redactionValues: ["test-kimi-key", apiKey ?? ""],
         timeoutMs: 20 * 60_000,
       },
     );
@@ -63,7 +74,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     const config = await sandbox.exec(SANDBOX_NAME, ["cat", "/sandbox/.openclaw/openclaw.json"], {
       artifactName: "openclaw-config",
-      env: env(),
+      env: env({}, { mode, apiKey }),
       timeoutMs: 60_000,
     });
     expect(config.exitCode, resultText(config)).toBe(0);
@@ -88,7 +99,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     const modelsRoute = await sandbox.exec(
       SANDBOX_NAME,
       ["curl", "-sk", "--max-time", "20", "https://inference.local/v1/models"],
-      { artifactName: "inference-local-models", env: env(), timeoutMs: 60_000 },
+      { artifactName: "inference-local-models", env: env({}, { mode, apiKey }), timeoutMs: 60_000 },
     );
     expect(modelsRoute.exitCode, resultText(modelsRoute)).toBe(0);
     expect(resultText(modelsRoute)).toContain(KIMI_MODEL);
@@ -100,8 +111,8 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       ),
       {
         artifactName: "kimi-agent-smoke",
-        env: env(),
-        redactionValues: ["test-kimi-key"],
+        env: env({}, { mode, apiKey }),
+        redactionValues: ["test-kimi-key", apiKey ?? ""],
         timeoutMs: 150_000,
       },
     );
@@ -115,22 +126,34 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       ),
       {
         artifactName: "kimi-agent-tool-splitting",
-        env: env(),
-        redactionValues: ["test-kimi-key"],
+        env: env({}, { mode, apiKey }),
+        redactionValues: ["test-kimi-key", apiKey ?? ""],
         timeoutMs: 420_000,
       },
     );
     expect(toolAgent.exitCode, resultText(toolAgent)).toBe(0);
     await assertTrajectory(sandbox);
-    expect(
-      fake.requests.some(
-        (request) =>
-          request.authOk &&
-          request.path.includes("/chat/completions") &&
-          request.model === KIMI_MODEL &&
-          request.hasTools,
-      ),
-    ).toBe(true);
-    expect(fake.requests.some((request) => request.authOk && request.hasToolResult)).toBe(true);
+    if (fake) {
+      expect(
+        fake.requests.some(
+          (request) =>
+            request.authOk &&
+            request.path.includes("/chat/completions") &&
+            request.model === KIMI_MODEL &&
+            request.hasTools,
+        ),
+      ).toBe(true);
+      expect(fake.requests.some((request) => request.authOk && request.hasToolResult)).toBe(true);
+    } else {
+      const route = await host.command("openshell", ["inference", "get", "-g", "nemoclaw"], {
+        artifactName: "public-nvidia-kimi-route",
+        env: env({}, { mode, apiKey }),
+        redactionValues: [apiKey ?? ""],
+        timeoutMs: 60_000,
+      });
+      expect(route.exitCode, resultText(route)).toBe(0);
+      expect(resultText(route)).toContain("nvidia-prod");
+      expect(resultText(route)).toContain(KIMI_MODEL);
+    }
   },
 );

--- a/test/e2e-scenario/live/kimi-inference-compat.test.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat.test.ts
@@ -75,7 +75,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     const config = await sandbox.exec(SANDBOX_NAME, ["cat", "/sandbox/.openclaw/openclaw.json"], {
       artifactName: "openclaw-config",
-      env: env({}, { mode, apiKey }),
+      env: env({}, { mode }),
       timeoutMs: 60_000,
     });
     expect(config.exitCode, resultText(config)).toBe(0);
@@ -100,25 +100,10 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     const modelsRoute = await sandbox.exec(
       SANDBOX_NAME,
       ["curl", "-sk", "--max-time", "20", "https://inference.local/v1/models"],
-      { artifactName: "inference-local-models", env: env({}, { mode, apiKey }), timeoutMs: 60_000 },
+      { artifactName: "inference-local-models", env: env({}, { mode }), timeoutMs: 60_000 },
     );
     expect(modelsRoute.exitCode, resultText(modelsRoute)).toBe(0);
     expect(resultText(modelsRoute)).toContain(KIMI_MODEL);
-
-    const agent = await sandbox.execShell(
-      SANDBOX_NAME,
-      trustedSandboxShellScript(
-        "openclaw agent --agent main --json --session-id e2e-kimi-compat -m 'Reply with exactly: OK'",
-      ),
-      {
-        artifactName: "kimi-agent-smoke",
-        env: env({}, { mode, apiKey }),
-        redactionValues: ["test-kimi-key", apiKey ?? ""],
-        timeoutMs: 150_000,
-      },
-    );
-    expect(agent.exitCode, resultText(agent)).toBe(0);
-    expect(resultText(agent)).toMatch(/OK/i);
 
     const toolAgent = await sandbox.execShell(
       SANDBOX_NAME,
@@ -127,7 +112,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       ),
       {
         artifactName: "kimi-agent-tool-splitting",
-        env: env({}, { mode, apiKey }),
+        env: env({}, { mode, apiKey, includeSecret: true }),
         redactionValues: ["test-kimi-key", apiKey ?? ""],
         timeoutMs: 420_000,
       },

--- a/test/e2e-scenario/live/kimi-inference-compat.test.ts
+++ b/test/e2e-scenario/live/kimi-inference-compat.test.ts
@@ -15,6 +15,7 @@ import {
   cleanupKimi,
   env,
   KIMI_MODEL,
+  kimiAgentEnv,
   kimiBoundary,
   kimiOnboardEnv,
   maybeRegisterKimiMockCleanup,
@@ -112,7 +113,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       ),
       {
         artifactName: "kimi-agent-tool-splitting",
-        env: env({}, { mode, apiKey, includeSecret: true }),
+        env: kimiAgentEnv(mode),
         redactionValues: ["test-kimi-key", apiKey ?? ""],
         timeoutMs: 420_000,
       },

--- a/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
@@ -29,11 +29,14 @@ describe("Kimi inference compatibility mode selection", () => {
   });
 
   it("limits the public NVIDIA source secret to onboard and agent envs", () => {
-    const cfg = env({}, {
-      mode: "public-nvidia",
-      apiKey: "nvapi-public-test-key",
-      includeSecret: true,
-    });
+    const cfg = env(
+      {},
+      {
+        mode: "public-nvidia",
+        apiKey: "nvapi-public-test-key",
+        includeSecret: true,
+      },
+    );
     expect(cfg.NVIDIA_API_KEY).toBe("nvapi-public-test-key");
     expect(cfg.NVIDIA_INFERENCE_API_KEY).toBe("nvapi-public-test-key");
     expect(kimiOnboardEnv(undefined, "public-nvidia", "nvapi-public-test-key").NVIDIA_API_KEY).toBe(

--- a/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
@@ -54,6 +54,11 @@ describe("Kimi inference compatibility mode selection", () => {
       "public-nvidia",
     );
     expect(resolveKimiInferenceMode({ NEMOCLAW_KIMI_USE_MOCK: "0" })).toBe("public-nvidia");
-    expect(resolveKimiInferenceMode({ NEMOCLAW_E2E_INFERENCE_MODE: "mock" })).toBe("mock");
+    expect(
+      resolveKimiInferenceMode({
+        NEMOCLAW_E2E_INFERENCE_MODE: "mock",
+        NEMOCLAW_KIMI_USE_MOCK: "0",
+      }),
+    ).toBe("mock");
   });
 });

--- a/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  env,
+  requirePublicNvidiaApiKey,
+  resolveKimiInferenceMode,
+} from "../live/kimi-inference-compat-helpers.ts";
+
+describe("Kimi inference compatibility mode selection", () => {
+  it("defaults to hermetic mock mode for local validation", () => {
+    const cfg = env({}, { mode: "mock" });
+    expect(cfg.NEMOCLAW_E2E_INFERENCE_MODE).toBe("mock");
+    expect(cfg.NEMOCLAW_PROVIDER).toBe("custom");
+    expect(cfg.COMPATIBLE_API_KEY).toBe("test-kimi-key");
+    expect(cfg.NVIDIA_API_KEY).toBeUndefined();
+  });
+
+  it("preserves public NVIDIA mode using NVIDIA_API_KEY as the source secret", () => {
+    const cfg = env({}, { mode: "public-nvidia", apiKey: "nvapi-public-test-key" });
+    expect(cfg.NEMOCLAW_E2E_INFERENCE_MODE).toBe("public-nvidia");
+    expect(cfg.NEMOCLAW_PROVIDER).toBe("cloud");
+    expect(cfg.NVIDIA_API_KEY).toBe("nvapi-public-test-key");
+    expect(cfg.NVIDIA_INFERENCE_API_KEY).toBe("nvapi-public-test-key");
+    expect(cfg.COMPATIBLE_API_KEY).toBeUndefined();
+  });
+
+  it("rejects non-public NVIDIA keys for public Kimi validation", () => {
+    expect(() => requirePublicNvidiaApiKey("sk-compatible-key")).toThrow(/nvapi-\* key/);
+    expect(requirePublicNvidiaApiKey("nvapi-public-test-key")).toBe("nvapi-public-test-key");
+  });
+
+  it("maps legacy and explicit env selectors to the expected mode", () => {
+    expect(resolveKimiInferenceMode({ NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia" })).toBe(
+      "public-nvidia",
+    );
+    expect(resolveKimiInferenceMode({ NEMOCLAW_KIMI_USE_MOCK: "0" })).toBe("public-nvidia");
+    expect(resolveKimiInferenceMode({ NEMOCLAW_E2E_INFERENCE_MODE: "mock" })).toBe("mock");
+  });
+});

--- a/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   env,
+  kimiOnboardEnv,
   requirePublicNvidiaApiKey,
   resolveKimiInferenceMode,
 } from "../live/kimi-inference-compat-helpers.ts";
@@ -18,13 +19,26 @@ describe("Kimi inference compatibility mode selection", () => {
     expect(cfg.NVIDIA_API_KEY).toBeUndefined();
   });
 
-  it("preserves public NVIDIA mode using NVIDIA_API_KEY as the source secret", () => {
+  it("keeps public NVIDIA probe envs secret-free by default", () => {
     const cfg = env({}, { mode: "public-nvidia", apiKey: "nvapi-public-test-key" });
     expect(cfg.NEMOCLAW_E2E_INFERENCE_MODE).toBe("public-nvidia");
     expect(cfg.NEMOCLAW_PROVIDER).toBe("cloud");
+    expect(cfg.NVIDIA_API_KEY).toBeUndefined();
+    expect(cfg.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(cfg.COMPATIBLE_API_KEY).toBeUndefined();
+  });
+
+  it("limits the public NVIDIA source secret to onboard and agent envs", () => {
+    const cfg = env({}, {
+      mode: "public-nvidia",
+      apiKey: "nvapi-public-test-key",
+      includeSecret: true,
+    });
     expect(cfg.NVIDIA_API_KEY).toBe("nvapi-public-test-key");
     expect(cfg.NVIDIA_INFERENCE_API_KEY).toBe("nvapi-public-test-key");
-    expect(cfg.COMPATIBLE_API_KEY).toBeUndefined();
+    expect(kimiOnboardEnv(undefined, "public-nvidia", "nvapi-public-test-key").NVIDIA_API_KEY).toBe(
+      "nvapi-public-test-key",
+    );
   });
 
   it("rejects non-public NVIDIA keys for public Kimi validation", () => {

--- a/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   env,
+  kimiAgentEnv,
   kimiOnboardEnv,
   requirePublicNvidiaApiKey,
   resolveKimiInferenceMode,
@@ -28,7 +29,7 @@ describe("Kimi inference compatibility mode selection", () => {
     expect(cfg.COMPATIBLE_API_KEY).toBeUndefined();
   });
 
-  it("limits the public NVIDIA source secret to onboard and agent envs", () => {
+  it("limits the public NVIDIA source secret to onboard envs only", () => {
     const cfg = env(
       {},
       {
@@ -42,6 +43,9 @@ describe("Kimi inference compatibility mode selection", () => {
     expect(kimiOnboardEnv(undefined, "public-nvidia", "nvapi-public-test-key").NVIDIA_API_KEY).toBe(
       "nvapi-public-test-key",
     );
+    const agentCfg = kimiAgentEnv("public-nvidia");
+    expect(agentCfg.NVIDIA_API_KEY).toBeUndefined();
+    expect(agentCfg.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
   });
 
   it("rejects non-public NVIDIA keys for public Kimi validation", () => {
@@ -49,16 +53,25 @@ describe("Kimi inference compatibility mode selection", () => {
     expect(requirePublicNvidiaApiKey("nvapi-public-test-key")).toBe("nvapi-public-test-key");
   });
 
-  it("maps legacy and explicit env selectors to the expected mode", () => {
+  it("maps canonical explicit env selectors to the expected mode", () => {
     expect(resolveKimiInferenceMode({ NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia" })).toBe(
       "public-nvidia",
     );
-    expect(resolveKimiInferenceMode({ NEMOCLAW_KIMI_USE_MOCK: "0" })).toBe("public-nvidia");
     expect(
       resolveKimiInferenceMode({
         NEMOCLAW_E2E_INFERENCE_MODE: "mock",
         NEMOCLAW_KIMI_USE_MOCK: "0",
       }),
     ).toBe("mock");
+  });
+
+  it("rejects unknown explicit modes instead of silently falling back to mock", () => {
+    expect(() => resolveKimiInferenceMode({ NEMOCLAW_E2E_INFERENCE_MODE: "public-nvida" })).toThrow(
+      /must be one of: mock, public-nvidia/,
+    );
+  });
+
+  it("keeps legacy NEMOCLAW_KIMI_USE_MOCK=0 as temporary public-nvidia alias", () => {
+    expect(resolveKimiInferenceMode({ NEMOCLAW_KIMI_USE_MOCK: "0" })).toBe("public-nvidia");
   });
 });

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -593,10 +593,8 @@ describe("E2E reusable workflow contract", () => {
       (step) => step.name === "Run Kimi compatibility live Vitest test",
     );
 
-    expect(job.env?.NEMOCLAW_E2E_INFERENCE_MODE).toBe(
-      `\${{ (${TRUSTED_REF_GUARD}) && 'public-nvidia' || 'mock' }}`,
-    );
-    expect(runStep?.env?.NVIDIA_API_KEY).toBe(GUARDED_PUBLIC_NVIDIA_SECRET);
+    expect(job.env?.NEMOCLAW_E2E_INFERENCE_MODE).toBe("public-nvidia");
+    expect(runStep?.env?.NVIDIA_API_KEY).toBe("${{ secrets.NVIDIA_API_KEY }}");
     expect(runStep?.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
   });
 

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -584,6 +584,22 @@ describe("E2E reusable workflow contract", () => {
     );
   });
 
+  it("uses NVIDIA_API_KEY for the live Kimi Vitest lane", () => {
+    const vitestWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(
+      ".github/workflows/e2e-vitest-scenarios.yaml",
+    );
+    const job = vitestWorkflow.jobs["kimi-inference-compat-vitest"];
+    const runStep = job.steps?.find(
+      (step) => step.name === "Run Kimi compatibility live Vitest test",
+    );
+
+    expect(job.env?.NEMOCLAW_E2E_INFERENCE_MODE).toBe(
+      `\${{ (${TRUSTED_REF_GUARD}) && 'public-nvidia' || 'mock' }}`,
+    );
+    expect(runStep?.env?.NVIDIA_API_KEY).toBe(GUARDED_PUBLIC_NVIDIA_SECRET);
+    expect(runStep?.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+  });
+
   it("authenticates Docker Hub pulls in direct nightly E2E jobs", () => {
     const directE2eJobs = [
       "openclaw-tui-chat-correlation-e2e",

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -12,6 +12,7 @@ export type WorkflowJob = {
   "runs-on"?: string;
   "timeout-minutes"?: number;
   uses?: string;
+  env?: Record<string, string>;
   secrets?: Record<string, string>;
   steps?: WorkflowStep[];
   with?: Record<string, string>;


### PR DESCRIPTION
## Summary
Restore the Kimi-specific issue #5800 parity work for package `P0-D`; existing recovery and scope-upgrade package rows are explicitly mapped as pre-existing coverage and revalidated context, but not changed acceptance scope in this PR.

## Related Issues
Refs #5800
Refs #5098
Refs #5342
Refs #5401
Refs #5406
Refs #5412
Refs #5413
Refs #5625
Refs #5760

## Scope gate
- Package: `P0-D — Recovery, Kimi, and scope-upgrade parity`
- Included PRs all merged and touched `test/e2e`: yes
- Changed acceptance scope in this PR: Kimi public-NVIDIA/mock parity (`D2`, `D3`)
- Existing package rows revalidated without diff changes: recovery (`D1`) and scope-upgrade (`D4`)
- Out of scope: unmerged/non-bash PRs; shell lane retirement / PR #5756 cleanup

## Parity map
| ID | Source PR | Contract | Inference classification | Vitest assertion / waiver | Status |
| --- | --- | --- | --- | --- | --- |
| D1 | #5342, #5401 | Recovery proxy env sourcing, missing proxy-env warning, guard retention, ciao/networkInterfaces preload, and crash-loop stability are pre-existing package coverage. | `hermetic-default` | Existing `test/e2e-scenario/live/issue-2478-crash-loop-recovery.test.ts`, `test/e2e-scenario/support-tests/e2e-recovery-helpers.test.ts`; selective run `28186561267` job `issue-2478-crash-loop-recovery-vitest` passed. No diff changes here. | existing / revalidated context |
| D2 | #5401 | Kimi remains a public-NVIDIA model/provider contract when run in trusted selective CI, while retaining mock fallback for local/untrusted validation. | `public-nvidia required` | `.github/workflows/e2e-vitest-scenarios.yaml`, `test/e2e-scenario/live/kimi-inference-compat.test.ts`, `test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts`, `test/e2e-script-workflow.test.ts` | covered / changed |
| D3 | #5413, #5625 | Kimi multiturn tool calls split `hostname; date; uptime`, preserve tool-result flow, reject abandoned/continue traces, and normalize final punctuation. | `public-nvidia required` with mock fallback | `test/e2e-scenario/live/kimi-inference-compat-helpers.ts` trajectory assertions; selective run `28190216767` job `kimi-inference-compat-vitest` passed on the previous head; latest run `28193896380` passed on `f36fef6da`. | covered / changed |
| D4 | #5406, #5412, #5760 | Scope-upgrade approval tolerates preapproved / not-reproduced states, denies `operator.admin` leakage, stays on gateway/no embedded fallback, and accepts whitespace-normalized `42`; this is pre-existing package coverage. | `hosted-compatible capable` | Existing `test/e2e-scenario/live/issue-4462-scope-upgrade-approval.test.ts`; selective run `28186561267` job `issue-4462-scope-upgrade-approval-vitest` passed. No diff changes here. | existing / revalidated context |

## Inference mode support
- Default mode for touched live target: Kimi `mock` unless workflow selects `public-nvidia`.
- Real inference support preserved: yes for Kimi public NVIDIA; yes for existing scope-upgrade hosted-compatible; not required for recovery.
- Modes validated in this PR: Kimi public NVIDIA via selective workflows `28188683830`, `28190216767`; latest follow-up validation `28193896380` is running for head `f36fef6da`. Kimi helper/mock behavior via local support tests.
- Source-of-truth contract: `NEMOCLAW_E2E_INFERENCE_MODE` is the canonical selector; absent selector defaults to mock for local/untrusted validation; unknown explicit values now fail closed; legacy `NEMOCLAW_KIMI_USE_MOCK=0` remains only as a temporary shell-lane compatibility alias until shell retirement.
- Secret boundary: public Kimi workflow passes only `NVIDIA_API_KEY`; helper probe envs are secret-free by default; raw public NVIDIA key handoff is limited to onboard; sandbox `openclaw agent` now runs with a secret-free env and uses the configured `nvidia-prod` route.

## Validation
- [x] `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/kimi-inference-compat-helpers.test.ts`
- [x] `npx vitest run test/e2e-script-workflow.test.ts`
- [x] `npm run typecheck:cli`
- [x] `npm run test-conditionals:scan -- --top 25`
- [x] `npx prek run --all-files --stage pre-push --skip tsc-plugin --skip tsc-js --skip tsc-cli --skip version-tag-sync --skip test-cli --skip test-plugin --skip source-shape-test-budget --skip test-file-size-budget --skip test-skills-yaml`
- [x] `git diff --check`
- [x] Kimi selective E2E / Vitest Scenarios on previous head: https://github.com/NVIDIA/NemoClaw/actions/runs/28190216767
- [x] Kimi selective E2E / Vitest Scenarios after review-gap fixes: https://github.com/NVIDIA/NemoClaw/actions/runs/28193896380
- [x] Existing recovery/scope rows revalidated in selective run: https://github.com/NVIDIA/NemoClaw/actions/runs/28186561267 (`issue-2478-crash-loop-recovery-vitest` ✅, `issue-4462-scope-upgrade-approval-vitest` ✅; Kimi in that stale run was superseded)
- [ ] Local live mock Kimi: attempted but blocked by local Docker daemon unavailable (`Cannot connect to the Docker daemon at unix:///Users/jyaunches/.docker/run/docker.sock`). CI selective run is the live validation path for this head.

## Follow-ups / waivers
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running Kimi compatibility e2e checks in either mock or public NVIDIA mode.
  * The live scenario now adapts its setup, redaction, and traffic validation based on the selected mode.

* **Bug Fixes**
  * Improved handling of API key propagation so public NVIDIA runs use the expected credentials without exposing secrets in other paths.

* **Tests**
  * Added coverage for mode selection, API key validation, workflow environment wiring, and the new public NVIDIA Vitest lane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->