### PR TITLE
fix(messaging): fix Hermes messaging after upgrade

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -184,6 +184,11 @@ ENV NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
     NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER=${NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER} \
     NEMOCLAW_HERMES_TOOL_GATEWAY_PRESETS_B64=${NEMOCLAW_HERMES_TOOL_GATEWAY_PRESETS_B64}
 
+# Bake reduced messaging runtime metadata for the entrypoint. Hermes runtime
+# config refresh consumes generic manifest-owned aliases from this artifact.
+# hadolint ignore=DL3059
+RUN node --experimental-strip-types /src/lib/messaging/applier/build/messaging-build-applier.mts --agent hermes --phase runtime-setup
+
 # Apply messaging agent-install hooks as root so Hermes Python packages can update
 # /opt/hermes/.venv before the runtime drops to the sandbox user.
 WORKDIR /opt/hermes

--- a/agents/hermes/runtime-config-guard.py
+++ b/agents/hermes/runtime-config-guard.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import errno
 import hashlib
+import json
 import os
 import re
 import secrets
@@ -25,6 +26,7 @@ PROVIDER_PLACEHOLDER_KEYS = (
     "SLACK_BOT_TOKEN",
     "SLACK_APP_TOKEN",
 )
+PROVIDER_PLACEHOLDER_KEY_SET = set(PROVIDER_PLACEHOLDER_KEYS)
 
 
 class UnsafePathError(RuntimeError):
@@ -352,6 +354,77 @@ def _normalize_provider_placeholder_for_env_key(value: str, env_key: str) -> str
     return f"{SCOPED_PLACEHOLDER_PREFIX}{env_key}"
 
 
+def _has_env_control_chars(value: str) -> bool:
+    return "\x00" in value or "\r" in value or "\n" in value
+
+
+def _runtime_plan_alias_replacements(runtime_plan_path: str | None) -> dict[str, tuple[str, str]]:
+    if not runtime_plan_path or not os.path.isfile(runtime_plan_path):
+        return {}
+    try:
+        with open(runtime_plan_path, encoding="utf-8") as handle:
+            plan = json.load(handle)
+    except Exception as exc:
+        raise UnsafePathError(f"messaging runtime plan is invalid: {exc}") from exc
+    if not isinstance(plan, dict):
+        raise UnsafePathError("messaging runtime plan must be an object")
+
+    disabled_channels = {
+        channel_id
+        for channel_id in plan.get("disabledChannels", [])
+        if isinstance(channel_id, str)
+    }
+    active_channel_ids: set[str] = set()
+    for channel in plan.get("channels", []):
+        if not isinstance(channel, dict):
+            continue
+        channel_id = channel.get("channelId")
+        if (
+            isinstance(channel_id, str)
+            and channel.get("active") is True
+            and channel.get("disabled") is not True
+            and channel_id not in disabled_channels
+        ):
+            active_channel_ids.add(channel_id)
+
+    runtime_setup = plan.get("runtimeSetup") or {}
+    if not isinstance(runtime_setup, dict):
+        raise UnsafePathError("messaging runtime plan runtimeSetup must be an object")
+    aliases = runtime_setup.get("envAliases", [])
+    if not isinstance(aliases, list):
+        raise UnsafePathError("messaging runtime plan runtimeSetup.envAliases must be a list")
+
+    replacements: dict[str, tuple[str, str]] = {}
+    for alias in aliases:
+        if not isinstance(alias, dict):
+            raise UnsafePathError("messaging runtime plan envAliases entries must be objects")
+        channel_id = alias.get("channelId")
+        if not isinstance(channel_id, str) or channel_id not in active_channel_ids:
+            continue
+        env_key = alias.get("envKey")
+        pattern = alias.get("match")
+        value = alias.get("value")
+        message = alias.get("message") or ""
+        if (
+            not isinstance(env_key, str)
+            or env_key not in PROVIDER_PLACEHOLDER_KEY_SET
+            or not isinstance(pattern, str)
+            or not isinstance(value, str)
+            or not isinstance(message, str)
+            or env_key in replacements
+        ):
+            continue
+        if _has_env_control_chars(value) or _has_env_control_chars(message):
+            raise UnsafePathError("messaging runtime plan env alias contains unsafe characters")
+        try:
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            raise UnsafePathError(f"messaging runtime plan env alias regex is invalid: {exc}") from exc
+        if compiled.search(os.environ.get(env_key, "")):
+            replacements[env_key] = (value, message)
+    return replacements
+
+
 def ensure_api_key(hermes_dir: str, hash_file: str, mode: str) -> None:
     env_path = os.path.join(hermes_dir, ".env")
     if not os.path.exists(env_path):
@@ -395,21 +468,28 @@ def ensure_api_key(hermes_dir: str, hash_file: str, mode: str) -> None:
     print("minted=1")
 
 
-def provider_placeholders(hermes_dir: str, hash_file: str, mode: str) -> None:
+def provider_placeholders(
+    hermes_dir: str, hash_file: str, mode: str, runtime_plan_path: str | None
+) -> None:
     env_path = os.path.join(hermes_dir, ".env")
     if not os.path.exists(env_path):
         return
 
-    replacements = {
-        key: normalized
-        for key in PROVIDER_PLACEHOLDER_KEYS
-        if (normalized := _normalize_provider_placeholder_for_env_key(os.environ.get(key, ""), key))
-    }
+    runtime_aliases = _runtime_plan_alias_replacements(runtime_plan_path)
+    replacements: dict[str, tuple[str, str]] = {}
+    for key in PROVIDER_PLACEHOLDER_KEYS:
+        if key in runtime_aliases:
+            replacements[key] = runtime_aliases[key]
+            continue
+        normalized = _normalize_provider_placeholder_for_env_key(os.environ.get(key, ""), key)
+        if normalized:
+            replacements[key] = (normalized, "")
     if not replacements:
         return
 
     text, snapshot = _read_text(env_path)
     changed = False
+    refreshed_messages: set[str] = set()
     updated: list[str] = []
     for line in text.splitlines(keepends=True):
         parsed = _parse_env_assignment(line)
@@ -418,9 +498,13 @@ def provider_placeholders(hermes_dir: str, hash_file: str, mode: str) -> None:
             continue
         prefix, key, _value = parsed
         if key in replacements:
-            new_line = f"{prefix}{key}={replacements[key]}\n"
+            replacement, message = replacements[key]
+            new_line = f"{prefix}{key}={replacement}\n"
             updated.append(new_line)
-            changed = changed or new_line != line
+            if new_line != line:
+                changed = True
+                if message:
+                    refreshed_messages.add(message)
             continue
         updated.append(line)
 
@@ -439,6 +523,8 @@ def provider_placeholders(hermes_dir: str, hash_file: str, mode: str) -> None:
             )
             return
         raise
+    for message in sorted(refreshed_messages):
+        print(message, file=sys.stderr)
     print("[config] Refreshed Hermes provider placeholders from OpenShell runtime env", file=sys.stderr)
 
 
@@ -447,6 +533,7 @@ def main() -> int:
     parser.add_argument("action", choices=("ensure-api-key", "refresh-hashes", "provider-placeholders"))
     parser.add_argument("--hermes-dir", required=True)
     parser.add_argument("--hash-file", required=True)
+    parser.add_argument("--runtime-plan", default="")
     parser.add_argument("--mode", choices=("strict", "compat"), default="strict")
     args = parser.parse_args()
 
@@ -456,7 +543,7 @@ def main() -> int:
         elif args.action == "refresh-hashes":
             refresh_hashes(args.hermes_dir, args.hash_file, args.mode)
         elif args.action == "provider-placeholders":
-            provider_placeholders(args.hermes_dir, args.hash_file, args.mode)
+            provider_placeholders(args.hermes_dir, args.hash_file, args.mode, args.runtime_plan)
     except UnsafePathError as exc:
         _die(str(exc))
     except OSError as exc:

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1181,6 +1181,7 @@ migrate_legacy_layout() {
 refresh_hermes_provider_placeholders() {
   local mode="${1:-strict}"
   local env_file="${HERMES_DIR}/.env"
+  local runtime_plan="${NEMOCLAW_MESSAGING_RUNTIME_PLAN_PATH:-/usr/local/share/nemoclaw/messaging-runtime-plan.json}"
   [ -f "$env_file" ] || return 0
 
   local keys="TELEGRAM_BOT_TOKEN DISCORD_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN"
@@ -1197,6 +1198,7 @@ refresh_hermes_provider_placeholders() {
   "$_HERMES_PYTHON" "$_HERMES_RUNTIME_CONFIG_GUARD" provider-placeholders \
     --hermes-dir "$HERMES_DIR" \
     --hash-file "$HERMES_HASH_FILE" \
+    --runtime-plan "$runtime_plan" \
     --mode "$mode"
 }
 

--- a/src/lib/messaging/channels/slack/manifest.ts
+++ b/src/lib/messaging/channels/slack/manifest.ts
@@ -3,6 +3,23 @@
 
 import type { ChannelManifest } from "../../manifest";
 
+const slackRuntimeEnvAliases = [
+  {
+    envKey: "SLACK_BOT_TOKEN",
+    match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_BOT_TOKEN$",
+    value: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+    message:
+      "[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias",
+  },
+  {
+    envKey: "SLACK_APP_TOKEN",
+    match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$",
+    value: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+    message:
+      "[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias",
+  },
+] as const;
+
 export const slackManifest = {
   schemaVersion: 1,
   id: "slack",
@@ -152,22 +169,7 @@ export const slackManifest = {
         configKeys: ["slack"],
         logPatterns: ["slack"],
       },
-      envAliases: [
-        {
-          envKey: "SLACK_BOT_TOKEN",
-          match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_BOT_TOKEN$",
-          value: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
-          message:
-            "[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias",
-        },
-        {
-          envKey: "SLACK_APP_TOKEN",
-          match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$",
-          value: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
-          message:
-            "[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias",
-        },
-      ],
+      envAliases: slackRuntimeEnvAliases,
       nodePreloads: [
         {
           module: "slack-channel-guard",
@@ -186,6 +188,9 @@ export const slackManifest = {
           exitCode: 78,
         },
       ],
+    },
+    hermes: {
+      envAliases: slackRuntimeEnvAliases,
     },
   },
   agentPackages: [

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -411,6 +411,24 @@ describe("ManifestCompiler", () => {
     expect(JSON.stringify(plan.agentRender)).toContain(
       "TEAMS_CLIENT_SECRET=openshell:resolve:env:MSTEAMS_APP_PASSWORD",
     );
+    expect(plan.runtimeSetup?.envAliases).toEqual([
+      {
+        channelId: "slack",
+        envKey: "SLACK_BOT_TOKEN",
+        match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_BOT_TOKEN$",
+        value: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+        message:
+          "[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias",
+      },
+      {
+        channelId: "slack",
+        envKey: "SLACK_APP_TOKEN",
+        match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$",
+        value: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+        message:
+          "[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias",
+      },
+    ]);
     expect(plan.buildSteps).toEqual([
       {
         channelId: "teams",

--- a/test/hermes-runtime-api-key.test.ts
+++ b/test/hermes-runtime-api-key.test.ts
@@ -142,37 +142,42 @@ function runHermesRuntimeApiServerKeyMint(
 function runHermesRuntimeProviderPlaceholderRefresh(opts: {
   envFile: string;
   envOverrides: Record<string, string>;
+  runtimePlan?: unknown;
 }) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-provider-placeholders-"));
   const hermesHome = path.join(tmpDir, ".hermes");
   const configPath = path.join(hermesHome, "config.yaml");
   const envPath = path.join(hermesHome, ".env");
   const hashPath = path.join(tmpDir, "hermes.config-hash");
+  const runtimePlanPath = path.join(tmpDir, "messaging-runtime-plan.json");
 
   fs.mkdirSync(hermesHome, { recursive: true });
   fs.writeFileSync(configPath, "model:\n  default: test-model\n");
   fs.writeFileSync(envPath, opts.envFile, { mode: 0o640 });
   writeHermesHash(hashPath, configPath, envPath);
+  if (opts.runtimePlan !== undefined) {
+    fs.writeFileSync(runtimePlanPath, `${JSON.stringify(opts.runtimePlan, null, 2)}\n`);
+  }
 
   try {
-    const result = spawnSync(
-      "python3",
-      [
-        RUNTIME_CONFIG_GUARD,
-        "provider-placeholders",
-        "--hermes-dir",
-        hermesHome,
-        "--hash-file",
-        hashPath,
-        "--mode",
-        "strict",
-      ],
-      {
-        encoding: "utf-8",
-        timeout: 5000,
-        env: { ...process.env, ...opts.envOverrides },
-      },
-    );
+    const args = [
+      RUNTIME_CONFIG_GUARD,
+      "provider-placeholders",
+      "--hermes-dir",
+      hermesHome,
+      "--hash-file",
+      hashPath,
+      "--mode",
+      "strict",
+    ];
+    if (opts.runtimePlan !== undefined) {
+      args.push("--runtime-plan", runtimePlanPath);
+    }
+    const result = spawnSync("python3", args, {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: { ...process.env, ...opts.envOverrides },
+    });
     const envFileContent = fs.readFileSync(envPath, "utf-8");
     const strictHashCheck = spawnSync("sha256sum", ["-c", hashPath, "--status"], {
       encoding: "utf-8",
@@ -281,6 +286,62 @@ describe("agents/hermes/start.sh runtime API server key", () => {
       expect(run.envFileContent).not.toContain("v111_DISCORD_BOT_TOKEN");
       expect(run.strictHashValid).toBe(true);
     }
+  });
+
+  it("uses manifest runtime aliases for Hermes Slack provider placeholders", () => {
+    const run = runHermesRuntimeProviderPlaceholderRefresh({
+      envFile: [
+        "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN=openshell:resolve:env:v111_SLACK_APP_TOKEN",
+        "",
+      ].join("\n"),
+      envOverrides: {
+        SLACK_BOT_TOKEN: "openshell:resolve:env:v222_SLACK_BOT_TOKEN",
+        SLACK_APP_TOKEN: "openshell:resolve:env:SLACK_APP_TOKEN",
+      },
+      runtimePlan: {
+        schemaVersion: 1,
+        sandboxName: "test-sandbox",
+        agent: "hermes",
+        channels: [{ channelId: "slack", active: true, disabled: false }],
+        disabledChannels: [],
+        credentialBindings: [],
+        runtimeSetup: {
+          nodePreloads: [],
+          envAliases: [
+            {
+              channelId: "slack",
+              envKey: "SLACK_BOT_TOKEN",
+              match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_BOT_TOKEN$",
+              value: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+              message:
+                "[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias",
+            },
+            {
+              channelId: "slack",
+              envKey: "SLACK_APP_TOKEN",
+              match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$",
+              value: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+              message:
+                "[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias",
+            },
+          ],
+          secretScans: [],
+        },
+      },
+    });
+
+    expect(run.result.status, run.result.stderr).toBe(0);
+    expect(run.envFileContent).toContain(
+      "SLACK_BOT_TOKEN=xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN\n",
+    );
+    expect(run.envFileContent).toContain(
+      "SLACK_APP_TOKEN=xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN\n",
+    );
+    expect(run.envFileContent).not.toContain("openshell:resolve:env");
+    expect(run.result.stderr).toContain("Normalized SLACK_BOT_TOKEN");
+    expect(run.result.stderr).toContain("Normalized SLACK_APP_TOKEN");
+    expect(run.strictHashValid).toBe(true);
   });
 
   it("generates distinct API_SERVER_KEY values for separate sandbox homes", () => {

--- a/test/messaging-build-applier.test.ts
+++ b/test/messaging-build-applier.test.ts
@@ -344,6 +344,90 @@ describe("messaging-build-applier.mts: agent-install", () => {
     }
   });
 
+  it("preserves Hermes runtime env aliases in the reduced runtime plan artifact", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-runtime-plan-artifact-"));
+    const artifactPath = path.join(tmp, "runtime", "messaging-runtime-plan.json");
+    const plan = {
+      schemaVersion: 1,
+      sandboxName: "test-sandbox",
+      agent: "hermes",
+      workflow: "rebuild",
+      channels: [{ channelId: "slack", active: true, disabled: false }],
+      disabledChannels: [],
+      credentialBindings: [
+        {
+          channelId: "slack",
+          providerEnvKey: "SLACK_BOT_TOKEN",
+          placeholder: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+        },
+      ],
+      agentRender: [],
+      buildSteps: [],
+      runtimeSetup: {
+        nodePreloads: [],
+        envAliases: [
+          {
+            channelId: "slack",
+            envKey: "SLACK_BOT_TOKEN",
+            match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_BOT_TOKEN$",
+            value: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+            message:
+              "[channels] Normalized SLACK_BOT_TOKEN runtime placeholder to the Bolt-compatible alias",
+          },
+          {
+            channelId: "slack",
+            envKey: "SLACK_APP_TOKEN",
+            match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$",
+            value: "xapp-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN",
+            message:
+              "[channels] Normalized SLACK_APP_TOKEN runtime placeholder to the Bolt-compatible alias",
+          },
+        ],
+        secretScans: [],
+      },
+    };
+
+    try {
+      const result = spawnSync(
+        "node",
+        [
+          "--experimental-strip-types",
+          SCRIPT_PATH,
+          "--agent",
+          "hermes",
+          "--phase",
+          "runtime-setup",
+        ],
+        {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+          env: {
+            PATH: process.env.PATH || "/usr/bin:/bin",
+            NEMOCLAW_MESSAGING_RUNTIME_PLAN_PATH: artifactPath,
+            NEMOCLAW_MESSAGING_PLAN_B64: encodePlan(plan),
+          },
+          timeout: 10_000,
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf-8"));
+      expect(artifact).toMatchObject({
+        schemaVersion: 1,
+        sandboxName: "test-sandbox",
+        agent: "hermes",
+        workflow: "rebuild",
+        channels: [{ channelId: "slack", active: true, disabled: false }],
+        credentialBindings: [{ channelId: "slack", providerEnvKey: "SLACK_BOT_TOKEN" }],
+        runtimeSetup: {
+          envAliases: plan.runtimeSetup.envAliases,
+        },
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("installs package-install specs supplied by the compiled plan", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-package-plan-"));
     const tracePath = path.join(tmp, "openclaw.trace");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the Hermes Slack messaging regression introduced by the Hermes upgrade by applying manifest-owned runtime env aliases during Hermes startup. This keeps Slack provider placeholders in Bolt-compatible `xoxb-` / `xapp-` shape while preserving the generic messaging runtime setup flow.
Failed E2E test at https://github.com/NVIDIA/NemoClaw/actions/runs/28214133003/job/83581447911 

## Changes
- Reuses Slack runtime env alias metadata for both OpenClaw and Hermes in the Slack channel manifest.
- Bakes the reduced messaging runtime plan into the Hermes image and passes it to the Hermes runtime config guard.
- Applies active manifest-owned runtime aliases when safely refreshing `.hermes/.env`, with canonical placeholder normalization retained as fallback.
- Adds compiler, runtime artifact, and Hermes runtime guard coverage for the Slack alias path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal runtime placeholder plumbing; existing Slack docs already describe runtime placeholder normalization.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-reviewed generic manifest-first alias handling; no raw secret persistence added, runtime plan values are sanitized before `.env` rewrite.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>
