### PR TITLE
fix(cli): restore terminal after connect disconnect

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -35,8 +35,18 @@ type ConnectHarnessOptions = {
     secretBoundaryRefused?: boolean;
     secretBoundaryReason?: "raw-secret" | "inconclusive";
   };
+  spawnSignal?: NodeJS.Signals | null;
   spawnStatus?: number | null;
+  sttyThrows?: boolean;
 };
+
+function throwSttyFailure(): never {
+  throw new Error("stty failed");
+}
+
+function spawnStatusFromOptions(options: ConnectHarnessOptions): number | null {
+  return Object.hasOwn(options, "spawnStatus") ? (options.spawnStatus ?? null) : 0;
+}
 
 function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarness {
   delete require.cache[requireDist.resolve(connectModulePath)];
@@ -45,10 +55,15 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-  const spawnSyncSpy = vi.spyOn(childProcess, "spawnSync").mockReturnValue({
-    status: options.spawnStatus ?? 0,
-    signal: null,
-  } as never);
+  const spawnSyncSpy = vi.spyOn(childProcess, "spawnSync").mockImplementation(((
+    command: unknown,
+  ) =>
+    String(command) === "stty" && options.sttyThrows
+      ? throwSttyFailure()
+      : ({
+          status: spawnStatusFromOptions(options),
+          signal: options.spawnSignal ?? null,
+        } as never)) as never);
 
   const runtime = requireDist("../../../../dist/lib/adapters/openshell/runtime.js");
   const resolve = requireDist("../../../../dist/lib/adapters/openshell/resolve.js");
@@ -116,6 +131,7 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
     .mockReturnValue({ reported: 0, approved: 0 });
 
   logSpy.mockClear();
+  errorSpy.mockClear();
   spawnSyncSpy.mockClear();
 
   return {
@@ -215,6 +231,124 @@ describe("connectSandbox flow", () => {
       ["sane"],
       expect.objectContaining({ stdio: ["inherit", "ignore", "ignore"] }),
     );
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(errorOutput).toContain(
+      "Gateway connection lost. Reconnect with: nemoclaw alpha connect",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(255);
+  });
+
+  it.each([
+    ["SIGHUP", 129],
+    ["SIGPIPE", 141],
+  ] as const)("restores the terminal and preserves the exit code when SSH ends with %s", async (signal, exitCode) => {
+    const setRawModeSpy = vi.fn();
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawModeSpy,
+    });
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+      spawnSignal: signal,
+      spawnStatus: null,
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow(`process.exit(${exitCode})`);
+
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    expect(harness.spawnSyncSpy).toHaveBeenCalledWith(
+      "stty",
+      ["sane"],
+      expect.objectContaining({ stdio: ["inherit", "ignore", "ignore"] }),
+    );
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(errorOutput).toContain(
+      "Gateway connection lost. Reconnect with: nemoclaw alpha connect",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(exitCode);
+  });
+
+  it("prints reconnect guidance without terminal cleanup when stdin is not a TTY", async () => {
+    const setRawModeSpy = vi.fn();
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawModeSpy,
+    });
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+      spawnStatus: 255,
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(255)");
+
+    expect(setRawModeSpy).not.toHaveBeenCalled();
+    expect(harness.spawnSyncSpy).not.toHaveBeenCalledWith("stty", ["sane"], expect.any(Object));
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(errorOutput).toContain(
+      "Gateway connection lost. Reconnect with: nemoclaw alpha connect",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(255);
+  });
+
+  it("still runs stty cleanup when disabling raw mode throws", async () => {
+    const setRawModeSpy = vi.fn(() => {
+      throw new Error("raw mode failed");
+    });
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawModeSpy,
+    });
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+      spawnStatus: 255,
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(255)");
+
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    expect(harness.spawnSyncSpy).toHaveBeenCalledWith(
+      "stty",
+      ["sane"],
+      expect.objectContaining({ stdio: ["inherit", "ignore", "ignore"] }),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(255);
+  });
+
+  it("preserves the disconnect exit code when stty cleanup throws", async () => {
+    const setRawModeSpy = vi.fn();
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawModeSpy,
+    });
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+      spawnStatus: 255,
+      sttyThrows: true,
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(255)");
+
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
     const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
     expect(errorOutput).toContain(
       "Gateway connection lost. Reconnect with: nemoclaw alpha connect",

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -156,14 +156,10 @@ describe("connectSandbox flow", () => {
         value: originalStdoutIsTty,
       });
     }
-    if (originalStdinIsTty === undefined) {
-      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: undefined });
-    } else {
-      Object.defineProperty(process.stdin, "isTTY", {
-        configurable: true,
-        value: originalStdinIsTty,
-      });
-    }
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: originalStdinIsTty,
+    });
     Object.defineProperty(process.stdin, "setRawMode", {
       configurable: true,
       value: originalStdinSetRawMode,

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -17,6 +17,7 @@ type ConnectHarness = {
   checkAndRecoverSpy: MockInstance;
   connectSandbox: ConnectSandbox;
   ensureOllamaAuthProxySpy: MockInstance;
+  errorSpy: MockInstance;
   logSpy: MockInstance;
   runAutoPairSpy: MockInstance;
   spawnSyncSpy: MockInstance;
@@ -41,7 +42,7 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
   delete require.cache[requireDist.resolve(connectModulePath)];
 
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   const spawnSyncSpy = vi.spyOn(childProcess, "spawnSync").mockReturnValue({
@@ -122,6 +123,7 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
     checkAndRecoverSpy,
     connectSandbox: requireDist(connectModulePath).connectSandbox,
     ensureOllamaAuthProxySpy,
+    errorSpy,
     logSpy,
     runAutoPairSpy,
     spawnSyncSpy,
@@ -130,6 +132,10 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
 
 describe("connectSandbox flow", () => {
   let exitSpy: MockInstance;
+  const originalStdinIsTty = process.stdin.isTTY;
+  const originalStdinSetRawMode = (
+    process.stdin as typeof process.stdin & { setRawMode?: (mode: boolean) => unknown }
+  ).setRawMode;
   const originalStdoutIsTty = process.stdout.isTTY;
 
   beforeEach(() => {
@@ -150,6 +156,18 @@ describe("connectSandbox flow", () => {
         value: originalStdoutIsTty,
       });
     }
+    if (originalStdinIsTty === undefined) {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: undefined });
+    } else {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: originalStdinIsTty,
+      });
+    }
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: originalStdinSetRawMode,
+    });
     delete process.env.NEMOCLAW_TEST_NO_SLEEP;
     delete require.cache[requireDist.resolve(connectModulePath)];
   });
@@ -175,6 +193,37 @@ describe("connectSandbox flow", () => {
     expect(output).toContain("existing SSH sessions");
     expect(output).toContain("Connecting to sandbox 'alpha'");
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("restores the terminal and prints reconnect guidance when SSH disconnects", async () => {
+    const setRawModeSpy = vi.fn();
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      configurable: true,
+      value: setRawModeSpy,
+    });
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+      spawnStatus: 255,
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(255)");
+
+    expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    expect(harness.spawnSyncSpy).toHaveBeenCalledWith(
+      "stty",
+      ["sane"],
+      expect.objectContaining({ stdio: ["inherit", "ignore", "ignore"] }),
+    );
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(errorOutput).toContain(
+      "Gateway connection lost. Reconnect with: nemoclaw alpha connect",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(255);
   });
 
   it("prints the terminal launch command in the connect hint for terminal agents", async () => {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -842,6 +842,42 @@ function exitWithSpawnResult(result: SpawnLikeResult): void {
   process.exit(1);
 }
 
+function restoreInteractiveTerminal(): void {
+  if (!process.stdin.isTTY) return;
+
+  try {
+    const stdin = process.stdin as typeof process.stdin & {
+      setRawMode?: (mode: boolean) => unknown;
+    };
+    stdin.setRawMode?.(false);
+  } catch {
+    // Best-effort: still try `stty sane` below.
+  }
+
+  try {
+    spawnSync("stty", ["sane"], {
+      stdio: ["inherit", "ignore", "ignore"],
+      cwd: ROOT,
+      env: process.env,
+    });
+  } catch {
+    // Terminal cleanup must never mask the original connect failure.
+  }
+}
+
+function isLikelySshDisconnect(result: SpawnLikeResult): boolean {
+  return result.status === 255 || result.signal === "SIGHUP" || result.signal === "SIGPIPE";
+}
+
+function exitWithConnectSpawnResult(sandboxName: string, result: SpawnLikeResult): void {
+  if (isLikelySshDisconnect(result)) {
+    restoreInteractiveTerminal();
+    console.error("");
+    console.error(`  Gateway connection lost. Reconnect with: ${CLI_NAME} ${sandboxName} connect`);
+  }
+  exitWithSpawnResult(result);
+}
+
 export async function connectSandbox(
   sandboxName: string,
   { probeOnly = false }: SandboxConnectOptions = {},
@@ -1074,5 +1110,5 @@ export async function connectSandbox(
     cwd: ROOT,
     env: process.env,
   });
-  exitWithSpawnResult(result);
+  exitWithConnectSpawnResult(sandboxName, result);
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR makes `nemoclaw <sandbox> connect` recover the host terminal after an abrupt SSH disconnect and prints a clear reconnect command. It targets the DCode TUI failure mode where restarting the OpenShell gateway mid-session leaves the terminal corrupted with raw SSH broken-pipe output.

## Related Issue
Fixes #5769

## Changes
- Restores interactive terminal state on likely SSH disconnects by clearing Node raw mode when available and running `stty sane` best-effort.
- Prints `Gateway connection lost. Reconnect with: nemoclaw <sandbox> connect` before preserving the child process exit behavior.
- Adds connect-flow regression coverage for SSH status `255`, `SIGHUP`, `SIGPIPE`, non-TTY stdin, raw-mode cleanup failure, and `stty sane` cleanup failure.
- Docs impact review: no docs update needed; existing connect, troubleshooting, and DCode quickstart docs cover the public workflow, and the new failure-mode message is self-contained.
- Local hook caveat: the full `test-cli` hook failed in this environment due unrelated `fork: Resource temporarily unavailable` failures in `test/sandbox-init.test.ts` and `test/sandbox-rlimit-hooks.test.ts`; targeted connect validation passed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: docs impact subagent found this is a self-contained failure-mode UX improvement; existing command/troubleshooting/DCode docs cover the public workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; sandbox connect change is limited to post-connect terminal cleanup/reconnect guidance and preserves the child exit result.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification performed:
- `npm run build:cli`
- `npx vitest run --project cli src/lib/actions/sandbox/connect-flow.test.ts test/cli/connect-terminal-agent.test.ts test/cli/connect-recovery.test.ts`
- `npx vitest run --project cli src/lib/actions/sandbox/connect-flow.test.ts`
- `npx biome check src/lib/actions/sandbox/connect-flow.test.ts`
- `npm run typecheck:cli`
- `git diff --check`
- `npm run test-conditionals:scan -- --top 25`
- Pushed commit verification:
  - `19f2795dcb4aab679e4e832bc99c18ea4ea8a049 verified=true reason=valid`
  - `60b900cc6ae3023fb23afd99ce4d85534e7b4c93 verified=true reason=valid`
  - `8ce3fa99d076eff0cc2aa65927adcb9e662474d9 verified=true reason=valid`

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive terminal cleanup when SSH disconnects, reliably disabling raw input mode and resetting the terminal state.
  * Enhanced disconnect handling to show clearer reconnect guidance while preserving the original termination behavior (exit code or signal).
  * Made cleanup best-effort so terminal reset failures no longer mask the original connect failure.
* **Tests**
  * Added/expanded automated coverage for various disconnect outcomes, including TTY vs non-TTY and cleanup error scenarios, to verify messaging and correct exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
