### PR TITLE
fix(cli): dispatch sandbox agent to terminal runtimes

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -439,7 +439,7 @@ The exit code is the remote command's exit code.
 
 ### `nemohermes <name> agent`
 
-The `agent` wrapper is an OpenClaw passthrough and rejects Hermes sandboxes with guidance for the Hermes HTTP API.
+The `agent` wrapper rejects Hermes sandboxes with guidance for the Hermes HTTP API.
 Hermes sandboxes expose an OpenAI-compatible API on port `8642` inside the sandbox, so non-interactive use does not need a wrapper command.
 
 Forward the port and POST chat completions directly:

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -546,27 +546,32 @@ The exit code is the remote command's exit code.
 
 <AgentOnly variant="openclaw">
 
-Run one OpenClaw agent turn non-interactively in a running sandbox.
-This command forwards every argument verbatim to `openclaw agent ...` inside the sandbox via `openshell sandbox exec`, with `HOME=/sandbox` so the addressed agent profile resolves the same way as `connect`.
+Run one agent turn non-interactively in a running sandbox.
+For OpenClaw sandboxes, this command forwards arguments to `openclaw agent ...` inside the sandbox via `openshell sandbox exec`, with `HOME=/sandbox` so the addressed agent profile resolves the same way as `connect`.
+For terminal-runtime sandboxes, NemoClaw forwards arguments to the manifest-declared interactive command; LangChain Deep Agents Code sandboxes run `dcode ...`.
 Use this when driving the sandbox programmatically from another process (CI job, multi-agent platform, evaluation harness) rather than from an interactive terminal.
 
-All flags accepted by the in-sandbox OpenClaw CLI are forwarded verbatim, so the upstream surface stays the single source of truth.
+All flags accepted by the selected in-sandbox agent CLI are forwarded verbatim, so the upstream surface stays the single source of truth.
 
 ```bash
 $$nemoclaw my-assistant agent -m "Summarise README.md"
 $$nemoclaw my-assistant agent --agent work -m "Status update?"
 $$nemoclaw my-assistant agent --session-id review-42 -m "Any new findings?"
 $$nemoclaw my-assistant agent --json -m 'ping'
+$$nemoclaw dcode-sandbox agent --help
+$$nemoclaw dcode-sandbox agent -n "Summarize this repository"
 ```
 
-The wrapper inherits the remote command's exit code, so host-side pipelines can branch on it. Streaming forwards whatever `openclaw agent` already emits on `stdout`; the wrapper adds no buffering.
+The wrapper inherits the remote command's exit code, so host-side pipelines can branch on it. Streaming forwards whatever the in-sandbox agent command emits on `stdout`; the wrapper adds no buffering.
 
-Common upstream flags include `-m <text>`, `--session-id <id>`, `--agent <id>`, `--model <id>`, `--thinking <level>`, `--json`, `--deliver`, `--reply-channel <channel>`, and `--timeout <seconds>`. Run `$$nemoclaw <name> agent --help` for the wrapper-level summary, or invoke `$$nemoclaw <name> exec -- openclaw agent --help` to view the upstream OpenClaw help text directly.
+Common OpenClaw flags include `-m <text>`, `--session-id <id>`, `--agent <id>`, `--model <id>`, `--thinking <level>`, `--json`, `--deliver`, `--reply-channel <channel>`, and `--timeout <seconds>`.
+For OpenClaw sandboxes and registry fallbacks, `$$nemoclaw <name> agent` and `$$nemoclaw <name> agent --help` print the wrapper-level summary locally; invoke `$$nemoclaw <name> exec -- openclaw agent --help` to view the upstream OpenClaw help text directly.
+For registered terminal-runtime sandboxes, bare invocations and `--help` are forwarded to the terminal command, so a LangChain Deep Agents Code sandbox receives `dcode` for `$$nemoclaw <name> agent` and `dcode --help` for `$$nemoclaw <name> agent --help`.
 
 </AgentOnly>
 <AgentOnly variant="hermes">
 
-The `agent` wrapper is an OpenClaw passthrough and rejects Hermes sandboxes with guidance for the Hermes HTTP API.
+The `agent` wrapper rejects Hermes sandboxes with guidance for the Hermes HTTP API.
 Hermes sandboxes expose an OpenAI-compatible API on port `8642` inside the sandbox, so non-interactive use does not need a wrapper command.
 
 Forward the port and POST chat completions directly:

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -568,7 +568,8 @@ The wrapper inherits the remote command's exit code, so host-side pipelines can 
 Streaming forwards whatever the in-sandbox agent command emits on `stdout`; the wrapper adds no buffering.
 
 Common OpenClaw flags include `-m <text>`, `--session-id <id>`, `--agent <id>`, `--model <id>`, `--thinking <level>`, `--json`, `--deliver`, `--reply-channel <channel>`, and `--timeout <seconds>`.
-For OpenClaw sandboxes and registry fallbacks, invoke `$$nemoclaw <name> exec -- openclaw agent --help` to view the upstream OpenClaw help text directly.
+For OpenClaw sandboxes and registry fallbacks, `$$nemoclaw <name> agent --help` prints the wrapper-level summary locally.
+Invoke `$$nemoclaw <name> exec -- openclaw agent --help` to view the upstream OpenClaw help text directly.
 For registered terminal-runtime sandboxes, bare invocations and `--help` are forwarded to the terminal command, so a LangChain Deep Agents Code sandbox receives `dcode` for `$$nemoclaw <name> agent` and `dcode --help` for `$$nemoclaw <name> agent --help`.
 
 Host-side validation runs before the sandbox dispatch:

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -562,7 +562,8 @@ $$nemoclaw dcode-sandbox agent --help
 $$nemoclaw dcode-sandbox agent -n "Summarize this repository"
 ```
 
-The wrapper inherits the remote command's exit code, so host-side pipelines can branch on it. Streaming forwards whatever the in-sandbox agent command emits on `stdout`; the wrapper adds no buffering.
+The wrapper inherits the remote command's exit code, so host-side pipelines can branch on it.
+Streaming forwards whatever the in-sandbox agent command emits on `stdout`; the wrapper adds no buffering.
 
 Common OpenClaw flags include `-m <text>`, `--session-id <id>`, `--agent <id>`, `--model <id>`, `--thinking <level>`, `--json`, `--deliver`, `--reply-channel <channel>`, and `--timeout <seconds>`.
 For OpenClaw sandboxes and registry fallbacks, `$$nemoclaw <name> agent` and `$$nemoclaw <name> agent --help` print the wrapper-level summary locally; invoke `$$nemoclaw <name> exec -- openclaw agent --help` to view the upstream OpenClaw help text directly.

--- a/src/commands/sandbox/agent.test.ts
+++ b/src/commands/sandbox/agent.test.ts
@@ -31,11 +31,11 @@ describe("SandboxAgentCommand oclif parse path", () => {
     });
   });
 
-  it("does not call runAgentPassthrough when --help follows the sandbox name", async () => {
+  it("passes --help after the sandbox name to agent-aware dispatch (#5790)", async () => {
     await SandboxAgentCommand.run(["alpha", "--help"], rootDir);
-    expect(runAgentPassthroughMock).not.toHaveBeenCalled();
-    const help = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
-    expect(help).toMatch(/openclaw agent/);
+    expect(runAgentPassthroughMock).toHaveBeenCalledWith("alpha", {
+      extraArgs: ["--help"],
+    });
   });
 
   it("does not call runAgentPassthrough when no sandbox name is supplied", async () => {
@@ -50,13 +50,8 @@ describe("SandboxAgentCommand oclif parse path", () => {
     expect(runAgentPassthroughMock).not.toHaveBeenCalled();
   });
 
-  it("prints wrapper help and does not dispatch on a bare no-args invocation (#5658)", async () => {
-    // `nemoclaw <name> agent` with no further args cannot succeed in-sandbox
-    // (openclaw agent requires -m), so short-circuit to wrapper help locally
-    // instead of paying sandbox-exec latency to surface an upstream error.
+  it("passes a bare sandbox invocation to agent-aware dispatch (#5790)", async () => {
     await SandboxAgentCommand.run(["alpha"], rootDir);
-    expect(runAgentPassthroughMock).not.toHaveBeenCalled();
-    const help = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
-    expect(help).toMatch(/openclaw agent/);
+    expect(runAgentPassthroughMock).toHaveBeenCalledWith("alpha", { extraArgs: [] });
   });
 });

--- a/src/commands/sandbox/agent.ts
+++ b/src/commands/sandbox/agent.ts
@@ -1,20 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  hasAgentPassthroughHelpToken,
-  printAgentPassthroughHelp,
-} from "../../lib/actions/sandbox/agent/passthrough-help";
+import { printAgentPassthroughHelp } from "../../lib/actions/sandbox/agent/passthrough-help";
 import { runAgentPassthrough } from "../../lib/actions/sandbox/agent/passthrough";
 import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 
 export default class SandboxAgentCommand extends NemoClawCommand {
   static id = "sandbox:agent";
   static strict = false;
-  static summary = "Run one OpenClaw agent turn non-interactively in a sandbox";
+  static summary = "Run one agent turn non-interactively in a sandbox";
   static description =
-    "Pass through to `openclaw agent` inside the sandbox via `openshell sandbox exec`. Stream the agent's response back to stdout without owning a TTY; useful for driving the sandbox from another process (CI job, multi-agent platform, evaluation harness). All flags accepted by the in-sandbox OpenClaw CLI are forwarded verbatim, including `-m <text>`, `--session-id <id>`, `--agent <id>`, `--json`, `--thinking <level>`, `--deliver`, and `--reply-channel`. Currently supported on OpenClaw sandboxes only; Hermes sandboxes exit non-zero with a redirect to the OpenAI-compatible API on port 8642 inside the sandbox.";
-  static usage = ["<name> [openclaw-agent-flags...]"];
+    "Pass through to the sandbox's registered agent command via `openshell sandbox exec`. OpenClaw sandboxes run `openclaw agent`; terminal-runtime sandboxes run their manifest-declared interactive command, such as `dcode` for LangChain Deep Agents Code. Stream the agent's response back to stdout without owning a TTY; useful for driving the sandbox from another process (CI job, multi-agent platform, evaluation harness). Hermes sandboxes exit non-zero with a redirect to the OpenAI-compatible API on port 8642 inside the sandbox.";
+  static usage = ["<name> [agent-flags...]"];
   static examples = [
     '<%= config.bin %> sandbox agent alpha -m "Summarise README.md"',
     '<%= config.bin %> sandbox agent alpha --agent work -m "Status update?"',
@@ -31,14 +28,6 @@ export default class SandboxAgentCommand extends NemoClawCommand {
       sandboxName === "--help" ||
       sandboxName === "-h"
     ) {
-      printAgentPassthroughHelp();
-      return;
-    }
-    // A bare `<name> agent` with no further args cannot succeed in-sandbox
-    // (`openclaw agent` requires `-m`), so treat it like a help request and
-    // print the wrapper summary locally instead of paying sandbox-exec latency
-    // only to surface an upstream "Missing required option -m" error (#5658).
-    if (extraArgs.length === 0 || hasAgentPassthroughHelpToken(extraArgs)) {
       printAgentPassthroughHelp();
       return;
     }

--- a/src/lib/actions/sandbox/agent/passthrough-help.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-help.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { hasAgentPassthroughHelpToken } from "./passthrough-help";
+import { hasAgentPassthroughHelpToken, printAgentPassthroughHelp } from "./passthrough-help";
 
 describe("hasAgentPassthroughHelpToken", () => {
   it("returns true for --help before the OpenClaw argv separator", () => {
@@ -18,5 +18,25 @@ describe("hasAgentPassthroughHelpToken", () => {
   it("returns false for unrelated flags", () => {
     expect(hasAgentPassthroughHelpToken(["-m", "hi"])).toBe(false);
     expect(hasAgentPassthroughHelpToken([])).toBe(false);
+  });
+});
+
+describe("printAgentPassthroughHelp", () => {
+  it("describes both OpenClaw and terminal-runtime passthroughs (#5790)", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    let output = "";
+    try {
+      printAgentPassthroughHelp();
+      output = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(output).toContain("[agent-flags...]");
+    expect(output).toContain("registered agent command");
+    expect(output).toContain("OpenClaw sandboxes run `openclaw agent ...`");
+    expect(output).toContain("terminal-runtime sandboxes run");
+    expect(output).toContain("`dcode ...`");
+    expect(output).not.toContain("OpenClaw sandboxes only");
   });
 });

--- a/src/lib/actions/sandbox/agent/passthrough-help.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-help.ts
@@ -13,19 +13,24 @@ export function hasAgentPassthroughHelpToken(args: readonly string[]): boolean {
 
 export function printAgentPassthroughHelp(): void {
   console.log("");
-  console.log(`  Usage: ${CLI_NAME} <name> agent [openclaw-agent-flags...]`);
+  console.log(`  Usage: ${CLI_NAME} <name> agent [agent-flags...]`);
   console.log("");
   console.log(
-    "  Pass-through to `openclaw agent ...` inside the sandbox via `openshell sandbox exec`.",
+    "  Pass-through to the sandbox's registered agent command via `openshell sandbox exec`.",
   );
-  console.log("  All flags accepted by the in-sandbox OpenClaw CLI are forwarded verbatim.");
+  console.log("  OpenClaw sandboxes run `openclaw agent ...`; terminal-runtime sandboxes run");
   console.log(
-    "  Common flags: -m <text>, --session-id <id>, --agent <id>, --json, --thinking <level>.",
+    "  their manifest-declared interactive command, such as `dcode ...` for Deep Agents Code.",
+  );
+  console.log("  All flags accepted by the selected in-sandbox agent CLI are forwarded verbatim.");
+  console.log(
+    "  Common OpenClaw flags: -m <text>, --session-id <id>, --agent <id>, --json, --thinking <level>.",
   );
   console.log("");
-  console.log(
-    "  Currently supported on OpenClaw sandboxes only; Hermes sandboxes are rejected with a",
-  );
+  console.log(`  For terminal-runtime help, run \`${CLI_NAME} <name> agent --help\` to view the`);
+  console.log("  upstream command help from inside the sandbox.");
+  console.log("");
+  console.log("  Hermes sandboxes are rejected with a");
   console.log("  redirect to the OpenAI-compatible API on port 8642 inside the sandbox.");
   console.log("");
 }

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -120,6 +120,18 @@ describe("runAgentPassthrough", () => {
     expect(execMock).toHaveBeenCalledWith("dcode-help", ["dcode"], { tty: false });
   });
 
+  it("propagates bare Deep Agents Code non-zero exits from the sandbox exec path (#5790)", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "langchain-deepagents-code" });
+    execMock.mockRejectedValueOnce(new Error("__exit:42"));
+
+    await expect(runAgentPassthrough("dcode-fail")).rejects.toThrow("__exit:42");
+
+    expect(ensureLiveMock).toHaveBeenCalledWith("dcode-fail", { allowNonReadyPhase: true });
+    expect(execMock).toHaveBeenCalledWith("dcode-fail", ["dcode"], { tty: false });
+  });
+
   it("treats a clean registry miss as OpenClaw (preserves bootstrap and recovery paths)", async () => {
     execMock.mockClear();
     getSandboxMock.mockReturnValueOnce(null);

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -81,6 +81,18 @@ describe("runAgentPassthrough", () => {
     );
   });
 
+  it("keeps OpenClaw --help local so wrapper docs parity stays offline", async () => {
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runAgentPassthrough("alpha", { extraArgs: ["--help"] });
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
   it("dispatches Deep Agents Code help to dcode instead of local wrapper help (#5790)", async () => {
     getSandboxMock.mockReturnValueOnce({ agent: "langchain-deepagents-code" });
     await runAgentPassthrough("dcode-help", { extraArgs: ["--help"] });
@@ -112,6 +124,18 @@ describe("runAgentPassthrough", () => {
       ["openclaw", "agent", "--agent", "main", "-m", "hi"],
       { tty: false },
     );
+  });
+
+  it("keeps registry-miss --help local for offline docs parity", async () => {
+    getSandboxMock.mockReturnValueOnce(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runAgentPassthrough("placeholder-sandbox", { extraArgs: ["--help"] });
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
   });
 
   it("fails closed when the registry read throws and never spawns OpenShell exec", async () => {

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -5,11 +5,27 @@ import { describe, expect, it, vi } from "vitest";
 
 const execMock = vi.hoisted(() => vi.fn(async () => {}));
 const ensureLiveMock = vi.hoisted(() => vi.fn(async () => ({})));
-const getSandboxMock = vi.hoisted(() => vi.fn(() => null as { agent?: string } | null));
+const getSandboxMock = vi.hoisted(() => vi.fn(() => null as { agent?: string | null } | null));
+const loadAgentMock = vi.hoisted(() =>
+  vi.fn((name: string) => ({
+    name,
+    runtime:
+      name === "langchain-deepagents-code"
+        ? { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" }
+        : undefined,
+  })),
+);
+const isTerminalAgentMock = vi.hoisted(() =>
+  vi.fn((agent: { runtime?: { kind?: string } }) => agent.runtime?.kind === "terminal"),
+);
 
 vi.mock("../exec", () => ({ execSandbox: execMock }));
 vi.mock("../gateway-state", () => ({ ensureLiveSandboxOrExit: ensureLiveMock }));
 vi.mock("../../../state/registry", () => ({ getSandbox: getSandboxMock }));
+vi.mock("../../../agent/defs", () => ({
+  isTerminalAgent: isTerminalAgentMock,
+  loadAgent: loadAgentMock,
+}));
 
 import { runAgentPassthrough } from "./passthrough";
 
@@ -40,9 +56,7 @@ describe("runAgentPassthrough", () => {
     expect(execMock).not.toHaveBeenCalled();
     expect(ensureLiveMock).not.toHaveBeenCalled();
     expect(exit).toHaveBeenCalledWith(2);
-    expect(writes.join("")).toMatch(
-      /Only OpenClaw sandboxes support the `sandbox agent` wrapper today \(sandbox 'alpha' runs 'hermes'\)/,
-    );
+    expect(writes.join("")).toMatch(/cannot dispatch to sandbox 'alpha' because it runs 'hermes'/);
     expect(writes.join("")).toMatch(/port 8642/);
   });
 
@@ -59,6 +73,51 @@ describe("runAgentPassthrough", () => {
       ["openclaw", "agent", "--agent", "work", "--session-id", "s-1", "-m", "ping", "--json"],
       { tty: false },
     );
+  });
+
+  it("keeps OpenClaw --help local so wrapper help stays cheap (#5658)", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runAgentPassthrough("alpha", { extraArgs: ["--help"] });
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps bare OpenClaw invocations local so they do not pay sandbox latency (#5658)", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runAgentPassthrough("alpha");
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches Deep Agents Code help to dcode instead of local wrapper help (#5790)", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "langchain-deepagents-code" });
+    await runAgentPassthrough("dcode-help", { extraArgs: ["--help"] });
+    expect(ensureLiveMock).toHaveBeenCalledWith("dcode-help", { allowNonReadyPhase: true });
+    expect(execMock).toHaveBeenCalledWith("dcode-help", ["dcode", "--help"], { tty: false });
+  });
+
+  it("dispatches bare Deep Agents Code invocations to dcode so upstream owns exit code (#5790)", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "langchain-deepagents-code" });
+    await runAgentPassthrough("dcode-help");
+    expect(execMock).toHaveBeenCalledWith("dcode-help", ["dcode"], { tty: false });
   });
 
   it("treats a clean registry miss as OpenClaw (preserves bootstrap and recovery paths)", async () => {
@@ -89,10 +148,49 @@ describe("runAgentPassthrough", () => {
     expect(all).toMatch(/EACCES/);
   });
 
-  it("works with no extraArgs and still enforces --no-tty", async () => {
+  it("prints wrapper help when no extraArgs are passed to an OpenClaw fallback", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: null });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runAgentPassthrough("alpha");
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it("treats unknown registry misses as OpenClaw help for bare invocations", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runAgentPassthrough("ghost");
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it("works with explicit args for OpenClaw and still enforces --no-tty", async () => {
     execMock.mockClear();
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    await runAgentPassthrough("alpha");
-    expect(execMock).toHaveBeenCalledWith("alpha", ["openclaw", "agent"], { tty: false });
+    await runAgentPassthrough("alpha", { extraArgs: ["-m", "hi"] });
+    expect(execMock).toHaveBeenCalledWith("alpha", ["openclaw", "agent", "-m", "hi"], {
+      tty: false,
+    });
+  });
+
+  it("works with explicit args for OpenClaw fallbacks and still enforces --no-tty", async () => {
+    execMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: null });
+    await runAgentPassthrough("alpha", { extraArgs: ["-m", "hi"] });
+    expect(execMock).toHaveBeenCalledWith("alpha", ["openclaw", "agent", "-m", "hi"], {
+      tty: false,
+    });
   });
 });

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -148,6 +148,51 @@ describe("runAgentPassthrough", () => {
     expect(all).toMatch(/EACCES/);
   });
 
+  it("fails closed when a registered agent cannot be resolved before OpenShell exec", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "missing-agent" });
+    loadAgentMock.mockImplementationOnce(() => {
+      throw new Error("Agent manifest not found: agents/missing-agent/manifest.yaml");
+    });
+    const { writes, exit, proc } = makeProcMock();
+    await expect(
+      runAgentPassthrough("alpha", { extraArgs: ["-m", "hi"] }, { process: proc }),
+    ).rejects.toThrow("__exit:2");
+    expect(execMock).not.toHaveBeenCalled();
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(2);
+    const all = writes.join("");
+    expect(all).toMatch(/registered agent 'missing-agent'/);
+    expect(all).toMatch(/Agent manifest not found/);
+    expect(all).toMatch(/Refusing to dispatch/);
+  });
+
+  it("fails closed for quoted terminal manifest commands instead of splitting them incorrectly", async () => {
+    execMock.mockClear();
+    ensureLiveMock.mockClear();
+    getSandboxMock.mockReturnValueOnce({ agent: "custom-terminal" });
+    loadAgentMock.mockReturnValueOnce({
+      name: "custom-terminal",
+      runtime: {
+        kind: "terminal",
+        interactive_command: 'tool --profile "Deep Agents"',
+        headless_command: "tool -n",
+      },
+    });
+    const { writes, exit, proc } = makeProcMock();
+    await expect(
+      runAgentPassthrough("quoted-terminal", { extraArgs: ["--help"] }, { process: proc }),
+    ).rejects.toThrow("__exit:2");
+    expect(execMock).not.toHaveBeenCalled();
+    expect(ensureLiveMock).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(2);
+    const all = writes.join("");
+    expect(all).toMatch(/registered agent 'custom-terminal'/);
+    expect(all).toMatch(/simple whitespace-delimited argv tokens/);
+    expect(all).toMatch(/quoted or escaped shell syntax is not supported/);
+  });
+
   it("prints wrapper help when no extraArgs are passed to an OpenClaw fallback", async () => {
     execMock.mockClear();
     ensureLiveMock.mockClear();

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -91,6 +91,7 @@ import { parseSandboxPhase } from "../../../state/gateway";
 import * as registry from "../../../state/registry";
 import { execSandbox } from "../exec";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
+import { hasAgentPassthroughHelpToken, printAgentPassthroughHelp } from "./passthrough-help";
 
 export {
   hasAgentPassthroughHelpToken,
@@ -214,11 +215,19 @@ function getPassthroughCommand(
   proc: NonNullable<AgentPassthroughDeps["process"]>,
 ): string[] | null {
   if (lookup.kind === "missing") {
+    if (hasAgentPassthroughHelpToken(extraArgs)) {
+      printAgentPassthroughHelp();
+      return null;
+    }
     return ["openclaw", "agent", ...extraArgs];
   }
 
   const agentName = lookup.agent;
   if (agentName === null || agentName === "openclaw") {
+    if (hasAgentPassthroughHelpToken(extraArgs)) {
+      printAgentPassthroughHelp();
+      return null;
+    }
     return ["openclaw", "agent", ...extraArgs];
   }
 

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -31,9 +31,11 @@
 //   endpoint directly. The fail-closed branch can then be retired in favour of
 //   the live source.
 
+import { isTerminalAgent, loadAgent, type AgentDefinition } from "../../../agent/defs";
 import * as registry from "../../../state/registry";
 import { execSandbox } from "../exec";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
+import { hasAgentPassthroughHelpToken, printAgentPassthroughHelp } from "./passthrough-help";
 
 export {
   hasAgentPassthroughHelpToken,
@@ -58,6 +60,7 @@ type RegistryReadResult =
   | { kind: "missing" }
   | { kind: "agent"; agent: string | null }
   | { kind: "error"; message: string };
+type ResolvedRegistryReadResult = Exclude<RegistryReadResult, { kind: "error" }>;
 
 function readSandboxAgentFromRegistry(
   sandboxName: string,
@@ -78,7 +81,7 @@ function rejectNonOpenclawAgent(
   proc: NonNullable<AgentPassthroughDeps["process"]>,
 ): never {
   proc.stderr.write(
-    `  Only OpenClaw sandboxes support the \`sandbox agent\` wrapper today (sandbox '${sandboxName}' runs '${agent}').\n`,
+    `  The \`sandbox agent\` wrapper cannot dispatch to sandbox '${sandboxName}' because it runs '${agent}'.\n`,
   );
   proc.stderr.write("  Hermes exposes an OpenAI-compatible API on port 8642 inside the sandbox;\n");
   proc.stderr.write(
@@ -86,6 +89,51 @@ function rejectNonOpenclawAgent(
   );
   proc.stderr.write("  and POST to http://127.0.0.1:8642/v1/chat/completions instead.\n");
   return proc.exit(2);
+}
+
+function splitManifestCommand(command: string): string[] {
+  return command.trim().split(/\s+/).filter(Boolean);
+}
+
+function getTerminalInteractiveCommand(agent: AgentDefinition): string[] | null {
+  const command = agent.runtime?.interactive_command ?? agent.runtime?.headless_command ?? "";
+  const argv = splitManifestCommand(command);
+  return argv.length > 0 ? argv : null;
+}
+
+function getPassthroughCommand(
+  sandboxName: string,
+  lookup: ResolvedRegistryReadResult,
+  extraArgs: readonly string[],
+  proc: NonNullable<AgentPassthroughDeps["process"]>,
+): string[] | null {
+  if (lookup.kind === "missing") {
+    if (extraArgs.length === 0 || hasAgentPassthroughHelpToken(extraArgs)) {
+      printAgentPassthroughHelp();
+      return null;
+    }
+    return ["openclaw", "agent", ...extraArgs];
+  }
+
+  const agentName = lookup.agent;
+  if (agentName === null || agentName === "openclaw") {
+    if (extraArgs.length === 0 || hasAgentPassthroughHelpToken(extraArgs)) {
+      printAgentPassthroughHelp();
+      return null;
+    }
+    return ["openclaw", "agent", ...extraArgs];
+  }
+
+  const agent = loadAgent(agentName);
+  if (!isTerminalAgent(agent)) {
+    rejectNonOpenclawAgent(sandboxName, agentName, proc);
+  }
+
+  const terminalCommand = getTerminalInteractiveCommand(agent);
+  if (!terminalCommand) {
+    rejectNonOpenclawAgent(sandboxName, agentName, proc);
+  }
+  return [...terminalCommand, ...extraArgs];
 }
 
 function rejectRegistryReadError(
@@ -113,12 +161,10 @@ export async function runAgentPassthrough(
   if (lookup.kind === "error") {
     rejectRegistryReadError(sandboxName, lookup.message, proc);
   }
-  if (lookup.kind === "agent" && lookup.agent && lookup.agent !== "openclaw") {
-    rejectNonOpenclawAgent(sandboxName, lookup.agent, proc);
-  }
+  const command = getPassthroughCommand(sandboxName, lookup, extraArgs, proc);
+  if (!command) return;
   const ensureLive = deps.ensureLive ?? ensureLiveSandboxOrExit;
   await ensureLive(sandboxName, { allowNonReadyPhase: true });
-  const command = ["openclaw", "agent", ...extraArgs];
   const exec = deps.exec ?? execSandbox;
   await exec(sandboxName, command, { tty: false });
 }

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -10,10 +10,11 @@
 //   silently bypass the host-side guard intended to redirect Hermes callers to
 //   the OpenAI-compatible API on port 8642.
 //
-// - Source boundary: this wrapper owns the host-side guard only; the in-sandbox
-//   agent invocation, its argv contract, and its streaming behaviour are owned
-//   by upstream OpenClaw. NemoClaw does not rewrite OpenClaw flags here; it
-//   forwards them verbatim.
+// - Source boundary: this wrapper owns the host-side guard only. The in-sandbox
+//   agent invocation, OpenClaw argv contract, and streaming behaviour are owned
+//   by upstream OpenClaw. Terminal-runtime dispatch uses the manifest command
+//   only when it can be represented as simple whitespace-delimited argv tokens;
+//   shell quoting/escaping fails closed until the manifest exposes argv natively.
 //
 // - Source-fix constraint: NemoClaw cannot prove agent type from anywhere
 //   except the registry, because the OpenShell exec transport has no
@@ -23,13 +24,14 @@
 //   wrong binary on transient I/O errors.
 //
 // - Regression tests: `passthrough.test.ts` covers the Hermes redirect, the
-//   forwarded argv, the registry-miss fallback to OpenClaw, the registry-error
-//   fail-closed path, and the enforced `--no-tty` argv shape.
+//   forwarded argv, the registry-miss fallback to OpenClaw, registry and
+//   manifest-resolution fail-closed paths, quoted manifest command rejection,
+//   and the enforced `--no-tty` argv shape.
 //
 // - Removal condition: when OpenShell exposes a metadata endpoint that returns
 //   the sandbox's configured agent, drop the registry read and consult that
-//   endpoint directly. The fail-closed branch can then be retired in favour of
-//   the live source.
+//   endpoint directly. When terminal runtime manifests expose argv arrays, drop
+//   the simple-token parser and unsupported-shell-syntax rejection.
 
 import { isTerminalAgent, loadAgent, type AgentDefinition } from "../../../agent/defs";
 import * as registry from "../../../state/registry";
@@ -61,6 +63,9 @@ type RegistryReadResult =
   | { kind: "agent"; agent: string | null }
   | { kind: "error"; message: string };
 type ResolvedRegistryReadResult = Exclude<RegistryReadResult, { kind: "error" }>;
+type TerminalCommandResult =
+  | { kind: "command"; argv: string[] }
+  | { kind: "unsupported"; message: string };
 
 function readSandboxAgentFromRegistry(
   sandboxName: string,
@@ -91,14 +96,36 @@ function rejectNonOpenclawAgent(
   return proc.exit(2);
 }
 
-function splitManifestCommand(command: string): string[] {
-  return command.trim().split(/\s+/).filter(Boolean);
+function rejectAgentResolutionError(
+  sandboxName: string,
+  agent: string,
+  message: string,
+  proc: NonNullable<AgentPassthroughDeps["process"]>,
+): never {
+  proc.stderr.write(
+    `  Could not resolve a passthrough command for registered agent '${agent}' in sandbox '${sandboxName}'.\n`,
+  );
+  proc.stderr.write(`  Agent resolution error: ${message}\n`);
+  proc.stderr.write("  Refusing to dispatch because the sandbox agent guard cannot fail closed.\n");
+  return proc.exit(2);
 }
 
-function getTerminalInteractiveCommand(agent: AgentDefinition): string[] | null {
+function splitManifestCommand(command: string): TerminalCommandResult {
+  const trimmed = command.trim();
+  if (!trimmed) return { kind: "command", argv: [] };
+  if (/["'\\]/.test(trimmed)) {
+    return {
+      kind: "unsupported",
+      message:
+        "terminal runtime commands must be simple whitespace-delimited argv tokens; quoted or escaped shell syntax is not supported",
+    };
+  }
+  return { kind: "command", argv: trimmed.split(/\s+/).filter(Boolean) };
+}
+
+function getTerminalInteractiveCommand(agent: AgentDefinition): TerminalCommandResult {
   const command = agent.runtime?.interactive_command ?? agent.runtime?.headless_command ?? "";
-  const argv = splitManifestCommand(command);
-  return argv.length > 0 ? argv : null;
+  return splitManifestCommand(command);
 }
 
 function getPassthroughCommand(
@@ -124,16 +151,24 @@ function getPassthroughCommand(
     return ["openclaw", "agent", ...extraArgs];
   }
 
-  const agent = loadAgent(agentName);
+  let agent: AgentDefinition;
+  try {
+    agent = loadAgent(agentName);
+  } catch (error) {
+    rejectAgentResolutionError(sandboxName, agentName, (error as Error).message, proc);
+  }
   if (!isTerminalAgent(agent)) {
     rejectNonOpenclawAgent(sandboxName, agentName, proc);
   }
 
   const terminalCommand = getTerminalInteractiveCommand(agent);
-  if (!terminalCommand) {
+  if (terminalCommand.kind === "unsupported") {
+    rejectAgentResolutionError(sandboxName, agentName, terminalCommand.message, proc);
+  }
+  if (terminalCommand.argv.length === 0) {
     rejectNonOpenclawAgent(sandboxName, agentName, proc);
   }
-  return [...terminalCommand, ...extraArgs];
+  return [...terminalCommand.argv, ...extraArgs];
 }
 
 function rejectRegistryReadError(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the `nemoclaw <name> agent` host wrapper so registered terminal-runtime sandboxes dispatch through their manifest command instead of being short-circuited by OpenClaw-only help handling. This lets LangChain Deep Agents Code sandboxes receive bare `dcode` and `dcode --help` invocations while preserving local wrapper help for OpenClaw fallback cases.

## Related Issue
Fixes #5790

## Changes
- Route terminal-runtime sandboxes through their manifest `interactive_command`/`headless_command` in `runAgentPassthrough`.
- Keep bare and help invocations local only for OpenClaw sandboxes or registry fallbacks.
- Update command parsing tests and passthrough tests for Deep Agents Code bare/help dispatch.
- Update the command reference and generated Hermes command reference wording for the broader agent wrapper behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review completed; the change remains registry-gated, keeps registry read errors fail-closed, preserves OpenClaw fallback behavior, and keeps Hermes rejected with API guidance.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification notes:
- `npx vitest run src/commands/sandbox/agent.test.ts src/lib/actions/sandbox/agent/passthrough.test.ts src/lib/actions/sandbox/agent/passthrough-help.test.ts --project cli` passed.
- `npm run typecheck:cli` passed.
- `npm run docs` completed with 0 errors and 2 pre-existing Fern warnings about an available Fern upgrade.
- Local `test-cli` hook failed in unrelated rlimit tests with `fork: Resource temporarily unavailable`; reproduced with `npx vitest run test/sandbox-init.test.ts test/sandbox-rlimit-hooks.test.ts --project cli`.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The sandbox agent command runs a single non-interactive “agent turn” and forwards agent flags to the in-sandbox target; Deep Agents Code sandboxes route to the configured terminal-runtime command, including `--help` forwarding.
* **Bug Fixes**
  * Corrected `--help` and bare invocation dispatch behavior.
  * Improved fail-closed validation and safer manifest command parsing; invalid quoted/escaped commands are refused with clearer Hermes HTTP API guidance.
* **Documentation**
  * Updated sandbox-agent reference and passthrough help wording and examples (including Hermes HTTP API notes).
* **Tests**
  * Expanded coverage for routing, guard semantics, exit codes, and help/forwarding parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->