### PR TITLE
refactor(ci): centralize E2E workspace setup

### DIFF
--- a/.github/actions/prepare-e2e/action.yaml
+++ b/.github/actions/prepare-e2e/action.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: prepare-e2e
+description: Install the shared Node.js dependencies and optionally build the CLI for E2E jobs.
+
+inputs:
+  build-cli:
+    description: Build the CLI after installing dependencies.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      with:
+        node-version: 22
+        cache: npm
+
+    - name: Install root dependencies
+      shell: bash
+      run: npm ci --ignore-scripts
+
+    - name: Build CLI
+      if: ${{ inputs.build-cli == 'true' }}
+      shell: bash
+      run: npm run build:cli

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,14 +48,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - id: matrix
         name: Generate E2E target matrix
@@ -310,17 +306,8 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run live E2E tests
         env:
@@ -414,14 +401,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run OpenShell version-pin live test
         # Hermetic
@@ -467,17 +450,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_API_KEY -u NVIDIA_INFERENCE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
@@ -535,17 +509,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run onboard negative-paths live test
         # Direct E2E coverage
@@ -587,17 +552,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         # The migrated skill-agent lane invokes helper scripts that call
@@ -674,17 +630,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run OpenClaw skill CLI live test
         env:
@@ -729,14 +676,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run docs validation live Vitest test
         run: |
@@ -772,14 +715,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run Hermes root entrypoint smoke live test
         # This
@@ -823,14 +762,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run Hermes sandbox secret-boundary live test
         # This
@@ -872,17 +807,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run inference routing live test
         # Direct E2E coverage. The
@@ -928,17 +854,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run cloud inference live test
         # The Vitest test
@@ -993,15 +910,8 @@ jobs:
           persist-credentials: false
 
       - *dockerhub-auth
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run GPU Ollama live Vitest test
@@ -1062,15 +972,8 @@ jobs:
           persist-credentials: false
 
       - *dockerhub-auth
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run agent turn latency live Vitest test
@@ -1130,15 +1033,8 @@ jobs:
           persist-credentials: false
 
       - *dockerhub-auth
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run Kimi compatibility live Vitest test
@@ -1209,15 +1105,8 @@ jobs:
           persist-credentials: false
 
       - *dockerhub-auth
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run Hermes inference switch live Vitest test
@@ -1266,17 +1155,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -1335,14 +1215,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run Ollama auth proxy live Vitest test
         run: |
@@ -1387,17 +1263,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -1482,17 +1349,8 @@ jobs:
           done
           sudo apt-get install -y --no-install-recommends expect iptables
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -1555,17 +1413,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run credential sanitization live test
         # Preserves the
@@ -1615,17 +1464,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run credential migration live test
         # This live test
@@ -1682,17 +1522,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: |
@@ -1746,14 +1577,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run runtime overrides live test
         # Builds the real
@@ -1805,17 +1632,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run Hermes Slack live test
         # Preserves the
@@ -1871,17 +1689,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run Hermes live Vitest test
         env:
@@ -1933,17 +1742,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run Hermes dashboard live Vitest test
         env:
@@ -1992,17 +1792,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run Hermes Discord live test
         # Preserves the
@@ -2080,17 +1871,8 @@ jobs:
           done
           sudo apt-get install -y --no-install-recommends expect
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         # Runs without workflow tokens, Docker credentials, or NVIDIA_INFERENCE_API_KEY.
@@ -2150,17 +1932,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         # Direct Vitest execution uses bin/nemoclaw.js instead of install.sh,
@@ -2234,14 +2007,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run shields-config live test
         # The Vitest test runs
@@ -2290,17 +2059,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         # Direct Vitest execution uses bin/nemoclaw.js instead of install.sh,
@@ -2375,14 +2135,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run Hermes rebuild live test
         # Preserves the real
@@ -2440,14 +2196,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run Hermes stale-base rebuild live test
         # Uses NEMOCLAW_HERMES_STALE_BASE_REBUILD_E2E=1, preserving issue #3025's
@@ -2497,17 +2249,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         env:
@@ -2576,17 +2319,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         env:
@@ -2655,17 +2389,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run overlayfs autofix live test
         env:
@@ -2714,17 +2439,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         env:
@@ -2792,17 +2508,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: |
@@ -2866,17 +2573,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -2944,17 +2642,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Verify Jetson GPU availability
         run: |
@@ -3014,17 +2703,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3085,17 +2765,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_INFERENCE_API_KEY -u COMPATIBLE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
@@ -3158,17 +2829,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3251,17 +2913,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_API_KEY -u NVIDIA_INFERENCE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
@@ -3320,17 +2973,8 @@ jobs:
           set -euo pipefail
           printf 'NEMOCLAW_TRACE_DIR=%s\n' "${RUNNER_TEMP}/nemoclaw-cloud-onboard-traces" >> "${GITHUB_ENV}"
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3420,17 +3064,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3489,17 +3124,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3559,17 +3185,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3627,17 +3244,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run token rotation live test
         # Preserve the original runner class: ubuntu-latest with Docker/OpenShell
@@ -3694,17 +3302,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run messaging compatible endpoint live test
         # Preserves the fake OpenAI-compatible endpoint, Telegram messaging
@@ -3757,17 +3356,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run OpenShell gateway upgrade live Vitest test
         # This
@@ -3820,17 +3410,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run messaging providers live Vitest test
         # The test keeps
@@ -3895,14 +3476,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run launchable smoke live test
         env:
@@ -3950,17 +3527,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run Model Router provider-routed inference live test
         # Preserves the real provider-routed onboard, host model-router health, and
@@ -4011,14 +3579,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run snapshot commands live test
         # Preserves the
@@ -4075,17 +3639,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Verify CLI launcher
         run: |
@@ -4149,17 +3704,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run sandbox survival live test
         # This intentionally
@@ -4212,17 +3758,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run diagnostics live test
         # This preserves the
@@ -4267,17 +3804,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run gateway drift preflight Vitest test
         # This keeps
@@ -4327,17 +3855,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run OpenClaw TUI chat correlation live test
         env:
@@ -4404,17 +3923,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         # This target invokes `bin/nemoclaw.js onboard` directly, so install
@@ -4512,17 +4022,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run OpenClaw inference switch live test
         # Preserves
@@ -4581,17 +4082,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Run Bedrock Runtime compatible Anthropic live test
         # Direct Vitest coverage for
@@ -4638,17 +4130,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -4697,17 +4180,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -4774,17 +4248,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         env:
@@ -4860,17 +4325,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         env:
@@ -4947,17 +4403,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell
         env:
@@ -5033,17 +4480,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: |
@@ -5113,17 +4551,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -5186,17 +4615,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install OpenShell CLI
         run: |
@@ -5266,17 +4686,8 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Build CLI
-        run: npm run build:cli
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
 
       - name: Install and verify cloudflared prerequisite
         env:
@@ -5359,14 +4770,10 @@ jobs:
 
       - *dockerhub-auth
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+      - name: Prepare E2E workspace
+        uses: ./.github/actions/prepare-e2e
         with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+          build-cli: "false"
 
       - name: Run Spark install live test
         # This preserves the
@@ -5406,7 +4813,7 @@ jobs:
     # This entire workflow is dispatch-only. Keeping selective jobs in `needs`
     # makes the report wait for and record any requested job without adding
     # skipped checks to the normal pull_request workflow.
-    needs:
+    needs: &e2e-result-jobs
       [
         generate-matrix,
         live,
@@ -5680,83 +5087,7 @@ jobs:
   # ── Scheduled/manual scorecard ────────────────────────────────────────────
   scorecard:
     runs-on: ubuntu-latest
-    needs:
-      [
-        generate-matrix,
-        live,
-        openshell-version-pin,
-        openshell-gateway-auth-contract,
-        onboard-negative-paths,
-        skill-agent,
-        openclaw-skill-cli,
-        docs-validation,
-        inference-routing,
-        cloud-inference,
-        gpu-e2e,
-        agent-turn-latency,
-        kimi-inference-compat,
-        hermes-inference-switch,
-        brave-search,
-        ollama-auth-proxy,
-        cron-preflight-inference-local,
-        credential-sanitization,
-        credential-migration,
-        sessions-agents-cli,
-        runtime-overrides,
-        hermes-e2e,
-        hermes-dashboard,
-        hermes-slack,
-        hermes-discord,
-        hermes-root-entrypoint-smoke,
-        hermes-sandbox-secret-boundary,
-        network-policy,
-        common-egress-agent,
-        shields-config,
-        rebuild-openclaw,
-        rebuild-hermes,
-        rebuild-hermes-stale-base,
-        sandbox-rebuild,
-        sandbox-rlimits-connect,
-        overlayfs-autofix,
-        state-backup-restore,
-        upgrade-stale-sandbox,
-        openshell-gateway-upgrade,
-        token-rotation,
-        messaging-compatible-endpoint,
-        messaging-providers,
-        launchable-smoke,
-        double-onboard,
-        jetson-nvmap-gpu,
-        concurrent-gateway-ports,
-        full-e2e,
-        security-posture,
-        cloud-onboard,
-        gpu-double-onboard,
-        onboard-repair,
-        issue-4462-scope-upgrade-approval,
-        onboard-resume,
-        model-router-provider-routed-inference,
-        sandbox-operations,
-        sandbox-survival,
-        diagnostics,
-        snapshot-commands,
-        gateway-drift-preflight,
-        openclaw-tui-chat-correlation,
-        gateway-guard-recovery,
-        issue-4434-tui-unreachable-inference,
-        openclaw-inference-switch,
-        bedrock-runtime-compatible-anthropic,
-        issue-2478-crash-loop-recovery,
-        gateway-health-honest,
-        device-auth-health,
-        channels-add-remove,
-        tunnel-lifecycle,
-        telegram-injection,
-        openclaw-discord-pairing,
-        openclaw-slack-pairing,
-        channels-stop-start,
-        spark-install,
-      ]
+    needs: *e2e-result-jobs
     if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     permissions:
       actions: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -307,7 +307,7 @@ jobs:
           fi
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run live E2E tests
         env:
@@ -402,7 +402,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -451,7 +451,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_API_KEY -u NVIDIA_INFERENCE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
@@ -510,7 +510,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run onboard negative-paths live test
         # Direct E2E coverage
@@ -553,7 +553,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         # The migrated skill-agent lane invokes helper scripts that call
@@ -631,7 +631,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run OpenClaw skill CLI live test
         env:
@@ -677,7 +677,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -716,7 +716,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -763,7 +763,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -808,7 +808,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run inference routing live test
         # Direct E2E coverage. The
@@ -855,7 +855,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run cloud inference live test
         # The Vitest test
@@ -911,7 +911,7 @@ jobs:
 
       - *dockerhub-auth
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run GPU Ollama live Vitest test
@@ -973,7 +973,7 @@ jobs:
 
       - *dockerhub-auth
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run agent turn latency live Vitest test
@@ -1034,7 +1034,7 @@ jobs:
 
       - *dockerhub-auth
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run Kimi compatibility live Vitest test
@@ -1106,7 +1106,7 @@ jobs:
 
       - *dockerhub-auth
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
       - name: Run Hermes inference switch live Vitest test
@@ -1156,7 +1156,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -1216,7 +1216,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -1264,7 +1264,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -1350,7 +1350,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends expect iptables
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -1414,7 +1414,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run credential sanitization live test
         # Preserves the
@@ -1465,7 +1465,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run credential migration live test
         # This live test
@@ -1523,7 +1523,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: |
@@ -1578,7 +1578,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -1633,7 +1633,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run Hermes Slack live test
         # Preserves the
@@ -1690,7 +1690,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run Hermes live Vitest test
         env:
@@ -1743,7 +1743,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run Hermes dashboard live Vitest test
         env:
@@ -1793,7 +1793,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run Hermes Discord live test
         # Preserves the
@@ -1872,7 +1872,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends expect
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         # Runs without workflow tokens, Docker credentials, or NVIDIA_INFERENCE_API_KEY.
@@ -1933,7 +1933,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         # Direct Vitest execution uses bin/nemoclaw.js instead of install.sh,
@@ -2008,7 +2008,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -2060,7 +2060,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         # Direct Vitest execution uses bin/nemoclaw.js instead of install.sh,
@@ -2136,7 +2136,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -2197,7 +2197,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -2250,7 +2250,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         env:
@@ -2320,7 +2320,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         env:
@@ -2390,7 +2390,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run overlayfs autofix live test
         env:
@@ -2440,7 +2440,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         env:
@@ -2509,7 +2509,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: |
@@ -2574,7 +2574,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -2643,7 +2643,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Verify Jetson GPU availability
         run: |
@@ -2704,7 +2704,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -2766,7 +2766,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_INFERENCE_API_KEY -u COMPATIBLE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
@@ -2830,7 +2830,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -2914,7 +2914,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: env -u DOCKER_CONFIG -u DOCKERHUB_USERNAME -u DOCKERHUB_TOKEN -u NVIDIA_API_KEY -u NVIDIA_INFERENCE_API_KEY -u GITHUB_TOKEN bash scripts/install-openshell.sh
@@ -2974,7 +2974,7 @@ jobs:
           printf 'NEMOCLAW_TRACE_DIR=%s\n' "${RUNNER_TEMP}/nemoclaw-cloud-onboard-traces" >> "${GITHUB_ENV}"
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3065,7 +3065,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3125,7 +3125,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3186,7 +3186,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -3245,7 +3245,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run token rotation live test
         # Preserve the original runner class: ubuntu-latest with Docker/OpenShell
@@ -3303,7 +3303,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run messaging compatible endpoint live test
         # Preserves the fake OpenAI-compatible endpoint, Telegram messaging
@@ -3357,7 +3357,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run OpenShell gateway upgrade live Vitest test
         # This
@@ -3411,7 +3411,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run messaging providers live Vitest test
         # The test keeps
@@ -3477,7 +3477,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -3528,7 +3528,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run Model Router provider-routed inference live test
         # Preserves the real provider-routed onboard, host model-router health, and
@@ -3580,7 +3580,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 
@@ -3640,7 +3640,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Verify CLI launcher
         run: |
@@ -3705,7 +3705,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run sandbox survival live test
         # This intentionally
@@ -3759,7 +3759,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run diagnostics live test
         # This preserves the
@@ -3805,7 +3805,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run gateway drift preflight Vitest test
         # This keeps
@@ -3856,7 +3856,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run OpenClaw TUI chat correlation live test
         env:
@@ -3924,7 +3924,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         # This target invokes `bin/nemoclaw.js onboard` directly, so install
@@ -4023,7 +4023,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run OpenClaw inference switch live test
         # Preserves
@@ -4083,7 +4083,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run Bedrock Runtime compatible Anthropic live test
         # Direct Vitest coverage for
@@ -4131,7 +4131,7 @@ jobs:
           persist-credentials: false
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -4181,7 +4181,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -4249,7 +4249,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         env:
@@ -4326,7 +4326,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         env:
@@ -4404,7 +4404,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell
         env:
@@ -4481,7 +4481,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: |
@@ -4552,7 +4552,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: bash scripts/install-openshell.sh
@@ -4616,7 +4616,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install OpenShell CLI
         run: |
@@ -4687,7 +4687,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Install and verify cloudflared prerequisite
         env:
@@ -4771,7 +4771,7 @@ jobs:
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
-        uses: ./.github/actions/prepare-e2e
+        uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
         with:
           build-cli: "false"
 

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -50,7 +50,9 @@ describe("release gate workflow resource contracts", () => {
     expect(auth?.["continue-on-error"]).toBeUndefined();
     expect(auth?.env).toHaveProperty("DOCKERHUB_AUTH_REQUIRED");
     expect(auth?.run).toEqual(expect.any(String));
-    expect(stepIndex("Authenticate to Docker Hub")).toBeLessThan(stepIndex("Set up Node"));
+    expect(stepIndex("Authenticate to Docker Hub")).toBeLessThan(
+      stepIndex("Prepare E2E workspace"),
+    );
     expect(stepIndex("Authenticate to Docker Hub")).toBeLessThan(
       stepIndex("Run Spark install live test"),
     );

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -37,6 +37,7 @@ describe("E2E operations workflow boundary", () => {
 
   it("rejects aggregation, permission, and secret-scope drift", () => {
     const workflow = readE2eOperationsWorkflow();
+    workflow.jobs.scorecard.needs = [...(workflow.jobs.scorecard.needs as string[])];
     (workflow.jobs.scorecard.needs as string[]).pop();
     workflow.jobs.scorecard.permissions = {
       actions: "read",

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -1057,16 +1057,6 @@ jobs:
       if (typeof step.uses === "string" && step.uses.startsWith("actions/checkout@")) {
         step.with = { ...(step.with as Record<string, unknown>), "persist-credentials": true };
       }
-      if (step.name === "Set up Node") {
-        step.env = { NVIDIA_INFERENCE_API_KEY: "${{ secrets.NVIDIA_INFERENCE_API_KEY }}" };
-      }
-      if (step.name === "Install root dependencies") {
-        step.env = {
-          DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
-          DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}",
-        };
-        step.run = "npm install";
-      }
       if (step.name === "Run snapshot commands live test") {
         step.run = String(step.run).replace(
           "test/e2e/live/snapshot-commands.test.ts",
@@ -1090,12 +1080,8 @@ jobs:
           "snapshot-commands job must not set DOCKER_CONFIG at job level",
           "snapshot-commands checkout step must set persist-credentials=false",
           "snapshot-commands job env must not include NVIDIA_INFERENCE_API_KEY",
-          "snapshot-commands step 'Set up Node' env must not include NVIDIA_INFERENCE_API_KEY",
-          "snapshot-commands step 'Install root dependencies' env must not include DOCKERHUB_USERNAME",
-          "snapshot-commands step 'Install root dependencies' env must not include DOCKERHUB_TOKEN",
           "snapshot-commands artifact upload must set include-hidden-files: false",
           "artifact upload path must include e2e-artifacts/live/snapshot-commands/",
-          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
           "step 'Run snapshot commands live test' run script must include test/e2e/live/snapshot-commands.test.ts",
         ]),
       );
@@ -1205,10 +1191,6 @@ jobs:
       "persist-credentials": true,
     };
 
-    const installRootStep = job.steps.find((step) => step.name === "Install root dependencies");
-    expect(installRootStep).toBeDefined();
-    installRootStep!.run = "npm install";
-
     const installOpenShellStep = job.steps.find((step) => step.name === "Install OpenShell");
     expect(installOpenShellStep).toBeDefined();
     installOpenShellStep!.run = "bash scripts/install-openshell.sh";
@@ -1249,7 +1231,6 @@ jobs:
           "channels-stop-start job env must not include DOCKER_CONFIG",
           "channels-stop-start job env must not include NVIDIA_INFERENCE_API_KEY",
           "channels-stop-start checkout step must set persist-credentials=false",
-          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
           "step 'Install OpenShell' run script must include env -u DOCKER_CONFIG",
           "channels-stop-start step must receive NVIDIA_INFERENCE_API_KEY from secrets",
           "channels-stop-start step must set the fake Telegram token",
@@ -1302,9 +1283,9 @@ jobs:
     };
     const steps = workflow.jobs["messaging-compatible-endpoint"]?.steps;
     expect(steps).toEqual(expect.any(Array));
-    const setupNodeIndex = steps.findIndex((step) => step.name === "Set up Node");
-    expect(setupNodeIndex).toBeGreaterThan(0);
-    steps.splice(setupNodeIndex, 0, {
+    const prepareIndex = steps.findIndex((step) => step.name === "Prepare E2E workspace");
+    expect(prepareIndex).toBeGreaterThan(0);
+    steps.splice(prepareIndex, 0, {
       name: "Authenticate to Docker Hub",
       env: {
         DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
@@ -1372,9 +1353,9 @@ jobs:
       NVIDIA_INFERENCE_API_KEY: "${{ secrets.NVIDIA_INFERENCE_API_KEY }}",
       GITHUB_TOKEN: "${{ github.token }}",
     };
-    const setupNodeIndex = job.steps.findIndex((step) => step.name === "Set up Node");
-    expect(setupNodeIndex).toBeGreaterThan(0);
-    job.steps.splice(setupNodeIndex, 0, {
+    const prepareIndex = job.steps.findIndex((step) => step.name === "Prepare E2E workspace");
+    expect(prepareIndex).toBeGreaterThan(0);
+    job.steps.splice(prepareIndex, 0, {
       name: "Authenticate to Docker Hub",
       env: {
         DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",
@@ -1424,9 +1405,9 @@ jobs:
     };
     const steps = workflow.jobs["hermes-root-entrypoint-smoke"]?.steps;
     expect(steps).toEqual(expect.any(Array));
-    const setupNodeIndex = steps.findIndex((step) => step.name === "Set up Node");
-    expect(setupNodeIndex).toBeGreaterThan(0);
-    steps.splice(setupNodeIndex, 0, {
+    const prepareIndex = steps.findIndex((step) => step.name === "Prepare E2E workspace");
+    expect(prepareIndex).toBeGreaterThan(0);
+    steps.splice(prepareIndex, 0, {
       name: "Authenticate to Docker Hub",
       env: {
         DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}",

--- a/test/e2e/support/inference-switch-workflow-boundary.test.ts
+++ b/test/e2e/support/inference-switch-workflow-boundary.test.ts
@@ -72,7 +72,7 @@ describe("inference switch workflow boundary", () => {
     );
     [steps[cleanupIndex], steps[uploadIndex]] = [steps[uploadIndex], steps[cleanupIndex]];
     expect(validateInferenceSwitchWorkflow(lingeringCredentials)).toContain(
-      "openclaw-inference-switch must authenticate, build, test, upload artifacts, then clean credentials",
+      "openclaw-inference-switch must authenticate, prepare, test, upload artifacts, then clean credentials",
     );
   });
 

--- a/test/e2e/support/openclaw-discord-workflow-boundary.test.ts
+++ b/test/e2e/support/openclaw-discord-workflow-boundary.test.ts
@@ -10,7 +10,7 @@ import YAML from "yaml";
 import { validateE2eWorkflowBoundary } from "../../../tools/e2e/workflow-boundary.mts";
 
 describe("OpenClaw Discord pairing workflow boundary", () => {
-  it("rejects secret, checkout, dependency, build, and installer drift", () => {
+  it("rejects secret, checkout, and installer drift", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-workflow-"));
     const workflowPath = path.join(tmp, "workflow.yaml");
     const workflow = fs.readFileSync(
@@ -34,19 +34,6 @@ describe("OpenClaw Discord pairing workflow boundary", () => {
     ) as { uses: string; with: Record<string, unknown> };
     checkout.uses = "actions/checkout@v4";
     checkout.with["persist-credentials"] = true;
-    const setupNode = discordJob.steps.find((step) => step.name === "Set up Node") as {
-      uses: string;
-    };
-    setupNode.uses = "actions/setup-node@v4";
-    const installRootDependencies = discordJob.steps.find(
-      (step) => step.name === "Install root dependencies",
-    ) as Record<string, unknown>;
-    Object.assign(installRootDependencies, { run: "npm install" });
-    const buildCli = discordJob.steps.find((step) => step.name === "Build CLI") as Record<
-      string,
-      unknown
-    >;
-    Object.assign(buildCli, { run: "echo skipping build" });
     const installOpenShell = discordJob.steps.find(
       (step) => step.name === "Install OpenShell CLI",
     ) as Record<string, unknown>;
@@ -59,9 +46,6 @@ describe("OpenClaw Discord pairing workflow boundary", () => {
           "openclaw-discord-pairing job must not set DOCKER_CONFIG at job level",
           "openclaw-discord-pairing checkout action must be pinned to a full commit SHA",
           "openclaw-discord-pairing checkout step must set persist-credentials=false",
-          "openclaw-discord-pairing setup-node action must be pinned to a full commit SHA",
-          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
-          "step 'Build CLI' run script must include npm run build:cli",
           "step 'Install OpenShell CLI' run script must include env -u DOCKER_CONFIG",
         ]),
       );

--- a/test/e2e/support/openclaw-slack-workflow-boundary.test.ts
+++ b/test/e2e/support/openclaw-slack-workflow-boundary.test.ts
@@ -10,7 +10,7 @@ import YAML from "yaml";
 import { validateE2eWorkflowBoundary } from "../../../tools/e2e/workflow-boundary.mts";
 
 describe("OpenClaw Slack pairing workflow boundary", () => {
-  it("rejects workspace Docker auth, secret, checkout, dependency, build, and installer drift", () => {
+  it("rejects workspace Docker auth, secret, checkout, and installer drift", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-workflow-"));
     const workflowPath = path.join(tmp, "workflow.yaml");
     const workflow = fs.readFileSync(
@@ -33,19 +33,6 @@ describe("OpenClaw Slack pairing workflow boundary", () => {
     ) as { uses: string; with: Record<string, unknown> };
     checkout.uses = "actions/checkout@v4";
     checkout.with["persist-credentials"] = true;
-    const setupNode = slackJob.steps.find((step) => step.name === "Set up Node") as {
-      uses: string;
-    };
-    setupNode.uses = "actions/setup-node@v4";
-    const installRootDependencies = slackJob.steps.find(
-      (step) => step.name === "Install root dependencies",
-    ) as Record<string, unknown>;
-    Object.assign(installRootDependencies, { run: "npm install" });
-    const buildCli = slackJob.steps.find((step) => step.name === "Build CLI") as Record<
-      string,
-      unknown
-    >;
-    Object.assign(buildCli, { run: "echo skipping build" });
     const liveStep = slackJob.steps.find(
       (step) => step.name === "Run OpenClaw Slack pairing live test",
     ) as { env: Record<string, string> };
@@ -62,9 +49,6 @@ describe("OpenClaw Slack pairing workflow boundary", () => {
           "openclaw-slack-pairing job must not set DOCKER_CONFIG at job level",
           "openclaw-slack-pairing checkout action must be pinned to a full commit SHA",
           "openclaw-slack-pairing checkout step must set persist-credentials=false",
-          "openclaw-slack-pairing setup-node action must be pinned to a full commit SHA",
-          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
-          "step 'Build CLI' run script must include npm run build:cli",
           "openclaw-slack-pairing step must use fake Slack app token",
           "step 'Install OpenShell CLI' run script must include env -u DOCKER_CONFIG",
         ]),

--- a/test/e2e/support/prepare-e2e-workflow-boundary.test.ts
+++ b/test/e2e/support/prepare-e2e-workflow-boundary.test.ts
@@ -55,6 +55,24 @@ describe("prepare-e2e workflow boundary", () => {
     }
   });
 
+  it("rejects semantic-neutral content drift from the immutable action pin", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "prepare-e2e-provenance-"));
+    const actionPath = path.join(directory, "action.yaml");
+    const source = fs.readFileSync(
+      path.join(process.cwd(), ".github/actions/prepare-e2e/action.yaml"),
+      "utf8",
+    );
+    fs.writeFileSync(actionPath, `${source}# unreviewed drift\n`);
+
+    try {
+      expect(validatePrepareE2eAction(actionPath)).toEqual([
+        "prepare-e2e content must match the action reviewed at its immutable commit pin",
+      ]);
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
   it("rejects build-mode, duplicate-step, and ordering drift", () => {
     const workflow = readWorkflow() as Workflow;
     const buildJob = workflow.jobs["sandbox-operations"];

--- a/test/e2e/support/prepare-e2e-workflow-boundary.test.ts
+++ b/test/e2e/support/prepare-e2e-workflow-boundary.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import {
+  PREPARE_E2E_ACTION,
+  PREPARE_E2E_STEP,
+  validatePrepareE2eAction,
+  validatePrepareE2eInvocations,
+} from "../../../tools/e2e/prepare-e2e-workflow-boundary.mts";
+import { readWorkflow } from "../../helpers/e2e-workflow-contract";
+
+type WorkflowStep = Record<string, unknown> & {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+};
+
+describe("prepare-e2e workflow boundary", () => {
+  it("keeps one canonical bootstrap invocation on every E2E execution job", () => {
+    expect(validatePrepareE2eAction()).toEqual([]);
+    expect(validatePrepareE2eInvocations(readWorkflow())).toEqual([]);
+  });
+
+  it("rejects action implementation drift", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "prepare-e2e-action-"));
+    const actionPath = path.join(directory, "action.yaml");
+    const source = fs.readFileSync(
+      path.join(process.cwd(), ".github/actions/prepare-e2e/action.yaml"),
+      "utf8",
+    );
+    const action = YAML.parse(source) as Record<string, unknown>;
+    const runs = action.runs as { steps: WorkflowStep[] };
+    runs.steps.find((step) => step.name === "Set up Node")!.uses = "actions/setup-node@v6";
+    runs.steps.find((step) => step.name === "Install root dependencies")!.run = "npm install";
+    runs.steps.find((step) => step.name === "Build CLI")!.run = "echo skipped";
+    fs.writeFileSync(actionPath, YAML.stringify(action));
+
+    try {
+      expect(validatePrepareE2eAction(actionPath)).toContain(
+        "prepare-e2e must pin Node 22, run npm ci, and conditionally build the CLI",
+      );
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects build-mode, duplicate-step, and ordering drift", () => {
+    const workflow = readWorkflow() as Workflow;
+    const buildJob = workflow.jobs["sandbox-operations"];
+    const buildPrepare = buildJob.steps!.find((step) => step.uses === PREPARE_E2E_ACTION)!;
+    buildPrepare.with = { "build-cli": "false" };
+    buildJob.steps!.splice(buildJob.steps!.indexOf(buildPrepare), 0, {
+      name: "Build CLI",
+      run: "npm run build:cli",
+    });
+
+    const noBuildJob = workflow.jobs["docs-validation"];
+    const noBuildPrepare = noBuildJob.steps!.find((step) => step.uses === PREPARE_E2E_ACTION)!;
+    delete noBuildPrepare.with;
+
+    const orderedJob = workflow.jobs["network-policy"];
+    const orderedPrepareIndex = orderedJob.steps!.findIndex(
+      (step) => step.name === PREPARE_E2E_STEP,
+    );
+    const [orderedPrepare] = orderedJob.steps!.splice(orderedPrepareIndex, 1);
+    orderedJob.steps!.unshift(orderedPrepare);
+
+    expect(validatePrepareE2eInvocations(workflow)).toEqual(
+      expect.arrayContaining([
+        "sandbox-operations prepare-e2e must use the default CLI build",
+        "sandbox-operations prepare-e2e invocation must not override its canonical contract",
+        "sandbox-operations must not duplicate prepare-e2e step 'Build CLI'",
+        "docs-validation prepare-e2e must set build-cli to false",
+        "docs-validation prepare-e2e invocation must not override its canonical contract",
+        "network-policy must check out the repository before prepare-e2e",
+        "network-policy must authenticate to Docker Hub before prepare-e2e",
+      ]),
+    );
+  });
+});

--- a/test/e2e/support/prepare-e2e-workflow-boundary.test.ts
+++ b/test/e2e/support/prepare-e2e-workflow-boundary.test.ts
@@ -69,6 +69,10 @@ describe("prepare-e2e workflow boundary", () => {
     const noBuildPrepare = noBuildJob.steps!.find((step) => step.uses === PREPARE_E2E_ACTION)!;
     delete noBuildPrepare.with;
 
+    const untrustedJob = workflow.jobs["inference-routing"];
+    const untrustedPrepare = untrustedJob.steps!.find((step) => step.uses === PREPARE_E2E_ACTION)!;
+    untrustedPrepare.uses = "./.github/actions/prepare-e2e";
+
     const orderedJob = workflow.jobs["network-policy"];
     const orderedPrepareIndex = orderedJob.steps!.findIndex(
       (step) => step.name === PREPARE_E2E_STEP,
@@ -83,6 +87,8 @@ describe("prepare-e2e workflow boundary", () => {
         "sandbox-operations must not duplicate prepare-e2e step 'Build CLI'",
         "docs-validation prepare-e2e must set build-cli to false",
         "docs-validation prepare-e2e invocation must not override its canonical contract",
+        "inference-routing must not load prepare-e2e from the target checkout",
+        "inference-routing must use prepare-e2e exactly once",
         "network-policy must check out the repository before prepare-e2e",
         "network-policy must authenticate to Docker Hub before prepare-e2e",
       ]),

--- a/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
@@ -127,7 +127,7 @@ describe("sandbox operations workflow boundary", () => {
 
     const broadInferenceSecret = readSandboxOperationsWorkflow();
     broadInferenceSecret.jobs["sandbox-operations"].steps!.find(
-      (step) => step.name === "Build CLI",
+      (step) => step.name === "Prepare E2E workspace",
     )!.env = { NVIDIA_INFERENCE_API_KEY: "${{ secrets.NVIDIA_INFERENCE_API_KEY }}" };
     expect(validateSandboxOperationsWorkflow(broadInferenceSecret)).toContain(
       "sandbox-operations exposes the inference key outside the live test step",
@@ -188,12 +188,12 @@ describe("sandbox operations workflow boundary", () => {
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) =>
           jobSource.replace(
-            "      - name: Build CLI\n        run: npm run build:cli",
+            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e",
             [
-              "      - name: Build CLI",
+              "      - name: Prepare E2E workspace",
               "        env:",
               "          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}",
-              "        run: npm run build:cli",
+              "        uses: ./.github/actions/prepare-e2e",
             ].join("\n"),
           ),
         ),
@@ -205,47 +205,50 @@ describe("sandbox operations workflow boundary", () => {
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) =>
           jobSource.replace(
-            "      - name: Build CLI\n        run: npm run build:cli",
+            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e",
             [
-              "      - name: Build CLI",
+              "      - name: Prepare E2E workspace",
               "        env:",
               '          DOCKER_CONFIG: "${{ runner.temp }}/docker"',
-              "        run: npm run build:cli",
+              "        uses: ./.github/actions/prepare-e2e",
             ].join("\n"),
           ),
         ),
-      expected: "sandbox-operations must not expose DOCKER_CONFIG through step 'Build CLI'",
+      expected:
+        "sandbox-operations must not expose DOCKER_CONFIG through step 'Prepare E2E workspace'",
     },
     {
       label: "persistent environment write outside the configure step",
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) =>
           jobSource.replace(
-            "      - name: Build CLI\n        run: npm run build:cli",
+            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e",
             [
-              "      - name: Build CLI",
+              "      - name: Prepare E2E workspace",
               "        run: |",
-              "          npm run build:cli",
               '          echo "DOCKER_CONFIG=${{ github.workspace }}/docker" >> "$GITHUB_ENV"',
+              "        uses: ./.github/actions/prepare-e2e",
             ].join("\n"),
           ),
         ),
-      expected: "sandbox-operations step 'Build CLI' must not write persistent environment",
+      expected:
+        "sandbox-operations step 'Prepare E2E workspace' must not write persistent environment",
     },
     {
       label: "a persistent workspace Docker config outside shared auth",
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) => {
-          const buildMarker = "      - name: Build CLI\n";
-          expect(jobSource).toContain(buildMarker);
+          const prepareMarker =
+            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e\n";
+          expect(jobSource).toContain(prepareMarker);
           return jobSource.replace(
-            buildMarker,
+            prepareMarker,
             [
               "      - name: Persist workspace Docker config",
               "        run: |",
               '          echo "DOCKER_CONFIG=${{ github.workspace }}/docker" >> "$GITHUB_ENV"',
               "",
-              buildMarker.trimEnd(),
+              prepareMarker.trimEnd(),
               "",
             ].join("\n"),
           );

--- a/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-operations-workflow-boundary.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { PREPARE_E2E_ACTION } from "../../../tools/e2e/prepare-e2e-workflow-boundary.mts";
 import {
   readSandboxOperationsWorkflow,
   validateSandboxOperationsWorkflow,
@@ -17,6 +18,10 @@ import {
 } from "../../../tools/e2e/workflow-boundary.mts";
 
 const WORKFLOW_PATH = join(process.cwd(), ".github", "workflows", "e2e.yaml");
+const PREPARE_STEP_SOURCE = [
+  "      - name: Prepare E2E workspace",
+  `        uses: ${PREPARE_E2E_ACTION}`,
+].join("\n");
 
 function validateCentralWorkflowMutation(mutate: (source: string) => string): string[] {
   const directory = mkdtempSync(join(tmpdir(), "nemoclaw-sandbox-operations-boundary-"));
@@ -188,12 +193,12 @@ describe("sandbox operations workflow boundary", () => {
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) =>
           jobSource.replace(
-            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e",
+            PREPARE_STEP_SOURCE,
             [
               "      - name: Prepare E2E workspace",
               "        env:",
               "          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}",
-              "        uses: ./.github/actions/prepare-e2e",
+              `        uses: ${PREPARE_E2E_ACTION}`,
             ].join("\n"),
           ),
         ),
@@ -205,12 +210,12 @@ describe("sandbox operations workflow boundary", () => {
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) =>
           jobSource.replace(
-            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e",
+            PREPARE_STEP_SOURCE,
             [
               "      - name: Prepare E2E workspace",
               "        env:",
               '          DOCKER_CONFIG: "${{ runner.temp }}/docker"',
-              "        uses: ./.github/actions/prepare-e2e",
+              `        uses: ${PREPARE_E2E_ACTION}`,
             ].join("\n"),
           ),
         ),
@@ -222,12 +227,12 @@ describe("sandbox operations workflow boundary", () => {
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) =>
           jobSource.replace(
-            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e",
+            PREPARE_STEP_SOURCE,
             [
               "      - name: Prepare E2E workspace",
               "        run: |",
               '          echo "DOCKER_CONFIG=${{ github.workspace }}/docker" >> "$GITHUB_ENV"',
-              "        uses: ./.github/actions/prepare-e2e",
+              `        uses: ${PREPARE_E2E_ACTION}`,
             ].join("\n"),
           ),
         ),
@@ -238,8 +243,7 @@ describe("sandbox operations workflow boundary", () => {
       label: "a persistent workspace Docker config outside shared auth",
       mutate: (source: string) =>
         mutateSandboxOperationsJob(source, (jobSource) => {
-          const prepareMarker =
-            "      - name: Prepare E2E workspace\n        uses: ./.github/actions/prepare-e2e\n";
+          const prepareMarker = `${PREPARE_STEP_SOURCE}\n`;
           expect(jobSource).toContain(prepareMarker);
           return jobSource.replace(
             prepareMarker,

--- a/test/e2e/support/spark-install-workflow-boundary.test.ts
+++ b/test/e2e/support/spark-install-workflow-boundary.test.ts
@@ -91,15 +91,6 @@ describe("spark install workflow boundary", () => {
       "persist-credentials": true,
     };
 
-    const setupNode = job.steps.find((step) => step.name === "Set up Node");
-    expect(setupNode).toBeDefined();
-    setupNode!.uses = "actions/setup-node@v6";
-
-    const install = job.steps.find((step) => step.name === "Install root dependencies");
-    expect(install).toBeDefined();
-    install!.env = { NVIDIA_INFERENCE_API_KEY: "${{ secrets.NVIDIA_INFERENCE_API_KEY }}" };
-    install!.run = "npm install";
-
     const runSpark = job.steps.find((step) => step.name === "Run Spark install live test");
     expect(runSpark).toBeDefined();
     runSpark!.env = {};
@@ -134,9 +125,6 @@ describe("spark install workflow boundary", () => {
           "spark-install job env must not include NVIDIA_INFERENCE_API_KEY",
           "spark-install checkout action must be pinned to a full commit SHA",
           "spark-install checkout step must set persist-credentials=false",
-          "spark-install setup-node action must be pinned to a full commit SHA",
-          "spark-install step 'Install root dependencies' env must not include NVIDIA_INFERENCE_API_KEY",
-          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
           "spark-install live E2E step must receive NVIDIA_INFERENCE_API_KEY from secrets",
           "step 'Run Spark install live test' run script must include set -euo pipefail",
           "step 'Run Spark install live test' run script must include test/e2e/live/spark-install.test.ts",

--- a/test/e2e/support/tunnel-lifecycle-workflow-boundary.test.ts
+++ b/test/e2e/support/tunnel-lifecycle-workflow-boundary.test.ts
@@ -81,14 +81,6 @@ describe("tunnel lifecycle workflow boundary", () => {
       "persist-credentials": true,
     };
 
-    const install = job.steps.find((step) => step.name === "Install root dependencies");
-    expect(install).toBeDefined();
-    install!.env = {
-      NVIDIA_INFERENCE_API_KEY: "${{ secrets.NVIDIA_INFERENCE_API_KEY }}",
-      NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}",
-    };
-    install!.run = "npm install";
-
     const cloudflared = job.steps.find(
       (step) => step.name === "Install and verify cloudflared prerequisite",
     );
@@ -118,9 +110,6 @@ describe("tunnel lifecycle workflow boundary", () => {
         expect.arrayContaining([
           "tunnel-lifecycle job must not set DOCKER_CONFIG at job level",
           "tunnel-lifecycle checkout step must set persist-credentials=false",
-          "tunnel-lifecycle step 'Install root dependencies' env must not include NVIDIA_INFERENCE_API_KEY",
-          "tunnel-lifecycle step 'Install root dependencies' env must not include NVIDIA_API_KEY",
-          "step 'Install root dependencies' run script must include npm ci --ignore-scripts",
           "tunnel-lifecycle step 'Install and verify cloudflared prerequisite' env must not include NVIDIA_INFERENCE_API_KEY",
           "tunnel-lifecycle step 'Install and verify cloudflared prerequisite' env must not include NVIDIA_API_KEY",
           "tunnel-lifecycle cloudflared prerequisite step env must not include NVIDIA_INFERENCE_API_KEY",

--- a/tools/e2e/docs-validation-workflow-boundary.mts
+++ b/tools/e2e/docs-validation-workflow-boundary.mts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
+import { PREPARE_E2E_ACTION, PREPARE_E2E_STEP } from "./prepare-e2e-workflow-boundary.mts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
@@ -104,11 +105,9 @@ export function validateDocsValidationWorkflow(workflow: DocsValidationWorkflow)
     errors.push(`${JOB_NAME} checkout must disable persisted credentials`);
   }
 
-  const setup = findStep(job, "Set up Node");
-  if (!/^actions\/setup-node@[0-9a-f]{40}$/u.test(setup.uses ?? "")) {
-    errors.push(`${JOB_NAME} setup-node must pin a full action SHA`);
-  }
-  requireRunContains(errors, findStep(job, "Install root dependencies"), "npm ci --ignore-scripts");
+  const prepare = findStep(job, PREPARE_E2E_STEP);
+  requireEqual(errors, prepare.uses, PREPARE_E2E_ACTION, `${JOB_NAME} must use prepare-e2e`);
+  requireEqual(errors, prepare.with?.["build-cli"], "false", `${JOB_NAME} must skip the CLI build`);
 
   const run = findStep(job, "Run docs validation live Vitest test");
   requireRunContains(errors, run, "npx vitest run --project e2e-live");

--- a/tools/e2e/inference-switch-workflow-boundary.mts
+++ b/tools/e2e/inference-switch-workflow-boundary.mts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import YAML from "yaml";
+import { PREPARE_E2E_STEP } from "./prepare-e2e-workflow-boundary.mts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
@@ -116,7 +117,7 @@ function validateOpenClawDockerAuthOrder(errors: string[], job: WorkflowJob): vo
 
   const stepOrder = [
     "Authenticate to Docker Hub",
-    "Build CLI",
+    PREPARE_E2E_STEP,
     "Run OpenClaw inference switch live test",
     "Upload OpenClaw inference switch artifacts",
     "Clean up Docker auth",
@@ -127,7 +128,7 @@ function validateOpenClawDockerAuthOrder(errors: string[], job: WorkflowJob): vo
     )
   ) {
     errors.push(
-      "openclaw-inference-switch must authenticate, build, test, upload artifacts, then clean credentials",
+      "openclaw-inference-switch must authenticate, prepare, test, upload artifacts, then clean credentials",
     );
   }
 }

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -10,8 +10,11 @@ import YAML from "yaml";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_ACTION_PATH = join(REPO_ROOT, ".github", "actions", "prepare-e2e", "action.yaml");
 
-export const PREPARE_E2E_ACTION = "./.github/actions/prepare-e2e";
+export const PREPARE_E2E_ACTION =
+  "NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28";
 export const PREPARE_E2E_STEP = "Prepare E2E workspace";
+
+const CHECKOUT_LOCAL_PREPARE_E2E_ACTION = "./.github/actions/prepare-e2e";
 
 const NO_BUILD_JOBS = new Set([
   "docs-validation",
@@ -103,6 +106,9 @@ export function validatePrepareE2eInvocations(workflow: WorkflowRecord): string[
 
   for (const [jobName, value] of Object.entries(jobs)) {
     const jobSteps = steps(record(value).steps);
+    if (jobSteps.some((step) => step.uses === CHECKOUT_LOCAL_PREPARE_E2E_ACTION)) {
+      errors.push(`${jobName} must not load prepare-e2e from the target checkout`);
+    }
     const prepareSteps = jobSteps.filter((step) => step.uses === PREPARE_E2E_ACTION);
     if (!expectedJobs.has(jobName)) {
       if (prepareSteps.length > 0) errors.push(`${jobName} must not use prepare-e2e`);

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import YAML from "yaml";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DEFAULT_ACTION_PATH = join(REPO_ROOT, ".github", "actions", "prepare-e2e", "action.yaml");
+
+export const PREPARE_E2E_ACTION = "./.github/actions/prepare-e2e";
+export const PREPARE_E2E_STEP = "Prepare E2E workspace";
+
+const NO_BUILD_JOBS = new Set([
+  "docs-validation",
+  "generate-matrix",
+  "hermes-root-entrypoint-smoke",
+  "hermes-sandbox-secret-boundary",
+  "launchable-smoke",
+  "ollama-auth-proxy",
+  "openshell-version-pin",
+  "rebuild-hermes",
+  "rebuild-hermes-stale-base",
+  "runtime-overrides",
+  "shields-config",
+  "snapshot-commands",
+  "spark-install",
+]);
+
+type WorkflowRecord = Record<string, unknown>;
+type WorkflowStep = WorkflowRecord & {
+  name?: string;
+  uses?: string;
+  with?: WorkflowRecord;
+};
+
+function record(value: unknown): WorkflowRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as WorkflowRecord)
+    : {};
+}
+
+function steps(value: unknown): WorkflowStep[] {
+  return Array.isArray(value) ? (value as WorkflowStep[]) : [];
+}
+
+export function validatePrepareE2eAction(actionPath = DEFAULT_ACTION_PATH): string[] {
+  const action = record(YAML.parse(readFileSync(actionPath, "utf8")));
+  const errors: string[] = [];
+  const expectedInput = {
+    description: "Build the CLI after installing dependencies.",
+    required: false,
+    default: "true",
+  };
+  if (!isDeepStrictEqual(record(record(action.inputs)["build-cli"]), expectedInput)) {
+    errors.push("prepare-e2e build-cli input must default to true");
+  }
+  if (Object.keys(record(action.inputs)).length !== 1) {
+    errors.push("prepare-e2e must expose only the build-cli input");
+  }
+
+  const runs = record(action.runs);
+  if (runs.using !== "composite") errors.push("prepare-e2e must be a composite action");
+  const expectedSteps = [
+    {
+      name: "Set up Node",
+      uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+      with: { "node-version": 22, cache: "npm" },
+    },
+    {
+      name: "Install root dependencies",
+      shell: "bash",
+      run: "npm ci --ignore-scripts",
+    },
+    {
+      name: "Build CLI",
+      if: "${{ inputs.build-cli == 'true' }}",
+      shell: "bash",
+      run: "npm run build:cli",
+    },
+  ];
+  if (!isDeepStrictEqual(runs.steps, expectedSteps)) {
+    errors.push("prepare-e2e must pin Node 22, run npm ci, and conditionally build the CLI");
+  }
+  return errors;
+}
+
+export function validatePrepareE2eInvocations(workflow: WorkflowRecord): string[] {
+  const errors: string[] = [];
+  const jobs = record(workflow.jobs);
+  const expectedJobs = new Set(
+    Object.entries(jobs)
+      .filter(([jobName, value]) => {
+        const job = record(value);
+        return (
+          jobName === "generate-matrix" || jobName === "live" || record(job.env).E2E_JOB === "1"
+        );
+      })
+      .map(([jobName]) => jobName),
+  );
+
+  for (const [jobName, value] of Object.entries(jobs)) {
+    const jobSteps = steps(record(value).steps);
+    const prepareSteps = jobSteps.filter((step) => step.uses === PREPARE_E2E_ACTION);
+    if (!expectedJobs.has(jobName)) {
+      if (prepareSteps.length > 0) errors.push(`${jobName} must not use prepare-e2e`);
+      continue;
+    }
+    if (prepareSteps.length !== 1) {
+      errors.push(`${jobName} must use prepare-e2e exactly once`);
+      continue;
+    }
+
+    const prepare = prepareSteps[0];
+    if (prepare.name !== PREPARE_E2E_STEP) {
+      errors.push(`${jobName} prepare-e2e step must be named '${PREPARE_E2E_STEP}'`);
+    }
+    const withInputs = record(prepare.with);
+    const shouldBuild = !NO_BUILD_JOBS.has(jobName);
+    if (shouldBuild && Object.keys(withInputs).length !== 0) {
+      errors.push(`${jobName} prepare-e2e must use the default CLI build`);
+    }
+    if (!shouldBuild && !isDeepStrictEqual(withInputs, { "build-cli": "false" })) {
+      errors.push(`${jobName} prepare-e2e must set build-cli to false`);
+    }
+    const allowedKeys = shouldBuild ? ["name", "uses"] : ["name", "uses", "with"];
+    if (!isDeepStrictEqual(Object.keys(prepare).sort(), allowedKeys.sort())) {
+      errors.push(`${jobName} prepare-e2e invocation must not override its canonical contract`);
+    }
+
+    for (const retiredStep of ["Set up Node", "Install root dependencies", "Build CLI"]) {
+      if (jobSteps.some((step) => step.name === retiredStep)) {
+        errors.push(`${jobName} must not duplicate prepare-e2e step '${retiredStep}'`);
+      }
+    }
+    const checkoutIndex = jobSteps.findIndex((step) => step.uses?.startsWith("actions/checkout@"));
+    const prepareIndex = jobSteps.indexOf(prepare);
+    if (checkoutIndex < 0 || prepareIndex <= checkoutIndex) {
+      errors.push(`${jobName} must check out the repository before prepare-e2e`);
+    }
+    const authIndex = jobSteps.findIndex((step) => step.name === "Authenticate to Docker Hub");
+    if (authIndex >= 0 && prepareIndex <= authIndex) {
+      errors.push(`${jobName} must authenticate to Docker Hub before prepare-e2e`);
+    }
+  }
+
+  for (const jobName of NO_BUILD_JOBS) {
+    if (!expectedJobs.has(jobName)) errors.push(`prepare-e2e no-build job is missing: ${jobName}`);
+  }
+  return errors;
+}
+
+export function validatePrepareE2eWorkflowBoundary(
+  workflow: WorkflowRecord,
+  actionPath = DEFAULT_ACTION_PATH,
+): string[] {
+  return [...validatePrepareE2eAction(actionPath), ...validatePrepareE2eInvocations(workflow)];
+}

--- a/tools/e2e/prepare-e2e-workflow-boundary.mts
+++ b/tools/e2e/prepare-e2e-workflow-boundary.mts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,8 +11,12 @@ import YAML from "yaml";
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_ACTION_PATH = join(REPO_ROOT, ".github", "actions", "prepare-e2e", "action.yaml");
 
-export const PREPARE_E2E_ACTION =
-  "NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28";
+const PREPARE_E2E_ACTION_PROVENANCE = {
+  reference: "NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28",
+  contentSha256: "eca1994acd70f4305cddae2990d1604e9fac455b45d3d89dfb4b08a07d7552a1",
+} as const;
+
+export const PREPARE_E2E_ACTION = PREPARE_E2E_ACTION_PROVENANCE.reference;
 export const PREPARE_E2E_STEP = "Prepare E2E workspace";
 
 const CHECKOUT_LOCAL_PREPARE_E2E_ACTION = "./.github/actions/prepare-e2e";
@@ -50,8 +55,15 @@ function steps(value: unknown): WorkflowStep[] {
 }
 
 export function validatePrepareE2eAction(actionPath = DEFAULT_ACTION_PATH): string[] {
-  const action = record(YAML.parse(readFileSync(actionPath, "utf8")));
+  const actionSource = readFileSync(actionPath, "utf8");
+  const action = record(YAML.parse(actionSource));
   const errors: string[] = [];
+  if (
+    createHash("sha256").update(actionSource).digest("hex") !==
+    PREPARE_E2E_ACTION_PROVENANCE.contentSha256
+  ) {
+    errors.push("prepare-e2e content must match the action reviewed at its immutable commit pin");
+  }
   const expectedInput = {
     description: "Build the CLI after installing dependencies.",
     required: false,

--- a/tools/e2e/sandbox-operations-workflow-boundary.mts
+++ b/tools/e2e/sandbox-operations-workflow-boundary.mts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
-import { PREPARE_E2E_ACTION, PREPARE_E2E_STEP } from "./prepare-e2e-workflow-boundary.mts";
+import { PREPARE_E2E_STEP } from "./prepare-e2e-workflow-boundary.mts";
 
 // Current-state security boundary for the default sandbox-operations job.
 // The shared workflow boundary owns the guarded Docker login and cleanup
@@ -93,7 +93,7 @@ export function validateSandboxOperationsWorkflow(workflow: {
     errors.push(`${JOB_NAME} checkout must disable persisted credentials`);
   }
   for (const step of steps.filter((entry) => entry.uses)) {
-    if (step.uses !== PREPARE_E2E_ACTION && !FULL_SHA_ACTION.test(step.uses ?? "")) {
+    if (!FULL_SHA_ACTION.test(step.uses ?? "")) {
       errors.push(`${JOB_NAME} action '${step.name ?? step.uses}' must pin a full SHA`);
     }
   }

--- a/tools/e2e/sandbox-operations-workflow-boundary.mts
+++ b/tools/e2e/sandbox-operations-workflow-boundary.mts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
+import { PREPARE_E2E_ACTION, PREPARE_E2E_STEP } from "./prepare-e2e-workflow-boundary.mts";
 
 // Current-state security boundary for the default sandbox-operations job.
 // The shared workflow boundary owns the guarded Docker login and cleanup
@@ -92,7 +93,7 @@ export function validateSandboxOperationsWorkflow(workflow: {
     errors.push(`${JOB_NAME} checkout must disable persisted credentials`);
   }
   for (const step of steps.filter((entry) => entry.uses)) {
-    if (!FULL_SHA_ACTION.test(step.uses ?? "")) {
+    if (step.uses !== PREPARE_E2E_ACTION && !FULL_SHA_ACTION.test(step.uses ?? "")) {
       errors.push(`${JOB_NAME} action '${step.name ?? step.uses}' must pin a full SHA`);
     }
   }
@@ -140,8 +141,8 @@ export function validateSandboxOperationsWorkflow(workflow: {
     }
   }
 
-  requireStepOrder(errors, steps, authenticate.name ?? "", "Build CLI");
-  requireStepOrder(errors, steps, "Build CLI", verifyLauncher.name ?? "");
+  requireStepOrder(errors, steps, authenticate.name ?? "", PREPARE_E2E_STEP);
+  requireStepOrder(errors, steps, PREPARE_E2E_STEP, verifyLauncher.name ?? "");
   requireStepOrder(errors, steps, verifyLauncher.name ?? "", "Install OpenShell CLI");
   requireStepOrder(errors, steps, "Install OpenShell CLI", "Run sandbox operations live test");
 

--- a/tools/e2e/security-posture-workflow-boundary.mts
+++ b/tools/e2e/security-posture-workflow-boundary.mts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
+import { PREPARE_E2E_ACTION } from "./prepare-e2e-workflow-boundary.mts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
@@ -122,7 +123,7 @@ export function validateSecurityPostureWorkflow(workflow: WorkflowRecord): strin
     errors.push(`${JOB_NAME} checkout must disable persisted credentials`);
   }
   for (const step of jobSteps.filter((entry) => entry.uses)) {
-    if (!FULL_SHA_ACTION.test(step.uses ?? "")) {
+    if (step.uses !== PREPARE_E2E_ACTION && !FULL_SHA_ACTION.test(step.uses ?? "")) {
       errors.push(`${JOB_NAME} action '${step.name ?? step.uses}' must pin a full SHA`);
     }
   }

--- a/tools/e2e/security-posture-workflow-boundary.mts
+++ b/tools/e2e/security-posture-workflow-boundary.mts
@@ -5,7 +5,6 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
-import { PREPARE_E2E_ACTION } from "./prepare-e2e-workflow-boundary.mts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DEFAULT_WORKFLOW_PATH = join(REPO_ROOT, ".github", "workflows", "e2e.yaml");
@@ -123,7 +122,7 @@ export function validateSecurityPostureWorkflow(workflow: WorkflowRecord): strin
     errors.push(`${JOB_NAME} checkout must disable persisted credentials`);
   }
   for (const step of jobSteps.filter((entry) => entry.uses)) {
-    if (step.uses !== PREPARE_E2E_ACTION && !FULL_SHA_ACTION.test(step.uses ?? "")) {
+    if (!FULL_SHA_ACTION.test(step.uses ?? "")) {
       errors.push(`${JOB_NAME} action '${step.name ?? step.uses}' must pin a full SHA`);
     }
   }

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -9,10 +9,7 @@ import { validateDocsValidationWorkflowBoundary } from "./docs-validation-workfl
 import { validateHermesDashboardWorkflowBoundary } from "./hermes-dashboard-workflow-boundary.mts";
 import { validateInferenceSwitchWorkflowBoundary } from "./inference-switch-workflow-boundary.mts";
 import { validateE2eOperationsWorkflowBoundary } from "./operations-workflow-boundary.mts";
-import {
-  PREPARE_E2E_ACTION,
-  validatePrepareE2eWorkflowBoundary,
-} from "./prepare-e2e-workflow-boundary.mts";
+import { validatePrepareE2eWorkflowBoundary } from "./prepare-e2e-workflow-boundary.mts";
 import { validateSandboxOperationsWorkflow } from "./sandbox-operations-workflow-boundary.mts";
 import { validateSecurityPostureWorkflowBoundary } from "./security-posture-workflow-boundary.mts";
 
@@ -620,9 +617,7 @@ function validateFreeStandingInventoryBoundary(
     requireNoDispatchInputInterpolation(errors, steps);
     for (const step of steps) {
       if (step.uses) {
-        if (step.uses !== PREPARE_E2E_ACTION) {
-          requireFullShaAction(errors, step, `${jobName} step '${step.name ?? step.uses}'`);
-        }
+        requireFullShaAction(errors, step, `${jobName} step '${step.name ?? step.uses}'`);
         if (stringValue(step.uses).startsWith("actions/upload-artifact@")) {
           requireUploadPathDoesNotContain(errors, stringValue(asRecord(step.with).path), "/tmp/");
         }

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -9,6 +9,10 @@ import { validateDocsValidationWorkflowBoundary } from "./docs-validation-workfl
 import { validateHermesDashboardWorkflowBoundary } from "./hermes-dashboard-workflow-boundary.mts";
 import { validateInferenceSwitchWorkflowBoundary } from "./inference-switch-workflow-boundary.mts";
 import { validateE2eOperationsWorkflowBoundary } from "./operations-workflow-boundary.mts";
+import {
+  PREPARE_E2E_ACTION,
+  validatePrepareE2eWorkflowBoundary,
+} from "./prepare-e2e-workflow-boundary.mts";
 import { validateSandboxOperationsWorkflow } from "./sandbox-operations-workflow-boundary.mts";
 import { validateSecurityPostureWorkflowBoundary } from "./security-posture-workflow-boundary.mts";
 
@@ -616,7 +620,9 @@ function validateFreeStandingInventoryBoundary(
     requireNoDispatchInputInterpolation(errors, steps);
     for (const step of steps) {
       if (step.uses) {
-        requireFullShaAction(errors, step, `${jobName} step '${step.name ?? step.uses}'`);
+        if (step.uses !== PREPARE_E2E_ACTION) {
+          requireFullShaAction(errors, step, `${jobName} step '${step.name ?? step.uses}'`);
+        }
         if (stringValue(step.uses).startsWith("actions/upload-artifact@")) {
           requireUploadPathDoesNotContain(errors, stringValue(asRecord(step.with).path), "/tmp/");
         }
@@ -712,18 +718,6 @@ function validateOpenShellVersionPinJob(errors: string[], jobs: WorkflowRecord):
     errors.push("openshell-version-pin checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("openshell-version-pin job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "openshell-version-pin setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
   const runVitest = requireJobStep(errors, jobName, steps, "Run OpenShell version-pin live test");
   requireRunContains(errors, runVitest, "npx vitest run --project e2e-live");
   requireRunContains(errors, runVitest, "test/e2e/live/openshell-version-pin.test.ts");
@@ -791,21 +785,6 @@ function validateSkillAgentJob(errors: string[], jobs: WorkflowRecord): void {
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("skill-agent checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("skill-agent job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "skill-agent setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
@@ -951,21 +930,6 @@ function validateNetworkPolicyJob(errors: string[], jobs: WorkflowRecord): void 
     ["expect"],
   );
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("network-policy job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "network-policy setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -1102,21 +1066,6 @@ function validateCommonEgressAgentJob(errors: string[], jobs: WorkflowRecord): v
     errors.push("common-egress-agent checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("common-egress-agent job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "common-egress-agent setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -1227,18 +1176,6 @@ function validateShieldsConfigJob(errors: string[], jobs: WorkflowRecord): void 
     errors.push("shields-config checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("shields-config job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "shields-config setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
   const runVitest = requireJobStep(errors, jobName, steps, "Run shields-config live test");
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
@@ -1315,21 +1252,6 @@ function validateRebuildOpenClawJob(errors: string[], jobs: WorkflowRecord): voi
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("rebuild-openclaw checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("rebuild-openclaw job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "rebuild-openclaw setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireEnvDoesNotExposeSecret(
@@ -1463,18 +1385,6 @@ function validateRebuildHermesJob(
     errors.push(`${jobName} checkout step must set persist-credentials=false`);
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push(`${jobName} job missing step: Set up Node`);
-  requireFullShaAction(errors, setupNode, `${jobName} setup-node`);
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
   const runVitest = requireJobStep(
     errors,
     jobName,
@@ -1583,21 +1493,6 @@ function validateSandboxRebuildJob(errors: string[], jobs: WorkflowRecord): void
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("sandbox-rebuild checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("sandbox-rebuild job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "sandbox-rebuild setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
@@ -1709,21 +1604,6 @@ function validateStateBackupRestoreJob(errors: string[], jobs: WorkflowRecord): 
     errors.push("state-backup-restore checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("state-backup-restore job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "state-backup-restore setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -1828,21 +1708,6 @@ function validateUpgradeStaleSandboxJob(errors: string[], jobs: WorkflowRecord):
     errors.push("upgrade-stale-sandbox checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("upgrade-stale-sandbox job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "upgrade-stale-sandbox setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -1930,21 +1795,6 @@ function validateTokenRotationJob(errors: string[], jobs: WorkflowRecord): void 
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("token-rotation checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("token-rotation job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "token-rotation setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const runVitest = requireJobStep(errors, jobName, steps, "Run token rotation live test");
   const runVitestEnv = asRecord(runVitest?.env);
@@ -2093,21 +1943,6 @@ function validateMessagingCompatibleEndpointJob(errors: string[], jobs: Workflow
     errors.push("messaging-compatible-endpoint checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("messaging-compatible-endpoint job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "messaging-compatible-endpoint setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const runVitest = requireJobStep(
     errors,
     jobName,
@@ -2214,21 +2049,6 @@ function validateOnboardNegativePathsJob(errors: string[], jobs: WorkflowRecord)
     errors.push("onboard-negative-paths checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("onboard-negative-paths job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "onboard-negative-paths setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const runVitest = requireJobStep(errors, jobName, steps, "Run onboard negative-paths live test");
   requireRunContains(errors, runVitest, "npx vitest run --project e2e-live");
   requireRunContains(errors, runVitest, "test/e2e/live/onboard-negative-paths.test.ts");
@@ -2307,21 +2127,6 @@ function validateCloudInferenceJob(errors: string[], jobs: WorkflowRecord): void
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("cloud-inference checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("cloud-inference job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "cloud-inference setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const runVitest = requireJobStep(errors, jobName, steps, "Run cloud inference live test");
   const runVitestEnv = asRecord(runVitest?.env);
@@ -2667,21 +2472,6 @@ function validateDoubleOnboardJob(errors: string[], jobs: WorkflowRecord): void 
     errors.push("double-onboard checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("double-onboard job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "double-onboard setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installTools = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installTools, "bash scripts/install-openshell.sh");
 
@@ -2758,18 +2548,6 @@ function validateRuntimeOverridesJob(errors: string[], jobs: WorkflowRecord): vo
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("runtime-overrides checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("runtime-overrides job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "runtime-overrides setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
 
   const runVitest = requireJobStep(errors, jobName, steps, "Run runtime overrides live test");
   requireRunContains(errors, runVitest, "npx vitest run --project e2e-live");
@@ -2855,21 +2633,6 @@ function validateHermesE2EJob(errors: string[], jobs: WorkflowRecord): void {
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("hermes-e2e checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("hermes-e2e job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "hermes-e2e setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const runVitest = requireJobStep(errors, jobName, steps, "Run Hermes live Vitest test");
   const runVitestEnv = asRecord(runVitest?.env);
@@ -2994,18 +2757,6 @@ function validateHermesRootEntrypointSmokeJob(errors: string[], jobs: WorkflowRe
     errors.push("hermes-root-entrypoint-smoke checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("hermes-root-entrypoint-smoke job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "hermes-root-entrypoint-smoke setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
   const runVitest = requireJobStep(
     errors,
     jobName,
@@ -3098,18 +2849,6 @@ function validateHermesSandboxSecretBoundaryJob(errors: string[], jobs: Workflow
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("hermes-sandbox-secret-boundary checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("hermes-sandbox-secret-boundary job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "hermes-sandbox-secret-boundary setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
 
   const runVitest = requireJobStep(
     errors,
@@ -3227,21 +2966,6 @@ function validateDiagnosticsJob(errors: string[], jobs: WorkflowRecord): void {
     errors.push("diagnostics checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("diagnostics job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "diagnostics setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const runVitest = requireJobStep(errors, jobName, steps, "Run diagnostics live test");
   const runVitestEnv = asRecord(runVitest?.env);
   if (runVitestEnv.NVIDIA_INFERENCE_API_KEY !== "${{ secrets.NVIDIA_INFERENCE_API_KEY }}") {
@@ -3342,20 +3066,6 @@ function validateSparkInstallJob(errors: string[], jobs: WorkflowRecord): void {
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("spark-install checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) {
-    errors.push("spark-install job missing step: Set up Node");
-  }
-  requireFullShaAction(errors, setupNode, "spark-install setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
 
   const runVitest = requireJobStep(errors, jobName, steps, "Run Spark install live test");
   const runVitestEnv = asRecord(runVitest?.env);
@@ -3459,20 +3169,6 @@ function validateSnapshotCommandsJob(errors: string[], jobs: WorkflowRecord): vo
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("snapshot-commands checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) {
-    errors.push("snapshot-commands job missing step: Set up Node");
-  }
-  requireFullShaAction(errors, setupNode, "snapshot-commands setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
 
   const runVitest = requireJobStep(errors, jobName, steps, "Run snapshot commands live test");
   const runVitestEnv = asRecord(runVitest?.env);
@@ -3587,23 +3283,6 @@ function validateModelRouterProviderRoutedInferenceJob(
       "model-router-provider-routed-inference checkout step must set persist-credentials=false",
     );
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) {
-    errors.push("model-router-provider-routed-inference job missing step: Set up Node");
-  }
-  requireFullShaAction(errors, setupNode, "model-router-provider-routed-inference setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const runVitest = requireJobStep(
     errors,
@@ -3743,23 +3422,6 @@ function validateTunnelLifecycleJob(errors: string[], jobs: WorkflowRecord): voi
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("tunnel-lifecycle checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) {
-    errors.push("tunnel-lifecycle job missing step: Set up Node");
-  }
-  requireFullShaAction(errors, setupNode, "tunnel-lifecycle setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const cloudflaredPrereq = requireJobStep(
     errors,
@@ -3904,23 +3566,6 @@ function validateIssue2478CrashLoopRecoveryJob(errors: string[], jobs: WorkflowR
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("issue-2478-crash-loop-recovery checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) {
-    errors.push("issue-2478-crash-loop-recovery job missing step: Set up Node");
-  }
-  requireFullShaAction(errors, setupNode, "issue-2478-crash-loop-recovery setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
@@ -4067,21 +3712,6 @@ function validateChannelsAddRemoveJob(errors: string[], jobs: WorkflowRecord): v
     errors.push("channels-add-remove checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("channels-add-remove job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "channels-add-remove setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -4180,21 +3810,6 @@ function validateOpenClawDiscordPairingJob(errors: string[], jobs: WorkflowRecor
     errors.push("openclaw-discord-pairing checkout step must set persist-credentials=false");
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("openclaw-discord-pairing job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "openclaw-discord-pairing setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
   requireRunContains(errors, installOpenShell, "env -u DOCKER_CONFIG");
@@ -4287,21 +3902,6 @@ function validateOpenClawSlackPairingJob(errors: string[], jobs: WorkflowRecord)
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("openclaw-slack-pairing checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("openclaw-slack-pairing job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "openclaw-slack-pairing setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell CLI");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
@@ -4434,21 +4034,6 @@ function validateChannelsStopStartJob(errors: string[], jobs: WorkflowRecord): v
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("channels-stop-start checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("channels-stop-start job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "channels-stop-start setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const installOpenShell = requireJobStep(errors, jobName, steps, "Install OpenShell");
   requireRunContains(errors, installOpenShell, "bash scripts/install-openshell.sh");
@@ -4692,23 +4277,6 @@ function validateBedrockRuntimeCompatibleAnthropicJob(
     );
   }
 
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) {
-    errors.push("bedrock-runtime-compatible-anthropic job missing step: Set up Node");
-  }
-  requireFullShaAction(errors, setupNode, "bedrock-runtime-compatible-anthropic setup-node");
-
-  const installRootDependencies = requireJobStep(
-    errors,
-    jobName,
-    steps,
-    "Install root dependencies",
-  );
-  requireRunContains(errors, installRootDependencies, "npm ci --ignore-scripts");
-
-  const buildCli = requireJobStep(errors, jobName, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
-
   const runVitest = requireJobStep(
     errors,
     jobName,
@@ -4760,6 +4328,7 @@ function validateBedrockRuntimeCompatibleAnthropicJob(
 export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_PATH): string[] {
   const workflow = readWorkflowRecord(workflowPath);
   const errors: string[] = [];
+  errors.push(...validatePrepareE2eWorkflowBoundary(workflow));
   errors.push(...validateHermesDashboardWorkflowBoundary(workflowPath));
   errors.push(...validateInferenceSwitchWorkflowBoundary(workflowPath));
   errors.push(...validateE2eOperationsWorkflowBoundary(workflowPath));
@@ -4823,9 +4392,6 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
   if (asRecord(generateCheckout?.with)["persist-credentials"] !== false) {
     errors.push("generate-matrix checkout step must set persist-credentials=false");
   }
-  const generateSetupNode = namedStep(generateSteps, "Set up Node");
-  if (!generateSetupNode) errors.push("generate-matrix job missing step: Set up Node");
-  requireFullShaAction(errors, generateSetupNode, "generate-matrix setup-node");
   const generate = requireStep(errors, generateSteps, "Generate E2E target matrix");
   const generateEnv = asRecord(generate?.env);
   if (generateEnv.JOBS !== "${{ inputs.jobs }}") {
@@ -4927,13 +4493,6 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
   if (asRecord(checkout?.with)["persist-credentials"] !== false) {
     errors.push("checkout step must set persist-credentials=false");
   }
-
-  const setupNode = namedStep(steps, "Set up Node");
-  if (!setupNode) errors.push("live job missing step: Set up Node");
-  requireFullShaAction(errors, setupNode, "setup-node");
-
-  const buildCli = requireStep(errors, steps, "Build CLI");
-  requireRunContains(errors, buildCli, "npm run build:cli");
 
   const runVitest = requireStep(errors, steps, "Run live E2E tests");
   const runVitestEnv = asRecord(runVitest?.env);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This first PR in a three-PR CI cleanup stack centralizes the repeated E2E Node/dependency/CLI bootstrap without changing what any job executes. It removes 856 net lines while preserving all 76 job definitions, selectors, runners, permissions, secret scopes, and commands.

## Changes
- Add one `prepare-e2e` composite for Node 22 setup, `npm ci --ignore-scripts`, and the optional per-job CLI build; invoke it from an immutable full commit SHA so target-ref checkouts cannot replace trusted bootstrap code.
- Replace 74 inline bootstrap sequences while preserving the original 61 build jobs and 13 no-build jobs.
- Share the identical 74-job report/scorecard dependency list with one YAML alias, keeping the workflow at 67 aliases under the 100-alias parser limit.
- Replace repeated per-job bootstrap assertions with one strict action/invocation boundary validator and focused mutation tests.
- Reject checkout-local bootstrap invocations with focused trust-boundary mutation coverage.
- Bind the immutable action reference and reviewed content digest in one provenance manifest; reject even semantic-neutral byte drift.
- Reduce `.github/workflows/e2e.yaml` by 669 lines and the complete change by 856 net lines.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: CI-only refactor with no user-facing product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The shared action is loaded from immutable commit `50281ee84c4a6fc759da95ea28fc0b7d9c378a28`, not the target checkout. One provenance manifest binds that reference to the reviewed SHA-256 content digest. The strict boundary validator pins the implementation, allowed inputs, build modes, checkout/auth ordering, and secret-free invocation shape; focused mutations reject checkout-local and byte-drift regressions. Two independent security reviews found no remaining issues.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared E2E preparation step to standardize setup across workflows, including Node.js 22 setup, dependency installation, and an optional CLI build.
  * Updated workflow contracts/validation to account for this new preparation step and its expected configuration.

* **Bug Fixes**
  * Refactored E2E workflows to use the shared preparation step, including lanes that intentionally skip the CLI build while still running the same tests and artifacts.

* **Tests**
  * Updated E2E boundary tests and assertions to match the new required step ordering and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->