### PR TITLE
fix(e2e): avoid multiline Deep Agents secret probe

### DIFF
--- a/test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
+++ b/test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
@@ -87,6 +87,28 @@ describe("P0-E cloud-experimental parity guardrails", () => {
     expect(result.stdout.trim()).toBe("NO_NEWLINE_IN_COMMAND");
   });
 
+  it("keeps Deep Agents secret-boundary probe command single-line for OpenShell exec", () => {
+    const result = spawnSync(
+      "bash",
+      [
+        path.join(
+          process.cwd(),
+          "test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh",
+        ),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          NEMOCLAW_E2E_SECRET_BOUNDARY_SELF_TEST: "probe-command-shape",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("NO_NEWLINE_IN_COMMAND");
+  });
+
   it("registers executable Deep Agents cloud-experimental checks", () => {
     expect(DEEPAGENTS_CLOUD_EXPERIMENTAL_CHECKS).toEqual([
       "test/e2e/e2e-cloud-experimental/checks/05-deepagents-code-landlock-readonly.sh",

--- a/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
@@ -37,6 +37,10 @@ sandbox_exec() {
 dcode_secret_probe() {
   local command="$1"
   local remote_cmd
+  # This helper is intentionally used only with hardcoded probe commands below;
+  # secret material is inserted by callers with Bash @Q quoting. Keep the
+  # remote command single-line because OpenShell rejects newline-bearing exec
+  # arguments.
   remote_cmd="tmp=\$(mktemp /tmp/dcode-secret-boundary.XXXXXX); ${command} >\"\$tmp\" 2>&1; status=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf 'DCODE_EXIT:%s\\n' \"\$status\"; exit 0"
   sandbox_exec "$remote_cmd"
 }
@@ -184,6 +188,23 @@ assert_no_rejected_interval_audit_logs() {
 
 PASSED=0
 FAILED=0
+
+if [ "${NEMOCLAW_E2E_SECRET_BOUNDARY_SELF_TEST:-}" = "probe-command-shape" ]; then
+  sandbox_exec() {
+    case "$1" in
+      *$'\n'*)
+        printf '%s\n' "NEWLINE_IN_COMMAND"
+        return 1
+        ;;
+      *)
+        printf '%s\n' "NO_NEWLINE_IN_COMMAND"
+        return 0
+        ;;
+    esac
+  }
+  dcode_secret_probe "env OPENAI_API_KEY=${FAKE_SECRET@Q} dcode -n 'Reply with the single word PING'"
+  exit 0
+fi
 
 if ! sandbox_exec "test -d /sandbox/.deepagents && command -v dcode >/dev/null 2>&1" >/dev/null; then
   info "SKIP: sandbox '${SANDBOX_NAME}' is not a Deep Agents Code sandbox"

--- a/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
@@ -36,15 +36,9 @@ sandbox_exec() {
 
 dcode_secret_probe() {
   local command="$1"
-  sandbox_exec "
-tmp=\$(mktemp /tmp/dcode-secret-boundary.XXXXXX)
-${command} >\"\$tmp\" 2>&1
-status=\$?
-cat \"\$tmp\"
-rm -f \"\$tmp\"
-printf 'DCODE_EXIT:%s\n' \"\$status\"
-exit 0
-"
+  local remote_cmd
+  remote_cmd="tmp=\$(mktemp /tmp/dcode-secret-boundary.XXXXXX); ${command} >\"\$tmp\" 2>&1; status=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf 'DCODE_EXIT:%s\\n' \"\$status\"; exit 0"
+  sandbox_exec "$remote_cmd"
 }
 
 make_log_marker() {

--- a/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
@@ -34,14 +34,16 @@ sandbox_exec() {
   openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "$1" 2>&1
 }
 
-dcode_secret_probe() {
-  local command="$1"
+dcode_secret_probe_runtime_env() {
+  # Keep this probe single-line: OpenShell rejects newline-bearing exec arguments.
   local remote_cmd
-  # This helper is intentionally used only with hardcoded probe commands below;
-  # secret material is inserted by callers with Bash @Q quoting. Keep the
-  # remote command single-line because OpenShell rejects newline-bearing exec
-  # arguments.
-  remote_cmd="tmp=\$(mktemp /tmp/dcode-secret-boundary.XXXXXX); ${command} >\"\$tmp\" 2>&1; status=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf 'DCODE_EXIT:%s\\n' \"\$status\"; exit 0"
+  remote_cmd="tmp=\$(mktemp /tmp/dcode-secret-boundary.XXXXXX); env OPENAI_API_KEY=${FAKE_SECRET@Q} dcode -n 'Reply with the single word PING' >\"\$tmp\" 2>&1; status=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf 'DCODE_EXIT:%s\\n' \"\$status\"; exit 0"
+  sandbox_exec "$remote_cmd"
+}
+
+dcode_secret_probe_env_file() {
+  local remote_cmd
+  remote_cmd="tmp=\$(mktemp /tmp/dcode-secret-boundary.XXXXXX); dcode -n 'Reply with the single word PING' >\"\$tmp\" 2>&1; status=\$?; cat \"\$tmp\"; rm -f \"\$tmp\"; printf 'DCODE_EXIT:%s\\n' \"\$status\"; exit 0"
   sandbox_exec "$remote_cmd"
 }
 
@@ -202,7 +204,7 @@ if [ "${NEMOCLAW_E2E_SECRET_BOUNDARY_SELF_TEST:-}" = "probe-command-shape" ]; th
         ;;
     esac
   }
-  dcode_secret_probe "env OPENAI_API_KEY=${FAKE_SECRET@Q} dcode -n 'Reply with the single word PING'"
+  dcode_secret_probe_runtime_env
   exit 0
 fi
 
@@ -217,7 +219,7 @@ enable_openshell_audit_logs
 runtime_log_marker="$(make_log_marker runtime-env)"
 runtime_audit_start="$(($(date +%s) - 1))"
 mark_sandbox_logs "$runtime_log_marker"
-runtime_output="$(dcode_secret_probe "env OPENAI_API_KEY=${FAKE_SECRET@Q} dcode -n 'Reply with the single word PING'" || true)"
+runtime_output="$(dcode_secret_probe_runtime_env || true)"
 runtime_logs="$(sandbox_logs_since_marker "$runtime_log_marker" || true)"
 runtime_audit_logs="$(openshell_audit_logs_since_epoch "$runtime_audit_start" || true)"
 assert_secret_rejected "runtime environment injection" "$runtime_output" "OPENAI_API_KEY"
@@ -235,7 +237,7 @@ env_before_hash="$(sandbox_exec "sha256sum ${DEEPAGENTS_ENV_FILE@Q} | awk '{prin
 env_log_marker="$(make_log_marker env-file)"
 env_audit_start="$(($(date +%s) - 1))"
 mark_sandbox_logs "$env_log_marker"
-env_output="$(dcode_secret_probe "dcode -n 'Reply with the single word PING'" || true)"
+env_output="$(dcode_secret_probe_env_file || true)"
 env_logs="$(sandbox_logs_since_marker "$env_log_marker" || true)"
 env_audit_logs="$(openshell_audit_logs_since_epoch "$env_audit_start" || true)"
 env_after_hash="$(sandbox_exec "sha256sum ${DEEPAGENTS_ENV_FILE@Q} | awk '{print \$1}'" || true)"

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -433,6 +433,8 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(secretBoundaryCheck).toContain("Case: Deep Agents Code dcode secret boundary");
     expect(secretBoundaryCheck).toContain("env OPENAI_API_KEY=");
     expect(secretBoundaryCheck).toContain("dcode -n 'Reply with the single word PING'");
+    expect(secretBoundaryCheck).toContain("dcode_secret_probe_runtime_env");
+    expect(secretBoundaryCheck).toContain("dcode_secret_probe_env_file");
     expect(secretBoundaryCheck).toContain("remote_cmd=");
     expect(secretBoundaryCheck).toContain("OpenShell rejects newline-bearing exec");
     expect(secretBoundaryCheck).toContain("NEMOCLAW_E2E_SECRET_BOUNDARY_SELF_TEST");

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -433,6 +433,8 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(secretBoundaryCheck).toContain("Case: Deep Agents Code dcode secret boundary");
     expect(secretBoundaryCheck).toContain("env OPENAI_API_KEY=");
     expect(secretBoundaryCheck).toContain("dcode -n 'Reply with the single word PING'");
+    expect(secretBoundaryCheck).toContain("remote_cmd=");
+    expect(secretBoundaryCheck).toContain("DCODE_EXIT:%s\\\\n");
     expect(secretBoundaryCheck).toContain("DCODE_EXIT:0");
     expect(secretBoundaryCheck).toContain("refusing to start");
     expect(secretBoundaryCheck).toContain("NETWORK_LOG_PATTERN=");

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -434,6 +434,9 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(secretBoundaryCheck).toContain("env OPENAI_API_KEY=");
     expect(secretBoundaryCheck).toContain("dcode -n 'Reply with the single word PING'");
     expect(secretBoundaryCheck).toContain("remote_cmd=");
+    expect(secretBoundaryCheck).toContain("OpenShell rejects newline-bearing exec");
+    expect(secretBoundaryCheck).toContain("NEMOCLAW_E2E_SECRET_BOUNDARY_SELF_TEST");
+    expect(secretBoundaryCheck).toContain("NO_NEWLINE_IN_COMMAND");
     expect(secretBoundaryCheck).toContain("DCODE_EXIT:%s\\\\n");
     expect(secretBoundaryCheck).toContain("DCODE_EXIT:0");
     expect(secretBoundaryCheck).toContain("refusing to start");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the Deep Agents Code secret-boundary check so its `dcode_secret_probe` no longer sends a multi-line shell snippet as a single OpenShell exec argument. The post-#5899 rerun showed OpenShell now rejects those newline-bearing command arguments before the secret-boundary assertions can run.

## Changes
- Compacts `dcode_secret_probe` into a single-line remote shell command while preserving stdout/stderr capture and `DCODE_EXIT` reporting.
- Updates the Deep Agents image contract test to assert the compact remote command shape.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; command-shape-only change preserves existing secret-boundary assertions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
npm test -- --run test/langchain-deepagents-code-image.test.ts
npm run typecheck:cli
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened secret-boundary end-to-end checks with additional stdout assertions, including formatted command output and explicit captured exit-status markers.
  * Added/extended an opt-in self-test mode that validates the probe execution argument contains no newline characters and verifies the expected “no newline” marker.
  * Added a new cloud-experimental end-to-end scenario that runs the secret-boundary check in self-test mode, confirms successful execution, and checks for the new stdout marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->