### PR TITLE
fix(onboard): inject Ollama interaction state

### DIFF
--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -859,8 +859,8 @@ async function checkOllamaModelToolSupport(
 
 async function prepareOllamaModel(
   model,
-  installedModels: string[],
-  interaction: OllamaToolCapabilityInteraction,
+  installedModels: string[] = [],
+  interaction: OllamaToolCapabilityInteraction = defaultOllamaToolCapabilityInteraction,
 ): Promise<{
   ok: boolean;
   message?: string;

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -772,47 +772,15 @@ async function pullOllamaModel(model) {
 // override env var in non-interactive mode, or block. Probe failures
 // degrade to "unknown" and never block onboarding.
 
-function isProxyNonInteractive(): boolean {
-  // Lazy-require to avoid a circular import (onboard.ts requires this file
-  // at module-load time). isNonInteractive is exported from onboard.ts;
-  // fall back to the env var if onboard hasn't fully loaded yet.
-  try {
-    const onboardMod = require("./onboard");
-    if (typeof onboardMod.isNonInteractive === "function") {
-      return Boolean(onboardMod.isNonInteractive());
-    }
-  } catch {
-    /* fall through to env-var check */
-  }
-  return process.env.NEMOCLAW_NON_INTERACTIVE === "1";
-}
-
-function isProxyAutoYes(): boolean {
-  // isAutoYes is not exported from onboard.ts, so fall back to the env var.
-  // The interactive override prompt path still covers --yes-only invocations
-  // because non-interactive mode is the gate that matters here.
-  try {
-    const onboardMod = require("./onboard");
-    if (typeof onboardMod.isAutoYes === "function") {
-      return Boolean(onboardMod.isAutoYes());
-    }
-  } catch {
-    /* fall through to env-var check */
-  }
-  return process.env.NEMOCLAW_YES === "1";
-}
+export type OllamaToolCapabilityInteraction = Readonly<{
+  isNonInteractive: () => boolean;
+  isAutoYes: () => boolean;
+  confirm: (question: string, defaultIsYes: boolean) => Promise<boolean>;
+}>;
 
 async function promptProxyYesNo(question: string, defaultIsYes: boolean): Promise<boolean> {
-  // Prefer onboard's promptYesNoOrDefault so we get the same indicator
-  // formatting and non-interactive note. Lazy-require to avoid the cycle.
-  try {
-    const onboardMod = require("./onboard");
-    if (typeof onboardMod.promptYesNoOrDefault === "function") {
-      return Boolean(await onboardMod.promptYesNoOrDefault(question, null, defaultIsYes));
-    }
-  } catch {
-    /* fall through */
-  }
+  // Standalone callers use the credential-store prompt. Onboarding injects
+  // its own confirmation helper so this module does not depend on onboard.ts.
   const reply = await prompt(`${question} ${defaultIsYes ? "[Y/n]" : "[y/N]"}: `);
   const v = String(reply ?? "")
     .trim()
@@ -821,6 +789,12 @@ async function promptProxyYesNo(question: string, defaultIsYes: boolean): Promis
   if (v === "n" || v === "no") return false;
   return defaultIsYes;
 }
+
+const defaultOllamaToolCapabilityInteraction: OllamaToolCapabilityInteraction = {
+  isNonInteractive: () => process.env.NEMOCLAW_NON_INTERACTIVE === "1",
+  isAutoYes: () => process.env.NEMOCLAW_YES === "1",
+  confirm: promptProxyYesNo,
+};
 
 function printToolsIncompatibleWarning(model: string): void {
   console.log("");
@@ -834,6 +808,7 @@ function printToolsIncompatibleWarning(model: string): void {
 
 async function checkOllamaModelToolSupport(
   model: string,
+  interaction: OllamaToolCapabilityInteraction = defaultOllamaToolCapabilityInteraction,
 ): Promise<{ ok: boolean; message?: string; allowToolsIncompatible?: boolean }> {
   const caps = probeOllamaModelCapabilities(model);
 
@@ -857,12 +832,12 @@ async function checkOllamaModelToolSupport(
   // reject the same model on the same condition — see issue #4241.
   printToolsIncompatibleWarning(model);
 
-  if (isProxyAutoYes()) {
+  if (interaction.isAutoYes()) {
     console.log("  Continuing because --yes was passed.");
     return { ok: true, allowToolsIncompatible: true };
   }
 
-  if (isProxyNonInteractive()) {
+  if (interaction.isNonInteractive()) {
     if (process.env.NEMOCLAW_OLLAMA_REQUIRE_TOOLS === "0") {
       console.error(
         `  NEMOCLAW_OLLAMA_REQUIRE_TOOLS=0 set — proceeding with '${model}' despite missing 'tools'.`,
@@ -875,7 +850,7 @@ async function checkOllamaModelToolSupport(
     return { ok: false, message: "Tools-incompatible model in non-interactive mode." };
   }
 
-  const proceed = await promptProxyYesNo("  Use this model anyway?", false);
+  const proceed = await interaction.confirm("  Use this model anyway?", false);
   if (!proceed) {
     return { ok: false, message: "Choose a tools-capable model." };
   }
@@ -884,7 +859,13 @@ async function checkOllamaModelToolSupport(
 
 async function prepareOllamaModel(
   model,
-  installedModels: string[] = [],
+  {
+    installedModels = [],
+    interaction,
+  }: {
+    installedModels?: string[];
+    interaction: OllamaToolCapabilityInteraction;
+  },
 ): Promise<{
   ok: boolean;
   message?: string;
@@ -904,7 +885,7 @@ async function prepareOllamaModel(
     }
   }
 
-  const capCheck = await checkOllamaModelToolSupport(model);
+  const capCheck = await checkOllamaModelToolSupport(model, interaction);
   if (!capCheck.ok) {
     return { ok: false, message: capCheck.message };
   }

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -859,13 +859,8 @@ async function checkOllamaModelToolSupport(
 
 async function prepareOllamaModel(
   model,
-  {
-    installedModels = [],
-    interaction,
-  }: {
-    installedModels?: string[];
-    interaction: OllamaToolCapabilityInteraction;
-  },
+  installedModels: string[],
+  interaction: OllamaToolCapabilityInteraction,
 ): Promise<{
   ok: boolean;
   message?: string;

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1065,7 +1065,7 @@ const {
   promptOllamaModel,
   printOllamaExposureWarning,
   prepareOllamaModel,
-} = require("./inference/ollama/proxy");
+}: typeof import("./inference/ollama/proxy") = require("./inference/ollama/proxy");
 
 const {
   handleWindowsHostOllamaSelection,
@@ -3281,6 +3281,11 @@ async function selectAndValidateOllamaModel(
 ): Promise<OllamaModelSelectionOutcome> {
   const { requestedModel, recoveredModel } = defaults;
   const probeFailures = new OllamaProbeFailureTracker();
+  const interaction: import("./inference/ollama/proxy").OllamaToolCapabilityInteraction = {
+    isNonInteractive,
+    isAutoYes,
+    confirm: (question, defaultIsYes) => promptYesNoOrDefault(question, null, defaultIsYes),
+  };
   while (true) {
     const installedModels = getOllamaModelOptions();
     let model: string | typeof BACK_TO_SELECTION;
@@ -3323,7 +3328,10 @@ async function selectAndValidateOllamaModel(
         }
       }
     }
-    const probe = await prepareOllamaModel(selectedModel, installedModels);
+    const probe = await prepareOllamaModel(selectedModel, {
+      installedModels,
+      interaction,
+    });
     if (!probe.ok) {
       const probeFailureLimitReached = probeFailures.recordFailure(selectedModel);
       const action = handleOllamaProbeFailure(probe, selectedModel, isNonInteractive);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1058,9 +1058,6 @@ const { shouldIncludeBuildContextPath, copyBuildContextDir, printSandboxCreateRe
   buildContext;
 // classifySandboxCreateFailure — see validation import above
 
-// ---------------------------------------------------------------------------
-// Ollama model prompt/pull/prepare functions — from inference/ollama/proxy.ts
-// (proxy lifecycle functions already imported at the top of this file)
 const {
   promptOllamaModel,
   printOllamaExposureWarning,
@@ -3281,11 +3278,9 @@ async function selectAndValidateOllamaModel(
 ): Promise<OllamaModelSelectionOutcome> {
   const { requestedModel, recoveredModel } = defaults;
   const probeFailures = new OllamaProbeFailureTracker();
-  const interaction: import("./inference/ollama/proxy").OllamaToolCapabilityInteraction = {
-    isNonInteractive,
-    isAutoYes,
-    confirm: (question, defaultIsYes) => promptYesNoOrDefault(question, null, defaultIsYes),
-  };
+  const confirm = (question: string, defaultIsYes: boolean) =>
+    promptYesNoOrDefault(question, null, defaultIsYes);
+  const interaction = { isNonInteractive, isAutoYes, confirm };
   while (true) {
     const installedModels = getOllamaModelOptions();
     let model: string | typeof BACK_TO_SELECTION;
@@ -3328,10 +3323,7 @@ async function selectAndValidateOllamaModel(
         }
       }
     }
-    const probe = await prepareOllamaModel(selectedModel, {
-      installedModels,
-      interaction,
-    });
+    const probe = await prepareOllamaModel(selectedModel, installedModels, interaction);
     if (!probe.ok) {
       const probeFailureLimitReached = probeFailures.recordFailure(selectedModel);
       const action = handleOllamaProbeFailure(probe, selectedModel, isNonInteractive);

--- a/test/ollama-tools-capability.test.ts
+++ b/test/ollama-tools-capability.test.ts
@@ -55,6 +55,15 @@ interface OnboardOllamaProxyModule {
       confirm: (question: string, defaultIsYes: boolean) => Promise<boolean>;
     },
   ) => Promise<{ ok: boolean; message?: string; allowToolsIncompatible?: boolean }>;
+  prepareOllamaModel: (
+    model: string,
+    installedModels?: string[],
+    interaction?: {
+      isNonInteractive: () => boolean;
+      isAutoYes: () => boolean;
+      confirm: (question: string, defaultIsYes: boolean) => Promise<boolean>;
+    },
+  ) => Promise<{ ok: boolean; message?: string; allowToolsIncompatible?: boolean }>;
 }
 
 function loadLocalInference(): LocalInferenceModule {
@@ -479,6 +488,28 @@ describe("checkOllamaModelToolSupport", () => {
     expect(out).toEqual({ ok: true, allowToolsIncompatible: true });
     expect(confirm).toHaveBeenCalledWith("  Use this model anyway?", false);
     expect(h.promptCalls.length).toBe(0);
+  });
+
+  it("threads caller interaction through model preparation", async () => {
+    const h = loadProxyWithStubs();
+    h.setProbeResult({
+      source: "api",
+      capabilities: ["completion"],
+      supportsTools: false,
+    });
+    const confirm = vi.fn(async () => true);
+
+    const out = await h.proxy.prepareOllamaModel("phi4", ["phi4"], {
+      isNonInteractive: () => true,
+      isAutoYes: () => false,
+      confirm,
+    });
+
+    expect(out).toEqual({
+      ok: false,
+      message: "Tools-incompatible model in non-interactive mode.",
+    });
+    expect(confirm).not.toHaveBeenCalled();
   });
 
   it("probe failed (capabilities unknown) → {ok:true} (graceful degradation)", async () => {

--- a/test/ollama-tools-capability.test.ts
+++ b/test/ollama-tools-capability.test.ts
@@ -49,6 +49,11 @@ interface LocalInferenceModule {
 interface OnboardOllamaProxyModule {
   checkOllamaModelToolSupport: (
     model: string,
+    interaction?: {
+      isNonInteractive: () => boolean;
+      isAutoYes: () => boolean;
+      confirm: (question: string, defaultIsYes: boolean) => Promise<boolean>;
+    },
   ) => Promise<{ ok: boolean; message?: string; allowToolsIncompatible?: boolean }>;
 }
 
@@ -209,11 +214,10 @@ describe("validateOllamaModel — tools-capable error mapping", () => {
 // onboard-ollama-proxy from the require cache between tests so it
 // re-binds to the patched local-inference function.
 //
-// Equally critical: onboard.js destructures `prompt` from credentials
-// at load time, so our credentials.prompt monkey-patch must be in
-// place BEFORE onboard.js is first required. We install one durable
-// proxy via shared state so re-creating per-test mocks doesn't hand
-// onboard a stale closure.
+// Equally critical: the proxy destructures `prompt` from credentials at
+// load time, so our credentials.prompt monkey-patch must be in place before
+// the proxy is first required. We install one durable proxy via shared state
+// so re-creating per-test mocks does not leave the module with a stale closure.
 // ─────────────────────────────────────────────────────────────────
 
 interface ProxyTestHarness {
@@ -411,6 +415,69 @@ describe("checkOllamaModelToolSupport", () => {
     // Note about --yes is printed.
     expect(h.logs.some((l) => l.toLowerCase().includes("--yes"))).toBe(true);
     // Prompt should NOT have been shown.
+    expect(h.promptCalls.length).toBe(0);
+  });
+
+  it("uses the caller's non-interactive state instead of rediscovering onboard globals", async () => {
+    const h = loadProxyWithStubs();
+    h.setProbeResult({
+      source: "api",
+      capabilities: ["completion"],
+      supportsTools: false,
+    });
+    const confirm = vi.fn(async () => true);
+
+    const out = await h.proxy.checkOllamaModelToolSupport("phi4", {
+      isNonInteractive: () => true,
+      isAutoYes: () => false,
+      confirm,
+    });
+
+    expect(out).toEqual({
+      ok: false,
+      message: "Tools-incompatible model in non-interactive mode.",
+    });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(h.promptCalls.length).toBe(0);
+  });
+
+  it("uses the caller's auto-yes state without prompting", async () => {
+    const h = loadProxyWithStubs();
+    h.setProbeResult({
+      source: "api",
+      capabilities: ["completion"],
+      supportsTools: false,
+    });
+    const confirm = vi.fn(async () => false);
+
+    const out = await h.proxy.checkOllamaModelToolSupport("phi4", {
+      isNonInteractive: () => false,
+      isAutoYes: () => true,
+      confirm,
+    });
+
+    expect(out).toEqual({ ok: true, allowToolsIncompatible: true });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(h.promptCalls.length).toBe(0);
+  });
+
+  it("delegates interactive confirmation to the caller", async () => {
+    const h = loadProxyWithStubs();
+    h.setProbeResult({
+      source: "api",
+      capabilities: ["completion"],
+      supportsTools: false,
+    });
+    const confirm = vi.fn(async () => true);
+
+    const out = await h.proxy.checkOllamaModelToolSupport("phi4", {
+      isNonInteractive: () => false,
+      isAutoYes: () => false,
+      confirm,
+    });
+
+    expect(out).toEqual({ ok: true, allowToolsIncompatible: true });
+    expect(confirm).toHaveBeenCalledWith("  Use this model anyway?", false);
     expect(h.promptCalls.length).toBe(0);
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR removes the Ollama tools-capability gate's hidden dependency on the onboarding entrypoint. Onboarding now supplies its interaction state explicitly, fixing `--non-interactive` and `--yes` behavior without a circular lazy import.

## Related Issue
Fixes #4139.

Replacement for #4140, which identified the moved-path regression and established the initial test direction but cannot be updated without rewriting its unsigned, conflicting history.

## Changes
- Add a typed `OllamaToolCapabilityInteraction` boundary for non-interactive, auto-yes, and confirmation decisions.
- Pass onboarding's in-memory interaction state into `prepareOllamaModel` explicitly.
- Keep environment and credential-prompt defaults for standalone capability checks.
- Remove all three lazy onboarding lookups and their swallowed exceptions from the Ollama proxy.
- Add focused regressions for caller-supplied non-interactive, auto-yes, and interactive confirmation behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the proxy and onboarding-selection suites cover the surrounding pull, validation, and selection flows.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the already-documented `--non-interactive`, `--yes`, and Ollama tools-gate semantics without changing commands or output contracts.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: focused diff review verified that only interaction-state ownership changes; capability validation, override requirements, and credential handling are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama model tool-capability checks to consistently respect interaction modes (non-interactive, auto-yes, and explicit yes/no confirmation), skipping prompts when appropriate.
  * Updated onboarding flow so confirmation behavior is delegated cleanly when interactive input is required.
* **Tests**
  * Expanded unit coverage to ensure non-interactive/auto-yes short-circuit correctly and that interactive confirmation receives the expected question and default choice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->