### PR TITLE
fix(e2e): harden full release gate resources

### DIFF
--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -5672,6 +5672,8 @@ jobs:
 
       - name: Authenticate to Docker Hub
         if: github.ref == 'refs/heads/main'
+        # Authentication only accelerates pulls; anonymous pulls remain valid.
+        continue-on-error: true
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: docker.io

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -804,6 +804,7 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_PROVIDER: "ollama"
+      NEMOCLAW_OLLAMA_PULL_TIMEOUT: "2400"
       NEMOCLAW_SANDBOX_NAME: "e2e-gpu-ollama"
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
@@ -5664,6 +5665,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure isolated Docker auth directory
+        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-spark-install" >> "$GITHUB_ENV"
+
+      - name: Authenticate to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -5695,6 +5706,13 @@ jobs:
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        run: |
+          set -euo pipefail
+          docker logout docker.io || true
+          rm -rf "${DOCKER_CONFIG}"
 
   # ── PR result comment (mirrors nightly-e2e.yaml's report-to-pr) ───────────
   # Posts a results table on the open PR for the dispatching branch (or the

--- a/.github/workflows/e2e-vitest-scenarios.yaml
+++ b/.github/workflows/e2e-vitest-scenarios.yaml
@@ -794,6 +794,8 @@ jobs:
     needs: generate-matrix
     if: ${{ (inputs.jobs == '' && inputs.scenarios == '') || contains(format(',{0},', inputs.jobs), ',gpu-e2e-vitest,') || contains(format(',{0},', inputs.scenarios), ',gpu-e2e,') }}
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
+    # The 55 minute install command includes a cold 40 minute model pull;
+    # 35 minutes remain for runner setup, assertions, artifacts, and cleanup.
     timeout-minutes: 90
     env:
       FREE_STANDING_VITEST_JOB: "1"
@@ -5669,6 +5671,7 @@ jobs:
         run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-spark-install" >> "$GITHUB_ENV"
 
       - name: Authenticate to Docker Hub
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: docker.io
@@ -5711,8 +5714,10 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+          if [[ -n "${DOCKER_CONFIG:-}" && "${DOCKER_CONFIG}" == "${RUNNER_TEMP}/docker-config-spark-install" ]]; then
+            docker logout docker.io || true
+            rm -rf -- "${DOCKER_CONFIG}"
+          fi
 
   # ── PR result comment (mirrors nightly-e2e.yaml's report-to-pr) ───────────
   # Posts a results table on the open PR for the dispatching branch (or the

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -2250,6 +2250,8 @@ jobs:
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',gpu-e2e,'))
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
+    # A cold runner may spend up to 40 minutes pulling the 35B model;
+    # 15 minutes remain for install/assertions and 5 minutes for cleanup.
     timeout-minutes: 60
     env:
       NEMOCLAW_NON_INTERACTIVE: "1"

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -407,7 +407,15 @@ jobs:
       github_token: true
     secrets: *nightly-e2e-default-secrets
   openclaw-tui-chat-correlation-e2e:
+    # Keep this strict hosted-correlation probe out of the peak inference burst.
+    # Selective dispatches skip unselected dependencies, so always() preserves
+    # targeted execution while the full gate waits for the longest hosted jobs.
+    needs:
+      - token-rotation-e2e
+      - channels-stop-start-openclaw-e2e
+      - channels-stop-start-hermes-e2e
     if: >-
+      always() &&
       github.repository == 'NVIDIA/NemoClaw' &&
       (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
@@ -2242,13 +2250,14 @@ jobs:
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',gpu-e2e,'))
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_SANDBOX_NAME: "e2e-gpu-ollama"
       NEMOCLAW_RECREATE_SANDBOX: "1"
       NEMOCLAW_PROVIDER: "ollama"
+      NEMOCLAW_OLLAMA_PULL_TIMEOUT: "2400"
     steps:
       - *target-ref-checkout
 

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -409,7 +409,7 @@ jobs:
   openclaw-tui-chat-correlation-e2e:
     # Keep this strict hosted-correlation probe out of the peak inference burst.
     # Selective dispatches skip unselected dependencies, so always() preserves
-    # targeted execution while the full gate waits for the longest hosted jobs.
+    # targeted execution while the full gate waits for the peak hosted jobs.
     needs:
       - token-rotation-e2e
       - channels-stop-start-openclaw-e2e

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -17,7 +17,7 @@ const vitestWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(
 );
 
 describe("release gate workflow resource contracts", () => {
-  it("runs the strict hosted TUI correlation probe after the longest hosted jobs", () => {
+  it("runs the strict hosted TUI correlation probe after peak hosted lifecycle jobs", () => {
     const job = nightlyWorkflow.jobs["openclaw-tui-chat-correlation-e2e"];
     const dependencies = [
       "token-rotation-e2e",
@@ -60,6 +60,7 @@ describe("release gate workflow resource contracts", () => {
     );
     expect(auth?.uses).toBe("docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee");
     expect(auth?.if).toBe("github.ref == 'refs/heads/main'");
+    expect(auth?.["continue-on-error"]).toBe(true);
     expect(auth?.with).toMatchObject({
       registry: "docker.io",
       username: "${{ secrets.DOCKERHUB_USERNAME }}",

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -19,12 +19,14 @@ const vitestWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(
 describe("release gate workflow resource contracts", () => {
   it("runs the strict hosted TUI correlation probe after the longest hosted jobs", () => {
     const job = nightlyWorkflow.jobs["openclaw-tui-chat-correlation-e2e"];
-
-    expect(job.needs).toEqual([
+    const dependencies = [
       "token-rotation-e2e",
       "channels-stop-start-openclaw-e2e",
       "channels-stop-start-hermes-e2e",
-    ]);
+    ];
+
+    expect(job.needs).toEqual(dependencies);
+    for (const dependency of dependencies) expect(nightlyWorkflow.jobs).toHaveProperty(dependency);
     expect(job.if).toContain("always()");
     expect(job.if).toContain(",openclaw-tui-chat-correlation-e2e,");
   });
@@ -57,6 +59,7 @@ describe("release gate workflow resource contracts", () => {
       'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-spark-install" >> "$GITHUB_ENV"',
     );
     expect(auth?.uses).toBe("docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee");
+    expect(auth?.if).toBe("github.ref == 'refs/heads/main'");
     expect(auth?.with).toMatchObject({
       registry: "docker.io",
       username: "${{ secrets.DOCKERHUB_USERNAME }}",
@@ -71,7 +74,10 @@ describe("release gate workflow resource contracts", () => {
       stepIndex("Run Spark install live test"),
     );
     expect(cleanup?.if).toBe("always()");
+    expect(cleanup?.run).toContain(
+      '"${DOCKER_CONFIG}" == "${RUNNER_TEMP}/docker-config-spark-install"',
+    );
     expect(cleanup?.run).toContain("docker logout docker.io || true");
-    expect(cleanup?.run).toContain('rm -rf "${DOCKER_CONFIG}"');
+    expect(cleanup?.run).toContain('rm -rf -- "${DOCKER_CONFIG}"');
   });
 });

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  loadE2eWorkflowContract,
+  readYaml,
+  type WorkflowJob,
+} from "./helpers/e2e-workflow-contract";
+
+const { nightlyWorkflow } = loadE2eWorkflowContract();
+const vitestWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(
+  ".github/workflows/e2e-vitest-scenarios.yaml",
+);
+
+describe("release gate workflow resource contracts", () => {
+  it("runs the strict hosted TUI correlation probe after the longest hosted jobs", () => {
+    const job = nightlyWorkflow.jobs["openclaw-tui-chat-correlation-e2e"];
+
+    expect(job.needs).toEqual([
+      "token-rotation-e2e",
+      "channels-stop-start-openclaw-e2e",
+      "channels-stop-start-hermes-e2e",
+    ]);
+    expect(job.if).toContain("always()");
+    expect(job.if).toContain(",openclaw-tui-chat-correlation-e2e,");
+  });
+
+  it("budgets cold Ollama pulls in both retained and Vitest GPU lanes", () => {
+    const nightlyJob = nightlyWorkflow.jobs["gpu-e2e"];
+    const vitestJob = vitestWorkflow.jobs["gpu-e2e-vitest"];
+    const liveTest = readFileSync(
+      new URL("./e2e-scenario/live/gpu-e2e.test.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(nightlyJob["timeout-minutes"]).toBe(60);
+    expect(nightlyJob.env?.NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("2400");
+    expect(vitestJob["timeout-minutes"]).toBe(90);
+    expect(vitestJob.env?.NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("2400");
+    expect(liveTest).toContain("timeoutMs: 55 * 60_000");
+  });
+
+  it("authenticates Spark image pulls with an isolated Docker config", () => {
+    const steps = vitestWorkflow.jobs["spark-install-vitest"].steps ?? [];
+    const stepIndex = (name: string) => steps.findIndex((step) => step.name === name);
+    const configure = steps.find(
+      (step) => step.name === "Configure isolated Docker auth directory",
+    );
+    const auth = steps.find((step) => step.name === "Authenticate to Docker Hub");
+    const cleanup = steps.find((step) => step.name === "Clean up Docker auth");
+
+    expect(configure?.run).toBe(
+      'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-spark-install" >> "$GITHUB_ENV"',
+    );
+    expect(auth?.uses).toBe("docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee");
+    expect(auth?.with).toMatchObject({
+      registry: "docker.io",
+      username: "${{ secrets.DOCKERHUB_USERNAME }}",
+      password: "${{ secrets.DOCKERHUB_TOKEN }}",
+    });
+    expect(auth?.env).toBeUndefined();
+    expect(auth?.run).toBeUndefined();
+    expect(stepIndex("Configure isolated Docker auth directory")).toBeLessThan(
+      stepIndex("Authenticate to Docker Hub"),
+    );
+    expect(stepIndex("Authenticate to Docker Hub")).toBeLessThan(
+      stepIndex("Run Spark install live test"),
+    );
+    expect(cleanup?.if).toBe("always()");
+    expect(cleanup?.run).toContain("docker logout docker.io || true");
+    expect(cleanup?.run).toContain('rm -rf "${DOCKER_CONFIG}"');
+  });
+});

--- a/test/e2e-scenario/fixtures/availability-env.ts
+++ b/test/e2e-scenario/fixtures/availability-env.ts
@@ -11,14 +11,15 @@ const AVAILABILITY_PROBE_EXTRA_ENV_KEYS = [
   "DOCKER_CERT_PATH",
   "DOCKER_API_VERSION",
   "XDG_RUNTIME_DIR",
+  "NEMOCLAW_OLLAMA_PULL_TIMEOUT",
 ];
 
 export function buildAvailabilityProbeEnv(
   base: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
   // Availability probes run outside live scenario phases, but they need
-  // the same child-env and PATH policy. Add only Docker
-  // discovery knobs on top of the shared fixture boundary.
+  // the same child-env and PATH policy. Add Docker discovery knobs and the
+  // workflow-owned local-model pull budget on top of the shared boundary.
   return buildChildEnv(base, {
     additionalAllowedEnv: AVAILABILITY_PROBE_EXTRA_ENV_KEYS,
     fixtureOverlay: {},

--- a/test/e2e-scenario/live/gpu-e2e-helpers.ts
+++ b/test/e2e-scenario/live/gpu-e2e-helpers.ts
@@ -16,11 +16,7 @@ export const CLI = path.join(REPO_ROOT, "bin", "nemoclaw.js");
 export const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-gpu-ollama";
 validateSandboxName(SANDBOX_NAME);
 export const PROXY_PORT = tcpPort(process.env.NEMOCLAW_OLLAMA_PROXY_PORT, "11435");
-export const DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS = "2400";
-
-export function resolveOllamaPullTimeoutSeconds(value: string | undefined): string {
-  return value?.trim() || DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS;
-}
+const DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS = "2400";
 
 function tcpPort(value: string | undefined, fallback: string): string {
   const raw = value ?? fallback;
@@ -30,15 +26,17 @@ function tcpPort(value: string | undefined, fallback: string): string {
   return raw;
 }
 
-export function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+export function env(
+  extra: NodeJS.ProcessEnv = {},
+  base: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   return {
-    ...buildAvailabilityProbeEnv(),
+    ...buildAvailabilityProbeEnv(base),
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROVIDER: "ollama",
-    NEMOCLAW_OLLAMA_PULL_TIMEOUT: resolveOllamaPullTimeoutSeconds(
-      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT,
-    ),
+    NEMOCLAW_OLLAMA_PULL_TIMEOUT:
+      base.NEMOCLAW_OLLAMA_PULL_TIMEOUT?.trim() || DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
     NEMOCLAW_OLLAMA_PROXY_PORT: PROXY_PORT,
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,

--- a/test/e2e-scenario/live/gpu-e2e-helpers.ts
+++ b/test/e2e-scenario/live/gpu-e2e-helpers.ts
@@ -16,7 +16,6 @@ export const CLI = path.join(REPO_ROOT, "bin", "nemoclaw.js");
 export const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-gpu-ollama";
 validateSandboxName(SANDBOX_NAME);
 export const PROXY_PORT = tcpPort(process.env.NEMOCLAW_OLLAMA_PROXY_PORT, "11435");
-const DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS = "2400";
 
 function tcpPort(value: string | undefined, fallback: string): string {
   const raw = value ?? fallback;
@@ -35,8 +34,6 @@ export function env(
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROVIDER: "ollama",
-    NEMOCLAW_OLLAMA_PULL_TIMEOUT:
-      base.NEMOCLAW_OLLAMA_PULL_TIMEOUT?.trim() || DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
     NEMOCLAW_OLLAMA_PROXY_PORT: PROXY_PORT,
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,

--- a/test/e2e-scenario/live/gpu-e2e-helpers.ts
+++ b/test/e2e-scenario/live/gpu-e2e-helpers.ts
@@ -16,6 +16,7 @@ export const CLI = path.join(REPO_ROOT, "bin", "nemoclaw.js");
 export const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-gpu-ollama";
 validateSandboxName(SANDBOX_NAME);
 export const PROXY_PORT = tcpPort(process.env.NEMOCLAW_OLLAMA_PROXY_PORT, "11435");
+export const DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS = "2400";
 
 function tcpPort(value: string | undefined, fallback: string): string {
   const raw = value ?? fallback;
@@ -31,6 +32,8 @@ export function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROVIDER: "ollama",
+    NEMOCLAW_OLLAMA_PULL_TIMEOUT:
+      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT?.trim() || DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
     NEMOCLAW_OLLAMA_PROXY_PORT: PROXY_PORT,
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,

--- a/test/e2e-scenario/live/gpu-e2e-helpers.ts
+++ b/test/e2e-scenario/live/gpu-e2e-helpers.ts
@@ -18,6 +18,10 @@ validateSandboxName(SANDBOX_NAME);
 export const PROXY_PORT = tcpPort(process.env.NEMOCLAW_OLLAMA_PROXY_PORT, "11435");
 export const DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS = "2400";
 
+export function resolveOllamaPullTimeoutSeconds(value: string | undefined): string {
+  return value?.trim() || DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS;
+}
+
 function tcpPort(value: string | undefined, fallback: string): string {
   const raw = value ?? fallback;
   if (!/^[1-9][0-9]*$/u.test(raw)) throw new Error(`invalid TCP port: ${raw}`);
@@ -32,8 +36,9 @@ export function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
     NEMOCLAW_NON_INTERACTIVE: "1",
     NEMOCLAW_PROVIDER: "ollama",
-    NEMOCLAW_OLLAMA_PULL_TIMEOUT:
-      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT?.trim() || DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
+    NEMOCLAW_OLLAMA_PULL_TIMEOUT: resolveOllamaPullTimeoutSeconds(
+      process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT,
+    ),
     NEMOCLAW_OLLAMA_PROXY_PORT: PROXY_PORT,
     NEMOCLAW_RECREATE_SANDBOX: "1",
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,

--- a/test/e2e-scenario/live/gpu-e2e.test.ts
+++ b/test/e2e-scenario/live/gpu-e2e.test.ts
@@ -132,7 +132,7 @@ test.skipIf(!shouldRunLiveE2EScenarios())(
       artifactName: "install-gpu-ollama",
       cwd: REPO_ROOT,
       env: env(),
-      timeoutMs: 45 * 60_000,
+      timeoutMs: 55 * 60_000,
     });
     expect(install.exitCode, resultText(install)).toBe(0);
     await artifacts.writeText("install-gpu-ollama.log", resultText(install));

--- a/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
@@ -3,19 +3,19 @@
 
 import { describe, expect, it } from "vitest";
 
-import {
-  DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
-  resolveOllamaPullTimeoutSeconds,
-} from "../live/gpu-e2e-helpers.ts";
+import { env } from "../live/gpu-e2e-helpers.ts";
 
 describe("GPU E2E helpers", () => {
   it("gives cold Ollama model pulls a 40 minute wall-clock budget", () => {
-    expect(DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS).toBe("2400");
-    expect(resolveOllamaPullTimeoutSeconds(undefined)).toBe("2400");
-    expect(resolveOllamaPullTimeoutSeconds(" ")).toBe("2400");
+    expect(env({}, {}).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("2400");
+    expect(env({}, { NEMOCLAW_OLLAMA_PULL_TIMEOUT: " " }).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe(
+      "2400",
+    );
   });
 
   it("preserves an explicit Ollama model pull timeout override", () => {
-    expect(resolveOllamaPullTimeoutSeconds("3600")).toBe("3600");
+    expect(env({}, { NEMOCLAW_OLLAMA_PULL_TIMEOUT: "3600" }).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe(
+      "3600",
+    );
   });
 });

--- a/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
@@ -6,16 +6,13 @@ import { describe, expect, it } from "vitest";
 import { env } from "../live/gpu-e2e-helpers.ts";
 
 describe("GPU E2E helpers", () => {
-  it("gives cold Ollama model pulls a 40 minute wall-clock budget", () => {
-    expect(env({}, {}).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("2400");
-    expect(env({}, { NEMOCLAW_OLLAMA_PULL_TIMEOUT: " " }).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe(
+  it("forwards the workflow-owned Ollama model pull timeout", () => {
+    expect(env({}, { NEMOCLAW_OLLAMA_PULL_TIMEOUT: "2400" }).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe(
       "2400",
     );
   });
 
-  it("preserves an explicit Ollama model pull timeout override", () => {
-    expect(env({}, { NEMOCLAW_OLLAMA_PULL_TIMEOUT: "3600" }).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe(
-      "3600",
-    );
+  it("does not synthesize an Ollama model pull timeout outside workflow configuration", () => {
+    expect(env({}, {}).NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBeUndefined();
   });
 });

--- a/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS, env } from "../live/gpu-e2e-helpers.ts";
+
+const ORIGINAL_PULL_TIMEOUT = process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
+
+afterEach(() => {
+  if (ORIGINAL_PULL_TIMEOUT === undefined) {
+    delete process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
+  } else {
+    process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = ORIGINAL_PULL_TIMEOUT;
+  }
+});
+
+describe("GPU E2E helpers", () => {
+  it("gives cold Ollama model pulls a 40 minute wall-clock budget", () => {
+    delete process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
+
+    expect(DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS).toBe("2400");
+    expect(env().NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("2400");
+  });
+
+  it("preserves an explicit Ollama model pull timeout override", () => {
+    process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = "3600";
+
+    expect(env().NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("3600");
+  });
+});

--- a/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
+++ b/test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts
@@ -1,31 +1,21 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS, env } from "../live/gpu-e2e-helpers.ts";
-
-const ORIGINAL_PULL_TIMEOUT = process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
-
-afterEach(() => {
-  if (ORIGINAL_PULL_TIMEOUT === undefined) {
-    delete process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
-  } else {
-    process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = ORIGINAL_PULL_TIMEOUT;
-  }
-});
+import {
+  DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS,
+  resolveOllamaPullTimeoutSeconds,
+} from "../live/gpu-e2e-helpers.ts";
 
 describe("GPU E2E helpers", () => {
   it("gives cold Ollama model pulls a 40 minute wall-clock budget", () => {
-    delete process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT;
-
     expect(DEFAULT_OLLAMA_PULL_TIMEOUT_SECONDS).toBe("2400");
-    expect(env().NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("2400");
+    expect(resolveOllamaPullTimeoutSeconds(undefined)).toBe("2400");
+    expect(resolveOllamaPullTimeoutSeconds(" ")).toBe("2400");
   });
 
   it("preserves an explicit Ollama model pull timeout override", () => {
-    process.env.NEMOCLAW_OLLAMA_PULL_TIMEOUT = "3600";
-
-    expect(env().NEMOCLAW_OLLAMA_PULL_TIMEOUT).toBe("3600");
+    expect(resolveOllamaPullTimeoutSeconds("3600")).toBe("3600");
   });
 });

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -9,6 +9,8 @@ import YAML from "yaml";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 export type WorkflowJob = {
+  if?: string;
+  needs?: string | string[];
   "runs-on"?: string;
   "timeout-minutes"?: number;
   uses?: string;

--- a/test/helpers/e2e-workflow-contract.ts
+++ b/test/helpers/e2e-workflow-contract.ts
@@ -25,6 +25,7 @@ export type WorkflowJob = {
 };
 
 export type WorkflowStep = {
+  "continue-on-error"?: boolean;
   id?: string;
   name?: string;
   if?: string;

--- a/test/package-contract/inference-selection-validation.test.ts
+++ b/test/package-contract/inference-selection-validation.test.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it } from "vitest";
 
-const REPO_ROOT = path.join(import.meta.dirname, "../../..");
+const REPO_ROOT = path.join(import.meta.dirname, "../..");
 
 describe("inference selection validation", () => {
   it("preserves non-zero exit signaling when non-interactive endpoint validation fails (#5721)", () => {


### PR DESCRIPTION
## Summary

Stabilize the full Nightly and live Vitest release gates without weakening their assertions. The strict hosted TUI correlation probe now runs after the longest hosted lifecycle lanes, Spark authenticates its Docker image pulls, and cold GPU model pulls receive an explicit 40-minute budget.

## Changes

- serialize the strict TUI correlation lane behind the three longest hosted lifecycle jobs while preserving selective dispatch via `always()`
- authenticate Spark Docker Hub pulls with a pinned action, isolated `DOCKER_CONFIG`, and unconditional cleanup
- give retained Nightly and live Vitest GPU lanes a 40-minute Ollama pull budget within larger job/test timeouts
- add focused workflow and helper contract coverage for all three release-gate fixes
- move the newly merged compiled-output validation test into the package-contract project so the current `origin/main` repository boundary gate passes
- sensitive-path review: hosted `NVIDIA_INFERENCE_API_KEY` and public `NVIDIA_API_KEY` boundaries are unchanged; Docker credentials are scoped to the pinned login action and an isolated config removed with `always()`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal CI/E2E harness behavior only; no user-facing product behavior changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Docker auth uses the repo-pinned action, isolated config, and unconditional cleanup; inference secret/provider boundaries remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted evidence:

- `npm test -- --run test/package-contract/inference-selection-validation.test.ts test/e2e-release-gate-workflow.test.ts test/e2e-scenario/support-tests/spark-install-workflow-boundary.test.ts test/e2e-scenario/support-tests/gpu-e2e-helpers.test.ts` — 8 tests passed
- earlier combined focused run before splitting the size-budget test file — 41 tests passed
- `npm run checks` — passed
- `npm run test-size:check` — passed
- `npm run typecheck:cli` — passed
- normal pre-commit and pre-push hooks — passed

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of end-to-end GPU workflows by increasing GPU job timeouts and extending the GPU Ollama installation command timeout.
  * Increased the Ollama pull budget by standardizing `NEMOCLAW_OLLAMA_PULL_TIMEOUT` and aligning it across nightly and GPU lanes (plus availability-probe env support).
  * Updated nightly hosted-correlation job scheduling to wait for prerequisite jobs, including safer conditional evaluation.

* **Tests**
  * Strengthened end-to-end workflow contract tests to validate `needs`/`if` rules, timeout and Ollama budget settings, and isolated Docker auth login/logout cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->