### PR TITLE
fix(messaging): queue Teams chat.send turns like webchat (Refs #5851)

### DIFF
--- a/scripts/patch-openclaw-chat-send.js
+++ b/scripts/patch-openclaw-chat-send.js
@@ -142,7 +142,27 @@ function patchGetReplyFollowupRunId(source, file) {
 }
 
 function patchGetReplyWebchatQueueMode(source, file) {
-  if (source.includes("force webchat chat.send queued turns")) {
+  const oldMarker = "force webchat chat.send queued turns";
+  const marker = "force webchat/msteams chat.send queued turns";
+  const oldCondition =
+    'opts?.runId && sessionCtx.Provider === "webchat" && resolvedQueue.mode === "steer"';
+  const newCondition =
+    'opts?.runId && ["webchat", "msteams"].includes(sessionCtx.Provider) && resolvedQueue.mode === "steer"';
+
+  if (source.includes(marker)) {
+    return { nextSource: source, status: "already-applied" };
+  }
+  if (source.includes(oldMarker)) {
+    const nextSource = source
+      .replace(oldCondition, newCondition)
+      .replace(oldMarker, marker)
+      .replace(
+        "force webchat/msteams chat.send queued turns to keep per-message replies (#2603, #3145)",
+        "force webchat/msteams chat.send queued turns to keep per-message replies (#2603, #3145, #5851)",
+      );
+    if (nextSource !== source) {
+      return { nextSource, status: "would-apply" };
+    }
     return { nextSource: source, status: "already-applied" };
   }
   let working = source;
@@ -161,11 +181,11 @@ function patchGetReplyWebchatQueueMode(source, file) {
   const nextSource = working.replace(
     /\n(\s*)(const (?:piRuntime|embeddedAgentRuntime) = useFastReplyRuntime \? null : await traceRunPhase\("reply\.(?:load_pi_runtime|load_embedded_agent_runtime)", \(\) => (?:loadPiEmbeddedRuntime|loadEmbeddedAgentRuntime)\(\)\);)/,
     (_match, indent, runtimeLine) =>
-      `\n${indent}if (opts?.runId && sessionCtx.Provider === "webchat" && resolvedQueue.mode === "steer") resolvedQueue = {\n` +
+      `\n${indent}if (${newCondition}) resolvedQueue = {\n` +
       `${indent}\t...resolvedQueue,\n` +
       `${indent}\tmode: "followup",\n` +
       `${indent}\tdebounceMs: 0\n` +
-      `${indent}}; // nemoclaw: force webchat chat.send queued turns to keep per-message replies (#2603, #3145)\n` +
+      `${indent}}; // nemoclaw: force webchat/msteams chat.send queued turns to keep per-message replies (#2603, #3145, #5851)\n` +
       `${indent}${runtimeLine}`,
   );
   if (nextSource === working) {
@@ -303,8 +323,8 @@ const FILES = [
       },
       {
         id: "webchat-queue-mode",
-        marker: "force webchat chat.send queued turns",
-        postVerifyError: "get-reply webchat queue mode patch did not apply",
+        marker: "force webchat/msteams chat.send queued turns",
+        postVerifyError: "get-reply webchat/msteams queue mode patch did not apply",
         patch: patchGetReplyWebchatQueueMode,
       },
     ],

--- a/test/openclaw-chat-send-patch.test.ts
+++ b/test/openclaw-chat-send-patch.test.ts
@@ -669,10 +669,10 @@ describe("OpenClaw chat.send compatibility patch", () => {
         "runId: opts?.runId, // nemoclaw: carry chat.send run id into queued followup (#2603, #3145)",
       );
       expect(patchedGetReply).toContain(
-        'if (opts?.runId && sessionCtx.Provider === "webchat" && resolvedQueue.mode === "steer") resolvedQueue = {',
+        'if (opts?.runId && ["webchat", "msteams"].includes(sessionCtx.Provider) && resolvedQueue.mode === "steer") resolvedQueue = {',
       );
       expect(patchedGetReply).toContain(
-        "}; // nemoclaw: force webchat chat.send queued turns to keep per-message replies (#2603, #3145)",
+        "}; // nemoclaw: force webchat/msteams chat.send queued turns to keep per-message replies (#2603, #3145, #5851)",
       );
 
       const rerun = runPatch(dist);
@@ -689,7 +689,7 @@ describe("OpenClaw chat.send compatibility patch", () => {
       expect(
         rerunPatchedGetReply.match(/carry chat\.send run id into queued followup/g),
       ).toHaveLength(1);
-      expect(rerunPatchedGetReply.match(/force webchat chat\.send queued turns/g)).toHaveLength(1);
+      expect(rerunPatchedGetReply.match(/force webchat\/msteams chat\.send queued turns/g)).toHaveLength(1);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -803,10 +803,10 @@ describe("OpenClaw chat.send compatibility patch", () => {
         "runId: opts?.runId, // nemoclaw: carry chat.send run id into queued followup (#2603, #3145)",
       );
       expect(patchedGetReply).toContain(
-        'if (opts?.runId && sessionCtx.Provider === "webchat" && resolvedQueue.mode === "steer") resolvedQueue = {',
+        'if (opts?.runId && ["webchat", "msteams"].includes(sessionCtx.Provider) && resolvedQueue.mode === "steer") resolvedQueue = {',
       );
       expect(patchedGetReply).toContain(
-        "}; // nemoclaw: force webchat chat.send queued turns to keep per-message replies (#2603, #3145)",
+        "}; // nemoclaw: force webchat/msteams chat.send queued turns to keep per-message replies (#2603, #3145, #5851)",
       );
       expect(patchedGetReply).toContain(
         'const embeddedAgentRuntime = useFastReplyRuntime ? null : await traceRunPhase("reply.load_embedded_agent_runtime", () => loadEmbeddedAgentRuntime());',
@@ -823,7 +823,7 @@ describe("OpenClaw chat.send compatibility patch", () => {
       const rerunPatchedChat = fs.readFileSync(chatFixture, "utf-8");
       expect(rerunPatchedChat.match(/suppressing empty final event/g)).toHaveLength(1);
       const rerunPatchedGetReply = fs.readFileSync(getReplyFixture, "utf-8");
-      expect(rerunPatchedGetReply.match(/force webchat chat\.send queued turns/g)).toHaveLength(1);
+      expect(rerunPatchedGetReply.match(/force webchat\/msteams chat\.send queued turns/g)).toHaveLength(1);
       const rerunPatchedFollowup = fs.readFileSync(followupFixture, "utf-8");
       expect(
         rerunPatchedFollowup.match(/preserve chat\.send run ids in followup queue/g),
@@ -889,7 +889,7 @@ describe("OpenClaw chat.send compatibility patch", () => {
       expect(patchedGetReply).toContain(
         'const embeddedAgentRuntime = useFastReplyRuntime ? null : await traceRunPhase("reply.load_embedded_agent_runtime", () => loadEmbeddedAgentRuntime());',
       );
-      expect(patchedGetReply).toContain("force webchat chat.send queued turns");
+      expect(patchedGetReply).toContain("force webchat/msteams chat.send queued turns");
 
       const rerun = runPatch(dist);
       expect(rerun.status, `${rerun.stdout}${rerun.stderr}`).toBe(0);
@@ -946,6 +946,42 @@ describe("OpenClaw chat.send compatibility patch", () => {
       expect(patch.stderr).toContain(
         "OpenClaw embedded-agent user persistence callback shape not recognized",
       );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("upgrades the old webchat-only queue shim to cover Microsoft Teams", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-chat-send-msteams-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist);
+    writeChatSendFixture(dist);
+    writeFollowupRunnerFixture(dist);
+    const getReplyFixture = writeGetReplyFixture(dist);
+
+    try {
+      const patch = runPatch(dist);
+      expect(patch.status, `${patch.stdout}${patch.stderr}`).toBe(0);
+      const patched = fs.readFileSync(getReplyFixture, "utf-8");
+      const oldPatched = patched
+        .replace(
+          'opts?.runId && ["webchat", "msteams"].includes(sessionCtx.Provider) && resolvedQueue.mode === "steer"',
+          'opts?.runId && sessionCtx.Provider === "webchat" && resolvedQueue.mode === "steer"',
+        )
+        .replace("force webchat/msteams chat.send queued turns", "force webchat chat.send queued turns")
+        .replace(", #5851", "");
+      fs.writeFileSync(getReplyFixture, oldPatched);
+
+      const upgrade = runPatch(dist);
+      expect(upgrade.status, `${upgrade.stdout}${upgrade.stderr}`).toBe(0);
+      const upgraded = fs.readFileSync(getReplyFixture, "utf-8");
+      expect(upgraded).toContain(
+        'opts?.runId && ["webchat", "msteams"].includes(sessionCtx.Provider) && resolvedQueue.mode === "steer"',
+      );
+      expect(upgraded).toContain(
+        "force webchat/msteams chat.send queued turns to keep per-message replies (#2603, #3145, #5851)",
+      );
+      expect(upgraded).not.toContain('sessionCtx.Provider === "webchat"');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Extends NemoClaw's OpenClaw chat.send compatibility patch so Microsoft Teams queued turns use the same per-message followup behavior as webchat.
- Upgrades older webchat-only shims in existing OpenClaw installs instead of treating them as already patched.
- Adds regression coverage for fresh patching, reruns, and old-shim upgrade behavior.

## Changes

- Broadened the queue-mode guard from `sessionCtx.Provider === "webchat"` to webchat or `msteams`.
- Added upgrade logic for previously patched dist files that still contain the old webchat-only marker.
- Updated patch verification markers and tests to cover Teams.

## Testing

- `npx vitest run test/openclaw-chat-send-patch.test.ts`
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run source-shape:check`
- `git diff --check`

## Evidence it works

The regression test rewrites a freshly patched OpenClaw fixture back to the old webchat-only shim, reruns the patch script, and verifies it upgrades to the webchat/Teams guard without leaving the old provider check behind.

Refs #5851

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat reply handling so queued replies work more reliably across both web and Microsoft Teams.
  * Updated the patching behavior to recognize and upgrade older queue logic, helping avoid inconsistent reply behavior after updates.
  * Expanded automated coverage to verify the fix applies correctly, remains idempotent, and can upgrade a web-only configuration to include Microsoft Teams support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->