### PR TITLE
refactor(connect): project registry inference once

### DIFF
--- a/src/lib/actions/sandbox/connect-route-repair.test.ts
+++ b/src/lib/actions/sandbox/connect-route-repair.test.ts
@@ -298,7 +298,7 @@ function makeResetDeps(
       calls.probeOptions.push(options);
       return queue.shift() ?? broken("missing mocked reset probe");
     }),
-    printUnrecoverableInferenceRoute: vi.fn((sandboxName, _sb, detail) => {
+    printUnrecoverableInferenceRoute: vi.fn((sandboxName, _route, detail) => {
       calls.unrecoverable.push({ sandboxName, detail });
     }),
     log: (message) => calls.logs.push(message),

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -403,8 +403,9 @@ function reapplyVmInferenceRoute(
   sandboxName: string,
   sb: SandboxEntry | null,
 ): SandboxInferenceRouteProbe | null {
-  if (!sb?.provider || !sb.model) return null;
-  runOpenshell(buildInferenceSetArgs(sb.provider, sb.model), {
+  const inference = sb ? registry.getSandboxEntryInference(sb) : null;
+  if (inference?.kind !== "configured") return null;
+  runOpenshell(buildInferenceSetArgs(inference.provider, inference.model), {
     ignoreError: true,
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
@@ -627,44 +628,28 @@ export function resetManagedInferenceRouteWithDeps(
   deps: ManagedInferenceRouteResetDeps,
 ): boolean {
   const log = deps.log ?? console.log;
-  const error = deps.error ?? console.error;
-  if (!sb.provider || !sb.model) return false;
-
-  if (!deps.verifyLocalInferenceRouteDependencies(sb.provider, { quiet })) {
+  const inference = registry.getSandboxEntryInference(sb);
+  if (inference.kind !== "configured") return false;
+  const { provider, model } = inference;
+  const fail = (failureDetail: string, message?: string): false => {
     if (!quiet) {
-      deps.printUnrecoverableInferenceRoute(sandboxName, sb, detail);
+      if (message) (deps.error ?? console.error)(message);
+      deps.printUnrecoverableInferenceRoute(sandboxName, sb, failureDetail);
     }
     return false;
+  };
+
+  if (!deps.verifyLocalInferenceRouteDependencies(provider, { quiet })) {
+    return fail(detail);
   }
 
   if (!quiet) {
-    log(`  Resetting inference route to ${sb.provider}/${sb.model}.`);
+    log(`  Resetting inference route to ${provider}/${model}.`);
   }
-  const resetResult = deps.runInferenceSet(sb.provider, sb.model);
-  if (resetResult.status !== 0) {
-    const finalProbe = deps.probe(sandboxName, {
-      attempts: INFERENCE_ROUTE_POST_REPAIR_PROBE_ATTEMPTS,
-      delayMs: INFERENCE_ROUTE_POST_REPAIR_PROBE_DELAY_MS,
-    });
-    if (finalProbe.healthy) {
-      if (!quiet) {
-        log("  inference.local route repaired.");
-      }
-      return true;
-    }
-
-    if (!quiet) {
-      error("  Error: failed to reset the OpenShell inference route.");
-      deps.printUnrecoverableInferenceRoute(sandboxName, sb, finalProbe.detail || detail);
-    }
-    return false;
-  }
-
-  if (!deps.verifyLocalInferenceRouteDependencies(sb.provider, { quiet })) {
-    if (!quiet) {
-      deps.printUnrecoverableInferenceRoute(sandboxName, sb, detail);
-    }
-    return false;
+  const resetResult = deps.runInferenceSet(provider, model);
+  const resetFailed = resetResult.status !== 0;
+  if (!resetFailed && !deps.verifyLocalInferenceRouteDependencies(provider, { quiet })) {
+    return fail(detail);
   }
 
   const finalProbe = deps.probe(sandboxName, {
@@ -678,10 +663,10 @@ export function resetManagedInferenceRouteWithDeps(
     return true;
   }
 
-  if (!quiet) {
-    deps.printUnrecoverableInferenceRoute(sandboxName, sb, finalProbe.detail);
-  }
-  return false;
+  return fail(
+    resetFailed ? finalProbe.detail || detail : finalProbe.detail,
+    resetFailed ? "  Error: failed to reset the OpenShell inference route." : undefined,
+  );
 }
 
 function resetManagedInferenceRoute(
@@ -711,71 +696,72 @@ function ensureSandboxInferenceRoute(
   { quiet = false }: { quiet?: boolean } = {},
 ): SandboxInferenceRouteEnsureResult {
   let sb: SandboxEntry | null = null;
+  let inference: ReturnType<typeof registry.getSandboxEntryInference> | null = null;
   try {
     sb = registry.getSandbox(sandboxName);
-    if (sb && sb.provider && sb.model) {
-      const live = parseGatewayInference(
-        captureOpenshell(["inference", "get"], {
-          ignoreError: true,
-          timeout: OPENSHELL_PROBE_TIMEOUT_MS,
-        }).output,
-      );
-      const plan = planInferenceRouteReconcile(live, { provider: sb.provider, model: sb.model });
-      if (plan.kind !== "aligned") {
-        if (plan.kind === "diverged") {
-          // Shared gateway: re-point loudly (even when quiet) — silent revert was
-          // #3726. Values sanitized: registry/gateway strings are untrusted.
-          const liveProvider = sanitizeRouteValueForDisplay(plan.live.provider);
-          const liveModel = sanitizeRouteValueForDisplay(plan.live.model);
-          const recordedRoute = `${sanitizeRouteValueForDisplay(sb.provider)}/${sanitizeRouteValueForDisplay(sb.model)}`;
-          console.error(
-            `  ${YW}Warning: gateway inference route (${liveProvider}/${liveModel}) ` +
-              `differs from the recorded route for sandbox '${sandboxName}' (${recordedRoute}).${R}`,
-          );
-          console.error(
-            `  ${YW}Aligning the gateway to ${recordedRoute}. To keep ` +
-              `${liveProvider}/${liveModel}, set it the supported way:${R}`,
-          );
-          console.error(
-            `    ${CLI_NAME} inference set --provider ${liveProvider} --model ${liveModel} --sandbox ${sandboxName}`,
-          );
-        } else if (!quiet) {
-          // plan.kind === "repair": empty gateway, genuine repair — quiet-aware.
-          console.log(
-            `  Setting inference route to ${sb.provider}/${sb.model} for sandbox '${sandboxName}'`,
-          );
-        }
-        const swapResult = runOpenshell(buildInferenceSetArgs(sb.provider, sb.model), {
-          ignoreError: true,
-          timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
-        });
-        if (swapResult.status !== 0 && (plan.kind === "diverged" || !quiet)) {
-          console.error(
-            `  ${YW}Warning: failed to switch inference route — connect will proceed anyway.${R}`,
-          );
-        }
+    if (!sb) return { sandbox: null, routeHealthy: null };
+    inference = registry.getSandboxEntryInference(sb);
+    if (inference.kind !== "configured") return { sandbox: sb, routeHealthy: null };
+    const { provider, model } = inference;
+    const live = parseGatewayInference(
+      captureOpenshell(["inference", "get"], {
+        ignoreError: true,
+        timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+      }).output,
+    );
+    const plan = planInferenceRouteReconcile(live, { provider, model });
+    if (plan.kind !== "aligned") {
+      if (plan.kind === "diverged") {
+        // Shared gateway: re-point loudly (even when quiet) — silent revert was
+        // #3726. Values sanitized: registry/gateway strings are untrusted.
+        const liveProvider = sanitizeRouteValueForDisplay(plan.live.provider);
+        const liveModel = sanitizeRouteValueForDisplay(plan.live.model);
+        const recordedRoute = `${sanitizeRouteValueForDisplay(provider)}/${sanitizeRouteValueForDisplay(model)}`;
+        console.error(
+          `  ${YW}Warning: gateway inference route (${liveProvider}/${liveModel}) ` +
+            `differs from the recorded route for sandbox '${sandboxName}' (${recordedRoute}).${R}`,
+        );
+        console.error(
+          `  ${YW}Aligning the gateway to ${recordedRoute}. To keep ` +
+            `${liveProvider}/${liveModel}, set it the supported way:${R}`,
+        );
+        console.error(
+          `    ${CLI_NAME} inference set --provider ${liveProvider} --model ${liveModel} --sandbox ${sandboxName}`,
+        );
+      } else if (!quiet) {
+        // plan.kind === "repair": empty gateway, genuine repair — quiet-aware.
+        console.log(
+          `  Setting inference route to ${provider}/${model} for sandbox '${sandboxName}'`,
+        );
       }
-      const repairResult = repairSandboxInferenceRouteIfNeeded(sandboxName, sb, { quiet });
-      if (!repairResult.healthy && repairResult.repairAttempted) {
-        const resetResult = resetManagedInferenceRoute(sandboxName, sb, {
-          detail: repairResult.detail,
-          quiet,
-        });
-        return { sandbox: sb, routeHealthy: resetResult };
+      const swapResult = runOpenshell(buildInferenceSetArgs(provider, model), {
+        ignoreError: true,
+        timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+      });
+      if (swapResult.status !== 0 && (plan.kind === "diverged" || !quiet)) {
+        console.error(
+          `  ${YW}Warning: failed to switch inference route — connect will proceed anyway.${R}`,
+        );
       }
-      return { sandbox: sb, routeHealthy: repairResult.healthy };
     }
+    const repairResult = repairSandboxInferenceRouteIfNeeded(sandboxName, sb, { quiet });
+    if (!repairResult.healthy && repairResult.repairAttempted) {
+      const resetResult = resetManagedInferenceRoute(sandboxName, sb, {
+        detail: repairResult.detail,
+        quiet,
+      });
+      return { sandbox: sb, routeHealthy: resetResult };
+    }
+    return { sandbox: sb, routeHealthy: repairResult.healthy };
   } catch (error) {
-    if (sb?.provider && sb.model) {
-      const detail = error instanceof Error && error.message ? error.message : String(error);
-      if (!quiet) {
-        console.error(`  Error: failed to verify or repair inference route: ${detail}`);
-        printUnrecoverableInferenceRoute(sandboxName, sb, detail);
-      }
-      return { sandbox: sb, routeHealthy: false };
+    if (!sb || inference?.kind !== "configured") return { sandbox: sb, routeHealthy: null };
+    const detail = error instanceof Error && error.message ? error.message : String(error);
+    if (!quiet) {
+      console.error(`  Error: failed to verify or repair inference route: ${detail}`);
+      printUnrecoverableInferenceRoute(sandboxName, sb, detail);
     }
+    return { sandbox: sb, routeHealthy: false };
   }
-  return { sandbox: sb, routeHealthy: null };
 }
 
 function ensureSandboxInferenceRouteOrExit(

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -642,7 +642,7 @@ export function resetManagedInferenceRouteWithDeps(
     return fail(detail);
   }
 
-  if (!quiet) log(`  Resetting inference route to ${provider}/${model}.`);
+  if (!quiet) log(`  Resetting inference route to ${route}.`);
   const resetResult = deps.runInferenceSet(provider, model);
   const resetFailed = resetResult.status !== 0;
   if (!resetFailed && !deps.verifyLocalInferenceRouteDependencies(provider, { quiet })) {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -695,6 +695,7 @@ function ensureSandboxInferenceRoute(
   try {
     sb = registry.getSandbox(sandboxName);
     if (!sb) return { sandbox: null, routeHealthy: null };
+    // This projection is total; the catch below handles only later gateway and repair failures.
     inference = registry.getSandboxEntryInference(sb);
     if (inference.kind !== "configured") return { sandbox: sb, routeHealthy: null };
     const { provider, model } = inference;

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -706,12 +706,12 @@ function ensureSandboxInferenceRoute(
     );
     const plan = planInferenceRouteReconcile(live, { provider, model });
     if (plan.kind !== "aligned") {
+      const recordedRoute = `${sanitizeRouteValueForDisplay(provider)}/${sanitizeRouteValueForDisplay(model)}`;
       if (plan.kind === "diverged") {
         // Shared gateway: re-point loudly (even when quiet) — silent revert was
         // #3726. Values sanitized: registry/gateway strings are untrusted.
         const liveProvider = sanitizeRouteValueForDisplay(plan.live.provider);
         const liveModel = sanitizeRouteValueForDisplay(plan.live.model);
-        const recordedRoute = `${sanitizeRouteValueForDisplay(provider)}/${sanitizeRouteValueForDisplay(model)}`;
         console.error(
           `  ${YW}Warning: gateway inference route (${liveProvider}/${liveModel}) ` +
             `differs from the recorded route for sandbox '${sandboxName}' (${recordedRoute}).${R}`,
@@ -725,9 +725,7 @@ function ensureSandboxInferenceRoute(
         );
       } else if (!quiet) {
         // plan.kind === "repair": empty gateway, genuine repair — quiet-aware.
-        console.log(
-          `  Setting inference route to ${provider}/${model} for sandbox '${sandboxName}'`,
-        );
+        console.log(`  Setting inference route to ${recordedRoute} for sandbox '${sandboxName}'`);
       }
       const swapResult = runOpenshell(buildInferenceSetArgs(provider, model), {
         ignoreError: true,

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -121,7 +121,7 @@ export type ManagedInferenceRouteResetDeps = {
   ) => boolean;
   runInferenceSet: (provider: string, model: string) => { status: number | null };
   probe: (sandboxName: string, options?: InferenceRouteProbeOptions) => SandboxInferenceRouteProbe;
-  printUnrecoverableInferenceRoute: (sandboxName: string, sb: SandboxEntry, detail: string) => void;
+  printUnrecoverableInferenceRoute: (sandboxName: string, route: string, detail: string) => void;
   log?: (message: string) => void;
   error?: (message: string) => void;
 };
@@ -607,16 +607,14 @@ function verifyLocalInferenceRouteDependencies(
 
 function printUnrecoverableInferenceRoute(
   sandboxName: string,
-  sb: SandboxEntry,
+  route: string,
   detail: string,
 ): void {
   console.error(
     `  Error: inference.local is still unavailable inside '${sandboxName}' after DNS and route repair.`,
   );
-  console.error(`  Route: ${sb.provider}/${sb.model}`);
-  if (detail) {
-    console.error(`  Last probe: ${detail}`);
-  }
+  console.error(`  Route: ${route}`);
+  if (detail) console.error(`  Last probe: ${detail}`);
   console.error(`  Run:  ${CLI_NAME} ${sandboxName} doctor`);
   console.error("  Connect is stopping because the sandbox inference route is known to be broken.");
 }
@@ -631,10 +629,11 @@ export function resetManagedInferenceRouteWithDeps(
   const inference = registry.getSandboxEntryInference(sb);
   if (inference.kind !== "configured") return false;
   const { provider, model } = inference;
+  const route = `${sanitizeRouteValueForDisplay(provider)}/${sanitizeRouteValueForDisplay(model)}`;
   const fail = (failureDetail: string, message?: string): false => {
     if (!quiet) {
       if (message) (deps.error ?? console.error)(message);
-      deps.printUnrecoverableInferenceRoute(sandboxName, sb, failureDetail);
+      deps.printUnrecoverableInferenceRoute(sandboxName, route, failureDetail);
     }
     return false;
   };
@@ -643,9 +642,7 @@ export function resetManagedInferenceRouteWithDeps(
     return fail(detail);
   }
 
-  if (!quiet) {
-    log(`  Resetting inference route to ${provider}/${model}.`);
-  }
+  if (!quiet) log(`  Resetting inference route to ${provider}/${model}.`);
   const resetResult = deps.runInferenceSet(provider, model);
   const resetFailed = resetResult.status !== 0;
   if (!resetFailed && !deps.verifyLocalInferenceRouteDependencies(provider, { quiet })) {
@@ -657,9 +654,7 @@ export function resetManagedInferenceRouteWithDeps(
     delayMs: INFERENCE_ROUTE_POST_REPAIR_PROBE_DELAY_MS,
   });
   if (finalProbe.healthy) {
-    if (!quiet) {
-      log("  inference.local route repaired.");
-    }
+    if (!quiet) log("  inference.local route repaired.");
     return true;
   }
 
@@ -758,7 +753,11 @@ function ensureSandboxInferenceRoute(
     const detail = error instanceof Error && error.message ? error.message : String(error);
     if (!quiet) {
       console.error(`  Error: failed to verify or repair inference route: ${detail}`);
-      printUnrecoverableInferenceRoute(sandboxName, sb, detail);
+      printUnrecoverableInferenceRoute(
+        sandboxName,
+        `${sanitizeRouteValueForDisplay(inference.provider)}/${sanitizeRouteValueForDisplay(inference.model)}`,
+        detail,
+      );
     }
     return { sandbox: sb, routeHealthy: false };
   }

--- a/test/sandbox-connect-inference/helpers.ts
+++ b/test/sandbox-connect-inference/helpers.ts
@@ -93,6 +93,7 @@ function initStateFile(stateFile: string, options: SetupFixtureOptions) {
       curlEnvs: [],
       inferenceProbeExitStatuses: options.inferenceProbeExitStatuses ?? [],
       inferenceProbeResponses: options.inferenceProbeResponses ?? ["OK 200"],
+      inferenceGetCalls: [],
       inferenceSetCalls: [],
       sandboxConnectCalls: [],
       sandboxExecCalls: [],
@@ -198,6 +199,8 @@ if (args[0] === "sandbox" && args[1] === "connect") {
 }
 
 if (args[0] === "inference" && args[1] === "get") {
+  state.inferenceGetCalls.push(args.slice(2));
+  fs.writeFileSync(stateFile, JSON.stringify(state));
   process.stdout.write(${JSON.stringify(inferenceBlock.replace(/\\n/g, "\n"))});
   process.exit(0);
 }

--- a/test/sandbox-connect-inference/route-swap-repair.test.ts
+++ b/test/sandbox-connect-inference/route-swap-repair.test.ts
@@ -64,6 +64,7 @@ describe("sandbox connect inference route swap (#1248)", () => {
       expect(result.status).toBe(0);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      expect(state.inferenceGetCalls).toEqual([[]]);
       expect(state.inferenceSetCalls.length).toBe(1);
       expect(state.inferenceSetCalls[0]).toEqual([
         "--provider",
@@ -114,13 +115,21 @@ describe("sandbox connect inference route swap (#1248)", () => {
     },
   );
 
-  it(
-    "does not swap inference route for legacy sandbox without provider",
+  it.each([
+    ["null", null, null],
+    ["provider-only", "nvidia-prod", null],
+    ["model-only", null, "nvidia/test"],
+    ["blank-provider", "   ", "nvidia/test"],
+    ["blank-model", "nvidia-prod", "   "],
+  ])(
+    "skips inference reconciliation for %s registry entries (#5937)",
     testTimeoutOptions(20_000),
-    () => {
+    (_description, provider, model) => {
       const { tmpDir, stateFile, sandboxName } = setupFixture(
         {
           name: "legacy-sandbox",
+          provider,
+          model,
           gpuEnabled: false,
           policies: [],
         },
@@ -132,7 +141,8 @@ describe("sandbox connect inference route swap (#1248)", () => {
       expect(result.status).toBe(0);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
-      expect(state.inferenceSetCalls.length).toBe(0);
+      expect(state.inferenceGetCalls).toEqual([]);
+      expect(state.inferenceSetCalls).toEqual([]);
     },
   );
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Projects sandbox registry inference once at each connect recovery boundary, then uses the configured provider/model pair for route reapply, reset, reconciliation, and terminal-safe display. Production code is 16 lines smaller and the complete tested slice is 3 lines smaller overall.

## Related Issue
Closes #5937

## Changes
- Use `getSandboxEntryInference()` instead of repeated nullable provider/model guards in connect recovery.
- Flatten route reconciliation around an early configured/unconfigured boundary.
- Combine duplicate post-reset probing and failure reporting without changing status-dependent behavior.
- Reuse one terminal-sanitized display route across reconcile, reset, and unrecoverable diagnostics.
- Cover configured, null, partial, and whitespace-only entries at the real CLI command boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal behavior-preserving refactor with no CLI, configuration, or user-facing change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Raw projected route values remain argv-only while display values are sanitized; 124 targeted unit and integration tests cover configured, null, partial, blank, reset, local-provider, VM, and sanitizer paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
