### PR TITLE
docs(policy): clarify network request approval flow

### DIFF
--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -14,6 +14,8 @@ skill:
 Review network requests that the agent makes to endpoints that are not listed in the sandbox policy.
 OpenShell intercepts those requests and presents them in the TUI for operator approval.
 
+<Steps toc={true}>
+
 ## Prerequisites
 
 - A running NemoClaw sandbox.
@@ -82,29 +84,41 @@ They are not persisted to the baseline policy file.
 To keep an endpoint allowed for future sandbox instances, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](customize-network-policy).
 Rejected rules stay blocked unless you later approve the same rule or add a matching endpoint to the policy.
 
-## Run the Walkthrough
+## Run the Walkthrough Script
 
 The walkthrough script is available in the NemoClaw repository at [`scripts/walkthrough.sh`](https://github.com/NVIDIA/NemoClaw/blob/main/scripts/walkthrough.sh).
-If you installed NemoClaw with the public installer, download only that script before running it.
+It requires a cloned NemoClaw source checkout on the host where the sandbox is running.
 
-<Download
-  sources={[
-    "https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/walkthrough.sh",
-  ]}
-  filename="nemoclaw-walkthrough.sh"
->
-  <Button icon="download">Download walkthrough script</Button>
-</Download>
+<Steps>
+  <Step>
+    If the sandbox runs on a remote host, SSH to that host before you clone the repository and run the script.
+  </Step>
+  <Step>
+    Clone the NemoClaw repository on the host where the sandbox is running.
+    Do this even if you installed NemoClaw with the public installer, because the walkthrough script is a source-checkout helper.
 
-Run the walkthrough script after you onboard at least one sandbox and confirm that it is reachable.
+    ```bash
+    git clone https://github.com/NVIDIA/NemoClaw.git ~/nemoclaw
+    cd ~/nemoclaw
+    ```
+  </Step>
+  <Step>
+    Onboard at least one sandbox and confirm that it is attached to the active gateway.
+  </Step>
+  <Step>
+    Run the walkthrough script from the NemoClaw repository root.
 
-```bash
-bash nemoclaw-walkthrough.sh
-```
+    ```bash
+    ./scripts/walkthrough.sh
+    ```
+  </Step>
+</Steps>
 
 The script opens a split tmux session with the TUI on the left and the agent on the right.
-The walkthrough requires tmux, the `NVIDIA_INFERENCE_API_KEY` environment variable, and at least one onboarded sandbox attached to the active gateway.
+The walkthrough requires `tmux`, the `NVIDIA_INFERENCE_API_KEY` environment variable, and at least one onboarded sandbox attached to the active gateway.
 It attaches to an existing sandbox.
+
+</Steps>
 
 ## Related Topics
 

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -18,6 +18,7 @@ OpenShell intercepts those requests and presents them in the TUI for operator ap
 
 - A running NemoClaw sandbox.
 - The OpenShell CLI on your `PATH`.
+- Access to the host where the sandbox is running.
 
 ## Open the TUI
 
@@ -47,6 +48,7 @@ openshell term
 </Tabs>
 
 The TUI shows the sandbox state, active inference provider, and live network activity.
+From the dashboard, select the running sandbox with `j` or `k`, then press `Enter` to open the sandbox view.
 
 ## Trigger a Blocked Request
 
@@ -59,25 +61,37 @@ The blocked request includes the following details:
 
 ## Approve or Deny the Request
 
-The TUI shows an approval prompt for each blocked request.
+Blocked requests appear as pending entries in the sandbox view's `Network Rules` panel.
+From the sandbox policy view, press `r` to focus `Network Rules`.
+Use `j` or `k` to select a pending rule, and press `Enter` to inspect its details.
 
-- Select **Approve** to add the endpoint to the running policy for the current session.
-- Select **Deny** to keep the endpoint blocked.
+- Press `a` to approve the selected pending rule and add the endpoint to the running policy for the current session.
+- Press `x` to reject the selected pending rule and keep the endpoint blocked.
+- Press `A` to approve all pending rules, then press `y` or `Enter` at the confirmation prompt.
 
 Approved endpoints remain in the running policy until the sandbox stops.
 They are not persisted to the baseline policy file.
 To keep an endpoint allowed after restart, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](customize-network-policy).
+Rejected rules stay blocked unless you later approve the same rule or add a matching endpoint to the policy.
 
 ## Run the Walkthrough
 
-From the NemoClaw repository root, run the walkthrough script after you onboard at least one sandbox and confirm that it is reachable:
+The walkthrough script is available only in a NemoClaw source checkout.
+If you installed NemoClaw with the public installer, clone the repository before running it.
+
+```bash
+git clone https://github.com/NVIDIA/NemoClaw.git
+cd NemoClaw
+```
+
+From the NemoClaw repository root, run the walkthrough script after you onboard at least one sandbox and confirm that it is reachable.
 
 ```bash
 ./scripts/walkthrough.sh
 ```
 
 The script opens a split tmux session with the TUI on the left and the agent on the right.
-The walkthrough requires tmux and the `NVIDIA_INFERENCE_API_KEY` environment variable.
+The walkthrough requires tmux, the `NVIDIA_INFERENCE_API_KEY` environment variable, and at least one onboarded sandbox attached to the active gateway.
 It attaches to an existing sandbox.
 
 ## Related Topics

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -35,7 +35,13 @@ openshell term
 <Tab title="Remote Sandbox">
 
 Connect to the remote host first.
-Use a host that resolves from your terminal, such as a Brev SSH alias or `user@host`.
+Replace `<your-sandbox-host>` with the SSH host or alias where your NemoClaw sandbox is running.
+Use a host that resolves from your terminal, such as a Brev SSH alias.
+
+```bash
+ssh <your-sandbox-host>
+```
+
 Then run the TUI from the NemoClaw directory on that host.
 
 ```bash
@@ -62,16 +68,18 @@ The blocked request includes the following details:
 ## Approve or Deny the Request
 
 Blocked requests appear as pending entries in the sandbox view's `Network Rules` panel.
-From the sandbox policy view, press `r` to focus `Network Rules`.
+After the sandbox opens, the TUI focuses the sandbox policy view.
+Press `r` to focus `Network Rules`.
 Use `j` or `k` to select a pending rule, and press `Enter` to inspect its details.
 
 - Press `a` to approve the selected pending rule and add the endpoint to the running policy for the current session.
 - Press `x` to reject the selected pending rule and keep the endpoint blocked.
 - Press `A` to approve all pending rules, then press `y` or `Enter` at the confirmation prompt.
 
-Approved endpoints remain in the running policy until the sandbox stops.
+Approved endpoints remain in the running policy for the sandbox instance.
+They reset to the baseline when you destroy and recreate the sandbox.
 They are not persisted to the baseline policy file.
-To keep an endpoint allowed after restart, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](customize-network-policy).
+To keep an endpoint allowed for future sandbox instances, update the policy YAML or apply a preset as described in [Customize the Sandbox Network Policy](customize-network-policy).
 Rejected rules stay blocked unless you later approve the same rule or add a matching endpoint to the policy.
 
 ## Run the Walkthrough
@@ -80,8 +88,8 @@ The walkthrough script is available only in a NemoClaw source checkout.
 If you installed NemoClaw with the public installer, clone the repository before running it.
 
 ```bash
-git clone https://github.com/NVIDIA/NemoClaw.git
-cd NemoClaw
+git clone https://github.com/NVIDIA/NemoClaw.git ~/nemoclaw
+cd ~/nemoclaw
 ```
 
 From the NemoClaw repository root, run the walkthrough script after you onboard at least one sandbox and confirm that it is reachable.

--- a/docs/network-policy/approve-network-requests.mdx
+++ b/docs/network-policy/approve-network-requests.mdx
@@ -84,18 +84,22 @@ Rejected rules stay blocked unless you later approve the same rule or add a matc
 
 ## Run the Walkthrough
 
-The walkthrough script is available only in a NemoClaw source checkout.
-If you installed NemoClaw with the public installer, clone the repository before running it.
+The walkthrough script is available in the NemoClaw repository at [`scripts/walkthrough.sh`](https://github.com/NVIDIA/NemoClaw/blob/main/scripts/walkthrough.sh).
+If you installed NemoClaw with the public installer, download only that script before running it.
+
+<Download
+  sources={[
+    "https://raw.githubusercontent.com/NVIDIA/NemoClaw/main/scripts/walkthrough.sh",
+  ]}
+  filename="nemoclaw-walkthrough.sh"
+>
+  <Button icon="download">Download walkthrough script</Button>
+</Download>
+
+Run the walkthrough script after you onboard at least one sandbox and confirm that it is reachable.
 
 ```bash
-git clone https://github.com/NVIDIA/NemoClaw.git ~/nemoclaw
-cd ~/nemoclaw
-```
-
-From the NemoClaw repository root, run the walkthrough script after you onboard at least one sandbox and confirm that it is reachable.
-
-```bash
-./scripts/walkthrough.sh
+bash nemoclaw-walkthrough.sh
 ```
 
 The script opens a split tmux session with the TUI on the left and the agent on the right.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Clarifies how operators find and act on blocked network requests in the OpenShell TUI.
This updates the how-to with the sandbox selection flow, `Network Rules` keybindings, remote-host expectations, and source-checkout prerequisites for the walkthrough.

## Related Issue
Fixes #5082

## Changes
- Documented selecting a sandbox from the TUI dashboard and opening the `Network Rules` panel.
- Added the `a`, `x`, and `A` approval and rejection keybindings, including the approve-all confirmation prompt.
- Clarified that the walkthrough script requires a NemoClaw source checkout, tmux, `NVIDIA_INFERENCE_API_KEY`, and an onboarded sandbox.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only how-to update with no runtime behavior changes.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: docs-only network-policy guidance; no runtime policy, credential, sandbox, or security enforcement code changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification notes:
- `npm run docs` passed with 0 errors; Fern reported 1 hidden warning plus an upgrade notice, so the "without warnings" checkbox is intentionally unchecked.
- The OpenShell TUI keybindings were checked against `crates/openshell-tui/src/app.rs` and `crates/openshell-tui/src/ui/sandbox_draft.rs` in the sibling OpenShell checkout.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified prerequisites for accessing the OpenShell TUI on the host running the NemoClaw sandbox, including explicit access requirements.
  * Improved the “Open the TUI” remote workflow with SSH host/alias placeholders and added guidance for locating the active sandbox in the dashboard (select with `j/k`, open with `Enter`).
  * Rewrote the approval walkthrough to manage pending entries in the `Network Rules` panel (focus `r`, inspect `Enter`, approve/reject selected, and bulk-approve with confirmation).
  * Updated walkthrough script setup to clone on the sandbox host (after SSH if needed) and run `./scripts/walkthrough.sh`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->