### PR TITLE
fix(onboard): refresh compatible route on messaging resume

### DIFF
--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -383,6 +383,192 @@ describe("handleProviderInferenceState", () => {
     );
   });
 
+  it("refreshes compatible-endpoint route on OpenClaw messaging resume", async () => {
+    const session = createSession({
+      provider: "compatible-endpoint",
+      model: "nvidia/nemotron",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      hydrateCredentialEnv: vi.fn(() => null),
+      isInferenceRouteReady: vi.fn(() => true),
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "my-assistant",
+      selectedMessagingChannels: ["telegram"],
+    });
+
+    expect(calls.setupNim).not.toHaveBeenCalled();
+    expect(calls.skipped).not.toHaveBeenCalledWith(
+      "inference",
+      "compatible-endpoint / nvidia/nemotron",
+    );
+    expect(calls.setupInference).toHaveBeenCalledWith(
+      "my-assistant",
+      "nvidia/nemotron",
+      "compatible-endpoint",
+      "https://integrate.api.nvidia.com/v1",
+      "COMPATIBLE_API_KEY",
+      null,
+      [],
+      { allowToolsIncompatible: false, skipHostInferenceSmoke: true },
+    );
+    expect(calls.log).toHaveBeenCalledWith(
+      "  [resume] Refreshing compatible-endpoint inference route with the stored gateway credential.",
+    );
+  });
+
+  it("refreshes compatible-endpoint route when messaging is only recorded in the session plan", async () => {
+    const session = createSession({
+      provider: "compatible-endpoint",
+      model: "nvidia/nemotron",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+      messagingPlan: {
+        schemaVersion: 1,
+        sandboxName: "my-assistant",
+        agent: "openclaw",
+        workflow: "rebuild",
+        channels: [
+          {
+            channelId: "telegram",
+            displayName: "Telegram",
+            authMode: "token-paste",
+            active: true,
+            selected: true,
+            configured: true,
+            disabled: false,
+            inputs: [],
+            hooks: [],
+          },
+        ],
+        disabledChannels: [],
+        credentialBindings: [],
+        networkPolicy: { presets: [], entries: [] },
+        agentRender: [],
+        buildSteps: [],
+        stateUpdates: [],
+        healthChecks: [],
+      },
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      hydrateCredentialEnv: vi.fn(() => null),
+      isInferenceRouteReady: vi.fn(() => true),
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "my-assistant",
+    });
+
+    expect(calls.setupInference).toHaveBeenCalledWith(
+      "my-assistant",
+      "nvidia/nemotron",
+      "compatible-endpoint",
+      "https://integrate.api.nvidia.com/v1",
+      "COMPATIBLE_API_KEY",
+      null,
+      [],
+      { allowToolsIncompatible: false, skipHostInferenceSmoke: true },
+    );
+  });
+
+  it("keeps the compatible-endpoint resume shortcut when no messaging channels are selected", async () => {
+    const session = createSession({
+      provider: "compatible-endpoint",
+      model: "nvidia/nemotron",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      hydrateCredentialEnv: vi.fn(() => null),
+      isInferenceRouteReady: vi.fn(() => true),
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "my-assistant",
+    });
+
+    expect(calls.setupInference).not.toHaveBeenCalled();
+    expect(calls.skipped).toHaveBeenCalledWith(
+      "inference",
+      "compatible-endpoint / nvidia/nemotron",
+    );
+  });
+
+  it("keeps the compatible-endpoint resume shortcut for Hermes messaging", async () => {
+    const session = createSession({
+      provider: "compatible-endpoint",
+      model: "nvidia/nemotron",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      hydrateCredentialEnv: vi.fn(() => null),
+      isInferenceRouteReady: vi.fn(() => true),
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "my-assistant",
+      agent: { name: "hermes" },
+      selectedMessagingChannels: ["slack"],
+    });
+
+    expect(calls.setupInference).not.toHaveBeenCalled();
+    expect(calls.skipped).toHaveBeenCalledWith(
+      "inference",
+      "compatible-endpoint / nvidia/nemotron",
+    );
+  });
+
+  it("runs compatible-endpoint route refresh with host smoke when the credential is locally hydrated", async () => {
+    const session = createSession({
+      provider: "compatible-endpoint",
+      model: "nvidia/nemotron",
+      endpointUrl: "https://integrate.api.nvidia.com/v1",
+      credentialEnv: "COMPATIBLE_API_KEY",
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      hydrateCredentialEnv: vi.fn(() => "nvapi-test"),
+      isInferenceRouteReady: vi.fn(() => true),
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "my-assistant",
+      selectedMessagingChannels: ["telegram"],
+    });
+
+    expect(calls.setupInference).toHaveBeenCalledWith(
+      "my-assistant",
+      "nvidia/nemotron",
+      "compatible-endpoint",
+      "https://integrate.api.nvidia.com/v1",
+      "COMPATIBLE_API_KEY",
+      null,
+      [],
+      { allowToolsIncompatible: false },
+    );
+    expect(calls.log).toHaveBeenCalledWith(
+      "  [resume] Refreshing compatible-endpoint inference route for messaging.",
+    );
+  });
+
   it("reconciles model router on resumed routed inference", async () => {
     const session = createSession({ provider: "nvidia-router", model: "router/model" });
     session.steps.provider_selection.status = "complete";

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -88,7 +88,7 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
         metadata?: Record<string, unknown> | null;
       },
     ): Promise<Session>;
-    hydrateCredentialEnv(credentialEnv: string | null): void;
+    hydrateCredentialEnv(credentialEnv: string | null): string | null | undefined;
     repairLocalInferenceSystemdOverrideOrExit(
       provider: string | null,
       isNonInteractive: () => boolean,
@@ -171,6 +171,36 @@ function clearStagedCredentialEnv(
   if (credentialEnv) deps.deleteEnv(credentialEnv);
 }
 
+function agentName(agent: unknown): string {
+  const name = (agent as { name?: string | null } | null)?.name;
+  return typeof name === "string" && name.length > 0 ? name : "openclaw";
+}
+
+function hasActiveMessagingChannels(
+  selectedMessagingChannels: string[],
+  session: Session | null,
+): boolean {
+  if (selectedMessagingChannels.length > 0) return true;
+  const channels = session?.messagingPlan?.channels;
+  return Boolean(
+    Array.isArray(channels) &&
+      channels.some((channel) => channel.active === true && channel.disabled !== true),
+  );
+}
+
+function shouldRefreshCompatibleEndpointRouteForMessaging(
+  provider: string | null,
+  selectedMessagingChannels: string[],
+  session: Session | null,
+  agent: unknown,
+): boolean {
+  return (
+    provider === "compatible-endpoint" &&
+    agentName(agent) === "openclaw" &&
+    hasActiveMessagingChannels(selectedMessagingChannels, session)
+  );
+}
+
 export async function handleProviderInferenceState<Gpu, Agent, Host>({
   resume,
   fresh,
@@ -225,7 +255,33 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
         provider,
         model,
       });
-      deps.hydrateCredentialEnv(credentialEnv);
+      const hydratedCredential = deps.hydrateCredentialEnv(credentialEnv);
+      // A rebuild recreate may leave `openshell inference get` reporting the
+      // same provider/model while the newly created messaging sandbox's
+      // `inference.local` route is not actually wired to the compatible
+      // endpoint. For the OpenClaw+messaging path that later performs a
+      // sandbox-side compatible-endpoint smoke, refresh the gateway route in
+      // the inference phase instead of trusting the provider/model-only resume
+      // shortcut. If the local key is absent but the gateway provider exists,
+      // setupInference can still re-apply the route with the stored gateway
+      // credential; skip only the host direct smoke that would otherwise probe
+      // unauthenticated.
+      if (
+        shouldRefreshCompatibleEndpointRouteForMessaging(
+          provider,
+          selectedMessagingChannels,
+          session,
+          agent,
+        )
+      ) {
+        forceInferenceSetup = true;
+        skipHostInferenceSmoke = !hydratedCredential;
+        deps.log(
+          skipHostInferenceSmoke
+            ? "  [resume] Refreshing compatible-endpoint inference route with the stored gateway credential."
+            : "  [resume] Refreshing compatible-endpoint inference route for messaging.",
+        );
+      }
       if (provider === "ollama-local") {
         const repairMetadata = { repair: "ollama-systemd-loopback" };
         await deps.recordRepairEvent("state.repair.started", {


### PR DESCRIPTION
## Summary
- refresh the compatible-endpoint inference route during OpenClaw messaging resume/rebuild instead of trusting provider/model-only route metadata
- reuse the stored gateway credential when the local key is absent, skipping only the unauthenticated host smoke
- add resume-path regression coverage for selected messaging channels and session-recorded messaging plans

## Validation
- npm run build:cli
- npm test -- --run src/lib/onboard/machine/handlers/provider-inference.test.ts test/onboard-build-recreate-credential-reuse.test.ts

## Nightly context
Addresses channels-add-remove-e2e post-add rebuild failure where the recreated sandbox reached an empty/non-JSON inference.local response and provider details did not report the selected endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume behavior when reconnecting a compatible endpoint during messaging setup.
  * Ensures the connection route is refreshed in cases where messaging is active, while preserving the existing shortcut when no messaging channels are selected.
  * Uses hydrated credentials when available to keep resume behavior consistent across environments.
  * Added clearer logging for the refresh flow during resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->