### PR TITLE
fix(sandbox): honor model override in reconcile and log guard-chain warning to file

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -1065,6 +1065,10 @@ PYOVERRIDE
 # Ref: https://github.com/NVIDIA/NemoClaw/issues/3175
 
 reconcile_agent_model_with_provider() {
+  # apply_model_override already won; reconciling against the gateway would
+  # overwrite the user's explicit choice with an inference/-prefixed variant.
+  [ -z "${NEMOCLAW_MODEL_OVERRIDE:-}" ] || return 0
+
   if [ "$(id -u)" -ne 0 ]; then
     return 0
   fi
@@ -4464,7 +4468,9 @@ openclaw_runtime_guard_chain_complete() {
 
 restore_openclaw_runtime_guard_chain() {
   if ! openclaw_runtime_guard_chain_complete; then
-    echo "[gateway-recovery] WARNING: /tmp guard chain missing or unsafe - restoring library guards from packaged preloads (#2478/#2701)" >&2
+    local _guard_warn="[gateway-recovery] WARNING: /tmp guard chain missing or unsafe - restoring library guards from packaged preloads (#2478/#2701)"
+    echo "$_guard_warn" >&2
+    echo "$_guard_warn" >>"${_NEMOCLAW_GATEWAY_LOG:-/tmp/gateway.log}" 2>/dev/null || true
   fi
 
   # Preserve startup ordering: immutable core preloads first, then the


### PR DESCRIPTION
## Summary

Two E2E regressions introduced by #5874:

- **`runtime-overrides`**: `reconcile_agent_model_with_provider` ran after `apply_model_override` and overwrote `agents.defaults.model.primary` with an `inference/`-prefixed variant because `qualify()` unconditionally prepends `inference/`. The comment at the call site already documented that the explicit override should win; this adds the guard to enforce it.

- **`issue-2478-crash-loop-recovery`**: `restore_openclaw_runtime_guard_chain` wrote its warning only to stderr. The new host-mediated recovery path (`docker exec … nemoclaw-gateway-control recover`) runs inside PID 1, not a fresh sandbox exec, so stderr never reached `/tmp/gateway.log`. Mirrors the warning to the gateway log file using the same `_NEMOCLAW_GATEWAY_LOG` seam the watchdog already uses.

## Test plan

- [ ] Trigger the `runtime-overrides` E2E target — expect `primaryModel(modelOverride)` to return `"anthropic/claude-sonnet-4-6"` (not `"inference/anthropic/…"`)
- [ ] Trigger the `issue-2478-crash-loop-recovery` E2E target — expect `[gateway-recovery] WARNING: .*restoring library guards from packaged preloads` to appear in `/tmp/gateway.log`
- [ ] Full main E2E run to confirm no regressions

Signed-off-by: Preksha Vijayvargiya <prekshiv@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicit model overrides so they are not replaced by later reconciliation.
  * Added startup guard-chain warnings to the gateway log as well as stderr for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->