### PR TITLE
docs: refresh Deep Agents Code guidance

### DIFF
--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -25,9 +25,16 @@ Run onboarding with the canonical agent ID.
 nemoclaw onboard --agent langchain-deepagents-code
 ```
 
+For scripted installs, pass the same agent ID to the non-interactive onboard flow:
+
+```bash
+NEMOCLAW_AGENT=langchain-deepagents-code nemoclaw onboard --non-interactive --yes-i-accept-third-party-software
+```
+
 The image installs a hash-locked, pinned Deep Agents Code release with NVIDIA provider support.
 NemoClaw writes `/sandbox/.deepagents/config.toml` with an OpenAI-compatible provider pointed at `https://inference.local/v1`, uses a scoped placeholder API key for that managed route, and sets `use_responses_api = false` for Chat Completions compatibility.
 NemoClaw/OpenShell keeps real provider credentials in credential handling and does not write them into the Deep Agents config file.
+Do not paste upstream provider keys into `/sandbox/.deepagents/.env`; use the NemoClaw provider prompts, provider environment variables, or `nemoclaw credentials` commands instead.
 
 ## Use the Harness
 
@@ -42,6 +49,12 @@ For a single headless task, run:
 
 ```bash
 dcode -n "Summarize this repository"
+```
+
+From the host, the `agent` wrapper forwards to the same manifest-declared command:
+
+```bash
+nemoclaw <sandbox-name> agent -n "Summarize this repository"
 ```
 
 The managed wrapper launches Deep Agents Code with `HOME=/sandbox`, update checks disabled, remote Deep Agents sandbox providers disabled, MCP auto-loading disabled, and shell allow-list overrides blocked.
@@ -64,7 +77,8 @@ NemoClaw intentionally does not preserve `.env` or `.mcp.json` because users may
 ## Optional Web Search
 
 Deep Agents Code can use Tavily web search when you provide a Tavily credential in the runtime environment.
-NemoClaw does not enable Tavily or LangSmith by default for this harness. The sandbox policy denies `api.tavily.com` and `api.smith.langchain.com` until you opt in.
+NemoClaw does not enable Tavily, LangSmith, MCP servers, or remote Deep Agents sandbox providers by default for this harness.
+The sandbox policy denies `api.tavily.com` and `api.smith.langchain.com` until you opt in.
 
 To enable Tavily, apply the maintained `tavily` policy preset so the sandbox may reach the Tavily API, then supply the credential.
 
@@ -105,6 +119,7 @@ nemoclaw <sandbox-name> snapshot create --name before-change
 `status` reports the selected harness as a terminal runtime and prints the interactive/headless command shape.
 If `status` reports `Runtime health: degraded` with an OOM kill count, rebuild the sandbox to restore the terminal runtime.
 There is no dashboard port or long-running gateway process for this harness.
+Commands such as `dashboard-url`, `gateway-token`, and OpenClaw/Hermes API examples do not apply to `langchain-deepagents-code` sandboxes.
 
 ## Next Steps
 

--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -36,6 +36,9 @@ The sandbox does not receive your API key.
 Local Ollama and local vLLM do not require your host `OPENAI_API_KEY`.
 NemoClaw uses provider-specific local tokens for those routes, and rebuilds of legacy local-inference sandboxes migrate away from stale OpenAI credential requirements.
 
+For `langchain-deepagents-code`, the generated `/sandbox/.deepagents/config.toml` points Deep Agents Code at `https://inference.local/v1` and references a NemoClaw-managed placeholder API key.
+Keep raw NVIDIA, OpenAI, compatible-endpoint, or local-provider credentials in the NemoClaw/OpenShell provider flow rather than in `/sandbox/.deepagents/.env` or project files.
+
 ## Provider Status
 
 {/* provider-status:begin */}

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -203,6 +203,7 @@ Available presets:
 | `outlook` | Microsoft 365 and Outlook |
 | `pypi` | Python Package Index |
 | `slack` | Slack API and webhooks |
+| `tavily` | Tavily web search API |
 | `telegram` | Telegram Bot API |
 | `wechat` | WeChat (personal) iLink Bot API (experimental) |
 | `whatsapp` | WhatsApp Web messaging (experimental) |

--- a/docs/network-policy/integration-policy-examples.mdx
+++ b/docs/network-policy/integration-policy-examples.mdx
@@ -63,6 +63,7 @@ NemoClaw ships maintained policy presets for common services in `nemoclaw-bluepr
 | Public reference APIs | `public-reference` |
 | Python Package Index | `pypi` |
 | Slack messaging | `slack` |
+| Tavily web search | `tavily` |
 | Telegram Bot API | `telegram` |
 | Weather and geocoding APIs | `weather` |
 | WeChat (personal) iLink Bot API (experimental) | `wechat` |
@@ -233,6 +234,26 @@ Remove access when the task is done:
 $$nemoclaw my-assistant policy-remove github --yes
 $$nemoclaw my-assistant policy-remove jira --yes
 ```
+
+## Tavily Web Search for Deep Agents Code
+
+Use `tavily` when a LangChain Deep Agents Code sandbox needs Tavily-backed web search.
+This preset opens `api.tavily.com:443` for the sandbox Python and Node runtimes that the `dcode` harness may use.
+It does not inject `TAVILY_API_KEY`; provide that credential at runtime and keep it out of policy YAML, snapshots, and committed project files.
+
+```bash
+$$nemoclaw my-assistant policy-add tavily --dry-run
+$$nemoclaw my-assistant policy-add tavily --yes
+```
+
+Remove the preset when web search is no longer needed:
+
+```bash
+$$nemoclaw my-assistant policy-remove tavily --yes
+```
+
+LangSmith and MCP are separate from Tavily.
+NemoClaw does not currently ship a maintained LangSmith preset for the Deep Agents Code harness, and the managed `dcode` wrapper disables MCP auto-loading and MCP config overrides.
 
 ## Brave Search
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -144,6 +144,19 @@ nemoclaw onboard --agent hermes [options]
 
 </AgentOnly>
 
+<AgentOnly variant="openclaw">
+
+For LangChain Deep Agents Code, pass the terminal runtime agent explicitly:
+
+```bash
+nemoclaw onboard --agent langchain-deepagents-code
+```
+
+After onboarding, connect and run `dcode` interactively, or drive one headless turn from the host with `nemoclaw <name> agent -n "..."`.
+This runtime does not expose an OpenClaw or Hermes dashboard, dashboard URL, gateway token, or long-running in-sandbox API service.
+
+</AgentOnly>
+
 #### `--resume` and `--fresh`
 
 NemoClaw records onboarding progress so interrupted runs can continue.
@@ -524,6 +537,9 @@ $$nemoclaw my-assistant connect [--probe-only]
 
 The `--probe-only` flag verifies the sandbox is reachable over SSH and exits without opening a shell.
 Use it for health checks and scripted readiness probes.
+<AgentOnly variant="openclaw">
+For LangChain Deep Agents Code sandboxes, `connect` drops you into the terminal runtime environment; run `dcode` for the interactive UI or `dcode -n "..."` for one headless task.
+</AgentOnly>
 
 ### `$$nemoclaw <name> exec`
 
@@ -690,6 +706,9 @@ The JSON output includes at least `schemaVersion`, `name`, `found`, `model`, `pr
 In that case, text output keeps OpenShell's authoritative phase but prints a `docker unpause <container>` recovery hint instead of sending you directly to rebuild.
 For terminal runtime sandboxes, the command also checks cgroup OOM kill counters.
 If the counter records an OOM kill, text output prints `Runtime health: degraded (... OOM kill recorded)` and points you to `$$nemoclaw <name> rebuild`; JSON output reports `terminalRuntimeHealth.kind: "degraded"` with the OOM kill count and source counter path.
+<AgentOnly variant="openclaw">
+For LangChain Deep Agents Code sandboxes, text status identifies the terminal runtime and its interactive/headless command shape instead of reporting an agent dashboard.
+</AgentOnly>
 The command exits non-zero when the sandbox is missing locally, the gateway state is not `present`, the gateway reports a schema/protobuf mismatch (mirrored as `rpcIssue`), `failureLayer` is non-null, or a terminal runtime sandbox reports a recorded OOM kill.
 The alias form `$$nemoclaw <name> status --json` requires the sandbox to be registered locally; the canonical form `$$nemoclaw sandbox status <name> --json` is the one to use from automation that may run against an unknown sandbox name, since it still emits a JSON document with `found: false` instead of a text error.
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -666,6 +666,18 @@ The status command detects the sandbox context and reports "active (inside sandb
 
 Run `openshell sandbox list` on the host to check the underlying sandbox state.
 
+### LangChain Deep Agents Code has no dashboard URL
+
+`langchain-deepagents-code` is a terminal runtime.
+Use `nemoclaw <name> connect` and then run `dcode`, or run one task from the host with `nemoclaw <name> agent -n "..."`.
+Commands and examples that expect an OpenClaw or Hermes dashboard, gateway token, forwarded API port, or long-running in-sandbox gateway do not apply to this agent.
+
+If `nemoclaw <name> status` reports terminal runtime degradation, such as an OOM kill counter, rebuild the sandbox:
+
+```bash
+nemoclaw <name> rebuild
+```
+
 ### Git clone fails with a certificate verification error
 
 In networks that inspect TLS, OpenShell injects a proxy CA bundle into the sandbox.

--- a/docs/security/credential-storage.mdx
+++ b/docs/security/credential-storage.mdx
@@ -17,6 +17,10 @@ The OpenShell gateway is the only system of record for stored credentials.
 When you provide a provider credential, either interactively during `$$nemoclaw onboard` or through an environment variable, NemoClaw holds the value in memory only long enough to register it with the OpenShell gateway through `openshell provider create` or `openshell provider update`.
 The gateway stores the credential and the OpenShell L7 proxy substitutes it into outbound requests at egress, so sandboxed agents see placeholders instead of the raw secret.
 
+For LangChain Deep Agents Code sandboxes, NemoClaw writes only non-secret provider and model configuration to `/sandbox/.deepagents/config.toml`.
+That file points `dcode` at `https://inference.local/v1` with a scoped placeholder key so OpenShell can resolve the real upstream credential at egress time.
+Keep raw provider, Tavily, LangSmith, and MCP service credentials out of `/sandbox/.deepagents/.env` and committed project files; the managed `dcode` wrapper rejects obvious secret-shaped runtime values, and NemoClaw intentionally does not preserve `.deepagents/.env` or `.deepagents/.mcp.json` during snapshot and rebuild state capture.
+
 <AgentOnly variant="openclaw">
 The sandbox-side OpenClaw gateway token is generated at container startup and is not rotated through provider credential commands.
 </AgentOnly>


### PR DESCRIPTION
## Summary

Refreshes the LangChain Deep Agents Code docs so the supported path is clearer for current NemoClaw users.

## Changes

- Documents the canonical `nemoclaw onboard --agent langchain-deepagents-code` path, plus host-side headless `nemoclaw <name> agent -n "..."`.
- Clarifies that `dcode` uses NemoClaw-managed inference through `https://inference.local/v1` and should not receive raw provider keys in `.deepagents/.env`.
- Adds Tavily to the maintained policy preset docs and explains the Tavily/LangSmith/MCP boundaries for this terminal runtime.
- Calls out that LangChain Deep Agents Code has no dashboard URL, gateway token, forwarded API port, or long-running in-sandbox gateway.

## Testing

- `npm run docs:check-agent-variants`
- `npm run docs`
- `git diff --check`
- `git diff --cached --check`
- Touched-file lint/format check: scoped `prek run --files ...` and Biome applicability check

## Evidence it works

`npm run docs` completed with Fern reporting 0 errors. The scoped `prek` run passed the touched-file whitespace, EOF, merge-conflict, large-file, env-var documentation, secret-scan, and related applicable hooks, then exited non-zero because the platform-matrix sync hook rewrote generated tables outside this PR scope. Biome and markdownlint had no MDX files to process. `npm run build:cli` was not run because this is docs-only and does not change source, manifests, or runtime behavior.

Fixes #5858

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified onboarding and usage for the Deep Agents Code runtime, including scripted setup, headless task execution, and how to connect after onboarding.
  * Added notes explaining that dashboard, gateway, and in-sandbox API guidance does not apply to this runtime.
  * Expanded network-policy docs to include Tavily web search access and when to opt in.
  * Strengthened security guidance around keeping provider and search credentials out of project files and using the managed runtime flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->