### PR TITLE
fix: verify Ollama model discovery after pull

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -10,7 +10,7 @@
     "test/install-preflight.test.ts": 3934,
     "test/nemoclaw-start.test.ts": 4827,
     "test/onboard-messaging.test.ts": 2062,
-    "test/onboard-selection.test.ts": 6146,
+    "test/onboard-selection.test.ts": 6062,
     "test/onboard.test.ts": 4057,
     "test/policies.test.ts": 2332
   }

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -11,7 +11,7 @@ const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const { ROOT, SCRIPTS, redact, run, runCapture, shellQuote } = require("../../runner");
 const { OLLAMA_PORT, OLLAMA_PROXY_PORT } = require("../../core/ports");
-const { waitForPort } = require("../../core/wait");
+const { sleepMs, waitForPort } = require("../../core/wait");
 const {
   getDefaultOllamaModel,
   getBootstrapOllamaModelOptions,
@@ -763,6 +763,27 @@ async function pullOllamaModel(model) {
   return pullOllamaModelViaCli(model);
 }
 
+const PULLED_MODEL_LIST_ATTEMPTS = 8;
+const PULLED_MODEL_LIST_INITIAL_DELAY_MS = 250;
+const PULLED_MODEL_LIST_MAX_DELAY_MS = 2_000;
+
+/**
+ * Confirms that Ollama exposes a just-pulled model before onboarding continues.
+ */
+function waitForPulledOllamaModel(model): boolean {
+  let delayMs = PULLED_MODEL_LIST_INITIAL_DELAY_MS;
+  for (let attempt = 0; attempt < PULLED_MODEL_LIST_ATTEMPTS; attempt++) {
+    if (getOllamaModelOptions().includes(model)) return true;
+    if (attempt < PULLED_MODEL_LIST_ATTEMPTS - 1) {
+      if (process.env.VITEST !== "true" && process.env.NEMOCLAW_TEST_NO_SLEEP !== "1") {
+        sleepMs(delayMs);
+      }
+      delayMs = Math.min(PULLED_MODEL_LIST_MAX_DELAY_MS, delayMs * 2);
+    }
+  }
+  return false;
+}
+
 // ── Tools-capability gate (issue #2667) ─────────────────────────
 //
 // Ollama models without the "tools" capability fail at first agent prompt
@@ -857,6 +878,9 @@ async function checkOllamaModelToolSupport(
   return { ok: true, allowToolsIncompatible: true };
 }
 
+/**
+ * Pulls, validates, and warms the selected Ollama model for onboarding.
+ */
 async function prepareOllamaModel(
   model,
   installedModels: string[] = [],
@@ -876,6 +900,14 @@ async function prepareOllamaModel(
         message:
           `Failed to pull Ollama model '${model}'. ` +
           "Check the model name and that Ollama can access the registry, then try another model.",
+      };
+    }
+    if (!waitForPulledOllamaModel(model)) {
+      return {
+        ok: false,
+        message:
+          `Ollama pull for '${model}' completed, but Ollama did not list the model afterward. ` +
+          "Wait for Ollama to finish registering the model, then choose it again.",
       };
     }
   }

--- a/test/onboard-ollama-pull-registration.test.ts
+++ b/test/onboard-ollama-pull-registration.test.ts
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+import { testTimeout } from "./helpers/timeouts";
+
+const OLLAMA_CHAT_COMPLETIONS_TOOL_CALL_RESPONSE =
+  '{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"type":"function","function":{"name":"emit_ok","arguments":"{\\"ok\\":true}"}}]}}]}';
+
+/**
+ * Writes a fake curl binary that mimics successful Ollama proxy probes.
+ */
+function writeAlwaysOkCurl(fakeBin: string, body = OLLAMA_CHAT_COMPLETIONS_TOOL_CALL_RESPONSE) {
+  fs.writeFileSync(
+    path.join(fakeBin, "curl"),
+    `#!/usr/bin/env bash
+body='${body}'
+status="200"
+outfile=""
+url=""
+has_config=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) outfile="$2"; shift 2 ;;
+    --config) has_config=1; shift 2 ;;
+    http://*|https://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+if [ "$has_config" -eq 0 ] && [[ "$url" == *:11435/* ]]; then
+  status="401"
+fi
+if [ -n "$outfile" ]; then
+  printf '%s' "$body" > "$outfile"
+fi
+printf '%s' "$status"
+`,
+    { mode: 0o755 },
+  );
+}
+
+function writeAlwaysOkOllama(fakeBin: string, pullLog: string) {
+  fs.writeFileSync(
+    path.join(fakeBin, "ollama"),
+    `#!/usr/bin/env bash
+if [ "$1" = "pull" ]; then
+  echo "$2" >> ${JSON.stringify(pullLog)}
+  exit 0
+fi
+exit 0
+`,
+    { mode: 0o755 },
+  );
+}
+
+describe("Ollama onboarding pull registration", { timeout: testTimeout(60_000) }, () => {
+  it("offers starter Ollama models and verifies discovery after pulling the selected model", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-ollama-bootstrap-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "ollama-bootstrap-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+    const credentialsPath = JSON.stringify(
+      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+    );
+    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+    const pullLog = path.join(tmpDir, "pulls.log");
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    writeAlwaysOkCurl(fakeBin);
+    writeAlwaysOkOllama(fakeBin, pullLog);
+
+    const script = String.raw`
+const fs = require("fs");
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+
+const answers = ["7", "1", "y"];
+const messages = [];
+const pullLog = ${JSON.stringify(pullLog)};
+const listChecks = [];
+
+credentials.prompt = async (message) => {
+  messages.push(message);
+  return answers.shift() || "";
+};
+runner.runCapture = (command) => {
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
+  if (cmd.includes("ollama list")) {
+    const afterPull = fs.existsSync(pullLog);
+    listChecks.push(afterPull ? "after-pull" : "before-pull");
+    return afterPull ? "qwen3.5:9b  abc  6 GB  now" : "";
+  }
+  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
+  return "";
+};
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim(null);
+    originalLog(JSON.stringify({ result, messages, lines, listChecks }));
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.result.provider, "ollama-local");
+    assert.equal(payload.result.model, "qwen3.5:9b");
+    assert.ok(payload.lines.some((line: string) => line.includes("Ollama starter models:")));
+    assert.ok(
+      payload.lines.some((line: string) =>
+        line.includes("No local Ollama models are installed yet"),
+      ),
+    );
+    assert.ok(
+      payload.lines.some((line: string) => line.includes("Pulling Ollama model: qwen3.5:9b")),
+    );
+    assert.ok(
+      payload.listChecks.includes("after-pull"),
+      "expected onboarding to verify Ollama model discovery after the pull completed",
+    );
+    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b");
+  });
+
+  it("reprompts when a pulled Ollama model never appears in discovery", () => {
+    const repoRoot = path.join(import.meta.dirname, "..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-ollama-register-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const scriptPath = path.join(tmpDir, "ollama-register-check.js");
+    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+    const credentialsPath = JSON.stringify(
+      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+    );
+    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+    const pullLog = path.join(tmpDir, "pulls.log");
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    writeAlwaysOkCurl(fakeBin);
+    writeAlwaysOkOllama(fakeBin, pullLog);
+
+    const script = String.raw`
+const fs = require("fs");
+const credentials = require(${credentialsPath});
+const runner = require(${runnerPath});
+
+const answers = ["7", "1", "y", "2", "llama3.2:3b", "y"];
+const messages = [];
+const pullLog = ${JSON.stringify(pullLog)};
+
+credentials.prompt = async (message) => {
+  messages.push(message);
+  return answers.shift() || "";
+};
+runner.runCapture = (command) => {
+  const cmd = Array.isArray(command) ? command.join(" ") : command;
+  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
+  if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
+  if (cmd.includes("ollama list")) {
+    return fs.existsSync(pullLog) && fs.readFileSync(pullLog, "utf8").includes("llama3.2:3b")
+      ? "llama3.2:3b  def  2 GB  now"
+      : "";
+  }
+  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
+  if (cmd.includes("api/generate")) return '{"response":"hello"}';
+  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
+  return "";
+};
+
+const { setupNim } = require(${onboardPath});
+
+(async () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const lines = [];
+  console.log = (...args) => lines.push(args.join(" "));
+  console.error = (...args) => lines.push(args.join(" "));
+  try {
+    const result = await setupNim(null);
+    originalLog(JSON.stringify({ result, messages, lines }));
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+`;
+    fs.writeFileSync(scriptPath, script);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        NEMOCLAW_TEST_NO_SLEEP: "1",
+        PATH: `${fakeBin}:${process.env.PATH || ""}`,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout.trim());
+    assert.equal(payload.result.provider, "ollama-local");
+    assert.equal(payload.result.model, "llama3.2:3b");
+    assert.ok(
+      payload.lines.some((line: string) =>
+        line.includes("Ollama pull for 'qwen3.5:9b' completed, but Ollama did not list"),
+      ),
+    );
+    assert.ok(
+      payload.lines.some((line: string) =>
+        line.includes("Choose a different Ollama model or select Other."),
+      ),
+    );
+    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b\nllama3.2:3b");
+  });
+});

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -2297,104 +2297,6 @@ const { setupNim } = require(${onboardPath});
     );
   });
 
-  it("offers starter Ollama models when none are installed and pulls the selected model", () => {
-    const repoRoot = path.join(import.meta.dirname, "..");
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-ollama-bootstrap-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "ollama-bootstrap-check.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const pullLog = path.join(tmpDir, "pulls.log");
-
-    fs.mkdirSync(fakeBin, { recursive: true });
-    writeAlwaysOkCurl(fakeBin, OLLAMA_CHAT_COMPLETIONS_TOOL_CALL_RESPONSE);
-    fs.writeFileSync(
-      path.join(fakeBin, "ollama"),
-      `#!/usr/bin/env bash
-if [ "$1" = "pull" ]; then
-  echo "$2" >> ${JSON.stringify(pullLog)}
-  exit 0
-fi
-exit 0
-`,
-      { mode: 0o755 },
-    );
-
-    const script = String.raw`
-const credentials = require(${credentialsPath});
-const runner = require(${runnerPath});
-
-const answers = ["7", "1", "y"];
-const messages = [];
-
-credentials.prompt = async (message) => {
-  messages.push(message);
-  return answers.shift() || "";
-};
-runner.runCapture = (command) => {
-  // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.
-  // Once onboard.ts is migrated to argv (#1889), these mocks can assert Array.isArray.
-  const cmd = Array.isArray(command) ? command.join(" ") : command;
-  if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
-  if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
-  if (cmd.includes("ollama list")) return "";
-  if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
-  if (cmd.includes("api/generate")) return '{"response":"hello"}';
-  if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
-  return "";
-};
-
-const { setupNim } = require(${onboardPath});
-
-(async () => {
-  const originalLog = console.log;
-  const originalError = console.error;
-  const lines = [];
-  console.log = (...args) => lines.push(args.join(" "));
-  console.error = (...args) => lines.push(args.join(" "));
-  try {
-    const result = await setupNim(null);
-    originalLog(JSON.stringify({ result, messages, lines }));
-  } finally {
-    console.log = originalLog;
-    console.error = originalError;
-  }
-})().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
-`;
-    fs.writeFileSync(scriptPath, script);
-
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-      },
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.result.provider, "ollama-local");
-    assert.equal(payload.result.model, "qwen3.5:9b");
-    assert.ok(payload.lines.some((line: string) => line.includes("Ollama starter models:")));
-    assert.ok(
-      payload.lines.some((line: string) =>
-        line.includes("No local Ollama models are installed yet"),
-      ),
-    );
-    assert.ok(
-      payload.lines.some((line: string) => line.includes("Pulling Ollama model: qwen3.5:9b")),
-    );
-    assert.equal(fs.readFileSync(pullLog, "utf8").trim(), "qwen3.5:9b");
-  });
-
   it("reprompts inside the Ollama model flow when a pull fails", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-ollama-retry-"));
@@ -2425,11 +2327,13 @@ exit 0
     );
 
     const script = String.raw`
+const fs = require("fs");
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
 const answers = ["7", "1", "y", "2", "llama3.2:3b", "y"];
 const messages = [];
+const pullLog = ${JSON.stringify(pullLog)};
 
 credentials.prompt = async (message) => {
   messages.push(message);
@@ -2441,7 +2345,11 @@ runner.runCapture = (command) => {
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
-  if (cmd.includes("ollama list")) return "";
+  if (cmd.includes("ollama list")) {
+    return fs.existsSync(pullLog) && fs.readFileSync(pullLog, "utf8").includes("llama3.2:3b")
+      ? "llama3.2:3b  def  2 GB  now"
+      : "";
+  }
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
   if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
@@ -2528,11 +2436,13 @@ exit 0
     );
 
     const script = String.raw`
+const fs = require("fs");
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
 const answers = ["7", "1", "n", "1", "y"];
 const messages = [];
+const pullLog = ${JSON.stringify(pullLog)};
 
 credentials.prompt = async (message) => {
   messages.push(message);
@@ -2542,7 +2452,9 @@ runner.runCapture = (command) => {
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
-  if (cmd.includes("ollama list")) return "";
+  if (cmd.includes("ollama list")) {
+    return fs.existsSync(pullLog) ? "qwen3.5:9b  abc  6 GB  now" : "";
+  }
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
   if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";
@@ -2631,11 +2543,13 @@ exit 0
     );
 
     const script = String.raw`
+const fs = require("fs");
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
 const answers = ["7", "1"];
 const messages = [];
+const pullLog = ${JSON.stringify(pullLog)};
 
 credentials.prompt = async (message) => {
   messages.push(message);
@@ -2645,7 +2559,9 @@ runner.runCapture = (command) => {
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "/usr/bin/ollama";
   if (cmd.includes("127.0.0.1:11434/api/tags")) return JSON.stringify({ models: [] });
-  if (cmd.includes("ollama list")) return "";
+  if (cmd.includes("ollama list")) {
+    return fs.existsSync(pullLog) ? "qwen3.5:9b  abc  6 GB  now" : "";
+  }
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
   if (cmd.includes("-o args=")) return "node ollama-auth-proxy.js";


### PR DESCRIPTION
## Summary
Makes Ollama onboarding confirm that a just-pulled model is visible in local discovery before continuing, so a zero-exit pull that has not registered yet does not silently produce a broken route.
The current-main salvage also treats an omitted model tag as `:latest` and preserves the newer onboarding test structure.

## Related Issue
Closes #6038

## Changes
- Poll Ollama discovery after a successful pull before accepting the selected model.
- Return a clear reprompt message when a pulled model never appears in discovery.
- Treat untagged model references as equivalent to Ollama's canonical `:latest` listing.
- Add focused delayed-discovery, retry-budget, reference-normalization, pull-failure, and reprompt coverage.
- Preserve current-main onboarding test refactors and ratchet the existing test-file budget downward.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing Ollama docs already state that onboarding pulls, loads, and validates the selected model before continuing; this change enforces that contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging) — local Ollama onboarding and inference preparation.
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/inference/ollama/proxy.test.ts` passed 12/12; `npx vitest run --project integration test/onboard-selection.test.ts -t "Ollama"` passed 23/23 with 41 unrelated tests skipped; `npm run typecheck:cli`, Biome, test-size, and conditional scans passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama onboarding now waits for newly pulled models to appear before continuing, reducing false “not installed” states.
  * Model detection is more flexible and now handles common tag variations more consistently.

* **Bug Fixes**
  * Improved handling for cases where a model pull succeeds but the model is not immediately listed.
  * Added better failure feedback when onboarding cannot confirm the pulled model is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->