### PR TITLE
docs: clarify copyable how-to examples

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,7 +68,7 @@ jobs:
           echo "DOCS_ONLY_FROM_REF=$DOCS_ONLY_FROM_REF" >> "$GITHUB_ENV"
 
       - name: Run docs-only hook checks
-        run: SKIP=hadolint npx prek run --from-ref "$DOCS_ONLY_FROM_REF" --to-ref HEAD
+        run: npx prek run --from-ref "$DOCS_ONLY_FROM_REF" --to-ref HEAD
 
       - name: Verify platform matrix is in sync
         run: python3 scripts/generate-platform-docs.py --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,7 +68,7 @@ jobs:
           echo "DOCS_ONLY_FROM_REF=$DOCS_ONLY_FROM_REF" >> "$GITHUB_ENV"
 
       - name: Run docs-only hook checks
-        run: npx prek run --from-ref "$DOCS_ONLY_FROM_REF" --to-ref HEAD
+        run: SKIP=hadolint npx prek run --from-ref "$DOCS_ONLY_FROM_REF" --to-ref HEAD
 
       - name: Verify platform matrix is in sync
         run: python3 scripts/generate-platform-docs.py --check

--- a/docs/deployment/deploy-to-remote-gpu.mdx
+++ b/docs/deployment/deploy-to-remote-gpu.mdx
@@ -30,7 +30,7 @@ For another cloud provider, replace the provisioning and SSH commands with that 
 
 ```bash
 # On your local machine
-brev start --name <instance-name> --gpu <gpu-type>
+brev create <instance-name>
 ```
 
 If `brev` is missing or unauthenticated, install or log in to the Brev CLI first, or provision the VM through your cloud console and connect with `ssh <user>@<host>`.
@@ -38,6 +38,12 @@ If `brev` is missing or unauthenticated, install or log in to the Brev CLI first
 For Brev, create a dashboard tunnel before you connect to the VM.
 Open the instance in the Brev console, go to the **Access** tab, and add a tunnel for port `18789`.
 Copy the generated tunnel URL.
+
+<Warning>
+Brev tunnel URLs are non-loopback origins.
+When `CHAT_UI_URL` points at one, NemoClaw disables OpenClaw device pairing in the generated sandbox configuration because browser-only remote users cannot complete terminal-based pairing.
+Avoid exposing the dashboard on internet-reachable or shared-network deployments unless you intend that access.
+</Warning>
 
 You can list instances from your local machine:
 

--- a/docs/deployment/deploy-to-remote-gpu.mdx
+++ b/docs/deployment/deploy-to-remote-gpu.mdx
@@ -30,21 +30,20 @@ For another cloud provider, replace the provisioning and SSH commands with that 
 
 ```bash
 # On your local machine
-brev create <instance-name> --gpu <gpu-type>
+brev start --name <instance-name> --gpu <gpu-type>
 ```
 
 If `brev` is missing or unauthenticated, install or log in to the Brev CLI first, or provision the VM through your cloud console and connect with `ssh <user>@<host>`.
 
-For Brev, get the instance ID before you connect to the VM.
-Run this command on your local machine:
+For Brev, create a dashboard tunnel before you connect to the VM.
+Open the instance in the Brev console, go to the **Access** tab, and add a tunnel for port `18789`.
+Copy the generated tunnel URL.
+
+You can list instances from your local machine:
 
 ```bash
 brev ls --json
 ```
-
-In the output, find the object whose `name` matches `<instance-name>`, then set `BREV_INSTANCE_ID` to that object's `id` value.
-You can also find the same ID in the Brev web UI.
-The Brev dashboard origin uses the format `https://openclaw0-${BREV_INSTANCE_ID}.brevlab.com`.
 
 Connect to the remote VM:
 
@@ -56,12 +55,13 @@ Set any remote-only environment variables on the VM before onboarding.
 For example, set the browser origin if you will open the dashboard through a Brev public URL, raise the first-run readiness budget on cold cloud hosts, and then run the installer:
 
 ```bash
-export BREV_INSTANCE_ID="<id-from-brev-ls>"
-export CHAT_UI_URL="https://openclaw0-${BREV_INSTANCE_ID}.brevlab.com"
+export CHAT_UI_URL="<copied-brev-tunnel-origin>"
 export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
+Use the origin from the Brev tunnel URL.
+For example, if the copied URL is `https://example.host/path`, set `CHAT_UI_URL=https://example.host`.
 If NemoClaw is already installed on the VM, run `nemoclaw onboard` instead of the installer after exporting the variables.
 
 After successful onboarding, you should see output that reports a ready sandbox and the next command to connect:
@@ -130,12 +130,11 @@ nemoclaw <name> exec -- openclaw agent --agent main -m "Hello from the remote sa
 
 The NemoClaw dashboard validates the browser origin against an allowlist baked into the sandbox image at build time.
 By default, the allowlist only contains `http://127.0.0.1:18789`.
-When you access the dashboard from a remote browser, for example through a Brev public URL or an SSH port-forward, set `CHAT_UI_URL` to the origin the browser uses before running `nemoclaw onboard` on the remote VM.
-For Brev, use the `BREV_INSTANCE_ID` value from `brev ls --json` or the Brev web UI:
+When you access the dashboard from a remote browser, for example through a Brev tunnel URL or an SSH port-forward, set `CHAT_UI_URL` to the origin the browser uses before running `nemoclaw onboard` on the remote VM.
+For Brev, create a tunnel for port `18789` in the instance **Access** tab and copy the generated URL origin:
 
 ```bash
-test -n "$BREV_INSTANCE_ID"
-export CHAT_UI_URL="https://openclaw0-${BREV_INSTANCE_ID}.brevlab.com"
+export CHAT_UI_URL="<copied-brev-tunnel-origin>"
 nemoclaw onboard
 ```
 

--- a/docs/deployment/deploy-to-remote-gpu.mdx
+++ b/docs/deployment/deploy-to-remote-gpu.mdx
@@ -31,25 +31,38 @@ For another cloud provider, replace the provisioning and SSH commands with that 
 ```bash
 # On your local machine
 brev create <instance-name> --gpu <gpu-type>
-brev ssh <instance-name>
 ```
 
 If `brev` is missing or unauthenticated, install or log in to the Brev CLI first, or provision the VM through your cloud console and connect with `ssh <user>@<host>`.
 
-Run the installer on the remote VM:
+For Brev, get the instance ID before you connect to the VM.
+Run this command on your local machine:
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+brev ls --json
+```
+
+In the output, find the object whose `name` matches `<instance-name>`, then set `BREV_INSTANCE_ID` to that object's `id` value.
+You can also find the same ID in the Brev web UI.
+The Brev dashboard origin uses the format `https://openclaw0-${BREV_INSTANCE_ID}.brevlab.com`.
+
+Connect to the remote VM:
+
+```bash
+brev ssh <instance-name>
 ```
 
 Set any remote-only environment variables on the VM before onboarding.
-For example, set the browser origin if you will open the dashboard through a Brev public URL, and raise the first-run readiness budget on cold cloud hosts:
+For example, set the browser origin if you will open the dashboard through a Brev public URL, raise the first-run readiness budget on cold cloud hosts, and then run the installer:
 
 ```bash
-export CHAT_UI_URL="https://openclaw0-<id>.brevlab.com"
+export BREV_INSTANCE_ID="<id-from-brev-ls>"
+export CHAT_UI_URL="https://openclaw0-${BREV_INSTANCE_ID}.brevlab.com"
 export NEMOCLAW_SANDBOX_READY_TIMEOUT=600
-nemoclaw onboard
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
+
+If NemoClaw is already installed on the VM, run `nemoclaw onboard` instead of the installer after exporting the variables.
 
 After successful onboarding, you should see output that reports a ready sandbox and the next command to connect:
 
@@ -117,10 +130,12 @@ nemoclaw <name> exec -- openclaw agent --agent main -m "Hello from the remote sa
 
 The NemoClaw dashboard validates the browser origin against an allowlist baked into the sandbox image at build time.
 By default, the allowlist only contains `http://127.0.0.1:18789`.
-When you access the dashboard from a remote browser, for example through a Brev public URL or an SSH port-forward, set `CHAT_UI_URL` to the origin the browser uses before running `nemoclaw onboard` on the remote VM:
+When you access the dashboard from a remote browser, for example through a Brev public URL or an SSH port-forward, set `CHAT_UI_URL` to the origin the browser uses before running `nemoclaw onboard` on the remote VM.
+For Brev, use the `BREV_INSTANCE_ID` value from `brev ls --json` or the Brev web UI:
 
 ```bash
-export CHAT_UI_URL="https://openclaw0-<id>.brevlab.com"
+test -n "$BREV_INSTANCE_ID"
+export CHAT_UI_URL="https://openclaw0-${BREV_INSTANCE_ID}.brevlab.com"
 nemoclaw onboard
 ```
 

--- a/docs/deployment/install-openclaw-plugins.mdx
+++ b/docs/deployment/install-openclaw-plugins.mdx
@@ -31,9 +31,13 @@ NemoClaw still applies its own secret-safety exclusions for credential-like path
 my-plugin-sandbox/
 ├── Dockerfile
 └── my-plugin/
+    ├── package-lock.json
     ├── package.json
     └── src/
 ```
+
+The example Dockerfile uses `npm ci`, so `my-plugin/` must include `package-lock.json`.
+If your plugin does not have a lockfile yet, create one in the plugin project with `npm install --package-lock-only`.
 
 ## Example Dockerfile
 
@@ -99,7 +103,7 @@ Order Dockerfile instructions from least-changing to most-changing so warm rebui
 
 1. Base image.
 2. System package installs.
-3. Dependency manifests such as `package.json`.
+3. Dependency manifests such as `package.json` and `package-lock.json`.
 4. Dependency install such as `npm ci`.
 5. Application source.
 

--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -98,6 +98,8 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
 Use the provider variables from [Inference Options](../inference/inference-options) when you choose a different provider.
+If a scripted installer rerun finds a failed onboarding session, choose whether to discard the saved state with `--fresh` or retry it with `nemohermes onboard --resume`.
+For the recovery commands, refer to [Previous onboarding session failed](../reference/troubleshooting#previous-onboarding-session-failed).
 
 ## Connect to Hermes
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -56,6 +56,9 @@ To run both installation and onboarding without prompts, also set non-interactiv
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | NEMOCLAW_NON_INTERACTIVE=1 NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 bash
 ```
 
+If a scripted installer rerun finds a failed onboarding session, choose whether to discard the saved state with `--fresh` or retry it with `nemoclaw onboard --resume`.
+For the recovery commands, refer to [Previous onboarding session failed](../reference/troubleshooting#previous-onboarding-session-failed).
+
 Do not place `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1` before `curl`.
 In `NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 curl ... | bash`, the variable applies only to `curl`, so the installer process cannot see the acceptance.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -49,7 +49,7 @@ Copy the starter prompt and paste it into your local coding agent such as Codex,
 
 ### From Your Terminal
 
-Paste the following command into your terminal for the default installation process:
+Paste this command into your terminal for the default installation process.
 
 <llms-ignore>
 
@@ -65,8 +65,8 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 </llms-only>
 
-For non-interactive installs, choose a quickstart guide below.
-For failed-session recovery, refer to [Troubleshooting](reference/troubleshooting#previous-onboarding-session-failed).
+This starts the interactive installer and onboard wizard.
+Use the quickstart guides for scripted installs and failed-session recovery.
 
 By default, NemoClaw installs the OpenClaw agent. Use one of the following quickstart guides to get started with your preferred agent.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -59,11 +59,22 @@ Paste the following command into your terminal for the default installation proc
 
 <llms-only>
 
-```shell
+```bash
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
 </llms-only>
+
+The default installer opens the interactive onboard wizard.
+If a previous onboarding session failed, the installer asks whether to resume the failed session or start fresh.
+For unattended runs, pass the non-interactive flags and choose the session behavior explicitly:
+
+```bash
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --non-interactive --yes-i-accept-third-party-software --fresh
+```
+
+Use `--fresh` only when you want to discard a failed or interrupted onboarding session.
+Use `nemoclaw onboard --resume` after installation when you want to retry the same saved session instead.
 
 By default, NemoClaw installs the OpenClaw agent. Use one of the following quickstart guides to get started with your preferred agent.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -65,16 +65,8 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 </llms-only>
 
-The default installer opens the interactive onboard wizard.
-If a previous onboarding session failed, the installer asks whether to resume the failed session or start fresh.
-For unattended runs, pass the non-interactive flags and choose the session behavior explicitly:
-
-```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --non-interactive --yes-i-accept-third-party-software --fresh
-```
-
-Use `--fresh` only when you want to discard a failed or interrupted onboarding session.
-Use `nemoclaw onboard --resume` after installation when you want to retry the same saved session instead.
+For non-interactive installs, choose a quickstart guide below.
+For failed-session recovery, refer to [Troubleshooting](reference/troubleshooting#previous-onboarding-session-failed).
 
 By default, NemoClaw installs the OpenClaw agent. Use one of the following quickstart guides to get started with your preferred agent.
 

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -23,19 +23,28 @@ OpenShell intercepts these requests and presents them in the TUI for operator ap
 
 Start the OpenShell terminal UI to monitor sandbox activity:
 
+<Tabs>
+<Tab title="Local Sandbox">
+
 ```bash
 openshell term
 ```
 
-For a remote sandbox, connect to the remote host first.
+</Tab>
+<Tab title="Remote Sandbox">
+
+Connect to the remote host first.
 Use a host that resolves from your terminal, such as a Brev SSH alias or `user@host`.
-Then run the TUI from the NemoClaw directory on that host:
+Then run the TUI from the NemoClaw directory on that host.
 
 ```bash
 cd ~/nemoclaw
 . .env
 openshell term
 ```
+
+</Tab>
+</Tabs>
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.
 

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -27,10 +27,14 @@ Start the OpenShell terminal UI to monitor sandbox activity:
 openshell term
 ```
 
-For a remote sandbox, pass the instance name:
+For a remote sandbox, connect to the remote host first.
+Use a host that resolves from your terminal, such as a Brev SSH alias or `user@host`.
+Then run the TUI from the NemoClaw directory on that host:
 
 ```bash
-ssh my-gpu-box 'cd ~/nemoclaw && . .env && openshell term'
+cd ~/nemoclaw
+. .env
+openshell term
 ```
 
 The TUI displays the sandbox state, active inference provider, and a live feed of network activity.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Clarifies the documentation examples reported in #5763 so readers are not blocked by undeclared hosts, dashboard URL setup, or missing plugin lockfiles.
The home page stays on the default interactive install path, while scripted and failed-session recovery guidance lives in the quickstart and troubleshooting docs.

## Related Issue
Fixes #5763

## Changes
- Keeps the home installer command concise and identifies it as the interactive installer and onboard wizard path.
- Adds quickstart pointers for scripted installer reruns and failed onboarding session recovery.
- Replaces the unresolved remote TUI `my-gpu-box` command with local and remote sandbox tabs.
- Updates remote GPU deployment guidance to use the repository-aligned `brev create <instance-name>` provisioning shape and Brev console tunnel setup for `CHAT_UI_URL`.
- Places the non-loopback dashboard exposure warning next to the first Brev tunnel setup.
- Adds `package-lock.json` to the OpenClaw plugin build context example because the Dockerfile uses `npm ci`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only corrections to prose and copyable examples; no runtime behavior changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npx prek run --from-ref origin/main --to-ref HEAD` passed locally. `ReadLints` reports no diagnostics for the changed doc pages.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>
