### PR TITLE
docs: add OpenClaw gateway recovery ladder

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -606,6 +606,27 @@ rm ~/.nemoclaw/onboard-session.json
 
 ## Runtime
 
+### OpenShell gateway and OpenClaw gateway startup order
+
+NemoClaw uses two gateway layers:
+
+- The OpenShell gateway runs on the host side and owns sandbox lifecycle, provider routes, port forwards, and `openshell sandbox list` / `status` queries.
+- The OpenClaw gateway runs inside the sandbox container and serves the OpenClaw dashboard, agent API, and sub-agent WebSocket traffic.
+
+Start and recover them in that order: container runtime, OpenShell gateway, sandbox container, then the in-sandbox OpenClaw gateway.
+Do not start the OpenClaw gateway by hand before the OpenShell gateway is healthy, because NemoClaw cannot select, inspect, or reconnect the sandbox until OpenShell can see the owning gateway.
+
+If the host rebooted or the OpenShell gateway is down, first run:
+
+```bash
+$$nemoclaw <name> status
+```
+
+The status command selects or starts the sandbox's recorded OpenShell gateway when possible, then checks whether OpenShell can still see the sandbox.
+If the sandbox container is present but stopped on a Docker-driver host, status can recover the labeled container and then re-query OpenShell.
+After the sandbox is visible again, use `$$nemoclaw <name> recover` only for the in-sandbox OpenClaw gateway and host forwards.
+Use `$$nemoclaw <name> gateway restart` when you intentionally need the in-sandbox gateway to reload supported runtime configuration.
+
 ### Reconnect after a host reboot
 
 After a host reboot, the container runtime, OpenShell gateway, and sandbox may not be running.
@@ -778,8 +799,44 @@ $$nemoclaw <name> rebuild
 
 ### Sandbox shows as stopped
 
-The sandbox may have been stopped or deleted.
-Run `$$nemoclaw onboard` to recreate the sandbox from the same blueprint and policy definitions.
+When status reports `sandbox_container_stopped`, Docker still has a container for the sandbox, but the container is not running.
+Use the lightest recovery path first instead of rebuilding immediately.
+
+1. Confirm Docker can still see the labeled container.
+
+   ```bash
+   docker ps -a --filter "label=openshell.ai/sandbox-name=<name>"
+   ```
+
+   If a container is listed, start it:
+
+   ```bash
+   docker start <container-name>
+   ```
+
+1. Run status recovery from the host.
+
+   ```bash
+   $$nemoclaw <name> status
+   ```
+
+   On Docker-driver hosts, status also attempts non-destructive recovery when OpenShell reports the sandbox as missing but Docker still has a stopped `openshell.ai/sandbox-name=<name>` container or the latest GPU-backup sibling.
+   A successful recovery prints that the sandbox was recovered from Docker and then shows the refreshed OpenShell state.
+
+1. If the sandbox is running but the OpenClaw gateway or dashboard forward is still down, recover the in-sandbox gateway and forwards:
+
+   ```bash
+   $$nemoclaw <name> recover
+   ```
+
+1. Rebuild only if the sandbox cannot be restarted or status still cannot recover it while the local registry entry exists:
+
+   ```bash
+   $$nemoclaw <name> rebuild --yes
+   ```
+
+   Rebuild recreates the sandbox from recorded metadata and preserves supported workspace and agent state.
+   If the sandbox was intentionally deleted and you want a clean setup, run `$$nemoclaw <name> destroy` to remove the stale local entry, then run `$$nemoclaw onboard`.
 
 ### Sandbox is registered locally but missing from the gateway
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -614,7 +614,11 @@ NemoClaw uses two gateway layers:
 - The OpenClaw gateway runs inside the sandbox container and serves the OpenClaw dashboard, agent API, and sub-agent WebSocket traffic.
 
 Start and recover them in that order: container runtime, OpenShell gateway, sandbox container, then the in-sandbox OpenClaw gateway.
-Do not start the OpenClaw gateway by hand before the OpenShell gateway is healthy, because NemoClaw cannot select, inspect, or reconnect the sandbox until OpenShell can see the owning gateway.
+
+<Warning>
+Do not start the OpenClaw gateway by hand before the OpenShell gateway is healthy.
+NemoClaw cannot select, inspect, or reconnect the sandbox until OpenShell can see the owning gateway.
+</Warning>
 
 If the host rebooted or the OpenShell gateway is down, first run:
 


### PR DESCRIPTION
## Summary
- document the startup order and relationship between the host-side OpenShell gateway and the in-sandbox OpenClaw gateway
- add a `sandbox_container_stopped` recovery ladder: start the stopped Docker container, run status recovery, recover the in-sandbox gateway/forwards, rebuild only as a last resort
- replace the previous direct onboard guidance for stopped sandboxes with state-preserving recovery steps

Closes #6031

## Validation
- `git diff --check`
- `rg -n "OpenShell gateway and OpenClaw gateway startup order|sandbox_container_stopped|openshell.ai/sandbox-name|docker start <container-name>" docs/reference/troubleshooting.mdx`

Note: `npm run docs:check-agent-variants` still fails on existing unrelated generated-doc drift: `docs/reference/commands-nemohermes.mdx is out of sync`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for gateway startup order and recovery after host reboots or gateway downtime.
  * Added clearer step-by-step procedures for sandboxes that appear stopped, including when to start, recover, rebuild, or re-onboard.
  * Included updated guidance on using status and recovery commands to restore access with minimal disruption, plus a final fallback for intentionally deleted sandboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->