### PR TITLE
fix(onboard): ignore stale provider recovery on fresh

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3973,7 +3973,7 @@ async function setupNim(
     ollamaInstallMenu,
     gpuNimCapable,
   } = providerHostState;
-  const requestedProvider = getNonInteractiveProvider() || (recoverProvider ? null : "build");
+  const requestedProvider = getNonInteractiveProvider();
   const requestedModel = isNonInteractive()
     ? getNonInteractiveModel(requestedProvider || "build")
     : null;
@@ -4033,9 +4033,9 @@ async function setupNim(
           isWindowsHostOllama,
           windowsHostOllamaSupported: windowsHostOllamaDockerRequirement.supported,
           hermesProviderAvailable,
-          readRecordedProvider,
-          readRecordedNimContainer,
-          readRecordedModel,
+          readRecordedProvider: recoverProvider ? readRecordedProvider : () => null,
+          readRecordedNimContainer: recoverProvider ? readRecordedNimContainer : () => null,
+          readRecordedModel: recoverProvider ? readRecordedModel : () => null,
         });
         if (providerSelection.kind === "failure") {
           reportProviderSelectionFailure({

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3264,22 +3264,12 @@ async function createSandbox(
 // ── Step 3: Inference selection ──────────────────────────────────
 
 type ProviderChoice = import("./onboard/provider-menu").ProviderMenuChoice;
-type ProviderSelectionRecoveryReaders =
-  import("./onboard/provider-selection").ProviderSelectionRecoveryReaders;
-type SetupNimOptions = {
-  allowRecordedProviderRecovery?: boolean;
-};
 
 const { readRecordedProvider, readRecordedNimContainer, readRecordedModel } =
   providerRecovery.createProviderRecoveryHelpers({
     parseGatewayInference,
     runCaptureOpenshell,
   });
-const DISABLED_PROVIDER_RECOVERY_READERS: ProviderSelectionRecoveryReaders = {
-  readRecordedProvider: () => null,
-  readRecordedNimContainer: () => null,
-  readRecordedModel: () => null,
-};
 
 type OllamaModelSelectionOutcome =
   | { outcome: "selected"; model: string; allowToolsIncompatible: boolean }
@@ -3935,7 +3925,7 @@ async function setupNim(
   gpu: ReturnType<typeof nim.detectGpu>,
   sandboxName: string | null = null,
   agent: AgentDefinition | null = null,
-  setupOptions: SetupNimOptions = {},
+  recoverProvider = true,
 ): Promise<{
   model: string | null;
   provider: string;
@@ -3983,17 +3973,12 @@ async function setupNim(
     ollamaInstallMenu,
     gpuNimCapable,
   } = providerHostState;
-  const requestedProvider = getNonInteractiveProvider();
+  const requestedProvider = getNonInteractiveProvider() || (recoverProvider ? null : "build");
   const requestedModel = isNonInteractive()
     ? getNonInteractiveModel(requestedProvider || "build")
     : null;
   const agentProviderOptions = getAgentInferenceProviderOptions(agent);
-  const providerRecoveryReaders =
-    setupOptions.allowRecordedProviderRecovery === false
-      ? DISABLED_PROVIDER_RECOVERY_READERS
-      : { readRecordedProvider, readRecordedNimContainer, readRecordedModel };
 
-  // Model Router: complexity-based routing via blueprint config.
   const blueprintRouterCfg = loadBlueprintProfile("routed");
   const { options, hermesProviderAvailable } = buildInferenceProviderMenu({
     remoteProviderConfig: REMOTE_PROVIDER_CONFIG,
@@ -4048,7 +4033,9 @@ async function setupNim(
           isWindowsHostOllama,
           windowsHostOllamaSupported: windowsHostOllamaDockerRequirement.supported,
           hermesProviderAvailable,
-          ...providerRecoveryReaders,
+          readRecordedProvider,
+          readRecordedNimContainer,
+          readRecordedModel,
         });
         if (providerSelection.kind === "failure") {
           reportProviderSelectionFailure({

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3264,12 +3264,22 @@ async function createSandbox(
 // ── Step 3: Inference selection ──────────────────────────────────
 
 type ProviderChoice = import("./onboard/provider-menu").ProviderMenuChoice;
+type ProviderSelectionRecoveryReaders =
+  import("./onboard/provider-selection").ProviderSelectionRecoveryReaders;
+type SetupNimOptions = {
+  allowRecordedProviderRecovery?: boolean;
+};
 
 const { readRecordedProvider, readRecordedNimContainer, readRecordedModel } =
   providerRecovery.createProviderRecoveryHelpers({
     parseGatewayInference,
     runCaptureOpenshell,
   });
+const DISABLED_PROVIDER_RECOVERY_READERS: ProviderSelectionRecoveryReaders = {
+  readRecordedProvider: () => null,
+  readRecordedNimContainer: () => null,
+  readRecordedModel: () => null,
+};
 
 type OllamaModelSelectionOutcome =
   | { outcome: "selected"; model: string; allowToolsIncompatible: boolean }
@@ -3925,6 +3935,7 @@ async function setupNim(
   gpu: ReturnType<typeof nim.detectGpu>,
   sandboxName: string | null = null,
   agent: AgentDefinition | null = null,
+  setupOptions: SetupNimOptions = {},
 ): Promise<{
   model: string | null;
   provider: string;
@@ -3977,6 +3988,10 @@ async function setupNim(
     ? getNonInteractiveModel(requestedProvider || "build")
     : null;
   const agentProviderOptions = getAgentInferenceProviderOptions(agent);
+  const providerRecoveryReaders =
+    setupOptions.allowRecordedProviderRecovery === false
+      ? DISABLED_PROVIDER_RECOVERY_READERS
+      : { readRecordedProvider, readRecordedNimContainer, readRecordedModel };
 
   // Model Router: complexity-based routing via blueprint config.
   const blueprintRouterCfg = loadBlueprintProfile("routed");
@@ -4033,9 +4048,7 @@ async function setupNim(
           isWindowsHostOllama,
           windowsHostOllamaSupported: windowsHostOllamaDockerRequirement.supported,
           hermesProviderAvailable,
-          readRecordedProvider,
-          readRecordedNimContainer,
-          readRecordedModel,
+          ...providerRecoveryReaders,
         });
         if (providerSelection.kind === "failure") {
           reportProviderSelectionFailure({

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -203,6 +203,29 @@ describe("core onboard flow phases", () => {
     expect(Array.isArray(result.result)).toBe(true);
   });
 
+  it("passes fresh context through to provider setup recovery policy", async () => {
+    const setupNim = vi.fn(async () => ({
+      model: "nvidia/test",
+      provider: "nim",
+      endpointUrl: "https://example.test/v1",
+      credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      hermesAuthMethod: null,
+      hermesToolGateways: [],
+      preferredInferenceApi: "chat",
+      nimContainer: null,
+    }));
+    const [providerPhase] = createPhases({ providerDeps: { setupNim } });
+
+    await providerPhase.run(context({ fresh: true }));
+
+    expect(setupNim).toHaveBeenCalledWith(
+      { platform: "linux" },
+      "my-sandbox",
+      { name: "openclaw" },
+      { allowRecordedProviderRecovery: false },
+    );
+  });
+
   it("uses normalized context Hermes tool gateways for provider inference resume", async () => {
     const setupInference = vi.fn(async () => ({ ok: true as const }));
     const [providerPhase] = createPhases({

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -222,7 +222,7 @@ describe("core onboard flow phases", () => {
       { platform: "linux" },
       "my-sandbox",
       { name: "openclaw" },
-      { allowRecordedProviderRecovery: false },
+      false,
     );
   });
 

--- a/src/lib/onboard/machine/core-flow-phases.ts
+++ b/src/lib/onboard/machine/core-flow-phases.ts
@@ -57,6 +57,7 @@ export function createCoreOnboardFlowPhases<
     async run(context) {
       const providerInferenceResult = await handleProviderInferenceState({
         resume: context.resume,
+        fresh: context.fresh,
         session: context.session,
         gpu: context.gpu,
         sandboxName: context.sandboxName,

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -110,6 +110,7 @@ function baseOptions(
 ): ProviderInferenceStateOptions<Gpu, Agent, Host> {
   return {
     resume: false,
+    fresh: false,
     session,
     gpu: { type: "nvidia" },
     sandboxName: null,
@@ -143,7 +144,9 @@ describe("handleProviderInferenceState", () => {
     const result = await handleProviderInferenceState(baseOptions(deps));
 
     expect(calls.startStep).toHaveBeenNthCalledWith(1, "provider_selection");
-    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, null, null);
+    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, null, null, {
+      allowRecordedProviderRecovery: true,
+    });
     expect(calls.complete).toHaveBeenCalledWith(
       "provider_selection",
       expect.objectContaining({ provider: "nvidia-prod" }),
@@ -189,6 +192,20 @@ describe("handleProviderInferenceState", () => {
       },
       result.stateResult,
     ]);
+  });
+
+  it("disables recorded provider recovery during fresh provider selection", async () => {
+    const { deps, calls } = createDeps();
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps),
+      fresh: true,
+      sandboxName: "dcode-station",
+    });
+
+    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, "dcode-station", null, {
+      allowRecordedProviderRecovery: false,
+    });
   });
 
   it("clears non-NVIDIA provider credentials when inference setup fails", async () => {

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -144,9 +144,7 @@ describe("handleProviderInferenceState", () => {
     const result = await handleProviderInferenceState(baseOptions(deps));
 
     expect(calls.startStep).toHaveBeenNthCalledWith(1, "provider_selection");
-    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, null, null, {
-      allowRecordedProviderRecovery: true,
-    });
+    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, null, null, true);
     expect(calls.complete).toHaveBeenCalledWith(
       "provider_selection",
       expect.objectContaining({ provider: "nvidia-prod" }),
@@ -203,9 +201,7 @@ describe("handleProviderInferenceState", () => {
       sandboxName: "dcode-station",
     });
 
-    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, "dcode-station", null, {
-      allowRecordedProviderRecovery: false,
-    });
+    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, "dcode-station", null, false);
   });
 
   it("clears non-NVIDIA provider credentials when inference setup fails", async () => {

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -204,6 +204,24 @@ describe("handleProviderInferenceState", () => {
     expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, "dcode-station", null, false);
   });
 
+  it("does not use resume shortcuts when fresh is also set", async () => {
+    const session = createSession({ provider: "ollama-local", model: "llama3.1" });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({ isInferenceRouteReady: vi.fn(() => true) });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      fresh: true,
+      sandboxName: "dcode-station",
+    });
+
+    expect(calls.recoverProvider).not.toHaveBeenCalled();
+    expect(calls.skipped).not.toHaveBeenCalledWith("provider_selection", expect.anything());
+    expect(calls.setupNim).toHaveBeenCalledWith({ type: "nvidia" }, "dcode-station", null, false);
+    expect(calls.setupInference).toHaveBeenCalled();
+  });
+
   it("clears non-NVIDIA provider credentials when inference setup fails", async () => {
     const setupNim = vi.fn(async () => ({
       ...baseSelection,

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -21,10 +21,6 @@ export interface ProviderSelectionResult {
   skipHostInferenceSmoke?: boolean;
 }
 
-export interface ProviderSelectionSetupOptions {
-  allowRecordedProviderRecovery?: boolean;
-}
-
 export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
   resume: boolean;
   fresh: boolean;
@@ -57,7 +53,7 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
       gpu: Gpu,
       sandboxName: string | null,
       agent: Agent,
-      options?: ProviderSelectionSetupOptions,
+      allowRecordedProviderRecovery?: boolean,
     ): Promise<ProviderSelectionResult>;
     setupInference(
       sandboxName: string | null,
@@ -257,10 +253,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
       const selection = await withProviderSelectionTrace(
         sandboxName,
         (agent as { name?: string } | null)?.name,
-        () =>
-          deps.setupNim(gpu, sandboxName, agent, {
-            allowRecordedProviderRecovery: !fresh,
-          }),
+        () => deps.setupNim(gpu, sandboxName, agent, !fresh),
       );
       model = selection.model;
       provider = selection.provider;

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -21,8 +21,13 @@ export interface ProviderSelectionResult {
   skipHostInferenceSmoke?: boolean;
 }
 
+export interface ProviderSelectionSetupOptions {
+  allowRecordedProviderRecovery?: boolean;
+}
+
 export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
   resume: boolean;
+  fresh: boolean;
   session: Session | null;
   gpu: Gpu;
   sandboxName: string | null;
@@ -48,7 +53,12 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
   };
   deps: {
     normalizeHermesAuthMethod(value: string | null | undefined): string | null;
-    setupNim(gpu: Gpu, sandboxName: string | null, agent: Agent): Promise<ProviderSelectionResult>;
+    setupNim(
+      gpu: Gpu,
+      sandboxName: string | null,
+      agent: Agent,
+      options?: ProviderSelectionSetupOptions,
+    ): Promise<ProviderSelectionResult>;
     setupInference(
       sandboxName: string | null,
       model: string,
@@ -167,6 +177,7 @@ function clearStagedCredentialEnv(
 
 export async function handleProviderInferenceState<Gpu, Agent, Host>({
   resume,
+  fresh,
   session,
   gpu,
   sandboxName,
@@ -246,7 +257,10 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
       const selection = await withProviderSelectionTrace(
         sandboxName,
         (agent as { name?: string } | null)?.name,
-        () => deps.setupNim(gpu, sandboxName, agent),
+        () =>
+          deps.setupNim(gpu, sandboxName, agent, {
+            allowRecordedProviderRecovery: !fresh,
+          }),
       );
       model = selection.model;
       provider = selection.provider;

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -202,6 +202,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
   let forceProviderSelection = initialForceProviderSelection;
   let allowToolsIncompatible = false;
   let skipHostInferenceSmoke = false;
+  const effectiveResume = resume && !fresh;
   const stateResults: OnboardStateTransitionResult[] = [];
   const retryStateResults: OnboardStateTransitionResult[] = [];
 
@@ -209,7 +210,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
     let forceInferenceSetup = false;
     const resumeProviderSelection =
       !forceProviderSelection &&
-      resume &&
+      effectiveResume &&
       session?.steps?.provider_selection?.status === "complete" &&
       typeof provider === "string" &&
       typeof model === "string";
@@ -299,7 +300,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
       !needsBedrockRuntimeAdapter &&
       !forceProviderSelection &&
       !forceInferenceSetup &&
-      resume &&
+      effectiveResume &&
       deps.isInferenceRouteReady(provider, model);
     if (resumeInference) {
       if (provider === constants.hermesProviderName) {

--- a/test/onboard-resume-provider-recovery.test.ts
+++ b/test/onboard-resume-provider-recovery.test.ts
@@ -452,9 +452,16 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
   console.error = (...args) => lines.push(args.join(" "));
   try {
     const nonInteractive = await setupNim(null, "dcode-station", null, false);
+    process.env.NEMOCLAW_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.NEMOCLAW_MODEL = "gpt-5.4";
+    const explicitProvider = await setupNim(null, "dcode-station", null, false);
+    delete process.env.NEMOCLAW_PROVIDER;
+    delete process.env.OPENAI_API_KEY;
+    process.env.NEMOCLAW_MODEL = "nvidia/test-model";
     __setNonInteractive(false);
     const interactive = await setupNim(null, "dcode-station", null, false);
-    originalLog(JSON.stringify({ nonInteractive, interactive, prompts, lines }));
+    originalLog(JSON.stringify({ nonInteractive, explicitProvider, interactive, prompts, lines }));
   } finally {
     console.log = originalLog;
     console.error = originalError;
@@ -482,6 +489,8 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
     expect(payload.nonInteractive.provider).toBe("nvidia-prod");
     expect(payload.nonInteractive.model).toBe("nvidia/test-model");
     expect(payload.nonInteractive.preferredInferenceApi).toBe("openai-completions");
+    expect(payload.explicitProvider.provider).toBe("openai-api");
+    expect(payload.explicitProvider.model).toBe("gpt-5.4");
     expect(payload.interactive.provider).toBe("nvidia-prod");
     expect(payload.interactive.preferredInferenceApi).toBe("openai-completions");
     expect(payload.prompts[0]).toMatch(/^  Choose \[\d+\]: $/);

--- a/test/onboard-resume-provider-recovery.test.ts
+++ b/test/onboard-resume-provider-recovery.test.ts
@@ -360,3 +360,125 @@ console.log(JSON.stringify({
     expect(payload.model).toBe("qwen2.5:14b");
   });
 });
+
+describe("setupNim provider recovery policy", () => {
+  it("ignores stale recorded providers when fresh setup disables provider recovery", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-fresh-provider-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "fresh-provider-recovery-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "onboard.js"));
+    const sessionPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "state", "onboard-session.js"),
+    );
+    const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
+    const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+body='{"choices":[{"message":{"role":"assistant","content":"OK"}}]}'
+status="200"
+outfile=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s' "$body" > "$outfile"
+printf '%s' "$status"
+`,
+      { mode: 0o755 },
+    );
+
+    const script = String.raw`
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const runner = require(${runnerPath});
+const registry = require(${registryPath});
+const onboardSession = require(${sessionPath});
+
+runner.runCapture = () => "";
+registry.getSandbox = () => null;
+registry.listSandboxes = () => ({ sandboxes: [], defaultSandbox: null });
+onboardSession.loadSession = () => ({
+  sandboxName: "dcode-station",
+  provider: "ollama-local",
+  model: "llama3.1",
+});
+
+const onboardFile = ${onboardPath};
+const source = fs.readFileSync(onboardFile, "utf-8");
+const injected = source + "\nmodule.exports.__setNonInteractive = (value) => { NON_INTERACTIVE = value; };";
+const onboardModule = new Module(onboardFile, module);
+onboardModule.filename = onboardFile;
+onboardModule.paths = Module._nodeModulePaths(path.dirname(onboardFile));
+onboardModule._compile(injected, onboardFile);
+
+const { setupNim, __setNonInteractive } = onboardModule.exports;
+
+(async () => {
+  for (const key of [
+    "NEMOCLAW_PROVIDER",
+    "NEMOCLAW_PROVIDER_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "COMPATIBLE_API_KEY",
+    "COMPATIBLE_ANTHROPIC_API_KEY",
+  ]) {
+    delete process.env[key];
+  }
+  process.env.NVIDIA_INFERENCE_API_KEY = "nvapi-test";
+  process.env.NEMOCLAW_MODEL = "nvidia/test-model";
+  __setNonInteractive(true);
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim(null, "dcode-station", null, {
+      allowRecordedProviderRecovery: false,
+    });
+    originalLog(JSON.stringify({ result, lines }));
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_TEST_NO_SLEEP: "1",
+      },
+    });
+
+    if (result.status !== 0) {
+      throw new Error(result.stderr || result.stdout);
+    }
+    const payload = JSON.parse(result.stdout.trim());
+    expect(payload.result.provider).toBe("nvidia-prod");
+    expect(payload.result.model).toBe("nvidia/test-model");
+    expect(payload.result.preferredInferenceApi).toBe("openai-completions");
+    expect(
+      payload.lines.some((line: string) => line.includes("[non-interactive] Provider: build")),
+    ).toBe(true);
+    expect(payload.lines.every((line: string) => !line.includes("recovered from sandbox"))).toBe(
+      true,
+    );
+  });
+});

--- a/test/onboard-resume-provider-recovery.test.ts
+++ b/test/onboard-resume-provider-recovery.test.ts
@@ -441,9 +441,7 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
   console.log = (...args) => lines.push(args.join(" "));
   console.error = (...args) => lines.push(args.join(" "));
   try {
-    const result = await setupNim(null, "dcode-station", null, {
-      allowRecordedProviderRecovery: false,
-    });
+    const result = await setupNim(null, "dcode-station", null, false);
     originalLog(JSON.stringify({ result, lines }));
   } finally {
     console.log = originalLog;

--- a/test/onboard-resume-provider-recovery.test.ts
+++ b/test/onboard-resume-provider-recovery.test.ts
@@ -465,9 +465,7 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
       },
     });
 
-    if (result.status !== 0) {
-      throw new Error(result.stderr || result.stdout);
-    }
+    expect(result.status).toBe(0);
     const payload = JSON.parse(result.stdout.trim());
     expect(payload.result.provider).toBe("nvidia-prod");
     expect(payload.result.model).toBe("nvidia/test-model");

--- a/test/onboard-resume-provider-recovery.test.ts
+++ b/test/onboard-resume-provider-recovery.test.ts
@@ -373,6 +373,9 @@ describe("setupNim provider recovery policy", () => {
     );
     const registryPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "state", "registry.js"));
     const runnerPath = JSON.stringify(path.join(repoRoot, "dist", "lib", "runner.js"));
+    const credentialsPath = JSON.stringify(
+      path.join(repoRoot, "dist", "lib", "credentials", "store.js"),
+    );
 
     fs.mkdirSync(fakeBin, { recursive: true });
     fs.writeFileSync(
@@ -397,6 +400,7 @@ printf '%s' "$status"
 const fs = require("fs");
 const path = require("path");
 const Module = require("module");
+const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 const registry = require(${registryPath});
 const onboardSession = require(${sessionPath});
@@ -409,6 +413,12 @@ onboardSession.loadSession = () => ({
   provider: "ollama-local",
   model: "llama3.1",
 });
+const prompts = [];
+credentials.prompt = async (message) => {
+  prompts.push(message);
+  return "";
+};
+credentials.ensureApiKey = async () => {};
 
 const onboardFile = ${onboardPath};
 const source = fs.readFileSync(onboardFile, "utf-8");
@@ -441,8 +451,10 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
   console.log = (...args) => lines.push(args.join(" "));
   console.error = (...args) => lines.push(args.join(" "));
   try {
-    const result = await setupNim(null, "dcode-station", null, false);
-    originalLog(JSON.stringify({ result, lines }));
+    const nonInteractive = await setupNim(null, "dcode-station", null, false);
+    __setNonInteractive(false);
+    const interactive = await setupNim(null, "dcode-station", null, false);
+    originalLog(JSON.stringify({ nonInteractive, interactive, prompts, lines }));
   } finally {
     console.log = originalLog;
     console.error = originalError;
@@ -467,9 +479,15 @@ const { setupNim, __setNonInteractive } = onboardModule.exports;
 
     expect(result.status).toBe(0);
     const payload = JSON.parse(result.stdout.trim());
-    expect(payload.result.provider).toBe("nvidia-prod");
-    expect(payload.result.model).toBe("nvidia/test-model");
-    expect(payload.result.preferredInferenceApi).toBe("openai-completions");
+    expect(payload.nonInteractive.provider).toBe("nvidia-prod");
+    expect(payload.nonInteractive.model).toBe("nvidia/test-model");
+    expect(payload.nonInteractive.preferredInferenceApi).toBe("openai-completions");
+    expect(payload.interactive.provider).toBe("nvidia-prod");
+    expect(payload.interactive.preferredInferenceApi).toBe("openai-completions");
+    expect(payload.prompts[0]).toMatch(/^  Choose \[\d+\]: $/);
+    expect(
+      payload.lines.some((line: string) => line.includes("Select your inference provider")),
+    ).toBe(true);
     expect(
       payload.lines.some((line: string) => line.includes("[non-interactive] Provider: build")),
     ).toBe(true);


### PR DESCRIPTION
## Summary
Fixes fresh non-interactive onboarding so stale recorded provider/model recovery is ignored before provider selection. This keeps `--fresh` from auto-selecting an old `ollama-local` provider for a `dcode-station` sandbox when the current environment should choose NVIDIA Endpoints or an explicitly requested provider.

## Related Issue
Fixes #5719

## Changes
- Thread `fresh` from the core onboarding flow into provider inference setup.
- Add a `setupNim` recovery policy option and use inert recovery readers when fresh onboarding disables recorded provider recovery.
- Add regression coverage for the handler, core flow boundary, and the stale-session `setupNim` behavior.
- Docs pass completed: no docs changes needed because existing docs already describe `--fresh` as discarding saved provider/model selection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing docs already state `--fresh` starts over and discards saved provider/model selection; this PR fixes implementation drift.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review focused on preserving non-fresh recovery behavior while disabling stale recovery only for fresh provider selection; targeted tests cover both the flow boundary and setupNim behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification run locally:
- `npm run build:cli`
- `npm test -- --run src/lib/onboard/machine/handlers/provider-inference.test.ts src/lib/onboard/machine/core-flow-phases.test.ts test/onboard-resume-provider-recovery.test.ts`
- `npm run typecheck:cli`
- `git diff --check`
- `npm run source-shape:check`
- `SKIP=test-cli npx prek run --files src/lib/onboard.ts src/lib/onboard/machine/core-flow-phases.test.ts src/lib/onboard/machine/core-flow-phases.ts src/lib/onboard/machine/handlers/provider-inference.test.ts src/lib/onboard/machine/handlers/provider-inference.ts test/onboard-resume-provider-recovery.test.ts`
- Commit/push hooks passed with `SKIP=test-cli`; the targeted CLI tests above were run directly.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “fresh” onboarding option and a configurable provider recovery flag that improves deterministic provider/model selection.

* **Bug Fixes**
  * Updated provider inference/resume behavior so recorded provider recovery is skipped for fresh runs, and recovery-based provider selection is disabled when recovery is turned off.

* **Tests**
  * Added and updated unit/integration coverage to confirm correct `setupNim` recovery-policy arguments, resume-vs-fresh routing, and expected non-interactive vs interactive prompts/logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->