### PR TITLE
fix(cli): probe terminal runtime versions in status

### DIFF
--- a/src/lib/actions/sandbox/status-flow.test.ts
+++ b/src/lib/actions/sandbox/status-flow.test.ts
@@ -12,6 +12,7 @@ const requireDist = createRequire(import.meta.url);
 const statusModulePath = "../../../../dist/lib/actions/sandbox/status.js";
 
 type StatusFlowHarness = {
+  checkAgentVersionSpy: MockInstance;
   getActiveSandboxSessionsSpy: MockInstance;
   getSandboxDockerRuntimeSpy: MockInstance;
   logSpy: MockInstance;
@@ -39,7 +40,15 @@ const baseSandboxEntry = {
   agentVersion: "0.1.0",
 };
 
-function createStatusFlowHarness(options: { lookupState?: "present" | "missing" } = {}) {
+function createStatusFlowHarness(
+  options: {
+    lookupState?: "present" | "missing";
+    sandboxEntry?: Partial<Omit<typeof baseSandboxEntry, "agentVersion">> & {
+      agent?: string | null;
+      agentVersion?: string | null;
+    };
+  } = {},
+) {
   delete require.cache[requireDist.resolve(statusModulePath)];
 
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -74,7 +83,9 @@ function createStatusFlowHarness(options: { lookupState?: "present" | "missing" 
           recoverySandboxVia: "docker unpause",
         };
 
-  vi.spyOn(registry, "getSandbox").mockReturnValue(baseSandboxEntry);
+  const sandboxEntry = { ...baseSandboxEntry, ...options.sandboxEntry };
+
+  vi.spyOn(registry, "getSandbox").mockReturnValue(sandboxEntry);
   vi.spyOn(statusPreflight, "getSandboxStatusPreflight").mockResolvedValue({
     failure: null,
     failureLayer: null,
@@ -82,7 +93,7 @@ function createStatusFlowHarness(options: { lookupState?: "present" | "missing" 
     exitCode: 0,
   });
   vi.spyOn(statusSnapshot, "collectSandboxStatusSnapshot").mockResolvedValue({
-    sb: baseSandboxEntry,
+    sb: sandboxEntry,
     lookup,
     rpcIssue: null,
     currentModel: "nvidia/nemotron-live",
@@ -129,7 +140,7 @@ function createStatusFlowHarness(options: { lookupState?: "present" | "missing" 
     container: null,
   });
   vi.spyOn(nim, "shouldShowNimLine").mockReturnValue(true);
-  vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
+  const checkAgentVersionSpy = vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
     sandboxVersion: "0.1.0",
     expectedVersion: "0.2.0",
     isStale: true,
@@ -149,6 +160,7 @@ function createStatusFlowHarness(options: { lookupState?: "present" | "missing" 
   logSpy.mockClear();
 
   return {
+    checkAgentVersionSpy,
     getActiveSandboxSessionsSpy,
     getSandboxDockerRuntimeSpy,
     logSpy,
@@ -199,6 +211,27 @@ describe("showSandboxStatus flow", () => {
     expect(harness.getActiveSandboxSessionsSpy).toHaveBeenCalledWith("alpha", expect.any(Object));
     expect(harness.getSandboxDockerRuntimeSpy).toHaveBeenCalledWith("alpha");
     expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("probes terminal runtime agent version when cached metadata is missing", async () => {
+    const harness = createStatusFlowHarness({
+      sandboxEntry: {
+        agent: "langchain-deepagents-code",
+        agentVersion: null,
+      },
+    });
+
+    await expect(harness.showSandboxStatus("alpha")).resolves.toBeUndefined();
+
+    const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Harness:  LangChain Deep Agents Code (terminal)");
+    expect(output).toContain("Agent:    LangChain Deep Agents Code v0.1.0");
+    expect(output).toContain("Update:");
+    expect(output).toContain("Run `nemoclaw alpha rebuild` to upgrade");
+    expect(harness.checkAgentVersionSpy).toHaveBeenCalledWith("alpha", {
+      forceProbe: true,
+      skipProbe: false,
+    });
   });
 
   it("preserves the registry entry and exits when the live gateway is missing the sandbox", async () => {

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -51,13 +51,16 @@ export {
 } from "./status-snapshot";
 
 /**
- * Returns true when status can validate a cached agent version against the running sandbox.
+ * Returns true when status can validate an agent version against the running sandbox.
  */
 function shouldProbeSandboxRuntimeVersion(
   lookup: SandboxGatewayState,
   sandbox: registry.SandboxEntry,
+  agentRuntimeKind: string,
 ): boolean {
-  return lookup.state === "present" && Boolean(sandbox.agentVersion);
+  return (
+    lookup.state === "present" && (Boolean(sandbox.agentVersion) || agentRuntimeKind === "terminal")
+  );
 }
 
 // True when sandbox GPU is enabled but no CUDA-usability proof has confirmed it
@@ -263,7 +266,11 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
 
     // Agent version check
     try {
-      const shouldProbeRuntimeVersion = shouldProbeSandboxRuntimeVersion(lookup, sb);
+      const shouldProbeRuntimeVersion = shouldProbeSandboxRuntimeVersion(
+        lookup,
+        sb,
+        statusAgent.agentRuntime,
+      );
       const versionCheck = sandboxVersion.checkAgentVersion(sandboxName, {
         forceProbe: shouldProbeRuntimeVersion,
         skipProbe: !shouldProbeRuntimeVersion,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`status` now live-probes terminal-runtime agent versions when the sandbox is present, even if older registry metadata is missing a cached `agentVersion`. This lets drifted LangChain Deep Agents Code sandboxes surface the existing `Update:`/`rebuild` warning instead of looking healthy by omission.

## Related Issue
Fixes #5778

## Changes
- Update the sandbox status version-probe gate so terminal runtimes force a live manifest-controlled version probe when the sandbox is present.
- Add a DCode regression to the status-flow test for a terminal sandbox with no cached `agentVersion`, asserting the stale version and rebuild hint are printed.
- Documentation impact review found no docs changes needed because existing docs already describe status update warnings and rebuild as the upgrade path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing command/lifecycle docs already describe `status` update warnings and `rebuild` as the sandbox agent upgrade path.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-reviewed; change is limited to the read-only status path and uses the existing manifest-controlled version command with existing timeout/probe handling.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted/local verification:
- `npx vitest run --project cli src/lib/actions/sandbox/status-flow.test.ts src/lib/sandbox/version.test.ts`
- `npm run typecheck:cli`
- `git diff --check`

Local hook note: pre-commit/pre-push ran successfully except `test-cli`, which was skipped for the final commit/push after two full-hook attempts failed in unrelated rlimit/fork-storm tests with `fork: Resource temporarily unavailable`. The focused status/version tests and CLI typecheck above passed.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox status checks so terminal runtimes can still be version-verified even when cached agent metadata is missing.
  * Updated status output to show clearer upgrade guidance in this scenario, including instructions to rebuild when needed.
  * Fixed the underlying status flow so version checks are triggered correctly for terminal agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->