### PR TITLE
docs(quickstart): make nemoclaw onboard an explicit step before chat (#6001)

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -241,6 +241,21 @@ Manage later
 If you picked a different option, the `Model` line shows that provider's model and label instead.
 For example, you might see `gpt-5.4 (OpenAI)`, `claude-sonnet-4-6 (Anthropic)`, `gemini-2.5-flash (Google Gemini)`, `llama3.1:8b (Local Ollama)`, `nvidia-routed (Model Router)`, or `<your-model> (Other OpenAI-compatible endpoint)`.
 
+## Confirm Onboarding Finished Before You Chat
+
+The sandbox exists only after `nemoclaw onboard` completes.
+The installer auto-launches the wizard, but some paths do not run it for you: remote or Brev hosts where the installer cannot locate the freshly installed binary, or any host where a blocking preflight check fails.
+In those cases the installer prints a `To finish setup, run:` block instead of starting the wizard, and the sandbox does not exist yet.
+
+If you did not see the **NemoClaw is ready** summary above, run onboarding explicitly before you connect or chat:
+
+```bash
+nemoclaw onboard
+```
+
+To confirm the sandbox exists, run `nemoclaw <sandbox-name> status`.
+Do not run `nemoclaw <sandbox-name> connect` or `openclaw tui` until onboarding has created the sandbox; otherwise the connect step fails because no sandbox exists.
+
 ## Run Your First Agent Prompt
 
 Chat with the agent from the terminal or the browser.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The OpenClaw quickstart wove `nemoclaw onboard` into installer prose, so users on paths where the installer does not auto-launch the wizard (remote or Brev hosts, or after a blocking preflight) reached the connect-and-chat section assuming a sandbox already existed, and the connect step failed. This adds an explicit onboarding section before the chat section so the step cannot be skipped accidentally.

## Related Issue
Fixes #6001

## Changes
- Add a `## Confirm Onboarding Finished Before You Chat` section to `docs/get-started/quickstart.mdx`, placed immediately before `## Run Your First Agent Prompt`.
- State that the sandbox exists only after `nemoclaw onboard` completes, call out the remote/Brev paths where the installer does not auto-launch the wizard, give the explicit `nemoclaw onboard` command, and tell users not to run `connect` / `openclaw tui` until the sandbox exists.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation-only change, no runtime behavior is modified.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — 0 errors; the 2 Fern warnings are pre-existing and unrelated to this change
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to confirm onboarding is complete before starting a chat session.
  * Clarified that a sandbox is created only after onboarding finishes.
  * Noted cases where the setup wizard may not launch automatically and provided the recommended manual verification steps before connecting or opening the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->