### PR TITLE
fix(hermes): explain Desktop version mismatch (Refs #5845)

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -38,6 +38,8 @@ type ConnectHarnessOptions = {
   spawnSignal?: NodeJS.Signals | null;
   spawnStatus?: number | null;
   sttyThrows?: boolean;
+  versionCheck?: unknown;
+  versionWarningLines?: string[];
 };
 
 function throwSttyFailure(): never {
@@ -108,8 +110,12 @@ function createConnectHarness(options: ConnectHarnessOptions = {}): ConnectHarne
     detected: true,
     sessions: [{ pid: 1 }, { pid: 2 }],
   });
-  vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({ isStale: false });
-  vi.spyOn(sandboxVersion, "formatStalenessWarning").mockReturnValue([]);
+  vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue(
+    (options.versionCheck ?? { isStale: false }) as never,
+  );
+  vi.spyOn(sandboxVersion, "formatStalenessWarning").mockReturnValue(
+    options.versionWarningLines ?? [],
+  );
   const checkAndRecoverSpy = vi
     .spyOn(processRecovery, "checkAndRecoverSandboxProcesses")
     .mockReturnValue(options.processCheck ?? { checked: true, wasRunning: true, recovered: false });
@@ -371,6 +377,30 @@ describe("connectSandbox flow", () => {
     expect(output).toContain("Inside the sandbox, run `dcode`");
     expect(output).not.toContain("Inside the sandbox, run `langchain-deepagents-code`");
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("prints stale Hermes Desktop compatibility guidance before connecting", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      versionCheck: {
+        sandboxVersion: "2026.5.16",
+        expectedVersion: "2026.6.19",
+        isStale: true,
+        detectionMethod: "registry",
+      },
+      versionWarningLines: [
+        "",
+        "  Hermes Desktop requires Hermes Agent v2026.6.5+ (2026.5.16 lacks /api/profiles/sessions).",
+        "  Rebuild this sandbox before connecting it from Hermes Desktop.",
+      ],
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
+
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(errorOutput).toContain("Hermes Desktop requires Hermes Agent v2026.6.5+");
+    expect(errorOutput).toContain("/api/profiles/sessions");
+    expect(errorOutput).toContain("Rebuild this sandbox");
   });
 
   it("stops before opening SSH when the sandbox list reports a terminal failure phase", async () => {

--- a/src/lib/actions/sandbox/status-flow.test.ts
+++ b/src/lib/actions/sandbox/status-flow.test.ts
@@ -234,6 +234,28 @@ describe("showSandboxStatus flow", () => {
     });
   });
 
+  it("prints Hermes Desktop compatibility guidance for stale Hermes backends", async () => {
+    const harness = createStatusFlowHarness({
+      sandboxEntry: {
+        agent: "hermes",
+        agentVersion: "2026.5.16",
+      },
+    });
+    harness.checkAgentVersionSpy.mockReturnValue({
+      sandboxVersion: "2026.5.16",
+      expectedVersion: "2026.6.19",
+      isStale: true,
+      detectionMethod: "registry",
+    });
+
+    await expect(harness.showSandboxStatus("alpha")).resolves.toBeUndefined();
+
+    const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Hermes Desktop requires Hermes Agent v2026.6.5+");
+    expect(output).toContain("/api/profiles/sessions");
+    expect(output).toContain("Rebuild this sandbox");
+  });
+
   it("preserves the registry entry and exits when the live gateway is missing the sandbox", async () => {
     const harness = createStatusFlowHarness({ lookupState: "missing" });
 

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -286,6 +286,12 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
       if (versionCheck.isStale) {
         console.log(`    ${YW}Update:   v${versionCheck.expectedVersion} available${R}`);
         console.log(`              Run \`${CLI_NAME} ${sandboxName} rebuild\` to upgrade`);
+        for (const line of sandboxVersion.formatHermesDesktopCompatibilityWarning(
+          sandboxName,
+          versionCheck,
+        )) {
+          console.log(line);
+        }
       } else if (
         shouldProbeRuntimeVersion &&
         versionCheck.detectionMethod === "unavailable" &&

--- a/src/lib/sandbox/version.test.ts
+++ b/src/lib/sandbox/version.test.ts
@@ -55,7 +55,11 @@ import { spawnSync } from "child_process";
 import { captureSandboxSshConfigCommand } from "../adapters/openshell/client.js";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "../adapters/openshell/timeouts.js";
 import * as registry from "../state/registry.js";
-import { checkAgentVersion, formatStalenessWarning } from "./version.js";
+import {
+  checkAgentVersion,
+  formatHermesDesktopCompatibilityWarning,
+  formatStalenessWarning,
+} from "./version.js";
 
 describe("checkAgentVersion", () => {
   let tmpDir: string;
@@ -260,5 +264,43 @@ describe("formatStalenessWarning", () => {
     expect(joined).toContain("2026.3.11");
     expect(joined).toContain("2026.5.27");
     expect(joined).toContain("rebuild");
+  });
+
+  it("explains the Hermes Desktop API mismatch for old Hermes sandboxes", () => {
+    registry.registerSandbox({ name: "my-hermes", agent: "hermes" });
+
+    const lines = formatHermesDesktopCompatibilityWarning("my-hermes", {
+      sandboxVersion: "2026.5.16",
+      expectedVersion: "2026.6.19",
+      isStale: true,
+      detectionMethod: "registry",
+    });
+    const joined = lines.join("\n");
+
+    expect(joined).toContain("Hermes Desktop requires Hermes Agent v2026.6.5+");
+    expect(joined).toContain("/api/profiles/sessions");
+    expect(joined).toContain("Rebuild this sandbox");
+  });
+
+  it("does not show the Hermes Desktop warning for current Hermes or other agents", () => {
+    registry.registerSandbox({ name: "my-hermes", agent: "hermes" });
+
+    expect(
+      formatHermesDesktopCompatibilityWarning("my-hermes", {
+        sandboxVersion: "2026.6.19",
+        expectedVersion: "2026.6.19",
+        isStale: false,
+        detectionMethod: "registry",
+      }),
+    ).toEqual([]);
+
+    expect(
+      formatHermesDesktopCompatibilityWarning("my-sb", {
+        sandboxVersion: "2026.5.16",
+        expectedVersion: "2026.6.19",
+        isStale: true,
+        detectionMethod: "registry",
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/lib/sandbox/version.ts
+++ b/src/lib/sandbox/version.ts
@@ -18,8 +18,11 @@ import {
 import { resolveOpenshell } from "../adapters/openshell/resolve.js";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "../adapters/openshell/timeouts.js";
 import { loadAgent } from "../agent/defs.js";
+import { D, R } from "../cli/terminal-style.js";
 import * as registry from "../state/registry.js";
 import { createTempSshConfig } from "./temp-ssh-config.js";
+
+const HERMES_DESKTOP_MIN_VERSION = "2026.6.5";
 
 export interface VersionCheckResult {
   sandboxVersion: string | null;
@@ -170,6 +173,24 @@ export function formatStalenessWarning(sandboxName: string, result: VersionCheck
     "",
     `  \u26a0 Sandbox '${sandboxName}' is running ${agentName} ${result.sandboxVersion} (current: ${result.expectedVersion})`,
     `    Run: nemoclaw ${sandboxName} rebuild`,
+    ...formatHermesDesktopCompatibilityWarning(sandboxName, result),
     "",
+  ];
+}
+
+/**
+ * Explain the Hermes Desktop/backend API mismatch for old Hermes sandboxes.
+ */
+export function formatHermesDesktopCompatibilityWarning(
+  sandboxName: string,
+  result: VersionCheckResult,
+): string[] {
+  const agent = resolveAgentForSandbox(sandboxName);
+  if (agent.name !== "hermes") return [];
+  if (!result.sandboxVersion) return [];
+  if (versionGte(result.sandboxVersion, HERMES_DESKTOP_MIN_VERSION)) return [];
+  return [
+    `    ${D}Hermes Desktop requires Hermes Agent v${HERMES_DESKTOP_MIN_VERSION}+ (${result.sandboxVersion} lacks /api/profiles/sessions).${R}`,
+    "    Rebuild this sandbox before connecting it from Hermes Desktop.",
   ];
 }


### PR DESCRIPTION
## Summary

PR #5594 already moved new Hermes sandboxes to Hermes Agent `v2026.6.19`, which is newer than the first Desktop-compatible backend. This PR covers existing stale Hermes sandboxes: when NemoClaw detects a Hermes backend older than `v2026.6.5`, it now says why Hermes Desktop will fail and points the user at `rebuild`.

## Changes

- `src/lib/sandbox/version.ts`: adds a Hermes Desktop compatibility warning for stale Hermes versions that lack `/api/profiles/sessions`.
- `src/lib/actions/sandbox/status.ts`: prints that warning next to the existing stale-version rebuild hint.
- `src/lib/sandbox/version.test.ts`, `src/lib/actions/sandbox/status-flow.test.ts`, `src/lib/actions/sandbox/connect-flow.test.ts`: cover helper, status, and connect warning behavior.

## Testing

- `npm install --ignore-scripts` - installed this worktree's locked dependencies; npm reported the existing audit warnings and that local Node `v22.12.0` is below the repo's `>=22.16.0` engine.
- `npm run build:cli` - passed.
- `HOME=/private/tmp/nemoclaw-5845-vitest-home npx vitest run --project cli src/lib/sandbox/version.test.ts src/lib/actions/sandbox/status-flow.test.ts src/lib/actions/sandbox/connect-flow.test.ts` - passed, 30 tests.
- `npm run typecheck:cli` - passed.
- `npm run source-shape:check` - passed outside the sandbox after the sandboxed run hit the known `tsx` IPC pipe `EPERM`.
- `npm run test-size:check` - passed outside the sandbox.
- `npx @biomejs/biome format src/lib/sandbox/version.ts src/lib/sandbox/version.test.ts src/lib/actions/sandbox/status.ts src/lib/actions/sandbox/status-flow.test.ts src/lib/actions/sandbox/connect-flow.test.ts` - passed, no fixes applied.
- `npx @biomejs/biome lint src/lib/sandbox/version.ts src/lib/sandbox/version.test.ts src/lib/actions/sandbox/status.ts src/lib/actions/sandbox/status-flow.test.ts src/lib/actions/sandbox/connect-flow.test.ts` - passed.
- `git diff --check` - passed.
- `HOME=/private/tmp/nemoclaw-5845-fulltest-home npm test` - attempted; timed out after 300s with unrelated local environment-sensitive failures visible in Docker/port/gateway process suites such as `test/sandbox-provisioning.test.ts`, `src/lib/onboard/preflight.test.ts`, and `test/cli/doctor-gateway-token.test.ts`.

## Evidence it works

The focused regression tests simulate a Hermes sandbox at `2026.5.16` with a current expected version of `2026.6.19`. `status` now prints that Hermes Desktop requires `v2026.6.5+` and that the old backend lacks `/api/profiles/sessions`; `connect` prints the same stale-version guidance before attaching.

Refs #5845

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hermes Desktop compatibility warnings when a sandbox agent version is out of date.
  * Status and connection flows now show clearer guidance, including update and rebuild instructions.

* **Bug Fixes**
  * Improved version-staleness messaging for Hermes sandboxes so outdated setups are flagged more explicitly.
  * Added coverage to ensure the warning appears only for the relevant agent and version state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->