### PR TITLE
fix(e2e): skip Deep Agents first-run TUI

### DIFF
--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -20,11 +20,11 @@ const tuiStartupCheckPath = path.join(
 const tuiStartupCheckSource = fs
   .readFileSync(tuiStartupCheckPath, "utf8")
   .replace('\nif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then\n  main "$@"\nfi\n', "\n");
-const tuiExpectProgram = tuiStartupCheckSource.match(/expect <<'EXPECT'\n([\s\S]*?)\nEXPECT/)?.[1];
-
-if (!tuiExpectProgram) {
-  throw new Error("Deep Agents Code TUI check is missing its embedded Expect program");
-}
+const tuiExpectProgram =
+  tuiStartupCheckSource.match(/expect <<'EXPECT'\n([\s\S]*?)\nEXPECT/)?.[1] ??
+  (() => {
+    throw new Error("Deep Agents Code TUI check is missing its embedded Expect program");
+  })();
 
 function runTuiStartupCheckHelper(snippet: string, env: NodeJS.ProcessEnv = {}): string {
   return execFileSync("bash", ["-s"], {

--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -192,6 +192,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     expect(readiness("Deep Agents Code starting...\nLoading tools...")).toBe("not-ready");
     expect(readiness("Press Enter to continue")).toBe("not-ready");
     expect(readiness("Your name (optional)")).toBe("not-ready");
+    expect(readiness("What should Deep Agents call you?")).toBe("not-ready");
     expect(readiness("What would you like to do next?")).toBe("ready");
     expect(readiness("Enter your task, then press Enter")).toBe("ready");
     expect(readiness("How can I help with the codebase today?")).toBe("ready");
@@ -221,6 +222,8 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     expect(traceText).toBe("1b,03,03");
     expect(markerText).toContain("Your name (optional)");
     expect(markerText).toContain("What would you like to build?");
+    expect(markerText).toContain("NEMOCLAW_TUI_ONBOARDING_SKIPPED");
+    expect(markerText).toContain("NEMOCLAW_TUI_READY");
     expect(markerText.indexOf("NEMOCLAW_TUI_ONBOARDING_SKIPPED")).toBeLessThan(
       markerText.indexOf("NEMOCLAW_TUI_READY"),
     );

--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -20,6 +20,11 @@ const tuiStartupCheckPath = path.join(
 const tuiStartupCheckSource = fs
   .readFileSync(tuiStartupCheckPath, "utf8")
   .replace('\nif [[ "${BASH_SOURCE[0]}" == "$0" ]]; then\n  main "$@"\nfi\n', "\n");
+const tuiExpectProgram = tuiStartupCheckSource.match(/expect <<'EXPECT'\n([\s\S]*?)\nEXPECT/)?.[1];
+
+if (!tuiExpectProgram) {
+  throw new Error("Deep Agents Code TUI check is missing its embedded Expect program");
+}
 
 function runTuiStartupCheckHelper(snippet: string, env: NodeJS.ProcessEnv = {}): string {
   return execFileSync("bash", ["-s"], {
@@ -46,6 +51,92 @@ function fingerprint(pattern: RegExp): string {
 
 function secretFixture(...parts: string[]): string {
   return parts.join("");
+}
+
+function runTuiExpectStateMachine(events: string[]) {
+  const captureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-expect-"));
+  const capture = path.join(captureDir, "raw.log");
+  const markers = path.join(captureDir, "markers.log");
+  const trace = path.join(captureDir, "trace.log");
+  fs.writeFileSync(capture, "");
+  fs.writeFileSync(markers, "");
+
+  const prelude = String.raw`
+rename after real_after
+rename exit real_exit
+set ::fake_events [list ${events.map((event) => `{${event}}`).join(" ")}]
+set ::fake_sent {}
+
+proc log_file {args} {}
+proc spawn {args} {}
+proc after {args} {}
+proc send {args} {
+  binary scan [lindex $args end] H* key_hex
+  lappend ::fake_sent $key_hex
+}
+proc expect {branches} {
+  if {[llength $::fake_events] == 0} {
+    error "fake Expect event queue exhausted"
+  }
+  set event [lindex $::fake_events 0]
+  set ::fake_events [lrange $::fake_events 1 end]
+  switch -- $event {
+    onboarding {
+      set branch_index [lsearch -exact $branches {$onboarding_pattern}]
+      set ::expect_out(0,string) "Your name (optional)"
+    }
+    ready {
+      set branch_index [lsearch -exact $branches {$ready_pattern}]
+      set ::expect_out(0,string) "What would you like to build?"
+    }
+    exit {
+      set branch_index [lsearch -glob $branches {NEMOCLAW_TUI_EXIT:*}]
+      set ::expect_out(0,string) "NEMOCLAW_TUI_EXIT:0"
+      set ::expect_out(1,string) "0"
+    }
+    timeout {
+      set branch_index [lsearch -exact $branches timeout]
+    }
+    eof {
+      set branch_index [lsearch -exact $branches eof]
+    }
+    default {
+      error "unsupported fake Expect event: $event"
+    }
+  }
+  if {$branch_index < 0} {
+    error "fake Expect event $event has no matching branch"
+  }
+  uplevel 1 [lindex $branches [expr {$branch_index + 1}]]
+}
+proc exit {{code 0}} {
+  set trace_file [open $::env(NEMOCLAW_TUI_TRACE) w]
+  puts $trace_file [join $::fake_sent ,]
+  close $trace_file
+  real_exit $code
+}
+`;
+  const result = spawnSync("tclsh", ["-"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NEMOCLAW_TUI_CAPTURE: capture,
+      NEMOCLAW_TUI_MARKERS: markers,
+      NEMOCLAW_TUI_ONBOARDING_PATTERN:
+        "(your name \\(optional\\)|what should deep agents call you)",
+      NEMOCLAW_TUI_READY_PATTERN:
+        "(what would you like|enter (your )?(task|message|prompt)|how can i help)",
+      NEMOCLAW_TUI_SANDBOX_NAME: "fake-deepagents",
+      NEMOCLAW_TUI_TIMEOUT: "5",
+      NEMOCLAW_TUI_TRACE: trace,
+    },
+    input: `${prelude}\n${tuiExpectProgram}\n`,
+  });
+
+  const markerText = fs.readFileSync(markers, "utf8");
+  const traceText = fs.existsSync(trace) ? fs.readFileSync(trace, "utf8").trim() : "";
+  fs.rmSync(captureDir, { force: true, recursive: true });
+  return { markerText, result, traceText };
 }
 
 describe("Deep Agents Code TUI startup check helpers", () => {
@@ -117,6 +208,33 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     expect(isOnboarding("What should Deep Agents call you?")).toBe("onboarding");
     expect(isOnboarding("Your project name")).toBe("other");
     expect(isOnboarding("What would you like to build?")).toBe("other");
+  });
+
+  it("skips first-run onboarding before marking the real TUI prompt ready", () => {
+    const { markerText, result, traceText } = runTuiExpectStateMachine([
+      "onboarding",
+      "ready",
+      "exit",
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(traceText).toBe("1b,03,03");
+    expect(markerText).toContain("Your name (optional)");
+    expect(markerText).toContain("What would you like to build?");
+    expect(markerText.indexOf("NEMOCLAW_TUI_ONBOARDING_SKIPPED")).toBeLessThan(
+      markerText.indexOf("NEMOCLAW_TUI_READY"),
+    );
+    expect(markerText).toContain("NEMOCLAW_TUI_EXIT_CAPTURED:0");
+  });
+
+  it("does not mark the TUI ready when the coding prompt times out after onboarding", () => {
+    const { markerText, result, traceText } = runTuiExpectStateMachine(["onboarding", "timeout"]);
+
+    expect(result.status, result.stderr).toBe(20);
+    expect(traceText).toBe("1b,03");
+    expect(markerText).toContain("NEMOCLAW_TUI_ONBOARDING_SKIPPED");
+    expect(markerText).toContain("NEMOCLAW_TUI_TIMEOUT");
+    expect(markerText).not.toContain("NEMOCLAW_TUI_READY");
   });
 
   it("does not treat generic TUI exit status 1 as a clean Ctrl-C exit", () => {

--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -100,9 +100,23 @@ describe("Deep Agents Code TUI startup check helpers", () => {
 
     expect(readiness("Deep Agents Code starting...\nLoading tools...")).toBe("not-ready");
     expect(readiness("Press Enter to continue")).toBe("not-ready");
+    expect(readiness("Your name (optional)")).toBe("not-ready");
     expect(readiness("What would you like to do next?")).toBe("ready");
     expect(readiness("Enter your task, then press Enter")).toBe("ready");
     expect(readiness("How can I help with the codebase today?")).toBe("ready");
+  });
+
+  it("matches only the pinned first-run onboarding name screen", () => {
+    const isOnboarding = (capture: string) =>
+      runTuiStartupCheckHelper(
+        'if printf "%s" "$CAPTURE" | grep -Eiq "$TUI_ONBOARDING_PATTERN"; then printf onboarding; else printf other; fi',
+        { CAPTURE: capture },
+      );
+
+    expect(isOnboarding("Your name (optional)")).toBe("onboarding");
+    expect(isOnboarding("What should Deep Agents call you?")).toBe("onboarding");
+    expect(isOnboarding("Your project name")).toBe("other");
+    expect(isOnboarding("What would you like to build?")).toBe("other");
   });
 
   it("does not treat generic TUI exit status 1 as a clean Ctrl-C exit", () => {
@@ -139,7 +153,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
           "sandbox_exec() { printf 'NEMOCLAW_DCODE_PROBE:deepagents\\n'; }",
           "ensure_expect_available() { return 0; }",
           "run_tui_expect() {",
-          '  printf "What would you like to do next?\\nNEMOCLAW_TUI_READY\\nNEMOCLAW_TUI_EXIT_CAPTURED:130\\n" >>"$2"',
+          '  printf "Your name (optional)\\nNEMOCLAW_TUI_ONBOARDING_SKIPPED\\nWhat would you like to do next?\\nNEMOCLAW_TUI_READY\\nNEMOCLAW_TUI_EXIT_CAPTURED:130\\n" >>"$2"',
           "  return 0",
           "}",
           "main",
@@ -152,6 +166,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
       expect(result.stdout).toContain("finite expect harness reached startup and observed exit");
       expect(result.stdout).toContain("dcode TUI rendered a usable startup prompt signature");
       expect(result.stdout).toContain("dcode TUI exited cleanly after Ctrl-C (exit 130)");
+      expect(sanitizedText).toContain("NEMOCLAW_TUI_ONBOARDING_SKIPPED");
       expect(sanitizedText).toContain("NEMOCLAW_TUI_READY");
       expect(sanitizedText).toContain("NEMOCLAW_TUI_EXIT_CAPTURED:130");
     } finally {

--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -53,7 +53,20 @@ function secretFixture(...parts: string[]): string {
   return parts.join("");
 }
 
-function runTuiExpectStateMachine(events: string[]) {
+type TuiExpectEvent = "eof" | "exit" | "onboarding" | "ready" | "timeout";
+
+const tclEventLiterals: Record<TuiExpectEvent, string> = {
+  eof: "{eof}",
+  exit: "{exit}",
+  onboarding: "{onboarding}",
+  ready: "{ready}",
+  timeout: "{timeout}",
+};
+const tclshAvailable =
+  spawnSync("tclsh", ["-"], { encoding: "utf8", input: "exit 0\n" }).status === 0;
+const itWithTclsh = it.runIf(tclshAvailable);
+
+function runTuiExpectStateMachine(events: TuiExpectEvent[]) {
   const captureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-expect-"));
   const capture = path.join(captureDir, "raw.log");
   const markers = path.join(captureDir, "markers.log");
@@ -64,7 +77,7 @@ function runTuiExpectStateMachine(events: string[]) {
   const prelude = String.raw`
 rename after real_after
 rename exit real_exit
-set ::fake_events [list ${events.map((event) => `{${event}}`).join(" ")}]
+set ::fake_events [list ${events.map((event) => tclEventLiterals[event]).join(" ")}]
 set ::fake_sent {}
 
 proc log_file {args} {}
@@ -211,7 +224,7 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     expect(isOnboarding("What would you like to build?")).toBe("other");
   });
 
-  it("skips first-run onboarding before marking the real TUI prompt ready", () => {
+  itWithTclsh("skips first-run onboarding before marking the real TUI prompt ready (tclsh)", () => {
     const { markerText, result, traceText } = runTuiExpectStateMachine([
       "onboarding",
       "ready",
@@ -230,15 +243,18 @@ describe("Deep Agents Code TUI startup check helpers", () => {
     expect(markerText).toContain("NEMOCLAW_TUI_EXIT_CAPTURED:0");
   });
 
-  it("does not mark the TUI ready when the coding prompt times out after onboarding", () => {
-    const { markerText, result, traceText } = runTuiExpectStateMachine(["onboarding", "timeout"]);
+  itWithTclsh(
+    "does not mark the TUI ready when the coding prompt times out after onboarding (tclsh)",
+    () => {
+      const { markerText, result, traceText } = runTuiExpectStateMachine(["onboarding", "timeout"]);
 
-    expect(result.status, result.stderr).toBe(20);
-    expect(traceText).toBe("1b,03");
-    expect(markerText).toContain("NEMOCLAW_TUI_ONBOARDING_SKIPPED");
-    expect(markerText).toContain("NEMOCLAW_TUI_TIMEOUT");
-    expect(markerText).not.toContain("NEMOCLAW_TUI_READY");
-  });
+      expect(result.status, result.stderr).toBe(20);
+      expect(traceText).toBe("1b,03");
+      expect(markerText).toContain("NEMOCLAW_TUI_ONBOARDING_SKIPPED");
+      expect(markerText).toContain("NEMOCLAW_TUI_TIMEOUT");
+      expect(markerText).not.toContain("NEMOCLAW_TUI_READY");
+    },
+  );
 
   it("does not treat generic TUI exit status 1 as a clean Ctrl-C exit", () => {
     const assertExit = (exitCode: string) =>

--- a/test/deepagents-code-tui-startup-check.test.ts
+++ b/test/deepagents-code-tui-startup-check.test.ts
@@ -66,7 +66,10 @@ const tclshAvailable =
   spawnSync("tclsh", ["-"], { encoding: "utf8", input: "exit 0\n" }).status === 0;
 const itWithTclsh = it.runIf(tclshAvailable);
 
-function runTuiExpectStateMachine(events: TuiExpectEvent[]) {
+function runTuiExpectStateMachine(
+  events: TuiExpectEvent[],
+  options: { closeAfterFirstCtrlC?: boolean } = {},
+) {
   const captureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tui-expect-"));
   const capture = path.join(captureDir, "raw.log");
   const markers = path.join(captureDir, "markers.log");
@@ -79,13 +82,20 @@ rename after real_after
 rename exit real_exit
 set ::fake_events [list ${events.map((event) => tclEventLiterals[event]).join(" ")}]
 set ::fake_sent {}
+set ::fake_closed 0
 
 proc log_file {args} {}
 proc spawn {args} {}
 proc after {args} {}
 proc send {args} {
   binary scan [lindex $args end] H* key_hex
+  if {$::fake_closed} {
+    error "fake spawn id is closed"
+  }
   lappend ::fake_sent $key_hex
+  if {$key_hex eq "03" && $::env(NEMOCLAW_TUI_CLOSE_AFTER_FIRST_CTRL_C) eq "1"} {
+    set ::fake_closed 1
+  }
 }
 proc expect {branches} {
   if {[llength $::fake_events] == 0} {
@@ -134,6 +144,7 @@ proc exit {{code 0}} {
     env: {
       ...process.env,
       NEMOCLAW_TUI_CAPTURE: capture,
+      NEMOCLAW_TUI_CLOSE_AFTER_FIRST_CTRL_C: options.closeAfterFirstCtrlC ? "1" : "0",
       NEMOCLAW_TUI_MARKERS: markers,
       NEMOCLAW_TUI_ONBOARDING_PATTERN:
         "(your name \\(optional\\)|what should deep agents call you)",
@@ -255,6 +266,17 @@ describe("Deep Agents Code TUI startup check helpers", () => {
       expect(markerText).not.toContain("NEMOCLAW_TUI_READY");
     },
   );
+
+  itWithTclsh("captures a clean exit when dcode closes after the first Ctrl-C (tclsh)", () => {
+    const { markerText, result, traceText } = runTuiExpectStateMachine(["ready", "exit"], {
+      closeAfterFirstCtrlC: true,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(traceText).toBe("03");
+    expect(markerText).toContain("NEMOCLAW_TUI_READY");
+    expect(markerText).toContain("NEMOCLAW_TUI_EXIT_CAPTURED:0");
+  });
 
   it("does not treat generic TUI exit status 1 as a clean Ctrl-C exit", () => {
     const assertExit = (exitCode: string) =>

--- a/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
@@ -25,6 +25,8 @@ CONTEXT_SECRET_VALUE_PATTERN='[A-Za-z0-9_.+\/=-]{10,}'
 TUI_READY_PATTERN='(what would you like|what do you want|enter (your )?(task|message|prompt)|describe (the )?(task|change)|how can i help)'
 # New dcode homes enter a first-run modal before the coding prompt. Match only
 # the pinned upstream name screen so Expect can take its documented skip path.
+# deepagents-code 0.1.12 has no non-interactive first-run switch for its name screen.
+# Remove this compatibility path once the pinned TUI exposes a stable skip or ready contract.
 TUI_ONBOARDING_PATTERN='(your name \(optional\)|what should deep agents call you)'
 SENSITIVE_CAPTURE_FILES=()
 

--- a/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
@@ -23,6 +23,9 @@ CONTEXT_SECRET_VALUE_PATTERN='[A-Za-z0-9_.+\/=-]{10,}'
 # Upstream dcode does not expose a stable machine-readable TUI ready marker.
 # Keep this localized heuristic prompt-shaped; do not match banner-only text.
 TUI_READY_PATTERN='(what would you like|what do you want|enter (your )?(task|message|prompt)|describe (the )?(task|change)|how can i help)'
+# New dcode homes enter a first-run modal before the coding prompt. Match only
+# the pinned upstream name screen so Expect can take its documented skip path.
+TUI_ONBOARDING_PATTERN='(your name \(optional\)|what should deep agents call you)'
 SENSITIVE_CAPTURE_FILES=()
 
 ok() { printf '%s\n' "${PREFIX}: OK ($*)"; }
@@ -142,6 +145,7 @@ run_tui_expect() {
   env \
     NEMOCLAW_TUI_CAPTURE="$raw_capture_file" \
     NEMOCLAW_TUI_MARKERS="$marker_capture_file" \
+    NEMOCLAW_TUI_ONBOARDING_PATTERN="$TUI_ONBOARDING_PATTERN" \
     NEMOCLAW_TUI_READY_PATTERN="$TUI_READY_PATTERN" \
     NEMOCLAW_TUI_SANDBOX_NAME="$SANDBOX_NAME" \
     NEMOCLAW_TUI_TIMEOUT="$TUI_TIMEOUT" \
@@ -150,6 +154,7 @@ set timeout $env(NEMOCLAW_TUI_TIMEOUT)
 set sandbox $env(NEMOCLAW_TUI_SANDBOX_NAME)
 set capture $env(NEMOCLAW_TUI_CAPTURE)
 set markers $env(NEMOCLAW_TUI_MARKERS)
+set onboarding_pattern $env(NEMOCLAW_TUI_ONBOARDING_PATTERN)
 set ready_pattern $env(NEMOCLAW_TUI_READY_PATTERN)
 log_file -a $capture
 
@@ -161,12 +166,18 @@ proc append_marker {markers marker} {
 
 set cmd [list openshell sandbox exec --name $sandbox --tty -- sh -lc {export TERM=xterm-256color; cd /sandbox; dcode; status=$?; printf "\nNEMOCLAW_TUI_EXIT:%s\n" "$status"}]
 spawn {*}$cmd
+set saw_onboarding 0
+set ready_match ""
 expect {
   -nocase -re $ready_pattern {
+    set ready_match $expect_out(0,string)
+  }
+  -nocase -re $onboarding_pattern {
     append_marker $markers "$expect_out(0,string)"
-    append_marker $markers "NEMOCLAW_TUI_READY"
-    puts "\nNEMOCLAW_TUI_READY"
-    send -- "\003"
+    append_marker $markers "NEMOCLAW_TUI_ONBOARDING_SKIPPED"
+    puts "\nNEMOCLAW_TUI_ONBOARDING_SKIPPED"
+    send -- "\033"
+    set saw_onboarding 1
   }
   timeout {
     append_marker $markers "NEMOCLAW_TUI_TIMEOUT"
@@ -180,6 +191,33 @@ expect {
     exit 21
   }
 }
+
+if {$saw_onboarding} {
+  expect {
+    -nocase -re $ready_pattern {
+      set ready_match $expect_out(0,string)
+    }
+    timeout {
+      append_marker $markers "NEMOCLAW_TUI_TIMEOUT"
+      puts "\nNEMOCLAW_TUI_TIMEOUT"
+      send -- "\003"
+      exit 20
+    }
+    eof {
+      append_marker $markers "NEMOCLAW_TUI_EOF_BEFORE_READY"
+      puts "\nNEMOCLAW_TUI_EOF_BEFORE_READY"
+      exit 21
+    }
+  }
+}
+
+append_marker $markers "$ready_match"
+append_marker $markers "NEMOCLAW_TUI_READY"
+puts "\nNEMOCLAW_TUI_READY"
+# Idle dcode arms quit on the first Ctrl-C and exits on the second.
+send -- "\003"
+after 250
+send -- "\003"
 
 set timeout 20
 expect {

--- a/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
@@ -219,7 +219,7 @@ puts "\nNEMOCLAW_TUI_READY"
 # Idle dcode arms quit on the first Ctrl-C and exits on the second.
 send -- "\003"
 after 250
-send -- "\003"
+catch {send -- "\003"}
 
 set timeout 20
 expect {

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -471,6 +471,12 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tuiStartupCheck).toContain("unable to probe sandbox");
     expect(tuiStartupCheck).toContain("unexpected sandbox probe output");
     expect(tuiStartupCheck).toContain("cd /sandbox; dcode");
+    expect(tuiStartupCheck).toContain('NEMOCLAW_TUI_ONBOARDING_PATTERN="$TUI_ONBOARDING_PATTERN"');
+    expect(tuiStartupCheck).toContain("-nocase -re $onboarding_pattern");
+    expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_ONBOARDING_SKIPPED"');
+    expect(tuiStartupCheck).toContain('send -- "\\033"');
+    expect(tuiStartupCheck).toContain("if {$saw_onboarding}");
+    expect(tuiStartupCheck).toContain('send -- "\\003"\nafter 250\nsend -- "\\003"');
     expect(tuiStartupCheck).toContain('append_marker $markers "$expect_out(0,string)"');
     expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_READY"');
     expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_TIMEOUT"');

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -476,7 +476,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_ONBOARDING_SKIPPED"');
     expect(tuiStartupCheck).toContain('send -- "\\033"');
     expect(tuiStartupCheck).toContain("if {$saw_onboarding}");
-    expect(tuiStartupCheck).toContain('send -- "\\003"\nafter 250\nsend -- "\\003"');
+    expect(tuiStartupCheck).toContain('send -- "\\003"\nafter 250\ncatch {send -- "\\003"}');
     expect(tuiStartupCheck).toContain('append_marker $markers "$expect_out(0,string)"');
     expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_READY"');
     expect(tuiStartupCheck).toContain('append_marker $markers "NEMOCLAW_TUI_TIMEOUT"');


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Stabilizes the Deep Agents Code TUI release gate when a fresh sandbox opens upstream's first-run onboarding modal. The Expect harness takes the modal's documented Escape skip path once, then still requires the real coding prompt and the documented double-Ctrl-C idle exit.

## Changes

- Match only the pinned upstream first-run name screen and record a dedicated onboarding-skip marker.
- Send Escape once for that modal, then wait for the existing prompt-shaped readiness signature.
- Send Ctrl-C twice after readiness to follow dcode's idle quit contract.
- Extend behavioral and image-contract tests without broadening the ready-pattern assertion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: release-gate harness behavior only; no user-facing NemoClaw behavior changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review confirms the harness matches only the pinned upstream onboarding copy, uses the modal's documented skip binding, preserves the strict coding-prompt assertion, and retains sanitized secret-screened capture handling.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

```bash
bash -n test/e2e/e2e-cloud-experimental/checks/10-deepagents-code-tui-startup.sh
npm test -- --run test/deepagents-code-tui-startup-check.test.ts test/langchain-deepagents-code-image.test.ts
npm run typecheck:cli
```

Live failure evidence identifying the first-run modal:

https://github.com/NVIDIA/NemoClaw/actions/runs/28303850957

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Deep Agents Code TUI startup readiness detection to properly handle the first-run onboarding modal.
  * Refined “Your name (optional)” handling so it’s not considered ready, while later prompt-like states still are.
  * Improved the post-readiness exit flow by sending additional interrupts when needed.
* **Tests**
  * Strengthened the TUI startup automation to fail fast if the embedded expect logic is missing.
  * Added onboarding pattern validation, onboarding-skip markers, and tighter assertions against sanitized startup logs and captured artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->