### PR TITLE
ci(e2e): restore Docker Hub authentication coverage

### DIFF
--- a/.github/scripts/docker-auth-cleanup.sh
+++ b/.github/scripts/docker-auth-cleanup.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail_unsafe_path() {
+  echo "::error::Docker auth cleanup refused an unsafe path or file type." >&2
+  exit 1
+}
+
+if (($# != 0)); then
+  fail_unsafe_path
+fi
+
+docker_config="${DOCKER_CONFIG:-}"
+if [[ -z "${docker_config}" ]]; then
+  exit 0
+fi
+
+runner_temp="${RUNNER_TEMP:-}"
+github_job="${GITHUB_JOB:-}"
+while [[ "${runner_temp}" != "/" && "${runner_temp}" == */ ]]; do
+  runner_temp="${runner_temp%/}"
+done
+if [[ -z "${runner_temp}" || "${runner_temp}" != /* || "${runner_temp}" == "/" ]]; then
+  fail_unsafe_path
+fi
+if [[ ! "${github_job}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  fail_unsafe_path
+fi
+
+config_parent="${docker_config%/*}"
+while [[ "${config_parent}" != "/" && "${config_parent}" == */ ]]; do
+  config_parent="${config_parent%/}"
+done
+config_name="${docker_config##*/}"
+config_prefix="docker-config-${github_job}-"
+if [[ "${config_parent}" != "${runner_temp}" || "${config_name}" != "${config_prefix}"* ]]; then
+  fail_unsafe_path
+fi
+config_suffix="${config_name#"${config_prefix}"}"
+if [[ ! "${config_suffix}" =~ ^[[:alnum:]]{6}$ ]]; then
+  fail_unsafe_path
+fi
+
+if [[ ! -e "${docker_config}" && ! -L "${docker_config}" ]]; then
+  exit 0
+fi
+if [[ -L "${docker_config}" || ! -d "${docker_config}" || ! -O "${docker_config}" ]]; then
+  fail_unsafe_path
+fi
+
+logout_status=0
+auth_marker="${docker_config}/.nemoclaw-docker-login-attempted"
+config_file="${docker_config}/config.json"
+if [[ -L "${auth_marker}" || (-e "${auth_marker}" && (! -f "${auth_marker}" || ! -O "${auth_marker}")) ]]; then
+  logout_status=1
+elif [[ -f "${auth_marker}" ]]; then
+  if [[ -L "${config_file}" || (-e "${config_file}" && (! -f "${config_file}" || ! -O "${config_file}")) ]]; then
+    logout_status=1
+  else
+    set +e
+    timeout 30s docker --config "${docker_config}" logout docker.io >/dev/null 2>&1
+    logout_status=$?
+    set -e
+  fi
+fi
+
+if ! rm -rf -- "${docker_config}"; then
+  echo "::error::Failed to remove isolated Docker credentials." >&2
+  exit 1
+fi
+if ((logout_status != 0)); then
+  echo "::error::Docker logout failed; isolated credentials were removed." >&2
+  exit 1
+fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -266,6 +266,50 @@ jobs:
         with:
           persist-credentials: false
 
+      # Keep only the credential-bearing step anchored. Cleanup mappings stay
+      # explicit because strict YAML decoders reject 100 or more aliases here.
+      - &dockerhub-auth
+        name: Authenticate to Docker Hub
+        env:
+          DOCKERHUB_AUTH_REQUIRED: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
+          DOCKERHUB_USERNAME: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && secrets.DOCKERHUB_USERNAME || '' }}
+          DOCKERHUB_TOKEN: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && secrets.DOCKERHUB_TOKEN || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker_config="$(mktemp -d "${RUNNER_TEMP}/docker-config-${GITHUB_JOB}-XXXXXX")"
+          chmod 700 "${docker_config}"
+          export DOCKER_CONFIG="${docker_config}"
+          printf 'DOCKER_CONFIG=%s\n' "${DOCKER_CONFIG}" >> "${GITHUB_ENV}"
+
+          if [[ "${DOCKERHUB_AUTH_REQUIRED}" != "1" ]]; then
+            echo "::notice::Docker Hub credentials are withheld for this ref; continuing with anonymous pulls."
+            exit 0
+          fi
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "::error::Docker Hub credentials are required for trusted E2E runs."
+            exit 1
+          fi
+
+          auth_marker="${DOCKER_CONFIG}/.nemoclaw-docker-login-attempted"
+          : > "${auth_marker}"
+          chmod 600 "${auth_marker}"
+          login_succeeded=0
+          for attempt in 1 2 3; do
+            if printf '%s' "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
+              login_succeeded=1
+              break
+            fi
+            if [[ "${attempt}" -lt 3 ]]; then
+              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
+              sleep 5
+            fi
+          done
+          if [[ "${login_succeeded}" -ne 1 ]]; then
+            echo "::error::Docker Hub login failed after 3 attempts."
+            exit 1
+          fi
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -346,6 +390,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   # Free-standing live tests under test/e2e/live/ that don't fit the
   # registry-driven steady-state probe model. Each gets a discrete job here
   # because the matrix above only runs registry-targets.test.ts. Modeled on
@@ -416,6 +465,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - *dockerhub-auth
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -463,6 +514,11 @@ jobs:
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   onboard-negative-paths:
     needs: generate-matrix
@@ -529,31 +585,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -615,6 +647,12 @@ jobs:
           retention-days: 14
 
   # Direct OpenClaw skills CLI contract.
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   openclaw-skill-cli:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',openclaw-skill-cli,') || contains(format(',{0},', inputs.targets), ',openclaw-skill-cli,') }}
@@ -634,31 +672,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -694,8 +708,7 @@ jobs:
       - name: Clean up Docker auth
         if: always()
         shell: bash
-        run: |
-          docker logout docker.io >/dev/null 2>&1 || true
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   # Checkout-local CLI/docs parity and deterministic local Markdown/MDX link
   # validation. Keep this discrete until the focused docs workflows are
@@ -757,6 +770,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - *dockerhub-auth
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -786,6 +801,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   hermes-sandbox-secret-boundary:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',hermes-sandbox-secret-boundary,') || contains(format(',{0},', inputs.targets), ',hermes-sandbox-secret-boundary,') }}
@@ -800,6 +820,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -829,6 +851,11 @@ jobs:
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   inference-routing:
     needs: generate-matrix
@@ -899,6 +926,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - *dockerhub-auth
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -934,6 +963,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   gpu-e2e:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',gpu-e2e,') || contains(format(',{0},', inputs.targets), ',gpu-e2e,') }}
@@ -957,6 +991,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -995,6 +1031,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   agent-turn-latency:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',agent-turn-latency,') || contains(format(',{0},', inputs.targets), ',agent-turn-latency,') }}
@@ -1019,6 +1060,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -1060,6 +1103,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   kimi-inference-compat:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',kimi-inference-compat,') || contains(format(',{0},', inputs.targets), ',kimi-inference-compat,') }}
@@ -1080,6 +1128,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -1108,6 +1158,11 @@ jobs:
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   hermes-inference-switch:
     needs: generate-matrix
@@ -1152,6 +1207,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -1181,6 +1238,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   brave-search:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',brave-search,') || contains(format(',{0},', inputs.targets), ',brave-search,') }}
@@ -1201,6 +1263,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1247,6 +1311,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   ollama-auth-proxy:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',ollama-auth-proxy,') || contains(format(',{0},', inputs.targets), ',ollama-auth-proxy,') }}
@@ -1263,6 +1332,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1288,6 +1359,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   cron-preflight-inference-local:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',cron-preflight-inference-local,') || contains(format(',{0},', inputs.targets), ',cron-preflight-inference-local,') }}
@@ -1308,6 +1384,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1353,6 +1431,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   issue-4434-tui-unreachable-inference:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',issue-4434-tui-unreachable-inference,') || contains(format(',{0},', inputs.targets), ',issue-4434-tui-unreachable-inference,') }}
@@ -1373,6 +1456,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       # This free-standing job checks out and executes the PR target ref. It
       # keeps privileged host dependency setup inline in trusted workflow YAML
@@ -1396,32 +1481,6 @@ jobs:
             sleep $((attempt * 5))
           done
           sudo apt-get install -y --no-install-recommends expect iptables
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1470,6 +1529,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   credential-sanitization:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',credential-sanitization,') || contains(format(',{0},', inputs.targets), ',credential-sanitization,') }}
@@ -1489,31 +1553,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1553,8 +1593,7 @@ jobs:
       - name: Clean up Docker auth
         if: always()
         shell: bash
-        run: |
-          docker logout docker.io >/dev/null 2>&1 || true
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   credential-migration:
     needs: generate-matrix
@@ -1574,31 +1613,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1641,6 +1656,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   sessions-agents-cli:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',sessions-agents-cli,') || contains(format(',{0},', inputs.targets), ',sessions-agents-cli,') }}
@@ -1660,31 +1680,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1728,6 +1724,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   runtime-overrides:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',runtime-overrides,') || contains(format(',{0},', inputs.targets), ',runtime-overrides,') }}
@@ -1742,6 +1743,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1771,6 +1774,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   hermes-slack:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',hermes-slack,') || contains(format(',{0},', inputs.targets), ',hermes-slack,') }}
@@ -1795,36 +1803,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-hermes-slack" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1864,10 +1843,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   hermes-e2e:
     needs: generate-matrix
@@ -1891,6 +1868,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1923,6 +1902,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   hermes-dashboard:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',hermes-dashboard,') || contains(format(',{0},', inputs.targets), ',hermes-dashboard,') }}
@@ -1946,6 +1930,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -1978,6 +1964,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   hermes-discord:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',hermes-discord,') || contains(format(',{0},', inputs.targets), ',hermes-discord,') }}
@@ -1999,34 +1990,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Isolate Docker auth
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-hermes-discord" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2068,10 +2032,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG:-}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   network-policy:
     needs: generate-matrix
@@ -2093,6 +2055,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       # Expect is a reviewed host-tool consumer for the interactive policy-add
       # test. Keep this privileged setup inline in trusted workflow YAML. This
@@ -2158,6 +2122,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   common-egress-agent:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',common-egress-agent,') || contains(format(',{0},', inputs.targets), ',common-egress-agent,') }}
@@ -2178,6 +2147,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2236,6 +2207,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   shields-config:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',shields-config,') || contains(format(',{0},', inputs.targets), ',shields-config,') }}
@@ -2256,31 +2232,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2314,6 +2266,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   rebuild-openclaw:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',rebuild-openclaw,') || contains(format(',{0},', inputs.targets), ',rebuild-openclaw,') }}
@@ -2331,31 +2288,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2409,6 +2342,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   rebuild-hermes:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',rebuild-hermes,') || contains(format(',{0},', inputs.targets), ',rebuild-hermes,') }}
@@ -2435,31 +2373,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2492,6 +2406,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   rebuild-hermes-stale-base:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',rebuild-hermes-stale-base,') || contains(format(',{0},', inputs.targets), ',rebuild-hermes-stale-base,') }}
@@ -2519,31 +2438,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2575,6 +2470,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   sandbox-rebuild:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',sandbox-rebuild,') || contains(format(',{0},', inputs.targets), ',sandbox-rebuild,') }}
@@ -2595,31 +2495,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2671,6 +2547,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   sandbox-rlimits-connect:
     needs: generate-matrix
     if: ${{ contains(format(',{0},', inputs.jobs), ',sandbox-rlimits-connect,') || contains(format(',{0},', inputs.targets), ',sandbox-rlimits-connect,') }}
@@ -2693,31 +2574,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2769,6 +2626,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   overlayfs-autofix:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',overlayfs-autofix,') || contains(format(',{0},', inputs.targets), ',overlayfs-autofix,') }}
@@ -2791,36 +2653,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-overlayfs-autofix" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2853,9 +2686,10 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Clean Docker auth
+      - name: Clean up Docker auth
         if: always()
-        run: rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   state-backup-restore:
     needs: generate-matrix
@@ -2878,31 +2712,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -2954,6 +2764,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   upgrade-stale-sandbox:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',upgrade-stale-sandbox,') || contains(format(',{0},', inputs.targets), ',upgrade-stale-sandbox,') }}
@@ -2975,36 +2790,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-upgrade-stale-sandbox" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3057,10 +2843,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   double-onboard:
     needs: generate-matrix
@@ -3080,31 +2864,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3151,6 +2911,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   jetson-nvmap-gpu:
     needs: generate-matrix
     # Explicit-only until a stable Jetson runner is available; otherwise full-suite dispatches remain queued forever.
@@ -3163,7 +2928,6 @@ jobs:
       E2E_JOB: "1"
       E2E_DEFAULT_ENABLED: "0"
       E2E_TARGET_ID: "jetson-nvmap-gpu"
-      DOCKER_CONFIG: ${{ github.workspace }}/.docker-config-jetson-nvmap-gpu
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/jetson-nvmap-gpu
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_LIVE_E2E: "1"
@@ -3178,33 +2942,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3253,10 +2991,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   concurrent-gateway-ports:
     needs: generate-matrix
@@ -3276,31 +3012,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3347,6 +3059,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   onboard-resume:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',onboard-resume,') || contains(format(',{0},', inputs.targets), ',onboard-resume,') }}
@@ -3365,6 +3082,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3409,6 +3128,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   full-e2e:
     # Keep the load-sensitive agent-mediated proof out of the peak hosted
     # lifecycle burst. always() preserves targeted dispatch when the
@@ -3431,6 +3155,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3477,6 +3203,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   security-posture:
     permissions:
       contents: read
@@ -3518,6 +3249,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - *dockerhub-auth
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -3553,6 +3286,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   cloud-onboard:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',cloud-onboard,') || contains(format(',{0},', inputs.targets), ',cloud-onboard,') }}
@@ -3573,6 +3311,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Configure cloud-onboard trace directory
         shell: bash
@@ -3652,6 +3392,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   gpu-double-onboard:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',gpu-double-onboard,') || contains(format(',{0},', inputs.targets), ',gpu-double-onboard,') }}
@@ -3672,6 +3417,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3716,6 +3463,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   onboard-repair:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',onboard-repair,') || contains(format(',{0},', inputs.targets), ',onboard-repair,') }}
@@ -3734,6 +3486,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3778,6 +3532,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   issue-4462-scope-upgrade-approval:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',issue-4462-scope-upgrade-approval,') || contains(format(',{0},', inputs.targets), ',issue-4462-scope-upgrade-approval,') }}
@@ -3797,6 +3556,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3843,6 +3604,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   token-rotation:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',token-rotation,') || contains(format(',{0},', inputs.targets), ',token-rotation,') }}
@@ -3859,31 +3625,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3927,6 +3669,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   messaging-compatible-endpoint:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',messaging-compatible-endpoint,') || contains(format(',{0},', inputs.targets), ',messaging-compatible-endpoint,') }}
@@ -3944,6 +3691,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -3981,6 +3730,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   openshell-gateway-upgrade:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',openshell-gateway-upgrade,') || contains(format(',{0},', inputs.targets), ',openshell-gateway-upgrade,') }}
@@ -4001,34 +3755,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openshell-gateway-upgrade" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4069,9 +3796,7 @@ jobs:
       - name: Clean up Docker auth
         if: always()
         shell: bash
-        run: |
-          docker logout docker.io >/dev/null 2>&1 || true
-          rm -rf "${DOCKER_CONFIG}"
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   messaging-providers:
     needs: generate-matrix
@@ -4093,31 +3818,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4163,6 +3864,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   launchable-smoke:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',launchable-smoke,') || contains(format(',{0},', inputs.targets), ',launchable-smoke,') }}
@@ -4187,31 +3893,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4243,6 +3925,12 @@ jobs:
           retention-days: 14
 
   # Provider-routed Model Router inference contract.
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   model-router-provider-routed-inference:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',model-router-provider-routed-inference,') || contains(format(',{0},', inputs.targets), ',model-router-provider-routed-inference,') }}
@@ -4260,36 +3948,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-model-router-provider-routed-inference" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4327,10 +3986,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   snapshot-commands:
     needs: generate-matrix
@@ -4352,36 +4009,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-snapshot-commands" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4416,10 +4044,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   sandbox-operations:
     needs: generate-matrix
@@ -4446,6 +4072,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4474,37 +4102,6 @@ jobs:
             -u GITHUB_TOKEN \
             bash scripts/install-openshell.sh
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-sandbox-operations" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
-
       - name: Run sandbox operations live test
         env:
           NVIDIA_INFERENCE_API_KEY: ${{ secrets.NVIDIA_INFERENCE_API_KEY }}
@@ -4527,10 +4124,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   sandbox-survival:
     needs: generate-matrix
@@ -4540,7 +4135,6 @@ jobs:
     env:
       E2E_JOB: "1"
       E2E_TARGET_ID: "sandbox-survival"
-      DOCKER_CONFIG: ${{ github.workspace }}/.docker-config-sandbox-survival
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/sandbox-survival
       NEMOCLAW_RUN_LIVE_E2E: "1"
       NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
@@ -4553,33 +4147,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4618,10 +4186,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   diagnostics:
     needs: generate-matrix
@@ -4643,6 +4209,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4676,6 +4244,11 @@ jobs:
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   gateway-drift-preflight:
     needs: generate-matrix
@@ -4752,31 +4325,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4819,6 +4368,12 @@ jobs:
   # First failing-test-first guard for #2701 (gateway recovery does not
   # restore the /tmp guard chain after pod recreate). Will fail on `main`
   # until the #2701 fix lands; flips green afterwards.
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   gateway-guard-recovery:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',gateway-guard-recovery,') || contains(format(',{0},', inputs.targets), ',gateway-guard-recovery,') }}
@@ -4846,6 +4401,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -4904,6 +4461,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
+
   openclaw-inference-switch:
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',openclaw-inference-switch,') || contains(format(',{0},', inputs.targets), ',openclaw-inference-switch,') }}
@@ -4948,6 +4510,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - *dockerhub-auth
+
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
@@ -4959,41 +4523,6 @@ jobs:
 
       - name: Build CLI
         run: npm run build:cli
-
-      - name: Configure isolated Docker auth directory
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker_config="${RUNNER_TEMP}/docker-config-openclaw-inference-switch-${{ matrix.mode }}"
-          mkdir -p "${docker_config}"
-          chmod 700 "${docker_config}"
-          echo "DOCKER_CONFIG=${docker_config}" >> "${GITHUB_ENV}"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
 
       - name: Run OpenClaw inference switch live test
         # Preserves
@@ -5008,15 +4537,6 @@ jobs:
             test/e2e/live/openclaw-inference-switch.test.ts \
             --silent=false --reporter=default
 
-      - name: Clean up Docker auth
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker_config="${DOCKER_CONFIG:-${RUNNER_TEMP}/docker-config-openclaw-inference-switch-${{ matrix.mode }}}"
-          DOCKER_CONFIG="${docker_config}" docker logout docker.io >/dev/null 2>&1 || true
-          rm -rf "${docker_config}"
-
       - name: Upload OpenClaw inference switch artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -5026,6 +4546,11 @@ jobs:
           include-hidden-files: false
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Clean up Docker auth
+        if: always()
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   # Bedrock Runtime compatible Anthropic endpoint contract.
   bedrock-runtime-compatible-anthropic:
@@ -5054,36 +4579,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-bedrock-runtime-compatible-anthropic-${{ matrix.agent }}" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5121,10 +4617,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   gateway-health-honest:
     needs: generate-matrix
@@ -5201,36 +4695,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-device-auth-health" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5278,10 +4743,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   channels-add-remove:
     needs: generate-matrix
@@ -5291,7 +4754,6 @@ jobs:
     env:
       E2E_JOB: "1"
       E2E_TARGET_ID: "channels-add-remove"
-      DOCKER_CONFIG: ${{ github.workspace }}/.docker-config-channels-add-remove
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/channels-add-remove
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_LIVE_E2E: "1"
@@ -5310,33 +4772,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5398,10 +4834,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   telegram-injection:
     needs: generate-matrix
@@ -5424,36 +4858,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-telegram-injection" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5510,10 +4915,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   channels-stop-start:
     needs: generate-matrix
@@ -5527,7 +4930,6 @@ jobs:
     env:
       E2E_JOB: "1"
       E2E_TARGET_ID: "channels-stop-start"
-      DOCKER_CONFIG: ${{ github.workspace }}/.docker-config-channels-stop-start-${{ matrix.agent }}
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live/channels-stop-start/${{ matrix.agent }}
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_LIVE_E2E: "1"
@@ -5543,20 +4945,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin || echo "::warning::Docker Hub login failed; continuing with anonymous pulls."
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5618,10 +5007,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   openclaw-slack-pairing:
     needs: generate-matrix
@@ -5644,25 +5031,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: |
-          set -euo pipefail
-          echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-slack-pairing" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin || echo "::warning::Docker Hub login failed; continuing with anonymous pulls."
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5719,10 +5088,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   issue-2478-crash-loop-recovery:
     needs: generate-matrix
@@ -5744,36 +5111,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-issue-2478-crash-loop-recovery" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5822,10 +5160,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   openclaw-discord-pairing:
     needs: generate-matrix
@@ -5848,36 +5184,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-discord-pairing" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -5933,10 +5240,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   tunnel-lifecycle:
     needs: generate-matrix
@@ -5959,36 +5264,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-tunnel-lifecycle" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::notice::Docker Hub credentials not configured; continuing with anonymous pulls."
-            exit 0
-          fi
-          mkdir -p "${DOCKER_CONFIG}"
-          chmod 700 "${DOCKER_CONFIG}"
-          login_succeeded=0
-          for attempt in 1 2 3; do
-            if echo "${DOCKERHUB_TOKEN}" | timeout 30s docker login docker.io --username "${DOCKERHUB_USERNAME}" --password-stdin; then
-              login_succeeded=1
-              break
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "::warning::Docker Hub login attempt ${attempt} failed; retrying."
-              sleep 5
-            fi
-          done
-          if [[ "$login_succeeded" -ne 1 ]]; then
-            echo "::warning::Docker Hub login failed after 3 attempts; continuing with anonymous pulls."
-          fi
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -6055,10 +5331,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          docker logout docker.io || true
-          rm -rf "${DOCKER_CONFIG}"
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   spark-install:
     needs: generate-matrix
@@ -6083,18 +5357,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure isolated Docker auth directory
-        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-spark-install" >> "$GITHUB_ENV"
-
-      - name: Authenticate to Docker Hub
-        if: github.ref == 'refs/heads/main'
-        # Authentication only accelerates pulls; anonymous pulls remain valid.
-        continue-on-error: true
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - *dockerhub-auth
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
@@ -6130,12 +5393,8 @@ jobs:
 
       - name: Clean up Docker auth
         if: always()
-        run: |
-          set -euo pipefail
-          if [[ -n "${DOCKER_CONFIG:-}" && "${DOCKER_CONFIG}" == "${RUNNER_TEMP}/docker-config-spark-install" ]]; then
-            docker logout docker.io || true
-            rm -rf -- "${DOCKER_CONFIG}"
-          fi
+        shell: bash
+        run: bash .github/scripts/docker-auth-cleanup.sh
 
   # ── Scheduled failure routing ──────────────────────────────────────────────
   notify-on-failure:

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -36,39 +36,28 @@ describe("release gate workflow resource contracts", () => {
     expect(liveTest).toContain("timeoutMs: 55 * 60_000");
   });
 
-  it("authenticates Spark image pulls with an isolated Docker config", () => {
+  it("authenticates Spark image pulls through the shared guarded steps", () => {
     const steps = e2eWorkflow.jobs["spark-install"].steps ?? [];
     const stepIndex = (name: string) => steps.findIndex((step) => step.name === name);
-    const configure = steps.find(
-      (step) => step.name === "Configure isolated Docker auth directory",
-    );
     const auth = steps.find((step) => step.name === "Authenticate to Docker Hub");
     const cleanup = steps.find((step) => step.name === "Clean up Docker auth");
 
-    expect(configure?.run).toBe(
-      'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-spark-install" >> "$GITHUB_ENV"',
+    expect(steps.some((step) => step.name === "Configure isolated Docker auth directory")).toBe(
+      false,
     );
-    expect(auth?.uses).toBe("docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee");
-    expect(auth?.if).toBe("github.ref == 'refs/heads/main'");
-    expect(auth?.["continue-on-error"]).toBe(true);
-    expect(auth?.with).toMatchObject({
-      registry: "docker.io",
-      username: "${{ secrets.DOCKERHUB_USERNAME }}",
-      password: "${{ secrets.DOCKERHUB_TOKEN }}",
-    });
-    expect(auth?.env).toBeUndefined();
-    expect(auth?.run).toBeUndefined();
-    expect(stepIndex("Configure isolated Docker auth directory")).toBeLessThan(
-      stepIndex("Authenticate to Docker Hub"),
-    );
+    expect(auth?.uses).toBeUndefined();
+    expect(auth?.if).toBeUndefined();
+    expect(auth?.["continue-on-error"]).toBeUndefined();
+    expect(auth?.env).toHaveProperty("DOCKERHUB_AUTH_REQUIRED");
+    expect(auth?.run).toEqual(expect.any(String));
+    expect(stepIndex("Authenticate to Docker Hub")).toBeLessThan(stepIndex("Set up Node"));
     expect(stepIndex("Authenticate to Docker Hub")).toBeLessThan(
       stepIndex("Run Spark install live test"),
     );
     expect(cleanup?.if).toBe("always()");
-    expect(cleanup?.run).toContain(
-      '"${DOCKER_CONFIG}" == "${RUNNER_TEMP}/docker-config-spark-install"',
+    expect(cleanup?.run).toBe("bash .github/scripts/docker-auth-cleanup.sh");
+    expect(stepIndex("Run Spark install live test")).toBeLessThan(
+      stepIndex("Clean up Docker auth"),
     );
-    expect(cleanup?.run).toContain("docker logout docker.io || true");
-    expect(cleanup?.run).toContain('rm -rf -- "${DOCKER_CONFIG}"');
   });
 });

--- a/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
+++ b/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
@@ -164,6 +164,21 @@ describe("shared Docker Hub authentication workflow boundary", () => {
     );
   });
 
+  it("rejects step-level Docker config overrides outside the canonical auth step", () => {
+    const errors = validateMutation((workflow) => {
+      const run = namedStep(workflow.jobs["runtime-overrides"], "Run runtime overrides live test");
+      expect(run).toBeDefined();
+      run!.env = {
+        ...run!.env,
+        DOCKER_CONFIG: "${{ runner.temp }}/alternate-docker-config",
+      };
+    });
+
+    expect(errors).toContain(
+      "runtime-overrides step 'Run runtime overrides live test' env must not include DOCKER_CONFIG",
+    );
+  });
+
   it("rejects trust, isolation, retry, password, and cleanup mapping drift", () => {
     const errors = validateMutation((workflow) => {
       const auth = namedStep(workflow.jobs.live, AUTH_STEP_NAME);

--- a/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
+++ b/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
@@ -1,0 +1,540 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { validateE2eWorkflowBoundary } from "../../../tools/e2e/workflow-boundary.mts";
+import { readWorkflow } from "../../helpers/e2e-workflow-contract";
+
+const NO_IMAGE_E2E_JOBS = [
+  "docs-validation",
+  "gateway-drift-preflight",
+  "gateway-health-honest",
+  "inference-routing",
+  "onboard-negative-paths",
+  "openshell-version-pin",
+] as const;
+const AUTH_STEP_NAME = "Authenticate to Docker Hub";
+const CLEANUP_STEP_NAME = "Clean up Docker auth";
+const CLEANUP_HELPER_RUN = "bash .github/scripts/docker-auth-cleanup.sh";
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CLEANUP_HELPER_PATH = path.join(REPO_ROOT, ".github", "scripts", "docker-auth-cleanup.sh");
+const EXPECTED_CLEANUP_STEP = {
+  name: CLEANUP_STEP_NAME,
+  if: "always()",
+  shell: "bash",
+  run: CLEANUP_HELPER_RUN,
+};
+
+type WorkflowStep = Record<string, unknown> & {
+  env?: Record<string, unknown>;
+  name?: string;
+  run?: string;
+  uses?: string;
+};
+
+type WorkflowJob = {
+  env?: Record<string, unknown>;
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  jobs: Record<string, WorkflowJob>;
+};
+
+function loadWorkflow(): Workflow {
+  return readWorkflow() as Workflow;
+}
+
+function imageJobNames(workflow: Workflow): string[] {
+  return [
+    "live",
+    ...Object.entries(workflow.jobs)
+      .filter(
+        ([jobName, job]) =>
+          job.env?.E2E_JOB === "1" &&
+          !NO_IMAGE_E2E_JOBS.includes(jobName as (typeof NO_IMAGE_E2E_JOBS)[number]),
+      )
+      .map(([jobName]) => jobName),
+  ];
+}
+
+function namedStep(job: WorkflowJob, name: string): WorkflowStep | undefined {
+  return job.steps?.find((step) => step.name === name);
+}
+
+function validateMutation(mutate: (workflow: Workflow) => void): string[] {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-auth-workflow-"));
+  const workflowPath = path.join(directory, "workflow.yaml");
+  try {
+    const workflow = loadWorkflow();
+    mutate(workflow);
+    fs.writeFileSync(workflowPath, YAML.stringify(workflow));
+    return validateE2eWorkflowBoundary(workflowPath);
+  } finally {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function writeExecutable(filePath: string, source: string): void {
+  fs.writeFileSync(filePath, source);
+  fs.chmodSync(filePath, 0o755);
+}
+
+describe("shared Docker Hub authentication workflow boundary", () => {
+  it("reuses one auth alias and one explicit audited cleanup step across every image job", () => {
+    const workflow = loadWorkflow();
+    const requiredJobs = imageJobNames(workflow);
+    const canonicalAuth = namedStep(workflow.jobs.live, AUTH_STEP_NAME);
+    const cleanupSteps: WorkflowStep[] = [];
+
+    expect(requiredJobs.length).toBeGreaterThan(50);
+    expect(requiredJobs).toEqual(
+      expect.arrayContaining([
+        "live",
+        "diagnostics",
+        "hermes-root-entrypoint-smoke",
+        "hermes-sandbox-secret-boundary",
+        "messaging-compatible-endpoint",
+        "openshell-gateway-auth-contract",
+        "runtime-overrides",
+      ]),
+    );
+    expect(canonicalAuth).toBeDefined();
+
+    for (const jobName of requiredJobs) {
+      const job = workflow.jobs[jobName];
+      expect(job, jobName).toBeDefined();
+      expect(
+        job.steps?.filter((step) => step.name === AUTH_STEP_NAME),
+        `${jobName} auth steps`,
+      ).toHaveLength(1);
+      expect(
+        job.steps?.filter((step) => step.name === CLEANUP_STEP_NAME),
+        `${jobName} cleanup steps`,
+      ).toHaveLength(1);
+      expect(namedStep(job, AUTH_STEP_NAME), `${jobName} auth alias`).toBe(canonicalAuth);
+      const cleanup = namedStep(job, CLEANUP_STEP_NAME);
+      expect(cleanup, `${jobName} cleanup mapping`).toEqual(EXPECTED_CLEANUP_STEP);
+      cleanupSteps.push(cleanup!);
+
+      const checkoutIndex =
+        job.steps?.findIndex((step) => String(step.uses ?? "").startsWith("actions/checkout@")) ??
+        -1;
+      const authIndex = job.steps?.findIndex((step) => step.name === AUTH_STEP_NAME) ?? -1;
+      const cleanupIndex = job.steps?.findIndex((step) => step.name === CLEANUP_STEP_NAME) ?? -1;
+      expect(authIndex, `${jobName} auth order`).toBe(checkoutIndex + 1);
+      expect(cleanupIndex, `${jobName} cleanup order`).toBe((job.steps?.length ?? 0) - 1);
+    }
+    expect(new Set(cleanupSteps).size, "cleanup steps must not consume the YAML alias budget").toBe(
+      requiredJobs.length,
+    );
+
+    for (const jobName of NO_IMAGE_E2E_JOBS) {
+      expect(namedStep(workflow.jobs[jobName], AUTH_STEP_NAME), jobName).toBeUndefined();
+      expect(namedStep(workflow.jobs[jobName], CLEANUP_STEP_NAME), jobName).toBeUndefined();
+    }
+  });
+
+  it("rejects missing auth and cleanup coverage for every classified image job", () => {
+    const workflow = loadWorkflow();
+    const requiredJobs = imageJobNames(workflow);
+    const errors = validateMutation((mutatedWorkflow) => {
+      for (const jobName of requiredJobs) {
+        mutatedWorkflow.jobs[jobName].steps = mutatedWorkflow.jobs[jobName].steps?.filter(
+          (step) => step.name !== AUTH_STEP_NAME && step.name !== CLEANUP_STEP_NAME,
+        );
+      }
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining(
+        requiredJobs.flatMap((jobName) => [
+          `${jobName} image-consuming job must have exactly one Docker Hub auth step`,
+          `${jobName} image-consuming job must have exactly one Docker Hub cleanup step`,
+        ]),
+      ),
+    );
+  });
+
+  it("rejects trust, isolation, retry, password, and cleanup mapping drift", () => {
+    const errors = validateMutation((workflow) => {
+      const auth = namedStep(workflow.jobs.live, AUTH_STEP_NAME);
+      const cleanup = namedStep(workflow.jobs.live, CLEANUP_STEP_NAME);
+      expect(auth).toBeDefined();
+      expect(cleanup).toBeDefined();
+
+      auth!.if = "github.event_name == 'schedule'";
+      auth!.env = {
+        ...auth!.env,
+        DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
+      };
+      auth!.run = String(auth!.run)
+        .replace(
+          "${RUNNER_TEMP}/docker-config-${GITHUB_JOB}-XXXXXX",
+          "${GITHUB_WORKSPACE}/docker-config",
+        )
+        .replace("for attempt in 1 2 3; do", "for attempt in 1 2; do")
+        .replace(
+          'auth_marker="${DOCKER_CONFIG}/.nemoclaw-docker-login-attempted"',
+          'auth_marker="${GITHUB_WORKSPACE}/login-attempted"',
+        )
+        .replace(': > "${auth_marker}"', 'touch "${auth_marker}"')
+        .replace('chmod 600 "${auth_marker}"', 'chmod 644 "${auth_marker}"')
+        .replace("--password-stdin", '--password "${DOCKERHUB_TOKEN}"')
+        .replaceAll("exit 1", "exit 0");
+
+      cleanup!.if = "success()";
+      cleanup!.run = `${String(cleanup!.run)} || true`;
+      cleanup!.env = { DOCKER_CONFIG: "${{ github.workspace }}/docker-config" };
+
+      const runtimeSteps = workflow.jobs["runtime-overrides"].steps!;
+      const runtimeCleanupIndex = runtimeSteps.findIndex((step) => step.name === CLEANUP_STEP_NAME);
+      const [runtimeCleanup] = runtimeSteps.splice(runtimeCleanupIndex, 1);
+      runtimeSteps.splice(2, 0, runtimeCleanup);
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "canonical Docker Hub auth step must always run so untrusted refs receive an isolated empty Docker config",
+        "canonical Docker Hub auth must gate DOCKERHUB_USERNAME on the trusted repository, main ref, and scheduled/manual events",
+        'canonical Docker Hub auth run script must include mktemp -d "${RUNNER_TEMP}/docker-config-${GITHUB_JOB}-XXXXXX"',
+        "canonical Docker Hub auth directory must not use the checkout workspace",
+        "canonical Docker Hub auth run script must include for attempt in 1 2 3; do",
+        'canonical Docker Hub auth run script must include auth_marker="${DOCKER_CONFIG}/.nemoclaw-docker-login-attempted"',
+        'canonical Docker Hub auth run script must include : > "${auth_marker}"',
+        'canonical Docker Hub auth run script must include chmod 600 "${auth_marker}"',
+        "canonical Docker Hub auth must create and protect its login-attempt marker after trusted credential validation and before login",
+        "canonical Docker Hub auth run script must include --password-stdin",
+        "canonical Docker Hub auth must pass the token only through --password-stdin",
+        "canonical Docker Hub auth must fail when trusted credentials are missing",
+        "canonical Docker Hub auth must fail after exhausting login retries",
+        "live Docker Hub cleanup step must contain exactly name, if, shell, and run",
+        "live Docker Hub cleanup step must always run",
+        `live Docker Hub cleanup step must run only ${CLEANUP_HELPER_RUN}`,
+        "runtime-overrides Docker Hub cleanup must be the final job step",
+      ]),
+    );
+  });
+
+  it("rejects uniform unsafe cleanup drift without trusting the live job as canonical", () => {
+    const workflow = loadWorkflow();
+    const requiredJobs = imageJobNames(workflow);
+    const errors = validateMutation((mutatedWorkflow) => {
+      for (const jobName of requiredJobs) {
+        const cleanup = namedStep(mutatedWorkflow.jobs[jobName], CLEANUP_STEP_NAME)!;
+        cleanup.run = `${CLEANUP_HELPER_RUN} || true`;
+        cleanup["continue-on-error"] = true;
+      }
+    });
+
+    for (const jobName of requiredJobs) {
+      expect(errors).toContain(
+        `${jobName} Docker Hub cleanup step must contain exactly name, if, shell, and run`,
+      );
+      expect(errors).toContain(
+        `${jobName} Docker Hub cleanup step must run only ${CLEANUP_HELPER_RUN}`,
+      );
+    }
+  });
+
+  it("treats every new E2E job as image-consuming unless it is explicitly exempt", () => {
+    const errors = validateMutation((workflow) => {
+      workflow.jobs["future-image-job"] = {
+        env: { E2E_JOB: "1", E2E_TARGET_ID: "future-image-job" },
+        steps: [{ uses: "actions/checkout@0000000000000000000000000000000000000000" }],
+      };
+    });
+
+    expect(errors).toContain(
+      "future-image-job image-consuming job must have exactly one Docker Hub auth step",
+    );
+    expect(errors).toContain(
+      "future-image-job image-consuming job must have exactly one Docker Hub cleanup step",
+    );
+  });
+
+  it("executes the shared auth script with isolated config and bounded fail-closed retries", () => {
+    const workflow = loadWorkflow();
+    const authScript = String(namedStep(workflow.jobs.live, AUTH_STEP_NAME)?.run ?? "");
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-auth-script-"));
+    const fakeBin = path.join(directory, "bin");
+    const runnerTemp = path.join(directory, "runner-temp");
+    const callsPath = path.join(directory, "docker-calls");
+    const tokensPath = path.join(directory, "docker-tokens");
+    const githubEnv = path.join(directory, "github-env");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(runnerTemp);
+    writeExecutable(
+      path.join(fakeBin, "timeout"),
+      '#!/usr/bin/env bash\nset -euo pipefail\n[[ "$1" == "30s" ]]\nshift\nexec "$@"\n',
+    );
+    writeExecutable(path.join(fakeBin, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+    writeExecutable(
+      path.join(fakeBin, "docker"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "\${DOCKER_CALLS}"
+cat >> "\${DOCKER_TOKENS}"
+printf '\\n' >> "\${DOCKER_TOKENS}"
+attempt="$(wc -l < "\${DOCKER_CALLS}")"
+if [[ "\${attempt}" -lt "\${DOCKER_SUCCESS_ATTEMPT}" ]]; then
+  exit 1
+fi
+`,
+    );
+
+    const runAuth = (options: {
+      authRequired: "0" | "1";
+      successAttempt: number;
+      token?: string;
+      username?: string;
+    }) => {
+      fs.rmSync(callsPath, { force: true });
+      fs.rmSync(tokensPath, { force: true });
+      fs.rmSync(githubEnv, { force: true });
+      return spawnSync("bash", ["-c", authScript], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DOCKER_CALLS: callsPath,
+          DOCKER_SUCCESS_ATTEMPT: String(options.successAttempt),
+          DOCKER_TOKENS: tokensPath,
+          DOCKERHUB_AUTH_REQUIRED: options.authRequired,
+          DOCKERHUB_TOKEN: options.token ?? "",
+          DOCKERHUB_USERNAME: options.username ?? "",
+          GITHUB_ENV: githubEnv,
+          GITHUB_JOB: "live",
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          RUNNER_TEMP: runnerTemp,
+        },
+      });
+    };
+
+    try {
+      const untrusted = runAuth({ authRequired: "0", successAttempt: 1 });
+      expect(untrusted.status).toBe(0);
+      expect(fs.existsSync(callsPath)).toBe(false);
+      const isolatedConfig = fs.readFileSync(githubEnv, "utf8").trim().split("=")[1];
+      expect(isolatedConfig.startsWith(`${runnerTemp}/docker-config-live-`)).toBe(true);
+      expect(fs.statSync(isolatedConfig).mode & 0o777).toBe(0o700);
+      expect(fs.existsSync(path.join(isolatedConfig, ".nemoclaw-docker-login-attempted"))).toBe(
+        false,
+      );
+
+      const retried = runAuth({
+        authRequired: "1",
+        successAttempt: 3,
+        token: "test-docker-token",
+        username: "test-user",
+      });
+      expect(retried.status, retried.stderr).toBe(0);
+      const authenticatedConfig = fs.readFileSync(githubEnv, "utf8").trim().split("=")[1];
+      const authMarker = path.join(authenticatedConfig, ".nemoclaw-docker-login-attempted");
+      expect(fs.existsSync(authMarker)).toBe(true);
+      expect(fs.statSync(authMarker).mode & 0o777).toBe(0o600);
+      expect(fs.readFileSync(callsPath, "utf8").trim().split("\n")).toHaveLength(3);
+      expect(fs.readFileSync(callsPath, "utf8")).toContain("--password-stdin");
+      expect(fs.readFileSync(callsPath, "utf8")).not.toContain("test-docker-token");
+      expect(fs.readFileSync(tokensPath, "utf8").trim().split("\n")).toEqual([
+        "test-docker-token",
+        "test-docker-token",
+        "test-docker-token",
+      ]);
+
+      const exhausted = runAuth({
+        authRequired: "1",
+        successAttempt: 4,
+        token: "test-docker-token",
+        username: "test-user",
+      });
+      expect(exhausted.status).toBe(1);
+      expect(fs.readFileSync(callsPath, "utf8").trim().split("\n")).toHaveLength(3);
+      expect(`${exhausted.stdout}${exhausted.stderr}`).toContain(
+        "Docker Hub login failed after 3 attempts",
+      );
+
+      const missing = runAuth({ authRequired: "1", successAttempt: 1 });
+      expect(missing.status).toBe(1);
+      expect(fs.existsSync(callsPath)).toBe(false);
+      expect(`${missing.stdout}${missing.stderr}`).toContain(
+        "Docker Hub credentials are required for trusted E2E runs",
+      );
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("runs the checked-in cleanup helper only for exact job-owned Docker configs", () => {
+    expect(fs.statSync(CLEANUP_HELPER_PATH).mode & 0o111).not.toBe(0);
+
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-cleanup-script-"));
+    const fakeBin = path.join(directory, "bin");
+    const runnerTemp = path.join(directory, "runner-temp");
+    const callsPath = path.join(directory, "docker-calls");
+    const sentinelPath = path.join(directory, "command-substitution-ran");
+    fs.mkdirSync(fakeBin);
+    fs.mkdirSync(runnerTemp);
+    writeExecutable(
+      path.join(fakeBin, "timeout"),
+      '#!/usr/bin/env bash\nset -euo pipefail\n[[ "${1:-}" == "30s" ]]\nshift\nexec "$@"\n',
+    );
+    writeExecutable(
+      path.join(fakeBin, "docker"),
+      '#!/usr/bin/env bash\nset -euo pipefail\nprintf \'%s\\n\' "$*" >> "${DOCKER_CALLS}"\nexit "${DOCKER_EXIT_CODE:-0}"\n',
+    );
+
+    const createConfig = (name: string): string => {
+      const dockerConfig = path.join(runnerTemp, name);
+      fs.mkdirSync(dockerConfig, { recursive: true });
+      fs.writeFileSync(path.join(dockerConfig, "config.json"), "{}\n");
+      const authMarker = path.join(dockerConfig, ".nemoclaw-docker-login-attempted");
+      fs.writeFileSync(authMarker, "");
+      fs.chmodSync(authMarker, 0o600);
+      return dockerConfig;
+    };
+    const runCleanup = (options: {
+      dockerConfig?: string;
+      dockerExitCode?: number;
+      githubJob?: string;
+      runnerTemp?: string;
+    }) => {
+      fs.rmSync(callsPath, { force: true });
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        DOCKER_CALLS: callsPath,
+        DOCKER_EXIT_CODE: String(options.dockerExitCode ?? 0),
+        GITHUB_JOB: options.githubJob ?? "live",
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        RUNNER_TEMP: options.runnerTemp ?? runnerTemp,
+      };
+      if (options.dockerConfig === undefined) {
+        delete env.DOCKER_CONFIG;
+      } else {
+        env.DOCKER_CONFIG = options.dockerConfig;
+      }
+      return spawnSync(CLEANUP_HELPER_PATH, [], {
+        encoding: "utf8",
+        env,
+      });
+    };
+    const expectRefused = (options: Parameters<typeof runCleanup>[0]) => {
+      const result = runCleanup(options);
+      expect(result.status, `${result.stdout}${result.stderr}`).toBe(1);
+      expect(fs.existsSync(callsPath)).toBe(false);
+      return result;
+    };
+
+    try {
+      const empty = runCleanup({});
+      expect(empty.status, empty.stderr).toBe(0);
+      expect(fs.existsSync(callsPath)).toBe(false);
+
+      const absentConfig = path.join(runnerTemp, "docker-config-live-Ab12Cd");
+      const absent = runCleanup({ dockerConfig: absentConfig });
+      expect(absent.status, absent.stderr).toBe(0);
+      expect(fs.existsSync(callsPath)).toBe(false);
+
+      const anonymousConfig = path.join(runnerTemp, "docker-config-live-Cd34Ef");
+      fs.mkdirSync(anonymousConfig);
+      const anonymous = runCleanup({ dockerConfig: anonymousConfig });
+      expect(anonymous.status, anonymous.stderr).toBe(0);
+      expect(fs.existsSync(anonymousConfig)).toBe(false);
+      expect(fs.existsSync(callsPath)).toBe(false);
+
+      const validConfig = createConfig("docker-config-live-Ef34Gh");
+      const valid = runCleanup({ dockerConfig: validConfig });
+      expect(valid.status, valid.stderr).toBe(0);
+      expect(fs.existsSync(validConfig)).toBe(false);
+      expect(fs.readFileSync(callsPath, "utf8")).toContain(
+        `--config ${validConfig} logout docker.io`,
+      );
+
+      const outsideConfig = path.join(directory, "docker-config-live-Ij56Kl");
+      fs.mkdirSync(outsideConfig);
+      expectRefused({ dockerConfig: outsideConfig });
+      expect(fs.existsSync(outsideConfig)).toBe(true);
+
+      const prefixCollision = path.join(`${runnerTemp}-other`, "docker-config-live-Mn78Op");
+      fs.mkdirSync(prefixCollision, { recursive: true });
+      expectRefused({ dockerConfig: prefixCollision });
+      expect(fs.existsSync(prefixCollision)).toBe(true);
+
+      const traversalTarget = path.join(directory, "traversal-target");
+      fs.mkdirSync(traversalTarget);
+      const traversalConfig = `${runnerTemp}/docker-config-live-Qr90St/../../traversal-target`;
+      expectRefused({ dockerConfig: traversalConfig });
+      expect(fs.existsSync(traversalTarget)).toBe(true);
+
+      const wrongJobConfig = createConfig("docker-config-other-Uv12Wx");
+      expectRefused({ dockerConfig: wrongJobConfig });
+      expect(fs.existsSync(wrongJobConfig)).toBe(true);
+
+      const malformedSuffixConfig = createConfig("docker-config-live-short");
+      expectRefused({ dockerConfig: malformedSuffixConfig });
+      expect(fs.existsSync(malformedSuffixConfig)).toBe(true);
+
+      const symlinkTarget = path.join(directory, "symlink-target");
+      fs.mkdirSync(symlinkTarget);
+      const configSymlink = path.join(runnerTemp, "docker-config-live-Yz34Ab");
+      fs.symlinkSync(symlinkTarget, configSymlink);
+      expectRefused({ dockerConfig: configSymlink });
+      expect(fs.existsSync(configSymlink)).toBe(true);
+      expect(fs.existsSync(symlinkTarget)).toBe(true);
+
+      const configFileTarget = path.join(directory, "external-config.json");
+      fs.writeFileSync(configFileTarget, '{"auths":{"docker.io":{}}}\n');
+      const configFileSymlinkDir = path.join(runnerTemp, "docker-config-live-Cd56Ef");
+      fs.mkdirSync(configFileSymlinkDir);
+      const configFileSymlinkMarker = path.join(
+        configFileSymlinkDir,
+        ".nemoclaw-docker-login-attempted",
+      );
+      fs.writeFileSync(configFileSymlinkMarker, "");
+      fs.chmodSync(configFileSymlinkMarker, 0o600);
+      fs.symlinkSync(configFileTarget, path.join(configFileSymlinkDir, "config.json"));
+      const configFileSymlink = runCleanup({ dockerConfig: configFileSymlinkDir });
+      expect(configFileSymlink.status).toBe(1);
+      expect(fs.existsSync(configFileSymlinkDir)).toBe(false);
+      expect(fs.readFileSync(configFileTarget, "utf8")).toContain("docker.io");
+      expect(fs.existsSync(callsPath)).toBe(false);
+
+      const markerTarget = path.join(directory, "external-login-marker");
+      fs.writeFileSync(markerTarget, "preserve me\n");
+      const markerSymlinkDir = path.join(runnerTemp, "docker-config-live-Ef67Gh");
+      fs.mkdirSync(markerSymlinkDir);
+      fs.writeFileSync(path.join(markerSymlinkDir, "config.json"), "{}\n");
+      fs.symlinkSync(markerTarget, path.join(markerSymlinkDir, ".nemoclaw-docker-login-attempted"));
+      const markerSymlink = runCleanup({ dockerConfig: markerSymlinkDir });
+      expect(markerSymlink.status).toBe(1);
+      expect(fs.existsSync(markerSymlinkDir)).toBe(false);
+      expect(fs.readFileSync(markerTarget, "utf8")).toBe("preserve me\n");
+      expect(fs.existsSync(callsPath)).toBe(false);
+
+      const metacharConfig = `${runnerTemp}/docker-config-live-$(touch ${sentinelPath})`;
+      expectRefused({ dockerConfig: metacharConfig });
+      expect(fs.existsSync(sentinelPath)).toBe(false);
+
+      const logoutFailureConfig = createConfig("docker-config-live-Gh78Ij");
+      const logoutFailure = runCleanup({
+        dockerConfig: logoutFailureConfig,
+        dockerExitCode: 42,
+      });
+      expect(logoutFailure.status).toBe(1);
+      expect(fs.existsSync(logoutFailureConfig)).toBe(false);
+      expect(fs.readFileSync(callsPath, "utf8")).toContain(
+        `--config ${logoutFailureConfig} logout docker.io`,
+      );
+      expect(`${logoutFailure.stdout}${logoutFailure.stderr}`).toContain("Docker logout failed");
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
+++ b/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
@@ -415,11 +415,11 @@ fi
         PATH: `${fakeBin}:${process.env.PATH}`,
         RUNNER_TEMP: options.runnerTemp ?? runnerTemp,
       };
-      if (options.dockerConfig === undefined) {
-        delete env.DOCKER_CONFIG;
-      } else {
-        env.DOCKER_CONFIG = options.dockerConfig;
-      }
+      delete env.DOCKER_CONFIG;
+      Object.assign(
+        env,
+        options.dockerConfig === undefined ? {} : { DOCKER_CONFIG: options.dockerConfig },
+      );
       return spawnSync(CLEANUP_HELPER_PATH, [], {
         encoding: "utf8",
         env,

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -1057,10 +1057,6 @@ jobs:
       if (typeof step.uses === "string" && step.uses.startsWith("actions/checkout@")) {
         step.with = { ...(step.with as Record<string, unknown>), "persist-credentials": true };
       }
-      if (step.name === "Configure isolated Docker auth directory") {
-        step.run =
-          'echo "DOCKER_CONFIG=${{ github.workspace }}/.docker-config-shared" >> "$GITHUB_ENV"';
-      }
       if (step.name === "Set up Node") {
         step.env = { NVIDIA_INFERENCE_API_KEY: "${{ secrets.NVIDIA_INFERENCE_API_KEY }}" };
       }
@@ -1084,9 +1080,6 @@ jobs:
           "include-hidden-files": true,
         };
       }
-      if (step.name === "Clean up Docker auth") {
-        step.run = String(step.run).replace('rm -rf "${DOCKER_CONFIG}"', 'echo "missing cleanup"');
-      }
     }
     fs.writeFileSync(workflowPath, YAML.stringify(parsedWorkflow));
 
@@ -1095,7 +1088,6 @@ jobs:
         expect.arrayContaining([
           "snapshot-commands job must keep a 40 minute timeout",
           "snapshot-commands job must not set DOCKER_CONFIG at job level",
-          'step \'Configure isolated Docker auth directory\' run script must include echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-snapshot-commands" >> "$GITHUB_ENV"',
           "snapshot-commands checkout step must set persist-credentials=false",
           "snapshot-commands job env must not include NVIDIA_INFERENCE_API_KEY",
           "snapshot-commands step 'Set up Node' env must not include NVIDIA_INFERENCE_API_KEY",
@@ -1103,7 +1095,6 @@ jobs:
           "snapshot-commands step 'Install root dependencies' env must not include DOCKERHUB_TOKEN",
           "snapshot-commands artifact upload must set include-hidden-files: false",
           "artifact upload path must include e2e-artifacts/live/snapshot-commands/",
-          "step 'Clean up Docker auth' run script must include rm -rf \"${DOCKER_CONFIG}\"",
           "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
           "step 'Run snapshot commands live test' run script must include test/e2e/live/snapshot-commands.test.ts",
         ]),
@@ -1214,11 +1205,6 @@ jobs:
       "persist-credentials": true,
     };
 
-    const dockerAuthStep = job.steps.find((step) => step.name === "Authenticate to Docker Hub");
-    expect(dockerAuthStep).toBeDefined();
-    dockerAuthStep!.run =
-      "docker login docker.io --username user --password ${{ secrets.DOCKERHUB_TOKEN }}";
-
     const installRootStep = job.steps.find((step) => step.name === "Install root dependencies");
     expect(installRootStep).toBeDefined();
     installRootStep!.run = "npm install";
@@ -1250,10 +1236,6 @@ jobs:
       "retention-days": 1,
     };
 
-    const cleanupStep = job.steps.find((step) => step.name === "Clean up Docker auth");
-    expect(cleanupStep).toBeDefined();
-    delete cleanupStep!.if;
-    cleanupStep!.run = "docker logout docker.io";
     fs.writeFileSync(workflowPath, YAML.stringify(workflow));
 
     try {
@@ -1264,7 +1246,7 @@ jobs:
           "channels-stop-start strategy.fail-fast must be false",
           "channels-stop-start matrix.agent must be openclaw,hermes",
           "channels-stop-start job must derive NEMOCLAW_SANDBOX_NAME from matrix.agent with the e2e-channels-stop-start- prefix",
-          "channels-stop-start job must isolate Docker auth by matrix agent",
+          "channels-stop-start job env must not include DOCKER_CONFIG",
           "channels-stop-start job env must not include NVIDIA_INFERENCE_API_KEY",
           "channels-stop-start checkout step must set persist-credentials=false",
           "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
@@ -1276,8 +1258,6 @@ jobs:
           "channels-stop-start artifact upload name must include matrix.agent",
           "channels-stop-start artifact upload must set include-hidden-files: false",
           "channels-stop-start artifact upload retention-days must be 14",
-          "channels-stop-start Docker auth cleanup must always run",
-          "step 'Clean up Docker auth' run script must include rm -rf \"${DOCKER_CONFIG}\"",
         ]),
       );
     } finally {
@@ -1314,7 +1294,7 @@ jobs:
     }
   });
 
-  it("rejects Docker Hub auth in the messaging-compatible-endpoint job", () => {
+  it("rejects duplicate unguarded Docker Hub auth in messaging-compatible-endpoint", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-workflow-"));
     const workflowPath = path.join(tmp, "workflow.yaml");
     const workflow = readWorkflow() as {
@@ -1338,10 +1318,10 @@ jobs:
       const errors = validateE2eWorkflowBoundary(workflowPath);
       expect(errors).toEqual(
         expect.arrayContaining([
-          "messaging-compatible-endpoint must not authenticate to Docker Hub before branch-controlled test code runs",
+          "messaging-compatible-endpoint image-consuming job must have exactly one Docker Hub auth step",
           "messaging-compatible-endpoint step 'Authenticate to Docker Hub' env must not include DOCKERHUB_USERNAME",
           "messaging-compatible-endpoint step 'Authenticate to Docker Hub' env must not include DOCKERHUB_TOKEN",
-          "messaging-compatible-endpoint step 'Authenticate to Docker Hub' run script must not use docker login or inline secret interpolation",
+          "messaging-compatible-endpoint step 'Authenticate to Docker Hub' must not authenticate or interpolate Docker Hub secrets",
         ]),
       );
     } finally {
@@ -1419,12 +1399,13 @@ jobs:
       expect(errors).toEqual(
         expect.arrayContaining([
           "diagnostics job must not expose Docker auth to branch-controlled steps",
+          "diagnostics job env must not include DOCKER_CONFIG",
           "diagnostics job env must not include NVIDIA_INFERENCE_API_KEY",
           "diagnostics job env must not include GITHUB_TOKEN",
-          "diagnostics job must not authenticate to Docker Hub before branch-controlled test code runs",
+          "diagnostics image-consuming job must have exactly one Docker Hub auth step",
           "diagnostics step 'Authenticate to Docker Hub' env must not include DOCKERHUB_USERNAME",
           "diagnostics step 'Authenticate to Docker Hub' env must not include DOCKERHUB_TOKEN",
-          "diagnostics step 'Authenticate to Docker Hub' run script must not use docker login or inline secret interpolation",
+          "diagnostics step 'Authenticate to Docker Hub' must not authenticate or interpolate Docker Hub secrets",
           "step 'Run diagnostics live test' run script must not interpolate dispatch inputs directly",
           "diagnostics artifact upload must set include-hidden-files: false",
           "diagnostics artifact upload retention-days must be 14",
@@ -1435,7 +1416,7 @@ jobs:
     }
   });
 
-  it("rejects Docker Hub auth in the Hermes root-entrypoint smoke job", () => {
+  it("rejects duplicate unguarded Docker Hub auth in Hermes root-entrypoint smoke", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-workflow-"));
     const workflowPath = path.join(tmp, "workflow.yaml");
     const workflow = readWorkflow() as {
@@ -1459,10 +1440,10 @@ jobs:
       const errors = validateE2eWorkflowBoundary(workflowPath);
       expect(errors).toEqual(
         expect.arrayContaining([
-          "hermes-root-entrypoint-smoke must not authenticate to Docker Hub before branch-controlled test code runs",
+          "hermes-root-entrypoint-smoke image-consuming job must have exactly one Docker Hub auth step",
           "hermes-root-entrypoint-smoke step 'Authenticate to Docker Hub' env must not include DOCKERHUB_USERNAME",
           "hermes-root-entrypoint-smoke step 'Authenticate to Docker Hub' env must not include DOCKERHUB_TOKEN",
-          "hermes-root-entrypoint-smoke step 'Authenticate to Docker Hub' run script must not use docker login or inline secret interpolation",
+          "hermes-root-entrypoint-smoke step 'Authenticate to Docker Hub' must not authenticate or interpolate Docker Hub secrets",
         ]),
       );
     } finally {

--- a/test/e2e/support/hermes-secret-boundary-workflow.test.ts
+++ b/test/e2e/support/hermes-secret-boundary-workflow.test.ts
@@ -49,7 +49,7 @@ it("routes Hermes sandbox secret-boundary selective dispatch to its free-standin
   });
 });
 
-it("rejects Hermes sandbox secret-boundary workflow secret and Docker-auth drift", () => {
+it("rejects broad Hermes sandbox secret-boundary workflow secret scope", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-secret-boundary-workflow-"));
   const workflowPath = path.join(tmp, "workflow.yaml");
   const workflow = readWorkflow() as {
@@ -64,14 +64,6 @@ it("rejects Hermes sandbox secret-boundary workflow secret and Docker-auth drift
     DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
     DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}",
   };
-  job.steps.splice(1, 0, {
-    name: "Authenticate to Docker Hub",
-    env: {
-      DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
-      DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}",
-    },
-    run: "docker login docker.io --username $DOCKERHUB_USERNAME --password $DOCKERHUB_TOKEN",
-  });
   const runVitest = job.steps.find(
     (step) => step.name === "Run Hermes sandbox secret-boundary live test",
   );
@@ -87,10 +79,6 @@ it("rejects Hermes sandbox secret-boundary workflow secret and Docker-auth drift
         "hermes-sandbox-secret-boundary job env must not include NVIDIA_INFERENCE_API_KEY",
         "hermes-sandbox-secret-boundary job env must not include DOCKERHUB_USERNAME",
         "hermes-sandbox-secret-boundary job env must not include DOCKERHUB_TOKEN",
-        "hermes-sandbox-secret-boundary must not authenticate to Docker Hub before branch-controlled test code runs",
-        "hermes-sandbox-secret-boundary step 'Authenticate to Docker Hub' env must not include DOCKERHUB_USERNAME",
-        "hermes-sandbox-secret-boundary step 'Authenticate to Docker Hub' env must not include DOCKERHUB_TOKEN",
-        "hermes-sandbox-secret-boundary step 'Authenticate to Docker Hub' run script must not use docker login or inline secret interpolation",
         "hermes-sandbox-secret-boundary step 'Run Hermes sandbox secret-boundary live test' env must not include NVIDIA_INFERENCE_API_KEY",
       ]),
     );

--- a/test/e2e/support/inference-switch-workflow-boundary.test.ts
+++ b/test/e2e/support/inference-switch-workflow-boundary.test.ts
@@ -72,8 +72,28 @@ describe("inference switch workflow boundary", () => {
     );
     [steps[cleanupIndex], steps[uploadIndex]] = [steps[uploadIndex], steps[cleanupIndex]];
     expect(validateInferenceSwitchWorkflow(lingeringCredentials)).toContain(
-      "openclaw-inference-switch must build, authenticate, test, clean credentials, then upload",
+      "openclaw-inference-switch must authenticate, build, test, upload artifacts, then clean credentials",
     );
+  });
+
+  it("accepts shared guarded Docker authentication without mode-specific auth scripts", () => {
+    const workflow = readInferenceSwitchWorkflow();
+    const steps = workflow.jobs["openclaw-inference-switch"].steps!;
+    const configureIndex = steps.findIndex(
+      (step) => step.name === "Configure isolated Docker auth directory",
+    );
+    if (configureIndex >= 0) steps.splice(configureIndex, 1);
+
+    const authenticate = steps.find((step) => step.name === "Authenticate to Docker Hub")!;
+    const authIndex = steps.indexOf(authenticate);
+    steps.splice(authIndex, 1);
+    steps.splice(1, 0, authenticate);
+    authenticate.run = "shared guarded Docker Hub login";
+
+    const cleanup = steps.find((step) => step.name === "Clean up Docker auth")!;
+    cleanup.run = "shared guarded Docker auth cleanup";
+
+    expect(validateInferenceSwitchWorkflow(workflow)).toEqual([]);
   });
 
   it("keeps the mode ratchet in the central workflow check", () => {

--- a/test/e2e/support/inference-switch-workflow-boundary.test.ts
+++ b/test/e2e/support/inference-switch-workflow-boundary.test.ts
@@ -79,10 +79,9 @@ describe("inference switch workflow boundary", () => {
   it("accepts shared guarded Docker authentication without mode-specific auth scripts", () => {
     const workflow = readInferenceSwitchWorkflow();
     const steps = workflow.jobs["openclaw-inference-switch"].steps!;
-    const configureIndex = steps.findIndex(
-      (step) => step.name === "Configure isolated Docker auth directory",
+    expect(steps.some((step) => step.name === "Configure isolated Docker auth directory")).toBe(
+      false,
     );
-    if (configureIndex >= 0) steps.splice(configureIndex, 1);
 
     const authenticate = steps.find((step) => step.name === "Authenticate to Docker Hub")!;
     const authIndex = steps.indexOf(authenticate);

--- a/test/e2e/support/openclaw-slack-workflow-boundary.test.ts
+++ b/test/e2e/support/openclaw-slack-workflow-boundary.test.ts
@@ -37,11 +37,6 @@ describe("OpenClaw Slack pairing workflow boundary", () => {
       uses: string;
     };
     setupNode.uses = "actions/setup-node@v4";
-    const configureDockerAuth = slackJob.steps.find(
-      (step) => step.name === "Configure isolated Docker auth directory",
-    ) as Record<string, unknown>;
-    configureDockerAuth.run =
-      'echo "DOCKER_CONFIG=${{ github.workspace }}/.docker-config-openclaw-slack-pairing" >> "$GITHUB_ENV"';
     const installRootDependencies = slackJob.steps.find(
       (step) => step.name === "Install root dependencies",
     ) as Record<string, unknown>;
@@ -65,8 +60,6 @@ describe("OpenClaw Slack pairing workflow boundary", () => {
       expect(validateE2eWorkflowBoundary(workflowPath)).toEqual(
         expect.arrayContaining([
           "openclaw-slack-pairing job must not set DOCKER_CONFIG at job level",
-          'step \'Configure isolated Docker auth directory\' run script must include echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-slack-pairing" >> "$GITHUB_ENV"',
-          "step 'Configure isolated Docker auth directory' run script must not include ${{ github.workspace }}",
           "openclaw-slack-pairing checkout action must be pinned to a full commit SHA",
           "openclaw-slack-pairing checkout step must set persist-credentials=false",
           "openclaw-slack-pairing setup-node action must be pinned to a full commit SHA",

--- a/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
@@ -64,10 +64,9 @@ describe("sandbox operations workflow boundary", () => {
   it("accepts shared guarded Docker authentication without a job-specific configure step", () => {
     const workflow = readSandboxOperationsWorkflow();
     const steps = workflow.jobs["sandbox-operations"].steps!;
-    const configureIndex = steps.findIndex(
-      (step) => step.name === "Configure isolated Docker auth directory",
+    expect(steps.some((step) => step.name === "Configure isolated Docker auth directory")).toBe(
+      false,
     );
-    if (configureIndex >= 0) steps.splice(configureIndex, 1);
 
     const authenticate = steps.find((step) => step.name === "Authenticate to Docker Hub")!;
     authenticate.env = {

--- a/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
@@ -61,6 +61,43 @@ describe("sandbox operations workflow boundary", () => {
     );
   });
 
+  it("accepts shared guarded Docker authentication without a job-specific configure step", () => {
+    const workflow = readSandboxOperationsWorkflow();
+    const steps = workflow.jobs["sandbox-operations"].steps!;
+    const configureIndex = steps.findIndex(
+      (step) => step.name === "Configure isolated Docker auth directory",
+    );
+    if (configureIndex >= 0) steps.splice(configureIndex, 1);
+
+    const authenticate = steps.find((step) => step.name === "Authenticate to Docker Hub")!;
+    authenticate.env = {
+      DOCKERHUB_AUTH_REQUIRED:
+        "${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}",
+      DOCKERHUB_USERNAME:
+        "${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && secrets.DOCKERHUB_USERNAME || '' }}",
+      DOCKERHUB_TOKEN:
+        "${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && secrets.DOCKERHUB_TOKEN || '' }}",
+    };
+    authenticate.run = [
+      'docker_config="$(mktemp -d "${RUNNER_TEMP}/docker-config-${GITHUB_JOB}-XXXXXX")"',
+      'echo "DOCKER_CONFIG=${docker_config}" >> "$GITHUB_ENV"',
+      "echo shared guarded login",
+    ].join("\n");
+
+    const authIndex = steps.indexOf(authenticate);
+    steps.splice(authIndex, 1);
+    steps.splice(1, 0, authenticate);
+
+    const cleanup = steps.find((step) => step.name === "Clean up Docker auth")!;
+    cleanup.run = [
+      'docker_config="${DOCKER_CONFIG:-}"',
+      "docker logout docker.io >/dev/null 2>&1 || true",
+      'rm -rf -- "${docker_config}"',
+    ].join("\n");
+
+    expect(validateSandboxOperationsWorkflow(workflow)).toEqual([]);
+  });
+
   it("rejects workspace-scoped auth, unsanitized installs, and broad inference secrets", () => {
     const jobMarker = ['      E2E_JOB: "1"', '      E2E_TARGET_ID: "sandbox-operations"', ""].join(
       "\n",
@@ -197,19 +234,25 @@ describe("sandbox operations workflow boundary", () => {
       expected: "sandbox-operations step 'Build CLI' must not write persistent environment",
     },
     {
-      label: "workspace override in the configure step",
+      label: "a persistent workspace Docker config outside shared auth",
       mutate: (source: string) =>
-        mutateSandboxOperationsJob(source, (jobSource) =>
-          jobSource.replace(
-            '        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-sandbox-operations" >> "$GITHUB_ENV"',
+        mutateSandboxOperationsJob(source, (jobSource) => {
+          const buildMarker = "      - name: Build CLI\n";
+          expect(jobSource).toContain(buildMarker);
+          return jobSource.replace(
+            buildMarker,
             [
+              "      - name: Persist workspace Docker config",
               "        run: |",
-              '          echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-sandbox-operations" >> "$GITHUB_ENV"',
               '          echo "DOCKER_CONFIG=${{ github.workspace }}/docker" >> "$GITHUB_ENV"',
+              "",
+              buildMarker.trimEnd(),
+              "",
             ].join("\n"),
-          ),
-        ),
-      expected: "sandbox-operations Docker auth directory must not use the checkout workspace",
+          );
+        }),
+      expected:
+        "sandbox-operations step 'Persist workspace Docker config' must not write persistent environment",
     },
   ])("rejects $label", ({ expected, mutate }) => {
     expect(validateCentralWorkflowMutation(mutate)).toContain(expected);

--- a/test/e2e/support/tunnel-lifecycle-workflow-boundary.test.ts
+++ b/test/e2e/support/tunnel-lifecycle-workflow-boundary.test.ts
@@ -81,13 +81,6 @@ describe("tunnel lifecycle workflow boundary", () => {
       "persist-credentials": true,
     };
 
-    const configureDockerAuth = job.steps.find(
-      (step) => step.name === "Configure isolated Docker auth directory",
-    );
-    expect(configureDockerAuth).toBeDefined();
-    configureDockerAuth!.run =
-      'echo "DOCKER_CONFIG=${{ github.workspace }}/docker-config-tunnel-lifecycle" >> "$GITHUB_ENV"';
-
     const install = job.steps.find((step) => step.name === "Install root dependencies");
     expect(install).toBeDefined();
     install!.env = {
@@ -118,18 +111,12 @@ describe("tunnel lifecycle workflow boundary", () => {
       "include-hidden-files": true,
     };
 
-    const cleanup = job.steps.find((step) => step.name === "Clean up Docker auth");
-    expect(cleanup).toBeDefined();
-    cleanup!.if = "success()";
-    cleanup!.run = 'set -euo pipefail\necho "missing Docker auth cleanup"\n';
     fs.writeFileSync(workflowPath, YAML.stringify(workflow));
 
     try {
       expect(validateE2eWorkflowBoundary(workflowPath)).toEqual(
         expect.arrayContaining([
           "tunnel-lifecycle job must not set DOCKER_CONFIG at job level",
-          'step \'Configure isolated Docker auth directory\' run script must include echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-tunnel-lifecycle" >> "$GITHUB_ENV"',
-          "step 'Configure isolated Docker auth directory' run script must not include ${{ github.workspace }}",
           "tunnel-lifecycle checkout step must set persist-credentials=false",
           "tunnel-lifecycle step 'Install root dependencies' env must not include NVIDIA_INFERENCE_API_KEY",
           "tunnel-lifecycle step 'Install root dependencies' env must not include NVIDIA_API_KEY",
@@ -148,9 +135,6 @@ describe("tunnel lifecycle workflow boundary", () => {
           "tunnel-lifecycle live E2E step must not run cloudflared APT installation with NVIDIA_INFERENCE_API_KEY in scope",
           "artifact upload path must include e2e-artifacts/live/tunnel-lifecycle/",
           "tunnel-lifecycle artifact upload must set include-hidden-files: false",
-          "tunnel-lifecycle Docker auth cleanup must always run",
-          "step 'Clean up Docker auth' run script must include docker logout docker.io",
-          "step 'Clean up Docker auth' run script must include rm -rf \"${DOCKER_CONFIG}\"",
         ]),
       );
     } finally {

--- a/tools/e2e/inference-switch-workflow-boundary.mts
+++ b/tools/e2e/inference-switch-workflow-boundary.mts
@@ -108,29 +108,18 @@ function validateJob(errors: string[], spec: JobSpec, job: WorkflowJob): void {
   }
 }
 
-function validateOpenClawDockerAuth(errors: string[], job: WorkflowJob): void {
-  const configure = job.steps?.find(
-    (step) => step.name === "Configure isolated Docker auth directory",
-  );
+function validateOpenClawDockerAuthOrder(errors: string[], job: WorkflowJob): void {
   const cleanup = job.steps?.find((step) => step.name === "Clean up Docker auth");
-  const matrixPath = "docker-config-openclaw-inference-switch-${{ matrix.mode }}";
-  if (!configure?.run?.includes(matrixPath)) {
-    errors.push("openclaw-inference-switch Docker auth path must identify its mode");
-  }
-  if (!cleanup?.run?.includes(matrixPath) || !cleanup.run.includes('rm -rf "${docker_config}"')) {
-    errors.push("openclaw-inference-switch must always remove its mode-specific Docker auth");
-  }
   if (cleanup?.if !== "always()") {
     errors.push("openclaw-inference-switch Docker auth cleanup must always run");
   }
 
   const stepOrder = [
-    "Build CLI",
-    "Configure isolated Docker auth directory",
     "Authenticate to Docker Hub",
+    "Build CLI",
     "Run OpenClaw inference switch live test",
-    "Clean up Docker auth",
     "Upload OpenClaw inference switch artifacts",
+    "Clean up Docker auth",
   ].map((name) => job.steps?.findIndex((step) => step.name === name) ?? -1);
   if (
     stepOrder.some(
@@ -138,7 +127,7 @@ function validateOpenClawDockerAuth(errors: string[], job: WorkflowJob): void {
     )
   ) {
     errors.push(
-      "openclaw-inference-switch must build, authenticate, test, clean credentials, then upload",
+      "openclaw-inference-switch must authenticate, build, test, upload artifacts, then clean credentials",
     );
   }
 }
@@ -152,7 +141,7 @@ export function readInferenceSwitchWorkflow(
 export function validateInferenceSwitchWorkflow(workflow: InferenceSwitchWorkflow): string[] {
   const errors: string[] = [];
   for (const spec of JOBS) validateJob(errors, spec, workflow.jobs[spec.job] ?? {});
-  validateOpenClawDockerAuth(errors, workflow.jobs["openclaw-inference-switch"] ?? {});
+  validateOpenClawDockerAuthOrder(errors, workflow.jobs["openclaw-inference-switch"] ?? {});
   return errors;
 }
 

--- a/tools/e2e/sandbox-operations-workflow-boundary.mts
+++ b/tools/e2e/sandbox-operations-workflow-boundary.mts
@@ -7,15 +7,14 @@ import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 
 // Current-state security boundary for the default sandbox-operations job.
-// It pins the isolated Docker-auth pattern that free-standing live jobs should
-// reuse: trusted setup first, credentials only on the login step, target code
-// only after login, and unconditional artifact/auth cleanup.
+// The shared workflow boundary owns the guarded Docker login and cleanup
+// implementation. This focused validator keeps the job-specific ordering and
+// secret-scope guarantees without duplicating that shared implementation.
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
 const JOB_NAME = "sandbox-operations";
 const FULL_SHA_ACTION = /^[^\s@]+@[0-9a-f]{40}$/u;
 const GITHUB_ENV_REFERENCE = /\$\{?GITHUB_ENV\}?/u;
-const WORKSPACE_REFERENCE = /github\.workspace|GITHUB_WORKSPACE/u;
 const DOCKER_CREDENTIALS = ["DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"] as const;
 
 type WorkflowStep = {
@@ -115,16 +114,7 @@ export function validateSandboxOperationsWorkflow(workflow: {
   requireRunContains(errors, verifyLauncher, 'test -x "${NEMOCLAW_CLI_BIN}"');
   requireRunContains(errors, verifyLauncher, '"${NEMOCLAW_CLI_BIN}" --version');
 
-  const configure = findStep(job, "Configure isolated Docker auth directory");
-  requireRunContains(
-    errors,
-    configure,
-    "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-sandbox-operations",
-  );
-  requireRunContains(errors, configure, '>> "$GITHUB_ENV"');
-  if (WORKSPACE_REFERENCE.test(configure.run ?? "")) {
-    errors.push(`${JOB_NAME} Docker auth directory must not use the checkout workspace`);
-  }
+  const authenticate = findStep(job, "Authenticate to Docker Hub");
 
   for (const step of steps) {
     if (step.env?.DOCKER_CONFIG !== undefined) {
@@ -132,20 +122,13 @@ export function validateSandboxOperationsWorkflow(workflow: {
         `${JOB_NAME} must not expose DOCKER_CONFIG through step '${step.name ?? "<unnamed>"}'`,
       );
     }
-    if (step !== configure && GITHUB_ENV_REFERENCE.test(step.run ?? "")) {
+    if (step !== authenticate && GITHUB_ENV_REFERENCE.test(step.run ?? "")) {
       errors.push(
         `${JOB_NAME} step '${step.name ?? "<unnamed>"}' must not write persistent environment`,
       );
     }
   }
 
-  const authenticate = findStep(job, "Authenticate to Docker Hub");
-  if (authenticate.env?.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(`${JOB_NAME} Docker username must be scoped to the auth step`);
-  }
-  if (authenticate.env?.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(`${JOB_NAME} Docker token must be scoped to the auth step`);
-  }
   for (const step of steps.filter((entry) => entry !== authenticate)) {
     for (const variable of DOCKER_CREDENTIALS) {
       if (
@@ -157,11 +140,10 @@ export function validateSandboxOperationsWorkflow(workflow: {
     }
   }
 
+  requireStepOrder(errors, steps, authenticate.name ?? "", "Build CLI");
   requireStepOrder(errors, steps, "Build CLI", verifyLauncher.name ?? "");
   requireStepOrder(errors, steps, verifyLauncher.name ?? "", "Install OpenShell CLI");
-  requireStepOrder(errors, steps, "Install OpenShell CLI", configure.name ?? "");
-  requireStepOrder(errors, steps, configure.name ?? "", authenticate.name ?? "");
-  requireStepOrder(errors, steps, authenticate.name ?? "", "Run sandbox operations live test");
+  requireStepOrder(errors, steps, "Install OpenShell CLI", "Run sandbox operations live test");
 
   const run = findStep(job, "Run sandbox operations live test");
   if (run.env?.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
@@ -186,8 +168,6 @@ export function validateSandboxOperationsWorkflow(workflow: {
 
   const cleanup = findStep(job, "Clean up Docker auth");
   if (cleanup.if !== "always()") errors.push(`${JOB_NAME} Docker auth cleanup must always run`);
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 
   return errors;
 }

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2580,6 +2580,7 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
       const stepEnv = asRecord(step.env);
       if (step !== auth) {
         for (const variable of [
+          "DOCKER_CONFIG",
           "DOCKERHUB_AUTH_REQUIRED",
           "DOCKERHUB_USERNAME",
           "DOCKERHUB_TOKEN",

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -59,6 +59,23 @@ const PUBLIC_NVIDIA_ENDPOINT_KEY_JOBS = new Set([
   "device-auth-health",
   "model-router-provider-routed-inference",
 ]);
+const NO_IMAGE_E2E_JOBS = new Set([
+  "docs-validation",
+  "gateway-drift-preflight",
+  "gateway-health-honest",
+  "inference-routing",
+  "onboard-negative-paths",
+  "openshell-version-pin",
+]);
+const DOCKER_HUB_AUTH_STEP = "Authenticate to Docker Hub";
+const DOCKER_HUB_CLEANUP_STEP = "Clean up Docker auth";
+const DOCKER_HUB_CLEANUP_RUN = "bash .github/scripts/docker-auth-cleanup.sh";
+const DOCKER_HUB_CLEANUP_KEYS = ["if", "name", "run", "shell"];
+const TRUSTED_DOCKER_HUB_PREDICATE =
+  "github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')";
+const GUARDED_DOCKER_HUB_AUTH_REQUIRED = `\${{ ${TRUSTED_DOCKER_HUB_PREDICATE} && '1' || '0' }}`;
+const GUARDED_DOCKER_HUB_USERNAME = `\${{ ${TRUSTED_DOCKER_HUB_PREDICATE} && secrets.DOCKERHUB_USERNAME || '' }}`;
+const GUARDED_DOCKER_HUB_TOKEN = `\${{ ${TRUSTED_DOCKER_HUB_PREDICATE} && secrets.DOCKERHUB_TOKEN || '' }}`;
 
 function asRecord(value: unknown): WorkflowRecord {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -949,10 +966,6 @@ function validateNetworkPolicyJob(errors: string[], jobs: WorkflowRecord): void 
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  if (namedStep(steps, "Authenticate to Docker Hub")) {
-    errors.push("network-policy must not include unused Docker Hub authentication");
-  }
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -1068,7 +1081,11 @@ function validateCommonEgressAgentJob(errors: string[], jobs: WorkflowRecord): v
         "NVIDIA_INFERENCE_API_KEY",
       );
     }
-    for (const secret of ["DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN", "GITHUB_TOKEN"]) {
+    const forbiddenSecrets =
+      step.name === DOCKER_HUB_AUTH_STEP
+        ? ["GITHUB_TOKEN"]
+        : ["DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN", "GITHUB_TOKEN"];
+    for (const secret of forbiddenSecrets) {
       requireEnvDoesNotExposeSecret(
         errors,
         `common-egress-agent step '${stepName}'`,
@@ -1210,16 +1227,6 @@ function validateShieldsConfigJob(errors: string[], jobs: WorkflowRecord): void 
     errors.push("shields-config checkout step must set persist-credentials=false");
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("shields-config Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("shields-config Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("shields-config job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "shields-config setup-node");
@@ -1308,16 +1315,6 @@ function validateRebuildOpenClawJob(errors: string[], jobs: WorkflowRecord): voi
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("rebuild-openclaw checkout step must set persist-credentials=false");
   }
-
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("rebuild-openclaw Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("rebuild-openclaw Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("rebuild-openclaw job missing step: Set up Node");
@@ -1466,17 +1463,6 @@ function validateRebuildHermesJob(
     errors.push(`${jobName} checkout step must set persist-credentials=false`);
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(`${jobName} Docker Hub auth must receive DOCKERHUB_USERNAME from secrets`);
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(`${jobName} Docker Hub auth must receive DOCKERHUB_TOKEN from secrets`);
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-  requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push(`${jobName} job missing step: Set up Node`);
   requireFullShaAction(errors, setupNode, `${jobName} setup-node`);
@@ -1597,17 +1583,6 @@ function validateSandboxRebuildJob(errors: string[], jobs: WorkflowRecord): void
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("sandbox-rebuild checkout step must set persist-credentials=false");
   }
-
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("sandbox-rebuild Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("sandbox-rebuild Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-  requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("sandbox-rebuild job missing step: Set up Node");
@@ -1734,19 +1709,6 @@ function validateStateBackupRestoreJob(errors: string[], jobs: WorkflowRecord): 
     errors.push("state-backup-restore checkout step must set persist-credentials=false");
   }
 
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "state-backup-restore Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("state-backup-restore Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-  requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("state-backup-restore job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "state-backup-restore setup-node");
@@ -1866,33 +1828,6 @@ function validateUpgradeStaleSandboxJob(errors: string[], jobs: WorkflowRecord):
     errors.push("upgrade-stale-sandbox checkout step must set persist-credentials=false");
   }
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-upgrade-stale-sandbox" >> "$GITHUB_ENV"',
-  );
-
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "upgrade-stale-sandbox Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("upgrade-stale-sandbox Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerHubAuth, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-  requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("upgrade-stale-sandbox job missing step: Set up Node");
   requireFullShaAction(errors, setupNode, "upgrade-stale-sandbox setup-node");
@@ -1947,10 +1882,6 @@ function validateUpgradeStaleSandboxJob(errors: string[], jobs: WorkflowRecord):
   if (uploadWith["retention-days"] !== 14) {
     errors.push("upgrade-stale-sandbox artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateTokenRotationJob(errors: string[], jobs: WorkflowRecord): void {
@@ -1999,16 +1930,6 @@ function validateTokenRotationJob(errors: string[], jobs: WorkflowRecord): void 
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("token-rotation checkout step must set persist-credentials=false");
   }
-
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("token-rotation Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("token-rotation Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("token-rotation job missing step: Set up Node");
@@ -2144,29 +2065,25 @@ function validateMessagingCompatibleEndpointJob(errors: string[], jobs: Workflow
       stepEnv,
       "NVIDIA_INFERENCE_API_KEY",
     );
-    requireEnvDoesNotExposeSecret(
-      errors,
-      `messaging-compatible-endpoint step '${stepName}'`,
-      stepEnv,
-      "DOCKERHUB_USERNAME",
-    );
-    requireEnvDoesNotExposeSecret(
-      errors,
-      `messaging-compatible-endpoint step '${stepName}'`,
-      stepEnv,
-      "DOCKERHUB_TOKEN",
-    );
-    requireNoDockerHubAuthInRun(
-      errors,
-      `messaging-compatible-endpoint step '${stepName}'`,
-      stringValue(step.run),
-    );
-  }
-
-  if (namedStep(steps, "Authenticate to Docker Hub")) {
-    errors.push(
-      "messaging-compatible-endpoint must not authenticate to Docker Hub before branch-controlled test code runs",
-    );
+    if (step.name !== DOCKER_HUB_AUTH_STEP) {
+      requireEnvDoesNotExposeSecret(
+        errors,
+        `messaging-compatible-endpoint step '${stepName}'`,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        `messaging-compatible-endpoint step '${stepName}'`,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
+      requireNoDockerHubAuthInRun(
+        errors,
+        `messaging-compatible-endpoint step '${stepName}'`,
+        stringValue(step.run),
+      );
+    }
   }
 
   const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
@@ -2442,6 +2359,261 @@ function requireNoDockerHubAuthInRun(errors: string[], owner: string, runScript:
   }
 }
 
+function requireCanonicalDockerHubAuthRun(
+  errors: string[],
+  authStep: WorkflowStep | undefined,
+): void {
+  if (!authStep) return;
+  if (Object.hasOwn(authStep, "if")) {
+    errors.push(
+      "canonical Docker Hub auth step must always run so untrusted refs receive an isolated empty Docker config",
+    );
+  }
+  if (authStep.shell !== "bash") {
+    errors.push("canonical Docker Hub auth step must use bash");
+  }
+  if (authStep.uses !== undefined) {
+    errors.push("canonical Docker Hub auth step must use the audited inline retry script");
+  }
+  if (authStep["continue-on-error"] !== undefined) {
+    errors.push(
+      "canonical Docker Hub auth step must fail closed when trusted authentication fails",
+    );
+  }
+
+  const authEnv = asRecord(authStep.env);
+  if (authEnv.DOCKERHUB_AUTH_REQUIRED !== GUARDED_DOCKER_HUB_AUTH_REQUIRED) {
+    errors.push(
+      "canonical Docker Hub auth must gate DOCKERHUB_AUTH_REQUIRED on the trusted repository, main ref, and scheduled/manual events",
+    );
+  }
+  if (authEnv.DOCKERHUB_USERNAME !== GUARDED_DOCKER_HUB_USERNAME) {
+    errors.push(
+      "canonical Docker Hub auth must gate DOCKERHUB_USERNAME on the trusted repository, main ref, and scheduled/manual events",
+    );
+  }
+  if (authEnv.DOCKERHUB_TOKEN !== GUARDED_DOCKER_HUB_TOKEN) {
+    errors.push(
+      "canonical Docker Hub auth must gate DOCKERHUB_TOKEN on the trusted repository, main ref, and scheduled/manual events",
+    );
+  }
+  const unexpectedEnv = Object.keys(authEnv).filter(
+    (name) => !["DOCKERHUB_AUTH_REQUIRED", "DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"].includes(name),
+  );
+  if (unexpectedEnv.length > 0) {
+    errors.push("canonical Docker Hub auth step must expose only its three guarded inputs");
+  }
+
+  const runScript = stringValue(authStep.run);
+  for (const fragment of [
+    'mktemp -d "${RUNNER_TEMP}/docker-config-${GITHUB_JOB}-XXXXXX"',
+    'chmod 700 "${docker_config}"',
+    'export DOCKER_CONFIG="${docker_config}"',
+    'if [[ "${DOCKERHUB_AUTH_REQUIRED}" != "1" ]]; then',
+    "continuing with anonymous pulls",
+    'if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then',
+    'auth_marker="${DOCKER_CONFIG}/.nemoclaw-docker-login-attempted"',
+    ': > "${auth_marker}"',
+    'chmod 600 "${auth_marker}"',
+    "for attempt in 1 2 3; do",
+    "timeout 30s docker login docker.io",
+    '--username "${DOCKERHUB_USERNAME}"',
+    "--password-stdin",
+    "Docker Hub login failed after 3 attempts",
+  ]) {
+    if (!runScript.includes(fragment)) {
+      errors.push(`canonical Docker Hub auth run script must include ${fragment}`);
+    }
+  }
+  if (
+    !runScript.includes("printf 'DOCKER_CONFIG=%s\\n'") ||
+    !runScript.includes('"${DOCKER_CONFIG}"') ||
+    !runScript.includes('>> "${GITHUB_ENV}"')
+  ) {
+    errors.push(
+      "canonical Docker Hub auth run script must persist the isolated DOCKER_CONFIG through GITHUB_ENV",
+    );
+  }
+  if (runScript.includes("${{ github.workspace }}") || runScript.includes("GITHUB_WORKSPACE")) {
+    errors.push("canonical Docker Hub auth directory must not use the checkout workspace");
+  }
+  if (/--password(?:=|\s)(?!-stdin\b)/u.test(runScript)) {
+    errors.push("canonical Docker Hub auth must pass the token only through --password-stdin");
+  }
+
+  const configIndex = runScript.indexOf(
+    'mktemp -d "${RUNNER_TEMP}/docker-config-${GITHUB_JOB}-XXXXXX"',
+  );
+  const trustIndex = runScript.indexOf('if [[ "${DOCKERHUB_AUTH_REQUIRED}" != "1" ]]; then');
+  const loginIndex = runScript.indexOf("docker login docker.io");
+  if (configIndex < 0 || trustIndex <= configIndex || loginIndex <= trustIndex) {
+    errors.push(
+      "canonical Docker Hub auth must isolate Docker config before evaluating trust and authenticating",
+    );
+  }
+  const missingCredentialsIndex = runScript.indexOf(
+    'if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then',
+  );
+  const missingCredentialsEndIndex = runScript.indexOf("\nfi", missingCredentialsIndex);
+  const markerPathIndex = runScript.indexOf(
+    'auth_marker="${DOCKER_CONFIG}/.nemoclaw-docker-login-attempted"',
+  );
+  const markerCreateIndex = runScript.indexOf(': > "${auth_marker}"');
+  const markerChmodIndex = runScript.indexOf('chmod 600 "${auth_marker}"');
+  const retryIndex = runScript.indexOf("for attempt in 1 2 3; do");
+  const missingCredentialsBlock =
+    missingCredentialsIndex >= 0 && retryIndex > missingCredentialsIndex
+      ? runScript.slice(missingCredentialsIndex, retryIndex)
+      : "";
+  if (!missingCredentialsBlock.includes("exit 1")) {
+    errors.push("canonical Docker Hub auth must fail when trusted credentials are missing");
+  }
+  if (
+    missingCredentialsEndIndex < 0 ||
+    markerPathIndex <= missingCredentialsEndIndex ||
+    markerCreateIndex <= markerPathIndex ||
+    markerChmodIndex <= markerCreateIndex ||
+    retryIndex <= markerChmodIndex ||
+    loginIndex <= retryIndex
+  ) {
+    errors.push(
+      "canonical Docker Hub auth must create and protect its login-attempt marker after trusted credential validation and before login",
+    );
+  }
+  const exhaustedLoginIndex = runScript.indexOf("Docker Hub login failed after 3 attempts");
+  if (exhaustedLoginIndex < 0 || !runScript.slice(exhaustedLoginIndex).includes("exit 1")) {
+    errors.push("canonical Docker Hub auth must fail after exhausting login retries");
+  }
+}
+
+function requireCanonicalDockerHubCleanupRun(
+  errors: string[],
+  jobName: string,
+  cleanupStep: WorkflowStep | undefined,
+): void {
+  if (!cleanupStep) return;
+
+  const cleanupKeys = Object.keys(cleanupStep).sort();
+  if (
+    cleanupKeys.length !== DOCKER_HUB_CLEANUP_KEYS.length ||
+    cleanupKeys.some((key, index) => key !== DOCKER_HUB_CLEANUP_KEYS[index])
+  ) {
+    errors.push(`${jobName} Docker Hub cleanup step must contain exactly name, if, shell, and run`);
+  }
+  if (cleanupStep.name !== DOCKER_HUB_CLEANUP_STEP) {
+    errors.push(`${jobName} Docker Hub cleanup step must use the canonical name`);
+  }
+  if (cleanupStep.if !== "always()") {
+    errors.push(`${jobName} Docker Hub cleanup step must always run`);
+  }
+  if (cleanupStep.shell !== "bash") {
+    errors.push(`${jobName} Docker Hub cleanup step must use bash`);
+  }
+  if (cleanupStep.run !== DOCKER_HUB_CLEANUP_RUN) {
+    errors.push(`${jobName} Docker Hub cleanup step must run only ${DOCKER_HUB_CLEANUP_RUN}`);
+  }
+}
+
+function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): void {
+  const e2eJobNames = Object.entries(jobs)
+    .filter(([, rawJob]) => asRecord(asRecord(rawJob).env).E2E_JOB === "1")
+    .map(([jobName]) => jobName);
+  for (const exemptJobName of NO_IMAGE_E2E_JOBS) {
+    if (!e2eJobNames.includes(exemptJobName)) {
+      errors.push(`Docker Hub no-image exemption references unknown E2E job: ${exemptJobName}`);
+    }
+  }
+
+  const imageJobNames = [
+    "live",
+    ...e2eJobNames.filter((jobName) => !NO_IMAGE_E2E_JOBS.has(jobName)),
+  ];
+  const liveSteps = asSteps(asRecord(jobs.live).steps);
+  const canonicalAuth = namedStep(liveSteps, DOCKER_HUB_AUTH_STEP);
+  requireCanonicalDockerHubAuthRun(errors, canonicalAuth);
+
+  for (const jobName of imageJobNames) {
+    const job = asRecord(jobs[jobName]);
+    const jobEnv = asRecord(job.env);
+    for (const variable of [
+      "DOCKER_CONFIG",
+      "DOCKERHUB_AUTH_REQUIRED",
+      "DOCKERHUB_USERNAME",
+      "DOCKERHUB_TOKEN",
+    ]) {
+      requireEnvDoesNotExposeSecret(errors, `${jobName} job`, jobEnv, variable);
+    }
+
+    const steps = asSteps(job.steps);
+    const authSteps = steps.filter((step) => step.name === DOCKER_HUB_AUTH_STEP);
+    const cleanupSteps = steps.filter((step) => step.name === DOCKER_HUB_CLEANUP_STEP);
+    if (authSteps.length !== 1) {
+      errors.push(`${jobName} image-consuming job must have exactly one Docker Hub auth step`);
+    }
+    if (cleanupSteps.length !== 1) {
+      errors.push(`${jobName} image-consuming job must have exactly one Docker Hub cleanup step`);
+    }
+    const auth = authSteps[0];
+    const cleanup = cleanupSteps[0];
+    if (auth && canonicalAuth && auth !== canonicalAuth) {
+      errors.push(`${jobName} Docker Hub auth must reuse the canonical workflow alias`);
+    }
+    requireCanonicalDockerHubCleanupRun(errors, jobName, cleanup);
+
+    const checkoutIndex = steps.findIndex((step) =>
+      stringValue(step.uses).startsWith("actions/checkout@"),
+    );
+    const authIndex = steps.indexOf(auth);
+    const cleanupIndex = steps.indexOf(cleanup);
+    if (checkoutIndex < 0 || authIndex !== checkoutIndex + 1) {
+      errors.push(`${jobName} Docker Hub auth must run immediately after checkout`);
+    }
+    if (authIndex < 0 || cleanupIndex <= authIndex) {
+      errors.push(`${jobName} Docker Hub cleanup must run after authentication and test work`);
+    }
+    if (cleanupIndex !== steps.length - 1) {
+      errors.push(`${jobName} Docker Hub cleanup must be the final job step`);
+    }
+
+    for (const step of steps) {
+      const stepName = `${jobName} step '${step.name ?? step.uses ?? "<unnamed>"}'`;
+      const stepEnv = asRecord(step.env);
+      if (step !== auth) {
+        for (const variable of [
+          "DOCKERHUB_AUTH_REQUIRED",
+          "DOCKERHUB_USERNAME",
+          "DOCKERHUB_TOKEN",
+        ]) {
+          requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, variable);
+        }
+        const runScript = stringValue(step.run);
+        if (/\bdocker\s+login\b/iu.test(runScript) || /secrets\.DOCKERHUB_/u.test(runScript)) {
+          errors.push(`${stepName} must not authenticate or interpolate Docker Hub secrets`);
+        }
+        if (/DOCKER_CONFIG=.*GITHUB_ENV/su.test(runScript) && step !== cleanup) {
+          errors.push(`${stepName} must not override the canonical Docker auth directory`);
+        }
+      }
+    }
+  }
+
+  for (const jobName of NO_IMAGE_E2E_JOBS) {
+    const steps = asSteps(asRecord(jobs[jobName]).steps);
+    if (namedStep(steps, DOCKER_HUB_AUTH_STEP) || namedStep(steps, DOCKER_HUB_CLEANUP_STEP)) {
+      errors.push(`${jobName} no-image job must not receive Docker Hub authentication`);
+    }
+  }
+
+  const classifiedJobNames = new Set([...imageJobNames, ...NO_IMAGE_E2E_JOBS]);
+  for (const [jobName, rawJob] of Object.entries(jobs)) {
+    if (classifiedJobNames.has(jobName)) continue;
+    const steps = asSteps(asRecord(rawJob).steps);
+    if (namedStep(steps, DOCKER_HUB_AUTH_STEP) || namedStep(steps, DOCKER_HUB_CLEANUP_STEP)) {
+      errors.push(`${jobName} non-E2E job must not own the shared Docker Hub auth aliases`);
+    }
+  }
+}
+
 function validateDoubleOnboardJob(errors: string[], jobs: WorkflowRecord): void {
   const jobName = "double-onboard";
   const job = asRecord(jobs[jobName]);
@@ -2493,17 +2665,6 @@ function validateDoubleOnboardJob(errors: string[], jobs: WorkflowRecord): void 
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("double-onboard checkout step must set persist-credentials=false");
   }
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("double-onboard Docker login step must read DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("double-onboard Docker login step must read DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("double-onboard job missing step: Set up Node");
@@ -2583,9 +2744,11 @@ function validateRuntimeOverridesJob(errors: string[], jobs: WorkflowRecord): vo
     const stepName = `runtime-overrides step '${step.name ?? step.uses ?? "<unnamed>"}'`;
     const stepEnv = asRecord(step.env);
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
-    requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
+    if (step.name !== DOCKER_HUB_AUTH_STEP) {
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
+    }
   }
 
   const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
@@ -2802,29 +2965,25 @@ function validateHermesRootEntrypointSmokeJob(errors: string[], jobs: WorkflowRe
       stepEnv,
       "NVIDIA_INFERENCE_API_KEY",
     );
-    requireEnvDoesNotExposeSecret(
-      errors,
-      `hermes-root-entrypoint-smoke step '${stepName}'`,
-      stepEnv,
-      "DOCKERHUB_USERNAME",
-    );
-    requireEnvDoesNotExposeSecret(
-      errors,
-      `hermes-root-entrypoint-smoke step '${stepName}'`,
-      stepEnv,
-      "DOCKERHUB_TOKEN",
-    );
-    requireNoDockerHubAuthInRun(
-      errors,
-      `hermes-root-entrypoint-smoke step '${stepName}'`,
-      stringValue(step.run),
-    );
-  }
-
-  if (namedStep(steps, "Authenticate to Docker Hub")) {
-    errors.push(
-      "hermes-root-entrypoint-smoke must not authenticate to Docker Hub before branch-controlled test code runs",
-    );
+    if (step.name !== DOCKER_HUB_AUTH_STEP) {
+      requireEnvDoesNotExposeSecret(
+        errors,
+        `hermes-root-entrypoint-smoke step '${stepName}'`,
+        stepEnv,
+        "DOCKERHUB_USERNAME",
+      );
+      requireEnvDoesNotExposeSecret(
+        errors,
+        `hermes-root-entrypoint-smoke step '${stepName}'`,
+        stepEnv,
+        "DOCKERHUB_TOKEN",
+      );
+      requireNoDockerHubAuthInRun(
+        errors,
+        `hermes-root-entrypoint-smoke step '${stepName}'`,
+        stringValue(step.run),
+      );
+    }
   }
 
   const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
@@ -2925,15 +3084,11 @@ function validateHermesSandboxSecretBoundaryJob(errors: string[], jobs: Workflow
     }'`;
     const stepEnv = asRecord(step.env);
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
-    requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
-  }
-
-  if (namedStep(steps, "Authenticate to Docker Hub")) {
-    errors.push(
-      "hermes-sandbox-secret-boundary must not authenticate to Docker Hub before branch-controlled test code runs",
-    );
+    if (step.name !== DOCKER_HUB_AUTH_STEP) {
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
+    }
   }
 
   const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
@@ -3056,16 +3211,12 @@ function validateDiagnosticsJob(errors: string[], jobs: WorkflowRecord): void {
     if (step.name !== "Run diagnostics live test") {
       requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
     }
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
-    requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
+    if (step.name !== DOCKER_HUB_AUTH_STEP) {
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+      requireNoDockerHubAuthInRun(errors, stepName, stringValue(step.run));
+    }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
-  }
-
-  if (namedStep(steps, "Authenticate to Docker Hub")) {
-    errors.push(
-      "diagnostics job must not authenticate to Docker Hub before branch-controlled test code runs",
-    );
   }
 
   const checkout = steps.find((step) => stringValue(step.uses).startsWith("actions/checkout@"));
@@ -3175,8 +3326,10 @@ function validateSparkInstallJob(errors: string[], jobs: WorkflowRecord): void {
     if (step.name !== "Run Spark install live test") {
       requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "NVIDIA_INFERENCE_API_KEY");
     }
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
-    requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+    if (step.name !== DOCKER_HUB_AUTH_STEP) {
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_USERNAME");
+      requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "DOCKERHUB_TOKEN");
+    }
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
@@ -3306,33 +3459,6 @@ function validateSnapshotCommandsJob(errors: string[], jobs: WorkflowRecord): vo
     errors.push("snapshot-commands checkout step must set persist-credentials=false");
   }
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-snapshot-commands" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("snapshot-commands Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("snapshot-commands Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-  requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
     errors.push("snapshot-commands job missing step: Set up Node");
@@ -3374,13 +3500,6 @@ function validateSnapshotCommandsJob(errors: string[], jobs: WorkflowRecord): vo
   if (uploadWith["retention-days"] !== 14) {
     errors.push("snapshot-commands artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("snapshot-commands Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateModelRouterProviderRoutedInferenceJob(
@@ -3468,37 +3587,6 @@ function validateModelRouterProviderRoutedInferenceJob(
     );
   }
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-model-router-provider-routed-inference" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "model-router-provider-routed-inference Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(
-      "model-router-provider-routed-inference Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
-    );
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-  requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
     errors.push("model-router-provider-routed-inference job missing step: Set up Node");
@@ -3565,13 +3653,6 @@ function validateModelRouterProviderRoutedInferenceJob(
   if (uploadWith["retention-days"] !== 14) {
     errors.push("model-router-provider-routed-inference artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("model-router-provider-routed-inference Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateGatewayDriftPreflightJob(errors: string[], jobs: WorkflowRecord): void {
@@ -3661,34 +3742,6 @@ function validateTunnelLifecycleJob(errors: string[], jobs: WorkflowRecord): voi
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("tunnel-lifecycle checkout step must set persist-credentials=false");
   }
-
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-tunnel-lifecycle" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("tunnel-lifecycle Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("tunnel-lifecycle Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-  requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
@@ -3784,13 +3837,6 @@ function validateTunnelLifecycleJob(errors: string[], jobs: WorkflowRecord): voi
   if (uploadWith["retention-days"] !== 14) {
     errors.push("tunnel-lifecycle artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("tunnel-lifecycle Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateIssue2478CrashLoopRecoveryJob(errors: string[], jobs: WorkflowRecord): void {
@@ -3858,38 +3904,6 @@ function validateIssue2478CrashLoopRecoveryJob(errors: string[], jobs: WorkflowR
     errors.push("issue-2478-crash-loop-recovery checkout step must set persist-credentials=false");
   }
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-issue-2478-crash-loop-recovery" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "issue-2478-crash-loop-recovery Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(
-      "issue-2478-crash-loop-recovery Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
-    );
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-  requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
     errors.push("issue-2478-crash-loop-recovery job missing step: Set up Node");
@@ -3956,13 +3970,6 @@ function validateIssue2478CrashLoopRecoveryJob(errors: string[], jobs: WorkflowR
   if (uploadWith["retention-days"] !== 14) {
     errors.push("issue-2478-crash-loop-recovery artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("issue-2478-crash-loop-recovery Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateChannelsAddRemoveJob(errors: string[], jobs: WorkflowRecord): void {
@@ -4058,17 +4065,6 @@ function validateChannelsAddRemoveJob(errors: string[], jobs: WorkflowRecord): v
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("channels-add-remove checkout step must set persist-credentials=false");
   }
-
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("channels-add-remove Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("channels-add-remove Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-  requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("channels-add-remove job missing step: Set up Node");
@@ -4198,37 +4194,6 @@ function validateOpenClawDiscordPairingJob(errors: string[], jobs: WorkflowRecor
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-discord-pairing" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "openclaw-discord-pairing Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(
-      "openclaw-discord-pairing Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
-    );
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -4272,13 +4237,6 @@ function validateOpenClawDiscordPairingJob(errors: string[], jobs: WorkflowRecor
   if (uploadWith["retention-days"] !== 14) {
     errors.push("openclaw-discord-pairing artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("openclaw-discord-pairing Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateOpenClawSlackPairingJob(errors: string[], jobs: WorkflowRecord): void {
@@ -4344,35 +4302,6 @@ function validateOpenClawSlackPairingJob(errors: string[], jobs: WorkflowRecord)
   const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
   requireRunContains(errors, buildCli, "npm run build:cli");
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-openclaw-slack-pairing" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "openclaw-slack-pairing Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("openclaw-slack-pairing Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -4409,13 +4338,6 @@ function validateOpenClawSlackPairingJob(errors: string[], jobs: WorkflowRecord)
   if (uploadWith["retention-days"] !== 14) {
     errors.push("openclaw-slack-pairing artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("openclaw-slack-pairing Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateChannelsStopStartJob(errors: string[], jobs: WorkflowRecord): void {
@@ -4480,12 +4402,6 @@ function validateChannelsStopStartJob(errors: string[], jobs: WorkflowRecord): v
   if (jobEnv.OPENSHELL_GATEWAY !== "nemoclaw") {
     errors.push("channels-stop-start job must force OPENSHELL_GATEWAY=nemoclaw");
   }
-  if (
-    jobEnv.DOCKER_CONFIG !==
-    "${{ github.workspace }}/.docker-config-channels-stop-start-${{ matrix.agent }}"
-  ) {
-    errors.push("channels-stop-start job must isolate Docker auth by matrix agent");
-  }
   for (const secret of [
     "NVIDIA_INFERENCE_API_KEY",
     "DOCKERHUB_USERNAME",
@@ -4517,20 +4433,6 @@ function validateChannelsStopStartJob(errors: string[], jobs: WorkflowRecord): v
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("channels-stop-start checkout step must set persist-credentials=false");
   }
-
-  const dockerHubAuth = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerHubEnv = asRecord(dockerHubAuth?.env);
-  if (dockerHubEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("channels-stop-start Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerHubEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("channels-stop-start Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerHubAuth, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerHubAuth, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerHubAuth, "docker login docker.io");
-  requireRunContains(errors, dockerHubAuth, "--password-stdin");
-  requireRunContains(errors, dockerHubAuth, "continuing with anonymous pulls");
 
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) errors.push("channels-stop-start job missing step: Set up Node");
@@ -4602,13 +4504,6 @@ function validateChannelsStopStartJob(errors: string[], jobs: WorkflowRecord): v
   if (uploadWith["retention-days"] !== 14) {
     errors.push("channels-stop-start artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("channels-stop-start Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateTelegramInjectionJob(errors: string[], jobs: WorkflowRecord): void {
@@ -4653,33 +4548,6 @@ function validateTelegramInjectionJob(errors: string[], jobs: WorkflowRecord): v
     requireEnvDoesNotExposeSecret(errors, stepName, stepEnv, "GITHUB_TOKEN");
   }
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-telegram-injection" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ github.workspace }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push("telegram-injection Docker Hub auth must receive DOCKERHUB_USERNAME from secrets");
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push("telegram-injection Docker Hub auth must receive DOCKERHUB_TOKEN from secrets");
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -4709,13 +4577,6 @@ function validateTelegramInjectionJob(errors: string[], jobs: WorkflowRecord): v
   if (uploadWith["retention-days"] !== 14) {
     errors.push("telegram-injection artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("telegram-injection Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 function validateBedrockRuntimeCompatibleAnthropicJob(
@@ -4830,37 +4691,6 @@ function validateBedrockRuntimeCompatibleAnthropicJob(
     );
   }
 
-  const configureDockerAuth = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Configure isolated Docker auth directory",
-  );
-  requireRunContains(
-    errors,
-    configureDockerAuth,
-    'echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config-bedrock-runtime-compatible-anthropic-${{ matrix.agent }}" >> "$GITHUB_ENV"',
-  );
-  requireRunDoesNotContain(errors, configureDockerAuth, "${{ runner.temp }}");
-
-  const dockerLogin = requireJobStep(errors, jobName, steps, "Authenticate to Docker Hub");
-  const dockerLoginEnv = asRecord(dockerLogin?.env);
-  if (dockerLoginEnv.DOCKERHUB_USERNAME !== "${{ secrets.DOCKERHUB_USERNAME }}") {
-    errors.push(
-      "bedrock-runtime-compatible-anthropic Docker Hub auth must receive DOCKERHUB_USERNAME from secrets",
-    );
-  }
-  if (dockerLoginEnv.DOCKERHUB_TOKEN !== "${{ secrets.DOCKERHUB_TOKEN }}") {
-    errors.push(
-      "bedrock-runtime-compatible-anthropic Docker Hub auth must receive DOCKERHUB_TOKEN from secrets",
-    );
-  }
-  requireRunContains(errors, dockerLogin, 'mkdir -p "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, 'chmod 700 "${DOCKER_CONFIG}"');
-  requireRunContains(errors, dockerLogin, "docker login docker.io");
-  requireRunContains(errors, dockerLogin, "--password-stdin");
-  requireRunContains(errors, dockerLogin, "continuing with anonymous pulls");
-
   const setupNode = namedStep(steps, "Set up Node");
   if (!setupNode) {
     errors.push("bedrock-runtime-compatible-anthropic job missing step: Set up Node");
@@ -4924,13 +4754,6 @@ function validateBedrockRuntimeCompatibleAnthropicJob(
   if (uploadWith["retention-days"] !== 14) {
     errors.push("bedrock-runtime-compatible-anthropic artifact upload retention-days must be 14");
   }
-
-  const cleanup = requireJobStep(errors, jobName, steps, "Clean up Docker auth");
-  if (cleanup?.if !== "always()") {
-    errors.push("bedrock-runtime-compatible-anthropic Docker auth cleanup must always run");
-  }
-  requireRunContains(errors, cleanup, "docker logout docker.io");
-  requireRunContains(errors, cleanup, 'rm -rf "${DOCKER_CONFIG}"');
 }
 
 export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_PATH): string[] {
@@ -4973,6 +4796,7 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
     deriveFreeStandingJobsInventoryFromJobs(jobs);
   errors.push(...inventoryErrors);
   validateFreeStandingInventoryBoundary(errors, jobs, freeStandingInventory);
+  validateDockerHubAuthBoundary(errors, jobs);
   const generateMatrix = asRecord(jobs["generate-matrix"]);
   if (Object.keys(generateMatrix).length === 0) errors.push("workflow missing generate-matrix job");
   if (generateMatrix["runs-on"] !== "ubuntu-latest") {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Restores Docker Hub authentication across every image-consuming scheduled/manual-main E2E job after the legacy nightly workflow retirement left 27 jobs anonymous. Trusted main runs now use one guarded login contract, while untrusted refs retain isolated anonymous Docker configs.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Fixes #4036

## Changes
<!-- Bullet list of key changes. -->

- Apply the canonical guarded login to all 67 image-consuming E2E jobs, with six no-image jobs kept as explicit exemptions.
- Add hardened isolated cleanup, a trusted-login marker, bounded retries, and fail-closed behavior for trusted runs.
- Centralize regression validation and behavior tests so future E2E jobs cannot silently omit authentication.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal CI workflow/auth boundary only; no user-facing behavior or documentation surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Credential scope and cleanup boundaries were reviewed locally; guards restrict secrets to NVIDIA/NemoClaw main schedule/manual runs, and focused adversarial tests cover traversal and symlink attacks.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [x] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized Docker Hub authentication and cleanup across E2E workflows for more consistent CI behavior.
  * Standardized guarded login and cleanup so image jobs follow the same audited process.
* **Bug Fixes**
  * Reduced the risk of leftover Docker credentials by cleaning up auth state reliably after runs.
  * Improved handling when authentication is skipped or fails, preventing unsafe credential persistence.
* **Tests**
  * Expanded workflow boundary coverage to enforce the canonical auth/cleanup steps, ordering, and secret-safety rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->