### PR TITLE
fix(onboard): surface escape hint on empty Brave Search API key input (#6025)

### DIFF
--- a/src/lib/onboard/web-search-flow.test.ts
+++ b/src/lib/onboard/web-search-flow.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { testTimeoutOptions } from "../../../test/helpers/timeouts";
 import { runCurlProbe } from "../adapters/http/probe";
+import { isBackToSelection } from "./credential-navigation";
 import { createWebSearchFlowHelpers } from "./web-search-flow";
 
 vi.mock("../adapters/http/probe", () => ({
@@ -39,6 +40,32 @@ function helpers() {
     runCaptureOpenshell: () => null,
   });
 }
+
+describe("Brave key prompt empty-input escape (#6025)", () => {
+  it("surfaces the back/exit hint on empty input and loops instead of dead-ending", async () => {
+    const errors: string[] = [];
+    const errSpy = vi.spyOn(console, "error").mockImplementation((message?: unknown) => {
+      errors.push(String(message));
+    });
+    const responses = ["", "back"];
+    let call = 0;
+    const flow = createWebSearchFlowHelpers({
+      prompt: async () => responses[call++] ?? "back",
+      note: () => {},
+      isNonInteractive: () => false,
+      cliName: () => "nemoclaw",
+      runCaptureOpenshell: () => null,
+    });
+
+    const result = await flow.promptBraveSearchApiKey();
+    errSpy.mockRestore();
+
+    expect(isBackToSelection(result)).toBe(true);
+    expect(call).toBe(2);
+    expect(errors.join("\n")).toContain("Brave Search API key is required.");
+    expect(errors.join("\n")).toMatch(/back to choose a different option|exit to quit/);
+  });
+});
 
 describe("web search flow Brave validation", () => {
   beforeEach(() => {

--- a/src/lib/onboard/web-search-flow.test.ts
+++ b/src/lib/onboard/web-search-flow.test.ts
@@ -62,8 +62,12 @@ describe("Brave key prompt empty-input escape (#6025)", () => {
 
     expect(isBackToSelection(result)).toBe(true);
     expect(call).toBe(2);
-    expect(errors.join("\n")).toContain("Brave Search API key is required.");
-    expect(errors.join("\n")).toMatch(/back to choose a different option|exit to quit/);
+    const errorText = errors.join("\n");
+    expect(errorText).toContain("Brave Search API key is required.");
+    // Assert both escape routes independently so the test fails if either the
+    // "back" or the "exit" hint regresses, not just when both disappear (#6025).
+    expect(errorText).toContain("back to choose a different option");
+    expect(errorText).toContain("exit to quit");
   });
 });
 

--- a/src/lib/onboard/web-search-flow.ts
+++ b/src/lib/onboard/web-search-flow.ts
@@ -162,7 +162,12 @@ export function createWebSearchFlowHelpers(deps: WebSearchFlowDeps): WebSearchFl
       }
       const key = normalizeCredentialValue(value);
       if (!key) {
-        console.error("  Brave Search API key is required.");
+        // Empty input used to loop with no visible escape, leaving Ctrl+C as
+        // the only way out (#6025). Surface the existing back/exit options so
+        // the user can skip Brave Search instead of being stuck.
+        console.error(
+          "  Brave Search API key is required. Type back to choose a different option, or exit to quit.",
+        );
         continue;
       }
       return key;


### PR DESCRIPTION
## Summary

At the `nemoclaw onboard` Brave Search API key prompt, pressing Enter with no key printed "Brave Search API key is required." and looped — with no visible escape, so Ctrl+C (which aborts the entire onboard) was the only way out. The prompt already accepts `back`/`exit`, but empty input never surfaced them. This adds the escape hint to the empty-input message.

## Related Issue

Fixes #6025

## Changes

- `src/lib/onboard/web-search-flow.ts`: in `promptBraveSearchApiKey`, the empty-input message now reads "Brave Search API key is required. Type back to choose a different option, or exit to quit." — surfacing the existing `back` (skip Brave Search) and `exit` paths instead of dead-ending. No other behavior change.
- `src/lib/onboard/web-search-flow.test.ts`: test that empty input prints the hint, loops, and then `back` returns to selection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: a prompt hint string only; no command/flag/behavior surface change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: onboarding prompt; change is a single message string surfacing already-supported back/exit intents — no control-flow, credential-handling, or validation change. Covered by a new unit test plus existing Brave-flow tests.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the message shown when the Brave Search API key prompt is submitted empty.
  * Added clearer on-screen guidance to type `back` to choose a different option or `exit` to quit.

* **Tests**
  * Added a regression test covering the empty-input “back to selection” escape behavior, including prompt invocation and expected error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->