### PR TITLE
refactor(cli): separate sandbox status rendering

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -129,6 +129,21 @@
       }
     },
     {
+      "includes": ["src/lib/actions/sandbox/status.ts", "src/lib/actions/sandbox/status-text.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": {
+              "level": "error",
+              "options": {
+                "maxAllowedComplexity": 10
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["nemoclaw/src/**/*.ts"],
       "linter": {
         "rules": {

--- a/src/lib/actions/sandbox/status-text.ts
+++ b/src/lib/actions/sandbox/status-text.ts
@@ -179,7 +179,8 @@ function printActiveSessions(sandboxName: string): void {
     const connected = count > 0 ? `${G}yes${R} (${count} session${count > 1 ? "s" : ""})` : "no";
     console.log(`    Connected: ${connected}`);
   } catch {
-    /* non-fatal */
+    // Session detection is informational; an unavailable OpenShell client must
+    // not suppress the primary sandbox and gateway health report.
   }
 }
 
@@ -223,7 +224,8 @@ function printAgentVersion(context: SandboxStatusTextContext, sandbox: SandboxEn
       );
     }
   } catch {
-    /* non-fatal */
+    // Version metadata is advisory; omit it when probing fails so the primary
+    // sandbox and gateway health report remains available.
   }
 }
 

--- a/src/lib/actions/sandbox/status-text.ts
+++ b/src/lib/actions/sandbox/status-text.ts
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolveOpenshell } from "../../adapters/openshell/resolve";
+import * as agentRuntime from "../../agent/runtime";
+import { CLI_NAME } from "../../cli/branding";
+import { D, G, R, RD, YW } from "../../cli/terminal-style";
+import type { ProviderHealthStatus } from "../../inference/health";
+import * as nim from "../../inference/nim";
+import * as sandboxVersion from "../../sandbox/version";
+import * as shields from "../../shields";
+import type { SandboxGpuProofResult, SandboxEntry } from "../../state/registry";
+import {
+  createSystemDeps as createSessionDeps,
+  getActiveSandboxSessions,
+} from "../../state/sandbox-session";
+import type { SandboxDockerRuntime } from "./docker-health";
+import type { SandboxGatewayState } from "./gateway-state";
+import { isSandboxGatewayRunningForStatus } from "./process-recovery";
+import type { SandboxStatusAgentInfo, SandboxStatusSnapshot } from "./status-snapshot";
+
+export interface SandboxStatusTextContext
+  extends Pick<
+    SandboxStatusSnapshot,
+    | "sb"
+    | "lookup"
+    | "currentModel"
+    | "currentProvider"
+    | "inferenceHealth"
+    | "terminalRuntimeHealth"
+  > {
+  sandboxName: string;
+  statusAgent: SandboxStatusAgentInfo;
+}
+
+export interface SandboxStatusTextOutcome {
+  exitCode: number | null;
+}
+
+/** Returns true when status can validate an agent version against the running sandbox. */
+function shouldProbeSandboxRuntimeVersion(
+  lookup: SandboxGatewayState,
+  sandbox: SandboxEntry,
+  agentRuntimeKind: string,
+): boolean {
+  return (
+    lookup.state === "present" && (Boolean(sandbox.agentVersion) || agentRuntimeKind === "terminal")
+  );
+}
+
+// True when sandbox GPU is enabled but no CUDA-usability proof has confirmed it
+// (older entries with no recorded proof, or a run whose CUDA proof could not
+// execute). Treated as not-yet-proven rather than healthy (#4231).
+export function sandboxGpuProofUnverified(
+  proof: SandboxGpuProofResult | null | undefined,
+): boolean {
+  return !proof || proof.status === "unverified";
+}
+
+// Render the proof-state suffix appended to the `Sandbox GPU: enabled` line so
+// the status reflects verified/unverified/failed CUDA usability instead of
+// reporting any configured GPU as healthy (#4231).
+export function sandboxGpuProofStatusSuffix(
+  proof: SandboxGpuProofResult | null | undefined,
+): string {
+  if (proof?.status === "verified") return ` ${G}(CUDA verified)${R}`;
+  if (proof?.status === "failed") {
+    const label = proof.label ? `: ${proof.label}` : "";
+    return ` ${RD}(last CUDA proof failed${label})${R}`;
+  }
+  return ` ${YW}(CUDA unverified)${R}`;
+}
+
+/** Render one inference probe so every hop uses the same status vocabulary. */
+function printInferenceProbeLine(probe: ProviderHealthStatus): void {
+  const label = probe.probeLabel ? `Inference (${probe.probeLabel})` : "Inference";
+  if (!probe.probed) {
+    console.log(`    ${label}: ${D}not probed${R} (${probe.detail})`);
+    return;
+  }
+  if (probe.ok) {
+    console.log(`    ${label}: ${G}healthy${R} (${probe.endpoint})`);
+    return;
+  }
+  console.log(`    ${label}: ${RD}${probe.failureLabel || "unreachable"}${R} (${probe.endpoint})`);
+  console.log(`      ${probe.detail}`);
+}
+
+function printInferenceStatus(context: SandboxStatusTextContext): void {
+  if (context.inferenceHealth) {
+    printInferenceProbeLine(context.inferenceHealth);
+    for (const subprobe of context.inferenceHealth.subprobes ?? []) {
+      printInferenceProbeLine(subprobe);
+    }
+  }
+  if (context.lookup.state !== "present") {
+    console.log("    Inference: not verified (gateway/sandbox state not verified)");
+  }
+}
+
+function getSandboxGpuDisplay(sandbox: SandboxEntry): {
+  enabled: boolean;
+  hostGpu: string;
+  sandboxGpu: string;
+} {
+  const hostGpu = sandbox.hostGpuDetected ? "yes" : "no";
+  const enabled = sandbox.sandboxGpuEnabled ?? sandbox.gpuEnabled === true;
+  const state = enabled ? "enabled" : "disabled";
+  const mode = sandbox.sandboxGpuMode ? ` (${sandbox.sandboxGpuMode})` : "";
+  const device = sandbox.sandboxGpuDevice ? ` device=${sandbox.sandboxGpuDevice}` : "";
+  const proofSuffix = enabled ? sandboxGpuProofStatusSuffix(sandbox.sandboxGpuProof) : "";
+  return {
+    enabled,
+    hostGpu,
+    sandboxGpu: `${state}${mode}${device}${proofSuffix}`,
+  };
+}
+
+function printSandboxGpuStatus(sandbox: SandboxEntry): void {
+  const display = getSandboxGpuDisplay(sandbox);
+  console.log(`    Host GPU: ${display.hostGpu}`);
+  console.log(`    Sandbox GPU: ${display.sandboxGpu}`);
+  if (!display.enabled) return;
+
+  if (sandbox.sandboxGpuProof?.status === "failed") {
+    if (sandbox.sandboxGpuProof.detail) console.log(`      ${sandbox.sandboxGpuProof.detail}`);
+    console.log(
+      "      CUDA failed a live proof. Recreate with corrected GPU device/group access, or rerun onboard with --no-gpu.",
+    );
+    return;
+  }
+  if (sandboxGpuProofUnverified(sandbox.sandboxGpuProof)) {
+    console.log(
+      "      CUDA usability has not been proven. Rerun onboard to verify, or use --no-gpu for CPU.",
+    );
+  }
+}
+
+function printTerminalHarness(context: SandboxStatusTextContext): number | null {
+  const { lookup, sandboxName, statusAgent, terminalRuntimeHealth } = context;
+  if (!statusAgent.agentDefinition || statusAgent.agentRuntime !== "terminal") return null;
+
+  const interactiveCommand = agentRuntime.getTerminalCommand(
+    statusAgent.agentDefinition,
+    "interactive",
+  );
+  const headlessCommand = agentRuntime.getTerminalCommand(statusAgent.agentDefinition, "headless");
+  if (interactiveCommand) console.log(`    Interactive: ${interactiveCommand}`);
+  if (headlessCommand) console.log(`    Headless: ${headlessCommand} "<prompt>"`);
+  console.log("    Updates: managed by NemoClaw image rebuilds");
+
+  if (lookup.state !== "present" || terminalRuntimeHealth?.kind !== "degraded") return null;
+  const countLabel =
+    terminalRuntimeHealth.oomKillCount === 1
+      ? "1 OOM kill"
+      : `${terminalRuntimeHealth.oomKillCount} OOM kills`;
+  console.log(`    Runtime health: ${YW}degraded${R} (${countLabel} recorded)`);
+  console.log("      Sandbox may be degraded after an OOM kill.");
+  console.log(`      Run \`${CLI_NAME} ${sandboxName} rebuild\` to restore.`);
+  return 1;
+}
+
+function printAgentHarness(context: SandboxStatusTextContext): number | null {
+  const { statusAgent } = context;
+  console.log(`    Harness:  ${statusAgent.agentDisplayName} (${statusAgent.agentRuntime})`);
+  if (statusAgent.agentLoadError) {
+    console.log(`    Agent load error: ${statusAgent.agentLoadError}`);
+  }
+  return printTerminalHarness(context);
+}
+
+function printActiveSessions(sandboxName: string): void {
+  try {
+    const openshell = resolveOpenshell();
+    if (!openshell) return;
+    const sessionResult = getActiveSandboxSessions(sandboxName, createSessionDeps(openshell));
+    if (!sessionResult.detected) return;
+    const count = sessionResult.sessions.length;
+    const connected = count > 0 ? `${G}yes${R} (${count} session${count > 1 ? "s" : ""})` : "no";
+    console.log(`    Connected: ${connected}`);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+function printShieldsPosture(sandboxName: string): void {
+  const posture = shields.getShieldsPosture(sandboxName, true);
+  if (posture.mode === "locked") return;
+  const detail =
+    posture.mode === "mutable_default"
+      ? posture.detail
+      : `${posture.detail} (check \`shields status\` for details)`;
+  console.log(`    Permissions: ${detail}`);
+}
+
+function printAgentVersion(context: SandboxStatusTextContext, sandbox: SandboxEntry): void {
+  try {
+    const { lookup, sandboxName, statusAgent } = context;
+    const shouldProbe = shouldProbeSandboxRuntimeVersion(lookup, sandbox, statusAgent.agentRuntime);
+    const versionCheck = sandboxVersion.checkAgentVersion(sandboxName, {
+      forceProbe: shouldProbe,
+      skipProbe: !shouldProbe,
+    });
+    const agentName = statusAgent.agentDisplayName;
+    if (versionCheck.sandboxVersion) {
+      console.log(`    Agent:    ${agentName} v${versionCheck.sandboxVersion}`);
+    } else if (shouldProbe && versionCheck.expectedVersion) {
+      console.log(
+        `    Agent:    ${agentName} version not verified (expected v${versionCheck.expectedVersion})`,
+      );
+    }
+    if (versionCheck.isStale) {
+      console.log(`    ${YW}Update:   v${versionCheck.expectedVersion} available${R}`);
+      console.log(`              Run \`${CLI_NAME} ${sandboxName} rebuild\` to upgrade`);
+    } else if (
+      shouldProbe &&
+      versionCheck.detectionMethod === "unavailable" &&
+      versionCheck.expectedVersion
+    ) {
+      console.log(`    ${YW}Update:   unable to verify sandbox ${agentName} version${R}`);
+      console.log(
+        `              Run \`${CLI_NAME} ${sandboxName} rebuild\` if this sandbox predates the current install`,
+      );
+    }
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/** Render registry-backed sandbox details and return any non-fatal degraded outcome. */
+export function printSandboxDetails(context: SandboxStatusTextContext): SandboxStatusTextOutcome {
+  const { sb, currentModel, currentProvider, sandboxName } = context;
+  if (!sb) return { exitCode: null };
+
+  console.log("");
+  console.log(`  Sandbox: ${sb.name}`);
+  console.log(`    Model:    ${currentModel}`);
+  console.log(`    Provider: ${currentProvider}`);
+  printInferenceStatus(context);
+  printSandboxGpuStatus(sb);
+  console.log(
+    `    OpenShell: ${sb.openshellVersion || "unknown"} (${sb.openshellDriver || "unknown"})`,
+  );
+  console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
+  const exitCode = printAgentHarness(context);
+  printActiveSessions(sandboxName);
+  printShieldsPosture(sandboxName);
+  printAgentVersion(context, sb);
+  return { exitCode };
+}
+
+async function printGatewayProcessStatus(context: SandboxStatusTextContext): Promise<void> {
+  const { sandboxName, statusAgent } = context;
+  const running = await isSandboxGatewayRunningForStatus(sandboxName);
+  if (running === null) return;
+  const agentName = statusAgent.agentDisplayName;
+  if (running) {
+    console.log(`    ${agentName}: ${G}running${R}`);
+    return;
+  }
+  console.log(`    ${agentName}: ${RD}not running${R}`);
+  console.log("");
+  console.log(`  The sandbox is alive but the ${agentName} gateway process is not running.`);
+  console.log("  This typically happens after a gateway restart (e.g., laptop close/open).");
+  console.log("");
+  console.log("  To recover, run:");
+  console.log(`    ${D}${CLI_NAME} ${sandboxName} connect${R}  (auto-recovers on connect)`);
+  console.log("  Or manually inside the sandbox:");
+  console.log(`    ${D}${agentRuntime.getGatewayCommand(statusAgent.agentDefinition)}${R}`);
+}
+
+/** Render the live agent process status after the gateway lookup is shown. */
+export async function printAgentProcessStatus(context: SandboxStatusTextContext): Promise<void> {
+  if (context.lookup.state !== "present") return;
+  if (context.statusAgent.agentRuntime === "gateway") {
+    await printGatewayProcessStatus(context);
+    return;
+  }
+  if (context.statusAgent.agentRuntime === "unknown") {
+    console.log(`    Agent '${context.statusAgent.agentName}' runtime: ${YW}unknown${R}`);
+    return;
+  }
+  console.log(`    ${context.statusAgent.agentDisplayName} runtime: ${G}terminal${R}`);
+}
+
+/**
+ * Render Docker's in-container health signal independently from host-side
+ * delivery probes. On OpenShell-managed forwarding the Docker probe can be
+ * stale even when host-side delivery is healthy, so report the mismatch
+ * without overriding either signal. (#3975)
+ */
+export function printDockerHealth(dockerRuntime: SandboxDockerRuntime | null): void {
+  if (!dockerRuntime || dockerRuntime.health === "none" || dockerRuntime.health === "unknown") {
+    return;
+  }
+  if (dockerRuntime.health === "healthy") {
+    console.log(`    Docker health: ${G}healthy${R}`);
+    return;
+  }
+  if (dockerRuntime.health === "starting") {
+    console.log(`    Docker health: ${D}starting${R}`);
+    return;
+  }
+  console.log(`    Docker health: ${RD}unhealthy${R}`);
+  console.log(
+    `      ${D}This is the in-container Docker probe; compare with the host-side delivery${R}`,
+  );
+  console.log(`      ${D}chain above. A mismatch can be a stale signal on OpenShell-managed${R}`);
+  console.log(`      ${D}runtimes — see #3975.${R}`);
+}
+
+/** Render the optional local NIM process and health signal. */
+export function printNimStatus(sandboxName: string, sandbox: SandboxEntry | null): void {
+  const nimStat = sandbox?.nimContainer
+    ? nim.nimStatusByName(sandbox.nimContainer)
+    : nim.nimStatus(sandboxName);
+  if (!nim.shouldShowNimLine(sandbox?.nimContainer ?? null, nimStat.running)) return;
+  console.log(
+    `    NIM:      ${nimStat.running ? `running (${nimStat.container})` : "not running"}`,
+  );
+  if (nimStat.running) console.log(`    Healthy:  ${nimStat.healthy ? "yes" : "no"}`);
+}

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -2,24 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { printOpenShellStateRpcIssue } from "../../adapters/openshell/gateway-drift";
-import { resolveOpenshell } from "../../adapters/openshell/resolve";
-import * as agentRuntime from "../../agent/runtime";
 import { CLI_NAME } from "../../cli/branding";
-import { D, G, R, RD, YW } from "../../cli/terminal-style";
-import { type ProviderHealthStatus } from "../../inference/health";
-import * as nim from "../../inference/nim";
-import * as sandboxVersion from "../../sandbox/version";
-import * as shields from "../../shields";
 import { parseSandboxPhase } from "../../state/gateway";
-import type { SandboxGpuProofResult } from "../../state/registry";
 import * as registry from "../../state/registry";
-import {
-  createSystemDeps as createSessionDeps,
-  getActiveSandboxSessions,
-} from "../../state/sandbox-session";
 import { getSandboxDockerRuntime } from "./docker-health";
-import type { SandboxGatewayState } from "./gateway-state";
-import { isSandboxGatewayRunningForStatus } from "./process-recovery";
 import { printSandboxGatewayLookupStatus } from "./status-lookup-rendering";
 import {
   getSandboxStatusPreflight,
@@ -27,6 +13,13 @@ import {
   withoutTerminalPhasePreflight,
 } from "./status-preflight";
 import { collectSandboxStatusSnapshot, resolveSandboxStatusAgent } from "./status-snapshot";
+import {
+  printAgentProcessStatus,
+  printDockerHealth,
+  printNimStatus,
+  printSandboxDetails,
+  type SandboxStatusTextContext,
+} from "./status-text";
 
 export {
   type ClassifySandboxStatusPreflightFailureDeps,
@@ -50,66 +43,6 @@ export {
   type SandboxStatusSnapshot,
 } from "./status-snapshot";
 
-/**
- * Returns true when status can validate an agent version against the running sandbox.
- */
-function shouldProbeSandboxRuntimeVersion(
-  lookup: SandboxGatewayState,
-  sandbox: registry.SandboxEntry,
-  agentRuntimeKind: string,
-): boolean {
-  return (
-    lookup.state === "present" && (Boolean(sandbox.agentVersion) || agentRuntimeKind === "terminal")
-  );
-}
-
-// True when sandbox GPU is enabled but no CUDA-usability proof has confirmed it
-// (older entries with no recorded proof, or a run whose CUDA proof could not
-// execute). Treated as not-yet-proven rather than healthy (#4231).
-export function sandboxGpuProofUnverified(
-  proof: SandboxGpuProofResult | null | undefined,
-): boolean {
-  return !proof || proof.status === "unverified";
-}
-
-// Render the proof-state suffix appended to the `Sandbox GPU: enabled` line so
-// the status reflects verified/unverified/failed CUDA usability instead of
-// reporting any configured GPU as healthy (#4231).
-export function sandboxGpuProofStatusSuffix(
-  proof: SandboxGpuProofResult | null | undefined,
-): string {
-  if (proof?.status === "verified") return ` ${G}(CUDA verified)${R}`;
-  if (proof?.status === "failed") {
-    const label = proof.label ? `: ${proof.label}` : "";
-    return ` ${RD}(last CUDA proof failed${label})${R}`;
-  }
-  return ` ${YW}(CUDA unverified)${R}`;
-}
-
-/**
- * Render one Inference status line. The main probe and each subprobe go
- * through this helper so multi-hop providers (e.g. ollama-local backend +
- * auth proxy) get parallel formatting and the failure of any hop is
- * surfaced individually instead of being hidden by a healthy hop. (#3265)
- */
-function printInferenceProbeLine(probe: ProviderHealthStatus): void {
-  const label = probe.probeLabel ? `Inference (${probe.probeLabel})` : "Inference";
-  if (!probe.probed) {
-    console.log(`    ${label}: ${D}not probed${R} (${probe.detail})`);
-    return;
-  }
-  if (probe.ok) {
-    console.log(`    ${label}: ${G}healthy${R} (${probe.endpoint})`);
-    return;
-  }
-  // `failureLabel` is set by the probe (e.g. `unauthorized` for HTTP 401 on
-  // the auth proxy in `inference/local.ts:probeOllamaAuthProxyHealth`); the
-  // `|| "unreachable"` fallback only applies when an upstream forgot to set
-  // one. Don't infer the failure mode here — preserve what the probe said. (#3265)
-  console.log(`    ${label}: ${RD}${probe.failureLabel || "unreachable"}${R} (${probe.endpoint})`);
-  console.log(`      ${probe.detail}`);
-}
-
 function maybeEnsureHermesToolGatewayBroker(sb: registry.SandboxEntry | null): void {
   if (
     !sb ||
@@ -127,7 +60,6 @@ function maybeEnsureHermesToolGatewayBroker(sb: registry.SandboxEntry | null): v
   }
 }
 
-// eslint-disable-next-line complexity
 export async function showSandboxStatus(sandboxName: string): Promise<void> {
   const preflight = await getSandboxStatusPreflight(registry.getSandbox(sandboxName));
   // #2666: never let an unexpected throw from the gateway probe (e.g. openshell
@@ -165,140 +97,19 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
     });
     process.exit(1);
   }
-  if (sb) {
-    console.log("");
-    console.log(`  Sandbox: ${sb.name}`);
-    console.log(`    Model:    ${currentModel}`);
-    console.log(`    Provider: ${currentProvider}`);
-    if (inferenceHealth) {
-      printInferenceProbeLine(inferenceHealth);
-      for (const sub of inferenceHealth.subprobes ?? []) {
-        printInferenceProbeLine(sub);
-      }
-    }
-    if (lookup.state !== "present") {
-      console.log("    Inference: not verified (gateway/sandbox state not verified)");
-    }
-    const hostGpu = sb.hostGpuDetected ? "yes" : "no";
-    const sandboxGpuEnabled = sb.sandboxGpuEnabled ?? sb.gpuEnabled === true;
-    const sandboxGpu = sandboxGpuEnabled ? "enabled" : "disabled";
-    const sandboxGpuMode = sb.sandboxGpuMode ? ` (${sb.sandboxGpuMode})` : "";
-    const sandboxGpuDevice = sb.sandboxGpuDevice ? ` device=${sb.sandboxGpuDevice}` : "";
-    const sandboxGpuProofSuffix = sandboxGpuEnabled
-      ? sandboxGpuProofStatusSuffix(sb.sandboxGpuProof)
-      : "";
-    const openshellDriver = sb.openshellDriver || "unknown";
-    const openshellVersion = sb.openshellVersion || "unknown";
-    console.log(`    Host GPU: ${hostGpu}`);
-    console.log(
-      `    Sandbox GPU: ${sandboxGpu}${sandboxGpuMode}${sandboxGpuDevice}${sandboxGpuProofSuffix}`,
-    );
-    if (sandboxGpuEnabled && sb.sandboxGpuProof?.status === "failed") {
-      const detail = sb.sandboxGpuProof.detail;
-      if (detail) console.log(`      ${detail}`);
-      console.log(
-        "      CUDA failed a live proof. Recreate with corrected GPU device/group access, or rerun onboard with --no-gpu.",
-      );
-    } else if (sandboxGpuEnabled && sandboxGpuProofUnverified(sb.sandboxGpuProof)) {
-      console.log(
-        "      CUDA usability has not been proven. Rerun onboard to verify, or use --no-gpu for CPU.",
-      );
-    }
-    console.log(`    OpenShell: ${openshellVersion} (${openshellDriver})`);
-    console.log(`    Policies: ${(sb.policies || []).join(", ") || "none"}`);
-    console.log(`    Harness:  ${statusAgent.agentDisplayName} (${statusAgent.agentRuntime})`);
-    if (statusAgent.agentLoadError) {
-      console.log(`    Agent load error: ${statusAgent.agentLoadError}`);
-    }
-    if (statusAgent.agentDefinition && statusAgent.agentRuntime === "terminal") {
-      const interactiveCommand = agentRuntime.getTerminalCommand(
-        statusAgent.agentDefinition,
-        "interactive",
-      );
-      const headlessCommand = agentRuntime.getTerminalCommand(
-        statusAgent.agentDefinition,
-        "headless",
-      );
-      if (interactiveCommand) console.log(`    Interactive: ${interactiveCommand}`);
-      if (headlessCommand) console.log(`    Headless: ${headlessCommand} "<prompt>"`);
-      console.log("    Updates: managed by NemoClaw image rebuilds");
-      if (lookup.state === "present") {
-        if (terminalRuntimeHealth?.kind === "degraded") {
-          process.exitCode = process.exitCode && process.exitCode !== 0 ? process.exitCode : 1;
-          const countLabel =
-            terminalRuntimeHealth.oomKillCount === 1
-              ? "1 OOM kill"
-              : `${terminalRuntimeHealth.oomKillCount} OOM kills`;
-          console.log(`    Runtime health: ${YW}degraded${R} (${countLabel} recorded)`);
-          console.log("      Sandbox may be degraded after an OOM kill.");
-          console.log(`      Run \`${CLI_NAME} ${sandboxName} rebuild\` to restore.`);
-        }
-      }
-    }
-
-    // Active session indicator
-    try {
-      const opsBinStatus = resolveOpenshell();
-      if (opsBinStatus) {
-        const sessionResult = getActiveSandboxSessions(
-          sandboxName,
-          createSessionDeps(opsBinStatus),
-        );
-        if (sessionResult.detected) {
-          const count = sessionResult.sessions.length;
-          console.log(
-            `    Connected: ${count > 0 ? `${G}yes${R} (${count} session${count > 1 ? "s" : ""})` : "no"}`,
-          );
-        }
-      }
-    } catch {
-      /* non-fatal */
-    }
-
-    const shieldsPosture = shields.getShieldsPosture(sandboxName, true);
-    if (shieldsPosture.mode !== "locked") {
-      const detail =
-        shieldsPosture.mode === "mutable_default"
-          ? shieldsPosture.detail
-          : `${shieldsPosture.detail} (check \`shields status\` for details)`;
-      console.log(`    Permissions: ${detail}`);
-    }
-
-    // Agent version check
-    try {
-      const shouldProbeRuntimeVersion = shouldProbeSandboxRuntimeVersion(
-        lookup,
-        sb,
-        statusAgent.agentRuntime,
-      );
-      const versionCheck = sandboxVersion.checkAgentVersion(sandboxName, {
-        forceProbe: shouldProbeRuntimeVersion,
-        skipProbe: !shouldProbeRuntimeVersion,
-      });
-      const agentName = statusAgent.agentDisplayName;
-      if (versionCheck.sandboxVersion) {
-        console.log(`    Agent:    ${agentName} v${versionCheck.sandboxVersion}`);
-      } else if (shouldProbeRuntimeVersion && versionCheck.expectedVersion) {
-        console.log(
-          `    Agent:    ${agentName} version not verified (expected v${versionCheck.expectedVersion})`,
-        );
-      }
-      if (versionCheck.isStale) {
-        console.log(`    ${YW}Update:   v${versionCheck.expectedVersion} available${R}`);
-        console.log(`              Run \`${CLI_NAME} ${sandboxName} rebuild\` to upgrade`);
-      } else if (
-        shouldProbeRuntimeVersion &&
-        versionCheck.detectionMethod === "unavailable" &&
-        versionCheck.expectedVersion
-      ) {
-        console.log(`    ${YW}Update:   unable to verify sandbox ${agentName} version${R}`);
-        console.log(
-          `              Run \`${CLI_NAME} ${sandboxName} rebuild\` if this sandbox predates the current install`,
-        );
-      }
-    } catch {
-      /* non-fatal */
-    }
+  const textContext: SandboxStatusTextContext = {
+    sandboxName,
+    sb,
+    lookup,
+    currentModel,
+    currentProvider,
+    inferenceHealth,
+    terminalRuntimeHealth,
+    statusAgent,
+  };
+  const textOutcome = printSandboxDetails(textContext);
+  if (textOutcome.exitCode && (!process.exitCode || process.exitCode === 0)) {
+    process.exitCode = textOutcome.exitCode;
   }
 
   await printSandboxGatewayLookupStatus({
@@ -309,80 +120,11 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
     effectivePreflight,
   });
 
-  // OpenClaw process health inside the sandbox
-  if (lookup.state === "present") {
-    if (statusAgent.agentRuntime !== "gateway") {
-      if (statusAgent.agentRuntime === "unknown") {
-        console.log(`    Agent '${statusAgent.agentName}' runtime: ${YW}unknown${R}`);
-      } else {
-        console.log(`    ${statusAgent.agentDisplayName} runtime: ${G}terminal${R}`);
-      }
-    } else {
-      const running = await isSandboxGatewayRunningForStatus(sandboxName);
-      if (running !== null) {
-        const sessionAgentName = statusAgent.agentDisplayName;
-        if (running) {
-          console.log(`    ${sessionAgentName}: ${G}running${R}`);
-        } else {
-          console.log(`    ${sessionAgentName}: ${RD}not running${R}`);
-          console.log("");
-          console.log(
-            `  The sandbox is alive but the ${sessionAgentName} gateway process is not running.`,
-          );
-          console.log(
-            "  This typically happens after a gateway restart (e.g., laptop close/open).",
-          );
-          console.log("");
-          console.log("  To recover, run:");
-          console.log(`    ${D}${CLI_NAME} ${sandboxName} connect${R}  (auto-recovers on connect)`);
-          console.log("  Or manually inside the sandbox:");
-          console.log(`    ${D}${agentRuntime.getGatewayCommand(statusAgent.agentDefinition)}${R}`);
-        }
-      }
-    }
-  }
+  await printAgentProcessStatus(textContext);
 
-  // Surface the Docker healthcheck signal as its own line so users can
-  // tell when it disagrees with NemoClaw's own delivery-chain probes
-  // (sandbox phase, OpenClaw process, host port forward). On runtimes
-  // where the dashboard port lives in a different network namespace
-  // (e.g. DGX Spark / aarch64 with OpenShell-managed forwarding), the
-  // in-container /health curl can fail even though the delivery chain
-  // is fine — older images without the #3975 healthcheck fallback will
-  // emit a stale "unhealthy" here while the rest of `status` shows the
-  // sandbox is reachable. We deliberately do not downgrade the signal
-  // automatically: the in-sandbox `isSandboxGatewayRunningForStatus`
-  // probe uses the same 127.0.0.1 endpoint Docker checks, so it cannot
-  // independently confirm that Docker's reading is stale. (#3975)
-  if (lookup.state === "present" && dockerRuntime) {
-    const dockerHealth = dockerRuntime;
-    if (dockerHealth.health !== "none" && dockerHealth.health !== "unknown") {
-      if (dockerHealth.health === "healthy") {
-        console.log(`    Docker health: ${G}healthy${R}`);
-      } else if (dockerHealth.health === "starting") {
-        console.log(`    Docker health: ${D}starting${R}`);
-      } else {
-        console.log(`    Docker health: ${RD}unhealthy${R}`);
-        console.log(
-          `      ${D}This is the in-container Docker probe; compare with the host-side delivery${R}`,
-        );
-        console.log(
-          `      ${D}chain above. A mismatch can be a stale signal on OpenShell-managed${R}`,
-        );
-        console.log(`      ${D}runtimes — see #3975.${R}`);
-      }
-    }
-  }
-
-  const nimStat =
-    sb && sb.nimContainer ? nim.nimStatusByName(sb.nimContainer) : nim.nimStatus(sandboxName);
-  if (nim.shouldShowNimLine(sb && sb.nimContainer, nimStat.running)) {
-    console.log(
-      `    NIM:      ${nimStat.running ? `running (${nimStat.container})` : "not running"}`,
-    );
-    if (nimStat.running) {
-      console.log(`    Healthy:  ${nimStat.healthy ? "yes" : "no"}`);
-    }
-  }
+  printDockerHealth(dockerRuntime);
+  printNimStatus(sandboxName, sb);
   console.log("");
 }
+
+export { sandboxGpuProofStatusSuffix, sandboxGpuProofUnverified } from "./status-text";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Refactor sandbox status reporting so gateway orchestration no longer owns every text-rendering branch and optional probe. The former complexity-138 workflow is now a small coordinator, and both status modules have a durable Biome complexity ceiling of 10.

## Changes

- Move sandbox details, GPU proof, agent/session/version, process, Docker health, and NIM rendering into a cohesive `status-text` boundary.
- Return non-fatal degraded outcomes from the renderer so the orchestrator, rather than presentation code, owns `process.exitCode` policy.
- Preserve gateway reconciliation, fatal RPC handling, lookup rendering, and output order in `showSandboxStatus`.
- Add a file-scoped Biome ratchet that prevents either status module from exceeding cognitive complexity 10.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: source flow tests and process-level CLI tests assert the status sections, exit codes, failure layers, terminal runtimes, Docker states, GPU proof output, and JSON stdout isolation moved by this refactor.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is an internal separation-of-concerns refactor with unchanged CLI behavior and output contracts.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: sandbox status is read-only; the refactor preserves probe order and fatal handling, and the complete focused source/process suites plus the repository-wide CLI hook pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details:

- `VITEST_MAX_WORKERS=16 npx vitest run --project cli src/lib/actions/sandbox/status.test.ts src/lib/actions/sandbox/status-flow.test.ts`: 22 tests passed.
- `VITEST_MAX_WORKERS=16 npx vitest run --project integration test/cli/sandbox-status-text.test.ts test/sandbox-status-json-stdout.test.ts`: 10 tests passed.
- `VITEST_MAX_WORKERS=16 npx prek run --all-files`: passed, including the full CLI and plugin hook lanes.
- Normal commit hooks and pre-push CLI typecheck/version synchronization passed.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded sandbox status output with clearer health and runtime details, including GPU proof verification, inference probe status, gateway/agent process state, Docker health, and optional NIM status.
  * Added richer, actionable recovery guidance for degraded states (including instructions and rerun options when GPU/inference isn’t verified).

* **Bug Fixes**
  * Improved handling and messaging for degraded or unknown runtime states, including more explicit OOM-degradation summaries.

* **Chores**
  * Tightened linting rules for reduced excessive complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->