### PR TITLE
test(e2e): restore onboard rebuild lifecycle parity

### DIFF
--- a/src/lib/onboard/machine/handlers/sandbox.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.test.ts
@@ -549,6 +549,45 @@ describe("handleSandboxState", () => {
     expect(getSession().messagingPlan?.credentialBindings[0]?.credentialHash).toBe(newHash);
   });
 
+  it("refreshes credential hashes when restoring a registry plan for rebuild resume", async () => {
+    const oldHash = hashCredential("telegram-token-a");
+    const newHash = hashCredential("telegram-token-b");
+    const registryPlan = withTelegramCredentialHash(
+      makeMinimalPlan("my-assistant", "openclaw", ["telegram"]),
+      oldHash,
+    );
+    const session = createSession({ sandboxName: "my-assistant", messagingPlan: registryPlan });
+    const getRecordedMessagingChannelsForResume = vi.fn(() => ["telegram"]);
+    const writePlanToEnv = vi.fn();
+    const { deps, calls, getSession } = createDeps({
+      getRecordedMessagingChannelsForResume,
+      writePlanToEnv,
+      readMessagingPlanFromEnv: () => null,
+      getRegistrySandboxMessagingPlan: () => registryPlan,
+    });
+
+    await withEnv("TELEGRAM_BOT_TOKEN", "telegram-token-b", async () => {
+      await handleSandboxState({
+        ...baseOptions(deps, session),
+        resume: true,
+        sandboxName: "my-assistant",
+      });
+    });
+
+    expect(calls.setupMessaging).not.toHaveBeenCalled();
+    expect(writePlanToEnv).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialBindings: [
+          expect.objectContaining({
+            providerEnvKey: "TELEGRAM_BOT_TOKEN",
+            credentialHash: newHash,
+          }),
+        ],
+      }),
+    );
+    expect(getSession().messagingPlan?.credentialBindings[0]?.credentialHash).toBe(newHash);
+  });
+
   it("preserves an empty env-staged rebuild plan instead of rediscovering token-backed channels", async () => {
     const emptyRebuildPlan = makeMinimalPlan("my-assistant");
     const session = createSession({ sandboxName: "my-assistant", messagingPlan: emptyRebuildPlan });

--- a/test/e2e-scenario/live/onboard-resume.test.ts
+++ b/test/e2e-scenario/live/onboard-resume.test.ts
@@ -60,8 +60,20 @@ interface SessionStateComplete {
   >;
 }
 
+interface MutableSessionState extends Record<string, unknown> {
+  status?: string;
+  resumable?: boolean;
+}
+
 function readSession<T>(file: string): T {
   return JSON.parse(fs.readFileSync(file, "utf8")) as T;
+}
+
+function markSessionInProgress(file: string): void {
+  const session = readSession<MutableSessionState>(file);
+  session.status = "in_progress";
+  session.resumable = true;
+  fs.writeFileSync(file, JSON.stringify(session, null, 2), "utf8");
 }
 
 function interruptedSessionSummary(session: SessionStateInterrupted): Record<string, unknown> {
@@ -338,5 +350,57 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     expect(fs.existsSync(REGISTRY_FILE)).toBe(true);
     const registry = JSON.parse(fs.readFileSync(REGISTRY_FILE, "utf8")) as unknown;
     expect(containsExactJsonToken(registry, SANDBOX_NAME)).toBe(true);
+
+    // ──────────────────────────────────────────────────────────────────
+    // Phase 3.5: implicit resume — a plain `onboard` auto-detects an
+    // in_progress session, and `--fresh` suppresses that auto-resume.
+    // ──────────────────────────────────────────────────────────────────
+    markSessionInProgress(SESSION_FILE);
+    const implicitResumeRun = await host.command(
+      "node",
+      [CLI_ENTRYPOINT, "onboard", "--non-interactive"],
+      {
+        artifactName: "phase-3-5-onboard-implicit-resume",
+        env: {
+          ...buildAvailabilityProbeEnv(),
+          NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+          NEMOCLAW_POLICY_MODE: "skip",
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        },
+        redactionValues: [apiKey],
+        timeoutMs: ONBOARD_TIMEOUT_MS,
+      },
+    );
+    const implicitResumeText = `${implicitResumeRun.stdout}\n${implicitResumeRun.stderr}`;
+    expect(implicitResumeRun.exitCode, implicitResumeText).toBe(0);
+    expect(implicitResumeText).toContain("(resume mode)");
+    expect(
+      implicitResumeText.includes("[resume] Skipping") ||
+        implicitResumeText.includes("[reuse] Skipping"),
+      implicitResumeText,
+    ).toBe(true);
+
+    markSessionInProgress(SESSION_FILE);
+    const freshRun = await host.command(
+      "node",
+      [CLI_ENTRYPOINT, "onboard", "--fresh", "--non-interactive"],
+      {
+        artifactName: "phase-3-5-onboard-fresh-suppresses-resume",
+        env: {
+          ...buildAvailabilityProbeEnv(),
+          NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+          NEMOCLAW_POLICY_MODE: "skip",
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+          NEMOCLAW_E2E_FAILURE_INJECTION: "1",
+          NEMOCLAW_E2E_FORCE_FAIL_AT_STEP: "preflight",
+        },
+        redactionValues: [apiKey],
+        timeoutMs: ONBOARD_TIMEOUT_MS,
+      },
+    );
+    const freshText = `${freshRun.stdout}\n${freshRun.stderr}`;
+    expect(freshRun.exitCode, freshText).not.toBe(0);
+    expect(freshText).toContain("[e2e] Forced onboarding failure at step 'preflight'.");
+    expect(freshText).not.toContain("(resume mode)");
   },
 );

--- a/test/e2e-scenario/live/rebuild-hermes.test.ts
+++ b/test/e2e-scenario/live/rebuild-hermes.test.ts
@@ -6,15 +6,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
-
+import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { resultText, type HostCliClient } from "../fixtures/clients/index.ts";
+import { type HostCliClient, resultText } from "../fixtures/clients/index.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import { listCredentialLeakPaths } from "../fixtures/phases/state-validation.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
-import { shellQuote } from "../../../src/lib/core/shell-quote";
 
 // Direct Vitest replacement coverage for test/e2e/test-rebuild-hermes.sh.
 // The migrated scope is the legacy non-interactive shell regression: install.sh,
@@ -304,6 +303,13 @@ function seedRegistryAndSession(): SessionArtifactSummary {
     agentVersion: OLD_HERMES_REGISTRY_VERSION,
     messaging: { schemaVersion: 1, plan: messagingPlan },
   };
+  expect(
+    Object.prototype.hasOwnProperty.call(
+      registry.sandboxes[SANDBOX_NAME],
+      "providerCredentialHashes",
+    ),
+    "legacy providerCredentialHashes must stay out of the curated rebuild registry; credential fingerprints live on messaging plan bindings",
+  ).toBe(false);
   registry.defaultSandbox = SANDBOX_NAME;
   writeJsonFile(REGISTRY_FILE, registry);
 


### PR DESCRIPTION
## Summary
Restore issue #5800 parity package `P0-B` for merged onboard/rebuild/lifecycle bash-suite deltas only.

## Related Issues
Refs #5800
Refs #5098
Refs #5225
Refs #5487
Refs #5410
Refs #5760

## Scope gate
- Package: `P0-B — Onboard/rebuild/lifecycle parity`
- Included PRs all merged and touched `test/e2e`: yes — #5225, #5487, #5410, #5760
- Out of scope: unmerged/non-bash PRs; shell lane retirement / PR #5756 cleanup

## Parity map
| ID | Source PR | Contract | Inference classification | Vitest assertion / waiver | Status |
| --- | --- | --- | --- | --- | --- |
| B1 | #5225 | Persisted sandbox-entry gateway resolution is used by lifecycle commands. | `none` | Existing `src/lib/actions/sandbox/sandbox-gateway-routing.test.ts`, `src/lib/onboard/gateway-binding.test.ts`, `src/lib/onboard/sandbox-registration.test.ts` | covered |
| B2 | #5225 | Onboard repair/double-onboard failures include captured onboard output diagnostics. | `none` | Existing live `test/e2e-scenario/live/onboard-repair.test.ts`, `test/e2e-scenario/live/double-onboard.test.ts`; diagnostics are bash-runner-only verbosity and not a durable Vitest assertion. | waived |
| B3 | #5487 | Plain `nemoclaw onboard` auto-detects an `in_progress` session and resumes without `--resume`; `--fresh` suppresses auto-resume. | `hosted-compatible capable` | `test/e2e-scenario/live/onboard-resume.test.ts` Phase 3.5 mutates the completed session to `in_progress`, asserts `(resume mode)` + cached skips, then asserts `--fresh` fails at injected preflight without resume banner. | covered |
| B4 | #5410 | Rebuild resumes messaging from `messaging.plan` rather than legacy `providerCredentialHashes`; stale top-level provider hash state is not used. | `none` | `test/e2e-scenario/live/rebuild-hermes.test.ts` curated registry omits `providerCredentialHashes`; `src/lib/onboard/machine/handlers/sandbox.test.ts` refreshes registry-plan credential hashes from env on rebuild resume. | covered |
| B5 | #5410 | Empty/staged rebuild messaging plan is preserved and token-backed channels are not rediscovered. | `none` | Existing `src/lib/actions/sandbox/rebuild-messaging-stage.test.ts` and `src/lib/onboard/machine/handlers/sandbox.test.ts`. | covered |
| B6 | #5760 | Hosted-inference/messaging rebuild and live answer assertions tolerate model whitespace around integer `42`. | `hosted-compatible capable` | Existing `test/helpers/e2e-answer-assertions.test.ts`, consumed by `agent-turn-latency`, `full-e2e`, `launchable-smoke`, and `sandbox-operations` live Vitests. | covered |
| B7 | #5760 | Stabilized hosted inference and messaging rebuild remain validated by live full/sandbox/launchable/rebuild targets. | `hosted-compatible capable` | Existing live targets remain unchanged; local live execution blocked by Docker daemon unavailable. Selective workflow required after PR opens. | follow-up |

## Inference mode support
- Default mode for touched live targets: `hosted-compatible capable` for onboard-resume/rebuild-hermes/full/sandbox/launchable answer paths; `none` for unit/process registry and gateway routing tests.
- Real inference support preserved: yes for existing hosted-compatible live targets; no new inference adapter seam added here.
- Modes validated in this PR: local unit/process Vitests only; live hosted-compatible validation needs GitHub runner/secrets because local Docker daemon is unavailable.
- If not validated with real inference: local `NEMOCLAW_RUN_E2E_SCENARIOS=1 npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/onboard-resume.test.ts test/e2e-scenario/live/rebuild-hermes.test.ts` failed at prereq Docker daemon check before scenario assertions.

## Validation
- [x] `git diff --check`
- [x] `npm test -- src/lib/onboard/machine/handlers/sandbox.test.ts test/helpers/e2e-answer-assertions.test.ts src/lib/actions/sandbox/sandbox-gateway-routing.test.ts src/lib/onboard/entry-options.test.ts src/lib/onboard/sandbox-registration.test.ts src/lib/actions/sandbox/rebuild-messaging-stage.test.ts`
- [x] `npm run typecheck:cli`
- [x] `npm run build:cli`
- [x] `npm run test-size:check`
- [ ] hosted-compatible selective E2E workflow: pending PR / runner dispatch

## Follow-ups / waivers
- Waiver B2: bash-only diagnostic verbosity from #5225 is not a durable Vitest contract; existing live tests already preserve the functional repair/double-onboard behavior.
- Follow-up B7: dispatch selective live Vitest scenarios on GitHub runner with Docker + hosted inference secret after PR opens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for sandbox resume flows to verify updated Telegram credentials are picked up when resuming a rebuild.
  * Expanded end-to-end onboarding resume scenarios to confirm implicit resume behavior, including skipped cached steps and fresh runs starting from the expected point.
  * Strengthened rebuild scenario checks to ensure curated registry entries no longer include legacy credential-hash data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->