### PR TITLE
fix(messaging): disable Teams streaming by default

### DIFF
--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -278,8 +278,6 @@ MSTEAMS_APP_ID=<your-teams-app-id> \
 After the rebuild starts the Teams webhook forward, route your public HTTPS endpoint to `http://127.0.0.1:3978/api/messages` or the port you selected with `MSTEAMS_PORT`.
 If `channels add teams` reports that another sandbox already uses the same Teams webhook port, choose another `MSTEAMS_PORT` for one sandbox or stop and remove the conflicting sandbox.
 
-For OpenClaw sandboxes, NemoClaw renders `channels.msteams.streaming.mode: "off"` by default so Teams receives one final message instead of relying on the native Teams streaming preview/final collapse path.
-
 ### `channels add wechat`
 
 `channels add wechat` (experimental) follows the same shape as the other channels with two differences driven by the iLink QR handshake.

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -116,6 +116,7 @@ The client secret is stored as the `<sandbox>-teams-bridge` OpenShell provider a
 Use `TEAMS_ALLOWED_USERS` or `MSTEAMS_ALLOWED_USERS` to list comma-separated Microsoft Entra ID object IDs that may interact with the bot.
 For OpenClaw group and channel messages, `TEAMS_REQUIRE_MENTION` defaults to `1`, so the bot replies only when mentioned.
 Direct messages are unaffected by mention mode.
+NemoClaw configures OpenClaw Teams with `channels.msteams.streaming.mode: "off"` so the channel uses final-message delivery while the upstream Teams streaming path can duplicate or collapse preview and final messages.
 
 WeChat (experimental) delivers messages over Tencent's iLink gateway through the upstream `@tencent-weixin/openclaw-weixin` plugin installed into WeChat-enabled OpenClaw sandbox images and the built-in Hermes iLink WeChat adapter.
 The supported mode in this release is **personal WeChat** (`bot_type=3`).

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -278,6 +278,8 @@ MSTEAMS_APP_ID=<your-teams-app-id> \
 After the rebuild starts the Teams webhook forward, route your public HTTPS endpoint to `http://127.0.0.1:3978/api/messages` or the port you selected with `MSTEAMS_PORT`.
 If `channels add teams` reports that another sandbox already uses the same Teams webhook port, choose another `MSTEAMS_PORT` for one sandbox or stop and remove the conflicting sandbox.
 
+For OpenClaw sandboxes, NemoClaw renders `channels.msteams.streaming.mode: "off"` by default so Teams receives one final message instead of relying on the native Teams streaming preview/final collapse path.
+
 ### `channels add wechat`
 
 `channels add wechat` (experimental) follows the same shape as the other channels with two differences driven by the iLink QR handshake.

--- a/src/lib/messaging/channels/manifests.test.ts
+++ b/src/lib/messaging/channels/manifests.test.ts
@@ -727,6 +727,7 @@ describe("built-in channel manifests", () => {
     expect(renderJson(teamsManifest)).toContain('"path":"platforms.teams"');
     expect(renderJson(teamsManifest)).toContain("credential.teamsClientSecret.placeholder");
     expect(renderJson(teamsManifest)).toContain("teamsConfig.webhookPort");
+    expect(renderJson(teamsManifest)).toContain('"streaming":{"mode":"off"}');
     expect(renderJson(teamsManifest)).toContain('"groupPolicy":"open"');
     expect(renderJson(teamsManifest)).not.toContain("groupAllowFrom");
     expectTokenPasteEnrollHook(teamsManifest, ["clientSecret"]);

--- a/src/lib/messaging/channels/teams/manifest.ts
+++ b/src/lib/messaging/channels/teams/manifest.ts
@@ -126,6 +126,9 @@ export const teamsManifest = {
           healthMonitor: {
             enabled: false,
           },
+          streaming: {
+            mode: "off",
+          },
           dmPolicy: "{{allowedIds.teams.dmPolicy}}",
           allowFrom: "{{allowedIds.teams.values}}",
           groupPolicy: "open",

--- a/src/lib/messaging/channels/teams/manifest.ts
+++ b/src/lib/messaging/channels/teams/manifest.ts
@@ -126,6 +126,8 @@ export const teamsManifest = {
           healthMonitor: {
             enabled: false,
           },
+          // OpenClaw Teams streaming can duplicate or collapse preview and final messages.
+          // Keep final-only mode until that path is fixed and covered by runtime validation.
           streaming: {
             mode: "off",
           },

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -564,6 +564,7 @@ describe("ManifestCompiler", () => {
       }),
     );
     expect(JSON.stringify(plan.agentRender)).toContain('"port":3978');
+    expect(JSON.stringify(plan.agentRender)).toContain('"streaming":{"mode":"off"}');
     expect(JSON.stringify(plan.agentRender)).toContain('"groupPolicy":"open"');
     expect(JSON.stringify(plan.agentRender)).not.toContain("groupAllowFrom");
     expect(JSON.stringify(plan.agentRender)).toContain('"requireMention":true');
@@ -595,6 +596,7 @@ describe("ManifestCompiler", () => {
       disabled: false,
     });
     expect(JSON.stringify(plan.agentRender)).toContain("channels.msteams");
+    expect(JSON.stringify(plan.agentRender)).toContain('"streaming":{"mode":"off"}');
     expect(JSON.stringify(plan.agentRender)).toContain('"groupPolicy":"open"');
     expect(JSON.stringify(plan.agentRender)).not.toContain("dmPolicy");
     expect(JSON.stringify(plan.agentRender)).not.toContain("allowFrom");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR renders OpenClaw Microsoft Teams channels with `channels.msteams.streaming.mode: "off"` by default. The change avoids the native Teams streaming preview/final collapse path while OpenClaw Teams duplicate-delivery issues remain open upstream.

## Related Issue
Refs #5851

## Changes
- Add `streaming: { mode: "off" }` to the OpenClaw Teams channel fragment rendered by the messaging manifest.
- Assert the default in the built-in manifest and manifest compiler tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no docs changes remain in this PR.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: messaging manifest-only config default; no credential, policy, or egress expansion; targeted manifest/compiler tests passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification run:
- `./node_modules/.bin/vitest run src/lib/messaging/channels/manifests.test.ts src/lib/messaging/compiler/manifest-compiler.test.ts`
- `npm run typecheck:cli`
- `git diff --check`
- Pre-push TypeScript hook passed.
- The docs-removal cleanup commit passed its staged-file commit hooks.

Note: the original pre-commit `Test (CLI)` hook did not pass locally because unrelated environment-sensitive tests failed outside this diff, including `src/lib/actions/sandbox/snapshot.test.ts`, `src/lib/agent/runtime-recovery-preload.test.ts`, `test/langchain-deepagents-code-image.test.ts`, and `test/sandbox-rlimit-hooks.test.ts`.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: San Dang <sdang@nvidia.com>
\n\n## Maintainer Runtime-Validation Rationale\n\nThis is a declarative OpenClaw configuration default. The manifest and compiler tests prove that the compiled agent render contains the exact `channels.msteams.streaming.mode: "off"` value consumed by the existing build applier. A live Teams delivery test requires external tenant credentials and webhook infrastructure, so it is not a deterministic PR gate; the E2E Advisor also marked live E2E as unnecessary for this change. The source comment records the compatibility boundary and removal condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft Teams messaging now uses final-message delivery in OpenClaw sandboxes, avoiding the upstream streaming preview/final behavior.
  * Updated Teams manifest output to include the correct streaming setting.

* **Documentation**
  * Added a note explaining the Microsoft Teams streaming behavior for OpenClaw sandboxes.

* **Tests**
  * Expanded Teams-related checks to verify the new streaming configuration appears in generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->