### PR TITLE
fix(e2e): preserve Deep Agents TUI outcome

### DIFF
--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -185,6 +185,30 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     }
   });
 
+  it("suppresses the capture excerpt when secret-shaped data remains", () => {
+    const captureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-secret-"));
+    const capture = path.join(captureDir, "sanitized.log");
+    const secret = `sk-${"A".repeat(20)}`;
+
+    try {
+      fs.writeFileSync(capture, `diagnostic body\n${secret}\n`);
+      const result = runTuiStartupCheckHelperResult('print_sanitized_capture_excerpt "$CAPTURE"', {
+        CAPTURE: capture,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        "sanitized TUI capture omitted because secret-shaped data remains",
+      );
+      expect(result.stdout).not.toContain(secret);
+      expect(result.stderr).not.toContain(secret);
+      expect(result.stderr).not.toContain("sanitized capture excerpt");
+      expect(result.stderr).not.toContain("diagnostic body");
+    } finally {
+      fs.rmSync(captureDir, { force: true, recursive: true });
+    }
+  });
+
   it("detects and redacts every canonical secret family in TUI startup artifacts", () => {
     const detectsSecret = (token: string) =>
       runTuiStartupCheckHelper(

--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -140,6 +140,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
           "ensure_expect_available() { return 0; }",
           "run_tui_expect() {",
           '  printf "What would you like to do next?\\nNEMOCLAW_TUI_READY\\nNEMOCLAW_TUI_EXIT_CAPTURED:130\\n" >>"$2"',
+          "  return 0",
           "}",
           "main",
         ].join("\n"),
@@ -153,6 +154,32 @@ describe("Deep Agents Code TUI startup check helpers", () => {
       expect(result.stdout).toContain("dcode TUI exited cleanly after Ctrl-C (exit 130)");
       expect(sanitizedText).toContain("NEMOCLAW_TUI_READY");
       expect(sanitizedText).toContain("NEMOCLAW_TUI_EXIT_CAPTURED:130");
+    } finally {
+      fs.rmSync(captureDir, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves a failed expect status and emits only the sanitized capture excerpt", () => {
+    const captureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-failure-"));
+
+    try {
+      const result = runTuiStartupCheckHelperResult(
+        [
+          "sandbox_exec() { printf 'NEMOCLAW_DCODE_PROBE:deepagents\\n'; }",
+          "ensure_expect_available() { return 0; }",
+          "run_tui_expect() {",
+          '  printf "NEMOCLAW_TUI_EOF_BEFORE_READY\\n" >>"$2"',
+          "  return 21",
+          "}",
+          "main",
+        ].join("\n"),
+        { DEEPAGENTS_TUI_CAPTURE_DIR: captureDir },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("finite expect harness exited 21");
+      expect(result.stderr).toContain("sanitized capture excerpt (last 20000 bytes)");
+      expect(result.stderr).toContain("NEMOCLAW_TUI_EOF_BEFORE_READY");
     } finally {
       fs.rmSync(captureDir, { force: true, recursive: true });
     }

--- a/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
@@ -203,6 +203,22 @@ expect {
 EXPECT
 }
 
+print_sanitized_capture_excerpt() {
+  local plain_capture_file="$1"
+  if [ ! -r "$plain_capture_file" ]; then
+    info "sanitized TUI capture unavailable for diagnostics"
+    return
+  fi
+  if contains_secret <"$plain_capture_file"; then
+    info "sanitized TUI capture omitted because secret-shaped data remains"
+    return
+  fi
+
+  printf '%s\n' "${PREFIX}: sanitized capture excerpt (last 20000 bytes):" >&2
+  tail -c 20000 -- "$plain_capture_file" >&2
+  printf '\n%s\n' "${PREFIX}: end sanitized capture excerpt" >&2
+}
+
 assert_clean_exit_code() {
   local plain_capture_file="$1"
   local exit_code
@@ -280,9 +296,9 @@ main() {
   info "Running Deep Agents Code TUI startup check in sandbox: $SANDBOX_NAME"
   info "Capture directory: $capture_dir"
 
+  local expect_rc
   set +e
   run_tui_expect "$raw_capture_file" "$marker_capture_file" >"$expect_log_file" 2>&1
-  local expect_rc
   expect_rc=$?
   set -e
 
@@ -304,6 +320,7 @@ main() {
     pass "finite expect harness reached startup and observed exit"
   else
     fail_test "finite expect harness exited ${expect_rc}"
+    print_sanitized_capture_excerpt "$plain_capture_file"
   fi
 
   if grep -q "NEMOCLAW_TUI_READY" "$plain_capture_file" && is_tui_ready_capture <"$plain_capture_file"; then

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -484,6 +484,10 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tuiStartupCheck).toContain(
       'cat "$raw_capture_file" "$expect_log_file" "$marker_capture_file"',
     );
+    expect(tuiStartupCheck.indexOf("local expect_rc")).toBeLessThan(
+      tuiStartupCheck.indexOf('run_tui_expect "$raw_capture_file"'),
+    );
+    expect(tuiStartupCheck).toContain('print_sanitized_capture_excerpt "$plain_capture_file"');
     expect(tuiStartupCheck).toContain("DEEPAGENTS_TUI_TIMEOUT must be a positive integer");
     expect(tuiStartupCheck).toContain("strip_terminal_control_sequences");
     expect(tuiStartupCheck).toContain("is_tui_ready_capture");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Preserves the real exit status from the Deep Agents Code Expect harness and emits a bounded, secret-screened sanitized capture excerpt when the harness fails. This removes a shell declaration-order bug that made timeout and EOF outcomes appear successful, while keeping the strict prompt and exit assertions intact.

## Changes
- Declare the Expect status variable before invoking the harness so `local` cannot reset `$?`.
- Print the last 20,000 bytes of the sanitized capture after failures only when no secret-shaped value remains.
- Add behavioral and image-contract coverage for nonzero Expect outcomes and safe diagnostics.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: release-gate harness diagnostics only; no user-facing behavior changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review confirms diagnostic output is read only from the already-sanitized artifact, is suppressed if secret-shaped data remains, and raw/combined captures are still deleted.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
npm test -- --run test/deepagents-code-tui-startup-check.test.ts test/langchain-deepagents-code-image.test.ts
npm run typecheck:cli
```

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded TUI startup-check coverage to explicitly preserve lifecycle markers and ensure the embedded harness exits cleanly after marker writes.
  * Added a new failure-case test that verifies the helper returns the correct non-zero status and emits only the sanitized capture excerpt (including the EOF marker) for diagnostics.
  * Updated end-to-end checks to confirm the generated startup-check script includes and positions `expect_rc` correctly and prints the sanitized capture excerpt on non-zero runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->