### PR TITLE
docs: clarify descoped OpenClaw plugin CLI path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Load the `nemoclaw-skills-guide` skill for a full catalog and quick decision gui
 |------|----------|---------|
 | `bin/` | JavaScript (CJS) | CLI launcher (`nemoclaw.js`) and small compatibility helpers |
 | `src/lib/` | TypeScript | Core CLI logic: onboard, credentials, inference, policies, preflight, runner |
-| `nemoclaw/` | TypeScript | Plugin project (Commander CLI extension for OpenClaw) |
+| `nemoclaw/` | TypeScript | Plugin registering `/nemoclaw` TUI slash commands inside OpenClaw; `openclaw nemoclaw <cmd>` shell subcommand path is descoped |
 | `nemoclaw/src/blueprint/` | TypeScript | Runner, snapshot, SSRF validation, state management |
 | `nemoclaw/src/commands/` | TypeScript | Slash commands, migration state |
 | `nemoclaw/src/onboard/` | TypeScript | Onboarding config |


### PR DESCRIPTION
﻿## Summary
- clarify that `nemoclaw/` registers `/nemoclaw` TUI slash commands inside OpenClaw
- document that the `openclaw nemoclaw <cmd>` shell subcommand path is descoped
- keep the change limited to the AGENTS.md architecture table row called out in the issue

Fixes #6030

## Validation
- `git diff --check`
- `rg -n "Commander CLI extension|Plugin registering `/nemoclaw` TUI slash commands|openclaw nemoclaw <cmd>|descoped" AGENTS.md CLAUDE.md`

## Notes
- `npm run docs:check-agent-variants` still fails on the existing unrelated generated-doc drift: `docs/reference/commands-nemohermes.mdx is out of sync. Run npm run docs:sync-agent-variants`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture notes to reflect the current `nemoclaw` integration path and clarify that the shell subcommand route is no longer in scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->