### PR TITLE
test(cli): cover dcode status harness label

### DIFF
--- a/test/cli/sandbox-status-text.test.ts
+++ b/test/cli/sandbox-status-text.test.ts
@@ -126,6 +126,62 @@ describe("CLI sandbox status text output", () => {
     expect(r.out).not.toContain("OpenClaw: running");
   });
 
+  it("sandbox <name> status reports the Deep Agents Code terminal harness (#5718)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-dcode-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "dcode-station", {
+      agent: "langchain-deepagents-code",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      openshellDriver: "docker",
+      openshellVersion: "0.0.44",
+    });
+    writeHealthyDockerStub(localBin);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "dcode-station" ]; then',
+        "  echo 'Sandbox:'",
+        "  echo '  Name: dcode-station'",
+        "  echo '  Phase: Ready'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'Gateway inference:'",
+        "  echo '  Provider: nvidia-prod'",
+        "  echo '  Model: nvidia/nemotron-3-super-120b-a12b'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("dcode-station status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Harness:  LangChain Deep Agents Code (terminal)");
+    expect(r.out).toContain("Interactive: dcode");
+    expect(r.out).toContain('Headless: dcode -n "<prompt>"');
+    expect(r.out).toContain("LangChain Deep Agents Code runtime: terminal");
+    expect(r.out).not.toContain("Harness:  OpenClaw (gateway)");
+    expect(r.out).not.toContain("OpenClaw: running");
+  });
+
   it("sandbox <name> status preserves Inference probe and exits 0 when openshellDriver is not docker", () => {
     const home = fs.mkdtempSync(
       path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-non-docker-driver-"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds a regression test for the Deep Agents Code status harness label reported in #5718.
Current main already resolves a registered `langchain-deepagents-code` sandbox to `LangChain Deep Agents Code (terminal)`; this locks that user-facing status contract so it cannot regress to `OpenClaw (gateway)`.

## Related Issue
Fixes #5718

## Changes
- Add CLI status text coverage for a registered `langchain-deepagents-code` sandbox named `dcode-station`.
- Assert the exact harness line, dcode interactive/headless command hints, and terminal runtime line.
- Assert the status output does not fall back to `Harness: OpenClaw (gateway)` or `OpenClaw: running`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-only coverage for an existing documented status contract; docs already describe Deep Agents Code as a terminal harness and `status` as reporting the terminal runtime plus interactive/headless command shapes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: no sensitive production paths changed; this is CLI status regression coverage only.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification detail:
- `npx vitest run test/cli/sandbox-status-text.test.ts --project cli` passed (7 tests).
- `npm run typecheck:cli` passed.
- `SKIP=test-cli npx prek run --files test/cli/sandbox-status-text.test.ts` passed.
- Commit `da9df7334baf0c0d02dabdaf0ea89c4df3be8b06` is GitHub Verified (`reason: valid`).
- Docs writer pass found no docs changes needed.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for `sandbox <name> status` to verify the reported status output and successful exit behavior.
  * Confirmed the display includes terminal harness/runtime details and omits unrelated runtime lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->