### PR TITLE
fix(agent): clean up alias follow-up findings

### DIFF
--- a/src/lib/agent/defs.ts
+++ b/src/lib/agent/defs.ts
@@ -9,7 +9,6 @@ import path from "node:path";
 import { DASHBOARD_PORT } from "../core/ports";
 import { ROOT } from "../runner";
 import {
-  agentAliasSummary,
   formatAgentAliasSuffix,
   resolveAgentNameAlias as resolveKnownAgentNameAlias,
 } from "./aliases";

--- a/test/install-agent-alias-parity.test.ts
+++ b/test/install-agent-alias-parity.test.ts
@@ -6,25 +6,25 @@ import os from "node:os";
 
 import { describe, expect, it } from "vitest";
 
+import { AGENT_ALIASES } from "../dist/lib/agent/aliases";
 import { resolveAgentNameAlias } from "../dist/lib/agent/defs";
 import { INSTALLER_PAYLOAD, TEST_SYSTEM_PATH } from "./helpers/installer-sourced-env";
 
 const AVAILABLE_AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"];
-const ALIAS_CASES = [
+const CANONICAL_CASES = [
   ["openclaw", "openclaw"],
-  ["nemoclaw", "openclaw"],
   ["hermes", "hermes"],
-  ["nemohermes", "hermes"],
   ["langchain-deepagents-code", "langchain-deepagents-code"],
-  ["nemo-deepagents", "langchain-deepagents-code"],
+] as const;
+const NORMALIZATION_CASES = [
   ["NEMO_DEEPAGENTS", "langchain-deepagents-code"],
-  ["dcode", "langchain-deepagents-code"],
-  ["deepagents", "langchain-deepagents-code"],
   ["Deep Agents", "langchain-deepagents-code"],
-  ["deepagents-code", "langchain-deepagents-code"],
-  ["deepagentscode", "langchain-deepagents-code"],
-  ["langchain", "langchain-deepagents-code"],
   ["LANGCHAIN", "langchain-deepagents-code"],
+] as const;
+const ALIAS_CASES = [
+  ...CANONICAL_CASES,
+  ...Object.entries(AGENT_ALIASES),
+  ...NORMALIZATION_CASES,
 ] as const;
 
 function installerCanonicalAgentName(input: string): string {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Follow-up to #5881 that addresses automated review feedback after the Deep Agents alias PR merged.
It removes an unused alias import and expands installer/TypeScript alias parity coverage so every exported alias key is checked.

## Changes
- Removed the unused `agentAliasSummary` named import from `src/lib/agent/defs.ts`.
- Changed `test/install-agent-alias-parity.test.ts` to derive parity cases from exported `AGENT_ALIASES` rather than a hand-picked subset.
- Kept normalization-only cases for uppercase, underscore, and spaced alias inputs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: follow-up only changes an unused import and test coverage.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification commands run:
- `npm run build:cli`
- `npx vitest run test/install-agent-alias-parity.test.ts src/lib/agent/defs.test.ts --reporter=dot`
- `npm run typecheck:cli`
- Commit and push hooks passed.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved alias coverage by generating test cases dynamically, helping ensure agent name matching stays consistent across more inputs.
* **Chores**
  * Cleaned up internal module imports without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->