### PR TITLE
test(e2e): restore onboard resume hermetic parity

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -2987,10 +2987,6 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_SANDBOX_NAME: "e2e-resume"
-      NEMOCLAW_PROVIDER: "custom"
-      NEMOCLAW_ENDPOINT_URL: "https://inference-api.nvidia.com/v1"
-      NEMOCLAW_MODEL: "nvidia/nvidia/nemotron-3-ultra"
-      NEMOCLAW_COMPAT_MODEL: "nvidia/nvidia/nemotron-3-ultra"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -3009,12 +3005,9 @@ jobs:
         run: npm run build:cli
 
       - name: Install OpenShell CLI
-        run: bash scripts/install-openshell.sh
+        run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_INFERENCE_API_KEY -u COMPATIBLE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
 
       - name: Run onboard-resume live Vitest test
-        env:
-          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
-          COMPATIBLE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"

--- a/test/e2e-scenario/live/onboard-resume.test.ts
+++ b/test/e2e-scenario/live/onboard-resume.test.ts
@@ -6,20 +6,25 @@ import os from "node:os";
 import path from "node:path";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
-import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+import {
+  type FakeOpenAiCompatibleServer,
+  startFakeOpenAiCompatibleServer,
+} from "../fixtures/fake-openai-compatible.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 
 // Adds focused Vitest live coverage for test/e2e/test-onboard-resume.sh's
 // disruption-recovery contract — regression for #446.
 //
-// Shape: drive the real `nemoclaw onboard` CLI through the deterministic E2E
-// failure-injection hook (NEMOCLAW_E2E_FAILURE_INJECTION +
-// NEMOCLAW_E2E_FORCE_FAIL_AT_STEP), then invoke
-// `nemoclaw onboard --resume --non-interactive` with NVIDIA_INFERENCE_API_KEY stripped
-// from the environment to prove the credential is hydrated from the onboard
-// session file.
+// Shape: start a local fake OpenAI-compatible endpoint, drive the real
+// `nemoclaw onboard` CLI through the deterministic E2E failure-injection hook
+// (NEMOCLAW_E2E_FAILURE_INJECTION + NEMOCLAW_E2E_FORCE_FAIL_AT_STEP), then
+// invoke `nemoclaw onboard --resume --non-interactive` with both
+// NVIDIA_INFERENCE_API_KEY and COMPATIBLE_API_KEY absent from the environment to
+// prove the credential is hydrated from gateway/session state rather than hosted
+// repository secrets.
 //
 // This stays as a simple live Vitest test: assertions are inline, no registry,
 // no migration ledger, no new shared helper, and no workflow replacement. The
@@ -31,6 +36,8 @@ const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
 const SESSION_FILE = path.join(os.homedir(), ".nemoclaw", "onboard-session.json");
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-resume";
+const FAKE_COMPATIBLE_AUTH_VALUE = "e2e-compatible-auth-value";
+const FAKE_COMPATIBLE_MODEL = "test-model";
 validateSandboxName(SANDBOX_NAME);
 
 // 15 minutes per onboard run; matches NEMOCLAW_E2E_DEFAULT_TIMEOUT in the
@@ -105,13 +112,66 @@ function containsExactJsonToken(value: unknown, token: string): boolean {
   return false;
 }
 
+async function hostAddressForSandbox(host: HostCliClient): Promise<string> {
+  const probe = await host.command(
+    "bash",
+    [
+      "-lc",
+      [
+        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
+        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
+        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        'if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then',
+        "  for iface in en0 en1 bridge100; do",
+        '    ip_addr="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"',
+        '    if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        "  done",
+        "  ip_addr=\"$(ifconfig 2>/dev/null | awk '/inet / && $2 !~ /^127\\./ {print $2; exit}')\"",
+        '  if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        "fi",
+        "echo 127.0.0.1",
+      ].join("\n"),
+    ],
+    {
+      artifactName: "host-ip-for-onboard-resume-compatible-endpoint",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 30_000,
+    },
+  );
+  return probe.stdout.trim().split(/\s+/)[0] || "127.0.0.1";
+}
+
+function expectHermeticCompatibleInferenceUsed(fake: FakeOpenAiCompatibleServer): void {
+  const requests = fake.requests();
+  const inferencePosts = requests.filter(
+    (entry) =>
+      entry.method === "POST" &&
+      ["/v1/chat/completions", "/chat/completions", "/v1/responses", "/responses"].includes(
+        entry.path,
+      ),
+  );
+  expect(
+    inferencePosts.length,
+    `expected fake inference POST, got ${JSON.stringify(requests)}`,
+  ).toBeGreaterThan(0);
+  expect(
+    requests.filter((entry) => entry.auth === "missing"),
+    `fake endpoint saw unauthenticated requests: ${JSON.stringify(requests)}`,
+  ).toEqual([]);
+  expect(
+    inferencePosts.filter((entry) => entry.auth !== "ok"),
+    `fake inference POST had missing auth: ${JSON.stringify(requests)}`,
+  ).toEqual([]);
+}
+
 // Gate the test on NEMOCLAW_RUN_E2E_SCENARIOS=1 so accidental cli-test-shard
-// discovery does not run it without real `openshell`, Docker, or NVIDIA_INFERENCE_API_KEY.
-// Live-only tests opt in to the same gate used by the `e2e-scenarios-live`
-// project include glob in vitest.config.ts.
+// discovery does not run it without real `openshell`, Docker, or a sandbox-
+// reachable fake OpenAI-compatible endpoint. Live-only tests opt in to the same
+// gate used by the `e2e-scenarios-live` project include glob in vitest.config.ts.
 test.skipIf(!shouldRunLiveE2EScenarios())(
   "onboard-resume: interrupted onboard then --resume completes without redoing cached steps",
-  async ({ artifacts, cleanup, host, sandbox, secrets }) => {
+  async ({ artifacts, cleanup, host, sandbox }) => {
     // ──────────────────────────────────────────────────────────────────
     // Phase 1: prerequisites (host-side, all faithful on ubuntu-latest)
     // ──────────────────────────────────────────────────────────────────
@@ -144,11 +204,31 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     });
     expect(openshellVersion.exitCode, openshellVersion.stderr).toBe(0);
 
-    // Assertion: hosted-inference-secret-present — the workflow passes the
-    // scoped NVIDIA_INFERENCE_API_KEY secret through the compatible-endpoint
-    // contract, matching the legacy hosted-compatible E2E helper.
-    const hosted = requireHostedInferenceConfig(secrets);
-    const apiKey = hosted.apiKey;
+    // Assertion: hermetic-compatible-endpoint-ready — the workflow does not
+    // pass hosted NVIDIA inference secrets. Instead, this test exposes a local
+    // fake OpenAI-compatible endpoint at a host address the OpenShell gateway and
+    // sandbox can route to, matching test/e2e/lib/hermetic-compatible-inference.sh.
+    const fakePublicHost = await hostAddressForSandbox(host);
+    const fake = await startFakeOpenAiCompatibleServer({
+      apiKey: FAKE_COMPATIBLE_AUTH_VALUE,
+      host: "0.0.0.0",
+      model: FAKE_COMPATIBLE_MODEL,
+      publicHost: fakePublicHost,
+      requireAuth: true,
+    });
+    cleanup.add("close fake OpenAI-compatible endpoint", async () => {
+      await artifacts.writeJson("fake-openai-compatible-requests.json", fake.requests());
+      await fake.close();
+    });
+    await artifacts.writeJson("fake-openai-compatible.json", {
+      baseUrl: fake.baseUrl,
+      model: FAKE_COMPATIBLE_MODEL,
+      publicHost: fakePublicHost,
+    });
+    const modelsResponse = await fetch(`${fake.baseUrl}/models`);
+    expect(modelsResponse.ok, `fake endpoint ${fake.baseUrl}/models should be reachable`).toBe(
+      true,
+    );
 
     // ──────────────────────────────────────────────────────────────────
     // Phase 0 (deferred): pre-cleanup of leftover sandbox/session state.
@@ -219,20 +299,26 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     // ──────────────────────────────────────────────────────────────────
     // Phase 2: first onboard (forced failure at the policies step)
     // ──────────────────────────────────────────────────────────────────
+    const firstRunEnv: NodeJS.ProcessEnv = {
+      ...buildAvailabilityProbeEnv(),
+      COMPATIBLE_API_KEY: FAKE_COMPATIBLE_AUTH_VALUE,
+      NEMOCLAW_COMPAT_MODEL: FAKE_COMPATIBLE_MODEL,
+      NEMOCLAW_ENDPOINT_URL: fake.baseUrl,
+      NEMOCLAW_MODEL: FAKE_COMPATIBLE_MODEL,
+      NEMOCLAW_PREFERRED_API: "openai-completions",
+      NEMOCLAW_PROVIDER: "custom",
+      NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+      NEMOCLAW_RECREATE_SANDBOX: "1",
+      NEMOCLAW_POLICY_MODE: "suggested",
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+      NEMOCLAW_E2E_FAILURE_INJECTION: "1",
+      NEMOCLAW_E2E_FORCE_FAIL_AT_STEP: "policies",
+    };
+    expect(firstRunEnv.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
     const firstRun = await host.command("node", [CLI_ENTRYPOINT, "onboard", "--non-interactive"], {
       artifactName: "phase-2-onboard-interrupted",
-      env: {
-        ...buildAvailabilityProbeEnv(),
-        NVIDIA_INFERENCE_API_KEY: apiKey,
-        ...hosted.env,
-        NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-        NEMOCLAW_RECREATE_SANDBOX: "1",
-        NEMOCLAW_POLICY_MODE: "suggested",
-        NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
-        NEMOCLAW_E2E_FAILURE_INJECTION: "1",
-        NEMOCLAW_E2E_FORCE_FAIL_AT_STEP: "policies",
-      },
-      redactionValues: [apiKey],
+      env: firstRunEnv,
+      redactionValues: [FAKE_COMPATIBLE_AUTH_VALUE],
       timeoutMs: ONBOARD_TIMEOUT_MS,
     });
     const firstText = `${firstRun.stdout}\n${firstRun.stderr}`;
@@ -269,27 +355,29 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     expect(interrupted.lastCompletedStep).toBe("openclaw");
     expect(interrupted.failure?.step).toBe("policies");
 
+    await artifacts.writeJson("phase-2-fake-openai-compatible-requests.json", fake.requests());
+    expectHermeticCompatibleInferenceUsed(fake);
+
     // ──────────────────────────────────────────────────────────────────
-    // Phase 3: resume — NVIDIA_INFERENCE_API_KEY removed from env so the resume run
-    // must hydrate the credential from the session file.
+    // Phase 3: resume — NVIDIA_INFERENCE_API_KEY and COMPATIBLE_API_KEY are
+    // removed from env so the resume run must hydrate the credential from the
+    // gateway/session state.
     // ──────────────────────────────────────────────────────────────────
+    const resumeEnv: NodeJS.ProcessEnv = {
+      ...buildAvailabilityProbeEnv(),
+      NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
+      NEMOCLAW_POLICY_MODE: "skip",
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+    };
+    expect(resumeEnv.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(resumeEnv.COMPATIBLE_API_KEY).toBeUndefined();
     const resumeRun = await host.command(
       "node",
       [CLI_ENTRYPOINT, "onboard", "--resume", "--non-interactive"],
       {
         artifactName: "phase-3-onboard-resume",
-        // buildAvailabilityProbeEnv() does NOT pass NVIDIA_INFERENCE_API_KEY through —
-        // it's outside the fixture env allowlist. Resume must hydrate the
-        // credential from the session file. This is exactly the bash test's
-        // `env -u NVIDIA_INFERENCE_API_KEY` invariant, expressed via explicit
-        // secret-passthrough.
-        env: {
-          ...buildAvailabilityProbeEnv(),
-          NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-          NEMOCLAW_POLICY_MODE: "skip",
-          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
-        },
-        redactionValues: [apiKey],
+        env: resumeEnv,
+        redactionValues: [FAKE_COMPATIBLE_AUTH_VALUE],
         timeoutMs: ONBOARD_TIMEOUT_MS,
       },
     );
@@ -332,7 +420,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     const complete = readSession<SessionStateComplete>(SESSION_FILE);
     await artifacts.writeJson("phase-3-session-summary.json", completeSessionSummary(complete));
     expect(complete.status).toBe("complete");
-    expect(complete.provider).toBe(hosted.providerName);
+    expect(complete.provider).toBe("compatible-endpoint");
     for (const step of [
       "preflight",
       "gateway",
@@ -367,7 +455,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
           NEMOCLAW_POLICY_MODE: "skip",
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
         },
-        redactionValues: [apiKey],
+        redactionValues: [FAKE_COMPATIBLE_AUTH_VALUE],
         timeoutMs: ONBOARD_TIMEOUT_MS,
       },
     );
@@ -394,7 +482,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
           NEMOCLAW_E2E_FAILURE_INJECTION: "1",
           NEMOCLAW_E2E_FORCE_FAIL_AT_STEP: "preflight",
         },
-        redactionValues: [apiKey],
+        redactionValues: [FAKE_COMPATIBLE_AUTH_VALUE],
         timeoutMs: ONBOARD_TIMEOUT_MS,
       },
     );

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -642,12 +642,10 @@ describe("e2e-vitest-scenarios workflow boundary", () => {
     expect(validateFreeStandingWorkflowInventory()).toEqual([]);
     expect(inventory.allowedJobs).toContain("openshell-version-pin-vitest");
     expect(inventory.allowedJobs).toContain("gateway-guard-recovery");
-    expect(inventory.allowedJobs).toContain("onboard-resume-vitest");
     expect(inventory.allowedJobs).toContain("upgrade-stale-sandbox-vitest");
     expect(inventory.scenarioToJob.get("openshell-version-pin")).toBe(
       "openshell-version-pin-vitest",
     );
-    expect(inventory.scenarioToJob.get("onboard-resume")).toBe("onboard-resume-vitest");
     expect(inventory.scenarioToJob.get("upgrade-stale-sandbox")).toBe(
       "upgrade-stale-sandbox-vitest",
     );
@@ -1366,37 +1364,6 @@ jobs:
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
-  });
-
-  it("keeps onboard-resume hermetic and off hosted inference secrets", () => {
-    const workflow = readWorkflow() as {
-      jobs: Record<
-        string,
-        { env?: Record<string, string>; steps?: Array<Record<string, unknown>> }
-      >;
-    };
-    const job = workflow.jobs["onboard-resume-vitest"];
-    expect(job).toBeDefined();
-    expect(job.env?.FREE_STANDING_VITEST_JOB).toBe("1");
-    expect(job.env?.FREE_STANDING_SCENARIO_ID).toBe("onboard-resume");
-    expect(job.env?.NEMOCLAW_PROVIDER).toBeUndefined();
-    expect(job.env?.NEMOCLAW_ENDPOINT_URL).toBeUndefined();
-    expect(job.env?.NEMOCLAW_MODEL).toBeUndefined();
-    expect(job.env?.NEMOCLAW_COMPAT_MODEL).toBeUndefined();
-    expect(job.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
-    expect(job.env?.COMPATIBLE_API_KEY).toBeUndefined();
-
-    const installOpenShellStep = job.steps?.find((step) => step.name === "Install OpenShell CLI");
-    const runStep = job.steps?.find((step) => step.name === "Run onboard-resume live Vitest test");
-    expect(installOpenShellStep?.run).toContain("-u NVIDIA_INFERENCE_API_KEY");
-    expect(installOpenShellStep?.run).toContain("-u COMPATIBLE_API_KEY");
-    expect(
-      (runStep?.env as Record<string, string> | undefined)?.NVIDIA_INFERENCE_API_KEY,
-    ).toBeUndefined();
-    expect(
-      (runStep?.env as Record<string, string> | undefined)?.COMPATIBLE_API_KEY,
-    ).toBeUndefined();
-    expect(runStep?.run).toContain("test/e2e-scenario/live/onboard-resume.test.ts");
   });
 
   it("rejects diagnostics workflow-boundary drift for secret and Docker auth handling", () => {

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -642,10 +642,12 @@ describe("e2e-vitest-scenarios workflow boundary", () => {
     expect(validateFreeStandingWorkflowInventory()).toEqual([]);
     expect(inventory.allowedJobs).toContain("openshell-version-pin-vitest");
     expect(inventory.allowedJobs).toContain("gateway-guard-recovery");
+    expect(inventory.allowedJobs).toContain("onboard-resume-vitest");
     expect(inventory.allowedJobs).toContain("upgrade-stale-sandbox-vitest");
     expect(inventory.scenarioToJob.get("openshell-version-pin")).toBe(
       "openshell-version-pin-vitest",
     );
+    expect(inventory.scenarioToJob.get("onboard-resume")).toBe("onboard-resume-vitest");
     expect(inventory.scenarioToJob.get("upgrade-stale-sandbox")).toBe(
       "upgrade-stale-sandbox-vitest",
     );
@@ -1364,6 +1366,37 @@ jobs:
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("keeps onboard-resume hermetic and off hosted inference secrets", () => {
+    const workflow = readWorkflow() as {
+      jobs: Record<
+        string,
+        { env?: Record<string, string>; steps?: Array<Record<string, unknown>> }
+      >;
+    };
+    const job = workflow.jobs["onboard-resume-vitest"];
+    expect(job).toBeDefined();
+    expect(job.env?.FREE_STANDING_VITEST_JOB).toBe("1");
+    expect(job.env?.FREE_STANDING_SCENARIO_ID).toBe("onboard-resume");
+    expect(job.env?.NEMOCLAW_PROVIDER).toBeUndefined();
+    expect(job.env?.NEMOCLAW_ENDPOINT_URL).toBeUndefined();
+    expect(job.env?.NEMOCLAW_MODEL).toBeUndefined();
+    expect(job.env?.NEMOCLAW_COMPAT_MODEL).toBeUndefined();
+    expect(job.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(job.env?.COMPATIBLE_API_KEY).toBeUndefined();
+
+    const installOpenShellStep = job.steps?.find((step) => step.name === "Install OpenShell CLI");
+    const runStep = job.steps?.find((step) => step.name === "Run onboard-resume live Vitest test");
+    expect(installOpenShellStep?.run).toContain("-u NVIDIA_INFERENCE_API_KEY");
+    expect(installOpenShellStep?.run).toContain("-u COMPATIBLE_API_KEY");
+    expect(
+      (runStep?.env as Record<string, string> | undefined)?.NVIDIA_INFERENCE_API_KEY,
+    ).toBeUndefined();
+    expect(
+      (runStep?.env as Record<string, string> | undefined)?.COMPATIBLE_API_KEY,
+    ).toBeUndefined();
+    expect(runStep?.run).toContain("test/e2e-scenario/live/onboard-resume.test.ts");
   });
 
   it("rejects diagnostics workflow-boundary drift for secret and Docker auth handling", () => {

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1246,6 +1246,27 @@ describe("E2E reusable workflow contract", () => {
     expect(helper).toContain('COMPATIBLE_API_KEY="$fake_key"');
     expect(helper).toContain("FAKE_OPENAI_REQUIRE_AUTH=1");
     expect(helper).not.toContain('FAKE_OPENAI_REQUIRE_AUTH="${FAKE_OPENAI_REQUIRE_AUTH:-1}"');
+
+    const vitestWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(
+      ".github/workflows/e2e-vitest-scenarios.yaml",
+    );
+    const vitestJob = vitestWorkflow.jobs["onboard-resume-vitest"];
+    const vitestInstallOpenShellStep = vitestJob.steps?.find(
+      (step) => step.name === "Install OpenShell CLI",
+    );
+    const vitestRunStep = vitestJob.steps?.find(
+      (step) => step.name === "Run onboard-resume live Vitest test",
+    );
+    expect(vitestJob.env?.NEMOCLAW_PROVIDER).toBeUndefined();
+    expect(vitestJob.env?.NEMOCLAW_ENDPOINT_URL).toBeUndefined();
+    expect(vitestJob.env?.NEMOCLAW_MODEL).toBeUndefined();
+    expect(vitestJob.env?.NEMOCLAW_COMPAT_MODEL).toBeUndefined();
+    expect(vitestJob.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(vitestJob.env?.COMPATIBLE_API_KEY).toBeUndefined();
+    expect(vitestInstallOpenShellStep?.run).toContain("-u NVIDIA_INFERENCE_API_KEY");
+    expect(vitestInstallOpenShellStep?.run).toContain("-u COMPATIBLE_API_KEY");
+    expect(vitestRunStep?.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(vitestRunStep?.env?.COMPATIBLE_API_KEY).toBeUndefined();
   });
 
   it("keeps converted jobs dispatchable through the reusable workflow", () => {


### PR DESCRIPTION
## Summary
Restore issue #5849 parity package `Package A` for merged bash-suite deltas from #5702 only.

This moves the `onboard-resume-vitest` path to the same hermetic fake OpenAI-compatible contract as the late bash guard:
- no `NVIDIA_INFERENCE_API_KEY` / hosted `COMPATIBLE_API_KEY` workflow dependency
- local fake OpenAI-compatible endpoint started by the Vitest
- authenticated fake endpoint request capture asserted
- resume runs with both hosted secret env vars absent and must hydrate from gateway/session state

## Related Issues
Refs #5849
Refs #5702

## Scope gate
- Package: `Package A`
- Included PRs all merged and touched `test/e2e`: yes — #5702 touched `test/e2e/README.md`, `test/e2e/lib/hermetic-compatible-inference.sh`, `test/e2e/test-onboard-resume.sh`
- Out of scope: unmerged/non-bash PRs; shell lane retirement / PR #5756 cleanup

## Parity map
| ID | Source PR | Contract | Inference classification | Vitest assertion / waiver | Status |
| --- | --- | --- | --- | --- | --- |
| A1 | #5702 | Onboard-resume uses a local fake OpenAI-compatible endpoint instead of hosted NVIDIA inference secrets. | `hermetic-default` | `test/e2e-scenario/live/onboard-resume.test.ts` starts `startFakeOpenAiCompatibleServer`, sets `NEMOCLAW_PROVIDER=custom` + `COMPATIBLE_API_KEY` only for first onboard, and asserts fake authenticated inference requests. | covered |
| A2 | #5702 | Resume run removes both `NVIDIA_INFERENCE_API_KEY` and `COMPATIBLE_API_KEY`, proving credential recovery comes from gateway/session state. | `hermetic-default` | `test/e2e-scenario/live/onboard-resume.test.ts` builds resume env from fixture allowlist and asserts both secret env vars are undefined. | covered |
| A3 | #5702 | Selective Vitest workflow routing must not inject hosted inference secrets into onboard-resume. | `hermetic-default` | `.github/workflows/e2e-vitest-scenarios.yaml` removes hosted env/model wiring; `test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts` guards the workflow shape. | covered |
| A4 | #5702 | Legacy bash workflow remains hermetic until shell retirement. | `hermetic-default` | Existing `test/e2e-script-workflow.test.ts` guard still covers `nightly-e2e.yaml` / bash lane shape. | already covered |

## Inference mode support
- Default mode for touched live targets: `mock/hermetic`
- Real inference support preserved: not applicable; this package explicitly removes hosted inference dependency for onboard-resume
- Modes validated in this PR: hermetic/source-shape locally; selective `onboard-resume-vitest` workflow required for full live Docker/OpenShell execution
- If not validated with real inference: real inference is not required by `hermetic-default`; the regression contract is fake-compatible auth/request capture without hosted secrets

## Validation
- [x] `git diff --check`
- [x] `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts`
- [x] `npx tsc --noEmit --allowImportingTsExtensions --module ESNext --moduleResolution Bundler --target ES2022 --types node,vitest/globals --skipLibCheck test/e2e-scenario/live/onboard-resume.test.ts`
- [x] `npx vitest run test/e2e-script-workflow.test.ts`
- [x] selective `onboard-resume-vitest` workflow: https://github.com/NVIDIA/NemoClaw/actions/runs/28241580508

## Follow-ups / waivers
- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the resume onboarding flow to work with a local compatible inference endpoint instead of relying on hosted credentials.
  * Tightened credential handling so sensitive keys are no longer passed into the related setup and test steps.
  * Updated end-to-end coverage to verify the workflow runs without injecting inference secrets and still completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
