### PR TITLE
fix(inference): retire GLM 5.1 endpoint selection

### DIFF
--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -64,7 +64,7 @@ The managed install/start vLLM entry appears by default on DGX Spark and DGX Sta
 
 | Option | Description | Curated models |
 |--------|-------------|----------------|
-| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_INFERENCE_API_KEY`. | Nemotron 3 Super 120B, Nemotron 3 Ultra 550B, GLM-5.1, MiniMax M2.7, GPT-OSS 120B, DeepSeek V4 Pro |
+| NVIDIA Endpoints | Routes to models hosted on [build.nvidia.com](https://build.nvidia.com). You can also enter any model ID from the catalog. Set `NVIDIA_INFERENCE_API_KEY`. | Nemotron 3 Super 120B, Nemotron 3 Ultra 550B, MiniMax M2.7, GPT-OSS 120B, DeepSeek V4 Pro |
 | OpenAI | Routes to the OpenAI API. Set `OPENAI_API_KEY`. | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro-2026-03-05` |
 | Other OpenAI-compatible endpoint | Routes to any server that implements `/v1/chat/completions`. NemoClaw uses `/v1/chat/completions` at runtime by default; set `NEMOCLAW_PREFERRED_API=openai-responses` to allow `/v1/responses` for proxies that implement it, such as some llama.cpp builds. The wizard prompts for a base URL and model name. The adapter is validated against OpenRouter (refer to the status table above); behavior on other OpenAI-compatible proxies, gateways, and self-hosted implementations such as LocalAI or llama.cpp may vary. When you enable Telegram messaging, onboarding also runs a bounded sandbox-side smoke check through `https://inference.local/v1/chat/completions`. Set `COMPATIBLE_API_KEY`. | You provide the model name. |
 | Anthropic | Routes to the Anthropic Messages API. Set `ANTHROPIC_API_KEY`. | `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-opus-4-6` |
@@ -73,6 +73,10 @@ The managed install/start vLLM entry appears by default on DGX Spark and DGX Sta
 | Hermes Provider | Routes Hermes Agent through the host OpenShell provider registered by NemoClaw when onboarding Hermes Agent. | Curated Hermes Provider models such as `moonshotai/kimi-k2.6`, `openai/gpt-5.4-mini`, and `z-ai/glm-5.1`. |
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to [Use a Local Inference Server](use-local-inference). |
 | Model Router | Starts a host-side router on port `4000`, registers it as an OpenAI-compatible provider, and keeps the sandbox pointed at `inference.local`. Set `NEMOCLAW_PROVIDER=routed` for non-interactive setup. | The router pool defines the model names. |
+
+NVIDIA Endpoints and Hermes Provider use independent model catalogs, so a model can remain available through one provider after it leaves the other's curated list.
+Curated-list updates affect new onboarding choices and do not rewrite existing sandbox configurations.
+Use [Switch Inference Providers](switch-inference-providers) to move an existing sandbox before its configured model becomes unavailable.
 
 ## Model Task-Fit Guide
 
@@ -85,7 +89,6 @@ The relative labels below are qualitative and compare models within the curated 
 | `nvidia/nemotron-3-super-120b-a12b` | Default hosted agent work, multi-step planning, and tool-heavy shell workflows | Medium | Strong default for OpenClaw tool loops | Large agent context | Medium |
 | `nvidia/nemotron-3-ultra-550b-a55b` | Quality-sensitive reasoning, careful synthesis, and complex reviews | Higher | Strong for complex tool plans | Large agent context | Higher |
 | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Reasoning-first and multimodal experiments where a compact hosted model is enough | Medium | Good after the smoke probe confirms final-answer content | Large agent context | Medium |
-| `z-ai/glm-5.1` | General chat, multilingual text work, and fast iteration | Low-to-medium | Good for straightforward tool loops | Large agent context | Low-to-medium |
 | `minimaxai/minimax-m2.7` | Long-form writing, multi-turn assistant work, and broad instruction following | Medium | Good for structured assistant turns | Large agent context | Medium |
 | `moonshotai/kimi-k2.6` | Coding tasks and shell-heavy agent trajectories | Medium | Strong with NemoClaw's Kimi tool-call compatibility path | Large-context friendly | Medium |
 | `openai/gpt-oss-120b` | Hosted open-weight style experimentation and cost-aware general agents | Medium | Good when provider-side tool calling is enabled | Large agent context | Medium |

--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -74,9 +74,11 @@ The managed install/start vLLM entry appears by default on DGX Spark and DGX Sta
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to [Use a Local Inference Server](use-local-inference). |
 | Model Router | Starts a host-side router on port `4000`, registers it as an OpenAI-compatible provider, and keeps the sandbox pointed at `inference.local`. Set `NEMOCLAW_PROVIDER=routed` for non-interactive setup. | The router pool defines the model names. |
 
+<Note>
 NVIDIA Endpoints and Hermes Provider use independent model catalogs, so a model can remain available through one provider after it leaves the other's curated list.
 Curated-list updates affect new onboarding choices and do not rewrite existing sandbox configurations.
 Use [Switch Inference Providers](switch-inference-providers) to move an existing sandbox before its configured model becomes unavailable.
+</Note>
 
 ## Model Task-Fit Guide
 

--- a/src/lib/inference/config.test.ts
+++ b/src/lib/inference/config.test.ts
@@ -29,7 +29,6 @@ describe("inference selection config", () => {
       "nvidia/nemotron-3-super-120b-a12b",
       "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
-      "z-ai/glm-5.1",
       "minimaxai/minimax-m2.7",
       "moonshotai/kimi-k2.6",
       "openai/gpt-oss-120b",
@@ -52,6 +51,11 @@ describe("inference selection config", () => {
       "openai/gpt-5.5",
     ]);
     expect(HERMES_PROVIDER_MODEL_OPTIONS.length).toBeGreaterThan(10);
+  });
+
+  it("retires GLM 5.1 only from the NVIDIA Endpoints picker", () => {
+    expect(CLOUD_MODEL_OPTIONS.map((option) => option.id)).not.toContain("z-ai/glm-5.1");
+    expect(HERMES_PROVIDER_MODEL_OPTIONS).toContain("z-ai/glm-5.1");
   });
 
   it("maps ollama-local to the sandbox inference route and default model", () => {

--- a/src/lib/inference/config.ts
+++ b/src/lib/inference/config.ts
@@ -56,7 +56,6 @@ export const CLOUD_MODEL_OPTIONS = [
   { id: "nvidia/nemotron-3-super-120b-a12b", label: "Nemotron 3 Super 120B" },
   { id: "nvidia/nemotron-3-ultra-550b-a55b", label: "Nemotron 3 Ultra 550B" },
   { id: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning", label: "Nemotron 3 Nano Omni 30B" },
-  { id: "z-ai/glm-5.1", label: "GLM-5" },
   { id: "minimaxai/minimax-m2.7", label: "MiniMax M2.7" },
   { id: "moonshotai/kimi-k2.6", label: "Kimi K2.6" },
   { id: "openai/gpt-oss-120b", label: "GPT-OSS 120B" },

--- a/src/lib/inference/model-prompts.test.ts
+++ b/src/lib/inference/model-prompts.test.ts
@@ -34,7 +34,7 @@ describe("model prompt helpers", () => {
   });
 
   it("returns DeepSeek V4 Pro from the default cloud model menu", async () => {
-    const promptFn = promptSequence(["8"]);
+    const promptFn = promptSequence(["7"]);
     const result = await promptCloudModel({
       promptFn,
       writeLine: vi.fn(),

--- a/test/e2e/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e/live/hermes-inference-switch-helpers.ts
@@ -34,7 +34,7 @@ export const SWITCH_PROVIDER =
   (USE_COMPATIBLE_HOSTED ? "compatible-endpoint" : "nvidia-prod");
 export const SWITCH_MODEL =
   process.env.NEMOCLAW_SWITCH_MODEL ??
-  (USE_COMPATIBLE_HOSTED ? DEFAULT_COMPAT_MODEL : "z-ai/glm-5.1");
+  (USE_COMPATIBLE_HOSTED ? DEFAULT_COMPAT_MODEL : "nvidia/nemotron-3-super-120b-a12b");
 export const SWITCH_API = process.env.NEMOCLAW_SWITCH_INFERENCE_API ?? "openai-completions";
 const SWITCH_MOCK_ANTHROPIC = process.env.NEMOCLAW_SWITCH_MOCK_ANTHROPIC ?? "0";
 const SWITCH_MOCK_PORT = Number.parseInt(process.env.NEMOCLAW_SWITCH_MOCK_PORT ?? "0", 10);

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -44,7 +44,7 @@ const SWITCH_PROVIDER =
   (USE_COMPATIBLE_HOSTED ? "compatible-endpoint" : "nvidia-prod");
 const SWITCH_MODEL =
   process.env.NEMOCLAW_SWITCH_MODEL ??
-  (USE_COMPATIBLE_HOSTED ? DEFAULT_COMPAT_MODEL : "z-ai/glm-5.1");
+  (USE_COMPATIBLE_HOSTED ? DEFAULT_COMPAT_MODEL : "nvidia/nemotron-3-super-120b-a12b");
 const SWITCH_INFERENCE_API = process.env.NEMOCLAW_SWITCH_INFERENCE_API ?? "openai-completions";
 const SWITCH_MOCK_ANTHROPIC = process.env.NEMOCLAW_SWITCH_MOCK_ANTHROPIC ?? "0";
 const SWITCH_MOCK_PORT = parsePortEnv("NEMOCLAW_SWITCH_MOCK_PORT", 0);

--- a/test/inference-options-docs.test.ts
+++ b/test/inference-options-docs.test.ts
@@ -121,8 +121,25 @@ describe("inference options model task-fit docs (#4755)", () => {
     expect(section).not.toMatch(/\bTBD\b|\bTODO\b/i);
     expect(section).not.toContain("Very large context");
 
-    for (const modelId of readCuratedOnboardingModelIds()) {
-      expect(section).toContain(`| \`${modelId}\` |`);
-    }
+    const documentedModelIds = Array.from(
+      section.matchAll(/^\| `([^`]+)` \|/gm),
+      (match) => match[1],
+    );
+    expect(documentedModelIds).toEqual(readCuratedOnboardingModelIds());
+  });
+
+  it("keeps GLM 5.1 scoped to the independent Hermes Provider catalog", () => {
+    const markdown = fs.readFileSync(inferenceOptionsPath, "utf8");
+    const start = markdown.indexOf("## Provider Options");
+    const end = markdown.indexOf("## Model Task-Fit Guide", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const section = markdown.slice(start, end);
+    const nvidiaRow = section.split("\n").find((line) => line.startsWith("| NVIDIA Endpoints |"));
+    const hermesRow = section.split("\n").find((line) => line.startsWith("| Hermes Provider |"));
+
+    expect(nvidiaRow).toBeDefined();
+    expect(nvidiaRow).not.toMatch(/GLM-?5\.1|z-ai\/glm-5\.1/i);
+    expect(hermesRow).toContain("`z-ai/glm-5.1`");
   });
 });

--- a/test/inference-options-docs.test.ts
+++ b/test/inference-options-docs.test.ts
@@ -135,8 +135,9 @@ describe("inference options model task-fit docs (#4755)", () => {
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
     const section = markdown.slice(start, end);
-    const nvidiaRow = section.split("\n").find((line) => line.startsWith("| NVIDIA Endpoints |"));
-    const hermesRow = section.split("\n").find((line) => line.startsWith("| Hermes Provider |"));
+    const lines = section.split("\n");
+    const nvidiaRow = lines.find((line) => line.startsWith("| NVIDIA Endpoints |"));
+    const hermesRow = lines.find((line) => line.startsWith("| Hermes Provider |"));
 
     expect(nvidiaRow).toBeDefined();
     expect(nvidiaRow).not.toMatch(/GLM-?5\.1|z-ai\/glm-5\.1/i);

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -553,7 +553,7 @@ printf '%s' "$status"
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
-const answers = ["1", "8"];
+const answers = ["1", "7"];
 const messages = [];
 
 credentials.prompt = async (message) => {
@@ -656,7 +656,7 @@ printf '%s' "$status"
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
-const answers = ["1", "9", "custom/provider-model"];
+const answers = ["1", "8", "custom/provider-model"];
 const messages = [];
 
 credentials.prompt = async (message) => {
@@ -742,7 +742,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 if echo "$url" | grep -q '/v1/models$'; then
-  body='{"data":[{"id":"nvidia/nemotron-3-super-120b-a12b"},{"id":"z-ai/glm-5.1"}]}'
+  body='{"data":[{"id":"nvidia/nemotron-3-super-120b-a12b"},{"id":"custom/provider-model"}]}'
 fi
 printf '%s' "$body" > "$outfile"
 printf '%s' "$status"
@@ -754,7 +754,7 @@ printf '%s' "$status"
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
-const answers = ["1", "9", "bad/model", "z-ai/glm-5.1"];
+const answers = ["1", "8", "bad/model", "custom/provider-model"];
 const messages = [];
 
 credentials.prompt = async (message) => {
@@ -806,7 +806,7 @@ const { setupNim } = require(${onboardPath});
 
     assert.equal(result.status, 0, result.stderr);
     const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.result.model, "z-ai/glm-5.1");
+    assert.equal(payload.result.model, "custom/provider-model");
     assert.equal(
       payload.messages.filter((message: string) => /NVIDIA Endpoints model id:/.test(message))
         .length,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Removes `z-ai/glm-5.1` from the NVIDIA Endpoints curated onboarding choices ahead of its provider retirement and moves direct NVIDIA inference-switch test defaults to Nemotron 3 Super. The independent Hermes Provider catalog remains unchanged, and this PR does not change Kimi models.

## Changes
- Remove GLM 5.1 from the NVIDIA Endpoints picker and update menu-selection coverage.
- Preserve GLM 5.1 in the Hermes Provider catalog with explicit source and documentation boundary tests.
- Require the task-fit documentation table to exactly match the curated onboarding model IDs.
- Keep the Provider Options cells as concise provider summaries; exact catalog parity is enforced by the source-backed task-fit contract.
- Replace direct NVIDIA inference-switch test defaults with `nvidia/nemotron-3-super-120b-a12b`.
- Update inference documentation with the provider-catalog boundary and migration guidance for existing sandboxes.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cloud model selection to remove an unavailable option and align the picker with current provider availability.
  * Clarified provider-specific model availability so existing setups can be migrated when a selected model is no longer offered.
  * Adjusted related selection flows and automated checks to match the updated model lists.

* **Documentation**
  * Improved inference guidance to reflect the latest curated model options and provider-specific catalog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->