### PR TITLE
fix(e2e): route gateway guard through hosted inference

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -4346,6 +4346,7 @@ jobs:
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/vitest/gateway-guard-recovery
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_E2E_SCENARIOS: "1"
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       # nemoclaw onboard registers the gateway under the canonical name

--- a/test/e2e-scenario/support-tests/gateway-guard-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/gateway-guard-workflow-boundary.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { validateE2eVitestScenariosWorkflowBoundary } from "../../../tools/e2e-scenarios/workflow-boundary.mts";
+
+describe("gateway guard workflow boundary", () => {
+  it("rejects missing hosted-compatible inference mode", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(".github/workflows/e2e-vitest-scenarios.yaml", "utf8"),
+    );
+    delete workflow.jobs["gateway-guard-recovery"].env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-gateway-guard-workflow-"));
+    const workflowPath = path.join(tmp, "workflow.yaml");
+    try {
+      fs.writeFileSync(workflowPath, YAML.stringify(workflow));
+      expect(validateE2eVitestScenariosWorkflowBoundary(workflowPath)).toContain(
+        "gateway-guard-recovery job must enable hosted-compatible inference mode",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -484,6 +484,15 @@ function validateFreeStandingJobSelector(
   }
 }
 
+function validateGatewayGuardRecoveryVitestJob(errors: string[], jobs: WorkflowRecord): void {
+  const job = asRecord(jobs["gateway-guard-recovery"]);
+  if (Object.keys(job).length === 0) return;
+  const jobEnv = asRecord(job.env);
+  if (jobEnv.NEMOCLAW_E2E_USE_HOSTED_INFERENCE !== "1") {
+    errors.push("gateway-guard-recovery job must enable hosted-compatible inference mode");
+  }
+}
+
 function validateFreeStandingInventoryBoundary(
   errors: string[],
   jobs: WorkflowRecord,
@@ -7757,6 +7766,7 @@ export function validateE2eVitestScenariosWorkflowBoundary(
     "openclaw-tui-chat-correlation",
   );
   validateFreeStandingJobSelector(errors, jobs, "gateway-guard-recovery");
+  validateGatewayGuardRecoveryVitestJob(errors, jobs);
   validateFreeStandingJobSelector(
     errors,
     jobs,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Routes the free-standing `gateway-guard-recovery` Vitest E2E job through hosted-compatible inference. The targeted rerun after #5887 showed the job still selected the public NVIDIA provider and failed early because the CI secret is not `nvapi-*`.

## Changes
- Adds `NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1` to the `gateway-guard-recovery` job environment in `.github/workflows/e2e-vitest-scenarios.yaml`.
- Extends the workflow boundary validator so this routing cannot drift again.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: CI/E2E workflow routing only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; change passes only the CI mode flag, not credentials, and keeps the secret on the existing step-level boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
npm test -- --run test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
npm run source-shape:check
npm run test-size:check
npm run build:cli
npm run typecheck:cli
```

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end workflow consistency for the gateway guard recovery scenario by ensuring the hosted inference setting is enabled.
  * Added workflow boundary validation to detect and report misconfigured scenario runs earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->