### PR TITLE
test(e2e): remove stale inference key prefix check

### DIFF
--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -970,9 +970,6 @@ RUN_NETWORK_POLICY_TEST(
     expect(openshellVersion.exitCode, text(openshellVersion)).toBe(0);
 
     const apiKey = secrets.required("NVIDIA_INFERENCE_API_KEY");
-    expect(apiKey.startsWith("nvapi-"), "NVIDIA_INFERENCE_API_KEY must start with nvapi-").toBe(
-      true,
-    );
 
     cleanup.add(`destroy restricted-zero-presets sandbox ${SUPPRESSION_SANDBOX_NAME}`, async () => {
       await runNemoclaw(host, [SUPPRESSION_SANDBOX_NAME, "destroy", "--yes"], {


### PR DESCRIPTION
## Summary

Remove the stale `nvapi-` prefix assertion from the restricted network-policy live E2E. The test still requires `NVIDIA_INFERENCE_API_KEY`, but treats it as an opaque hosted-inference credential, matching the repository shared contract.

## Changes

- Remove the provider-specific prefix assertion from the zero-preset network-policy scenario.
- Keep the required credential check and the actual restricted-network inference validation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the hosted-inference support suite explicitly covers compatible non-`nvapi-` credentials.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-only correction; no user-facing behavior changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: scoped test-only deletion; production credential handling and network policy are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted verification: `npx vitest run --project e2e-support test/e2e/support/hosted-inference.test.ts test/e2e/support/ci-compatible-inference.test.ts --silent=false --reporter=default` (23 tests passed); `npx biome check test/e2e/live/network-policy.test.ts`; `git diff --check`.

Live verification: [`network-policy` E2E run 28472472733](https://github.com/NVIDIA/NemoClaw/actions/runs/28472472733) passed both tests on commit `05065c113` (2 passed, 0 failed).

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an end-to-end scenario to continue onboarding and policy checks without requiring a specific API key prefix validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->