### PR TITLE
fix(e2e): stage device auth through hosted inference

### DIFF
--- a/test/e2e/live/device-auth-health-helpers.ts
+++ b/test/e2e/live/device-auth-health-helpers.ts
@@ -12,6 +12,7 @@ import {
   trustedSandboxShellScript,
   validateSandboxName,
 } from "../fixtures/clients/sandbox.ts";
+import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
@@ -31,7 +32,10 @@ export function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
     NEMOCLAW_SANDBOX_NAME: SANDBOX_NAME,
     OPENSHELL_GATEWAY: process.env.OPENSHELL_GATEWAY ?? "nemoclaw",
   };
-  apiKey && Object.assign(env, { NVIDIA_INFERENCE_API_KEY: apiKey });
+  if (apiKey) {
+    const hosted = requireHostedInferenceConfig({ required: () => apiKey });
+    Object.assign(env, hosted.env);
+  }
   return env;
 }
 
@@ -102,7 +106,7 @@ export async function installDeviceAuthSandbox(
 ): Promise<ShellProbeResult> {
   let install: ShellProbeResult | undefined;
   for (let attempt = 1; attempt <= INSTALL_ATTEMPTS; attempt += 1) {
-    install = await host.command("bash", ["install.sh", "--non-interactive"], {
+    install = await host.command("bash", ["install.sh", "--non-interactive", "--fresh"], {
       artifactName:
         attempt === 1
           ? "phase-1-install-device-auth-health"

--- a/test/e2e/support/device-auth-health-helpers.test.ts
+++ b/test/e2e/support/device-auth-health-helpers.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { HostCliClient } from "../fixtures/clients/host.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { commandEnv, installDeviceAuthSandbox } from "../live/device-auth-health-helpers.ts";
+
+function okResult(command: string[]): ShellProbeResult {
+  return {
+    artifacts: { result: "", stderr: "", stdout: "" },
+    command,
+    exitCode: 0,
+    signal: null,
+    stderr: "",
+    stdout: "ok",
+    timedOut: false,
+  };
+}
+
+describe("device auth health hosted inference wiring", () => {
+  it("stages the repo NVIDIA_INFERENCE_API_KEY as a compatible endpoint credential", () => {
+    const env = commandEnv("repo-hosted-key");
+
+    expect(env.NEMOCLAW_E2E_USE_HOSTED_INFERENCE).toBe("1");
+    expect(env.NEMOCLAW_PROVIDER).toBe("custom");
+    expect(env.NEMOCLAW_ENDPOINT_URL).toBe("https://inference-api.nvidia.com/v1");
+    expect(env.NEMOCLAW_MODEL).toBe("nvidia/nvidia/nemotron-3-ultra");
+    expect(env.NEMOCLAW_COMPAT_MODEL).toBe("nvidia/nvidia/nemotron-3-ultra");
+    expect(env.NEMOCLAW_PREFERRED_API).toBe("openai-completions");
+    expect(env.NVIDIA_INFERENCE_API_KEY).toBe("repo-hosted-key");
+    expect(env.COMPATIBLE_API_KEY).toBe("repo-hosted-key");
+  });
+
+  it("runs install.sh fresh with hosted-compatible inference env", async () => {
+    const calls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const host = {
+      command: async (_command: string, args: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        calls.push({ args, env: options.env });
+        return okResult([_command, ...args]);
+      },
+    } as HostCliClient;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "device-auth-health-helper-"));
+
+    try {
+      await installDeviceAuthSandbox(host, "repo-hosted-key", path.join(tmpDir, "install.log"));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual(["install.sh", "--non-interactive", "--fresh"]);
+    expect(calls[0].env).toMatchObject({
+      COMPATIBLE_API_KEY: "repo-hosted-key",
+      NVIDIA_INFERENCE_API_KEY: "repo-hosted-key",
+      NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1",
+      NEMOCLAW_PROVIDER: "custom",
+    });
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes the `device-auth-health` live E2E wiring so the repo `NVIDIA_INFERENCE_API_KEY` is staged through the shared hosted-compatible inference config instead of being validated as the public NVIDIA endpoint provider. The install helper now starts each install attempt with `--fresh` so Vitest retries do not fail on leftover failed onboarding session state.

## Related Issue
Fixes #2342

## Changes
- Stage `device-auth-health` installs with `requireHostedInferenceConfig`, including `COMPATIBLE_API_KEY`, `NEMOCLAW_PROVIDER=custom`, and the hosted-compatible default endpoint/model.
- Run the live install path with `install.sh --non-interactive --fresh` to prevent retry attempts from tripping the failed-session guard.
- Add E2E support coverage for the helper env contract and install arguments.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal E2E CI wiring only; no user-facing behavior change
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-reviewed credential/inference test wiring; secrets are still passed only via fixture env and redaction values
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)


Verification run:
- `npx @biomejs/biome check test/e2e/live/device-auth-health-helpers.ts test/e2e/support/device-auth-health-helpers.test.ts`
- `npx vitest run --project e2e-support test/e2e/support/device-auth-health-helpers.test.ts test/e2e/support/hosted-inference.test.ts --silent=false --reporter=default`
- `npm run build:cli && npm run typecheck:cli`
- Commit hook ran with `SKIP=test-cli`; the broad CLI coverage hook failed unrelated local macOS environment checks requiring GNU `timeout`, privileged control paths, and shell assumptions. Push TypeScript hooks passed, and targeted tests above passed.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device auth health setup to correctly use hosted inference credentials when available.
  * Updated sandbox installation to use a fresh install path during retries, helping avoid stale setup issues.
  * Added coverage for hosted inference environment wiring and install behavior to improve reliability of end-to-end checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->