### PR TITLE
fix(cli): suggest closest sandbox name on typo

### DIFF
--- a/src/lib/cli/public-dispatch.ts
+++ b/src/lib/cli/public-dispatch.ts
@@ -83,6 +83,10 @@ function suggestGlobalCommand(token: string): string | null {
   return suggestCommand(token, GLOBAL_COMMANDS);
 }
 
+function suggestSandboxName(token: string, registeredNames: readonly string[]): string | null {
+  return suggestCommand(token, registeredNames);
+}
+
 function hasHelpFlag(args: readonly string[]): boolean {
   return args.includes("--help") || args.includes("-h");
 }
@@ -224,6 +228,10 @@ async function recoverRequestedSandboxIfNeeded(
     .listSandboxes()
     .sandboxes.map((s: { name: string }) => s.name);
   if (allNames.length > 0) {
+    const nameSuggestion = suggestSandboxName(sandboxName, allNames);
+    if (nameSuggestion) {
+      console.error(`  Did you mean: ${CLI_NAME} ${nameSuggestion} ${action}?`);
+    }
     console.error("");
     console.error(`  Registered sandboxes: ${allNames.join(", ")}`);
     console.error(`  Run '${CLI_NAME} list' to see all sandboxes.`);
@@ -379,6 +387,11 @@ export async function dispatchCli(argv: string[] = process.argv.slice(2)): Promi
     .listSandboxes()
     .sandboxes.map((s: { name: string }) => s.name);
   if (allNames.length > 0) {
+    const nameSuggestion = suggestSandboxName(cmd, allNames);
+    if (nameSuggestion) {
+      console.error(`  Did you mean: ${CLI_NAME} ${nameSuggestion} connect?`);
+      console.error("");
+    }
     console.error(`  Registered sandboxes: ${allNames.join(", ")}`);
     console.error(`  Try: ${CLI_NAME} <sandbox-name> connect`);
     console.error("");

--- a/test/cli/dispatch-basics.test.ts
+++ b/test/cli/dispatch-basics.test.ts
@@ -379,4 +379,70 @@ describe("CLI dispatch", () => {
     expect(r.out).toContain("Command order is: nemoclaw <sandbox-name> connect");
     expect(r.out).toContain("Did you mean: nemoclaw alpha connect?");
   });
+
+  it("suggests the closest registered sandbox name for a mistyped sandbox action", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-typo-action-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "my-assistant");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      ["#!/usr/bin/env bash", "exit 1"].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("my-assitant status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Sandbox 'my-assitant' does not exist");
+    expect(r.out).toContain("Did you mean: nemoclaw my-assistant status?");
+    expect(r.out).toContain("Registered sandboxes: my-assistant");
+  });
+
+  it("suggests the closest registered sandbox name when a bare typo lacks a known action", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-typo-bare-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "my-assistant");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      ["#!/usr/bin/env bash", "exit 1"].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("my-assitant unknownaction", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Unknown command: my-assitant");
+    expect(r.out).toContain("Did you mean: nemoclaw my-assistant connect?");
+    expect(r.out).toContain("Registered sandboxes: my-assistant");
+  });
+
+  it("omits the did-you-mean hint when no registered sandbox is within edit-distance threshold", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-typo-miss-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "alpha");
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      ["#!/usr/bin/env bash", "exit 1"].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("zulu-quebec status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("Sandbox 'zulu-quebec' does not exist");
+    expect(r.out).not.toContain("Did you mean: nemoclaw alpha");
+    expect(r.out).toContain("Registered sandboxes: alpha");
+  });
 });


### PR DESCRIPTION
## Summary

Add a Levenshtein-based "Did you mean: nemoclaw <sandbox-name> <action>?" suggestion to the sandbox-not-found and bare-unknown-command paths in the public dispatcher. Users mistyping a registered sandbox name (e.g. `my-assitant` vs `my-assistant`) now see a fuzzy hint instead of scanning the full registered list.

## Related Issue

Fixes #5957

## Changes

- New `suggestSandboxName(token, registeredNames)` helper in `src/lib/cli/public-dispatch.ts` wrapping the existing `suggestCommand` from `argv-normalizer` (already used for global commands).
- `recoverRequestedSandboxIfNeeded` (sandbox-action path) prints `Did you mean: nemoclaw <suggestion> <action>?` before the registered list when a fuzzy match exists.
- Bare-unknown-command path prints `Did you mean: nemoclaw <suggestion> connect?` before the registered list when a fuzzy match exists.
- Three new tests in `test/cli/dispatch-basics.test.ts` covering both fix paths and the negative no-match case.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: CLI error-hint wording change; no doc page covers the registered-list error format
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] \`npm run docs\` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typo-friendly suggestions when a sandbox name is misspelled in CLI commands.
  * Users now see a “Did you mean” hint with the closest matching sandbox name before the usual sandbox guidance.

* **Bug Fixes**
  * Improved handling of unknown sandbox paths so the CLI better recovers from naming mistakes.
  * Kept existing registered sandbox details and connection hints in the output for easier correction.

* **Tests**
  * Added coverage for sandbox-name typo suggestions and the no-suggestion fallback case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->