### PR TITLE
test(dcode): stabilize empty prompt wrapper harness

### DIFF
--- a/test/dcode-wrapper-empty-prompt.test.ts
+++ b/test/dcode-wrapper-empty-prompt.test.ts
@@ -7,8 +7,8 @@
 // running a task or dropping into the interactive TUI.
 //
 // Linux gated: the wrapper hardcodes `PATH=/usr/local/bin:...` and launches
-// `python3 -m deepagents_code`. CI runs on Linux where /usr/local/bin/python3 is
-// absent, so the wrapper resolves to the stubbed python3 planted below.
+// `python3 -m deepagents_code`. The test patches only the copied wrapper's
+// managed PATH so the launch reaches the stubbed python3 planted below.
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -48,12 +48,30 @@ type WrapperRun = {
 function runWrapper(args: string[]): WrapperRun {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-wrapper-"));
   try {
-    fs.copyFileSync(WRAPPER, path.join(dir, "dcode"));
-    fs.chmodSync(path.join(dir, "dcode"), 0o755);
-
     const marker = path.join(dir, "launched.txt");
     const bin = path.join(dir, "bin");
     fs.mkdirSync(bin);
+
+    const managedPath = [
+      bin,
+      "/usr/local/bin",
+      "/opt/venv/bin",
+      "/usr/local/sbin",
+      "/usr/sbin",
+      "/usr/bin",
+      "/sbin",
+      "/bin",
+    ].join(":");
+    const wrapperSource = fs.readFileSync(WRAPPER, "utf-8");
+    const wrapperWithStubbedPath = wrapperSource.replace(
+      'export PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"',
+      `export PATH=${JSON.stringify(managedPath)}`,
+    );
+    if (wrapperWithStubbedPath === wrapperSource) {
+      throw new Error("Unable to patch dcode wrapper managed PATH for test stub");
+    }
+    fs.writeFileSync(path.join(dir, "dcode"), wrapperWithStubbedPath, { mode: 0o755 });
+
     fs.writeFileSync(
       path.join(bin, "python3"),
       `#!/usr/bin/env bash\nprintf '%s' "$*" > ${JSON.stringify(marker)}\nexit 0\n`,

--- a/test/dcode-wrapper-empty-prompt.test.ts
+++ b/test/dcode-wrapper-empty-prompt.test.ts
@@ -67,9 +67,7 @@ function runWrapper(args: string[]): WrapperRun {
       'export PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"',
       `export PATH=${JSON.stringify(managedPath)}`,
     );
-    if (wrapperWithStubbedPath === wrapperSource) {
-      throw new Error("Unable to patch dcode wrapper managed PATH for test stub");
-    }
+    expect(wrapperWithStubbedPath).not.toBe(wrapperSource);
     fs.writeFileSync(path.join(dir, "dcode"), wrapperWithStubbedPath, { mode: 0o755 });
 
     fs.writeFileSync(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Stabilizes the Deep Agents Code empty-prompt wrapper test so positive passthrough cases use the test's stubbed `python3` deterministically instead of depending on the host `/usr/local/bin/python3` layout.

## Related Issue
Refs #5752

## Changes
- Patch only the copied `dcode-wrapper.sh` fixture's managed `PATH` inside `test/dcode-wrapper-empty-prompt.test.ts`.
- Preserve production wrapper behavior while keeping the #5752 reject and passthrough assertions hermetic across CI and developer hosts.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-harness-only change; docs review subagent confirmed no user-facing behavior, API, CLI, policy, or workflow docs changed.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
  - Normal commit/push hooks were attempted; the `test-cli` hook failed in unrelated resource-limit tests with `fork: Resource temporarily unavailable`.
  - `SKIP=test-cli npx prek run --files test/dcode-wrapper-empty-prompt.test.ts` passed.
  - Push with `SKIP=test-cli` passed pre-push TypeScript and non-test hooks.
- [x] Targeted tests pass for changed behavior
  - `npx vitest run test/dcode-wrapper-empty-prompt.test.ts --project cli`
  - `npm run build:cli`
  - `npm run test-conditionals:scan -- --top 25`
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for wrapper startup when prompts are empty.
  * Updated the wrapper startup test to patch the wrapper’s managed `PATH`, ensuring it reliably uses the stubbed `python3` in the test environment and reducing launch-flow flakiness.
  * Added assertions verifying the patched wrapper content changes as expected before execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->