### PR TITLE
fix(e2e): keep TUI correlation prompts tool-free

### DIFF
--- a/test/openclaw-tui-chat-correlation.test.ts
+++ b/test/openclaw-tui-chat-correlation.test.ts
@@ -476,9 +476,9 @@ ws.on("open", async () => {
 
     const sentRuns = [];
     const messages = [
-      ["A2603", "A2603-REPLY", "A2603: First task. Wait 8 seconds, then reply exactly A2603-REPLY and nothing else."],
-      ["B2603", "B2603-REPLY", "B2603: Second task. Reply exactly B2603-REPLY and nothing else."],
-      ["C2603", "C2603-REPLY", "C2603: Third task. Reply exactly C2603-REPLY and nothing else."],
+      ["A2603", "A2603-REPLY", "A2603: First task. Reply exactly A2603-REPLY and nothing else. Do not use tools."],
+      ["B2603", "B2603-REPLY", "B2603: Second task. Reply exactly B2603-REPLY and nothing else. Do not use tools."],
+      ["C2603", "C2603-REPLY", "C2603: Third task. Reply exactly C2603-REPLY and nothing else. Do not use tools."],
     ];
 
     for (const [promptToken, replyToken, message] of messages) {
@@ -719,6 +719,21 @@ describe("OpenClaw TUI chat correlation regression (#2603)", () => {
         historyMessages: [],
       }),
     ).toBe(false);
+  });
+
+  it("keeps the live repro prompts deterministic and tool-free", () => {
+    const script = buildLiveReproScript();
+
+    expect(script).not.toContain("Wait 8 seconds");
+    expect(script).toContain(
+      "A2603: First task. Reply exactly A2603-REPLY and nothing else. Do not use tools.",
+    );
+    expect(script).toContain(
+      "B2603: Second task. Reply exactly B2603-REPLY and nothing else. Do not use tools.",
+    );
+    expect(script).toContain(
+      "C2603: Third task. Reply exactly C2603-REPLY and nothing else. Do not use tools.",
+    );
   });
 
   it.runIf(process.env[LIVE_REPRO_ENV] === "1")(

--- a/test/openclaw-tui-chat-correlation.test.ts
+++ b/test/openclaw-tui-chat-correlation.test.ts
@@ -255,6 +255,10 @@ function buildFailureSummary(
   );
 }
 
+// Frozen historical #2603 trace: it intentionally retains the original
+// tool-triggering wait prompt so the classifier keeps covering the observed
+// broken gateway behavior. The live repro below uses deterministic no-tools
+// prompts instead.
 const capturedIssue2603Trace: Issue2603Trace = {
   sentRuns: [
     {
@@ -475,6 +479,10 @@ ws.on("open", async () => {
     await request("chat.history", { sessionKey, limit: 20 });
 
     const sentRuns = [];
+    // This guard measures websocket run correlation, not tool execution. Keep
+    // the prompts tool-free so a model-selected tool cannot replace the reply;
+    // the strict empty-final, missing-reply, and history assertions below still
+    // fail if the instruction is ignored and the expected reply is lost.
     const messages = [
       ["A2603", "A2603-REPLY", "A2603: First task. Reply exactly A2603-REPLY and nothing else. Do not use tools."],
       ["B2603", "B2603-REPLY", "B2603: Second task. Reply exactly B2603-REPLY and nothing else. Do not use tools."],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The retained Nightly TUI correlation repro asked the model to wait eight seconds, which caused Nemotron to invoke a sandbox tool and fail on `/proc/self/oom_score_adj` before producing the expected reply. Align the retained driver with its green Vitest counterpart by keeping all rapid-send prompts deterministic and tool-free while preserving the strict correlation and history assertions.

## Related Issue
Related to #2603 and #3145.

## Changes
- Replace the retained live repro's tool-triggering wait prompt with explicit no-tools reply prompts for A/B/C.
- Preserve the one-second rapid-send cadence and all empty-final, run-correlation, reply-count, and history assertions.
- Add a unit contract that rejects the old wait prompt and locks all three live prompts to the tool-free shape.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-harness-only prompt stabilization; no user-facing behavior changes
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for the live reproduction script by asserting the generated prompts are deterministic and tool-free.
  * Added checks that the output no longer includes time-based wording (“Wait 8 seconds”) while confirming the updated prompt variants are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->