### PR TITLE
ci: bootstrap source coverage migration

### DIFF
--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -78,6 +78,12 @@ runs:
     - name: Merge CLI coverage
       shell: bash
       run: |
+        coverage_include="dist/lib/**/*.js"
+        # Keep the merge denominator aligned with the shard command during
+        # the PR #5904 transition. That PR removes this probe after landing.
+        if npx vitest list --project integration --filesOnly >/dev/null 2>&1; then
+          coverage_include="src/**/*.ts"
+        fi
         npx vitest --mergeReports .vitest-reports \
           --reporter=json \
           --outputFile.json=coverage/cli/vitest-results.json \
@@ -87,7 +93,7 @@ runs:
           --coverage.reporter=cobertura \
           --coverage.reportsDirectory=coverage/cli \
           --coverage.include="bin/**/*.js" \
-          --coverage.include="dist/lib/**/*.js" \
+          --coverage.include="$coverage_include" \
           --coverage.exclude="test/**/*.js" \
           --coverage.exclude="test/**/*.ts"
         npx tsx scripts/check-coverage-ratchet.ts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json "CLI coverage"

--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -81,8 +81,12 @@ runs:
         coverage_include="dist/lib/**/*.js"
         # Keep the merge denominator aligned with the shard command during
         # the PR #5904 transition. That PR removes this probe after landing.
-        if npx vitest list --project integration --filesOnly >/dev/null 2>&1; then
+        integration_probe_output=""
+        if integration_probe_output=$(npx vitest list --project integration --filesOnly 2>&1); then
           coverage_include="src/**/*.ts"
+        elif ! grep -Fqx 'Error: No projects matched the filter "integration".' <<<"$integration_probe_output"; then
+          printf '%s\n' "$integration_probe_output" >&2
+          exit 1
         fi
         npx vitest --mergeReports .vitest-reports \
           --reporter=json \

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -71,9 +71,13 @@ runs:
         # Bootstrap the source-test migration without executing action code
         # from the PR branch. PR #5904 removes this probe once `integration`
         # is part of the trusted base configuration.
-        if npx vitest list --project integration --filesOnly >/dev/null 2>&1; then
+        integration_probe_output=""
+        if integration_probe_output=$(npx vitest list --project integration --filesOnly 2>&1); then
           additional_projects+=(--project integration)
           coverage_include="src/**/*.ts"
+        elif ! grep -Fqx 'Error: No projects matched the filter "integration".' <<<"$integration_probe_output"; then
+          printf '%s\n' "$integration_probe_output" >&2
+          exit 1
         fi
         npx vitest run --project cli \
           "${additional_projects[@]}" \

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -66,7 +66,17 @@ runs:
         node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
         npm run build:cli
         npx tsx scripts/check-dist-sourcemaps.ts dist
+        coverage_include="dist/lib/**/*.js"
+        additional_projects=()
+        # Bootstrap the source-test migration without executing action code
+        # from the PR branch. PR #5904 removes this probe once `integration`
+        # is part of the trusted base configuration.
+        if npx vitest list --project integration --filesOnly >/dev/null 2>&1; then
+          additional_projects+=(--project integration)
+          coverage_include="src/**/*.ts"
+        fi
         npx vitest run --project cli \
+          "${additional_projects[@]}" \
           --shard="${CLI_SHARD}/${CLI_SHARD_COUNT}" \
           --reporter=github-actions \
           --reporter=blob \
@@ -75,7 +85,7 @@ runs:
           --coverage.reporter=json-summary \
           --coverage.reportsDirectory="coverage/cli/shard-${CLI_SHARD}" \
           --coverage.include="bin/**/*.js" \
-          --coverage.include="dist/lib/**/*.js" \
+          --coverage.include="$coverage_include" \
           --coverage.exclude="test/**/*.js" \
           --coverage.exclude="test/**/*.ts"
 

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -469,6 +469,8 @@ describe("pull request and main workflow contracts", () => {
     for (const run of [shardRun, mergeRun]) {
       expect(run).toContain('coverage_include="dist/lib/**/*.js"');
       expect(run).toContain("npx vitest list --project integration --filesOnly");
+      expect(run).toContain('Error: No projects matched the filter "integration".');
+      expect(run).toContain("printf '%s\\n' \"$integration_probe_output\" >&2");
       expect(run).toContain('coverage_include="src/**/*.ts"');
       expect(run).toContain('--coverage.include="$coverage_include"');
     }

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -462,6 +462,22 @@ describe("pull request and main workflow contracts", () => {
     expect(installerRuns).toContain("CI=true npx vitest run --project installer-integration");
   });
 
+  it("keeps the temporary CLI source-coverage switch aligned across shard and merge", () => {
+    const shardRun = requiredStep(sharedActions.cliCoverageShard, "Run CLI coverage shard").run;
+    const mergeRun = requiredStep(sharedActions.cliCoverageMerge, "Merge CLI coverage").run;
+
+    for (const run of [shardRun, mergeRun]) {
+      expect(run).toContain('coverage_include="dist/lib/**/*.js"');
+      expect(run).toContain("npx vitest list --project integration --filesOnly");
+      expect(run).toContain('coverage_include="src/**/*.ts"');
+      expect(run).toContain('--coverage.include="$coverage_include"');
+    }
+
+    expect(shardRun).toContain("additional_projects=()");
+    expect(shardRun).toContain("additional_projects+=(--project integration)");
+    expect(shardRun).toContain('"${additional_projects[@]}"');
+  });
+
   it("keeps PR coverage for non-opt-in Vitest projects after removing the self-hosted full run", () => {
     const vitestConfig = readFileSync("vitest.config.ts", "utf8");
     const cliShardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Let the trusted CLI coverage actions recognize the source-test project split introduced by #5904 without executing action code from that PR. Preserve the current compiled coverage path until an `integration` Vitest project exists, then keep shard execution and merge-time coverage accounting aligned on source.

## Related Issue

Unblocks #5904.

## Changes

- Probe Vitest for the `integration` project from the trusted base action.
- Preserve the existing `cli` plus `dist/lib/**/*.js` coverage path on current `main`.
- Select `cli + integration` and `src/**/*.ts` together when the migrated project exists.
- Keep the shard and merge denominators identical; #5904 replaces this transition probe with its final unconditional source configuration.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is an internal CI rollout bridge with no user-facing behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI CLI coverage handling by dynamically choosing the appropriate coverage include pattern (compiled output vs. TypeScript sources) based on whether the integration project is available.
  * Coverage merging and sharding now use the same computed include settings to avoid inaccurate or missing coverage.

* **Tests**
  * Added a contract test to verify the shared CI coverage steps stay consistent, including the optional integration-project probing and shard parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->