### PR TITLE
docs: fix Hermes docs links

### DIFF
--- a/docs/about/how-it-works.mdx
+++ b/docs/about/how-it-works.mdx
@@ -132,13 +132,13 @@ NemoClaw's runtime context tells supported agents to try allowed network and fil
 - Refer to the [Architecture](../reference/architecture) for the full technical structure, including file layouts and the blueprint lifecycle.
 - Refer to [Inference Options](../inference/inference-options) for detailed provider configuration.
 - For details on the baseline rules, refer to [Network Policies](../reference/network-policies).
-- For container-level hardening, refer to [Sandbox Hardening](../manage-sandboxes/sandbox-hardening).
+- For container-level hardening, refer to [Sandbox Hardening](../deployment/sandbox-hardening).
 
 </AgentOnly>
 <AgentOnly variant="hermes">
 
 - Read [Ecosystem](ecosystem) for stack-level relationships and NemoClaw versus OpenShell-only paths.
-- Follow [Quickstart with Hermes](../get-started/quickstart) to launch your first sandbox.
+- Follow [Quickstart with Hermes](../get-started/quickstart-hermes) to launch your first sandbox.
 - Refer to the [Architecture](../reference/architecture) for the full technical structure, including file layouts and the blueprint lifecycle.
 - Refer to [Inference Options](../inference/inference-options) for detailed provider configuration.
 - For details on the baseline rules, refer to [Network Policies](../reference/network-policies).

--- a/docs/inference/use-local-inference.mdx
+++ b/docs/inference/use-local-inference.mdx
@@ -26,7 +26,7 @@ OpenShell intercepts inference traffic and forwards it to the local endpoint you
 - NemoClaw installed. Refer to the [Quickstart](../get-started/quickstart) if you have not installed yet.
 </AgentOnly>
 <AgentOnly variant="hermes">
-- NemoClaw installed. Refer to [Quickstart with Hermes](../get-started/quickstart) if you have not installed yet.
+- NemoClaw installed. Refer to [Quickstart with Hermes](../get-started/quickstart-hermes) if you have not installed yet.
 </AgentOnly>
 - A local model server running, or a supported Ollama, vLLM, or NIM setup that the NemoClaw onboard wizard can use, start, or install.
 
@@ -115,7 +115,7 @@ Ollama is convenient for local chat, but some model/template combinations can
 return tool calls as plain text under realistic agent load. If the TUI shows raw
 JSON such as `{"name":"memory_search","arguments":{...}}` instead of running a
 tool, switch to vLLM with `--enable-auto-tool-choice` and the correct
-`--tool-call-parser`. See [Tool-Calling Reliability](tool-calling-reliability).
+`--tool-call-parser`. See [Tool-Calling Reliability](../../openclaw/inference/tool-calling-reliability).
 </Warning>
 </AgentOnly>
 
@@ -250,7 +250,7 @@ If the provider itself needs to change (for example, switching from vLLM to a cl
 <AgentOnly variant="openclaw">
 
 - [Inference Options](inference-options) for the full list of providers available during onboarding.
-- [Tool-Calling Reliability](tool-calling-reliability) for diagnosing raw JSON tool-call output with local models.
+- [Tool-Calling Reliability](../../openclaw/inference/tool-calling-reliability) for diagnosing raw JSON tool-call output with local models.
 - [Switch Inference Models](switch-inference-providers) for runtime model switching.
 - [Quickstart](../get-started/quickstart) for first-time installation.
 
@@ -259,6 +259,6 @@ If the provider itself needs to change (for example, switching from vLLM to a cl
 
 - [Inference Options](inference-options) for the full list of providers available during onboarding.
 - [Switch Inference Models](switch-inference-providers) for runtime model switching.
-- [Quickstart with Hermes](../get-started/quickstart) for first-time installation.
+- [Quickstart with Hermes](../get-started/quickstart-hermes) for first-time installation.
 
 </AgentOnly>


### PR DESCRIPTION
## Summary
Fixes broken docs links in the shared OpenClaw/Hermes source pages so generated Hermes routes no longer point at missing pages or the OpenClaw quickstart.

## Related Issue
Fixes #5762

## Changes
- Point Architecture Overview's Sandbox Hardening link at the existing deployment page.
- Point Hermes quickstart links at the Hermes quickstart source page.
- Point OpenClaw-only Tool-Calling Reliability links at the explicit OpenClaw variant route so Hermes route validation does not treat them as Hermes-local links.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification
- [ ] `npx prek run --all-files` passes
- [ ] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for user-facing behavior changes
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional focused verification run:
- `npm run docs` passed with 0 errors; Fern reported 2 warnings that were not printed by default.
- `npm test -- --run test/agent-variant-docs.test.ts test/check-docs-links.test.ts` passed: 2 files, 16 tests.
- `npm run docs:sync-agent-variants --silent` passed.
- `git diff --check` passed.

---
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding and “Next Steps” guidance for different AI variants.
  * Pointed Hermes setup links to the correct Hermes-specific quickstart page.
  * Adjusted related guidance links for local inference so they resolve correctly.
  * Improved references for tool-calling reliability and WSL/Ollama warnings to match the latest documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->