### PR TITLE
fix(e2e): route gateway guard through hosted inference

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -4346,6 +4346,7 @@ jobs:
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/gateway-guard-recovery
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_E2E_SCENARIOS: "1"
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       # nemoclaw onboard registers the gateway under the canonical name

--- a/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
@@ -637,6 +637,16 @@ describe("e2e-vitest-scenarios workflow boundary", () => {
     },
   );
 
+  it("keeps gateway guard recovery on the hosted-compatible CI inference route", () => {
+    const workflow = readWorkflow();
+    const jobs = workflow.jobs as Record<string, { env?: Record<string, string> }>;
+
+    expect(jobs["gateway-guard-recovery"]?.env).toMatchObject({
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1",
+      NEMOCLAW_RUN_E2E_SCENARIOS: "1",
+    });
+  });
+
   it("derives the free-standing inventory from workflow job metadata", { timeout: 60_000 }, () => {
     const inventory = readFreeStandingJobsInventory();
     expect(validateFreeStandingWorkflowInventory()).toEqual([]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Routes the free-standing `gateway-guard-recovery` Vitest E2E job through the same hosted-compatible inference mode as the other OpenClaw live Vitest jobs. The targeted rerun after #5887 showed the job still selected the public NVIDIA provider and failed early because the CI secret is not `nvapi-*`.

## Changes
- Adds `NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1` to the `gateway-guard-recovery` job environment in `.github/workflows/e2e-vitest-scenarios.yaml`.
- Adds a workflow boundary test to keep that job on the hosted-compatible route.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: CI/E2E workflow routing only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; change passes only the CI mode flag, not credentials, and keeps the secret on the existing step-level boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
npm test -- --run test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
npm run build:cli
npm run typecheck:cli
```

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end workflow check to ensure the relevant Vitest scenario job includes the expected runtime settings.

* **Chores**
  * Updated the workflow configuration for the recovery scenario to run with hosted inference enabled alongside the existing scenario flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->