### PR TITLE
test(onboard): keep validation test on source boundary

### DIFF
--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -1,110 +1,48 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { describe, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const REPO_ROOT = path.join(import.meta.dirname, "../../..");
+import { createInferenceSelectionValidationHelpers } from "./inference-selection-validation";
 
 describe("inference selection validation", () => {
-  it("preserves non-zero exit signaling when non-interactive endpoint validation fails (#5721)", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-validation-exit-"));
-    const scriptPath = path.join(tmpDir, "validation-exit-check.js");
-    const validationPath = JSON.stringify(
-      path.join(REPO_ROOT, "dist", "lib", "onboard", "inference-selection-validation.js"),
-    );
-    const probesPath = JSON.stringify(
-      path.join(REPO_ROOT, "dist", "lib", "inference", "onboard-probes.js"),
-    );
-    const credentialsPath = JSON.stringify(
-      path.join(REPO_ROOT, "dist", "lib", "credentials", "store.js"),
-    );
-
-    const script = String.raw`
-const probesPath = require.resolve(${probesPath});
-const credentialsPath = require.resolve(${credentialsPath});
-require.cache[probesPath] = {
-  id: probesPath,
-  filename: probesPath,
-  loaded: true,
-  exports: {
-    probeAnthropicEndpoint: () => {
-      throw new Error("unexpected anthropic probe");
-    },
-    probeOpenAiLikeEndpoint: () => ({
-      ok: false,
-      failures: [{ name: "Chat Completions API", httpStatus: 403 }],
-    }),
-  },
-};
-require.cache[credentialsPath] = {
-  id: credentialsPath,
-  filename: credentialsPath,
-  loaded: true,
-  exports: {
-    getCredential: () => "nvapi-invalid-key-12345",
-  },
-};
-const { createInferenceSelectionValidationHelpers } = require(${validationPath});
-
-const lines = [];
-const exitCalls = [];
-let promptCalls = 0;
-const originalLog = console.log;
-console.error = (...args) => lines.push(args.join(" "));
-process.exitCode = undefined;
-process.exit = (code) => {
-  exitCalls.push(code);
-  return undefined;
-};
-
-(async () => {
-  const helpers = createInferenceSelectionValidationHelpers({
-    isNonInteractive: () => true,
-    agentProductName: () => "OpenClaw",
-    promptValidationRecovery: async () => {
-      promptCalls += 1;
-      return "selection";
-    },
-  });
-  let thrown = null;
-  try {
-    await helpers.validateOpenAiLikeSelection(
-      "NVIDIA Endpoints",
-      "https://integrate.api.nvidia.com/v1",
-      "meta/llama-3.3-70b-instruct",
-      "NVIDIA_INFERENCE_API_KEY",
-    );
-  } catch (error) {
-    thrown = error instanceof Error ? error.message : String(error);
-  }
-  originalLog(JSON.stringify({ thrown, exitCalls, exitCode: process.exitCode, promptCalls, lines }));
-})().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
-`;
-    fs.writeFileSync(scriptPath, script);
-
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: REPO_ROOT,
-      encoding: "utf-8",
+  it("preserves non-zero exit signaling when non-interactive endpoint validation fails (#5721)", async () => {
+    const originalExitCode = process.exitCode;
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const promptValidationRecovery = vi.fn(async () => "selection" as const);
+    const helpers = createInferenceSelectionValidationHelpers({
+      isNonInteractive: () => true,
+      agentProductName: () => "OpenClaw",
+      getCredential: () => "nvapi-invalid-key-12345",
+      probeOpenAiLikeEndpoint: () => ({
+        ok: false,
+        failures: [{ name: "Chat Completions API", httpStatus: 403 }],
+      }),
+      promptValidationRecovery,
     });
 
-    assert.equal(result.status, 1, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.thrown, "Non-interactive endpoint validation failed.");
-    assert.deepEqual(payload.exitCalls, [1]);
-    assert.equal(payload.exitCode, 1);
-    assert.equal(payload.promptCalls, 0);
-    assert.deepEqual(payload.lines, [
-      "  NVIDIA Endpoints endpoint validation failed.",
-      "  Validation probe summary: Chat Completions API: HTTP 403.",
-      "  Validation details were omitted to avoid exposing credentials.",
-    ]);
+    try {
+      await expect(
+        helpers.validateOpenAiLikeSelection(
+          "NVIDIA Endpoints",
+          "https://integrate.api.nvidia.com/v1",
+          "meta/llama-3.3-70b-instruct",
+          "NVIDIA_INFERENCE_API_KEY",
+        ),
+      ).rejects.toThrow("Non-interactive endpoint validation failed.");
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(process.exitCode).toBe(1);
+      expect(promptValidationRecovery).not.toHaveBeenCalled();
+      expect(error.mock.calls.map((args) => args.join(" "))).toEqual([
+        "  NVIDIA Endpoints endpoint validation failed.",
+        "  Validation probe summary: Chat Completions API: HTTP 403.",
+        "  Validation details were omitted to avoid exposing credentials.",
+      ]);
+    } finally {
+      process.exitCode = originalExitCode;
+      error.mockRestore();
+      exit.mockRestore();
+    }
   });
 });

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -29,6 +29,9 @@ export type EndpointValidationResult =
 export interface InferenceSelectionValidationDeps {
   isNonInteractive(): boolean;
   agentProductName(): string;
+  getCredential?: typeof getCredential;
+  probeAnthropicEndpoint?: typeof probeAnthropicEndpoint;
+  probeOpenAiLikeEndpoint?: typeof probeOpenAiLikeEndpoint;
   promptValidationRecovery(
     label: string,
     recovery: ReturnType<typeof getProbeRecovery>,
@@ -81,6 +84,10 @@ export interface InferenceSelectionValidationHelpers {
 export function createInferenceSelectionValidationHelpers(
   deps: InferenceSelectionValidationDeps,
 ): InferenceSelectionValidationHelpers {
+  const resolveCredential = deps.getCredential ?? getCredential;
+  const runAnthropicProbe = deps.probeAnthropicEndpoint ?? probeAnthropicEndpoint;
+  const runOpenAiLikeProbe = deps.probeOpenAiLikeEndpoint ?? probeOpenAiLikeEndpoint;
+
   function exitNonInteractiveValidationFailure(): never {
     process.exitCode = 1;
     (process.exit as (code?: number) => void)(1);
@@ -112,8 +119,8 @@ export function createInferenceSelectionValidationHelpers(
       allowHostDockerInternal?: boolean;
     } = {},
   ): Promise<EndpointValidationResult> {
-    const apiKey = credentialEnv ? getCredential(credentialEnv) : "";
-    const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, options);
+    const apiKey = credentialEnv ? resolveCredential(credentialEnv) : "";
+    const probe = runOpenAiLikeProbe(endpointUrl, model, apiKey, options);
     if (!probe.ok) {
       printValidationFailure(label, probe);
       if (deps.isNonInteractive()) {
@@ -147,8 +154,8 @@ export function createInferenceSelectionValidationHelpers(
     retryMessage = "Please choose a provider/model again.",
     helpUrl: string | null = null,
   ): Promise<EndpointValidationResult> {
-    const apiKey = getCredential(credentialEnv);
-    const probe = probeAnthropicEndpoint(endpointUrl, model, apiKey);
+    const apiKey = resolveCredential(credentialEnv);
+    const probe = runAnthropicProbe(endpointUrl, model, apiKey);
     if (!probe.ok) {
       printValidationFailure(label, probe);
       if (deps.isNonInteractive()) {
@@ -177,8 +184,8 @@ export function createInferenceSelectionValidationHelpers(
     credentialEnv: string,
     helpUrl: string | null = null,
   ): Promise<EndpointValidationResult> {
-    const apiKey = getCredential(credentialEnv);
-    const probe = probeOpenAiLikeEndpoint(endpointUrl, model, apiKey, {
+    const apiKey = resolveCredential(credentialEnv);
+    const probe = runOpenAiLikeProbe(endpointUrl, model, apiKey, {
       requireResponsesToolCalling: true,
       skipResponsesProbe: shouldForceCompletionsApi(process.env.NEMOCLAW_PREFERRED_API),
       probeStreaming: true,
@@ -217,8 +224,8 @@ export function createInferenceSelectionValidationHelpers(
     credentialEnv: string,
     helpUrl: string | null = null,
   ): Promise<EndpointValidationResult> {
-    const apiKey = getCredential(credentialEnv);
-    const probe = probeAnthropicEndpoint(endpointUrl, model, apiKey);
+    const apiKey = resolveCredential(credentialEnv);
+    const probe = runAnthropicProbe(endpointUrl, model, apiKey);
     if (probe.ok) {
       console.log(`  ${probe.label} available — ${deps.agentProductName()} will use ${probe.api}.`);
       return { ok: true, api: probe.api };


### PR DESCRIPTION
## Summary

Restores `main`'s source/package test boundary after #5738 added a colocated test that constructed paths into `dist/lib`. The test now imports source directly and injects its credential/probe collaborators, removing the child-process and `require.cache` fixture while preserving the non-zero exit regression coverage.

## Related Issue

Refs #5919

## Changes

- expose credential and endpoint probes through the validation helper's existing dependency boundary
- replace the compiled-output child-process fixture with a direct Vitest source test
- preserve assertions for `process.exit(1)`, `process.exitCode`, fallback throwing, redacted diagnostics, and bypassed recovery prompting

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: testability refactor with no user-facing behavior change
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: CodeQL, CodeRabbit, and both PR Review Advisor checks passed with no blocking findings or inline comments
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted evidence: focused Vitest test; `npm run build:cli`; `npm run typecheck:cli`; `npm run checks`; normal commit and push hooks (including the full CLI test hook). The source-level test is sufficient for this testability-only refactor; existing onboarding integration tests and the strict-tool-call probe driver retain caller/runtime coverage.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>
