### PR TITLE
feat(messaging): add catalog boundary

### DIFF
--- a/src/lib/actions/sandbox/channel-status.ts
+++ b/src/lib/actions/sandbox/channel-status.ts
@@ -19,7 +19,7 @@ import {
   type MessagingChannelDiagnosticSpec,
 } from "../../messaging/diagnostics";
 import {
-  createBuiltInChannelManifestRegistry,
+  createBuiltInMessagingCatalog,
   getMessagingManifestAvailabilityContext,
 } from "../../messaging";
 import * as policies from "../../policy";
@@ -99,7 +99,7 @@ export type ChannelStatusReport =
 // channels status from inheriting that hang.
 const WHATSAPP_PROBE_TIMEOUT_MS = 8_000;
 const CHANNEL_STATUS_DIAGNOSTICS = collectBuiltInMessagingChannelDiagnostics();
-const channelManifestRegistry = createBuiltInChannelManifestRegistry();
+const channelManifestRegistry = createBuiltInMessagingCatalog().manifestRegistry;
 
 const SHELL_OK = "NEMOCLAW_WA_DIAG_OK";
 const HEARTBEAT_BEGIN = "NEMOCLAW_WA_HEARTBEAT_BEGIN";

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -10,9 +10,7 @@ import { prompt as askPrompt, getCredential } from "../../credentials/store";
 import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import {
   type ChannelManifest,
-  createBuiltInChannelManifestRegistry,
-  createBuiltInMessagingHookRegistry,
-  createBuiltInRenderTemplateResolver,
+  createBuiltInMessagingCatalog,
   createMessagingPreEnableHookInputs,
   formatSupportedMessagingAgentIds,
   getMessagingManifestAvailabilityContext,
@@ -72,7 +70,8 @@ type ChannelMutationOptions = {
   force?: boolean;
 };
 
-const messagingManifestRegistry = createBuiltInChannelManifestRegistry();
+const messagingCatalog = createBuiltInMessagingCatalog();
+const messagingManifestRegistry = messagingCatalog.manifestRegistry;
 
 const useColor = !process.env.NO_COLOR && !!process.stdout.isTTY;
 const trueColor =
@@ -386,9 +385,7 @@ async function checkChannelAddConflict(
   // what planToConflictChannelRequests() produces from bindings. QR-only
   // channels (e.g. WhatsApp) have no manifest credentials → early exit with no
   // conflict possible. Unknown channelName → also exits early.
-  const channelManifest = createBuiltInChannelManifestRegistry()
-    .list()
-    .find((m) => m.id === channelName);
+  const channelManifest = messagingManifestRegistry.get(channelName);
   if (!channelManifest || channelManifest.credentials.length === 0) return true;
 
   const credentialHashes: Record<string, string> = {};
@@ -478,7 +475,7 @@ async function checkMessagingPreEnableHooks(
     return true;
   }
 
-  const hookRegistry = createBuiltInMessagingHookRegistry();
+  const hookRegistry = createBuiltInMessagingCatalog().hookRegistry;
   const currentGatewayName = getSandboxTargetGatewayName(sandboxName);
   const additionalInputs = createMessagingPreEnableHookInputs({
     currentSandbox: sandboxName,
@@ -699,13 +696,15 @@ async function runMessagingHealthChecksAfterRebuild(
 ): Promise<void> {
   if (MessagingSetupApplier.listHealthChecks(plan).length === 0) return;
 
-  const hookRegistry = createBuiltInMessagingHookRegistry({
-    openclawBridgeHealth: {
-      sandboxName,
-      executeSandboxCommand: (command, timeoutMs) =>
-        executeSandboxExecCommand(sandboxName, command, timeoutMs),
+  const hookRegistry = createBuiltInMessagingCatalog({
+    hooks: {
+      openclawBridgeHealth: {
+        sandboxName,
+        executeSandboxCommand: (command, timeoutMs) =>
+          executeSandboxExecCommand(sandboxName, command, timeoutMs),
+      },
     },
-  });
+  }).hookRegistry;
   try {
     await MessagingSetupApplier.applyHealthChecks(plan, {
       runHook: (request) =>
@@ -742,8 +741,8 @@ async function planSandboxChannelAdd(
 ): Promise<SandboxMessagingPlan> {
   const planner = new MessagingWorkflowPlanner(
     messagingManifestRegistry,
-    createBuiltInMessagingHookRegistry(),
-    createBuiltInRenderTemplateResolver(),
+    createBuiltInMessagingCatalog().hookRegistry,
+    messagingCatalog.renderTemplateResolver,
   );
   const availableChannels = availableManifestChannelsForAgent(agent);
   const supportedChannelIds = availableChannels.map((manifest) => manifest.id);
@@ -782,7 +781,7 @@ export async function persistManifestChannelDisabledPlan(
   const planner = new MessagingWorkflowPlanner(
     messagingManifestRegistry,
     undefined,
-    createBuiltInRenderTemplateResolver(),
+    messagingCatalog.renderTemplateResolver,
   );
   const context = {
     sandboxName,
@@ -815,7 +814,7 @@ export async function persistManifestChannelRemovePlan(
   const planner = new MessagingWorkflowPlanner(
     messagingManifestRegistry,
     undefined,
-    createBuiltInRenderTemplateResolver(),
+    messagingCatalog.renderTemplateResolver,
   );
   const plan = await planner.buildChannelRemovePlanFromSandboxEntry({
     sandboxName,

--- a/src/lib/actions/sandbox/rebuild.ts
+++ b/src/lib/actions/sandbox/rebuild.ts
@@ -41,8 +41,7 @@ import type {
   SandboxMessagingPlan,
 } from "../../messaging";
 import {
-  createBuiltInChannelManifestRegistry,
-  createBuiltInRenderTemplateResolver,
+  createBuiltInMessagingCatalog,
   isMessagingSupportedAgent,
   listSupportedMessagingChannelIdsForAgent,
   MessagingSetupApplier,
@@ -222,7 +221,8 @@ export async function stageMessagingManifestPlanForRebuild(
   log: (msg: string) => void,
 ): Promise<SandboxMessagingPlan | null> {
   const agent = loadAgent(rebuildAgent || "openclaw");
-  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const catalog = createBuiltInMessagingCatalog();
+  const manifestRegistry = catalog.manifestRegistry;
   const manifests = manifestRegistry.list();
   const agentId = tryGetMessagingAgentId(agent, manifests);
   if (agentId === null) {
@@ -243,7 +243,7 @@ export async function stageMessagingManifestPlanForRebuild(
   const planner = new MessagingWorkflowPlanner(
     manifestRegistry,
     undefined,
-    createBuiltInRenderTemplateResolver(),
+    catalog.renderTemplateResolver,
   );
   const plan = await planner.buildRebuildPlanFromSandboxEntry({
     sandboxName,

--- a/src/lib/messaging/AGENTS.md
+++ b/src/lib/messaging/AGENTS.md
@@ -12,13 +12,14 @@ The design goal is to keep messaging channel behavior out of core onboard/rebuil
 ## Data Flow
 
 1. Channel manifests live in `channels/<channel>/manifest.ts` and are registered by `channels/built-ins.ts`.
-2. `MessagingWorkflowPlanner` selects the right workflow shape for onboard, add, remove, start, stop, or rebuild.
-3. `ManifestCompiler` and `compiler/engines/*` compile manifests into a `SandboxMessagingPlan`.
-4. `MessagingSetupApplier` serializes the plan through `NEMOCLAW_MESSAGING_PLAN_B64`.
-5. `onboard/dockerfile-patch.ts` bakes the plan into the sandbox build.
-6. `applier/build/messaging-build-applier.mts` applies agent install, render, post-agent-install build files, and writes the reduced runtime plan artifact.
-7. `MessagingHostStateApplier` persists durable plan state under the sandbox registry entry.
-8. Rebuild reads the persisted plan, stages a fresh build plan, and reapplies OpenClaw render/post-install hooks after `openclaw doctor` rewrites config.
+2. `catalog/` packages the built-in manifests, hook registry, template resolver, and policy-source metadata behind one application-facing boundary.
+3. `MessagingWorkflowPlanner` selects the right workflow shape for onboard, add, remove, start, stop, or rebuild.
+4. `ManifestCompiler` and `compiler/engines/*` compile manifests into a `SandboxMessagingPlan`.
+5. `MessagingSetupApplier` serializes the plan through `NEMOCLAW_MESSAGING_PLAN_B64`.
+6. `onboard/dockerfile-patch.ts` bakes the plan into the sandbox build.
+7. `applier/build/messaging-build-applier.mts` applies agent install, render, post-agent-install build files, and writes the reduced runtime plan artifact.
+8. `MessagingHostStateApplier` persists durable plan state under the sandbox registry entry.
+9. Rebuild reads the persisted plan, stages a fresh build plan, and reapplies OpenClaw render/post-install hooks after `openclaw doctor` rewrites config.
 
 ## Package Map
 
@@ -26,6 +27,7 @@ The design goal is to keep messaging channel behavior out of core onboard/rebuil
 |---|---|
 | `manifest/` | Serializable manifest and plan contracts. Keep these JSON-compatible. |
 | `channels/` | Built-in channel manifests, channel metadata helpers, template resolvers, runtime preload assets, and channel hook implementations. |
+| `catalog/` | Application-facing catalog assembly for built-in manifests, hooks, render-template resolution, and policy-source metadata. |
 | `compiler/` | Manifest-to-plan compilation. It may resolve env/config inputs and run enrollment/reachability/build hooks, but should not mutate OpenShell or registry state directly. |
 | `hooks/` | Hook contracts, registries, runner validation, common prompt/static-output helpers, and conflict error types. |
 | `applier/` | Host/OpenShell side effects: plan env serialization, provider upsert/reuse, policy apply, agent config writes, hook phase execution, conflict detection, registry persistence, and build-time applier. |
@@ -43,7 +45,7 @@ The design goal is to keep messaging channel behavior out of core onboard/rebuil
 - Channel render/build-file targets must stay inside `/sandbox/.openclaw` or `/sandbox/.hermes`; rely on existing applier validation instead of bypassing it.
 - Disabled channels are not active. Always filter effects through `enabledPlanChannels()` or `filterEnabledPlanEntries()` when applying providers, policies, render, hooks, runtime setup, or conflicts.
 - Conflict detection has two axes: generic credential-hash overlap in `applier/conflict-detection/` and channel-owned `pre-enable` hooks such as Slack Socket Mode gateway checks.
-- Keep transitional compatibility tables derived from manifests. `src/lib/sandbox/channels.ts` intentionally builds legacy CLI metadata from `listBuiltInMessagingChannelManifests()`.
+- Keep transitional compatibility tables derived from built-in manifests. `src/lib/sandbox/channels.ts` intentionally builds legacy CLI metadata from `listBuiltInMessagingChannelManifests()` because common hook registration depends on that legacy table.
 
 ## Adding or Changing a Channel
 

--- a/src/lib/messaging/README.md
+++ b/src/lib/messaging/README.md
@@ -14,6 +14,7 @@ Channel-specific behavior belongs in manifests, template resolvers, hook handler
 ```mermaid
 flowchart TD
   manifest["channels/<channel>/manifest.ts"]
+  catalog["MessagingCatalog"]
   registry["ChannelManifestRegistry"]
   planner["MessagingWorkflowPlanner"]
   compiler["ManifestCompiler"]
@@ -25,7 +26,8 @@ flowchart TD
   state["MessagingHostStateApplier and sandbox registry"]
   rebuild["rebuild hydration"]
 
-  manifest --> registry
+  manifest --> catalog
+  catalog --> registry
   registry --> planner
   planner --> compiler
   compiler --> plan
@@ -42,13 +44,14 @@ flowchart TD
 The workflow has these stages.
 
 1. Built-in manifests live under `channels/<channel>/manifest.ts` and are registered by `channels/built-ins.ts`.
-2. `MessagingWorkflowPlanner` chooses the workflow shape for onboard, add, remove, start, stop, or rebuild.
-3. `ManifestCompiler` filters supported channels, resolves inputs, runs compiler-time hooks, and compiles a `SandboxMessagingPlan`.
-4. `MessagingSetupApplier` serializes the plan through `NEMOCLAW_MESSAGING_PLAN_B64` and applies provider, policy, agent config, and hook phases on the host side.
-5. `src/lib/onboard/dockerfile-patch.ts` passes the encoded plan into image builds.
-6. `applier/build/messaging-build-applier.mts` applies build-time package installs, render entries, post-agent-install files, and the reduced runtime plan artifact.
-7. `MessagingHostStateApplier` persists compact plan state under the sandbox registry entry.
-8. Rebuild hydrates persisted plans from current manifests so compacted render, host-forward, package, runtime, and hook fields stay current.
+2. `MessagingCatalog` packages the manifest registry, hook registry, render-template resolver, and policy-source metadata used by application code.
+3. `MessagingWorkflowPlanner` chooses the workflow shape for onboard, add, remove, start, stop, or rebuild.
+4. `ManifestCompiler` filters supported channels, resolves inputs, runs compiler-time hooks, and compiles a `SandboxMessagingPlan`.
+5. `MessagingSetupApplier` serializes the plan through `NEMOCLAW_MESSAGING_PLAN_B64` and applies provider, policy, agent config, and hook phases on the host side.
+6. `src/lib/onboard/dockerfile-patch.ts` passes the encoded plan into image builds.
+7. `applier/build/messaging-build-applier.mts` applies build-time package installs, render entries, post-agent-install files, and the reduced runtime plan artifact.
+8. `MessagingHostStateApplier` persists compact plan state under the sandbox registry entry.
+9. Rebuild hydrates persisted plans from current manifests so compacted render, host-forward, package, runtime, and hook fields stay current.
    Non-empty persisted `networkPolicy` entries are preserved and regenerated only when they are absent or empty.
 
 ## Class Diagram
@@ -96,6 +99,14 @@ classDiagram
     +listAvailable(ctx)
   }
 
+  class MessagingCatalog {
+    manifests: ChannelManifest[]
+    manifestRegistry: ChannelManifestRegistry
+    hookRegistry: MessagingHookRegistry
+    renderTemplateResolver
+    policySources
+  }
+
   class MessagingWorkflowPlanner {
     -compiler: ManifestCompiler
     +buildPlan(context)
@@ -141,6 +152,8 @@ classDiagram
     +applyPlanToRegistry(sandboxName, plan, options)
   }
 
+  MessagingCatalog --> ChannelManifestRegistry
+  MessagingCatalog --> MessagingHookRegistry
   ChannelManifestRegistry "1" o-- "*" ChannelManifest
   MessagingWorkflowPlanner --> ManifestCompiler
   ManifestCompiler --> ChannelManifestRegistry
@@ -157,6 +170,7 @@ classDiagram
 |---|---|
 | `manifest/` | Serializable manifest and plan contracts plus `ChannelManifestRegistry`. |
 | `channels/` | Built-in channel manifests, channel metadata, template resolvers, runtime preload assets, and channel hook implementations. |
+| `catalog/` | Application-facing assembly of manifests, registries, render-template resolution, and policy-source metadata. |
 | `compiler/` | Manifest-to-plan compilation for inputs, credentials, policy, render, host forwards, build steps, runtime setup, state, and health checks. |
 | `hooks/` | Hook contracts, registries, runner validation, common handlers, and conflict errors. |
 | `applier/` | Host/OpenShell side effects for credentials, policy, config writes, hook phase execution, plan env serialization, filtering, conflicts, registry persistence, and build-time application. |
@@ -402,16 +416,15 @@ The planner understands lifecycle workflows and persisted sandbox state.
 
 ```ts
 import {
-  createBuiltInChannelManifestRegistry,
-  createBuiltInMessagingHookRegistry,
-  createBuiltInRenderTemplateResolver,
+  createBuiltInMessagingCatalog,
   MessagingWorkflowPlanner,
 } from "../messaging";
 
+const catalog = createBuiltInMessagingCatalog();
 const planner = new MessagingWorkflowPlanner(
-  createBuiltInChannelManifestRegistry(),
-  createBuiltInMessagingHookRegistry(),
-  createBuiltInRenderTemplateResolver(),
+  catalog.manifestRegistry,
+  catalog.hookRegistry,
+  catalog.renderTemplateResolver,
 );
 
 const plan = await planner.buildPlan({

--- a/src/lib/messaging/catalog/index.test.ts
+++ b/src/lib/messaging/catalog/index.test.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { BUILT_IN_CHANNEL_MANIFESTS } from "../channels";
+import type { ChannelManifest } from "../manifest";
+import { createBuiltInMessagingCatalog, createMessagingCatalog } from "./index";
+
+const demoManifest = {
+  schemaVersion: 1,
+  id: "demo",
+  displayName: "Demo",
+  supportedAgents: ["openclaw"],
+  auth: { mode: "none" },
+  inputs: [],
+  credentials: [],
+  policyPresets: ["demo-policy", { name: "demo-extra-policy" }],
+  render: [],
+  hooks: [],
+} as const satisfies ChannelManifest;
+
+describe("MessagingCatalog", () => {
+  it("assembles built-in messaging dependencies behind one boundary", () => {
+    const catalog = createBuiltInMessagingCatalog();
+    const builtInIds = BUILT_IN_CHANNEL_MANIFESTS.map((manifest) => manifest.id);
+
+    expect(catalog.manifests.map((manifest) => manifest.id)).toEqual(builtInIds);
+    expect(catalog.manifestRegistry.list().map((manifest) => manifest.id)).toEqual(builtInIds);
+    expect(catalog.hookRegistry.listIds()).toContain("common.staticOutputs");
+    expect(catalog.renderTemplateResolver("unknown.reference", { inputs: [] })).toBeUndefined();
+    expect(catalog.policySources).toContainEqual({
+      channelId: "telegram",
+      presetName: "telegram",
+    });
+  });
+
+  it("builds custom catalogs from supplied manifests, hooks, resolver, and policy sources", () => {
+    const hookHandler = () => ({ outputs: {} });
+    const renderTemplateResolver = () => ({ matched: true, value: "resolved" }) as const;
+    const catalog = createMessagingCatalog({
+      manifests: [demoManifest],
+      hookRegistrations: [{ id: "demo.hook", handler: hookHandler }],
+      renderTemplateResolver,
+      policySources: [{ channelId: "demo", presetName: "demo-policy" }],
+    });
+
+    expect(catalog.manifestRegistry.get("demo")).toBe(demoManifest);
+    expect(catalog.hookRegistry.require("demo.hook")).toBe(hookHandler);
+    expect(catalog.renderTemplateResolver("demo.reference", { inputs: [] })).toEqual({
+      matched: true,
+      value: "resolved",
+    });
+    expect(catalog.policySources).toEqual([{ channelId: "demo", presetName: "demo-policy" }]);
+  });
+
+  it("keeps manifest id validation at the catalog boundary", () => {
+    expect(() =>
+      createMessagingCatalog({
+        manifests: [demoManifest, demoManifest],
+      }).manifestRegistry.list(),
+    ).toThrow("Duplicate channel manifest id 'demo'");
+  });
+});

--- a/src/lib/messaging/catalog/index.ts
+++ b/src/lib/messaging/catalog/index.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BUILT_IN_CHANNEL_MANIFESTS, createBuiltInRenderTemplateResolver } from "../channels";
+import type { RenderTemplateReferenceResolver } from "../compiler/engines/template";
+import {
+  type BuiltInMessagingHookOptions,
+  createBuiltInMessagingHookRegistrations,
+} from "../hooks";
+import { MessagingHookRegistry } from "../hooks/registry";
+import type { MessagingHookRegistration } from "../hooks/types";
+import type { ChannelManifest } from "../manifest";
+import { ChannelManifestRegistry } from "../manifest";
+
+export interface MessagingPolicySource {
+  readonly presetName: string;
+  readonly channelId: string;
+}
+
+export interface MessagingCatalog {
+  readonly manifests: readonly ChannelManifest[];
+  readonly manifestRegistry: ChannelManifestRegistry;
+  readonly hookRegistrations: readonly MessagingHookRegistration[];
+  readonly hookRegistry: MessagingHookRegistry;
+  readonly renderTemplateResolver: RenderTemplateReferenceResolver;
+  readonly policySources: readonly MessagingPolicySource[];
+}
+
+export interface MessagingCatalogSource {
+  readonly manifests?: readonly ChannelManifest[];
+  readonly hookRegistrations?:
+    | readonly MessagingHookRegistration[]
+    | (() => readonly MessagingHookRegistration[]);
+  readonly renderTemplateResolver?: RenderTemplateReferenceResolver;
+  readonly policySources?: readonly MessagingPolicySource[];
+}
+
+export interface BuiltInMessagingCatalogOptions {
+  readonly hooks?: BuiltInMessagingHookOptions;
+}
+
+export function createMessagingCatalog(source: MessagingCatalogSource = {}): MessagingCatalog {
+  const manifests = [...(source.manifests ?? [])];
+  let hookRegistrations: readonly MessagingHookRegistration[] | undefined;
+  let manifestRegistry: ChannelManifestRegistry | undefined;
+  let hookRegistry: MessagingHookRegistry | undefined;
+  const getHookRegistrations = () => {
+    if (!hookRegistrations) {
+      const registrations =
+        typeof source.hookRegistrations === "function"
+          ? source.hookRegistrations()
+          : (source.hookRegistrations ?? []);
+      hookRegistrations = [...registrations];
+    }
+    return hookRegistrations;
+  };
+  return {
+    manifests,
+    get manifestRegistry() {
+      manifestRegistry ??= new ChannelManifestRegistry(manifests);
+      return manifestRegistry;
+    },
+    get hookRegistrations() {
+      return getHookRegistrations();
+    },
+    get hookRegistry() {
+      hookRegistry ??= new MessagingHookRegistry(getHookRegistrations());
+      return hookRegistry;
+    },
+    renderTemplateResolver: source.renderTemplateResolver ?? (() => undefined),
+    policySources: [...(source.policySources ?? [])],
+  };
+}
+
+export function createBuiltInMessagingCatalog(
+  options: BuiltInMessagingCatalogOptions = {},
+): MessagingCatalog {
+  return createMessagingCatalog({
+    manifests: BUILT_IN_CHANNEL_MANIFESTS,
+    hookRegistrations: () => createBuiltInMessagingHookRegistrations(options.hooks),
+    renderTemplateResolver: createBuiltInRenderTemplateResolver(),
+    policySources: builtInMessagingPolicySources(),
+  });
+}
+
+function builtInMessagingPolicySources(): MessagingPolicySource[] {
+  return BUILT_IN_CHANNEL_MANIFESTS.flatMap((manifest) =>
+    (manifest.policyPresets ?? []).map((preset) => ({
+      channelId: manifest.id,
+      presetName: typeof preset === "string" ? preset : preset.name,
+    })),
+  );
+}

--- a/src/lib/messaging/compiler/engines/agent-render-engine.ts
+++ b/src/lib/messaging/compiler/engines/agent-render-engine.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createBuiltInMessagingHookRegistry, runMessagingHook } from "../../hooks";
+import { createBuiltInMessagingCatalog } from "../../catalog";
+import { runMessagingHook } from "../../hooks";
 import { COMMON_STATIC_OUTPUTS_HOOK_HANDLER_ID } from "../../hooks/common/static-outputs";
 import type {
   ChannelHookSpec,
@@ -29,7 +30,7 @@ export async function planAgentRender(
   manifest: ChannelManifest,
   context: ManifestCompilerContext,
   inputs: readonly SandboxMessagingInputReference[] = [],
-  hooks = createBuiltInMessagingHookRegistry(),
+  hooks = createBuiltInMessagingCatalog().hookRegistry,
   referenceResolver?: RenderTemplateReferenceResolver,
 ): Promise<SandboxMessagingAgentRenderPlan[]> {
   const plans: SandboxMessagingAgentRenderPlan[] = [];

--- a/src/lib/messaging/diagnostics.ts
+++ b/src/lib/messaging/diagnostics.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createBuiltInChannelManifestRegistry } from "./channels";
+import { createBuiltInMessagingCatalog } from "./catalog";
 import type { ChannelManifest, ChannelPolicyPresetReference, MessagingAgentId } from "./manifest";
 
 export interface MessagingChannelDiagnosticSpec {
@@ -19,7 +19,7 @@ export function collectBuiltInMessagingChannelDiagnostics(
   options: { readonly agent?: MessagingAgentId } = {},
 ): MessagingChannelDiagnosticSpec[] {
   return collectMessagingChannelDiagnostics(
-    createBuiltInChannelManifestRegistry().listAvailable(
+    createBuiltInMessagingCatalog().manifestRegistry.listAvailable(
       options.agent ? { agent: options.agent } : undefined,
     ),
   );

--- a/src/lib/messaging/index.ts
+++ b/src/lib/messaging/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from "./applier";
+export * from "./catalog";
 export * from "./channels";
 export * from "./compiler";
 export * from "./diagnostics";

--- a/src/lib/messaging/persistence.ts
+++ b/src/lib/messaging/persistence.ts
@@ -1,10 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  createBuiltInChannelManifestRegistry,
-  createBuiltInRenderTemplateResolver,
-} from "./channels";
+import { createBuiltInMessagingCatalog, type MessagingCatalog } from "./catalog";
 import { planCredentialBindings } from "./compiler/engines/credential-binding-engine";
 import { planHealthChecks } from "./compiler/engines/health-check-engine";
 import { planHostForward } from "./compiler/engines/host-forward-engine";
@@ -22,7 +19,7 @@ import {
 } from "./compiler/engines/template";
 import type { ManifestCompilerContext } from "./compiler/types";
 import type { MessagingHookInputMap, MessagingHookOutputMap } from "./hooks";
-import { BUILT_IN_MESSAGING_HOOK_REGISTRY, runMessagingHookSync } from "./hooks";
+import { runMessagingHookSync } from "./hooks";
 import type {
   ChannelHookSpec,
   ChannelInputSpec,
@@ -46,6 +43,13 @@ import {
   normalizeFullPersistedCredentialBindings,
   normalizePersistedAgentCredentialPlaceholders,
 } from "./persisted-placeholders";
+
+let cachedBuiltInMessagingCatalog: MessagingCatalog | undefined;
+
+function getBuiltInMessagingCatalog(): MessagingCatalog {
+  cachedBuiltInMessagingCatalog ??= createBuiltInMessagingCatalog();
+  return cachedBuiltInMessagingCatalog;
+}
 
 export type PersistedSandboxMessagingInputReference = Pick<
   SandboxMessagingInputReference,
@@ -150,7 +154,7 @@ export function compactSandboxMessagingPlanForPersistence(
 export function hydrateDerivedSandboxMessagingPlanFields(
   plan: SandboxMessagingPlan,
 ): SandboxMessagingPlan {
-  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const manifestRegistry = getBuiltInMessagingCatalog().manifestRegistry;
   const channels = plan.channels.map((channel) =>
     hydrateChannelFromManifest(plan, channel, manifestRegistry.get(channel.channelId)),
   );
@@ -187,7 +191,7 @@ export function hydrateDerivedSandboxMessagingPlanFields(
 export function normalizePersistedSandboxMessagingPlanShape(
   plan: MaybeCompactMessagingPlan,
 ): SandboxMessagingPlan {
-  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const manifestRegistry = getBuiltInMessagingCatalog().manifestRegistry;
   const disabledChannels = plan.disabledChannels.filter(
     (channelId) => typeof channelId === "string",
   );
@@ -249,7 +253,12 @@ function normalizePersistedChannel(
   const active =
     channel.active ?? (configured && !disabled && requiredInputsAvailable(manifest, inputs));
   const hostForward = manifest
-    ? planHostForward(manifest, inputs, active && !disabled, createBuiltInRenderTemplateResolver())
+    ? planHostForward(
+        manifest,
+        inputs,
+        active && !disabled,
+        getBuiltInMessagingCatalog().renderTemplateResolver,
+      )
     : undefined;
 
   return {
@@ -362,7 +371,7 @@ function requiredInputsAvailable(
 function normalizePersistedCredentialBindings(
   plan: MaybeCompactMessagingPlan,
   channels: readonly SandboxMessagingChannelPlan[],
-  manifestRegistry: ReturnType<typeof createBuiltInChannelManifestRegistry>,
+  manifestRegistry: MessagingCatalog["manifestRegistry"],
 ): SandboxMessagingCredentialBindingPlan[] {
   const persisted = plan.credentialBindings ?? [];
   if (
@@ -409,7 +418,7 @@ function hydrateChannelFromManifest(
   const configured = channel.configured;
   const active = channel.active && !disabled;
   const hostForward = manifest
-    ? planHostForward(manifest, inputs, active, createBuiltInRenderTemplateResolver())
+    ? planHostForward(manifest, inputs, active, getBuiltInMessagingCatalog().renderTemplateResolver)
     : undefined;
   return {
     ...channelWithoutHostForward,
@@ -546,7 +555,7 @@ function buildHookOutputs(
   hook: ChannelHookSpec,
   channel: SandboxMessagingChannelPlan,
 ): MessagingHookOutputMap {
-  return runMessagingHookSync(hook, BUILT_IN_MESSAGING_HOOK_REGISTRY, {
+  return runMessagingHookSync(hook, getBuiltInMessagingCatalog().hookRegistry, {
     channelId: manifest.id,
     inputs: selectHookInputs(buildHookInputMap(channel, plan.credentialBindings), hook.inputs),
   }).outputs;
@@ -660,10 +669,10 @@ function channelHooksFromManifest(
 
 function agentRenderFromManifests(
   plan: SandboxMessagingPlan,
-  manifestRegistry: ReturnType<typeof createBuiltInChannelManifestRegistry>,
+  manifestRegistry: MessagingCatalog["manifestRegistry"],
 ): SandboxMessagingAgentRenderPlan[] {
   const render: SandboxMessagingAgentRenderPlan[] = [];
-  const referenceResolver = createBuiltInRenderTemplateResolver();
+  const referenceResolver = getBuiltInMessagingCatalog().renderTemplateResolver;
   for (const channel of plan.channels) {
     const manifest = manifestRegistry.get(channel.channelId);
     if (!manifest) continue;

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  createBuiltInChannelManifestRegistry,
+  createBuiltInMessagingCatalog,
   listSupportedMessagingChannelIdsForAgent,
   tryGetMessagingAgentId,
 } from "../../../messaging";
@@ -47,7 +47,7 @@ export interface ReconcileSandboxMessagingOptions<Agent> {
   readonly deps: SandboxMessagingDeps<Agent>;
 }
 
-const messagingManifestRegistry = createBuiltInChannelManifestRegistry();
+const messagingManifestRegistry = createBuiltInMessagingCatalog().manifestRegistry;
 
 function refreshCredentialHashesFromEnv(plan: SandboxMessagingPlan): {
   plan: SandboxMessagingPlan;

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -6,11 +6,10 @@ import { getCredential, normalizeCredentialValue } from "../credentials/store";
 import {
   type ChannelInputSpec,
   type ChannelManifest,
-  createBuiltInChannelManifestRegistry,
-  createBuiltInMessagingHookRegistry,
-  createBuiltInRenderTemplateResolver,
+  createBuiltInMessagingCatalog,
   getMessagingManifestAvailabilityContext,
   hasMessagingManifestRequiredInputs,
+  type MessagingCatalog,
   MessagingHostStateApplier,
   MessagingSetupApplier,
   MessagingWorkflowPlanner,
@@ -38,6 +37,7 @@ export interface SetupSelectedMessagingChannelsOptions {
   readonly agent?: { readonly name?: string } | null;
   readonly sandboxName?: string | null;
   readonly interactive?: boolean;
+  readonly catalog?: MessagingCatalog;
 }
 
 export interface SetupMessagingChannelsDeps {
@@ -68,7 +68,7 @@ const getMessagingInputValue = (input: ChannelInputSpec): string | null => {
  * presets are not messaging channel selection.
  */
 export function detectMessagingChannelsFromEnv(agent: AgentDefinition | null = null): string[] {
-  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const manifestRegistry = createBuiltInMessagingCatalog().manifestRegistry;
   const availabilityContext = getMessagingManifestAvailabilityContext(
     agent,
     manifestRegistry.list(),
@@ -99,7 +99,8 @@ export async function setupMessagingChannels(
   const note = deps.note ?? console.log;
   const isNonInteractive =
     deps.isNonInteractive ?? (() => process.env.NEMOCLAW_NON_INTERACTIVE === "1");
-  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const catalog = createBuiltInMessagingCatalog();
+  const manifestRegistry = catalog.manifestRegistry;
   const availabilityContext = getMessagingManifestAvailabilityContext(
     agent,
     manifestRegistry.list(),
@@ -121,6 +122,7 @@ export async function setupMessagingChannels(
         agent,
         interactive: false,
         sandboxName: deps.sandboxName,
+        catalog,
       });
     } else {
       MessagingSetupApplier.clearPlanEnv();
@@ -167,6 +169,7 @@ export async function setupMessagingChannels(
   await setupSelectedMessagingChannels(selected, enabled, availableChannels, {
     agent,
     sandboxName: deps.sandboxName,
+    catalog,
   });
   console.log("");
 
@@ -187,7 +190,8 @@ export async function setupSelectedMessagingChannels(
   messagingChannels: readonly ChannelManifest[],
   options: SetupSelectedMessagingChannelsOptions = {},
 ): Promise<SandboxMessagingPlan | null> {
-  const registry = createBuiltInChannelManifestRegistry();
+  const catalog = options.catalog ?? createBuiltInMessagingCatalog();
+  const registry = catalog.manifestRegistry;
   const supportedChannelIds = messagingChannels.map((channel) => channel.id);
   const selectedChannels = uniqueSelectedChannels(selected, supportedChannelIds, registry);
   if (selectedChannels.length === 0) {
@@ -199,8 +203,8 @@ export async function setupSelectedMessagingChannels(
   const sandboxName = resolveMessagingSetupSandboxName(options);
   const planner = new MessagingWorkflowPlanner(
     registry,
-    createBuiltInMessagingHookRegistry(),
-    createBuiltInRenderTemplateResolver(),
+    catalog.hookRegistry,
+    catalog.renderTemplateResolver,
   );
 
   if (options.interactive === false) {
@@ -246,7 +250,7 @@ export async function setupSelectedMessagingChannels(
 function uniqueSelectedChannels(
   selected: readonly string[],
   supportedChannelIds: readonly string[],
-  registry: ReturnType<typeof createBuiltInChannelManifestRegistry>,
+  registry: MessagingCatalog["manifestRegistry"],
 ): string[] {
   const supported = new Set(supportedChannelIds);
   const result: string[] = [];
@@ -269,7 +273,7 @@ function logEnrollmentHelp(manifest: ChannelManifest): void {
 }
 
 function buildCredentialAvailability(
-  registry: ReturnType<typeof createBuiltInChannelManifestRegistry>,
+  registry: MessagingCatalog["manifestRegistry"],
   channelIds: readonly string[],
 ): Record<string, boolean> {
   const availability: Record<string, boolean> = {};

--- a/src/lib/onboard/messaging-conflict-guard.ts
+++ b/src/lib/onboard/messaging-conflict-guard.ts
@@ -19,11 +19,8 @@ import {
   findChannelConflictsFromPlan,
   MessagingSetupApplier,
 } from "../messaging/applier";
-import {
-  createBuiltInMessagingHookRegistry,
-  isMessagingHookConflictError,
-  runMessagingHook,
-} from "../messaging/hooks";
+import { createBuiltInMessagingCatalog } from "../messaging/catalog";
+import { isMessagingHookConflictError, runMessagingHook } from "../messaging/hooks";
 import type { SandboxMessagingPlan } from "../messaging/manifest";
 
 export interface MessagingConflictGuardDeps {
@@ -127,7 +124,7 @@ async function enforceMessagingPreEnableHooks(
   const requests = MessagingSetupApplier.listPreEnableChecks(currentPlan);
   if (requests.length === 0) return;
 
-  const hookRegistry = createBuiltInMessagingHookRegistry();
+  const hookRegistry = createBuiltInMessagingCatalog().hookRegistry;
   const additionalInputs = createMessagingPreEnableHookInputs({
     currentSandbox: deps.sandboxName,
     currentGatewayName: deps.gatewayName,

--- a/src/lib/onboard/messaging-state.ts
+++ b/src/lib/onboard/messaging-state.ts
@@ -3,7 +3,7 @@
 
 import type { AgentDefinition } from "../agent/defs";
 import {
-  createBuiltInChannelManifestRegistry,
+  createBuiltInMessagingCatalog,
   getMessagingManifestAvailabilityContext,
 } from "../messaging";
 import { channelUsesInSandboxQrPairing, type ChannelDef } from "../sandbox/channels";
@@ -29,7 +29,7 @@ export function filterEnabledChannelsByAgent<T extends string[] | null | undefin
 ): T {
   if (!Array.isArray(enabledChannels)) return enabledChannels;
   if (!agent) return enabledChannels;
-  const registry = createBuiltInChannelManifestRegistry();
+  const registry = createBuiltInMessagingCatalog().manifestRegistry;
   const available = registry.listAvailable(
     getMessagingManifestAvailabilityContext(agent, registry.list()),
   );

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -4,10 +4,10 @@
 // Policy preset management — list, load, merge, and apply presets.
 
 import type { JsonObject, JsonValue } from "../core/json-types";
+import { createBuiltInMessagingCatalog } from "../messaging/catalog";
 import {
   getMessagingPolicyKeyAliases,
   getMessagingPolicyPresetValidationWarnings,
-  listBuiltInMessagingChannelManifests,
   listMessagingPolicyPresetMetadata,
 } from "../messaging/channels";
 
@@ -26,6 +26,7 @@ const openshellResolveModule = require("../adapters/openshell/resolve");
 const PRESETS_DIR = path.join(ROOT, "nemoclaw-blueprint", "policies", "presets");
 
 const MAX_PRESET_FILE_BYTES = 10_000_000;
+const builtInMessagingCatalog = createBuiltInMessagingCatalog();
 
 type PresetInfo = {
   file: string;
@@ -115,7 +116,7 @@ function parsePresetPolicyKeys(presetContent: string | null | undefined): string
 }
 
 const AGENT_PRESET_KEY_ALIASES: Readonly<Record<string, readonly string[]>> =
-  getMessagingPolicyKeyAliases();
+  getMessagingPolicyKeyAliases({ manifests: builtInMessagingCatalog.manifests });
 
 function selectAgentPolicyKeys(
   agentPolicies: PolicyObject,
@@ -209,16 +210,16 @@ function getPresetEndpoints(content: string): string[] {
  * without a running bridge. See #1691.
  */
 const MESSAGING_PRESET_LABELS: Readonly<Record<string, string>> = Object.fromEntries(
-  listMessagingPolicyPresetMetadata().flatMap((preset) => {
-    const manifest = listBuiltInMessagingChannelManifests().find(
-      (entry) => entry.id === preset.channelId,
-    );
-    return manifest ? [[preset.presetName, manifest.displayName]] : [];
-  }),
+  listMessagingPolicyPresetMetadata({ manifests: builtInMessagingCatalog.manifests }).flatMap(
+    (preset) => {
+      const manifest = builtInMessagingCatalog.manifestRegistry.get(preset.channelId);
+      return manifest ? [[preset.presetName, manifest.displayName]] : [];
+    },
+  ),
 );
 
 const MESSAGING_PRESET_VALIDATION_WARNING_LINES: Readonly<Record<string, readonly string[]>> =
-  getMessagingPolicyPresetValidationWarnings();
+  getMessagingPolicyPresetValidationWarnings({ manifests: builtInMessagingCatalog.manifests });
 
 function getPresetValidationWarning(presetName: string): string | null {
   if (presetName === "jira") {

--- a/src/lib/status-command-deps.ts
+++ b/src/lib/status-command-deps.ts
@@ -17,8 +17,8 @@ import type {
   ShowStatusCommandDeps,
 } from "./inventory";
 import { findAllOverlaps } from "./messaging/applier";
-import { createBuiltInChannelManifestRegistry } from "./messaging/channels";
-import { createBuiltInMessagingHookRegistry, runMessagingHookSync } from "./messaging/hooks";
+import { createBuiltInMessagingCatalog, type MessagingCatalog } from "./messaging/catalog";
+import { runMessagingHookSync } from "./messaging/hooks";
 import type {
   ChannelHookSpec,
   MessagingAgentId,
@@ -59,14 +59,16 @@ function checkMessagingBridgeHealth(
     channels: channelSet,
     currentSandbox: sandboxName,
     registryEntries: safeListRegistryEntries(),
-    hookRegistry: createBuiltInMessagingHookRegistry({
-      telegram: {
-        gatewayConflictStatus: {
-          executeSandboxCommand: (name, command, timeoutMs) =>
-            executeSandboxCommand(rootDir, openshell, name, command, timeoutMs),
+    hookRegistry: createBuiltInMessagingCatalog({
+      hooks: {
+        telegram: {
+          gatewayConflictStatus: {
+            executeSandboxCommand: (name, command, timeoutMs) =>
+              executeSandboxCommand(rootDir, openshell, name, command, timeoutMs),
+          },
         },
       },
-    }),
+    }).hookRegistry,
   }).flatMap(readBridgeHealthOutputs);
 }
 
@@ -102,7 +104,7 @@ interface MessagingStatusHookRunOptions {
   readonly channels?: ReadonlySet<string>;
   readonly currentSandbox?: string;
   readonly registryEntries?: readonly registry.SandboxEntry[];
-  readonly hookRegistry?: ReturnType<typeof createBuiltInMessagingHookRegistry>;
+  readonly hookRegistry?: MessagingCatalog["hookRegistry"];
 }
 
 type MessagingStatusHookRunResult = {
@@ -114,8 +116,9 @@ type MessagingStatusHookRunResult = {
 function runMessagingStatusHooks(
   options: MessagingStatusHookRunOptions,
 ): MessagingStatusHookRunResult[] {
-  const hookRegistry = options.hookRegistry ?? createBuiltInMessagingHookRegistry();
-  const manifestRegistry = createBuiltInChannelManifestRegistry();
+  const catalog = createBuiltInMessagingCatalog();
+  const hookRegistry = options.hookRegistry ?? catalog.hookRegistry;
+  const manifestRegistry = catalog.manifestRegistry;
   const agents: ReadonlySet<MessagingAgentId> = options.agent
     ? new Set<MessagingAgentId>([options.agent])
     : (options.agents ?? new Set<MessagingAgentId>(["openclaw"]));


### PR DESCRIPTION
## Summary
Introduces a behavior-preserving `MessagingCatalog` boundary for messaging built-ins so application code can consume manifests, hook registry, render-template resolution, and policy metadata from one place. This is step 1 for #6097 and does not add external plugin discovery, installation, or third-party loading.

## Related Issue
Refs #6097

## Changes
- Add `src/lib/messaging/catalog` with built-in and custom catalog constructors.
- Rewire higher-level onboard, status, rebuild, policy, diagnostics, persistence, and channel lifecycle call sites to consume the catalog boundary.
- Add catalog unit coverage and update package-local messaging architecture guidance.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: messaging compiler/applier/onboard/policy/status tests cover unchanged behavior through the new boundary.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing behavior, commands, env vars, channel support, or plugin discovery changes; package-local README/AGENTS were updated for the internal architecture boundary.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: author review; behavior-preserving dependency-boundary refactor with focused messaging/onboard/policy/status coverage.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification details:
- `npm run typecheck:cli`
- `npx vitest run --project cli src/lib/messaging src/lib/messaging-channel-config.test.ts src/lib/sandbox/channels.test.ts`
- `npx vitest run --project cli src/lib/messaging/catalog/index.test.ts src/lib/onboard/messaging-channel-setup.test.ts src/lib/onboard/messaging-channel-setup-fallback.test.ts src/lib/onboard/messaging-conflict-guard.test.ts src/lib/onboard/messaging-state.test.ts src/lib/onboard/machine/handlers/sandbox-messaging.test.ts src/lib/actions/sandbox/rebuild-messaging-stage.test.ts src/lib/actions/sandbox/channel-status.test.ts src/lib/actions/sandbox/policy-channel-conflict.test.ts src/lib/actions/sandbox/policy-channel-list.test.ts src/lib/actions/sandbox/policy-channel-policy.test.ts src/lib/actions/sandbox/policy-channel-agent-gate.test.ts src/lib/actions/sandbox/policy-channel-refresh.test.ts src/lib/actions/sandbox/policy-channel-remove-flow.test.ts src/lib/actions/sandbox/policy-channel-cleanup.test.ts src/lib/status-command-deps.test.ts src/lib/messaging-channel-config.test.ts src/lib/sandbox/channels.test.ts`
- `npx prek run --stage pre-push --from-ref main --to-ref HEAD`
- `npx prek run --stage pre-commit --files ...` ran hygiene/lint/security/docs gates successfully, then failed in broad `Test (CLI)` on unrelated local integration-shell failures (`${1^^}: bad substitution`, rlimit hook failures, and skills fixture output). The targeted messaging/onboard/policy tests above pass.

---
Signed-off-by: San Dang <sdang@nvidia.com>
