### PR TITLE
fix(sandbox): keep rlimit shell hooks quiet

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -12,7 +12,7 @@ on:
         default: ""
         type: string
       jobs:
-        description: "Optional comma-separated free-standing live Vitest job ids. Empty runs default-enabled jobs only when scenarios is also empty; explicit-only jobs such as jetson-nvmap-gpu-vitest are skipped unless selected."
+        description: "Optional comma-separated free-standing live Vitest job ids. Empty runs default-enabled jobs only when scenarios is also empty; explicit-only jobs such as jetson-nvmap-gpu-vitest and sandbox-rlimits-connect-vitest are skipped unless selected."
         required: false
         default: ""
         type: string
@@ -2395,6 +2395,103 @@ jobs:
         with:
           name: e2e-vitest-scenarios-sandbox-rebuild
           path: e2e-artifacts/vitest/sandbox-rebuild/
+          include-hidden-files: false
+          if-no-files-found: ignore
+          retention-days: 14
+
+  sandbox-rlimits-connect-vitest:
+    needs: generate-matrix
+    if: ${{ contains(format(',{0},', inputs.jobs), ',sandbox-rlimits-connect-vitest,') || contains(format(',{0},', inputs.scenarios), ',sandbox-rlimits-connect,') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      FREE_STANDING_VITEST_JOB: "1"
+      FREE_STANDING_SCENARIO_ID: "sandbox-rlimits-connect"
+      E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/sandbox-rlimits-connect
+      NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
+      NEMOCLAW_RUN_E2E_SCENARIOS: "1"
+      NEMOCLAW_E2E_CONNECT_RLIMITS: "1"
+      NEMOCLAW_NON_INTERACTIVE: "1"
+      NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
+      NEMOCLAW_SANDBOX_NAME: e2e-rlimits-connect
+      OPENSHELL_GATEWAY: nemoclaw
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
+            exit 0
+          fi
+          login_succeeded=0
+          for attempt in 1 2 3; do
+            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
+              login_succeeded=1
+              break
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
+              sleep 5
+            fi
+          done
+          if [[ "$login_succeeded" -ne 1 ]]; then
+            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
+          fi
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build CLI
+        run: npm run build:cli
+
+      - name: Install OpenShell
+        env:
+          NEMOCLAW_NON_INTERACTIVE: "1"
+        run: |
+          set -euo pipefail
+          env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_API_KEY -u NVIDIA_INFERENCE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
+
+      - name: Run sandbox rlimit connect live test
+        env:
+          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
+          if command -v openshell >/dev/null 2>&1; then
+            OPENSHELL_BIN="$(command -v openshell)"
+          elif [ -x "$HOME/.local/bin/openshell" ]; then
+            OPENSHELL_BIN="$HOME/.local/bin/openshell"
+          else
+            echo "::error::OpenShell CLI not found after install"
+            ls -la /usr/local/bin/openshell "$HOME/.local/bin/openshell" 2>&1 || true
+            exit 1
+          fi
+          export OPENSHELL_BIN
+          "$OPENSHELL_BIN" --version
+          npx vitest run --project e2e-scenarios-live \
+            test/e2e-scenario/live/sandbox-rlimits-connect.test.ts \
+            --silent=false --reporter=default
+
+      - name: Upload sandbox rlimit connect artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-vitest-scenarios-sandbox-rlimits-connect
+          path: e2e-artifacts/vitest/sandbox-rlimits-connect/
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
@@ -5518,6 +5615,7 @@ jobs:
         rebuild-hermes-vitest,
         rebuild-hermes-stale-base-vitest,
         sandbox-rebuild-vitest,
+        sandbox-rlimits-connect-vitest,
         overlayfs-autofix-vitest,
         state-backup-restore-vitest,
         upgrade-stale-sandbox-vitest,
@@ -5583,6 +5681,11 @@ jobs:
                 job: 'jetson-nvmap-gpu-vitest',
                 scenario: 'jetson-nvmap-gpu',
                 reason: 'default dispatch excludes Jetson until a stable Jetson runner is available',
+              },
+              {
+                job: 'sandbox-rlimits-connect-vitest',
+                scenario: 'sandbox-rlimits-connect',
+                reason: 'default dispatch excludes the destructive rlimit fork/connect probe unless selected',
               },
             ];
             const scenariosRejected = rawRequestedScenarios && !selectorValidationPassed;
@@ -5669,7 +5772,7 @@ jobs:
                 ? '**Requested jobs:** _(selector rejected by workflow validation)_'
                 : requestedJobs
                   ? `**Requested jobs:** \`${requestedJobs}\``
-                  : '**Requested jobs:** _(default — all default-enabled free-standing jobs; explicit-only jobs such as `jetson-nvmap-gpu-vitest` are skipped unless selected)_',
+                  : '**Requested jobs:** _(default — all default-enabled free-standing jobs; explicit-only jobs such as `jetson-nvmap-gpu-vitest` and `sandbox-rlimits-connect-vitest` are skipped unless selected)_',
               `**Summary:** ${passed.length} passed, ${failed.length} failed, ${cancelled.length} cancelled, ${skipped.length} skipped`,
               '',
               '| Job | Result |',

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -2467,7 +2467,7 @@ jobs:
 
       - name: Run sandbox rlimit connect live test
         env:
-          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -952,7 +952,7 @@ RUN chmod 444 /usr/local/lib/nemoclaw/sandbox-rlimits.sh \
     && if ! grep -q "sandbox-rlimits.sh" /etc/profile.d/nemoclaw-rlimits.sh 2>/dev/null; then \
         printf '%s\n' \
             '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-            '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits' \
+            '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true' \
             > /etc/profile.d/nemoclaw-rlimits.sh \
         && chmod 444 /etc/profile.d/nemoclaw-rlimits.sh; \
     fi \
@@ -969,7 +969,7 @@ RUN chmod 444 /usr/local/lib/nemoclaw/sandbox-rlimits.sh \
           '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
           '' \
           '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-          '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits' \
+          '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true' \
           ''; \
         grep -Ev 'NemoClaw runtime proxy config|nemoclaw-proxy-env[.]sh|NemoClaw sandbox resource limits|sandbox-rlimits[.]sh' /etc/bash.bashrc || true; \
       } > /etc/bash.bashrc.new \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -166,7 +166,7 @@ RUN printf '%s\n' \
 RUN chmod 444 /usr/local/lib/nemoclaw/sandbox-rlimits.sh \
     && printf '%s\n' \
         '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-        '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits' \
+        '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true' \
         > /etc/profile.d/nemoclaw-rlimits.sh \
     && chmod 444 /etc/profile.d/nemoclaw-rlimits.sh \
     && printf '%s\n' \
@@ -179,7 +179,7 @@ RUN chmod 444 /usr/local/lib/nemoclaw/sandbox-rlimits.sh \
             '[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh' \
             '' \
             '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-            '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits' \
+            '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true' \
             ''; \
          cat /etc/bash.bashrc; \
        } > /etc/bash.bashrc.new \

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -126,13 +126,13 @@ RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init
     && mkdir -p /etc/profile.d \
     && printf '%s\n' \
         '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-        '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits' \
+        '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true' \
         > /etc/profile.d/nemoclaw-rlimits.sh \
     && chmod 444 /etc/profile.d/nemoclaw-rlimits.sh \
     && (chmod 644 /etc/bash.bashrc 2>/dev/null || true) \
     && { printf '%s\n' \
           '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-          '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits' \
+          '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true' \
           ''; \
         if [ -f /etc/bash.bashrc ]; then \
           grep -Ev 'NemoClaw sandbox resource limits|sandbox-rlimits[.]sh' /etc/bash.bashrc || true; \

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -69,7 +69,7 @@ const getMessagingInputValue = (input: ChannelInputSpec): string | null => {
  */
 export function detectMessagingChannelsFromEnv(agent: AgentDefinition | null = null): string[] {
   const manifestRegistry = createBuiltInChannelManifestRegistry();
-  const availabilityContext = getMessagingManifestAvailabilityContext(agent);
+  const availabilityContext = getMessagingManifestAvailabilityContext(agent, manifestRegistry.list());
   const availableChannels = manifestRegistry.listAvailable(availabilityContext);
   return availableChannels
     .filter((manifest) => hasMessagingManifestRequiredInputs(manifest, getMessagingInputValue))

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -69,7 +69,10 @@ const getMessagingInputValue = (input: ChannelInputSpec): string | null => {
  */
 export function detectMessagingChannelsFromEnv(agent: AgentDefinition | null = null): string[] {
   const manifestRegistry = createBuiltInChannelManifestRegistry();
-  const availabilityContext = getMessagingManifestAvailabilityContext(agent, manifestRegistry.list());
+  const availabilityContext = getMessagingManifestAvailabilityContext(
+    agent,
+    manifestRegistry.list(),
+  );
   const availableChannels = manifestRegistry.listAvailable(availabilityContext);
   return availableChannels
     .filter((manifest) => hasMessagingManifestRequiredInputs(manifest, getMessagingInputValue))

--- a/test/e2e-scenario/live/sandbox-rlimits-connect.test.ts
+++ b/test/e2e-scenario/live/sandbox-rlimits-connect.test.ts
@@ -26,6 +26,12 @@ function numericProbe(text: string, key: string): number {
   return Number(match?.[1] ?? "NaN");
 }
 
+function expectNoRlimitStartupDiagnostics(text: string): void {
+  expect(text, "connect shell startup must not print rlimit security diagnostics").not.toMatch(
+    /\[SECURITY\].*(?:Effective|Could not set).*(?:nproc|nofile).*limit/iu,
+  );
+}
+
 function connectAcceptanceScript(cliPath: string, sandboxName: string): string {
   const cli = JSON.stringify(cliPath);
   const sandbox = JSON.stringify(sandboxName);
@@ -66,6 +72,7 @@ runConnectRlimitTest(
         "bash -lc 'ulimit -u; ulimit -n'",
         "bash -ic 'ulimit -u; ulimit -n'",
         "ulimit -a",
+        "shell startup does not emit [SECURITY] rlimit diagnostics before user commands",
         "for i in $(seq 1 5000); do sleep 60 & done 2>&1 | tail -5",
       ],
       hermesCoverage:
@@ -127,6 +134,7 @@ runConnectRlimitTest(
     expect(connect.exitCode, output).toBe(0);
     expect(output).toContain("__NEMOCLAW_RLIMIT_CONNECT_BEGIN__");
     expect(output).toContain("__NEMOCLAW_RLIMIT_CONNECT_END__");
+    expectNoRlimitStartupDiagnostics(output);
 
     expect(numericProbe(output, "login_nproc")).toBeLessThanOrEqual(4096);
     expect(numericProbe(output, "login_nofile")).toBeLessThanOrEqual(65536);

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -643,11 +643,15 @@ describe("e2e-vitest-scenarios workflow boundary", () => {
     expect(inventory.allowedJobs).toContain("openshell-version-pin-vitest");
     expect(inventory.allowedJobs).toContain("gateway-guard-recovery");
     expect(inventory.allowedJobs).toContain("upgrade-stale-sandbox-vitest");
+    expect(inventory.allowedJobs).toContain("sandbox-rlimits-connect-vitest");
     expect(inventory.scenarioToJob.get("openshell-version-pin")).toBe(
       "openshell-version-pin-vitest",
     );
     expect(inventory.scenarioToJob.get("upgrade-stale-sandbox")).toBe(
       "upgrade-stale-sandbox-vitest",
+    );
+    expect(inventory.scenarioToJob.get("sandbox-rlimits-connect")).toBe(
+      "sandbox-rlimits-connect-vitest",
     );
     expect(inventory.scenarioToJob.get("credential-migration")).toBeUndefined();
     expect(
@@ -1001,6 +1005,29 @@ jobs:
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("routes the rlimit connect acceptance selector to an explicit free-standing job", () => {
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "sandbox-rlimits-connect" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["sandbox-rlimits-connect-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ jobs: "sandbox-rlimits-connect-vitest" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["sandbox-rlimits-connect-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ jobs: "", scenarios: "" })
+        .selectedFreeStandingJobs,
+    ).not.toContain("sandbox-rlimits-connect-vitest");
   });
 
   it("rejects workflow selector drift from the free-standing inventory", () => {

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -643,15 +643,11 @@ describe("e2e-vitest-scenarios workflow boundary", () => {
     expect(inventory.allowedJobs).toContain("openshell-version-pin-vitest");
     expect(inventory.allowedJobs).toContain("gateway-guard-recovery");
     expect(inventory.allowedJobs).toContain("upgrade-stale-sandbox-vitest");
-    expect(inventory.allowedJobs).toContain("sandbox-rlimits-connect-vitest");
     expect(inventory.scenarioToJob.get("openshell-version-pin")).toBe(
       "openshell-version-pin-vitest",
     );
     expect(inventory.scenarioToJob.get("upgrade-stale-sandbox")).toBe(
       "upgrade-stale-sandbox-vitest",
-    );
-    expect(inventory.scenarioToJob.get("sandbox-rlimits-connect")).toBe(
-      "sandbox-rlimits-connect-vitest",
     );
     expect(inventory.scenarioToJob.get("credential-migration")).toBeUndefined();
     expect(
@@ -1007,28 +1003,6 @@ jobs:
     }
   });
 
-  it("routes the rlimit connect acceptance selector to an explicit free-standing job", () => {
-    expect(
-      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "sandbox-rlimits-connect" }),
-    ).toMatchObject({
-      valid: true,
-      liveScenariosRuns: false,
-      selectedFreeStandingJobs: ["sandbox-rlimits-connect-vitest"],
-      registryScenarios: [],
-    });
-    expect(
-      evaluateE2eVitestWorkflowDispatchSelectors({ jobs: "sandbox-rlimits-connect-vitest" }),
-    ).toMatchObject({
-      valid: true,
-      liveScenariosRuns: false,
-      selectedFreeStandingJobs: ["sandbox-rlimits-connect-vitest"],
-      registryScenarios: [],
-    });
-    expect(
-      evaluateE2eVitestWorkflowDispatchSelectors({ jobs: "", scenarios: "" })
-        .selectedFreeStandingJobs,
-    ).not.toContain("sandbox-rlimits-connect-vitest");
-  });
 
   it("rejects workflow selector drift from the free-standing inventory", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-vitest-workflow-"));

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -1003,7 +1003,6 @@ jobs:
     }
   });
 
-
   it("rejects workflow selector drift from the free-standing inventory", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-vitest-workflow-"));
     const workflowPath = path.join(tmp, "workflow.yaml");

--- a/test/e2e-scenario/support-tests/rlimit-connect-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/rlimit-connect-workflow-boundary.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+  evaluateE2eVitestWorkflowDispatchSelectors,
+  readFreeStandingJobsInventory,
+} from "../../../tools/e2e-scenarios/workflow-boundary.mts";
+
+describe("rlimit connect workflow boundary", () => {
+  it("maps the rlimit connect acceptance selector to its explicit Vitest job", () => {
+    const inventory = readFreeStandingJobsInventory();
+    expect(inventory.allowedJobs).toContain("sandbox-rlimits-connect-vitest");
+    expect(inventory.scenarioToJob.get("sandbox-rlimits-connect")).toBe(
+      "sandbox-rlimits-connect-vitest",
+    );
+
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ scenarios: "sandbox-rlimits-connect" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["sandbox-rlimits-connect-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ jobs: "sandbox-rlimits-connect-vitest" }),
+    ).toMatchObject({
+      valid: true,
+      liveScenariosRuns: false,
+      selectedFreeStandingJobs: ["sandbox-rlimits-connect-vitest"],
+      registryScenarios: [],
+    });
+    expect(
+      evaluateE2eVitestWorkflowDispatchSelectors({ jobs: "", scenarios: "" })
+        .selectedFreeStandingJobs,
+    ).not.toContain("sandbox-rlimits-connect-vitest");
+  });
+});

--- a/test/sandbox-provisioning.test.ts
+++ b/test/sandbox-provisioning.test.ts
@@ -902,7 +902,7 @@ describe("sandbox provisioning: unified .openclaw layout (#2227)", () => {
     const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");
     const bashrc = path.join(tmp, "bash.bashrc");
     const runtimeEnvShim = "[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh";
-    const rlimitShim = `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits`;
+    const rlimitShim = `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits --quiet || true`;
 
     try {
       fs.mkdirSync(path.dirname(profileHook), { recursive: true });
@@ -946,7 +946,7 @@ describe("sandbox provisioning: unified .openclaw layout (#2227)", () => {
     const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");
     const bashrc = path.join(tmp, "bash.bashrc");
     const runtimeEnvShim = "[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh";
-    const rlimitShim = `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits`;
+    const rlimitShim = `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits --quiet || true`;
 
     try {
       fs.mkdirSync(path.dirname(profileHook), { recursive: true });

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -73,7 +73,7 @@ function copyRlimitFixtureWithNprocLimit(rlimitLib: string, limit: number): void
 }
 
 function rlimitShim(rlimitLib: string): string {
-  return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits`;
+  return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits --quiet || true`;
 }
 
 type ProbeValues = Record<string, string | undefined>;
@@ -165,6 +165,36 @@ function expectSystemRlimitHookBypassesShadowedUlimit(hookPath: string): void {
   expect(values.shadow).toBe("function");
   expect(Number(values.nproc)).toBeLessThanOrEqual(4096);
   expect(Number(values.nofile)).toBeLessThanOrEqual(65536);
+}
+
+function expectSystemRlimitHookIsSilentWhenVerificationFails(
+  hookPath: string,
+  rlimitLib: string,
+): void {
+  fs.chmodSync(rlimitLib, 0o644);
+  fs.writeFileSync(
+    rlimitLib,
+    [
+      "harden_resource_limits() { :; }",
+      "verify_resource_limits() {",
+      '  if [ "${1:-}" != "--quiet" ]; then',
+      '    echo "[SECURITY] noisy verification failure" >&2',
+      "  fi",
+      "  return 1",
+      "}",
+    ].join("\n"),
+  );
+  const probe = ["set -euo pipefail", `source ${JSON.stringify(hookPath)}`, 'printf "OK\\n"'].join(
+    "\n",
+  );
+  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", probe], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toBe("OK\n");
+  expect(result.stderr).toBe("");
 }
 
 function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
@@ -388,6 +418,7 @@ describe("sandbox rlimit system hooks (#2173)", () => {
       expectSystemRlimitHookEnforcesLimits(rlimitHook);
       expectSystemRlimitHookEnforcesLimits(bashrc);
       expectSystemRlimitHookBypassesShadowedUlimit(rlimitHook);
+      expectSystemRlimitHookIsSilentWhenVerificationFails(rlimitHook, rlimitLib);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -447,7 +478,7 @@ describe("sandbox rlimit system hooks (#2173)", () => {
           "# NemoClaw runtime proxy config — see /tmp/nemoclaw-proxy-env.sh (#2704)",
           "[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh",
           "# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)",
-          "[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits",
+          "[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits --quiet || true",
         ].join("\n"),
       );
       const command = dockerRunCommandBetween(
@@ -467,6 +498,7 @@ describe("sandbox rlimit system hooks (#2173)", () => {
       expect(occurrenceCount(bashrcBody, expectedRlimitShim)).toBe(1);
       expectSystemRlimitHookEnforcesLimits(rlimitHook);
       expectSystemRlimitHookEnforcesLimits(bashrc);
+      expectSystemRlimitHookIsSilentWhenVerificationFails(bashrc, rlimitLib);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -517,6 +549,7 @@ describe("sandbox rlimit system hooks (#2173)", () => {
       expect(fs.readFileSync(bashrc, "utf-8")).toContain(expectedRlimitShim);
       expectSystemRlimitHookEnforcesLimits(profileHook);
       expectSystemRlimitHookEnforcesLimits(bashrc);
+      expectSystemRlimitHookIsSilentWhenVerificationFails(bashrc, rlimitLib);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -7840,11 +7840,8 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     if (!runScript.includes("test/e2e-scenario/live/sandbox-rlimits-connect.test.ts")) {
       errors.push("sandbox-rlimits-connect-vitest job must run sandbox-rlimits-connect.test.ts");
     }
-    if (
-      asRecord(sandboxRlimitConnectRun.env).NVIDIA_INFERENCE_API_KEY !==
-      "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
-    ) {
-      errors.push("sandbox-rlimits-connect-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+    if (asRecord(sandboxRlimitConnectRun.env).NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
+      errors.push("sandbox-rlimits-connect-vitest step must receive NVIDIA_API_KEY from secrets");
     }
   }
 

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -51,8 +51,12 @@ const FREE_STANDING_SELECTOR_SPECIAL_CASES = new Set([
   "hermes-e2e-vitest",
   "hermes-root-entrypoint-smoke-vitest",
   "jetson-nvmap-gpu-vitest",
+  "sandbox-rlimits-connect-vitest",
 ]);
-const FULL_SUITE_EXCLUDED_FREE_STANDING_JOBS = new Set(["jetson-nvmap-gpu-vitest"]);
+const FULL_SUITE_EXCLUDED_FREE_STANDING_JOBS = new Set([
+  "jetson-nvmap-gpu-vitest",
+  "sandbox-rlimits-connect-vitest",
+]);
 
 function asRecord(value: unknown): WorkflowRecord {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -7797,6 +7801,53 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   if (jetsonJob.if !== explicitOnlyFreeStandingJobIf("jetson-nvmap-gpu-vitest", "jetson-nvmap-gpu")) {
     errors.push("jetson-nvmap-gpu-vitest job must run only when explicitly selected");
   }
+
+  const sandboxRlimitConnectJob = asRecord(jobs["sandbox-rlimits-connect-vitest"]);
+  if (sandboxRlimitConnectJob.needs !== "generate-matrix") {
+    errors.push("sandbox-rlimits-connect-vitest job must depend on generate-matrix");
+  }
+  if (
+    sandboxRlimitConnectJob.if !==
+    explicitOnlyFreeStandingJobIf(
+      "sandbox-rlimits-connect-vitest",
+      "sandbox-rlimits-connect",
+    )
+  ) {
+    errors.push("sandbox-rlimits-connect-vitest job must run only when explicitly selected");
+  }
+  const sandboxRlimitConnectEnv = asRecord(sandboxRlimitConnectJob.env);
+  if (sandboxRlimitConnectEnv.NEMOCLAW_RUN_E2E_SCENARIOS !== "1") {
+    errors.push("sandbox-rlimits-connect-vitest job must set NEMOCLAW_RUN_E2E_SCENARIOS=1");
+  }
+  if (sandboxRlimitConnectEnv.NEMOCLAW_E2E_CONNECT_RLIMITS !== "1") {
+    errors.push("sandbox-rlimits-connect-vitest job must opt in with NEMOCLAW_E2E_CONNECT_RLIMITS=1");
+  }
+  if (
+    sandboxRlimitConnectEnv.E2E_ARTIFACT_DIR !==
+    "${{ github.workspace }}/e2e-artifacts/vitest/sandbox-rlimits-connect"
+  ) {
+    errors.push("sandbox-rlimits-connect-vitest job must write artifacts under e2e-artifacts/vitest/sandbox-rlimits-connect");
+  }
+  const sandboxRlimitConnectSteps = asSteps(sandboxRlimitConnectJob.steps);
+  const sandboxRlimitConnectRun = namedStep(
+    sandboxRlimitConnectSteps,
+    "Run sandbox rlimit connect live test",
+  );
+  if (!sandboxRlimitConnectRun) {
+    errors.push("sandbox-rlimits-connect-vitest job missing step: Run sandbox rlimit connect live test");
+  } else {
+    const runScript = stringValue(sandboxRlimitConnectRun.run);
+    if (!runScript.includes("test/e2e-scenario/live/sandbox-rlimits-connect.test.ts")) {
+      errors.push("sandbox-rlimits-connect-vitest job must run sandbox-rlimits-connect.test.ts");
+    }
+    if (
+      asRecord(sandboxRlimitConnectRun.env).NVIDIA_INFERENCE_API_KEY !==
+      "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
+    ) {
+      errors.push("sandbox-rlimits-connect-vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets");
+    }
+  }
+
   validateFreeStandingJobSelector(
     errors,
     jobs,
@@ -7922,6 +7973,16 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     if (!reportScript.includes("scenarios=${scenario}") || !reportScript.includes("jetson-nvmap-gpu")) {
       errors.push(
         "step 'Post Vitest scenario results to PR' run script must document the explicit Jetson scenario selector",
+      );
+    }
+    if (!reportScript.includes("sandbox-rlimits-connect-vitest")) {
+      errors.push(
+        "step 'Post Vitest scenario results to PR' run script must document the explicit rlimit jobs selector",
+      );
+    }
+    if (!reportScript.includes("sandbox-rlimits-connect")) {
+      errors.push(
+        "step 'Post Vitest scenario results to PR' run script must document the explicit rlimit scenario selector",
       );
     }
     for (const forbidden of [


### PR DESCRIPTION
## Summary
- keep connect/login shell rlimit hooks quiet and best-effort so startup diagnostics do not pollute command, agent, or inference response streams
- preserve loud PID 1 entrypoint rlimit enforcement while shell hooks use `verify_resource_limits --quiet || true`
- add regression coverage proving shell hooks remain silent when verification fails

## Root cause
PR #5682 added `verify_resource_limits` to `/etc/profile.d` and `/etc/bash.bashrc` hooks. When a shell cannot report/enforce a limit, that non-quiet verification emits `[SECURITY] ...` diagnostics on stderr before user commands run. Nightly E2E jobs then captured those diagnostics in API/model probes and failed assertions expecting clean responses.

## Test plan
- `./node_modules/.bin/vitest run test/sandbox-rlimit-hooks.test.ts test/sandbox-provisioning.test.ts test/sandbox-build-context.test.ts test/sandbox-init.test.ts`
- targeted nightly E2E dispatch pending for the rlimit-output-contamination failures

Refs #5682 / #2173.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new explicit test job for the rlimit connect scenario, making it selectable on demand in CI.
  * Improved shell startup behavior so resource-limit checks no longer interrupt builds or login shells when verification fails.

* **Bug Fixes**
  * Reduced noisy security diagnostics during shell startup.
  * Messaging channel detection now considers built-in channel availability more consistently.

* **Tests**
  * Expanded coverage for silent rlimit verification failures and the new workflow/job selection path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->