### PR TITLE
test(cli): stabilize source shields coverage

### DIFF
--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testTimeoutOptions } from "../../../test/helpers/timeouts";
 
 // The shields module uses CJS require("./runner") etc., which vitest resolves
 // relative to src/lib/. We mock the absolute paths that vitest will resolve.
@@ -293,15 +294,21 @@ describe("shields — unit logic", () => {
   // NC-2227-02: Three-state shields model
   // -------------------------------------------------------------------
   describe("NC-2227-02: three-state shields model", () => {
-    it("deriveShieldsMode encodes the fresh, locked, unlocked, and legacy-state cases", async () => {
-      const sourceModulePath = path.join(process.cwd(), "src", "lib", "shields", "index.ts");
-      const { deriveShieldsMode } = await import(sourceModulePath);
+    // The first source import instruments the full shields dependency graph.
+    // Loaded coverage shards can spend well beyond the unit-test default here.
+    it(
+      "deriveShieldsMode encodes the fresh, locked, unlocked, and legacy-state cases",
+      testTimeoutOptions(30_000),
+      async () => {
+        const sourceModulePath = path.join(process.cwd(), "src", "lib", "shields", "index.ts");
+        const { deriveShieldsMode } = await import(sourceModulePath);
 
-      expect(deriveShieldsMode({}, false)).toBe("mutable_default");
-      expect(deriveShieldsMode({ shieldsDown: true }, true)).toBe("temporarily_unlocked");
-      expect(deriveShieldsMode({ shieldsDown: false }, true)).toBe("locked");
-      expect(deriveShieldsMode({}, true)).toBe("mutable_default");
-    });
+        expect(deriveShieldsMode({}, false)).toBe("mutable_default");
+        expect(deriveShieldsMode({ shieldsDown: true }, true)).toBe("temporarily_unlocked");
+        expect(deriveShieldsMode({ shieldsDown: false }, true)).toBe("locked");
+        expect(deriveShieldsMode({}, true)).toBe("mutable_default");
+      },
+    );
 
     it("getShieldsPosture exposes canonical status wording for callers", async () => {
       const sourceModulePath = path.join(process.cwd(), "src", "lib", "shields", "index.ts");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Stabilize the CLI coverage shard that repeatedly times out while instrumenting the source-backed shields dependency graph. Give the first shields source import an environment-aware 30-second budget instead of the default 5-second unit-test budget.

## Changes

- Apply `testTimeoutOptions(30_000)` to the first source-backed shields test.
- Document why coverage instrumentation needs the larger budget on loaded runners.
- Preserve `NEMOCLAW_TEST_TIMEOUT` overrides through the shared timeout helper.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes test timing only; user-facing runtime behavior is unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: only shields test timeout metadata changed; production security behavior is unchanged, and the exact failing coverage shard passes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for one shields-related unit test to make it more reliable in slower environments.
  * Kept the test expectations unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->