### PR TITLE
fix(e2e): use hosted validation models in Vitest lanes

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -1719,7 +1719,6 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_RECREATE_SANDBOX: "1"
       NEMOCLAW_SANDBOX_NAME: e2e-hermes
-      NEMOCLAW_MODEL: minimaxai/minimax-m2.7
       NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS: "60"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/test/e2e-scenario/live/cron-preflight-inference-local.test.ts
+++ b/test/e2e-scenario/live/cron-preflight-inference-local.test.ts
@@ -18,14 +18,17 @@ import { resultText } from "../fixtures/clients/index.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
-import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+import {
+  DEFAULT_HOSTED_INFERENCE_MODEL,
+  requireHostedInferenceConfig,
+} from "../fixtures/hosted-inference.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-cron-preflight";
 validateSandboxName(SANDBOX_NAME);
-const MODEL = process.env.NEMOCLAW_CRON_PREFLIGHT_MODEL ?? "nvidia/nemotron-3-super-120b-a12b";
+const MODEL = process.env.NEMOCLAW_CRON_PREFLIGHT_MODEL ?? DEFAULT_HOSTED_INFERENCE_MODEL;
 const INSTALL_ATTEMPTS = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true" ? 3 : 1;
 const LIVE_TIMEOUT_MS = 35 * 60_000;
 const PROBE_SOURCE = String.raw`

--- a/test/e2e-scenario/live/diagnostics.test.ts
+++ b/test/e2e-scenario/live/diagnostics.test.ts
@@ -18,17 +18,13 @@ import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
-import {
-  DEFAULT_HOSTED_INFERENCE_MODEL,
-  requireHostedInferenceConfig,
-} from "../fixtures/hosted-inference.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
 const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? `e2e-diag-${process.pid}`;
-const DIAGNOSTICS_MODEL = process.env.NEMOCLAW_MODEL ?? DEFAULT_HOSTED_INFERENCE_MODEL;
 const DEBUG_QUICK_TIMEOUT_MS = 30_000;
 const INSTALL_TIMEOUT_MS = 35 * 60_000;
 const TEST_TIMEOUT_MS = 55 * 60_000;
@@ -88,7 +84,6 @@ function testEnv(home: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-    NEMOCLAW_MODEL: DIAGNOSTICS_MODEL,
     NEMOCLAW_DISABLE_GATEWAY_DRIFT_PREFLIGHT: "1",
     OPENSHELL_GATEWAY: process.env.OPENSHELL_GATEWAY ?? "nemoclaw",
     ...extra,
@@ -142,7 +137,7 @@ runDiagnosticsTest(
       "run `npm run build:cli` before live repo CLI scenarios",
     ).toBe(true);
 
-    const hosted = requireHostedInferenceConfig(secrets, process.env, { model: DIAGNOSTICS_MODEL });
+    const hosted = requireHostedInferenceConfig(secrets);
     const apiKey = hosted.apiKey;
     await artifacts.writeJson("scenario.json", {
       id: "diagnostics",
@@ -422,7 +417,7 @@ runDiagnosticsTest(
     await artifacts.writeJson("scenario-result.json", {
       id: "diagnostics",
       sandboxName: SANDBOX_NAME,
-      model: DIAGNOSTICS_MODEL,
+      model: hosted.model,
       assertions: {
         versionPrintedSemver: /\d+\.\d+\.\d+/.test(resultText(version)),
         quickDebugArchiveCreated: fs.existsSync(quickArchive) && fs.statSync(quickArchive).size > 0,

--- a/test/e2e-scenario/live/diagnostics.test.ts
+++ b/test/e2e-scenario/live/diagnostics.test.ts
@@ -18,13 +18,17 @@ import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import {
+  DEFAULT_HOSTED_INFERENCE_MODEL,
+  requireHostedInferenceConfig,
+} from "../fixtures/hosted-inference.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
 const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? `e2e-diag-${process.pid}`;
-const DIAGNOSTICS_MODEL = process.env.NEMOCLAW_MODEL ?? "openai/gpt-oss-120b";
+const DIAGNOSTICS_MODEL = process.env.NEMOCLAW_MODEL ?? DEFAULT_HOSTED_INFERENCE_MODEL;
 const DEBUG_QUICK_TIMEOUT_MS = 30_000;
 const INSTALL_TIMEOUT_MS = 35 * 60_000;
 const TEST_TIMEOUT_MS = 55 * 60_000;
@@ -138,7 +142,8 @@ runDiagnosticsTest(
       "run `npm run build:cli` before live repo CLI scenarios",
     ).toBe(true);
 
-    const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
+    const hosted = requireHostedInferenceConfig(secrets, process.env, { model: DIAGNOSTICS_MODEL });
+    const apiKey = hosted.apiKey;
     await artifacts.writeJson("scenario.json", {
       id: "diagnostics",
       runner: "vitest",
@@ -195,7 +200,7 @@ runDiagnosticsTest(
       fs.rmSync(home, { recursive: true, force: true });
     });
 
-    const env = testEnv(home, { NVIDIA_INFERENCE_API_KEY: apiKey });
+    const env = testEnv(home, hosted.env);
     await bestEffort(() =>
       host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "destroy", "--yes"], {
         artifactName: "pre-cleanup-nemoclaw-destroy-diagnostics",

--- a/test/e2e-scenario/live/hermes-e2e.test.ts
+++ b/test/e2e-scenario/live/hermes-e2e.test.ts
@@ -99,9 +99,9 @@ function commandEnv(hostedEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return env;
 }
 
-function chatPayload(prompt: string, maxTokens = 256): string {
+function chatPayload(model: string, prompt: string, maxTokens = 256): string {
   return JSON.stringify({
-    model: CHAT_MODEL,
+    model,
     messages: [{ role: "user", content: prompt }],
     max_tokens: maxTokens,
   });
@@ -494,7 +494,11 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
           }),
           {
             artifactName: `phase-5-direct-nvidia-chat-attempt-${attempt}`,
-            body: chatPayload("Reply with exactly one word: PONG", attempt === 1 ? 256 : 1024),
+            body: chatPayload(
+              hosted.model,
+              "Reply with exactly one word: PONG",
+              attempt === 1 ? 256 : 1024,
+            ),
             curlMaxTimeSeconds: 90,
             headers: ["Content-Type: application/json", `Authorization: Bearer ${apiKey}`],
             env: buildAvailabilityProbeEnv(),
@@ -523,7 +527,11 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
             "-H",
             "Content-Type: application/json",
             "--data-raw",
-            chatPayload("Reply with exactly one word: PONG", attempt === 1 ? 256 : 1024),
+            chatPayload(
+              hosted.model,
+              "Reply with exactly one word: PONG",
+              attempt === 1 ? 256 : 1024,
+            ),
             "https://inference.local/v1/chat/completions",
           ],
           {

--- a/test/e2e-scenario/live/hermes-e2e.test.ts
+++ b/test/e2e-scenario/live/hermes-e2e.test.ts
@@ -11,7 +11,10 @@ import { trustedProviderEndpoint } from "../fixtures/clients/provider.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
-import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+import {
+  DEFAULT_HOSTED_INFERENCE_MODEL,
+  requireHostedInferenceConfig,
+} from "../fixtures/hosted-inference.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 // Migrated from test/e2e/test-hermes-e2e.sh.
@@ -33,7 +36,7 @@ const HERMES_DASHBOARD_INTERNAL_PORT =
 const SESSION_FILE = path.join(os.homedir(), ".nemoclaw", "onboard-session.json");
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const LIVE_TIMEOUT_MS = 70 * 60_000;
-const CHAT_MODEL = process.env.NEMOCLAW_MODEL ?? "nvidia/nemotron-3-super-120b-a12b";
+const CHAT_MODEL = process.env.NEMOCLAW_MODEL ?? DEFAULT_HOSTED_INFERENCE_MODEL;
 const ONBOARD_VALIDATION_TIMEOUT_SECONDS =
   process.env.NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS ?? "60";
 
@@ -65,18 +68,18 @@ function hermesDashboardE2eEnabled(): boolean {
   );
 }
 
-function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
+function commandEnv(hostedEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...buildAvailabilityProbeEnv(),
+    ...hostedEnv,
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_AGENT: "hermes",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_RECREATE_SANDBOX: "1",
-    NEMOCLAW_MODEL: CHAT_MODEL,
+    NEMOCLAW_MODEL: hostedEnv.NEMOCLAW_MODEL ?? CHAT_MODEL,
     NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS: ONBOARD_VALIDATION_TIMEOUT_SECONDS,
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
   };
-  if (apiKey) env.NVIDIA_INFERENCE_API_KEY = apiKey;
   if (process.env.NEMOCLAW_E2E_HERMES_DASHBOARD) {
     env.NEMOCLAW_E2E_HERMES_DASHBOARD = process.env.NEMOCLAW_E2E_HERMES_DASHBOARD;
   }
@@ -232,7 +235,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       dashboardEnabled: hermesDashboardE2eEnabled(),
     });
 
-    const env = commandEnv(apiKey);
+    const env = commandEnv(hosted.env);
     const redactionValues = [apiKey];
 
     const cleanupHermes = async (label: string) => {

--- a/test/e2e-scenario/live/upgrade-stale-sandbox-helpers.ts
+++ b/test/e2e-scenario/live/upgrade-stale-sandbox-helpers.ts
@@ -43,9 +43,10 @@ function assertSafeSandboxName(): void {
   }
 }
 
-export function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {
+export function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
     ...buildAvailabilityProbeEnv(),
+    ...extra,
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_REBUILD_VERBOSE: "1",
@@ -53,8 +54,6 @@ export function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
     OPENSHELL_GATEWAY: process.env.OPENSHELL_GATEWAY ?? "nemoclaw",
   };
-  apiKey && Object.assign(env, { NVIDIA_INFERENCE_API_KEY: apiKey });
-  return env;
 }
 
 export async function bestEffort(run: () => Promise<unknown>): Promise<void> {
@@ -201,7 +200,7 @@ export async function cleanupOldImage(host: HostCliClient): Promise<void> {
 
 export async function installCurrentNemoclaw(
   host: HostCliClient,
-  apiKey: string,
+  hosted: { apiKey: string; env: NodeJS.ProcessEnv },
 ): Promise<ShellProbeResult> {
   let install: ShellProbeResult | undefined;
   for (let attempt = 1; attempt <= INSTALL_ATTEMPTS; attempt += 1) {
@@ -211,8 +210,8 @@ export async function installCurrentNemoclaw(
           ? "phase-1-install-current-nemoclaw"
           : `phase-1-install-current-nemoclaw-attempt-${attempt}`,
       cwd: REPO_ROOT,
-      env: commandEnv(apiKey),
-      redactionValues: [apiKey],
+      env: commandEnv(hosted.env),
+      redactionValues: [hosted.apiKey],
       timeoutMs: 20 * 60_000,
     });
     const retry =

--- a/test/e2e-scenario/live/upgrade-stale-sandbox.test.ts
+++ b/test/e2e-scenario/live/upgrade-stale-sandbox.test.ts
@@ -13,6 +13,7 @@
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/index.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import {
   assertDeleteInstalledSandboxAllowed,
@@ -37,7 +38,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
   "upgrade-sandboxes detects and rebuilds stale OpenClaw sandboxes (#1904)",
   { timeout: LIVE_TIMEOUT_MS },
   async ({ artifacts, cleanup, host, sandbox, secrets, skip }) => {
-    const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
+    const hosted = requireHostedInferenceConfig(secrets);
 
     await artifacts.writeJson("scenario.json", {
       id: "upgrade-stale-sandbox",
@@ -67,7 +68,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
     cleanup.add("remove stale OpenClaw test image", () => cleanupOldImage(host));
     await cleanupStaleSandbox(host, sandbox);
 
-    const install = await installCurrentNemoclaw(host, apiKey);
+    const install = await installCurrentNemoclaw(host, hosted);
     expect(install.exitCode, resultText(install)).toBe(0);
 
     const deleteInstalledSandbox = await sandbox.openshell(["sandbox", "delete", SANDBOX_NAME], {
@@ -119,8 +120,8 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     const staleCheck = await host.nemoclaw(["upgrade-sandboxes", "--check"], {
       artifactName: "phase-5-upgrade-sandboxes-check-stale",
-      env: commandEnv(apiKey),
-      redactionValues: [apiKey],
+      env: commandEnv(hosted.env),
+      redactionValues: [hosted.apiKey],
       timeoutMs: 120_000,
     });
     expect(staleCheck.exitCode, resultText(staleCheck)).toBe(0);
@@ -129,8 +130,8 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     const rebuild = await host.nemoclaw([SANDBOX_NAME, "rebuild", "--yes"], {
       artifactName: "phase-6-rebuild-stale-sandbox",
-      env: commandEnv(apiKey),
-      redactionValues: [apiKey],
+      env: commandEnv(hosted.env),
+      redactionValues: [hosted.apiKey],
       timeoutMs: 25 * 60_000,
     });
     expect(rebuild.exitCode, resultText(rebuild)).toBe(0);
@@ -148,8 +149,8 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
 
     const cleanCheck = await host.nemoclaw(["upgrade-sandboxes", "--check"], {
       artifactName: "phase-7-upgrade-sandboxes-check-clean",
-      env: commandEnv(apiKey),
-      redactionValues: [apiKey],
+      env: commandEnv(hosted.env),
+      redactionValues: [hosted.apiKey],
       timeoutMs: 120_000,
     });
     expect(cleanCheck.exitCode, resultText(cleanCheck)).toBe(0);

--- a/test/e2e-scenario/support-tests/hermes-workflow-boundary.test.ts
+++ b/test/e2e-scenario/support-tests/hermes-workflow-boundary.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { validateE2eVitestScenariosWorkflowBoundary } from "../../../tools/e2e-scenarios/workflow-boundary.mts";
+
+describe("Hermes E2E workflow boundary", () => {
+  it("rejects pinned Hermes Vitest model overrides", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(".github/workflows/e2e-vitest-scenarios.yaml", "utf8"),
+    );
+    workflow.jobs["hermes-e2e-vitest"].env.NEMOCLAW_MODEL = "minimaxai/minimax-m2.7";
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-hermes-workflow-"));
+    const workflowPath = path.join(tmp, "workflow.yaml");
+    try {
+      fs.writeFileSync(workflowPath, YAML.stringify(workflow));
+      expect(validateE2eVitestScenariosWorkflowBoundary(workflowPath)).toContain(
+        "hermes-e2e-vitest job must use the shared hosted-compatible model default",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -3874,8 +3874,8 @@ function validateHermesE2EVitestJob(
   if (jobEnv.NEMOCLAW_AGENT !== "hermes") {
     errors.push("hermes-e2e-vitest job must set NEMOCLAW_AGENT=hermes");
   }
-  if (jobEnv.NEMOCLAW_MODEL !== "minimaxai/minimax-m2.7") {
-    errors.push("hermes-e2e-vitest job must pin the CI-safe Hermes model");
+  if (jobEnv.NEMOCLAW_MODEL !== undefined) {
+    errors.push("hermes-e2e-vitest job must use the shared hosted-compatible model default");
   }
   if (jobEnv.NEMOCLAW_ONBOARD_VALIDATION_TIMEOUT_SECONDS !== "60") {
     errors.push(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes hosted-compatible Vitest lanes that reached the custom provider path but still used public/provider-specific model or env setup, causing hosted endpoint validation to fail with HTTP 401/403. The affected tests now use the shared hosted-compatible model/env plumbing consistently.

## Changes
- Removes the Hermes Vitest workflow override for `NEMOCLAW_MODEL=minimaxai/minimax-m2.7` so hosted-compatible runs use the shared hosted model default.
- Updates Hermes and cron live Vitest tests to default to `DEFAULT_HOSTED_INFERENCE_MODEL`.
- Routes diagnostics and stale-upgrade live Vitest setup through `requireHostedInferenceConfig()` / `hosted.env` instead of manually passing only `NVIDIA_INFERENCE_API_KEY`.
- Updates the workflow boundary validator to require Hermes Vitest to use the shared hosted-compatible model default.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: workflow boundary tests cover the Hermes model contract; TypeScript covers the live helper env signatures.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; change narrows test model/env selection to the existing hosted-compatible fixture boundary without broadening secret exposure.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
npm test -- --run test/e2e-scenario/support-tests/e2e-scenarios-workflow.test.ts
npm run typecheck:cli
```

Live scenario test files are gated locally unless `NEMOCLAW_RUN_E2E_SCENARIOS=1` is set; the validation evidence will come from targeted GitHub E2E reruns after merge.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end live scenarios (Hermes chat, diagnostics, cron preflight, and stale sandbox upgrade) to use shared hosted-inference model defaults instead of hardcoded model strings and to wire hosted env/model consistently.
  * Removed direct model pinning from the Hermes Vitest workflow job configuration and expanded validation to disallow user-pinned overrides.
  * Added an E2E test covering the workflow boundary rejection behavior.

* **Bug Fixes**
  * Reduced configuration mismatches that could cause E2E failures when model settings diverged from hosted inference defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->