### PR TITLE
fix(backup-all): catch orphan-manifest errors without swallowing real failures

### DIFF
--- a/src/lib/actions/maintenance.test.ts
+++ b/src/lib/actions/maintenance.test.ts
@@ -163,4 +163,27 @@ describe("backupAll", () => {
 
     await expect(backupAll()).rejects.toThrow(/Agent 'phantom' not found/);
   });
+
+  it("re-throws an Agent-not-found message whose path does not end in manifest.yaml", async () => {
+    // The matcher is anchored to the manifest file path loadAgent() emits
+    // (`path.join(AGENTS_DIR, name, "manifest.yaml")` at
+    // src/lib/agent/defs.ts:367). A future error that wraps `Agent '...' not
+    // found:` with a different artifact path (e.g. a binary, config, or
+    // registry entry) must keep aborting the batch instead of being treated
+    // as an orphan manifest.
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }],
+      defaultSandbox: null,
+    });
+    mocks.parseReadySandboxNames.mockReturnValue(new Set(["sb-bad"]));
+    mocks.captureSandboxListWithGatewayRecovery.mockResolvedValue({
+      result: { status: 0, output: "sb-bad\n" },
+    });
+
+    mocks.backupSandboxState.mockImplementation(() => {
+      throw new Error("Agent 'phantom' not found: /agents/phantom/binary");
+    });
+
+    await expect(backupAll()).rejects.toThrow(/binary/);
+  });
 });

--- a/src/lib/actions/maintenance.test.ts
+++ b/src/lib/actions/maintenance.test.ts
@@ -106,7 +106,7 @@ describe("backupAll", () => {
     });
 
     mocks.backupSandboxState.mockImplementation(() => {
-      throw new Error("Agent 'orphan' not found");
+      throw new Error("Agent 'orphan' not found: /agents/orphan/manifest.yaml");
     });
 
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -140,5 +140,27 @@ describe("backupAll", () => {
     });
 
     await expect(backupAll()).rejects.toThrow(/EACCES/);
+  });
+
+  it("re-throws an Agent-not-found message without the `: manifest.yaml` suffix (loadAgent contract)", async () => {
+    // The orphan-manifest matcher is anchored to the exact loadAgent() shape
+    // `Agent '<name>' not found: <manifestPath>`. A bare `Agent '...' not found`
+    // could plausibly surface from a different layer (registry lookup, manifest
+    // index, future code) and should still abort the batch instead of being
+    // silently skipped as if it were a missing manifest file.
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }],
+      defaultSandbox: null,
+    });
+    mocks.parseReadySandboxNames.mockReturnValue(new Set(["sb-bad"]));
+    mocks.captureSandboxListWithGatewayRecovery.mockResolvedValue({
+      result: { status: 0, output: "sb-bad\n" },
+    });
+
+    mocks.backupSandboxState.mockImplementation(() => {
+      throw new Error("Agent 'phantom' not found");
+    });
+
+    await expect(backupAll()).rejects.toThrow(/Agent 'phantom' not found/);
   });
 });

--- a/src/lib/actions/maintenance.test.ts
+++ b/src/lib/actions/maintenance.test.ts
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listSandboxes: vi.fn(),
+  backupSandboxState: vi.fn(),
+  detectOpenShellStateRpcPreflightIssue: vi.fn().mockReturnValue(null),
+  detectOpenShellStateRpcResultIssue: vi.fn().mockReturnValue(null),
+  printOpenShellStateRpcIssue: vi.fn(),
+  captureSandboxListWithGatewayRecovery: vi.fn(),
+  printSandboxListFailureWithRecoveryContext: vi.fn(),
+  parseReadySandboxNames: vi.fn(),
+  dockerListImagesFormat: vi.fn().mockReturnValue(""),
+  dockerRmi: vi.fn(),
+  prompt: vi.fn(),
+}));
+
+vi.mock("../state/registry", () => ({
+  listSandboxes: mocks.listSandboxes,
+}));
+vi.mock("../state/sandbox", () => ({
+  backupSandboxState: mocks.backupSandboxState,
+  BackupResult: {},
+}));
+vi.mock("../adapters/openshell/gateway-drift", () => ({
+  detectOpenShellStateRpcPreflightIssue: mocks.detectOpenShellStateRpcPreflightIssue,
+  detectOpenShellStateRpcResultIssue: mocks.detectOpenShellStateRpcResultIssue,
+  printOpenShellStateRpcIssue: mocks.printOpenShellStateRpcIssue,
+}));
+vi.mock("../openshell-sandbox-list", () => ({
+  captureSandboxListWithGatewayRecovery: mocks.captureSandboxListWithGatewayRecovery,
+  printSandboxListFailureWithRecoveryContext: mocks.printSandboxListFailureWithRecoveryContext,
+}));
+vi.mock("../runtime-recovery", () => ({
+  parseReadySandboxNames: mocks.parseReadySandboxNames,
+}));
+vi.mock("../adapters/docker", () => ({
+  dockerListImagesFormat: mocks.dockerListImagesFormat,
+  dockerRmi: mocks.dockerRmi,
+}));
+vi.mock("../cli/branding", () => ({
+  CLI_NAME: "nemoclaw",
+}));
+vi.mock("../credentials/store", () => ({
+  prompt: mocks.prompt,
+}));
+vi.mock("../domain/lifecycle/options", () => ({
+  normalizeGarbageCollectImagesOptions: (o: unknown) => o || {},
+}));
+vi.mock("../domain/maintenance/images", () => ({
+  findOrphanedSandboxImages: vi.fn().mockReturnValue([]),
+  parseSandboxImageRows: vi.fn().mockReturnValue([]),
+}));
+
+import { backupAll } from "./maintenance";
+
+describe("backupAll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.captureSandboxListWithGatewayRecovery.mockResolvedValue({
+      result: { status: 0, output: "sb-good\nsb-bad\n" },
+    });
+    mocks.parseReadySandboxNames.mockReturnValue(new Set(["sb-good", "sb-bad"]));
+  });
+
+  it("continues backup loop when backupSandboxState throws for one sandbox", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }, { name: "sb-good" }],
+      defaultSandbox: null,
+    });
+
+    // First sandbox throws (simulating missing agent manifest)
+    mocks.backupSandboxState.mockImplementationOnce(() => {
+      throw new Error("Agent 'unknown-agent' not found: /path/to/manifest.yaml");
+    });
+
+    // Second sandbox succeeds
+    mocks.backupSandboxState.mockImplementationOnce(() => ({
+      success: true,
+      backedUpDirs: ["dir1"],
+      failedDirs: [],
+      backedUpFiles: [],
+      failedFiles: [],
+      manifest: { backupPath: "/backups/sb-good/timestamp" },
+    }));
+
+    // Should not throw — the loop should catch and continue
+    await backupAll();
+
+    // Both sandboxes should have been attempted
+    expect(mocks.backupSandboxState).toHaveBeenCalledTimes(2);
+    expect(mocks.backupSandboxState).toHaveBeenCalledWith("sb-bad");
+    expect(mocks.backupSandboxState).toHaveBeenCalledWith("sb-good");
+  });
+
+  it("counts thrown sandboxes as skipped, not failed", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }],
+      defaultSandbox: null,
+    });
+    mocks.parseReadySandboxNames.mockReturnValue(new Set(["sb-bad"]));
+    mocks.captureSandboxListWithGatewayRecovery.mockResolvedValue({
+      result: { status: 0, output: "sb-bad\n" },
+    });
+
+    mocks.backupSandboxState.mockImplementation(() => {
+      throw new Error("Agent 'orphan' not found");
+    });
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await backupAll();
+
+    // Should log "Skipped" warning, not "backup failed"
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("Skipped");
+    expect(output).toContain("orphan");
+    expect(output).toContain("0 failed");
+    expect(output).toContain("1 skipped");
+    consoleSpy.mockRestore();
+  });
+
+  it("re-throws non-orphan-manifest errors so the installer aborts the upgrade", async () => {
+    // Real failures (disk full, SSH timeout, permission denied, programming
+    // bugs) must propagate. Counting them as 'skipped' and returning exit 0
+    // would let the installer march forward with a corrupt or absent backup
+    // and silently lose state on restore.
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }],
+      defaultSandbox: null,
+    });
+    mocks.parseReadySandboxNames.mockReturnValue(new Set(["sb-bad"]));
+    mocks.captureSandboxListWithGatewayRecovery.mockResolvedValue({
+      result: { status: 0, output: "sb-bad\n" },
+    });
+
+    mocks.backupSandboxState.mockImplementation(() => {
+      throw new Error("EACCES: permission denied, open '/var/backups/state'");
+    });
+
+    await expect(backupAll()).rejects.toThrow(/EACCES/);
+  });
+});

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -73,7 +73,26 @@ export async function backupAll(): Promise<void> {
       continue;
     }
     console.log(`  Backing up '${sb.name}'...`);
-    const result = sandboxState.backupSandboxState(sb.name);
+    let result: sandboxState.BackupResult;
+    try {
+      result = sandboxState.backupSandboxState(sb.name);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Only skip the orphan-manifest case (#5734): an agent name in the
+      // registry has no corresponding manifest on disk (e.g. orphan from a
+      // previous higher-version install). The upgrade itself re-introduces
+      // the missing manifest, so swallowing the error here is safe and lets
+      // the rest of the batch back up. Anything else (disk full, SSH
+      // timeout, permission denied, programming bugs) must propagate so the
+      // installer aborts instead of marching forward with a silently
+      // corrupt or absent backup.
+      if (!/^Agent '[^']*' not found/.test(msg)) {
+        throw err;
+      }
+      console.log(`  ${YW}⚠${R} Skipped '${sb.name}' (orphan manifest): ${msg}`);
+      skipped++;
+      continue;
+    }
     if (result.success) {
       console.log(
         `  ${G}✓${R} ${sb.name}: ${result.backedUpDirs.length} dirs, ${result.backedUpFiles.length} files → ${result.manifest?.backupPath || "unknown"}`,

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -77,20 +77,38 @@ export async function backupAll(): Promise<void> {
     try {
       result = sandboxState.backupSandboxState(sb.name);
     } catch (err: unknown) {
+      // Source-of-truth review (#5734 / #5819):
+      //
+      // - Invalid state: a sandbox in the registry references an agent whose
+      //   manifest no longer exists on disk (orphan after a higher-version
+      //   install replaced the manifest tree). loadAgent() at
+      //   src/lib/agent/defs.ts:365-372 throws `Agent '<name>' not found:
+      //   <manifestPath>` when this happens.
+      // - Source boundary: the orphan is owned upstream by the install/upgrade
+      //   flow that mutates the agents/ directory without reconciling the
+      //   registry. The narrow skip here exists purely so the pre-upgrade
+      //   backup-all loop survives until the upgrade itself reinstalls the
+      //   missing manifest.
+      // - Source-fix constraint: the registry cannot be reconciled before the
+      //   backup runs because the backup IS what gates the upgrade that ships
+      //   the reconciled manifests. A registry-side fix at boot or post-install
+      //   would solve the root cause but is out of scope here.
+      // - Regression test: maintenance.test.ts covers the orphan-skip,
+      //   skipped-not-failed counter, non-orphan re-throw (EACCES), and the
+      //   `: <path>`-suffixed shape boundary so widening or eliminating the
+      //   matcher fails CI.
+      // - Removal condition: drop this catch when the registry is reconciled
+      //   on install/upgrade and orphan sandboxes can no longer reach
+      //   backup-all (or when backupSandboxState surfaces a typed
+      //   MissingAgentManifestError that the caller can identify without
+      //   string matching).
+      //
+      // Anchored to the exact loadAgent() throw shape. Requiring the
+      // `: <path>` suffix prevents accidentally catching unrelated
+      // "Agent '...' not found" messages from other layers that should still
+      // abort the backup batch (disk full, SSH timeout, permission denied,
+      // programming bugs all propagate).
       const msg = err instanceof Error ? err.message : String(err);
-      // Only skip the orphan-manifest case (#5734): an agent name in the
-      // registry has no corresponding manifest on disk (e.g. orphan from a
-      // previous higher-version install). The upgrade itself re-introduces
-      // the missing manifest, so swallowing the error here is safe and lets
-      // the rest of the batch back up. Anything else (disk full, SSH
-      // timeout, permission denied, programming bugs) must propagate so the
-      // installer aborts instead of marching forward with a silently
-      // corrupt or absent backup.
-      // Anchor to the exact loadAgent() throw shape at
-      // src/lib/agent/defs.ts:365-372: `Agent '<name>' not found: <manifestPath>`.
-      // Requiring the `: <path>` suffix prevents accidentally catching unrelated
-      // "Agent '...' not found" messages that may surface from other layers and
-      // should still abort the backup batch.
       if (!/^Agent '[^']+' not found: .+$/.test(msg)) {
         throw err;
       }

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -109,7 +109,7 @@ export async function backupAll(): Promise<void> {
       // abort the backup batch (disk full, SSH timeout, permission denied,
       // programming bugs all propagate).
       const msg = err instanceof Error ? err.message : String(err);
-      if (!/^Agent '[^']+' not found: .+$/.test(msg)) {
+      if (!/^Agent '[^']+' not found: .+\/manifest\.yaml$/.test(msg)) {
         throw err;
       }
       console.log(`  ${YW}⚠${R} Skipped '${sb.name}' (orphan manifest): ${msg}`);

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -86,7 +86,12 @@ export async function backupAll(): Promise<void> {
       // timeout, permission denied, programming bugs) must propagate so the
       // installer aborts instead of marching forward with a silently
       // corrupt or absent backup.
-      if (!/^Agent '[^']*' not found/.test(msg)) {
+      // Anchor to the exact loadAgent() throw shape at
+      // src/lib/agent/defs.ts:365-372: `Agent '<name>' not found: <manifestPath>`.
+      // Requiring the `: <path>` suffix prevents accidentally catching unrelated
+      // "Agent '...' not found" messages that may surface from other layers and
+      // should still abort the backup batch.
+      if (!/^Agent '[^']+' not found: .+$/.test(msg)) {
         throw err;
       }
       console.log(`  ${YW}⚠${R} Skipped '${sb.name}' (orphan manifest): ${msg}`);


### PR DESCRIPTION
## Summary

Catches the `loadAgent()` orphan-manifest case from #5734 so the pre-upgrade backup loop survives a sandbox whose agent manifest is missing, **without** silently swallowing real failures (disk full, SSH timeout, permission denied, programming bugs) the way #5740's broad catch did.

## Related Issue

Closes #5734. **Supersedes #5740**.

## Why a new PR

#5740 (kagura-agent) implemented the right outcome with a broad try/catch that swallowed every error and counted it as 'skipped', then exited 0. That lets the installer march forward with an upgrade after a real disk-full or SSH-timeout failure, and the restore path later reads a manifest pointing at a corrupt or absent backup. Data loss scenario.

That PR is on a fork I cannot push to, so this is a fresh PR on the NVIDIA upstream so the PR Advisor and full CI run.

## Changes

- `src/lib/actions/maintenance.ts`: narrow try/catch on `backupSandboxState()` that only matches the exact orphan-manifest pattern (`Agent '...' not found`) thrown by `loadAgent()` at `src/lib/agent/defs.ts:367`. Anything else re-throws so the installer aborts as it did before any wrapping existed.
- `src/lib/actions/maintenance.test.ts`: new test file with 3 cases:
  - Orphan manifest in one sandbox does not abort the batch
  - Orphan manifest is counted as `skipped`, not `failed`
  - **Non-orphan errors (e.g. EACCES) are re-thrown so the installer aborts the upgrade**

## Verification

- `npx vitest run src/lib/actions/maintenance.test.ts` — 3/3 pass
- The narrow regex `/^Agent '[^']*' not found/` matches the exact error shape from `loadAgent` at `defs.ts:367`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch backup reliability: if a sandbox fails due to a missing/orphan agent manifest (matching the expected “not found: <path>…manifest.yaml” pattern), the batch now logs a warning, marks the sandbox as skipped, updates counters, and continues processing remaining sandboxes.
  * Non-matching or unrecoverable errors still abort the batch as before.

* **Tests**
  * Expanded maintenance test coverage for partial success/continuation, skipped behavior, and correct abort behavior for non-matching “not found” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->