### PR TITLE
ci(e2e): retire scheduled issue routing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6137,137 +6137,6 @@ jobs:
             rm -rf -- "${DOCKER_CONFIG}"
           fi
 
-  # ── Scheduled failure routing ──────────────────────────────────────────────
-  notify-on-failure:
-    runs-on: ubuntu-latest
-    needs:
-      [
-        generate-matrix,
-        live,
-        openshell-version-pin,
-        openshell-gateway-auth-contract,
-        onboard-negative-paths,
-        skill-agent,
-        openclaw-skill-cli,
-        docs-validation,
-        inference-routing,
-        cloud-inference,
-        gpu-e2e,
-        agent-turn-latency,
-        kimi-inference-compat,
-        hermes-inference-switch,
-        brave-search,
-        ollama-auth-proxy,
-        cron-preflight-inference-local,
-        credential-sanitization,
-        credential-migration,
-        sessions-agents-cli,
-        runtime-overrides,
-        hermes-e2e,
-        hermes-dashboard,
-        hermes-slack,
-        hermes-discord,
-        hermes-root-entrypoint-smoke,
-        hermes-sandbox-secret-boundary,
-        network-policy,
-        common-egress-agent,
-        shields-config,
-        rebuild-openclaw,
-        rebuild-hermes,
-        rebuild-hermes-stale-base,
-        sandbox-rebuild,
-        sandbox-rlimits-connect,
-        overlayfs-autofix,
-        state-backup-restore,
-        upgrade-stale-sandbox,
-        openshell-gateway-upgrade,
-        token-rotation,
-        messaging-compatible-endpoint,
-        messaging-providers,
-        launchable-smoke,
-        double-onboard,
-        jetson-nvmap-gpu,
-        concurrent-gateway-ports,
-        full-e2e,
-        security-posture,
-        cloud-onboard,
-        gpu-double-onboard,
-        onboard-repair,
-        issue-4462-scope-upgrade-approval,
-        onboard-resume,
-        model-router-provider-routed-inference,
-        sandbox-operations,
-        sandbox-survival,
-        diagnostics,
-        snapshot-commands,
-        gateway-drift-preflight,
-        openclaw-tui-chat-correlation,
-        gateway-guard-recovery,
-        issue-4434-tui-unreachable-inference,
-        openclaw-inference-switch,
-        bedrock-runtime-compatible-anthropic,
-        issue-2478-crash-loop-recovery,
-        gateway-health-honest,
-        device-auth-health,
-        channels-add-remove,
-        tunnel-lifecycle,
-        telegram-injection,
-        openclaw-discord-pairing,
-        openclaw-slack-pairing,
-        channels-stop-start,
-        spark-install,
-      ]
-    if: ${{ always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
-    permissions:
-      issues: write
-    steps:
-      - name: Create or update scheduled E2E failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            // Preserve the existing issue thread and its historical title.
-            const title = 'Nightly E2E failed';
-            const needs = ${{ toJSON(needs) }};
-            const failed = Object.entries(needs)
-              .filter(([, value]) => value.result === 'failure')
-              .map(([name]) => name);
-            const cancelled = Object.entries(needs)
-              .filter(([, value]) => value.result === 'cancelled')
-              .map(([name]) => name);
-            const summary = [
-              failed.length ? `**Failed:** ${failed.join(', ')}` : '',
-              cancelled.length ? `**Cancelled:** ${cancelled.join(', ')}` : '',
-            ].filter(Boolean).join('\n');
-            const body = `**Run:** ${runUrl}\n${summary}\n**Artifacts:** Check the run artifacts for target logs and structured evidence.`;
-
-            const { data: existing } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'CI/CD',
-              per_page: 100,
-            });
-            const match = existing.find(
-              (issue) => !issue.pull_request && issue.title.startsWith(title),
-            );
-            if (match) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: match.number,
-                body: `Failed again on ${new Date().toISOString().split('T')[0]}.\n\n${body}`,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: `${title} — ${new Date().toISOString().split('T')[0]}`,
-                body: `The scheduled E2E pipeline failed.\n\n${body}`,
-                labels: ['bug', 'CI/CD'],
-              });
-            }
-
   # ── PR result comment ─────────────────────────────────────────────────────
   # Posts a results table on the open PR for the dispatching branch (or the
   # PR identified by `inputs.pr_number`). `if: always()` so the comment lands
@@ -6357,7 +6226,8 @@ jobs:
       ]
     if: ${{ always() && github.event_name == 'workflow_dispatch' }}
     permissions:
-      issues: write
+      # The issue-comment endpoint accepts pull request write permission for PR comments.
+      # Keep issues: write absent so this job cannot restore general issue routing.
       pull-requests: write
     steps:
       - name: Post E2E target results to PR
@@ -6680,7 +6550,6 @@ jobs:
                 : 'Scheduled E2E';
             const metaJobs = [
               'generate-matrix',
-              'notify-on-failure',
               'report-to-pr',
               'scorecard',
             ];

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -24,8 +24,12 @@ E2E tests when those boundaries are the behavior under test.
 The consolidated workflow keeps its operational reporting in the same job
 graph as the live targets:
 
-- `notify-on-failure` creates or updates the open `CI/CD` failure issue only
-  when a scheduled run fails or is cancelled.
+- GitHub Actions run history is the authoritative record for scheduled and
+  manual E2E results.
+- Automated issue routing and the workflow's `issues: write` capability are
+  retired. Any future issue escalation should use a separately reviewed
+  exceptional threshold, such as the same lane failing twice consecutively or
+  remaining broken for 24 hours, rather than posting on every failed schedule.
 - `scorecard` writes the scheduled/manual result summary, compares the trusted
   cloud-onboard timing summary with the latest prior-release `e2e.yaml` run,
   and posts to the daily or full-run Slack route.
@@ -36,5 +40,5 @@ graph as the live targets:
 Raw cloud-onboard traces stay under the runner temporary directory. Before
 artifact upload, `scripts/e2e/sanitize-trace-timing.py` reduces them to the
 allowlisted `cloud-onboard-trace-timing-summary.json` timing schema and deletes
-the raw directory. Aggregation ratchets require `notify-on-failure`,
-`report-to-pr`, and `scorecard` to wait for the same execution-job set.
+the raw directory. Aggregation ratchets require `report-to-pr` and `scorecard`
+to wait for the same execution-job set.

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -115,6 +115,23 @@ describe("E2E operations workflow boundary", () => {
     );
   });
 
+  it.each([
+    ["an aliased issue API", "const issues = github.rest.issues; await issues.create({});"],
+    ["a bracketed issue API", 'await github.rest.issues["create"]({});'],
+    ["a generic REST request", 'await github.request("POST /repos/{owner}/{repo}/issues", {});'],
+    [
+      "a GraphQL mutation",
+      "await github.graphql(`mutation { createIssue(input: {}) { issue { id } } }`);",
+    ],
+  ])("rejects %s outside the PR reporter", (_label, mutation) => {
+    const workflow = readE2eOperationsWorkflow();
+    workflow.jobs.scorecard.steps!.push({ run: mutation });
+
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "scorecard must not mutate GitHub issues",
+    );
+  });
+
   it("pins the Node 24 helper runtime and separate always-on raw trace cleanup", () => {
     const workflow = readE2eOperationsWorkflow();
     workflow.jobs["cloud-onboard"].env!.NEMOCLAW_TRACE_DIR =

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -25,19 +25,19 @@ function workflowScript(jobName: string, stepName: string): string {
 }
 
 describe("E2E operations workflow boundary", () => {
-  it("keeps scheduled routing and scorecards aggregated over the report job set", () => {
+  it("keeps Actions reporting and scorecards aggregated over the report job set", () => {
     expect(validateE2eOperationsWorkflowBoundary()).toEqual([]);
 
     const workflow = readE2eOperationsWorkflow();
     const reportNeeds = workflow.jobs["report-to-pr"].needs as string[];
-    expect(workflow.jobs["notify-on-failure"].needs).toEqual(reportNeeds);
+    expect(workflow.jobs["notify-on-failure"]).toBeUndefined();
+    expect(workflow.jobs["report-to-pr"].permissions).toEqual({ "pull-requests": "write" });
     expect(workflow.jobs.scorecard.needs).toEqual(reportNeeds);
   });
 
   it("rejects aggregation, permission, and secret-scope drift", () => {
     const workflow = readE2eOperationsWorkflow();
-    (workflow.jobs["notify-on-failure"].needs as string[]).pop();
-    workflow.jobs["notify-on-failure"].permissions = { contents: "write", issues: "write" };
+    (workflow.jobs.scorecard.needs as string[]).pop();
     workflow.jobs.scorecard.permissions = {
       actions: "read",
       contents: "read",
@@ -49,10 +49,68 @@ describe("E2E operations workflow boundary", () => {
 
     expect(validateE2eOperationsWorkflow(workflow)).toEqual(
       expect.arrayContaining([
-        "notify-on-failure needs must exactly match report-to-pr needs",
-        "notify-on-failure must hold only issues: write",
+        "scorecard needs must exactly match report-to-pr needs",
         "scorecard permissions must be actions: read and contents: read",
         "scorecard must not expose credentials at job scope",
+      ]),
+    );
+  });
+
+  it("rejects restoration of scheduled issue routing or broad issue-write access", () => {
+    const workflow = readE2eOperationsWorkflow();
+    workflow.permissions = "write-all";
+    workflow.jobs["notify-on-failure"] = {
+      permissions: { issues: "write" },
+      steps: [{ run: "await github.rest.issues.create({});" }],
+    };
+    workflow.jobs.scorecard.permissions = { issues: "write" };
+    workflow.jobs.scorecard.steps!.push({
+      run: "await github.rest.issues.createComment({});",
+    });
+    workflow.jobs["cloud-onboard"].permissions = "write-all";
+    workflow.jobs["report-to-pr"].permissions = "write-all";
+    workflow.jobs["report-to-pr"].if = "${{ always() && github.event_name == 'schedule' }}";
+    workflow.jobs["report-to-pr"].steps!.push({
+      run: "await github.rest.issues.create({});",
+    });
+
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "notify-on-failure must remain retired",
+        "E2E workflow must not grant top-level issues: write",
+        "notify-on-failure must not hold issues: write",
+        "notify-on-failure must not mutate GitHub issues",
+        "scorecard must not hold issues: write",
+        "scorecard must not mutate GitHub issues",
+        "cloud-onboard must not hold issues: write",
+        "report-to-pr must not hold issues: write",
+        "report-to-pr must hold only pull-requests: write",
+        "report-to-pr must run only for manual workflow dispatches",
+        "report-to-pr must contain only its PR-comment step",
+        "report-to-pr must not use issue mutations or generic GitHub write surfaces",
+      ]),
+    );
+  });
+
+  it("ties the remaining issue-comment permission to the validated PR", () => {
+    const workflow = readE2eOperationsWorkflow();
+    const report = workflow.jobs["report-to-pr"].steps!.find(
+      (step) => step.name === "Post E2E target results to PR",
+    )!;
+    report.with!.script = String(report.with!.script)
+      .replace(
+        "issue_number: prNumber,",
+        "issue_number: 5093,\n              // issue_number: prNumber,",
+      )
+      .concat(
+        '\nawait github.request("POST /repos/{owner}/{repo}/issues", {});',
+        "\nconst createIssue = github.rest.issues.create; await createIssue({});",
+      );
+
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "report-to-pr must limit issue mutation to one validated PR-scoped createComment call",
+        "report-to-pr must not use issue mutations or generic GitHub write surfaces",
       ]),
     );
   });
@@ -84,45 +142,6 @@ describe("E2E operations workflow boundary", () => {
         "scorecard Slack publisher must not execute workflow-ref code via GITHUB_WORKSPACE",
         "scorecard Slack publisher must not execute workflow-ref code via require(",
       ]),
-    );
-  });
-
-  it("creates the scheduled failure issue when no historical thread exists", async () => {
-    const script = workflowScript(
-      "notify-on-failure",
-      "Create or update scheduled E2E failure issue",
-    ).replace(
-      "${{ toJSON(needs) }}",
-      JSON.stringify({ cloud: { result: "failure" }, hermes: { result: "cancelled" } }),
-    );
-    const create = vi.fn().mockResolvedValue({ data: { number: 123 } });
-    const createComment = vi.fn();
-    const github = {
-      rest: {
-        issues: {
-          create,
-          createComment,
-          listForRepo: vi.fn().mockResolvedValue({ data: [] }),
-        },
-      },
-    };
-    const context = {
-      repo: { owner: "NVIDIA", repo: "NemoClaw" },
-      runId: 456,
-      serverUrl: "https://github.com",
-    };
-
-    await new AsyncFunction("github", "context", script)(github, context);
-
-    expect(createComment).not.toHaveBeenCalled();
-    expect(create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining("**Failed:** cloud\n**Cancelled:** hermes"),
-        labels: ["bug", "CI/CD"],
-        owner: "NVIDIA",
-        repo: "NemoClaw",
-        title: expect.stringMatching(/^Nightly E2E failed — \d{4}-\d{2}-\d{2}$/u),
-      }),
     );
   });
 

--- a/test/e2e/support/openshell-gateway-auth-contract-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-auth-contract-workflow-boundary.test.ts
@@ -103,7 +103,7 @@ describe("OpenShell gateway auth contract workflow boundary", () => {
 
   it("waits for the auth contract in every aggregate result job", () => {
     const jobs = workflowJobs();
-    for (const aggregate of ["notify-on-failure", "report-to-pr", "scorecard"]) {
+    for (const aggregate of ["report-to-pr", "scorecard"]) {
       expect(jobs[aggregate]?.needs).toContain("openshell-gateway-auth-contract");
     }
   });

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -14,6 +14,14 @@ const META_JOBS = new Set(["report-to-pr", "scorecard"]);
 const FULL_SHA_ACTION = /^[^\s@]+@[0-9a-f]{40}$/u;
 const GITHUB_SCRIPT_NODE24_ACTION =
   "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3";
+const ISSUE_API_REFERENCE = /\bgithub\.rest\.issues\b/u;
+const ISSUE_MUTATION_BEYOND_COMMENT =
+  /github\.rest\.issues\.(?:addAssignees|addLabels|create|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
+const GENERIC_GITHUB_WRITE_SURFACE = /github\.(?:graphql|request)\s*\(|\bfetch\s*\(|\bgh\s+api\b/u;
+const GENERIC_ISSUE_REST_MUTATION =
+  /github\.request\s*\(\s*["'`](?:POST|PATCH|PUT|DELETE)\s+\/repos\/[^/\s]+\/[^/\s]+\/issues(?:\/|\b)/u;
+const GENERIC_ISSUE_GRAPHQL_MUTATION =
+  /github\.graphql\s*\(\s*["'`]\s*mutation\b[\s\S]*?\b(?:addComment|closeIssue|createIssue|reopenIssue|updateIssue)\b/u;
 
 type WorkflowStep = {
   env?: Record<string, unknown>;
@@ -72,6 +80,13 @@ function findStep(job: WorkflowJob, name: string): WorkflowStep {
   return job.steps?.find((step) => step.name === name) ?? {};
 }
 
+function executableSource(job: WorkflowJob): string {
+  return (job.steps ?? [])
+    .flatMap((step) => [step.run, step.with?.script])
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
+}
+
 function requirePinnedAction(errors: string[], step: WorkflowStep, owner: string): void {
   if (!FULL_SHA_ACTION.test(step.uses ?? "")) {
     errors.push(`${owner} must pin its action to a full SHA`);
@@ -112,12 +127,9 @@ function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWo
     errors.push("E2E workflow must not grant top-level issues: write");
   }
 
-  const issueMutation =
-    /github\.rest\.issues\.(?:addAssignees|addLabels|create|createComment|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
-  const issueMutationBeyondComment =
-    /github\.rest\.issues\.(?:addAssignees|addLabels|create|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
   for (const [name, job] of Object.entries(workflow.jobs)) {
     const permissions = permissionMap(job.permissions);
+    const jobSource = executableSource(job);
     if (job.permissions === "write-all" || permissions.issues === "write") {
       errors.push(`${name} must not hold issues: write`);
     }
@@ -138,7 +150,6 @@ function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWo
       }
       requireNode24GithubScript(errors, report, "report-to-pr");
       const reportScript = String(report.with?.script ?? "");
-      const jobSource = JSON.stringify(job);
       const commentCalls = jobSource.match(/github\.rest\.issues\.createComment\s*\(/gu);
       const issueNamespaceReferences = reportScript.match(/github\.rest\.issues\b/gu);
       const prScopedComment =
@@ -148,19 +159,21 @@ function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWo
           "report-to-pr must limit issue mutation to one validated PR-scoped createComment call",
         );
       }
-      const genericGithubWriteSurface =
-        /github\.(?:graphql|request)\s*\(|\bfetch\s*\(|\bgh\s+api\b/u;
       if (
         issueNamespaceReferences?.length !== 1 ||
-        issueMutationBeyondComment.test(jobSource) ||
-        genericGithubWriteSurface.test(jobSource)
+        ISSUE_MUTATION_BEYOND_COMMENT.test(jobSource) ||
+        GENERIC_GITHUB_WRITE_SURFACE.test(jobSource)
       ) {
         errors.push("report-to-pr must not use issue mutations or generic GitHub write surfaces");
       }
       continue;
     }
 
-    if (issueMutation.test(JSON.stringify(job))) {
+    if (
+      ISSUE_API_REFERENCE.test(jobSource) ||
+      GENERIC_ISSUE_REST_MUTATION.test(jobSource) ||
+      GENERIC_ISSUE_GRAPHQL_MUTATION.test(jobSource)
+    ) {
       errors.push(`${name} must not mutate GitHub issues`);
     }
   }

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -10,7 +10,7 @@ import YAML from "yaml";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
 const DEFAULT_ADVISOR_PATH = join(REPO_ROOT, ".github", "workflows", "e2e-advisor.yaml");
-const META_JOBS = new Set(["notify-on-failure", "report-to-pr", "scorecard"]);
+const META_JOBS = new Set(["report-to-pr", "scorecard"]);
 const FULL_SHA_ACTION = /^[^\s@]+@[0-9a-f]{40}$/u;
 const GITHUB_SCRIPT_NODE24_ACTION =
   "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3";
@@ -94,38 +94,74 @@ function validateAggregation(errors: string[], workflow: OperationsWorkflow): vo
   for (const name of reportNeeds) {
     if (!executionJobs.includes(name)) errors.push(`report-to-pr waits for unknown job ${name}`);
   }
-  for (const aggregate of ["notify-on-failure", "scorecard"]) {
-    const aggregateNeeds = needs(workflow.jobs[aggregate] ?? {});
-    if (!sameMembers(aggregateNeeds, reportNeeds)) {
-      errors.push(`${aggregate} needs must exactly match report-to-pr needs`);
-    }
+  const scorecardNeeds = needs(workflow.jobs.scorecard ?? {});
+  if (!sameMembers(scorecardNeeds, reportNeeds)) {
+    errors.push("scorecard needs must exactly match report-to-pr needs");
   }
 }
 
-function validateNotify(errors: string[], workflow: OperationsWorkflow): void {
-  const job = workflow.jobs["notify-on-failure"] ?? {};
+function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWorkflow): void {
+  if ("notify-on-failure" in workflow.jobs) {
+    errors.push("notify-on-failure must remain retired");
+  }
+
   if (
-    job.if !==
-    "${{ always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}"
+    workflow.permissions === "write-all" ||
+    permissionMap(workflow.permissions).issues === "write"
   ) {
-    errors.push("notify-on-failure must run only for failed or cancelled scheduled runs");
+    errors.push("E2E workflow must not grant top-level issues: write");
   }
-  const permissions = permissionMap(job.permissions);
-  if (permissions.issues !== "write" || Object.keys(permissions).length !== 1) {
-    errors.push("notify-on-failure must hold only issues: write");
-  }
-  const notify = findStep(job, "Create or update scheduled E2E failure issue");
-  requirePinnedAction(errors, notify, "notify-on-failure");
-  const script = String(notify.with?.script ?? "");
-  for (const fragment of [
-    "github.rest.issues.listForRepo",
-    "github.rest.issues.createComment",
-    "github.rest.issues.create",
-    "Nightly E2E failed",
-    "contains(needs.*.result",
-  ]) {
-    if (!script.includes(fragment) && !String(job.if ?? "").includes(fragment)) {
-      errors.push(`notify-on-failure must retain ${fragment}`);
+
+  const issueMutation =
+    /github\.rest\.issues\.(?:addAssignees|addLabels|create|createComment|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
+  const issueMutationBeyondComment =
+    /github\.rest\.issues\.(?:addAssignees|addLabels|create|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
+  for (const [name, job] of Object.entries(workflow.jobs)) {
+    const permissions = permissionMap(job.permissions);
+    if (job.permissions === "write-all" || permissions.issues === "write") {
+      errors.push(`${name} must not hold issues: write`);
+    }
+    if (name === "report-to-pr") {
+      if (
+        job.permissions === "write-all" ||
+        permissions["pull-requests"] !== "write" ||
+        Object.keys(permissions).length !== 1
+      ) {
+        errors.push("report-to-pr must hold only pull-requests: write");
+      }
+      if (job.if !== "${{ always() && github.event_name == 'workflow_dispatch' }}") {
+        errors.push("report-to-pr must run only for manual workflow dispatches");
+      }
+      const report = findStep(job, "Post E2E target results to PR");
+      if (job.steps?.length !== 1) {
+        errors.push("report-to-pr must contain only its PR-comment step");
+      }
+      requireNode24GithubScript(errors, report, "report-to-pr");
+      const reportScript = String(report.with?.script ?? "");
+      const jobSource = JSON.stringify(job);
+      const commentCalls = jobSource.match(/github\.rest\.issues\.createComment\s*\(/gu);
+      const issueNamespaceReferences = reportScript.match(/github\.rest\.issues\b/gu);
+      const prScopedComment =
+        /await\s+github\.rest\.issues\.createComment\(\{\s*owner:\s*context\.repo\.owner,\s*repo:\s*context\.repo\.repo,\s*issue_number:\s*prNumber,\s*body:\s*lines\.join\('\\n'\),?\s*\}\);/u;
+      if (commentCalls?.length !== 1 || !prScopedComment.test(reportScript)) {
+        errors.push(
+          "report-to-pr must limit issue mutation to one validated PR-scoped createComment call",
+        );
+      }
+      const genericGithubWriteSurface =
+        /github\.(?:graphql|request)\s*\(|\bfetch\s*\(|\bgh\s+api\b/u;
+      if (
+        issueNamespaceReferences?.length !== 1 ||
+        issueMutationBeyondComment.test(jobSource) ||
+        genericGithubWriteSurface.test(jobSource)
+      ) {
+        errors.push("report-to-pr must not use issue mutations or generic GitHub write surfaces");
+      }
+      continue;
+    }
+
+    if (issueMutation.test(JSON.stringify(job))) {
+      errors.push(`${name} must not mutate GitHub issues`);
     }
   }
 }
@@ -317,7 +353,7 @@ export function validateE2eOperationsWorkflow(
 ): string[] {
   const errors: string[] = [];
   validateAggregation(errors, workflow);
-  validateNotify(errors, workflow);
+  validateIssueRoutingRetirement(errors, workflow);
   validateScorecard(errors, workflow);
   validateTraceTiming(errors, workflow);
   validateAdvisorRetirement(errors, advisorPath);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Retires per-schedule GitHub issue routing from the consolidated E2E workflow while preserving GitHub Actions run history as the authoritative record, scheduled scorecards and Slack notifications, trace timing, and manual PR result comments. Removes general issue-write capability and adds regression boundaries so issue routing cannot be restored accidentally.

## Related Issue
Implements the retired issue-routing disposition in #5919. #5093 was closed as retired (`not planned`), not fixed by this PR.

## Changes
- Remove the `notify-on-failure` job, its `issues: write` permission, and its scorecard metadata entry.
- Restrict `report-to-pr` to `pull-requests: write` and retain its single validated PR-scoped comment path.
- Extend the E2E operations boundary to reject restored scheduled issue routing, top-level or job-level issue-write access, `write-all`, and non-PR issue mutations.
- Update E2E support tests and the operations README so only `report-to-pr` and `scorecard` aggregate execution jobs, and document that any future issue escalation needs a separately reviewed exceptional threshold.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing documentation changes; the internal E2E operations README is updated.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Fresh independent approval of the retired disposition is requested in the [Domain 8 review request](https://github.com/NVIDIA/NemoClaw/issues/5919#issuecomment-4837036523); the prior approval covered the superseded Equivalent disposition.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification evidence: all 51 targeted E2E support tests pass. Repository checks, workflow/config validation, TypeScript type-checking, Biome, diff checks, normal commit hooks, and normal push hooks pass. [Selective run 28497565173](https://github.com/NVIDIA/NemoClaw/actions/runs/28497565173) also proves that `report-to-pr` can post with only `pull-requests: write` and that Slack remains skipped off `main` even when `post_to_slack=true`.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped scheduled E2E failure routing from creating/updating “Nightly E2E failed” issues.
  * Restricted PR result reporting so it no longer has broad issue-write access.
  * Updated E2E workflow validation to match the new allowed job set and PR-comment–only behavior.

* **Documentation**
  * Clarified how scheduled/manual E2E results are sourced and how issue escalation is handled.
  * Updated guidance for aggregation prerequisites and trace sanitization.

* **Tests**
  * Adjusted workflow boundary and permission/error-message expectations to reflect the retired routing and revised job dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->