### PR TITLE
fix(e2e): avoid multiline Deep Agents Tavily probe

### DIFF
--- a/test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
+++ b/test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts
@@ -109,6 +109,28 @@ describe("P0-E cloud-experimental parity guardrails", () => {
     expect(result.stdout).toContain("NO_NEWLINE_IN_COMMAND");
   });
 
+  it("keeps Deep Agents Tavily opt-in probe command single-line for OpenShell exec", () => {
+    const result = spawnSync(
+      "bash",
+      [
+        path.join(
+          process.cwd(),
+          "test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh",
+        ),
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          NEMOCLAW_E2E_TAVILY_SELF_TEST: "probe-command-shape",
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("NO_NEWLINE_IN_COMMAND");
+  });
+
   it("registers executable Deep Agents cloud-experimental checks", () => {
     expect(DEEPAGENTS_CLOUD_EXPERIMENTAL_CHECKS).toEqual([
       "test/e2e/e2e-cloud-experimental/checks/05-deepagents-code-landlock-readonly.sh",

--- a/test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
@@ -34,9 +34,8 @@ nemoclaw_cli() {
   fi
 }
 
-python_probe() {
-  local url="$1"
-  sandbox_exec "python3 - ${url@Q} <<'PY'
+python_probe_source() {
+  cat <<'PY'
 import sys
 import urllib.error
 import urllib.request
@@ -90,11 +89,39 @@ except OSError as exc:
 except Exception as exc:
     print(f'ERROR:{type(exc).__name__}:{exc}')
 PY
-"
+}
+
+python_probe() {
+  local url="$1"
+  local encoded remote_cmd
+  if [ -n "${NEMOCLAW_E2E_TAVILY_PROBE_FIXTURE+x}" ]; then
+    printf '%s\n' "$NEMOCLAW_E2E_TAVILY_PROBE_FIXTURE"
+    return 0
+  fi
+  encoded="$(python_probe_source | base64 | tr -d '\n')"
+  remote_cmd="python3 -c \"\$(printf '%s' ${encoded@Q} | base64 -d)\" ${url@Q}"
+  sandbox_exec "$remote_cmd"
 }
 
 PASSED=0
 FAILED=0
+
+if [ "${NEMOCLAW_E2E_TAVILY_SELF_TEST:-}" = "probe-command-shape" ]; then
+  sandbox_exec() {
+    case "$1" in
+      *$'\n'*)
+        printf '%s\n' "NEWLINE_IN_COMMAND"
+        return 1
+        ;;
+      *)
+        printf '%s\n' "NO_NEWLINE_IN_COMMAND"
+        return 0
+        ;;
+    esac
+  }
+  python_probe "https://api.tavily.com/"
+  exit 0
+fi
 
 if ! sandbox_exec "test -d /sandbox/.deepagents && command -v dcode >/dev/null 2>&1" >/dev/null; then
   info "SKIP: sandbox '${SANDBOX_NAME}' is not a Deep Agents Code sandbox"

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -497,6 +497,10 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tavilyOptInCheck).toContain("policy-add tavily --dry-run");
     expect(tavilyOptInCheck).toContain("policy-add tavily --yes");
     expect(tavilyOptInCheck).toContain("https://api.tavily.com/");
+    expect(tavilyOptInCheck).toContain("python_probe_source");
+    expect(tavilyOptInCheck).toContain("base64 | tr -d");
+    expect(tavilyOptInCheck).toContain("python3 -c");
+    expect(tavilyOptInCheck).toContain("NEMOCLAW_E2E_TAVILY_SELF_TEST");
     expect(tavilyOptInCheck).toContain("/opt/venv/");
     expect(tavilyOptInCheck).toContain("managed Deep Agents Code python can reach Tavily");
     expect(cloudExperimentalChecksForOnboarding("cloud-langchain-deepagents-code")).toEqual([


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the Deep Agents Code Tavily opt-in check so its Python reachability probe no longer sends a multiline heredoc as a single OpenShell exec argument. The post-#5903 rerun showed the scenario now reaches the Tavily check and fails on the same newline command-shape issue.

## Changes
- Encodes the Tavily Python probe source locally with portable `base64 | tr -d '\n'` and decodes it inside a single-line `python3 -c` command.
- Adds a self-test mode that proves the command sent through `sandbox_exec` is newline-free.
- Updates Deep Agents image contract tests for the new probe shape.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; same Python probe, single-line transport only.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
NEMOCLAW_E2E_TAVILY_SELF_TEST=probe-command-shape bash test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
npm test -- --run test/e2e-scenario/support-tests/platform-parity-cloud-experimental.test.ts test/langchain-deepagents-code-image.test.ts
npm run typecheck:cli
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of a cloud-experimental check by verifying a command runs in the expected format and completes successfully.
  * Strengthened validation around an opt-in workflow so it is less likely to break due to formatting issues in generated commands.
  * Added broader test coverage for the same behavior to catch regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->