### PR TITLE
fix(onboard): validate hydrated credential on resume provider recreate

### DIFF
--- a/src/lib/onboard/resume-provider-recovery.test.ts
+++ b/src/lib/onboard/resume-provider-recovery.test.ts
@@ -34,6 +34,7 @@ function makeDeps(overrides: {
   credentialValue?: string | null;
   nonInteractive?: boolean;
   remoteProviderConfig?: Record<string, RemoteProviderConfigEntry>;
+  validate?: (key: string, credentialEnv: string) => string | null;
 }): DepsRecorder {
   const log: string[] = [];
   const warn: string[] = [];
@@ -58,7 +59,7 @@ function makeDeps(overrides: {
       replaceCalls.push({ env, label });
       return "fresh-key";
     },
-    validateNvidiaApiKeyValue: () => null,
+    validateNvidiaApiKeyValue: overrides.validate ?? (() => null),
   };
   return { log, warn, note, exitCalls, replaceCalls, deps };
 }
@@ -144,5 +145,43 @@ describe("ensureResumeProviderReady", () => {
     expect(recorder.warn.join("\n")).toContain("COMPATIBLE_API_KEY");
     expect(recorder.warn.join("\n")).toContain("during resume");
     expect(recorder.replaceCalls).toHaveLength(0);
+  });
+
+  it("exits 1 without recreating the provider when a hydrated key is invalid in non-interactive mode", async () => {
+    const recorder = makeDeps({
+      providerExists: false,
+      credentialValue: "not-a-nvidia-key",
+      nonInteractive: true,
+      validate: () => "  Invalid NVIDIA API key. Must start with nvapi-",
+    });
+    const result = await ensureResumeProviderReady(
+      "compatible-endpoint",
+      "COMPATIBLE_API_KEY",
+      recorder.deps,
+    );
+    expect(result.forceInferenceSetup).toBe(false);
+    expect(recorder.exitCalls).toEqual([1]);
+    expect(recorder.warn.join("\n")).toContain("Must start with nvapi-");
+    expect(recorder.replaceCalls).toHaveLength(0);
+    expect(recorder.note).toHaveLength(0);
+  });
+
+  it("re-prompts instead of recreating when a hydrated key is invalid in interactive mode", async () => {
+    const recorder = makeDeps({
+      providerExists: false,
+      credentialValue: "not-a-nvidia-key",
+      validate: () => "  Invalid NVIDIA API key. Must start with nvapi-",
+    });
+    const result = await ensureResumeProviderReady(
+      "compatible-endpoint",
+      "COMPATIBLE_API_KEY",
+      recorder.deps,
+    );
+    expect(result.forceInferenceSetup).toBe(true);
+    expect(recorder.exitCalls).toEqual([]);
+    expect(recorder.replaceCalls).toEqual([
+      { env: "COMPATIBLE_API_KEY", label: "Compatible Endpoint API key" },
+    ]);
+    expect(recorder.note).toHaveLength(0);
   });
 });

--- a/src/lib/onboard/resume-provider-recovery.ts
+++ b/src/lib/onboard/resume-provider-recovery.ts
@@ -107,20 +107,34 @@ export async function ensureResumeProviderReady(
   const credentialValue = deps.hydrateCredentialEnv(resolvedCredentialEnv);
   const providerLabel = config?.label || deps.getProviderLabel(provider) || provider;
   const helpUrl = config?.helpUrl || null;
-  if (!credentialValue) {
+  const credentialError = credentialValue
+    ? deps.validateNvidiaApiKeyValue(credentialValue, resolvedCredentialEnv)
+    : null;
+  if (!credentialValue || credentialError) {
     if (deps.isNonInteractive()) {
-      deps.warn(
-        `  ${resolvedCredentialEnv} is required to recreate provider '${provider}' during resume.`,
-      );
-      deps.warn(
-        `  Re-run without --non-interactive to enter it, or set ${resolvedCredentialEnv} and retry.`,
-      );
+      if (credentialError) {
+        deps.warn(credentialError);
+        deps.warn(
+          `  Set a valid ${resolvedCredentialEnv} and retry, or re-run without --non-interactive to enter it.`,
+        );
+      } else {
+        deps.warn(
+          `  ${resolvedCredentialEnv} is required to recreate provider '${provider}' during resume.`,
+        );
+        deps.warn(
+          `  Re-run without --non-interactive to enter it, or set ${resolvedCredentialEnv} and retry.`,
+        );
+      }
       deps.exit(1);
       return { forceInferenceSetup: false, credentialEnv: resolvedCredentialEnv };
     }
     deps.log("");
     deps.log(`  [resume] Provider '${provider}' is missing from the gateway.`);
-    deps.log("  Re-enter the API key so onboarding can recreate it before rebuilding.");
+    deps.log(
+      credentialError
+        ? "  The stored API key is invalid. Re-enter it so onboarding can recreate the provider before rebuilding."
+        : "  Re-enter the API key so onboarding can recreate it before rebuilding.",
+    );
     await deps.replaceNamedCredential(
       resolvedCredentialEnv,
       `${providerLabel} API key`,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Non-interactive `nemoclaw onboard` resume recreated a gateway-missing provider from the stored credential without the syntactic API-key check the fresh and interactive paths apply, so an invalid NVIDIA API key was accepted and the sandbox built anyway.

## Related Issue

Fixes #6036

## Changes

- `src/lib/onboard/resume-provider-recovery.ts` — validate a hydrated credential before recreating a missing provider; reject and exit in non-interactive mode, re-prompt when interactive. Keyless gateway reuse unchanged.
- `src/lib/onboard/resume-provider-recovery.test.ts` — cover non-interactive rejection and interactive re-prompt.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>
