### PR TITLE
fix: install package CLI alias shims

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1155,11 +1155,12 @@ EOF
 }
 
 ensure_nemoclaw_shim() {
-  local status=0
+  local cli_bin status=0
   ensure_cli_shim "$_CLI_BIN" || status=$?
-  if [[ "$_CLI_BIN" != "nemoclaw" ]]; then
-    ensure_cli_shim "nemoclaw" || true
-  fi
+  for cli_bin in nemoclaw nemohermes nemo-deepagents; do
+    [[ "$cli_bin" == "$_CLI_BIN" ]] && continue
+    ensure_cli_shim "$cli_bin" || true
+  done
   return "$status"
 }
 

--- a/test/install-npm-resolution.test.ts
+++ b/test/install-npm-resolution.test.ts
@@ -9,19 +9,47 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
+const BASH_BIN = resolveBashBin();
+
+function resolveBashBin(): string {
+  const whereResult =
+    process.platform === "win32" ? spawnSync("where.exe", ["bash"], { encoding: "utf-8" }) : null;
+  const firstWindowsBash =
+    typeof whereResult?.stdout === "string"
+      ? whereResult.stdout
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .find(Boolean)
+      : undefined;
+  return firstWindowsBash ?? "bash";
+}
+
+function systemBinDirs(): string[] {
+  return [
+    "/usr/bin",
+    "/bin",
+    ...(process.platform === "win32" && path.isAbsolute(BASH_BIN) ? [path.dirname(BASH_BIN)] : []),
+  ];
+}
 
 function buildIsolatedSystemPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-npm-sysbin-"));
   const exclude = new Set(["node", "npm", "npx"]);
 
-  for (const sysDir of ["/usr/bin", "/bin"]) {
+  for (const sysDir of systemBinDirs()) {
     if (!fs.existsSync(sysDir)) continue;
     for (const name of fs.readdirSync(sysDir)) {
       if (exclude.has(name)) continue;
       try {
         fs.symlinkSync(path.join(sysDir, name), path.join(dir, name));
       } catch (error) {
-        if (error && typeof error === "object" && "code" in error && error.code === "EEXIST") {
+        if (
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
+          (error.code === "EEXIST" ||
+            (process.platform === "win32" && (error.code === "EPERM" || error.code === "EACCES")))
+        ) {
           continue;
         }
         throw error;
@@ -38,6 +66,10 @@ function writeExecutable(target: string, contents: string): void {
   fs.writeFileSync(target, contents, { mode: 0o755 });
 }
 
+function normalizeShellPathForAssert(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
 function runInstallerFunction(
   bashSnippet: string,
   fakeBin: string,
@@ -49,12 +81,12 @@ function runInstallerFunction(
   const cmd = rawSnippet
     ? bashSnippet
     : `source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1; ${bashSnippet}`;
-  return spawnSync("bash", ["-c", cmd], {
+  return spawnSync(BASH_BIN, ["-c", cmd], {
     cwd: cwd ?? path.join(import.meta.dirname, ".."),
     encoding: "utf-8",
     env: {
       ...process.env,
-      PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+      PATH: [fakeBin, TEST_SYSTEM_PATH].join(path.delimiter),
       ...extraEnv,
     },
   });
@@ -71,6 +103,59 @@ function isLinuxRoot(): boolean {
 }
 
 describe("installer npm resolution", () => {
+  it("creates user-local shims for every packaged CLI alias during the default install path", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-package-shims-"));
+    const fakeBin = path.join(tmp, "bin");
+    const prefix = path.join(tmp, "prefix");
+    const prefixBin = path.join(prefix, "bin");
+
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(prefixBin, { recursive: true });
+
+    writeExecutable(
+      path.join(fakeBin, "node"),
+      `#!/usr/bin/env bash
+exit 0
+`,
+    );
+    writeExecutable(
+      path.join(fakeBin, "npm"),
+      `#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "get" ] && [ "$3" = "prefix" ]; then
+  echo "$ACTIVE_NPM_PREFIX"
+  exit 0
+fi
+exit 99
+`,
+    );
+    for (const cliBin of ["nemoclaw", "nemohermes", "nemo-deepagents"]) {
+      writeExecutable(
+        path.join(prefixBin, cliBin),
+        `#!/usr/bin/env bash
+echo "${cliBin} v0.1.0"
+`,
+      );
+    }
+
+    const result = runInstallerFunction(
+      '_CLI_BIN=nemoclaw; ensure_nemoclaw_shim; for name in nemoclaw nemohermes nemo-deepagents; do test -x "$NEMOCLAW_SHIM_DIR/$name"; done',
+      fakeBin,
+      {
+        ACTIVE_NPM_PREFIX: prefix,
+        HOME: tmp,
+      },
+    );
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    for (const cliBin of ["nemoclaw", "nemohermes", "nemo-deepagents"]) {
+      expect(
+        normalizeShellPathForAssert(
+          fs.readFileSync(path.join(tmp, ".local", "bin", cliBin), "utf-8"),
+        ),
+      ).toContain(normalizeShellPathForAssert(path.join(prefixBin, cliBin)));
+    }
+  });
+
   it("prefers the active npm on PATH over a hostile nvm environment", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-path-npm-"));
     const fakeBin = path.join(tmp, "bin");
@@ -122,7 +207,9 @@ exit 98
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe(path.join(activePrefix, "bin"));
+    expect(normalizeShellPathForAssert(result.stdout.trim())).toBe(
+      normalizeShellPathForAssert(path.join(activePrefix, "bin")),
+    );
     expect(fs.existsSync(marker)).toBe(false);
   });
 
@@ -165,61 +252,66 @@ exit 98
     });
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe(path.join(nvmPrefix, "bin"));
+    expect(normalizeShellPathForAssert(result.stdout.trim())).toBe(
+      normalizeShellPathForAssert(path.join(nvmPrefix, "bin")),
+    );
     expect(fs.readFileSync(marker, "utf-8")).toContain("sourced");
   });
 
-  it("reports npm link targets as unwritable when npm_prefix/lib exists but cannot create node_modules", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-npm-targets-"));
-    const fakeBin = path.join(tmp, "bin");
-    const prefix = path.join(tmp, "prefix");
-    const prefixBin = path.join(prefix, "bin");
-    const prefixLib = path.join(prefix, "lib");
-    const needsDrop = isLinuxRoot();
+  it.skipIf(process.platform === "win32")(
+    "reports npm link targets as unwritable when npm_prefix/lib exists but cannot create node_modules",
+    () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-npm-targets-"));
+      const fakeBin = path.join(tmp, "bin");
+      const prefix = path.join(tmp, "prefix");
+      const prefixBin = path.join(prefix, "bin");
+      const prefixLib = path.join(prefix, "lib");
+      const needsDrop = isLinuxRoot();
 
-    fs.mkdirSync(fakeBin);
-    fs.mkdirSync(prefixBin, { recursive: true });
-    fs.mkdirSync(prefixLib, { recursive: true });
-    fs.chmodSync(tmp, 0o755);
-    fs.chmodSync(fakeBin, 0o755);
-    // When running as root, we wrap the snippet in `runuser` to drop to
-    // nobody so `test -w` behaves like a normal installer user. Make bin
-    // world-writable in that mode so the lib directory is the actual blocker.
-    fs.chmodSync(prefixBin, needsDrop ? 0o777 : 0o755);
-    fs.chmodSync(prefixLib, 0o555);
+      fs.mkdirSync(fakeBin);
+      fs.mkdirSync(prefixBin, { recursive: true });
+      fs.mkdirSync(prefixLib, { recursive: true });
+      fs.chmodSync(tmp, 0o755);
+      fs.chmodSync(fakeBin, 0o755);
+      // When running as root, we wrap the snippet in `runuser` to drop to
+      // nobody so `test -w` behaves like a normal installer user. Make bin
+      // world-writable in that mode so the lib directory is the actual blocker.
+      fs.chmodSync(prefixBin, needsDrop ? 0o777 : 0o755);
+      fs.chmodSync(prefixLib, 0o555);
 
-    const innerSnippet =
-      'if npm_link_targets_writable "$TARGET_PREFIX"; then echo WRITABLE; else echo BLOCKED; fi';
+      const innerSnippet =
+        'if npm_link_targets_writable "$TARGET_PREFIX"; then echo WRITABLE; else echo BLOCKED; fi';
 
-    let result;
-    if (needsDrop) {
-      // WSL does not support setuid via Node's uid/gid spawn options (EACCES).
-      // Copy the installer payload into the temp dir (world-readable) and use
-      // su to drop to nobody for the permission-sensitive assertion.
-      const localPayload = path.join(tmp, "install.sh");
-      fs.copyFileSync(INSTALLER_PAYLOAD, localPayload);
-      fs.chmodSync(localPayload, 0o644);
-      const wrapped = `su -s /bin/bash nobody -c 'source "${localPayload}" >/dev/null 2>&1; ${innerSnippet}'`;
-      result = runInstallerFunction(
-        wrapped,
-        fakeBin,
-        {
+      let result;
+      if (needsDrop) {
+        // WSL does not support setuid via Node's uid/gid spawn options (EACCES).
+        // Copy the installer payload into the temp dir (world-readable) and use
+        // su to drop to nobody for the permission-sensitive assertion.
+        const localPayload = path.join(tmp, "install.sh");
+        fs.copyFileSync(INSTALLER_PAYLOAD, localPayload);
+        fs.chmodSync(localPayload, 0o644);
+        const wrapped = `su -s /bin/bash nobody -c 'source "${localPayload}" >/dev/null 2>&1; ${innerSnippet}'`;
+        result = runInstallerFunction(
+          wrapped,
+          fakeBin,
+          {
+            HOME: tmp,
+            TARGET_PREFIX: prefix,
+          },
+          tmp,
+          true,
+        );
+      } else {
+        result = runInstallerFunction(innerSnippet, fakeBin, {
           HOME: tmp,
           TARGET_PREFIX: prefix,
-        },
-        tmp,
-        true,
-      );
-    } else {
-      result = runInstallerFunction(innerSnippet, fakeBin, {
-        HOME: tmp,
-        TARGET_PREFIX: prefix,
-      });
-    }
+        });
+      }
 
-    expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("BLOCKED");
-  });
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("BLOCKED");
+    },
+  );
 
   it("reports npm link targets as writable when bin and lib/node_modules are writable", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-npm-targets-"));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix the source installer so every packaged NemoClaw CLI alias is made available through the user-local shim directory. This restores `nemohermes` after a default `nemoclaw` install while preserving the active CLI's failure semantics.

## Related Issue
Closes #6041.

## Changes
- Create best-effort user-local shims for `nemoclaw`, `nemohermes`, and `nemo-deepagents` after installing the active CLI.
- Verify that every generated alias shim points to its corresponding packaged binary.
- Keep the installer test fixture portable across POSIX and Windows development shells.
- Replay the validated contributor change onto current `main` with repository formatter output applied.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — installer restores already-packaged CLI aliases without changing the documented interface
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — installer shim targets and best-effort failure boundaries reviewed; focused alias tests pass 5/5
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every replayed commit is expected to appear as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes — formatting and read-only hooks passed; the broad local coverage lane did not settle under shared host load, so exact-head CI remains required
- [x] Targeted tests pass for changed behavior — `npx vitest run --project integration test/install-npm-resolution.test.ts` (5/5)
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: WilliamK112 <164879897+WilliamK112@users.noreply.github.com>
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installer now creates local command shims for all bundled CLI aliases, so more entry points are available after setup.
* **Bug Fixes**
  * Improved installer behavior across platforms, including better Windows support and more reliable path handling.
  * Fallback installation paths are now reported more consistently when npm isn’t available.
* **Tests**
  * Expanded installer coverage for alias creation, fallback behavior, and cross-platform path normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->