### PR TITLE
fix(sandbox): warn host agent CLI after shields auto-relock

### DIFF
--- a/src/lib/actions/sandbox/agent/passthrough-json.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-json.test.ts
@@ -149,7 +149,7 @@ describe("runAgentJsonPassthrough", () => {
       runAgentJsonPassthrough("alpha", ["openclaw", "agent", "--json"], proc, {
         getOpenshellBinary: () => "/usr/local/bin/openshell",
         provenanceLines: () => {
-          throw new RangeError("Maximum call stack size exceeded");
+          throw new SyntaxError("Unexpected token in OpenClaw JSON output");
         },
         spawnSync,
       }),

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ShieldsAutoRestoreReadResult } from "../../../shields/audit";
 
@@ -35,7 +39,7 @@ vi.mock("../../../shields/audit", () => ({
   readRecentShieldsAutoRestore: vi.fn(() => ({ kind: "none" })),
 }));
 
-import { runAgentPassthrough } from "./passthrough";
+import { type AgentPassthroughDeps, runAgentPassthrough } from "./passthrough";
 
 function makeProcMock() {
   const writes: string[] = [];
@@ -108,6 +112,62 @@ describe("runAgentPassthrough shields-relock warning", () => {
     );
     expect(output).toContain("nemoclaw 'alpha; touch /tmp/pwn' shields down --timeout 20s");
     expect(output).not.toContain("nemoclaw alpha; touch /tmp/pwn");
+  });
+
+  it("keeps JSON stdout parseable while warning from a real audit file on stderr (#5922)", async () => {
+    const actualAudit =
+      await vi.importActual<typeof import("../../../shields/audit")>("../../../shields/audit");
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-shields-warning-"));
+    const auditPath = path.join(tempDir, "shields-audit.jsonl");
+    const restoreTimestamp = new Date().toISOString();
+    const stdoutWrites: string[] = [];
+    const { writes, proc } = makeProcMock();
+    const processWithStdout = {
+      ...proc,
+      stdout: { write: (value: string) => stdoutWrites.push(value) },
+    };
+    const execJson = vi.fn(((_sandboxName, _command, jsonProc): never => {
+      jsonProc?.stdout.write('{"ok":true}\n');
+      throw new Error("__json-exit:0");
+    }) as NonNullable<AgentPassthroughDeps["execJson"]>);
+
+    try {
+      fs.writeFileSync(
+        auditPath,
+        [
+          JSON.stringify({
+            action: "shields_down",
+            sandbox: "alpha",
+            timestamp: new Date(Date.now() - 20 * 1000).toISOString(),
+            timeout_seconds: 20,
+          }),
+          JSON.stringify({
+            action: "shields_auto_restore",
+            sandbox: "alpha",
+            timestamp: restoreTimestamp,
+          }),
+        ].join("\n") + "\n",
+      );
+
+      await expect(
+        runAgentPassthrough(
+          "alpha",
+          { extraArgs: ["--agent", "main", "-m", "hi", "--json"] },
+          {
+            process: processWithStdout,
+            execJson,
+            getRecentShieldsAutoRestore: (sandboxName) =>
+              actualAudit.readRecentShieldsAutoRestore(sandboxName, 10 * 60 * 1000, auditPath),
+          },
+        ),
+      ).rejects.toThrow("__json-exit:0");
+
+      expect(JSON.parse(stdoutWrites.join(""))).toEqual({ ok: true });
+      expect(writes.join("")).toMatch(/Shields auto-relocked after 20s/);
+      expect(execJson).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("emits no relock warning when the audit has no recent event (#5922)", async () => {

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
@@ -114,6 +114,17 @@ describe("runAgentPassthrough shields-relock warning", () => {
     expect(output).not.toContain("nemoclaw alpha; touch /tmp/pwn");
   });
 
+  it("escapes embedded single quotes in recovery command suggestions (#5922)", async () => {
+    const output = await runWarning(
+      {
+        kind: "event",
+        event: { timestamp: new Date().toISOString(), timeoutSeconds: 20 },
+      },
+      "alpha'beta",
+    );
+    expect(output).toContain("nemoclaw 'alpha'\\''beta' shields down --timeout 20s");
+  });
+
   it("keeps JSON stdout parseable while warning from a real audit file on stderr (#5922)", async () => {
     const actualAudit =
       await vi.importActual<typeof import("../../../shields/audit")>("../../../shields/audit");

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShieldsAutoRestoreReadResult } from "../../../shields/audit";
+
+const execMock = vi.hoisted(() => vi.fn(async () => {}));
+const ensureLiveMock = vi.hoisted(() =>
+  vi.fn(async () => ({ state: "present", output: "Phase: Ready" }) as { output?: string }),
+);
+const getSandboxMock = vi.hoisted(() => vi.fn(() => ({ agent: "openclaw" })));
+const listAgentsMock = vi.hoisted(() => vi.fn(() => ["langchain-deepagents-code", "openclaw"]));
+const loadAgentMock = vi.hoisted(() =>
+  vi.fn((name: string) => ({
+    name,
+    runtime:
+      name === "langchain-deepagents-code"
+        ? { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" }
+        : undefined,
+  })),
+);
+const isTerminalAgentMock = vi.hoisted(() =>
+  vi.fn((agent: { runtime?: { kind?: string } }) => agent.runtime?.kind === "terminal"),
+);
+
+vi.mock("../exec", () => ({ execSandbox: execMock }));
+vi.mock("../gateway-state", () => ({ ensureLiveSandboxOrExit: ensureLiveMock }));
+vi.mock("../../../state/registry", () => ({ getSandbox: getSandboxMock }));
+vi.mock("../../../agent/defs", () => ({
+  isTerminalAgent: isTerminalAgentMock,
+  listAgents: listAgentsMock,
+  loadAgent: loadAgentMock,
+}));
+vi.mock("../../../shields/audit", () => ({
+  readRecentShieldsAutoRestore: vi.fn(() => ({ kind: "none" })),
+}));
+
+import { runAgentPassthrough } from "./passthrough";
+
+function makeProcMock() {
+  const writes: string[] = [];
+  return {
+    writes,
+    proc: {
+      exit: ((code: number): never => {
+        throw new Error(`__exit:${code}`);
+      }) as (code: number) => never,
+      stderr: { write: (value: string) => writes.push(value) },
+    },
+  };
+}
+
+describe("runAgentPassthrough shields-relock warning", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function runWarning(result: ShieldsAutoRestoreReadResult): Promise<string> {
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const { writes, proc } = makeProcMock();
+    await runAgentPassthrough(
+      "alpha",
+      { extraArgs: ["--agent", "main", "-m", "hi"] },
+      { process: proc, getRecentShieldsAutoRestore: () => result },
+    );
+    return writes.join("");
+  }
+
+  it("emits the original timeout after a recent auto-relock (#5922)", async () => {
+    const output = await runWarning({
+      kind: "event",
+      event: { timestamp: new Date().toISOString(), timeoutSeconds: 20 },
+    });
+    expect(execMock).toHaveBeenCalled();
+    expect(output).toMatch(/[Ss]hields auto-relocked after 20s/);
+    expect(output).toMatch(/shields down --timeout 20s/);
+  });
+
+  it("uses the safe fallback timeout when the original timeout is unavailable (#5922)", async () => {
+    const output = await runWarning({
+      kind: "event",
+      event: { timestamp: new Date().toISOString(), timeoutSeconds: null },
+    });
+    expect(execMock).toHaveBeenCalled();
+    expect(output).toMatch(/[Ss]hields auto-relocked/);
+    expect(output).toMatch(/shields down --timeout 60s/);
+  });
+
+  it("defensively rejects an invalid injected timeout from the command suggestion (#5922)", async () => {
+    const output = await runWarning({
+      kind: "event",
+      event: { timestamp: new Date().toISOString(), timeoutSeconds: 9999 },
+    });
+    expect(output).not.toContain("9999s");
+    expect(output).toMatch(/shields down --timeout 60s/);
+  });
+
+  it("emits no relock warning when the audit has no recent event (#5922)", async () => {
+    const output = await runWarning({ kind: "none" });
+    expect(execMock).toHaveBeenCalled();
+    expect(output).not.toMatch(/[Ss]hields auto-relocked/);
+  });
+
+  it("reports unreadable audit history without blocking agent dispatch (#5922)", async () => {
+    const output = await runWarning({ kind: "unreadable" });
+    expect(execMock).toHaveBeenCalled();
+    expect(output).toMatch(/Could not read shields audit history/);
+    expect(output).toMatch(/shields status/);
+  });
+
+  it("does not consult OpenClaw relock history for terminal-runtime passthroughs (#5922)", async () => {
+    getSandboxMock.mockReturnValueOnce({ agent: "langchain-deepagents-code" });
+    const getRecentShieldsAutoRestore = vi.fn(
+      (): ShieldsAutoRestoreReadResult => ({
+        kind: "event",
+        event: { timestamp: new Date().toISOString(), timeoutSeconds: 20 },
+      }),
+    );
+    const { writes, proc } = makeProcMock();
+
+    await runAgentPassthrough(
+      "alpha",
+      { extraArgs: ["--help"] },
+      { process: proc, getRecentShieldsAutoRestore },
+    );
+
+    expect(execMock).toHaveBeenCalledWith("alpha", ["dcode", "--help"], { tty: false });
+    expect(getRecentShieldsAutoRestore).not.toHaveBeenCalled();
+    expect(writes.join("")).not.toMatch(/[Ss]hields auto-relocked/);
+  });
+});

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.test.ts
@@ -55,11 +55,14 @@ describe("runAgentPassthrough shields-relock warning", () => {
     vi.clearAllMocks();
   });
 
-  async function runWarning(result: ShieldsAutoRestoreReadResult): Promise<string> {
+  async function runWarning(
+    result: ShieldsAutoRestoreReadResult,
+    sandboxName = "alpha",
+  ): Promise<string> {
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
     const { writes, proc } = makeProcMock();
     await runAgentPassthrough(
-      "alpha",
+      sandboxName,
       { extraArgs: ["--agent", "main", "-m", "hi"] },
       { process: proc, getRecentShieldsAutoRestore: () => result },
     );
@@ -93,6 +96,18 @@ describe("runAgentPassthrough shields-relock warning", () => {
     });
     expect(output).not.toContain("9999s");
     expect(output).toMatch(/shields down --timeout 60s/);
+  });
+
+  it("shell-quotes sandbox names in recovery command suggestions (#5922)", async () => {
+    const output = await runWarning(
+      {
+        kind: "event",
+        event: { timestamp: new Date().toISOString(), timeoutSeconds: 20 },
+      },
+      "alpha; touch /tmp/pwn",
+    );
+    expect(output).toContain("nemoclaw 'alpha; touch /tmp/pwn' shields down --timeout 20s");
+    expect(output).not.toContain("nemoclaw alpha; touch /tmp/pwn");
   });
 
   it("emits no relock warning when the audit has no recent event (#5922)", async () => {

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.ts
@@ -9,6 +9,30 @@ import {
   type ShieldsAutoRestoreReadResult,
 } from "../../../shields/audit";
 
+// Source-of-truth boundary for the host CLI relock diagnostic:
+//
+// - Invalid state: after shields auto-relock, OpenClaw can report only
+//   `missing scope: operator.write`; an older relock warning also becomes stale
+//   after the user lowers shields again.
+// - Source boundary: OpenShell/OpenClaw own current scope state. NemoClaw audit
+//   JSONL is non-authoritative context. Validated chronology may suppress stale
+//   context but never establishes current policy state, and unreadable history
+//   never blocks dispatch. The audit writers are the shields timer and inline
+//   expired-timer recovery paths.
+// - Presentation boundary: sandbox names are user-controlled command text and
+//   must remain shell-quoted. Direct stderr output is deliberate so the warning
+//   is visible in a one-shot CLI while machine-readable stdout stays clean.
+// - Source-fix constraint: an already-running in-sandbox TUI has no host CLI
+//   interception point. That surface needs an upstream structured relock error
+//   or a separate extend-on-activity design; this helper covers only host
+//   `nemoclaw <name> agent` dispatches.
+// - Regression tests cover validated/fallback timeouts, shell metacharacters
+//   and embedded quotes, real-file JSON stdout separation, unreadable/absent
+//   history, newer-down suppression, and terminal-runtime exclusion.
+// - Removal condition: drop this diagnostic when OpenClaw exposes the relock
+//   cause directly or NemoClaw prevents mid-session relock by extending on
+//   activity.
+
 // A relock remains useful context briefly after it happens. This is a
 // relevance window measured from the restore event, independent of the
 // original shields-down timeout; a longer window risks stale-session warnings.

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CLI_NAME } from "../../../cli/branding";
+import { shellQuote } from "../../../core/shell-quote";
+import {
+  readRecentShieldsAutoRestore,
+  type ShieldsAutoRestoreEvent,
+  type ShieldsAutoRestoreReadResult,
+} from "../../../shields/audit";
+
+// A relock remains useful context briefly after it happens. This is a
+// relevance window measured from the restore event, independent of the
+// original shields-down timeout; a longer window risks stale-session warnings.
+const SHIELDS_RELOCK_WARNING_WINDOW_MS = 10 * 60 * 1000;
+
+type ShieldsWarningProcess = {
+  stderr: { write(value: string): unknown };
+};
+
+type RecentShieldsAutoRestoreReader = (sandboxName: string) => ShieldsAutoRestoreReadResult;
+
+function emitShieldsRelockWarning(
+  proc: ShieldsWarningProcess,
+  relock: ShieldsAutoRestoreEvent,
+  sandboxName: string,
+): void {
+  // Defend the user-facing command suggestion even when tests or future
+  // callers inject an event without going through the audit reader.
+  const timeoutSeconds =
+    relock.timeoutSeconds !== null &&
+    Number.isInteger(relock.timeoutSeconds) &&
+    relock.timeoutSeconds >= 1 &&
+    relock.timeoutSeconds <= 1800
+      ? relock.timeoutSeconds
+      : null;
+  const afterPart = timeoutSeconds !== null ? ` after ${String(timeoutSeconds)}s` : "";
+  const timeoutSuggestion =
+    timeoutSeconds !== null ? `--timeout ${String(timeoutSeconds)}s` : "--timeout 60s";
+  proc.stderr.write(
+    `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${shellQuote(sandboxName)} shields down ${timeoutSuggestion}\` to extend.\n`,
+  );
+}
+
+function emitShieldsAuditUnreadableWarning(proc: ShieldsWarningProcess, sandboxName: string): void {
+  proc.stderr.write(
+    `  ⚠ Could not read shields audit history; continuing without relock context. Run \`${CLI_NAME} ${shellQuote(sandboxName)} shields status\` to verify current state.\n`,
+  );
+}
+
+export function maybeEmitShieldsRelockWarning(
+  proc: ShieldsWarningProcess,
+  sandboxName: string,
+  getRecentShieldsAutoRestore: RecentShieldsAutoRestoreReader = (name) =>
+    readRecentShieldsAutoRestore(name, SHIELDS_RELOCK_WARNING_WINDOW_MS),
+): void {
+  const relock = getRecentShieldsAutoRestore(sandboxName);
+  if (relock.kind === "event") {
+    emitShieldsRelockWarning(proc, relock.event, sandboxName);
+  } else if (relock.kind === "unreadable") {
+    emitShieldsAuditUnreadableWarning(proc, sandboxName);
+  }
+}

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -152,13 +152,13 @@ describe("runAgentPassthrough", () => {
     );
   });
 
-  it("keeps --json after an unknown future value flag on the normal passthrough path", async () => {
+  it("keeps --json-something --json on the normal passthrough path", async () => {
     const execJson = vi.fn(((): never => {
       throw new Error("__unexpected-json");
     }) as NonNullable<AgentPassthroughDeps["execJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
-    // Unknown --json-* flags stay conservative until added to the documented value-flag set.
+    // The first unknown flag selects conservative passthrough before the later --json token.
     await runAgentPassthrough(
       "alpha",
       { extraArgs: ["--agent", "work", "--json-something", "--json"] },

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -34,7 +34,9 @@ vi.mock("../../../agent/defs", () => ({
 }));
 // Default to no recent shields auto-restore so tests that don't inject
 // getRecentShieldsAutoRestore don't read ~/.nemoclaw/state/shields-audit.jsonl.
-vi.mock("../../../shields/audit", () => ({ readRecentShieldsAutoRestore: vi.fn(() => null) }));
+vi.mock("../../../shields/audit", () => ({
+  readRecentShieldsAutoRestore: vi.fn(() => ({ kind: "none" })),
+}));
 
 import { type AgentPassthroughDeps, runAgentPassthrough } from "./passthrough";
 
@@ -448,45 +450,6 @@ describe("runAgentPassthrough", () => {
       ["openclaw", "agent", "--session-key=abc-123", "-m", "ping"],
       { tty: false },
     );
-  });
-
-  // Shared helper for shields-warning tests: wires up the OpenClaw mock and
-  // proc, dispatches with a fixed extraArgs, and returns the stderr output.
-  async function runShieldsWarningTest(
-    restore: { timeoutSeconds: number | null } | null,
-  ): Promise<string> {
-    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    const { writes, proc } = makeProcMock();
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "main", "-m", "hi"] },
-      {
-        process: proc,
-        getRecentShieldsAutoRestore: () =>
-          restore !== null ? { timestamp: new Date().toISOString(), ...restore } : null,
-      },
-    );
-    return writes.join("");
-  }
-
-  it("emits a shields-relock warning with timeout when shields auto-relocked recently (#5922)", async () => {
-    const all = await runShieldsWarningTest({ timeoutSeconds: 20 });
-    expect(execMock).toHaveBeenCalled();
-    expect(all).toMatch(/[Ss]hields auto-relocked after 20s/);
-    expect(all).toMatch(/shields down --timeout 20s/);
-  });
-
-  it("emits a shields-relock warning with fallback timeout when timeoutSeconds is null (#5922)", async () => {
-    const all = await runShieldsWarningTest({ timeoutSeconds: null });
-    expect(execMock).toHaveBeenCalled();
-    expect(all).toMatch(/[Ss]hields auto-relocked/);
-    expect(all).toMatch(/shields down --timeout 60s/);
-  });
-
-  it("emits no shields warning when there was no recent auto-restore (#5922)", async () => {
-    const all = await runShieldsWarningTest(null);
-    expect(execMock).toHaveBeenCalled();
-    expect(all).not.toMatch(/[Ss]hields auto-relocked/);
   });
 
   it("rejects with exit 1 + recovery hints when sandbox phase is non-Ready", async () => {

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -160,14 +160,14 @@ describe("runAgentPassthrough", () => {
 
     await runAgentPassthrough(
       "alpha",
-      { extraArgs: ["--agent", "work", "--some-future-value-flag", "--json"] },
+      { extraArgs: ["--agent", "work", "--json-output", "--json"] },
       { execJson },
     );
 
     expect(execJson).not.toHaveBeenCalled();
     expect(execMock).toHaveBeenCalledWith(
       "alpha",
-      ["openclaw", "agent", "--agent", "work", "--some-future-value-flag", "--json"],
+      ["openclaw", "agent", "--agent", "work", "--json-output", "--json"],
       { tty: false },
     );
   });

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -492,11 +492,11 @@ describe("runAgentPassthrough", () => {
 
   it("emits no shields warning when there was no recent auto-restore (#5922)", async () => {
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    const { writes } = makeProcMock();
+    const { writes, proc } = makeProcMock();
     await runAgentPassthrough(
       "alpha",
       { extraArgs: ["--agent", "main", "-m", "hi"] },
-      { getRecentShieldsAutoRestore: () => null },
+      { getRecentShieldsAutoRestore: () => null, process: proc },
     );
     expect(execMock).toHaveBeenCalled();
     expect(writes.join("")).not.toMatch(/[Ss]hields auto-relocked/);

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -158,16 +158,17 @@ describe("runAgentPassthrough", () => {
     }) as NonNullable<AgentPassthroughDeps["execJson"]>);
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
 
+    // Unknown --json-* flags stay conservative until added to the documented value-flag set.
     await runAgentPassthrough(
       "alpha",
-      { extraArgs: ["--agent", "work", "--json-output", "--json"] },
+      { extraArgs: ["--agent", "work", "--json-something", "--json"] },
       { execJson },
     );
 
     expect(execJson).not.toHaveBeenCalled();
     expect(execMock).toHaveBeenCalledWith(
       "alpha",
-      ["openclaw", "agent", "--agent", "work", "--json-output", "--json"],
+      ["openclaw", "agent", "--agent", "work", "--json-something", "--json"],
       { tty: false },
     );
   });

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -32,6 +32,9 @@ vi.mock("../../../agent/defs", () => ({
   listAgents: listAgentsMock,
   loadAgent: loadAgentMock,
 }));
+// Default to no recent shields auto-restore so tests that don't inject
+// getRecentShieldsAutoRestore don't read ~/.nemoclaw/state/shields-audit.jsonl.
+vi.mock("../../../shields/audit", () => ({ readRecentShieldsAutoRestore: vi.fn(() => null) }));
 
 import { type AgentPassthroughDeps, runAgentPassthrough } from "./passthrough";
 

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -447,6 +447,58 @@ describe("runAgentPassthrough", () => {
     );
   });
 
+  it("emits a shields-relock warning with timeout when shields auto-relocked recently (#5922)", async () => {
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const { writes, proc } = makeProcMock();
+    await runAgentPassthrough(
+      "alpha",
+      { extraArgs: ["--agent", "main", "-m", "hi"] },
+      {
+        process: proc,
+        getRecentShieldsAutoRestore: () => ({
+          timestamp: new Date().toISOString(),
+          timeoutSeconds: 20,
+        }),
+      },
+    );
+    expect(execMock).toHaveBeenCalled();
+    const all = writes.join("");
+    expect(all).toMatch(/[Ss]hields auto-relocked after 20s/);
+    expect(all).toMatch(/shields down --timeout 20s/);
+  });
+
+  it("emits a shields-relock warning with fallback timeout when timeoutSeconds is null (#5922)", async () => {
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const { writes, proc } = makeProcMock();
+    await runAgentPassthrough(
+      "alpha",
+      { extraArgs: ["--agent", "main", "-m", "hi"] },
+      {
+        process: proc,
+        getRecentShieldsAutoRestore: () => ({
+          timestamp: new Date().toISOString(),
+          timeoutSeconds: null,
+        }),
+      },
+    );
+    expect(execMock).toHaveBeenCalled();
+    const all = writes.join("");
+    expect(all).toMatch(/[Ss]hields auto-relocked/);
+    expect(all).toMatch(/shields down --timeout 60s/);
+  });
+
+  it("emits no shields warning when there was no recent auto-restore (#5922)", async () => {
+    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
+    const { writes } = makeProcMock();
+    await runAgentPassthrough(
+      "alpha",
+      { extraArgs: ["--agent", "main", "-m", "hi"] },
+      { getRecentShieldsAutoRestore: () => null },
+    );
+    expect(execMock).toHaveBeenCalled();
+    expect(writes.join("")).not.toMatch(/[Ss]hields auto-relocked/);
+  });
+
   it("rejects with exit 1 + recovery hints when sandbox phase is non-Ready", async () => {
     ensureLiveMock.mockResolvedValueOnce({ output: "Phase: Error" });
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });

--- a/src/lib/actions/sandbox/agent/passthrough.test.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.test.ts
@@ -450,7 +450,11 @@ describe("runAgentPassthrough", () => {
     );
   });
 
-  it("emits a shields-relock warning with timeout when shields auto-relocked recently (#5922)", async () => {
+  // Shared helper for shields-warning tests: wires up the OpenClaw mock and
+  // proc, dispatches with a fixed extraArgs, and returns the stderr output.
+  async function runShieldsWarningTest(
+    restore: { timeoutSeconds: number | null } | null,
+  ): Promise<string> {
     getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
     const { writes, proc } = makeProcMock();
     await runAgentPassthrough(
@@ -458,48 +462,31 @@ describe("runAgentPassthrough", () => {
       { extraArgs: ["--agent", "main", "-m", "hi"] },
       {
         process: proc,
-        getRecentShieldsAutoRestore: () => ({
-          timestamp: new Date().toISOString(),
-          timeoutSeconds: 20,
-        }),
+        getRecentShieldsAutoRestore: () =>
+          restore !== null ? { timestamp: new Date().toISOString(), ...restore } : null,
       },
     );
+    return writes.join("");
+  }
+
+  it("emits a shields-relock warning with timeout when shields auto-relocked recently (#5922)", async () => {
+    const all = await runShieldsWarningTest({ timeoutSeconds: 20 });
     expect(execMock).toHaveBeenCalled();
-    const all = writes.join("");
     expect(all).toMatch(/[Ss]hields auto-relocked after 20s/);
     expect(all).toMatch(/shields down --timeout 20s/);
   });
 
   it("emits a shields-relock warning with fallback timeout when timeoutSeconds is null (#5922)", async () => {
-    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    const { writes, proc } = makeProcMock();
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "main", "-m", "hi"] },
-      {
-        process: proc,
-        getRecentShieldsAutoRestore: () => ({
-          timestamp: new Date().toISOString(),
-          timeoutSeconds: null,
-        }),
-      },
-    );
+    const all = await runShieldsWarningTest({ timeoutSeconds: null });
     expect(execMock).toHaveBeenCalled();
-    const all = writes.join("");
     expect(all).toMatch(/[Ss]hields auto-relocked/);
     expect(all).toMatch(/shields down --timeout 60s/);
   });
 
   it("emits no shields warning when there was no recent auto-restore (#5922)", async () => {
-    getSandboxMock.mockReturnValueOnce({ agent: "openclaw" });
-    const { writes, proc } = makeProcMock();
-    await runAgentPassthrough(
-      "alpha",
-      { extraArgs: ["--agent", "main", "-m", "hi"] },
-      { getRecentShieldsAutoRestore: () => null, process: proc },
-    );
+    const all = await runShieldsWarningTest(null);
     expect(execMock).toHaveBeenCalled();
-    expect(writes.join("")).not.toMatch(/[Ss]hields auto-relocked/);
+    expect(all).not.toMatch(/[Ss]hields auto-relocked/);
   });
 
   it("rejects with exit 1 + recovery hints when sandbox phase is non-Ready", async () => {

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -3,7 +3,8 @@
 
 // Source-of-truth boundary for the `nemoclaw <name> agent` passthrough.
 //
-// The wrapper enforces three host-side mirrors of upstream contracts:
+// The wrapper enforces three host-side mirrors of upstream contracts and one
+// advisory diagnostic:
 //
 // 1. Agent-kind guard (registry mirror).
 //
@@ -67,6 +68,20 @@
 //      selector case is intercepted; everything else still flows through to
 //      the in-sandbox binary.
 //
+// 4. Recent shields-relock diagnostic (advisory audit mirror).
+//
+//    - Invalid state: after shields auto-relock, the next host CLI
+//      `openclaw agent` dispatch can fail with only `missing scope:
+//      operator.write`, which does not explain the recovery action.
+//    - Source boundary: OpenShell/OpenClaw own current scope state. NemoClaw's
+//      local audit JSONL is non-authoritative and is used only to add likely
+//      relock context; unreadable history never blocks dispatch, and terminal
+//      runtimes are excluded from this OpenClaw-specific diagnostic.
+//    - Source-fix constraint: an already-running in-sandbox OpenClaw TUI has no
+//      host CLI interception point. Covering that surface requires an upstream
+//      structured relock error or a separate extend-on-activity design. This
+//      wrapper intentionally covers only `nemoclaw <name> agent` dispatches.
+//
 // Regression tests: `passthrough.test.ts` covers the Hermes redirect, the
 // forwarded argv, the registry-miss fallback to OpenClaw, registry and
 // manifest-resolution fail-closed paths, quoted manifest command rejection,
@@ -74,8 +89,9 @@
 // unparseable phase fail-closed path, the OpenClaw no-selector rejection, and
 // the `--flag=value` selector-acceptance branch, plus the OpenClaw JSON
 // captured transport path used to append failure provenance without polluting
-// machine-readable stdout, plus shields auto-relock warning with timeout,
-// null-timeout fallback, and no-warning path.
+// machine-readable stdout. `passthrough-shields-warning.test.ts` covers the
+// OpenClaw-only relock diagnostic, validated and fallback timeouts, unreadable
+// and absent audit history, and terminal-runtime exclusion.
 //
 // Removal conditions:
 //
@@ -95,7 +111,11 @@
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";
-import { type ShieldsAutoRestoreEvent, readRecentShieldsAutoRestore } from "../../../shields/audit";
+import {
+  readRecentShieldsAutoRestore,
+  type ShieldsAutoRestoreEvent,
+  type ShieldsAutoRestoreReadResult,
+} from "../../../shields/audit";
 import { parseSandboxPhase } from "../../../state/gateway";
 import * as registry from "../../../state/registry";
 import { execSandbox } from "../exec";
@@ -125,6 +145,11 @@ const OPENCLAW_AGENT_VALUE_FLAGS = new Set([
 
 const OPENCLAW_AGENT_BOOLEAN_FLAGS = new Set(["--deliver"]);
 
+// A relock remains useful context briefly after it happens. This is a
+// relevance window measured from the restore event, independent of the
+// original shields-down timeout; a longer window risks stale-session warnings.
+const SHIELDS_RELOCK_WARNING_WINDOW_MS = 10 * 60 * 1000;
+
 export interface AgentPassthroughOptions {
   extraArgs?: readonly string[];
 }
@@ -134,7 +159,7 @@ export interface AgentPassthroughDeps {
   ensureLive?: typeof ensureLiveSandboxOrExit;
   exec?: typeof execSandbox;
   execJson?: typeof runAgentJsonPassthrough;
-  getRecentShieldsAutoRestore?: (sandboxName: string) => ShieldsAutoRestoreEvent | null;
+  getRecentShieldsAutoRestore?: (sandboxName: string) => ShieldsAutoRestoreReadResult;
   process?: {
     exit(code: number): never;
     stdout?: { write(s: string): unknown };
@@ -358,15 +383,29 @@ function emitShieldsRelockWarning(
   relock: ShieldsAutoRestoreEvent,
   sandboxName: string,
 ): void {
-  const afterPart =
-    relock.timeoutSeconds !== null ? ` after ${String(relock.timeoutSeconds)}s` : "";
-  // timeoutSeconds is pre-validated by readRecentShieldsAutoRestore (finite integer, 1–1800).
+  // Defend the user-facing command suggestion even when tests or future
+  // callers inject an event without going through the audit reader.
+  const timeoutSeconds =
+    relock.timeoutSeconds !== null &&
+    Number.isInteger(relock.timeoutSeconds) &&
+    relock.timeoutSeconds >= 1 &&
+    relock.timeoutSeconds <= 1800
+      ? relock.timeoutSeconds
+      : null;
+  const afterPart = timeoutSeconds !== null ? ` after ${String(timeoutSeconds)}s` : "";
   const timeoutSuggestion =
-    relock.timeoutSeconds !== null
-      ? `--timeout ${String(relock.timeoutSeconds)}s`
-      : "--timeout 60s";
+    timeoutSeconds !== null ? `--timeout ${String(timeoutSeconds)}s` : "--timeout 60s";
   proc.stderr.write(
     `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${sandboxName} shields down ${timeoutSuggestion}\` to extend.\n`,
+  );
+}
+
+function emitShieldsAuditUnreadableWarning(
+  proc: NonNullable<AgentPassthroughDeps["process"]>,
+  sandboxName: string,
+): void {
+  proc.stderr.write(
+    `  ⚠ Could not read shields audit history; continuing without relock context. Run \`${CLI_NAME} ${sandboxName} shields status\` to verify current state.\n`,
   );
 }
 
@@ -439,15 +478,16 @@ export async function runAgentPassthrough(
   if (isOpenClawPassthroughCommand(command) && !hasTargetSelector(extraArgs)) {
     rejectNoTargetSelector(proc);
   }
-  // 10-min window: shields timeouts range 1–1800s; 10 min covers even the max
-  // 30-min timeout with a 2× buffer. A longer window risks false-positive warnings
-  // on a relock from a prior session. Adjust if the upstream max changes.
-  const checkShields =
-    deps.getRecentShieldsAutoRestore ??
-    ((name: string) => readRecentShieldsAutoRestore(name, 10 * 60 * 1000));
-  const relock = checkShields(sandboxName);
-  if (relock) {
-    emitShieldsRelockWarning(proc, relock, sandboxName);
+  if (isOpenClawPassthroughCommand(command)) {
+    const checkShields =
+      deps.getRecentShieldsAutoRestore ??
+      ((name: string) => readRecentShieldsAutoRestore(name, SHIELDS_RELOCK_WARNING_WINDOW_MS));
+    const relock = checkShields(sandboxName);
+    if (relock.kind === "event") {
+      emitShieldsRelockWarning(proc, relock.event, sandboxName);
+    } else if (relock.kind === "unreadable") {
+      emitShieldsAuditUnreadableWarning(proc, sandboxName);
+    }
   }
   if (isOpenClawPassthroughCommand(command) && requestsOpenClawJsonOutput(extraArgs)) {
     const execJson = deps.execJson ?? runAgentJsonPassthrough;

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -91,6 +91,7 @@
 //     directly (e.g., a distinct exit code or structured error field for
 //     missing-scope-after-relock), or when NemoClaw implements
 //     extend-on-activity so the scope never lapses mid-session.
+//     (The shields_auto_restore audit entry is appended by timer.ts:295–302.)
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";
@@ -352,6 +353,23 @@ function hasTargetSelector(args: readonly string[]): boolean {
   return false;
 }
 
+function emitShieldsRelockWarning(
+  proc: NonNullable<AgentPassthroughDeps["process"]>,
+  relock: ShieldsAutoRestoreEvent,
+  sandboxName: string,
+): void {
+  const afterPart =
+    relock.timeoutSeconds !== null ? ` after ${String(relock.timeoutSeconds)}s` : "";
+  // timeoutSeconds is pre-validated by readRecentShieldsAutoRestore (finite integer, 1–1800).
+  const timeoutSuggestion =
+    relock.timeoutSeconds !== null
+      ? `--timeout ${String(relock.timeoutSeconds)}s`
+      : "--timeout 60s";
+  proc.stderr.write(
+    `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${sandboxName} shields down ${timeoutSuggestion}\` to extend.\n`,
+  );
+}
+
 function rejectNoTargetSelector(proc: NonNullable<AgentPassthroughDeps["process"]>): never {
   proc.stderr.write(
     "  No target session selected. Use --agent <id>, --session-key <key>, --session-id <id>, or --to <E.164>.\n",
@@ -421,20 +439,15 @@ export async function runAgentPassthrough(
   if (isOpenClawPassthroughCommand(command) && !hasTargetSelector(extraArgs)) {
     rejectNoTargetSelector(proc);
   }
+  // 10-min window: shields timeouts range 1–1800s; 10 min covers even the max
+  // 30-min timeout with a 2× buffer. A longer window risks false-positive warnings
+  // on a relock from a prior session. Adjust if the upstream max changes.
   const checkShields =
     deps.getRecentShieldsAutoRestore ??
     ((name: string) => readRecentShieldsAutoRestore(name, 10 * 60 * 1000));
   const relock = checkShields(sandboxName);
   if (relock) {
-    const afterPart =
-      relock.timeoutSeconds !== null ? ` after ${String(relock.timeoutSeconds)}s` : "";
-    const timeoutSuggestion =
-      relock.timeoutSeconds !== null
-        ? `--timeout ${String(relock.timeoutSeconds)}s`
-        : "--timeout 60s";
-    proc.stderr.write(
-      `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${sandboxName} shields down ${timeoutSuggestion}\` to extend.\n`,
-    );
+    emitShieldsRelockWarning(proc, relock, sandboxName);
   }
   if (isOpenClawPassthroughCommand(command) && requestsOpenClawJsonOutput(extraArgs)) {
     const execJson = deps.execJson ?? runAgentJsonPassthrough;

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -89,6 +89,7 @@
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";
+import { type ShieldsAutoRestoreEvent, readRecentShieldsAutoRestore } from "../../../shields/audit";
 import { parseSandboxPhase } from "../../../state/gateway";
 import * as registry from "../../../state/registry";
 import { execSandbox } from "../exec";
@@ -127,6 +128,7 @@ export interface AgentPassthroughDeps {
   ensureLive?: typeof ensureLiveSandboxOrExit;
   exec?: typeof execSandbox;
   execJson?: typeof runAgentJsonPassthrough;
+  getRecentShieldsAutoRestore?: (sandboxName: string) => ShieldsAutoRestoreEvent | null;
   process?: {
     exit(code: number): never;
     stdout?: { write(s: string): unknown };
@@ -413,6 +415,21 @@ export async function runAgentPassthrough(
   }
   if (isOpenClawPassthroughCommand(command) && !hasTargetSelector(extraArgs)) {
     rejectNoTargetSelector(proc);
+  }
+  const checkShields =
+    deps.getRecentShieldsAutoRestore ??
+    ((name: string) => readRecentShieldsAutoRestore(name, 10 * 60 * 1000));
+  const relock = checkShields(sandboxName);
+  if (relock) {
+    const afterPart =
+      relock.timeoutSeconds !== null ? ` after ${String(relock.timeoutSeconds)}s` : "";
+    const timeoutSuggestion =
+      relock.timeoutSeconds !== null
+        ? `--timeout ${String(relock.timeoutSeconds)}s`
+        : "--timeout 60s";
+    proc.stderr.write(
+      `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${sandboxName} shields down ${timeoutSuggestion}\` to extend.\n`,
+    );
   }
   if (isOpenClawPassthroughCommand(command) && requestsOpenClawJsonOutput(extraArgs)) {
     const execJson = deps.execJson ?? runAgentJsonPassthrough;

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -72,11 +72,14 @@
 //
 //    - Invalid state: after shields auto-relock, the next host CLI
 //      `openclaw agent` dispatch can fail with only `missing scope:
-//      operator.write`, which does not explain the recovery action.
+//      operator.write`, which does not explain the recovery action. An older
+//      relock warning is also stale once the user lowers shields again.
 //    - Source boundary: OpenShell/OpenClaw own current scope state. NemoClaw's
 //      local audit JSONL is non-authoritative and is used only to add likely
-//      relock context; unreadable history never blocks dispatch, and terminal
-//      runtimes are excluded from this OpenClaw-specific diagnostic.
+//      relock context. Validated audit chronology can suppress stale context
+//      but never establishes current policy state; unreadable history never
+//      blocks dispatch, and terminal runtimes are excluded from this
+//      OpenClaw-specific diagnostic.
 //    - Source-fix constraint: an already-running in-sandbox OpenClaw TUI has no
 //      host CLI interception point. Covering that surface requires an upstream
 //      structured relock error or a separate extend-on-activity design. This
@@ -91,7 +94,8 @@
 // captured transport path used to append failure provenance without polluting
 // machine-readable stdout. `passthrough-shields-warning.test.ts` covers the
 // OpenClaw-only relock diagnostic, validated and fallback timeouts, unreadable
-// and absent audit history, and terminal-runtime exclusion.
+// and absent audit history, newer-down suppression, and terminal-runtime
+// exclusion.
 //
 // Removal conditions:
 //

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -107,7 +107,8 @@
 //     directly (e.g., a distinct exit code or structured error field for
 //     missing-scope-after-relock), or when NemoClaw implements
 //     extend-on-activity so the scope never lapses mid-session.
-//     (The shields_auto_restore audit entry is appended by timer.ts:295–302.)
+//     (shields_auto_restore audit entries are written by the shields timer
+//     and inline expired-timer recovery paths.)
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -68,22 +68,9 @@
 //      selector case is intercepted; everything else still flows through to
 //      the in-sandbox binary.
 //
-// 4. Recent shields-relock diagnostic (advisory audit mirror).
-//
-//    - Invalid state: after shields auto-relock, the next host CLI
-//      `openclaw agent` dispatch can fail with only `missing scope:
-//      operator.write`, which does not explain the recovery action. An older
-//      relock warning is also stale once the user lowers shields again.
-//    - Source boundary: OpenShell/OpenClaw own current scope state. NemoClaw's
-//      local audit JSONL is non-authoritative and is used only to add likely
-//      relock context. Validated audit chronology can suppress stale context
-//      but never establishes current policy state; unreadable history never
-//      blocks dispatch, and terminal runtimes are excluded from this
-//      OpenClaw-specific diagnostic.
-//    - Source-fix constraint: an already-running in-sandbox OpenClaw TUI has no
-//      host CLI interception point. Covering that surface requires an upstream
-//      structured relock error or a separate extend-on-activity design. This
-//      wrapper intentionally covers only `nemoclaw <name> agent` dispatches.
+// 4. Recent shields-relock diagnostic (advisory audit mirror). Its complete
+//    source-boundary analysis lives with the focused implementation in
+//    `passthrough-shields-warning.ts`.
 //
 // Regression tests: `passthrough.test.ts` covers the Hermes redirect, the
 // forwarded argv, the registry-miss fallback to OpenClaw, registry and
@@ -92,10 +79,7 @@
 // unparseable phase fail-closed path, the OpenClaw no-selector rejection, and
 // the `--flag=value` selector-acceptance branch, plus the OpenClaw JSON
 // captured transport path used to append failure provenance without polluting
-// machine-readable stdout. `passthrough-shields-warning.test.ts` covers the
-// OpenClaw-only relock diagnostic, validated and fallback timeouts, unreadable
-// and absent audit history, newer-down suppression, and terminal-runtime
-// exclusion.
+// machine-readable stdout. The focused shields diagnostic owns its tests.
 //
 // Removal conditions:
 //
@@ -107,12 +91,6 @@
 //     missing selector with a clean exit 2 and an actionable message.
 //   - Drop the simple-token parser when terminal runtime manifests expose
 //     argv arrays natively.
-//   - Drop the shields-relock warning when OpenClaw exposes the relock cause
-//     directly (e.g., a distinct exit code or structured error field for
-//     missing-scope-after-relock), or when NemoClaw implements
-//     extend-on-activity so the scope never lapses mid-session.
-//     (shields_auto_restore audit entries are written by the shields timer
-//     and inline expired-timer recovery paths.)
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -325,9 +325,11 @@ function requestsOpenClawJsonOutput(extraArgs: readonly string[]): boolean {
   // a value by another OpenClaw option. Source boundary: upstream OpenClaw owns
   // the complete argv grammar; NemoClaw mirrors documented flags only to choose
   // the host transport path. Unknown options fail conservative to normal
-  // passthrough, where OpenClaw parses argv itself. Regression tests cover each
-  // documented value flag, documented equals-form value flags, documented
-  // boolean flags, unknown flag fallback, and the `--` terminator. Removal
+  // passthrough, where OpenClaw parses argv itself. Any newly documented value
+  // flag, including a `--json-*` name, must be added to the value-flag set and
+  // its tests together. Regression tests cover each documented value flag,
+  // documented equals-form value flags, documented boolean flags, unknown flag
+  // fallback, and the `--` terminator. Removal
   // condition: OpenClaw exposes a machine-readable argv schema or NemoClaw stops
   // special-casing the JSON transport path.
   let skipNextValue = false;

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -74,7 +74,8 @@
 // unparseable phase fail-closed path, the OpenClaw no-selector rejection, and
 // the `--flag=value` selector-acceptance branch, plus the OpenClaw JSON
 // captured transport path used to append failure provenance without polluting
-// machine-readable stdout.
+// machine-readable stdout, plus shields auto-relock warning with timeout,
+// null-timeout fallback, and no-warning path.
 //
 // Removal conditions:
 //
@@ -86,6 +87,10 @@
 //     missing selector with a clean exit 2 and an actionable message.
 //   - Drop the simple-token parser when terminal runtime manifests expose
 //     argv arrays natively.
+//   - Drop the shields-relock warning when OpenClaw exposes the relock cause
+//     directly (e.g., a distinct exit code or structured error field for
+//     missing-scope-after-relock), or when NemoClaw implements
+//     extend-on-activity so the scope never lapses mid-session.
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";

--- a/src/lib/actions/sandbox/agent/passthrough.ts
+++ b/src/lib/actions/sandbox/agent/passthrough.ts
@@ -111,17 +111,14 @@
 
 import { type AgentDefinition, isTerminalAgent, listAgents, loadAgent } from "../../../agent/defs";
 import { CLI_NAME } from "../../../cli/branding";
-import {
-  readRecentShieldsAutoRestore,
-  type ShieldsAutoRestoreEvent,
-  type ShieldsAutoRestoreReadResult,
-} from "../../../shields/audit";
+import type { ShieldsAutoRestoreReadResult } from "../../../shields/audit";
 import { parseSandboxPhase } from "../../../state/gateway";
 import * as registry from "../../../state/registry";
 import { execSandbox } from "../exec";
 import { ensureLiveSandboxOrExit } from "../gateway-state";
 import { hasAgentPassthroughHelpToken, printAgentPassthroughHelp } from "./passthrough-help";
 import { type AgentJsonPassthroughProcess, runAgentJsonPassthrough } from "./passthrough-json";
+import { maybeEmitShieldsRelockWarning } from "./passthrough-shields-warning";
 
 export {
   hasAgentPassthroughHelpToken,
@@ -144,11 +141,6 @@ const OPENCLAW_AGENT_VALUE_FLAGS = new Set([
 ]);
 
 const OPENCLAW_AGENT_BOOLEAN_FLAGS = new Set(["--deliver"]);
-
-// A relock remains useful context briefly after it happens. This is a
-// relevance window measured from the restore event, independent of the
-// original shields-down timeout; a longer window risks stale-session warnings.
-const SHIELDS_RELOCK_WARNING_WINDOW_MS = 10 * 60 * 1000;
 
 export interface AgentPassthroughOptions {
   extraArgs?: readonly string[];
@@ -378,37 +370,6 @@ function hasTargetSelector(args: readonly string[]): boolean {
   return false;
 }
 
-function emitShieldsRelockWarning(
-  proc: NonNullable<AgentPassthroughDeps["process"]>,
-  relock: ShieldsAutoRestoreEvent,
-  sandboxName: string,
-): void {
-  // Defend the user-facing command suggestion even when tests or future
-  // callers inject an event without going through the audit reader.
-  const timeoutSeconds =
-    relock.timeoutSeconds !== null &&
-    Number.isInteger(relock.timeoutSeconds) &&
-    relock.timeoutSeconds >= 1 &&
-    relock.timeoutSeconds <= 1800
-      ? relock.timeoutSeconds
-      : null;
-  const afterPart = timeoutSeconds !== null ? ` after ${String(timeoutSeconds)}s` : "";
-  const timeoutSuggestion =
-    timeoutSeconds !== null ? `--timeout ${String(timeoutSeconds)}s` : "--timeout 60s";
-  proc.stderr.write(
-    `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${sandboxName} shields down ${timeoutSuggestion}\` to extend.\n`,
-  );
-}
-
-function emitShieldsAuditUnreadableWarning(
-  proc: NonNullable<AgentPassthroughDeps["process"]>,
-  sandboxName: string,
-): void {
-  proc.stderr.write(
-    `  ⚠ Could not read shields audit history; continuing without relock context. Run \`${CLI_NAME} ${sandboxName} shields status\` to verify current state.\n`,
-  );
-}
-
 function rejectNoTargetSelector(proc: NonNullable<AgentPassthroughDeps["process"]>): never {
   proc.stderr.write(
     "  No target session selected. Use --agent <id>, --session-key <key>, --session-id <id>, or --to <E.164>.\n",
@@ -479,15 +440,7 @@ export async function runAgentPassthrough(
     rejectNoTargetSelector(proc);
   }
   if (isOpenClawPassthroughCommand(command)) {
-    const checkShields =
-      deps.getRecentShieldsAutoRestore ??
-      ((name: string) => readRecentShieldsAutoRestore(name, SHIELDS_RELOCK_WARNING_WINDOW_MS));
-    const relock = checkShields(sandboxName);
-    if (relock.kind === "event") {
-      emitShieldsRelockWarning(proc, relock.event, sandboxName);
-    } else if (relock.kind === "unreadable") {
-      emitShieldsAuditUnreadableWarning(proc, sandboxName);
-    }
+    maybeEmitShieldsRelockWarning(proc, sandboxName, deps.getRecentShieldsAutoRestore);
   }
   if (isOpenClawPassthroughCommand(command) && requestsOpenClawJsonOutput(extraArgs)) {
     const execJson = deps.execJson ?? runAgentJsonPassthrough;

--- a/src/lib/shields/audit-format.test.ts
+++ b/src/lib/shields/audit-format.test.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Test the audit entry format and JSONL structure using the same logic
+// as the production module but with a controllable output path.
+
+type AuditScalar = string | number | boolean | null | undefined;
+type AuditValue = AuditScalar | AuditRecord | AuditValue[];
+type AuditRecord = { [key: string]: AuditValue };
+
+let tmpDir: string;
+let auditPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "shields-audit-test-"));
+  auditPath = path.join(tmpDir, "shields-audit.jsonl");
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Inline audit append — mirrors the production appendAuditEntry() but writes
+ * to our test-controlled path instead of ~/.nemoclaw/state/.
+ */
+function appendAuditEntry(entry: AuditRecord) {
+  fs.appendFileSync(auditPath, JSON.stringify(entry) + "\n", { mode: 0o600 });
+}
+
+describe("shields-audit format", () => {
+  it("creates file on first write and writes valid JSONL", () => {
+    expect(fs.existsSync(auditPath)).toBe(false);
+
+    appendAuditEntry({
+      action: "shields_down",
+      sandbox: "openclaw",
+      timestamp: "2026-04-13T14:30:00Z",
+      timeout_seconds: 300,
+      reason: "Installing Slack plugin",
+      policy_applied: "permissive",
+      policy_snapshot: "/tmp/snapshot.yaml",
+    });
+
+    expect(fs.existsSync(auditPath)).toBe(true);
+    const content = fs.readFileSync(auditPath, "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const entry = JSON.parse(lines[0]);
+    expect(entry.action).toBe("shields_down");
+    expect(entry.sandbox).toBe("openclaw");
+    expect(entry.timeout_seconds).toBe(300);
+  });
+
+  it("appends multiple entries as separate lines", () => {
+    appendAuditEntry({
+      action: "shields_down",
+      sandbox: "openclaw",
+      timestamp: "2026-04-13T14:30:00Z",
+    });
+
+    appendAuditEntry({
+      action: "shields_up",
+      sandbox: "openclaw",
+      timestamp: "2026-04-13T14:32:00Z",
+      restored_by: "operator",
+      duration_seconds: 120,
+    });
+
+    const lines = fs.readFileSync(auditPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+
+    const second = JSON.parse(lines[1]);
+    expect(second.action).toBe("shields_up");
+    expect(second.restored_by).toBe("operator");
+    expect(second.duration_seconds).toBe(120);
+  });
+
+  it("each line is valid JSON", () => {
+    for (let i = 0; i < 5; i++) {
+      appendAuditEntry({
+        action: "shields_down",
+        sandbox: `sandbox-${i}`,
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    const lines = fs.readFileSync(auditPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(5);
+
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("never includes credential-like values in entries", () => {
+    const entry = {
+      action: "shields_down",
+      sandbox: "openclaw",
+      timestamp: "2026-04-13T14:30:00Z",
+      reason: "Installing plugin",
+      policy_applied: "permissive",
+    };
+
+    appendAuditEntry(entry);
+
+    const line = fs.readFileSync(auditPath, "utf-8").trim();
+    expect(line).not.toContain("nvapi-");
+    expect(line).not.toContain("ghp_");
+    expect(line).not.toContain("sk-");
+  });
+});

--- a/src/lib/shields/audit-reader.test.ts
+++ b/src/lib/shields/audit-reader.test.ts
@@ -11,13 +11,6 @@ import {
   type ShieldsAutoRestoreReadResult,
 } from "./audit";
 
-// Test the audit entry format and JSONL structure using the same logic
-// as the production module but with a controllable output path.
-
-type AuditScalar = string | number | boolean | null | undefined;
-type AuditValue = AuditScalar | AuditRecord | AuditValue[];
-type AuditRecord = { [key: string]: AuditValue };
-
 let tmpDir: string;
 let auditPath: string;
 
@@ -30,102 +23,10 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-/**
- * Inline audit append — mirrors the production appendAuditEntry() but writes
- * to our test-controlled path instead of ~/.nemoclaw/state/.
- */
-function appendAuditEntry(entry: AuditRecord) {
-  fs.appendFileSync(auditPath, JSON.stringify(entry) + "\n", { mode: 0o600 });
-}
-
 function requireEvent(result: ShieldsAutoRestoreReadResult): ShieldsAutoRestoreEvent {
   expect(result.kind).toBe("event");
   return (result as Extract<ShieldsAutoRestoreReadResult, { kind: "event" }>).event;
 }
-
-describe("shields-audit", () => {
-  it("creates file on first write and writes valid JSONL", () => {
-    expect(fs.existsSync(auditPath)).toBe(false);
-
-    appendAuditEntry({
-      action: "shields_down",
-      sandbox: "openclaw",
-      timestamp: "2026-04-13T14:30:00Z",
-      timeout_seconds: 300,
-      reason: "Installing Slack plugin",
-      policy_applied: "permissive",
-      policy_snapshot: "/tmp/snapshot.yaml",
-    });
-
-    expect(fs.existsSync(auditPath)).toBe(true);
-    const content = fs.readFileSync(auditPath, "utf-8");
-    const lines = content.trim().split("\n");
-    expect(lines).toHaveLength(1);
-
-    const entry = JSON.parse(lines[0]);
-    expect(entry.action).toBe("shields_down");
-    expect(entry.sandbox).toBe("openclaw");
-    expect(entry.timeout_seconds).toBe(300);
-  });
-
-  it("appends multiple entries as separate lines", () => {
-    appendAuditEntry({
-      action: "shields_down",
-      sandbox: "openclaw",
-      timestamp: "2026-04-13T14:30:00Z",
-    });
-
-    appendAuditEntry({
-      action: "shields_up",
-      sandbox: "openclaw",
-      timestamp: "2026-04-13T14:32:00Z",
-      restored_by: "operator",
-      duration_seconds: 120,
-    });
-
-    const lines = fs.readFileSync(auditPath, "utf-8").trim().split("\n");
-    expect(lines).toHaveLength(2);
-
-    const second = JSON.parse(lines[1]);
-    expect(second.action).toBe("shields_up");
-    expect(second.restored_by).toBe("operator");
-    expect(second.duration_seconds).toBe(120);
-  });
-
-  it("each line is valid JSON", () => {
-    for (let i = 0; i < 5; i++) {
-      appendAuditEntry({
-        action: "shields_down",
-        sandbox: `sandbox-${i}`,
-        timestamp: new Date().toISOString(),
-      });
-    }
-
-    const lines = fs.readFileSync(auditPath, "utf-8").trim().split("\n");
-    expect(lines).toHaveLength(5);
-
-    for (const line of lines) {
-      expect(() => JSON.parse(line)).not.toThrow();
-    }
-  });
-
-  it("never includes credential-like values in entries", () => {
-    const entry = {
-      action: "shields_down",
-      sandbox: "openclaw",
-      timestamp: "2026-04-13T14:30:00Z",
-      reason: "Installing plugin",
-      policy_applied: "permissive",
-    };
-
-    appendAuditEntry(entry);
-
-    const line = fs.readFileSync(auditPath, "utf-8").trim();
-    expect(line).not.toContain("nvapi-");
-    expect(line).not.toContain("ghp_");
-    expect(line).not.toContain("sk-");
-  });
-});
 
 describe("readRecentShieldsAutoRestore", () => {
   it("returns timestamp and timeoutSeconds when shields_down precedes shields_auto_restore (#5922)", () => {
@@ -398,6 +299,28 @@ describe("readRecentShieldsAutoRestore", () => {
 
     const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
     expect(event.timestamp).toBe(timestamp);
+  });
+
+  it("uses a null timeout when shields_down falls outside the bounded tail (#5922)", () => {
+    const timestamp = new Date().toISOString();
+    fs.writeFileSync(
+      auditPath,
+      JSON.stringify({
+        action: "shields_down",
+        sandbox: "alpha",
+        timestamp: new Date(Date.now() - 25 * 1000).toISOString(),
+        timeout_seconds: 20,
+      }) +
+        "\n" +
+        "x".repeat(1024 * 1024 + 100) +
+        "\n" +
+        JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp }) +
+        "\n",
+    );
+
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(timestamp);
+    expect(event.timeoutSeconds).toBeNull();
   });
 
   it("reports an oversized unterminated JSONL entry as unreadable (#5922)", () => {

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -1,11 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
-import { readRecentShieldsAutoRestore } from "./audit";
-import path from "node:path";
 import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readRecentShieldsAutoRestore,
+  type ShieldsAutoRestoreEvent,
+  type ShieldsAutoRestoreReadResult,
+} from "./audit";
 
 // Test the audit entry format and JSONL structure using the same logic
 // as the production module but with a controllable output path.
@@ -32,6 +36,12 @@ afterEach(() => {
  */
 function appendAuditEntry(entry: AuditRecord) {
   fs.appendFileSync(auditPath, JSON.stringify(entry) + "\n", { mode: 0o600 });
+}
+
+function requireEvent(result: ShieldsAutoRestoreReadResult): ShieldsAutoRestoreEvent {
+  expect(result.kind).toBe("event");
+  if (result.kind !== "event") throw new Error(`expected event result, got ${result.kind}`);
+  return result.event;
 }
 
 describe("shields-audit", () => {
@@ -133,9 +143,9 @@ describe("readRecentShieldsAutoRestore", () => {
         JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
         "\n",
     );
-    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result?.timestamp).toBe(now);
-    expect(result?.timeoutSeconds).toBe(20);
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(now);
+    expect(event.timeoutSeconds).toBe(20);
   });
 
   it("returns timestamp with null timeoutSeconds when no shields_down entry exists (#5922)", () => {
@@ -144,12 +154,12 @@ describe("readRecentShieldsAutoRestore", () => {
       auditPath,
       JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) + "\n",
     );
-    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result?.timestamp).toBe(now);
-    expect(result?.timeoutSeconds).toBeNull();
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(now);
+    expect(event.timeoutSeconds).toBeNull();
   });
 
-  it("returns null when the shields_auto_restore entry is future-dated (#5922)", () => {
+  it("returns no event when the shields_auto_restore entry is future-dated (#5922)", () => {
     const future = new Date(Date.now() + 60 * 1000).toISOString();
     fs.appendFileSync(
       auditPath,
@@ -157,20 +167,20 @@ describe("readRecentShieldsAutoRestore", () => {
         "\n",
     );
     const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: "none" });
   });
 
-  it("returns null when the most recent shields_auto_restore entry is older than the window (#5922)", () => {
+  it("returns no event when the most recent shields_auto_restore entry is older than the window (#5922)", () => {
     const old = new Date(Date.now() - 20 * 60 * 1000).toISOString();
     fs.appendFileSync(
       auditPath,
       JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: old }) + "\n",
     );
     const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: "none" });
   });
 
-  it("returns null when the recent shields_auto_restore entry is for a different sandbox (#5922)", () => {
+  it("returns no event when the recent shields_auto_restore entry is for a different sandbox (#5922)", () => {
     const now = new Date().toISOString();
     fs.appendFileSync(
       auditPath,
@@ -178,12 +188,12 @@ describe("readRecentShieldsAutoRestore", () => {
         "\n",
     );
     const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: "none" });
   });
 
-  it("returns null when the audit file does not exist (#5922)", () => {
+  it("returns no event when the audit file does not exist (#5922)", () => {
     const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: "none" });
   });
 
   it("returns null timeoutSeconds for out-of-bounds timeout values in shields_down entry (#5922)", () => {
@@ -202,9 +212,9 @@ describe("readRecentShieldsAutoRestore", () => {
           JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
           "\n",
       );
-      const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-      expect(result?.timestamp, `bad value ${String(bad)}`).toBe(now);
-      expect(result?.timeoutSeconds, `bad value ${String(bad)}`).toBeNull();
+      const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+      expect(event.timestamp, `bad value ${String(bad)}`).toBe(now);
+      expect(event.timeoutSeconds, `bad value ${String(bad)}`).toBeNull();
     }
   });
 
@@ -225,9 +235,9 @@ describe("readRecentShieldsAutoRestore", () => {
         JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
         "\n",
     );
-    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result?.timestamp).toBe(now);
-    expect(result?.timeoutSeconds).toBe(30);
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(now);
+    expect(event.timeoutSeconds).toBe(30);
   });
 
   it("uses the immediately-preceding shields_down when multiple exist (#5922)", () => {
@@ -253,9 +263,9 @@ describe("readRecentShieldsAutoRestore", () => {
         JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
         "\n",
     );
-    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-    expect(result?.timestamp).toBe(now);
-    expect(result?.timeoutSeconds).toBe(45);
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(now);
+    expect(event.timeoutSeconds).toBe(45);
   });
 
   it("returns null timeoutSeconds when shields_down has NaN or Infinity as a raw string payload (#5922)", () => {
@@ -271,9 +281,69 @@ describe("readRecentShieldsAutoRestore", () => {
       });
       fs.writeFileSync(auditPath, downLine + "\n" + restoreLine + "\n");
       // Malformed JSON (NaN/Infinity are not valid JSON) → parseEntry returns null → timeoutSeconds stays null
-      const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
-      expect(result?.timestamp, `raw value ${rawValue}`).toBe(now);
-      expect(result?.timeoutSeconds, `raw value ${rawValue}`).toBeNull();
+      const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+      expect(event.timestamp, `raw value ${rawValue}`).toBe(now);
+      expect(event.timeoutSeconds, `raw value ${rawValue}`).toBeNull();
     }
+  });
+
+  it("distinguishes unreadable audit history from an absent audit file (#5922)", () => {
+    fs.mkdirSync(auditPath);
+    expect(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath)).toEqual({
+      kind: "unreadable",
+    });
+  });
+
+  it("skips invalid restore timestamps and finds the next valid recent event (#5922)", () => {
+    const validTimestamp = new Date(Date.now() - 1000).toISOString();
+    fs.writeFileSync(
+      auditPath,
+      [
+        JSON.stringify({
+          action: "shields_auto_restore",
+          sandbox: "alpha",
+          timestamp: validTimestamp,
+        }),
+        JSON.stringify({
+          action: "shields_auto_restore",
+          sandbox: "alpha",
+          timestamp: "not-a-timestamp",
+        }),
+      ].join("\n") + "\n",
+    );
+
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(validTimestamp);
+  });
+
+  it("skips non-object JSONL tail rows while finding a valid restore event (#5922)", () => {
+    const timestamp = new Date().toISOString();
+    fs.writeFileSync(
+      auditPath,
+      [
+        JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp }),
+        "null",
+        "[]",
+        '"text"',
+        "42",
+      ].join("\n") + "\n",
+    );
+
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(timestamp);
+  });
+
+  it("reads only the bounded audit tail and discards its partial first line (#5922)", () => {
+    const timestamp = new Date().toISOString();
+    fs.writeFileSync(
+      auditPath,
+      "x".repeat(1024 * 1024 + 100) +
+        "\n" +
+        JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp }) +
+        "\n",
+    );
+
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(timestamp);
   });
 });

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -370,11 +370,11 @@ describe("readRecentShieldsAutoRestore", () => {
     expect(event.timestamp).toBe(timestamp);
   });
 
-  it("returns no event when the bounded tail has no complete JSONL entry (#5922)", () => {
+  it("reports an oversized unterminated JSONL entry as unreadable (#5922)", () => {
     fs.writeFileSync(auditPath, "x".repeat(1024 * 1024 + 100));
 
     expect(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath)).toEqual({
-      kind: "none",
+      kind: "unreadable",
     });
   });
 });

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -267,6 +267,30 @@ describe("readRecentShieldsAutoRestore", () => {
     expect(event.timeoutSeconds).toBe(45);
   });
 
+  it("rejects a shields_down timeout timestamped after its auto-restore (#5922)", () => {
+    const restoreTimestamp = new Date().toISOString();
+    fs.writeFileSync(
+      auditPath,
+      JSON.stringify({
+        action: "shields_down",
+        sandbox: "alpha",
+        timestamp: new Date(Date.now() + 60 * 1000).toISOString(),
+        timeout_seconds: 45,
+      }) +
+        "\n" +
+        JSON.stringify({
+          action: "shields_auto_restore",
+          sandbox: "alpha",
+          timestamp: restoreTimestamp,
+        }) +
+        "\n",
+    );
+
+    const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
+    expect(event.timestamp).toBe(restoreTimestamp);
+    expect(event.timeoutSeconds).toBeNull();
+  });
+
   it("returns null timeoutSeconds when shields_down has NaN or Infinity as a raw string payload (#5922)", () => {
     // JSON.stringify(NaN) and JSON.stringify(Infinity) both produce "null",
     // so write the JSONL line manually to exercise the non-finite path.
@@ -344,5 +368,13 @@ describe("readRecentShieldsAutoRestore", () => {
 
     const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
     expect(event.timestamp).toBe(timestamp);
+  });
+
+  it("returns no event when the bounded tail has no complete JSONL entry (#5922)", () => {
+    fs.writeFileSync(auditPath, "x".repeat(1024 * 1024 + 100));
+
+    expect(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath)).toEqual({
+      kind: "none",
+    });
   });
 });

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -208,6 +208,56 @@ describe("readRecentShieldsAutoRestore", () => {
     }
   });
 
+  it("returns correct timeoutSeconds when a malformed JSONL line sits between shields_down and shields_auto_restore (#5922)", () => {
+    const now = new Date().toISOString();
+    const downLine = JSON.stringify({
+      action: "shields_down",
+      sandbox: "alpha",
+      timestamp: new Date(Date.now() - 25 * 1000).toISOString(),
+      timeout_seconds: 30,
+    });
+    // Malformed line between the two valid entries; parseEntry must skip it and
+    // continue to find the preceding shields_down.
+    fs.writeFileSync(
+      auditPath,
+      downLine +
+        "\n{not valid json\n" +
+        JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
+        "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result?.timestamp).toBe(now);
+    expect(result?.timeoutSeconds).toBe(30);
+  });
+
+  it("uses the immediately-preceding shields_down when multiple exist (#5922)", () => {
+    const now = new Date().toISOString();
+    // Two shields_down entries with different timeout_seconds. The second (most
+    // recent) should be used because it immediately precedes the auto-restore.
+    fs.writeFileSync(
+      auditPath,
+      JSON.stringify({
+        action: "shields_down",
+        sandbox: "alpha",
+        timestamp: new Date(Date.now() - 60 * 1000).toISOString(),
+        timeout_seconds: 120,
+      }) +
+        "\n" +
+        JSON.stringify({
+          action: "shields_down",
+          sandbox: "alpha",
+          timestamp: new Date(Date.now() - 25 * 1000).toISOString(),
+          timeout_seconds: 45,
+        }) +
+        "\n" +
+        JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
+        "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result?.timestamp).toBe(now);
+    expect(result?.timeoutSeconds).toBe(45);
+  });
+
   it("returns null timeoutSeconds when shields_down has NaN or Infinity as a raw string payload (#5922)", () => {
     // JSON.stringify(NaN) and JSON.stringify(Infinity) both produce "null",
     // so write the JSONL line manually to exercise the non-finite path.

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -174,4 +174,25 @@ describe("readRecentShieldsAutoRestore", () => {
     const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
     expect(result).toBeNull();
   });
+
+  it("returns null timeoutSeconds for out-of-bounds timeout values in shields_down entry (#5922)", () => {
+    const now = new Date().toISOString();
+    for (const bad of [0, -1, 1801, 9999, 1.5, Number.POSITIVE_INFINITY, Number.NaN]) {
+      fs.writeFileSync(
+        auditPath,
+        JSON.stringify({
+          action: "shields_down",
+          sandbox: "alpha",
+          timestamp: new Date(Date.now() - 25 * 1000).toISOString(),
+          timeout_seconds: bad,
+        }) +
+          "\n" +
+          JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
+          "\n",
+      );
+      const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+      expect(result?.timestamp, `bad value ${String(bad)}`).toBe(now);
+      expect(result?.timeoutSeconds, `bad value ${String(bad)}`).toBeNull();
+    }
+  });
 });

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -149,6 +149,16 @@ describe("readRecentShieldsAutoRestore", () => {
     expect(result?.timeoutSeconds).toBeNull();
   });
 
+  it("returns null when the shields_auto_restore entry is future-dated (#5922)", () => {
+    const future = new Date(Date.now() + 60 * 1000).toISOString();
+    fs.appendFileSync(
+      auditPath,
+      JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: future }) + "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result).toBeNull();
+  });
+
   it("returns null when the most recent shields_auto_restore entry is older than the window (#5922)", () => {
     const old = new Date(Date.now() - 20 * 60 * 1000).toISOString();
     fs.appendFileSync(

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -291,6 +291,36 @@ describe("readRecentShieldsAutoRestore", () => {
     expect(event.timeoutSeconds).toBeNull();
   });
 
+  it("suppresses stale relock context after a newer shields_down (#5922)", () => {
+    const now = Date.now();
+    fs.writeFileSync(
+      auditPath,
+      [
+        JSON.stringify({
+          action: "shields_down",
+          sandbox: "alpha",
+          timestamp: new Date(now - 30 * 1000).toISOString(),
+          timeout_seconds: 20,
+        }),
+        JSON.stringify({
+          action: "shields_auto_restore",
+          sandbox: "alpha",
+          timestamp: new Date(now - 20 * 1000).toISOString(),
+        }),
+        JSON.stringify({
+          action: "shields_down",
+          sandbox: "alpha",
+          timestamp: new Date(now - 10 * 1000).toISOString(),
+          timeout_seconds: 60,
+        }),
+      ].join("\n") + "\n",
+    );
+
+    expect(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath)).toEqual({
+      kind: "none",
+    });
+  });
+
   it("returns null timeoutSeconds when shields_down has NaN or Infinity as a raw string payload (#5922)", () => {
     // JSON.stringify(NaN) and JSON.stringify(Infinity) both produce "null",
     // so write the JSONL line manually to exercise the non-finite path.

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -153,7 +153,8 @@ describe("readRecentShieldsAutoRestore", () => {
     const future = new Date(Date.now() + 60 * 1000).toISOString();
     fs.appendFileSync(
       auditPath,
-      JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: future }) + "\n",
+      JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: future }) +
+        "\n",
     );
     const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
     expect(result).toBeNull();

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import { readRecentShieldsAutoRestore } from "./audit";
 import path from "node:path";
 import os from "node:os";
 
@@ -114,5 +115,63 @@ describe("shields-audit", () => {
     expect(line).not.toContain("nvapi-");
     expect(line).not.toContain("ghp_");
     expect(line).not.toContain("sk-");
+  });
+});
+
+describe("readRecentShieldsAutoRestore", () => {
+  it("returns timestamp and timeoutSeconds when shields_down precedes shields_auto_restore (#5922)", () => {
+    const now = new Date().toISOString();
+    fs.appendFileSync(
+      auditPath,
+      JSON.stringify({
+        action: "shields_down",
+        sandbox: "alpha",
+        timestamp: new Date(Date.now() - 25 * 1000).toISOString(),
+        timeout_seconds: 20,
+      }) +
+        "\n" +
+        JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) +
+        "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result?.timestamp).toBe(now);
+    expect(result?.timeoutSeconds).toBe(20);
+  });
+
+  it("returns timestamp with null timeoutSeconds when no shields_down entry exists (#5922)", () => {
+    const now = new Date().toISOString();
+    fs.appendFileSync(
+      auditPath,
+      JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: now }) + "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result?.timestamp).toBe(now);
+    expect(result?.timeoutSeconds).toBeNull();
+  });
+
+  it("returns null when the most recent shields_auto_restore entry is older than the window (#5922)", () => {
+    const old = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+    fs.appendFileSync(
+      auditPath,
+      JSON.stringify({ action: "shields_auto_restore", sandbox: "alpha", timestamp: old }) + "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the recent shields_auto_restore entry is for a different sandbox (#5922)", () => {
+    const now = new Date().toISOString();
+    fs.appendFileSync(
+      auditPath,
+      JSON.stringify({ action: "shields_auto_restore", sandbox: "other-sb", timestamp: now }) +
+        "\n",
+    );
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the audit file does not exist (#5922)", () => {
+    const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+    expect(result).toBeNull();
   });
 });

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -177,7 +177,8 @@ describe("readRecentShieldsAutoRestore", () => {
 
   it("returns null timeoutSeconds for out-of-bounds timeout values in shields_down entry (#5922)", () => {
     const now = new Date().toISOString();
-    for (const bad of [0, -1, 1801, 9999, 1.5, Number.POSITIVE_INFINITY, Number.NaN]) {
+    // JSON.stringify serializes these correctly (finite numbers)
+    for (const bad of [0, -1, 1801, 9999, 1.5]) {
       fs.writeFileSync(
         auditPath,
         JSON.stringify({
@@ -193,6 +194,25 @@ describe("readRecentShieldsAutoRestore", () => {
       const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
       expect(result?.timestamp, `bad value ${String(bad)}`).toBe(now);
       expect(result?.timeoutSeconds, `bad value ${String(bad)}`).toBeNull();
+    }
+  });
+
+  it("returns null timeoutSeconds when shields_down has NaN or Infinity as a raw string payload (#5922)", () => {
+    // JSON.stringify(NaN) and JSON.stringify(Infinity) both produce "null",
+    // so write the JSONL line manually to exercise the non-finite path.
+    const now = new Date().toISOString();
+    for (const rawValue of ["NaN", "Infinity", "-Infinity"]) {
+      const downLine = `{"action":"shields_down","sandbox":"alpha","timestamp":"${new Date(Date.now() - 25 * 1000).toISOString()}","timeout_seconds":${rawValue}}`;
+      const restoreLine = JSON.stringify({
+        action: "shields_auto_restore",
+        sandbox: "alpha",
+        timestamp: now,
+      });
+      fs.writeFileSync(auditPath, downLine + "\n" + restoreLine + "\n");
+      // Malformed JSON (NaN/Infinity are not valid JSON) → parseEntry returns null → timeoutSeconds stays null
+      const result = readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath);
+      expect(result?.timestamp, `raw value ${rawValue}`).toBe(now);
+      expect(result?.timeoutSeconds, `raw value ${rawValue}`).toBeNull();
     }
   });
 });

--- a/src/lib/shields/audit.test.ts
+++ b/src/lib/shields/audit.test.ts
@@ -40,8 +40,7 @@ function appendAuditEntry(entry: AuditRecord) {
 
 function requireEvent(result: ShieldsAutoRestoreReadResult): ShieldsAutoRestoreEvent {
   expect(result.kind).toBe("event");
-  if (result.kind !== "event") throw new Error(`expected event result, got ${result.kind}`);
-  return result.event;
+  return (result as Extract<ShieldsAutoRestoreReadResult, { kind: "event" }>).event;
 }
 
 describe("shields-audit", () => {

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -93,9 +93,12 @@ function readAuditTail(auditFile: string): string {
 
     // The bounded read can begin in the middle of a JSONL entry. Drop that
     // partial first line and retain only complete entries from the tail. If
-    // there is no newline, the tail contains no complete JSONL entry.
+    // there is no newline, an oversized unterminated entry has consumed the
+    // entire tail; report degraded visibility instead of treating it as an
+    // empty audit log.
     const firstNewline = content.indexOf("\n");
-    return firstNewline === -1 ? "" : content.slice(firstNewline + 1);
+    if (firstNewline === -1) throw new Error("audit JSONL entry exceeds bounded tail");
+    return content.slice(firstNewline + 1);
   } finally {
     closeSync(fd);
   }
@@ -118,10 +121,13 @@ function readAuditTail(auditFile: string): string {
  * this advisory check into a denial-of-service boundary. Future-dated entries
  * are rejected so a crafted row cannot pin the warning permanently.
  *
- * Only the last 1 MiB is read. This bounds synchronous work on the dispatch
- * path while retaining thousands of normal audit entries; if the matching
- * `shields_down` row falls outside that tail, the event remains useful with a
- * null timeout and the caller uses its safe fallback suggestion.
+ * Only the last 1 MiB is read. This intentionally keeps the one-shot CLI read
+ * synchronous so the warning is ordered before dispatch while bounding the
+ * work to thousands of normal audit entries. If the matching `shields_down`
+ * row falls outside that tail, the event remains useful with a null timeout
+ * and the caller uses its safe fallback suggestion. Revisit the synchronous
+ * API if audit storage moves off the local filesystem or into a long-lived
+ * process.
  *
  * Remove this reader when OpenClaw exposes a structured relock cause or when
  * extend-on-activity removes the mid-session relock condition.

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -92,7 +92,8 @@ function readAuditTail(auditFile: string): string {
     if (offset === 0) return content;
 
     // The bounded read can begin in the middle of a JSONL entry. Drop that
-    // partial first line and retain only complete entries from the tail.
+    // partial first line and retain only complete entries from the tail. If
+    // there is no newline, the tail contains no complete JSONL entry.
     const firstNewline = content.indexOf("\n");
     return firstNewline === -1 ? "" : content.slice(firstNewline + 1);
   } finally {
@@ -178,7 +179,11 @@ export function readRecentShieldsAutoRestore(
     for (let j = i - 1; j >= 0; j--) {
       const prev = parseEntry(lines[j]);
       if (prev?.action === "shields_down" && prev.sandbox === sandboxName) {
+        const downMs =
+          typeof prev.timestamp === "string" ? new Date(prev.timestamp).getTime() : Number.NaN;
         if (
+          Number.isFinite(downMs) &&
+          downMs <= restoreMs &&
           typeof prev.timeout_seconds === "number" &&
           Number.isFinite(prev.timeout_seconds) &&
           Number.isInteger(prev.timeout_seconds) &&

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -118,7 +118,13 @@ export function readRecentShieldsAutoRestore(
       for (let j = i - 1; j >= 0; j--) {
         const prev = parseEntry(lines[j]);
         if (prev?.action === "shields_down" && prev.sandbox === sandboxName) {
-          if (typeof prev.timeout_seconds === "number") {
+          if (
+            typeof prev.timeout_seconds === "number" &&
+            Number.isFinite(prev.timeout_seconds) &&
+            Number.isInteger(prev.timeout_seconds) &&
+            prev.timeout_seconds >= 1 &&
+            prev.timeout_seconds <= 1800
+          ) {
             timeoutSeconds = prev.timeout_seconds;
           }
           break;

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -10,7 +10,7 @@
  * Entries never contain credential values — only key names and policy labels.
  */
 
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { redactFull } from "../security/redact";
 import { ensureConfigDir } from "../state/config-io";
@@ -54,6 +54,80 @@ export function appendAuditEntry(entry: ShieldsAuditEntry): void {
   if (safe.reason) safe.reason = redactFull(safe.reason);
   if (safe.error) safe.error = redactFull(safe.error);
   appendFileSync(AUDIT_FILE, JSON.stringify(safe) + "\n", { mode: 0o600 });
+}
+
+export interface ShieldsAutoRestoreEvent {
+  /** ISO timestamp written by the auto-restore timer. */
+  timestamp: string;
+  /**
+   * Original timeout in seconds from the preceding `shields_down` entry, or
+   * null when that entry is not found in the audit log.
+   */
+  timeoutSeconds: number | null;
+}
+
+/**
+ * Scan the audit log in reverse and return details about the most recent
+ * `shields_auto_restore` event for the given sandbox that falls within
+ * `withinMs` milliseconds of now. Also reads the preceding `shields_down`
+ * entry to recover the original timeout so callers can echo it back.
+ *
+ * Returns null when no matching entry is found or the file is unreadable.
+ * The optional `auditFile` parameter overrides the default path; used in tests.
+ */
+export function readRecentShieldsAutoRestore(
+  sandboxName: string,
+  withinMs: number,
+  auditFile: string = AUDIT_FILE,
+): ShieldsAutoRestoreEvent | null {
+  let content: string;
+  try {
+    content = readFileSync(auditFile, "utf8");
+  } catch {
+    return null;
+  }
+  const cutoff = Date.now() - withinMs;
+  const lines = content.split("\n");
+
+  function parseEntry(line: string): Record<string, unknown> | null {
+    const trimmed = line.trim();
+    if (!trimmed) return null;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // malformed line — skip
+    }
+    return null;
+  }
+
+  // Scan backwards for the most recent shields_auto_restore within the window.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const entry = parseEntry(lines[i]);
+    if (
+      entry?.action === "shields_auto_restore" &&
+      entry.sandbox === sandboxName &&
+      typeof entry.timestamp === "string" &&
+      new Date(entry.timestamp).getTime() >= cutoff
+    ) {
+      const restoreTs = entry.timestamp;
+      // Continue backwards to find the preceding shields_down to get timeout_seconds.
+      let timeoutSeconds: number | null = null;
+      for (let j = i - 1; j >= 0; j--) {
+        const prev = parseEntry(lines[j]);
+        if (prev?.action === "shields_down" && prev.sandbox === sandboxName) {
+          if (typeof prev.timeout_seconds === "number") {
+            timeoutSeconds = prev.timeout_seconds;
+          }
+          break;
+        }
+      }
+      return { timestamp: restoreTs, timeoutSeconds };
+    }
+  }
+  return null;
 }
 
 export { AUDIT_FILE, AUDIT_DIR };

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -103,35 +103,37 @@ export function readRecentShieldsAutoRestore(
     return null;
   }
 
+  const now = Date.now();
   // Scan backwards for the most recent shields_auto_restore within the window.
   for (let i = lines.length - 1; i >= 0; i--) {
     const entry = parseEntry(lines[i]);
     if (
-      entry?.action === "shields_auto_restore" &&
-      entry.sandbox === sandboxName &&
-      typeof entry.timestamp === "string" &&
-      new Date(entry.timestamp).getTime() >= cutoff
-    ) {
-      const restoreTs = entry.timestamp;
-      // Continue backwards to find the preceding shields_down to get timeout_seconds.
-      let timeoutSeconds: number | null = null;
-      for (let j = i - 1; j >= 0; j--) {
-        const prev = parseEntry(lines[j]);
-        if (prev?.action === "shields_down" && prev.sandbox === sandboxName) {
-          if (
-            typeof prev.timeout_seconds === "number" &&
-            Number.isFinite(prev.timeout_seconds) &&
-            Number.isInteger(prev.timeout_seconds) &&
-            prev.timeout_seconds >= 1 &&
-            prev.timeout_seconds <= 1800
-          ) {
-            timeoutSeconds = prev.timeout_seconds;
-          }
-          break;
+      entry?.action !== "shields_auto_restore" ||
+      entry.sandbox !== sandboxName ||
+      typeof entry.timestamp !== "string"
+    )
+      continue;
+    const restoreMs = new Date(entry.timestamp).getTime();
+    if (!Number.isFinite(restoreMs) || restoreMs < cutoff || restoreMs > now) continue;
+    const restoreTs = entry.timestamp;
+    // Continue backwards to find the preceding shields_down to get timeout_seconds.
+    let timeoutSeconds: number | null = null;
+    for (let j = i - 1; j >= 0; j--) {
+      const prev = parseEntry(lines[j]);
+      if (prev?.action === "shields_down" && prev.sandbox === sandboxName) {
+        if (
+          typeof prev.timeout_seconds === "number" &&
+          Number.isFinite(prev.timeout_seconds) &&
+          Number.isInteger(prev.timeout_seconds) &&
+          prev.timeout_seconds >= 1 &&
+          prev.timeout_seconds <= 1800
+        ) {
+          timeoutSeconds = prev.timeout_seconds;
         }
+        break;
       }
-      return { timestamp: restoreTs, timeoutSeconds };
     }
+    return { timestamp: restoreTs, timeoutSeconds };
   }
   return null;
 }

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -72,7 +72,16 @@ export interface ShieldsAutoRestoreEvent {
  * `withinMs` milliseconds of now. Also reads the preceding `shields_down`
  * entry to recover the original timeout so callers can echo it back.
  *
- * Returns null when no matching entry is found or the file is unreadable.
+ * Returns null when no matching entry is found OR when the file is unreadable.
+ * Fail-open is intentional: blocking agent dispatch on audit I/O errors (e.g.
+ * EACCES, EIO) would be a DoS vector — callers must treat null as "no warning"
+ * rather than "no event." Future-dated entries are rejected as a clock-skew
+ * defense so a crafted entry cannot pin the warning permanently.
+ *
+ * File-size note: the audit file is user-owned and written only by NemoClaw at
+ * ~200 bytes per entry. An unbounded readFileSync is acceptable for this
+ * warning-only path; add a size cap if the audit log gains a rotation policy.
+ *
  * The optional `auditFile` parameter overrides the default path; used in tests.
  */
 export function readRecentShieldsAutoRestore(
@@ -98,7 +107,9 @@ export function readRecentShieldsAutoRestore(
         return parsed as Record<string, unknown>;
       }
     } catch {
-      // malformed line — skip
+      // Intentional resilient skip: a malformed or truncated JSONL line (e.g.
+      // from a partial write or manual edit) must not prevent finding valid
+      // surrounding entries. The reverse scan continues past it.
     }
     return null;
   }

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -10,7 +10,7 @@
  * Entries never contain credential values — only key names and policy labels.
  */
 
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, closeSync, fstatSync, openSync, readSync } from "node:fs";
 import { join } from "node:path";
 import { redactFull } from "../security/redact";
 import { ensureConfigDir } from "../state/config-io";
@@ -66,21 +66,64 @@ export interface ShieldsAutoRestoreEvent {
   timeoutSeconds: number | null;
 }
 
+export type ShieldsAutoRestoreReadResult =
+  | { kind: "event"; event: ShieldsAutoRestoreEvent }
+  | { kind: "none" }
+  | { kind: "unreadable" };
+
+const MAX_RECENT_AUDIT_BYTES = 1024 * 1024;
+
+function readAuditTail(auditFile: string): string {
+  const fd = openSync(auditFile, "r");
+  try {
+    const size = fstatSync(fd).size;
+    const bytesToRead = Math.min(size, MAX_RECENT_AUDIT_BYTES);
+    if (bytesToRead === 0) return "";
+
+    const offset = size - bytesToRead;
+    const buffer = Buffer.alloc(bytesToRead);
+    let bytesRead = 0;
+    while (bytesRead < bytesToRead) {
+      const count = readSync(fd, buffer, bytesRead, bytesToRead - bytesRead, offset + bytesRead);
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    const content = buffer.subarray(0, bytesRead).toString("utf8");
+    if (offset === 0) return content;
+
+    // The bounded read can begin in the middle of a JSONL entry. Drop that
+    // partial first line and retain only complete entries from the tail.
+    const firstNewline = content.indexOf("\n");
+    return firstNewline === -1 ? "" : content.slice(firstNewline + 1);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /**
  * Scan the audit log in reverse and return details about the most recent
  * `shields_auto_restore` event for the given sandbox that falls within
  * `withinMs` milliseconds of now. Also reads the preceding `shields_down`
  * entry to recover the original timeout so callers can echo it back.
  *
- * Returns null when no matching entry is found OR when the file is unreadable.
- * Fail-open is intentional: blocking agent dispatch on audit I/O errors (e.g.
- * EACCES, EIO) would be a DoS vector — callers must treat null as "no warning"
- * rather than "no event." Future-dated entries are rejected as a clock-skew
- * defense so a crafted entry cannot pin the warning permanently.
+ * This log is non-authoritative UX input. Missing, corrupt, or locally tampered
+ * rows must never make policy or current shield-state decisions; callers use an
+ * `event` result only to explain a likely relock. Current state is queried by
+ * the shields commands themselves.
  *
- * File-size note: the audit file is user-owned and written only by NemoClaw at
- * ~200 bytes per entry. An unbounded readFileSync is acceptable for this
- * warning-only path; add a size cap if the audit log gains a rotation policy.
+ * Missing files return `none`. Other read failures return `unreadable` so the
+ * caller can surface degraded audit visibility while still dispatching the
+ * agent. Fail-open is intentional: blocking dispatch on EACCES/EIO would turn
+ * this advisory check into a denial-of-service boundary. Future-dated entries
+ * are rejected so a crafted row cannot pin the warning permanently.
+ *
+ * Only the last 1 MiB is read. This bounds synchronous work on the dispatch
+ * path while retaining thousands of normal audit entries; if the matching
+ * `shields_down` row falls outside that tail, the event remains useful with a
+ * null timeout and the caller uses its safe fallback suggestion.
+ *
+ * Remove this reader when OpenClaw exposes a structured relock cause or when
+ * extend-on-activity removes the mid-session relock condition.
  *
  * The optional `auditFile` parameter overrides the default path; used in tests.
  */
@@ -88,12 +131,15 @@ export function readRecentShieldsAutoRestore(
   sandboxName: string,
   withinMs: number,
   auditFile: string = AUDIT_FILE,
-): ShieldsAutoRestoreEvent | null {
+): ShieldsAutoRestoreReadResult {
+  if (!Number.isFinite(withinMs) || withinMs <= 0) return { kind: "none" };
+
   let content: string;
   try {
-    content = readFileSync(auditFile, "utf8");
-  } catch {
-    return null;
+    content = readAuditTail(auditFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "none" };
+    return { kind: "unreadable" };
   }
   const cutoff = Date.now() - withinMs;
   const lines = content.split("\n");
@@ -144,9 +190,9 @@ export function readRecentShieldsAutoRestore(
         break;
       }
     }
-    return { timestamp: restoreTs, timeoutSeconds };
+    return { kind: "event", event: { timestamp: restoreTs, timeoutSeconds } };
   }
-  return null;
+  return { kind: "none" };
 }
 
-export { AUDIT_FILE, AUDIT_DIR };
+export { AUDIT_DIR, AUDIT_FILE };

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -119,7 +119,9 @@ function readAuditTail(auditFile: string): string {
  * caller can surface degraded audit visibility while still dispatching the
  * agent. Fail-open is intentional: blocking dispatch on EACCES/EIO would turn
  * this advisory check into a denial-of-service boundary. Future-dated entries
- * are rejected so a crafted row cannot pin the warning permanently.
+ * are rejected strictly so a crafted row cannot pin the warning permanently;
+ * the same host clock writes and reads this local log, and a rare false
+ * negative after a backward clock adjustment is safer than stale guidance.
  *
  * Only the last 1 MiB is read. This intentionally keeps the one-shot CLI read
  * synchronous so the warning is ordered before dispatch while bounding the

--- a/src/lib/shields/audit.ts
+++ b/src/lib/shields/audit.ts
@@ -169,16 +169,27 @@ export function readRecentShieldsAutoRestore(
 
   const now = Date.now();
   // Scan backwards for the most recent shields_auto_restore within the window.
+  // A later shields_down for the same sandbox makes older relock context stale,
+  // but remains advisory: it suppresses only this warning and never establishes
+  // current shield state.
+  let newerShieldsDownMs: number | null = null;
   for (let i = lines.length - 1; i >= 0; i--) {
     const entry = parseEntry(lines[i]);
-    if (
-      entry?.action !== "shields_auto_restore" ||
-      entry.sandbox !== sandboxName ||
-      typeof entry.timestamp !== "string"
-    )
+    if (entry?.sandbox !== sandboxName) continue;
+    if (entry.action === "shields_down") {
+      const downMs =
+        typeof entry.timestamp === "string" ? new Date(entry.timestamp).getTime() : Number.NaN;
+      if (Number.isFinite(downMs) && downMs <= now) {
+        newerShieldsDownMs = Math.max(newerShieldsDownMs ?? downMs, downMs);
+      }
       continue;
+    }
+    if (entry?.action !== "shields_auto_restore" || typeof entry.timestamp !== "string") continue;
     const restoreMs = new Date(entry.timestamp).getTime();
     if (!Number.isFinite(restoreMs) || restoreMs < cutoff || restoreMs > now) continue;
+    if (newerShieldsDownMs !== null && newerShieldsDownMs >= restoreMs) {
+      return { kind: "none" };
+    }
     const restoreTs = entry.timestamp;
     // Continue backwards to find the preceding shields_down to get timeout_seconds.
     let timeoutSeconds: number | null = null;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

After shields auto-restore, the next host `nemoclaw <sb> agent` invocation can fail with OpenClaw's cryptic `missing scope: operator.write` error. This PR adds a bounded, non-authoritative audit check that emits actionable recovery context on stderr before host CLI dispatch without contaminating JSON stdout.

## Related Issue and Scope

Refs #5922

**Partial host-CLI fix:** this PR covers only the host `nemoclaw <sb> agent` dispatch path and does not close #5922. An already-running in-sandbox OpenClaw TUI has no host interception point, so the TUI/extend-on-activity acceptance clause remains open in #5922.

## Changes

- `src/lib/shields/audit.ts` reads at most the last 1 MiB of audit JSONL and returns explicit `event`, `none`, or `unreadable` results. The reader validates restore chronology, timestamps, and timeout bounds; treats oversized unterminated records as degraded visibility; and suppresses stale relock context after a newer same-sandbox `shields_down`. Audit history remains advisory and never establishes current policy state.
- `src/lib/actions/sandbox/agent/passthrough-shields-warning.ts` contains the OpenClaw-only warning lookup and rendering. Suggested commands shell-quote sandbox names, invalid timeout values use a safe fallback, and unreadable history emits generic status guidance without blocking dispatch.
- `src/lib/actions/sandbox/agent/passthrough.ts` makes one pre-dispatch call after readiness and selector validation. Terminal runtimes are excluded, and the source-boundary comment documents why an already-running TUI remains outside this host wrapper.
- Focused tests cover real-file audit-to-JSON passthrough, stderr/stdout separation, timeout validation, malformed and oversized audit input, chronology ordering, stale-warning suppression, shell metacharacters, absent/unreadable history, and terminal-runtime exclusion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: focused runtime recovery copy; the canonical TUI/extend-on-activity work remains tracked in #5922
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: read-only, bounded, fail-open advisory input; no credential, authorization, policy, or shield-state mutation
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every pushed commit appears as `Verified` in GitHub
- [x] Normal commit and push hooks passed
- [x] Focused tests pass for changed behavior (72/72)
- [x] CLI typecheck, Biome, test-size budget, and conditional scan pass
- [x] Required `shields-config-vitest` and `sandbox-operations-vitest` passed in run 28432672398 on runtime head `6341d0385`; final `7b20a6470` changes only tests and source-boundary comments
- [x] No secrets, API keys, or credentials committed
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] `npm run docs` builds without warnings (doc changes only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>
