### PR TITLE
fix(cli): warn on terminal runtime OOM degradation

### DIFF
--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -71,6 +71,7 @@ nemoclaw <sandbox-name> snapshot create --name before-change
 ```
 
 `status` reports the selected harness as a terminal runtime and prints the interactive/headless command shape.
+If `status` reports `Runtime health: degraded` with an OOM kill count, rebuild the sandbox to restore the terminal runtime.
 There is no dashboard port or long-running gateway process for this harness.
 
 ## Next Steps

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -517,7 +517,9 @@ The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `pr
 `failureLayer` is `null` when no preflight failure was detected and otherwise one of `docker_unreachable`, `sandbox_container_stopped`, or `sandbox_dashboard_port_conflict`; when set, `inferenceHealth` is suppressed to `null` so automation does not see a stale remote-provider healthy status during a local outage.
 `dockerPaused` is `true` when NemoClaw detects that the Docker-driver sandbox container is paused.
 In that case, text output keeps OpenShell's authoritative phase but prints a `docker unpause <container>` recovery hint instead of sending you directly to rebuild.
-The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), or `failureLayer` is non-null.
+For terminal runtime sandboxes, the command also checks cgroup OOM kill counters.
+If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `nemohermes <name> rebuild`.
+The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), `failureLayer` is non-null, or a terminal runtime sandbox reports a recorded OOM kill.
 The alias form `nemohermes <name> status --json` requires the sandbox to be registered locally; the canonical form `nemohermes sandbox status <name> --json` is the one to use from automation that may run against an unknown sandbox name, since it still emits a JSON document with `found: false` instead of a text error.
 
 ```bash

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -512,13 +512,13 @@ Older Hermes sandbox images that predate the standalone validator are detected a
 Show sandbox status, health, and inference configuration.
 
 Pass `--json` to emit a structured per-sandbox report instead of the text renderer.
-The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `policies`, `failureLayer`, and `dockerPaused`.
+The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `policies`, `failureLayer`, `terminalRuntimeHealth`, and `dockerPaused`.
 `openshellDriver` and `openshellVersion` are always strings (falling back to `"unknown"` when the registry has no value), so consumers can rely on `typeof` checks.
 `failureLayer` is `null` when no preflight failure was detected and otherwise one of `docker_unreachable`, `sandbox_container_stopped`, or `sandbox_dashboard_port_conflict`; when set, `inferenceHealth` is suppressed to `null` so automation does not see a stale remote-provider healthy status during a local outage.
 `dockerPaused` is `true` when NemoClaw detects that the Docker-driver sandbox container is paused.
 In that case, text output keeps OpenShell's authoritative phase but prints a `docker unpause <container>` recovery hint instead of sending you directly to rebuild.
 For terminal runtime sandboxes, the command also checks cgroup OOM kill counters.
-If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `nemohermes <name> rebuild`.
+If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `nemohermes <name> rebuild`; JSON output reports `terminalRuntimeHealth.kind: "degraded"` with the OOM kill count and source counter path.
 The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), `failureLayer` is non-null, or a terminal runtime sandbox reports a recorded OOM kill.
 The alias form `nemohermes <name> status --json` requires the sandbox to be registered locally; the canonical form `nemohermes sandbox status <name> --json` is the one to use from automation that may run against an unknown sandbox name, since it still emits a JSON document with `found: false` instead of a text error.
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -650,7 +650,9 @@ The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `pr
 `failureLayer` is `null` when no preflight failure was detected and otherwise one of `docker_unreachable`, `sandbox_container_stopped`, or `sandbox_dashboard_port_conflict`; when set, `inferenceHealth` is suppressed to `null` so automation does not see a stale remote-provider healthy status during a local outage.
 `dockerPaused` is `true` when NemoClaw detects that the Docker-driver sandbox container is paused.
 In that case, text output keeps OpenShell's authoritative phase but prints a `docker unpause <container>` recovery hint instead of sending you directly to rebuild.
-The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), or `failureLayer` is non-null.
+For terminal runtime sandboxes, the command also checks cgroup OOM kill counters.
+If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `$$nemoclaw <name> rebuild`.
+The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), `failureLayer` is non-null, or a terminal runtime sandbox reports a recorded OOM kill.
 The alias form `$$nemoclaw <name> status --json` requires the sandbox to be registered locally; the canonical form `$$nemoclaw sandbox status <name> --json` is the one to use from automation that may run against an unknown sandbox name, since it still emits a JSON document with `found: false` instead of a text error.
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -645,13 +645,13 @@ Older Hermes sandbox images that predate the standalone validator are detected a
 Show sandbox status, health, and inference configuration.
 
 Pass `--json` to emit a structured per-sandbox report instead of the text renderer.
-The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `policies`, `failureLayer`, and `dockerPaused`.
+The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `provider`, `phase`, `gatewayState`, `inferenceHealth`, `rpcIssue`, `hostGpuDetected`, `sandboxGpuEnabled`, `sandboxGpuMode`, `sandboxGpuDevice`, `openshellDriver`, `openshellVersion`, `policies`, `failureLayer`, `terminalRuntimeHealth`, and `dockerPaused`.
 `openshellDriver` and `openshellVersion` are always strings (falling back to `"unknown"` when the registry has no value), so consumers can rely on `typeof` checks.
 `failureLayer` is `null` when no preflight failure was detected and otherwise one of `docker_unreachable`, `sandbox_container_stopped`, or `sandbox_dashboard_port_conflict`; when set, `inferenceHealth` is suppressed to `null` so automation does not see a stale remote-provider healthy status during a local outage.
 `dockerPaused` is `true` when NemoClaw detects that the Docker-driver sandbox container is paused.
 In that case, text output keeps OpenShell's authoritative phase but prints a `docker unpause <container>` recovery hint instead of sending you directly to rebuild.
 For terminal runtime sandboxes, the command also checks cgroup OOM kill counters.
-If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `$$nemoclaw <name> rebuild`.
+If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `$$nemoclaw <name> rebuild`; JSON output reports `terminalRuntimeHealth.kind: "degraded"` with the OOM kill count and source counter path.
 The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), `failureLayer` is non-null, or a terminal runtime sandbox reports a recorded OOM kill.
 The alias form `$$nemoclaw <name> status --json` requires the sandbox to be registered locally; the canonical form `$$nemoclaw sandbox status <name> --json` is the one to use from automation that may run against an unknown sandbox name, since it still emits a JSON document with `found: false` instead of a text error.
 

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -1,9 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
-
 import { getSandboxStatusReport, showSandboxStatus } from "../../lib/actions/sandbox/status";
+import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 import { sandboxNameArg } from "../../lib/sandbox/command-support";
 import { redactForLog } from "../../lib/security/redact";
 
@@ -31,7 +30,8 @@ export default class SandboxStatusCommand extends NemoClawCommand {
         !report.found ||
         report.gatewayState !== "present" ||
         report.rpcIssue ||
-        report.failureLayer
+        report.failureLayer ||
+        report.terminalRuntimeHealth?.kind === "degraded"
       ) {
         process.exitCode = 1;
       }

--- a/src/lib/actions/sandbox/status-snapshot.ts
+++ b/src/lib/actions/sandbox/status-snapshot.ts
@@ -25,6 +25,10 @@ import {
   type SandboxStatusFailureLayer,
   withoutTerminalPhasePreflight,
 } from "./status-preflight";
+import {
+  probeTerminalRuntimeCgroupOom,
+  type TerminalRuntimeOomProbeResult,
+} from "./terminal-runtime-health";
 
 type ProbeProviderHealth = (
   provider: string,
@@ -91,6 +95,7 @@ export interface SandboxStatusReport {
   openshellVersion: string;
   policies: string[];
   failureLayer: SandboxStatusFailureLayer | null;
+  terminalRuntimeHealth: TerminalRuntimeOomProbeResult | null;
   /**
    * Whether the resolved docker-driver sandbox container is paused
    * (`docker pause`). `false` for non-docker-driver sandboxes or when no
@@ -107,6 +112,7 @@ export interface SandboxStatusSnapshot {
   currentModel: string;
   currentProvider: string;
   inferenceHealth: ProviderHealthStatus | null;
+  terminalRuntimeHealth: TerminalRuntimeOomProbeResult | null;
 }
 
 export interface SandboxStatusAgentInfo {
@@ -143,10 +149,12 @@ export function resolveSandboxStatusAgent(agentName = "openclaw"): SandboxStatus
 }
 
 type ReconcileSandboxGatewayState = (sandboxName: string) => Promise<SandboxGatewayState>;
+type ProbeTerminalRuntimeHealth = (sandboxName: string) => TerminalRuntimeOomProbeResult;
 
 interface CollectSandboxStatusSnapshotDeps {
   getSandbox?: typeof registry.getSandbox;
   probeProviderHealthImpl?: ProbeProviderHealth;
+  probeTerminalRuntimeHealth?: ProbeTerminalRuntimeHealth;
   reconcile?: ReconcileSandboxGatewayState;
 }
 
@@ -192,6 +200,7 @@ export async function collectSandboxStatusSnapshot(
       currentModel: "unknown",
       currentProvider: "unknown",
       inferenceHealth: null,
+      terminalRuntimeHealth: null,
     };
   }
   const live =
@@ -230,7 +239,20 @@ export async function collectSandboxStatusSnapshot(
       inferenceHealth.subprobes = [...(inferenceHealth.subprobes ?? []), gatewaySubprobe];
     }
   }
-  return { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth };
+  const statusAgent = resolveSandboxStatusAgent(sb?.agent || "openclaw");
+  const terminalRuntimeHealth =
+    lookup.state === "present" && statusAgent.agentRuntime === "terminal"
+      ? (opts.deps?.probeTerminalRuntimeHealth ?? probeTerminalRuntimeCgroupOom)(sandboxName)
+      : null;
+  return {
+    sb,
+    lookup,
+    rpcIssue,
+    currentModel,
+    currentProvider,
+    inferenceHealth,
+    terminalRuntimeHealth,
+  };
 }
 
 export async function getSandboxStatusReport(
@@ -255,7 +277,15 @@ async function buildSandboxStatusReport(
     suppressInferenceProbe: preflight.suppressInferenceProbe,
     deps,
   });
-  const { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth } = snapshot;
+  const {
+    sb,
+    lookup,
+    rpcIssue,
+    currentModel,
+    currentProvider,
+    inferenceHealth,
+    terminalRuntimeHealth,
+  } = snapshot;
   const dockerRuntime = lookup.state === "present" ? getSandboxDockerRuntime(sandboxName) : null;
   const phase = lookup.state === "present" ? parseSandboxPhase(lookup.output || "") : null;
   const effectivePreflight = withoutTerminalPhasePreflight(preflight, phase);
@@ -288,6 +318,7 @@ async function buildSandboxStatusReport(
     openshellVersion: (sb && sb.openshellVersion) || "unknown",
     policies,
     failureLayer: effectivePreflight.failureLayer,
+    terminalRuntimeHealth,
     dockerPaused: !!dockerRuntime?.paused,
   };
 }

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -27,6 +27,7 @@ import {
   withoutTerminalPhasePreflight,
 } from "./status-preflight";
 import { collectSandboxStatusSnapshot, resolveSandboxStatusAgent } from "./status-snapshot";
+import { probeTerminalRuntimeCgroupOom } from "./terminal-runtime-health";
 
 export {
   type ClassifySandboxStatusPreflightFailureDeps,
@@ -211,6 +212,19 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
       if (interactiveCommand) console.log(`    Interactive: ${interactiveCommand}`);
       if (headlessCommand) console.log(`    Headless: ${headlessCommand} "<prompt>"`);
       console.log("    Updates: managed by NemoClaw image rebuilds");
+      if (lookup.state === "present") {
+        const terminalHealth = probeTerminalRuntimeCgroupOom(sandboxName);
+        if (terminalHealth.kind === "degraded") {
+          process.exitCode = process.exitCode && process.exitCode !== 0 ? process.exitCode : 1;
+          const countLabel =
+            terminalHealth.oomKillCount === 1
+              ? "1 OOM kill"
+              : `${terminalHealth.oomKillCount} OOM kills`;
+          console.log(`    Runtime health: ${YW}degraded${R} (${countLabel} recorded)`);
+          console.log("      Sandbox may be degraded after an OOM kill.");
+          console.log(`      Run \`${CLI_NAME} ${sandboxName} rebuild\` to restore.`);
+        }
+      }
     }
 
     // Active session indicator

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -27,7 +27,6 @@ import {
   withoutTerminalPhasePreflight,
 } from "./status-preflight";
 import { collectSandboxStatusSnapshot, resolveSandboxStatusAgent } from "./status-snapshot";
-import { probeTerminalRuntimeCgroupOom } from "./terminal-runtime-health";
 
 export {
   type ClassifySandboxStatusPreflightFailureDeps,
@@ -136,7 +135,15 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
   const snapshot = await collectSandboxStatusSnapshot(sandboxName, {
     suppressInferenceProbe: preflight.suppressInferenceProbe,
   });
-  const { sb, lookup, rpcIssue, currentModel, currentProvider, inferenceHealth } = snapshot;
+  const {
+    sb,
+    lookup,
+    rpcIssue,
+    currentModel,
+    currentProvider,
+    inferenceHealth,
+    terminalRuntimeHealth,
+  } = snapshot;
   // Resolve the docker-driver container once: reused for the paused-container
   // recovery hint (#4495) and the Docker health line below (#3975).
   const dockerRuntime = lookup.state === "present" ? getSandboxDockerRuntime(sandboxName) : null;
@@ -213,13 +220,12 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
       if (headlessCommand) console.log(`    Headless: ${headlessCommand} "<prompt>"`);
       console.log("    Updates: managed by NemoClaw image rebuilds");
       if (lookup.state === "present") {
-        const terminalHealth = probeTerminalRuntimeCgroupOom(sandboxName);
-        if (terminalHealth.kind === "degraded") {
+        if (terminalRuntimeHealth?.kind === "degraded") {
           process.exitCode = process.exitCode && process.exitCode !== 0 ? process.exitCode : 1;
           const countLabel =
-            terminalHealth.oomKillCount === 1
+            terminalRuntimeHealth.oomKillCount === 1
               ? "1 OOM kill"
-              : `${terminalHealth.oomKillCount} OOM kills`;
+              : `${terminalRuntimeHealth.oomKillCount} OOM kills`;
           console.log(`    Runtime health: ${YW}degraded${R} (${countLabel} recorded)`);
           console.log("      Sandbox may be degraded after an OOM kill.");
           console.log(`      Run \`${CLI_NAME} ${sandboxName} rebuild\` to restore.`);

--- a/src/lib/actions/sandbox/terminal-runtime-health.test.ts
+++ b/src/lib/actions/sandbox/terminal-runtime-health.test.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseTerminalRuntimeOomProbeOutput,
+  probeTerminalRuntimeCgroupOom,
+} from "./terminal-runtime-health";
+
+describe("parseTerminalRuntimeOomProbeOutput", () => {
+  it("classifies zero cgroup OOM kills as healthy", () => {
+    expect(
+      parseTerminalRuntimeOomProbeOutput("oom_kill=0\nsource=/sys/fs/cgroup/memory.events.local\n"),
+    ).toEqual({
+      kind: "ok",
+      oomKillCount: 0,
+      source: "/sys/fs/cgroup/memory.events.local",
+    });
+  });
+
+  it("classifies non-zero cgroup OOM kills as degraded", () => {
+    expect(
+      parseTerminalRuntimeOomProbeOutput("oom_kill=2\nsource=/sys/fs/cgroup/memory.events\n"),
+    ).toEqual({
+      kind: "degraded",
+      oomKillCount: 2,
+      source: "/sys/fs/cgroup/memory.events",
+    });
+  });
+
+  it("returns unavailable when the probe output is missing the counter", () => {
+    expect(parseTerminalRuntimeOomProbeOutput("")).toEqual({
+      kind: "unavailable",
+      detail: "missing oom_kill counter",
+    });
+  });
+});
+
+describe("probeTerminalRuntimeCgroupOom", () => {
+  it("checks cgroup OOM counters through a bounded sandbox exec", () => {
+    const calls: Array<{ args: readonly string[]; binary: string }> = [];
+    const run = vi.fn((binary: string, args: readonly string[]) => {
+      calls.push({ args, binary });
+      return {
+        status: 0,
+        stdout: "oom_kill=1\nsource=/sys/fs/cgroup/memory.events\n",
+        stderr: "",
+      };
+    });
+
+    const result = probeTerminalRuntimeCgroupOom("alpha", {
+      openshellBinary: "/usr/bin/openshell",
+      run,
+    });
+
+    expect(result).toEqual({
+      kind: "degraded",
+      oomKillCount: 1,
+      source: "/sys/fs/cgroup/memory.events",
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+    const firstCall = calls[0];
+    expect(firstCall).toBeDefined();
+    const { args, binary } = firstCall as { args: readonly string[]; binary: string };
+    expect(binary).toBe("/usr/bin/openshell");
+    expect(args).toEqual(
+      expect.arrayContaining(["sandbox", "exec", "--name", "alpha", "--no-tty", "--timeout", "5"]),
+    );
+    const separator = args.indexOf("--");
+    expect(args.slice(separator + 1, separator + 3)).toEqual(["sh", "-lc"]);
+    expect(args[separator + 3]).toContain("/sys/fs/cgroup/memory.events");
+    expect(args[separator + 3]).toContain("oom_kill");
+  });
+
+  it("treats sandbox exec failures as unavailable", () => {
+    const result = probeTerminalRuntimeCgroupOom("alpha", {
+      openshellBinary: "/usr/bin/openshell",
+      run: () => ({ status: 2, stdout: "", stderr: "no cgroup file" }),
+    });
+
+    expect(result).toEqual({ kind: "unavailable", detail: "no cgroup file" });
+  });
+});

--- a/src/lib/actions/sandbox/terminal-runtime-health.test.ts
+++ b/src/lib/actions/sandbox/terminal-runtime-health.test.ts
@@ -35,6 +35,13 @@ describe("parseTerminalRuntimeOomProbeOutput", () => {
       detail: "missing oom_kill counter",
     });
   });
+
+  it("returns unavailable when the probe output contains an invalid counter", () => {
+    expect(parseTerminalRuntimeOomProbeOutput("oom_kill=bogus\n")).toEqual({
+      kind: "unavailable",
+      detail: "invalid oom_kill counter",
+    });
+  });
 });
 
 describe("probeTerminalRuntimeCgroupOom", () => {
@@ -70,6 +77,8 @@ describe("probeTerminalRuntimeCgroupOom", () => {
     const separator = args.indexOf("--");
     expect(args.slice(separator + 1, separator + 3)).toEqual(["sh", "-lc"]);
     expect(args[separator + 3]).toContain("/sys/fs/cgroup/memory.events");
+    expect(args[separator + 3]).toContain("/sys/fs/cgroup/memory.oom_control");
+    expect(args[separator + 3]).toContain("/sys/fs/cgroup/memory/memory.oom_control");
     expect(args[separator + 3]).toContain("oom_kill");
   });
 

--- a/src/lib/actions/sandbox/terminal-runtime-health.ts
+++ b/src/lib/actions/sandbox/terminal-runtime-health.ts
@@ -7,13 +7,26 @@ import { resolveOpenshell } from "../../adapters/openshell/resolve";
 import { buildOpenshellExecArgs } from "./exec";
 
 const CGROUP_OOM_PROBE_SCRIPT = [
-  "for f in /sys/fs/cgroup/memory.events.local /sys/fs/cgroup/memory.events; do",
-  '  if [ -r "$f" ]; then',
-  '    value="$(awk \'$1 == "oom_kill" { print $2; exit }\' "$f" 2>/dev/null || true)"',
-  '    case "$value" in ""|*[!0-9]*) value=0 ;; esac',
-  '    printf "oom_kill=%s\\nsource=%s\\n" "$value" "$f"',
-  "    exit 0",
+  "probe_cgroup_file() {",
+  '  file="$1"',
+  '  key="$2"',
+  '  if [ ! -r "$file" ]; then',
+  "    return 1",
   "  fi",
+  "  while IFS=' ' read -r current value _rest; do",
+  '    if [ "$current" = "$key" ]; then',
+  '      case "$value" in ""|*[!0-9]*) exit 3 ;; esac',
+  '      printf "oom_kill=%s\\nsource=%s\\n" "$value" "$file"',
+  "      exit 0",
+  "    fi",
+  '  done < "$file"',
+  "  exit 3",
+  "}",
+  "for f in /sys/fs/cgroup/memory.events.local /sys/fs/cgroup/memory.events; do",
+  '  probe_cgroup_file "$f" oom_kill',
+  "done",
+  "for f in /sys/fs/cgroup/memory.oom_control /sys/fs/cgroup/memory/memory.oom_control; do",
+  '  probe_cgroup_file "$f" oom_kill',
   "done",
   "exit 2",
 ].join("\n");
@@ -37,8 +50,11 @@ export function parseTerminalRuntimeOomProbeOutput(
   stdout: string | Buffer | undefined,
 ): TerminalRuntimeOomProbeResult {
   const text = Buffer.isBuffer(stdout) ? stdout.toString("utf8") : (stdout ?? "");
-  const countMatch = text.match(/^oom_kill=(\d+)$/m);
+  const countMatch = text.match(/^oom_kill=([^\n]+)$/m);
   if (!countMatch) return { kind: "unavailable", detail: "missing oom_kill counter" };
+  if (!/^\d+$/.test(countMatch[1])) {
+    return { kind: "unavailable", detail: "invalid oom_kill counter" };
+  }
   const oomKillCount = Number(countMatch[1]);
   const source = text.match(/^source=(.+)$/m)?.[1];
   if (!Number.isFinite(oomKillCount)) {

--- a/src/lib/actions/sandbox/terminal-runtime-health.ts
+++ b/src/lib/actions/sandbox/terminal-runtime-health.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+
+import { resolveOpenshell } from "../../adapters/openshell/resolve";
+import { buildOpenshellExecArgs } from "./exec";
+
+const CGROUP_OOM_PROBE_SCRIPT = [
+  "for f in /sys/fs/cgroup/memory.events.local /sys/fs/cgroup/memory.events; do",
+  '  if [ -r "$f" ]; then',
+  '    value="$(awk \'$1 == "oom_kill" { print $2; exit }\' "$f" 2>/dev/null || true)"',
+  '    case "$value" in ""|*[!0-9]*) value=0 ;; esac',
+  '    printf "oom_kill=%s\\nsource=%s\\n" "$value" "$f"',
+  "    exit 0",
+  "  fi",
+  "done",
+  "exit 2",
+].join("\n");
+
+export type TerminalRuntimeOomProbeResult =
+  | { kind: "ok"; oomKillCount: 0; source?: string }
+  | { kind: "degraded"; oomKillCount: number; source?: string }
+  | { kind: "unavailable"; detail?: string };
+
+export type TerminalRuntimeOomProbeRunner = (
+  binary: string,
+  args: readonly string[],
+) => {
+  status: number | null;
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+  error?: Error;
+};
+
+export function parseTerminalRuntimeOomProbeOutput(
+  stdout: string | Buffer | undefined,
+): TerminalRuntimeOomProbeResult {
+  const text = Buffer.isBuffer(stdout) ? stdout.toString("utf8") : (stdout ?? "");
+  const countMatch = text.match(/^oom_kill=(\d+)$/m);
+  if (!countMatch) return { kind: "unavailable", detail: "missing oom_kill counter" };
+  const oomKillCount = Number(countMatch[1]);
+  const source = text.match(/^source=(.+)$/m)?.[1];
+  if (!Number.isFinite(oomKillCount)) {
+    return { kind: "unavailable", detail: "invalid oom_kill counter" };
+  }
+  if (oomKillCount > 0) return { kind: "degraded", oomKillCount, source };
+  return { kind: "ok", oomKillCount: 0, source };
+}
+
+export function probeTerminalRuntimeCgroupOom(
+  sandboxName: string,
+  options: {
+    openshellBinary?: string | null;
+    run?: TerminalRuntimeOomProbeRunner;
+  } = {},
+): TerminalRuntimeOomProbeResult {
+  const binary = options.openshellBinary ?? resolveOpenshell();
+  if (!binary) return { kind: "unavailable", detail: "openshell not found" };
+
+  const run =
+    options.run ??
+    ((cmd, args) =>
+      spawnSync(cmd, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }));
+  const result = run(
+    binary,
+    buildOpenshellExecArgs(sandboxName, ["sh", "-lc", CGROUP_OOM_PROBE_SCRIPT], {
+      timeoutSeconds: 5,
+      tty: false,
+    }),
+  );
+  if (result.error) return { kind: "unavailable", detail: result.error.message };
+  if (result.status !== 0) {
+    const stderr = Buffer.isBuffer(result.stderr)
+      ? result.stderr.toString("utf8")
+      : (result.stderr ?? "");
+    return { kind: "unavailable", detail: stderr.trim() || `exit ${String(result.status)}` };
+  }
+  return parseTerminalRuntimeOomProbeOutput(result.stdout);
+}

--- a/test/cli/sandbox-status-json.test.ts
+++ b/test/cli/sandbox-status-json.test.ts
@@ -1,13 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-import { runWithEnv, testTimeoutOptions, writeSandboxRegistry } from "./helpers";
+import {
+  runWithEnv,
+  testTimeoutOptions,
+  writeHealthyDockerStub,
+  writeSandboxRegistry,
+} from "./helpers";
 
 describe("CLI sandbox status JSON output", testTimeoutOptions(20_000), () => {
   it("sandbox status --json emits structured per-sandbox report", () => {
@@ -379,6 +384,68 @@ describe("CLI sandbox status JSON output", testTimeoutOptions(20_000), () => {
     expect(parsed.failureLayer).toBe("sandbox_container_stopped");
     expect(parsed.phase).toBe("Error");
     expect(parsed.inferenceHealth).toBeNull();
+  });
+
+  it("sandbox status --json reports terminal runtime OOM degradation and exits 1 (#5796)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-status-json-dcode-oom-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha", {
+      agent: "langchain-deepagents-code",
+      provider: "openai-api",
+      model: "gpt-4o-mini",
+      openshellDriver: "docker",
+    });
+    writeHealthyDockerStub(localBin);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+        "  echo 'Sandbox:'",
+        "  echo '  Name: alpha'",
+        "  echo '  Phase: Ready'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ]; then',
+        "  echo 'oom_kill=3'",
+        "  echo 'source=/sys/fs/cgroup/memory.oom_control'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'Gateway inference:'",
+        "  echo '  Provider: openai-api'",
+        "  echo '  Model: gpt-4o-mini'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("alpha status --json", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    const parsed = JSON.parse(r.out);
+    expect(parsed.phase).toBe("Ready");
+    expect(parsed.agentRuntime).toBe("terminal");
+    expect(parsed.terminalRuntimeHealth).toEqual({
+      kind: "degraded",
+      oomKillCount: 3,
+      source: "/sys/fs/cgroup/memory.oom_control",
+    });
   });
 
   it("sandbox status --json sets failureLayer=sandbox_dashboard_port_conflict when the dashboard port is held by a foreign listener", async () => {

--- a/test/cli/sandbox-status-text.test.ts
+++ b/test/cli/sandbox-status-text.test.ts
@@ -126,6 +126,67 @@ describe("CLI sandbox status text output", () => {
     expect(r.out).not.toContain("OpenClaw: running");
   });
 
+  it("sandbox <name> status warns when a terminal runtime cgroup records an OOM kill (#5796)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-status-dcode-oom-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha", {
+      agent: "langchain-deepagents-code",
+      provider: "openai-api",
+      model: "gpt-4o-mini",
+      openshellDriver: "docker",
+    });
+    writeHealthyDockerStub(localBin);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && [ "$3" = "alpha" ]; then',
+        "  echo 'Sandbox:'",
+        "  echo '  Name: alpha'",
+        "  echo '  Phase: Ready'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ]; then',
+        "  echo 'oom_kill=1'",
+        "  echo 'source=/sys/fs/cgroup/memory.events'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'Gateway inference:'",
+        "  echo '  Provider: openai-api'",
+        "  echo '  Model: gpt-4o-mini'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("alpha status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Phase: Ready");
+    expect(r.out).toContain("Harness:  LangChain Deep Agents Code (terminal)");
+    expect(r.out).toContain("Runtime health:");
+    expect(r.out).toContain("degraded");
+    expect(r.out).toContain("1 OOM kill recorded");
+    expect(r.out).toContain("Sandbox may be degraded after an OOM kill.");
+    expect(r.out).toContain("Run `nemoclaw alpha rebuild` to restore.");
+  });
+
   it("sandbox <name> status preserves Inference probe and exits 0 when openshellDriver is not docker", () => {
     const home = fs.mkdtempSync(
       path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-non-docker-driver-"),


### PR DESCRIPTION
## Summary
Adds a terminal-runtime health probe to `nemoclaw status` so LangChain Deep Agents Code sandboxes that have recorded cgroup OOM kills are reported as degraded with a rebuild hint.
The OpenShell phase remains authoritative, but status now exits non-zero when the OOM counter indicates the runtime may be unusable.

## Related Issue
Fixes #5796

## Changes
- Added a bounded OpenShell `sandbox exec` probe for terminal runtime cgroup `memory.events(.local)` OOM kill counters.
- Updated text status output to print `Runtime health: degraded` and `nemoclaw <name> rebuild` guidance when OOM kills are recorded.
- Added parser/unit coverage plus a CLI regression test for the dcode OOM status path.
- Updated command reference and dcode quickstart troubleshooting docs.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; probe is read-only, bounded to 5s, unavailable probes do not fail status, and only non-zero OOM counters change exit status.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes — commit/push hooks passed with `SKIP=test-cli`; targeted CLI tests and typecheck below passed.
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only) — not run; local full CLI shard has unrelated rlimit/fork resource failures in sandbox rlimit tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed; Fern reported 2 warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification run:
- `npx vitest run src/lib/actions/sandbox/terminal-runtime-health.test.ts --project cli`
- `npx vitest run test/cli/sandbox-status-text.test.ts --project cli`
- `npx vitest run src/lib/actions/sandbox/terminal-runtime-health.test.ts test/cli/sandbox-status-text.test.ts --project cli`
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run docs`
- `SKIP=test-cli npx prek run --files src/lib/actions/sandbox/terminal-runtime-health.ts src/lib/actions/sandbox/terminal-runtime-health.test.ts src/lib/actions/sandbox/status.ts test/cli/sandbox-status-text.test.ts docs/reference/commands.mdx docs/reference/commands-nemohermes.mdx docs/get-started/quickstart-langchain-deepagents-code.mdx`

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `status` now detects terminal-runtime cgroup OOM kills and marks the sandbox as degraded.
  * Added OOM-kill awareness to `status` non-zero exit behavior for faster surfacing of unhealthy sandboxes.
  * When degraded, the CLI now reports the OOM details and prompts rebuilding the sandbox to restore the terminal runtime.
* **Documentation**
  * Updated `status` and quickstart troubleshooting docs to explain the new degraded-runtime behavior and recovery step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->