### PR TITLE
fix(sandbox): make rlimit helper posix-sh safe

### DIFF
--- a/scripts/lib/sandbox-rlimits.sh
+++ b/scripts/lib/sandbox-rlimits.sh
@@ -1,11 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# shellcheck shell=bash
+# shellcheck shell=sh
 #
-# Shared NemoClaw sandbox RLIMIT defaults.
+# Shared NemoClaw sandbox RLIMIT defaults. Sourced by bash entrypoints and by
+# /bin/sh-compatible profile hooks during `openshell sandbox exec`.
 
 NEMOCLAW_SANDBOX_NPROC_LIMIT=512
 NEMOCLAW_SANDBOX_NOFILE_LIMIT=65536
+
+_nemoclaw_ulimit() {
+  # `command` bypasses shell functions named `ulimit` in bash and POSIX sh,
+  # while still invoking the shell's special builtin. `builtin ulimit` is
+  # bash-only and breaks when /etc/profile.d hooks are sourced by /bin/sh.
+  command ulimit "$@"
+}
+
+_nemoclaw_supports_resource_limit() {
+  _nemoclaw_support_flag="$1"
+  _nemoclaw_support_status=0
+
+  _nemoclaw_ulimit "-S${_nemoclaw_support_flag}" >/dev/null 2>&1 || _nemoclaw_support_status=1
+
+  _nemoclaw_support_return="$_nemoclaw_support_status"
+  unset _nemoclaw_support_flag _nemoclaw_support_status
+  return "$_nemoclaw_support_return"
+}
 
 _nemoclaw_set_resource_limit() {
   _nemoclaw_limit_flag="$1"
@@ -13,14 +32,16 @@ _nemoclaw_set_resource_limit() {
   _nemoclaw_limit_label="$3"
   _nemoclaw_limit_quiet="${4:-}"
 
-  if ! builtin ulimit "-S${_nemoclaw_limit_flag}" "$_nemoclaw_limit_value" 2>/dev/null; then
-    if [ "$_nemoclaw_limit_quiet" != "--quiet" ]; then
-      echo "[SECURITY] Could not set soft ${_nemoclaw_limit_label} limit (container runtime may restrict ulimit)" >&2
+  if _nemoclaw_supports_resource_limit "$_nemoclaw_limit_flag"; then
+    if ! _nemoclaw_ulimit "-S${_nemoclaw_limit_flag}" "$_nemoclaw_limit_value" 2>/dev/null; then
+      if [ "$_nemoclaw_limit_quiet" != "--quiet" ]; then
+        echo "[SECURITY] Could not set soft ${_nemoclaw_limit_label} limit (container runtime may restrict ulimit)" >&2
+      fi
     fi
-  fi
-  if ! builtin ulimit "-H${_nemoclaw_limit_flag}" "$_nemoclaw_limit_value" 2>/dev/null; then
-    if [ "$_nemoclaw_limit_quiet" != "--quiet" ]; then
-      echo "[SECURITY] Could not set hard ${_nemoclaw_limit_label} limit (container runtime may restrict ulimit)" >&2
+    if ! _nemoclaw_ulimit "-H${_nemoclaw_limit_flag}" "$_nemoclaw_limit_value" 2>/dev/null; then
+      if [ "$_nemoclaw_limit_quiet" != "--quiet" ]; then
+        echo "[SECURITY] Could not set hard ${_nemoclaw_limit_label} limit (container runtime may restrict ulimit)" >&2
+      fi
     fi
   fi
 
@@ -45,6 +66,11 @@ _nemoclaw_verify_resource_limit() {
   _nemoclaw_limit_quiet="${4:-}"
   _nemoclaw_limit_status=0
 
+  if ! _nemoclaw_supports_resource_limit "$_nemoclaw_limit_flag"; then
+    unset _nemoclaw_limit_flag _nemoclaw_limit_value _nemoclaw_limit_label _nemoclaw_limit_quiet
+    return 0
+  fi
+
   for _nemoclaw_limit_bound in soft hard; do
     case "$_nemoclaw_limit_bound" in
       soft)
@@ -54,7 +80,7 @@ _nemoclaw_verify_resource_limit() {
         _nemoclaw_limit_mode="H"
         ;;
     esac
-    _nemoclaw_effective_limit="$(builtin ulimit "-${_nemoclaw_limit_mode}${_nemoclaw_limit_flag}" 2>/dev/null || printf '%s' unknown)"
+    _nemoclaw_effective_limit="$(_nemoclaw_ulimit "-${_nemoclaw_limit_mode}${_nemoclaw_limit_flag}" 2>/dev/null || printf '%s' unknown)"
 
     if ! _nemoclaw_is_decimal_limit "$_nemoclaw_effective_limit" \
       || [ "$_nemoclaw_effective_limit" -gt "$_nemoclaw_limit_value" ]; then
@@ -83,13 +109,15 @@ harden_resource_limits() {
 }
 
 verify_resource_limits() {
-  local _nemoclaw_rlimit_quiet="${1:-}"
-  local _nemoclaw_rlimit_status=0
+  _nemoclaw_rlimit_quiet="${1:-}"
+  _nemoclaw_rlimit_status=0
 
   _nemoclaw_verify_resource_limit u "$NEMOCLAW_SANDBOX_NPROC_LIMIT" nproc "$_nemoclaw_rlimit_quiet" \
     || _nemoclaw_rlimit_status=1
   _nemoclaw_verify_resource_limit n "$NEMOCLAW_SANDBOX_NOFILE_LIMIT" nofile "$_nemoclaw_rlimit_quiet" \
     || _nemoclaw_rlimit_status=1
 
-  return "$_nemoclaw_rlimit_status"
+  _nemoclaw_rlimit_return="$_nemoclaw_rlimit_status"
+  unset _nemoclaw_rlimit_quiet _nemoclaw_rlimit_status
+  return "$_nemoclaw_rlimit_return"
 }

--- a/scripts/lib/sandbox-rlimits.sh
+++ b/scripts/lib/sandbox-rlimits.sh
@@ -67,6 +67,15 @@ _nemoclaw_verify_resource_limit() {
   _nemoclaw_limit_status=0
 
   if ! _nemoclaw_supports_resource_limit "$_nemoclaw_limit_flag"; then
+    # POSIX profile hooks can be sourced by /bin/sh (dash on Ubuntu), which
+    # supports nofile (-n) but not nproc (-u). Treat an unsupported flag as
+    # not enforceable in this shell rather than as drift; otherwise ordinary
+    # `openshell sandbox exec ... sh -lc ...` probes emit false security
+    # warnings before user code runs. Supported limits are still set and
+    # verified independently by verify_resource_limits. Remove or escalate this
+    # compatibility path if OpenShell guarantees profile hooks run under a shell
+    # with nproc support, or if a currently supported flag such as nofile
+    # becomes unsupported.
     unset _nemoclaw_limit_flag _nemoclaw_limit_value _nemoclaw_limit_label _nemoclaw_limit_quiet
     return 0
   fi

--- a/test/sandbox-init.test.ts
+++ b/test/sandbox-init.test.ts
@@ -697,8 +697,8 @@ EOF
       }
     });
 
-    it("uses bash builtin ulimit for nproc and nofile enforcement and verification", () => {
-      const nprocLimit = process.platform === "darwin" ? 4000 : 512;
+    it("bypasses shadowed ulimit functions for nproc and nofile enforcement and verification", () => {
+      const nprocLimit = process.platform === "darwin" ? 4000 : 4096;
       const { stdout } = runWithLib(
         [
           `NEMOCLAW_SANDBOX_NPROC_LIMIT=${nprocLimit}`,

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -76,8 +76,7 @@ function rlimitShim(rlimitLib: string): string {
   return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits`;
 }
 
-type ProbeKey = "nproc" | "nofile" | "raise_nproc" | "raise_nofile" | "shadow";
-type ProbeValues = Partial<Record<ProbeKey | "fork_error" | "fork_status" | "spawned", string>>;
+type ProbeValues = Record<string, string | undefined>;
 
 function parseProbeOutput(stdout: string): ProbeValues {
   return Object.fromEntries(

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -170,16 +170,23 @@ function expectSystemRlimitHookBypassesShadowedUlimit(hookPath: string): void {
 
 function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
   const probe = [
+    "set -e",
     `. ${JSON.stringify(rlimitLib)}`,
     'current_nproc="$(command ulimit -u 2>/dev/null || printf "%s" 512)"',
     'case "$current_nproc" in "" | *[!0-9]*) current_nproc=512 ;; esac',
     'current_nofile="$(command ulimit -n 2>/dev/null || printf "%s" 256)"',
     'case "$current_nofile" in "" | *[!0-9]*) current_nofile=256 ;; esac',
+    'target_nofile="$current_nofile"',
+    'if [ "$current_nofile" -gt 64 ]; then target_nofile=$((current_nofile - 1)); fi',
     'NEMOCLAW_SANDBOX_NPROC_LIMIT="$current_nproc"',
-    'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$current_nofile"',
+    'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$target_nofile"',
     "harden_resource_limits --quiet",
     "verify_resource_limits",
-    'printf "ok\\n"',
+    'effective_nofile="$(command ulimit -n)"',
+    'printf "ok=true\\n"',
+    'printf "current_nofile=%s\\n" "$current_nofile"',
+    'printf "target_nofile=%s\\n" "$target_nofile"',
+    'printf "effective_nofile=%s\\n" "$effective_nofile"',
   ].join("\n");
   const result = spawnSync("sh", ["-c", probe], {
     encoding: "utf-8",
@@ -188,7 +195,47 @@ function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
 
   expect(result.status, result.stderr).toBe(0);
   expect(result.stderr).toBe("");
-  expect(result.stdout).toBe("ok\n");
+  const values = parseProbeOutput(result.stdout);
+  expect(values.ok).toBe("true");
+  expect(Number(values.effective_nofile)).toBeLessThanOrEqual(Number(values.target_nofile));
+  if (Number(values.current_nofile) > 64) {
+    expect(Number(values.effective_nofile)).toBeLessThan(Number(values.current_nofile));
+  }
+}
+
+function expectRlimitLibRejectsUnboundedPosixShNoFile(rlimitLib: string): void {
+  const probe = [
+    "set -e",
+    `. ${JSON.stringify(rlimitLib)}`,
+    'current_nproc="$(command ulimit -u 2>/dev/null || printf "%s" 512)"',
+    'case "$current_nproc" in "" | *[!0-9]*) current_nproc=512 ;; esac',
+    'current_nofile="$(command ulimit -n 2>/dev/null || printf "%s" 0)"',
+    'case "$current_nofile" in "" | *[!0-9]*) current_nofile=0 ;; esac',
+    'if [ "$current_nofile" -le 64 ]; then printf "skip=low-nofile\\n"; exit 0; fi',
+    "target_nofile=$((current_nofile - 1))",
+    'NEMOCLAW_SANDBOX_NPROC_LIMIT="$current_nproc"',
+    'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$target_nofile"',
+    "set +e",
+    'verify_output="$(verify_resource_limits 2>&1)"',
+    'verify_status="$?"',
+    "set -e",
+    'printf "verify_status=%s\\n" "$verify_status"',
+    'printf "target_nofile=%s\\n" "$target_nofile"',
+    'printf "effective_nofile=%s\\n" "$(command ulimit -n)"',
+    'printf "verify_output=%s\\n" "$verify_output"',
+  ].join("\n");
+  const result = spawnSync("sh", ["-c", probe], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stderr).toBe("");
+  const values = parseProbeOutput(result.stdout);
+  expect(values.skip).toBeUndefined();
+  expect(values.verify_status).toBe("1");
+  expect(Number(values.effective_nofile)).toBeGreaterThan(Number(values.target_nofile));
+  expect(values.verify_output).toContain("Effective soft nofile limit is");
 }
 
 function expectHookDeniesBoundedForkStorm(hookPath: string, safetyCap: number): void {
@@ -262,13 +309,14 @@ function expectHookDeniesBoundedForkStorm(hookPath: string, safetyCap: number): 
 describe("sandbox rlimit system hooks (#2173)", () => {
   const forkStormIt = process.platform === "linux" ? it : it.skip;
 
-  it("rlimit helper is quiet and successful under POSIX sh", () => {
+  it("rlimit helper enforces supported nofile limits under POSIX sh", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-posix-sh-rlimit-"));
     const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");
 
     try {
       copyRlimitFixture(rlimitLib);
       expectRlimitLibIsPosixShSafe(rlimitLib);
+      expectRlimitLibRejectsUnboundedPosixShNoFile(rlimitLib);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -141,7 +141,7 @@ function expectSystemRlimitHookEnforcesLimits(hookPath: string): void {
   expect(Number(values.raise_nofile)).not.toBe(0);
 }
 
-function expectSystemRlimitHookUsesBuiltinUlimit(hookPath: string): void {
+function expectSystemRlimitHookBypassesShadowedUlimit(hookPath: string): void {
   const probe = [
     "set -euo pipefail",
     "ulimit() {",
@@ -166,6 +166,29 @@ function expectSystemRlimitHookUsesBuiltinUlimit(hookPath: string): void {
   expect(values.shadow).toBe("function");
   expect(Number(values.nproc)).toBeLessThanOrEqual(4096);
   expect(Number(values.nofile)).toBeLessThanOrEqual(65536);
+}
+
+function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
+  const probe = [
+    `. ${JSON.stringify(rlimitLib)}`,
+    'current_nproc="$(command ulimit -u 2>/dev/null || printf "%s" 512)"',
+    'case "$current_nproc" in "" | *[!0-9]*) current_nproc=512 ;; esac',
+    'current_nofile="$(command ulimit -n 2>/dev/null || printf "%s" 256)"',
+    'case "$current_nofile" in "" | *[!0-9]*) current_nofile=256 ;; esac',
+    'NEMOCLAW_SANDBOX_NPROC_LIMIT="$current_nproc"',
+    'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$current_nofile"',
+    "harden_resource_limits --quiet",
+    "verify_resource_limits",
+    'printf "ok\\n"',
+  ].join("\n");
+  const result = spawnSync("sh", ["-c", probe], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(result.stdout).toBe("ok\n");
 }
 
 function expectHookDeniesBoundedForkStorm(hookPath: string, safetyCap: number): void {
@@ -239,6 +262,18 @@ function expectHookDeniesBoundedForkStorm(hookPath: string, safetyCap: number): 
 describe("sandbox rlimit system hooks (#2173)", () => {
   const forkStormIt = process.platform === "linux" ? it : it.skip;
 
+  it("rlimit helper is quiet and successful under POSIX sh", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-posix-sh-rlimit-"));
+    const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");
+
+    try {
+      copyRlimitFixture(rlimitLib);
+      expectRlimitLibIsPosixShSafe(rlimitLib);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("connect shell reports numeric nproc <=4096 and nofile <=65536 and denies raising limits after system-wide rlimit hook startup", () => {
     const dockerfile = fs.readFileSync(DOCKERFILE_BASE, "utf-8");
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-base-rlimit-hooks-"));
@@ -268,7 +303,7 @@ describe("sandbox rlimit system hooks (#2173)", () => {
       expect(fs.readFileSync(bashrc, "utf-8")).toContain(expectedRlimitShim);
       expectSystemRlimitHookEnforcesLimits(rlimitHook);
       expectSystemRlimitHookEnforcesLimits(bashrc);
-      expectSystemRlimitHookUsesBuiltinUlimit(rlimitHook);
+      expectSystemRlimitHookBypassesShadowedUlimit(rlimitHook);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -207,7 +207,6 @@ function expectRlimitLibRejectsUnboundedPosixShNoFile(rlimitLib: string): void {
     'case "$current_nproc" in "" | *[!0-9]*) current_nproc=512 ;; esac',
     'current_nofile="$(command ulimit -n 2>/dev/null || printf "%s" 0)"',
     'case "$current_nofile" in "" | *[!0-9]*) current_nofile=0 ;; esac',
-    'if [ "$current_nofile" -le 64 ]; then printf "skip=low-nofile\\n"; exit 0; fi',
     "target_nofile=$((current_nofile - 1))",
     'NEMOCLAW_SANDBOX_NPROC_LIMIT="$current_nproc"',
     'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$target_nofile"',
@@ -228,10 +227,50 @@ function expectRlimitLibRejectsUnboundedPosixShNoFile(rlimitLib: string): void {
   expect(result.status, result.stderr).toBe(0);
   expect(result.stderr).toBe("");
   const values = parseProbeOutput(result.stdout);
-  expect(values.skip).toBeUndefined();
   expect(values.verify_status).toBe("1");
   expect(Number(values.effective_nofile)).toBeGreaterThan(Number(values.target_nofile));
   expect(values.verify_output).toContain("Effective soft nofile limit is");
+}
+
+function expectUnsupportedNprocDoesNotMaskPosixShNoFile(rlimitLib: string): void {
+  const probe = [
+    "set -e",
+    `. ${JSON.stringify(rlimitLib)}`,
+    '_nemoclaw_ulimit() { case "$1" in -Su | -Hu) return 2 ;; esac; command ulimit "$@"; }',
+    'current_nofile="$(command ulimit -n 2>/dev/null || printf "%s" 0)"',
+    'case "$current_nofile" in "" | *[!0-9]*) current_nofile=0 ;; esac',
+    "target_nofile=$((current_nofile - 1))",
+    'NEMOCLAW_SANDBOX_NPROC_LIMIT="1"',
+    'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$target_nofile"',
+    'harden_log="${TMPDIR:-/tmp}/nemoclaw-rlimit-harden-$$.log"',
+    'harden_resource_limits --quiet 2>"$harden_log"',
+    "verify_resource_limits",
+    'harden_output="$(cat "$harden_log")"',
+    'rm -f "$harden_log"',
+    'printf "harden_output=%s\\n" "$harden_output"',
+    'printf "effective_nofile=%s\\n" "$(command ulimit -n)"',
+    'printf "target_nofile=%s\\n" "$target_nofile"',
+    "set +e",
+    'verify_output="$(NEMOCLAW_SANDBOX_NOFILE_LIMIT=$((target_nofile - 1)) verify_resource_limits 2>&1)"',
+    'verify_status="$?"',
+    "set -e",
+    'printf "verify_status=%s\\n" "$verify_status"',
+    'printf "verify_output=%s\\n" "$verify_output"',
+  ].join("\n");
+  const result = spawnSync("sh", ["-c", probe], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stderr).toBe("");
+  const values = parseProbeOutput(result.stdout);
+  expect(values.harden_output).toBe("");
+  expect(Number(values.effective_nofile)).toBeLessThanOrEqual(Number(values.target_nofile));
+  expect(values.verify_status).toBe("1");
+  expect(values.verify_output).toContain("Effective soft nofile limit is");
+  expect(values.verify_output).not.toContain("nproc");
+  expect(values.verify_output).not.toContain("unknown");
 }
 
 function expectHookDeniesBoundedForkStorm(hookPath: string, safetyCap: number): void {
@@ -313,6 +352,7 @@ describe("sandbox rlimit system hooks (#2173)", () => {
       copyRlimitFixture(rlimitLib);
       expectRlimitLibIsPosixShSafe(rlimitLib);
       expectRlimitLibRejectsUnboundedPosixShNoFile(rlimitLib);
+      expectUnsupportedNprocDoesNotMaskPosixShNoFile(rlimitLib);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -175,8 +175,7 @@ function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
     'case "$current_nproc" in "" | *[!0-9]*) current_nproc=512 ;; esac',
     'current_nofile="$(command ulimit -n 2>/dev/null || printf "%s" 256)"',
     'case "$current_nofile" in "" | *[!0-9]*) current_nofile=256 ;; esac',
-    'target_nofile="$current_nofile"',
-    'if [ "$current_nofile" -gt 64 ]; then target_nofile=$((current_nofile - 1)); fi',
+    "target_nofile=$((current_nofile - 1))",
     'NEMOCLAW_SANDBOX_NPROC_LIMIT="$current_nproc"',
     'NEMOCLAW_SANDBOX_NOFILE_LIMIT="$target_nofile"',
     "harden_resource_limits --quiet",
@@ -197,9 +196,7 @@ function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
   const values = parseProbeOutput(result.stdout);
   expect(values.ok).toBe("true");
   expect(Number(values.effective_nofile)).toBeLessThanOrEqual(Number(values.target_nofile));
-  if (Number(values.current_nofile) > 64) {
-    expect(Number(values.effective_nofile)).toBeLessThan(Number(values.current_nofile));
-  }
+  expect(Number(values.effective_nofile)).toBeLessThan(Number(values.current_nofile));
 }
 
 function expectRlimitLibRejectsUnboundedPosixShNoFile(rlimitLib: string): void {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Make the shared sandbox rlimit helper safe to source from POSIX `/bin/sh` profile hooks. This prevents `openshell sandbox exec ... sh -lc ...` probes from emitting bash-only `builtin ulimit` warnings while preserving the shadowed-`ulimit` bypass in bash.

## Changes
- Switch `scripts/lib/sandbox-rlimits.sh` from bash-only `builtin ulimit` calls to a POSIX-safe `command ulimit` wrapper.
- Skip verification for resource-limit flags unsupported by the active shell, such as `ulimit -u` under dash, instead of reporting `unknown` limits.
- Add a POSIX-sh regression test and update shadowed-`ulimit` tests to cover the new helper behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal sandbox rlimit/profile-hook compatibility fix; no user-facing command or configuration change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: author self-review; change is limited to the sandbox rlimit helper, keeps the shadowed-`ulimit` hardening test, and passes shellcheck/prek plus targeted tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource-limit hardening and verification for POSIX `sh`, especially when `ulimit` is shadowed by shell functions.
  * Resource-limit checks now detect supported `ulimit` flags and validate effective numeric limits more reliably, reducing incorrect verification failures.
* **Tests**
  * Expanded POSIX `sh` test coverage for rlimit hooks and sandbox hardening, including bypassing shadowed `ulimit`.
  * Added/adjusted scenarios to confirm unsafe or unbounded `nofile` targets are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->