### PR TITLE
docs: refresh v0.0.71 release docs

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,29 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.71
+
+NemoClaw v0.0.71 improves gateway recovery, OpenShell gateway authentication, policy provenance, uninstall safety, Windows bootstrap diagnostics, messaging behavior, and inference guidance.
+
+- Gateway lifecycle operations use a host-mediated control path for built-in OpenClaw and Hermes sandboxes.
+  `recover` and `gateway restart` target the supervised gateway through the supported topology controller, re-check forwards after replacement, preserve explicit runtime model overrides during OpenClaw reconciliation, and write guard-chain recovery warnings into the gateway log for crash-loop diagnosis.
+  For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), [NemoClaw CLI Commands Reference](../reference/commands), [Troubleshooting](../reference/troubleshooting), and [Trusted Computing Base](../security/trusted-computing-base).
+- OpenShell 0.0.71 is the validated gateway release for this train.
+  NemoClaw generates local TLS, mTLS, and sandbox JWT material for Docker-driver gateways, keeps gateway binds on loopback while JWT auth is active, and documents the explicit compatibility-container boundary for older trusted Linux hosts.
+  For more information, refer to [OpenShell 0.0.71 Review](../security/openshell-0.0.71-gateway-auth-review), [Security Best Practices](../security/best-practices), and [Troubleshooting](../reference/troubleshooting).
+- Network policy output now explains why active presets are present.
+  `policy-list` annotates verified active presets with tier, agent, user-added, or source-unverified provenance; Restricted onboarding suppresses agent-required preset additions; the Balanced tier no longer includes `weather`; and the `weather` preset covers read-only `wttr.in` lookups when you add it explicitly.
+  For more information, refer to [Network Policies](../reference/network-policies), [NemoClaw CLI Commands Reference](../reference/commands), and [Common NemoClaw Integration Policy Examples](../network-policy/integration-policy-examples).
+- Day-two maintenance paths are more explicit.
+  `$$nemoclaw uninstall --destroy-user-data` provides a visible full-purge flag while keeping `--yes` non-destructive for preserved user data, custom Dockerfile onboarding documents cold and warm build-cache behavior, and host-side OpenClaw `agent` dispatch warns on stderr when a recent shields auto-relock may explain a failed one-shot command.
+  For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Messaging and inference setup have clearer runtime defaults and selection guidance.
+  Microsoft Teams channel setup uses final-message delivery by default and runtime mention hints, non-interactive Ollama setup refuses unsafe loopback rewrites when sudo evidence is unavailable, compatible local endpoint docs explain the default chat-completions path, and the inference guide adds model task-fit and capability-audit guidance.
+  For more information, refer to [Messaging Channels](../manage-sandboxes/messaging-channels), [Use a Local Inference Server](../inference/use-local-inference), [NemoClaw Inference Options](../inference/inference-options), and [Model Capability Audit](../inference/model-capability-audit).
+- Windows setup output is safer to share during troubleshooting.
+  The Windows bootstrap redacts PowerShell transcript metadata and temporary paths from WSL install output, and it asks for a reboot only when WSL reports one is required.
+  For more information, refer to [Prepare Windows for NemoClaw](../get-started/prerequisites/windows-preparation) and [Troubleshooting](../reference/troubleshooting).
+
 ## v0.0.70
 
 NemoClaw v0.0.70 completes the E2E migration and improves day-two operation, inference setup, messaging repair, Windows bootstrap guidance, and documentation.

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -56,6 +56,8 @@ When Ubuntu needs first-run account setup, the script opens a handoff window and
 It enables Docker Desktop WSL integration for the target distro, restarts Docker Desktop only when Docker was already running, and leaves your global default WSL distro unchanged.
 If the target Ubuntu distro is already registered, the script confirms it uses WSL 2, converts it from WSL 1 when needed, and verifies Docker is reachable from WSL.
 If Windows requires a reboot after enabling WSL features, the script prompts for the reboot and registers a one-time continuation for the next sign-in.
+When the Ubuntu install command completes but the distro is not registered yet, the script requests a reboot only when WSL output says a reboot is required.
+Any WSL install transcript printed for troubleshooting removes PowerShell transcript metadata and temporary local paths before display.
 If Docker Desktop shows first-run prompts, complete them and return to the PowerShell window.
 
 For advanced options, download the script first and run `Get-Help "$env:TEMP\bootstrap-windows.ps1" -Detailed`.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -624,6 +624,7 @@ Host-side validation runs before the sandbox dispatch:
 
 - OpenClaw sandboxes and registry fallbacks must include at least one target selector flag: `--agent`, `--session-id`, `--session-key`, or `--to` in either `--flag value` or `--flag=value` form. OpenClaw invocations without a selector exit `2` and print `No target session selected` locally, without paying the in-sandbox dispatch cost. Registered terminal-runtime sandboxes delegate bare invocations and help flags to the manifest command instead.
 - If the sandbox is registered but not in a `Ready` or `Running` phase, the wrapper exits `1` and prints the documented recovery commands (`$$nemoclaw <name> recover`, `$$nemoclaw <name> rebuild --yes`, `$$nemoclaw onboard --resume`) rather than deferring the readiness rejection to `openshell sandbox exec`.
+- If a recent timed shields window auto-restored before the one-shot OpenClaw command, the wrapper prints a stderr-only reminder such as `Shields auto-relocked` with the matching `$$nemoclaw <name> shields down --timeout ...` command before dispatch. JSON stdout stays parseable, and the warning is advisory because current scope state still belongs to OpenClaw and OpenShell.
 
 </AgentOnly>
 <AgentOnly variant="hermes">
@@ -2300,6 +2301,9 @@ OpenClaw-specific build-time agent configuration:
 | Variable | Format | Effect |
 |----------|--------|--------|
 | `NEMOCLAW_AGENT_TIMEOUT` | positive integer (seconds) | Overrides `agents.defaults.timeoutSeconds` in the built OpenClaw config. Raise for slow inference. |
+| `NEMOCLAW_AUTO_PAIR_SLOW_INTERVAL_SECS` | positive number of seconds | Sets the post-pairing poll cadence for the in-sandbox OpenClaw auto-pair watcher. Defaults to `5` so late allowlisted CLI and browser scope upgrades are approved before clients time out. Raise only on load-sensitive gateways. |
+| `NEMOCLAW_AUTO_PAIR_FAST_REENTRY_POLLS` | positive integer | Sets how many fast polls run after the watcher observes a fresh allowlisted scope-upgrade request. Defaults to `5`; set lower only when you need to reduce gateway polling. |
+| `NEMOCLAW_AUTO_PAIR_FAST_REENTRY_INTERVAL_SECS` | positive number of seconds | Sets the fast-reentry interval after a fresh allowlisted scope-upgrade request. Defaults to `1`. |
 | `NEMOCLAW_CONTEXT_WINDOW` | positive integer (tokens) | Overrides the model's context-window value in the built OpenClaw config. |
 | `NEMOCLAW_MAX_TOKENS` | positive integer (tokens) | Overrides the model's `maxTokens` in the built OpenClaw config. |
 | `NEMOCLAW_REASONING` | `true` or `false` | Overrides the model's reasoning-mode flag in the built OpenClaw config. |

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -373,6 +373,24 @@ Upgrade NemoClaw to a version that supports your OpenShell release, or install a
 For fresh installs, NemoClaw passes the blueprint range to `install-openshell.sh` and resolves a compatible published OpenShell release before downloading.
 If GitHub release metadata is unavailable, the script uses its bundled fallback pin and the post-install gate still enforces the configured range.
 
+### Sandbox build fails during OpenClaw plugin install
+
+During sandbox creation, the OpenClaw image setup can install managed plugins for selected features such as web search or diagnostics.
+If the build reaches `openclaw plugins install` and the npm registry or ClawHub is blocked, NemoClaw classifies that narrow failure and prints a policy hint instead of only generic resume guidance.
+
+Check that the active policy and host network allow the npm registry and ClawHub endpoints needed by the plugin, or disable the feature that requested the plugin.
+For example, if the plugin is for web search, disable that feature and resume onboarding:
+
+```bash
+NEMOCLAW_WEB_SEARCH_ENABLED=0 $$nemoclaw onboard --resume
+```
+
+If you want the feature, fix the network or policy path first, then resume onboarding:
+
+```bash
+$$nemoclaw onboard --resume
+```
+
 ### Sandbox containers cannot reach the gateway
 
 On native Linux Docker-driver hosts, `$$nemoclaw onboard` verifies the route that sandbox containers use to reach the OpenShell gateway.
@@ -1572,7 +1590,8 @@ Download the latest official WSL `.msi` package from the [Microsoft WSL releases
 
 The bootstrap script checks `wsl --status` before it installs or opens Ubuntu.
 If Windows reports that the WSL runtime is not installed, the script attempts `wsl --install --no-distribution` automatically.
-If the repair command succeeds, reboot when prompted and let the bootstrap resume after sign-in.
+If the repair command succeeds and WSL reports that the changes require a reboot, reboot and let the bootstrap resume after sign-in.
+If the repair command succeeds but WSL still cannot be verified and the output does not request a reboot, follow the printed repair guidance instead of rebooting by default.
 If the repair command fails, follow the printed repair steps.
 If the repair command returns `Forbidden (403)` or remains blocked, install WSL manually with Microsoft's [offline install guidance](https://learn.microsoft.com/en-us/windows/wsl/install#offline-install).
 Download the latest official WSL `.msi` package from the [Microsoft WSL releases page](https://github.com/microsoft/WSL/releases/latest), choose the matching `.x64.msi` or `.arm64.msi`, install it, reboot if Windows requests it, then rerun the bootstrap script.
@@ -1587,8 +1606,12 @@ Manual WSL installation only helps when the WSL runtime is missing or the online
 
 ### `wsl -d Ubuntu` says "There is no distribution with the supplied name"
 
-The Ubuntu package was installed with `--no-launch` but never registered.
-Run `ubuntu.exe install --root` from PowerShell to register it, or reinstall without `--no-launch`:
+The Ubuntu package was installed with `--no-launch` but never registered, or Windows finished the install command before the distribution appeared in `wsl -l`.
+When this happens during the NemoClaw bootstrap, the script prints a sanitized `WSL install output` block.
+PowerShell transcript headers, footers, temporary transcript paths, and status-file paths are redacted before display so you can paste the useful WSL output into a bug report with less local machine metadata.
+
+If the sanitized output says a reboot is required, reboot and rerun the bootstrap.
+If it does not request a reboot, register the distro manually or reinstall without `--no-launch`:
 
 ```bash
 wsl --unregister Ubuntu


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Refreshes the public documentation for NemoClaw v0.0.71 after scanning commits since v0.0.70. Adds release notes and fills the remaining doc gaps for Windows bootstrap diagnostics, OpenClaw agent auto-relock warnings, auto-pair cadence tuning, and plugin-install recovery hints.

## Changes
- `docs/about/release-notes.mdx`: adds the v0.0.71 release-note section, grouped by gateway recovery, OpenShell auth, policy provenance, day-two maintenance, messaging/inference, and Windows setup.
- `docs/get-started/windows-preparation.mdx`: documents sanitized WSL install output and reboot gating in the Windows bootstrap.
- `docs/reference/commands.mdx`: documents the host `agent` wrapper's shields auto-relock warning and OpenClaw auto-pair watcher tuning variables.
- `docs/reference/troubleshooting.mdx`: adds plugin-install network failure recovery guidance and updates Windows WSL troubleshooting for sanitized install logs and reboot-required handling.

Source summary:
- #6065 -> `docs/about/release-notes.mdx`: Notes explicit model override preservation and gateway-log guard-chain recovery diagnostics.
- #5874 -> `docs/about/release-notes.mdx`: Summarizes host-mediated `recover` and `gateway restart`, linking to lifecycle, command, troubleshooting, and trusted-boundary docs already added by the source PR.
- #5596 -> `docs/about/release-notes.mdx`: Summarizes OpenShell 0.0.71 gateway auth, loopback binding, and compatibility-container docs already added by the source PR.
- #5797 and #5798 -> `docs/about/release-notes.mdx`: Summarizes `policy-list` provenance, Restricted tier suppression, and Balanced tier weather behavior already reflected in policy docs.
- #5784 -> `docs/about/release-notes.mdx`: Summarizes `--destroy-user-data` and the safe `--yes` uninstall behavior already documented in lifecycle and command docs.
- #6034 -> `docs/about/release-notes.mdx`: Summarizes custom Dockerfile warm-build cache behavior already documented in the command reference.
- #5951 -> `docs/reference/commands.mdx`: Documents the stderr-only host `agent` wrapper warning after recent shields auto-relock.
- #5387 -> `docs/reference/commands.mdx`: Documents OpenClaw auto-pair watcher cadence and fast-reentry tuning variables.
- #5835 -> `docs/reference/troubleshooting.mdx`: Adds recovery guidance for OpenClaw plugin-install network failures.
- #5995 and #5956 -> `docs/about/release-notes.mdx`: Summarizes Microsoft Teams final-message delivery and runtime mention hints already covered by messaging docs.
- #5716 -> `docs/about/release-notes.mdx`: Summarizes non-interactive Ollama loopback safety already covered by local inference docs.
- #5505, #5527, and #5528 -> `docs/about/release-notes.mdx`: Summarizes compatible local endpoint, model task-fit, and model capability audit docs.
- #6009 -> `docs/get-started/windows-preparation.mdx`, `docs/reference/troubleshooting.mdx`: Documents sanitized Windows bootstrap WSL output and reboot-required gating.
- #6055 -> no additional source doc page change needed beyond the already-merged quickstart update; release notes did not duplicate routine quickstart cleanup.

No matching v0.0.71 GitHub announcement discussion was found in the latest 20 discussions, so this refresh is based on the commit scan and existing source PR docs.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: docs-only refresh with no runtime behavior changes.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — ran `npm run docs`; Fern reported 0 errors and 2 existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release-notes entry covering gateway recovery, authentication, network policy/provenance output, uninstall safety, Windows bootstrap diagnostics, messaging defaults, and inference setup guidance.
  * Clarified Windows preparation steps around reboot behavior and redacting troubleshooting transcripts.
  * Expanded command reference details for OpenClaw wrapper behavior and new auto-pair tuning options.
  * Improved troubleshooting guidance for plugin installation issues, WSL repair/reboot cases, and install timing problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->