### PR TITLE
docs: add Kubernetes namespace recovery steps

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -410,6 +410,19 @@ sudo ufw allow from "$SUBNET" to any port 8080 proto tcp
 $$nemoclaw onboard
 ```
 
+### Onboard fails with "Kubernetes namespace not ready"
+
+This error usually means a previous install or onboard attempt left the local OpenShell/Kubernetes state partially initialized.
+Clean up the failed setup state, then run the installer again:
+
+```bash
+$$nemoclaw uninstall --yes
+curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+```
+
+The `$$nemoclaw uninstall` command runs the version-pinned `uninstall.sh` that shipped with the installed CLI and preserves user data such as rebuild backups, workspace backups, and the sandbox registry unless you pass `--destroy-user-data`.
+If the CLI is missing or broken, use the hosted `uninstall.sh` fallback from [Uninstall](../manage-sandboxes/lifecycle#uninstall), then rerun the installer.
+
 ### `connect` exits because the gateway is down
 
 `$$nemoclaw <name> connect` checks the OpenShell gateway before it tries dashboard forwarding, SSH, or inference repair.


### PR DESCRIPTION
﻿## Summary- add a troubleshooting entry for the "Kubernetes namespace not ready" onboard failure- document the cleanup-first recovery path before re-running the installer- point users to the existing uninstall guidance and preserve the user-data warningFixes #6027## Validation- `git diff --check`- `rg -n "Kubernetes namespace not ready|$$nemoclaw uninstall --yes|hosted `uninstall.sh` fallback|lifecycle#uninstall|www.nvidia.com/nemoclaw.sh" docs/reference/troubleshooting.mdx`## Notes- `npm run docs:check-agent-variants` still fails on existing unrelated generated-doc drift: `docs/reference/commands-nemohermes.mdx is out of sync. Run npm run docs:sync-agent-variants`.<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit* **Documentation**
- Added a new troubleshooting guide for onboarding failures caused by a Kubernetes namespace not being ready.
- Included a recovery flow to uninstall and reinstall after a partially failed setup.
- Clarified what the uninstall command preserves by default and how to proceed if the local uninstall step is missing or broken.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>
