### PR TITLE
fix(scripts): restore .openclaw perms after nemoclaw exec command

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -2499,7 +2499,10 @@ if [ "$(id -u)" -ne 0 ]; then
   lock_rc_files "$_SANDBOX_HOME" || true
 
   if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
-    exec "${NEMOCLAW_CMD[@]}"
+    "${NEMOCLAW_CMD[@]}"
+    _nemoclaw_cmd_rc=$?
+    normalize_mutable_config_perms
+    exit $_nemoclaw_cmd_rc
   fi
 
   configure_messaging_channels
@@ -2604,7 +2607,10 @@ gosu sandbox bash -c "$(declare -f write_auth_profile harden_auth_profiles); wri
 
 # If a command was passed (e.g., "openclaw agent ..."), run it as sandbox user
 if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
-  exec gosu sandbox "${NEMOCLAW_CMD[@]}"
+  gosu sandbox "${NEMOCLAW_CMD[@]}"
+  _nemoclaw_cmd_rc=$?
+  normalize_mutable_config_perms
+  exit $_nemoclaw_cmd_rc
 fi
 
 # Gateway log: owned by gateway user, world-readable for diagnostics.


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` collapses `/sandbox/.openclaw` from 2770 to 700 and `openclaw.json` from 660 to 600 when run via `nemoclaw exec` (issue #6047). The two NEMOCLAW_CMD exec paths in `nemoclaw-start.sh` use bare `exec` to replace the shell process, so `normalize_mutable_config_perms` (which runs before the command) has no opportunity to restore permissions after doctor's explicit `chmod` calls collapse them.

This PR replaces the bare `exec` with a regular call in both paths, captures the exit code, restores permissions via `normalize_mutable_config_perms`, and exits with the original code.

## Related Issue

Fixes #6047

## Changes

- `scripts/nemoclaw-start.sh` (non-root NEMOCLAW_CMD path, ~line 2501): replace `exec "${NEMOCLAW_CMD[@]}"` with a non-exec wrapper that restores permissions after the command exits
- `scripts/nemoclaw-start.sh` (root NEMOCLAW_CMD path, ~line 2609): same pattern for `exec gosu sandbox "${NEMOCLAW_CMD[@]}"`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run --all-files` passes
- [x] `npm test` passes
- [ ] Tests added or updated for new or changed behavior
- [x] No secrets, API keys, or credentials committed
- [ ] Docs updated for user-facing behavior changes
- [ ] `make docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup command handling so the app now finishes its cleanup step after running the requested command.
  * Exit codes from the launched command are now returned correctly in both normal and sandboxed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->