### PR TITLE
refactor(onboard): separate sandbox state orchestration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -164,6 +164,25 @@
       }
     },
     {
+      "includes": [
+        "src/lib/onboard/machine/handlers/sandbox.ts",
+        "src/lib/onboard/machine/handlers/sandbox-messaging.ts",
+        "src/lib/onboard/machine/handlers/sandbox-resume.ts"
+      ],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": {
+              "level": "error",
+              "options": {
+                "maxAllowedComplexity": 10
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["nemoclaw/src/**/*.ts"],
       "linter": {
         "rules": {

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { SandboxMessagingPlan } from "../../../messaging/manifest";
-import { filterMessagingPlanForCurrentAgent } from "./sandbox-messaging";
+import { reconcileReusedSandboxMessaging } from "./sandbox-messaging";
 
 const channelIds = ["telegram", "unsupported"];
 
@@ -99,11 +99,18 @@ function channelIdsFrom<T extends { readonly channelId: string }>(entries: reado
   return entries.map((entry) => entry.channelId);
 }
 
-describe("filterMessagingPlanForCurrentAgent", () => {
+describe("reconcileReusedSandboxMessaging", () => {
   it("removes every unsupported channel artifact from a reused plan", () => {
-    const filtered = filterMessagingPlanForCurrentAgent(mixedChannelPlan(), { name: "openclaw" });
+    const result = reconcileReusedSandboxMessaging(
+      mixedChannelPlan(),
+      { name: "openclaw" },
+      { clearPlanEnv() {} },
+    );
+    const filtered = result.plan;
 
     expect(filtered).not.toBeNull();
+    expect(result.selectedChannels).toEqual(["telegram"]);
+    expect(result.changed).toBe(true);
     expect({
       channels: channelIdsFrom(filtered?.channels ?? []),
       disabledChannels: filtered?.disabledChannels,

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import type { SandboxMessagingPlan } from "../../../messaging/manifest";
+import { filterMessagingPlanForCurrentAgent } from "./sandbox-messaging";
+
+const channelIds = ["telegram", "unsupported"];
+
+function mixedChannelPlan(): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName: "alpha",
+    agent: "openclaw",
+    workflow: "onboard",
+    channels: channelIds.map((channelId) => ({
+      channelId,
+      displayName: channelId,
+      authMode: "token-paste",
+      active: channelId === "telegram",
+      selected: true,
+      configured: true,
+      disabled: channelId !== "telegram",
+      inputs: [],
+      hooks: [],
+    })),
+    disabledChannels: ["unsupported"],
+    credentialBindings: channelIds.map((channelId) => ({
+      channelId,
+      credentialId: "token",
+      sourceInput: "token",
+      providerName: `alpha-${channelId}`,
+      providerEnvKey: `${channelId.toUpperCase()}_TOKEN`,
+      placeholder: `openshell:resolve:env:${channelId.toUpperCase()}_TOKEN`,
+      credentialAvailable: true,
+    })),
+    networkPolicy: {
+      presets: [...channelIds],
+      entries: channelIds.map((channelId) => ({
+        channelId,
+        presetName: channelId,
+        policyKeys: [`${channelId}_api`],
+        source: "manifest",
+      })),
+    },
+    agentRender: channelIds.map((channelId) => ({
+      channelId,
+      kind: "json-fragment",
+      agent: "openclaw",
+      target: "openclaw.json",
+      path: `channels.${channelId}`,
+      value: { enabled: true },
+      templateRefs: [],
+    })),
+    buildSteps: channelIds.map((channelId) => ({
+      channelId,
+      kind: "build-arg",
+      outputId: `${channelId}-arg`,
+      required: true,
+      value: "enabled",
+    })),
+    runtimeSetup: {
+      nodePreloads: channelIds.map((channelId) => ({
+        channelId,
+        module: `${channelId}-preload`,
+        source: "manifest",
+        target: "agent",
+      })),
+      envAliases: channelIds.map((channelId) => ({
+        channelId,
+        envKey: `${channelId.toUpperCase()}_TOKEN`,
+        match: "source",
+        value: "target",
+      })),
+      secretScans: channelIds.map((channelId) => ({
+        channelId,
+        path: `/sandbox/${channelId}`,
+        pattern: "secret",
+        message: "secret found",
+      })),
+    },
+    stateUpdates: channelIds.map((channelId) => ({
+      channelId,
+      kind: "persist-inputs",
+      stateKey: `${channelId}Config`,
+      inputIds: ["token"],
+    })),
+    healthChecks: channelIds.map((channelId) => ({
+      channelId,
+      phase: "health-check",
+      requiredBefore: "lifecycle-success",
+      hookIds: [`${channelId}-health`],
+    })),
+  };
+}
+
+function channelIdsFrom<T extends { readonly channelId: string }>(entries: readonly T[]): string[] {
+  return entries.map((entry) => entry.channelId);
+}
+
+describe("filterMessagingPlanForCurrentAgent", () => {
+  it("removes every unsupported channel artifact from a reused plan", () => {
+    const filtered = filterMessagingPlanForCurrentAgent(mixedChannelPlan(), { name: "openclaw" });
+
+    expect(filtered).not.toBeNull();
+    expect({
+      channels: channelIdsFrom(filtered?.channels ?? []),
+      disabledChannels: filtered?.disabledChannels,
+      credentialBindings: channelIdsFrom(filtered?.credentialBindings ?? []),
+      networkPolicyPresets: filtered?.networkPolicy.presets,
+      networkPolicyEntries: channelIdsFrom(filtered?.networkPolicy.entries ?? []),
+      agentRender: channelIdsFrom(filtered?.agentRender ?? []),
+      buildSteps: channelIdsFrom(filtered?.buildSteps ?? []),
+      nodePreloads: channelIdsFrom(filtered?.runtimeSetup?.nodePreloads ?? []),
+      envAliases: channelIdsFrom(filtered?.runtimeSetup?.envAliases ?? []),
+      secretScans: channelIdsFrom(filtered?.runtimeSetup?.secretScans ?? []),
+      stateUpdates: channelIdsFrom(filtered?.stateUpdates ?? []),
+      healthChecks: channelIdsFrom(filtered?.healthChecks ?? []),
+    }).toEqual({
+      channels: ["telegram"],
+      disabledChannels: [],
+      credentialBindings: ["telegram"],
+      networkPolicyPresets: ["telegram"],
+      networkPolicyEntries: ["telegram"],
+      agentRender: ["telegram"],
+      buildSteps: ["telegram"],
+      nodePreloads: ["telegram"],
+      envAliases: ["telegram"],
+      secretScans: ["telegram"],
+      stateUpdates: ["telegram"],
+      healthChecks: ["telegram"],
+    });
+  });
+});

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createBuiltInChannelManifestRegistry,
+  listSupportedMessagingChannelIdsForAgent,
+  tryGetMessagingAgentId,
+} from "../../../messaging";
+import type { MessagingAgentId, SandboxMessagingPlan } from "../../../messaging/manifest";
+import { hashCredential } from "../../../security/credential-hash";
+import type { Session } from "../../../state/onboard-session";
+import { detectMessagingChannelsFromEnv } from "../../messaging-channel-setup";
+import { getActiveChannelsFromPlan, getChannelsFromPlan } from "../../messaging-plan-session";
+
+type MessagingAgentLike = {
+  readonly name?: string;
+};
+
+export interface SandboxMessagingDeps<Agent> {
+  note(message: string): void;
+  getRecordedMessagingChannelsForResume(
+    resume: boolean,
+    session: Session | null,
+    sandboxName: string | null,
+  ): string[] | null;
+  setupMessagingChannels(
+    agent: Agent,
+    existingChannels: string[] | null,
+    sandboxName: string,
+  ): Promise<string[]>;
+  readMessagingPlanFromEnv(): SandboxMessagingPlan | null;
+  writePlanToEnv(plan: SandboxMessagingPlan): void;
+  clearPlanEnv(): void;
+  getRegistrySandboxMessagingPlan(sandboxName: string): SandboxMessagingPlan | null;
+}
+
+export interface SandboxMessagingSelection {
+  readonly plan: SandboxMessagingPlan | null;
+  readonly selectedChannels: string[];
+}
+
+export interface ReconcileSandboxMessagingOptions<Agent> {
+  readonly resume: boolean;
+  readonly session: Session | null;
+  readonly sandboxName: string;
+  readonly agent: Agent;
+  readonly deps: SandboxMessagingDeps<Agent>;
+}
+
+const messagingManifestRegistry = createBuiltInChannelManifestRegistry();
+
+function refreshCredentialHashesFromEnv(plan: SandboxMessagingPlan): {
+  plan: SandboxMessagingPlan;
+  changed: boolean;
+} {
+  let changed = false;
+  const credentialBindings = plan.credentialBindings.map((binding) => {
+    if (binding.credentialAvailable !== true) return binding;
+    const credentialHash = hashCredential(process.env[binding.providerEnvKey]);
+    if (!credentialHash || credentialHash === binding.credentialHash) return binding;
+    changed = true;
+    return { ...binding, credentialHash };
+  });
+  return changed ? { plan: { ...plan, credentialBindings }, changed } : { plan, changed };
+}
+
+function resolveCurrentMessagingAgent(agent: unknown): {
+  readonly agentId: MessagingAgentId | null;
+  readonly supportedChannelIds: readonly string[] | null;
+} {
+  const descriptor = (agent ?? {}) as MessagingAgentLike;
+  const name = typeof descriptor.name === "string" ? descriptor.name.trim() : "";
+  if (!name) return { agentId: null, supportedChannelIds: null };
+  const manifests = messagingManifestRegistry.list();
+  const agentId = tryGetMessagingAgentId(descriptor, manifests);
+  if (agentId === null) return { agentId: null, supportedChannelIds: [] };
+  return {
+    agentId,
+    supportedChannelIds: listSupportedMessagingChannelIdsForAgent(manifests, agentId),
+  };
+}
+
+function filterChannelNamesForCurrentAgent(
+  channelIds: readonly string[],
+  agent: unknown,
+): string[] {
+  const availability = resolveCurrentMessagingAgent(agent);
+  if (availability.supportedChannelIds === null) return [...channelIds];
+  if (availability.agentId === null || availability.supportedChannelIds.length === 0) return [];
+  const supported = new Set(availability.supportedChannelIds);
+  return channelIds.filter((channelId) => supported.has(channelId));
+}
+
+export function filterMessagingPlanForCurrentAgent(
+  plan: SandboxMessagingPlan,
+  agent: unknown,
+): SandboxMessagingPlan | null {
+  const availability = resolveCurrentMessagingAgent(agent);
+  if (availability.supportedChannelIds === null) return plan;
+  if (availability.agentId === null || plan.agent !== availability.agentId) return null;
+  const supported = new Set(availability.supportedChannelIds);
+  const channels = plan.channels.filter((channel) => supported.has(channel.channelId));
+  if (channels.length === 0) return null;
+  if (channels.length === plan.channels.length) return plan;
+
+  const remainingChannelIds = new Set(channels.map((channel) => channel.channelId));
+  const keepEntry = <T extends { readonly channelId: string }>(entry: T): boolean =>
+    remainingChannelIds.has(entry.channelId);
+  const networkEntries = plan.networkPolicy.entries.filter(keepEntry);
+  const filterRuntimeSetup = <T extends { readonly channelId: string }>(entries?: readonly T[]) =>
+    (entries ?? []).filter(keepEntry);
+
+  return {
+    ...plan,
+    channels,
+    disabledChannels: plan.disabledChannels.filter((channelId) =>
+      remainingChannelIds.has(channelId),
+    ),
+    credentialBindings: plan.credentialBindings.filter(keepEntry),
+    networkPolicy: {
+      presets: [...new Set(networkEntries.map((entry) => entry.presetName))].sort(),
+      entries: networkEntries,
+    },
+    agentRender: plan.agentRender.filter(keepEntry),
+    buildSteps: plan.buildSteps.filter(keepEntry),
+    runtimeSetup: plan.runtimeSetup
+      ? {
+          nodePreloads: filterRuntimeSetup(plan.runtimeSetup.nodePreloads),
+          envAliases: filterRuntimeSetup(plan.runtimeSetup.envAliases),
+          secretScans: filterRuntimeSetup(plan.runtimeSetup.secretScans),
+        }
+      : undefined,
+    stateUpdates: plan.stateUpdates.filter(keepEntry),
+    healthChecks: plan.healthChecks.filter(keepEntry),
+  };
+}
+
+function selectionFromReusablePlan<Agent>(
+  plan: SandboxMessagingPlan,
+  agent: Agent,
+  writeToEnv: boolean,
+  deps: SandboxMessagingDeps<Agent>,
+): SandboxMessagingSelection {
+  const refreshed = refreshCredentialHashesFromEnv(plan);
+  const filtered = filterMessagingPlanForCurrentAgent(refreshed.plan, agent);
+  if (!filtered) {
+    deps.clearPlanEnv();
+    return { plan: null, selectedChannels: [] };
+  }
+  if (writeToEnv || refreshed.changed || filtered !== refreshed.plan) deps.writePlanToEnv(filtered);
+  return {
+    plan: filtered,
+    selectedChannels: getActiveChannelsFromPlan(filtered) ?? [],
+  };
+}
+
+async function selectionFromMessagingSetup<Agent>(
+  existingChannels: string[] | null,
+  options: ReconcileSandboxMessagingOptions<Agent>,
+): Promise<SandboxMessagingSelection> {
+  const existing = existingChannels
+    ? filterChannelNamesForCurrentAgent(existingChannels, options.agent)
+    : existingChannels;
+  const selected = filterChannelNamesForCurrentAgent(
+    await options.deps.setupMessagingChannels(options.agent, existing, options.sandboxName),
+    options.agent,
+  );
+  const plan = options.deps.readMessagingPlanFromEnv();
+  if (!plan) return { plan: null, selectedChannels: selected };
+  const filtered = filterMessagingPlanForCurrentAgent(plan, options.agent);
+  if (!filtered) {
+    options.deps.clearPlanEnv();
+    return { plan: null, selectedChannels: [] };
+  }
+  if (filtered === plan) return { plan, selectedChannels: selected };
+  options.deps.writePlanToEnv(filtered);
+  return {
+    plan: filtered,
+    selectedChannels: getActiveChannelsFromPlan(filtered) ?? [],
+  };
+}
+
+function selectionFromRecordedChannels<Agent>(
+  recordedChannels: string[],
+  envPlan: SandboxMessagingPlan | null,
+  registryPlan: SandboxMessagingPlan | null,
+  options: ReconcileSandboxMessagingOptions<Agent>,
+): SandboxMessagingSelection {
+  let selection: SandboxMessagingSelection = {
+    plan: null,
+    selectedChannels: filterChannelNamesForCurrentAgent(recordedChannels, options.agent),
+  };
+  if (envPlan) selection = selectionFromReusablePlan(envPlan, options.agent, false, options.deps);
+  else if (registryPlan)
+    selection = selectionFromReusablePlan(registryPlan, options.agent, true, options.deps);
+  if (selection.selectedChannels.length > 0) {
+    options.deps.note(
+      `  [non-interactive] Reusing messaging channel configuration: ${selection.selectedChannels.join(", ")}`,
+    );
+  }
+  return selection;
+}
+
+function channelsForRegistryPlanRefresh(
+  registryPlan: SandboxMessagingPlan,
+  agent: unknown,
+): string[] | null {
+  const activeChannels = filterChannelNamesForCurrentAgent(
+    getActiveChannelsFromPlan(registryPlan) ?? [],
+    agent,
+  );
+  if (activeChannels.length > 0) return null;
+  const detectedChannels = filterChannelNamesForCurrentAgent(
+    detectMessagingChannelsFromEnv(agent as Parameters<typeof detectMessagingChannelsFromEnv>[0]),
+    agent,
+  );
+  return detectedChannels.length > 0 ? detectedChannels : null;
+}
+
+async function selectionFromRegistryPlan<Agent>(
+  registryPlan: SandboxMessagingPlan,
+  options: ReconcileSandboxMessagingOptions<Agent>,
+): Promise<SandboxMessagingSelection> {
+  const detectedChannels = channelsForRegistryPlanRefresh(registryPlan, options.agent);
+  if (!detectedChannels) {
+    return selectionFromReusablePlan(registryPlan, options.agent, true, options.deps);
+  }
+  options.deps.note(
+    `  [non-interactive] Detected messaging channel inputs for ${detectedChannels.join(", ")}; refreshing reused sandbox messaging plan.`,
+  );
+  // The registry is authoritative for channels that cannot be rediscovered
+  // from host env (for example, an in-sandbox QR-authenticated channel).
+  return selectionFromMessagingSetup(
+    getChannelsFromPlan(registryPlan) ?? getChannelsFromPlan(options.session?.messagingPlan),
+    options,
+  );
+}
+
+export function reconcileReusedSandboxMessaging<Agent>(
+  plan: SandboxMessagingPlan | null,
+  agent: Agent,
+  deps: Pick<SandboxMessagingDeps<Agent>, "clearPlanEnv">,
+): SandboxMessagingSelection & { readonly changed: boolean } {
+  const filtered = plan ? filterMessagingPlanForCurrentAgent(plan, agent) : null;
+  if (filtered !== plan) deps.clearPlanEnv();
+  return {
+    plan: filtered,
+    selectedChannels: getActiveChannelsFromPlan(filtered) ?? [],
+    changed: filtered !== plan,
+  };
+}
+
+export async function reconcileSandboxMessaging<Agent>(
+  options: ReconcileSandboxMessagingOptions<Agent>,
+): Promise<SandboxMessagingSelection> {
+  const recordedChannels = options.deps.getRecordedMessagingChannelsForResume(
+    options.resume,
+    options.session,
+    options.sandboxName,
+  );
+  const envPlan = options.deps.readMessagingPlanFromEnv();
+  const registryPlan = options.deps.getRegistrySandboxMessagingPlan(options.sandboxName);
+  if (recordedChannels) {
+    return selectionFromRecordedChannels(recordedChannels, envPlan, registryPlan, options);
+  }
+  if (envPlan) return selectionFromReusablePlan(envPlan, options.agent, false, options.deps);
+  if (registryPlan) return selectionFromRegistryPlan(registryPlan, options);
+  return selectionFromMessagingSetup(getChannelsFromPlan(options.session?.messagingPlan), options);
+}

--- a/src/lib/onboard/machine/handlers/sandbox-resume.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-resume.test.ts
@@ -39,7 +39,7 @@ describe("decideSandboxResume", () => {
 
   it("repairs a recorded sandbox that is present but not ready", () => {
     expect(decideSandboxResume(resumeSignals({ sandboxReuseState: "not_ready" }))).toEqual({
-      kind: "repair",
+      kind: "repair-and-recreate",
     });
   });
 

--- a/src/lib/onboard/machine/handlers/sandbox-resume.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-resume.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { decideSandboxResume, type SandboxResumeSignals } from "./sandbox-resume";
+
+function resumeSignals(overrides: Partial<SandboxResumeSignals> = {}): SandboxResumeSignals {
+  return {
+    resume: true,
+    resumeAgentChanged: false,
+    sandboxStepComplete: true,
+    sandboxReuseState: "ready",
+    webSearchConfigChanged: false,
+    sandboxGpuConfigChanged: false,
+    messagingChannelConfigChanged: false,
+    hermesToolGatewayConfigChanged: false,
+    ...overrides,
+  };
+}
+
+describe("decideSandboxResume", () => {
+  it("reuses only a complete ready sandbox without configuration drift", () => {
+    expect(decideSandboxResume(resumeSignals())).toEqual({ kind: "reuse" });
+  });
+
+  it.each([
+    ["agent", { resumeAgentChanged: true }, false],
+    ["web search", { webSearchConfigChanged: true }, true],
+    ["sandbox GPU", { sandboxGpuConfigChanged: true }, true],
+    ["messaging", { messagingChannelConfigChanged: true }, true],
+    ["Hermes tool gateway", { hermesToolGatewayConfigChanged: true }, true],
+  ] as const)("recreates for %s drift", (_label, overrides, removeRegistryEntry) => {
+    expect(decideSandboxResume(resumeSignals(overrides))).toMatchObject({
+      kind: "recreate",
+      removeRegistryEntry,
+    });
+  });
+
+  it("repairs a recorded sandbox that is present but not ready", () => {
+    expect(decideSandboxResume(resumeSignals({ sandboxReuseState: "not_ready" }))).toEqual({
+      kind: "repair",
+    });
+  });
+
+  it("creates without resume-specific cleanup when the step is incomplete", () => {
+    expect(
+      decideSandboxResume(
+        resumeSignals({ sandboxStepComplete: false, webSearchConfigChanged: true }),
+      ),
+    ).toEqual({ kind: "create" });
+  });
+});

--- a/src/lib/onboard/machine/handlers/sandbox-resume.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-resume.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface SandboxResumeSignals {
+  readonly resume: boolean;
+  readonly resumeAgentChanged: boolean;
+  readonly sandboxStepComplete: boolean;
+  readonly sandboxReuseState: string;
+  readonly webSearchConfigChanged: boolean;
+  readonly sandboxGpuConfigChanged: boolean;
+  readonly messagingChannelConfigChanged: boolean;
+  readonly hermesToolGatewayConfigChanged: boolean;
+}
+
+export type SandboxResumeDecision =
+  | { readonly kind: "create" }
+  | { readonly kind: "reuse" }
+  | {
+      readonly kind: "recreate";
+      readonly note: string;
+      readonly removeRegistryEntry: boolean;
+    }
+  | { readonly kind: "repair" };
+
+export interface SandboxResumeDeps {
+  note(message: string): void;
+  removeSandboxFromRegistry(sandboxName: string): void;
+  repairRecordedSandbox(sandboxName: string | null): void;
+  recordRepairEvent(
+    type: "state.repair.started" | "state.repair.completed" | "state.repair.failed",
+    options?: {
+      state?: "sandbox";
+      error?: string | null;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): Promise<unknown>;
+}
+
+function canReuseSandbox(signals: SandboxResumeSignals): boolean {
+  return (
+    !signals.resumeAgentChanged &&
+    !signals.webSearchConfigChanged &&
+    !signals.sandboxGpuConfigChanged &&
+    !signals.messagingChannelConfigChanged &&
+    !signals.hermesToolGatewayConfigChanged &&
+    signals.sandboxReuseState === "ready"
+  );
+}
+
+export function decideSandboxResume(signals: SandboxResumeSignals): SandboxResumeDecision {
+  if (!signals.resume || !signals.sandboxStepComplete) return { kind: "create" };
+  if (canReuseSandbox(signals)) return { kind: "reuse" };
+  if (signals.resumeAgentChanged) {
+    return {
+      kind: "recreate",
+      note: "  [resume] Agent selection changed; revalidating sandbox compatibility.",
+      removeRegistryEntry: false,
+    };
+  }
+  if (signals.webSearchConfigChanged) {
+    return {
+      kind: "recreate",
+      note: "  [resume] Web Search configuration changed; recreating sandbox.",
+      removeRegistryEntry: true,
+    };
+  }
+  if (signals.sandboxGpuConfigChanged) {
+    return {
+      kind: "recreate",
+      note: "  [resume] Sandbox GPU settings changed; recreating sandbox.",
+      removeRegistryEntry: true,
+    };
+  }
+  if (signals.messagingChannelConfigChanged) {
+    return {
+      kind: "recreate",
+      note: "  [resume] Messaging channel configuration changed; recreating sandbox.",
+      removeRegistryEntry: true,
+    };
+  }
+  if (signals.hermesToolGatewayConfigChanged) {
+    return {
+      kind: "recreate",
+      note: "  [resume] Hermes managed tool gateway selection changed; recreating sandbox.",
+      removeRegistryEntry: true,
+    };
+  }
+  if (signals.sandboxReuseState === "not_ready") return { kind: "repair" };
+  return {
+    kind: "recreate",
+    note: "  [resume] Recorded sandbox state is unavailable; recreating it.",
+    removeRegistryEntry: true,
+  };
+}
+
+async function repairRecordedSandbox(
+  sandboxName: string | null,
+  deps: SandboxResumeDeps,
+): Promise<void> {
+  deps.note(`  [resume] Recorded sandbox '${sandboxName}' exists but is not ready; recreating it.`);
+  const metadata = { repair: "recorded-sandbox-cleanup", sandboxName };
+  await deps.recordRepairEvent("state.repair.started", { state: "sandbox", metadata });
+  try {
+    deps.repairRecordedSandbox(sandboxName);
+  } catch (error) {
+    await deps.recordRepairEvent("state.repair.failed", {
+      state: "sandbox",
+      error: error instanceof Error ? error.message : String(error),
+      metadata,
+    });
+    throw error;
+  }
+  await deps.recordRepairEvent("state.repair.completed", { state: "sandbox", metadata });
+}
+
+export async function applySandboxResumeDecision(
+  decision: SandboxResumeDecision,
+  sandboxName: string | null,
+  deps: SandboxResumeDeps,
+): Promise<void> {
+  if (decision.kind === "repair") {
+    await repairRecordedSandbox(sandboxName, deps);
+    return;
+  }
+  if (decision.kind !== "recreate") return;
+  deps.note(decision.note);
+  if (decision.removeRegistryEntry && sandboxName) deps.removeSandboxFromRegistry(sandboxName);
+}

--- a/src/lib/onboard/machine/handlers/sandbox-resume.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-resume.ts
@@ -20,7 +20,7 @@ export type SandboxResumeDecision =
       readonly note: string;
       readonly removeRegistryEntry: boolean;
     }
-  | { readonly kind: "repair" };
+  | { readonly kind: "repair-and-recreate" };
 
 export interface SandboxResumeDeps {
   note(message: string): void;
@@ -85,7 +85,7 @@ export function decideSandboxResume(signals: SandboxResumeSignals): SandboxResum
       removeRegistryEntry: true,
     };
   }
-  if (signals.sandboxReuseState === "not_ready") return { kind: "repair" };
+  if (signals.sandboxReuseState === "not_ready") return { kind: "repair-and-recreate" };
   return {
     kind: "recreate",
     note: "  [resume] Recorded sandbox state is unavailable; recreating it.",
@@ -118,7 +118,7 @@ export async function applySandboxResumeDecision(
   sandboxName: string | null,
   deps: SandboxResumeDeps,
 ): Promise<void> {
-  if (decision.kind === "repair") {
+  if (decision.kind === "repair-and-recreate") {
     await repairRecordedSandbox(sandboxName, deps);
     return;
   }

--- a/src/lib/onboard/machine/handlers/sandbox.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.test.ts
@@ -124,9 +124,12 @@ function createDeps(
     stopStale: vi.fn(),
     createSandbox: vi.fn(async () => "my-assistant"),
     updateSandbox: vi.fn(),
-    complete: vi.fn(async () => createSession()),
+    complete: vi.fn(async (_stepName: string, updates: SessionUpdates) => {
+      Object.assign(session, updates);
+      return session;
+    }),
     skipped: vi.fn(),
-    recordSkip: vi.fn(async () => createSession()),
+    recordSkip: vi.fn(async () => session),
     repairEvent: vi.fn(async () => createSession()),
     error: vi.fn(),
     exit: vi.fn((code: number): never => {
@@ -271,6 +274,7 @@ describe("handleSandboxState", () => {
       selectedMessagingChannels: ["telegram"],
       webSearchSupported: true,
     });
+    expect(result.session?.sandboxName).toBe("my-assistant");
     expect(result.stateResult).toEqual({
       type: "transition",
       next: "openclaw",
@@ -286,7 +290,12 @@ describe("handleSandboxState", () => {
       messagingPlan: makeMinimalPlan("saved", "openclaw", ["slack"]),
     });
     session.steps.sandbox.status = "complete";
-    const { deps, calls } = createDeps({ getSandboxReuseState: () => "ready" });
+    const skippedSession = createSession({ sandboxName: "saved-after-skip" });
+    const recordStateSkipped = vi.fn(async () => skippedSession);
+    const { deps, calls } = createDeps({
+      getSandboxReuseState: () => "ready",
+      recordStateSkipped,
+    });
 
     const result = await handleSandboxState({
       ...baseOptions(deps, session),
@@ -296,11 +305,12 @@ describe("handleSandboxState", () => {
 
     expect(calls.createSandbox).not.toHaveBeenCalled();
     expect(calls.skipped).toHaveBeenCalledWith("sandbox", "saved");
-    expect(calls.recordSkip).toHaveBeenCalledWith("sandbox", {
+    expect(recordStateSkipped).toHaveBeenCalledWith("sandbox", {
       reason: "resume",
       sandboxName: "saved",
     });
     expect(result.selectedMessagingChannels).toEqual(["slack"]);
+    expect(result.session).toBe(skippedSession);
   });
 
   it("removes registry state when messaging config drift forces sandbox recreation", async () => {

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -279,11 +279,15 @@ class SandboxStateFlow<
         })
       : state.session;
     this.deps.skippedStepMessage("sandbox", state.sandboxName);
-    await this.deps.recordStateSkipped("sandbox", {
+    const skippedSession = await this.deps.recordStateSkipped("sandbox", {
       reason: "resume",
       sandboxName: state.sandboxName,
     });
-    return { ...state, session, selectedMessagingChannels: messaging.selectedChannels };
+    return {
+      ...state,
+      session: skippedSession,
+      selectedMessagingChannels: messaging.selectedChannels,
+    };
   }
 
   private async resolveWebSearchForCreation(
@@ -350,7 +354,7 @@ class SandboxStateFlow<
     });
     // Finalization marks the default so a cancelled onboarding cannot leave a
     // partially configured sandbox selected as the default.
-    await this.deps.recordStepComplete(
+    const completedSession = await this.deps.recordStepComplete(
       "sandbox",
       this.deps.toSessionUpdates({
         sandboxName,
@@ -362,7 +366,7 @@ class SandboxStateFlow<
         hermesToolGateways: this.options.hermesToolGateways,
       }),
     );
-    return { ...state, sandboxName };
+    return { ...state, sandboxName, session: completedSession };
   }
 
   private async recreateSandbox(

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -272,12 +272,12 @@ class SandboxStateFlow<
       this.options.agent,
       this.deps,
     );
-    const session = messaging.changed
-      ? this.deps.updateSession((current) => {
-          current.messagingPlan = messaging.plan;
-          return current;
-        })
-      : state.session;
+    if (messaging.changed) {
+      this.deps.updateSession((current) => {
+        current.messagingPlan = messaging.plan;
+        return current;
+      });
+    }
     this.deps.skippedStepMessage("sandbox", state.sandboxName);
     const skippedSession = await this.deps.recordStateSkipped("sandbox", {
       reason: "resume",

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -1,18 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  createBuiltInChannelManifestRegistry,
-  listSupportedMessagingChannelIdsForAgent,
-  tryGetMessagingAgentId,
-} from "../../../messaging";
-import type { MessagingAgentId, SandboxMessagingPlan } from "../../../messaging/manifest";
-import { hashCredential } from "../../../security/credential-hash";
+import type { SandboxMessagingPlan } from "../../../messaging/manifest";
 import type { Session, SessionUpdates } from "../../../state/onboard-session";
-import { detectMessagingChannelsFromEnv } from "../../messaging-channel-setup";
-import { getActiveChannelsFromPlan, getChannelsFromPlan } from "../../messaging-plan-session";
 import { withSandboxPhaseTrace } from "../../tracing";
 import { branchTo, type OnboardStateTransitionResult } from "../result";
+import { reconcileReusedSandboxMessaging, reconcileSandboxMessaging } from "./sandbox-messaging";
+import {
+  applySandboxResumeDecision,
+  decideSandboxResume,
+  type SandboxResumeDecision,
+} from "./sandbox-resume";
 
 export interface SandboxStateOptions<
   Gpu,
@@ -145,99 +143,294 @@ export interface SandboxStateResult<WebSearchConfig> {
   stateResult: OnboardStateTransitionResult;
 }
 
-function refreshCredentialHashesFromEnv(plan: SandboxMessagingPlan): {
-  plan: SandboxMessagingPlan;
-  changed: boolean;
-} {
-  let changed = false;
-  const credentialBindings = plan.credentialBindings.map((binding) => {
-    if (binding.credentialAvailable !== true) return binding;
-    const credentialHash = hashCredential(process.env[binding.providerEnvKey]);
-    if (!credentialHash || credentialHash === binding.credentialHash) return binding;
-    changed = true;
-    return { ...binding, credentialHash };
-  });
-
-  return changed ? { plan: { ...plan, credentialBindings }, changed } : { plan, changed };
+interface SandboxStepState<WebSearchConfig> {
+  readonly session: Session | null;
+  readonly sandboxName: string | null;
+  readonly webSearchConfig: WebSearchConfig | null;
+  readonly selectedMessagingChannels: string[];
+  readonly webSearchSupported: boolean;
+  readonly webSearchSupportDropped: boolean;
+  readonly webSearchSupportProbePath: string | null;
 }
 
-type MessagingAgentLike = {
-  readonly name?: string;
-};
+type SandboxCreationDecision = Exclude<SandboxResumeDecision, { readonly kind: "reuse" }>;
 
-const messagingManifestRegistry = createBuiltInChannelManifestRegistry();
+class SandboxStateFlow<
+  Gpu,
+  Agent,
+  WebSearchConfig,
+  MessagingChannelConfig,
+  SandboxGpuConfig,
+  ResourceProfile,
+> {
+  constructor(
+    private readonly options: SandboxStateOptions<
+      Gpu,
+      Agent,
+      WebSearchConfig,
+      MessagingChannelConfig,
+      SandboxGpuConfig,
+      ResourceProfile
+    >,
+  ) {}
 
-function resolveCurrentMessagingAgent(agent: unknown): {
-  readonly agentId: MessagingAgentId | null;
-  readonly supportedChannelIds: readonly string[] | null;
-} {
-  const descriptor = (agent ?? {}) as MessagingAgentLike;
-  const name = typeof descriptor.name === "string" ? descriptor.name.trim() : "";
-  if (!name) return { agentId: null, supportedChannelIds: null };
-  const manifests = messagingManifestRegistry.list();
-  const agentId = tryGetMessagingAgentId(descriptor, manifests);
-  if (agentId === null) {
-    return { agentId: null, supportedChannelIds: [] };
+  private get deps(): SandboxStateOptions<
+    Gpu,
+    Agent,
+    WebSearchConfig,
+    MessagingChannelConfig,
+    SandboxGpuConfig,
+    ResourceProfile
+  >["deps"] {
+    return this.options.deps;
   }
-  return {
-    agentId,
-    supportedChannelIds: listSupportedMessagingChannelIdsForAgent(manifests, agentId),
-  };
-}
 
-function filterChannelNamesForCurrentAgent(
-  channelIds: readonly string[],
-  agent: unknown,
-): string[] {
-  const availability = resolveCurrentMessagingAgent(agent);
-  if (availability.supportedChannelIds === null) return [...channelIds];
-  if (availability.agentId === null || availability.supportedChannelIds.length === 0) return [];
-  const supported = new Set(availability.supportedChannelIds);
-  return channelIds.filter((channelId) => supported.has(channelId));
-}
+  private prepareWebSearchSupport(): SandboxStepState<WebSearchConfig> {
+    const probePath = this.options.fromDockerfile
+      ? this.deps.resolvePath(this.options.fromDockerfile)
+      : null;
+    const supported = this.deps.agentSupportsWebSearch(
+      this.options.agent,
+      probePath,
+      this.options.rootDir,
+    );
+    const dropped = Boolean(this.options.webSearchConfig) && !supported;
+    if (!dropped) {
+      return {
+        session: this.options.session,
+        sandboxName: this.options.sandboxName,
+        webSearchConfig: this.options.webSearchConfig,
+        selectedMessagingChannels: this.options.selectedMessagingChannels,
+        webSearchSupported: supported,
+        webSearchSupportDropped: false,
+        webSearchSupportProbePath: probePath,
+      };
+    }
 
-function filterMessagingPlanForCurrentAgent(
-  plan: SandboxMessagingPlan,
-  agent: unknown,
-): SandboxMessagingPlan | null {
-  const availability = resolveCurrentMessagingAgent(agent);
-  if (availability.supportedChannelIds === null) return plan;
-  if (availability.agentId === null || plan.agent !== availability.agentId) return null;
-  const supported = new Set(availability.supportedChannelIds);
-  const channels = plan.channels.filter((channel) => supported.has(channel.channelId));
-  if (channels.length === 0) return null;
-  if (channels.length === plan.channels.length) return plan;
+    this.deps.note(
+      `  Web search is not yet supported by ${(this.options.agent as { displayName?: string } | null)?.displayName ?? "this sandbox image"}. Clearing stale config.`,
+    );
+    if (this.options.session) this.options.session.webSearchConfig = null;
+    const session = this.deps.updateSession((current) => {
+      current.webSearchConfig = null;
+      return current;
+    });
+    return {
+      session,
+      sandboxName: this.options.sandboxName,
+      webSearchConfig: null,
+      selectedMessagingChannels: this.options.selectedMessagingChannels,
+      webSearchSupported: supported,
+      webSearchSupportDropped: true,
+      webSearchSupportProbePath: probePath,
+    };
+  }
 
-  const remainingChannelIds = new Set(channels.map((channel) => channel.channelId));
-  const keepEntry = <T extends { readonly channelId: string }>(entry: T): boolean =>
-    remainingChannelIds.has(entry.channelId);
-  const networkEntries = plan.networkPolicy.entries.filter(keepEntry);
-  const filterRuntimeSetup = <T extends { readonly channelId: string }>(entries?: readonly T[]) =>
-    (entries ?? []).filter(keepEntry);
+  private resolveResumeDecision(state: SandboxStepState<WebSearchConfig>): SandboxResumeDecision {
+    const storedMessagingConfig = this.deps.getStoredMessagingChannelConfig(
+      state.sandboxName,
+      state.session,
+    );
+    const effectiveMessagingConfig = this.deps.hydrateMessagingChannelConfig(storedMessagingConfig);
+    const recordedToolGateways = state.sandboxName
+      ? this.deps.normalizeHermesToolGatewaySelections(
+          this.deps.getSandboxHermesToolGateways(state.sandboxName),
+        )
+      : [];
+    return decideSandboxResume({
+      resume: this.options.resume,
+      resumeAgentChanged: this.options.resumeAgentChanged,
+      sandboxStepComplete: state.session?.steps?.sandbox?.status === "complete",
+      sandboxReuseState: this.deps.getSandboxReuseState(state.sandboxName),
+      webSearchConfigChanged:
+        state.webSearchSupportDropped ||
+        Boolean(state.session?.webSearchConfig) !== Boolean(state.webSearchConfig),
+      sandboxGpuConfigChanged: state.sandboxName
+        ? this.deps.hasSandboxGpuDrift(state.sandboxName, this.options.sandboxGpuConfig)
+        : false,
+      messagingChannelConfigChanged: !this.deps.messagingChannelConfigsEqual(
+        effectiveMessagingConfig,
+        storedMessagingConfig,
+      ),
+      hermesToolGatewayConfigChanged: !this.deps.stringSetsEqual(
+        recordedToolGateways,
+        this.options.hermesToolGateways,
+      ),
+    });
+  }
 
-  return {
-    ...plan,
-    channels,
-    disabledChannels: plan.disabledChannels.filter((channelId) =>
-      remainingChannelIds.has(channelId),
-    ),
-    credentialBindings: plan.credentialBindings.filter(keepEntry),
-    networkPolicy: {
-      presets: [...new Set(networkEntries.map((entry) => entry.presetName))].sort(),
-      entries: networkEntries,
-    },
-    agentRender: plan.agentRender.filter(keepEntry),
-    buildSteps: plan.buildSteps.filter(keepEntry),
-    runtimeSetup: plan.runtimeSetup
-      ? {
-          nodePreloads: filterRuntimeSetup(plan.runtimeSetup.nodePreloads),
-          envAliases: filterRuntimeSetup(plan.runtimeSetup.envAliases),
-          secretScans: filterRuntimeSetup(plan.runtimeSetup.secretScans),
-        }
-      : undefined,
-    stateUpdates: plan.stateUpdates.filter(keepEntry),
-    healthChecks: plan.healthChecks.filter(keepEntry),
-  };
+  private async reuseSandbox(
+    state: SandboxStepState<WebSearchConfig>,
+  ): Promise<SandboxStepState<WebSearchConfig>> {
+    if (state.webSearchConfig) {
+      this.deps.note(
+        "  [resume] Reusing Brave Search configuration already baked into the sandbox.",
+      );
+    }
+    const messaging = reconcileReusedSandboxMessaging(
+      state.session?.messagingPlan ?? null,
+      this.options.agent,
+      this.deps,
+    );
+    const session = messaging.changed
+      ? this.deps.updateSession((current) => {
+          current.messagingPlan = messaging.plan;
+          return current;
+        })
+      : state.session;
+    this.deps.skippedStepMessage("sandbox", state.sandboxName);
+    await this.deps.recordStateSkipped("sandbox", {
+      reason: "resume",
+      sandboxName: state.sandboxName,
+    });
+    return { ...state, session, selectedMessagingChannels: messaging.selectedChannels };
+  }
+
+  private async resolveWebSearchForCreation(
+    state: SandboxStepState<WebSearchConfig>,
+  ): Promise<WebSearchConfig | null> {
+    if (!state.webSearchConfig) {
+      return this.deps.configureWebSearch(
+        null,
+        this.options.agent,
+        state.webSearchSupportProbePath,
+      );
+    }
+    this.deps.note("  [resume] Revalidating Brave Search configuration for sandbox recreation.");
+    const credential = await this.deps.ensureValidatedBraveSearchCredential();
+    if (this.deps.isBackToSelection(credential) || !credential) return null;
+    this.deps.note("  [resume] Reusing Brave Search configuration.");
+    return state.webSearchConfig;
+  }
+
+  private async createAndRecordSandbox(
+    state: SandboxStepState<WebSearchConfig>,
+    requestedSandboxName: string,
+    messagingPlan: SandboxMessagingPlan | null,
+  ): Promise<SandboxStepState<WebSearchConfig>> {
+    const resourceProfile = await this.deps.selectResourceProfileForSandbox();
+    if (this.options.fresh) {
+      this.deps.stopStaleDashboardListenersForSandbox(
+        this.deps.listRegistrySandboxes().sandboxes,
+        requestedSandboxName,
+      );
+    }
+    const sandboxName = await withSandboxPhaseTrace(
+      requestedSandboxName,
+      this.options.provider,
+      this.options.model,
+      (this.options.agent as { name?: string } | null)?.name,
+      () =>
+        this.deps.createSandbox(
+          this.options.gpu,
+          this.options.model,
+          this.options.provider,
+          this.options.preferredInferenceApi,
+          requestedSandboxName,
+          state.webSearchConfig,
+          state.selectedMessagingChannels,
+          this.options.fromDockerfile,
+          this.options.agent,
+          this.options.controlUiPort,
+          this.options.sandboxGpuConfig,
+          resourceProfile,
+          this.options.hermesToolGateways,
+        ),
+    );
+    // createSandbox() owns the build fingerprint. In particular, reusing an
+    // image must not stamp it with the current version and hide build drift.
+    const { nemoclawVersion: _builtFingerprint, ...agentRegistryFields } =
+      this.deps.getSandboxAgentRegistryFields(this.options.agent, !this.options.fromDockerfile);
+    this.deps.updateSandboxRegistry(sandboxName, {
+      model: this.options.model,
+      provider: this.options.provider,
+      nimContainer: this.options.nimContainer,
+      preferredInferenceApi: this.options.preferredInferenceApi,
+      ...agentRegistryFields,
+    });
+    // Finalization marks the default so a cancelled onboarding cannot leave a
+    // partially configured sandbox selected as the default.
+    await this.deps.recordStepComplete(
+      "sandbox",
+      this.deps.toSessionUpdates({
+        sandboxName,
+        provider: this.options.provider,
+        model: this.options.model,
+        nimContainer: this.options.nimContainer,
+        webSearchConfig: state.webSearchConfig,
+        messagingPlan,
+        hermesToolGateways: this.options.hermesToolGateways,
+      }),
+    );
+    return { ...state, sandboxName };
+  }
+
+  private async recreateSandbox(
+    state: SandboxStepState<WebSearchConfig>,
+    decision: SandboxCreationDecision,
+  ): Promise<SandboxStepState<WebSearchConfig>> {
+    await applySandboxResumeDecision(decision, state.sandboxName, this.deps);
+    const webSearchConfig = await this.resolveWebSearchForCreation(state);
+    await this.deps.startRecordedStep("sandbox", {
+      provider: this.options.provider,
+      model: this.options.model,
+    });
+    const requestedSandboxName =
+      state.sandboxName ?? (await this.deps.promptValidatedSandboxName(this.options.agent));
+    const messaging = await reconcileSandboxMessaging({
+      resume: this.options.resume,
+      session: state.session,
+      sandboxName: requestedSandboxName,
+      agent: this.options.agent,
+      deps: this.deps,
+    });
+    const session = this.deps.updateSession((current) => {
+      current.messagingPlan = messaging.plan;
+      return current;
+    });
+    return this.createAndRecordSandbox(
+      {
+        ...state,
+        session,
+        sandboxName: requestedSandboxName,
+        webSearchConfig,
+        selectedMessagingChannels: messaging.selectedChannels,
+      },
+      requestedSandboxName,
+      messaging.plan,
+    );
+  }
+
+  private complete(state: SandboxStepState<WebSearchConfig>): SandboxStateResult<WebSearchConfig> {
+    if (!state.sandboxName) {
+      this.deps.error("  Onboarding state is incomplete after sandbox setup.");
+      return this.deps.exitProcess(1);
+    }
+    return {
+      sandboxName: state.sandboxName,
+      webSearchConfig: state.webSearchConfig,
+      selectedMessagingChannels: state.selectedMessagingChannels,
+      webSearchSupported: state.webSearchSupported,
+      session: state.session,
+      stateResult: branchTo(this.options.agent ? "agent_setup" : "openclaw", {
+        metadata: {
+          state: "sandbox",
+          sandboxName: state.sandboxName,
+          agent: (this.options.agent as { name?: string } | null)?.name ?? "openclaw",
+        },
+      }),
+    };
+  }
+
+  async run(): Promise<SandboxStateResult<WebSearchConfig>> {
+    const initialState = this.prepareWebSearchSupport();
+    const decision = this.resolveResumeDecision(initialState);
+    const completedState =
+      decision.kind === "reuse"
+        ? await this.reuseSandbox(initialState)
+        : await this.recreateSandbox(initialState, decision);
+    return this.complete(completedState);
+  }
 }
 
 export async function handleSandboxState<
@@ -247,356 +440,15 @@ export async function handleSandboxState<
   MessagingChannelConfig,
   SandboxGpuConfig,
   ResourceProfile,
->({
-  resume,
-  fresh,
-  resumeAgentChanged,
-  session,
-  sandboxName,
-  model,
-  provider,
-  nimContainer,
-  webSearchConfig,
-  selectedMessagingChannels,
-  fromDockerfile,
-  agent,
-  gpu,
-  preferredInferenceApi,
-  sandboxGpuConfig,
-  hermesToolGateways,
-  controlUiPort,
-  rootDir,
-  deps,
-}: SandboxStateOptions<
-  Gpu,
-  Agent,
-  WebSearchConfig,
-  MessagingChannelConfig,
-  SandboxGpuConfig,
-  ResourceProfile
->): Promise<SandboxStateResult<WebSearchConfig>> {
-  const webSearchSupportProbePath = fromDockerfile ? deps.resolvePath(fromDockerfile) : null;
-  const webSearchSupported = deps.agentSupportsWebSearch(agent, webSearchSupportProbePath, rootDir);
-  const webSearchSupportDropped = Boolean(webSearchConfig) && !webSearchSupported;
-  if (webSearchSupportDropped) {
-    deps.note(
-      `  Web search is not yet supported by ${(agent as { displayName?: string } | null)?.displayName ?? "this sandbox image"}. Clearing stale config.`,
-    );
-    webSearchConfig = null;
-    if (session) session.webSearchConfig = null;
-    session = deps.updateSession((current) => {
-      current.webSearchConfig = null;
-      return current;
-    });
-  }
-
-  const storedMessagingChannelConfig = deps.getStoredMessagingChannelConfig(sandboxName, session);
-  const effectiveMessagingChannelConfig = deps.hydrateMessagingChannelConfig(
-    storedMessagingChannelConfig,
-  );
-  const messagingChannelConfigChanged = !deps.messagingChannelConfigsEqual(
-    effectiveMessagingChannelConfig,
-    storedMessagingChannelConfig,
-  );
-
-  const sandboxReuseState = deps.getSandboxReuseState(sandboxName);
-  const webSearchConfigChanged =
-    webSearchSupportDropped || Boolean(session?.webSearchConfig) !== Boolean(webSearchConfig);
-  const sandboxGpuConfigChanged = sandboxName
-    ? deps.hasSandboxGpuDrift(sandboxName, sandboxGpuConfig)
-    : false;
-  const recordedHermesToolGateways = sandboxName
-    ? deps.normalizeHermesToolGatewaySelections(deps.getSandboxHermesToolGateways(sandboxName))
-    : [];
-  const hermesToolGatewayConfigChanged = !deps.stringSetsEqual(
-    recordedHermesToolGateways,
-    hermesToolGateways,
-  );
-  const resumeSandbox =
-    resume &&
-    !resumeAgentChanged &&
-    !webSearchConfigChanged &&
-    !sandboxGpuConfigChanged &&
-    !messagingChannelConfigChanged &&
-    !hermesToolGatewayConfigChanged &&
-    session?.steps?.sandbox?.status === "complete" &&
-    sandboxReuseState === "ready";
-
-  if (resumeSandbox) {
-    if (webSearchConfig)
-      deps.note("  [resume] Reusing Brave Search configuration already baked into the sandbox.");
-    const currentMessagingPlan = session?.messagingPlan ?? null;
-    const filteredPlan = currentMessagingPlan
-      ? filterMessagingPlanForCurrentAgent(currentMessagingPlan, agent)
-      : null;
-    if (filteredPlan !== currentMessagingPlan) {
-      deps.clearPlanEnv();
-      session = deps.updateSession((current) => {
-        current.messagingPlan = filteredPlan;
-        return current;
-      });
-    }
-    selectedMessagingChannels = getActiveChannelsFromPlan(filteredPlan) ?? [];
-    deps.skippedStepMessage("sandbox", sandboxName);
-    await deps.recordStateSkipped("sandbox", { reason: "resume", sandboxName });
-  } else {
-    if (resume && session?.steps?.sandbox?.status === "complete") {
-      if (resumeAgentChanged) {
-        deps.note("  [resume] Agent selection changed; revalidating sandbox compatibility.");
-      } else if (webSearchConfigChanged) {
-        deps.note("  [resume] Web Search configuration changed; recreating sandbox.");
-        if (sandboxName) deps.removeSandboxFromRegistry(sandboxName);
-      } else if (sandboxGpuConfigChanged) {
-        deps.note("  [resume] Sandbox GPU settings changed; recreating sandbox.");
-        if (sandboxName) deps.removeSandboxFromRegistry(sandboxName);
-      } else if (messagingChannelConfigChanged) {
-        deps.note("  [resume] Messaging channel configuration changed; recreating sandbox.");
-        if (sandboxName) deps.removeSandboxFromRegistry(sandboxName);
-      } else if (hermesToolGatewayConfigChanged) {
-        deps.note("  [resume] Hermes managed tool gateway selection changed; recreating sandbox.");
-        if (sandboxName) deps.removeSandboxFromRegistry(sandboxName);
-      } else if (sandboxReuseState === "not_ready") {
-        deps.note(
-          `  [resume] Recorded sandbox '${sandboxName}' exists but is not ready; recreating it.`,
-        );
-        const repairMetadata = { repair: "recorded-sandbox-cleanup", sandboxName };
-        await deps.recordRepairEvent("state.repair.started", {
-          state: "sandbox",
-          metadata: repairMetadata,
-        });
-        try {
-          deps.repairRecordedSandbox(sandboxName);
-        } catch (err) {
-          await deps.recordRepairEvent("state.repair.failed", {
-            state: "sandbox",
-            error: err instanceof Error ? err.message : String(err),
-            metadata: repairMetadata,
-          });
-          throw err;
-        }
-        await deps.recordRepairEvent("state.repair.completed", {
-          state: "sandbox",
-          metadata: repairMetadata,
-        });
-      } else {
-        deps.note("  [resume] Recorded sandbox state is unavailable; recreating it.");
-        if (sandboxName) deps.removeSandboxFromRegistry(sandboxName);
-      }
-    }
-
-    let nextWebSearchConfig = webSearchConfig;
-    if (nextWebSearchConfig) {
-      deps.note("  [resume] Revalidating Brave Search configuration for sandbox recreation.");
-      const braveApiKey = await deps.ensureValidatedBraveSearchCredential();
-      if (deps.isBackToSelection(braveApiKey)) {
-        nextWebSearchConfig = null;
-      } else {
-        nextWebSearchConfig = braveApiKey ? webSearchConfig : null;
-      }
-      if (nextWebSearchConfig) deps.note("  [resume] Reusing Brave Search configuration.");
-    } else {
-      nextWebSearchConfig = await deps.configureWebSearch(null, agent, webSearchSupportProbePath);
-    }
-
-    await deps.startRecordedStep("sandbox", { provider, model });
-    if (!sandboxName) sandboxName = await deps.promptValidatedSandboxName(agent);
-    const recordedMessagingChannels = deps.getRecordedMessagingChannelsForResume(
-      resume,
-      session,
-      sandboxName,
-    );
-    let messagingPlan: SandboxMessagingPlan | null = null;
-    const envMessagingPlan = deps.readMessagingPlanFromEnv();
-    const registryMessagingPlan = sandboxName
-      ? deps.getRegistrySandboxMessagingPlan(sandboxName)
-      : null;
-    const reuseMessagingPlan = (plan: SandboxMessagingPlan, writeToEnv: boolean): void => {
-      const refreshed = refreshCredentialHashesFromEnv(plan);
-      const filtered = filterMessagingPlanForCurrentAgent(refreshed.plan, agent);
-      if (!filtered) {
-        deps.clearPlanEnv();
-        messagingPlan = null;
-        selectedMessagingChannels = [];
-        return;
-      }
-      messagingPlan = filtered;
-      selectedMessagingChannels = getActiveChannelsFromPlan(messagingPlan) ?? [];
-      if (writeToEnv || refreshed.changed || filtered !== refreshed.plan) {
-        deps.writePlanToEnv(filtered);
-      }
-    };
-    // Run messaging channel setup, then adopt the plan it stages in env:
-    // filter both the selected channels and the plan for the current agent,
-    // clearing env when no channel is supported and writing the filtered plan
-    // back when it changed. Shared by the registry-refresh branch (#5680) and
-    // the normal setup branch so plan adoption stays consistent across both.
-    const setupAndAdoptMessagingPlan = async (
-      existingChannels: string[] | null,
-      targetSandboxName: string,
-    ): Promise<void> => {
-      const existing = existingChannels
-        ? filterChannelNamesForCurrentAgent(existingChannels, agent)
-        : existingChannels;
-      let selected = filterChannelNamesForCurrentAgent(
-        await deps.setupMessagingChannels(agent, existing, targetSandboxName),
-        agent,
-      );
-      let plan = deps.readMessagingPlanFromEnv();
-      if (plan) {
-        const filtered = filterMessagingPlanForCurrentAgent(plan, agent);
-        if (!filtered) {
-          deps.clearPlanEnv();
-          plan = null;
-          selected = [];
-        } else if (filtered !== plan) {
-          plan = filtered;
-          selected = getActiveChannelsFromPlan(plan) ?? [];
-          deps.writePlanToEnv(filtered);
-        }
-      }
-      messagingPlan = plan;
-      selectedMessagingChannels = selected;
-    };
-
-    if (recordedMessagingChannels) {
-      selectedMessagingChannels = filterChannelNamesForCurrentAgent(
-        recordedMessagingChannels,
-        agent,
-      );
-      if (envMessagingPlan) {
-        reuseMessagingPlan(envMessagingPlan, false);
-      } else if (registryMessagingPlan) {
-        reuseMessagingPlan(registryMessagingPlan, true);
-      }
-      if (selectedMessagingChannels.length > 0) {
-        deps.note(
-          `  [non-interactive] Reusing messaging channel configuration: ${selectedMessagingChannels.join(", ")}`,
-        );
-      }
-    } else if (envMessagingPlan) {
-      reuseMessagingPlan(envMessagingPlan, false);
-    } else if (registryMessagingPlan) {
-      // Honor newly supplied messaging env inputs when the reused registry plan
-      // has no active channels for the current agent (the reporter's empty/stale
-      // "Messaging: none" case). Rebuild via setupMessagingChannels so newly
-      // supplied channels (e.g. Telegram via TELEGRAM_BOT_TOKEN) are discovered
-      // and run their reachability checks instead of being silently bypassed
-      // (#5680). When the reused plan already has active channels, preserve it
-      // as-is so we never drop an existing channel whose token is absent from
-      // this run's env. The explicit env-staged branch above stays authoritative.
-      const registryActiveChannels = filterChannelNamesForCurrentAgent(
-        getActiveChannelsFromPlan(registryMessagingPlan) ?? [],
-        agent,
-      );
-      const envDetectedChannels = filterChannelNamesForCurrentAgent(
-        detectMessagingChannelsFromEnv(
-          agent as Parameters<typeof detectMessagingChannelsFromEnv>[0],
-        ),
-        agent,
-      );
-      if (registryActiveChannels.length === 0 && envDetectedChannels.length > 0) {
-        deps.note(
-          `  [non-interactive] Detected messaging channel inputs for ${envDetectedChannels.join(", ")}; refreshing reused sandbox messaging plan.`,
-        );
-        // Seed previously-configured channels from the authoritative reused
-        // registry plan, not session?.messagingPlan (which may be null or stale
-        // on a fresh non-interactive run). This preserves channels configured on
-        // the sandbox whose inputs aren't re-derivable from env this run — e.g.
-        // an in-sandbox-QR channel like WhatsApp that has no host-side token.
-        await setupAndAdoptMessagingPlan(
-          getChannelsFromPlan(registryMessagingPlan) ?? getChannelsFromPlan(session?.messagingPlan),
-          sandboxName,
-        );
-      } else {
-        reuseMessagingPlan(registryMessagingPlan, true);
-      }
-    } else {
-      await setupAndAdoptMessagingPlan(getChannelsFromPlan(session?.messagingPlan), sandboxName);
-    }
-    session = deps.updateSession((current) => {
-      current.messagingPlan = messagingPlan;
-      return current;
-    });
-
-    const confirmedSandboxName = sandboxName;
-    const resourceProfile = await deps.selectResourceProfileForSandbox();
-    if (fresh)
-      deps.stopStaleDashboardListenersForSandbox(
-        deps.listRegistrySandboxes().sandboxes,
-        confirmedSandboxName,
-      );
-    sandboxName = await withSandboxPhaseTrace(
-      confirmedSandboxName,
-      provider,
-      model,
-      (agent as { name?: string } | null)?.name,
-      () =>
-        deps.createSandbox(
-          gpu,
-          model,
-          provider,
-          preferredInferenceApi,
-          confirmedSandboxName,
-          nextWebSearchConfig,
-          selectedMessagingChannels,
-          fromDockerfile,
-          agent,
-          controlUiPort,
-          sandboxGpuConfig,
-          resourceProfile,
-          hermesToolGateways,
-        ),
-    );
-    webSearchConfig = nextWebSearchConfig;
-    // createSandbox() already wrote the NemoClaw build fingerprint correctly:
-    // a fresh build stamps the current version, while reuse preserves the
-    // existing value (updateReusedSandboxMetadata never overwrites it). Drop it
-    // from this supplementary update so reusing a sandbox after a NemoClaw
-    // upgrade does not re-stamp a stale image as current and mask drift (#5026).
-    const { nemoclawVersion: _builtFingerprint, ...agentRegistryFields } =
-      deps.getSandboxAgentRegistryFields(agent, !fromDockerfile);
-    deps.updateSandboxRegistry(sandboxName, {
-      model,
-      provider,
-      nimContainer,
-      preferredInferenceApi,
-      ...agentRegistryFields,
-    });
-    // Default-marking is deferred to finalization so a cancelled onboard never
-    // leaves this sandbox registered as default (#4614).
-    await deps.recordStepComplete(
-      "sandbox",
-      deps.toSessionUpdates({
-        sandboxName,
-        provider,
-        model,
-        nimContainer,
-        webSearchConfig,
-        messagingPlan,
-        hermesToolGateways,
-      }),
-    );
-  }
-
-  if (!sandboxName) {
-    deps.error("  Onboarding state is incomplete after sandbox setup.");
-    deps.exitProcess(1);
-  }
-  const completedSandboxName = sandboxName;
-  if (!completedSandboxName) throw new Error("Sandbox name is required after sandbox setup");
-
-  return {
-    sandboxName: completedSandboxName,
-    webSearchConfig,
-    selectedMessagingChannels,
-    webSearchSupported,
-    session,
-    stateResult: branchTo(agent ? "agent_setup" : "openclaw", {
-      metadata: {
-        state: "sandbox",
-        sandboxName: completedSandboxName,
-        agent: (agent as { name?: string } | null)?.name ?? "openclaw",
-      },
-    }),
-  };
+>(
+  options: SandboxStateOptions<
+    Gpu,
+    Agent,
+    WebSearchConfig,
+    MessagingChannelConfig,
+    SandboxGpuConfig,
+    ResourceProfile
+  >,
+): Promise<SandboxStateResult<WebSearchConfig>> {
+  return new SandboxStateFlow(options).run();
 }


### PR DESCRIPTION
## Summary

Separate the onboarding sandbox state handler into cohesive orchestration, resume-policy, and messaging-reconciliation components. This turns the implicit resume branch ordering into an explicit decision model and ratchets every function in this area to cognitive complexity 10 or lower.

## Changes

- replace the 103-complexity `handleSandboxState` procedure with a small state-flow orchestrator
- extract sandbox resume/recreate/repair policy into a pure discriminated decision model
- extract messaging plan filtering, reuse, credential refresh, and environment reconciliation behind one boundary
- add table-driven tests for every resume drift decision and direct mixed-channel artifact-filtering coverage while retaining the existing 19 branch-level handler tests
- add a Biome override that prevents the three sandbox-state modules from exceeding cognitive complexity 10

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the existing sandbox handler suite covers creation, reuse, repair, web-search drift, and every messaging plan reconciliation branch
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: behavior and CLI output are preserved; this changes internal architecture and its complexity guardrail only
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: behavior-equivalence review completed against the original branch order, with focused, trust-boundary, and full-matrix verification
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details:

- `VITEST_MAX_WORKERS=16 npm test` — 812 files and 9,543 tests passed; 18 skipped
- `make check` — all hooks passed, including CLI coverage and its ratchet
- `npm run typecheck:cli`
- focused sandbox state suite — 28 tests passed

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced sandbox resume flow with clearer create/reuse/recreate/repair-and-recreate decisioning.
  * Improved sandbox messaging-channel reconciliation for reused or detected plans, excluding unsupported channels.
* **Bug Fixes**
  * Automatically repairs recorded sandboxes that aren’t ready.
  * Clears stale web-search configuration when support is no longer available.
  * Removes incompatible persisted messaging plan data and prunes unsupported channel artifacts.
* **Refactor**
  * Streamlined sandbox onboarding orchestration into a dedicated flow.
* **Tests**
  * Added/updated Vitest coverage for resume decisions and messaging-plan filtering.
* **Chores**
  * Tightened linting limits for sandbox onboarding complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->