### PR TITLE
ci(hooks): separate pre-commit and pre-push stages

### DIFF
--- a/.github/actions/ci-static-checks/action.yaml
+++ b/.github/actions/ci-static-checks/action.yaml
@@ -36,11 +36,7 @@ runs:
     - name: Run static hook checks
       shell: bash
       run: |
-        npx prek run --all-files --stage pre-push \
-          --skip tsc-plugin \
-          --skip tsc-js \
-          --skip tsc-cli \
-          --skip version-tag-sync \
+        npx prek run --all-files --stage pre-commit \
           --skip test-cli \
           --skip test-plugin \
           --skip source-shape-test-budget \

--- a/.github/actions/ci-static-checks/action.yaml
+++ b/.github/actions/ci-static-checks/action.yaml
@@ -33,6 +33,7 @@ runs:
       shell: bash
       run: npm run validate:configs
 
+    # TypeScript checks and version sync run in the build-typecheck job.
     - name: Run static hook checks
       shell: bash
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@
 
 exclude: ^(nemoclaw/dist/|nemoclaw/node_modules/|docs/_build/|\.venv/|uv\.lock$)
 
+# Stage-less hooks run only while creating a commit. Hooks for later Git
+# lifecycle stages declare their own `stages` explicitly below.
+default_stages:
+  - pre-commit
+
 # Which git hook shims `prek install` writes (separate from each hook's `stages:`).
 # https://prek.j178.dev/configuration/#default_install_hook_types
 default_install_hook_types:
@@ -42,9 +47,11 @@ repos:
     hooks:
       - id: trailing-whitespace
         exclude: ^skills/[^/]+/skill\.oms\.sig$
+        stages: [pre-commit]
         priority: 0
       - id: end-of-file-fixer
         exclude: ^skills/[^/]+/skill\.oms\.sig$
+        stages: [pre-commit]
         priority: 0
       - id: mixed-line-ending
         args: ["--fix=lf"]
@@ -98,6 +105,7 @@ repos:
           - "2"
           - -ci
           - -bn
+        stages: [pre-commit]
         priority: 5
 
   - repo: local
@@ -129,6 +137,7 @@ repos:
         priority: 10
       - id: check-added-large-files
         args: ["--maxkb=2000"]
+        stages: [pre-commit]
         priority: 10
       - id: check-case-conflict
         priority: 10
@@ -141,8 +150,10 @@ repos:
       - id: detect-private-key
         priority: 10
       - id: check-executables-have-shebangs
+        stages: [pre-commit]
         priority: 10
       - id: check-shebang-scripts-are-executable
+        stages: [pre-commit]
         priority: 10
 
   - repo: local

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -19,6 +19,13 @@ type CodebaseGrowthGuardrailsWorkflow = {
   jobs: Record<string, WorkflowJob>;
 };
 
+type PrekConfig = {
+  default_stages?: string[];
+  repos: Array<{
+    hooks?: Array<{ id: string; stages?: string[] }>;
+  }>;
+};
+
 const sharedActionPaths = {
   staticChecks: "./.github/actions/ci-static-checks",
   buildTypecheck: "./.github/actions/ci-build-typecheck",
@@ -129,6 +136,7 @@ function codeFilterMatchesChangedPaths(workflow: CiWorkflow, paths: string[]): b
 describe("pull request and main workflow contracts", () => {
   const prWorkflow = readYaml<CiWorkflow>(".github/workflows/pr.yaml");
   const mainWorkflow = readYaml<CiWorkflow>(".github/workflows/main.yaml");
+  const prekConfig = readYaml<PrekConfig>(".pre-commit-config.yaml");
   const sharedActions = {
     staticChecks: readYaml<CompositeAction>(".github/actions/ci-static-checks/action.yaml"),
     buildTypecheck: readYaml<CompositeAction>(".github/actions/ci-build-typecheck/action.yaml"),
@@ -164,6 +172,28 @@ describe("pull request and main workflow contracts", () => {
         "src/lib/runner.ts",
       ]),
     ).toBe(true);
+  });
+
+  it("keeps ordinary hooks in pre-commit and heavyweight push hooks explicit", () => {
+    const hooks = prekConfig.repos.flatMap((repo) => repo.hooks ?? []);
+    const hook = (id: string) => hooks.find((candidate) => candidate.id === id);
+
+    expect(prekConfig.default_stages).toEqual(["pre-commit"]);
+    expect(hook("test-cli")?.stages).toBeUndefined();
+    expect(hook("test-plugin")?.stages).toBeUndefined();
+    for (const id of [
+      "trailing-whitespace",
+      "end-of-file-fixer",
+      "shfmt",
+      "check-added-large-files",
+      "check-executables-have-shebangs",
+      "check-shebang-scripts-are-executable",
+    ]) {
+      expect(hook(id)?.stages, id).toEqual(["pre-commit"]);
+    }
+    for (const id of ["tsc-plugin", "tsc-js", "tsc-cli", "version-tag-sync"]) {
+      expect(hook(id)?.stages, id).toEqual(["pre-push"]);
+    }
   });
 
   it("reuses the same shared CI actions in PR and main workflows", () => {
@@ -353,7 +383,7 @@ describe("pull request and main workflow contracts", () => {
     const staticRuns = stepRuns(sharedActions.staticChecks);
     const staticRunsJoined = staticRuns.join("\n");
     const staticPrekRun = staticRuns.find((run) =>
-      run.includes("npx prek run --all-files --stage pre-push"),
+      run.includes("npx prek run --all-files --stage pre-commit"),
     );
     const buildRuns = stepRuns(sharedActions.buildTypecheck);
     const cliShardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
@@ -363,12 +393,8 @@ describe("pull request and main workflow contracts", () => {
 
     expect(staticRuns).toContain("npm install --ignore-scripts");
     expect(staticRuns).toContain("npm run validate:configs");
-    expect(staticPrekRun).toContain("npx prek run --all-files --stage pre-push");
+    expect(staticPrekRun).toContain("npx prek run --all-files --stage pre-commit");
     for (const skippedHook of [
-      "tsc-plugin",
-      "tsc-js",
-      "tsc-cli",
-      "version-tag-sync",
       "test-cli",
       "test-plugin",
       "source-shape-test-budget",

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -57,8 +57,9 @@ function runLoggedDockerShell(command: string, tmp: string) {
 }
 
 function copyRlimitFixture(rlimitLib: string): void {
-  // RLIMIT_NPROC is shared by the real user, so the production default can
-  // starve this test's own shell when Vitest runs many workers concurrently.
+  // TEST-ONLY OVERRIDE: production remains 512 in scripts/lib/sandbox-rlimits.sh.
+  // RLIMIT_NPROC is shared by the real user, so that default can starve this
+  // test's own shell when Vitest runs many workers concurrently.
   copyRlimitFixtureWithNprocLimit(rlimitLib, 4096);
 }
 
@@ -292,6 +293,12 @@ function expectUnsupportedNprocDoesNotMaskPosixShNoFile(rlimitLib: string): void
 }
 
 describe("sandbox rlimit system hooks (#2173)", () => {
+  it("keeps the production nproc default at 512", () => {
+    expect(fs.readFileSync(SANDBOX_RLIMITS, "utf-8")).toMatch(
+      /^NEMOCLAW_SANDBOX_NPROC_LIMIT=512$/m,
+    );
+  });
+
   it("rlimit helper enforces supported nofile limits under POSIX sh", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-posix-sh-rlimit-"));
     const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -57,7 +57,9 @@ function runLoggedDockerShell(command: string, tmp: string) {
 }
 
 function copyRlimitFixture(rlimitLib: string): void {
-  copyRlimitFixtureWithNprocLimit(rlimitLib, process.platform === "darwin" ? 4096 : 512);
+  // RLIMIT_NPROC is shared by the real user, so the production default can
+  // starve this test's own shell when Vitest runs many workers concurrently.
+  copyRlimitFixtureWithNprocLimit(rlimitLib, 4096);
 }
 
 function copyRlimitFixtureWithNprocLimit(rlimitLib: string, limit: number): void {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make prek's lifecycle stages explicit so pre-commit owns formatting, linting, and tests while pre-push owns typechecking and version synchronization. This keeps local hooks and static CI aligned without running the same expensive work twice.

## Changes

- Set `pre-commit` as the default stage and pin upstream hooks that opt into multiple stages to pre-commit.
- Run the static-checks action against the pre-commit stage; keep TypeScript and version-sync hooks exclusively on pre-push.
- Add a workflow contract test that ratchets the intended stage ownership.
- Raise only the copied rlimit test fixture's process cap to 4096 so 16-worker Vitest runs cannot starve their own shell; the production cap remains 512.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal hook and CI stage scheduling only; the stage boundary is documented by an executable contract test.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

- `VITEST_MAX_WORKERS=16 npx vitest run --project cli test/pr-workflow-contract.test.ts test/sandbox-rlimit-hooks.test.ts`
- `npx prek validate-config .pre-commit-config.yaml`
- `npx prek run --all-files --stage pre-push --dry-run --no-progress`
- Signed commit and push hooks with `VITEST_MAX_WORKERS=16`

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI static hook checks to run during the `pre-commit` lifecycle (instead of `pre-push`) and aligned related hook skipping behavior.
  * Improved sandbox test stability by standardizing the overridden `NPROC` limit during test setup.

* **Tests**
  * Enhanced pre-commit contract tests to validate `default_stages` and confirm which hooks are explicitly pinned to `pre-commit` vs `pre-push`.
  * Added coverage ensuring the production `sandbox-rlimits.sh` fixture retains its default `NPROC` limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->