### PR TITLE
fix(uninstall): remove agent-alias CLI shims (nemohermes, nemo-deepagents) (#6098)

### DIFF
--- a/src/lib/actions/uninstall/plan.ts
+++ b/src/lib/actions/uninstall/plan.ts
@@ -32,17 +32,21 @@ function errnoCode(error: unknown): string | undefined {
 function classifyShimPathByMetadata(
   shimPath: string,
   lstatSync: typeof fs.lstatSync,
+  binName: string,
 ): ShimClassification {
   try {
     const stat = lstatSync(shimPath);
-    return classifyNemoclawShim({
-      exists: true,
-      isFile: stat.isFile(),
-      isSymlink: stat.isSymbolicLink(),
-    });
+    return classifyNemoclawShim(
+      {
+        exists: true,
+        isFile: stat.isFile(),
+        isSymlink: stat.isSymbolicLink(),
+      },
+      binName,
+    );
   } catch (error) {
     if (errnoCode(error) === "ENOENT") {
-      return classifyNemoclawShim({ exists: false, isFile: false, isSymlink: false });
+      return classifyNemoclawShim({ exists: false, isFile: false, isSymlink: false }, binName);
     }
     throw error;
   }
@@ -52,7 +56,11 @@ function resolveUninstallHome(envHome: string | undefined): string {
   return envHome || os.homedir();
 }
 
-export function classifyShimPath(shimPath: string, deps: FileSystemDeps = {}): ShimClassification {
+export function classifyShimPath(
+  shimPath: string,
+  deps: FileSystemDeps = {},
+  binName = "nemoclaw",
+): ShimClassification {
   const lstatSync = deps.lstatSync ?? fs.lstatSync;
   const openSync = deps.openSync ?? fs.openSync;
   const fstatSync = deps.fstatSync ?? fs.fstatSync;
@@ -61,26 +69,29 @@ export function classifyShimPath(shimPath: string, deps: FileSystemDeps = {}): S
   const noFollowFlag =
     typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : undefined;
   if (noFollowFlag === undefined) {
-    return classifyShimPathByMetadata(shimPath, lstatSync);
+    return classifyShimPathByMetadata(shimPath, lstatSync, binName);
   }
   const nonblockFlag = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
   try {
     const fd = openSync(shimPath, fs.constants.O_RDONLY | noFollowFlag | nonblockFlag);
     try {
       const fdStat = fstatSync(fd);
-      return classifyNemoclawShim({
-        contents: fdStat.isFile() ? String(readFileSync(fd, "utf-8")) : undefined,
-        exists: true,
-        isFile: fdStat.isFile(),
-        isSymlink: false,
-      });
+      return classifyNemoclawShim(
+        {
+          contents: fdStat.isFile() ? String(readFileSync(fd, "utf-8")) : undefined,
+          exists: true,
+          isFile: fdStat.isFile(),
+          isSymlink: false,
+        },
+        binName,
+      );
     } finally {
       closeSync(fd);
     }
   } catch (error) {
     const code = errnoCode(error);
     if (code === "ENOENT") {
-      return classifyNemoclawShim({ exists: false, isFile: false, isSymlink: false });
+      return classifyNemoclawShim({ exists: false, isFile: false, isSymlink: false }, binName);
     }
     if (
       code === "ELOOP" ||
@@ -91,7 +102,7 @@ export function classifyShimPath(shimPath: string, deps: FileSystemDeps = {}): S
       code === "ENODEV" ||
       code === "ENOTSUP"
     ) {
-      return classifyShimPathByMetadata(shimPath, lstatSync);
+      return classifyShimPathByMetadata(shimPath, lstatSync, binName);
     }
     throw error;
   }

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -162,6 +162,45 @@ describe("uninstall run plan", () => {
     }
   });
 
+  it("removes agent-alias CLI shims (nemohermes, nemo-deepagents) (#6098)", () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-alias-shims-"));
+    const userBin = path.join(tmpHome, ".local", "bin");
+    fs.mkdirSync(userBin, { recursive: true });
+    const hermesShim = path.join(userBin, "nemohermes");
+    const deepagentsShim = path.join(userBin, "nemo-deepagents");
+    // Installer-managed symlinks → classified as managed-symlink → removed.
+    fs.symlinkSync("/tmp/prefix/bin/nemohermes", hermesShim);
+    fs.symlinkSync("/tmp/prefix/bin/nemo-deepagents", deepagentsShim);
+
+    const removed: string[] = [];
+    try {
+      const result = runUninstallPlan(
+        { assumeYes: true, deleteModels: false, keepOpenShell: false },
+        {
+          commandExists: (command) =>
+            command !== "docker" &&
+            command !== "lsof" &&
+            command !== "openshell" &&
+            command !== "pgrep",
+          env: { HOME: tmpHome } as NodeJS.ProcessEnv,
+          existsSync: (target) => target === hermesShim || target === deepagentsShim,
+          isTty: false,
+          log: () => {},
+          rmSync: vi.fn((target: fs.PathLike) => {
+            removed.push(String(target));
+          }),
+          run: vi.fn(() => ok()),
+          runDocker: () => ok(""),
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(removed).toEqual(expect.arrayContaining([hermesShim, deepagentsShim]));
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   it("uses NemoHermes uninstall copy when Hermes is the active agent", () => {
     const logs: string[] = [];
     const warnings: string[] = [];

--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -201,6 +201,54 @@ describe("uninstall run plan", () => {
     }
   });
 
+  it("removes agent-alias wrapper shims via binName-aware fd-read classification (#6098)", () => {
+    // Symlinks classify via the metadata fast path. Wrapper scripts go through
+    // classifyShimPath's fd-read branch which reads the file and matches the
+    // wrapper contract with the per-alias binName. Both paths must remove.
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-alias-wrapper-"));
+    const userBin = path.join(tmpHome, ".local", "bin");
+    fs.mkdirSync(userBin, { recursive: true });
+    const hermesShim = path.join(userBin, "nemohermes");
+    const deepagentsShim = path.join(userBin, "nemo-deepagents");
+    const managedWrapper = (binName: string) =>
+      [
+        "#!/usr/bin/env bash",
+        'export PATH="/tmp/node-bin:$PATH"',
+        `exec "/tmp/prefix/bin/${binName}" "$@"`,
+        "",
+      ].join("\n");
+    fs.writeFileSync(hermesShim, managedWrapper("nemohermes"), { mode: 0o755 });
+    fs.writeFileSync(deepagentsShim, managedWrapper("nemo-deepagents"), { mode: 0o755 });
+
+    const removed: string[] = [];
+    try {
+      const result = runUninstallPlan(
+        { assumeYes: true, deleteModels: false, keepOpenShell: false },
+        {
+          commandExists: (command) =>
+            command !== "docker" &&
+            command !== "lsof" &&
+            command !== "openshell" &&
+            command !== "pgrep",
+          env: { HOME: tmpHome } as NodeJS.ProcessEnv,
+          existsSync: (target) => target === hermesShim || target === deepagentsShim,
+          isTty: false,
+          log: () => {},
+          rmSync: vi.fn((target: fs.PathLike) => {
+            removed.push(String(target));
+          }),
+          run: vi.fn(() => ok()),
+          runDocker: () => ok(""),
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(removed).toEqual(expect.arrayContaining([hermesShim, deepagentsShim]));
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   it("uses NemoHermes uninstall copy when Hermes is the active agent", () => {
     const logs: string[] = [];
     const warnings: string[] = [];

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -686,6 +686,16 @@ function removeNemoclawCli(paths: UninstallPaths, runtime: UninstallRuntime): vo
       `Leaving ${paths.nemoclawShimPath} in place because it is not an installer-managed shim.`,
     );
   }
+  // Also remove the sibling agent-alias shims (nemohermes, nemo-deepagents) the
+  // installer creates; uninstall previously left them resolving on PATH (#6098).
+  // The same classification guard preserves any non-managed file of that name.
+  for (const alias of paths.agentAliasShimPaths) {
+    const aliasShim = classifyShimPath(alias.path, {}, alias.binName);
+    if (aliasShim.remove) removePath(alias.path, runtime);
+    else if (aliasShim.kind === "preserve-foreign-file") {
+      runtime.warn(`Leaving ${alias.path} in place because it is not an installer-managed shim.`);
+    }
+  }
   removeNvmLeftovers(paths, runtime);
   removeAliases(paths, runtime);
 }

--- a/src/lib/domain/uninstall/paths.ts
+++ b/src/lib/domain/uninstall/paths.ts
@@ -26,11 +26,16 @@ export interface UninstallPathOptions {
   xdgBinHome?: string;
 }
 
+/** Agent-alias CLI shims installed alongside `nemoclaw` (e.g. nemohermes). */
+export const AGENT_ALIAS_CLI_BINARIES = ["nemohermes", "nemo-deepagents"] as const;
+
 export interface UninstallPaths {
   helperServiceGlob: string;
   managedSwapMarkerPath: string;
   nemoclawConfigDir: string;
   nemoclawShimPath: string;
+  /** Sibling agent-alias shims (nemohermes, nemo-deepagents) in the same bin dir. */
+  agentAliasShimPaths: Array<{ binName: string; path: string }>;
   nemoclawStateDir: string;
   gatewayLocalStateDir: string;
   openshellConfigDir: string;
@@ -59,6 +64,10 @@ export function defaultUninstallPaths(options: UninstallPathOptions): UninstallP
     managedSwapMarkerPath: path.join(options.home, ".nemoclaw", "managed_swap"),
     nemoclawConfigDir: path.join(options.home, ".config", "nemoclaw"),
     nemoclawShimPath: path.join(options.home, ".local", "bin", "nemoclaw"),
+    agentAliasShimPaths: AGENT_ALIAS_CLI_BINARIES.map((binName) => ({
+      binName,
+      path: path.join(options.home, ".local", "bin", binName),
+    })),
     nemoclawStateDir: path.join(options.home, ".nemoclaw"),
     gatewayLocalStateDir: path.join(options.home, ".local", "state", "nemoclaw"),
     openshellConfigDir: path.join(options.home, ".config", "openshell"),

--- a/src/lib/domain/uninstall/shims.test.ts
+++ b/src/lib/domain/uninstall/shims.test.ts
@@ -40,6 +40,30 @@ describe("uninstall shim classification", () => {
     });
   });
 
+  it("recognizes agent-alias wrapper shims by bin name (#6098)", () => {
+    const hermesWrapper = [
+      "#!/usr/bin/env bash",
+      'export PATH="/tmp/node-bin:$PATH"',
+      'exec "/tmp/prefix/bin/nemohermes" "$@"',
+    ].join("\n");
+    // Matches when classified as its own bin, and the default (nemoclaw) does not.
+    expect(isInstallerManagedWrapperContents(hermesWrapper, "nemohermes")).toBe(true);
+    expect(isInstallerManagedWrapperContents(hermesWrapper)).toBe(false);
+    expect(
+      classifyNemoclawShim(
+        { contents: hermesWrapper, exists: true, isFile: true, isSymlink: false },
+        "nemohermes",
+      ),
+    ).toMatchObject({ kind: "managed-wrapper", remove: true });
+    // A nemoclaw wrapper must not be treated as a managed nemohermes shim.
+    expect(
+      classifyNemoclawShim(
+        { contents: wrapper(""), exists: true, isFile: true, isSymlink: false },
+        "nemohermes",
+      ),
+    ).toMatchObject({ kind: "preserve-foreign-file", remove: false });
+  });
+
   it("recognizes dev-install shims from npm-link-or-shim", () => {
     const contents = [
       "#!/usr/bin/env bash",

--- a/src/lib/domain/uninstall/shims.ts
+++ b/src/lib/domain/uninstall/shims.ts
@@ -29,7 +29,7 @@ function stripCommandSubstitutionTrailingNewlines(contents: string): string {
   return contents.replace(/\n+$/u, "");
 }
 
-export function isInstallerManagedWrapperContents(contents: string): boolean {
+export function isInstallerManagedWrapperContents(contents: string, binName = "nemoclaw"): boolean {
   const normalized = stripCommandSubstitutionTrailingNewlines(contents);
   const lines = normalized.split("\n");
   if (lines.length !== 3) return false;
@@ -39,7 +39,7 @@ export function isInstallerManagedWrapperContents(contents: string): boolean {
     pathLine.startsWith('export PATH="') &&
     pathLine.endsWith(':$PATH"') &&
     execLine.startsWith('exec "') &&
-    execLine.endsWith('/nemoclaw" "$@"')
+    execLine.endsWith(`/${binName}" "$@"`)
   );
 }
 
@@ -58,7 +58,7 @@ export function isDevShimContents(contents: string): boolean {
   );
 }
 
-export function classifyNemoclawShim(input: ShimInput): ShimClassification {
+export function classifyNemoclawShim(input: ShimInput, binName = "nemoclaw"): ShimClassification {
   if (!input.exists) {
     return { kind: "missing", remove: false, reason: "shim path does not exist" };
   }
@@ -76,7 +76,7 @@ export function classifyNemoclawShim(input: ShimInput): ShimClassification {
   }
 
   const contents = input.contents ?? "";
-  if (isInstallerManagedWrapperContents(contents)) {
+  if (isInstallerManagedWrapperContents(contents, binName)) {
     return { kind: "managed-wrapper", remove: true, reason: "installer-managed wrapper contents" };
   }
 


### PR DESCRIPTION
## Summary

`nemoclaw uninstall` removed the `nemoclaw` CLI shim, the `openshell*` binaries, and `~/.nemoclaw/`, but left the sibling **agent-alias shims** (`nemohermes`, `nemo-deepagents`) in `~/.local/bin`. After a "clean" uninstall those commands still resolved and reported a version. This removes them too, using the same installer-managed-shim safety classification.

## Related Issue

Fixes #6098

## Changes

- `src/lib/domain/uninstall/shims.ts`: `classifyNemoclawShim` / `isInstallerManagedWrapperContents` accept an optional `binName` (default `nemoclaw`) so a wrapper that execs `…/nemohermes` is recognized as installer-managed.
- `src/lib/domain/uninstall/paths.ts`: add `agentAliasShimPaths` (`nemohermes`, `nemo-deepagents`) under the same bin dir.
- `src/lib/actions/uninstall/plan.ts`: `classifyShimPath` threads `binName` through both the fd-read and metadata paths.
- `src/lib/actions/uninstall/run-plan.ts`: `removeNemoclawCli` now also classifies and removes each alias shim — reusing the existing guard, so a **non-managed file** of that name (foreign file) is preserved with a warning, exactly like the `nemoclaw` shim.
- Tests: per-bin-name classification (managed wrapper matched by its own name, and a `nemoclaw` wrapper is *not* treated as a managed `nemohermes` shim); an end-to-end run-plan test that creates managed alias symlinks and asserts both are removed.

Safe by construction: symlinks and installer-managed wrappers are removed; any other regular file at those paths (e.g. an unrelated user script) is preserved. npm-installed alias bins remain handled by the existing `npm uninstall -g nemoclaw` step.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: completes existing uninstall cleanup; no command/flag surface change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: uninstall/file-deletion path. Removal reuses the pre-existing `classifyNemoclawShim` guard (only symlinks + installer-managed wrappers removed; foreign files preserved), scoped to two fixed bin names in the resolved bin dir. 53 uninstall tests pass (51 pre-existing + 2 new), including a foreign-file-preserved assertion.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uninstall now removes supported CLI alias shims alongside the main binary.
  * Shim detection now supports alias wrappers for different command names.
* **Bug Fixes**
  * Improved shim classification and uninstall handling for missing files, symlinks, and other edge cases involving aliases.
  * Preserved “foreign” shims are now recognized more reliably when alias wrappers are involved.
* **Tests**
  * Added coverage for removing alias shims and correctly classifying alias wrapper contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->