### PR TITLE
fix(onboard): fail cleanly on unknown NEMOCLAW_AGENT instead of uncaught throw (#5972)

### DIFF
--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -141,6 +141,40 @@ describe("onboard command options", () => {
     expect(errors.join("\n")).toContain("aliases: nemohermes → hermes");
   });
 
+  it("rejects an unknown NEMOCLAW_AGENT cleanly instead of throwing uncaught (#5972)", () => {
+    // #5972: an unknown NEMOCLAW_AGENT must fail via the clean error/exit path,
+    // matching --agent, not by throwing uncaught deep in runOnboard.
+    const errors: string[] = [];
+    expect(() =>
+      resolve(
+        {},
+        {
+          env: { NEMOCLAW_AGENT: "bogus-agent" },
+          listAgents: () => ["openclaw", "hermes"],
+          error: (message = "") => errors.push(message),
+        },
+      ),
+    ).toThrow("exit:1");
+    expect(errors.join("\n")).toContain("Unknown agent 'bogus-agent' (from NEMOCLAW_AGENT)");
+    expect(errors.join("\n")).toContain("aliases: nemohermes → hermes");
+  });
+
+  it("accepts a valid NEMOCLAW_AGENT (and its aliases) without forcing the flag value", () => {
+    const listAgents = () => ["openclaw", "hermes", "langchain-deepagents-code"];
+    // Valid env agents resolve downstream, so resolveAgent leaves `agent` null.
+    expect(resolve({}, { env: { NEMOCLAW_AGENT: "hermes" }, listAgents }).agent).toBeNull();
+    expect(resolve({}, { env: { NEMOCLAW_AGENT: "nemohermes" }, listAgents }).agent).toBeNull();
+    expect(resolve({}, { env: {}, listAgents }).agent).toBeNull();
+  });
+
+  it("prefers the --agent flag over NEMOCLAW_AGENT for validation", () => {
+    const listAgents = () => ["openclaw", "hermes"];
+    // Flag is valid even when the env var is bogus — flag takes precedence.
+    expect(
+      resolve({ agent: "hermes" }, { env: { NEMOCLAW_AGENT: "bogus" }, listAgents }).agent,
+    ).toBe("hermes");
+  });
+
   it("runs onboard with resolved options", async () => {
     const runOnboard = vi.fn(async () => {});
     await runOnboardCommand({

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -64,19 +64,41 @@ function resolveFileOption(
   return preserveInput ? value : resolved;
 }
 
+// Validate the effective agent from the --agent flag, else the NEMOCLAW_AGENT
+// env var. Both feed the same downstream resolver, so validating the env var
+// here makes an unknown value fail with the clean flag-style message instead of
+// throwing uncaught deep inside runOnboard (a raw Node `throw new Error(...)`
+// source frame on stderr) (#5972). For a valid env value we return null and let
+// downstream resolution canonicalize it, leaving existing behavior unchanged.
+function failUnknownAgent(
+  deps: ResolveOnboardOptionsDeps,
+  value: string,
+  fromEnv: boolean,
+  knownAgents: readonly string[],
+): never {
+  const source = fromEnv ? " (from NEMOCLAW_AGENT)" : "";
+  return fail(
+    deps,
+    `  Unknown agent '${value}'${source}. Available: ${knownAgents.join(", ")}${formatAgentAliasSuffix(knownAgents)}`,
+  );
+}
+
 function resolveAgent(
   requestedAgent: string | undefined,
   deps: ResolveOnboardOptionsDeps,
 ): string | null {
-  if (requestedAgent === undefined) return null;
+  const fromEnv = requestedAgent === undefined;
+  const candidate = ((fromEnv ? deps.env.NEMOCLAW_AGENT : requestedAgent) ?? "").trim();
+  if (candidate === "") return null;
+
   const knownAgents = deps.listAgents?.() ?? [];
-  if (knownAgents.length === 0) return requestedAgent;
-  const resolvedAgent = resolveAgentNameAlias(requestedAgent, knownAgents);
-  if (resolvedAgent) return resolvedAgent;
-  return fail(
-    deps,
-    `  Unknown agent '${requestedAgent}'. Available: ${knownAgents.join(", ")}${formatAgentAliasSuffix(knownAgents)}`,
-  );
+  const resolved =
+    knownAgents.length === 0 ? candidate : resolveAgentNameAlias(candidate, knownAgents);
+  if (!resolved) failUnknownAgent(deps, candidate, fromEnv, knownAgents);
+
+  // The env path leaves canonicalization to downstream resolution (returns
+  // null); the flag path returns the canonical name as before.
+  return fromEnv ? null : resolved;
 }
 
 function resolveAgentsManifest(


### PR DESCRIPTION
## Summary

Setting `NEMOCLAW_AGENT` to an unknown agent name made `nemoclaw onboard` dump a raw Node `throw new Error(...)` source frame and stack trace to stderr (from `resolveAgentName` deep inside `runOnboard`), even though the exit code and message were otherwise fine. The `--agent <name>` flag already validates early and prints a clean message. This makes the env-var path do the same.

## Related Issue

Fixes #5972

## Changes

- `src/lib/onboard/command.ts`: `resolveAgent` now validates the effective agent from `--agent` **or** `NEMOCLAW_AGENT` through the same early `fail()` path. An unknown env value fails with the clean flag-style message (`Unknown agent '<x>' (from NEMOCLAW_AGENT). Available: …`) and exit 1, instead of throwing uncaught later. Valid/unset env values return `null`, leaving downstream canonicalization (and the `--agent` precedence) unchanged. Extracted `failUnknownAgent` to keep complexity within budget.
- `src/lib/onboard/command.test.ts`: tests for unknown `NEMOCLAW_AGENT` (clean reject), valid env agent + alias (no flag forced), and `--agent` precedence over a bogus env value.

Before: `NEMOCLAW_AGENT=bogus nemoclaw onboard …` printed a `throw new Error(...)` frame + `^` caret + stack. After: a single clean line, exit 1.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no flag/command surface change; only the error output for an invalid env value is cleaned up. `NEMOCLAW_AGENT` is already documented.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: onboarding path; change is limited to early agent-name validation (reuses the existing clean `--agent` failure path + the same `unknownAgentMessage`/alias resolver), no behavior change for valid/unset values; covered by unit tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding agent selection when using the `NEMOCLAW_AGENT` environment variable.
  * Unknown agent values now show a clearer error with available options.
  * Command-line `--agent` settings now correctly override the environment variable.

* **Tests**
  * Added coverage for valid, invalid, and precedence cases in agent resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->