### PR TITLE
fix(messaging): restore channel policy on start

### DIFF
--- a/src/lib/actions/sandbox/policy-channel-conflict.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-conflict.test.ts
@@ -1097,8 +1097,15 @@ describe("Teams host-forward lifecycle (PRA-2)", () => {
   });
 
   it("channels start restores the disabled plan and skips rebuild when its policy preset fails", async () => {
-    arrangeRegistry({ current: makeTeamsEntry("alpha", { disabled: true }) });
-    getDisabledChannelsMock.mockReturnValue(["teams"]);
+    const current = makeTeamsEntry("alpha", { disabled: true });
+    arrangeRegistry({ current });
+    getDisabledChannelsMock.mockImplementation(
+      () => current.messaging?.plan.disabledChannels ?? [],
+    );
+    updateSandboxMock.mockImplementation((_name: string, updates: Partial<SandboxEntry>) => {
+      Object.assign(current, updates);
+      return true;
+    });
     applyPresetMock.mockReturnValue(false);
 
     await expect(startSandboxChannel("alpha", { channel: "teams" })).rejects.toThrow(
@@ -1106,15 +1113,24 @@ describe("Teams host-forward lifecycle (PRA-2)", () => {
     );
 
     expect(applyPresetMock).toHaveBeenCalledWith("alpha", "teams");
-    expect(updateSandboxMock).toHaveBeenCalledTimes(2);
-    expect(updateSandboxMock.mock.calls[0]?.[1]).toMatchObject({
-      messaging: { plan: { disabledChannels: [] } },
-    });
-    expect(updateSandboxMock.mock.calls[1]?.[1]).toMatchObject({
-      messaging: { plan: { disabledChannels: ["teams"] } },
-    });
+    expect(registry.getDisabledChannels("alpha")).toContain("teams");
     expect(rebuildSandboxMock).not.toHaveBeenCalled();
     expect(loggedText()).toContain("channels start teams");
+  });
+
+  it("channels start prints recovery guidance when policy and disabled-plan rollback both fail", async () => {
+    arrangeRegistry({ current: makeTeamsEntry("alpha", { disabled: true }) });
+    getDisabledChannelsMock.mockReturnValue(["teams"]);
+    applyPresetMock.mockReturnValue(false);
+    updateSandboxMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    await expect(startSandboxChannel("alpha", { channel: "teams" })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(rebuildSandboxMock).not.toHaveBeenCalled();
+    expect(loggedText()).toContain("Could not restore 'teams' to disabled state");
+    expect(loggedText()).toContain("nemoclaw alpha channels stop teams");
   });
 });
 

--- a/src/lib/actions/sandbox/policy-channel-conflict.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-conflict.test.ts
@@ -1065,7 +1065,11 @@ describe("Teams host-forward lifecycle (PRA-2)", () => {
 
     await startSandboxChannel("alpha", { channel: "teams" });
 
+    expect(applyPresetMock).toHaveBeenCalledWith("alpha", "teams");
     expect(rebuildSandboxMock).toHaveBeenCalledWith("alpha", ["--yes"]);
+    expect(applyPresetMock.mock.invocationCallOrder[0]).toBeLessThan(
+      rebuildSandboxMock.mock.invocationCallOrder[0],
+    );
     expect(ensureMessagingHostForwardAfterRebuildMock).toHaveBeenCalledWith(
       "alpha",
       expect.any(Object),
@@ -1078,6 +1082,39 @@ describe("Teams host-forward lifecycle (PRA-2)", () => {
       port: 3978,
       label: "Microsoft Teams webhook",
     });
+  });
+
+  it("channels start reapplies its policy before a non-interactive rebuild is queued", async () => {
+    process.env.NEMOCLAW_NON_INTERACTIVE = "1";
+    arrangeRegistry({ current: makeTeamsEntry("alpha", { disabled: true }) });
+    getDisabledChannelsMock.mockReturnValue(["teams"]);
+
+    await startSandboxChannel("alpha", { channel: "teams" });
+
+    expect(applyPresetMock).toHaveBeenCalledWith("alpha", "teams");
+    expect(rebuildSandboxMock).not.toHaveBeenCalled();
+    expect(loggedText()).toContain("Change queued");
+  });
+
+  it("channels start restores the disabled plan and skips rebuild when its policy preset fails", async () => {
+    arrangeRegistry({ current: makeTeamsEntry("alpha", { disabled: true }) });
+    getDisabledChannelsMock.mockReturnValue(["teams"]);
+    applyPresetMock.mockReturnValue(false);
+
+    await expect(startSandboxChannel("alpha", { channel: "teams" })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(applyPresetMock).toHaveBeenCalledWith("alpha", "teams");
+    expect(updateSandboxMock).toHaveBeenCalledTimes(2);
+    expect(updateSandboxMock.mock.calls[0]?.[1]).toMatchObject({
+      messaging: { plan: { disabledChannels: [] } },
+    });
+    expect(updateSandboxMock.mock.calls[1]?.[1]).toMatchObject({
+      messaging: { plan: { disabledChannels: ["teams"] } },
+    });
+    expect(rebuildSandboxMock).not.toHaveBeenCalled();
+    expect(loggedText()).toContain("channels start teams");
   });
 });
 

--- a/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
@@ -67,4 +67,29 @@ describe("policy channel remove/enable flows", () => {
     );
     expect(exitSpy).not.toHaveBeenCalled();
   });
+
+  it("supports start dry runs without applying a preset or persisting the enabled plan", async () => {
+    const registry = requireDist("../../state/registry.js");
+    const policies = requireDist("../../policy/index.js");
+    const rebuild = requireDist("./rebuild.js");
+    vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "alpha" });
+    vi.spyOn(registry, "getConfiguredMessagingChannelsFromEntry").mockReturnValue(["telegram"]);
+    vi.spyOn(registry, "getDisabledChannels").mockReturnValue(["telegram"]);
+    const updateSandboxSpy = vi.spyOn(registry, "updateSandbox");
+    const applyPresetSpy = vi.spyOn(policies, "applyPreset");
+    const rebuildSpy = vi.spyOn(rebuild, "rebuildSandbox");
+    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
+
+    await expect(
+      policyChannel.startSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+    ).resolves.toBeUndefined();
+
+    expect(logSpy.mock.calls.flat().join("\n")).toContain(
+      "--dry-run: would start channel 'telegram' for 'alpha'.",
+    );
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(rebuildSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -8,7 +8,6 @@ import { type AgentDefinition, loadAgent } from "../../agent/defs";
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
 import { prompt as askPrompt, getCredential } from "../../credentials/store";
 import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
-import { getSandboxTargetGatewayName } from "./gateway-target";
 import {
   type ChannelManifest,
   createBuiltInChannelManifestRegistry,
@@ -30,6 +29,7 @@ import {
 } from "../../messaging";
 import { hydrateMessagingChannelConfig } from "../../messaging-channel-config";
 import { hashCredential } from "../../security/credential-hash";
+import { getSandboxTargetGatewayName } from "./gateway-target";
 
 const { isNonInteractive } = require("../../onboard") as { isNonInteractive: () => boolean };
 const onboardProviders = require("../../onboard/providers");
@@ -60,10 +60,10 @@ import {
 } from "../../sandbox/channels";
 import * as registry from "../../state/registry";
 import { isDockerRuntimeDown, printDockerRuntimeDownGuidance } from "./gateway-failure-classifier";
+import { ensureMessagingHostForwardAfterRebuild } from "./messaging-host-forward-lifecycle";
 import { refreshSandboxPolicyContextFile } from "./policy-context-refresh";
 import { executeSandboxCommand, executeSandboxExecCommand } from "./process-recovery";
 import { rebuildSandbox } from "./rebuild";
-import { ensureMessagingHostForwardAfterRebuild } from "./messaging-host-forward-lifecycle";
 
 type ChannelMutationOptions = {
   channel?: string;
@@ -1120,7 +1120,11 @@ async function rollbackChannelAdd(
   return result;
 }
 
-export function applyChannelPresetIfAvailable(sandboxName: string, channelName: string): boolean {
+export function applyChannelPresetIfAvailable(
+  sandboxName: string,
+  channelName: string,
+  retryAction: "add" | "start" = "add",
+): boolean {
   try {
     const applied = policies.applyPreset(sandboxName, channelName);
     if (!applied) {
@@ -1128,7 +1132,7 @@ export function applyChannelPresetIfAvailable(sandboxName: string, channelName: 
         `  ${YW}⚠${R} Cannot enable channel '${channelName}': policy preset failed to apply.`,
       );
       console.error(
-        `    Restore the preset YAML and re-run: ${CLI_NAME} ${sandboxName} channels add ${channelName}`,
+        `    Restore the preset YAML and re-run: ${CLI_NAME} ${sandboxName} channels ${retryAction} ${channelName}`,
       );
       return false;
     }
@@ -1139,7 +1143,7 @@ export function applyChannelPresetIfAvailable(sandboxName: string, channelName: 
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`  ${YW}⚠${R} Failed to apply '${channelName}' policy preset: ${msg}`);
     console.error(
-      `    Restore the preset YAML and re-run: ${CLI_NAME} ${sandboxName} channels add ${channelName}`,
+      `    Restore the preset YAML and re-run: ${CLI_NAME} ${sandboxName} channels ${retryAction} ${channelName}`,
     );
     return false;
   }
@@ -1424,6 +1428,21 @@ async function sandboxChannelsSetEnabled(
   const plan = await persistManifestChannelDisabledPlan(sandboxName, normalized, disabled);
   if (!plan) {
     console.error(`  Could not persist messaging plan for '${sandboxName}'.`);
+    process.exit(1);
+  }
+  // Rebuild persists only the presets it actually restores. Re-apply a
+  // restarted channel's preset before a queued or immediate rebuild so the
+  // registry and backup manifest carry the enabled plan's policy intent.
+  // If policy application fails, put the plan back in its disabled state so
+  // runtime configuration cannot later be rebuilt without the required egress.
+  if (!disabled && !applyChannelPresetIfAvailable(sandboxName, normalized, "start")) {
+    const rolledBack = await persistManifestChannelDisabledPlan(sandboxName, normalized, true);
+    if (!rolledBack) {
+      console.error(
+        `  ${YW}⚠${R} Could not restore '${normalized}' to disabled state after its policy preset failed to apply.`,
+      );
+      console.error(`    Re-run: ${CLI_NAME} ${sandboxName} channels stop ${normalized}`);
+    }
     process.exit(1);
   }
   const state = disabled ? "disabled" : "enabled";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`channels start` re-enabled the persisted messaging plan without re-applying the channel's network-policy preset. Once rebuild began truthfully pruning disabled presets in #5856, the next rebuild no longer had stale registry state to restore, so a restarted channel could have correct agent config but inactive egress policy. Re-apply the preset at the channel action boundary and fail closed by restoring the disabled plan when policy application fails.

## Related Issue

Contributes to #5919. Blocks the final `channels-stop-start` cutover proof in #5756; follow-up to #5856.

## Changes

- Re-apply the manifest-owned channel policy preset during `channels start`, before an immediate or queued rebuild.
- Use action-correct recovery guidance for failed `channels start` policy application.
- Roll the messaging plan back to disabled and skip rebuild when the preset cannot be applied.
- Cover interactive ordering, the exact non-interactive queued-rebuild path, and failure rollback.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: restores the already-documented `channels start` contract; no command or configuration surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending independent messaging/policy review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details:

- focused channel/rebuild suite: 68 passed
- `npm run typecheck:cli`
- `make check`
- full non-live suite at the source-change head: 2,421 suites passed; 9,689 tests passed; 26 skipped; 0 failed; subsequent commits are test-only and pass focused suites plus normal hooks
- normal signed commit and push hooks

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Teams channel start flow by reapplying the required policy preset before any rebuild is queued.
  * In non-interactive mode with Teams disabled, the preset is reapplied first; rebuilds are not queued and “Change queued” is logged.
  * If preset reapplication (or rollback) fails, the channel’s disabled state is restored, the process exits, and recovery guidance is shown (including “Could not restore 'teams' to disabled state” when applicable).
* **Tests**
  * Added coverage for preset/rebuild call order and failure/rollback scenarios.
  * Added a “dry run” test to ensure no rebuild or preset actions occur and the expected message is logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->