### PR TITLE
refactor(process): centralize spawn exit normalization

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import os from "node:os";
 import { resolveOpenshell } from "../../adapters/openshell/resolve";
 import {
   captureOpenshell,
@@ -17,6 +16,7 @@ import {
 import * as agentRuntime from "../../agent/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { D, G, R, YW } from "../../cli/terminal-style";
+import { spawnExitCode } from "../../core/process-exit";
 import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import {
   parseGatewayInference,
@@ -51,11 +51,11 @@ import {
 } from "./connect-autopair-budget";
 import { preflightVllmModelEnvOrExit } from "./connect-vllm-preflight";
 import { isDockerRuntimeDown, printDockerRuntimeDownGuidance } from "./gateway-failure-classifier";
-import { runTerminalAgentConnectProbe } from "./terminal-connect-probe";
 import { ensureLiveSandboxOrExit, printGatewayLifecycleHint } from "./gateway-state";
 import { getSandboxTargetGatewayName } from "./gateway-target";
 import { printGatewayWedgeDiagnostics } from "./gateway-wedge-diagnostics";
 import { checkAndRecoverSandboxProcesses, executeSandboxExecCommand } from "./process-recovery";
+import { runTerminalAgentConnectProbe } from "./terminal-connect-probe";
 import { applyOpenShellVmDnsMonkeypatch, shouldApplyVmDnsMonkeypatch } from "./vm-dns-monkeypatch";
 
 export type SandboxConnectOptions = {
@@ -829,19 +829,6 @@ function maybeEnsureHermesToolGatewayBroker(sb: SandboxEntry | null): void {
   }
 }
 
-function exitWithSpawnResult(result: SpawnLikeResult): void {
-  if (result.status !== null) {
-    process.exit(result.status);
-  }
-
-  if (result.signal) {
-    const signalNumber = os.constants.signals[result.signal];
-    process.exit(signalNumber ? 128 + signalNumber : 1);
-  }
-
-  process.exit(1);
-}
-
 function restoreInteractiveTerminal(): void {
   if (!process.stdin.isTTY) return;
 
@@ -875,7 +862,7 @@ function exitWithConnectSpawnResult(sandboxName: string, result: SpawnLikeResult
     console.error("");
     console.error(`  Gateway connection lost. Reconnect with: ${CLI_NAME} ${sandboxName} connect`);
   }
-  exitWithSpawnResult(result);
+  process.exit(spawnExitCode(result));
 }
 
 export async function connectSandbox(

--- a/src/lib/actions/sandbox/exec.test.ts
+++ b/src/lib/actions/sandbox/exec.test.ts
@@ -98,22 +98,6 @@ describe("computeExitCode", () => {
     expect(computeExitCode({ status: 42 })).toEqual({ code: 42 });
   });
 
-  it("translates a terminating signal into 128 + signal number", () => {
-    expect(computeExitCode({ status: null, signal: "SIGTERM" })).toEqual({ code: 128 + 15 });
-    expect(computeExitCode({ status: null, signal: "SIGKILL" })).toEqual({ code: 128 + 9 });
-  });
-
-  it("falls back to 1 when the signal is unknown to os.constants.signals", () => {
-    expect(computeExitCode({ status: null, signal: "SIGBOGUS" as NodeJS.Signals })).toEqual({
-      code: 1,
-    });
-  });
-
-  it("falls back to 1 when neither status nor signal is set", () => {
-    expect(computeExitCode({ status: null })).toEqual({ code: 1 });
-    expect(computeExitCode({ status: null, signal: null })).toEqual({ code: 1 });
-  });
-
   it("surfaces spawn transport errors with the error message and code 1", () => {
     const error = new Error("openshell: command not found");
     expect(computeExitCode({ status: null, error })).toEqual({

--- a/src/lib/actions/sandbox/exec.ts
+++ b/src/lib/actions/sandbox/exec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import os from "node:os";
+import { spawnExitCode } from "../../core/process-exit";
 
 export type SandboxExecOptions = {
   workdir?: string;
@@ -63,21 +63,7 @@ export function computeExitCode(result: SpawnLikeResult): {
   if (result.error) {
     return { code: 1, errorMessage: result.error.message };
   }
-  if (result.status !== null) return { code: result.status };
-  if (result.signal) {
-    const signalNumber = os.constants.signals[result.signal];
-    return { code: signalNumber ? 128 + signalNumber : 1 };
-  }
-  return { code: 1 };
-}
-
-function exitWithSpawnResult(result: SpawnLikeResult): never {
-  const { code, errorMessage } = computeExitCode(result);
-  if (errorMessage) {
-    console.error(`  Failed to invoke openshell: ${errorMessage}`);
-    console.error("  Ensure 'openshell' is installed and on PATH.");
-  }
-  process.exit(code);
+  return { code: spawnExitCode(result) };
 }
 
 const defaultWorkdirProbeRunner: WorkdirProbeRunner = (binary, args) => {
@@ -118,5 +104,10 @@ export async function execSandbox(
   const result = spawnSync(binary, buildOpenshellExecArgs(sandboxName, command, options), {
     stdio: "inherit",
   });
-  exitWithSpawnResult(result);
+  const { code, errorMessage } = computeExitCode(result);
+  if (errorMessage) {
+    console.error(`  Failed to invoke openshell: ${errorMessage}`);
+    console.error("  Ensure 'openshell' is installed and on PATH.");
+  }
+  process.exit(code);
 }

--- a/src/lib/actions/sandbox/logs.ts
+++ b/src/lib/actions/sandbox/logs.ts
@@ -4,13 +4,13 @@
 import { spawn } from "node:child_process";
 import { getOpenshellBinary, runOpenshell } from "../../adapters/openshell/runtime";
 import * as agentRuntime from "../../agent/runtime";
+import { spawnExitCode } from "../../core/process-exit";
 import type { SandboxLogsOptions } from "../../domain/sandbox/log-options";
 import {
   buildEnableSandboxAuditLogsArgs,
   buildSandboxLogsArgs,
   buildSandboxOpenclawGatewayLogsArgs,
   describeLogProbeResult,
-  exitCodeFromSignal,
   getLogsProbeTimeoutMs,
   type LogProbeResult,
   mergeTailLogLines,
@@ -35,15 +35,6 @@ export type SandboxLogsRuntimeDeps = {
   spawn?: SpawnFn;
   writeStdout?: (chunk: string) => void;
 };
-
-function exitWithSpawnResult(result: LogProbeResult, deps: SandboxLogsRuntimeDeps) {
-  const exit = deps.exit ?? process.exit;
-  if (result.status !== null) {
-    exit(result.status);
-  }
-
-  exit(exitCodeFromSignal(result.signal ?? null));
-}
 
 function runOpenclawGatewayLogs(
   sandboxName: string,
@@ -169,7 +160,7 @@ function streamSandboxFollowLogs(
     source.child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
       markSourceDone(
         source,
-        code ?? exitCodeFromSignal(signal),
+        spawnExitCode({ status: code, signal }),
         signal ? `signal ${signal}` : null,
       );
     });
@@ -271,5 +262,5 @@ export function showSandboxLogsWithDeps(
       `  Command failed (exit ${openshellResult.status}): openshell ${openshellArgs.join(" ")}`,
     );
   }
-  exitWithSpawnResult(openshellResult, deps);
+  (deps.exit ?? process.exit)(spawnExitCode(openshellResult));
 }

--- a/src/lib/core/process-exit.test.ts
+++ b/src/lib/core/process-exit.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { spawnExitCode } from "./process-exit";
+
+describe("spawnExitCode", () => {
+  it.each([
+    ["zero status", { status: 0 }, 0],
+    ["nonzero status", { status: 42 }, 42],
+    ["status before signal", { status: 7, signal: "SIGTERM" }, 7],
+    ["SIGTERM", { status: null, signal: "SIGTERM" }, 143],
+    ["SIGKILL", { status: null, signal: "SIGKILL" }, 137],
+    ["missing signal", { status: null }, 1],
+    ["null signal", { status: null, signal: null }, 1],
+    ["unknown signal", { status: null, signal: "SIGBOGUS" as NodeJS.Signals }, 1],
+  ] satisfies Array<
+    [string, Parameters<typeof spawnExitCode>[0], number]
+  >)("normalizes %s (#5936)", (_label, result, expected) => {
+    expect(spawnExitCode(result)).toBe(expected);
+  });
+});

--- a/src/lib/core/process-exit.ts
+++ b/src/lib/core/process-exit.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+
+export function spawnExitCode(result: {
+  status: number | null;
+  signal?: NodeJS.Signals | null;
+}): number {
+  if (result.status !== null) return result.status;
+  if (!result.signal) return 1;
+  const signalNumber = os.constants.signals[result.signal];
+  return signalNumber ? 128 + signalNumber : 1;
+}

--- a/src/lib/domain/sandbox/logs.test.ts
+++ b/src/lib/domain/sandbox/logs.test.ts
@@ -8,7 +8,6 @@ import {
   buildSandboxLogsArgs,
   buildSandboxOpenclawGatewayLogsArgs,
   describeLogProbeResult,
-  exitCodeFromSignal,
   getLogsProbeTimeoutMs,
   normalizeSandboxLogsOptions,
 } from "./logs";
@@ -74,11 +73,6 @@ describe("sandbox logs helpers", () => {
     expect(getLogsProbeTimeoutMs({ NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "0" })).toBe(5000);
     expect(getLogsProbeTimeoutMs({ NEMOCLAW_LOGS_PROBE_TIMEOUT_MS: "not-a-number" })).toBe(5000);
     expect(getLogsProbeTimeoutMs({})).toBe(5000);
-  });
-
-  it("maps signals to conventional process exit codes", () => {
-    expect(exitCodeFromSignal(null)).toBe(1);
-    expect(exitCodeFromSignal("SIGINT")).toBe(130);
   });
 });
 

--- a/src/lib/domain/sandbox/logs.ts
+++ b/src/lib/domain/sandbox/logs.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import os from "node:os";
-
 import type { SandboxLogsOptions } from "./log-options";
 import { DEFAULT_SANDBOX_LOG_LINES } from "./log-options";
 
@@ -37,12 +35,6 @@ export function describeLogProbeResult(result: LogProbeResult): string {
     return `signal ${result.signal}`;
   }
   return `exit ${result.status ?? "unknown"}`;
-}
-
-export function exitCodeFromSignal(signal: NodeJS.Signals | null): number {
-  if (!signal) return 1;
-  const signalNumber = os.constants.signals[signal];
-  return signalNumber ? 128 + signalNumber : 1;
 }
 
 export function normalizeSandboxLogsOptions(

--- a/src/lib/uninstall-command.test.ts
+++ b/src/lib/uninstall-command.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   buildVersionedUninstallUrl,
-  exitWithSpawnResult,
   resolveUninstallScript,
   runUninstallCommand,
 } from "./uninstall-command";
@@ -28,12 +27,6 @@ describe("uninstall command", () => {
   it("selects the first existing uninstall script", () => {
     const script = resolveUninstallScript(["/a", "/b"], (candidate) => candidate === "/b");
     expect(script).toBe("/b");
-  });
-
-  it("maps spawn signals to shell-style exit codes", () => {
-    expect(() => exitWithSpawnResult({ status: null, signal: "SIGTERM" }, exitWithCode)).toThrow(
-      "exit:143",
-    );
   });
 
   it("runs the local uninstall script when present", () => {

--- a/src/lib/uninstall-command.ts
+++ b/src/lib/uninstall-command.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import type { SpawnSyncOptions, SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnExitCode } from "./core/process-exit";
 
 export function buildVersionedUninstallUrl(version: string): string {
   const stableVersion = String(version || "")
@@ -24,22 +24,6 @@ export function resolveUninstallScript(
     }
   }
   return null;
-}
-
-export function exitWithSpawnResult(
-  result: Pick<SpawnSyncReturns<string>, "status" | "signal">,
-  exit: (code: number) => never = (code) => process.exit(code),
-): never {
-  if (result.status !== null) {
-    return exit(result.status);
-  }
-
-  if (result.signal) {
-    const signalNumber = os.constants.signals[result.signal];
-    return exit(signalNumber ? 128 + signalNumber : 1);
-  }
-
-  return exit(1);
 }
 
 export interface RunUninstallCommandDeps {
@@ -76,7 +60,7 @@ export function runUninstallCommand(deps: RunUninstallCommandDeps): never {
       cwd: deps.rootDir,
       env: deps.env,
     });
-    return exitWithSpawnResult(result, exit);
+    return exit(spawnExitCode(result));
   }
 
   error("  Local uninstall script not found.");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Centralizes Node child-process exit-code normalization in one leaf helper and migrates the uninstall, sandbox exec, connect, and logs paths to use it. The refactor removes 48 lines overall while preserving existing status, signal, error-reporting, and terminal-recovery behavior.

## Related Issue
Closes #5936

## Changes
- Add one `spawnExitCode` helper for numeric status, terminating signal, and fallback handling.
- Delete the four inline mappings, the old logs-domain helper, and single-use exit wrappers.
- Consolidate mapping coverage into one table-driven test while retaining consumer-specific tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal behavior-preserving refactor with no CLI, configuration, or documentation surface change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Behavior-preserving numeric exit mapping only; no subprocess arguments, spawning, policy, credential, or network behavior changed. Targeted exec, connect, logs, uninstall, and helper tests pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app translates command/process terminations into exit codes across sandbox connect, exec, logs, and uninstall flows.
  * Log probing now falls back to a sensible default timeout when no valid setting is provided.
  * Uninstall and sandbox commands now handle process exits more consistently in failure and disconnect scenarios.

* **Tests**
  * Updated and added coverage for exit-code handling and log timeout defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->