### PR TITLE
fix(e2e): correct full release gate lanes

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -1872,9 +1872,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # Keep this privileged setup inline in trusted workflow YAML. This job
-      # executes a selected target ref, so it must not load a repo-local action
-      # from that ref with sudo privileges.
+      # Expect is a reviewed host-tool consumer for the interactive policy-add
+      # test. Keep this privileged setup inline in trusted workflow YAML. This
+      # job executes a selected target ref, so it must not load a repo-local
+      # action from that ref with sudo privileges.
       - name: Install network-policy host dependencies
         shell: bash
         run: |

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -1872,6 +1872,26 @@ jobs:
         with:
           persist-credentials: false
 
+      # Keep this privileged setup inline in trusted workflow YAML. This job
+      # executes a selected target ref, so it must not load a repo-local action
+      # from that ref with sudo privileges.
+      - name: Install network-policy host dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if sudo apt-get update; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::apt-get update failed after 3 attempts." >&2
+              exit 1
+            fi
+            echo "::warning::apt-get update attempt ${attempt} failed; retrying." >&2
+            sleep $((attempt * 5))
+          done
+          sudo apt-get install -y --no-install-recommends expect
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -3958,7 +3958,7 @@ jobs:
         # sandbox inference.local completion boundaries without adding registry
         # or migration-ledger wiring.
         env:
-          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           set -euo pipefail
           npx vitest run --project e2e-scenarios-live \
@@ -4252,7 +4252,9 @@ jobs:
         # Docker/OpenShell mutation.
         run: |
           set -euo pipefail
-          npx vitest run --project cli             test/gateway-drift-preflight.test.ts             --silent=false --reporter=default
+          npx vitest run --project integration \
+            test/gateway-drift-preflight.test.ts \
+            --silent=false --reporter=default
 
       - name: Upload gateway drift preflight artifacts
         if: always()

--- a/.github/workflows/regression-e2e.yaml
+++ b/.github/workflows/regression-e2e.yaml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Run Model Router provider-routed inference E2E test
         env:
-          NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           NEMOCLAW_NON_INTERACTIVE: "1"
           NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
         run: bash test/e2e/test-model-router-provider-routed-inference.sh

--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -6,7 +6,7 @@
     "src/lib/inference/nim.test.ts": 2068,
     "src/lib/onboard/preflight.test.ts": 1904,
     "test/channels-add-preset.test.ts": 1871,
-    "test/generate-openclaw-config.test.ts": 1984,
+    "test/generate-openclaw-config.test.ts": 1982,
     "test/install-preflight.test.ts": 4006,
     "test/nemoclaw-start.test.ts": 5043,
     "test/onboard-messaging.test.ts": 2062,

--- a/nemoclaw-blueprint/model-specific-setup/openclaw/nemotron-3-ultra-managed-inference.json
+++ b/nemoclaw-blueprint/model-specific-setup/openclaw/nemotron-3-ultra-managed-inference.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../schema.json",
+  "id": "nemotron-3-ultra-managed-inference",
+  "agent": "openclaw",
+  "description": "Disables OpenClaw's native code-based tool search for hosted Nemotron 3 Ultra on the NemoClaw managed inference.local route. The model can emit invalid JavaScript for the tool_search_code surface and return '[tools] tool_search_code failed' instead of completing real tool calls; routing it back to the structured tool-calling surface preserves tool use.",
+  "match": {
+    "modelIds": ["nvidia/nvidia/nemotron-3-ultra"],
+    "providerKey": "inference",
+    "inferenceApi": "openai-completions",
+    "baseUrl": "https://inference.local/v1"
+  },
+  "effects": {
+    "openclawTools": {
+      "toolSearch": false
+    }
+  }
+}

--- a/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
@@ -347,6 +347,8 @@ export function expectedApiMode(): string | undefined {
   ]).get(SWITCH_API);
 }
 
+// This live lane runs on ubuntu-latest and intentionally uses GNU grep's
+// POSIX ERE character classes; support tests pin the accepted scalar shapes.
 export const API_KEY_SHAPE_PATTERN = `^[[:space:]]*api_key:[[:space:]]*("sk-[^"[:space:]]+"|'sk-[^'[:space:]]+'|sk-[^"'[:space:]]+)[[:space:]]*$`;
 
 export function apiKeyShapeCommand(): string[] {

--- a/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
@@ -347,14 +347,18 @@ export function expectedApiMode(): string | undefined {
   ]).get(SWITCH_API);
 }
 
+export const API_KEY_SHAPE_PATTERN = `^[[:space:]]+api_key:[[:space:]]*["']?sk-[^"'[:space:]]+`;
+
+export function apiKeyShapeCommand(): string[] {
+  return ["grep", "-Eq", API_KEY_SHAPE_PATTERN, "/sandbox/.hermes/config.yaml"];
+}
+
 export async function apiKeyShape(sandbox: SandboxClient): Promise<ShellProbeResult> {
-  return await sandbox.execShell(
-    SANDBOX_NAME,
-    trustedSandboxShellScript(
-      "python3 - <<'PY'\nimport re\ntext=open('/sandbox/.hermes/config.yaml', encoding='utf-8').read()\nmatch=re.search(r'^\\s+api_key:\\s*[\\\"\\']?(sk-[^\\\"\\'\\s]+)', text, re.M)\nraise SystemExit(0 if match else 1)\nPY",
-    ),
-    { artifactName: "hermes-config-api-key-shape", env: env(), timeoutMs: 30_000 },
-  );
+  return await sandbox.exec(SANDBOX_NAME, apiKeyShapeCommand(), {
+    artifactName: "hermes-config-api-key-shape",
+    env: env(),
+    timeoutMs: 30_000,
+  });
 }
 
 export async function hashCheck(

--- a/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e-scenario/live/hermes-inference-switch-helpers.ts
@@ -347,7 +347,7 @@ export function expectedApiMode(): string | undefined {
   ]).get(SWITCH_API);
 }
 
-export const API_KEY_SHAPE_PATTERN = `^[[:space:]]+api_key:[[:space:]]*["']?sk-[^"'[:space:]]+`;
+export const API_KEY_SHAPE_PATTERN = `^[[:space:]]*api_key:[[:space:]]*("sk-[^"[:space:]]+"|'sk-[^'[:space:]]+'|sk-[^"'[:space:]]+)[[:space:]]*$`;
 
 export function apiKeyShapeCommand(): string[] {
   return ["grep", "-Eq", API_KEY_SHAPE_PATTERN, "/sandbox/.hermes/config.yaml"];

--- a/test/e2e-scenario/live/model-router-provider-routed-inference-helpers.ts
+++ b/test/e2e-scenario/live/model-router-provider-routed-inference-helpers.ts
@@ -24,6 +24,11 @@ export function buildProviderRoutedEnv(
 ): NodeJS.ProcessEnv {
   return {
     ...buildAvailabilityProbeEnv(baseEnv),
+    // CI's NVIDIA_API_KEY is the public nvapi-* credential for
+    // integrate.api.nvidia.com. The routed blueprint still declares the
+    // historical NVIDIA_INFERENCE_API_KEY runtime credential name, so alias
+    // the public value only in this child environment. Hosted lanes instead
+    // source their sk-* NVIDIA_INFERENCE_API_KEY for inference-api.nvidia.com.
     NVIDIA_INFERENCE_API_KEY: apiKey,
     NEMOCLAW_PROVIDER_KEY: apiKey,
     NEMOCLAW_SANDBOX_NAME: sandboxName,

--- a/test/e2e-scenario/live/model-router-provider-routed-inference-helpers.ts
+++ b/test/e2e-scenario/live/model-router-provider-routed-inference-helpers.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+
+export const MODEL_ROUTER_PUBLIC_KEY_ENV = "NVIDIA_API_KEY";
+
+export interface ModelRouterSecrets {
+  required(name: string): string;
+}
+
+export function requireModelRouterPublicKey(secrets: ModelRouterSecrets): string {
+  const apiKey = secrets.required(MODEL_ROUTER_PUBLIC_KEY_ENV);
+  if (!apiKey.startsWith("nvapi-")) {
+    throw new Error("NVIDIA_API_KEY must be a public NVIDIA Endpoints nvapi-* key");
+  }
+  return apiKey;
+}
+
+export function buildProviderRoutedEnv(
+  apiKey: string,
+  sandboxName: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...buildAvailabilityProbeEnv(baseEnv),
+    NVIDIA_INFERENCE_API_KEY: apiKey,
+    NEMOCLAW_PROVIDER_KEY: apiKey,
+    NEMOCLAW_SANDBOX_NAME: sandboxName,
+    NEMOCLAW_NON_INTERACTIVE: "1",
+    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+    NEMOCLAW_POLICY_TIER: "open",
+    NEMOCLAW_PROVIDER: "routed",
+  };
+}

--- a/test/e2e-scenario/live/model-router-provider-routed-inference.test.ts
+++ b/test/e2e-scenario/live/model-router-provider-routed-inference.test.ts
@@ -7,6 +7,10 @@ import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
+import {
+  buildProviderRoutedEnv,
+  requireModelRouterPublicKey,
+} from "./model-router-provider-routed-inference-helpers.ts";
 
 // Focused Vitest live replacement for
 // test/e2e/test-model-router-provider-routed-inference.sh. Keep this as a
@@ -72,19 +76,6 @@ function routedPongReason(raw: string): "ok" | string {
   return "ok";
 }
 
-function withProviderRoutedEnv(apiKey: string): NodeJS.ProcessEnv {
-  return {
-    ...buildAvailabilityProbeEnv(),
-    NVIDIA_INFERENCE_API_KEY: apiKey,
-    NEMOCLAW_PROVIDER_KEY: apiKey,
-    NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
-    NEMOCLAW_NON_INTERACTIVE: "1",
-    NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
-    NEMOCLAW_POLICY_TIER: "open",
-    NEMOCLAW_PROVIDER: "routed",
-  };
-}
-
 test.skipIf(!shouldRunLiveE2EScenarios())(
   "model-router provider-routed onboard returns routed inference.local PONG",
   async ({ artifacts, cleanup, host, sandbox, secrets, skip }) => {
@@ -107,10 +98,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       skip("Docker is required for provider-routed Model Router onboarding");
     }
 
-    const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
-    expect(apiKey.startsWith("nvapi-"), "NVIDIA_INFERENCE_API_KEY must start with nvapi-").toBe(
-      true,
-    );
+    const apiKey = requireModelRouterPublicKey(secrets);
 
     await artifacts.writeJson("scenario.json", {
       id: "model-router-provider-routed-inference",
@@ -119,7 +107,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       legacySource: "test/e2e/test-model-router-provider-routed-inference.sh",
       contract: [
         "Docker is available before onboarding",
-        "NVIDIA_INFERENCE_API_KEY is present and nvapi-prefixed",
+        "NVIDIA_API_KEY is present and nvapi-prefixed, then staged for the router's NVIDIA_INFERENCE_API_KEY credential",
         "nemoclaw onboard --fresh completes with NEMOCLAW_PROVIDER=routed",
         "host model-router health reports at least one healthy endpoint",
         "sandbox inference.local returns model nvidia-routed with PONG content",
@@ -152,7 +140,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       ],
       {
         artifactName: "onboard-model-router-provider-routed",
-        env: withProviderRoutedEnv(apiKey),
+        env: buildProviderRoutedEnv(apiKey, SANDBOX_NAME),
         redactionValues: [apiKey],
         timeoutMs: ONBOARD_TIMEOUT_MS,
       },

--- a/test/e2e-scenario/live/network-policy-interactive.ts
+++ b/test/e2e-scenario/live/network-policy-interactive.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Trust boundary: the Expect program receives only a numeric preset index
+// parsed from NemoClaw's own numbered menu plus the literal confirmation Y.
+// No dispatch input, secret, or other user-controlled text enters the script.
+// Exit codes: 2=preset timeout, 3=preset EOF, 4=confirmation timeout,
+// 5=confirmation EOF, and 6=post-confirmation timeout.
 export const POLICY_ADD_EXPECT_SCRIPT = String.raw`
 set timeout 60
 spawn env NEMOCLAW_NON_INTERACTIVE= node $env(NEMOCLAW_E2E_CLI) $env(NEMOCLAW_E2E_SANDBOX) policy-add

--- a/test/e2e-scenario/live/network-policy-interactive.ts
+++ b/test/e2e-scenario/live/network-policy-interactive.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const POLICY_ADD_EXPECT_SCRIPT = String.raw`
+set timeout 60
+spawn env NEMOCLAW_NON_INTERACTIVE= node $env(NEMOCLAW_E2E_CLI) $env(NEMOCLAW_E2E_SANDBOX) policy-add
+expect {
+  -glob "*Choose preset*" {
+    send -- "$env(NEMOCLAW_E2E_PRESET_NUM)\r"
+  }
+  timeout {
+    puts stderr "timed out waiting for the policy preset prompt"
+    exit 2
+  }
+  eof {
+    puts stderr "policy-add exited before the policy preset prompt"
+    exit 3
+  }
+}
+expect {
+  -glob "*Y/n*" {
+    send -- "Y\r"
+  }
+  timeout {
+    puts stderr "timed out waiting for the policy confirmation prompt"
+    exit 4
+  }
+  eof {
+    puts stderr "policy-add exited before the policy confirmation prompt"
+    exit 5
+  }
+}
+expect {
+  eof {}
+  timeout {
+    puts stderr "policy-add did not exit after confirmation"
+    exit 6
+  }
+}
+set wait_result [wait]
+exit [lindex $wait_result 3]
+`;
+
+export function findPolicyPresetNumber(output: string, preset: string): string | null {
+  const escapedPreset = preset.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`^\\s*(\\d+)\\)\\s+(?:[●○]\\s+)?${escapedPreset}(?:\\s|$)`, "m").exec(
+    output,
+  );
+  return match?.[1] ?? null;
+}

--- a/test/e2e-scenario/live/network-policy-interactive.ts
+++ b/test/e2e-scenario/live/network-policy-interactive.ts
@@ -48,3 +48,11 @@ export function findPolicyPresetNumber(output: string, preset: string): string |
   );
   return match?.[1] ?? null;
 }
+
+export function requirePolicyPresetNumber(output: string, preset: string): string {
+  const presetNumber = findPolicyPresetNumber(output, preset);
+  if (!presetNumber) {
+    throw new Error(`preset ${preset} not found in interactive policy-add list: ${output}`);
+  }
+  return presetNumber;
+}

--- a/test/e2e-scenario/live/network-policy.test.ts
+++ b/test/e2e-scenario/live/network-policy.test.ts
@@ -570,6 +570,8 @@ hello
       curlStatus(sandbox, "https://pypi.org/simple/le/", "tc-net-02-pypi-post", "-X POST"),
     ).resolves.toBe("403");
 
+    // Use Slack's non-redirecting API probe on the preset's actual API host;
+    // the marketing root can leave the slack.com allowlist during redirects.
     const slackBefore = await fetchStatus(
       sandbox,
       "https://slack.com/api/api.test",

--- a/test/e2e-scenario/live/network-policy.test.ts
+++ b/test/e2e-scenario/live/network-policy.test.ts
@@ -560,11 +560,19 @@ hello
       curlStatus(sandbox, "https://pypi.org/simple/le/", "tc-net-02-pypi-post", "-X POST"),
     ).resolves.toBe("403");
 
-    const slackBefore = await fetchStatus(sandbox, "https://slack.com/", "tc-net-03-slack-before");
+    const slackBefore = await fetchStatus(
+      sandbox,
+      "https://slack.com/api/api.test",
+      "tc-net-03-slack-before",
+    );
     expect(slackBefore).toMatch(/STATUS_403|ERROR_/);
     const slackApply = await applyPresetInteractively(host, "slack");
     expect(slackApply.exitCode, text(slackApply)).toBe(0);
-    const slackAfter = await fetchStatus(sandbox, "https://slack.com/", "tc-net-03-slack-after");
+    const slackAfter = await fetchStatus(
+      sandbox,
+      "https://slack.com/api/api.test",
+      "tc-net-03-slack-after",
+    );
     expect(slackAfter).toMatch(/STATUS_200/);
 
     const atlassianBefore = await fetchStatus(

--- a/test/e2e-scenario/live/network-policy.test.ts
+++ b/test/e2e-scenario/live/network-policy.test.ts
@@ -6,9 +6,8 @@
  *
  * This keeps the legacy contract real: onboarding a restricted OpenClaw
  * sandbox, mutating live OpenShell network policy from the NemoClaw CLI, and
- * probing egress from inside the sandbox. Helpers stay local to this file so
- * the security/policy anchor does not add a new framework or shared fixture
- * before repeated migration needs prove one is warranted.
+ * probing egress from inside the sandbox. The prompt-driving helper is kept
+ * separate so support tests can pin its command shape without live infra.
  */
 
 import fs from "node:fs";
@@ -23,6 +22,7 @@ import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clien
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { findPolicyPresetNumber, POLICY_ADD_EXPECT_SCRIPT } from "./network-policy-interactive.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
@@ -110,22 +110,34 @@ async function applyPresetInteractively(
   host: HostCliClient,
   preset: string,
 ): Promise<ShellProbeResult> {
-  const script = String.raw`
-set -euo pipefail
-preset_list="$(env NEMOCLAW_NON_INTERACTIVE= node "$NEMOCLAW_E2E_CLI" "$NEMOCLAW_E2E_SANDBOX" policy-add </dev/null 2>&1 || true)"
-preset_num="$(printf '%s\n' "$preset_list" | python3 -c 'import re,sys; preset=sys.argv[1]; text=sys.stdin.read(); m=re.search(r"(?m)^\s*(\d+)\).*" + re.escape(preset), text); print(m.group(1) if m else "")' "$NEMOCLAW_E2E_PRESET")"
-if [ -z "$preset_num" ]; then
-  printf 'preset %s not found in list:\n%s\n' "$NEMOCLAW_E2E_PRESET" "$preset_list" >&2
-  exit 1
-fi
-printf '%s\nY\n' "$preset_num" | env NEMOCLAW_NON_INTERACTIVE= node "$NEMOCLAW_E2E_CLI" "$NEMOCLAW_E2E_SANDBOX" policy-add
-`;
-  const result = await host.command("bash", ["-lc", script], {
+  const listResult = await host.command(
+    "bash",
+    [
+      "-lc",
+      'env NEMOCLAW_NON_INTERACTIVE= node "$NEMOCLAW_E2E_CLI" "$NEMOCLAW_E2E_SANDBOX" policy-add </dev/null',
+    ],
+    {
+      artifactName: `policy-add-${preset}-interactive-list`,
+      env: baseEnv({
+        NEMOCLAW_E2E_CLI: CLI_ENTRYPOINT,
+        NEMOCLAW_E2E_SANDBOX: SANDBOX_NAME,
+      }),
+      timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
+    },
+  );
+  const presetNumber = findPolicyPresetNumber(text(listResult), preset);
+  if (!presetNumber) {
+    throw new Error(
+      `preset ${preset} not found in interactive policy-add list: ${text(listResult)}`,
+    );
+  }
+
+  const result = await host.command("expect", ["-c", POLICY_ADD_EXPECT_SCRIPT], {
     artifactName: `policy-add-${preset}-interactive`,
     env: baseEnv({
       NEMOCLAW_E2E_CLI: CLI_ENTRYPOINT,
       NEMOCLAW_E2E_SANDBOX: SANDBOX_NAME,
-      NEMOCLAW_E2E_PRESET: preset,
+      NEMOCLAW_E2E_PRESET_NUM: presetNumber,
     }),
     timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
   });
@@ -568,6 +580,10 @@ hello
     expect(slackBefore).toMatch(/STATUS_403|ERROR_/);
     const slackApply = await applyPresetInteractively(host, "slack");
     expect(slackApply.exitCode, text(slackApply)).toBe(0);
+    const slackPolicyList = await runNemoclaw(host, [SANDBOX_NAME, "policy-list"], {
+      artifactName: "tc-net-03-policy-list-slack",
+    });
+    expect(text(slackPolicyList)).toMatch(/● slack/);
     const slackAfter = await fetchStatus(
       sandbox,
       "https://slack.com/api/api.test",

--- a/test/e2e-scenario/live/network-policy.test.ts
+++ b/test/e2e-scenario/live/network-policy.test.ts
@@ -22,7 +22,10 @@ import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clien
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2EScenarios } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
-import { findPolicyPresetNumber, POLICY_ADD_EXPECT_SCRIPT } from "./network-policy-interactive.ts";
+import {
+  POLICY_ADD_EXPECT_SCRIPT,
+  requirePolicyPresetNumber,
+} from "./network-policy-interactive.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
@@ -125,12 +128,7 @@ async function applyPresetInteractively(
       timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
     },
   );
-  const presetNumber = findPolicyPresetNumber(text(listResult), preset);
-  if (!presetNumber) {
-    throw new Error(
-      `preset ${preset} not found in interactive policy-add list: ${text(listResult)}`,
-    );
-  }
+  const presetNumber = requirePolicyPresetNumber(text(listResult), preset);
 
   const result = await host.command("expect", ["-c", POLICY_ADD_EXPECT_SCRIPT], {
     artifactName: `policy-add-${preset}-interactive`,

--- a/test/e2e-scenario/support-tests/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e-scenario/support-tests/hermes-inference-switch-command-shape.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,10 +11,35 @@ import {
 } from "../live/hermes-inference-switch-helpers.ts";
 
 describe("Hermes inference switch command shape", () => {
+  function matchesApiKeyShape(line: string): boolean {
+    return (
+      spawnSync("grep", ["-Eq", API_KEY_SHAPE_PATTERN], {
+        encoding: "utf8",
+        input: `${line}\n`,
+      }).status === 0
+    );
+  }
+
   it("uses direct single-line argv for the in-sandbox API-key probe", () => {
     const command = apiKeyShapeCommand();
 
     expect(command).toEqual(["grep", "-Eq", API_KEY_SHAPE_PATTERN, "/sandbox/.hermes/config.yaml"]);
     expect(command.every((argument) => !/[\r\n]/u.test(argument))).toBe(true);
+  });
+
+  it("accepts only complete sk-prefixed YAML scalars", () => {
+    expect(
+      ["  api_key: sk-value", '  api_key: "sk-value"', "  api_key: 'sk-value'"].every(
+        matchesApiKeyShape,
+      ),
+    ).toBe(true);
+    expect(
+      [
+        "  api_key: not-sk-value",
+        "  api_key: sk-value trailing",
+        '  api_key: "sk-value',
+        '  api_key: sk-value"',
+      ].some(matchesApiKeyShape),
+    ).toBe(false);
   });
 });

--- a/test/e2e-scenario/support-tests/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e-scenario/support-tests/hermes-inference-switch-command-shape.test.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  API_KEY_SHAPE_PATTERN,
+  apiKeyShapeCommand,
+} from "../live/hermes-inference-switch-helpers.ts";
+
+describe("Hermes inference switch command shape", () => {
+  it("uses direct single-line argv for the in-sandbox API-key probe", () => {
+    const command = apiKeyShapeCommand();
+
+    expect(command).toEqual(["grep", "-Eq", API_KEY_SHAPE_PATTERN, "/sandbox/.hermes/config.yaml"]);
+    expect(command.every((argument) => !/[\r\n]/u.test(argument))).toBe(true);
+  });
+});

--- a/test/e2e-scenario/support-tests/model-router-provider-routed-inference.test.ts
+++ b/test/e2e-scenario/support-tests/model-router-provider-routed-inference.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildProviderRoutedEnv,
+  requireModelRouterPublicKey,
+} from "../live/model-router-provider-routed-inference-helpers.ts";
+
+describe("Model Router provider-routed live support", () => {
+  it("requires the public NVIDIA secret", () => {
+    const requested: string[] = [];
+    const apiKey = requireModelRouterPublicKey({
+      required(name) {
+        requested.push(name);
+        return "nvapi-public-test-key";
+      },
+    });
+
+    expect(requested).toEqual(["NVIDIA_API_KEY"]);
+    expect(apiKey).toBe("nvapi-public-test-key");
+    expect(() => requireModelRouterPublicKey({ required: () => "hosted-compatible-key" })).toThrow(
+      "NVIDIA_API_KEY must be a public NVIDIA Endpoints nvapi-* key",
+    );
+  });
+
+  it("stages the public key under the credential names consumed by the router", () => {
+    expect(buildProviderRoutedEnv("nvapi-public-test-key", "e2e-router", {})).toMatchObject({
+      NVIDIA_INFERENCE_API_KEY: "nvapi-public-test-key",
+      NEMOCLAW_PROVIDER_KEY: "nvapi-public-test-key",
+      NEMOCLAW_PROVIDER: "routed",
+      NEMOCLAW_SANDBOX_NAME: "e2e-router",
+    });
+  });
+});

--- a/test/e2e-scenario/support-tests/network-policy-interactive.test.ts
+++ b/test/e2e-scenario/support-tests/network-policy-interactive.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   findPolicyPresetNumber,
   POLICY_ADD_EXPECT_SCRIPT,
+  requirePolicyPresetNumber,
 } from "../live/network-policy-interactive.ts";
 
 describe("network-policy interactive preset harness", () => {
@@ -19,6 +20,7 @@ describe("network-policy interactive preset harness", () => {
     expect(findPolicyPresetNumber(output, "slack")).toBe("15");
     expect(findPolicyPresetNumber(output, "pypi")).toBe("16");
     expect(findPolicyPresetNumber(output, "missing")).toBeNull();
+    expect(() => requirePolicyPresetNumber(output, "missing")).toThrow(/preset missing not found/);
   });
 
   it("waits for each prompt before sending the corresponding response", () => {

--- a/test/e2e-scenario/support-tests/network-policy-interactive.test.ts
+++ b/test/e2e-scenario/support-tests/network-policy-interactive.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findPolicyPresetNumber,
+  POLICY_ADD_EXPECT_SCRIPT,
+} from "../live/network-policy-interactive.ts";
+
+describe("network-policy interactive preset harness", () => {
+  it("selects the exact requested preset from the interactive list", () => {
+    const output = `
+  14) ○ hermes-slack — unrelated prefix
+  15) ○ slack — Slack API access
+  16) ● pypi — Python Package Index
+`;
+
+    expect(findPolicyPresetNumber(output, "slack")).toBe("15");
+    expect(findPolicyPresetNumber(output, "pypi")).toBe("16");
+    expect(findPolicyPresetNumber(output, "missing")).toBeNull();
+  });
+
+  it("waits for each prompt before sending the corresponding response", () => {
+    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('-glob "*Choose preset*"');
+    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('send -- "$env(NEMOCLAW_E2E_PRESET_NUM)\\r"');
+    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('-glob "*Y/n*"');
+    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('send -- "Y\\r"');
+    expect(POLICY_ADD_EXPECT_SCRIPT).not.toMatch(/printf.*Y/);
+  });
+});

--- a/test/e2e-script-workflow.test.ts
+++ b/test/e2e-script-workflow.test.ts
@@ -1052,6 +1052,14 @@ describe("E2E reusable workflow contract", () => {
       (step) => step.name === "Install issue #4434 host dependencies",
     );
     const issue4434VitestInstallRun = issue4434VitestInstallStep?.run ?? "";
+    const networkPolicyVitestSteps =
+      vitestScenarioWorkflow.jobs["network-policy-vitest"].steps ?? [];
+    const networkPolicyVitestStepIndex = (name: string) =>
+      networkPolicyVitestSteps.findIndex((step) => step.name === name);
+    const networkPolicyVitestInstallStep = networkPolicyVitestSteps.find(
+      (step) => step.name === "Install network-policy host dependencies",
+    );
+    const networkPolicyVitestInstallRun = networkPolicyVitestInstallStep?.run ?? "";
     const installActionRun = installActionStep?.run ?? "";
 
     expect(issue4434VitestInstallStep?.uses).toBeUndefined();
@@ -1060,6 +1068,13 @@ describe("E2E reusable workflow contract", () => {
     );
     expect(issue4434VitestStepIndex("Install issue #4434 host dependencies")).toBeLessThan(
       issue4434VitestStepIndex("Authenticate to Docker Hub"),
+    );
+    expect(networkPolicyVitestInstallStep?.uses).toBeUndefined();
+    expect(networkPolicyVitestInstallRun).toContain(
+      "sudo apt-get install -y --no-install-recommends expect",
+    );
+    expect(networkPolicyVitestStepIndex("Install network-policy host dependencies")).toBeLessThan(
+      networkPolicyVitestStepIndex("Run network-policy live test"),
     );
 
     expect(installActionStep?.env?.APT_PACKAGES).toBe("${{ inputs.packages }}");
@@ -1082,6 +1097,7 @@ describe("E2E reusable workflow contract", () => {
       "sudo apt-get install -y --no-install-recommends",
     ]) {
       expect(issue4434VitestInstallRun, fragment).toContain(fragment);
+      expect(networkPolicyVitestInstallRun, fragment).toContain(fragment);
       expect(installActionRun, fragment).toContain(fragment);
     }
   });

--- a/test/e2e/test-model-router-provider-routed-inference.sh
+++ b/test/e2e/test-model-router-provider-routed-inference.sh
@@ -68,7 +68,11 @@ redact_file() {
   python3 - "$file" <<'PY'
 import os, sys
 path = sys.argv[1]
-secrets = [os.environ.get("NVIDIA_INFERENCE_API_KEY", ""), os.environ.get("NEMOCLAW_PROVIDER_KEY", "")]
+secrets = [
+    os.environ.get("NVIDIA_API_KEY", ""),
+    os.environ.get("NVIDIA_INFERENCE_API_KEY", ""),
+    os.environ.get("NEMOCLAW_PROVIDER_KEY", ""),
+]
 text = open(path, "r", errors="replace").read()
 for secret in filter(None, secrets):
     text = text.replace(secret, "<REDACTED>")
@@ -97,10 +101,10 @@ else
   exit 1
 fi
 
-if [ -n "${NVIDIA_INFERENCE_API_KEY:-}" ] && [[ "${NVIDIA_INFERENCE_API_KEY}" == nvapi-* ]]; then
-  pass "NVIDIA_INFERENCE_API_KEY is set"
+if [ -n "${NVIDIA_API_KEY:-}" ] && [[ "${NVIDIA_API_KEY}" == nvapi-* ]]; then
+  pass "NVIDIA_API_KEY is set"
 else
-  fail "NVIDIA_INFERENCE_API_KEY is required and must start with nvapi-"
+  fail "NVIDIA_API_KEY is required and must start with nvapi-"
   exit 1
 fi
 
@@ -124,13 +128,13 @@ rm -f "$HOME/.nemoclaw/onboard.lock" 2>/dev/null || true
 nemoclaw "$SANDBOX_NAME" destroy --yes >/dev/null 2>&1 || true
 
 env \
-  NEMOCLAW_PROVIDER_KEY="$NVIDIA_INFERENCE_API_KEY" \
+  NEMOCLAW_PROVIDER_KEY="$NVIDIA_API_KEY" \
   NEMOCLAW_SANDBOX_NAME="$SANDBOX_NAME" \
   NEMOCLAW_NON_INTERACTIVE=1 \
   NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE=1 \
   NEMOCLAW_POLICY_TIER="open" \
   NEMOCLAW_PROVIDER="routed" \
-  NVIDIA_INFERENCE_API_KEY="$NVIDIA_INFERENCE_API_KEY" \
+  NVIDIA_INFERENCE_API_KEY="$NVIDIA_API_KEY" \
   "$TIMEOUT_CMD" 1500 nemoclaw onboard --fresh --non-interactive --yes-i-accept-third-party-software \
   >"$ONBOARD_LOG" 2>&1
 onboard_rc=$?

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -467,6 +467,8 @@ bash /tmp/nemoclaw-brew-e2e.sh" "$PACKAGE_MANAGER_SANDBOX_TIMEOUT_SECONDS" 2>&1)
 test_net_03_live_policy_add() {
   log "=== TC-NET-03: Live Policy-Add Without Restart ==="
 
+  # Probe Slack's non-redirecting API path. The marketing root can redirect
+  # outside the slack.com allowlist and does not isolate preset behavior.
   local target_url="https://slack.com/api/api.test"
 
   log "  Step 1: Verify slack.com is blocked before policy-add..."

--- a/test/e2e/test-network-policy.sh
+++ b/test/e2e/test-network-policy.sh
@@ -467,7 +467,7 @@ bash /tmp/nemoclaw-brew-e2e.sh" "$PACKAGE_MANAGER_SANDBOX_TIMEOUT_SECONDS" 2>&1)
 test_net_03_live_policy_add() {
   log "=== TC-NET-03: Live Policy-Add Without Restart ==="
 
-  local target_url="https://slack.com/"
+  local target_url="https://slack.com/api/api.test"
 
   log "  Step 1: Verify slack.com is blocked before policy-add..."
   local before

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -1376,8 +1376,8 @@ describe("generate-openclaw-config.mts: config generation", () => {
   }, 20_000);
 
   // #4780: Nemotron can generate invalid JS for OpenClaw's native
-  // `tool_search_code`. Disable it on affected managed-inference routes so
-  // these models use the structured tool-calling surface they handle correctly.
+  // `tool_search_code`. The Super and Ultra managed-inference manifests disable
+  // it so both models use the structured tool-calling surface they handle.
   it("disables native OpenClaw Tool Search for Nemotron managed inference (#4780)", () => {
     for (const model of ["nvidia/nemotron-3-super-120b-a12b", "nvidia/nvidia/nemotron-3-ultra"]) {
       const config = runConfigScript({

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -1375,23 +1375,21 @@ describe("generate-openclaw-config.mts: config generation", () => {
     }
   }, 20_000);
 
-  // #4780: Nemotron generates invalid JS for OpenClaw's native code-based tool
-  // search (`tool_search_code`): CommonJS `require`, `openclaw.tools.search`
-  // called with an object instead of a string, `tool_describe`/`tool_call`
-  // invoked with bad ids. The run still succeeds via fallback, but the logs are
-  // flooded with `[tools] tool_search_code failed` errors. Disabling native
-  // tool search for this managed-inference route routes the model back to the
-  // structured tool-calling surface it handles correctly.
+  // #4780: Nemotron can generate invalid JS for OpenClaw's native
+  // `tool_search_code`. Disable it on affected managed-inference routes so
+  // these models use the structured tool-calling surface they handle correctly.
   it("disables native OpenClaw Tool Search for Nemotron managed inference (#4780)", () => {
-    const config = runConfigScript({
-      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
-      NEMOCLAW_PROVIDER_KEY: "inference",
-      NEMOCLAW_PRIMARY_MODEL_REF: "inference/nvidia/nemotron-3-super-120b-a12b",
-      NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
-      NEMOCLAW_INFERENCE_API: "openai-completions",
-    });
+    for (const model of ["nvidia/nemotron-3-super-120b-a12b", "nvidia/nvidia/nemotron-3-ultra"]) {
+      const config = runConfigScript({
+        NEMOCLAW_MODEL: model,
+        NEMOCLAW_PROVIDER_KEY: "inference",
+        NEMOCLAW_PRIMARY_MODEL_REF: `inference/${model}`,
+        NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+        NEMOCLAW_INFERENCE_API: "openai-completions",
+      });
 
-    expect(config.tools?.toolSearch).toBe(false);
+      expect(config.tools?.toolSearch, model).toBe(false);
+    }
   });
 
   it("does not disable native Tool Search for Nemotron on non-matching routes (#4780)", () => {

--- a/test/regression-e2e-workflow.test.ts
+++ b/test/regression-e2e-workflow.test.ts
@@ -63,6 +63,15 @@ describe("Regression E2E workflow contract", () => {
     expect(runText).not.toContain("test/e2e/test-whatsapp-qr-compact-e2e.sh");
   });
 
+  it("stages the public NVIDIA key for the Model Router's NVIDIA credential", () => {
+    const job = workflow.jobs?.["model-router-provider-routed-inference-e2e"];
+    const runStep = job?.steps?.find(
+      (step) => step.name === "Run Model Router provider-routed inference E2E test",
+    );
+    expect(runStep?.env?.NVIDIA_API_KEY).toBe("${{ secrets.NVIDIA_API_KEY }}");
+    expect(runStep?.env?.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
+  });
+
   it("runs OpenClaw plugin runtime-deps EXDEV through a secret-free Vitest lane", () => {
     const job = workflow.jobs?.["openclaw-plugin-runtime-exdev-e2e"];
     const steps = job?.steps ?? [];

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -1034,6 +1034,28 @@ function validateNetworkPolicyVitestJob(
     );
   }
 
+  const installHostDependencies = requireJobStep(
+    errors,
+    jobName,
+    steps,
+    "Install network-policy host dependencies",
+  );
+  if (installHostDependencies?.uses) {
+    errors.push(
+      "network-policy-vitest host dependency setup must stay inline in trusted workflow YAML",
+    );
+  }
+  for (const fragment of [
+    "for attempt in 1 2 3",
+    "sudo apt-get update",
+    'if [ "$attempt" -eq 3 ]; then',
+    "apt-get update failed after 3 attempts",
+    "sleep $((attempt * 5))",
+    "sudo apt-get install -y --no-install-recommends expect",
+  ]) {
+    requireRunContains(errors, installHostDependencies, fragment);
+  }
+
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode)
     errors.push("network-policy-vitest job missing step: Set up Node");

--- a/tools/e2e-scenarios/workflow-boundary.mts
+++ b/tools/e2e-scenarios/workflow-boundary.mts
@@ -4997,6 +4997,7 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     );
   }
   for (const secret of [
+    "NVIDIA_API_KEY",
     "NVIDIA_INFERENCE_API_KEY",
     "DOCKERHUB_USERNAME",
     "DOCKERHUB_TOKEN",
@@ -5020,9 +5021,15 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
         errors,
         stepName,
         stepEnv,
-        "NVIDIA_INFERENCE_API_KEY",
+        "NVIDIA_API_KEY",
       );
     }
+    requireEnvDoesNotExposeSecret(
+      errors,
+      stepName,
+      stepEnv,
+      "NVIDIA_INFERENCE_API_KEY",
+    );
     if (step.name !== "Authenticate to Docker Hub") {
       requireEnvDoesNotExposeSecret(
         errors,
@@ -5132,12 +5139,9 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
     "Run Model Router provider-routed inference live test",
   );
   const runVitestEnv = asRecord(runVitest?.env);
-  if (
-    runVitestEnv.NVIDIA_INFERENCE_API_KEY !==
-    "${{ secrets.NVIDIA_INFERENCE_API_KEY }}"
-  ) {
+  if (runVitestEnv.NVIDIA_API_KEY !== "${{ secrets.NVIDIA_API_KEY }}") {
     errors.push(
-      "model-router-provider-routed-inference-vitest Vitest step must receive NVIDIA_INFERENCE_API_KEY from secrets",
+      "model-router-provider-routed-inference-vitest Vitest step must receive NVIDIA_API_KEY from secrets",
     );
   }
   requireRunContains(
@@ -5206,6 +5210,35 @@ function validateModelRouterProviderRoutedInferenceVitestJob(
   }
   requireRunContains(errors, cleanup, "docker logout docker.io");
   requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
+}
+
+function validateGatewayDriftPreflightVitestJob(
+  errors: string[],
+  jobs: WorkflowRecord,
+): void {
+  const jobName = "gateway-drift-preflight-vitest";
+  const job = asRecord(jobs[jobName]);
+  validateFreeStandingJobSelector(
+    errors,
+    jobs,
+    jobName,
+    "gateway-drift-preflight",
+  );
+  if (Object.keys(job).length === 0) return;
+
+  const runVitest = requireJobStep(
+    errors,
+    jobName,
+    asSteps(job.steps),
+    "Run gateway drift preflight Vitest test",
+  );
+  requireRunContains(errors, runVitest, "npx vitest run --project integration");
+  requireRunContains(
+    errors,
+    runVitest,
+    "test/gateway-drift-preflight.test.ts",
+  );
+  requireRunDoesNotContain(errors, runVitest, "--project cli");
 }
 
 function runContainsCloudflaredAptInstall(run: string): boolean {
@@ -7805,12 +7838,7 @@ export function validateE2eVitestScenariosWorkflowBoundary(
   validateModelRouterProviderRoutedInferenceVitestJob(errors, jobs);
   validateSnapshotCommandsVitestJob(errors, jobs);
   validateSparkInstallVitestJob(errors, jobs);
-  validateFreeStandingJobSelector(
-    errors,
-    jobs,
-    "gateway-drift-preflight-vitest",
-    "gateway-drift-preflight",
-  );
+  validateGatewayDriftPreflightVitestJob(errors, jobs);
 
   validateFreeStandingJobSelector(
     errors,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Correct the deterministic failures exposed by the full nightly/Vitest release gate. The fixes cover credential and project selection, hosted Ultra tool compatibility, a stable Slack policy probe, and OpenShell's single-line command boundary.

## Changes

- pass `NVIDIA_API_KEY` to the Model Router workflow and stage it under the router's `NVIDIA_INFERENCE_API_KEY` credential boundary
- mirror the public-key fix in the retained regression Bash lane and add behavioral support coverage for key selection and staging
- run `test/gateway-drift-preflight.test.ts` through the `integration` Vitest project
- extend the workflow boundary validator so both command and credential contracts fail closed on future drift
- disable OpenClaw native Tool Search for hosted Nemotron 3 Ultra so it uses structured tool calls instead of invalid generated JavaScript
- probe the Slack preset through the non-redirecting `slack.com/api/api.test` endpoint in both Bash and Vitest lanes, using prompt-synchronized `expect` and an applied-policy assertion
- pass the Hermes API-key shape check as direct single-line argv accepted by current OpenShell, with support coverage

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the existing gateway-drift integration test and workflow-boundary suite exercise the corrected project and workflow contract
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: release-gate workflow and test-harness behavior only
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the public key remains step-scoped, the live helper stages only the credential aliases consumed by Model Router, and boundary tests reject hosted-key regression. The `expect` trust boundary is explicitly accepted: it is an existing reviewed host tool in the retained Bash lane; the Vitest lane installs it only from Ubuntu apt in trusted workflow YAML, feeds it only a regex-constrained numeric menu index plus literal `Y`, and enforces that shape with support and workflow-boundary tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nemotron 3 Ultra managed inference route with native tool search disabled.
* **Bug Fixes**
  * Updated routed-inference E2E credential wiring and secret redaction to use `NVIDIA_API_KEY` (`nvapi-*`) instead of `NVIDIA_INFERENCE_API_KEY`.
  * Updated network-policy Slack connectivity checks to target `https://slack.com/api/api.test`.
* **Tests**
  * Expanded router/gateway-drift preflight Vitest coverage (correct env staging and integration project selection).
  * Added/strengthened Hermes and network-policy interactive preset parsing/expect sequencing tests.
  * Added a regression assertion for workflow env handling.
* **Chores**
  * Improved CI workflow validation and ensured host dependency installation sequencing; adjusted a test file size budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->