### PR TITLE
fix(e2e): encode multiline sandbox scripts

### DIFF
--- a/test/e2e-scenario/fixtures/clients/sandbox.ts
+++ b/test/e2e-scenario/fixtures/clients/sandbox.ts
@@ -7,8 +7,8 @@ import { trustedShellCommand } from "../shell-probe.ts";
 import {
   artifactLabel,
   assertExitZero,
-  outputContainsSandbox,
   type CommandRunner,
+  outputContainsSandbox,
 } from "./command.ts";
 
 /**
@@ -42,10 +42,16 @@ export type TrustedSandboxShellScript = string & {
 };
 
 export function trustedSandboxShellScript(script: string): TrustedSandboxShellScript {
-  if (script.length === 0) {
-    throw new Error("sandbox shell script must not be empty");
+  if (script.length === 0 || script.includes("\0")) {
+    throw new Error("sandbox shell script must be non-empty and contain no NUL bytes");
   }
   return script as TrustedSandboxShellScript;
+}
+
+function sandboxShellArgument(script: TrustedSandboxShellScript): string {
+  if (!/[\r\n]/u.test(script)) return script;
+  const encoded = Buffer.from(script, "utf8").toString("base64");
+  return `eval "$(printf '%s' '${encoded}' | base64 -d)"`;
 }
 
 export class SandboxClient {
@@ -104,10 +110,13 @@ export class SandboxClient {
     options: ShellProbeRunOptions = {},
   ): Promise<ShellProbeResult> {
     validateSandboxName(name);
-    return this.openshell(["sandbox", "exec", "-n", name, "--", "sh", "-lc", script], {
-      artifactName: `sandbox-exec-shell-${name}`,
-      ...options,
-    });
+    return this.openshell(
+      ["sandbox", "exec", "-n", name, "--", "sh", "-lc", sandboxShellArgument(script)],
+      {
+        artifactName: `sandbox-exec-shell-${name}`,
+        ...options,
+      },
+    );
   }
 
   upload(

--- a/test/e2e-scenario/support-tests/e2e-clients.test.ts
+++ b/test/e2e-scenario/support-tests/e2e-clients.test.ts
@@ -402,8 +402,23 @@ describe("E2E fixture clients", () => {
     });
   });
 
+  it("encodes multiline shell scripts into an OpenShell-safe single argument", async () => {
+    const runner = new FakeRunner();
+    const sandbox = new SandboxClient(runner, { openshellPath: "openshell" });
+    const source = "set -e\nprintf 'ready\\n'\n";
+
+    await sandbox.execShell("assistant", trustedSandboxShellScript(source));
+
+    const argument = runner.calls[0]?.args.at(-1) ?? "";
+    expect(argument).not.toMatch(/[\r\n]/u);
+    const encoded = argument.match(/'([A-Za-z0-9+/=]+)' \| base64 -d/u)?.[1];
+    expect(encoded).toBeTruthy();
+    expect(Buffer.from(encoded ?? "", "base64").toString("utf8")).toBe(source);
+  });
+
   it("sandbox client requires trusted non-empty shell scripts", () => {
-    expect(() => trustedSandboxShellScript("")).toThrow(/must not be empty/);
+    expect(() => trustedSandboxShellScript("")).toThrow(/must be non-empty/);
+    expect(() => trustedSandboxShellScript("echo ready\0ignored")).toThrow(/no NUL bytes/);
     expectTypeOf<Parameters<SandboxClient["execShell"]>[1]>().not.toEqualTypeOf<string>();
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fix the shared Vitest E2E sandbox client after the exact-head security-posture run proved that current OpenShell rejects newline-bearing command arguments. Multiline trusted scripts are now base64-encoded into one shell argument at the client boundary instead of requiring every scenario to invent its own minifier.

## Related Issue

Contributes to #5919. Follow-up to merged #6010 and failed live run [28397462103](https://github.com/NVIDIA/NemoClaw/actions/runs/28397462103).

## Changes

- Preserve direct single-line `sh -lc` arguments.
- Encode multiline trusted scripts as a single newline-free `eval` argument and decode inside the sandbox.
- Reject NUL-bearing scripts before process construction.
- Add a round-trip contract test for the exact command argument.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal E2E transport compatibility only; no user-facing product behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending independent review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification:

- `VITEST_MAX_WORKERS=16 npx vitest run --project e2e-vitest-support test/e2e-scenario/support-tests/e2e-clients.test.ts test/e2e-scenario/support-tests/security-posture.test.ts`
- `npm run typecheck:cli`
- `make check`
- normal signed commit and push hooks

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of trusted sandbox shell scripts so multiline scripts are safely passed without raw line breaks.
  * Added stricter script validation to reject empty scripts and scripts containing NUL characters.
  * Updated shell execution behavior to reduce the risk of malformed command arguments when running scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->