### PR TITLE
test(e2e): add inference adapter fixture (Refs #5745)

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -16,6 +16,15 @@ on:
         required: false
         default: ""
         type: string
+      inference_mode:
+        description: "Inference adapter mode for compatible Vitest E2E jobs: mock, internal-nvidia, or public-nvidia."
+        required: false
+        default: "mock"
+        type: choice
+        options:
+          - mock
+          - internal-nvidia
+          - public-nvidia
       pr_number:
         description: Optional PR number for selective-dispatch result comments.
         required: false
@@ -1687,7 +1696,7 @@ jobs:
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/hermes-e2e
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_E2E_SCENARIOS: "1"
-      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
+      NEMOCLAW_E2E_INFERENCE_MODE: ${{ inputs.inference_mode }}
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_AGENT: hermes
       NEMOCLAW_NON_INTERACTIVE: "1"

--- a/test/e2e-scenario/fixtures/e2e-test.ts
+++ b/test/e2e-scenario/fixtures/e2e-test.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, test as base } from "vitest";
+import { test as base, expect } from "vitest";
 
-import { createArtifactSink, type ArtifactSink } from "./artifacts.ts";
+import { type ArtifactSink, createArtifactSink } from "./artifacts.ts";
+import { assertCleanupPassed, CleanupRegistry } from "./cleanup.ts";
 import {
   GatewayClient,
   HostCliClient,
@@ -11,7 +12,7 @@ import {
   SandboxClient,
   StateClient,
 } from "./clients/index.ts";
-import { assertCleanupPassed, CleanupRegistry } from "./cleanup.ts";
+import { createE2EInferenceAdapter, type E2EInferenceAdapter } from "./inference-adapter.ts";
 import {
   EnvironmentPhaseFixture,
   LifecyclePhaseFixture,
@@ -31,6 +32,7 @@ export interface E2EScenarioFixtures {
   gateway: GatewayClient;
   sandbox: SandboxClient;
   provider: ProviderClient;
+  inference: E2EInferenceAdapter;
   state: StateClient;
   environment: EnvironmentPhaseFixture;
   onboard: OnboardingPhaseFixture;
@@ -88,6 +90,14 @@ export const test = base.extend<E2EScenarioFixtures>({
   },
   provider: async ({ shellProbe }, use) => {
     await use(new ProviderClient(shellProbe));
+  },
+  inference: async ({ artifacts, host, provider, secrets }, use) => {
+    const inference = await createE2EInferenceAdapter({ artifacts, host, provider, secrets });
+    try {
+      await use(inference);
+    } finally {
+      await inference.close();
+    }
   },
   state: async ({}, use) => {
     await use(new StateClient());

--- a/test/e2e-scenario/fixtures/inference-adapter.ts
+++ b/test/e2e-scenario/fixtures/inference-adapter.ts
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ArtifactSink } from "./artifacts.ts";
+import { buildAvailabilityProbeEnv } from "./availability-env.ts";
+import type { HostCliClient } from "./clients/host.ts";
+import { type ProviderClient, trustedProviderEndpoint } from "./clients/provider.ts";
+import {
+  type FakeOpenAiCompatibleServer,
+  startFakeOpenAiCompatibleServer,
+} from "./fake-openai-compatible.ts";
+import {
+  DEFAULT_HOSTED_INFERENCE_BASE_URL,
+  DEFAULT_HOSTED_INFERENCE_MODEL,
+  HOSTED_INFERENCE_CREDENTIAL_ENV,
+  HOSTED_INFERENCE_PROVIDER,
+  HOSTED_INFERENCE_PROVIDER_NAME,
+  HOSTED_INFERENCE_SECRET,
+  type HostedInferenceSecrets,
+  requireHostedInferenceConfig,
+} from "./hosted-inference.ts";
+
+export type E2EInferenceMode = "mock" | "internal-nvidia" | "public-nvidia";
+
+export interface E2EInferenceAdapter {
+  readonly mode: E2EInferenceMode;
+  readonly model: string;
+  readonly provider: string;
+  readonly providerName: string;
+  readonly endpointUrl: string;
+  readonly expectedRouteProvider: string;
+  readonly contractLabel: string;
+  env(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+  redactionValues(): string[];
+  probeModels(artifactName: string): Promise<unknown>;
+  directChat(
+    prompt: string,
+    options?: { artifactName?: string; maxTokens?: number },
+  ): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export interface E2EInferenceAdapterOptions {
+  readonly artifacts: ArtifactSink;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly host: Pick<HostCliClient, "command">;
+  readonly provider: Pick<ProviderClient, "requestJson">;
+  readonly secrets: HostedInferenceSecrets;
+}
+
+const DEFAULT_MOCK_MODEL = "nvidia/nvidia/nemotron-3-ultra";
+const DEFAULT_MOCK_API_KEY = "nemoclaw-e2e-compatible-key";
+const DEFAULT_PUBLIC_NVIDIA_MODEL = "nvidia/nemotron-3-super-120b-a12b";
+
+function normalizeMode(env: NodeJS.ProcessEnv): E2EInferenceMode {
+  const raw = env.NEMOCLAW_E2E_INFERENCE_MODE?.trim().toLowerCase();
+  if (!raw) return "mock";
+  if (raw === "mock" || raw === "internal-nvidia" || raw === "public-nvidia") return raw;
+  throw new Error(
+    `NEMOCLAW_E2E_INFERENCE_MODE must be one of: mock, internal-nvidia, public-nvidia; got ${env.NEMOCLAW_E2E_INFERENCE_MODE}`,
+  );
+}
+
+export function requirePublicNvidiaInferenceKey(value: string): string {
+  if (!value.startsWith("nvapi-")) {
+    throw new Error(`${HOSTED_INFERENCE_SECRET} must start with nvapi- for public NVIDIA mode`);
+  }
+  return value;
+}
+
+function joinEndpoint(baseUrl: string, suffix: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${suffix.replace(/^\/+/, "")}`;
+}
+
+function providerAllowedHosts(endpointUrl: string): string[] {
+  return [new URL(endpointUrl).hostname];
+}
+
+function chatPayload(model: string, prompt: string, maxTokens = 256): string {
+  return JSON.stringify({
+    model,
+    messages: [{ role: "user", content: prompt }],
+    max_tokens: maxTokens,
+  });
+}
+
+async function hostAddressForSandbox(host: Pick<HostCliClient, "command">): Promise<string> {
+  const probe = await host.command(
+    "bash",
+    [
+      "-lc",
+      [
+        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
+        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
+        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        'if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then',
+        "  for iface in en0 en1 bridge100; do",
+        '    ip_addr="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"',
+        '    if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        "  done",
+        "  ip_addr=\"$(ifconfig 2>/dev/null | awk '/inet / && $2 !~ /^127\\./ {print $2; exit}')\"",
+        '  if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
+        "fi",
+        "echo 127.0.0.1",
+      ].join("\n"),
+    ],
+    {
+      artifactName: "host-ip-for-e2e-inference-adapter",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 30_000,
+    },
+  );
+  return probe.stdout.trim().split(/\s+/)[0] || "127.0.0.1";
+}
+
+class OpenAiCompatibleInferenceAdapter implements E2EInferenceAdapter {
+  readonly provider = HOSTED_INFERENCE_PROVIDER;
+  readonly providerName = HOSTED_INFERENCE_PROVIDER_NAME;
+  readonly expectedRouteProvider = HOSTED_INFERENCE_PROVIDER_NAME;
+  readonly contractLabel: string;
+
+  constructor(
+    readonly mode: "mock" | "internal-nvidia",
+    readonly model: string,
+    readonly endpointUrl: string,
+    private readonly apiKey: string,
+    private readonly providerClient: Pick<ProviderClient, "requestJson"> | undefined,
+    private readonly artifacts: ArtifactSink,
+    private readonly fake: FakeOpenAiCompatibleServer | undefined,
+  ) {
+    this.contractLabel =
+      mode === "mock"
+        ? "fake OpenAI-compatible endpoint is staged as the compatible endpoint credential"
+        : "NVIDIA_INFERENCE_API_KEY is staged as the compatible endpoint credential";
+  }
+
+  env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+      ...extra,
+      NEMOCLAW_E2E_INFERENCE_MODE: this.mode,
+      ...(this.mode === "internal-nvidia" ? { NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1" } : {}),
+      NEMOCLAW_PROVIDER: this.provider,
+      NEMOCLAW_ENDPOINT_URL: this.endpointUrl,
+      NEMOCLAW_MODEL: this.model,
+      NEMOCLAW_COMPAT_MODEL: this.model,
+      NEMOCLAW_PREFERRED_API: "openai-completions",
+      [HOSTED_INFERENCE_CREDENTIAL_ENV]: this.apiKey,
+      ...(this.mode === "internal-nvidia" ? { [HOSTED_INFERENCE_SECRET]: this.apiKey } : {}),
+    };
+  }
+
+  redactionValues(): string[] {
+    return [this.apiKey];
+  }
+
+  async probeModels(artifactName: string): Promise<unknown> {
+    if (this.providerClient) {
+      const response = await this.providerClient.requestJson(
+        trustedProviderEndpoint(joinEndpoint(this.endpointUrl, "models"), {
+          allowedHosts: providerAllowedHosts(this.endpointUrl),
+        }),
+        {
+          artifactName,
+          curlMaxTimeSeconds: 15,
+          headers: [`Authorization: Bearer ${this.apiKey}`],
+          env: buildAvailabilityProbeEnv(),
+          redactionValues: this.redactionValues(),
+          timeoutMs: 30_000,
+        },
+      );
+      return response.json;
+    }
+    const response = await fetch(joinEndpoint(this.endpointUrl, "models"));
+    const json = (await response.json()) as unknown;
+    await this.artifacts.writeJson(`${artifactName}.json`, json);
+    return json;
+  }
+
+  async directChat(
+    prompt: string,
+    options: { artifactName?: string; maxTokens?: number } = {},
+  ): Promise<unknown> {
+    const body = chatPayload(this.model, prompt, options.maxTokens);
+    if (this.providerClient) {
+      const response = await this.providerClient.requestJson(
+        trustedProviderEndpoint(joinEndpoint(this.endpointUrl, "chat/completions"), {
+          allowedHosts: providerAllowedHosts(this.endpointUrl),
+        }),
+        {
+          artifactName: options.artifactName ?? "direct-compatible-chat",
+          body,
+          curlMaxTimeSeconds: 90,
+          headers: ["Content-Type: application/json", `Authorization: Bearer ${this.apiKey}`],
+          env: buildAvailabilityProbeEnv(),
+          redactionValues: this.redactionValues(),
+          timeoutMs: 120_000,
+        },
+      );
+      return response.json;
+    }
+    const response = await fetch(joinEndpoint(this.endpointUrl, "chat/completions"), {
+      body,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+    const json = (await response.json()) as unknown;
+    await this.artifacts.writeJson(
+      `${options.artifactName ?? "direct-compatible-chat"}.json`,
+      json,
+    );
+    return json;
+  }
+
+  async close(): Promise<void> {
+    if (!this.fake) return;
+    await this.artifacts.writeJson("e2e-inference-adapter-requests.json", this.fake.requests());
+    await this.fake.close();
+  }
+}
+
+class PublicNvidiaInferenceAdapter implements E2EInferenceAdapter {
+  readonly mode = "public-nvidia";
+  readonly provider = "cloud";
+  readonly providerName = "nvidia";
+  readonly endpointUrl = DEFAULT_HOSTED_INFERENCE_BASE_URL;
+  readonly expectedRouteProvider = "nvidia-prod";
+  readonly contractLabel = "public NVIDIA Endpoints provider keeps nvapi validation centralized";
+
+  constructor(
+    readonly model: string,
+    private readonly apiKey: string,
+    private readonly providerClient: Pick<ProviderClient, "requestJson">,
+  ) {}
+
+  env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+      ...extra,
+      NEMOCLAW_E2E_INFERENCE_MODE: this.mode,
+      NEMOCLAW_PROVIDER: this.provider,
+      NEMOCLAW_MODEL: this.model,
+      [HOSTED_INFERENCE_SECRET]: this.apiKey,
+    };
+  }
+
+  redactionValues(): string[] {
+    return [this.apiKey];
+  }
+
+  async probeModels(artifactName: string): Promise<unknown> {
+    const response = await this.providerClient.requestJson(
+      trustedProviderEndpoint(joinEndpoint(this.endpointUrl, "models"), {
+        allowedHosts: providerAllowedHosts(this.endpointUrl),
+      }),
+      {
+        artifactName,
+        curlMaxTimeSeconds: 15,
+        headers: [`Authorization: Bearer ${this.apiKey}`],
+        env: buildAvailabilityProbeEnv(),
+        redactionValues: this.redactionValues(),
+        timeoutMs: 30_000,
+      },
+    );
+    return response.json;
+  }
+
+  async directChat(
+    prompt: string,
+    options: { artifactName?: string; maxTokens?: number } = {},
+  ): Promise<unknown> {
+    const response = await this.providerClient.requestJson(
+      trustedProviderEndpoint(joinEndpoint(this.endpointUrl, "chat/completions"), {
+        allowedHosts: providerAllowedHosts(this.endpointUrl),
+      }),
+      {
+        artifactName: options.artifactName ?? "direct-nvidia-chat",
+        body: chatPayload(this.model, prompt, options.maxTokens),
+        curlMaxTimeSeconds: 90,
+        headers: ["Content-Type: application/json", `Authorization: Bearer ${this.apiKey}`],
+        env: buildAvailabilityProbeEnv(),
+        redactionValues: this.redactionValues(),
+        timeoutMs: 120_000,
+      },
+    );
+    return response.json;
+  }
+
+  async close(): Promise<void> {}
+}
+
+export async function createE2EInferenceAdapter(
+  options: E2EInferenceAdapterOptions,
+): Promise<E2EInferenceAdapter> {
+  const env = options.env ?? process.env;
+  const mode = normalizeMode(env);
+  if (mode === "mock") {
+    const model = env.NEMOCLAW_MODEL || env.NEMOCLAW_COMPAT_MODEL || DEFAULT_MOCK_MODEL;
+    const apiKey = env.COMPATIBLE_API_KEY || DEFAULT_MOCK_API_KEY;
+    const publicHost = await hostAddressForSandbox(options.host);
+    const fake = await startFakeOpenAiCompatibleServer({
+      apiKey,
+      chatContent: "PONG",
+      host: "0.0.0.0",
+      model,
+      publicHost,
+      requireAuth: true,
+      responseText: "PONG",
+    });
+    await options.artifacts.writeJson("e2e-inference-adapter.json", {
+      mode,
+      model,
+      endpointUrl: fake.baseUrl,
+      expectedRouteProvider: HOSTED_INFERENCE_PROVIDER_NAME,
+      publicHost,
+    });
+    return new OpenAiCompatibleInferenceAdapter(
+      mode,
+      model,
+      fake.baseUrl,
+      apiKey,
+      undefined,
+      options.artifacts,
+      fake,
+    );
+  }
+  if (mode === "internal-nvidia") {
+    const hosted = requireHostedInferenceConfig(options.secrets, env);
+    return new OpenAiCompatibleInferenceAdapter(
+      mode,
+      hosted.model,
+      hosted.endpointUrl,
+      hosted.apiKey,
+      options.provider,
+      options.artifacts,
+      undefined,
+    );
+  }
+  const apiKey = requirePublicNvidiaInferenceKey(options.secrets.required(HOSTED_INFERENCE_SECRET));
+  const model = env.NEMOCLAW_MODEL || DEFAULT_PUBLIC_NVIDIA_MODEL;
+  return new PublicNvidiaInferenceAdapter(model, apiKey, options.provider);
+}
+
+export const E2E_INFERENCE_MODE_VALUES: readonly E2EInferenceMode[] = [
+  "mock",
+  "internal-nvidia",
+  "public-nvidia",
+];
+
+export { DEFAULT_HOSTED_INFERENCE_MODEL as DEFAULT_INTERNAL_NVIDIA_MODEL };

--- a/test/e2e-scenario/live/hermes-e2e.test.ts
+++ b/test/e2e-scenario/live/hermes-e2e.test.ts
@@ -7,11 +7,10 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { trustedProviderEndpoint } from "../fixtures/clients/provider.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import type { E2EInferenceAdapter } from "../fixtures/inference-adapter.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
-import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 // Migrated from test/e2e/test-hermes-e2e.sh.
@@ -33,7 +32,6 @@ const HERMES_DASHBOARD_INTERNAL_PORT =
 const SESSION_FILE = path.join(os.homedir(), ".nemoclaw", "onboard-session.json");
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const LIVE_TIMEOUT_MS = 70 * 60_000;
-const CHAT_MODEL = process.env.NEMOCLAW_MODEL ?? "nvidia/nemotron-3-super-120b-a12b";
 const ONBOARD_VALIDATION_TIMEOUT_SECONDS =
   process.env.NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS ?? "60";
 
@@ -65,18 +63,17 @@ function hermesDashboardE2eEnabled(): boolean {
   );
 }
 
-function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {
+function commandEnv(inference?: E2EInferenceAdapter): NodeJS.ProcessEnv {
+  const baseEnv: NodeJS.ProcessEnv = {
     ...buildAvailabilityProbeEnv(),
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_AGENT: "hermes",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_RECREATE_SANDBOX: "1",
-    NEMOCLAW_MODEL: CHAT_MODEL,
     NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS: ONBOARD_VALIDATION_TIMEOUT_SECONDS,
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
   };
-  if (apiKey) env.NVIDIA_INFERENCE_API_KEY = apiKey;
+  const env = inference ? inference.env(baseEnv) : baseEnv;
   if (process.env.NEMOCLAW_E2E_HERMES_DASHBOARD) {
     env.NEMOCLAW_E2E_HERMES_DASHBOARD = process.env.NEMOCLAW_E2E_HERMES_DASHBOARD;
   }
@@ -96,9 +93,9 @@ function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
   return env;
 }
 
-function chatPayload(prompt: string, maxTokens = 256): string {
+function chatPayload(model: string, prompt: string, maxTokens = 256): string {
   return JSON.stringify({
-    model: CHAT_MODEL,
+    model,
     messages: [{ role: "user", content: prompt }],
     max_tokens: maxTokens,
   });
@@ -219,10 +216,7 @@ async function retryHostedInference<T>(
 test.skipIf(!shouldRunLiveE2EScenarios())(
   "hermes-e2e: install.sh onboards Hermes and proves health plus live inference",
   { timeout: LIVE_TIMEOUT_MS },
-  async ({ artifacts, cleanup, host, provider, sandbox, secrets }) => {
-    const hosted = requireHostedInferenceConfig(secrets);
-    const apiKey = hosted.apiKey;
-
+  async ({ artifacts, cleanup, host, inference, sandbox }) => {
     await artifacts.writeJson("scenario.json", {
       id: "hermes-e2e",
       runner: "vitest",
@@ -230,10 +224,17 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       boundary: "install.sh --non-interactive + Hermes sandbox runtime",
       sandboxName: SANDBOX_NAME,
       dashboardEnabled: hermesDashboardE2eEnabled(),
+      inference: {
+        mode: inference.mode,
+        model: inference.model,
+        endpointUrl: inference.endpointUrl,
+        expectedRouteProvider: inference.expectedRouteProvider,
+        contractLabel: inference.contractLabel,
+      },
     });
 
-    const env = commandEnv(apiKey);
-    const redactionValues = [apiKey];
+    const env = commandEnv(inference);
+    const redactionValues = inference.redactionValues();
 
     const cleanupHermes = async (label: string) => {
       await bestEffort(() =>
@@ -277,20 +278,8 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     expect(fs.existsSync(path.join(REPO_ROOT, "agents", "hermes", "manifest.yaml"))).toBe(true);
 
-    const providerModels = await provider.requestJson(
-      trustedProviderEndpoint("https://inference-api.nvidia.com/v1/models", {
-        allowedHosts: ["inference-api.nvidia.com"],
-      }),
-      {
-        artifactName: "phase-1-inference-models",
-        curlMaxTimeSeconds: 15,
-        headers: [`Authorization: Bearer ${apiKey}`],
-        env: buildAvailabilityProbeEnv(),
-        redactionValues,
-        timeoutMs: 30_000,
-      },
-    );
-    expect(providerModels.json).toBeTruthy();
+    const providerModels = await inference.probeModels("phase-1-inference-models");
+    expect(providerModels).toBeTruthy();
 
     // Phase 2: real installer + non-interactive Hermes onboard.
     const install = await host.command("bash", ["install.sh", "--non-interactive"], {
@@ -349,13 +338,13 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     expect(fs.existsSync(SESSION_FILE), `${SESSION_FILE} missing`).toBe(true);
     expect(readJsonFile(SESSION_FILE)).toMatchObject({ agent: "hermes" });
 
-    const inference = await sandbox.openshell(["inference", "get"], {
+    const inferenceRoute = await sandbox.openshell(["inference", "get"], {
       artifactName: "phase-3-openshell-inference-get",
       env: commandEnv(),
       timeoutMs: 30_000,
     });
-    expect(inference.exitCode, resultText(inference)).toBe(0);
-    expect(resultText(inference)).toMatch(/nvidia-prod/i);
+    expect(inferenceRoute.exitCode, resultText(inferenceRoute)).toBe(0);
+    expect(resultText(inferenceRoute)).toContain(inference.expectedRouteProvider);
 
     const policy = await sandbox.openshell(["policy", "get", "--full", SANDBOX_NAME], {
       artifactName: "phase-3-openshell-policy-get",
@@ -479,32 +468,22 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       expect(httpStatusOk(dashboardInternal.stdout)).toBe(true);
     }
 
-    // Phase 5: live inference through both the external provider and the
+    // Phase 5: live inference through both the selected adapter and the
     // sandbox's inference.local route.
     const directChat = await retryHostedInference(
-      "direct NVIDIA Endpoints chat",
+      `direct ${inference.mode} adapter chat`,
       async (attempt) => {
-        const response = await provider.requestJson(
-          trustedProviderEndpoint("https://inference-api.nvidia.com/v1/chat/completions", {
-            allowedHosts: ["inference-api.nvidia.com"],
-          }),
-          {
-            artifactName: `phase-5-direct-nvidia-chat-attempt-${attempt}`,
-            body: chatPayload("Reply with exactly one word: PONG", attempt === 1 ? 256 : 1024),
-            curlMaxTimeSeconds: 90,
-            headers: ["Content-Type: application/json", `Authorization: Bearer ${apiKey}`],
-            env: buildAvailabilityProbeEnv(),
-            redactionValues,
-            timeoutMs: 120_000,
-          },
-        );
-        if (shouldRetryForReasoningBudget(response.json)) {
+        const response = await inference.directChat("Reply with exactly one word: PONG", {
+          artifactName: `phase-5-direct-adapter-chat-attempt-${attempt}`,
+          maxTokens: attempt === 1 ? 256 : 1024,
+        });
+        if (shouldRetryForReasoningBudget(response)) {
           throw new Error("direct chat exhausted response budget while reasoning before PONG");
         }
         return response;
       },
     );
-    expectPong("direct NVIDIA Endpoints chat", directChat.json);
+    expectPong(`direct ${inference.mode} adapter chat`, directChat);
 
     const sandboxChatJson = await retryHostedInference(
       "Hermes sandbox inference.local chat",
@@ -519,7 +498,11 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
             "-H",
             "Content-Type: application/json",
             "--data-raw",
-            chatPayload("Reply with exactly one word: PONG", attempt === 1 ? 256 : 1024),
+            chatPayload(
+              inference.model,
+              "Reply with exactly one word: PONG",
+              attempt === 1 ? 256 : 1024,
+            ),
             "https://inference.local/v1/chat/completions",
           ],
           {

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -971,6 +971,8 @@ jobs:
         expect.arrayContaining([
           "workflow_dispatch missing input: scenarios",
           "workflow_dispatch missing input: jobs",
+          "workflow_dispatch missing input: inference_mode",
+          "workflow_dispatch inference_mode input must be a mock-default choice over mock, internal-nvidia, and public-nvidia",
           "workflow_dispatch must not expose legacy test_filter input",
           "workflow missing generate-matrix job",
           "live-scenarios job must run on the matrix runner",

--- a/test/e2e-scenario/support-tests/inference-adapter.test.ts
+++ b/test/e2e-scenario/support-tests/inference-adapter.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ArtifactSink } from "../fixtures/artifacts.ts";
+import {
+  createE2EInferenceAdapter,
+  type E2EInferenceAdapter,
+  requirePublicNvidiaInferenceKey,
+} from "../fixtures/inference-adapter.ts";
+
+const adapters: E2EInferenceAdapter[] = [];
+
+function artifacts(): ArtifactSink {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-inference-adapter-test-"));
+  return new ArtifactSink(root);
+}
+
+function secrets(values: Record<string, string | undefined>) {
+  return {
+    required: (name: string) => {
+      const value = values[name];
+      if (!value) throw new Error(`missing ${name}`);
+      return value;
+    },
+  };
+}
+
+function host(stdout = "127.0.0.1\n") {
+  return {
+    command: async () => ({
+      artifacts: { result: "", stderr: "", stdout: "" },
+      command: ["stub-host-command"],
+      exitCode: 0,
+      artifactPaths: [],
+      signal: null,
+      stderr: "",
+      stdout,
+      timedOut: false,
+    }),
+  };
+}
+
+function provider() {
+  return {
+    requestJson: async <T = unknown>() => ({
+      json: { data: [{ id: "nvidia/nvidia/nemotron-3-ultra" }] } as T,
+      result: {
+        artifacts: { result: "", stderr: "", stdout: "" },
+        artifactPaths: [],
+        command: ["stub-provider-request"],
+        exitCode: 0,
+        signal: null,
+        stderr: "",
+        stdout: "{}",
+        timedOut: false,
+      },
+    }),
+  };
+}
+
+async function createAdapter(options: {
+  env?: NodeJS.ProcessEnv;
+  secrets?: Record<string, string | undefined>;
+}): Promise<E2EInferenceAdapter> {
+  const adapter = await createE2EInferenceAdapter({
+    artifacts: artifacts(),
+    env: options.env ?? {},
+    host: host(),
+    provider: provider(),
+    secrets: secrets(options.secrets ?? {}),
+  });
+  adapters.push(adapter);
+  return adapter;
+}
+
+afterEach(async () => {
+  while (adapters.length > 0) {
+    await adapters.pop()?.close();
+  }
+});
+
+describe("E2E inference adapter", () => {
+  it("defaults to hermetic mock mode with a fake compatible endpoint", async () => {
+    const adapter = await createAdapter({ env: {} });
+    const env = adapter.env({ NEMOCLAW_AGENT: "hermes" });
+
+    expect(adapter.mode).toBe("mock");
+    expect(adapter.expectedRouteProvider).toBe("compatible-endpoint");
+    expect(env).toMatchObject({
+      NEMOCLAW_AGENT: "hermes",
+      NEMOCLAW_E2E_INFERENCE_MODE: "mock",
+      NEMOCLAW_PROVIDER: "custom",
+      NEMOCLAW_MODEL: "nvidia/nvidia/nemotron-3-ultra",
+      NEMOCLAW_COMPAT_MODEL: "nvidia/nvidia/nemotron-3-ultra",
+      COMPATIBLE_API_KEY: "nemoclaw-e2e-compatible-key",
+    });
+    expect(env.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+    expect(await adapter.probeModels("mock-models")).toMatchObject({
+      data: [{ id: "nvidia/nvidia/nemotron-3-ultra" }],
+    });
+    expect(await adapter.directChat("Reply PONG")).toMatchObject({
+      choices: [{ message: { content: "PONG" } }],
+    });
+  });
+
+  it("stages internal NVIDIA hosted inference as a compatible endpoint", async () => {
+    const adapter = await createAdapter({
+      env: { NEMOCLAW_E2E_INFERENCE_MODE: "internal-nvidia" },
+      secrets: { NVIDIA_INFERENCE_API_KEY: "sk-compatible-hosted-key" },
+    });
+    const env = adapter.env();
+
+    expect(adapter.mode).toBe("internal-nvidia");
+    expect(adapter.expectedRouteProvider).toBe("compatible-endpoint");
+    expect(env).toMatchObject({
+      NEMOCLAW_E2E_INFERENCE_MODE: "internal-nvidia",
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1",
+      NEMOCLAW_PROVIDER: "custom",
+      NEMOCLAW_ENDPOINT_URL: "https://inference-api.nvidia.com/v1",
+      NEMOCLAW_MODEL: "nvidia/nvidia/nemotron-3-ultra",
+      NEMOCLAW_COMPAT_MODEL: "nvidia/nvidia/nemotron-3-ultra",
+      NVIDIA_INFERENCE_API_KEY: "sk-compatible-hosted-key",
+      COMPATIBLE_API_KEY: "sk-compatible-hosted-key",
+    });
+  });
+
+  it("centralizes public NVIDIA nvapi validation", async () => {
+    const adapter = await createAdapter({
+      env: { NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia" },
+      secrets: { NVIDIA_INFERENCE_API_KEY: "nvapi-public-test-key" },
+    });
+    const env = adapter.env();
+
+    expect(adapter.mode).toBe("public-nvidia");
+    expect(adapter.expectedRouteProvider).toBe("nvidia-prod");
+    expect(env).toMatchObject({
+      NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia",
+      NEMOCLAW_PROVIDER: "cloud",
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NVIDIA_INFERENCE_API_KEY: "nvapi-public-test-key",
+    });
+    expect(env.COMPATIBLE_API_KEY).toBeUndefined();
+    expect(requirePublicNvidiaInferenceKey("nvapi-public-test-key")).toBe("nvapi-public-test-key");
+  });
+
+  it("rejects hosted-style keys in public NVIDIA mode", async () => {
+    await expect(
+      createAdapter({
+        env: { NEMOCLAW_E2E_INFERENCE_MODE: "public-nvidia" },
+        secrets: { NVIDIA_INFERENCE_API_KEY: "sk-compatible-key" },
+      }),
+    ).rejects.toThrow(/must start with nvapi-/);
+  });
+
+  it("rejects unknown explicit modes instead of silently falling back", async () => {
+    await expect(
+      createAdapter({ env: { NEMOCLAW_E2E_INFERENCE_MODE: "public-nvida" } }),
+    ).rejects.toThrow(/must be one of: mock, internal-nvidia, public-nvidia/);
+  });
+});

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -225,6 +225,10 @@ function asSteps(value: unknown): WorkflowStep[] {
     : [];
 }
 
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(stringValue) : [];
+}
+
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
@@ -3837,6 +3841,16 @@ function validateHermesE2EVitestJob(
   if (jobEnv.NEMOCLAW_MODEL !== "minimaxai/minimax-m2.7") {
     errors.push("hermes-e2e-vitest job must pin the CI-safe Hermes model");
   }
+  if (jobEnv.NEMOCLAW_E2E_INFERENCE_MODE !== "${{ inputs.inference_mode }}") {
+    errors.push(
+      "hermes-e2e-vitest job must pass workflow_dispatch inference_mode into the adapter",
+    );
+  }
+  if (Object.hasOwn(jobEnv, "NEMOCLAW_E2E_USE_HOSTED_INFERENCE")) {
+    errors.push(
+      "hermes-e2e-vitest job must not hard-code hosted inference outside the adapter",
+    );
+  }
   if (jobEnv.NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS !== "60") {
     errors.push(
       "hermes-e2e-vitest job must give hosted endpoint validation a CI-safe timeout",
@@ -7381,6 +7395,17 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   const dispatchInputs = asRecord(workflowDispatch.inputs);
   requireInput(errors, dispatchInputs, "scenarios");
   const jobsInput = requireInput(errors, dispatchInputs, "jobs");
+  const inferenceModeInput = requireInput(errors, dispatchInputs, "inference_mode");
+  const inferenceModeOptions = asStringArray(inferenceModeInput.options);
+  if (
+    inferenceModeInput.type !== "choice" ||
+    inferenceModeInput.default !== "mock" ||
+    inferenceModeOptions.join(",") !== "mock,internal-nvidia,public-nvidia"
+  ) {
+    errors.push(
+      "workflow_dispatch inference_mode input must be a mock-default choice over mock, internal-nvidia, and public-nvidia",
+    );
+  }
   const jobsDescription = stringValue(jobsInput.description);
   if (!jobsDescription.includes("default-enabled jobs")) {
     errors.push(


### PR DESCRIPTION
## Summary

This adds a shared Vitest E2E inference adapter so live scenarios can choose between the hermetic fake OpenAI-compatible endpoint, the existing internal NVIDIA-compatible hosted path, and public NVIDIA Endpoints without each test hand-rolling provider setup.

This is a pilot slice for #5745. It converts `hermes-e2e.test.ts` to the adapter but does not migrate every E2E scenario in this PR.

## Changes

- Added `test/e2e-scenario/fixtures/inference-adapter.ts` with `mock`, `internal-nvidia`, and `public-nvidia` modes.
- Wired the adapter into the shared Vitest E2E fixture.
- Converted the Hermes live E2E scenario to use the adapter for env setup, model probes, direct chat, redaction, and route assertions.
- Added support tests for the adapter defaults, hosted-compatible staging, public `nvapi-` validation, and unknown-mode rejection.
- Added a manual `inference_mode` workflow input and static workflow validation for the Hermes Vitest job.

## Testing

- `npm run build:cli` - passed.
- `npm run typecheck:cli` - passed.
- `npm run source-shape:check` - passed outside the sandbox after the sandbox blocked `tsx` IPC pipe creation.
- `./node_modules/.bin/vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/inference-adapter.test.ts test/e2e-scenario/support-tests/hosted-inference.test.ts` - passed, 16 tests.
- `./node_modules/.bin/vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts -t "keeps the live Vitest scenario workflow manual"` - passed.
- `git diff --check` - passed.
- `./node_modules/.bin/biome ci .github/workflows/e2e-vitest-scenarios.yaml test/e2e-scenario/fixtures/e2e-test.ts test/e2e-scenario/fixtures/inference-adapter.ts test/e2e-scenario/live/hermes-e2e.test.ts test/e2e-scenario/support-tests/inference-adapter.test.ts test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts` - passed.
- `./node_modules/.bin/biome lint tools/e2e-scenarios/workflow-boundary.mts .github/workflows/e2e-vitest-scenarios.yaml test/e2e-scenario/fixtures/e2e-test.ts test/e2e-scenario/fixtures/inference-adapter.ts test/e2e-scenario/live/hermes-e2e.test.ts test/e2e-scenario/support-tests/inference-adapter.test.ts test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts` - passed.

## Evidence it works

The new support tests exercise the default fake-compatible mode end to end by starting the fake server, staging compatible endpoint env, probing `/models`, and calling `/chat/completions`. They also verify that internal NVIDIA mode keeps using the compatible endpoint contract and that public NVIDIA mode requires an `nvapi-` key before staging the cloud provider.

The Hermes scenario now records the selected adapter mode in `scenario.json`, uses the adapter for provider probes and direct chat, and asserts the expected OpenShell route provider from the adapter instead of hard-coding `nvidia-prod`.

## Caveats

I did not run the full live `hermes-e2e-vitest` scenario locally. It is a long Docker/OpenShell runtime scenario and should run on the GitHub E2E runner. I also did not run full `npm test`; the focused Vitest support tests above cover the new adapter and workflow guard.

The workflow-boundary file has pre-existing whole-file formatter drift, so I kept that file to lint-only validation instead of formatting it and adding a large unrelated diff.

Refs #5745

Signed-off-by: Deepak Jain <deepujain@gmail.com>
