### PR TITLE
chore: simplify CodeRabbit review guidance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,860 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Keep durable project guidance in the nearest AGENTS.md. CodeRabbit discovers
+# those files automatically, so path instructions here are reserved for review
+# gaps that need a narrower, change-specific lens.
 language: "en-US"
 early_access: false
 reviews:
   profile: "chill"
   request_changes_workflow: false
   high_level_summary: true
-  poem: true
+  in_progress_fortune: false
+  poem: false
   review_status: true
   review_details: false
   auto_review:
     enabled: true
     drafts: false
+
+  # E2E recommendations intentionally do not live here. The E2E Advisor derives
+  # them from each PR diff and the current workflows instead of a duplicated,
+  # manually synchronized path-to-job catalog.
   path_instructions:
-    - path: "docs/**"
+    - path: "src/**"
       instructions: |
-        You are an editorial reviewer for NemoClaw documentation.
-        Review every docs change against the style guide below. Flag violations
-        inline as review comments. Do not rewrite the content — point out the
-        issue and cite the relevant rule so the author can fix it.
+        Apply a migration-completion review whenever a PR introduces a
+        replacement path, architecture, state model, or framework.
 
-        ## Voice and Tone
+        - Trace every in-scope entrypoint and lifecycle path, including fresh
+          execution, resume/retry/rebuild, persisted state, scripts, tests, docs,
+          and workflow wiring. The new path existing is not evidence of cutover.
+        - Require in-scope callers to use one authoritative path and delete the
+          superseded runtime path, forwarding glue, support helpers, and tests in
+          the same PR.
+        - Retain compatibility only for a demonstrated external or persisted-data
+          contract. Derive it from the new source of truth, cover it through the
+          public boundary, and state an observable removal condition.
+        - If a PR intentionally migrates only a slice, it must say so and link the
+          remaining work in GitHub. Do not introduce repository-local migration
+          ledgers or describe the overall migration as complete.
+        - Tests must prove that public entrypoints reach the new path and that the
+          old path is deleted or cannot execute.
 
-        - Active voice required. Flag passive constructions.
-          Bad: "A gateway is created by the CLI."
-          Good: "The CLI creates a gateway."
-        - Second person ("you") when addressing the reader.
-        - Present tense. Flag future tense ("will") in descriptions of current behavior.
-        - No hedge words: flag "simply," "just," "easily," "of course."
-
-        ## LLM-Generated Patterns (Flag These)
-
-        These are common in AI-generated text and erode trust with technical readers.
-        Flag every occurrence:
-
-        - Unnecessary bold on routine instructions ("This is a **critical** step"
-          when nothing is actually critical). Bold is reserved for UI labels,
-          parameter names, and genuine warnings.
-        - Excessive em dashes. One per paragraph is fine; multiple per paragraph
-          or em dashes used instead of commas/periods should be flagged.
-        - Superlatives and marketing language ("powerful," "robust," "seamless,"
-          "cutting-edge"). Say what it does, not how great it is.
-        - Emoji in documentation prose.
-        - Rhetorical questions ("Want to secure your agents? Look no further!").
-          State the purpose directly.
-        - Filler introductions ("In this section, we will explore..."). Start
-          with the content.
-
-        ## Formatting Rules
-
-        - Every sentence must end with a period.
-        - One sentence per line in source (makes diffs readable). Flag paragraphs
-          where multiple sentences appear on the same line.
-        - CLI commands, file paths, flags, parameter names, and values must use
-          inline `code` formatting.
-        - Copyable CLI code blocks must use language-specific tags such as
-          `bash`, `sh`, or `powershell`, and must not include prompt markers
-          such as `$`. Reserve `console` blocks for terminal transcripts that
-          include prompts, output, or interactive sessions.
-        - Do not flag `$$nemoclaw` in docs. It is the correct build-time
-          variant placeholder for shared OpenClaw and Hermes command examples.
-        - When a docs PR adds a command-line example that works across all
-          NemoClaw agent aliases, comment if it uses a concrete alias such as
-          `nemoclaw` or `nemohermes`; ask the author to use `$$nemoclaw`
-          instead so generated OpenClaw and Hermes docs render the right
-          command name.
-        - Use Fern callout components (<Note>, <Tip>, <Warning>) for callouts
-          in MDX pages, not bold text or blockquotes. MyST admonitions are
-          acceptable only in legacy .md pages that have not migrated yet.
-        - No nested admonitions.
-        - Do not number section titles. Flag "Section 1: ...", "Step 3: ...", etc.
-        - No colons in titles. Flag "Inference: Cloud and Local" — should be
-          "Cloud and Local Inference."
-        - Colons should only introduce a list. Flag colons used as general
-          punctuation between clauses.
-
-        ## Word List (Flag Incorrect Usage)
-
-        | Correct        | Incorrect (flag these)                              |
-        |----------------|------------------------------------------------------|
-        | NVIDIA         | Nvidia, nvidia                                       |
-        | NemoClaw       | nemoclaw (in prose), Nemoclaw                        |
-        | OpenClaw       | openclaw (in prose), Openclaw                        |
-        | OpenShell      | Open Shell, openShell, Openshell, openshell (in prose)|
-        | CLI            | cli, Cli                                             |
-        | API key        | api key, API Key                                     |
-        | mTLS           | MTLS, mtls                                           |
-        | YAML           | yaml (in prose), Yaml                                |
-        | gateway        | Gateway (unless starting a sentence)                 |
-        | sandbox        | Sandbox (unless starting a sentence)                 |
-
-        Words inside code blocks or inline code spans are exempt from the word
-        list (e.g., `nemoclaw onboard` is correct).
-
-        ## Page Structure
-
-        When reviewing new pages, verify:
-        - SPDX license header is present after frontmatter.
-        - Frontmatter includes title, description, keywords, topics, tags,
-          content type, difficulty, audience, and status fields.
-        - H1 heading matches the `title.page` frontmatter value.
-        - Page starts with a one- or two-sentence introduction.
-        - Sections use H2 and H3, each starting with an introductory sentence.
-        - A "Next Steps" section at the bottom links to related pages.
-
-        ## Severity
-
-        - Word list and voice violations: flag as suggestions.
-        - Missing SPDX header, broken cross-references, or incorrect code
-          block language: flag as issues.
-        - LLM-generated patterns (bold overuse, em dashes, superlatives,
-          hedge words): flag as suggestions with the note "LLM pattern detected."
-    - path: "**/*.md"
+    - path: "src/lib/{actions,domain,adapters,state}/**"
       instructions: |
-        This rule applies to all Markdown files project-wide. For files
-        under docs/, the stricter docs/** rules defined earlier in this
-        file take precedence; this rule adds baseline checks for every
-        other Markdown file (README, CONTRIBUTING, architecture docs, etc.).
+        Review ownership against `src/lib/README.md`: actions orchestrate, domain
+        modules make pure decisions, adapters own host/process/network boundaries,
+        and state modules own persisted files and state I/O. Flag cross-layer
+        cycles, duplicate sources of truth, and forwarding wrappers that add a new
+        layer without retiring the old owner and its callers.
 
-        - NVIDIA must be all caps (not Nvidia, nvidia).
-        - NemoClaw, OpenClaw, and OpenShell must use correct casing.
-        - No emoji in technical prose.
-
-    # ── E2E test recommendations ──────────────────────────────────
-    # Maps sensitive file paths to the nightly E2E jobs that exercise them.
-    # CodeRabbit surfaces these as review comments on PRs that touch a
-    # matched path, so reviewers know which E2E jobs to run before merge.
-    #
-    # When adding a new E2E job to nightly-e2e.yaml, add a matching
-    # path_instructions entry below. The cross-validation test in
-    # test/validate-e2e-coverage.test.ts verifies consistency.
-
-    - path: "scripts/nemoclaw-start.sh"
-      instructions: &e2e-entrypoint |
-        This file is a sandbox entrypoint script. Changes affect every
-        sandbox boot and are invisible to unit tests (Landlock, non-root
-        execution, process lifecycle).
-
-        **E2E test recommendation:**
-        - `sandbox-survival-e2e` — gateway restart recovery
-        - `sandbox-operations-e2e` — process recovery after gateway kill
-        - `cloud-e2e` — full onboard + cloud inference
-        - `openclaw-slack-pairing-e2e` — gateway/connect-shell OpenClaw
-          pairing state root parity for Slack
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=sandbox-survival-e2e,sandbox-operations-e2e,cloud-e2e,openclaw-slack-pairing-e2e
-        ```
-
-    - path: "scripts/lib/sandbox-init.sh"
-      instructions: *e2e-entrypoint
-
-    - path: "Dockerfile"
-      instructions: &e2e-dockerfile |
-        This file affects the sandbox container image. Layer ordering,
-        permissions, and baked config changes are only testable with a
-        real container build.
-
-        **E2E test recommendation:**
-        - `cloud-e2e` — full onboard + cloud inference
-        - `sandbox-survival-e2e` — gateway restart recovery
-        - `hermes-e2e` — Hermes agent onboard + inference
-        - `rebuild-openclaw-e2e` — workspace state survives rebuild
-        - `openclaw-tui-chat-correlation-e2e` — baked OpenClaw chat send
-          patch preserves user/assistant turn correlation
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-e2e,sandbox-survival-e2e,hermes-e2e,rebuild-openclaw-e2e,openclaw-tui-chat-correlation-e2e
-        ```
-
-    - path: "Dockerfile.base"
-      instructions: *e2e-dockerfile
-
-    - path: "nemoclaw-blueprint/scripts/http-proxy-fix.js"
+    - path: "src/{commands,lib/cli}/**"
       instructions: |
-        This file is the L7 proxy rewrite script. Changes affect all
-        inference routing through the proxy. FORWARD-mode path needs
-        manual validation until a dedicated forward-proxy-e2e exists.
+        Review this change against the single-path oclif architecture.
 
-        **E2E test recommendation:**
-        - `cloud-e2e` — full inference through the proxy chain
-        - `inference-routing-e2e` — credential isolation + error classification
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-e2e,inference-routing-e2e
-        ```
-
-    - path: "src/lib/onboard.ts"
-      instructions: |
-        This file contains core onboarding logic. Changes here affect
-        the full sandbox creation and configuration flow.
-
-        **E2E test recommendation:**
-        - `cloud-e2e` — full onboard + cloud inference
-        - `sandbox-operations-e2e` — multi-sandbox lifecycle
-        - `rebuild-openclaw-e2e` — workspace state survives rebuild
-        - `channels-stop-start-e2e` — channel disable/enable lifecycle across
-          rebuild with cached Telegram credentials
-        - `messaging-compatible-endpoint-e2e` — Telegram + compatible endpoint
-          inference.local regression
-        - `bedrock-runtime-compatible-anthropic-e2e` — Bedrock Runtime
-          compatible Anthropic endpoint adapter boundary
-        - `hermes-discord-e2e` — Hermes Discord config schema + placeholder
-          isolation
-        - `hermes-slack-e2e` — Hermes Slack policy + Python placeholder egress
-        - `openshell-gateway-upgrade-e2e` — stale Linux Docker-driver gateway
-          process restart after OpenShell upgrade
-        - `issue-3600-gpu-proof-optional-e2e` — direct GPU verification remains
-          optional when CUDA probing fails before sandbox creation
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-e2e,sandbox-operations-e2e,rebuild-openclaw-e2e,channels-stop-start-e2e,messaging-compatible-endpoint-e2e,bedrock-runtime-compatible-anthropic-e2e,hermes-discord-e2e,hermes-slack-e2e,openshell-gateway-upgrade-e2e,issue-3600-gpu-proof-optional-e2e
-        ```
-
-    - path: "src/lib/onboard/bedrock-runtime.ts"
-      instructions: &e2e-bedrock-runtime-compatible-anthropic |
-        This file is part of the Bedrock Runtime compatible Anthropic endpoint
-        path. Changes affect endpoint classification, hidden adapter startup,
-        adapter-token isolation, and the sandbox-facing inference.local route.
-
-        **E2E test recommendation:**
-        - `bedrock-runtime-compatible-anthropic-e2e` — fake Bedrock Runtime
-          endpoint through OpenClaw and Hermes with sandbox leak checks
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=bedrock-runtime-compatible-anthropic-e2e
-        ```
-
-    - path: "src/lib/inference/bedrock-runtime*.ts"
-      instructions: *e2e-bedrock-runtime-compatible-anthropic
-    - path: "src/lib/onboard/channel-state.ts"
-      instructions: &e2e-channel-stop-start |
-        This file controls disabled channel resolution used during onboard
-        and rebuild. Changes affect whether `channels stop` persists across
-        sandbox destroy/recreate and whether `channels start` reattaches
-        cached credentials.
-
-        **E2E test recommendation:**
-        - `channels-stop-start-e2e` — Telegram channel stop/start lifecycle
-          across rebuild with cached credentials
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=channels-stop-start-e2e
-        ```
-
-    - path: "src/lib/state/onboard-session.ts"
-      instructions: *e2e-channel-stop-start
-
-    - path: "src/lib/actions/sandbox/rebuild.ts"
-      instructions: *e2e-channel-stop-start
-
-    - path: "src/commands/sandbox/channels/**"
-      instructions: *e2e-channel-stop-start
-
-    - path: "src/lib/sandbox/channels-command-support.ts"
-      instructions: *e2e-channel-stop-start
-
-    - path: "test/e2e/test-channels-stop-start.sh"
-      instructions: *e2e-channel-stop-start
-
-    - path: "src/lib/actions/inference-set.ts"
-      instructions: |
-        This file switches the OpenShell inference route and patches the
-        selected running agent config. Changes here affect OpenClaw and
-        Hermes model switching without a sandbox rebuild.
-
-        **E2E test recommendation:**
-        - `openclaw-inference-switch-e2e` — OpenClaw route + config patch
-          + live OpenClaw request after switch
-        - `hermes-inference-switch-e2e` — Hermes route + config.yaml patch
-          + live Hermes request after switch
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openclaw-inference-switch-e2e,hermes-inference-switch-e2e
-        ```
+        - Command classes own grammar, parsing, help, and translation into typed
+          action inputs. Behavior and orchestration belong in `src/lib/actions/**`.
+        - Flag manual argv parsing, ad hoc command routing, rebuilding string argv
+          after oclif has parsed it, or direct platform/registry/credential work in
+          a command class.
+        - Keep `src/lib/cli/**` limited to framework, metadata, routing, and help
+          infrastructure rather than product behavior.
 
     - path: "src/nemoclaw.ts"
       instructions: |
-        This file contains CLI dispatch, status, recovery, and connect
-        functions. Changes affect sandbox lifecycle commands.
+        This file is a compatibility front controller, not a command router.
+        Keep it limited to loading and exposing `dispatchCli`. Flag new command
+        grammar, branching, lifecycle behavior, or manual parsing here. If the
+        final caller of a compatibility export is removed, require the export and
+        its tests to be deleted in the same PR.
 
-        **E2E test recommendation:**
-        - `sandbox-survival-e2e` — gateway restart recovery
-        - `sandbox-operations-e2e` — process recovery after gateway kill
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=sandbox-survival-e2e,sandbox-operations-e2e
-        ```
-
-    - path: "src/lib/cluster-image-patch.ts"
-      instructions: &e2e-overlayfs |
-        This file handles Docker 26+ overlayfs compatibility. Changes
-        are only testable under real Docker + K3s execution.
-
-        **E2E test recommendation:**
-        - `overlayfs-autofix-e2e` — Docker 26+ nested-mount auto-fix
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=overlayfs-autofix-e2e
-        ```
-
-    - path: "src/lib/onboard/preflight.ts"
-      instructions: *e2e-overlayfs
-
-    - path: "src/lib/deploy/**"
+    - path: "src/lib/{onboard.ts,onboard/**,state/onboard-*.ts}"
       instructions: |
-        This file contains deployment lifecycle logic (start/stop
-        cloudflared tunnel).
+        Review onboarding and resume behavior against the target architecture in
+        `src/lib/onboard/machine/README.md`.
 
-        **E2E test recommendation:**
-        - `tunnel-lifecycle-e2e` — start/stop cloudflared tunnel
-        - `state-backup-restore-e2e` — backup/restore workspace state
+        - Keep `src/lib/onboard.ts` as entry setup and dependency wiring. State
+          sequencing, prompts, repair decisions, and phase effects belong in state
+          handlers or focused services.
+        - `OnboardRuntime` owns machine transitions. Step helpers record step
+          status; flag any expansion of direct machine mutation escape hatches.
+        - Resume and repair bridges must correspond to real persisted older-session
+          shapes, be idempotent across interruption/replay, keep secrets redacted,
+          and converge on the same authoritative path as a fresh run.
+        - A migrated phase must remove its old sequencing branch and bridge helpers,
+          with fresh, resumed, repair, and failure coverage at the public boundary.
 
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=tunnel-lifecycle-e2e,state-backup-restore-e2e
-        ```
-
-    - path: "src/lib/state/sandbox.ts"
+    - path: "src/lib/messaging/**"
       instructions: |
-        This file manages sandbox state (backup, restore, rebuild,
-        snapshot). Changes affect data persistence across sandbox
-        lifecycle operations.
+        Review against the manifest-first architecture in
+        `src/lib/messaging/AGENTS.md`.
 
-        **E2E test recommendation:**
-        - `state-backup-restore-e2e` — backup/restore workspace state
-        - `snapshot-commands-e2e` — snapshot create/list/restore lifecycle
-        - `rebuild-openclaw-e2e` — workspace state survives rebuild
+        - Channel behavior belongs in manifests, resolvers, hooks, and appliers;
+          onboard and sandbox actions should only plan and orchestrate.
+        - A channel migration must remove its duplicated provider, policy, render,
+          credential, and runtime logic from legacy onboarding, rebuild, scripts,
+          and generated-config paths. Transitional tables must be derived from the
+          manifest registry rather than maintained independently.
+        - Verify persisted-plan hydration and parity across onboard, add/remove,
+          start/stop, rebuild, resume, diagnostics, and build-time application.
+        - Plans and persisted state must remain serializable and secret-free.
 
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=state-backup-restore-e2e,snapshot-commands-e2e,rebuild-openclaw-e2e
-        ```
-
-    - path: "src/lib/shields/**"
+    - path: "src/lib/{sandbox/**,actions/sandbox/**,state/sandbox.ts}"
       instructions: |
-        These files control shields down/up, config mutability, audit
-        trail, and auto-restore timer.
+        Review sandbox behavior against the layer ownership in `src/lib/README.md`.
 
-        **Test recommendation:**
-        - `test/vm-driver-privileged-exec-routing.test.ts` — CLI Vitest
-          regression for direct Docker/VM privileged exec routing used by
-          shields/config mutations
-        - `shields-config-e2e` — live shields lifecycle + config get/set/rotate
+        - `src/lib/sandbox/**` is transitional support code, not a new home for
+          workflow orchestration. Actions own lifecycle workflows, domain modules
+          own pure decisions, adapters own Docker/OpenShell/process calls, and state
+          modules own persisted registry data.
+        - When moving a sandbox operation to an action, require every command and
+          internal caller to use it and delete the superseded helper path rather
+          than leaving two lifecycle implementations.
+        - Destructive lifecycle operations must validate before mutation, preserve
+          state/backup invariants, and cover failure, recovery, rebuild, and resume
+          behavior without bypassing the public action boundary.
 
-        To run the live E2E selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=shields-config-e2e
-        ```
+    - path: "src/lib/{security,credentials,shields}/**"
+      instructions: &security-boundary |
+        Treat this as a security boundary.
 
-    - path: "src/lib/sandbox/privileged-exec.ts"
-      instructions: |
-        This file selects the privileged mutation transport for host-side
-        sandbox writes. Changes can break shields up/down and config set on
-        Docker Desktop VM-driver sandboxes.
+        - Trace untrusted input, credential material, filesystem paths, subprocess
+          arguments, and network targets across the full changed flow.
+        - Preserve deny-by-default behavior, least privilege, redaction, and
+          fail-closed handling. Do not weaken a guard only to retain legacy behavior.
+        - Prefer argv arrays and structured APIs over shell command construction.
+        - Require negative-path tests that prove the boundary rejects bypasses and
+          does not leak secrets in errors, logs, state, or process arguments.
 
-        **Test recommendation:**
-        - `test/vm-driver-privileged-exec-routing.test.ts` — CLI Vitest
-          coverage for VM/Docker direct-container routing and prefix
-          collision handling
-        - `shields-config-e2e` — live shields lifecycle + config get/set/rotate
-
-        To run the live E2E selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=shields-config-e2e
-        ```
-
-    - path: "src/lib/sandbox/config.ts"
-      instructions: |
-        This file implements host-side config get/set/rotate. Changes to
-        config writes, hash recomputation, or privileged exec routing affect
-        Docker/VM sandboxes.
-
-        **Test recommendation:**
-        - `test/vm-driver-privileged-exec-routing.test.ts` — CLI Vitest
-          coverage for direct privileged exec routing used by host-side
-          config mutation
-        - `shields-config-e2e` — live config get/set/rotate while shields
-          transitions are exercised
-
-        To run the live E2E selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=shields-config-e2e
-        ```
-
-    - path: "agents/hermes/**"
-      instructions: |
-        This directory contains the Hermes agent. Changes affect
-        multi-agent onboarding, health probes, and inference routing.
-
-        **E2E test recommendation:**
-        - `hermes-e2e` — Hermes onboard + health probe + live inference
-        - `hermes-inference-switch-e2e` — Hermes route + config.yaml patch
-          + live Hermes request after switch
-        - `hermes-discord-e2e` — Hermes Discord config schema + placeholder
-          isolation
-        - `hermes-slack-e2e` — Hermes Slack policy + Python placeholder egress
-        - `hermes-onboard-security-posture-e2e` — Hermes onboard under a
-          non-root host security posture
-        - `rebuild-hermes-e2e` — Hermes upgrade path
-        - `rebuild-hermes-stale-base-e2e` — Hermes rebuild with stale cached base image
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-e2e,hermes-inference-switch-e2e,hermes-discord-e2e,hermes-slack-e2e,hermes-onboard-security-posture-e2e,rebuild-hermes-e2e,rebuild-hermes-stale-base-e2e
-        ```
-
-    - path: "test/e2e/test-hermes-slack-e2e.sh"
-      instructions: |
-        This script validates Hermes Slack onboarding, policy scoping, Slack
-        credential providers, and Python Slack API egress through OpenShell
-        placeholder substitution.
-
-        **E2E test recommendation:**
-        - `hermes-slack-e2e` — Hermes Slack policy + Python placeholder egress
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-slack-e2e
-        ```
-
-    - path: "scripts/patch-openclaw-chat-send.js"
-      instructions: &e2e-openclaw-tui-chat-correlation |
-        This helper patches OpenClaw chat send behavior inside the sandbox
-        image. Changes can affect TUI message ordering, duplicate sends, and
-        user/assistant turn correlation when OpenClaw is the active agent.
-
-        **E2E test recommendation:**
-        - `openclaw-tui-chat-correlation-e2e` - hermetic TUI chat proof for
-          correlated user/assistant turns
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openclaw-tui-chat-correlation-e2e
-        ```
-
-    - path: "test/e2e/test-openclaw-tui-chat-correlation.sh"
-      instructions: *e2e-openclaw-tui-chat-correlation
-
-    - path: "test/openclaw-tui-chat-correlation.test.ts"
-      instructions: *e2e-openclaw-tui-chat-correlation
-
-    - path: "test/e2e/test-issue-4434-tui-unreachable-inference.sh"
-      instructions: &e2e-issue-4434-tui-unreachable-inference |
-        This script is the privileged live repro for #4434. Changes affect
-        the Linux-only NVIDIA endpoint firewall block, OpenClaw TUI error
-        visibility, and active-spinner shutdown proof.
-
-        **E2E test recommendation:**
-        - `issue-4434-tui-unreachable-inference-e2e` - opt-in live proof
-          that unreachable NVIDIA inference surfaces a visible TUI error and
-          stops the active spinner
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=issue-4434-tui-unreachable-inference-e2e
-        ```
-
-    - path: "test/issue-4434-tui-unreachable-inference.test.ts"
-      instructions: *e2e-issue-4434-tui-unreachable-inference
-
-    - path: "test/e2e/test-openclaw-slack-pairing.sh"
-      instructions: |
-        This script validates OpenClaw Slack DM pairing across the gateway
-        and connect-shell runtime contexts with a hermetic fake Slack Socket
-        Mode event and fake chat.postMessage reply.
-
-        **E2E test recommendation:**
-        - `openclaw-slack-pairing-e2e` - Slack pairing request approval and
-          allowFrom state root parity
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openclaw-slack-pairing-e2e
-        ```
-
-    - path: "test/e2e/lib/fake-slack-api.cjs"
-      instructions: |
-        This helper backs hermetic Slack REST and Socket Mode tests. Changes
-        can alter Slack credential rewrite assertions, fake Socket Mode
-        envelopes, or chat.postMessage capture.
-
-        **E2E test recommendation:**
-        - `messaging-providers-e2e` - Slack REST provider placeholder rewrite
-        - `openclaw-slack-pairing-e2e` - fake Slack Socket Mode pairing flow
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=messaging-providers-e2e,openclaw-slack-pairing-e2e
-        ```
-
-    - path: "test/e2e/lib/slack-api-proof.sh"
-      instructions: |
-        This helper applies hermetic Slack REST and Socket Mode policies for
-        messaging E2E scripts. Changes can affect REST credential rewrite
-        probes and native websocket policy coverage.
-
-        **E2E test recommendation:**
-        - `messaging-providers-e2e` - Slack REST provider placeholder rewrite
-        - `openclaw-slack-pairing-e2e` - fake Slack Socket Mode pairing flow
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=messaging-providers-e2e,openclaw-slack-pairing-e2e
-        ```
+    - path: "src/lib/sandbox/{config,privileged-exec}.ts"
+      instructions: *security-boundary
 
     - path: "nemoclaw-blueprint/policies/**"
+      instructions: *security-boundary
+
+    - path: "test/{e2e,e2e-scenario}/**"
+      instructions: &e2e-migration |
+        Review against `test/e2e-scenario/docs/MIGRATION.md`: Vitest is the one E2E
+        execution path, and fixtures are support code rather than another runner.
+
+        - Preserve real shell, process, installer, platform, and full-journey
+          boundaries by invoking them from Vitest when they are the contract.
+        - Once replacement coverage preserves the contract, require the legacy
+          script, nightly workflow reference, and obsolete helpers to be deleted in
+          the same PR. A Vitest wrapper plus an independently scheduled bash test is
+          not a completed migration.
+        - Keep migration status and ownership in GitHub issues and PRs. Do not add a
+          repository-local inventory, checklist, or parallel status model.
+        - Flag new runners, compilers, fixture frameworks, or generalized registries
+          when a focused Vitest test and local helper would express the behavior.
+
+    - path: ".github/workflows/{nightly-e2e,e2e-vitest-scenarios}.yaml"
+      instructions: *e2e-migration
+
+    - path: "**/*.test.{ts,js,mts,mjs,cts,cjs}"
       instructions: |
-        This directory contains network policy definitions and presets.
-        Changes affect sandbox egress rules and SSRF filtering.
+        Review tests for behavioral confidence rather than implementation lock-in.
 
-        **E2E test recommendation:**
-        - `network-policy-e2e` — deny-by-default, whitelist, hot-reload, SSRF
+        - Prefer observable outcomes through the public boundary over source-text,
+          private-shape, or mock-call assertions.
+        - Flag copied production algorithms, broad mocks that bypass the behavior
+          under test, and conditionals that make a test pass without exercising its
+          claim.
+        - Migration tests must prove the superseded path is unreachable or removed,
+          not merely prove that the new path also works.
 
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=network-policy-e2e
-        ```
-
-    - path: "test/e2e/test-issue-2478-crash-loop-recovery.sh"
+    - path: ".github/workflows/**"
       instructions: |
-        STAYS_IN_PR_UNTIL_SHIP — long-running soak test for the gateway
-        recovery preload chain hardening (issue #2478). Removed in the
-        same commit that drops the test file before merge.
+        Review workflow changes as trusted automation.
+
+        - A `pull_request_target` workflow must not check out, import, install, or
+          execute PR-controlled code while holding base-repository secrets or write
+          permissions.
+        - Keep permissions least-privileged and pass untrusted values as data rather
+          than interpolating them into shell programs.
+        - Derive job inventories and aggregate dependencies from one source of truth
+          or validate them deterministically. Do not add another manually maintained
+          path-to-job mirror in `.coderabbit.yaml`.
+
+    - path: "scripts/checks/**"
+      instructions: &guardrail |
+        Review guardrails and advisors as product code, not policy prose.
+
+        - Enforce objective invariants with deterministic code. Reserve model prompts
+          for judgment that cannot be computed reliably.
+        - Derive inventories and limits from a canonical source where possible; flag
+          duplicated lists that can silently drift.
+        - A ratchet must be monotonic and must not be weakenable by the PR it checks.
+        - Require focused tests for both detection and false-positive behavior.
+        - Do not duplicate GitHub issue tracking, CI status, or another advisor's
+          responsibility.
+
+    - path: "tools/{pr-review-advisor,e2e-advisor}/**"
+      instructions: *guardrail
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
 
-        **E2E test recommendation:**
-        - `issue-2478-crash-loop-recovery-e2e` — gateway recovery preload
-          chain hardening soak
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=issue-2478-crash-loop-recovery-e2e
-        ```
-
-    - path: "test/e2e/lib/security-posture-assertions.sh"
-      instructions: &e2e-security-posture |
-        This helper asserts the Linux Docker-driver posture that protects
-        static rc-file shims and runtime proxy-env configure guards under
-        a non-root host user. Changes here affect both full onboard
-        security posture lanes.
-
-        **E2E test recommendation:**
-        - `openclaw-onboard-security-posture-e2e` — OpenClaw onboard under a
-          non-root host security posture
-        - `hermes-onboard-security-posture-e2e` — Hermes onboard under a
-          non-root host security posture
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openclaw-onboard-security-posture-e2e,hermes-onboard-security-posture-e2e
-        ```
-
-    - path: "test/e2e/test-full-e2e.sh"
-      instructions: |
-        This script drives the full OpenClaw onboard path. Changes can
-        alter the install, sandbox creation, health, inference, and
-        security posture assertions used by the OpenClaw nightly lanes.
-
-        **E2E test recommendation:**
-        - `cloud-e2e` — full onboard + cloud inference
-        - `openclaw-onboard-security-posture-e2e` — OpenClaw onboard under a
-          non-root host security posture
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-e2e,openclaw-onboard-security-posture-e2e
-        ```
-
-    - path: "test/e2e/test-hermes-e2e.sh"
-      instructions: |
-        This script drives the full Hermes onboard path. Changes can alter
-        install, sandbox creation, health, inference, and security posture
-        assertions used by the Hermes nightly lanes.
-
-        **E2E test recommendation:**
-        - `hermes-e2e` — Hermes onboard + health probe + live inference
-        - `hermes-onboard-security-posture-e2e` — Hermes onboard under a
-          non-root host security posture
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-e2e,hermes-onboard-security-posture-e2e
-        ```
-
-    # ── Split cloud-experimental tests (#2644) ──────────────────
-    - path: "test/e2e/test-cloud-onboard-e2e.sh"
-      instructions: &e2e-cloud-onboard |
-        This script tests the public installer flow, Landlock read-only
-        enforcement, API key leak detection, and inference.local HTTPS.
-
-        **E2E test recommendation:**
-        - `cloud-onboard-e2e` — public installer + sandbox health + security
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-onboard-e2e
-        ```
-
-    - path: "test/e2e/e2e-cloud-experimental/checks/**"
-      instructions: *e2e-cloud-onboard
-
-    - path: "test/e2e/test-cloud-inference-e2e.sh"
-      instructions: &e2e-cloud-inference |
-        This script tests live chat via inference.local and validates
-        the skill filesystem layout inside the sandbox.
-
-        **E2E test recommendation:**
-        - `cloud-inference-e2e` — live cloud inference + skill filesystem
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cloud-inference-e2e
-        ```
-
-    - path: "test/e2e/test-cron-preflight-inference-local-e2e.sh"
-      instructions: |
-        This script onboards a sandbox against the managed cloud
-        inference provider, then loads OpenClaw's cron isolated-agent
-        preflight runtime directly from the in-sandbox dist and calls
-        `preflightCronModelProvider` against the onboarded
-        `inference.local` provider/model, asserting the result reports
-        `status: "available"` and never `EAI_AGAIN` or the
-        "local provider endpoint is not reachable" message.
-
-        Exercises the Dockerfile fetch-guard patch that opts the cron
-        model-provider preflight into trusted env-proxy mode so the
-        managed inference hostname (`inference.local`) routes through
-        the OpenShell L7 proxy instead of failing pinned DNS lookup.
-        The scheduler boundary is intentionally bypassed: the cron CLI
-        surfaces require `operator.admin` scope, which the in-sandbox
-        auto-pair approval sweep deliberately omits.
-
-        **E2E test recommendation:**
-        - `cron-preflight-inference-local-e2e` — direct cron preflight
-          runtime probe via OpenShell L7 proxy
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=cron-preflight-inference-local-e2e
-        ```
-
-    - path: "test/e2e/test-openclaw-inference-switch.sh"
-      instructions: |
-        This script validates OpenClaw model/provider switching with
-        `nemoclaw inference set`, including OpenShell route state,
-        /sandbox/.openclaw/openclaw.json, config hash recomputation, and
-        live requests after the switch.
-
-        **E2E test recommendation:**
-        - `openclaw-inference-switch-e2e` — OpenClaw route + config patch
-          + live OpenClaw request after switch
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openclaw-inference-switch-e2e
-        ```
-
-    - path: "test/e2e/test-hermes-inference-switch.sh"
-      instructions: |
-        This script validates Hermes model/provider switching with
-        `nemohermes inference set`, including OpenShell route state,
-        /sandbox/.hermes/config.yaml, config hash recomputation, .env
-        preservation, and live requests after the switch.
-
-        **E2E test recommendation:**
-        - `hermes-inference-switch-e2e` — Hermes route + config.yaml patch
-          + live Hermes request after switch
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=hermes-inference-switch-e2e
-        ```
-
-    - path: "test/e2e/test-skill-agent-e2e.sh"
-      instructions: &e2e-skill-agent |
-        This script tests skill injection into the sandbox and verifies
-        the agent reads the skill and returns a verification token.
-
-        **E2E test recommendation:**
-        - `skill-agent-e2e` — skill injection + agent verification
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=skill-agent-e2e
-        ```
-
-    - path: "test/e2e/e2e-cloud-experimental/features/**"
-      instructions: *e2e-skill-agent
-
-    - path: "test/e2e/test-docs-validation.sh"
-      instructions: &e2e-docs-validation |
-        This script validates CLI/docs parity (nemoclaw --help vs
-        commands.md) and markdown link resolution.
-
-        **E2E test recommendation:**
-        - `docs-validation-e2e` — CLI/docs parity + link validation
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=docs-validation-e2e
-        ```
-
-    - path: "test/e2e/e2e-cloud-experimental/check-docs.sh"
-      instructions: *e2e-docs-validation
-
-    - path: "docs/reference/commands.md"
-      instructions: *e2e-docs-validation
-
-    - path: "test/e2e/test-messaging-compatible-endpoint.sh"
-      instructions: |
-        This script validates the Telegram + OpenAI-compatible endpoint
-        regression path with a local mock endpoint. Changes here affect
-        the hermetic coverage for managed inference.local routing from
-        messaging-triggered agent turns.
-
-        **E2E test recommendation:**
-        - `messaging-compatible-endpoint-e2e` — Telegram + compatible
-          endpoint inference.local routing
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=messaging-compatible-endpoint-e2e
-        ```
-
-    - path: "test/e2e/test-kimi-inference-compat.sh"
-      instructions: &e2e-kimi-inference-compat |
-        This script validates Kimi K2.6 managed inference.local
-        compatibility with a hermetic OpenAI-compatible mock endpoint.
-        Changes here affect OpenClaw tool-call splitting and trajectory
-        proof for the Kimi compatibility path.
-
-        **E2E test recommendation:**
-        - `kimi-inference-compat-e2e` — Kimi managed inference.local
-          compatibility and safe exec splitting
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=kimi-inference-compat-e2e
-        ```
-
-    - path: "nemoclaw-blueprint/openclaw-plugins/kimi-inference-compat/**"
-      instructions: *e2e-kimi-inference-compat
-
-    - path: "test/e2e/test-bedrock-runtime-compatible-anthropic.sh"
-      instructions: *e2e-bedrock-runtime-compatible-anthropic
-
-    - path: "test/e2e/test-openshell-gateway-upgrade.sh"
-      instructions: |
-        This script validates the old OpenShell install upgrade guard for
-        Linux Docker-driver gateway processes.
-
-        **E2E test recommendation:**
-        - `openshell-gateway-upgrade-e2e` — stale gateway process restart after
-          OpenShell upgrade
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=openshell-gateway-upgrade-e2e
-        ```
-
-    - path: "test/e2e/test-gateway-health-honest.sh"
-      instructions: |
-        This script is the coverage guard for #3111. It sabotages the
-        openshell-gateway binary with a shim that crashes on startup and
-        asserts onboard does NOT falsely log "Docker-driver gateway is
-        healthy" and does exit non-zero. Exercises the NemoClaw-side
-        false-positive (detached-zombie isPidAlive + metadata-only
-        isGatewayHealthy) regardless of OpenShell packaging choices.
-
-        **Regression E2E test recommendation:**
-        - Run `regression-e2e.yaml` with the jobs input set to
-          gateway-health-honest-e2e to validate false-positive health
-          checks when the gateway binary crashes on startup (#3111).
-
-        To run selectively:
-        ```
-        gh workflow run regression-e2e.yaml --ref <branch> -f 'jobs=gateway-health-honest-e2e'
-        ```
-
-    - path: "test/e2e/test-sessions-agents-cli.sh"
-      instructions: &e2e-sessions-agents-cli |
-        This script exercises the host-side `nemoclaw <name> sessions` and
-        `nemoclaw <name> agents` subcommand groups end-to-end: gateway RPC
-        envelope round-trip for `sessions reset` / `sessions delete`, plus
-        passthrough for `sessions list` and `agents add` / `agents delete`.
-        These flows are invisible to unit tests because the wrapper layer
-        depends on `openshell sandbox exec` and a live OpenClaw gateway.
-
-        **E2E test recommendation:**
-        - `sessions-agents-cli-e2e` — sessions + agents CLI wrapper coverage
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=sessions-agents-cli-e2e
-        ```
-
-    - path: "src/lib/actions/sandbox/sessions/**"
-      instructions: *e2e-sessions-agents-cli
-
-    - path: "src/lib/actions/sandbox/agents/**"
-      instructions: *e2e-sessions-agents-cli
-
-    - path: "src/commands/sandbox/sessions.ts"
-      instructions: *e2e-sessions-agents-cli
-
-    - path: "src/commands/sandbox/sessions/**"
-      instructions: *e2e-sessions-agents-cli
-
-    - path: "src/commands/sandbox/agents.ts"
-      instructions: *e2e-sessions-agents-cli
-
-    - path: "src/commands/sandbox/agents/**"
-      instructions: *e2e-sessions-agents-cli
-
-    - path: "test/e2e/test-jetson-nvmap-gpu.sh"
-      instructions: &e2e-jetson-nvmap |
-        This script is the reporter-workflow E2E for #4231: on a Jetson Orin
-        host it onboards with GPU, inspects the sandbox user's groups and
-        /dev/nvmap, runs the cuInit(0) CUDA proof inside the sandbox, and
-        asserts `nemoclaw status` reports `(CUDA verified)`. It validates that
-        the Jetson Docker GPU recreate grants the sandbox user the host group
-        owning /dev/nvmap so CUDA can initialize. Invisible to unit tests
-        because it needs real Tegra device nodes and a live sandbox.
-
-        **E2E test recommendation:**
-        - `gpu-jetson-nvmap-e2e` — Jetson /dev/nvmap CUDA usability + status
-          proof (Jetson-gated; needs a Jetson/Tegra GPU runner with
-          `vars.JETSON_E2E_ENABLED=true`)
-
-        To run selectively:
-        ```
-        gh workflow run nightly-e2e.yaml --ref <branch> -f jobs=gpu-jetson-nvmap-e2e
-        ```
-
-    - path: "src/lib/onboard/docker-gpu-patch.ts"
-      instructions: *e2e-jetson-nvmap
-
-    - path: ".github/workflows/nightly-e2e.yaml"
-      instructions: |
-        This is the nightly E2E workflow definition. Changes here affect
-        which tests run and how they are triggered.
-
-        If a new E2E job is added, verify corresponding
-        `path_instructions` entries exist in `.coderabbit.yaml` for the
-        source files it covers.
-
-        If a job is renamed or removed, update the corresponding aggregate
-        job `needs` lists (`notify-on-failure`, `report-to-pr`, and
-        `scorecard`).
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -135,6 +135,27 @@ reviews:
     - path: "src/lib/sandbox/{config,privileged-exec}.ts"
       instructions: *security-boundary
 
+    - path: "nemoclaw/src/security/**"
+      instructions: *security-boundary
+
+    - path: "nemoclaw/src/blueprint/ssrf.ts"
+      instructions: *security-boundary
+
+    - path: "Dockerfile*"
+      instructions: *security-boundary
+
+    - path: "agents/**"
+      instructions: *security-boundary
+
+    - path: "scripts/nemoclaw-start.sh"
+      instructions: *security-boundary
+
+    - path: "scripts/lib/sandbox-init.sh"
+      instructions: *security-boundary
+
+    - path: "nemoclaw-blueprint/scripts/http-proxy-fix.js"
+      instructions: *security-boundary
+
     - path: "nemoclaw-blueprint/policies/**"
       instructions: *security-boundary
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,10 +34,12 @@ reviews:
           and workflow wiring. The new path existing is not evidence of cutover.
         - Require in-scope callers to use one authoritative path and delete the
           superseded runtime path, forwarding glue, support helpers, and tests in
-          the same PR.
-        - Retain compatibility only for a demonstrated external or persisted-data
-          contract. Derive it from the new source of truth, cover it through the
-          public boundary, and state an observable removal condition.
+          the same PR unless it is in an explicitly bounded compatibility or
+          confidence window.
+        - Retain an old path only for a demonstrated external/persisted-data
+          contract or a bounded confidence/rollback window. Keep the replacement
+          authoritative, freeze the old path against new callers and features, link
+          the retirement issue or PR in GitHub, and state observable exit criteria.
         - If a PR intentionally migrates only a slice, it must say so and link the
           remaining work in GitHub. Do not introduce repository-local migration
           ledgers or describe the overall migration as complete.
@@ -138,21 +140,24 @@ reviews:
 
     - path: "test/{e2e,e2e-scenario}/**"
       instructions: &e2e-migration |
-        Review against `test/e2e-scenario/docs/MIGRATION.md`: Vitest is the one E2E
-        execution path, and fixtures are support code rather than another runner.
+        Review against the active guide at
+        `test/{e2e,e2e-scenario}/docs/MIGRATION.md`: Vitest is the one E2E execution
+        path, and fixtures are support code rather than another runner.
 
         - Preserve real shell, process, installer, platform, and full-journey
           boundaries by invoking them from Vitest when they are the contract.
-        - Once replacement coverage preserves the contract, require the legacy
-          script, nightly workflow reference, and obsolete helpers to be deleted in
-          the same PR. A Vitest wrapper plus an independently scheduled bash test is
-          not a completed migration.
+        - A bounded dual-run confidence window is allowed when the Vitest path is
+          authoritative and dispatchable, the legacy lane is frozen, and a linked
+          GitHub retirement issue or PR names the exact deletions and evidence-based
+          exit criteria. Do not describe the overall migration as complete yet.
+        - Once those exit criteria are met, require the retirement PR to delete the
+          legacy scripts, workflow references, and obsolete helpers together.
         - Keep migration status and ownership in GitHub issues and PRs. Do not add a
           repository-local inventory, checklist, or parallel status model.
         - Flag new runners, compilers, fixture frameworks, or generalized registries
           when a focused Vitest test and local helper would express the behavior.
 
-    - path: ".github/workflows/{nightly-e2e,e2e-vitest-scenarios}.yaml"
+    - path: ".github/workflows/{e2e,nightly-e2e,e2e-vitest-scenarios}.yaml"
       instructions: *e2e-migration
 
     - path: "**/*.test.{ts,js,mts,mjs,cts,cjs}"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -161,9 +161,9 @@ reviews:
 
     - path: "test/{e2e,e2e-scenario}/**"
       instructions: &e2e-migration |
-        Review against the active guide at
-        `test/{e2e,e2e-scenario}/docs/MIGRATION.md`: Vitest is the one E2E execution
-        path, and fixtures are support code rather than another runner.
+        Review against the active migration guide in the matching E2E tree. Vitest
+        is the one E2E execution path, and fixtures are support code rather than
+        another runner.
 
         - Preserve real shell, process, installer, platform, and full-journey
           boundaries by invoking them from Vitest when they are the contract.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Simplify CodeRabbit configuration so it reviews durable architectural boundaries instead of maintaining a stale path-to-E2E-job catalog. Add a general migration-completion lens and focused ownership checks for the active CLI, onboarding/resume, messaging, sandbox, and Vitest E2E migrations.

## Changes
- Remove duplicated documentation rules and 67 manually synchronized E2E path mappings, relying on scoped `AGENTS.md` guidance and the dynamic E2E Advisor instead.
- Require replacement architectures to cut over callers and delete superseded runtime paths, or explicitly track a partial slice in GitHub without claiming completion.
- Permit a bounded confidence/rollback window when the replacement is authoritative, the old path is frozen, and a linked GitHub retirement item defines observable exit criteria.
- Add focused review guidance for layer ownership, oclif adapters, onboarding/resume state, manifest-first messaging, sandbox lifecycle boundaries, security-sensitive code, and the single-path Vitest E2E migration.
- Preserve focused security review for sandbox boot, images, agent packaging, SSRF, proxy routing, policies, credentials, and shields.
- Disable CodeRabbit poems and in-progress fortunes to reduce review noise.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: this changes declarative reviewer guidance; the live CodeRabbit schema, YAML hooks, glob matching, and existing config-contract test validate its structure and integration.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no product or user-facing behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined automated code review guidance by narrowing rules to focus on source ownership, clear layer boundaries, and security-sensitive areas.
  * Simplified end-to-end review expectations by prioritizing the current authoritative test execution path and clarifying migration retirement criteria to prevent legacy accumulation.
  * Updated automated review settings (including disabling optional guidance) and enabled a shared code-guidelines knowledge base for more consistent reviewer support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->