### PR TITLE
fix(e2e): stabilize residual release gates

### DIFF
--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -139,7 +139,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
           "sandbox_exec() { printf 'NEMOCLAW_DCODE_PROBE:deepagents\\n'; }",
           "ensure_expect_available() { return 0; }",
           "run_tui_expect() {",
-          '  printf "What would you like to do next?\\nNEMOCLAW_TUI_READY\\nNEMOCLAW_TUI_EXIT_CAPTURED:130\\n" >>"$1"',
+          '  printf "What would you like to do next?\\nNEMOCLAW_TUI_READY\\nNEMOCLAW_TUI_EXIT_CAPTURED:130\\n" >>"$2"',
           "}",
           "main",
         ].join("\n"),
@@ -275,6 +275,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
   it("removes raw TUI startup artifacts after writing the sanitized capture", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-"));
     const rawCapture = path.join(tempDir, "raw.log");
+    const markerCapture = path.join(tempDir, "markers.log");
     const expectLog = path.join(tempDir, "expect.log");
     const combinedCapture = path.join(tempDir, "combined.log");
     const sanitizedCapture = path.join(tempDir, "sanitized.log");
@@ -283,21 +284,24 @@ describe("Deep Agents Code TUI startup check helpers", () => {
       const output = runTuiStartupCheckHelper(
         [
           'raw_capture_file="$RAW_CAPTURE"',
+          'marker_capture_file="$MARKER_CAPTURE"',
           'expect_log_file="$EXPECT_LOG"',
           'combined_capture_file="$COMBINED_CAPTURE"',
           'plain_capture_file="$SANITIZED_CAPTURE"',
-          'SENSITIVE_CAPTURE_FILES=("$raw_capture_file" "$expect_log_file" "$combined_capture_file")',
+          'SENSITIVE_CAPTURE_FILES=("$raw_capture_file" "$marker_capture_file" "$expect_log_file" "$combined_capture_file")',
           'printf "%s\\n" "$SECRET_TOKEN" >"$raw_capture_file"',
+          'printf "%s\\n" "NEMOCLAW_TUI_READY" >"$marker_capture_file"',
           'printf "%s\\n" "expect output" >"$expect_log_file"',
-          'cat "$raw_capture_file" "$expect_log_file" >"$combined_capture_file"',
+          'cat "$raw_capture_file" "$expect_log_file" "$marker_capture_file" >"$combined_capture_file"',
           'strip_terminal_control_sequences <"$combined_capture_file" >"$plain_capture_file"',
           "cleanup_sensitive_captures",
-          'for artifact in "$raw_capture_file" "$expect_log_file" "$combined_capture_file"; do if [ -e "$artifact" ]; then printf "leaked:%s" "$artifact"; exit 1; fi; done',
+          'for artifact in "$raw_capture_file" "$marker_capture_file" "$expect_log_file" "$combined_capture_file"; do if [ -e "$artifact" ]; then printf "leaked:%s" "$artifact"; exit 1; fi; done',
           'if [ -e "$plain_capture_file" ]; then printf sanitized; else printf missing; fi',
         ].join("; "),
         {
           COMBINED_CAPTURE: combinedCapture,
           EXPECT_LOG: expectLog,
+          MARKER_CAPTURE: markerCapture,
           RAW_CAPTURE: rawCapture,
           SANITIZED_CAPTURE: sanitizedCapture,
           SECRET_TOKEN: `sk-${"A".repeat(20)}`,
@@ -306,6 +310,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
 
       expect(output).toBe("sanitized");
       expect(fs.existsSync(rawCapture)).toBe(false);
+      expect(fs.existsSync(markerCapture)).toBe(false);
       expect(fs.existsSync(expectLog)).toBe(false);
       expect(fs.existsSync(combinedCapture)).toBe(false);
       expect(fs.existsSync(sanitizedCapture)).toBe(true);

--- a/test/e2e-scenario/fixtures/ci-compatible-inference.ts
+++ b/test/e2e-scenario/fixtures/ci-compatible-inference.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const PUBLIC_NVIDIA_PROVIDERS = new Set(["build", "cloud", "nvidia", "nvidia-prod"]);
+
+/** Mirrors nemoclaw_e2e_using_compatible_inference from the legacy shell harness. */
+export function isGatewayManagedCompatibleInference(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1") return true;
+  if (PUBLIC_NVIDIA_PROVIDERS.has(env.NEMOCLAW_PROVIDER ?? "")) return false;
+
+  const key = env.NVIDIA_INFERENCE_API_KEY ?? "";
+  return key.length > 0 && !key.startsWith("nvapi-");
+}

--- a/test/e2e-scenario/live/double-onboard.test.ts
+++ b/test/e2e-scenario/live/double-onboard.test.ts
@@ -75,11 +75,8 @@ function onboardEnv(sandboxName: string, fakeBaseUrl: string, recreate = false):
   });
 }
 
-function staleRebuildEnv(sandboxName: string): NodeJS.ProcessEnv {
-  return {
-    ...onboardEnv(sandboxName, "http://127.0.0.1:9/v1"),
-    NEMOCLAW_MODEL: "ambient-wrong-model",
-  };
+function staleRebuildEnv(sandboxName: string, fakeBaseUrl: string): NodeJS.ProcessEnv {
+  return onboardEnv(sandboxName, fakeBaseUrl);
 }
 
 async function ignoreCleanupError(run: () => Promise<unknown>): Promise<void> {
@@ -685,7 +682,7 @@ liveTest(
 
     const rebuild = await command(host, [SANDBOX_A, "rebuild", "--yes"], {
       artifactName: "phase-5-stale-rebuild-recovery",
-      env: staleRebuildEnv(SANDBOX_A),
+      env: staleRebuildEnv(SANDBOX_A, fake.baseUrl),
       timeoutMs: PHASE_TIMEOUT_MS,
     });
     const rebuildText = resultText(rebuild);

--- a/test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts
+++ b/test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts
@@ -7,8 +7,8 @@ import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
-import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
+import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import { ubuntuRepoDocker } from "../scenarios/matrix.ts";
 
 // Migrated from test/e2e/test-issue-4434-tui-unreachable-inference.sh.
@@ -135,6 +135,9 @@ runIssue4434LiveTest(
   "issue-4434: openclaw tui surfaces unreachable-inference errors and stops the connected spinner",
   { timeout: 120 * 60_000 },
   async ({ artifacts, cleanup, environment, host, onboard, sandbox, secrets, skip }) => {
+    if (process.env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1") {
+      skip("hosted compatible inference is gateway-managed; this repro only blocks sandbox egress");
+    }
     if (process.platform !== "linux") {
       skip("Linux host required for DOCKER-USER iptables repro");
     }

--- a/test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts
+++ b/test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts
@@ -46,9 +46,12 @@ const CONNECTED_SPINNER_RE =
 const STATUS_LINE_RE =
   /(connecting|gateway connected|connected|sending|running|flibbertigibbeting).*\|\s*(connected|error)/i;
 const ERROR_STATUS_RE = /\|\s*error\b/i;
+const HOSTED_INFERENCE_IS_GATEWAY_MANAGED = process.env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1";
 
 const runIssue4434LiveTest =
-  shouldRunLiveE2EScenarios() && process.env.NEMOCLAW_ISSUE_4434_LIVE === "1" ? test : test.skip;
+  shouldRunLiveE2EScenarios() && process.env.NEMOCLAW_ISSUE_4434_LIVE === "1"
+    ? test.skipIf(HOSTED_INFERENCE_IS_GATEWAY_MANAGED)
+    : test.skip;
 
 type CommandResultText = { stdout: string; stderr: string };
 
@@ -135,9 +138,8 @@ runIssue4434LiveTest(
   "issue-4434: openclaw tui surfaces unreachable-inference errors and stops the connected spinner",
   { timeout: 120 * 60_000 },
   async ({ artifacts, cleanup, environment, host, onboard, sandbox, secrets, skip }) => {
-    if (process.env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1") {
-      skip("hosted compatible inference is gateway-managed; this repro only blocks sandbox egress");
-    }
+    // Hosted compatible inference is gateway-managed; this repro only blocks
+    // sandbox egress, so runIssue4434LiveTest skips that mode before setup.
     if (process.platform !== "linux") {
       skip("Linux host required for DOCKER-USER iptables repro");
     }

--- a/test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts
+++ b/test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { isGatewayManagedCompatibleInference } from "../fixtures/ci-compatible-inference.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
@@ -46,7 +47,7 @@ const CONNECTED_SPINNER_RE =
 const STATUS_LINE_RE =
   /(connecting|gateway connected|connected|sending|running|flibbertigibbeting).*\|\s*(connected|error)/i;
 const ERROR_STATUS_RE = /\|\s*error\b/i;
-const HOSTED_INFERENCE_IS_GATEWAY_MANAGED = process.env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1";
+const HOSTED_INFERENCE_IS_GATEWAY_MANAGED = isGatewayManagedCompatibleInference();
 
 const runIssue4434LiveTest =
   shouldRunLiveE2EScenarios() && process.env.NEMOCLAW_ISSUE_4434_LIVE === "1"

--- a/test/e2e-scenario/support-tests/ci-compatible-inference.test.ts
+++ b/test/e2e-scenario/support-tests/ci-compatible-inference.test.ts
@@ -22,21 +22,20 @@ describe("gateway-managed compatible inference detection", () => {
       },
     },
   ])("skips the live issue #4434 sandbox-egress repro for $label", ({ env: hostedEnv }) => {
+    const {
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: _hostedSentinel,
+      NEMOCLAW_PROVIDER: _provider,
+      NVIDIA_INFERENCE_API_KEY: _hostedKey,
+      NVIDIA_API_KEY: _publicKey,
+      COMPATIBLE_API_KEY: _compatibleKey,
+      ...baseEnv
+    } = process.env;
     const env: NodeJS.ProcessEnv = {
-      ...process.env,
+      ...baseEnv,
       NEMOCLAW_RUN_E2E_SCENARIOS: "1",
       NEMOCLAW_ISSUE_4434_LIVE: "1",
       ...hostedEnv,
     };
-    for (const key of [
-      "NEMOCLAW_E2E_USE_HOSTED_INFERENCE",
-      "NEMOCLAW_PROVIDER",
-      "NVIDIA_INFERENCE_API_KEY",
-    ]) {
-      if (!(key in hostedEnv)) delete env[key];
-    }
-    delete env.NVIDIA_API_KEY;
-    delete env.COMPATIBLE_API_KEY;
 
     const output = execFileSync(
       process.execPath,

--- a/test/e2e-scenario/support-tests/ci-compatible-inference.test.ts
+++ b/test/e2e-scenario/support-tests/ci-compatible-inference.test.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { isGatewayManagedCompatibleInference } from "../fixtures/ci-compatible-inference.ts";
+
+describe("gateway-managed compatible inference detection", () => {
+  it.each([
+    {
+      label: "the explicit hosted sentinel",
+      env: { NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1" },
+    },
+    {
+      label: "a hosted-compatible key",
+      env: {
+        NEMOCLAW_PROVIDER: "custom",
+        NVIDIA_INFERENCE_API_KEY: "hosted-compatible-test-key",
+      },
+    },
+  ])("skips the live issue #4434 sandbox-egress repro for $label", ({ env: hostedEnv }) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      NEMOCLAW_RUN_E2E_SCENARIOS: "1",
+      NEMOCLAW_ISSUE_4434_LIVE: "1",
+      ...hostedEnv,
+    };
+    for (const key of [
+      "NEMOCLAW_E2E_USE_HOSTED_INFERENCE",
+      "NEMOCLAW_PROVIDER",
+      "NVIDIA_INFERENCE_API_KEY",
+    ]) {
+      if (!(key in hostedEnv)) delete env[key];
+    }
+    delete env.NVIDIA_API_KEY;
+    delete env.COMPATIBLE_API_KEY;
+
+    const output = execFileSync(
+      process.execPath,
+      [
+        path.resolve("node_modules/vitest/vitest.mjs"),
+        "run",
+        "--project",
+        "e2e-scenarios-live",
+        "test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts",
+        "--reporter=json",
+      ],
+      { encoding: "utf8", env, timeout: 30_000 },
+    );
+    const report = JSON.parse(output) as {
+      numPendingTests: number;
+      numFailedTests: number;
+      success: boolean;
+      testResults: Array<{ assertionResults: Array<{ status: string }> }>;
+    };
+
+    expect(report.success).toBe(true);
+    expect(report.numFailedTests).toBe(0);
+    expect(report.numPendingTests).toBe(1);
+    expect(report.testResults[0]?.assertionResults[0]?.status).toBe("skipped");
+  }, 30_000);
+
+  it("detects the explicit hosted inference sentinel", () => {
+    expect(isGatewayManagedCompatibleInference({ NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1" })).toBe(
+      true,
+    );
+  });
+
+  it("detects a hosted-compatible key for non-public providers", () => {
+    expect(
+      isGatewayManagedCompatibleInference({
+        NEMOCLAW_PROVIDER: "custom",
+        NVIDIA_INFERENCE_API_KEY: "hosted-compatible-test-key",
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    "build",
+    "cloud",
+    "nvidia",
+    "nvidia-prod",
+  ])("keeps %s on the public inference path", (provider) => {
+    expect(
+      isGatewayManagedCompatibleInference({
+        NEMOCLAW_PROVIDER: provider,
+        NVIDIA_INFERENCE_API_KEY: "hosted-compatible-test-key",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps public nvapi keys on the sandbox-egress repro path", () => {
+    expect(
+      isGatewayManagedCompatibleInference({ NVIDIA_INFERENCE_API_KEY: "nvapi-test-key" }),
+    ).toBe(false);
+  });
+});

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1287,6 +1287,23 @@ describe("E2E reusable workflow contract", () => {
     expect(nightlyWorkflow.jobs["common-egress-agent-e2e"].with?.inference_route).toBeUndefined();
   });
 
+  it("skips the issue #4434 sandbox-egress repro for gateway-managed hosted inference", () => {
+    const liveTest = readFileSync(
+      "test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts",
+      "utf8",
+    );
+    const hostedSkip = liveTest.indexOf('process.env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1"');
+    const hostedConfig = liveTest.indexOf("requireHostedInferenceConfig(secrets)");
+    const firewallMutation = liveTest.indexOf('["iptables", "-I", "DOCKER-USER"');
+
+    expect(hostedSkip).toBeGreaterThanOrEqual(0);
+    expect(liveTest).toContain(
+      "hosted compatible inference is gateway-managed; this repro only blocks sandbox egress",
+    );
+    expect(hostedSkip).toBeLessThan(hostedConfig);
+    expect(hostedSkip).toBeLessThan(firewallMutation);
+  });
+
   it("keeps rebuild fixture registry inference aligned with hosted custom inference", () => {
     const rebuildFixtures = [
       "test/e2e/test-rebuild-openclaw.sh",

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1304,6 +1304,18 @@ describe("E2E reusable workflow contract", () => {
     expect(hostedSkip).toBeLessThan(firewallMutation);
   });
 
+  it("uses the target custom endpoint for double-onboard stale rebuild recovery", () => {
+    const liveTest = readFileSync("test/e2e-scenario/live/double-onboard.test.ts", "utf8");
+
+    expect(liveTest).toContain(
+      "function staleRebuildEnv(sandboxName: string, fakeBaseUrl: string)",
+    );
+    expect(liveTest).toContain("return onboardEnv(sandboxName, fakeBaseUrl);");
+    expect(liveTest).toContain("env: staleRebuildEnv(SANDBOX_A, fake.baseUrl)");
+    expect(liveTest).not.toContain("ambient-wrong-model");
+    expect(liveTest).not.toContain('onboardEnv(sandboxName, "http://127.0.0.1:9/v1")');
+  });
+
   it("keeps rebuild fixture registry inference aligned with hosted custom inference", () => {
     const rebuildFixtures = [
       "test/e2e/test-rebuild-openclaw.sh",

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1287,23 +1287,6 @@ describe("E2E reusable workflow contract", () => {
     expect(nightlyWorkflow.jobs["common-egress-agent-e2e"].with?.inference_route).toBeUndefined();
   });
 
-  it("skips the issue #4434 sandbox-egress repro for gateway-managed hosted inference", () => {
-    const liveTest = readFileSync(
-      "test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts",
-      "utf8",
-    );
-    const hostedSkip = liveTest.indexOf("test.skipIf(HOSTED_INFERENCE_IS_GATEWAY_MANAGED)");
-    const hostedConfig = liveTest.indexOf("requireHostedInferenceConfig(secrets)");
-    const firewallMutation = liveTest.indexOf('["iptables", "-I", "DOCKER-USER"');
-
-    expect(hostedSkip).toBeGreaterThanOrEqual(0);
-    expect(liveTest).toContain(
-      "Hosted compatible inference is gateway-managed; this repro only blocks",
-    );
-    expect(hostedSkip).toBeLessThan(hostedConfig);
-    expect(hostedSkip).toBeLessThan(firewallMutation);
-  });
-
   it("uses the target custom endpoint for double-onboard stale rebuild recovery", () => {
     const liveTest = readFileSync("test/e2e-scenario/live/double-onboard.test.ts", "utf8");
 

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1292,13 +1292,13 @@ describe("E2E reusable workflow contract", () => {
       "test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts",
       "utf8",
     );
-    const hostedSkip = liveTest.indexOf('process.env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE === "1"');
+    const hostedSkip = liveTest.indexOf("test.skipIf(HOSTED_INFERENCE_IS_GATEWAY_MANAGED)");
     const hostedConfig = liveTest.indexOf("requireHostedInferenceConfig(secrets)");
     const firewallMutation = liveTest.indexOf('["iptables", "-I", "DOCKER-USER"');
 
     expect(hostedSkip).toBeGreaterThanOrEqual(0);
     expect(liveTest).toContain(
-      "hosted compatible inference is gateway-managed; this repro only blocks sandbox egress",
+      "Hosted compatible inference is gateway-managed; this repro only blocks",
     );
     expect(hostedSkip).toBeLessThan(hostedConfig);
     expect(hostedSkip).toBeLessThan(firewallMutation);

--- a/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
@@ -138,8 +138,10 @@ make_capture_dir() {
 
 run_tui_expect() {
   local raw_capture_file="$1"
+  local marker_capture_file="$2"
   env \
     NEMOCLAW_TUI_CAPTURE="$raw_capture_file" \
+    NEMOCLAW_TUI_MARKERS="$marker_capture_file" \
     NEMOCLAW_TUI_READY_PATTERN="$TUI_READY_PATTERN" \
     NEMOCLAW_TUI_SANDBOX_NAME="$SANDBOX_NAME" \
     NEMOCLAW_TUI_TIMEOUT="$TUI_TIMEOUT" \
@@ -147,11 +149,12 @@ run_tui_expect() {
 set timeout $env(NEMOCLAW_TUI_TIMEOUT)
 set sandbox $env(NEMOCLAW_TUI_SANDBOX_NAME)
 set capture $env(NEMOCLAW_TUI_CAPTURE)
+set markers $env(NEMOCLAW_TUI_MARKERS)
 set ready_pattern $env(NEMOCLAW_TUI_READY_PATTERN)
 log_file -a $capture
 
-proc append_marker {capture marker} {
-  set fh [open $capture a]
+proc append_marker {markers marker} {
+  set fh [open $markers a]
   puts $fh $marker
   close $fh
 }
@@ -160,18 +163,19 @@ set cmd [list openshell sandbox exec --name $sandbox --tty -- sh -lc {export TER
 spawn {*}$cmd
 expect {
   -nocase -re $ready_pattern {
-    append_marker $capture "NEMOCLAW_TUI_READY"
+    append_marker $markers "$expect_out(0,string)"
+    append_marker $markers "NEMOCLAW_TUI_READY"
     puts "\nNEMOCLAW_TUI_READY"
     send -- "\003"
   }
   timeout {
-    append_marker $capture "NEMOCLAW_TUI_TIMEOUT"
+    append_marker $markers "NEMOCLAW_TUI_TIMEOUT"
     puts "\nNEMOCLAW_TUI_TIMEOUT"
     send -- "\003"
     exit 20
   }
   eof {
-    append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_READY"
+    append_marker $markers "NEMOCLAW_TUI_EOF_BEFORE_READY"
     puts "\nNEMOCLAW_TUI_EOF_BEFORE_READY"
     exit 21
   }
@@ -180,18 +184,18 @@ expect {
 set timeout 20
 expect {
   -re {NEMOCLAW_TUI_EXIT:([0-9]+)} {
-    append_marker $capture "NEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"
+    append_marker $markers "NEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"
     puts "\nNEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"
     exit 0
   }
   timeout {
-    append_marker $capture "NEMOCLAW_TUI_EXIT_TIMEOUT"
+    append_marker $markers "NEMOCLAW_TUI_EXIT_TIMEOUT"
     puts "\nNEMOCLAW_TUI_EXIT_TIMEOUT"
     send -- "\003"
     exit 22
   }
   eof {
-    append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_EXIT"
+    append_marker $markers "NEMOCLAW_TUI_EOF_BEFORE_EXIT"
     puts "\nNEMOCLAW_TUI_EOF_BEFORE_EXIT"
     exit 23
   }
@@ -256,26 +260,33 @@ main() {
     exit 1
   fi
 
-  local capture_dir raw_capture_file expect_log_file combined_capture_file plain_capture_file
+  local capture_dir raw_capture_file marker_capture_file expect_log_file combined_capture_file plain_capture_file
   capture_dir="$(make_capture_dir)"
   raw_capture_file="${capture_dir}/${PREFIX}.raw.log"
+  marker_capture_file="${capture_dir}/${PREFIX}.markers.log"
   expect_log_file="${capture_dir}/${PREFIX}.expect.log"
   combined_capture_file="${capture_dir}/${PREFIX}.combined.log"
   plain_capture_file="${capture_dir}/${PREFIX}.sanitized.log"
-  SENSITIVE_CAPTURE_FILES=("$raw_capture_file" "$expect_log_file" "$combined_capture_file")
+  SENSITIVE_CAPTURE_FILES=(
+    "$raw_capture_file"
+    "$marker_capture_file"
+    "$expect_log_file"
+    "$combined_capture_file"
+  )
   : >"$raw_capture_file"
+  : >"$marker_capture_file"
   : >"$expect_log_file"
 
   info "Running Deep Agents Code TUI startup check in sandbox: $SANDBOX_NAME"
   info "Capture directory: $capture_dir"
 
   set +e
-  run_tui_expect "$raw_capture_file" >"$expect_log_file" 2>&1
+  run_tui_expect "$raw_capture_file" "$marker_capture_file" >"$expect_log_file" 2>&1
   local expect_rc
   expect_rc=$?
   set -e
 
-  cat "$raw_capture_file" "$expect_log_file" >"$combined_capture_file"
+  cat "$raw_capture_file" "$expect_log_file" "$marker_capture_file" >"$combined_capture_file"
   strip_terminal_control_sequences <"$combined_capture_file" >"$plain_capture_file"
   local secret_detected=0
   if contains_secret <"$plain_capture_file"; then

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -471,14 +471,19 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tuiStartupCheck).toContain("unable to probe sandbox");
     expect(tuiStartupCheck).toContain("unexpected sandbox probe output");
     expect(tuiStartupCheck).toContain("cd /sandbox; dcode");
-    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_READY"');
-    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_TIMEOUT"');
-    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_READY"');
+    expect(tuiStartupCheck).toContain('append_marker $markers "$expect_out(0,string)"');
+    expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_READY"');
+    expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_TIMEOUT"');
+    expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_EOF_BEFORE_READY"');
     expect(tuiStartupCheck).toContain(
-      'append_marker $capture "NEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"',
+      'append_marker $markers "NEMOCLAW_TUI_EXIT_CAPTURED:$expect_out(1,string)"',
     );
-    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_EXIT_TIMEOUT"');
-    expect(tuiStartupCheck).toContain('append_marker $capture "NEMOCLAW_TUI_EOF_BEFORE_EXIT"');
+    expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_EXIT_TIMEOUT"');
+    expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_EOF_BEFORE_EXIT"');
+    expect(tuiStartupCheck).toContain('NEMOCLAW_TUI_MARKERS="$marker_capture_file"');
+    expect(tuiStartupCheck).toContain(
+      'cat "$raw_capture_file" "$expect_log_file" "$marker_capture_file"',
+    );
     expect(tuiStartupCheck).toContain("DEEPAGENTS_TUI_TIMEOUT must be a positive integer");
     expect(tuiStartupCheck).toContain("strip_terminal_control_sequences");
     expect(tuiStartupCheck).toContain("is_tui_ready_capture");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Stabilizes the final residual release-gate harnesses uncovered by fresh `main` validation. Deep Agents TUI evidence now uses a sidecar so Expect's buffered `log_file` cannot overwrite lifecycle markers, the issue #4434 sandbox-egress repro skips gateway-managed hosted inference just as its legacy shell lane already does, and double-onboard stale recovery receives its exact target-scoped custom endpoint.

## Changes
- Write Deep Agents prompt and lifecycle evidence to a separate marker sidecar, fold it into the sanitized capture, and remove the sensitive intermediate during cleanup.
- Preserve the actual prompt match alongside readiness and exit markers so strict prompt/exit assertions remain intact.
- Skip the issue #4434 sandbox-egress firewall repro before onboarding or mutation when either the explicit sentinel or hosted-compatible key selects gateway-managed inference.
- Align double-onboard stale rebuild recovery with the legacy shell gate by passing the target's fake endpoint instead of intentionally mismatched ambient values.
- Extend helper, image-contract, workflow, and runtime support tests for the new boundaries.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: release-gate harness behavior only; no user-facing behavior changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review of E2E-only capture cleanup and firewall preconditions; the sidecar is sanitized then deleted, and the hosted-mode guard executes before onboarding or firewall mutation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
npm test -- --run test/deepagents-code-tui-startup-check.test.ts test/langchain-deepagents-code-image.test.ts test/e2e-script-workflow.test.ts test/e2e-scenario/support-tests/ci-compatible-inference.test.ts
NEMOCLAW_RUN_E2E_SCENARIOS=1 NEMOCLAW_ISSUE_4434_LIVE=1 NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1 npx vitest run --project e2e-scenarios-live test/e2e-scenario/live/issue-4434-tui-unreachable-inference.test.ts --silent=false --reporter=default
bash -n test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
npx prek run shfmt --files test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
npx prek run shellcheck --files test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
npm run typecheck:cli
```

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TUI startup lifecycle verification by isolating and preserving readiness/exit marker streams through sanitization, and ensuring temporary marker artifacts are fully cleaned up.
  * Updated the live issue-4434 scenario to skip when gateway-managed hosted inference is detected.

* **Tests**
  * Expanded Deep Agents Code TUI startup e2e coverage to validate marker appending/concatenation and final capture content.
  * Added CI-compatible inference detection fixture coverage (including live gating assertions).
  * Enhanced double-onboard rebuild coverage to use the provided fake base URL and avoid the prior hardcoded invalid endpoint/model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->