### PR TITLE
fix(e2e): avoid multiline Deep Agents Python probe

### DIFF
--- a/test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
+++ b/test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
@@ -65,6 +65,28 @@ describe("P0-E cloud-experimental parity guardrails", () => {
     );
   });
 
+  it("keeps Deep Agents Python egress probe command single-line for OpenShell exec", () => {
+    const result = spawnSync(
+      "bash",
+      [
+        path.join(
+          process.cwd(),
+          "test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh",
+        ),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          NEMOCLAW_E2E_PYTHON_EGRESS_SELF_TEST: "probe-command-shape",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("NO_NEWLINE_IN_COMMAND");
+  });
+
   it("registers executable Deep Agents cloud-experimental checks", () => {
     expect(DEEPAGENTS_CLOUD_EXPERIMENTAL_CHECKS).toEqual([
       "test/e2e/e2e-cloud-experimental/checks/05-deepagents-code-landlock-readonly.sh",

--- a/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
@@ -34,8 +34,8 @@ sandbox_exec() {
   openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "$1" 2>&1
 }
 
-python_probe_source_b64() {
-  base64 -w0 <<'PY'
+python_probe_source() {
+  cat <<'PY'
 import sys
 import urllib.error
 import urllib.request
@@ -99,8 +99,8 @@ python_probe() {
     printf '%s\n' "$NEMOCLAW_E2E_PYTHON_PROBE_FIXTURE"
     return 0
   fi
-  encoded="$(python_probe_source_b64)"
-  remote_cmd="probe=\$(mktemp /tmp/nemoclaw-python-egress.XXXXXX.py); printf '%s' ${encoded@Q} | base64 -d > \"\$probe\"; ${python_bin@Q} \"\$probe\" ${url@Q}; rc=\$?; rm -f \"\$probe\"; exit \"\$rc\""
+  encoded="$(python_probe_source | base64 | tr -d '\n')"
+  remote_cmd="probe_dir=\$(mktemp -d /tmp/nemoclaw-python-egress.XXXXXX); probe=\"\$probe_dir/probe.py\"; cleanup(){ rm -rf \"\$probe_dir\"; }; trap cleanup EXIT; printf '%s' ${encoded@Q} | base64 -d > \"\$probe\"; ${python_bin@Q} \"\$probe\" ${url@Q}"
   sandbox_exec "$remote_cmd"
 }
 

--- a/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
@@ -34,14 +34,8 @@ sandbox_exec() {
   openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "$1" 2>&1
 }
 
-python_probe() {
-  local python_bin="$1"
-  local url="$2"
-  if [ -n "${NEMOCLAW_E2E_PYTHON_PROBE_FIXTURE+x}" ]; then
-    printf '%s\n' "$NEMOCLAW_E2E_PYTHON_PROBE_FIXTURE"
-    return 0
-  fi
-  sandbox_exec "${python_bin@Q} - ${url@Q} <<'PY'
+python_probe_source_b64() {
+  base64 -w0 <<'PY'
 import sys
 import urllib.error
 import urllib.request
@@ -95,7 +89,19 @@ except OSError as exc:
 except Exception as exc:
     print(f'ERROR:{type(exc).__name__}:{exc}')
 PY
-"
+}
+
+python_probe() {
+  local python_bin="$1"
+  local url="$2"
+  local encoded remote_cmd
+  if [ -n "${NEMOCLAW_E2E_PYTHON_PROBE_FIXTURE+x}" ]; then
+    printf '%s\n' "$NEMOCLAW_E2E_PYTHON_PROBE_FIXTURE"
+    return 0
+  fi
+  encoded="$(python_probe_source_b64)"
+  remote_cmd="probe=\$(mktemp /tmp/nemoclaw-python-egress.XXXXXX.py); printf '%s' ${encoded@Q} | base64 -d > \"\$probe\"; ${python_bin@Q} \"\$probe\" ${url@Q}; rc=\$?; rm -f \"\$probe\"; exit \"\$rc\""
+  sandbox_exec "$remote_cmd"
 }
 
 expect_reached() {
@@ -135,6 +141,17 @@ if [ "${NEMOCLAW_E2E_PYTHON_EGRESS_SELF_TEST:-}" = "blocked-no-marker" ]; then
   expect_blocked "self-test Python" "fixture host" "https://blocked.example/"
   printf '%s\n' "${PREFIX}: $PASSED passed, $FAILED failed"
   [ "$FAILED" -eq 0 ] || exit 1
+  exit 0
+fi
+
+if [ "${NEMOCLAW_E2E_PYTHON_EGRESS_SELF_TEST:-}" = "probe-command-shape" ]; then
+  sandbox_exec() {
+    case "$1" in
+      *$'\n'*) printf '%s\n' "NEWLINE_IN_COMMAND" ; return 1 ;;
+      *) printf '%s\n' "NO_NEWLINE_IN_COMMAND" ; return 0 ;;
+    esac
+  }
+  python_probe "python3" "https://example.com/"
   exit 0
 fi
 

--- a/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
@@ -147,8 +147,14 @@ fi
 if [ "${NEMOCLAW_E2E_PYTHON_EGRESS_SELF_TEST:-}" = "probe-command-shape" ]; then
   sandbox_exec() {
     case "$1" in
-      *$'\n'*) printf '%s\n' "NEWLINE_IN_COMMAND" ; return 1 ;;
-      *) printf '%s\n' "NO_NEWLINE_IN_COMMAND" ; return 0 ;;
+      *$'\n'*)
+        printf '%s\n' "NEWLINE_IN_COMMAND"
+        return 1
+        ;;
+      *)
+        printf '%s\n' "NO_NEWLINE_IN_COMMAND"
+        return 0
+        ;;
     esac
   }
   python_probe "python3" "https://example.com/"

--- a/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
@@ -100,7 +100,7 @@ python_probe() {
     return 0
   fi
   encoded="$(python_probe_source | base64 | tr -d '\n')"
-  remote_cmd="probe_dir=\$(mktemp -d /tmp/nemoclaw-python-egress.XXXXXX); probe=\"\$probe_dir/probe.py\"; cleanup(){ rm -rf \"\$probe_dir\"; }; trap cleanup EXIT; printf '%s' ${encoded@Q} | base64 -d > \"\$probe\"; ${python_bin@Q} \"\$probe\" ${url@Q}"
+  remote_cmd="${python_bin@Q} -c \"\$(printf '%s' ${encoded@Q} | base64 -d)\" ${url@Q}"
   sandbox_exec "$remote_cmd"
 }
 

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -402,11 +402,13 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(pythonEgressCheck).toContain("except urllib.error.URLError as exc:");
     expect(pythonEgressCheck).toContain("ERROR:URLError");
     expect(pythonEgressCheck).toContain("lacked denial evidence");
-    expect(pythonEgressCheck).toContain("python_probe_source_b64");
-    expect(pythonEgressCheck).toContain("mktemp /tmp/nemoclaw-python-egress.XXXXXX.py");
+    expect(pythonEgressCheck).toContain("python_probe_source");
+    expect(pythonEgressCheck).toContain("base64 | tr -d");
+    expect(pythonEgressCheck).toContain("mktemp -d /tmp/nemoclaw-python-egress.XXXXXX");
+    expect(pythonEgressCheck).toContain("probe.py");
     expect(pythonEgressCheck).toContain("base64 -d");
     expect(pythonEgressCheck).toContain("${python_bin@Q}");
-    expect(pythonEgressCheck).toContain("${url@Q}; rc=\\$?");
+    expect(pythonEgressCheck).toContain("${url@Q}");
     expect(pythonEgressCheck).toContain(
       'expect_reached "arbitrary Python" "GitHub" "https://api.github.com/"',
     );

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -402,7 +402,11 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(pythonEgressCheck).toContain("except urllib.error.URLError as exc:");
     expect(pythonEgressCheck).toContain("ERROR:URLError");
     expect(pythonEgressCheck).toContain("lacked denial evidence");
-    expect(pythonEgressCheck).toContain("${python_bin@Q} - ${url@Q} <<'PY'");
+    expect(pythonEgressCheck).toContain("python_probe_source_b64");
+    expect(pythonEgressCheck).toContain("mktemp /tmp/nemoclaw-python-egress.XXXXXX.py");
+    expect(pythonEgressCheck).toContain("base64 -d");
+    expect(pythonEgressCheck).toContain("${python_bin@Q}");
+    expect(pythonEgressCheck).toContain("${url@Q}; rc=\\$?");
     expect(pythonEgressCheck).toContain(
       'expect_reached "arbitrary Python" "GitHub" "https://api.github.com/"',
     );

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -404,10 +404,9 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(pythonEgressCheck).toContain("lacked denial evidence");
     expect(pythonEgressCheck).toContain("python_probe_source");
     expect(pythonEgressCheck).toContain("base64 | tr -d");
-    expect(pythonEgressCheck).toContain("mktemp -d /tmp/nemoclaw-python-egress.XXXXXX");
-    expect(pythonEgressCheck).toContain("probe.py");
+    expect(pythonEgressCheck).not.toContain("mktemp");
     expect(pythonEgressCheck).toContain("base64 -d");
-    expect(pythonEgressCheck).toContain("${python_bin@Q}");
+    expect(pythonEgressCheck).toContain("${python_bin@Q} -c");
     expect(pythonEgressCheck).toContain("${url@Q}");
     expect(pythonEgressCheck).toContain(
       'expect_reached "arbitrary Python" "GitHub" "https://api.github.com/"',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the Deep Agents Code Python egress check so its OpenShell sandbox exec call no longer passes a multi-line heredoc as a command argument. The post-#5897 rerun showed OpenShell rejects that argument shape before the policy checks can run.

## Changes
- Encodes the Python egress probe source locally with base64 and decodes it to a temp file inside the sandbox.
- Executes the temp probe file with the requested Python interpreter and URL argument, then removes it.
- Adds a self-test/support test proving the command sent through `sandbox_exec` is single-line.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; command-shape fix keeps the same in-sandbox probe source and policy assertions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
NEMOCLAW_E2E_PYTHON_EGRESS_SELF_TEST=probe-command-shape bash test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh
npm test -- --run test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
npm run typecheck:cli
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened the cloud-experimental end-to-end check for the Python egress probe to ensure it completes successfully.
  * Added a self-test mode that validates the generated probe command is strictly single-line (no newline characters) and emits the expected sentinel output.
  * Updated Deep Agents Code policy behavior checks to match the revised probe construction/execution flow using an encoded probe payload, and to explicitly confirm the implementation does not rely on temporary file creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->