### PR TITLE
fix(windows): handle unavailable WSL runtime in windows bootstrap script

### DIFF
--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -91,6 +91,7 @@ wsl --install --no-distribution
 ```
 
 This enables both the Windows Subsystem for Linux and Virtual Machine Platform features.
+If the command returns `Forbidden (403)` or the online WSL installer is blocked, use the [Windows Subsystem for Linux troubleshooting section](../../reference/troubleshooting#windows-subsystem-for-linux) for manual WSL installation links.
 
 Reboot if prompted.
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1446,6 +1446,25 @@ For environment setup steps, refer to [Windows Prerequisites](../get-started/pre
 
 Check your network connectivity.
 If you are behind a VPN, try reconnecting or switching to a different network.
+If your network or Windows image blocks the online WSL installer, install WSL manually with Microsoft's [offline install guidance](https://learn.microsoft.com/en-us/windows/wsl/install#offline-install).
+Download the latest official WSL `.msi` package from the [Microsoft WSL releases page](https://github.com/microsoft/WSL/releases/latest), choose the matching `.x64.msi` or `.arm64.msi`, install it, reboot if Windows requests it, then rerun `wsl --status`.
+
+### Bootstrap says "Windows Subsystem for Linux is not fully installed"
+
+The bootstrap script checks `wsl --status` before it installs or opens Ubuntu.
+If Windows reports that the WSL runtime is not installed, the script attempts `wsl --install --no-distribution` automatically.
+If the repair command succeeds, reboot when prompted and let the bootstrap resume after sign-in.
+If the repair command fails, follow the printed repair steps.
+If the repair command returns `Forbidden (403)` or remains blocked, install WSL manually with Microsoft's [offline install guidance](https://learn.microsoft.com/en-us/windows/wsl/install#offline-install).
+Download the latest official WSL `.msi` package from the [Microsoft WSL releases page](https://github.com/microsoft/WSL/releases/latest), choose the matching `.x64.msi` or `.arm64.msi`, install it, reboot if Windows requests it, then rerun the bootstrap script.
+Use the same repair flow if the bootstrap says "Windows Subsystem for Linux could not be verified" and reports a nonzero `wsl --status` exit code.
+
+### Bootstrap says "Windows reports that WSL 2 cannot start yet"
+
+The bootstrap script attempts `wsl --install --no-distribution` automatically when `wsl --status` reports that WSL 2 cannot start.
+If the repair command succeeds, reboot when prompted and let the bootstrap resume after sign-in.
+If the message persists after repair and reboot, enable virtualization in firmware and confirm that the Virtual Machine Platform optional component is enabled.
+Manual WSL installation only helps when the WSL runtime is missing or the online installer is blocked.
 
 ### `wsl -d Ubuntu` says "There is no distribution with the supplied name"
 

--- a/scripts/bootstrap-windows.ps1
+++ b/scripts/bootstrap-windows.ps1
@@ -63,6 +63,8 @@ $script:DockerCli = 'C:\Program Files\Docker\Docker\resources\bin\docker.exe'
 $script:WingetDockerId = 'Docker.DockerDesktop'
 $script:InstallerWindowTitle = "NVIDIA NemoClaw Installer ($PID)"
 $script:InstallDistroAtHandoff = $false
+$script:WslOfflineInstallDocsUrl = 'https://learn.microsoft.com/en-us/windows/wsl/install#offline-install'
+$script:WslLatestReleaseUrl = 'https://github.com/microsoft/WSL/releases/latest'
 
 function Write-Status {
     param(
@@ -398,6 +400,22 @@ function Write-NativeOutput {
     }
 }
 
+function Write-CompactNativeOutput {
+    param([AllowNull()] $Value)
+    if ($null -eq $Value) {
+        return
+    }
+
+    $text = [string]$Value
+    $normalized = $text -replace "`r`n", "`n" -replace "`r", "`n"
+    foreach ($line in ($normalized -split "`n")) {
+        $display = ([string]$line).Replace([string][char]0, '').TrimEnd()
+        if ($display.Trim().Length -gt 0) {
+            Write-Host $display
+        }
+    }
+}
+
 function Invoke-NativeCommandOutput {
     param(
         [Parameter(Mandatory)] [string]$FilePath,
@@ -591,11 +609,15 @@ function Register-ResumeRunOnce {
     if (-not (Test-Path -LiteralPath $script:RunOnceKey)) {
         New-Item -Path $script:RunOnceKey -Force | Out-Null
     }
-    $argumentLine = (Get-ScriptInvocationArguments -ResumeRun | ForEach-Object { ConvertTo-ProcessArgument -Value $_ }) -join ' '
-    $cmd = "powershell.exe $argumentLine"
+    $cmd = Get-ManualResumeCommand
     New-ItemProperty -Path $script:RunOnceKey -Name $script:RunOnceValueName `
         -Value "!$cmd" -PropertyType String -Force | Out-Null
-    Write-Status "Registered reboot resume command."
+    Write-Status "Registered best-effort reboot resume command."
+}
+
+function Get-ManualResumeCommand {
+    $argumentLine = (Get-ScriptInvocationArguments -ResumeRun | ForEach-Object { ConvertTo-ProcessArgument -Value $_ }) -join ' '
+    return "powershell.exe $argumentLine"
 }
 
 function Unregister-ResumeRunOnce {
@@ -611,7 +633,16 @@ function Unregister-ResumeRunOnce {
 
 function Request-Reboot {
     Register-ResumeRunOnce
+    $manualResumeCommand = Get-ManualResumeCommand
     Write-Status -Level WARN 'A reboot is required to finish enabling WSL 2.'
+    Write-Host ''
+    Write-Host 'This bootstrap may resume automatically the next time you sign in.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host 'After reboot/sign-in, if no bootstrap window opens, rerun this command from an elevated PowerShell window:' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host "  $manualResumeCommand" -ForegroundColor White
+    Write-Host ''
+
     if ($AutoReboot) {
         Write-Status -Level WARN 'AutoReboot specified; restarting in 10 seconds. Save your work.'
         Start-Sleep -Seconds 10
@@ -620,7 +651,7 @@ function Request-Reboot {
     }
 
     Write-Host ''
-    Write-Host 'Please reboot now. This bootstrap will resume automatically the next time you sign in.' -ForegroundColor Yellow
+    Write-Host 'Please reboot now.' -ForegroundColor Yellow
     Write-Host ''
     $answer = Read-Host 'Reboot now? [Y/n]'
     if ([string]::IsNullOrWhiteSpace($answer) -or $answer.Trim().ToLowerInvariant().StartsWith('y')) {
@@ -663,6 +694,178 @@ function Enable-WslFeatures {
         Request-Reboot
     }
 
+}
+
+function Test-WslStatusReportsMissingRuntime {
+    param([AllowNull()] [string]$Output)
+
+    if (-not $Output) {
+        return $false
+    }
+    return $Output -match 'Windows Subsystem for Linux is not installed'
+}
+
+function Test-WslStatusReportsStartupBlocked {
+    param([AllowNull()] [string]$Output)
+
+    if (-not $Output) {
+        return $false
+    }
+    return ($Output -match 'WSL2 is unable to start since virtualization is not enabled') -or
+        (($Output -match 'Virtual Machine Platform') -and ($Output -match 'enablevirtualization'))
+}
+
+function Write-WslManualInstallGuidance {
+    Write-Host 'Manual WSL install links:' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host "  Offline install docs: $script:WslOfflineInstallDocsUrl" -ForegroundColor Yellow
+    Write-Host "  Latest WSL release:  $script:WslLatestReleaseUrl" -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host 'Download the matching .x64.msi or .arm64.msi, install it, reboot if required, then rerun this script.' -ForegroundColor Yellow
+}
+
+function Write-WslStartupBlockedNotice {
+    Write-Host ''
+    Write-Host 'Windows reports that WSL 2 cannot start yet.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host 'This script will try to repair the required WSL components automatically.' -ForegroundColor Yellow
+    Write-Host 'If this persists after repair and reboot, enable virtualization in firmware and confirm Virtual Machine Platform is enabled.' -ForegroundColor Yellow
+}
+
+function Write-WslStatusUnavailableNotice {
+    param([Parameter(Mandatory)] [int]$ExitCode)
+
+    Write-Host ''
+    Write-Host 'Windows Subsystem for Linux could not be verified.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host "The command 'wsl --status' exited with code $ExitCode, so this script cannot safely install or run the $DistroName WSL distro yet." -ForegroundColor Yellow
+    Write-Host 'This script will try to repair the required WSL components automatically.' -ForegroundColor Yellow
+}
+
+function Test-WslRepairOutputReportsForbidden {
+    param([AllowNull()] [string]$Output)
+
+    if (-not $Output) {
+        return $false
+    }
+    return $Output -match 'Forbidden\s*\(403\)'
+}
+
+function Test-WslRepairOutputRequiresReboot {
+    param([AllowNull()] [string]$Output)
+
+    if (-not $Output) {
+        return $false
+    }
+    return $Output -match 'Changes will not be effective until the system is rebooted'
+}
+
+function Write-WslRepairInstructions {
+    param(
+        [Parameter(Mandatory)] [int]$ExitCode,
+        [AllowNull()] [string]$Output
+    )
+
+    Write-Host ''
+    Write-Host 'Automatic WSL repair did not complete.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host "The command 'wsl --install --no-distribution' exited with code $ExitCode." -ForegroundColor Yellow
+    if (Test-WslRepairOutputReportsForbidden -Output $Output) {
+        Write-Host 'The online WSL installer returned Forbidden (403), so this machine may require the manual/offline WSL install path.' -ForegroundColor Yellow
+    }
+    Write-Host ''
+    Write-Host 'Repair WSL, then rerun this script:' -ForegroundColor Yellow
+    Write-Host '  1. Check VPN, proxy, firewall, or Windows image policy that may block the online WSL installer.' -ForegroundColor Yellow
+    Write-Host '  2. Run: wsl --install --no-distribution' -ForegroundColor Yellow
+    Write-Host '  3. Reboot if Windows requests it.' -ForegroundColor Yellow
+    Write-Host '  4. If the online installer returns Forbidden (403) or remains blocked, install WSL manually.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-WslManualInstallGuidance
+    Write-Host ''
+}
+
+function Write-WslRepairDidNotVerifyInstructions {
+    param(
+        [Parameter(Mandatory)] [int]$StatusExitCode,
+        [AllowNull()] [string]$StatusOutput
+    )
+
+    Write-Host ''
+    Write-Host 'Automatic WSL repair completed, but WSL still could not be verified.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-Host "After repair, 'wsl --status' exited with code $StatusExitCode." -ForegroundColor Yellow
+    if (-not [string]::IsNullOrWhiteSpace($StatusOutput)) {
+        Write-Host ''
+        Write-Host 'wsl --status output:' -ForegroundColor Yellow
+        Write-CompactNativeOutput -Value $StatusOutput
+    }
+    Write-Host ''
+    Write-Host 'Repair WSL, then rerun this script:' -ForegroundColor Yellow
+    Write-Host '  1. Reboot if Windows requested it.' -ForegroundColor Yellow
+    Write-Host '  2. Run: wsl --status' -ForegroundColor Yellow
+    Write-Host '  3. If WSL remains unavailable, run: wsl --install --no-distribution' -ForegroundColor Yellow
+    Write-Host '  4. If the online installer returns Forbidden (403) or remains blocked, install WSL manually.' -ForegroundColor Yellow
+    Write-Host ''
+    Write-WslManualInstallGuidance
+    Write-Host ''
+}
+
+function Invoke-WslNoDistributionInstallRepair {
+    $wsl = Resolve-WslExe
+    Write-Host ''
+    Write-Host "Attempting WSL repair: wsl --install --no-distribution" -ForegroundColor Yellow
+    Write-Host ''
+    $repairResult = Invoke-NativeCommandOutput -FilePath $wsl -ArgumentList @('--install', '--no-distribution') -MergeError
+    Write-CompactNativeOutput -Value $repairResult.Output
+
+    if ($repairResult.ExitCode -eq 0) {
+        Write-Status 'WSL repair command completed successfully.'
+        if (Test-WslRepairOutputRequiresReboot -Output $repairResult.Output) {
+            Request-Reboot
+            return
+        }
+
+        $statusResult = Invoke-NativeCommandOutput -FilePath $wsl -ArgumentList @('--status') -MergeError
+        $statusOutput = [string]$statusResult.Output
+        if (
+            $statusResult.ExitCode -eq 0 -and
+            -not (Test-WslStatusReportsMissingRuntime -Output $statusOutput) -and
+            -not (Test-WslStatusReportsStartupBlocked -Output $statusOutput)
+        ) {
+            Write-Status 'WSL status verified after repair.'
+            return
+        }
+
+        Write-WslRepairDidNotVerifyInstructions -StatusExitCode $statusResult.ExitCode -StatusOutput $statusResult.Output
+        throw "wsl --install --no-distribution completed, but 'wsl --status' still exited with code $($statusResult.ExitCode). Repair WSL, then rerun this script."
+    }
+
+    Write-WslRepairInstructions -ExitCode $repairResult.ExitCode -Output $repairResult.Output
+    throw "wsl --install --no-distribution failed with exit code $($repairResult.ExitCode). Repair WSL, then rerun this script."
+}
+
+function Assert-WslRuntimeAvailable {
+    $wsl = Resolve-WslExe
+    $result = Invoke-NativeCommandOutput -FilePath $wsl -ArgumentList @('--status') -MergeError
+    $statusOutput = [string]$result.Output
+
+    if (Test-WslStatusReportsMissingRuntime -Output $statusOutput) {
+        Write-WslSubsystemMissingNotice -Name $DistroName
+        Invoke-WslNoDistributionInstallRepair
+        return
+    }
+
+    if (Test-WslStatusReportsStartupBlocked -Output $statusOutput) {
+        Write-WslStartupBlockedNotice
+        Invoke-WslNoDistributionInstallRepair
+        return
+    }
+
+    if ($result.ExitCode -ne 0) {
+        Write-WslStatusUnavailableNotice -ExitCode $result.ExitCode
+        Invoke-WslNoDistributionInstallRepair
+        return
+    }
 }
 
 function Get-WslDistros {
@@ -745,23 +948,6 @@ function Get-WslInstallCommandText {
     return "wsl --install -d $Name"
 }
 
-function Wait-WslDistroRegistration {
-    param(
-        [Parameter(Mandatory)] [string]$Name,
-        [int]$TimeoutSeconds = 300
-    )
-
-    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
-    while ((Get-Date) -lt $deadline) {
-        if ((Get-WslDistros) -contains $Name) {
-            return $true
-        }
-        Start-Sleep -Seconds 5
-    }
-
-    return $false
-}
-
 function Get-WslDistroRegistryProperties {
     param([Parameter(Mandatory)] [string]$Name)
 
@@ -822,7 +1008,29 @@ function Start-WslInstallInPowerShellWindow {
     param([Parameter(Mandatory)] [string]$Name)
 
     $wsl = Resolve-WslExe
-    $installCommand = '& {0} --install -d {1}' -f (ConvertTo-PowerShellLiteral -Value $wsl), (ConvertTo-PowerShellLiteral -Value $Name)
+    $statusPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('nemoclaw-wsl-install-{0}-{1}.status' -f $PID, [guid]::NewGuid().ToString('N'))
+    $logPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ('nemoclaw-wsl-install-{0}-{1}.log' -f $PID, [guid]::NewGuid().ToString('N'))
+    $failurePrefix = "wsl --install -d $Name failed with exit code "
+    $successMessage = "Ubuntu installer command exited. This window will close automatically."
+    $installCommand = @(
+        '$ErrorActionPreference = ''Continue'''
+        ('$statusPath = {0}' -f (ConvertTo-PowerShellLiteral -Value $statusPath))
+        ('$logPath = {0}' -f (ConvertTo-PowerShellLiteral -Value $logPath))
+        '$transcriptStarted = $false'
+        'try { Start-Transcript -Path $logPath -Force | Out-Null; $transcriptStarted = $true } catch { }'
+        ('& {0} --install -d {1}' -f (ConvertTo-PowerShellLiteral -Value $wsl), (ConvertTo-PowerShellLiteral -Value $Name))
+        '$wslExitCode = if ($null -ne $LASTEXITCODE) { [int]$LASTEXITCODE } else { 0 }'
+        "Write-Host ''"
+        'if ($wslExitCode -ne 0) {'
+        ('    Write-Host ({0} + $wslExitCode) -ForegroundColor Red' -f (ConvertTo-PowerShellLiteral -Value $failurePrefix))
+        '    Write-Host ''Resolve the error above, then rerun the NemoClaw Windows bootstrap.'' -ForegroundColor Yellow'
+        '} else {'
+        ('    Write-Host {0} -ForegroundColor Cyan' -f (ConvertTo-PowerShellLiteral -Value $successMessage))
+        '}'
+        'if ($transcriptStarted) { try { Stop-Transcript | Out-Null } catch { } }'
+        'try { [System.IO.File]::WriteAllText($statusPath, [string]$wslExitCode) } catch { }'
+        'if ($wslExitCode -ne 0) { exit $wslExitCode }'
+    ) -join "`n"
     $installArguments = @(
         '-NoLogo',
         '-NoProfile',
@@ -833,7 +1041,116 @@ function Start-WslInstallInPowerShellWindow {
     )
     $installArgumentLine = ($installArguments | ForEach-Object { ConvertTo-ProcessArgument -Value $_ }) -join ' '
 
-    Start-Process -FilePath 'powershell.exe' -ArgumentList $installArgumentLine | Out-Null
+    $process = Start-Process -FilePath 'powershell.exe' -ArgumentList $installArgumentLine -PassThru
+    $processId = $null
+    if ($process) {
+        $idProperty = $process.PSObject.Properties['Id']
+        if ($null -ne $idProperty -and $null -ne $idProperty.Value) {
+            $processId = [int]$idProperty.Value
+        }
+    }
+
+    return [pscustomobject]@{
+        StatusPath = $statusPath
+        LogPath = $logPath
+        ProcessId = $processId
+    }
+}
+
+function Get-WslInstallExitCode {
+    param([AllowNull()] [string]$StatusPath)
+
+    if ([string]::IsNullOrWhiteSpace($StatusPath)) {
+        return $null
+    }
+
+    try {
+        if (-not (Test-Path -LiteralPath $StatusPath)) {
+            return $null
+        }
+        $rawStatus = (Get-Content -LiteralPath $StatusPath -Raw).Trim()
+        if ([string]::IsNullOrWhiteSpace($rawStatus)) {
+            return $null
+        }
+        return [int]$rawStatus
+    } catch {
+        Write-Status -Level WARN "Could not read WSL install status file: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Wait-WslDistroRegistrationOrInstallExit {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [AllowNull()] [string]$StatusPath,
+        [int]$TimeoutSeconds = 300
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if ((Get-WslDistros) -contains $Name) {
+            return [pscustomobject]@{
+                Registered = $true
+                ExitCode = Get-WslInstallExitCode -StatusPath $StatusPath
+            }
+        }
+
+        $exitCode = Get-WslInstallExitCode -StatusPath $StatusPath
+        if ($null -ne $exitCode) {
+            return [pscustomobject]@{
+                Registered = (Get-WslDistros) -contains $Name
+                ExitCode = $exitCode
+            }
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    $finalExitCode = Get-WslInstallExitCode -StatusPath $StatusPath
+    return [pscustomobject]@{
+        Registered = (Get-WslDistros) -contains $Name
+        ExitCode = $finalExitCode
+    }
+}
+
+function Write-WslInstallLog {
+    param([AllowNull()] [string]$LogPath)
+
+    if ([string]::IsNullOrWhiteSpace($LogPath)) {
+        return
+    }
+    if (-not (Test-Path -LiteralPath $LogPath)) {
+        return
+    }
+
+    try {
+        $log = Get-Content -LiteralPath $LogPath -Raw
+    } catch {
+        Write-Status -Level WARN "Could not read WSL install log: $($_.Exception.Message)"
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($log)) {
+        return
+    }
+
+    Write-Host ''
+    Write-Host 'WSL install output:' -ForegroundColor Yellow
+    Write-NativeOutput -Value $log
+    Write-Host ''
+}
+
+function Remove-WslInstallArtifacts {
+    param(
+        [AllowNull()] [string]$StatusPath,
+        [AllowNull()] [string]$LogPath
+    )
+
+    foreach ($path in @($StatusPath, $LogPath)) {
+        if (-not [string]::IsNullOrWhiteSpace($path)) {
+            Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 function Stop-WslDistroForDockerIntegration {
@@ -904,21 +1221,56 @@ function Ensure-UbuntuWsl {
     if ($distros -notcontains $DistroName) {
         Write-Host ''
         Write-Host "$DistroName is not registered yet. Installing it in a separate PowerShell window..." -ForegroundColor Cyan
-        Write-Host 'Create the Unix user in that window. This script will continue automatically after setup completes.' -ForegroundColor Cyan
+        Write-Host 'Create the Unix user in that window if prompted. This script will continue after setup completes.' -ForegroundColor Cyan
         Write-Host ''
-        Start-WslInstallInPowerShellWindow -Name $DistroName
+        $installResult = Start-WslInstallInPowerShellWindow -Name $DistroName
+        $installArtifactsRemoved = $false
+        $registrationResult = Wait-WslDistroRegistrationOrInstallExit -Name $DistroName -StatusPath $installResult.StatusPath
 
-        if (-not (Wait-WslDistroRegistration -Name $DistroName)) {
+        if ($null -ne $registrationResult.ExitCode -and $registrationResult.ExitCode -ne 0) {
+            Write-WslInstallLog -LogPath $installResult.LogPath
+            Remove-WslInstallArtifacts -StatusPath $installResult.StatusPath -LogPath $installResult.LogPath
+            $installArtifactsRemoved = $true
+            Write-WslUbuntuRequiredNotice -Name $DistroName
+            throw "WSL distro install command failed with exit code $($registrationResult.ExitCode)."
+        }
+
+        if (-not $registrationResult.Registered) {
+            if ($null -ne $registrationResult.ExitCode) {
+                Write-WslInstallLog -LogPath $installResult.LogPath
+                Remove-WslInstallArtifacts -StatusPath $installResult.StatusPath -LogPath $installResult.LogPath
+                $installArtifactsRemoved = $true
+                Write-Status -Level WARN "$DistroName install command completed, but the distro is not registered yet."
+                Write-Status -Level WARN 'A reboot is required before WSL can finish registering the distro.'
+                Request-Reboot
+                return
+            }
+
+            Remove-WslInstallArtifacts -StatusPath $installResult.StatusPath -LogPath $installResult.LogPath
+            $installArtifactsRemoved = $true
             Write-WslUbuntuRequiredNotice -Name $DistroName
             throw "WSL distro '$DistroName' is still not registered after install."
+        }
+
+        if ($null -ne $registrationResult.ExitCode) {
+            Remove-WslInstallArtifacts -StatusPath $installResult.StatusPath -LogPath $installResult.LogPath
+            $installArtifactsRemoved = $true
         }
 
         Write-Status "WSL distro registered: $DistroName"
         $defaultUid = Wait-WslDefaultUserReady -Name $DistroName
         if ($null -eq $defaultUid) {
+            if (-not $installArtifactsRemoved) {
+                Remove-WslInstallArtifacts -StatusPath $installResult.StatusPath -LogPath $installResult.LogPath
+                $installArtifactsRemoved = $true
+            }
             throw "Timed out waiting for $DistroName first-run user creation."
         }
 
+        if (-not $installArtifactsRemoved) {
+            Remove-WslInstallArtifacts -StatusPath $installResult.StatusPath -LogPath $installResult.LogPath
+            $installArtifactsRemoved = $true
+        }
         Write-Status "$DistroName first-run user is registered (UID $defaultUid)."
         Stop-WslDistroForDockerIntegration -Name $DistroName -Reason 'after first-run setup so Docker Desktop sees a settled user profile'
     } else {
@@ -938,9 +1290,8 @@ function Write-WslSubsystemMissingNotice {
     Write-Host ''
     Write-Host 'Windows Subsystem for Linux is not fully installed.' -ForegroundColor Yellow
     Write-Host ''
-    Write-Host "The required Windows optional features are enabled, but Windows could not install or run the $Name WSL distro automatically." -ForegroundColor Yellow
-    Write-Host 'Rerun this script after WSL is available on this machine.' -ForegroundColor Yellow
-    Write-Host ''
+    Write-Host "Windows reports that the WSL runtime is not installed, so this script cannot install or run the $Name WSL distro yet." -ForegroundColor Yellow
+    Write-Host 'This script will try to repair the required WSL components automatically.' -ForegroundColor Yellow
 }
 
 function Write-DockerDesktopNotice {
@@ -1091,6 +1442,7 @@ function Invoke-Main {
     }
 
     Enable-WslFeatures
+    Assert-WslRuntimeAvailable
     Ensure-UbuntuWsl
     Install-DockerDesktop
     Enable-DockerDesktopWslIntegration -Name $DistroName

--- a/test/bootstrap-windows.test.ts
+++ b/test/bootstrap-windows.test.ts
@@ -123,6 +123,347 @@ $script:events | ConvertTo-Json -Compress
     },
   );
 
+  itPowerShell("repairs WSL when status reports the runtime is missing", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:nativeCalls = @()
+$script:requestReboot = $false
+$script:outcome = 'success'
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Invoke-NativeCommandOutput {
+  param([string]$FilePath, [string[]]$ArgumentList = @(), [switch]$MergeError)
+  $argsText = $ArgumentList -join ' '
+  $script:nativeCalls += ,@($FilePath, $argsText)
+  if ($argsText -eq '--status') {
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output = @'
+The Windows Subsystem for Linux is not installed. You can install by running 'wsl.exe --install'.
+For more information please visit https://aka.ms/wslinstall
+'@
+    }
+  }
+  if ($argsText -eq '--install --no-distribution') {
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output = 'The requested operation is successful. Changes will not be effective until the system is rebooted.'
+    }
+  }
+  throw "Unexpected native call: $argsText"
+}
+function Request-Reboot {
+  $script:requestReboot = $true
+  throw 'REBOOT_REQUESTED'
+}
+
+try {
+  Assert-WslRuntimeAvailable
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  nativeCalls = $script:nativeCalls
+  requestReboot = $script:requestReboot
+  outcome = $script:outcome
+} | ConvertTo-Json -Depth 5 -Compress
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Windows reports that the WSL runtime is not installed");
+    expect(result.stdout).toContain("Attempting WSL repair: wsl --install --no-distribution");
+    expect(result.stdout).toContain("WSL repair command completed successfully.");
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "--status"]);
+    expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "--install --no-distribution"]);
+    expect(parsed.requestReboot).toBe(true);
+    expect(parsed.outcome).toContain("REBOOT_REQUESTED");
+  });
+
+  itPowerShell("continues when WSL repair succeeds without a reboot-required message", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:nativeCalls = @()
+$script:statusCalls = 0
+$script:outcome = 'success'
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Invoke-NativeCommandOutput {
+  param([string]$FilePath, [string[]]$ArgumentList = @(), [switch]$MergeError)
+  $argsText = $ArgumentList -join ' '
+  $script:nativeCalls += ,@($FilePath, $argsText)
+  if ($argsText -eq '--status') {
+    $script:statusCalls += 1
+    if ($script:statusCalls -eq 1) {
+      return [pscustomobject]@{
+        ExitCode = 0
+        Output = "The Windows Subsystem for Linux is not installed."
+      }
+    }
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output = 'Default Version: 2'
+    }
+  }
+  if ($argsText -eq '--install --no-distribution') {
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output = 'The operation completed successfully.'
+    }
+  }
+  throw "Unexpected native call: $argsText"
+}
+function Request-Reboot { throw 'UNEXPECTED_REBOOT' }
+
+try {
+  Assert-WslRuntimeAvailable
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  nativeCalls = $script:nativeCalls
+  statusCalls = $script:statusCalls
+  outcome = $script:outcome
+} | ConvertTo-Json -Depth 5 -Compress
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("WSL repair command completed successfully.");
+    expect(result.stdout).toContain("WSL status verified after repair.");
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(parsed.nativeCalls).toEqual([
+      ["wsl.exe", "--status"],
+      ["wsl.exe", "--install --no-distribution"],
+      ["wsl.exe", "--status"],
+    ]);
+    expect(parsed.statusCalls).toBe(2);
+    expect(parsed.outcome).toBe("success");
+  });
+
+  itPowerShell("stops when WSL repair succeeds without reboot but status remains unavailable", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:nativeCalls = @()
+$script:statusCalls = 0
+$script:outcome = 'success'
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Invoke-NativeCommandOutput {
+  param([string]$FilePath, [string[]]$ArgumentList = @(), [switch]$MergeError)
+  $argsText = $ArgumentList -join ' '
+  $script:nativeCalls += ,@($FilePath, $argsText)
+  if ($argsText -eq '--status') {
+    $script:statusCalls += 1
+    if ($script:statusCalls -eq 1) {
+      return [pscustomobject]@{
+        ExitCode = 50
+        Output = ''
+      }
+    }
+    return [pscustomobject]@{
+      ExitCode = 50
+      Output = 'Still unavailable after repair.'
+    }
+  }
+  if ($argsText -eq '--install --no-distribution') {
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output = 'The operation completed successfully.'
+    }
+  }
+  throw "Unexpected native call: $argsText"
+}
+function Request-Reboot { throw 'UNEXPECTED_REBOOT' }
+
+try {
+  Assert-WslRuntimeAvailable
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  nativeCalls = $script:nativeCalls
+  statusCalls = $script:statusCalls
+  outcome = $script:outcome
+} | ConvertTo-Json -Depth 5 -Compress
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Automatic WSL repair completed, but WSL still could not be verified.");
+    expect(result.stdout).toContain("Still unavailable after repair.");
+    expect(result.stdout).toContain(
+      "Offline install docs: https://learn.microsoft.com/en-us/windows/wsl/install#offline-install",
+    );
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(parsed.nativeCalls).toEqual([
+      ["wsl.exe", "--status"],
+      ["wsl.exe", "--install --no-distribution"],
+      ["wsl.exe", "--status"],
+    ]);
+    expect(parsed.statusCalls).toBe(2);
+    expect(parsed.outcome).toContain("wsl --install --no-distribution completed");
+    expect(parsed.outcome).toContain("wsl --status");
+  });
+
+  itPowerShell("prints repair instructions when automatic WSL repair fails", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:nativeCalls = @()
+$script:outcome = 'success'
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Invoke-NativeCommandOutput {
+  param([string]$FilePath, [string[]]$ArgumentList = @(), [switch]$MergeError)
+  $argsText = $ArgumentList -join ' '
+  $script:nativeCalls += ,@($FilePath, $argsText)
+  if ($argsText -eq '--status') {
+    return [pscustomobject]@{
+      ExitCode = 50
+      Output = ''
+    }
+  }
+  if ($argsText -eq '--install --no-distribution') {
+    return [pscustomobject]@{
+      ExitCode = 1
+      Output = "Forbidden (403).\`n\`n   \`n      \`n\`n"
+    }
+  }
+  throw "Unexpected native call: $argsText"
+}
+
+try {
+  Assert-WslRuntimeAvailable
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  nativeCalls = $script:nativeCalls
+  outcome = $script:outcome
+} | ConvertTo-Json -Depth 5 -Compress
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Windows Subsystem for Linux could not be verified.");
+    expect(result.stdout).toContain(
+      "The command 'wsl --status' exited with code 50, so this script cannot safely install or run the Ubuntu-24.04 WSL distro yet.",
+    );
+    expect(result.stdout).toContain("Attempting WSL repair: wsl --install --no-distribution");
+    expect(result.stdout).toContain("Automatic WSL repair did not complete.");
+    const normalizedStdout = result.stdout.replace(/\r\n/g, "\n");
+    expect(normalizedStdout).toContain("Forbidden (403).\n\nAutomatic WSL repair did not complete.");
+    expect(normalizedStdout).not.toMatch(/Forbidden \(403\)\.\n(?:[ \t]*\n){2,}Automatic WSL repair/);
+    expect(result.stdout).toContain("The command 'wsl --install --no-distribution' exited with code 1.");
+    expect(result.stdout).toContain("The online WSL installer returned Forbidden (403)");
+    expect(result.stdout).toContain(
+      "Offline install docs: https://learn.microsoft.com/en-us/windows/wsl/install#offline-install",
+    );
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "--status"]);
+    expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "--install --no-distribution"]);
+    expect(parsed.outcome).toContain("wsl --install --no-distribution failed");
+    expect(parsed.outcome).toContain("exit code 1");
+  });
+
+  itPowerShell("attempts WSL repair when WSL 2 cannot start", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:nativeCalls = @()
+$script:outcome = 'success'
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Invoke-NativeCommandOutput {
+  param([string]$FilePath, [string[]]$ArgumentList = @(), [switch]$MergeError)
+  $argsText = $ArgumentList -join ' '
+  $script:nativeCalls += ,@($FilePath, $argsText)
+  if ($argsText -eq '--status') {
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output = @'
+Default Version: 2
+WSL1 is not supported with your current machine configuration.
+Please enable the "Windows Subsystem for Linux" optional component to use WSL1.
+WSL2 is unable to start since virtualization is not enabled on this machine.
+Please ensure the "Virtual Machine Platform" optional component is enabled and virtualization is turned on in your computer's firmware settings.
+
+Enable "Virtual Machine Platform" by running: wsl.exe --install --no-distribution
+
+For information please visit https://aka.ms/enablevirtualization
+'@
+    }
+  }
+  if ($argsText -eq '--install --no-distribution') {
+    return [pscustomobject]@{
+      ExitCode = 1
+      Output = 'The virtual machine could not be started because a required feature is not installed.'
+    }
+  }
+  throw "Unexpected native call: $argsText"
+}
+
+try {
+  Assert-WslRuntimeAvailable
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  nativeCalls = $script:nativeCalls
+  outcome = $script:outcome
+} | ConvertTo-Json -Depth 5 -Compress
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Windows reports that WSL 2 cannot start yet.");
+    expect(result.stdout).toContain("reboot");
+    expect(result.stdout).toContain("enable virtualization");
+    expect(result.stdout).toContain("Attempting WSL repair: wsl --install --no-distribution");
+    expect(result.stdout).toContain("Automatic WSL repair did not complete.");
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "--status"]);
+    expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "--install --no-distribution"]);
+    expect(parsed.outcome).toContain("wsl --install --no-distribution failed");
+  });
+
+  itPowerShell("prints a manual resume command before prompting for reboot", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+function Register-ResumeRunOnce { Write-Status 'Registered best-effort reboot resume command.' }
+function Read-Host { param([string]$Prompt) Write-Host $Prompt; return 'n' }
+
+Request-Reboot
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("This bootstrap may resume automatically");
+    expect(result.stdout).toContain(
+      "After reboot/sign-in, if no bootstrap window opens, rerun this command from an elevated PowerShell window:",
+    );
+    expect(result.stdout).toContain("powershell.exe");
+    expect(result.stdout).toContain("-Resume");
+    expect(result.stdout).toContain("Please reboot now.");
+  });
+
   itPowerShell(
     "installs missing Ubuntu 24.04 through first-run setup before Docker integration",
     () => {
@@ -136,7 +477,10 @@ $script:statusMessages = @()
 
 function Resolve-WslExe { return 'wsl.exe' }
 function Get-WslDistros { return @() }
-function Wait-WslDistroRegistration { param([string]$Name) return $true }
+function Wait-WslDistroRegistrationOrInstallExit {
+  param([string]$Name, [string]$StatusPath, [int]$TimeoutSeconds = 300)
+  return [pscustomobject]@{ Registered = $true; ExitCode = $null }
+}
 function Wait-WslDefaultUserReady { param([string]$Name) return 1000 }
 function Ensure-WslDistroVersion2 { param([string]$Name) }
 function Stop-WslDistroForDockerIntegration { param([string]$Name, [string]$Reason) $script:nativeCalls += ,@('Stop-WslDistroForDockerIntegration', $Name) }
@@ -147,10 +491,10 @@ function Invoke-NativeCommand {
   return 0
 }
 function Start-Process {
-  param([string]$FilePath, [object]$ArgumentList = @())
+  param([string]$FilePath, [object]$ArgumentList = @(), [switch]$Wait, [switch]$PassThru)
   $argsText = if ($ArgumentList -is [array]) { $ArgumentList -join ' ' } else { [string]$ArgumentList }
   $script:startProcessCalls += ,@($FilePath, $argsText)
-  return [pscustomobject]@{}
+  return [pscustomobject]@{ Id = 1234 }
 }
 function Write-Status { param([string]$Message, [string]$Level = 'INFO') $script:statusMessages += $Message }
 
@@ -172,6 +516,15 @@ Ensure-UbuntuWsl
       expect(parsed.startProcessCalls[0][0]).toBe("powershell.exe");
       expect(parsed.startProcessCalls[0][1]).toContain("--install -d 'Ubuntu-24.04'");
       expect(parsed.startProcessCalls[0][1]).not.toContain("--no-launch");
+      expect(parsed.startProcessCalls[0][1]).toContain(
+        "wsl --install -d Ubuntu-24.04 failed with exit code ",
+      );
+      expect(parsed.startProcessCalls[0][1]).toContain(
+        "Ubuntu installer command exited. This window will close automatically.",
+      );
+      expect(parsed.startProcessCalls[0][1]).toContain("Start-Transcript");
+      expect(parsed.startProcessCalls[0][1]).not.toContain("Tee-Object -FilePath");
+      expect(parsed.startProcessCalls[0][1]).not.toContain("Press Enter to close this window");
       expect(parsed.nativeCalls).not.toContainEqual(["wsl.exe", "--set-default Ubuntu-24.04"]);
       expect(parsed.nativeCalls).toContainEqual(["wsl.exe", "-d Ubuntu-24.04 -- echo WSL_OK"]);
       expect(parsed.nativeCalls).toContainEqual([
@@ -188,6 +541,130 @@ Ensure-UbuntuWsl
       );
     },
   );
+
+  itPowerShell(
+    "requests reboot when Ubuntu install exits before distro registration",
+    () => {
+      const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:startProcessCalls = @()
+$script:statusMessages = @()
+$script:requestReboot = $false
+$script:outcome = 'success'
+$script:statusPath = Join-Path $env:TEMP ('ubuntu-install-' + [guid]::NewGuid().ToString('N') + '.status')
+$script:logPath = Join-Path $env:TEMP ('ubuntu-install-' + [guid]::NewGuid().ToString('N') + '.log')
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Get-WslDistros { return @() }
+function Start-WslInstallInPowerShellWindow {
+  param([string]$Name)
+  Set-Content -LiteralPath $script:statusPath -Value '0'
+  Set-Content -LiteralPath $script:logPath -Value @'
+**********************
+Windows PowerShell transcript start
+Username: NVIDIA.COM\\zyang
+Machine: TEST-HOST (Microsoft Windows NT 10.0.28000.0)
+Host Application: powershell.exe -Command $ErrorActionPreference = 'Continue'
+$statusPath = 'status-file'
+& 'C:\\WINDOWS\\System32\\wsl.exe' --install -d 'Ubuntu-24.04'
+Process ID: 1234
+PSVersion: 5.1.28000.1830
+**********************
+The requested operation is successful. Changes will not be effective until the system is rebooted.
+Ubuntu installer command exited. This window will close automatically.
+**********************
+Windows PowerShell transcript end
+**********************
+'@
+  return [pscustomobject]@{ StatusPath = $script:statusPath; LogPath = $script:logPath; ProcessId = 1234 }
+}
+function Request-Reboot {
+  $script:requestReboot = $true
+  throw 'REBOOT_REQUESTED'
+}
+function Write-Status { param([string]$Message, [string]$Level = 'INFO') $script:statusMessages += ('{0}:{1}' -f $Level, $Message) }
+
+try {
+  Ensure-UbuntuWsl
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  startProcessCalls = $script:startProcessCalls
+  statusMessages = $script:statusMessages
+  requestReboot = $script:requestReboot
+  outcome = $script:outcome
+} | ConvertTo-Json -Compress
+`);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+      expect(result.stdout).toContain("WSL install output:");
+      expect(result.stdout).toContain(
+        "The requested operation is successful. Changes will not be effective until the system is rebooted.",
+      );
+      expect(result.stdout).toContain("Ubuntu installer command exited. This window will close automatically.");
+      expect(result.stdout).toContain("Windows PowerShell transcript");
+      expect(result.stdout).toContain("Username:");
+      expect(result.stdout).toContain("Machine:");
+      expect(result.stdout).toContain("Host Application:");
+      expect(result.stdout).toContain("PSVersion:");
+      expect(parsed.statusMessages).toContain(
+        "WARN:Ubuntu-24.04 install command completed, but the distro is not registered yet.",
+      );
+      expect(parsed.statusMessages).toContain(
+        "WARN:A reboot is required before WSL can finish registering the distro.",
+      );
+      expect(parsed.requestReboot).toBe(true);
+      expect(parsed.outcome).toContain("REBOOT_REQUESTED");
+    },
+  );
+
+  itPowerShell("reports failed Ubuntu install output in the main window", () => {
+    const result = runPowerShellHarness(`
+$ErrorActionPreference = 'Stop'
+. ${JSON.stringify(BOOTSTRAP_WINDOWS)}
+
+$script:statusPath = Join-Path $env:TEMP ('ubuntu-install-' + [guid]::NewGuid().ToString('N') + '.status')
+$script:logPath = Join-Path $env:TEMP ('ubuntu-install-' + [guid]::NewGuid().ToString('N') + '.log')
+$script:outcome = 'success'
+
+function Resolve-WslExe { return 'wsl.exe' }
+function Get-WslDistros { return @() }
+function Start-WslInstallInPowerShellWindow {
+  param([string]$Name)
+  Set-Content -LiteralPath $script:statusPath -Value '87'
+  Set-Content -LiteralPath $script:logPath -Value 'Simulated WSL install failure'
+  return [pscustomobject]@{ StatusPath = $script:statusPath; LogPath = $script:logPath; ProcessId = 1234 }
+}
+
+try {
+  Ensure-UbuntuWsl
+} catch {
+  $script:outcome = $_.Exception.Message
+}
+
+[pscustomobject]@{
+  outcome = $script:outcome
+  statusPathExists = Test-Path -LiteralPath $script:statusPath
+  logPathExists = Test-Path -LiteralPath $script:logPath
+} | ConvertTo-Json -Compress
+`);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("WSL install output:");
+    expect(result.stdout).toContain("Simulated WSL install failure");
+    expect(result.stdout).toContain("NemoClaw on Windows ARM requires WSL2 Ubuntu 24.04.");
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(parsed.outcome).toContain("WSL distro install command failed with exit code 87");
+    expect(parsed.statusPathExists).toBe(false);
+    expect(parsed.logPathExists).toBe(false);
+  });
 
   itPowerShell("verifies WSL startup even when Docker Desktop install is disabled", () => {
     const result = runPowerShellHarness(`

--- a/test/bootstrap-windows.test.ts
+++ b/test/bootstrap-windows.test.ts
@@ -248,8 +248,10 @@ try {
     expect(parsed.outcome).toBe("success");
   });
 
-  itPowerShell("stops when WSL repair succeeds without reboot but status remains unavailable", () => {
-    const result = runPowerShellHarness(`
+  itPowerShell(
+    "stops when WSL repair succeeds without reboot but status remains unavailable",
+    () => {
+      const result = runPowerShellHarness(`
 $ErrorActionPreference = 'Stop'
 . ${JSON.stringify(BOOTSTRAP_WINDOWS)}
 
@@ -298,23 +300,26 @@ try {
 } | ConvertTo-Json -Depth 5 -Compress
 `);
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("Automatic WSL repair completed, but WSL still could not be verified.");
-    expect(result.stdout).toContain("Still unavailable after repair.");
-    expect(result.stdout).toContain(
-      "Offline install docs: https://learn.microsoft.com/en-us/windows/wsl/install#offline-install",
-    );
-    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
-    expect(parsed.nativeCalls).toEqual([
-      ["wsl.exe", "--status"],
-      ["wsl.exe", "--install --no-distribution"],
-      ["wsl.exe", "--status"],
-    ]);
-    expect(parsed.statusCalls).toBe(2);
-    expect(parsed.outcome).toContain("wsl --install --no-distribution completed");
-    expect(parsed.outcome).toContain("wsl --status");
-  });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain(
+        "Automatic WSL repair completed, but WSL still could not be verified.",
+      );
+      expect(result.stdout).toContain("Still unavailable after repair.");
+      expect(result.stdout).toContain(
+        "Offline install docs: https://learn.microsoft.com/en-us/windows/wsl/install#offline-install",
+      );
+      const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+      expect(parsed.nativeCalls).toEqual([
+        ["wsl.exe", "--status"],
+        ["wsl.exe", "--install --no-distribution"],
+        ["wsl.exe", "--status"],
+      ]);
+      expect(parsed.statusCalls).toBe(2);
+      expect(parsed.outcome).toContain("wsl --install --no-distribution completed");
+      expect(parsed.outcome).toContain("wsl --status");
+    },
+  );
 
   itPowerShell("prints repair instructions when automatic WSL repair fails", () => {
     const result = runPowerShellHarness(`
@@ -365,9 +370,15 @@ try {
     expect(result.stdout).toContain("Attempting WSL repair: wsl --install --no-distribution");
     expect(result.stdout).toContain("Automatic WSL repair did not complete.");
     const normalizedStdout = result.stdout.replace(/\r\n/g, "\n");
-    expect(normalizedStdout).toContain("Forbidden (403).\n\nAutomatic WSL repair did not complete.");
-    expect(normalizedStdout).not.toMatch(/Forbidden \(403\)\.\n(?:[ \t]*\n){2,}Automatic WSL repair/);
-    expect(result.stdout).toContain("The command 'wsl --install --no-distribution' exited with code 1.");
+    expect(normalizedStdout).toContain(
+      "Forbidden (403).\n\nAutomatic WSL repair did not complete.",
+    );
+    expect(normalizedStdout).not.toMatch(
+      /Forbidden \(403\)\.\n(?:[ \t]*\n){2,}Automatic WSL repair/,
+    );
+    expect(result.stdout).toContain(
+      "The command 'wsl --install --no-distribution' exited with code 1.",
+    );
     expect(result.stdout).toContain("The online WSL installer returned Forbidden (403)");
     expect(result.stdout).toContain(
       "Offline install docs: https://learn.microsoft.com/en-us/windows/wsl/install#offline-install",
@@ -542,10 +553,8 @@ Ensure-UbuntuWsl
     },
   );
 
-  itPowerShell(
-    "requests reboot when Ubuntu install exits before distro registration",
-    () => {
-      const result = runPowerShellHarness(`
+  itPowerShell("requests reboot when Ubuntu install exits before distro registration", () => {
+    const result = runPowerShellHarness(`
 $ErrorActionPreference = 'Stop'
 . ${JSON.stringify(BOOTSTRAP_WINDOWS)}
 
@@ -600,29 +609,30 @@ try {
 } | ConvertTo-Json -Compress
 `);
 
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe("");
-      const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
-      expect(result.stdout).toContain("WSL install output:");
-      expect(result.stdout).toContain(
-        "The requested operation is successful. Changes will not be effective until the system is rebooted.",
-      );
-      expect(result.stdout).toContain("Ubuntu installer command exited. This window will close automatically.");
-      expect(result.stdout).toContain("Windows PowerShell transcript");
-      expect(result.stdout).toContain("Username:");
-      expect(result.stdout).toContain("Machine:");
-      expect(result.stdout).toContain("Host Application:");
-      expect(result.stdout).toContain("PSVersion:");
-      expect(parsed.statusMessages).toContain(
-        "WARN:Ubuntu-24.04 install command completed, but the distro is not registered yet.",
-      );
-      expect(parsed.statusMessages).toContain(
-        "WARN:A reboot is required before WSL can finish registering the distro.",
-      );
-      expect(parsed.requestReboot).toBe(true);
-      expect(parsed.outcome).toContain("REBOOT_REQUESTED");
-    },
-  );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
+    expect(result.stdout).toContain("WSL install output:");
+    expect(result.stdout).toContain(
+      "The requested operation is successful. Changes will not be effective until the system is rebooted.",
+    );
+    expect(result.stdout).toContain(
+      "Ubuntu installer command exited. This window will close automatically.",
+    );
+    expect(result.stdout).toContain("Windows PowerShell transcript");
+    expect(result.stdout).toContain("Username:");
+    expect(result.stdout).toContain("Machine:");
+    expect(result.stdout).toContain("Host Application:");
+    expect(result.stdout).toContain("PSVersion:");
+    expect(parsed.statusMessages).toContain(
+      "WARN:Ubuntu-24.04 install command completed, but the distro is not registered yet.",
+    );
+    expect(parsed.statusMessages).toContain(
+      "WARN:A reboot is required before WSL can finish registering the distro.",
+    );
+    expect(parsed.requestReboot).toBe(true);
+    expect(parsed.outcome).toContain("REBOOT_REQUESTED");
+  });
 
   itPowerShell("reports failed Ubuntu install output in the main window", () => {
     const result = runPowerShellHarness(`


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Improves the Windows bootstrap WSL preflight so it verifies the WSL runtime before attempting to install or run the Ubuntu distro. When WSL is unavailable, the bootstrap now attempts the standard no-distro repair path, reports actionable manual/offline install guidance when repair is blocked, and preserves distro install output for troubleshooting.

## Changes
<!-- Bullet list of key changes. -->
- Verify `wsl --status` after enabling WSL Windows features and before Ubuntu distro setup.
- Attempt `wsl --install --no-distribution` when WSL is missing or unable to start.
- Request reboot only when WSL repair or distro install output indicates reboot is required.
- Print offline/manual WSL install guidance, including Microsoft docs and latest WSL release links, when automatic repair fails.
- Capture Ubuntu distro install exit status and transcript output from the child PowerShell window for main-window diagnostics.
- Update Windows troubleshooting docs for blocked WSL online install and manual MSI recovery.
- Add Windows bootstrap tests for WSL repair, blocked repair, reboot-required handling, and distro install diagnostics.


## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: zyang-dev <267119621+zyang-dev@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows WSL setup resilience when installation is blocked or fails, with clearer repair, log, and reboot guidance.
  * Added more robust detection for missing WSL runtime and WSL 2 startup/virtualization issues, including automated offline repair attempts and accurate stop conditions.
  * Enhanced Ubuntu installation behavior to handle non-zero installer exit codes and ensure temporary install artifacts are cleaned up.
* **Documentation**
  * Expanded Windows WSL troubleshooting with new offline installation and bootstrap-repair instructions for blocked or incomplete setups.
* **Tests**
  * Added coverage for WSL repair, reboot/resume messaging, and Ubuntu 24.04 install edge-cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->