### PR TITLE
docs: refresh v0.0.70 release docs

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -18,13 +18,22 @@ For more detailed release notes, refer to the [NemoClaw GitHub announcements](ht
 
 ## v0.0.70
 
-NemoClaw v0.0.70 hardens OpenShell gateway auth and Hermes recovery behavior:
+NemoClaw v0.0.70 completes the E2E migration and improves day-two operation, inference setup, messaging repair, Windows bootstrap guidance, and documentation.
 
-- OpenShell `0.0.71` Docker-driver gateway setup now generates and validates the local mTLS/JWT auth bundle more defensively, keeps the older-glibc compatibility container behind an explicit opt-in, and limits the live gateway auth contract job to explicit workflow dispatches pinned to OpenShell `0.0.71`.
-  For more information, refer to [OpenShell 0.0.71 Gateway Auth Review](../security/openshell-0.0.71-gateway-auth-review) and [Security Best Practices](../security/best-practices).
-- Hermes recovery now fails closed when an older sandbox image is missing the secret-boundary validator needed to re-check `/sandbox/.hermes/.env`.
-  The command refuses recovery, leaves an otherwise healthy gateway untouched, prints a re-image instruction, and requires rebuilding the sandbox with a current Hermes image before retrying recovery.
-  For more information, refer to [Troubleshooting](../reference/troubleshooting) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Day-two CLI operations are easier to steer from the host.
+  `$$nemoclaw use <name>` selects the default registered sandbox, and mistyped sandbox names now receive the closest registered-sandbox suggestion.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands).
+- Onboarding and inference validation handle more common setup drift.
+  Docker Desktop gateway bridge checks retry through the short first-start race, OpenAI-compatible endpoints can opt into reasoning-mode validation with `NEMOCLAW_REASONING`, and Windows bootstrap failures preserve WSL recovery guidance.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options), [Prepare Windows for NemoClaw](../get-started/prerequisites/windows-preparation), and [Troubleshooting](../reference/troubleshooting).
+- Messaging and Hermes repair paths carry less stale state forward.
+  Rebuilds write the effective policy preset set back to the sandbox registry, `channels start` reapplies the matching network policy preset before rebuilding, and Hermes image repair removes inherited OpenClaw state from older base layers.
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels), [NemoClaw CLI Commands Reference](../reference/commands), and [Troubleshooting](../reference/troubleshooting).
+- Documentation now covers the operator workflows added during this release.
+  The OpenClaw quickstart explains the two-terminal network approval workflow, and the messaging guide separates Teams direct-message allowlists from OpenClaw group and channel policy.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [Approve or Deny Agent Network Requests](../network-policy/approve-network-requests), and [Messaging Channels](../manage-sandboxes/messaging-channels).
+- Release validation now runs through one Vitest scenario system.
+  GitHub Actions owns orchestration and reporting, while the scenario runner keeps scheduled failure routing, scorecards, trace-timing summaries, docs validation, and two-agent security-posture coverage in the same selection model.
 
 ## v0.0.69
 

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -353,6 +353,8 @@ For WeChat specifically, `channels stop wechat` followed by a rebuild keeps the 
 </AgentOnly>
 A subsequent `channels start wechat` plus rebuild revives the bridge against the same iLink account without a fresh QR scan.
 The bot token is held by the OpenShell provider across the stop/start cycle.
+When `channels start` re-enables a channel, NemoClaw also reapplies the matching built-in network policy preset before rebuild.
+If policy restoration fails, the command keeps the channel disabled and exits without rebuilding into a partially active state.
 
 Telegram, Discord, Slack, and WeChat each allow only one active consumer per channel credential.
 Multiple sandboxes can use the same channel type at the same time when each sandbox uses a distinct bot/app token (or a distinct WeChat iLink bot account).

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1058,6 +1058,8 @@ Use `channels stop` instead of `channels remove` when you want to pause a bridge
 ### `nemohermes <name> channels start <channel>`
 
 Re-enable a channel previously paused with `channels stop`. The channel is removed from the disabled list, the sandbox is rebuilt, and the bridge registers with the gateway again using the stored credentials.
+Before the rebuild, NemoClaw reapplies the matching built-in network policy preset so the restored bridge has egress to its upstream API.
+If policy restoration fails, NemoClaw rolls the channel back to disabled and exits without rebuilding into a partially active state.
 
 ```bash
 nemohermes my-assistant channels start telegram

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1337,6 +1337,8 @@ Use `channels stop` instead of `channels remove` when you want to pause a bridge
 ### `$$nemoclaw <name> channels start <channel>`
 
 Re-enable a channel previously paused with `channels stop`. The channel is removed from the disabled list, the sandbox is rebuilt, and the bridge registers with the gateway again using the stored credentials.
+Before the rebuild, NemoClaw reapplies the matching built-in network policy preset so the restored bridge has egress to its upstream API.
+If policy restoration fails, NemoClaw rolls the channel back to disabled and exits without rebuilding into a partially active state.
 
 ```bash
 $$nemoclaw my-assistant channels start telegram

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.55.0"
+  "version": "5.59.0"
 }


### PR DESCRIPTION
## Summary
Refreshes the v0.0.70 release docs from the release announcement and the `v0.0.69..v0.0.70` commit range.
It also documents the `channels start` policy restoration behavior that was missing from the shared OpenClaw and Hermes command references, and bumps the Fern CLI version used for docs validation.

## Changes
- Replaced the stale `v0.0.70` release-notes entry with the actual release themes, including CLI, onboarding, inference, messaging, Windows, documentation, and release-validation changes.
- Documented that `channels start` reapplies the matching built-in network policy preset before rebuild and rolls back to disabled if policy restoration fails.
- Bumped `fern/fern.config.json` from `5.55.0` to `5.59.0` for the docs refresh.
- Source summary:
- #5754 -> `docs/about/release-notes.mdx`: Notes Docker Desktop gateway bridge retry behavior during onboarding.
- #5930 -> `docs/about/release-notes.mdx`: Links `nemoclaw use` default sandbox selection to the command reference.
- #5948 -> `docs/about/release-notes.mdx`: Links reasoning-compatible endpoint validation to inference documentation.
- #5950 -> `docs/about/release-notes.mdx`: Links Windows bootstrap WSL recovery behavior to Windows preparation and troubleshooting docs.
- #5856 -> `docs/about/release-notes.mdx`: Notes rebuilt policy preset registry repair.
- #5882 and #5949 -> `docs/about/release-notes.mdx`: Notes Hermes stale base-image state repair.
- #6016 -> `docs/reference/commands.mdx`, `docs/reference/commands-nemohermes.mdx`, and `docs/manage-sandboxes/messaging-channels.mdx`: Documents channel policy restoration and rollback on `channels start`.
- #5859 -> `docs/about/release-notes.mdx`: Links quickstart network approval guidance.
- #5863 -> `docs/about/release-notes.mdx`: Links Teams allowlist guidance in the messaging page.
- #5756, #5926, #6010, and #6011 -> `docs/about/release-notes.mdx`: Summarizes the Vitest E2E validation cutover.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only prose refresh with no runtime behavior change.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` exited 0 and Fern reported one existing light-mode accent contrast warning.
`fern check --warnings` confirmed the warning is the site theme contrast ratio, not content introduced by this PR.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>
