### PR TITLE
docs: refresh release notes for v0.0.69

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -30,7 +30,7 @@ NemoClaw v0.0.69 improves sandbox recovery, Deep Agents Code workflows, Hermes m
   For more information, refer to [Workspace Files](../manage-sandboxes/workspace-files), [Backup and Restore](../manage-sandboxes/backup-restore), and [Security Best Practices](../security/best-practices).
 - Hermes, messaging, and provider switching now use more explicit runtime state.
   Hermes moves to the 2026.6.19 release line, supported messaging channels come from manifests, invalid channel values fail fast, reused sandboxes refresh stale messaging plans, Hermes preserves Slack-compatible aliases after upgrades, and provider switches retain endpoint, credential, and inference API metadata.
-  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels), [NemoClaw Quickstart with Hermes](../../hermes/get-started/quickstart), and [Switch Inference Providers](../inference/switch-inference-providers).
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels), [NemoClaw Quickstart with Hermes](../get-started/quickstart-hermes), and [Switch Inference Providers](../inference/switch-inference-providers).
 - Inference setup now handles local and compatible endpoints with tighter validation.
   DGX Station managed vLLM defaults to DeepSeek V4 Flash, Ollama setup records explicit interaction state, compatible endpoint smoke checks retry only recognized transient failures, and validation redacts sensitive error details.
   For more information, refer to [NemoClaw Inference Options](../inference/inference-options) and [Use a Local Inference Server](../inference/use-local-inference).

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -15,6 +15,32 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.69
+
+NemoClaw v0.0.69 improves sandbox recovery, Deep Agents Code workflows, Hermes messaging, inference setup, policy approval guidance, and release validation.
+
+- Sandbox lifecycle and onboarding flows now preserve state more predictably across destroy, recreate, rebuild, recovery, and validation failures.
+  Destroy wipes persistent workspace and state directories, GPU recreate rolls back failed pre-patch sandboxes, recovery can rediscover live sandboxes when the local registry is empty, and hosted endpoint validation failures keep a nonzero exit status.
+  For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), [Backup and Restore](../manage-sandboxes/backup-restore), and [Troubleshooting](../reference/troubleshooting).
+- Deep Agents Code workflows now have clearer terminal and CLI behavior.
+  Session export reports actionable guidance for dash-prefixed arguments, warm-up sessions stay out of normal history, `nemo-deepagents` aliases share a consistent command surface, terminal runtime dispatch and version probes are more accurate, and status reports out-of-memory degradation with useful context.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](../get-started/quickstart-langchain-deepagents-code) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Deep Agents Code rebuild and snapshot operations now protect more user state.
+  Skills created with `skill-creator` persist across rebuilds, the managed Python environment stays on `PATH`, rebuild warns before dropping user-managed files, and snapshot creation refuses to capture an active Deep Agents Code session.
+  For more information, refer to [Workspace Files](../manage-sandboxes/workspace-files), [Backup and Restore](../manage-sandboxes/backup-restore), and [Security Best Practices](../security/best-practices).
+- Hermes, messaging, and provider switching now use more explicit runtime state.
+  Hermes moves to the 2026.6.19 release line, supported messaging channels come from manifests, invalid channel values fail fast, reused sandboxes refresh stale messaging plans, Hermes preserves Slack-compatible aliases after upgrades, and provider switches retain endpoint, credential, and inference API metadata.
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels), [NemoClaw Quickstart with Hermes](../../hermes/get-started/quickstart), and [Switch Inference Providers](../inference/switch-inference-providers).
+- Inference setup now handles local and compatible endpoints with tighter validation.
+  DGX Station managed vLLM defaults to DeepSeek V4 Flash, Ollama setup records explicit interaction state, compatible endpoint smoke checks retry only recognized transient failures, and validation redacts sensitive error details.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options) and [Use a Local Inference Server](../inference/use-local-inference).
+- Security, policy, and observability paths now report safer runtime state.
+  Auto-restore seals the expected configuration hash, sandbox connect and login apply process and file-descriptor limits quietly, JSON agent failures keep parseable output with provenance warnings, log collection preserves per-source breadcrumbs, and in-sandbox Shields status no longer claims host posture it cannot verify.
+  For more information, refer to [Security Best Practices](../security/best-practices), [Credential Storage](../security/credential-storage), [NemoClaw CLI Commands Reference](../reference/commands), and [Monitor Sandbox Activity](../monitoring/monitor-sandbox-activity).
+- Documentation and release gates now cover more policy, approval, and live validation paths.
+  The docs include clearer policy round-trip and network-request approval examples, while the live release gates distinguish public NVIDIA API keys from hosted inference keys and exercise Deep Agents Code terminal behavior more directly.
+  For more information, refer to [Network Policies](../reference/network-policies), [Customize the Network Policy](../network-policy/customize-network-policy), and [Approve or Deny Agent Network Requests](../network-policy/approve-network-requests).
+
 ## v0.0.68
 
 NemoClaw v0.0.68 improves onboarding recovery, messaging setup, agent-specific CLI behavior, local inference defaults, and release validation:


### PR DESCRIPTION
## Summary
Adds the v0.0.69 release notes to the published release-notes page so users can see the shipped sandbox recovery, Deep Agents Code, Hermes, inference, policy, and release-validation changes.
The section is based on the v0.0.69 announcement and links each user-facing theme to the deeper docs pages that already cover the behavior.

## Changes
- Added a new `v0.0.69` section to `docs/about/release-notes.mdx`.
- Linked release-note themes to lifecycle, backup, troubleshooting, Deep Agents Code, commands, workspace, messaging, Hermes, inference, security, monitoring, and network-policy docs.

Source summary:
- #5455 -> `docs/about/release-notes.mdx`: Summarized persistent workspace and state cleanup during sandbox destroy.
- #5738 -> `docs/about/release-notes.mdx`: Summarized nonzero exit status preservation for failed hosted endpoint validation.
- #5786 -> `docs/about/release-notes.mdx`: Summarized live sandbox rediscovery when local registry state is missing.
- #5881 -> `docs/about/release-notes.mdx`: Summarized the `nemo-deepagents` alias command surface.
- #5594 -> `docs/about/release-notes.mdx`: Summarized the Hermes Agent 2026.6.19 update.
- #5777 -> `docs/about/release-notes.mdx`: Summarized manifest-derived messaging channel support.
- #5825 -> `docs/about/release-notes.mdx`: Summarized DeepSeek V4 Flash managed-vLLM defaults for DGX Station.
- #5877 -> `docs/about/release-notes.mdx`: Summarized provider switch metadata preservation.
- #5932 -> `docs/about/release-notes.mdx`: Summarized transient inference smoke retry behavior.
- #5934 -> `docs/about/release-notes.mdx`: Summarized constrained inference smoke retry boundaries.
- #5681 -> `docs/about/release-notes.mdx`: Summarized Shields config-hash sealing during auto-restore.
- #5682 -> `docs/about/release-notes.mdx`: Summarized sandbox connect process-limit enforcement.
- #5683 -> `docs/about/release-notes.mdx`: Summarized JSON agent failure provenance warnings.
- #5711 -> `docs/about/release-notes.mdx`: Summarized sparse-source log breadcrumbs.
- #5838 -> `docs/about/release-notes.mdx`: Summarized host-authoritative Shields status.
- #5880 -> `docs/about/release-notes.mdx`: Summarized policy round-trip documentation updates.
- #5886 -> `docs/about/release-notes.mdx`: Summarized network request approval-flow documentation updates.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only release-notes prose; no runtime behavior changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` passed with 0 errors and the existing Fern light-mode accent contrast warning.
`fern check --warnings` reported the same accent-color warning.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for **v0.0.69**, covering improved sandbox lifecycle recovery (state preservation across destroy/recreate/rebuild/recovery/validation failures), clearer Deep Agents Code terminal/CLI behavior, and safer Hermes messaging/provider switching with manifest-driven channels.
  * Improved inference setup validation guidance, including handling of local/compatible endpoints and redaction of sensitive validation errors.
  * Refreshed release-gate documentation with clearer approval examples and validation behavior for NVIDIA API keys vs hosted inference keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->