### PR TITLE
fix(inference): trust explicit custom switch metadata

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1519,7 +1519,7 @@ Under the `nemohermes` alias, it uses the registered Hermes sandbox when exactly
 By default, the command syncs the default registered sandbox.
 
 ```bash
-nemohermes inference set --provider <provider> --model <model> [--sandbox <name>] [--no-verify]
+nemohermes inference set --provider <provider> --model <model> [--sandbox <name>] [--no-verify] [--endpoint-url <url>] [--credential-env <ENV>] [--inference-api <api>]
 ```
 
 Pass both `--provider` and `--model` when you want NemoClaw to update the OpenShell inference route and sync the selected sandbox's agent config.
@@ -1530,6 +1530,7 @@ If the in-sandbox config sync fails, NemoClaw keeps the gateway and registry ali
 
 Supported provider names are `nvidia-prod`, `nvidia-nim`, `nvidia-router`, `openai-api`, `anthropic-prod`, `compatible-anthropic-endpoint`, `gemini-api`, `compatible-endpoint`, `hermes-provider`, `ollama-local`, and `vllm-local`.
 Use `--no-verify` only when OpenShell cannot verify the provider at switch time but you have already confirmed the provider and credential.
+When switching to `compatible-endpoint` or `compatible-anthropic-endpoint` from a different provider family, pass `--endpoint-url` with the trusted custom provider URL so NemoClaw can persist durable rebuild metadata. `--credential-env` and `--inference-api` may also be supplied for the compatible provider metadata; supported API values are `openai-completions`, `anthropic-messages`, and `openai-responses`.
 
 ### `nemohermes setup`
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1874,7 +1874,7 @@ Under the `nemohermes` alias, it uses the registered Hermes sandbox when exactly
 By default, the command syncs the default registered sandbox.
 
 ```bash
-$$nemoclaw inference set --provider <provider> --model <model> [--sandbox <name>] [--no-verify]
+$$nemoclaw inference set --provider <provider> --model <model> [--sandbox <name>] [--no-verify] [--endpoint-url <url>] [--credential-env <ENV>] [--inference-api <api>]
 ```
 
 Pass both `--provider` and `--model` when you want NemoClaw to update the OpenShell inference route and sync the selected sandbox's agent config.
@@ -1885,6 +1885,7 @@ If the in-sandbox config sync fails, NemoClaw keeps the gateway and registry ali
 
 Supported provider names are `nvidia-prod`, `nvidia-nim`, `nvidia-router`, `openai-api`, `anthropic-prod`, `compatible-anthropic-endpoint`, `gemini-api`, `compatible-endpoint`, `hermes-provider`, `ollama-local`, and `vllm-local`.
 Use `--no-verify` only when OpenShell cannot verify the provider at switch time but you have already confirmed the provider and credential.
+When switching to `compatible-endpoint` or `compatible-anthropic-endpoint` from a different provider family, pass `--endpoint-url` with the trusted custom provider URL so NemoClaw can persist durable rebuild metadata. `--credential-env` and `--inference-api` may also be supplied for the compatible provider metadata; supported API values are `openai-completions`, `anthropic-messages`, and `openai-responses`.
 
 ### `$$nemoclaw setup`
 

--- a/src/commands/global-oclif-command-adapters.test.ts
+++ b/src/commands/global-oclif-command-adapters.test.ts
@@ -231,6 +231,12 @@ describe("global oclif command adapters", () => {
         "--sandbox",
         "alpha",
         "--no-verify",
+        "--endpoint-url",
+        "https://example.test/v1",
+        "--credential-env",
+        "COMPATIBLE_API_KEY",
+        "--inference-api",
+        "openai-completions",
       ],
       rootDir,
     );
@@ -240,6 +246,9 @@ describe("global oclif command adapters", () => {
       model: "nvidia/nemotron-3-super-120b-a12b",
       sandboxName: "alpha",
       noVerify: true,
+      endpointUrl: "https://example.test/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+      inferenceApi: "openai-completions",
     });
   });
 

--- a/src/commands/inference/set.ts
+++ b/src/commands/inference/set.ts
@@ -25,7 +25,7 @@ export default class InferenceSetCommand extends NemoClawCommand {
   static description =
     "Update the OpenShell inference route and sync the running OpenClaw or Hermes sandbox config.";
   static usage = [
-    "inference set --provider <provider> --model <model> [--sandbox <name>] [--no-verify]",
+    "inference set --provider <provider> --model <model> [--sandbox <name>] [--no-verify] [--endpoint-url <url>] [--credential-env <ENV>] [--inference-api <api>]",
   ];
   static examples = [
     "<%= config.bin %> inference set --provider nvidia-prod --model nvidia/nemotron-3-super-120b-a12b",
@@ -41,6 +41,17 @@ export default class InferenceSetCommand extends NemoClawCommand {
     "no-verify": Flags.boolean({
       description: "Pass --no-verify through to openshell inference set",
     }),
+    "endpoint-url": Flags.string({
+      description: "Trusted endpoint URL to persist when switching to a compatible custom provider",
+    }),
+    "credential-env": Flags.string({
+      description:
+        "Trusted credential env name to persist when switching to a compatible custom provider",
+    }),
+    "inference-api": Flags.string({
+      description:
+        "Trusted API family to persist for compatible custom providers (openai-completions, anthropic-messages, openai-responses)",
+    }),
   };
 
   public async run(): Promise<void> {
@@ -55,6 +66,9 @@ export default class InferenceSetCommand extends NemoClawCommand {
         model: flags.model,
         sandboxName: flags.sandbox ?? null,
         noVerify: flags["no-verify"] === true,
+        endpointUrl: flags["endpoint-url"] ?? null,
+        credentialEnv: flags["credential-env"] ?? null,
+        inferenceApi: flags["inference-api"] ?? null,
       });
     } catch (error) {
       if (error instanceof InferenceSetError) {

--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -693,6 +693,43 @@ describe("runInferenceSet", () => {
     expect(deps.calls.updateSandbox).not.toHaveBeenCalled();
   });
 
+  it("rejects Anthropic Messages metadata for OpenAI-compatible endpoint switches", async () => {
+    const deps = createDeps({
+      config: { agents: { defaults: { model: { primary: "inference/nvidia/model-a" } } } },
+      entry: {
+        name: "alpha",
+        agent: "openclaw",
+        provider: "nvidia-prod",
+        model: "nvidia/model-a",
+      },
+      session: baseSession({
+        provider: "nvidia-prod",
+        model: "nvidia/model-a",
+        endpointUrl: "https://integrate.api.nvidia.com/v1",
+        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      }),
+    });
+
+    await expect(
+      runInferenceSet(
+        {
+          provider: "compatible-endpoint",
+          model: "mock-openai-model",
+          noVerify: true,
+          endpointUrl: "https://compatible.example/v1",
+          credentialEnv: "COMPATIBLE_API_KEY",
+          inferenceApi: "anthropic-messages",
+        },
+        deps,
+      ),
+    ).rejects.toThrow(
+      /inference-api for 'compatible-endpoint' must be one of: openai-completions, openai-responses/,
+    );
+
+    expect(deps.calls.runOpenshell).not.toHaveBeenCalled();
+    expect(deps.calls.updateSandbox).not.toHaveBeenCalled();
+  });
+
   it("accepts explicit compatible Anthropic endpoint metadata for provider-family switches", async () => {
     const config: ConfigObject = {
       agents: { defaults: { model: { primary: "inference/nvidia/model-a" } } },

--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -693,6 +693,60 @@ describe("runInferenceSet", () => {
     expect(deps.calls.updateSandbox).not.toHaveBeenCalled();
   });
 
+  it("accepts explicit compatible Anthropic endpoint metadata for provider-family switches", async () => {
+    const config: ConfigObject = {
+      agents: { defaults: { model: { primary: "inference/nvidia/model-a" } } },
+      models: { providers: { inference: { api: "openai-completions", models: [] } } },
+    };
+    const deps = createDeps({
+      config,
+      entry: {
+        name: "alpha",
+        agent: "openclaw",
+        provider: "nvidia-prod",
+        model: "nvidia/model-a",
+      },
+      session: baseSession({
+        provider: "nvidia-prod",
+        model: "nvidia/model-a",
+        endpointUrl: "https://integrate.api.nvidia.com/v1",
+        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+      }),
+    });
+
+    await runInferenceSet(
+      {
+        provider: "compatible-anthropic-endpoint",
+        model: "mock-anthropic-model",
+        noVerify: true,
+        endpointUrl: "http://host.openshell.internal:18767/",
+        credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+        inferenceApi: "anthropic-messages",
+      },
+      deps,
+    );
+
+    expect(deps.calls.updateSandbox.mock.calls.at(-1)).toEqual([
+      "alpha",
+      expect.objectContaining({
+        provider: "compatible-anthropic-endpoint",
+        model: "mock-anthropic-model",
+        endpointUrl: "http://host.openshell.internal:18767",
+        credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+        preferredInferenceApi: "anthropic-messages",
+        nimContainer: null,
+      }),
+    ]);
+    expect(deps.getSession()).toMatchObject({
+      provider: "compatible-anthropic-endpoint",
+      model: "mock-anthropic-model",
+      endpointUrl: "http://host.openshell.internal:18767",
+      credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+      preferredInferenceApi: "anthropic-messages",
+      nimContainer: null,
+    });
+  });
+
   it("preserves same-provider Bedrock Runtime adapter routing for OpenClaw switches", async () => {
     const config: ConfigObject = {
       agents: {

--- a/src/lib/actions/inference-set.test.ts
+++ b/src/lib/actions/inference-set.test.ts
@@ -730,6 +730,67 @@ describe("runInferenceSet", () => {
     expect(deps.calls.updateSandbox).not.toHaveBeenCalled();
   });
 
+  it("preserves explicit inference API through the final registry and session sync", async () => {
+    const config: ConfigObject = {
+      agents: { defaults: { model: { primary: "inference/nvidia/model-a" } } },
+      models: { providers: { inference: { api: "openai-completions", models: [] } } },
+    };
+    const deps = createDeps({
+      config,
+      entry: {
+        name: "alpha",
+        agent: "openclaw",
+        provider: "nvidia-prod",
+        model: "nvidia/model-a",
+      },
+      session: baseSession({
+        provider: "nvidia-prod",
+        model: "nvidia/model-a",
+        endpointUrl: "https://integrate.api.nvidia.com/v1",
+        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        preferredInferenceApi: "openai-completions",
+      }),
+    });
+
+    await runInferenceSet(
+      {
+        provider: "compatible-endpoint",
+        model: "mock-responses-model",
+        noVerify: true,
+        endpointUrl: "https://compatible.example/v1",
+        credentialEnv: "COMPATIBLE_API_KEY",
+        inferenceApi: "openai-responses",
+      },
+      deps,
+    );
+
+    expect(config.models).toMatchObject({
+      providers: {
+        inference: {
+          api: "openai-responses",
+          models: [{ id: "mock-responses-model", name: "inference/mock-responses-model" }],
+        },
+      },
+    });
+    expect(deps.calls.updateSandbox.mock.calls.at(-1)).toEqual([
+      "alpha",
+      expect.objectContaining({
+        provider: "compatible-endpoint",
+        model: "mock-responses-model",
+        endpointUrl: "https://compatible.example/v1",
+        credentialEnv: "COMPATIBLE_API_KEY",
+        preferredInferenceApi: "openai-responses",
+      }),
+    ]);
+    expect(deps.getSession()).toMatchObject({
+      provider: "compatible-endpoint",
+      model: "mock-responses-model",
+      endpointUrl: "https://compatible.example/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+      preferredInferenceApi: "openai-responses",
+    });
+  });
+
   it("accepts explicit compatible Anthropic endpoint metadata for provider-family switches", async () => {
     const config: ConfigObject = {
       agents: { defaults: { model: { primary: "inference/nvidia/model-a" } } },

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -36,6 +36,9 @@ export interface InferenceSetOptions {
   model: string;
   sandboxName?: string | null;
   noVerify?: boolean;
+  endpointUrl?: string | null;
+  credentialEnv?: string | null;
+  inferenceApi?: string | null;
 }
 
 export interface InferenceSetResult {
@@ -312,6 +315,7 @@ function updateMatchingOnboardSession(
   provider: string,
   model: string,
   route: SandboxInferenceConfig,
+  registryMetadata: RegistryInferenceMetadata,
   deps: Pick<InferenceSetDeps, "loadSession" | "updateSession">,
 ): boolean {
   const session = deps.loadSession();
@@ -321,8 +325,15 @@ function updateMatchingOnboardSession(
     current.provider = provider;
     current.model = model;
     current.endpointUrl =
-      getProviderSelectionConfig(provider, model)?.endpointUrl ?? current.endpointUrl;
-    current.preferredInferenceApi = route.inferenceApi;
+      registryMetadata.endpointUrl ??
+      getProviderSelectionConfig(provider, model)?.endpointUrl ??
+      current.endpointUrl;
+    current.credentialEnv =
+      registryMetadata.credentialEnv ??
+      getProviderSelectionConfig(provider, model)?.credentialEnv ??
+      current.credentialEnv;
+    current.preferredInferenceApi = registryMetadata.preferredInferenceApi ?? route.inferenceApi;
+    current.nimContainer = registryMetadata.nimContainer ?? null;
     return current;
   });
   return true;
@@ -362,8 +373,97 @@ type RegistryInferenceMetadata = Pick<
   "endpointUrl" | "credentialEnv" | "preferredInferenceApi" | "nimContainer"
 >;
 
+const CUSTOM_COMPATIBLE_CREDENTIAL_ENV: Record<string, string> = {
+  "compatible-endpoint": "COMPATIBLE_API_KEY",
+  "compatible-anthropic-endpoint": "COMPATIBLE_ANTHROPIC_API_KEY",
+};
+
+const INFERENCE_SET_APIS = new Set([
+  "openai-completions",
+  "anthropic-messages",
+  "openai-responses",
+]);
+
 function isCustomCompatibleProvider(provider: string): boolean {
   return provider === "compatible-endpoint" || provider === "compatible-anthropic-endpoint";
+}
+
+function hasExplicitCustomMetadata(options: InferenceSetOptions): boolean {
+  return Boolean(options.endpointUrl || options.credentialEnv || options.inferenceApi);
+}
+
+function normalizeCustomEndpointUrl(value: string | null | undefined): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw)
+    throw new InferenceSetError("endpoint-url is required for custom-compatible metadata.", 2);
+  try {
+    const url = new URL(raw);
+    if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password) {
+      throw new Error("unsupported URL shape");
+    }
+    url.search = "";
+    url.hash = "";
+    const pathname = url.pathname.replace(/\/+$/, "");
+    url.pathname = pathname || "/";
+    return url.pathname === "/" ? url.origin : `${url.origin}${url.pathname}`;
+  } catch {
+    throw new InferenceSetError(
+      "endpoint-url must be a valid http(s) URL without embedded credentials.",
+      2,
+    );
+  }
+}
+
+function normalizeExplicitCredentialEnv(
+  provider: string,
+  value: string | null | undefined,
+): string {
+  const expected = CUSTOM_COMPATIBLE_CREDENTIAL_ENV[provider];
+  const normalized = typeof value === "string" && value.trim() ? value.trim() : expected;
+  if (normalized !== expected) {
+    throw new InferenceSetError(
+      `credential-env for '${provider}' must be '${expected}' so rebuild can safely reuse it.`,
+      2,
+    );
+  }
+  return normalized;
+}
+
+function normalizeExplicitInferenceApi(value: string | null | undefined): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) return null;
+  if (!INFERENCE_SET_APIS.has(normalized)) {
+    throw new InferenceSetError(
+      `inference-api must be one of: ${Array.from(INFERENCE_SET_APIS).join(", ")}.`,
+      2,
+    );
+  }
+  return normalized;
+}
+
+function explicitCustomProviderMetadata(
+  provider: string,
+  options: InferenceSetOptions,
+): RegistryInferenceMetadata | null {
+  if (!hasExplicitCustomMetadata(options)) return null;
+  if (!isCustomCompatibleProvider(provider)) {
+    throw new InferenceSetError(
+      "endpoint-url, credential-env, and inference-api are only supported for compatible-endpoint and compatible-anthropic-endpoint.",
+      2,
+    );
+  }
+
+  // Source boundary: custom-compatible endpoint URLs are operator-supplied and
+  // not discoverable from the gateway provider registry with a sandbox-scoped
+  // trust guarantee. Treat these explicit flags as the durable metadata source
+  // for this switch, after URL and credential-env validation, instead of
+  // borrowing from an unrelated onboard session or global OpenShell provider.
+  return {
+    endpointUrl: normalizeCustomEndpointUrl(options.endpointUrl),
+    credentialEnv: normalizeExplicitCredentialEnv(provider, options.credentialEnv),
+    preferredInferenceApi: normalizeExplicitInferenceApi(options.inferenceApi),
+    nimContainer: null,
+  };
 }
 
 function matchingSessionMetadata(options: {
@@ -395,8 +495,10 @@ function registryMetadataForProviderSwitch(options: {
   model: string;
   sandboxName: string;
   session: onboardSession.Session | null;
+  explicitMetadata: RegistryInferenceMetadata | null;
 }): RegistryInferenceMetadata {
-  const { entry, provider, model, sandboxName, session } = options;
+  const { entry, provider, model, sandboxName, session, explicitMetadata } = options;
+  if (explicitMetadata) return explicitMetadata;
   if (entry.provider === provider) {
     return {
       endpointUrl: entry.endpointUrl ?? null,
@@ -452,12 +554,14 @@ export async function runInferenceSet(
     );
   }
   const session = deps.loadSession();
+  const explicitMetadata = explicitCustomProviderMetadata(provider, options);
   const registryMetadata = registryMetadataForProviderSwitch({
     entry,
     provider,
     model,
     sandboxName,
     session,
+    explicitMetadata,
   });
 
   // Local providers (ollama-local, vllm-local) route through the sandbox-facing
@@ -600,6 +704,7 @@ export async function runInferenceSet(
     provider,
     model,
     patched.route,
+    registryMetadata,
     deps,
   );
 

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -429,12 +429,22 @@ function normalizeExplicitCredentialEnv(
   return normalized;
 }
 
-function normalizeExplicitInferenceApi(value: string | null | undefined): string | null {
+function allowedExplicitInferenceApis(provider: string): string[] {
+  return provider === "compatible-endpoint"
+    ? ["openai-completions", "openai-responses"]
+    : Array.from(INFERENCE_SET_APIS);
+}
+
+function normalizeExplicitInferenceApi(
+  provider: string,
+  value: string | null | undefined,
+): string | null {
   const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized) return null;
-  if (!INFERENCE_SET_APIS.has(normalized)) {
+  const allowed = allowedExplicitInferenceApis(provider);
+  if (!allowed.includes(normalized)) {
     throw new InferenceSetError(
-      `inference-api must be one of: ${Array.from(INFERENCE_SET_APIS).join(", ")}.`,
+      `inference-api for '${provider}' must be one of: ${allowed.join(", ")}.`,
       2,
     );
   }
@@ -461,7 +471,7 @@ function explicitCustomProviderMetadata(
   return {
     endpointUrl: normalizeCustomEndpointUrl(options.endpointUrl),
     credentialEnv: normalizeExplicitCredentialEnv(provider, options.credentialEnv),
-    preferredInferenceApi: normalizeExplicitInferenceApi(options.inferenceApi),
+    preferredInferenceApi: normalizeExplicitInferenceApi(provider, options.inferenceApi),
     nimContainer: null,
   };
 }

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -565,6 +565,7 @@ export async function runInferenceSet(
   }
   const session = deps.loadSession();
   const explicitMetadata = explicitCustomProviderMetadata(provider, options);
+  const explicitPreferredInferenceApi = explicitMetadata?.preferredInferenceApi ?? null;
   const registryMetadata = registryMetadataForProviderSwitch({
     entry,
     provider,
@@ -635,16 +636,23 @@ export async function runInferenceSet(
   }
 
   const config = deps.readSandboxConfig(sandboxName, target);
-  const preferredInferenceApi = resolveRuntimeInferenceApi({
-    agentName,
-    config,
-    currentProvider: entry.provider,
-    provider,
-    sandboxName,
-    session,
-  });
+  const preferredInferenceApi =
+    explicitPreferredInferenceApi ??
+    resolveRuntimeInferenceApi({
+      agentName,
+      config,
+      currentProvider: entry.provider,
+      provider,
+      sandboxName,
+      session,
+    });
+  const effectiveRegistryMetadata: RegistryInferenceMetadata = {
+    ...registryMetadata,
+    preferredInferenceApi,
+  };
   // Refresh the registry with config-derived API-family metadata before the
-  // crash-prone in-sandbox sync (#3725/#3726).
+  // crash-prone in-sandbox sync (#3725/#3726). Explicit operator-supplied
+  // metadata remains authoritative when present.
   if (!deps.updateSandbox(sandboxName, registryFields(preferredInferenceApi))) {
     throw new InferenceSetError(`Failed to update NemoClaw registry for sandbox '${sandboxName}'.`);
   }
@@ -714,7 +722,7 @@ export async function runInferenceSet(
     provider,
     model,
     patched.route,
-    registryMetadata,
+    effectiveRegistryMetadata,
     deps,
   );
 

--- a/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
@@ -241,6 +241,9 @@ export async function ensureCompatibleAnthropicSwitchProvider(
   const mock = SWITCH_MOCK_ANTHROPIC === "1" ? await startMockAnthropicProvider() : undefined;
   mock && cleanup.add("close compatible Anthropic switch mock", () => mock.close());
   const endpointUrl = process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? mock?.endpointUrl ?? "";
+  if (endpointUrl && !process.env.NEMOCLAW_SWITCH_ENDPOINT_URL) {
+    process.env.NEMOCLAW_SWITCH_ENDPOINT_URL = endpointUrl;
+  }
   const compatibleKey = process.env.COMPATIBLE_ANTHROPIC_API_KEY ?? "test-compatible-anthropic-key";
   expect(
     endpointUrl,

--- a/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
@@ -235,15 +235,12 @@ async function startMockAnthropicProvider(): Promise<MockAnthropicProvider> {
 export async function ensureCompatibleAnthropicSwitchProvider(
   host: HostCliClient,
   cleanup: { add(name: string, run: () => Promise<void> | void): void },
-): Promise<void> {
+): Promise<string | null> {
   if (SWITCH_PROVIDER !== "compatible-anthropic-endpoint" || SWITCH_API !== "anthropic-messages")
-    return;
+    return null;
   const mock = SWITCH_MOCK_ANTHROPIC === "1" ? await startMockAnthropicProvider() : undefined;
   mock && cleanup.add("close compatible Anthropic switch mock", () => mock.close());
   const endpointUrl = process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? mock?.endpointUrl ?? "";
-  if (endpointUrl && !process.env.NEMOCLAW_SWITCH_ENDPOINT_URL) {
-    process.env.NEMOCLAW_SWITCH_ENDPOINT_URL = endpointUrl;
-  }
   const compatibleKey = process.env.COMPATIBLE_ANTHROPIC_API_KEY ?? "test-compatible-anthropic-key";
   expect(
     endpointUrl,
@@ -271,6 +268,7 @@ export async function ensureCompatibleAnthropicSwitchProvider(
     timeoutMs: 120_000,
   });
   expect(result.exitCode).toBe(0);
+  return endpointUrl;
 }
 
 export async function installHermes(

--- a/test/e2e-scenario/live/hermes-inference-switch.test.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch.test.ts
@@ -65,39 +65,40 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     const install = await installHermes(host, apiKey);
     expect(install.exitCode, resultText(install)).toBe(0);
-    await ensureCompatibleAnthropicSwitchProvider(host, cleanup);
+    const switchEndpointUrl = await ensureCompatibleAnthropicSwitchProvider(host, cleanup);
 
     const pidBefore = await hermesGatewayPid(sandbox, "pid-before");
     const envHashBefore = await envHash(sandbox, "env-hash-before");
 
-    const switchArgs = [
-      CLI,
-      "inference",
-      "set",
-      "--provider",
-      SWITCH_PROVIDER,
-      "--model",
-      SWITCH_MODEL,
-    ];
-    if (
-      SWITCH_PROVIDER === "compatible-anthropic-endpoint" &&
-      SWITCH_API === "anthropic-messages"
-    ) {
-      switchArgs.push(
-        "--endpoint-url",
-        process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? "",
-        "--credential-env",
-        "COMPATIBLE_ANTHROPIC_API_KEY",
-        "--inference-api",
-        SWITCH_API,
-      );
-    }
-    const switched = await host.command("node", switchArgs, {
-      artifactName: "hermes-inference-set",
-      env: env(apiKey),
-      redactionValues: [apiKey],
-      timeoutMs: 180_000,
-    });
+    const compatibleMetadataArgs = switchEndpointUrl
+      ? [
+          "--endpoint-url",
+          switchEndpointUrl,
+          "--credential-env",
+          "COMPATIBLE_ANTHROPIC_API_KEY",
+          "--inference-api",
+          SWITCH_API,
+        ]
+      : [];
+    const switched = await host.command(
+      "node",
+      [
+        CLI,
+        "inference",
+        "set",
+        "--provider",
+        SWITCH_PROVIDER,
+        "--model",
+        SWITCH_MODEL,
+        ...compatibleMetadataArgs,
+      ],
+      {
+        artifactName: "hermes-inference-set",
+        env: env(apiKey),
+        redactionValues: [apiKey],
+        timeoutMs: 180_000,
+      },
+    );
     expect(switched.exitCode, resultText(switched)).toBe(0);
 
     const pidAfter = await hermesGatewayPid(sandbox, "pid-after");

--- a/test/e2e-scenario/live/hermes-inference-switch.test.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch.test.ts
@@ -70,16 +70,34 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     const pidBefore = await hermesGatewayPid(sandbox, "pid-before");
     const envHashBefore = await envHash(sandbox, "env-hash-before");
 
-    const switched = await host.command(
-      "node",
-      [CLI, "inference", "set", "--provider", SWITCH_PROVIDER, "--model", SWITCH_MODEL],
-      {
-        artifactName: "hermes-inference-set",
-        env: env(apiKey),
-        redactionValues: [apiKey],
-        timeoutMs: 180_000,
-      },
-    );
+    const switchArgs = [
+      CLI,
+      "inference",
+      "set",
+      "--provider",
+      SWITCH_PROVIDER,
+      "--model",
+      SWITCH_MODEL,
+    ];
+    if (
+      SWITCH_PROVIDER === "compatible-anthropic-endpoint" &&
+      SWITCH_API === "anthropic-messages"
+    ) {
+      switchArgs.push(
+        "--endpoint-url",
+        process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? "",
+        "--credential-env",
+        "COMPATIBLE_ANTHROPIC_API_KEY",
+        "--inference-api",
+        SWITCH_API,
+      );
+    }
+    const switched = await host.command("node", switchArgs, {
+      artifactName: "hermes-inference-set",
+      env: env(apiKey),
+      redactionValues: [apiKey],
+      timeoutMs: 180_000,
+    });
     expect(switched.exitCode, resultText(switched)).toBe(0);
 
     const pidAfter = await hermesGatewayPid(sandbox, "pid-after");

--- a/test/e2e-scenario/live/openclaw-inference-switch.test.ts
+++ b/test/e2e-scenario/live/openclaw-inference-switch.test.ts
@@ -381,9 +381,9 @@ async function ensureCompatibleAnthropicSwitchProvider(
   host: HostCliClient,
   home: string,
   mockProvider: MockAnthropicProvider | undefined,
-): Promise<void> {
-  if (SWITCH_PROVIDER !== "compatible-anthropic-endpoint") return;
-  if (SWITCH_INFERENCE_API !== "anthropic-messages") return;
+): Promise<string | null> {
+  if (SWITCH_PROVIDER !== "compatible-anthropic-endpoint") return null;
+  if (SWITCH_INFERENCE_API !== "anthropic-messages") return null;
 
   const endpointUrl = process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? mockProvider?.endpointUrl ?? "";
   const apiKey = process.env.COMPATIBLE_ANTHROPIC_API_KEY ?? "test-compatible-anthropic-key";
@@ -414,6 +414,7 @@ async function ensureCompatibleAnthropicSwitchProvider(
     timeoutMs: COMMAND_TIMEOUT_MS,
   });
   expect(provider.exitCode, resultText(provider)).toBe(0);
+  return endpointUrl;
 }
 
 async function openclawGatewayPid(sandbox: SandboxClient, home: string): Promise<string> {
@@ -815,8 +816,19 @@ async function runInferenceSetWithRetry(
   host: HostCliClient,
   home: string,
   redactionValues: string[],
+  switchEndpointUrl: string | null,
 ): Promise<ShellProbeResult> {
   const attempts = parsePositiveIntEnv("NEMOCLAW_SWITCH_SET_ATTEMPTS", 3);
+  const compatibleMetadataArgs = switchEndpointUrl
+    ? [
+        "--endpoint-url",
+        switchEndpointUrl,
+        "--credential-env",
+        "COMPATIBLE_ANTHROPIC_API_KEY",
+        "--inference-api",
+        SWITCH_INFERENCE_API,
+      ]
+    : [];
   const args = [
     "inference",
     "set",
@@ -826,20 +838,8 @@ async function runInferenceSetWithRetry(
     SWITCH_MODEL,
     "--sandbox",
     SANDBOX_NAME,
+    ...compatibleMetadataArgs,
   ];
-  if (
-    SWITCH_PROVIDER === "compatible-anthropic-endpoint" &&
-    SWITCH_INFERENCE_API === "anthropic-messages"
-  ) {
-    args.push(
-      "--endpoint-url",
-      process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? "",
-      "--credential-env",
-      "COMPATIBLE_ANTHROPIC_API_KEY",
-      "--inference-api",
-      SWITCH_INFERENCE_API,
-    );
-  }
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const result = await runNemoclaw(host, home, args, {
@@ -956,17 +956,14 @@ RUN_OPENCLAW_INFERENCE_SWITCH_TEST(
         endpointUrl: mockProvider.endpointUrl,
       });
     }
-    await ensureCompatibleAnthropicSwitchProvider(host, home, mockProvider);
-    if (
-      SWITCH_PROVIDER === "compatible-anthropic-endpoint" &&
-      SWITCH_INFERENCE_API === "anthropic-messages"
-    ) {
-      process.env.NEMOCLAW_SWITCH_ENDPOINT_URL =
-        process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? mockProvider?.endpointUrl;
-    }
+    const switchEndpointUrl = await ensureCompatibleAnthropicSwitchProvider(
+      host,
+      home,
+      mockProvider,
+    );
 
     const pidBefore = await openclawGatewayPid(sandbox, home);
-    const switchResult = await runInferenceSetWithRetry(host, home, [apiKey]);
+    const switchResult = await runInferenceSetWithRetry(host, home, [apiKey], switchEndpointUrl);
     expect(switchResult.exitCode, resultText(switchResult)).toBe(0);
 
     const pidAfter = await openclawGatewayPid(sandbox, home);

--- a/test/e2e-scenario/live/openclaw-inference-switch.test.ts
+++ b/test/e2e-scenario/live/openclaw-inference-switch.test.ts
@@ -827,6 +827,19 @@ async function runInferenceSetWithRetry(
     "--sandbox",
     SANDBOX_NAME,
   ];
+  if (
+    SWITCH_PROVIDER === "compatible-anthropic-endpoint" &&
+    SWITCH_INFERENCE_API === "anthropic-messages"
+  ) {
+    args.push(
+      "--endpoint-url",
+      process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? "",
+      "--credential-env",
+      "COMPATIBLE_ANTHROPIC_API_KEY",
+      "--inference-api",
+      SWITCH_INFERENCE_API,
+    );
+  }
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const result = await runNemoclaw(host, home, args, {
@@ -944,6 +957,13 @@ RUN_OPENCLAW_INFERENCE_SWITCH_TEST(
       });
     }
     await ensureCompatibleAnthropicSwitchProvider(host, home, mockProvider);
+    if (
+      SWITCH_PROVIDER === "compatible-anthropic-endpoint" &&
+      SWITCH_INFERENCE_API === "anthropic-messages"
+    ) {
+      process.env.NEMOCLAW_SWITCH_ENDPOINT_URL =
+        process.env.NEMOCLAW_SWITCH_ENDPOINT_URL ?? mockProvider?.endpointUrl;
+    }
 
     const pidBefore = await openclawGatewayPid(sandbox, home);
     const switchResult = await runInferenceSetWithRetry(host, home, [apiKey]);

--- a/test/e2e/test-hermes-inference-switch.sh
+++ b/test/e2e/test-hermes-inference-switch.sh
@@ -559,7 +559,11 @@ pid_before="$(hermes_gateway_pid)"
 ENV_HASH_BEFORE=$(openshell sandbox exec --name "$SANDBOX_NAME" -- sha256sum /sandbox/.hermes/.env 2>/dev/null | awk '{print $1}') || true
 
 info "Switching Hermes to ${SWITCH_PROVIDER} / ${SWITCH_MODEL} with nemohermes inference set..."
-switch_output=$(run_inference_set_with_retry nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL")
+switch_cmd=(nemohermes inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL")
+if [ "$SWITCH_PROVIDER" = "compatible-anthropic-endpoint" ] && [ "$SWITCH_INFERENCE_API" = "anthropic-messages" ]; then
+  switch_cmd+=(--endpoint-url "$SWITCH_ENDPOINT_URL" --credential-env COMPATIBLE_ANTHROPIC_API_KEY --inference-api "$SWITCH_INFERENCE_API")
+fi
+switch_output=$(run_inference_set_with_retry "${switch_cmd[@]}")
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemohermes inference set completed without --sandbox"

--- a/test/e2e/test-openclaw-inference-switch.sh
+++ b/test/e2e/test-openclaw-inference-switch.sh
@@ -463,7 +463,11 @@ ensure_compatible_anthropic_switch_provider || exit 1
 section "Phase 3: Switch inference"
 pid_before="$(openclaw_gateway_pid)"
 info "Switching ${SANDBOX_NAME} to ${SWITCH_PROVIDER} / ${SWITCH_MODEL}..."
-switch_output=$(run_inference_set_with_retry nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME")
+switch_cmd=(nemoclaw inference set --provider "$SWITCH_PROVIDER" --model "$SWITCH_MODEL" --sandbox "$SANDBOX_NAME")
+if [ "$SWITCH_PROVIDER" = "compatible-anthropic-endpoint" ] && [ "$SWITCH_INFERENCE_API" = "anthropic-messages" ]; then
+  switch_cmd+=(--endpoint-url "$SWITCH_ENDPOINT_URL" --credential-env COMPATIBLE_ANTHROPIC_API_KEY --inference-api "$SWITCH_INFERENCE_API")
+fi
+switch_output=$(run_inference_set_with_retry "${switch_cmd[@]}")
 switch_rc=$?
 if [ "$switch_rc" -eq 0 ]; then
   pass "nemoclaw inference set completed"


### PR DESCRIPTION
## Summary
- Add explicit trusted metadata flags for compatible custom provider switches: endpoint URL, credential env, and inference API.
- Persist explicit metadata into sandbox registry and matching onboard session during inference set.
- Update OpenClaw/Hermes Anthropic inference-switch E2Es to pass mock endpoint metadata instead of relying on unrelated session state.

## Why
Nightly openclaw-anthropic-inference-switch-e2e and hermes-anthropic-inference-switch-e2e fail after PR #5869 because the new source-boundary guard correctly refuses cross-provider compatible-Anthropic switches without durable endpoint metadata. This PR keeps that guard intact while giving the switch command a first-class trusted metadata path.

## Validation
- npm run build:cli
- npm test -- src/lib/actions/inference-set.test.ts src/commands/global-oclif-command-adapters.test.ts

## Related
- Regression from PR #5869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--endpoint-url`, `--credential-env`, and `--inference-api` flags to the Hermes/NemoClaw “inference set” commands.
* **Bug Fixes**
  * Enhanced compatible-provider switching by validating allowed `--inference-api` values, persisting durable rebuild metadata, and synchronizing onboarding settings (including `endpoint-url` normalization).
* **Documentation**
  * Updated command references and compatibility guidance, including trusted `--endpoint-url` requirements and allowed `--inference-api` values.
* **Tests**
  * Expanded unit and end-to-end scenarios to cover the new flags and compatible switch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->