### PR TITLE
fix(messaging): install botbuilder SDK for hermes Teams channel

### DIFF
--- a/src/lib/messaging/channels/manifests.test.ts
+++ b/src/lib/messaging/channels/manifests.test.ts
@@ -769,10 +769,17 @@ describe("built-in channel manifests", () => {
       required: true,
     });
     expect(teamsManifest.agentPackages).toContainEqual({
-      id: "hermesTeamsAppsPackage",
+      id: "hermesBotbuilderCorePackage",
       agent: "hermes",
       manager: "hermes-uv-pip",
-      spec: "microsoft-teams-apps==2.0.13.4",
+      spec: "botbuilder-core==4.17.1",
+      required: true,
+    });
+    expect(teamsManifest.agentPackages).toContainEqual({
+      id: "hermesBotbuilderAiohttpPackage",
+      agent: "hermes",
+      manager: "hermes-uv-pip",
+      spec: "botbuilder-integration-aiohttp==4.17.1",
       required: true,
     });
     expect(teamsManifest.agentPackages).toContainEqual({

--- a/src/lib/messaging/channels/metadata.test.ts
+++ b/src/lib/messaging/channels/metadata.test.ts
@@ -156,10 +156,17 @@ describe("built-in messaging channel metadata", () => {
     expect(listMessagingPackageInstallSpecs({ agent: "hermes" })).toEqual([
       {
         channelId: "teams",
-        packageId: "hermesTeamsAppsPackage",
+        packageId: "hermesBotbuilderCorePackage",
         agents: ["hermes"],
         manager: "hermes-uv-pip",
-        spec: "microsoft-teams-apps==2.0.13.4",
+        spec: "botbuilder-core==4.17.1",
+      },
+      {
+        channelId: "teams",
+        packageId: "hermesBotbuilderAiohttpPackage",
+        agents: ["hermes"],
+        manager: "hermes-uv-pip",
+        spec: "botbuilder-integration-aiohttp==4.17.1",
       },
       {
         channelId: "teams",

--- a/src/lib/messaging/channels/teams/manifest.ts
+++ b/src/lib/messaging/channels/teams/manifest.ts
@@ -195,10 +195,17 @@ export const teamsManifest = {
       required: true,
     },
     {
-      id: "hermesTeamsAppsPackage",
+      id: "hermesBotbuilderCorePackage",
       agent: "hermes",
       manager: "hermes-uv-pip",
-      spec: "microsoft-teams-apps==2.0.13.4",
+      spec: "botbuilder-core==4.17.1",
+      required: true,
+    },
+    {
+      id: "hermesBotbuilderAiohttpPackage",
+      agent: "hermes",
+      manager: "hermes-uv-pip",
+      spec: "botbuilder-integration-aiohttp==4.17.1",
       required: true,
     },
     {

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -433,11 +433,21 @@ describe("ManifestCompiler", () => {
       {
         channelId: "teams",
         kind: "package-install",
-        outputId: "hermesTeamsAppsPackage",
+        outputId: "hermesBotbuilderCorePackage",
         required: true,
         value: {
           manager: "hermes-uv-pip",
-          spec: "microsoft-teams-apps==2.0.13.4",
+          spec: "botbuilder-core==4.17.1",
+        },
+      },
+      {
+        channelId: "teams",
+        kind: "package-install",
+        outputId: "hermesBotbuilderAiohttpPackage",
+        required: true,
+        value: {
+          manager: "hermes-uv-pip",
+          spec: "botbuilder-integration-aiohttp==4.17.1",
         },
       },
       {

--- a/test/messaging-build-applier.test.ts
+++ b/test/messaging-build-applier.test.ts
@@ -638,7 +638,8 @@ describe("messaging-build-applier.mts: agent-install", () => {
       );
       expect(dryRun.status, dryRun.stderr).toBe(0);
       expect(JSON.parse(dryRun.stdout).hermesUvPackages).toEqual([
-        "microsoft-teams-apps==2.0.13.4",
+        "botbuilder-core==4.17.1",
+        "botbuilder-integration-aiohttp==4.17.1",
         "aiohttp==3.14.1",
       ]);
 
@@ -662,7 +663,7 @@ describe("messaging-build-applier.mts: agent-install", () => {
 
       expect(result.status, result.stderr).toBe(0);
       expect(fs.readFileSync(tracePath, "utf-8").trim()).toBe(
-        "pip install --python /opt/hermes/.venv/bin/python --no-cache -- microsoft-teams-apps==2.0.13.4 aiohttp==3.14.1",
+        "pip install --python /opt/hermes/.venv/bin/python --no-cache -- botbuilder-core==4.17.1 botbuilder-integration-aiohttp==4.17.1 aiohttp==3.14.1",
       );
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

The Hermes Teams channel never installed its runtime SDK in the sandbox. The manifest declared `microsoft-teams-apps==2.0.13.4` (the new fastapi/uvicorn-based Teams AI SDK), but the Hermes Teams adapter and its network policy target the **Bot Framework Connector**, i.e. the aiohttp-based Bot Framework SDK (`botbuilder-core` / `botbuilder-integration-aiohttp`). Those packages were therefore never installed, so the Teams bridge failed at runtime (#5952).

## Related Issue

Fixes #5952

## Changes

- `src/lib/messaging/channels/teams/manifest.ts`: replace the Hermes `microsoft-teams-apps==2.0.13.4` package with `botbuilder-core==4.17.1` and `botbuilder-integration-aiohttp==4.17.1`. `aiohttp==3.14.1` is kept and satisfies the integration package's `aiohttp<4.0,>=3.10` constraint.
- Updated manifest/compiler/applier tests that pinned the old spec (`manifests.test.ts`, `metadata.test.ts`, `manifest-compiler.test.ts`, `messaging-build-applier.test.ts`).

### Why these packages

The Hermes Teams network policy (`agents/hermes/policy-additions.yaml`) allows `login.botframework.com`, `api.botframework.com`, and `smba.trafficmanager.net` (Bot Connector), and the code comment states "The SDK follows Bot Connector serviceUrl values from inbound Teams activities." This is the Bot Framework SDK, not the new Teams AI SDK. The original feature commit (#5585) introduced both the Bot Framework policy hosts and the wrong package in one change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal package-install manifest fix; no user-facing doc surface changes (Teams onboarding behavior unchanged, only the installed SDK is corrected).
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: messaging path. Packages are pinned to exact versions of the official Microsoft Bot Framework SDK on PyPI; they enter the existing Hermes uv-pip trusted-package allowlist (validated by `trustedHermesUvPackageSpecsForPlan`), and the required egress hosts were already allowed by the Teams policy preset. Requesting maintainer sensitive-path review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior — 62 tests: 41 in the three `cli`-project messaging tests + 21 in `test/messaging-build-applier.test.ts` (incl. the Hermes Teams install test and the trusted-package allowlist test).
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tony Luo <xialuo@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Microsoft Teams support for the Hermes agent to install the correct BotBuilder dependencies.
  * Improved package installation expectations so Teams-related builds now use the latest pinned dependency versions.
  * Kept the rest of the messaging channel setup and build flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->