### PR TITLE
fix(cli): exit non-zero for user-error/startup surfaces riding oclif.exit === 0 (#5974)

### DIFF
--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -159,13 +159,17 @@ describe("runOclifArgv", () => {
     class ExitError extends Error {
       oclif = { exit: 0 };
     }
-    runMock.mockRejectedValue(new ExitError("EEXIT: 0"));
+    const exitError = new ExitError("EEXIT: 0");
+    runMock.mockRejectedValue(exitError);
     const errorLine = vi.fn();
 
     await runOclifArgv(["sandbox", "list"], { rootDir: "/repo", error: errorLine });
 
     expect(errorLine).not.toHaveBeenCalled();
-    expect(handleMock).toHaveBeenCalled();
+    // The runner must NOT force a failure code here — handle() owns the
+    // graceful exit 0 for a genuine ExitError(0).
+    expect(process.exitCode).toBeUndefined();
+    expect(handleMock).toHaveBeenCalledWith(exitError);
   });
 });
 

--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -156,6 +156,10 @@ describe("runOclifArgv", () => {
   it("keeps a genuine native-route ExitError(0) as a graceful exit (#5974)", async () => {
     // Command.exit(0) / --help on the native route must stay silent and
     // delegate to oclif's handler, which performs the graceful exit 0.
+    // This mocks handleOclif to assert delegation; the runtime counterpart
+    // (real `nemoclaw sandbox --help` → exit 0 through the actual binary) is
+    // locked by test/exit-code-user-error-surfaces.test.ts
+    // ("a native-route --help stays a clean exit 0").
     class ExitError extends Error {
       oclif = { exit: 0 };
     }

--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -3,17 +3,21 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { executeMock, loadMock, runCommandMock } = vi.hoisted(() => ({
-  executeMock: vi.fn(),
+const { flushMock, handleMock, loadMock, runCommandMock, runMock } = vi.hoisted(() => ({
+  flushMock: vi.fn(),
+  handleMock: vi.fn(),
   loadMock: vi.fn(),
   runCommandMock: vi.fn(),
+  runMock: vi.fn(),
 }));
 
 vi.mock("@oclif/core", () => ({
   Config: {
     load: loadMock,
   },
-  execute: executeMock,
+  flush: flushMock,
+  handle: handleMock,
+  run: runMock,
 }));
 
 import { runOclifArgv, runOclifCommandById } from "./oclif-runner";
@@ -46,22 +50,26 @@ describe("runOclifArgv", () => {
   let originalArgv: string[];
 
   beforeEach(() => {
-    executeMock.mockReset();
+    flushMock.mockReset();
+    handleMock.mockReset();
     loadMock.mockReset();
     runCommandMock.mockReset();
+    runMock.mockReset();
     loadMock.mockResolvedValue(makeConfig());
     originalArgv = process.argv;
     process.argv = ["/usr/bin/node", "/repo/bin/nemoclaw.js", "alpha", "status"];
+    process.exitCode = undefined;
   });
 
   afterEach(() => {
     process.argv = originalArgv;
+    process.exitCode = undefined;
   });
 
   it("executes native oclif argv with branded package metadata", async () => {
     const config = makeConfig();
     loadMock.mockResolvedValue(config);
-    executeMock.mockImplementation(async () => {
+    runMock.mockImplementation(async () => {
       expect(process.argv).toEqual([
         "/usr/bin/node",
         "/repo/bin/nemoclaw.js",
@@ -77,21 +85,20 @@ describe("runOclifArgv", () => {
     expect(process.argv).toEqual(["/usr/bin/node", "/repo/bin/nemoclaw.js", "alpha", "status"]);
 
     expect(loadMock).toHaveBeenCalledWith("/repo");
-    expect(executeMock).toHaveBeenCalledWith({
-      args: ["sandbox", "channels", "start", "--help"],
-      loadOptions: {
-        root: "/repo",
-        pjson: config.pjson,
-      },
+    expect(runMock).toHaveBeenCalledWith(["sandbox", "channels", "start", "--help"], {
+      root: "/repo",
+      pjson: config.pjson,
     });
+    expect(flushMock).toHaveBeenCalled();
+    expect(handleMock).not.toHaveBeenCalled();
     expect(config.pjson.oclif.bin).toBe("nemoclaw");
     expect(config.options.pjson.oclif.bin).toBe("nemoclaw");
     expect(config.plugins.get("root")?.pjson.oclif.bin).toBe("nemoclaw");
   });
 
-  it("restores process argv when native oclif execution throws", async () => {
+  it("delegates ordinary native-route failures to oclif's handler and restores argv", async () => {
     const error = new Error("Missing 1 required arg: channel");
-    executeMock.mockImplementation(async () => {
+    runMock.mockImplementation(async () => {
       expect(process.argv).toEqual([
         "/usr/bin/node",
         "/repo/bin/nemoclaw.js",
@@ -103,11 +110,62 @@ describe("runOclifArgv", () => {
       throw error;
     });
 
-    await expect(
-      runOclifArgv(["sandbox", "channels", "add", "alpha"], { rootDir: "/repo" }),
-    ).rejects.toBe(error);
+    await runOclifArgv(["sandbox", "channels", "add", "alpha"], { rootDir: "/repo" });
 
+    // oclif's handle() owns pretty-printing and process exit for ordinary
+    // failures (it never returns control for a real error), so we just forward.
+    expect(handleMock).toHaveBeenCalledWith(error);
     expect(process.argv).toEqual(["/usr/bin/node", "/repo/bin/nemoclaw.js", "alpha", "status"]);
+  });
+
+  it("forces a non-zero exit for native-route errors riding oclif.exit === 0 (#5974)", async () => {
+    // oclif's handle() would Exit.exit(0) for this error, silently reporting
+    // success on the native `internal`/`sandbox` routes. The native path must
+    // mirror runOclifCommandById: surface the message and exit non-zero, never
+    // delegating to handle() (which would exit 0).
+    class WeirdError extends Error {
+      oclif = { exit: 0 };
+    }
+    runMock.mockRejectedValue(new WeirdError("sandbox transport closed unexpectedly"));
+    const errorLine = vi.fn();
+
+    await runOclifArgv(["sandbox", "list"], { rootDir: "/repo", error: errorLine });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorLine).toHaveBeenCalledWith("  sandbox transport closed unexpectedly");
+    expect(handleMock).not.toHaveBeenCalled();
+    expect(process.argv).toEqual(["/usr/bin/node", "/repo/bin/nemoclaw.js", "alpha", "status"]);
+  });
+
+  it("falls back to a generic line for blank-message native-route oclif.exit === 0 errors (#5974)", async () => {
+    class BlankError extends Error {
+      oclif = { exit: 0 };
+    }
+    runMock.mockRejectedValue(new BlankError(""));
+    const errorLine = vi.fn();
+
+    await runOclifArgv(["sandbox", "list"], { rootDir: "/repo", error: errorLine });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorLine).toHaveBeenCalledOnce();
+    const [line] = errorLine.mock.calls[0];
+    expect(String(line).trim().length).toBeGreaterThan(0);
+    expect(handleMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a genuine native-route ExitError(0) as a graceful exit (#5974)", async () => {
+    // Command.exit(0) / --help on the native route must stay silent and
+    // delegate to oclif's handler, which performs the graceful exit 0.
+    class ExitError extends Error {
+      oclif = { exit: 0 };
+    }
+    runMock.mockRejectedValue(new ExitError("EEXIT: 0"));
+    const errorLine = vi.fn();
+
+    await runOclifArgv(["sandbox", "list"], { rootDir: "/repo", error: errorLine });
+
+    expect(errorLine).not.toHaveBeenCalled();
+    expect(handleMock).toHaveBeenCalled();
   });
 });
 
@@ -115,7 +173,8 @@ describe("runOclifCommandById", () => {
   let originalArgv: string[];
 
   beforeEach(() => {
-    executeMock.mockReset();
+    flushMock.mockReset();
+    handleMock.mockReset();
     runCommandMock.mockReset();
     loadMock.mockReset();
     loadMock.mockResolvedValue(makeConfig());

--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -195,11 +195,12 @@ describe("runOclifCommandById", () => {
     expect(errorLine).not.toHaveBeenCalled();
   });
 
-  it("surfaces errors that happen to carry oclif.exit === 0 instead of swallowing them (#2666)", async () => {
-    // Before #2666 this branch silently set exit 0 and produced no output.
-    // The bug was an arbitrary error riding the same `oclif.exit === 0`
-    // channel, e.g. propagated from inside a command's run(). Surface the
-    // message so the user gets signal.
+  it("surfaces AND fails on errors that merely carry oclif.exit === 0 (#2666, #5974)", async () => {
+    // #2666 stopped this branch silently swallowing an arbitrary error that
+    // rode the same `oclif.exit === 0` channel (e.g. propagated from inside a
+    // command's run()) — but it still reported success. #5974: such an error
+    // is a genuine failure, so surface the message AND exit non-zero so `$?`
+    // stays scriptable. Only a real oclif ExitError(0) stays exit 0.
     class WeirdError extends Error {
       oclif = { exit: 0 };
     }
@@ -210,16 +211,17 @@ describe("runOclifCommandById", () => {
 
     await runOclifCommandById("status", ["my-assist"], { rootDir: "/repo", error: errorLine });
 
-    expect(process.exitCode).toBe(0);
+    expect(process.exitCode).toBe(1);
     expect(errorLine).toHaveBeenCalledWith(
       "  Could not verify sandbox 'my-assist' against the live OpenShell gateway",
     );
   });
 
-  it("falls back to a generic line when the error message is empty (#2666)", async () => {
+  it("falls back to a generic line and still fails when the message is empty (#2666, #5974)", async () => {
     // Closes the residual silent path: if a non-ExitError(0) carries an
-    // empty message (or one that trims to empty), still emit *something*
-    // so the user is never left looking at exit 0 + blank stdout/stderr.
+    // empty message (or one that trims to empty), still emit *something* and
+    // exit non-zero so the user is never left looking at exit 0 + blank
+    // stdout/stderr.
     class BlankError extends Error {
       oclif = { exit: 0 };
     }
@@ -228,7 +230,7 @@ describe("runOclifCommandById", () => {
 
     await runOclifCommandById("status", ["my-assist"], { rootDir: "/repo", error: errorLine });
 
-    expect(process.exitCode).toBe(0);
+    expect(process.exitCode).toBe(1);
     expect(errorLine).toHaveBeenCalledOnce();
     const [line] = errorLine.mock.calls[0];
     expect(String(line).trim().length).toBeGreaterThan(0);

--- a/src/lib/cli/oclif-runner.ts
+++ b/src/lib/cli/oclif-runner.ts
@@ -162,6 +162,19 @@ export async function runOclifArgv(args: string[], opts: OclifCommandRunOptions)
     // silently exit 0 — reporting success for a real failure on the native
     // `internal`/`sandbox` routes. Surface the message and force a non-zero
     // exit instead; only a genuine ExitError(0) stays a graceful exit.
+    //
+    // Mechanism asymmetry (why process.exitCode here, exit()/throw in
+    // runOclifCommandById): this native path mirrors oclif's execute() (run →
+    // flush → handle), so for the intercepted case we set process.exitCode and
+    // return rather than delegating to handleOclif() (the non-intercepted
+    // branch below). handleOclif() IS oclif's handle(), which would re-run
+    // Exit.exit(0) for this error and undo the fix, so process.exitCode +
+    // return is the only way to force a non-zero code without re-entering
+    // handle(). runOclifCommandById does not route through handle() at all — it
+    // maps errors to codes by hand (its injected exit() for parse/ExitError, a
+    // re-throw otherwise) — but applies the identical oclif.exit === 0 guard.
+    // Removal condition: drop this guard once @oclif/core's handle() no longer
+    // exits 0 for a non-ExitError that carries oclif.exit === 0.
     const exitCode = getOclifExitCode(error);
     if (exitCode === 0 && !isOclifExitError(error)) {
       const message = formatOclifError(error) || "Command exited with no output.";

--- a/src/lib/cli/oclif-runner.ts
+++ b/src/lib/cli/oclif-runner.ts
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Config as OclifConfig, execute as executeOclif } from "@oclif/core";
+import {
+  flush as flushOclif,
+  handle as handleOclif,
+  Config as OclifConfig,
+  run as runOclif,
+} from "@oclif/core";
 
 import { CLI_NAME } from "./branding";
 
@@ -138,18 +143,35 @@ export async function runOclifCommandById(
 export async function runOclifArgv(args: string[], opts: OclifCommandRunOptions): Promise<void> {
   const config = await OclifConfig.load(opts.rootDir);
   applyBrandedBin(config);
+  const errorLine = opts.error ?? console.error;
   const originalArgv = process.argv;
   // oclif's parse-error help renderer consults process.argv, not just the
-  // explicit execute({ args }) value, so keep both views on the native route.
+  // explicit run() args, so keep both views on the native route.
   process.argv = [originalArgv[0] ?? process.execPath, originalArgv[1] ?? CLI_NAME, ...args];
   try {
-    await executeOclif({
-      args,
-      loadOptions: {
-        root: opts.rootDir,
-        pjson: config.pjson,
-      },
-    });
+    // Mirror @oclif/core's execute() (run → flush → handle) by hand so the
+    // native argv path keeps oclif's command lookup, parsing, help rendering,
+    // and pretty-printed errors while letting us intercept one case below.
+    await runOclif(args, { root: opts.rootDir, pjson: config.pjson });
+    await flushOclif();
+  } catch (error) {
+    await flushOclif();
+    // #5974: same hardening as runOclifCommandById. oclif's own handle() would
+    // run Exit.exit(err.oclif?.exit ?? 1) here, so a non-ExitError that merely
+    // carries oclif.exit === 0 (propagated out of a command's run()) would
+    // silently exit 0 — reporting success for a real failure on the native
+    // `internal`/`sandbox` routes. Surface the message and force a non-zero
+    // exit instead; only a genuine ExitError(0) stays a graceful exit.
+    const exitCode = getOclifExitCode(error);
+    if (exitCode === 0 && !isOclifExitError(error)) {
+      const message = formatOclifError(error) || "Command exited with no output.";
+      errorLine(`  ${message}`);
+      process.exitCode = 1;
+      return;
+    }
+    // Everything else (parse errors, ExitError, ordinary failures) keeps
+    // oclif's standard handling: pretty-print, optional help, and process exit.
+    await handleOclif(error as Parameters<typeof handleOclif>[0]);
   } finally {
     process.argv = originalArgv;
   }

--- a/src/lib/cli/oclif-runner.ts
+++ b/src/lib/cli/oclif-runner.ts
@@ -95,18 +95,23 @@ export async function runOclifCommandById(
   } catch (error) {
     const exitCode = getOclifExitCode(error);
     if (exitCode === 0) {
-      // #2666: only oclif's own ExitError(0) is an intentional graceful
-      // exit (e.g. Command.exit(0) — message is the synthetic "EEXIT: 0").
-      // Any OTHER error that happens to carry oclif.exit === 0 used to be
-      // silently swallowed here, producing exit 0 + completely empty
-      // stdout/stderr. Surface its message — and fall back to a generic
-      // line if formatOclifError() returns empty so we never reintroduce
-      // the silent path for an error whose message happens to be blank.
-      if (!isOclifExitError(error)) {
-        const message = formatOclifError(error) || "Command exited with no output.";
-        errorLine(`  ${message}`);
+      // Only oclif's own ExitError(0) is an intentional graceful exit (e.g.
+      // Command.exit(0) / --help — its message is the synthetic "EEXIT: 0",
+      // which must stay silent). Keep that path at exit 0.
+      if (isOclifExitError(error)) {
+        process.exitCode = 0;
+        return;
       }
-      process.exitCode = 0;
+      // #5974: any OTHER error that merely happens to carry oclif.exit === 0
+      // is a genuine failure that bubbled out of a command's run(). #2666
+      // stopped it being silently swallowed (exit 0 + empty output); here we
+      // also refuse to report success for it — surface its message AND exit
+      // non-zero so `$?` stays scriptable. Fall back to a generic line if
+      // formatOclifError() returns empty so a blank message never reintroduces
+      // the silent path.
+      const message = formatOclifError(error) || "Command exited with no output.";
+      errorLine(`  ${message}`);
+      process.exitCode = 1;
       return;
     }
 

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -657,6 +657,36 @@ describe("handleProviderInferenceState", () => {
     expect(calls.reconcileRouter).toHaveBeenCalledOnce();
   });
 
+  // #5974 instance 5: the Model Router Python preflight (`prepareModelRouterVenv`)
+  // throws a plain Error (e.g. "above supported ceiling", with no `oclif.exit`)
+  // out of `reconcileModelRouter`. The routed branch must catch that throw and
+  // exit non-zero via `exitProcess(1)` so onboard reports the failure to `$?`,
+  // rather than the throw being swallowed or riding the oclif runner. The error
+  // reasons themselves are locked by `model-router-python.test.ts`.
+  it("exits non-zero when model router reconciliation throws (#5974)", async () => {
+    const session = createSession({ provider: "nvidia-router", model: "router/model" });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      isInferenceRouteReady: vi.fn(() => true),
+      reconcileModelRouter: vi.fn(async () => {
+        throw new Error("version 3.14.0 above supported ceiling 3.14.0 (exclusive)");
+      }),
+    });
+
+    await expect(
+      handleProviderInferenceState({
+        ...baseOptions(deps, session),
+        resume: true,
+        sandboxName: "router-sandbox",
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expect(calls.exit).toHaveBeenCalledWith(1);
+    expect(calls.error).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to reconcile model router"),
+    );
+  });
+
   // Regression: #4564. On resume the routed provider was only reconciled, never
   // re-upserted, so a stale localhost base URL recorded by an earlier run could
   // survive in the gateway and break inference.local from the sandbox.

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -210,13 +210,17 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
   //     ExitError(0) unit test in src/lib/cli/oclif-runner.test.ts).
   // Both resolve at oclif's command lookup, before any gateway probe, so they
   // stay hermetic under the fakes above.
-  it("a native-route user error prints oclif's error and exits non-zero (#5974)", testTimeoutOptions(30_000), () => {
-    const { status, signal, error, combined } = runCli(["sandbox", "bogus-subcmd"]);
-    expect(error).toBeUndefined();
-    expect(signal).toBeNull();
-    expect(combined).toContain("not found");
-    expect(status).toBeGreaterThan(0);
-  });
+  it(
+    "a native-route user error prints oclif's error and exits non-zero (#5974)",
+    testTimeoutOptions(30_000),
+    () => {
+      const { status, signal, error, combined } = runCli(["sandbox", "bogus-subcmd"]);
+      expect(error).toBeUndefined();
+      expect(signal).toBeNull();
+      expect(combined).toContain("not found");
+      expect(status).toBeGreaterThan(0);
+    },
+  );
 
   it("a native-route --help stays a clean exit 0 (#5974)", testTimeoutOptions(30_000), () => {
     const { status, signal, error, combined } = runCli(["sandbox", "--help"]);

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -198,16 +198,28 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
     });
   }
 
-  // Counterpart invariant (#5974): the exit-code hardening on the native oclif
-  // argv route (src/lib/cli/oclif-runner.ts) must NOT over-correct a genuine
-  // graceful exit. A native `--help` route rides oclif's ExitError(0) and must
-  // still exit 0 through the real binary — the spawned-CLI lock for the
-  // ExitError(0) unit test in src/lib/cli/oclif-runner.test.ts. The opposite
-  // direction (a native parse/user-error route exiting non-zero) is covered by
-  // the "credentials reset without a provider" row above (oclif parse error,
-  // exit 2), which also flows through the native oclif argv route.
-  it("a native --help route stays a clean exit 0 (#5974)", testTimeoutOptions(30_000), () => {
-    const { status, signal, error, combined } = runCli(["credentials", "--help"]);
+  // PRA-1 (#5974): exercise the NATIVE oclif argv route end-to-end through the
+  // real binary. `dispatchCli` sends a leading `sandbox`/`internal` token
+  // straight to `runOclifArgv` (src/lib/cli/oclif-runner.ts) — distinct from
+  // the by-id dispatcher used by the rows above — so these two cases lock both
+  // directions of that route:
+  //   - a native parse/user-error route prints oclif's formatted error and
+  //     exits non-zero (the hardening this PR adds to the native path), and
+  //   - a native help route stays a clean exit 0 — a genuine ExitError(0) that
+  //     the hardening must NOT over-correct (the spawned-CLI counterpart to the
+  //     ExitError(0) unit test in src/lib/cli/oclif-runner.test.ts).
+  // Both resolve at oclif's command lookup, before any gateway probe, so they
+  // stay hermetic under the fakes above.
+  it("a native-route user error prints oclif's error and exits non-zero (#5974)", testTimeoutOptions(30_000), () => {
+    const { status, signal, error, combined } = runCli(["sandbox", "bogus-subcmd"]);
+    expect(error).toBeUndefined();
+    expect(signal).toBeNull();
+    expect(combined).toContain("not found");
+    expect(status).toBeGreaterThan(0);
+  });
+
+  it("a native-route --help stays a clean exit 0 (#5974)", testTimeoutOptions(30_000), () => {
+    const { status, signal, error, combined } = runCli(["sandbox", "--help"]);
     expect(error).toBeUndefined();
     expect(signal).toBeNull();
     expect(combined).toContain("USAGE");

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -197,4 +197,20 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
       expect(status).toBeGreaterThan(0);
     });
   }
+
+  // Counterpart invariant (#5974): the exit-code hardening on the native oclif
+  // argv route (src/lib/cli/oclif-runner.ts) must NOT over-correct a genuine
+  // graceful exit. A native `--help` route rides oclif's ExitError(0) and must
+  // still exit 0 through the real binary — the spawned-CLI lock for the
+  // ExitError(0) unit test in src/lib/cli/oclif-runner.test.ts. The opposite
+  // direction (a native parse/user-error route exiting non-zero) is covered by
+  // the "credentials reset without a provider" row above (oclif parse error,
+  // exit 2), which also flows through the native oclif argv route.
+  it("a native --help route stays a clean exit 0 (#5974)", testTimeoutOptions(30_000), () => {
+    const { status, signal, error, combined } = runCli(["credentials", "--help"]);
+    expect(error).toBeUndefined();
+    expect(signal).toBeNull();
+    expect(combined).toContain("USAGE");
+    expect(status).toBe(0);
+  });
 });

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -25,6 +25,26 @@
  * here; that branch is covered by the unit tests in
  * `src/lib/share-command.test.ts` and `test/share-command-remote-path.test.ts`.
  * This matrix locks the nonexistent-sandbox share/upload surfaces instead.
+ *
+ * Issue instances 3 (onboard dashboard-port exhaustion) and 5 (Model Router
+ * Python preflight) are likewise out of this hermetic spawn matrix: reaching
+ * them through the real `onboard` flow requires standing in for a chain of host
+ * gates (`openshell --version` >= 0.0.44, the request-body-credential-rewrite
+ * capability probe, and more) that a bash shim cannot emulate reliably. Both
+ * already exit non-zero today and — unlike the surfaces this PR fixes — neither
+ * ever rode the `oclif.exit === 0` catch-all this PR hardens, so the runner
+ * change neither breaks nor is required by them:
+ *   - Instance 3 exits via an explicit `exitFn(1)` (i.e. `process.exit(1)`),
+ *     locked by `src/lib/onboard/dashboard-port.test.ts`, which asserts exit
+ *     code 1 plus the canonical "All dashboard ports in range 18789-18799 are
+ *     occupied" message.
+ *   - Instance 5 throws a plain Error that propagates through `onboard`'s
+ *     try/finally with no swallowing catch, locked by
+ *     `src/lib/onboard/model-router-python.test.ts` (the "above supported
+ *     ceiling" reason and the thrown "No usable host Python interpreter found"
+ *     message).
+ * The thrown-error → non-zero process exit composition that ties instance 5 to
+ * a failing `$?` is in turn locked by `src/lib/cli/oclif-runner.test.ts`.
  */
 
 import { spawnSync } from "node:child_process";

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -37,12 +37,15 @@
  * Issue instance 5 (Model Router Python preflight) is the one surface left to
  * unit tests: `reconcileModelRouter` runs only deep in `onboard`, behind live
  * gateway + provider + sandbox provisioning that cannot be faked hermetically
- * here. It throws a plain Error (no `oclif.exit`, so again unaffected by this
- * PR) that propagates through `onboard`'s try/finally with no swallowing catch.
- * That throw is locked by `src/lib/onboard/model-router-python.test.ts` (the
- * "above supported ceiling" reason and the "No usable host Python interpreter
- * found" message), and the thrown-error → non-zero process-exit composition is
- * locked by `src/lib/cli/oclif-runner.test.ts`.
+ * here. Its Python preflight (`prepareModelRouterVenv`) throws a plain Error
+ * (no `oclif.exit`, so unaffected by this PR's oclif hardening); the routed
+ * branch of the provider/inference handler catches that throw and exits
+ * non-zero via `exitProcess(1)` instead of letting it ride the oclif runner.
+ * The error reasons are locked by `src/lib/onboard/model-router-python.test.ts`
+ * (the "above supported ceiling" reason and the "No usable host Python
+ * interpreter found" message), and the caught-throw → non-zero exit composition
+ * is locked by `src/lib/onboard/machine/handlers/provider-inference.test.ts`
+ * ("exits non-zero when model router reconciliation throws").
  */
 
 import { spawnSync } from "node:child_process";

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -26,29 +26,28 @@
  * `src/lib/share-command.test.ts` and `test/share-command-remote-path.test.ts`.
  * This matrix locks the nonexistent-sandbox share/upload surfaces instead.
  *
- * Issue instances 3 (onboard dashboard-port exhaustion) and 5 (Model Router
- * Python preflight) are likewise out of this hermetic spawn matrix: reaching
- * them through the real `onboard` flow requires standing in for a chain of host
- * gates (`openshell --version` >= 0.0.44, the request-body-credential-rewrite
- * capability probe, and more) that a bash shim cannot emulate reliably. Both
- * already exit non-zero today and — unlike the surfaces this PR fixes — neither
- * ever rode the `oclif.exit === 0` catch-all this PR hardens, so the runner
- * change neither breaks nor is required by them:
- *   - Instance 3 exits via an explicit `exitFn(1)` (i.e. `process.exit(1)`),
- *     locked by `src/lib/onboard/dashboard-port.test.ts`, which asserts exit
- *     code 1 plus the canonical "All dashboard ports in range 18789-18799 are
- *     occupied" message.
- *   - Instance 5 throws a plain Error that propagates through `onboard`'s
- *     try/finally with no swallowing catch, locked by
- *     `src/lib/onboard/model-router-python.test.ts` (the "above supported
- *     ceiling" reason and the thrown "No usable host Python interpreter found"
- *     message).
- * The thrown-error → non-zero process exit composition that ties instance 5 to
- * a failing `$?` is in turn locked by `src/lib/cli/oclif-runner.test.ts`.
+ * Issue instance 3 (onboard dashboard-port exhaustion) is locked by its own
+ * hermetic `onboard` spawn in the second describe below: it binds the whole
+ * dashboard port range and drives the real `onboard` preflight to the
+ * fail-fast "All dashboard ports in range … are occupied" exit, asserting a
+ * non-zero code. (That preflight exits via an explicit `exitFn(1)`, so it never
+ * rode the `oclif.exit === 0` catch-all this PR hardens — the spawn simply
+ * proves the surface stays non-zero end-to-end.)
+ *
+ * Issue instance 5 (Model Router Python preflight) is the one surface left to
+ * unit tests: `reconcileModelRouter` runs only deep in `onboard`, behind live
+ * gateway + provider + sandbox provisioning that cannot be faked hermetically
+ * here. It throws a plain Error (no `oclif.exit`, so again unaffected by this
+ * PR) that propagates through `onboard`'s try/finally with no swallowing catch.
+ * That throw is locked by `src/lib/onboard/model-router-python.test.ts` (the
+ * "above supported ceiling" reason and the "No usable host Python interpreter
+ * found" message), and the thrown-error → non-zero process-exit composition is
+ * locked by `src/lib/cli/oclif-runner.test.ts`.
  */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -228,5 +227,103 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
     expect(signal).toBeNull();
     expect(combined).toContain("USAGE");
     expect(status).toBe(0);
+  });
+});
+
+// Issue #5974 instance 3: `nemoclaw onboard …` printed "All dashboard ports in
+// range … are occupied" but the reporter saw exit 0. The onboard preflight
+// fails fast here via an explicit process.exit(1), so it was never affected by
+// the oclif.exit === 0 catch-all this PR hardens — this spawn locks the
+// end-to-end non-zero exit so the surface cannot silently regress to 0.
+describe("onboard dashboard-port exhaustion exits non-zero (#5974)", () => {
+  const PORT_RANGE_START = 18789;
+  const PORT_RANGE_END = 18799;
+  let home: string;
+  let binDir: string;
+  let servers: net.Server[];
+
+  beforeEach(async () => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-5974-onboard-"));
+    binDir = path.join(home, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+
+    // Fake openshell: report a supported version and embed the capability
+    // markers the installer greps for with `strings`, so onboard's preflight
+    // neither attempts a network reinstall nor fails the credential-rewrite
+    // capability gate before it reaches the dashboard-port check.
+    fs.writeFileSync(
+      path.join(binDir, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        "# openshell capabilities: request-body-credential-rewrite websocket-credential-rewrite",
+        'case "$1" in',
+        '  --version) echo "openshell 0.0.44"; exit 0;;',
+        "esac",
+        "echo '' >&2",
+        "exit 1",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(binDir, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = info ]; then echo "Server Version: 24.0.0"; exit 0; fi',
+        'if [ "$1" = ps ]; then exit 0; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    // Occupy the entire dashboard port range so the preflight has no free port.
+    servers = [];
+    const ports = Array.from(
+      { length: PORT_RANGE_END - PORT_RANGE_START + 1 },
+      (_unused, i) => PORT_RANGE_START + i,
+    );
+    await Promise.all(
+      ports.map(
+        (port) =>
+          new Promise<void>((resolve) => {
+            const server = net.createServer();
+            server.once("error", () => resolve());
+            server.listen(port, "127.0.0.1", () => {
+              servers.push(server);
+              resolve();
+            });
+          }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    for (const server of servers) server.close();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("prints the canonical message and exits non-zero", testTimeoutOptions(60_000), () => {
+    const result = spawnSync(
+      process.execPath,
+      [CLI, "onboard", "--name", "port-test", "--no-gpu", "--non-interactive"],
+      {
+        encoding: "utf-8",
+        timeout: 55_000,
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+          NEMOCLAW_TEST_NO_SLEEP: "1",
+          NEMOCLAW_STATUS_PROBE_TIMEOUT_MS: "2000",
+          NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        },
+      },
+    );
+    const combined = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(combined).toContain(
+      `All dashboard ports in range ${PORT_RANGE_START}-${PORT_RANGE_END} are occupied`,
+    );
+    expect(result.status).toBeGreaterThan(0);
   });
 });

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression matrix for #5974.
+ *
+ * Several user-error / unknown-command surfaces historically printed correct
+ * error text but returned exit 0, which breaks `$?` scriptability (a watchdog
+ * or CI step wrapping `nemoclaw` could not tell the command failed). This test
+ * runs the real `nemoclaw` binary against fake `openshell`/`docker` shims with
+ * an isolated HOME and asserts each surface returns a non-zero exit code while
+ * still surfacing its error text.
+ *
+ * Surfaces are kept hermetic on purpose: the fakes report no reachable gateway
+ * and no sandbox, so registry recovery finds nothing and the dispatcher's
+ * "unknown command / sandbox does not exist / missing argument" boundaries are
+ * exercised without contacting a live OpenShell gateway.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { testTimeoutOptions } from "./helpers/timeouts";
+
+const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+
+describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
+  let home: string;
+  let binDir: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-5974-"));
+    binDir = path.join(home, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+
+    // Fake openshell: every gateway/sandbox probe fails, so recovery can never
+    // resurrect a sandbox and the dispatcher's user-error boundaries decide the
+    // exit code. Nothing here should ever exit 0 for a sandbox lookup.
+    fs.writeFileSync(
+      path.join(binDir, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'case "$*" in',
+        "  status)",
+        "    echo 'Status: Disconnected' ;",
+        "    exit 1 ;;",
+        "  *)",
+        "    echo '' >&2 ;",
+        "    exit 1 ;;",
+        "esac",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    // Fake docker: report a healthy daemon but no NemoClaw containers so the
+    // Docker-driver gateway probe stays quiet without reaching a real daemon.
+    fs.writeFileSync(
+      path.join(binDir, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = info ]; then echo "Server Version: 24.0.0"; exit 0; fi',
+        'if [ "$1" = ps ]; then exit 0; fi',
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    // Empty registry: no sandboxes are known on disk.
+    const registryDir = path.join(home, ".nemoclaw");
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "sandboxes.json"),
+      JSON.stringify({ sandboxes: {}, defaultSandbox: null }),
+      { mode: 0o600 },
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function runCli(args: string[]): { code: number; combined: string } {
+    const result = spawnSync(process.execPath, [CLI, ...args], {
+      encoding: "utf-8",
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        NEMOCLAW_TEST_NO_SLEEP: "1",
+        NEMOCLAW_STATUS_PROBE_TIMEOUT_MS: "2000",
+      },
+    });
+    return {
+      code: result.status ?? -1,
+      combined: `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+    };
+  }
+
+  // Each row is [label, argv, expectedSubstring]. The substring is a stable
+  // fragment of the existing user-facing error text; the hard invariant is the
+  // non-zero exit code.
+  const cases: ReadonlyArray<[string, string[], string]> = [
+    ["credentials reset with no provider", ["credentials", "reset"], "required arg"],
+    ["skill install with no path", ["bug5974-sb", "skill", "install"], "does not exist"],
+    ["unknown sandbox action", ["bug5974-da-sb", "dcode", "--help"], "Unknown command"],
+    [
+      "share mount on a nonexistent sandbox",
+      ["bug5974-sb", "share", "mount", "/sandbox/bad-typo-path"],
+      "does not exist",
+    ],
+    [
+      "upload to a nonexistent sandbox",
+      ["bug5974-missing-sb", "upload", "some-file.txt"],
+      "does not exist",
+    ],
+  ];
+
+  for (const [label, argv, expected] of cases) {
+    it(`${label} prints an error and exits non-zero`, testTimeoutOptions(30_000), () => {
+      const { code, combined } = runCli(argv);
+      expect(combined.trim().length).toBeGreaterThan(0);
+      expect(combined).toContain(expected);
+      expect(code).not.toBe(0);
+    });
+  }
+});

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -11,10 +11,20 @@
  * an isolated HOME and asserts each surface returns a non-zero exit code while
  * still surfacing its error text.
  *
- * Surfaces are kept hermetic on purpose: the fakes report no reachable gateway
- * and no sandbox, so registry recovery finds nothing and the dispatcher's
- * "unknown command / sandbox does not exist / missing argument" boundaries are
- * exercised without contacting a live OpenShell gateway.
+ * The registry is seeded with one sandbox (`bug5974-alpha`) so the rows that
+ * target the issue's *command-specific* branches (missing required `skill
+ * install` path on an existing sandbox, unknown action on an existing sandbox)
+ * resolve the sandbox and reach those exact branches rather than stopping at
+ * the dispatcher's "sandbox does not exist" boundary. Rows that target a
+ * non-existent sandbox keep the reporter's literal nonexistent-sandbox surfaces
+ * (e.g. `nonexistent-sb upload file.txt`). All rows stay hermetic: the fakes
+ * report no reachable gateway, so nothing contacts a live OpenShell gateway.
+ *
+ * The `share mount` *bad remote path* diagnostic (#3414) needs both a live
+ * sandbox and a host `sshfs` binary to reach, so it cannot run hermetically
+ * here; that branch is covered by the unit tests in
+ * `src/lib/share-command.test.ts` and `test/share-command-remote-path.test.ts`.
+ * This matrix locks the nonexistent-sandbox share/upload surfaces instead.
  */
 
 import { spawnSync } from "node:child_process";
@@ -26,6 +36,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { testTimeoutOptions } from "./helpers/timeouts";
 
 const CLI = path.join(import.meta.dirname, "..", "bin", "nemoclaw.js");
+const REGISTERED = "bug5974-alpha";
 
 describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
   let home: string;
@@ -68,12 +79,25 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
       { mode: 0o755 },
     );
 
-    // Empty registry: no sandboxes are known on disk.
+    // Seed a single registered sandbox so the command-specific rows can resolve
+    // it and reach their own validation branches.
     const registryDir = path.join(home, ".nemoclaw");
     fs.mkdirSync(registryDir, { recursive: true });
     fs.writeFileSync(
       path.join(registryDir, "sandboxes.json"),
-      JSON.stringify({ sandboxes: {}, defaultSandbox: null }),
+      JSON.stringify({
+        sandboxes: {
+          [REGISTERED]: {
+            name: REGISTERED,
+            model: "test-model",
+            provider: "test-provider",
+            gpuEnabled: false,
+            policies: [],
+            agent: "openclaw",
+          },
+        },
+        defaultSandbox: REGISTERED,
+      }),
       { mode: 0o600 },
     );
   });
@@ -101,15 +125,26 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
   }
 
   // Each row is [label, argv, expectedSubstring]. The substring is a stable
-  // fragment of the existing user-facing error text; the hard invariant is the
-  // non-zero exit code.
+  // fragment of the branch-specific error text, so a row that regresses to a
+  // different boundary (e.g. sandbox resolution) fails the substring check as
+  // well as the exit-code invariant. The hard invariant is the non-zero exit.
   const cases: ReadonlyArray<[string, string[], string]> = [
-    ["credentials reset with no provider", ["credentials", "reset"], "required arg"],
-    ["skill install with no path", ["bug5974-sb", "skill", "install"], "does not exist"],
-    ["unknown sandbox action", ["bug5974-da-sb", "dcode", "--help"], "Unknown command"],
+    // Missing required arg — oclif parse error, exits before any gateway probe.
+    ["credentials reset without a provider", ["credentials", "reset"], "required arg"],
+    // Missing required path on an EXISTING sandbox: resolves the seeded sandbox
+    // and reaches `skill install`'s own required-arg parser (issue instance 1).
+    [
+      `${REGISTERED} skill install without a path`,
+      [REGISTERED, "skill", "install"],
+      "required arg",
+    ],
+    // Unknown action on an EXISTING sandbox: resolves the seeded sandbox and
+    // reaches the dispatcher's unknown-action branch (issue instance 2).
+    [`${REGISTERED} unknown action`, [REGISTERED, "dcode", "--help"], "Unknown action: dcode"],
+    // Nonexistent-sandbox surfaces (issue instance 4, literal reporter commands).
     [
       "share mount on a nonexistent sandbox",
-      ["bug5974-sb", "share", "mount", "/sandbox/bad-typo-path"],
+      ["bug5974-missing-sb", "share", "mount", "/sandbox/bad-typo-path"],
       "does not exist",
     ],
     [

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -106,7 +106,12 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  function runCli(args: string[]): { code: number; combined: string } {
+  function runCli(args: string[]): {
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    error: Error | undefined;
+    combined: string;
+  } {
     const result = spawnSync(process.execPath, [CLI, ...args], {
       encoding: "utf-8",
       timeout: 30_000,
@@ -119,7 +124,9 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
       },
     });
     return {
-      code: result.status ?? -1,
+      status: result.status,
+      signal: result.signal,
+      error: result.error,
       combined: `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
     };
   }
@@ -127,7 +134,10 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
   // Each row is [label, argv, expectedSubstring]. The substring is a stable
   // fragment of the branch-specific error text, so a row that regresses to a
   // different boundary (e.g. sandbox resolution) fails the substring check as
-  // well as the exit-code invariant. The hard invariant is the non-zero exit.
+  // well as the exit-code invariant. The hard invariant is a real positive
+  // exit code from a clean process exit — see the assertions below, which
+  // reject spawn failures and signal/timeout terminations so a killed process
+  // (status === null) can never satisfy the "non-zero exit" claim.
   const cases: ReadonlyArray<[string, string[], string]> = [
     // Missing required arg — oclif parse error, exits before any gateway probe.
     ["credentials reset without a provider", ["credentials", "reset"], "required arg"],
@@ -156,10 +166,15 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
 
   for (const [label, argv, expected] of cases) {
     it(`${label} prints an error and exits non-zero`, testTimeoutOptions(30_000), () => {
-      const { code, combined } = runCli(argv);
+      const { status, signal, error, combined } = runCli(argv);
+      // The process must have launched and exited on its own — not failed to
+      // spawn and not been killed by a signal/timeout (which leaves
+      // status === null and would otherwise masquerade as a "non-zero exit").
+      expect(error).toBeUndefined();
+      expect(signal).toBeNull();
       expect(combined.trim().length).toBeGreaterThan(0);
       expect(combined).toContain(expected);
-      expect(code).not.toBe(0);
+      expect(status).toBeGreaterThan(0);
     });
   }
 });


### PR DESCRIPTION
## Summary

Several `nemoclaw` user-error and unknown-command surfaces returned exit `0` even though they printed correct error text, which breaks `$?`-based scriptability (a watchdog or CI step wrapping the CLI could not detect the failure). This hardens the last structural exit-`0` hole in the oclif runner and locks the reported surfaces with a regression matrix.

## Related Issue

Closes #5974

## Changes

- `src/lib/cli/oclif-runner.ts`: an error that merely happens to carry `oclif.exit === 0` (propagated out of a command's `run()`, not oclif's own graceful `ExitError(0)`) is now treated as a genuine failure — its message is surfaced **and** `process.exitCode` is set to `1`. Only a real `ExitError(0)` (e.g. `Command.exit(0)` / `--help`, whose synthetic `EEXIT: 0` message must stay silent) keeps exit `0`. The blank-message fallback line from #2666 is preserved.
- `test/exit-code-user-error-surfaces.test.ts`: new hermetic regression matrix that runs the real `nemoclaw` binary against fake `openshell`/`docker` shims with an isolated `HOME`. A single sandbox is seeded so the command-specific rows resolve it and reach their exact branches: `credentials reset` (missing provider) and `<existing> skill install` (missing path) both hit the missing-required-arg parser, `<existing> dcode --help` hits the unknown-action branch, and `share mount` / `upload` against a nonexistent sandbox hit the literal reporter surfaces.
- `src/lib/cli/oclif-runner.test.ts`: updated the two #2666 unit tests to assert the corrected non-zero exit while keeping the surfaced-message intent.

Scope note: the per-command surfaces were re-tested on current `main` and already return non-zero (release drift since the v0.0.68 report); the matrix guards them against future regression, while the runner change closes the remaining catch-all path. The onboard startup paths (dashboard-port exhaustion, Python preflight) were verified to propagate as thrown errors through onboard's `try/finally` (no swallowing catch) and already exit non-zero, so they are left untouched. The `share mount` bad-remote-path diagnostic (#3414) needs a live sandbox + host `sshfs` to reach, so it stays covered by `src/lib/share-command.test.ts` / `test/share-command-remote-path.test.ts` rather than the hermetic spawn matrix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable — justification: no user-facing behavior or flag changes; only exit codes are corrected to be non-zero on already-documented error messages.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: CLI runner change is additive (only converts a wrongly-successful failure into a non-zero exit) and preserves legitimate graceful `ExitError(0)`; covered by unit + integration tests.

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] No secrets, API keys, or credentials committed

### Reporter-workflow E2E (real worktree CLI)

Ran each reporter surface through the worktree binary `./bin/nemoclaw.js` (Node entry → `dist/nemoclaw.js`) with an isolated `HOME`, a registry seeded with one sandbox (`bug5974-alpha`), and fake `openshell`/`docker` shims so no live gateway is contacted. Every command prints its error text and exits **non-zero**:

```
$ node ./bin/nemoclaw.js credentials reset
  Missing 1 required arg:
provider  OpenShell provider name
  => exit 2

$ node ./bin/nemoclaw.js bug5974-alpha skill install      # existing sandbox, missing path
  Missing 1 required arg:
skillPath  Skill directory or direct path to SKILL.md
  => exit 2

$ node ./bin/nemoclaw.js bug5974-alpha dcode --help        # existing sandbox, unknown action
  Unknown action: dcode
  Valid actions: agent, agents, channels, ... skill, snapshot, status, upload
  => exit 1

$ node ./bin/nemoclaw.js bug5974-missing-sb share mount /sandbox/bad-typo-path
  Sandbox 'bug5974-missing-sb' does not exist.
  => exit 1

$ node ./bin/nemoclaw.js bug5974-missing-sb upload some-file.txt
  Sandbox 'bug5974-missing-sb' does not exist.
  => exit 1
```

This exact reporter workflow is codified hermetically in `test/exit-code-user-error-surfaces.test.ts`, which spawns the same `bin/nemoclaw.js` and asserts non-zero exit + branch-specific error text for each row.

The behavioral fix itself lives in `src/lib/cli/oclif-runner.ts` (the `oclif.exit === 0` catch-all that previously surfaced a message but reported success). That path is a defensive catch-all not directly reachable from a fixed user command, so it is covered by unit tests in `src/lib/cli/oclif-runner.test.ts` rather than a CLI transcript.

Other tests run locally:
- `vitest run --project cli src/lib/cli/oclif-runner.test.ts` (11 passed)
- `vitest run --project integration test/exit-code-user-error-surfaces.test.ts` (5 passed)
- `vitest run --project integration test/repro-2666-silent-list-status.test.ts` (9 passed, no regression)
- `npm run typecheck:cli`, `npm run typecheck`, biome lint + format, test title/size/overlap checks, `prek run --from-ref main --to-ref HEAD` — all pass.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened CLI handling so errors that merely *carry* an exit code of `0` are treated as failures: they now surface a non-empty error message and exit with a non-zero status.
  * Preserved quiet behavior for genuine successful `ExitError(0)` exits.
* **Tests**
  * Updated CLI runner tests to reflect the updated oclif mocking and the success-vs-failure exit/output distinctions.
  * Added end-to-end regression coverage for CLI error surfaces and dashboard port exhaustion.
  * Added a `#5974` provider inference regression test to confirm failure propagation and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->