### PR TITLE
fix(sandbox): surface actionable recovery hint when destroy wipe fails

### DIFF
--- a/src/lib/actions/sandbox/wipe-state.ts
+++ b/src/lib/actions/sandbox/wipe-state.ts
@@ -219,7 +219,10 @@ export function wipeSandboxState(sandboxName: string, deps: WipeSandboxStateDeps
     // pins the gateway-select-then-exec-then-delete order.
     warn(
       `  ${YW}⚠${R} Could not wipe workspace state for '${sandboxName}' (sandbox not live?); ` +
-        "re-onboarding with the same name may resurface old files.",
+        "re-onboarding with the same name may resurface old files. " +
+        "To start clean, re-onboard with a different sandbox name, or — when this " +
+        "is your last sandbox — re-run destroy with --cleanup-gateway to purge the " +
+        "retained cluster volume.",
     );
   }
 }

--- a/test/destroy-wipe-sandbox-state.test.ts
+++ b/test/destroy-wipe-sandbox-state.test.ts
@@ -101,6 +101,28 @@ describe("wipeSandboxState (#5449)", () => {
     }
   });
 
+  // #5970: when sandbox exec fails (sandbox not live, 100% CI repro), the warning
+  // must name actionable recovery paths so the user knows how to avoid stale
+  // workspace files after re-onboard. Two self-serve paths exist: re-onboard with
+  // a different name (fresh PVC), or --cleanup-gateway on the last sandbox (purges
+  // the shared cluster volume that retains the PVC, so the same name comes up clean).
+  it("names both recovery paths in the exec-fail warning so users can avoid stale workspace after re-onboard (#5970)", () => {
+    const warnings: string[] = [];
+    const { deps } = buildDeps({
+      runOpenshell: vi.fn(() => ({ status: 1 })),
+      warn: (msg: string) => warnings.push(msg),
+    });
+
+    destroy.wipeSandboxState("test-sb", deps as never);
+
+    const wipeWarn = warnings.find((w) => w.includes("Could not wipe workspace state"));
+    expect(wipeWarn).toBeDefined();
+    // Simple path: different name → fresh PVC (always works).
+    expect(wipeWarn).toContain("re-onboard with a different sandbox name");
+    // Same-name path: --cleanup-gateway purges the retained cluster volume.
+    expect(wipeWarn).toContain("--cleanup-gateway");
+  });
+
   // PRA-6 #5455: a manifest declaring a relative escape (e.g. `../etc`) or an
   // absolute path (e.g. `/etc/passwd`) in state_dirs/state_files would be
   // shell-quoted but fed straight into `rm -rf -- ...` inside `cd ${dir}`,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
When `nemoclaw destroy` cannot wipe a sandbox's workspace because the pod is no longer live, the exec-fail warning now names concrete self-serve recovery paths so users don't hit stale `USER.md`/`SOUL.md` after re-onboarding with the same name (#5970). This is a message-only improvement; the durable PVC retention that causes the stale files is owned upstream by OpenShell `sandbox delete` semantics (NemoClaw can only `exec`+`rm` while the pod is live).

> **Scope:** intentionally a warning-text mitigation, not the root fix for #5970 — hence `Refs`, not `Fixes`/`Closes`. The actual PVC purge requires an upstream OpenShell change (`sandbox delete` retains the per-sandbox k3s PVC by design). See the response to the PR Review Advisor's `PRA-1` in the thread for the full rationale.

## Related Issue
Refs #5970

## Changes
- `src/lib/actions/sandbox/wipe-state.ts` — the best-effort exec-fail warning in `wipeSandboxState()` now names two self-serve recovery paths instead of a dead-end "may resurface old files" note: (1) re-onboard with a different sandbox name (fresh PVC), or (2) when this is the last sandbox, re-run `destroy --cleanup-gateway` to purge the shared cluster volume that retains the PVC so the same name comes up clean.
- `test/destroy-wipe-sandbox-state.test.ts` — new red→green test asserting the exec-fail warning (non-zero `sandbox exec`) names both recovery paths.
- Note: the local `test-cli` pre-commit hook (full CLI+integration suite with coverage) was skipped locally because it hangs starting an OpenShell gateway on this host (glibc 2.31, no live gateway); targeted tests for the changed behavior pass and CI runs the full suite (`cli-test-shards` 1–5 all green).
- Live E2E: the advisor-required `sandbox-operations` job was dispatched against this branch and **passed** ([run 28492424319](https://github.com/NVIDIA/NemoClaw/actions/runs/28492424319)), confirming the live destroy lifecycle this change touches does not regress.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal CLI warning-text change; no doc page quotes this specific message and `--cleanup-gateway` is already documented
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: message-only change (pure string append; no logic, control-flow, or signature change); all standard CI green plus the advisor-required `sandbox-operations` live E2E passed ([run 28492424319](https://github.com/NVIDIA/NemoClaw/actions/runs/28492424319))
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Dongni Yang <dongniy@nvidia.com>
