### PR TITLE
fix(cli): detect messaging credential conflict before rebuild destroy (#5954)

### DIFF
--- a/src/lib/actions/sandbox/rebuild-messaging-conflict-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-messaging-conflict-preflight.test.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * #5954: `channels start`/rebuild must detect a shared messaging credential
+ * BEFORE backup/delete, so a conflicting rebuild aborts with the sandbox still
+ * intact instead of being destroyed and then failing to recreate.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ConflictRegistryEntry } from "../../messaging/applier";
+import type { SandboxMessagingPlan } from "../../messaging/manifest";
+import type { MessagingConflictGuardDeps } from "../../onboard/messaging-conflict-guard";
+import { preflightRebuildMessagingConflicts } from "./rebuild-messaging-conflict-preflight";
+
+const TEAMS_SECRET_KEY = "MSTEAMS_APP_PASSWORD";
+
+function teamsPlan(sandboxName: string, credentialHash: string): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName,
+    agent: "openclaw",
+    workflow: "onboard",
+    channels: [
+      {
+        channelId: "teams",
+        displayName: "teams",
+        authMode: "token-paste",
+        active: true,
+        selected: true,
+        configured: true,
+        disabled: false,
+        inputs: [],
+        hooks: [],
+      },
+    ],
+    disabledChannels: [],
+    credentialBindings: [
+      {
+        channelId: "teams",
+        providerEnvKey: TEAMS_SECRET_KEY,
+        credentialAvailable: true,
+        credentialHash,
+      },
+    ],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  } as unknown as SandboxMessagingPlan;
+}
+
+function registryWith(entries: ConflictRegistryEntry[]): RegistryStub {
+  return {
+    listSandboxes: () => ({ sandboxes: entries }),
+  };
+}
+
+type RegistryStub = { listSandboxes: () => { sandboxes: ConflictRegistryEntry[] } };
+
+function makeDeps(
+  overrides: Partial<Parameters<typeof preflightRebuildMessagingConflicts>[1]> = {},
+) {
+  const log = vi.fn();
+  const error = vi.fn();
+  const bail = vi.fn((message: string) => {
+    throw new Error(message);
+  }) as unknown as (message: string, code?: number) => never;
+  return {
+    log,
+    error,
+    bail,
+    deps: {
+      sandboxName: "my-assistant",
+      gatewayName: "nemoclaw",
+      registry: registryWith([]) as never,
+      cliName: () => "nemoclaw",
+      log,
+      error,
+      bail,
+      ...overrides,
+    },
+  };
+}
+
+describe("preflightRebuildMessagingConflicts (#5954)", () => {
+  it("does nothing (no guard call) when there is no staged plan", async () => {
+    const enforce = vi.fn(async () => {});
+    const { deps } = makeDeps({ enforceMessagingChannelConflicts: enforce });
+
+    await preflightRebuildMessagingConflicts(null, deps);
+
+    expect(enforce).not.toHaveBeenCalled();
+  });
+
+  it("runs the guard with abort-on-conflict (non-interactive) semantics", async () => {
+    let captured: MessagingConflictGuardDeps | undefined;
+    const enforce = vi.fn(async (guardDeps: MessagingConflictGuardDeps) => {
+      captured = guardDeps;
+    });
+    const plan = teamsPlan("my-assistant", "hash-abc");
+    const { deps } = makeDeps({ enforceMessagingChannelConflicts: enforce });
+
+    await preflightRebuildMessagingConflicts(plan, deps);
+
+    expect(enforce).toHaveBeenCalledTimes(1);
+    expect(captured).toBeDefined();
+    const passed = captured as MessagingConflictGuardDeps;
+    expect(passed.currentPlan).toBe(plan);
+    expect(passed.isNonInteractive()).toBe(true);
+    await expect(passed.promptContinue()).resolves.toBe(false);
+  });
+
+  it("aborts via bail (sandbox preserved) when another sandbox shares the credential", async () => {
+    // Real guard + a registry where 'hermes' already holds the same Teams
+    // credential hash → matching-token conflict must abort the rebuild.
+    const plan = teamsPlan("my-assistant", "shared-hash");
+    const registry = registryWith([
+      { name: "my-assistant", messaging: { plan } },
+      { name: "hermes", messaging: { plan: teamsPlan("hermes", "shared-hash") } },
+    ]);
+    const { deps, bail, log } = makeDeps({ registry: registry as never });
+
+    await expect(preflightRebuildMessagingConflicts(plan, deps)).rejects.toThrow(
+      /messaging channel conflict/i,
+    );
+    expect(bail).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls.flat().join("\n")).toContain("uses the same teams credential");
+  });
+
+  it("proceeds (no bail) when no other sandbox shares the credential", async () => {
+    const plan = teamsPlan("my-assistant", "unique-hash");
+    const registry = registryWith([{ name: "my-assistant", messaging: { plan } }]);
+    const { deps, bail } = makeDeps({ registry: registry as never });
+
+    await preflightRebuildMessagingConflicts(plan, deps);
+
+    expect(bail).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/sandbox/rebuild-messaging-conflict-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-messaging-conflict-preflight.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Rebuild-time messaging credential conflict preflight (#5954).
+ *
+ * A `channels start`/rebuild that shares a messaging credential (e.g. the same
+ * Microsoft Teams app) with another sandbox used to surface the conflict only
+ * during the recreate (`onboard --resume`) phase — i.e. AFTER the original
+ * sandbox had already been backed up and destroyed. The recreate then aborted
+ * on the conflict, leaving the sandbox permanently lost with only a manual
+ * snapshot-restore recovery path. That is a regression of the rebuild
+ * non-atomicity boundary (#2273): a failed preflight must occur before any
+ * destructive backup/delete.
+ *
+ * Running the shared conflict guard here, against the already-staged rebuild
+ * plan and before backup/delete, aborts with the sandbox still intact.
+ *
+ * The guard is run with non-interactive (abort-on-conflict) semantics on
+ * purpose: the downstream recreate already runs it non-interactively, so an
+ * interactive "continue anyway" could never have survived the recreate guard
+ * anyway. Aborting before destroy is therefore both safe and faithful to the
+ * effective behavior, and it avoids leaving a half-destroyed sandbox.
+ */
+
+import type { SandboxMessagingPlan } from "../../messaging/manifest";
+import {
+  enforceMessagingChannelConflicts as defaultEnforceMessagingChannelConflicts,
+  type MessagingConflictGuardDeps,
+} from "../../onboard/messaging-conflict-guard";
+
+export interface RebuildMessagingConflictPreflightDeps {
+  readonly sandboxName: string;
+  /** OpenShell gateway registration name this sandbox is bound to. */
+  readonly gatewayName: string;
+  readonly registry: MessagingConflictGuardDeps["registry"];
+  readonly cliName: () => string;
+  readonly log: (message: string) => void;
+  readonly error: (message: string) => void;
+  /**
+   * Abort the rebuild while leaving the sandbox intact (rebuild's `bail`).
+   * Must not return — it either throws or exits the process.
+   */
+  readonly bail: (message: string, code?: number) => never;
+  /** Injectable for tests; defaults to the shared onboard conflict guard. */
+  readonly enforceMessagingChannelConflicts?: (deps: MessagingConflictGuardDeps) => Promise<void>;
+}
+
+export async function preflightRebuildMessagingConflicts(
+  plan: SandboxMessagingPlan | null,
+  deps: RebuildMessagingConflictPreflightDeps,
+): Promise<void> {
+  if (!plan) return;
+
+  const enforce = deps.enforceMessagingChannelConflicts ?? defaultEnforceMessagingChannelConflicts;
+
+  await enforce({
+    sandboxName: deps.sandboxName,
+    gatewayName: deps.gatewayName,
+    currentPlan: plan,
+    // The staged plan already carries this sandbox's `channels stop` set in
+    // `plan.disabledChannels`, which the guard folds in; nothing extra to add.
+    registry: deps.registry,
+    isNonInteractive: () => true,
+    promptContinue: async () => false,
+    cliName: deps.cliName,
+    log: deps.log,
+    error: deps.error,
+    exit: (code: number) => deps.bail("Rebuild aborted: messaging channel conflict.", code),
+  });
+}

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -67,6 +67,7 @@ import {
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
 import { removeSandboxRegistryEntry } from "./destroy";
+import { getSandboxTargetGatewayName } from "./gateway-target";
 import { ensureMessagingHostForwardAfterRebuild } from "./messaging-host-forward-lifecycle";
 import { executeSandboxCommand } from "./process-recovery";
 import { isolateAmbientRecreateEnv } from "./rebuild-env-isolation";
@@ -78,6 +79,7 @@ import {
   resolveRebuildLiveState,
 } from "./rebuild-flow-helpers";
 import { buildRebuildRecreateOnboardOpts } from "./rebuild-gpu-opt-out";
+import { preflightRebuildMessagingConflicts } from "./rebuild-messaging-conflict-preflight";
 import {
   checkRebuildGatewayProviderOrBail,
   shouldVerifyRebuildGatewayProvider,
@@ -646,6 +648,23 @@ export async function rebuildSandbox(
     log,
     bail,
   );
+
+  // #5954: detect cross-sandbox messaging credential conflicts (e.g. another
+  // sandbox already polling the same Teams app) BEFORE any destructive
+  // backup/delete. This guard previously ran only in the recreate
+  // (onboard --resume) phase — after the sandbox was destroyed — so a conflict
+  // left the sandbox permanently lost. Running it here keeps it intact.
+  await preflightRebuildMessagingConflicts(rebuildMessagingPlan, {
+    sandboxName,
+    gatewayName: getSandboxTargetGatewayName(sandboxName),
+    registry,
+    cliName: () => CLI_NAME,
+    // The conflict warning explains why the rebuild aborts, so it must reach
+    // the user regardless of the verbose flag (unlike the diagnostic `log`).
+    log: (message: string) => console.log(message),
+    error: (message: string) => console.error(message),
+    bail,
+  });
 
   // Step 1: Ensure sandbox is live for backup, or identify stale-sandbox recovery.
   const liveState = await resolveRebuildLiveState(sandboxName, sb, log, bail);

--- a/test/rebuild-messaging-conflict-preflight.test.ts
+++ b/test/rebuild-messaging-conflict-preflight.test.ts
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end regression for #5954: a `channels start`/rebuild that shares a
+ * messaging credential with another sandbox must abort BEFORE backup/delete,
+ * leaving the original sandbox intact — not destroy it first and then fail to
+ * recreate, which left the sandbox permanently lost.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const NODE_BIN = path.dirname(process.execPath);
+const tmpFixtures: string[] = [];
+
+afterEach(() => {
+  tmpFixtures.splice(0).forEach((dir) => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+});
+
+// A minimal valid SandboxMessagingPlan with one active Teams channel and a
+// credential binding carrying a hash — staging preserves credentialBindings
+// verbatim, so a shared hash across two sandboxes is a "matching-token"
+// conflict.
+function teamsPlan(sandboxName: string, credentialHash: string) {
+  return {
+    schemaVersion: 1,
+    sandboxName,
+    agent: "openclaw",
+    workflow: "onboard",
+    channels: [
+      {
+        channelId: "teams",
+        displayName: "teams",
+        authMode: "token-paste",
+        active: true,
+        selected: true,
+        configured: true,
+        disabled: false,
+        inputs: [],
+        hooks: [],
+      },
+    ],
+    disabledChannels: [],
+    credentialBindings: [
+      {
+        channelId: "teams",
+        providerEnvKey: "MSTEAMS_APP_PASSWORD",
+        credentialAvailable: true,
+        credentialHash,
+      },
+    ],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  };
+}
+
+function completeSession(sandboxName: string) {
+  const step = { status: "complete", startedAt: null, completedAt: null, error: null };
+  return {
+    version: 1,
+    sessionId: "s",
+    resumable: true,
+    status: "complete",
+    mode: "interactive",
+    startedAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    lastStepStarted: null,
+    lastCompletedStep: "policies",
+    failure: null,
+    agent: null,
+    sandboxName,
+    provider: "nvidia-prod",
+    model: "meta/llama-3.3-70b-instruct",
+    endpointUrl: null,
+    credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+    hermesAuthMethod: null,
+    preferredInferenceApi: null,
+    nimContainer: null,
+    webSearchConfig: null,
+    policyPresets: [],
+    messagingPlan: null,
+    metadata: { gatewayName: "nemoclaw", fromDockerfile: null },
+    steps: {
+      preflight: step,
+      gateway: step,
+      sandbox: step,
+      provider_selection: step,
+      inference: step,
+      openclaw: step,
+      agent_setup: { status: "pending", startedAt: null, completedAt: null, error: null },
+      policies: step,
+    },
+  };
+}
+
+// Build a HOME where `my-assistant` and `hermes` both hold the same Teams
+// credential (matching hash). Rebuilding `my-assistant` must detect the
+// conflict against `hermes` before touching anything destructive.
+function createConflictFixture() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-5954-"));
+  tmpFixtures.push(tmpDir);
+  const nemoclawDir = path.join(tmpDir, ".nemoclaw");
+  fs.mkdirSync(nemoclawDir, { recursive: true, mode: 0o700 });
+
+  const sandboxEntry = (name: string) => ({
+    name,
+    model: "meta/llama-3.3-70b-instruct",
+    provider: "nvidia-prod",
+    gpuEnabled: false,
+    policies: [],
+    agent: null,
+    messaging: { schemaVersion: 1, plan: teamsPlan(name, "shared-teams-hash") },
+  });
+
+  fs.writeFileSync(
+    path.join(nemoclawDir, "sandboxes.json"),
+    JSON.stringify({
+      defaultSandbox: "my-assistant",
+      sandboxes: {
+        "my-assistant": sandboxEntry("my-assistant"),
+        hermes: sandboxEntry("hermes"),
+      },
+    }),
+    { mode: 0o600 },
+  );
+
+  fs.writeFileSync(
+    path.join(nemoclawDir, "onboard-session.json"),
+    JSON.stringify(completeSession("my-assistant")),
+    { mode: 0o600 },
+  );
+
+  const sshConfig = [
+    "Host openshell-my-assistant",
+    "  HostName 127.0.0.1",
+    "  Port 2222",
+    "  User sandbox",
+    "  StrictHostKeyChecking no",
+    "  UserKnownHostsFile /dev/null",
+  ].join("\\n");
+
+  fs.writeFileSync(
+    path.join(tmpDir, "openshell"),
+    `#!/usr/bin/env node
+const a = process.argv.slice(2);
+if (a[0]==="sandbox" && a[1]==="list")       { process.stdout.write("my-assistant\\n"); process.exit(0); }
+if (a[0]==="sandbox" && a[1]==="ssh-config") { process.stdout.write("${sshConfig}\\n"); process.exit(0); }
+if (a[0]==="sandbox" && a[1]==="delete")     { process.exit(0); }
+if (a[0]==="status")                         { process.stdout.write("running\\n"); process.exit(0); }
+if (a[0]==="gateway" && a[1]==="info")       { process.stdout.write("nemoclaw\\n"); process.exit(0); }
+if (a[0]==="gateway" && a[1]==="select")     { process.exit(0); }
+if (a[0]==="inference" && a[1]==="get")      { process.stdout.write('{"provider":"nvidia-prod","model":"meta/llama-3.3-70b-instruct"}\\n'); process.exit(0); }
+if (a[0]==="inference")                      { process.exit(0); }
+if (a[0]==="provider" && a[1]==="get")       { process.exit(0); }
+if (a[0]==="provider")                       { process.exit(0); }
+if (a[0]==="forward")                        { process.exit(0); }
+process.exit(0);
+`,
+    { mode: 0o755 },
+  );
+
+  // No active SSH sessions.
+  fs.writeFileSync(path.join(tmpDir, "ps"), "#!/usr/bin/env node\nprocess.exit(0);\n", {
+    mode: 0o755,
+  });
+
+  // Docker / ssh should never be invoked: the conflict aborts before backup,
+  // base-image build, or delete. Failing loudly here would surface any
+  // ordering regression that let the rebuild proceed past the preflight.
+  fs.writeFileSync(
+    path.join(tmpDir, "docker"),
+    `#!/usr/bin/env node
+process.stderr.write("docker must not run before the conflict preflight: " + process.argv.slice(2).join(" ") + "\\n");
+process.exit(17);
+`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, "ssh"),
+    `#!/usr/bin/env node
+process.stderr.write("ssh must not run before the conflict preflight\\n");
+process.exit(17);
+`,
+    { mode: 0o755 },
+  );
+
+  return { tmpDir, nemoclawDir };
+}
+
+function runRebuild(tmpDir: string) {
+  const argv = [path.join(REPO_ROOT, "bin", "nemoclaw.js"), "my-assistant", "rebuild", "--yes"];
+  return spawnSync(process.execPath, argv, {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    env: {
+      HOME: tmpDir,
+      PATH: `${tmpDir}:${NODE_BIN}:/usr/bin:/bin`,
+      NEMOCLAW_NON_INTERACTIVE: "1",
+      NEMOCLAW_NO_CONNECT_HINT: "1",
+      NO_COLOR: "1",
+      NVIDIA_INFERENCE_API_KEY: "nvapi-test-key-for-rebuild",
+    },
+    timeout: 60_000,
+  });
+}
+
+function registryHasSandbox(nemoclawDir: string, name: string): boolean {
+  try {
+    const reg = JSON.parse(fs.readFileSync(path.join(nemoclawDir, "sandboxes.json"), "utf-8"));
+    return Boolean(reg?.sandboxes?.[name]);
+  } catch {
+    return false;
+  }
+}
+
+describe("rebuild messaging credential conflict preflight (#5954)", () => {
+  it("aborts BEFORE backup/delete when another sandbox shares the Teams credential", {
+    timeout: 90_000,
+  }, () => {
+    const f = createConflictFixture();
+    const result = runRebuild(f.tmpDir);
+    const output = `${result.stderr || ""}${result.stdout || ""}`;
+
+    // Aborted, with the actionable conflict explanation.
+    expect(result.status).not.toBe(0);
+    expect(output).toContain("uses the same teams credential");
+    expect(output).toContain("Aborting");
+
+    // Nothing destructive ran: the sandbox is untouched and still registered.
+    expect(output).not.toContain("Backing up sandbox state");
+    expect(output).not.toContain("Old sandbox deleted");
+    expect(output).not.toContain("must not run before the conflict preflight");
+    expect(registryHasSandbox(f.nemoclawDir, "my-assistant")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`nemoclaw <sb> channels start <channel>` (and any rebuild) that shared a messaging credential with another sandbox used to surface the conflict only during the recreate (`onboard --resume`) phase — i.e. *after* the original sandbox had already been backed up and destroyed — so the rebuild aborted with the sandbox permanently lost. This moves the messaging credential-conflict check into the rebuild Step-0 preflight, before any destructive backup/delete, so a conflict aborts with the sandbox intact.

## Related Issue

Fixes #5954

## Changes

- Add `src/lib/actions/sandbox/rebuild-messaging-conflict-preflight.ts`: `preflightRebuildMessagingConflicts(plan, deps)` runs the shared `enforceMessagingChannelConflicts` guard against the already-staged rebuild plan with non-interactive (abort-on-conflict) semantics, mapping the guard's `exit` onto rebuild's sandbox-preserving `bail`.
- Wire it into `src/lib/actions/sandbox/rebuild.ts` Step-0 preflight, immediately after `stageRebuildMessagingPlanOrBail` and before `resolveRebuildLiveState`/backup/delete. The conflict warning is printed to stdout (not the verbose-gated diagnostic log) so the user sees why the rebuild aborted.
- Unit test (`rebuild-messaging-conflict-preflight.test.ts`): null-plan no-op, abort-on-conflict (non-interactive) semantics, real-guard matching-token abort via `bail`, and no-conflict proceed.
- E2E regression (`test/rebuild-messaging-conflict-preflight.test.ts`): two registry sandboxes sharing a Teams credential → `my-assistant` rebuild aborts before backup/delete (fake `docker`/`ssh` fail loudly if reached) and the sandbox stays registered.

Why non-interactive abort-on-conflict: the downstream recreate already runs the guard non-interactively, so an interactive "continue anyway" could never have survived it anyway. Aborting before destroy is both safe and faithful to the effective behavior. The preflight consumes the exact staged plan + registry the recreate guard already uses, so it cannot raise conflicts the recreate would not — it just catches them before the sandbox is destroyed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal rebuild-ordering fix; the only new surface is an abort-time conflict warning + actionable remediation, not a documented feature or command.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: No new conflict logic — reuses the canonical `enforceMessagingChannelConflicts` guard; placed in the existing Step-0 preflight that already aborts before backup/delete (#2273); preserves the no-data-loss boundary (failed preflight precedes any mutation); covered by unit + E2E regression tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early conflict check for sandbox rebuilds so messaging credential clashes are detected before any destructive work begins.
  * Rebuilds now stop with a clear abort message when another sandbox uses the same Teams credential, and they continue normally when no conflict exists.
  * Added regression coverage to ensure rebuilds don’t proceed into backup/delete steps when a conflict is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->