### PR TITLE
fix(rebuild): clear stale policy presets from registry after rebuild

### DIFF
--- a/src/lib/actions/sandbox/rebuild-flow.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow.test.ts
@@ -48,6 +48,7 @@ type RebuildFlowOverrides = {
   buildMessagingRebuildPlan?: () => Promise<unknown> | unknown;
   sandboxEntry?: Record<string, unknown>;
   sessionSandboxName?: string;
+  backupPolicyPresets?: string[];
 };
 
 type RebuildFlowHarness = {
@@ -245,7 +246,7 @@ function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): Rebuild
     manifest: {
       backupPath: "/tmp/nemoclaw-rebuild-backup",
       timestamp: "2026-06-01T00:00:00.000Z",
-      policyPresets: ["npm", "bad", "throw"],
+      policyPresets: overrides.backupPolicyPresets ?? ["npm", "bad", "throw"],
     },
   });
   const restoreSandboxStateSpy = vi.spyOn(sandboxState, "restoreSandboxState").mockImplementation(
@@ -428,13 +429,49 @@ describe("rebuildSandbox flow", () => {
     expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "npm");
     expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "bad");
     expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "throw");
-    expect(harness.registryUpdateSpy).toHaveBeenCalledWith("alpha", { agentVersion: "0.2.0" });
+    expect(harness.registryUpdateSpy).toHaveBeenCalledWith("alpha", {
+      agentVersion: "0.2.0",
+      policies: ["npm", "bad", "throw"],
+    });
     expect(harness.executeSandboxCommandSpy).toHaveBeenCalledWith("alpha", "openclaw doctor --fix");
     expect(harness.relockSpy).toHaveBeenCalledWith("alpha", expect.any(Object), true, "nemoclaw");
     expect(process.env.NEMOCLAW_SANDBOX_NAME).toBe("alpha");
     expect(harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
       "rebuilt successfully",
     );
+  });
+
+  it("prunes disabled messaging channel presets from the final registry policies", async () => {
+    const disabledSlackPlan = {
+      schemaVersion: 1,
+      sandboxName: "alpha",
+      agent: "openclaw",
+      workflow: "rebuild",
+      channels: [],
+      disabledChannels: ["slack"],
+      credentialBindings: [],
+      networkPolicy: { presets: [], entries: [] },
+      agentRender: [],
+      buildSteps: [],
+      stateUpdates: [],
+      healthChecks: [],
+    };
+    const harness = createRebuildFlowHarness({
+      applyPreset: () => true,
+      backupPolicyPresets: ["slack", "npm"],
+      buildMessagingRebuildPlan: () => disabledSlackPlan,
+    });
+
+    await expect(
+      harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "npm");
+    expect(harness.applyPresetSpy).not.toHaveBeenCalledWith("alpha", "slack");
+    expect(harness.registryUpdateSpy).toHaveBeenCalledWith("alpha", {
+      agentVersion: "0.2.0",
+      policies: ["npm"],
+    });
   });
 
   it("aborts before backup/delete when messaging manifest staging fails", async () => {
@@ -506,6 +543,11 @@ describe("rebuildSandbox flow", () => {
     expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "throw");
     expect(harness.errorSpy).toHaveBeenCalledWith(expect.stringContaining("bad, throw"));
     expect(harness.relockSpy).toHaveBeenCalledWith("alpha", expect.any(Object), true, "nemoclaw");
+    expect(harness.registryUpdateSpy).toHaveBeenCalledWith("alpha", {
+      agentVersion: "0.2.0",
+      policies: ["npm"],
+    });
+    expect(output).toContain("Policy presets failed to reapply: bad, throw");
   });
 
   it("isolates ambient onboard-selection env during recreate, then restores it (#5735)", async () => {

--- a/src/lib/actions/sandbox/rebuild-flow.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow.test.ts
@@ -474,6 +474,39 @@ describe("rebuildSandbox flow", () => {
     });
   });
 
+  it("prunes the disabled Teams preset from the final registry policies after rebuild", async () => {
+    const disabledTeamsPlan = {
+      schemaVersion: 1,
+      sandboxName: "alpha",
+      agent: "openclaw",
+      workflow: "rebuild",
+      channels: [],
+      disabledChannels: ["teams"],
+      credentialBindings: [],
+      networkPolicy: { presets: [], entries: [] },
+      agentRender: [],
+      buildSteps: [],
+      stateUpdates: [],
+      healthChecks: [],
+    };
+    const harness = createRebuildFlowHarness({
+      applyPreset: () => true,
+      backupPolicyPresets: ["teams", "npm"],
+      buildMessagingRebuildPlan: () => disabledTeamsPlan,
+    });
+
+    await expect(
+      harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.applyPresetSpy).toHaveBeenCalledWith("alpha", "npm");
+    expect(harness.applyPresetSpy).not.toHaveBeenCalledWith("alpha", "teams");
+    expect(harness.registryUpdateSpy).toHaveBeenCalledWith("alpha", {
+      agentVersion: "0.2.0",
+      policies: ["npm"],
+    });
+  });
+
   it("aborts before backup/delete when messaging manifest staging fails", async () => {
     const harness = createRebuildFlowHarness({
       buildMessagingRebuildPlan: () => {

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -1008,11 +1008,11 @@ export async function rebuildSandbox(
       backupManifest?.policyPresets ?? registryPolicyPresets,
       rebuildDisabledChannels,
     );
+    const restoredPresets: string[] = [];
     if (savedPresets.length > 0) {
       console.log("");
       console.log("  Restoring policy presets...");
       log(`Policy presets to restore: [${savedPresets.join(",")}]`);
-      const restoredPresets: string[] = [];
       const failedPresets: string[] = [];
       for (const presetName of savedPresets) {
         try {
@@ -1136,8 +1136,11 @@ export async function rebuildSandbox(
     // Step 7: Update registry with new version
     registry.updateSandbox(sandboxName, {
       agentVersion: agentDef.expectedVersion || null,
+      policies: restoredPresets,
     });
-    log(`Registry updated: agentVersion=${agentDef.expectedVersion}`);
+    log(
+      `Registry updated: agentVersion=${agentDef.expectedVersion}, policies=[${restoredPresets.join(",")}]`,
+    );
 
     if (!relockShieldsIfNeeded(true)) return bail("Failed to re-apply shields lockdown.");
     if (!ensureMessagingHostForwardAfterRebuild(sandboxName, rebuildMessagingPlan)) {

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -1009,11 +1009,11 @@ export async function rebuildSandbox(
       rebuildDisabledChannels,
     );
     const restoredPresets: string[] = [];
+    const failedPresets: string[] = [];
     if (savedPresets.length > 0) {
       console.log("");
       console.log("  Restoring policy presets...");
       log(`Policy presets to restore: [${savedPresets.join(",")}]`);
-      const failedPresets: string[] = [];
       for (const presetName of savedPresets) {
         try {
           log(`Applying preset: ${presetName}`);
@@ -1048,6 +1048,7 @@ export async function rebuildSandbox(
     let mutablePermsRepairUnverified = false;
     let mutableConfigHashRefreshUnverified = false;
     let messagingHostForwardUnverified = false;
+    const policyPresetRestoreIncomplete = failedPresets.length > 0;
     if (agentDef.name === "openclaw") {
       // openclaw doctor --fix validates and repairs directory structure.
       // Idempotent and safe — catches structural changes between OpenClaw versions
@@ -1134,6 +1135,27 @@ export async function rebuildSandbox(
     // on_session_start. Gateway startup is non-fatal if state.db migration fails.
 
     // Step 7: Update registry with new version
+    //
+    // Source-of-truth reconciliation for `policies`:
+    //
+    // - Invalid state: `registry.policies` retained a preset name after the
+    //   reapply loop pruned it (disabled messaging channel) or skipped it
+    //   (failed `applyPreset`), so `policy-list` showed a ● marker for a
+    //   preset whose rules were absent from the gateway.
+    // - Source boundary: `policies.applyPreset` only appends to
+    //   `registry.policies`; nothing else writes the canonical post-rebuild
+    //   set. The reapply loop above is the only place that knows which
+    //   presets were actually reapplied.
+    // - Source-fix constraint: must run after the reapply loop and use the
+    //   successfully restored subset, not `savedPresets` (which still
+    //   includes failures).
+    // - Regression test:
+    //   `src/lib/actions/sandbox/rebuild-flow.test.ts` asserts
+    //   `registry.updateSandbox` receives `policies: restoredPresets` for
+    //   both the successful-rebuild and partial-restore harnesses.
+    // - Removal condition: drop this once `applyPreset` writes the
+    //   canonical post-apply set itself (replacing its append-only
+    //   contract), making the rebuild flow's reconciliation redundant.
     registry.updateSandbox(sandboxName, {
       agentVersion: agentDef.expectedVersion || null,
       policies: restoredPresets,
@@ -1152,7 +1174,8 @@ export async function rebuildSandbox(
       restoreSucceeded &&
       !mutablePermsRepairUnverified &&
       !mutableConfigHashRefreshUnverified &&
-      !messagingHostForwardUnverified
+      !messagingHostForwardUnverified &&
+      !policyPresetRestoreIncomplete
     ) {
       console.log(`  ${G}\u2713${R} Sandbox '${sandboxName}' rebuilt successfully`);
       if (staleRecovery) {
@@ -1189,6 +1212,11 @@ export async function rebuildSandbox(
       if (messagingHostForwardUnverified) {
         console.log(
           `    Messaging webhook forward was not verified \u2014 run \`${CLI_NAME} ${sandboxName} connect\` after resolving the port conflict`,
+        );
+      }
+      if (policyPresetRestoreIncomplete) {
+        console.log(
+          `    Policy presets failed to reapply: ${failedPresets.join(", ")} \u2014 re-apply manually with \`${CLI_NAME} ${sandboxName} policy-add\``,
         );
       }
     }

--- a/src/lib/messaging/channels/metadata.ts
+++ b/src/lib/messaging/channels/metadata.ts
@@ -242,6 +242,19 @@ export function listRequiredCreateTimeMessagingPolicyPresetsByChannel(
   return result;
 }
 
+export function listMessagingPolicyPresetsByChannel(
+  options: MessagingManifestMetadataOptions = {},
+): Readonly<Record<string, readonly string[]>> {
+  const result: Record<string, string[]> = {};
+  for (const preset of listMessagingPolicyPresetMetadata(options)) {
+    result[preset.channelId] = uniqueStrings([
+      ...(result[preset.channelId] ?? []),
+      preset.presetName,
+    ]);
+  }
+  return result;
+}
+
 export function getMessagingPolicyKeyAliases(
   options: MessagingManifestMetadataOptions = {},
 ): Readonly<Record<string, readonly string[]>> {

--- a/src/lib/onboard/messaging-policy-presets.test.ts
+++ b/src/lib/onboard/messaging-policy-presets.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  allMessagingChannelPolicyPresets,
   hasDisabledMessagingPolicyPreset,
   mergeAppliedPolicyPresetsForDisabledMessagingCleanup,
   mergePolicyMessagingChannels,
@@ -50,9 +51,21 @@ describe("messaging policy presets", () => {
     ]);
   });
 
-  it("preserves non-required policy presets when a same-named channel is disabled", () => {
+  it("maps every channel that has a policy preset to its preset for cleanup", () => {
+    expect(allMessagingChannelPolicyPresets(["teams"])).toEqual(["teams"]);
+    expect(allMessagingChannelPolicyPresets([" Teams "])).toEqual(["teams"]);
+    expect(allMessagingChannelPolicyPresets(["telegram"])).toEqual(["telegram"]);
+  });
+
+  it("removes the Teams preset when the Teams channel is disabled", () => {
+    expect(pruneDisabledMessagingPolicyPresets(["npm", "teams", "pypi"], ["teams"])).toEqual([
+      "npm",
+      "pypi",
+    ]);
+  });
+
+  it("removes optional channel presets when their channel is disabled", () => {
     expect(pruneDisabledMessagingPolicyPresets(["telegram", "npm", "pypi"], ["telegram"])).toEqual([
-      "telegram",
       "npm",
       "pypi",
     ]);
@@ -60,7 +73,8 @@ describe("messaging policy presets", () => {
 
   it("detects applied policy presets for disabled messaging channels", () => {
     expect(hasDisabledMessagingPolicyPreset(["npm", "slack", "pypi"], ["slack"])).toBe(true);
-    expect(hasDisabledMessagingPolicyPreset(["telegram", "npm"], ["telegram"])).toBe(false);
+    expect(hasDisabledMessagingPolicyPreset(["telegram", "npm"], ["telegram"])).toBe(true);
+    expect(hasDisabledMessagingPolicyPreset(["npm", "pypi"], ["slack"])).toBe(false);
   });
 
   it("preserves unrelated applied presets when cleaning disabled messaging presets", () => {

--- a/src/lib/onboard/messaging-policy-presets.ts
+++ b/src/lib/onboard/messaging-policy-presets.ts
@@ -71,9 +71,7 @@ export function mergeRequiredMessagingChannelPolicyPresets(
   return merged;
 }
 
-export function allMessagingChannelPolicyPresets(
-  channels: string[] | null | undefined,
-): string[] {
+export function allMessagingChannelPolicyPresets(channels: string[] | null | undefined): string[] {
   const all: string[] = [];
   for (const channel of normalizedNames(channels)) {
     for (const preset of ALL_POLICY_PRESETS_BY_MESSAGING_CHANNEL[channel] || []) {

--- a/src/lib/onboard/messaging-policy-presets.ts
+++ b/src/lib/onboard/messaging-policy-presets.ts
@@ -1,10 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { listRequiredCreateTimeMessagingPolicyPresetsByChannel } from "../messaging/channels";
+import {
+  listMessagingPolicyPresetsByChannel,
+  listRequiredCreateTimeMessagingPolicyPresetsByChannel,
+} from "../messaging/channels";
 
 const REQUIRED_POLICY_PRESETS_BY_MESSAGING_CHANNEL =
   listRequiredCreateTimeMessagingPolicyPresetsByChannel();
+
+const ALL_POLICY_PRESETS_BY_MESSAGING_CHANNEL = listMessagingPolicyPresetsByChannel();
 
 function normalizedNames(values: string[] | null | undefined): string[] {
   if (!Array.isArray(values)) return [];
@@ -66,14 +71,26 @@ export function mergeRequiredMessagingChannelPolicyPresets(
   return merged;
 }
 
+export function allMessagingChannelPolicyPresets(
+  channels: string[] | null | undefined,
+): string[] {
+  const all: string[] = [];
+  for (const channel of normalizedNames(channels)) {
+    for (const preset of ALL_POLICY_PRESETS_BY_MESSAGING_CHANNEL[channel] || []) {
+      if (!all.includes(preset)) all.push(preset);
+    }
+  }
+  return all;
+}
+
 export function pruneDisabledMessagingPolicyPresets(
   selectedPresets: string[],
   disabledChannels: string[] | null | undefined,
 ): string[] {
-  const disabledRequiredPresets = new Set(requiredMessagingChannelPolicyPresets(disabledChannels));
-  if (disabledRequiredPresets.size === 0) return selectedPresets;
+  const disabledChannelPresets = new Set(allMessagingChannelPolicyPresets(disabledChannels));
+  if (disabledChannelPresets.size === 0) return selectedPresets;
   return selectedPresets.filter(
-    (preset) => !disabledRequiredPresets.has(preset.trim().toLowerCase()),
+    (preset) => !disabledChannelPresets.has(preset.trim().toLowerCase()),
   );
 }
 

--- a/test/e2e-scenario/live/channels-stop-start-helpers.ts
+++ b/test/e2e-scenario/live/channels-stop-start-helpers.ts
@@ -522,6 +522,12 @@ export async function runChannelsStopStartScenario({
   await expectAgentConfig(sandbox, "absent", redactions);
   await expectProvidersExist(host, env, redactions, "after-stop");
   for (const channel of CHANNELS) expectPlanChannelState(channel, "disabled");
+  for (const channel of CHANNELS) {
+    expect(
+      await policyPresetActive(host, env, redactions, channel),
+      `${channel} policy inactive after stop+rebuild`,
+    ).toBe(false);
+  }
 
   for (const channel of CHANNELS) await runChannelCommand(host, env, redactions, "start", channel);
   expectChannelInputs();
@@ -537,4 +543,10 @@ export async function runChannelsStopStartScenario({
   await expectAgentConfig(sandbox, "present", redactions);
   await expectProvidersExist(host, env, redactions, "after-start");
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
+  for (const channel of CHANNELS) {
+    expect(
+      await policyPresetActive(host, env, redactions, channel),
+      `${channel} policy active after start+rebuild`,
+    ).toBe(true);
+  }
 }

--- a/test/e2e/test-channels-stop-start.sh
+++ b/test/e2e/test-channels-stop-start.sh
@@ -807,6 +807,9 @@ run_agent_scenario() {
   assert_provider_records_exist "after stop"
   assert_host_messaging_config "after stop+rebuild"
   assert_host_messaging_plan_state "disabled" "after stop+rebuild"
+  for channel in "${CHANNELS[@]}"; do
+    assert_policy_preset_active "$channel" "inactive" "after stop+rebuild"
+  done
 
   section "${agent}: channels start all + rebuild"
   start_all_channels
@@ -821,6 +824,9 @@ run_agent_scenario() {
   assert_provider_records_exist "after start"
   assert_host_messaging_config "after start+rebuild"
   assert_host_messaging_plan_state "active" "after start+rebuild"
+  for channel in "${CHANNELS[@]}"; do
+    assert_policy_preset_active "$channel" "active" "after start+rebuild"
+  done
 }
 
 section "Phase 0: Prerequisites"

--- a/test/rebuild-policy-presets.test.ts
+++ b/test/rebuild-policy-presets.test.ts
@@ -177,12 +177,12 @@ describe("rebuild policy preset restoration (#1952)", () => {
       expect(savedPresets).toEqual(["npm", "pypi"]);
     });
 
-    it("preserves non-required channel presets for later start and rebuild", () => {
+    it("removes optional channel presets when their channel is disabled", () => {
       const manifest = { policyPresets: ["telegram", "npm", "pypi"] };
       const savedPresets = pruneDisabledMessagingPolicyPresets(manifest.policyPresets || [], [
         "telegram",
       ]);
-      expect(savedPresets).toEqual(["telegram", "npm", "pypi"]);
+      expect(savedPresets).toEqual(["npm", "pypi"]);
     });
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`registry.policies` was append-only via `applyPreset`, so disabling a messaging channel and rebuilding left the disabled channel's preset stale in the registry even though the gateway state was correctly pruned. Reapply loop now records its effective output and Step 7 writes it back, so `policy-list` reflects the live applied set.

## Related Issue
Fixes #5847

## Changes
- `rebuild.ts`: hoist `restoredPresets` from the inner reapply block and fold `policies: restoredPresets` into the Step 7 `registry.updateSandbox` call so the registry always mirrors what was just reapplied to the gateway. Empty `savedPresets` correctly clears stale entries.
- `test/e2e-scenario/live/channels-stop-start-helpers.ts`: assert `policyPresetActive(channel) === false` after stop+rebuild and `=== true` after start+rebuild — closes the assertion gap that allowed the regression to ship.
- `test/e2e/test-channels-stop-start.sh`: mirror the post-stop / post-start preset assertions in the legacy bash E2E.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: defect fix, user-visible flag/command surface unchanged
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy preset restoration during sandbox rebuilds, including clearer reporting when some presets fail to reapply.
  * Registry updates now reflect only successfully restored policies, and rebuild success is blocked when preset restore is incomplete.
  * Messaging channel policy presets now correctly reflect channel state changes (inactive after stop+rebuild, active after start+rebuild), and disabled-channel preset pruning matches the full applicable set.
* **Tests**
  * Expanded end-to-end and unit coverage to verify per-channel preset activity and registry policy payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->