### PR TITLE
docs: explain quickstart egress approvals (Fixes #5841)

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -259,7 +259,14 @@ Treat the authenticated URL like a password.
 
 ### Chat with the Agent from the Terminal
 
-Connect to the sandbox and use the OpenClaw CLI.
+Use a two-terminal workflow for prompts that may need network access.
+In one terminal, connect to the sandbox and use the OpenClaw CLI.
+Open a second host terminal and run `openshell term` to watch for blocked network egress requests and approve or deny them while the agent runs.
+For remote sandboxes and detailed approval controls, refer to [Approve or Deny Agent Network Requests](../network-policy/approve-network-requests).
+
+```bash
+openshell term
+```
 
 ```bash
 nemoclaw my-assistant connect


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds the missing two-terminal network approval workflow to the OpenClaw quickstart where readers start terminal chat.
The quickstart now tells users to keep one terminal attached to the agent session and run `openshell term` in a second host terminal so blocked network egress requests can be approved or denied inline.

Fixes #5841

## Changes
- `docs/get-started/quickstart.mdx`: Adds the two-terminal workflow, the `openshell term` command, and a link to the detailed approval guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior - justification:
- [x] Tests not applicable - justification: docs-only quickstart guidance; no runtime behavior changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable - justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded - reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer - check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only) - attempted after `npm run build:cli`, but the local run timed out after 420s with environment-sensitive failures outside this docs change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) - passed with 0 errors and Fern's existing 2 warnings not printed by default.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Evidence
- `git diff --check` passed.
- `./node_modules/.bin/prek run --from-ref upstream/main --to-ref HEAD` passed.
- `npm run docs` passed outside the sandbox with 0 errors and 2 existing Fern warnings.
- `npm run build:cli` passed.
- `npm test` was attempted after the build, but did not complete within 420s locally; the observed failures were in environment-sensitive runtime suites such as Docker/gateway, real port probing, and platform-specific command behavior, not this docs-only quickstart change.

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quickstart guide with clearer terminal-based setup instructions for chatting with the agent.
  * Added a two-terminal workflow for cases that may require network access, including how to monitor and approve or deny blocked requests.
  * Linked to additional guidance for handling agent network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->