### PR TITLE
test(e2e): preserve Hermes retired-state parity

### DIFF
--- a/test/e2e-scenario/live/hermes-sandbox-secret-boundary.test.ts
+++ b/test/e2e-scenario/live/hermes-sandbox-secret-boundary.test.ts
@@ -117,6 +117,10 @@ def parse_platform_toolsets(text: str) -> dict[str, list[str]]:
 
 env_path = Path("/sandbox/.hermes/.env")
 config_path = Path("/sandbox/.hermes/config.yaml")
+for retired_path in (Path("/sandbox/.openclaw"), Path("/sandbox/.hermes-data")):
+    if retired_path.exists() or retired_path.is_symlink():
+        print(f"retired Hermes sandbox state is present: {retired_path}", file=sys.stderr)
+        sys.exit(1)
 if env_path.is_symlink():
     print(f"{env_path} is a symlink", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve the post-#5949 Hermes retired-state contract at the live Vitest image boundary before the legacy shell entrypoint is removed.

## Related Issue

Refs #5849
Refs #5919
Refs #5949

## Changes

- Fail the live Hermes production-image inspection when either retired `/sandbox/.openclaw` or `/sandbox/.hermes-data` state exists.
- Keep the assertion at the same real built-image boundary as the legacy shell check.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test parity only; no product or user-facing behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending independent review of the Hermes image boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

- `npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/hermes-secret-boundary-workflow.test.ts` — 2 tests passed.
- `NEMOCLAW_RUN_E2E_SCENARIOS=1 npx vitest list --project e2e-scenarios-live test/e2e-scenario/live/hermes-sandbox-secret-boundary.test.ts` — live test collected successfully.
- `npm run build:cli && npm run typecheck:cli` — passed.
- `npx biome check test/e2e-scenario/live/hermes-sandbox-secret-boundary.test.ts` — passed.
- Exact live Docker/image execution is delegated to the selective `hermes-sandbox-secret-boundary-vitest` workflow job.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened sandbox boundary checks by rejecting retired Hermes sandbox state paths when they are present or linked.
  * Added clearer failure reporting when an invalid path is detected, helping prevent outdated sandbox files from passing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->