### PR TITLE
chore(messaging): document manifest cleanup plan

### DIFF
--- a/src/lib/messaging/README.md
+++ b/src/lib/messaging/README.md
@@ -302,6 +302,22 @@ It is a serializable declaration for one channel and one set of supported agents
 Secret inputs cannot declare `statePath` or defaults.
 Plans may carry `credentialAvailable`, `credentialHash`, and placeholders, but they must not carry raw tokens.
 
+## Manifest Cleanup Direction
+
+`ChannelManifest` is the external channel authoring contract.
+Cleanup work should make that public shape simpler while preserving the current compiled plan and applier behavior.
+
+Prefer making the input declaration the source of truth.
+
+- Put env names, aliases, prompts, validation, persistence, and rebuild hydration on `inputs` when they describe the same value.
+- Derive credential bindings from secret inputs when provider name, placeholder, and env key follow the standard channel pattern.
+- Derive state persistence and rebuild hydration from config inputs instead of repeating `statePath`, `state.persist`, and `state.rebuildHydration` in separate sections.
+- Derive routine runtime visibility and env alias data from the active agent channel name unless the channel needs an explicit override.
+- Keep advanced behavior explicit for host forwards, agent render, package installs, network policy presets, and channel-specific hooks.
+
+The registry or compiler can normalize the simpler authoring shape into the existing internal manifest and plan structure.
+That keeps existing v1 manifests accepted during migration and avoids forcing lifecycle, persistence, build-applier, or policy code to understand two behavior models.
+
 ## Manifest Skeleton
 
 Use `satisfies ChannelManifest` so TypeScript checks the manifest while preserving literal IDs and template strings.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Documents the messaging manifest cleanup direction so the broader channel plugin work has a low-churn first step. The note clarifies that `ChannelManifest` stays the public authoring contract while registry/compiler normalization can hide the verbose internal shape.

## Related Issue
Refs #5984

## Changes
- Added a `Manifest Cleanup Direction` section to `src/lib/messaging/README.md`.
- Captured the input-centric authoring target for env aliases, persistence, credential bindings, rebuild hydration, and routine runtime metadata.
- Kept the scope explicitly behavior-preserving for existing v1 manifests and compiled plans.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: README-only architecture note; no runtime behavior changed.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing behavior change; this is package-local architecture documentation.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-reviewed doc-only messaging README update; no security, policy, credential, sandbox, or runtime code changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section describing cleaner channel manifest authoring guidance.
  * Clarified that inputs should be the primary source of truth, with related settings derived where possible.
  * Noted which advanced behaviors should remain explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->