### PR TITLE
fix(e2e): deny generic issue-routing surfaces

### DIFF
--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -144,8 +144,24 @@ describe("E2E operations workflow boundary", () => {
       'const { request: callApi } = github; await callApi("POST /repos/{owner}/{repo}/issues/1/comments", {});',
     ],
     [
+      "an indirect GitHub alias",
+      'const client = github; await client.request("POST /repos/{owner}/{repo}/issues/1/comments", {});',
+    ],
+    [
+      "a nested destructured request",
+      'const { request } = github.rest; await request("POST /repos/{owner}/{repo}/issues/1/comments", {});',
+    ],
+    [
+      "an optional-chained request",
+      'await github?.request("POST /repos/{owner}/{repo}/issues/1/comments", {});',
+    ],
+    [
       "a fetch call",
       "await fetch('https://api.github.com/repos/NVIDIA/NemoClaw/issues/1/comments', { method: 'POST' });",
+    ],
+    [
+      "an aliased fetch call",
+      "const send = fetch; await send('https://api.github.com/repos/NVIDIA/NemoClaw/issues/1/comments', { method: 'POST' });",
     ],
     ["a gh api call", "gh api repos/NVIDIA/NemoClaw/issues/1/comments -f body=failed"],
   ])("rejects %s outside the PR reporter", (_label, mutation) => {

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -78,11 +78,13 @@ describe("E2E operations workflow boundary", () => {
       expect.arrayContaining([
         "notify-on-failure must remain retired",
         "E2E workflow must not grant top-level issues: write",
+        "E2E workflow must not grant top-level pull-requests: write",
         "notify-on-failure must not hold issues: write",
         "notify-on-failure must not mutate GitHub issues",
         "scorecard must not hold issues: write",
         "scorecard must not mutate GitHub issues",
         "cloud-onboard must not hold issues: write",
+        "cloud-onboard must not hold pull-requests: write",
         "report-to-pr must not hold issues: write",
         "report-to-pr must hold only pull-requests: write",
         "report-to-pr must run only for manual workflow dispatches",
@@ -129,6 +131,46 @@ describe("E2E operations workflow boundary", () => {
 
     expect(validateE2eOperationsWorkflow(workflow)).toContain(
       "scorecard must not mutate GitHub issues",
+    );
+  });
+
+  it.each([
+    [
+      "an aliased generic REST request",
+      'const request = github.request; await request("POST /repos/{owner}/{repo}/issues/1/comments", {});',
+    ],
+    [
+      "a destructured generic REST request",
+      'const { request: callApi } = github; await callApi("POST /repos/{owner}/{repo}/issues/1/comments", {});',
+    ],
+    [
+      "a fetch call",
+      "await fetch('https://api.github.com/repos/NVIDIA/NemoClaw/issues/1/comments', { method: 'POST' });",
+    ],
+    ["a gh api call", "gh api repos/NVIDIA/NemoClaw/issues/1/comments -f body=failed"],
+  ])("rejects %s outside the PR reporter", (_label, mutation) => {
+    const workflow = readE2eOperationsWorkflow();
+    workflow.jobs.scorecard.steps!.push({ run: mutation });
+
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "scorecard must not use unvalidated generic write surfaces",
+    );
+  });
+
+  it("reserves pull-request write permission for the validated PR reporter", () => {
+    const workflow = readE2eOperationsWorkflow();
+    workflow.permissions = { "pull-requests": "write" };
+    workflow.jobs.scorecard.permissions = {
+      actions: "read",
+      contents: "read",
+      "pull-requests": "write",
+    };
+
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "E2E workflow must not grant top-level pull-requests: write",
+        "scorecard must not hold pull-requests: write",
+      ]),
     );
   });
 

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -18,7 +18,7 @@ const ISSUE_API_REFERENCE = /\bgithub\.rest\.issues\b/u;
 const ISSUE_MUTATION_BEYOND_COMMENT =
   /github\.rest\.issues\.(?:addAssignees|addLabels|create|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
 const GENERIC_GITHUB_WRITE_SURFACE =
-  /github\s*(?:\.\s*(?:graphql|request)\b|\[\s*["'](?:graphql|request)["']\s*\])|\b(?:const|let|var)\s*\{[^}]*\b(?:graphql|request)\b[^}]*\}\s*=\s*github\b|\bfetch\s*\(|\bgh\s+api\b/u;
+  /github\s*(?:(?:\?\.|\.)\s*(?:graphql|request)\b|\[\s*["'](?:graphql|request)["']\s*\])|\b(?:const|let|var)\s+(?:[A-Za-z_$][\w$]*\s*=\s*github\b|\{[^}]*\b(?:graphql|request)\b[^}]*\}\s*=\s*github(?:\.rest)?\b)|\bfetch\b|\bgh\s+api\b/u;
 const GENERIC_ISSUE_REST_MUTATION =
   /github\.request\s*\(\s*["'`](?:POST|PATCH|PUT|DELETE)\s+\/repos\/[^/\s]+\/[^/\s]+\/issues(?:\/|\b)/u;
 const GENERIC_ISSUE_GRAPHQL_MUTATION =
@@ -182,7 +182,8 @@ function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWo
 
     // Deny these generic API clients by default. The scorecard's single fixed
     // Slack webhook call is the only allowlisted use outside report-to-pr;
-    // validateScorecard binds webhookUrl to a step-scoped Slack secret.
+    // validateScorecard binds webhookUrl to a step-scoped Slack secret. This
+    // textual scan is defense in depth; token permissions are the hard boundary.
     const sourceWithoutSlackPublisher =
       name === "scorecard"
         ? jobSource.replace(/\bfetch\s*\(\s*webhookUrl\s*,/u, "validatedSlackFetch(")

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -17,7 +17,8 @@ const GITHUB_SCRIPT_NODE24_ACTION =
 const ISSUE_API_REFERENCE = /\bgithub\.rest\.issues\b/u;
 const ISSUE_MUTATION_BEYOND_COMMENT =
   /github\.rest\.issues\.(?:addAssignees|addLabels|create|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
-const GENERIC_GITHUB_WRITE_SURFACE = /github\.(?:graphql|request)\s*\(|\bfetch\s*\(|\bgh\s+api\b/u;
+const GENERIC_GITHUB_WRITE_SURFACE =
+  /github\s*(?:\.\s*(?:graphql|request)\b|\[\s*["'](?:graphql|request)["']\s*\])|\b(?:const|let|var)\s*\{[^}]*\b(?:graphql|request)\b[^}]*\}\s*=\s*github\b|\bfetch\s*\(|\bgh\s+api\b/u;
 const GENERIC_ISSUE_REST_MUTATION =
   /github\.request\s*\(\s*["'`](?:POST|PATCH|PUT|DELETE)\s+\/repos\/[^/\s]+\/[^/\s]+\/issues(?:\/|\b)/u;
 const GENERIC_ISSUE_GRAPHQL_MUTATION =
@@ -126,6 +127,12 @@ function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWo
   ) {
     errors.push("E2E workflow must not grant top-level issues: write");
   }
+  if (
+    workflow.permissions === "write-all" ||
+    permissionMap(workflow.permissions)["pull-requests"] === "write"
+  ) {
+    errors.push("E2E workflow must not grant top-level pull-requests: write");
+  }
 
   for (const [name, job] of Object.entries(workflow.jobs)) {
     const permissions = permissionMap(job.permissions);
@@ -169,12 +176,27 @@ function validateIssueRoutingRetirement(errors: string[], workflow: OperationsWo
       continue;
     }
 
+    if (job.permissions === "write-all" || permissions["pull-requests"] === "write") {
+      errors.push(`${name} must not hold pull-requests: write`);
+    }
+
+    // Deny these generic API clients by default. The scorecard's single fixed
+    // Slack webhook call is the only allowlisted use outside report-to-pr;
+    // validateScorecard binds webhookUrl to a step-scoped Slack secret.
+    const sourceWithoutSlackPublisher =
+      name === "scorecard"
+        ? jobSource.replace(/\bfetch\s*\(\s*webhookUrl\s*,/u, "validatedSlackFetch(")
+        : jobSource;
+
     if (
       ISSUE_API_REFERENCE.test(jobSource) ||
       GENERIC_ISSUE_REST_MUTATION.test(jobSource) ||
       GENERIC_ISSUE_GRAPHQL_MUTATION.test(jobSource)
     ) {
       errors.push(`${name} must not mutate GitHub issues`);
+    }
+    if (GENERIC_GITHUB_WRITE_SURFACE.test(sourceWithoutSlackPublisher)) {
+      errors.push(`${name} must not use unvalidated generic write surfaces`);
     }
   }
 }
@@ -267,6 +289,8 @@ function validateScorecard(errors: string[], workflow: OperationsWorkflow): void
     "Invalid precomputed Slack payload",
     "Selective dispatch without post_to_slack",
     "SLACK_WEBHOOK_URL_PREVIEW",
+    "const webhookUrl = process.env[envByChannel[channel]];",
+    "await fetch(webhookUrl, {",
   ]) {
     if (!slackScript.includes(fragment))
       errors.push(`scorecard Slack publisher must retain ${fragment}`);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hardens the issue-routing retirement boundary merged in #6102. Generic API clients are now denied by default outside the validated PR reporter, while the scorecard's fixed Slack webhook remains explicitly allowlisted.

## Related Issue

Follow-up to #6102; relates to #5919.

## Changes

- reject top-level `pull-requests: write` and reserve job-level PR write access for `report-to-pr`
- detect aliased or destructured `github.request`/`github.graphql`, `fetch`, and `gh api` surfaces outside the reporter
- keep the scorecard's single validated Slack webhook call as the only explicit exception
- add negative regression cases for each bypass reported by the PR Review Advisor

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this follow-up only tightens the internal workflow validator; #6102 already documented the retirement policy
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending fresh maintainer review
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Test evidence

- `npx vitest run --project e2e-support test/e2e/support/e2e-operations-workflow-boundary.test.ts test/e2e/support/openshell-gateway-auth-contract-workflow-boundary.test.ts test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts test/e2e/support/e2e-scorecard.test.ts test/e2e/support/e2e-workflow.test.ts` — 60 passed
- `npm run checks`
- `npm run typecheck:cli`
- normal commit and push hooks

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened workflow validation to catch additional unsafe write access patterns and permission drift.
  * Added checks to prevent pull-request write access from being granted at the workflow or job level where it isn’t allowed.
  * Improved detection of generic write-capable request patterns, including broader coverage, while preserving approved Slack webhook publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->