### PR TITLE
fix(onboard): point onboard failures at --resume recovery (#6003)

### DIFF
--- a/src/lib/build-context.ts
+++ b/src/lib/build-context.ts
@@ -9,6 +9,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CLI_NAME } from "./cli/branding";
+import { noteOnboardResumeHintShown } from "./onboard/resume-hint";
 
 import { classifySandboxCreateFailure, planSandboxCreateRecovery } from "./validation";
 
@@ -100,6 +101,9 @@ export function printSandboxCreateRecoveryHints(
     createArgs?: readonly string[];
   } = {},
 ): void {
+  // Every branch below prints tailored `--resume` recovery guidance, so suppress
+  // the generic incomplete-exit backstop (#6003).
+  noteOnboardResumeHintShown();
   const failure = classifySandboxCreateFailure(output);
   if (failure.kind === "image_upload_container_missing") {
     const { arm64ImageRefWorkaround } = planSandboxCreateRecovery(failure, { platform, arch });

--- a/src/lib/onboard/exit-step-failure.test.ts
+++ b/src/lib/onboard/exit-step-failure.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -172,4 +174,90 @@ describe("incomplete-onboard --resume backstop (#6003)", () => {
     noteOnboardResumeHintShown();
     expect(runExitHandler(1)).not.toContain("--resume");
   });
+
+  it("stays silent when cancel cleanup clears the session before a signal is re-raised", async () => {
+    const signalListeners = new Map<"SIGINT" | "SIGTERM", () => void>();
+    const kill = vi.fn();
+    const processLike = {
+      once: vi.fn(),
+      on: (signal: "SIGINT" | "SIGTERM", listener: () => void) => {
+        signalListeners.set(signal, listener);
+      },
+      removeListener: (signal: "SIGINT" | "SIGTERM", listener: () => void) => {
+        expect(signalListeners.get(signal)).toBe(listener);
+        signalListeners.delete(signal);
+      },
+      kill,
+      pid: 4242,
+    };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    session.saveSession(session.createSession({ lastStepStarted: "sandbox" }));
+
+    registerIncompleteOnboardExitFailureHandler(
+      session,
+      () => false,
+      "Onboarding exited before the step completed.",
+      processLike,
+    );
+    const onSigterm = signalListeners.get("SIGTERM");
+    expect(onSigterm).toBeDefined();
+    onSigterm?.();
+    session.clearSession();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(kill).toHaveBeenCalledOnce();
+    expect(kill).toHaveBeenCalledWith(4242, "SIGTERM");
+    errorSpy.mockRestore();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "prints the resume hint before re-raising SIGINT in a real subprocess",
+    async () => {
+      const childDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-resume-signal-"));
+      const childScript = path.join(childDir, "signal-resume-hint.cjs");
+      const helperPath = path.resolve("src/lib/onboard/exit-step-failure.ts");
+      fs.writeFileSync(
+        childScript,
+        `
+const { registerIncompleteOnboardExitFailureHandler } = require(${JSON.stringify(helperPath)});
+
+const resumableSession = { lastStepStarted: "inference" };
+registerIncompleteOnboardExitFailureHandler(
+  {
+    loadSession: () => resumableSession,
+    markStepFailed: () => resumableSession,
+  },
+  () => false,
+  "Onboarding exited before the step completed.",
+);
+process.stdout.write("ready\\n");
+setInterval(() => {}, 1_000);
+`,
+      );
+
+      const child = spawn(process.execPath, ["--require", "tsx/cjs", childScript], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stderr = "";
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+
+      try {
+        const [ready] = await once(child.stdout, "data");
+        expect(String(ready)).toContain("ready");
+        const exited = once(child, "exit");
+        child.kill("SIGINT");
+        const [code, signal] = await exited;
+        expect(code).toBeNull();
+        expect(signal).toBe("SIGINT");
+        expect(stderr).toContain("onboard --resume");
+      } finally {
+        child.kill("SIGKILL");
+        fs.rmSync(childDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/lib/onboard/exit-step-failure.test.ts
+++ b/src/lib/onboard/exit-step-failure.test.ts
@@ -12,6 +12,7 @@ import {
   markLastStartedStepFailed,
   registerIncompleteOnboardExitFailureHandler,
 } from "./exit-step-failure";
+import { noteOnboardResumeHintShown, resetOnboardResumeHintForTests } from "./resume-hint";
 
 const originalHome = process.env.HOME;
 const restoreOriginalHome =
@@ -31,6 +32,7 @@ beforeEach(async () => {
   vi.resetModules();
   session = await import("../state/onboard-session");
   session.clearSession();
+  resetOnboardResumeHintForTests();
 });
 
 afterEach(() => {
@@ -73,6 +75,8 @@ describe("terminal step failure helper", () => {
       },
     };
     session.saveSession(session.createSession({ lastStepStarted: "inference" }));
+    // The incomplete exit also prints the #6003 resume hint; capture it.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     registerIncompleteOnboardExitFailureHandler(
       session,
@@ -89,6 +93,7 @@ describe("terminal step failure helper", () => {
 
     complete = false;
     listeners[0](1);
+    errorSpy.mockRestore();
 
     const loaded = requireLoadedSession();
     expect(loaded.steps.inference.status).toBe("failed");
@@ -121,5 +126,50 @@ describe("terminal step failure helper", () => {
       ),
     ).toBeNull();
     expect(markStepFailed).not.toHaveBeenCalled();
+  });
+});
+
+describe("incomplete-onboard --resume backstop (#6003)", () => {
+  function runExitHandler(code: number, { complete = false } = {}): string {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+      lines.push(String(message ?? ""));
+    });
+    const listeners: Array<(code: number) => void> = [];
+    const processLike = {
+      once: (_event: "exit", listener: (code: number) => void) => {
+        listeners.push(listener);
+      },
+    };
+    registerIncompleteOnboardExitFailureHandler(
+      session,
+      () => complete,
+      "Onboarding exited before the step completed.",
+      processLike,
+    );
+    listeners[0](code);
+    spy.mockRestore();
+    return lines.join("\n");
+  }
+
+  it("prints the resume hint when a step was in progress at exit", () => {
+    session.saveSession(session.createSession({ lastStepStarted: "inference" }));
+    expect(runExitHandler(1)).toContain("onboard --resume");
+  });
+
+  it("stays silent when no step had started", () => {
+    session.saveSession(session.createSession());
+    expect(runExitHandler(1)).not.toContain("--resume");
+  });
+
+  it("stays silent on a successful exit", () => {
+    session.saveSession(session.createSession({ lastStepStarted: "inference" }));
+    expect(runExitHandler(0)).not.toContain("--resume");
+  });
+
+  it("does not duplicate a tailored hint that already printed", () => {
+    session.saveSession(session.createSession({ lastStepStarted: "sandbox" }));
+    noteOnboardResumeHintShown();
+    expect(runExitHandler(1)).not.toContain("--resume");
   });
 });

--- a/src/lib/onboard/exit-step-failure.ts
+++ b/src/lib/onboard/exit-step-failure.ts
@@ -6,6 +6,7 @@ import {
   LEGACY_MACHINE_STEP_MUTATION_OPTIONS,
   type StepMutationOptions,
 } from "../state/onboard-step-mutation";
+import { printOnboardResumeHint } from "./resume-hint";
 
 export interface ExitStepFailureSessionDeps {
   loadSession(): Pick<Session, "lastStepStarted"> | null;
@@ -38,6 +39,11 @@ export function registerIncompleteOnboardExitFailureHandler(
 ): void {
   processLike.once("exit", (code) => {
     if (isComplete() || code === 0) return;
-    markLastStartedStepFailed(deps, message);
+    // A non-null return means a step was in progress, so the session records a
+    // resumable point — surface `--resume` for the many exit paths that don't
+    // print their own recovery guidance (#6003). When an explicit cancel has
+    // already cleared the session (or no step started), this is null and stays
+    // silent; printOnboardResumeHint also self-dedupes against tailored hints.
+    if (markLastStartedStepFailed(deps, message)) printOnboardResumeHint();
   });
 }

--- a/src/lib/onboard/exit-step-failure.ts
+++ b/src/lib/onboard/exit-step-failure.ts
@@ -15,7 +15,13 @@ export interface ExitStepFailureSessionDeps {
 
 export interface OnboardExitFailureProcessLike {
   once(event: "exit", listener: (code: number) => void): unknown;
+  on?(event: OnboardInterruptSignal, listener: () => void): unknown;
+  removeListener?(event: OnboardInterruptSignal, listener: () => void): unknown;
+  kill?(pid: number, signal: OnboardInterruptSignal): unknown;
+  pid?: number;
 }
+
+type OnboardInterruptSignal = "SIGINT" | "SIGTERM";
 
 export function markLastStartedStepFailed(
   deps: ExitStepFailureSessionDeps,
@@ -37,13 +43,44 @@ export function registerIncompleteOnboardExitFailureHandler(
   message: string,
   processLike: OnboardExitFailureProcessLike = process,
 ): void {
-  processLike.once("exit", (code) => {
-    if (isComplete() || code === 0) return;
+  const failIncompleteStep = (): void => {
+    if (isComplete()) return;
     // A non-null return means a step was in progress, so the session records a
-    // resumable point — surface `--resume` for the many exit paths that don't
-    // print their own recovery guidance (#6003). When an explicit cancel has
-    // already cleared the session (or no step started), this is null and stays
-    // silent; printOnboardResumeHint also self-dedupes against tailored hints.
+    // resumable point — surface `--resume` for exit paths that don't print
+    // their own recovery guidance (#6003). When an explicit cancel has already
+    // cleared the session (or no step started), this is null and stays silent;
+    // printOnboardResumeHint also self-dedupes against tailored hints.
     if (markLastStartedStepFailed(deps, message)) printOnboardResumeHint();
+  };
+
+  processLike.once("exit", (code) => {
+    if (code === 0) return;
+    failIncompleteStep();
   });
+
+  const on = processLike.on?.bind(processLike);
+  const removeListener = processLike.removeListener?.bind(processLike);
+  const kill = processLike.kill?.bind(processLike);
+  const pid = processLike.pid;
+  if (!on || !removeListener || !kill || pid === undefined) return;
+
+  let pendingSignal: OnboardInterruptSignal | null = null;
+  const handleSignal = (signal: OnboardInterruptSignal): void => {
+    // Prompt handlers restore the terminal and may synchronously re-raise the
+    // signal. Keep this listener installed until the next turn so a nested
+    // delivery cannot terminate the process before the resume hint is printed.
+    if (pendingSignal) return;
+    pendingSignal = signal;
+    setImmediate(() => {
+      removeListener("SIGINT", onSigint);
+      removeListener("SIGTERM", onSigterm);
+      failIncompleteStep();
+      kill(pid, signal);
+    });
+  };
+  const onSigint = (): void => handleSignal("SIGINT");
+  const onSigterm = (): void => handleSignal("SIGTERM");
+
+  on("SIGINT", onSigint);
+  on("SIGTERM", onSigterm);
 }

--- a/src/lib/onboard/resume-hint.test.ts
+++ b/src/lib/onboard/resume-hint.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  noteOnboardResumeHintShown,
+  printOnboardResumeHint,
+  resetOnboardResumeHintForTests,
+} from "./resume-hint";
+
+beforeEach(() => resetOnboardResumeHintForTests());
+afterEach(() => resetOnboardResumeHintForTests());
+
+describe("onboard resume hint", () => {
+  it("prints the --resume recovery guidance through the injected logger", () => {
+    const lines: string[] = [];
+    printOnboardResumeHint((message) => lines.push(message));
+    const text = lines.join("\n");
+    expect(text).toContain("onboard --resume");
+    expect(text).toContain("--fresh");
+  });
+
+  it("prints at most once per process", () => {
+    const lines: string[] = [];
+    printOnboardResumeHint((message) => lines.push(message));
+    printOnboardResumeHint((message) => lines.push(message));
+    expect(lines.filter((line) => line.includes("onboard --resume"))).toHaveLength(1);
+  });
+
+  it("stays silent once a tailored hint was noted", () => {
+    const lines: string[] = [];
+    noteOnboardResumeHintShown();
+    printOnboardResumeHint((message) => lines.push(message));
+    expect(lines).toHaveLength(0);
+  });
+});

--- a/src/lib/onboard/resume-hint.ts
+++ b/src/lib/onboard/resume-hint.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CLI_NAME } from "../cli/branding";
+
+// Whether an onboard `--resume` recovery hint has already been emitted this run.
+// Context-specific failure explainers (e.g. the sandbox build-context hints)
+// print their own tailored `--resume` guidance and call
+// `noteOnboardResumeHintShown()` so the incomplete-exit backstop in
+// exit-step-failure.ts does not print a second, generic hint after them.
+let resumeHintShown = false;
+
+/**
+ * Print the generic onboard `--resume` recovery hint, once per process.
+ *
+ * Onboarding exits through dozens of scattered `process.exit(1)` paths; most
+ * never mention `--resume`, so users assume a failed run requires a full
+ * reinstall (#6003). The incomplete-exit handler calls this as a catch-all when
+ * a resumable step was in progress, covering every exit that does not already
+ * print its own recovery guidance.
+ */
+export function printOnboardResumeHint(
+  log: (message: string) => void = (message) => console.error(message),
+): void {
+  if (resumeHintShown) return;
+  resumeHintShown = true;
+  log("");
+  log("  Onboarding did not finish. Resume from the step that failed with:");
+  log(`    ${CLI_NAME} onboard --resume`);
+  log("  Completed steps are skipped; pass --fresh instead to start over.");
+}
+
+/**
+ * Record that a context-specific `--resume` hint was already printed this run so
+ * the catch-all in {@link printOnboardResumeHint} stays silent.
+ */
+export function noteOnboardResumeHintShown(): void {
+  resumeHintShown = true;
+}
+
+/** Reset the once-per-process latch. Test-only. */
+export function resetOnboardResumeHintForTests(): void {
+  resumeHintShown = false;
+}


### PR DESCRIPTION
## Summary

When `nemoclaw onboard` fails or is interrupted partway through, most of its many `process.exit(1)` paths print no recovery guidance. Users assume a transient failure (network timeout during an image pull, a bad key, a Docker hiccup) requires a full reinstall, when the run is actually resumable with `nemoclaw onboard --resume` (#6003).

## Approach

Rather than touch every scattered exit site, add a single catch-all in the centralized incomplete-onboard exit handler (`exit-step-failure.ts`). It fires on any non-zero exit while onboarding is incomplete and, **when a step was in progress** (a resumable point recorded in the session), prints:

```
  Onboarding did not finish. Resume from the step that failed with:
    nemoclaw onboard --resume
  Completed steps are skipped; pass --fresh instead to start over.
```

This automatically covers the non-interactive abort paths and any uncaught failure.

The hint is suppressed where it would be wrong or redundant:

- **Already-handled paths:** the sandbox build-context explainer prints tailored `--resume` guidance and calls `noteOnboardResumeHintShown()`, so the backstop never duplicates it.
- **Ctrl-C cancel:** the cancel-rollback clears the onboard session before this handler runs, so no resumable step remains and the hint stays silent (resuming a discarded session would be misleading).
- **Early exits** before any step started leave `lastStepStarted` unset, so the handler stays silent.

## Changes

- `src/lib/onboard/resume-hint.ts` (new): once-per-process `printOnboardResumeHint()` + `noteOnboardResumeHintShown()` dedup latch.
- `src/lib/onboard/exit-step-failure.ts`: print the hint from the incomplete-exit handler when a step was in progress.
- `src/lib/build-context.ts`: mark the hint shown on the sandbox-create path that already prints tailored `--resume` guidance.
- Tests: `resume-hint.test.ts` (new) and added cases in `exit-step-failure.test.ts`.

## Test

- `npx vitest run src/lib/onboard/resume-hint.test.ts src/lib/onboard/exit-step-failure.test.ts test/build-context.test.ts` — all passing.
- `tsc -p jsconfig.json`, `source-shape:check`, `check-test-file-size-budget.ts` pass.

Closes #6003

Signed-off-by: Abhimanyu Kumar <abhimanyukumar7290@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new onboarding recovery hint that points users to resume interrupted setup with a resume command.
  * The hint is shown only once, reducing repeated messages.

* **Bug Fixes**
  * Improved exit-time messaging so the resume hint appears only when onboarding was actually in progress.
  * Prevented duplicate recovery hints from being shown in overlapping recovery paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->