### PR TITLE
fix(e2e): avoid multiline Deep Agents log probes

### DIFF
--- a/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
@@ -54,30 +54,16 @@ make_log_marker() {
 
 mark_sandbox_logs() {
   local marker="$1"
-  sandbox_exec "
-for log in /tmp/gateway.log /tmp/nemoclaw-start.log; do
-  if [ ! -e \"\$log\" ]; then
-    : > \"\$log\" 2>/dev/null || true
-  fi
-  printf '%s\n' ${marker@Q} >> \"\$log\" 2>/dev/null || true
-done
-" >/dev/null || true
+  local remote_cmd
+  remote_cmd="for log in /tmp/gateway.log /tmp/nemoclaw-start.log; do if [ ! -e \"\$log\" ]; then : > \"\$log\" 2>/dev/null || true; fi; printf '%s\\n' ${marker@Q} >> \"\$log\" 2>/dev/null || true; done"
+  sandbox_exec "$remote_cmd" >/dev/null || true
 }
 
 sandbox_logs_since_marker() {
   local marker="$1"
-  sandbox_exec "
-found=0
-for log in /tmp/gateway.log /tmp/nemoclaw-start.log; do
-  [ -r \"\$log\" ] || continue
-  if grep -Fq ${marker@Q} \"\$log\" 2>/dev/null; then
-    found=1
-    printf '== %s ==\n' \"\$log\"
-    awk -v marker=${marker@Q} 'found { print } index(\$0, marker) { found=1; next }' \"\$log\" 2>/dev/null || true
-  fi
-done
-printf 'LOG_MARKER_FOUND:%s\n' \"\$found\"
-"
+  local remote_cmd
+  remote_cmd="found=0; for log in /tmp/gateway.log /tmp/nemoclaw-start.log; do [ -r \"\$log\" ] || continue; if grep -Fq ${marker@Q} \"\$log\" 2>/dev/null; then found=1; printf '== %s ==\\n' \"\$log\"; awk -v marker=${marker@Q} 'found { print } index(\$0, marker) { found=1; next }' \"\$log\" 2>/dev/null || true; fi; done; printf 'LOG_MARKER_FOUND:%s\\n' \"\$found\""
+  sandbox_exec "$remote_cmd"
 }
 
 enable_openshell_audit_logs() {

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -436,6 +436,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(secretBoundaryCheck).toContain("dcode_secret_probe_runtime_env");
     expect(secretBoundaryCheck).toContain("dcode_secret_probe_env_file");
     expect(secretBoundaryCheck).toContain("remote_cmd=");
+    expect(secretBoundaryCheck).toContain("LOG_MARKER_FOUND:%s");
     expect(secretBoundaryCheck).toContain("OpenShell rejects newline-bearing exec");
     expect(secretBoundaryCheck).toContain("NEMOCLAW_E2E_SECRET_BOUNDARY_SELF_TEST");
     expect(secretBoundaryCheck).toContain("NO_NEWLINE_IN_COMMAND");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Compacts the remaining Deep Agents Code secret-boundary log marker probes into single-line OpenShell exec commands. The post-#5902 rerun showed the dcode probes now pass, but the log-marker helpers still used newline-bearing sandbox exec arguments and were rejected by OpenShell.

## Changes
- Converts `mark_sandbox_logs` to build and run a single-line remote command.
- Converts `sandbox_logs_since_marker` to build and run a single-line remote command.
- Updates the Deep Agents image contract test to assert the log marker output remains present.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; command-shape-only change preserves existing log assertions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/08-deepagents-code-secret-boundary.sh
npm test -- --run test/langchain-deepagents-code-image.test.ts
npm run typecheck:cli
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox log marker checks so secret-boundary detection is more reliable.

* **Tests**
  * Updated end-to-end coverage to verify the expected `LOG_MARKER_FOUND` output in deep agent policy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->