### PR TITLE
docs: refresh v0.0.68 release notes

### DIFF
--- a/ci/platform-matrix.json
+++ b/ci/platform-matrix.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Single source of truth for NemoClaw launch claims and platform support. Covers platforms, inference providers, supported agents, messaging integrations, and deployment paths. Scripts read this to generate README and docs tables. QA/CI update platform/provider rows; the engineering owner reviews other rows. Docs are derived.",
   "version": "1.1",
-  "updated": "2026-06-12",
+  "updated": "2026-06-25",
 
   "project_status": {
     "stage": "alpha",
@@ -302,6 +302,11 @@
       "name": "WhatsApp",
       "status": "caveated",
       "notes": "Supported by both OpenClaw and Hermes (see `messaging_platforms` in `agents/openclaw/manifest.yaml` and `agents/hermes/manifest.yaml`). Pairing happens in the sandbox through WhatsApp Web by scanning a QR code at first run; the Hermes flow exposes this as `hermes whatsapp` and persists session credentials under `~/.hermes/platforms/whatsapp/session` (`agents/hermes/manifest.yaml:69-71`). Sandbox egress goes through the `whatsapp` policy preset, which carries the WebSocket / Noise / h1-ALPN caveats documented in `nemoclaw-blueprint/policies/presets/whatsapp.yaml`. No Meta Business API integration today; that path is out of scope for this matrix."
+    },
+    {
+      "name": "Microsoft Teams",
+      "status": "experimental",
+      "notes": "Supported by both OpenClaw and Hermes through the manifest-first messaging channel contract. Requires Bot Framework app credentials, a tenant ID, and a public HTTPS endpoint that reaches the sandbox webhook path `/api/messages`. Sandbox egress goes through the `teams` policy preset, and only one active Teams sandbox can use a given local `MSTEAMS_PORT` forward."
     }
   ],
 

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -15,6 +15,26 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.68
+
+NemoClaw v0.0.68 improves onboarding recovery, messaging setup, agent-specific CLI behavior, local inference defaults, and release validation:
+
+- Installer and onboarding paths now stop on real setup failures and recover more cleanly after interrupted runs.
+  Scripted installs propagate onboarding exit codes, interrupted installer runs start fresh when no sandbox exists to resume, and resume behavior stays tied to onboarding sessions with a real sandbox.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart) and [Troubleshooting](../reference/troubleshooting).
+- Messaging setup adds experimental Microsoft Teams channel onboarding for OpenClaw and Hermes, including Bot Framework credentials, webhook forwarding, the `teams` network policy preset, and local webhook port conflict checks.
+  NemoClaw also treats `messaging_platforms: []` as an explicit deny-all declaration and rejects `channels add` before policy, provider, registry, credential, or rebuild mutations when the selected agent does not support messaging.
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels) and [Platform Support and Launch Claims](../reference/platform-support).
+- Agent-specific CLI commands now route more accurately and fail earlier with clearer local guidance.
+  `sessions export` routes by sandbox agent kind, Hermes `gateway-token` points users to `dashboard-url`, bare OpenClaw `agent` invocations print wrapper help locally, and omitted extra-agent `workspace` and `agentDir` fields use canonical OpenClaw paths.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands).
+- LangChain Deep Agents Code sandboxes now stay alive with a stable entrypoint, use their own product branding, reject unsupported messaging mutations, and preserve the hosted-compatible default model ID without doubling the provider namespace.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](../get-started/quickstart-langchain-deepagents-code), [NemoClaw Inference Options](../inference/inference-options), and [Platform Support and Launch Claims](../reference/platform-support).
+- DGX Spark express install now selects managed local vLLM by default, while hosted NVIDIA inference setup preserves the provider, namespace, and model ID shape used by the compatible endpoint path.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [NemoClaw Inference Options](../inference/inference-options), and [Platform Support and Launch Claims](../reference/platform-support).
+- Platform-support docs now rely on the canonical support matrix, so users and agents see one source of truth for supported platforms, inference providers, agents, messaging integrations, deployment paths, capabilities, and out-of-scope items.
+  For more information, refer to [Platform Support and Launch Claims](../reference/platform-support).
+
 ## v0.0.67
 
 NemoClaw v0.0.67 improves onboarding recovery, messaging reliability, OpenClaw agent workflows, and AI-agent documentation routing:

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Messaging Channels"
 sidebar-title: "Set Up Messaging Channels"
-description: "Connect Telegram, Discord, Slack, WeChat, or WhatsApp to your sandboxed OpenClaw or Hermes agent using OpenShell-managed channel messaging."
-description-agent: "Explains how Telegram, Discord, Slack, WeChat, and WhatsApp reach sandboxed OpenClaw and Hermes agents through OpenShell-managed processes and NemoClaw channel commands. Use when setting up messaging channels, chat interfaces, or integrations without relying on nemoclaw tunnel start for bridges."
-keywords: ["nemoclaw messaging channels", "nemoclaw telegram", "nemoclaw discord", "nemoclaw slack", "nemoclaw wechat", "nemoclaw whatsapp", "openshell channel messaging"]
+description: "Connect Telegram, Discord, Slack, WeChat, WhatsApp, or Microsoft Teams to your sandboxed OpenClaw or Hermes agent using OpenShell-managed channel messaging."
+description-agent: "Explains how Telegram, Discord, Slack, WeChat, WhatsApp, and Microsoft Teams reach sandboxed OpenClaw and Hermes agents through OpenShell-managed processes and NemoClaw channel commands. Use when setting up messaging channels, chat interfaces, or integrations without relying on nemoclaw tunnel start for bridges."
+keywords: ["nemoclaw messaging channels", "nemoclaw telegram", "nemoclaw discord", "nemoclaw slack", "nemoclaw wechat", "nemoclaw whatsapp", "nemoclaw teams", "openshell channel messaging"]
 content:
   type: "how_to"
 skill:
@@ -13,15 +13,16 @@ skill:
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 
-Telegram, Discord, Slack, WeChat, and WhatsApp reach your OpenClaw or Hermes agent through OpenShell-managed processes and gateway constructs.
+Telegram, Discord, Slack, WeChat, WhatsApp, and Microsoft Teams reach your OpenClaw or Hermes agent through OpenShell-managed processes and gateway constructs.
 For token-based channels, NemoClaw registers credentials with OpenShell providers.
 WeChat captures a token through a host-side QR scan during onboarding.
 WhatsApp pairs inside the sandbox through a QR scan and intentionally stores mutable session state there.
+Microsoft Teams uses Bot Framework credentials plus a public HTTPS webhook that forwards to the sandbox.
 NemoClaw bakes the selected channel configuration into the sandbox image and keeps runtime delivery under OpenShell control.
 
 <Warning title="Experimental Channels">
-WeChat and WhatsApp are experimental.
-Both rely on QR-based pairing flows that are more fragile than token-based bots, and the upstream client libraries can change behavior without notice.
+WeChat, WhatsApp, and Microsoft Teams are experimental.
+WeChat and WhatsApp rely on QR-based pairing flows that are more fragile than token-based bots, and Microsoft Teams requires an externally reachable webhook path that depends on your host networking setup.
 Interfaces, defaults, and supported features can change, and NVIDIA does not recommend these channels for production use.
 </Warning>
 
@@ -47,7 +48,7 @@ For details, refer to [Commands](../reference/commands).
 ## Prerequisites
 
 - A machine where you can run `$$nemoclaw onboard` (local or remote host that runs the gateway and sandbox).
-- A token for each token-based messaging platform you want to enable, a personal WeChat account on your phone for the host-side QR scan during onboarding, or a phone you can use to scan the QR code for WhatsApp pairing.
+- A token or app credential set for each credential-based messaging platform you want to enable, a personal WeChat account on your phone for the host-side QR scan during onboarding, or a phone you can use to scan the QR code for WhatsApp pairing.
 - A network policy preset for each enabled channel, or equivalent custom egress rules.
 
 ## Channel Requirements
@@ -59,6 +60,7 @@ For details, refer to [Commands](../reference/commands).
 | Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `SLACK_ALLOWED_USERS` for DM and channel `@mention` user allowlisting, `SLACK_ALLOWED_CHANNELS` for channel ID allowlisting |
 | WeChat (experimental) | None. Captured through host-side QR scan during `$$nemoclaw onboard` | `WECHAT_ALLOWED_IDS` for DM allowlisting |
 | WhatsApp (experimental) | None. Pair through QR after rebuild | None |
+| Microsoft Teams (experimental) | `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, `MSTEAMS_TENANT_ID` | `TEAMS_ALLOWED_USERS` for Microsoft Entra ID object ID allowlisting, `MSTEAMS_PORT` for the local webhook port, `TEAMS_REQUIRE_MENTION` for OpenClaw group and channel mention mode |
 
 Telegram uses a bot token from [BotFather](https://t.me/BotFather).
 Open Telegram, send `/newbot` to [@BotFather](https://t.me/BotFather), follow the prompts, and copy the token.
@@ -100,6 +102,18 @@ Slack Socket Mode allows one active connection per app-level token.
 If another sandbox on the same gateway already uses the same Slack app token, onboarding and `channels add slack` warn before continuing in interactive mode and abort in non-interactive mode.
 Use `--force` only when you intentionally want to move the Slack Socket Mode session to the new sandbox.
 
+Microsoft Teams (experimental) uses the Bot Framework webhook path.
+Create or configure a Teams app whose messaging endpoint is a public HTTPS URL ending in `/api/messages`, and point that URL at the host port NemoClaw forwards for the sandbox.
+The default local webhook port is `3978`; set `MSTEAMS_PORT` or `TEAMS_PORT` before onboarding or `channels add teams` when you need another port.
+No two active Teams sandboxes can share the same local webhook port, so NemoClaw blocks the second enablement and asks you to choose a different `MSTEAMS_PORT` or stop the other sandbox.
+
+Teams requires an app ID, client secret, and tenant ID.
+Set `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, and `MSTEAMS_TENANT_ID`, or use the aliases `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID`.
+The client secret is stored as the `<sandbox>-teams-bridge` OpenShell provider and reaches the sandbox as an OpenShell placeholder, not as a raw value baked into the image.
+Use `TEAMS_ALLOWED_USERS` or `MSTEAMS_ALLOWED_USERS` to list comma-separated Microsoft Entra ID object IDs that may interact with the bot.
+For OpenClaw group and channel messages, `TEAMS_REQUIRE_MENTION` defaults to `1`, so the bot replies only when mentioned.
+Direct messages are unaffected by mention mode.
+
 WeChat (experimental) delivers messages over Tencent's iLink gateway through the upstream `@tencent-weixin/openclaw-weixin` plugin installed into WeChat-enabled OpenClaw sandbox images and the built-in Hermes iLink WeChat adapter.
 The supported mode in this release is **personal WeChat** (`bot_type=3`).
 WeChat Official Account and WeCom/Enterprise WeChat are not wired up.
@@ -136,7 +150,7 @@ Pair only one sandbox per WhatsApp account at a time.
 
 ## Enable Channels During Onboarding
 
-When the wizard reaches **Messaging channels**, it lists Telegram, Discord, Slack, WeChat, and WhatsApp.
+When the wizard reaches **Messaging channels**, it lists Telegram, Discord, Slack, WeChat, WhatsApp, and Microsoft Teams when the selected agent supports them.
 Press a channel number to toggle it on or off, then press **Enter** when done.
 If you select no channels, pressing **Enter** skips messaging setup.
 If a token-based channel token is not already in the environment or credential store, the wizard prompts for it and saves it.
@@ -161,6 +175,11 @@ export SLACK_BOT_TOKEN=<your-slack-bot-token>
 export SLACK_APP_TOKEN=<your-slack-app-token>
 export SLACK_ALLOWED_USERS=<your-slack-member-id>
 export SLACK_ALLOWED_CHANNELS=<your-slack-channel-id>
+export MSTEAMS_APP_ID=<your-teams-app-id>
+export MSTEAMS_APP_PASSWORD=<your-teams-client-secret>
+export MSTEAMS_TENANT_ID=<your-teams-tenant-id>
+export TEAMS_ALLOWED_USERS=<your-entra-object-id>
+export MSTEAMS_PORT=3978
 ```
 
 This release does not support non-interactive WeChat configuration because the iLink QR handshake requires a human to scan the QR on a paired phone.
@@ -172,7 +191,7 @@ Then run onboarding:
 $$nemoclaw onboard
 ```
 
-Complete the rest of the wizard so the blueprint can create OpenShell providers where needed (for example `<sandbox>-telegram-bridge` or `<sandbox>-wechat-bridge`), bake channel configuration into the image (`NEMOCLAW_MESSAGING_CHANNELS_B64`), and start the sandbox.
+Complete the rest of the wizard so the blueprint can create OpenShell providers where needed (for example `<sandbox>-telegram-bridge`, `<sandbox>-teams-bridge`, or `<sandbox>-wechat-bridge`), bake channel configuration into the image (`NEMOCLAW_MESSAGING_CHANNELS_B64`), and start the sandbox.
 
 ## Add Channels After Onboarding
 
@@ -191,10 +210,11 @@ $$nemoclaw my-assistant channels add discord
 $$nemoclaw my-assistant channels add slack
 $$nemoclaw my-assistant channels add wechat
 $$nemoclaw my-assistant channels add whatsapp
+$$nemoclaw my-assistant channels add teams
 ```
 
 `channels add` collects whatever each channel needs.
-It prompts for Telegram, Discord, and Slack tokens, runs an interactive host-side QR scan for WeChat, and collects nothing for WhatsApp because pairing happens in-sandbox after rebuild.
+It prompts for Telegram, Discord, Slack, and Microsoft Teams tokens and configuration, runs an interactive host-side QR scan for WeChat, and collects nothing for WhatsApp because pairing happens in-sandbox after rebuild.
 It registers bridge providers with the OpenShell gateway when it captures tokens, records the channel in the sandbox registry, and asks whether to rebuild immediately.
 The command accepts mixed-case input such as `Telegram`, then stores and prints the canonical lowercase channel name.
 `channels add` requires the matching built-in network policy preset YAML to be present.
@@ -206,8 +226,8 @@ It flags `gateway-providers` as residual because the in-flight upsert can leave 
 Verify the gateway bridge before relying on the channel.
 Restore the preset YAML and re-run `$$nemoclaw <sandbox> channels add <channel>`.
 Choose the rebuild so the running sandbox image picks up the new channel.
-For Telegram, Discord, and Slack, `channels add` also checks the rebuilt runtime for the selected bridge and reports startup, credential, or missing-plugin warnings before returning.
-If you need optional channel settings such as `TELEGRAM_ALLOWED_IDS`, `TELEGRAM_REQUIRE_MENTION`, `TELEGRAM_GROUP_POLICY`, `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION`, `SLACK_ALLOWED_USERS`, or `SLACK_ALLOWED_CHANNELS`, export them before the rebuild starts.
+For Telegram, Discord, Slack, and Microsoft Teams, `channels add` also checks the rebuilt runtime for the selected bridge and reports startup, credential, or missing-plugin warnings before returning.
+If you need optional channel settings such as `TELEGRAM_ALLOWED_IDS`, `TELEGRAM_REQUIRE_MENTION`, `TELEGRAM_GROUP_POLICY`, `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION`, `SLACK_ALLOWED_USERS`, `SLACK_ALLOWED_CHANNELS`, `TEAMS_ALLOWED_USERS`, `MSTEAMS_PORT`, or `TEAMS_REQUIRE_MENTION`, export them before the rebuild starts.
 You can omit `TELEGRAM_REQUIRE_MENTION` and `DISCORD_REQUIRE_MENTION` when you want the default mention-only mode.
 You can omit `TELEGRAM_GROUP_POLICY` when you want OpenClaw Telegram group access to stay open.
 Telegram Bot API `sendMessage` calls prove outbound delivery from the bot; to test inbound agent replies, send a message from the Telegram client as an allowed user.
@@ -237,6 +257,20 @@ DISCORD_BOT_TOKEN=<your-discord-bot-token> \
   DISCORD_REQUIRE_MENTION=1 \
   $$nemoclaw my-assistant channels add discord
 ```
+
+For Microsoft Teams, create the Teams app and public HTTPS endpoint first, then provide the app credentials and local webhook port when you add the channel:
+
+```bash
+MSTEAMS_APP_ID=<your-teams-app-id> \
+  MSTEAMS_APP_PASSWORD=<your-teams-client-secret> \
+  MSTEAMS_TENANT_ID=<your-teams-tenant-id> \
+  TEAMS_ALLOWED_USERS=<your-entra-object-id> \
+  MSTEAMS_PORT=3978 \
+  $$nemoclaw my-assistant channels add teams
+```
+
+After the rebuild starts the Teams webhook forward, route your public HTTPS endpoint to `http://127.0.0.1:3978/api/messages` or the port you selected with `MSTEAMS_PORT`.
+If `channels add teams` reports that another sandbox already uses the same Teams webhook port, choose another `MSTEAMS_PORT` for one sandbox or stop and remove the conflicting sandbox.
 
 ### `channels add wechat`
 
@@ -270,6 +304,7 @@ To remove a channel and clear its stored credentials, run:
 ```bash
 $$nemoclaw my-assistant channels remove telegram
 $$nemoclaw my-assistant channels remove wechat
+$$nemoclaw my-assistant channels remove teams
 ```
 
 `channels remove wechat` clears the bot token, deletes the `<sandbox>-wechat-bridge` OpenShell provider, and drops `wechat` from the sandbox's enabled-channel set.
@@ -312,6 +347,7 @@ For WeChat, each sandbox must own a distinct iLink `accountId` (bot identity).
 Running two sandboxes against the same WeChat account causes one of them to lose messages.
 If you enable a messaging channel and another sandbox already uses the same token, onboarding prompts you to confirm before continuing in interactive mode and exits non-zero in non-interactive mode.
 For Slack, NemoClaw checks both the bot token and the Socket Mode app token so duplicate Socket Mode sessions do not compete silently.
+For Microsoft Teams, NemoClaw also checks the local webhook port because active Teams sandboxes cannot share the same forwarded port.
 If NemoClaw only has legacy channel metadata and cannot compare credential hashes, it keeps the conservative warning.
 Re-run `channels add <channel>` with the intended token to refresh the stored non-secret hash.
 `$$nemoclaw status` reports cross-sandbox overlaps so you can resolve duplicates before messages start dropping.
@@ -325,13 +361,13 @@ Use `$$nemoclaw tunnel stop` or its deprecated alias `$$nemoclaw stop` when you 
 <AgentOnly variant="hermes">
 Use `$$nemoclaw tunnel stop` when you want to stop host auxiliary services and also ask NemoClaw to stop the Hermes gateway inside the selected sandbox.
 </AgentOnly>
-Stopping the in-sandbox gateway stops Telegram, Discord, Slack, WeChat, and WhatsApp polling for that sandbox until you restart the sandbox or gateway.
+Stopping the in-sandbox gateway stops Telegram, Discord, Slack, WeChat, WhatsApp, and Microsoft Teams delivery for that sandbox until you restart the sandbox or gateway.
 
 ## Confirm Delivery
 
 After the sandbox is running, send a message to the configured bot or app.
 If delivery fails, use `openshell term` on the host, check gateway logs, and verify network policy allows the channel API.
-Use the matching policy preset (`telegram`, `discord`, `slack`, `wechat`, or `whatsapp`) or review [Common Integration Policy Examples](../network-policy/integration-policy-examples).
+Use the matching policy preset (`telegram`, `discord`, `slack`, `wechat`, `whatsapp`, or `teams`) or review [Common Integration Policy Examples](../network-policy/integration-policy-examples).
 
 ## Tunnel Command
 

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1101,7 +1101,7 @@ nemohermes my-assistant sessions delete agent:main:slack:c-9 --json
 | `--json` | Print the delete result as JSON. |
 | `--verbose` | Print the gateway entry payload after a successful delete. |
 
-### `nemohermes <name> sessions export`
+### `nemohermes <name> sessions export [keys...]`
 
 Export the agent's session history from a running sandbox to the host.
 The command routes by the sandbox's agent kind recorded in the registry.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1101,7 +1101,7 @@ nemohermes my-assistant sessions delete agent:main:slack:c-9 --json
 | `--json` | Print the delete result as JSON. |
 | `--verbose` | Print the gateway entry payload after a successful delete. |
 
-### `nemohermes <name> sessions export [keys...]`
+### `nemohermes <name> sessions export`
 
 Export the agent's session history from a running sandbox to the host.
 The command routes by the sandbox's agent kind recorded in the registry.
@@ -1118,9 +1118,8 @@ The host destination defaults to `./sessions-<sandbox>.jsonl`; `--out` picks a d
 
 ```bash
 nemohermes my-assistant sessions export
-nemohermes my-assistant sessions export main --agent main
-nemohermes my-assistant sessions export agent:work:telegram:t-1 --include-trajectory
-nemohermes my-assistant sessions export --format tar --out ./bundles/alpha.tgz --json
+nemohermes my-assistant sessions export --agent hermes --out ./sessions-my-assistant.jsonl
+nemohermes my-assistant sessions export --json
 ```
 
 | Flag | Description |

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1399,16 +1399,7 @@ $$nemoclaw my-assistant sessions delete agent:main:slack:c-9 --json
 | `--json` | Print the delete result as JSON. |
 | `--verbose` | Print the gateway entry payload after a successful delete. |
 
-<AgentOnly variant="openclaw">
-
 ### `$$nemoclaw <name> sessions export [keys...]`
-
-</AgentOnly>
-<AgentOnly variant="hermes">
-
-### `$$nemoclaw <name> sessions export`
-
-</AgentOnly>
 
 Export the agent's session history from a running sandbox to the host.
 The command routes by the sandbox's agent kind recorded in the registry.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1399,7 +1399,16 @@ $$nemoclaw my-assistant sessions delete agent:main:slack:c-9 --json
 | `--json` | Print the delete result as JSON. |
 | `--verbose` | Print the gateway entry payload after a successful delete. |
 
+<AgentOnly variant="openclaw">
+
 ### `$$nemoclaw <name> sessions export [keys...]`
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+### `$$nemoclaw <name> sessions export`
+
+</AgentOnly>
 
 Export the agent's session history from a running sandbox to the host.
 The command routes by the sandbox's agent kind recorded in the registry.
@@ -1414,12 +1423,25 @@ Hermes stores session history in a SQLite database, so the command refuses posit
 `--agent` accepts only `hermes` as a no-op alias on a Hermes sandbox and rejects any other value.
 The host destination defaults to `./sessions-<sandbox>.jsonl`; `--out` picks a different path.
 
+<AgentOnly variant="openclaw">
+
 ```bash
 $$nemoclaw my-assistant sessions export
 $$nemoclaw my-assistant sessions export main --agent main
 $$nemoclaw my-assistant sessions export agent:work:telegram:t-1 --include-trajectory
 $$nemoclaw my-assistant sessions export --format tar --out ./bundles/alpha.tgz --json
 ```
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+```bash
+$$nemoclaw my-assistant sessions export
+$$nemoclaw my-assistant sessions export --agent hermes --out ./sessions-my-assistant.jsonl
+$$nemoclaw my-assistant sessions export --json
+```
+
+</AgentOnly>
 
 | Flag | Description |
 |------|-------------|

--- a/docs/reference/platform-support.mdx
+++ b/docs/reference/platform-support.mdx
@@ -117,6 +117,7 @@ NemoClaw configures messaging channels during onboarding. The OpenShell gateway 
 | Telegram | Tested | Configured through an OpenShell-managed channel during onboarding. |
 | WeChat | Tested with limitations | Channel hook available. Verify regional account access before relying on this path. |
 | WhatsApp | Tested with limitations | Supported by both OpenClaw and Hermes (see `messaging_platforms` in `agents/openclaw/manifest.yaml` and `agents/hermes/manifest.yaml`). Pairing happens in the sandbox through WhatsApp Web by scanning a QR code at first run; the Hermes flow exposes this as `hermes whatsapp` and persists session credentials under `~/.hermes/platforms/whatsapp/session` (`agents/hermes/manifest.yaml:69-71`). Sandbox egress goes through the `whatsapp` policy preset, which carries the WebSocket / Noise / h1-ALPN caveats documented in `nemoclaw-blueprint/policies/presets/whatsapp.yaml`. No Meta Business API integration today; that path is out of scope for this matrix. |
+| Microsoft Teams | Experimental | Supported by both OpenClaw and Hermes through the manifest-first messaging channel contract. Requires Bot Framework app credentials, a tenant ID, and a public HTTPS endpoint that reaches the sandbox webhook path `/api/messages`. Sandbox egress goes through the `teams` policy preset, and only one active Teams sandbox can use a given local `MSTEAMS_PORT` forward. |
 {/* integration-status:end */}
 
 ## Capabilities


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Refreshes the v0.0.68 docs with release notes, Microsoft Teams messaging guidance, and generated support-matrix coverage.
Also corrects the Hermes generated command reference so `sessions export` examples match Hermes-only behavior while keeping the shared command heading compatible with CLI parity checks.

## Changes
- #5585 -> `docs/manage-sandboxes/messaging-channels.mdx`, `docs/reference/platform-support.mdx`: Documents experimental Microsoft Teams channel setup, Bot Framework credentials, webhook forwarding, local `MSTEAMS_PORT` conflicts, and the generated integration support row.
- #5526 -> `docs/reference/commands.mdx`, `docs/reference/commands-nemohermes.mdx`: Keeps Hermes `sessions export` examples on the supported single-JSONL export path while preserving the canonical shared CLI heading.
- #5044 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for installer onboarding failure propagation.
- #5641 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for fresh recovery after pre-sandbox installer interruption.
- #5673 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for explicit deny-all messaging manifests.
- #5743 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for unsupported-agent channel-add rejection.
- #5252 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for Hermes `gateway-token` dashboard guidance.
- #5659 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for local OpenClaw `agent` wrapper help.
- #5661 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for default extra-agent paths.
- #5669 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for Deep Agents Code branding.
- #5672 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for hosted-compatible default model ID preservation.
- #5725 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for Deep Agents Code sandbox liveness.
- #5644 -> `docs/about/release-notes.mdx`: Adds v0.0.68 release-note coverage for DGX Spark managed-vLLM express install defaults.
- #5712 -> `docs/about/release-notes.mdx`, `docs/reference/platform-support.mdx`: Adds v0.0.68 release-note coverage for the canonical support matrix and updates the matrix source with Teams.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: docs-only release refresh; no runtime code changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed with 0 errors; Fern reported the existing light-mode accent contrast warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- `python3 scripts/generate-platform-docs.py --check` passed.
- `npm run docs:sync-agent-variants` passed.
- `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli` passed.
- `npm run docs` passed with 0 errors and one Fern theme warning: light-mode accent contrast ratio is 2.41:1 and should be at least 3:1.
- `npm run build:cli` refreshed local untracked `dist/` artifacts after rebase; no tracked files changed.
- `npm run typecheck:cli` passed.
- Normal commit and push hooks passed after the local CLI rebuild.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Microsoft Teams** as an experimental messaging channel, including manifest-first onboarding, local port routing/conflict handling, sandbox delivery controls, and policy preset support.

* **Documentation**
  * Expanded messaging-channel setup for Teams (prerequisites, credential/webhook setup, wizard flow, and add/remove commands).
  * Updated reference docs for **agent-specific** session export examples (OpenClaw vs Hermes).
  * Refreshed platform support guidance and added the latest release-notes entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->