### PR TITLE
fix(e2e): serialize hosted agent proofs

### DIFF
--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -192,7 +192,16 @@ concurrency:
 # the workflow changes how individual jobs opt in to selective dispatch.
 jobs:
   cloud-e2e:
+    # The agent-mediated assertion is load-sensitive even when its direct and
+    # routed API probes are healthy. Run it after the peak hosted lifecycle
+    # lanes, while always() keeps selective cloud-e2e dispatches runnable when
+    # those unselected dependencies are skipped.
+    needs:
+      - token-rotation-e2e
+      - channels-stop-start-openclaw-e2e
+      - channels-stop-start-hermes-e2e
     if: >-
+      always() &&
       github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'workflow_dispatch' ||
        inputs.jobs == '' ||
        contains(format(',{0},', inputs.jobs), ',cloud-e2e,'))
@@ -414,6 +423,7 @@ jobs:
       - token-rotation-e2e
       - channels-stop-start-openclaw-e2e
       - channels-stop-start-hermes-e2e
+      - cloud-e2e
     if: >-
       always() &&
       github.repository == 'NVIDIA/NemoClaw' &&

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -26,13 +26,16 @@ describe("release gate workflow resource contracts", () => {
       "channels-stop-start-hermes-e2e",
     ];
 
-    expect(cloudJob.needs).toEqual(peakDependencies);
+    expect(cloudJob.needs).toEqual(expect.arrayContaining(peakDependencies));
+    expect(cloudJob.needs).toHaveLength(peakDependencies.length);
     expect(cloudJob.if).toContain("always()");
     expect(cloudJob.if).toContain(",cloud-e2e,");
-    expect(tuiJob.needs).toEqual([...peakDependencies, "cloud-e2e"]);
+    const tuiDependencies = [...peakDependencies, "cloud-e2e"];
+    expect(tuiJob.needs).toEqual(expect.arrayContaining(tuiDependencies));
+    expect(tuiJob.needs).toHaveLength(tuiDependencies.length);
     expect(tuiJob.if).toContain("always()");
     expect(tuiJob.if).toContain(",openclaw-tui-chat-correlation-e2e,");
-    for (const dependency of [...peakDependencies, "cloud-e2e"])
+    for (const dependency of tuiDependencies)
       expect(nightlyWorkflow.jobs).toHaveProperty(dependency);
   });
 

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -17,18 +17,23 @@ const vitestWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(
 );
 
 describe("release gate workflow resource contracts", () => {
-  it("runs the strict hosted TUI correlation probe after peak hosted lifecycle jobs", () => {
-    const job = nightlyWorkflow.jobs["openclaw-tui-chat-correlation-e2e"];
-    const dependencies = [
+  it("serializes hosted agent proofs after peak hosted lifecycle jobs", () => {
+    const cloudJob = nightlyWorkflow.jobs["cloud-e2e"];
+    const tuiJob = nightlyWorkflow.jobs["openclaw-tui-chat-correlation-e2e"];
+    const peakDependencies = [
       "token-rotation-e2e",
       "channels-stop-start-openclaw-e2e",
       "channels-stop-start-hermes-e2e",
     ];
 
-    expect(job.needs).toEqual(dependencies);
-    for (const dependency of dependencies) expect(nightlyWorkflow.jobs).toHaveProperty(dependency);
-    expect(job.if).toContain("always()");
-    expect(job.if).toContain(",openclaw-tui-chat-correlation-e2e,");
+    expect(cloudJob.needs).toEqual(peakDependencies);
+    expect(cloudJob.if).toContain("always()");
+    expect(cloudJob.if).toContain(",cloud-e2e,");
+    expect(tuiJob.needs).toEqual([...peakDependencies, "cloud-e2e"]);
+    expect(tuiJob.if).toContain("always()");
+    expect(tuiJob.if).toContain(",openclaw-tui-chat-correlation-e2e,");
+    for (const dependency of [...peakDependencies, "cloud-e2e"])
+      expect(nightlyWorkflow.jobs).toHaveProperty(dependency);
   });
 
   it("budgets cold Ollama pulls in both retained and Vitest GPU lanes", () => {


### PR DESCRIPTION
## Summary
Serialize the two load-sensitive hosted agent proofs in the full Nightly E2E gate. The cloud agent proof now waits for peak hosted lifecycle jobs, and the strict TUI proof then waits for the cloud proof, while selective dispatch remains supported.

## Changes
- Defer cloud-e2e until the three peak hosted lifecycle jobs finish.
- Defer openclaw-tui-chat-correlation-e2e until cloud-e2e also finishes.
- Preserve selective dispatch with always() guards and the existing job selector.
- Extend workflow contract coverage for both dependency chains and guard expressions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal release-gate workflow scheduling only; no user-facing behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: reviewed the workflow diff; it changes only job dependencies and guard expressions, with no secret, endpoint, model, or provider wiring changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as Verified in GitHub
- [x] Git hooks passed during commit and push, or npx prek run --from-ref main --to-ref HEAD passes
- [x] Targeted tests pass for changed behavior
- [ ] Full npm test passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted local verification:
- npx biome check test/e2e-release-gate-workflow.test.ts
- npm test -- --run test/e2e-release-gate-workflow.test.ts test/e2e-advisor-dispatch.test.ts test/validate-e2e-coverage.test.ts (32 tests passed)
- npm run typecheck:cli
- git diff --check

Runtime evidence on 4db5d5d7edeabcc387f33a849350c976771f2166:
- Full Nightly run 28316894368 completed with 67 successful jobs, 4 skipped jobs, and only cloud-e2e failing. Its direct hosted API and sandbox-routed inference probes passed; the OpenClaw-mediated turn alone returned an empty reply after its 90-second timeout at peak load. The newly deferred strict TUI proof passed in that same full run.
- Drained targeted cloud-e2e run 28317776042 passed on the identical main SHA.
- Targeted strict TUI run 28315707926 passed with the prior peak-job deferral.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated nightly E2E job ordering so the cloud validation lane runs after its required upstream checks, while remaining eligible under selective dispatch conditions.
  * Ensured the correlation E2E job waits for the cloud E2E lane before starting, reducing out-of-order execution risk.
* **Tests**
  * Strengthened workflow contract tests to validate the exact dependency chain, job-level execution conditions, and that referenced dependency jobs exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->