### PR TITLE
fix(e2e): use hosted env in Vitest helper lanes

### DIFF
--- a/test/e2e-scenario/live/sessions-agents-cli.test.ts
+++ b/test/e2e-scenario/live/sessions-agents-cli.test.ts
@@ -20,6 +20,7 @@ import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { parseJsonFromText } from "./json-envelope.ts";
@@ -49,6 +50,8 @@ type CommandOptions = {
   redactionValues?: string[];
 };
 
+type HostedInferenceConfig = ReturnType<typeof requireHostedInferenceConfig>;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -61,7 +64,6 @@ function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_AGENT: "openclaw",
-    NEMOCLAW_PROVIDER: "cloud",
     NEMOCLAW_POLICY_TIER: "open",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
     OPENSHELL_GATEWAY: process.env.OPENSHELL_GATEWAY ?? "nemoclaw",
@@ -81,16 +83,16 @@ async function bestEffort(run: () => Promise<unknown>): Promise<void> {
 async function runNemoclaw(
   host: HostCliClient,
   args: string[],
-  apiKey: string,
+  hosted: HostedInferenceConfig,
   options: CommandOptions,
 ): Promise<ShellProbeResult> {
   return await host.command("node", [CLI_ENTRYPOINT, ...args], {
     artifactName: options.artifactName,
     env: commandEnv({
-      NVIDIA_INFERENCE_API_KEY: apiKey,
+      ...hosted.env,
       ...(options.env ?? {}),
     }),
-    redactionValues: [apiKey, ...(options.redactionValues ?? [])],
+    redactionValues: [hosted.apiKey, ...(options.redactionValues ?? [])],
     timeoutMs: options.timeoutMs ?? GATEWAY_RPC_TIMEOUT_MS,
   });
 }
@@ -134,10 +136,10 @@ async function ensureOpenshellAvailable(host: HostCliClient): Promise<void> {
   ).toBe(0);
 }
 
-async function cleanupSandbox(host: HostCliClient, apiKey: string): Promise<void> {
+async function cleanupSandbox(host: HostCliClient, hosted: HostedInferenceConfig): Promise<void> {
   if (process.env.NEMOCLAW_E2E_KEEP_SANDBOX === "1") return;
 
-  const destroy = await runNemoclaw(host, [SANDBOX_NAME, "destroy", "--yes"], apiKey, {
+  const destroy = await runNemoclaw(host, [SANDBOX_NAME, "destroy", "--yes"], hosted, {
     artifactName: "cleanup-nemoclaw-destroy-sessions-agents-cli",
     timeoutMs: 5 * 60_000,
   });
@@ -234,14 +236,14 @@ function pendingRequestIds(envelope: unknown): string[] {
 
 async function approvePendingPairingRequests(
   host: HostCliClient,
-  apiKey: string,
+  hosted: HostedInferenceConfig,
   artifactPrefix: string,
 ): Promise<boolean> {
   for (let attempt = 1; attempt <= 10; attempt += 1) {
     const state = await runNemoclaw(
       host,
       [SANDBOX_NAME, "exec", "--", "openclaw", "devices", "list", "--json"],
-      apiKey,
+      hosted,
       {
         artifactName: `${artifactPrefix}-devices-list-${attempt}`,
         timeoutMs: 60_000,
@@ -265,7 +267,7 @@ async function approvePendingPairingRequests(
       await runNemoclaw(
         host,
         [SANDBOX_NAME, "exec", "--", "openclaw", "devices", "approve", id, "--json"],
-        apiKey,
+        hosted,
         {
           artifactName: `${artifactPrefix}-devices-approve-${id}`,
           timeoutMs: 60_000,
@@ -280,18 +282,18 @@ async function approvePendingPairingRequests(
 async function runGatewayRpcWithScopeRetry(
   host: HostCliClient,
   args: string[],
-  apiKey: string,
+  hosted: HostedInferenceConfig,
   artifactName: string,
 ): Promise<ShellProbeResult> {
   let lastResult: ShellProbeResult | undefined;
   for (let attempt = 1; attempt <= SCOPE_RETRY_ATTEMPTS; attempt += 1) {
-    lastResult = await runNemoclaw(host, args, apiKey, {
+    lastResult = await runNemoclaw(host, args, hosted, {
       artifactName: `${artifactName}-attempt-${attempt}`,
       timeoutMs: GATEWAY_RPC_TIMEOUT_MS,
     });
     if (lastResult.exitCode === 0) return lastResult;
     if (!SCOPE_PENDING_PATTERN.test(resultText(lastResult))) break;
-    await approvePendingPairingRequests(host, apiKey, `${artifactName}-scope-${attempt}`);
+    await approvePendingPairingRequests(host, hosted, `${artifactName}-scope-${attempt}`);
     await sleep(SCOPE_RETRY_DELAY_MS);
   }
   return lastResult!;
@@ -300,10 +302,10 @@ async function runGatewayRpcWithScopeRetry(
 async function expectJsonCommand(
   host: HostCliClient,
   args: string[],
-  apiKey: string,
+  hosted: HostedInferenceConfig,
   artifactName: string,
 ): Promise<unknown> {
-  const result = await runNemoclaw(host, args, apiKey, { artifactName });
+  const result = await runNemoclaw(host, args, hosted, { artifactName });
   expect(result.exitCode, `${args.join(" ")} failed\n${resultText(result)}`).toBe(0);
   return parseJsonEnvelope(result, args.join(" "));
 }
@@ -347,18 +349,18 @@ runSessionsAgentsCliTest(
       `Docker is required for sessions/agents E2E\n${resultText(docker)}`,
     ).toBe(0);
 
-    const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
+    const hosted = requireHostedInferenceConfig(secrets);
     await ensureOpenshellAvailable(host);
     cleanup.add(`destroy sessions/agents sandbox ${SANDBOX_NAME}`, async () =>
-      bestEffort(() => cleanupSandbox(host, apiKey)),
+      bestEffort(() => cleanupSandbox(host, hosted)),
     );
-    await cleanupSandbox(host, apiKey);
+    await cleanupSandbox(host, hosted);
     fs.rmSync(path.join(process.env.HOME ?? "", ".nemoclaw", "onboard.lock"), { force: true });
 
     const onboard = await runNemoclaw(
       host,
       ["onboard", "--non-interactive", "--yes-i-accept-third-party-software"],
-      apiKey,
+      hosted,
       {
         artifactName: "onboard-sessions-agents-cli",
         timeoutMs: ONBOARD_TIMEOUT_MS,
@@ -378,12 +380,12 @@ runSessionsAgentsCliTest(
     }
     expect(onboard.exitCode, `onboard failed\n${resultText(onboard)}`).toBe(0);
 
-    await approvePendingPairingRequests(host, apiKey, "post-onboard-scope");
+    await approvePendingPairingRequests(host, hosted, "post-onboard-scope");
 
     const mainSeed = await runNemoclaw(
       host,
       [SANDBOX_NAME, "exec", "--", "openclaw", "agent", "--agent", "main", "-m", "ping"],
-      apiKey,
+      hosted,
       {
         artifactName: "seed-main-session",
         timeoutMs: AGENT_TURN_TIMEOUT_MS,
@@ -391,24 +393,24 @@ runSessionsAgentsCliTest(
     );
 
     if (mainSeed.exitCode === 0) {
-      await approvePendingPairingRequests(host, apiKey, "post-main-seed-scope");
+      await approvePendingPairingRequests(host, hosted, "post-main-seed-scope");
       await expectJsonCommand(
         host,
         [SANDBOX_NAME, "sessions", "--json"],
-        apiKey,
+        hosted,
         "tc-sess-01-sessions-default-json",
       );
       await expectJsonCommand(
         host,
         [SANDBOX_NAME, "sessions", "list", "--json"],
-        apiKey,
+        hosted,
         "tc-sess-02-sessions-list-json",
       );
 
       const reset = await runGatewayRpcWithScopeRetry(
         host,
         [SANDBOX_NAME, "sessions", "reset", "agent:main:main", "--json"],
-        apiKey,
+        hosted,
         "tc-sess-03-sessions-reset-main-json",
       );
       expect(reset.exitCode, `sessions reset failed\n${resultText(reset)}`).toBe(0);
@@ -420,7 +422,7 @@ runSessionsAgentsCliTest(
       await expectJsonCommand(
         host,
         [SANDBOX_NAME, "sessions", "list", "--json"],
-        apiKey,
+        hosted,
         "tc-sess-04-sessions-list-after-reset-json",
       );
     } else {
@@ -442,7 +444,7 @@ runSessionsAgentsCliTest(
         `/sandbox/.openclaw/workspace-${TEST_AGENT_ID}`,
         "--non-interactive",
       ],
-      apiKey,
+      hosted,
       {
         artifactName: "tc-agent-01-agents-add-passthrough",
         timeoutMs: 120_000,
@@ -453,14 +455,14 @@ runSessionsAgentsCliTest(
     await expectJsonCommand(
       host,
       [SANDBOX_NAME, "sessions", "list", "--agent", TEST_AGENT_ID, "--json"],
-      apiKey,
+      hosted,
       "tc-agent-01-sessions-list-agent-after-add-json",
     );
 
     const agentsList = await expectJsonCommand(
       host,
       [SANDBOX_NAME, "agents", "list", "--json"],
-      apiKey,
+      hosted,
       "tc-agent-03-agents-list-json",
     );
     expect(
@@ -471,7 +473,7 @@ runSessionsAgentsCliTest(
     const workSeed = await runNemoclaw(
       host,
       [SANDBOX_NAME, "exec", "--", "openclaw", "agent", "--agent", TEST_AGENT_ID, "-m", "ping"],
-      apiKey,
+      hosted,
       {
         artifactName: "seed-work-agent-session",
         timeoutMs: AGENT_TURN_TIMEOUT_MS,
@@ -479,11 +481,11 @@ runSessionsAgentsCliTest(
     );
     expect(workSeed.exitCode, `work-agent seed failed\n${resultText(workSeed)}`).toBe(0);
 
-    await approvePendingPairingRequests(host, apiKey, "post-work-seed-scope");
+    await approvePendingPairingRequests(host, hosted, "post-work-seed-scope");
     const workSessions = await expectJsonCommand(
       host,
       [SANDBOX_NAME, "sessions", "list", "--agent", TEST_AGENT_ID, "--json"],
-      apiKey,
+      hosted,
       "tc-sess-05-work-agent-sessions-json",
     );
     const sessionKey = firstSessionKey(workSessions);
@@ -495,7 +497,7 @@ runSessionsAgentsCliTest(
     const deleteSession = await runGatewayRpcWithScopeRetry(
       host,
       [SANDBOX_NAME, "sessions", "delete", sessionKey!, "--json"],
-      apiKey,
+      hosted,
       "tc-sess-05-sessions-delete-json",
     );
     expect(deleteSession.exitCode, `sessions delete failed\n${resultText(deleteSession)}`).toBe(0);
@@ -507,7 +509,7 @@ runSessionsAgentsCliTest(
     const workSessionsAfterDelete = await expectJsonCommand(
       host,
       [SANDBOX_NAME, "sessions", "list", "--agent", TEST_AGENT_ID, "--json"],
-      apiKey,
+      hosted,
       "tc-sess-05-work-agent-sessions-after-delete-json",
     );
     expect(
@@ -518,7 +520,7 @@ runSessionsAgentsCliTest(
     const deleteAgent = await runNemoclaw(
       host,
       [SANDBOX_NAME, "agents", "delete", TEST_AGENT_ID, "--force", "--json"],
-      apiKey,
+      hosted,
       {
         artifactName: "tc-agent-02-agents-delete-json",
         timeoutMs: 120_000,
@@ -529,7 +531,7 @@ runSessionsAgentsCliTest(
     const agentsAfterDelete = await expectJsonCommand(
       host,
       [SANDBOX_NAME, "agents", "list", "--json"],
-      apiKey,
+      hosted,
       "tc-agent-02-agents-list-after-delete-json",
     );
     expect(

--- a/test/e2e-scenario/live/spark-install.test.ts
+++ b/test/e2e-scenario/live/spark-install.test.ts
@@ -10,6 +10,7 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import {
   shouldRunInstallerIntegration,
   shouldRunLiveE2EScenarios,
@@ -47,7 +48,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     NEMOCLAW_FRESH: "1",
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-    NEMOCLAW_PROVIDER: "cloud",
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
@@ -112,8 +112,8 @@ liveTest(
 
     assertRequiredInstallerEnv(process.env);
 
-    const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
-    const redactionValues = [apiKey];
+    const hosted = requireHostedInferenceConfig(secrets);
+    const redactionValues = [hosted.apiKey];
     cleanup.add(`remove ${SANDBOX_NAME} after Spark install smoke`, () => bestEffortCleanup(host));
     await bestEffortCleanup(host);
 
@@ -140,9 +140,7 @@ liveTest(
     const install = await host.command("bash", ["-lc", installer.script], {
       artifactName: `phase-1-${installer.mode}-install`,
       cwd: REPO_ROOT,
-      env: env({
-        NVIDIA_INFERENCE_API_KEY: apiKey,
-      }),
+      env: env(hosted.env),
       redactionValues,
       timeoutMs: INSTALL_TIMEOUT_MS,
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes two live Vitest helper lanes that still forced public NVIDIA `cloud` provider onboarding after #5890 enabled hosted-compatible workflow routing. `sessions-agents-cli` and `spark-install` now pass the shared hosted-compatible inference env into their NemoClaw/install invocations.

## Changes
- Updates `sessions-agents-cli.test.ts` to use `requireHostedInferenceConfig()` for NemoClaw commands and cleanup instead of manually passing only `NVIDIA_INFERENCE_API_KEY` with `NEMOCLAW_PROVIDER=cloud`.
- Updates `spark-install.test.ts` to use the hosted-compatible env for the installer invocation and stop forcing `NEMOCLAW_PROVIDER=cloud`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: targeted Vitest/support tests verify hosted inference env construction and affected helper modules type-check.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; change routes existing test secrets through the already established hosted-compatible fixture env without broadening secret scope.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
npm test -- --run test/e2e-scenario/live/sessions-agents-cli.test.ts test/e2e-scenario/live/spark-install.test.ts test/e2e-scenario/support-tests/hosted-inference.test.ts test/e2e-scenario/support-tests/spark-install-helpers.test.ts
npm run typecheck:cli
```

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hosted inference settings in end-to-end flows, helping session, agent, and installer scenarios run with the correct environment and redaction behavior.
  * Reduced the chance of setup issues by standardizing how hosted inference configuration is applied during command execution.

* **Tests**
  * Updated automated scenario coverage to reflect the new hosted inference configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->