### PR TITLE
refactor(messaging): keep channel collections non-null

### DIFF
--- a/src/lib/onboard/channel-state.ts
+++ b/src/lib/onboard/channel-state.ts
@@ -20,11 +20,11 @@ export function resolveDisabledChannels(
 ): string[] {
   const envPlan = (deps?.readMessagingPlanFromEnv ?? readMessagingPlanFromEnv)();
   if (envPlan?.sandboxName === sandboxName) {
-    return getDisabledChannelsFromPlan(envPlan) ?? [];
+    return getDisabledChannelsFromPlan(envPlan);
   }
   const session = (deps?.loadSession ?? onboardSession.loadSession)();
   if (session?.sandboxName === sandboxName && session.messagingPlan) {
-    return getDisabledChannelsFromPlan(session.messagingPlan) ?? [];
+    return getDisabledChannelsFromPlan(session.messagingPlan);
   }
   return (deps?.getRegistryDisabledChannels ?? registry.getDisabledChannels)(sandboxName);
 }

--- a/src/lib/onboard/machine/events.ts
+++ b/src/lib/onboard/machine/events.ts
@@ -129,7 +129,7 @@ export function buildOnboardMachineContext(session: Session): OnboardMachineCont
     hermesAuthMethod: hermesAuthMethod(session.hermesAuthMethod),
     hermesToolGateways: stringArray(session.hermesToolGateways),
     policyPresets: stringArray(session.policyPresets),
-    messagingChannels: getActiveChannelsFromPlan(session.messagingPlan) ?? [],
+    messagingChannels: getActiveChannelsFromPlan(session.messagingPlan),
     gpuPassthrough: booleanValue(session.gpuPassthrough),
   };
 }

--- a/src/lib/onboard/machine/final-flow-phases.test.ts
+++ b/src/lib/onboard/machine/final-flow-phases.test.ts
@@ -29,7 +29,7 @@ describe("final onboard flow phases", () => {
 
     const result = await policiesPhase.run(context({ selectedMessagingChannels: ["slack"] }));
 
-    expect(mergePolicyMessagingChannels).toHaveBeenCalledWith(["slack"], [], null, null);
+    expect(mergePolicyMessagingChannels).toHaveBeenCalledWith(["slack"], [], [], []);
     expect(result.context.selectedMessagingChannels).toEqual(["slack", "discord"]);
   });
 

--- a/src/lib/onboard/machine/handlers/policies.test.ts
+++ b/src/lib/onboard/machine/handlers/policies.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createSession, type Session, type SessionUpdates } from "../../../state/onboard-session";
+import { mergePolicyMessagingChannels } from "../../messaging-policy-presets";
 import { handlePoliciesState, type PoliciesStateOptions } from "./policies";
 
 type Agent = { name: string } | null;
@@ -50,10 +51,7 @@ function createDeps(overrides: Partial<PoliciesStateOptions<Agent, WebSearchConf
     activeSandbox: vi.fn(() => ({
       messaging: { plan: makeMessagingPlan("my-assistant", ["telegram"]) },
     })),
-    mergeChannels: vi.fn(
-      (selected: string[], recorded: string[], active: string[] | null | undefined) =>
-        selected.length > 0 ? selected : (active ?? recorded),
-    ),
+    mergeChannels: vi.fn(mergePolicyMessagingChannels),
     smoke: vi.fn(),
     prepareResume: vi.fn(
       (

--- a/src/lib/onboard/machine/handlers/policies.ts
+++ b/src/lib/onboard/machine/handlers/policies.ts
@@ -137,7 +137,7 @@ export async function handlePoliciesState<Agent, WebSearchConfig>({
   const recordedPolicyPresets = Array.isArray(latestSession?.policyPresets)
     ? latestSession.policyPresets
     : null;
-  const recordedMessagingChannels = getActiveChannelsFromPlan(latestSession?.messagingPlan) ?? [];
+  const recordedMessagingChannels = getActiveChannelsFromPlan(latestSession?.messagingPlan);
   const activeSandbox = deps.getActiveSandbox(sandboxName);
   const activePlan = activeSandbox?.messaging?.plan;
   const activeMessagingChannels = getActiveChannelsFromPlan(activePlan);

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -150,7 +150,7 @@ function selectionFromReusablePlan<Agent>(
   if (writeToEnv || refreshed.changed || filtered !== refreshed.plan) deps.writePlanToEnv(filtered);
   return {
     plan: filtered,
-    selectedChannels: getActiveChannelsFromPlan(filtered) ?? [],
+    selectedChannels: getActiveChannelsFromPlan(filtered),
   };
 }
 
@@ -176,7 +176,7 @@ async function selectionFromMessagingSetup<Agent>(
   options.deps.writePlanToEnv(filtered);
   return {
     plan: filtered,
-    selectedChannels: getActiveChannelsFromPlan(filtered) ?? [],
+    selectedChannels: getActiveChannelsFromPlan(filtered),
   };
 }
 
@@ -206,7 +206,7 @@ function channelsForRegistryPlanRefresh(
   agent: unknown,
 ): string[] | null {
   const activeChannels = filterChannelNamesForCurrentAgent(
-    getActiveChannelsFromPlan(registryPlan) ?? [],
+    getActiveChannelsFromPlan(registryPlan),
     agent,
   );
   if (activeChannels.length > 0) return null;
@@ -245,7 +245,7 @@ export function reconcileReusedSandboxMessaging<Agent>(
   if (filtered !== plan) deps.clearPlanEnv();
   return {
     plan: filtered,
-    selectedChannels: getActiveChannelsFromPlan(filtered) ?? [],
+    selectedChannels: getActiveChannelsFromPlan(filtered),
     changed: filtered !== plan,
   };
 }

--- a/src/lib/onboard/messaging-plan-session.ts
+++ b/src/lib/onboard/messaging-plan-session.ts
@@ -2,36 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SandboxMessagingPlan } from "../messaging/manifest";
-import {
-  getActiveChannelIdsFromPlan,
-  getConfiguredChannelIdsFromPlan,
-  getDisabledChannelIdsFromPlan,
+import { getConfiguredChannelIdsFromPlan } from "../messaging/plan-validation";
+
+export {
+  getActiveChannelIdsFromPlan as getActiveChannelsFromPlan,
+  getDisabledChannelIdsFromPlan as getDisabledChannelsFromPlan,
   getMessagingChannelConfigFromPlan,
   parseSandboxMessagingPlan,
 } from "../messaging/plan-validation";
-
-export { getMessagingChannelConfigFromPlan, parseSandboxMessagingPlan };
 
 /** Derive configured channel IDs from a plan. */
 export function getChannelsFromPlan(
   plan: SandboxMessagingPlan | null | undefined,
 ): string[] | null {
   const channels = getConfiguredChannelIdsFromPlan(plan);
-  return channels.length > 0 ? channels : null;
-}
-
-/** Derive active channels from a plan, excluding stopped/disabled channels. */
-export function getActiveChannelsFromPlan(
-  plan: SandboxMessagingPlan | null | undefined,
-): string[] | null {
-  const channels = getActiveChannelIdsFromPlan(plan);
-  return channels.length > 0 ? channels : null;
-}
-
-/** Derive disabled channel IDs from a plan. */
-export function getDisabledChannelsFromPlan(
-  plan: SandboxMessagingPlan | null | undefined,
-): string[] | null {
-  const channels = getDisabledChannelIdsFromPlan(plan);
   return channels.length > 0 ? channels : null;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make active and disabled messaging channel derivations consistently return arrays, then remove redundant null-to-empty fallbacks at their callers. The slice is behavior-preserving and removes 19 net lines, including a duplicated test-only merger.

## Related Issue

Closes #5944.

## Changes

- Re-export the canonical non-null active and disabled channel derivation helpers.
- Remove redundant `?? []` fallbacks from onboarding and sandbox messaging callers.
- Update final-flow expectations from nullable collections to empty arrays.
- Replace a handwritten test merger with the production merge helper.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: messaging-plan, channel-state, policy, final-flow, and sandbox-messaging tests cover empty, active, disabled, recorded, and reused-plan behavior.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this normalizes an internal derived collection contract without changing user-visible behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the canonical plan-validation helpers retain their existing filtering semantics; only their nullable wrapper and redundant caller fallbacks are removed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification performed:

- `npx vitest run --project cli src/lib/onboard/channel-state.test.ts src/lib/onboard/machine/final-flow-phases.test.ts src/lib/onboard/machine/final-flow-phases.runtime.test.ts src/lib/onboard/machine/handlers/policies.test.ts src/lib/onboard/machine/handlers/sandbox-messaging.test.ts` (30 tests)
- Full pre-commit CLI test hook
- `npm run typecheck:cli`
- Pre-push CLI TypeScript and package/tag consistency hooks

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how messaging channels are carried through onboarding so the app now uses the plan’s actual channel data more consistently.
  * Removed several cases where channel lists were automatically replaced with empty arrays, reducing mismatches in messaging setup and final onboarding flow.
  * Updated related checks so sandbox messaging and policy-driven channel selection stay aligned with the latest session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->