### PR TITLE
fix(e2e): preserve Deep Agents TUI markers

### DIFF
--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -129,6 +129,35 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     expect(assertExit("1")).toBe("passed=0 failed=1");
   });
 
+  it("preserves TUI lifecycle markers in the sanitized capture artifact", () => {
+    const captureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-markers-"));
+    const sanitizedCapture = path.join(captureDir, "10-deepagents-code-tui-startup.sanitized.log");
+
+    try {
+      const result = runTuiStartupCheckHelperResult(
+        [
+          "sandbox_exec() { printf 'NEMOCLAW_DCODE_PROBE:deepagents\\n'; }",
+          "ensure_expect_available() { return 0; }",
+          "run_tui_expect() {",
+          '  printf "What would you like to do next?\\nNEMOCLAW_TUI_READY\\nNEMOCLAW_TUI_EXIT_CAPTURED:130\\n" >>"$1"',
+          "}",
+          "main",
+        ].join("\n"),
+        { DEEPAGENTS_TUI_CAPTURE_DIR: captureDir },
+      );
+
+      const sanitizedText = fs.readFileSync(sanitizedCapture, "utf8");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("finite expect harness reached startup and observed exit");
+      expect(result.stdout).toContain("dcode TUI rendered a usable startup prompt signature");
+      expect(result.stdout).toContain("dcode TUI exited cleanly after Ctrl-C (exit 130)");
+      expect(sanitizedText).toContain("NEMOCLAW_TUI_READY");
+      expect(sanitizedText).toContain("NEMOCLAW_TUI_EXIT_CAPTURED:130");
+    } finally {
+      fs.rmSync(captureDir, { force: true, recursive: true });
+    }
+  });
+
   it("detects and redacts every canonical secret family in TUI startup artifacts", () => {
     const detectsSecret = (token: string) =>
       runTuiStartupCheckHelper(

--- a/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
@@ -150,19 +150,28 @@ set capture $env(NEMOCLAW_TUI_CAPTURE)
 set ready_pattern $env(NEMOCLAW_TUI_READY_PATTERN)
 log_file -a $capture
 
+proc append_marker {capture marker} {
+  set fh [open $capture a]
+  puts $fh $marker
+  close $fh
+}
+
 set cmd [list openshell sandbox exec --name $sandbox --tty -- sh -lc {export TERM=xterm-256color; cd /sandbox; dcode; status=$?; printf "\nNEMOCLAW_TUI_EXIT:%s\n" "$status"}]
 spawn {*}$cmd
 expect {
   -nocase -re $ready_pattern {
+    append_marker $capture "NEMOCLAW_TUI_READY"
     puts "\nNEMOCLAW_TUI_READY"
     send -- "\003"
   }
   timeout {
+    append_marker $capture "NEMOCLAW_TUI_TIMEOUT"
     puts "\nNEMOCLAW_TUI_TIMEOUT"
     send -- "\003"
     exit 20
   }
   eof {
+    append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_READY"
     puts "\nNEMOCLAW_TUI_EOF_BEFORE_READY"
     exit 21
   }
@@ -171,15 +180,18 @@ expect {
 set timeout 20
 expect {
   -re {NEMOCLAW_TUI_EXIT:([0-9]+)} {
+    append_marker $capture "NEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"
     puts "\nNEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"
     exit 0
   }
   timeout {
+    append_marker $capture "NEMOCLAW_TUI_EXIT_TIMEOUT"
     puts "\nNEMOCLAW_TUI_EXIT_TIMEOUT"
     send -- "\003"
     exit 22
   }
   eof {
+    append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_EXIT"
     puts "\nNEMOCLAW_TUI_EOF_BEFORE_EXIT"
     exit 23
   }

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -471,10 +471,14 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tuiStartupCheck).toContain("unable to probe sandbox");
     expect(tuiStartupCheck).toContain("unexpected sandbox probe output");
     expect(tuiStartupCheck).toContain("cd /sandbox; dcode");
-    expect(tuiStartupCheck).toContain("NEMOCLAW_TUI_READY");
-    expect(tuiStartupCheck).toContain("append_marker");
-    expect(tuiStartupCheck).toContain("NEMOCLAW_TUI_READY");
-    expect(tuiStartupCheck).toContain("NEMOCLAW_TUI_EXIT_CAPTURED");
+    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_READY"');
+    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_TIMEOUT"');
+    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_READY"');
+    expect(tuiStartupCheck).toContain(
+      'append_marker $capture "NEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"',
+    );
+    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_EXIT_TIMEOUT"');
+    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_EXIT"');
     expect(tuiStartupCheck).toContain("DEEPAGENTS_TUI_TIMEOUT must be a positive integer");
     expect(tuiStartupCheck).toContain("strip_terminal_control_sequences");
     expect(tuiStartupCheck).toContain("is_tui_ready_capture");

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -472,6 +472,8 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tuiStartupCheck).toContain("unexpected sandbox probe output");
     expect(tuiStartupCheck).toContain("cd /sandbox; dcode");
     expect(tuiStartupCheck).toContain("NEMOCLAW_TUI_READY");
+    expect(tuiStartupCheck).toContain("append_marker");
+    expect(tuiStartupCheck).toContain("NEMOCLAW_TUI_READY");
     expect(tuiStartupCheck).toContain("NEMOCLAW_TUI_EXIT_CAPTURED");
     expect(tuiStartupCheck).toContain("DEEPAGENTS_TUI_TIMEOUT must be a positive integer");
     expect(tuiStartupCheck).toContain("strip_terminal_control_sequences");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Preserves Deep Agents TUI expect harness markers in the sanitized capture file. The post-#5905 rerun showed the expect harness reached startup and observed exit, but its markers were only printed to expect stdout and did not survive into the capture file checked by the assertions.

## Changes
- Adds an expect `append_marker` helper that writes readiness, timeout/EOF, and exit markers directly to the capture file.
- Keeps the existing strict prompt and clean-exit assertions unchanged.
- Extends the Deep Agents image contract test to assert marker preservation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: live E2E harness behavior only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; capture-marker persistence only, strict TUI assertions remain in place.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
npm test -- --run test/deepagents-code-tui-startup-check.test.ts test/langchain-deepagents-code-image.test.ts
npm run typecheck:cli
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Deep Agents Code TUI startup/exit-state checks by validating multiple lifecycle markers (readiness, timeout/error/EOF before readiness, and exit capture with timeout/EOF around exit) to make automation more dependable.
  * Added coverage to ensure startup sanitization preserves the lifecycle marker strings in the generated sanitized capture artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->