### PR TITLE
fix(e2e): align hosted validation assertions

### DIFF
--- a/test/e2e-scenario/live/diagnostics.test.ts
+++ b/test/e2e-scenario/live/diagnostics.test.ts
@@ -357,7 +357,10 @@ runDiagnosticsTest(
       /nvapi-[A-Za-z0-9_-]{10,}/.test(credentialsText),
       "credentials list must not expose nvapi-shaped values",
     ).toBe(false);
-    expect(/nvidia-prod|No provider credentials registered/i.test(credentialsText)).toBe(true);
+    expect(
+      credentialsText.includes(hosted.providerName) ||
+        /No provider credentials registered/i.test(credentialsText),
+    ).toBe(true);
 
     await host.command("node", [CLI_ENTRYPOINT, "credentials", "list"], {
       artifactName: "diagnostics-credentials-list",
@@ -369,11 +372,11 @@ runDiagnosticsTest(
     let credentialsResetExercised = false;
     let postResetCredentialsListRedacted = false;
     let providerCredentialAbsentBeforeReset = false;
-    if (credentialsText.includes("nvidia-prod")) {
+    if (credentialsText.includes(hosted.providerName)) {
       credentialsResetExercised = true;
       const reset = await host.command(
         "node",
-        [CLI_ENTRYPOINT, "credentials", "reset", "nvidia-prod", "--yes"],
+        [CLI_ENTRYPOINT, "credentials", "reset", hosted.providerName, "--yes"],
         {
           artifactName: "diagnostics-credentials-reset",
           env,
@@ -382,12 +385,12 @@ runDiagnosticsTest(
         },
       );
       expect(reset.exitCode, resultText(reset)).toBe(0);
-      expect(resultText(reset)).toContain("Removed provider 'nvidia-prod'");
+      expect(resultText(reset)).toContain(`Removed provider '${hosted.providerName}'`);
 
       const rawPostResetList = runRawNodeCliForLeakAssertion(["credentials", "list"], env, 60_000);
       const postResetText = rawResultText(rawPostResetList);
       expect(rawPostResetList.status, redactForAssertion(postResetText, apiKey)).toBe(0);
-      expect(postResetText.includes("nvidia-prod")).toBe(false);
+      expect(postResetText.includes(hosted.providerName)).toBe(false);
       expect(
         postResetText.includes(apiKey),
         "post-reset credentials list must not expose the exact NVIDIA_INFERENCE_API_KEY",
@@ -407,9 +410,8 @@ runDiagnosticsTest(
     } else {
       providerCredentialAbsentBeforeReset = true;
       await artifacts.writeJson("credentials-reset.skip.json", {
-        provider: "nvidia-prod",
-        reason:
-          "credentials list reported no nvidia-prod provider credential after install/onboard",
+        provider: hosted.providerName,
+        reason: `credentials list reported no ${hosted.providerName} provider credential after install/onboard`,
         acceptedNoProviderStore: /No provider credentials registered/i.test(credentialsText),
       });
     }

--- a/test/e2e-scenario/live/hermes-e2e.test.ts
+++ b/test/e2e-scenario/live/hermes-e2e.test.ts
@@ -359,7 +359,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       timeoutMs: 30_000,
     });
     expect(inference.exitCode, resultText(inference)).toBe(0);
-    expect(resultText(inference)).toMatch(/nvidia-prod/i);
+    expect(resultText(inference)).toContain(hosted.providerName);
 
     const policy = await sandbox.openshell(["policy", "get", "--full", SANDBOX_NAME], {
       artifactName: "phase-3-openshell-policy-get",

--- a/test/e2e-scenario/live/upgrade-stale-sandbox-helpers.ts
+++ b/test/e2e-scenario/live/upgrade-stale-sandbox-helpers.ts
@@ -16,6 +16,7 @@ import { isTransientProviderValidationFailure } from "./network-policy-transient
 export const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 const BLUEPRINT_RELPATH = path.join("nemoclaw-blueprint", "blueprint.yaml");
 const BLUEPRINT = path.join(REPO_ROOT, BLUEPRINT_RELPATH);
+const BASE_CONTEXT_SCRIPT_RELPATH = path.join("scripts", "lib", "sandbox-rlimits.sh");
 const TEST_SANDBOX_PREFIX = "e2e-upgrade-stale";
 export const SANDBOX_NAME =
   process.env.NEMOCLAW_SANDBOX_NAME ??
@@ -93,6 +94,9 @@ function restoreFile(file: string, snapshot: FileSnapshot): void {
 function createOldBaseBuildContext(): string {
   const buildContext = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-upgrade-stale-base-"));
   fs.mkdirSync(path.join(buildContext, path.dirname(BLUEPRINT_RELPATH)), { recursive: true });
+  fs.mkdirSync(path.join(buildContext, path.dirname(BASE_CONTEXT_SCRIPT_RELPATH)), {
+    recursive: true,
+  });
   const original = fs.readFileSync(BLUEPRINT, "utf8");
   const minOpenClawVersion = /^(\s*min_openclaw_version:\s*).*/m;
   expect(
@@ -103,6 +107,10 @@ function createOldBaseBuildContext(): string {
     path.join(buildContext, BLUEPRINT_RELPATH),
     original.replace(minOpenClawVersion, `$1"${OLD_OPENCLAW_VERSION}"`),
     "utf8",
+  );
+  fs.copyFileSync(
+    path.join(REPO_ROOT, BASE_CONTEXT_SCRIPT_RELPATH),
+    path.join(buildContext, BASE_CONTEXT_SCRIPT_RELPATH),
   );
   return buildContext;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the remaining post-#5893 hosted-compatible validation assertions in live Vitest lanes. Hermes and diagnostics now assert the hosted-compatible provider name, and the stale-upgrade old-base fixture includes the sandbox rlimits script required by the current base Dockerfile.

## Changes
- Updates Hermes `openshell inference get` assertion to expect `hosted.providerName` instead of hard-coded `nvidia-prod`.
- Updates diagnostics credential assertions/reset to use `hosted.providerName` instead of hard-coded `nvidia-prod`.
- Copies `scripts/lib/sandbox-rlimits.sh` into the stale-upgrade old-base Docker build context so `Dockerfile.base` can build.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: affected live tests are gated locally; TypeScript validates the helper and assertion updates.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; changes use existing hosted provider metadata and copy an existing checked-in script into a test Docker build context.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
npm run typecheck:cli
```

Live scenario test files are gated locally unless `NEMOCLAW_RUN_E2E_SCENARIOS=1` is set; validation evidence will come from targeted GitHub E2E reruns after merge.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end checks to use the active provider name dynamically instead of a fixed value.
  * Improved coverage for credential reset behavior, including the expected removal message and post-reset credential state.
  * Adjusted inference verification to match the current provider identifier format.
* **Chores**
  * Kept test artifacts in sync with the detected provider name and provider-specific skip reason.
  * Updated upgrade test setup to include an additional script in the temporary build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->