### PR TITLE
fix(shields): make relock recovery hint driver-neutral (#6126)

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -527,6 +527,9 @@ nemohermes my-assistant shields down --timeout 5m --reason "maintenance"
 | `shields up` | Lock the sandbox config and restore the saved restrictive policy |
 | `shields down` | Temporarily unlock the sandbox config. Supports `--timeout`, `--reason`, and `--policy` |
 
+If `shields up` reports that the config remains unlocked or drifted, confirm that the sandbox is running and ready, then retry `nemohermes <name> shields up`.
+If the retry still fails, rebuild a known-good baseline with `nemohermes <name> rebuild --yes`.
+
 Host-side config and inference writes, snapshot mutation, sandbox destruction, and shields transitions serialize per sandbox.
 When a timed shields-down window reaches its deadline, auto-restore can interrupt the exact process tree holding that transition and restore lockdown.
 Retry an interrupted command in a new shields-down window.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -681,6 +681,9 @@ $$nemoclaw my-assistant shields down --timeout 5m --reason "maintenance"
 | `shields up` | Lock the sandbox config and restore the saved restrictive policy |
 | `shields down` | Temporarily unlock the sandbox config. Supports `--timeout`, `--reason`, and `--policy` |
 
+If `shields up` reports that the config remains unlocked or drifted, confirm that the sandbox is running and ready, then retry `$$nemoclaw <name> shields up`.
+If the retry still fails, rebuild a known-good baseline with `$$nemoclaw <name> rebuild --yes`.
+
 Host-side config and inference writes, snapshot mutation, sandbox destruction, and shields transitions serialize per sandbox.
 When a timed shields-down window reaches its deadline, auto-restore can interrupt the exact process tree holding that transition and restore lockdown.
 Retry an interrupted command in a new shields-down window.

--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -279,7 +279,7 @@ describe("shields command flow", () => {
     expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
       "Config unlocked for openclaw (no auto-lockdown timer",
     );
-  });
+  }, 15_000);
 
   it("binds manual shields-up to the active auto-restore timer generation", () => {
     const stateDir = path.join(tmpDir, ".nemoclaw", "state");

--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -27,6 +27,7 @@ setTimeout(() => {}, 5000);
 
 type ShieldsHarness = {
   auditSpy: MockInstance;
+  errorSpy: MockInstance;
   logSpy: MockInstance;
   runSpy: MockInstance;
   shieldsDown: typeof import("./index.js").shieldsDown;
@@ -40,6 +41,18 @@ let tmpDir: string;
 
 type HarnessOptions = {
   dockerExecFileSync?: (argv: unknown) => string;
+  failOpenClawGuardActions?: Array<"lock" | "unlock">;
+  invokedAs?: "nemoclaw" | "nemohermes";
+  openClawGuardFailure?: {
+    code: string;
+    path: string;
+    detail: string;
+  };
+  openClawGuardFailures?: Array<{
+    code: string;
+    path: string;
+    detail: string;
+  }>;
   fork?: () => {
     pid: number;
     disconnect: () => void;
@@ -51,12 +64,14 @@ type HarnessOptions = {
 };
 
 function createHarness(options: HarnessOptions = {}): ShieldsHarness {
+  vi.stubEnv("NEMOCLAW_INVOKED_AS", options.invokedAs ?? "nemoclaw");
   delete require.cache[requireDist.resolve(shieldsModulePath)];
   delete require.cache[requireDist.resolve("./timer-bound-lock.js")];
   delete require.cache[requireDist.resolve("./transition-lock.js")];
   delete require.cache[requireDist.resolve("../sandbox/privileged-exec.js")];
+  delete require.cache[requireDist.resolve("../cli/branding.js")];
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
   const runner = requireDist("../runner.js");
@@ -104,6 +119,29 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
     const args = Array.isArray(argv) ? argv.map(String) : [];
     const action = ["preflight", "lock", "unlock"].find((candidate) => args.includes(candidate));
     const openClawGuard = args.some((arg) => arg.endsWith("openclaw-config-guard.py"));
+    if (
+      openClawGuard &&
+      (action === "lock" || action === "unlock") &&
+      options.failOpenClawGuardActions?.includes(action)
+    ) {
+      const failures = options.openClawGuardFailures ?? [
+        options.openClawGuardFailure ?? {
+          code: "startup-not-ready",
+          path: "/run/nemoclaw/openclaw-config-ready.json",
+          detail: "OpenClaw startup is not ready for host config mutations",
+        },
+      ];
+      return {
+        status: 1,
+        signal: null,
+        stdout: `${failures
+          .map((failure) => JSON.stringify({ type: "issue", ...failure }))
+          .join("\n")}\n${JSON.stringify({ type: "result", action, status: "failed" })}\n`,
+        stderr: "",
+        pid: 0,
+        output: [],
+      } as never;
+    }
     openClawPosture =
       openClawGuard && action === "lock"
         ? "locked"
@@ -156,9 +194,11 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
 
   const shields = requireDist(shieldsModulePath);
   logSpy.mockClear();
+  errorSpy.mockClear();
   auditSpy.mockClear();
   return {
     auditSpy,
+    errorSpy,
     logSpy,
     runSpy,
     shieldsDown: shields.shieldsDown,
@@ -167,6 +207,22 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
     isShieldsDown: shields.isShieldsDown,
     synchronizeAutoRestoreWithShieldsDown: shields.synchronizeAutoRestoreWithShieldsDown,
   };
+}
+
+function expectStagedDriverNeutralRecovery(
+  errorSpy: MockInstance,
+  sandboxName: string,
+  cliName = "nemoclaw",
+): string {
+  const output = errorSpy.mock.calls.flat().map(String).join("\n");
+  expect(output).toContain(
+    `Recovery: confirm the sandbox is running and ready, then retry \`${cliName} ${sandboxName} shields up\`.`,
+  );
+  expect(output).toContain(
+    `If the retry still fails, rebuild a known-good baseline with \`${cliName} ${sandboxName} rebuild --yes\`.`,
+  );
+  expect(output).not.toMatch(/kubectl/i);
+  return output;
 }
 
 describe("shields command flow", () => {
@@ -182,6 +238,7 @@ describe("shields command flow", () => {
     delete require.cache[requireDist.resolve(shieldsModulePath)];
     delete require.cache[requireDist.resolve("./timer-bound-lock.js")];
     delete require.cache[requireDist.resolve("./transition-lock.js")];
+    delete require.cache[requireDist.resolve("../cli/branding.js")];
   });
 
   it("shieldsDown captures policy, unlocks config, saves state, and skips timer on request", () => {
@@ -575,6 +632,181 @@ describe("shields command flow", () => {
     expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
       "Saved policy snapshot is missing",
     );
+  });
+
+  it("reports staged driver-neutral recovery when shields-down rollback cannot re-lock (#6126)", () => {
+    const harness = createHarness({ failOpenClawGuardActions: ["unlock", "lock"] });
+
+    expect(() =>
+      harness.shieldsDown("openclaw", {
+        timeout: "5m",
+        reason: "recovery-hint coverage",
+        skipTimer: true,
+        throwOnError: true,
+      }),
+    ).toThrow(/startup-not-ready/);
+
+    const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw");
+    expect(output).toContain("Rolling back — restoring policy from snapshot");
+    expect(output).toContain("Config remains unlocked — manual intervention required");
+  });
+
+  it("reports staged driver-neutral recovery when snapshot restoration fails (#6126)", () => {
+    const harness = createHarness({ run: () => ({ status: 1 }) });
+    const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+    const snapshotPath = path.join(stateDir, "policy-snapshot-failed-restore.yaml");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(snapshotPath, "version: 1\nnetwork_policies: {}\n");
+    fs.writeFileSync(
+      path.join(stateDir, "shields-openclaw.json"),
+      JSON.stringify({
+        shieldsDown: true,
+        shieldsDownAt: new Date().toISOString(),
+        shieldsDownTimeout: 300,
+        shieldsDownReason: "recovery-hint coverage",
+        shieldsDownPolicy: "permissive",
+        shieldsPolicySnapshotPath: snapshotPath,
+      }),
+    );
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      "policy restore exited with status 1",
+    );
+
+    const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw");
+    expect(output).toContain("Config remains unlocked — manual intervention required");
+  });
+
+  it("reports staged driver-neutral recovery when the initial config lock fails (#6126)", () => {
+    const harness = createHarness({ failOpenClawGuardActions: ["lock"] });
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /startup-not-ready/,
+    );
+
+    const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw");
+    expect(output).toContain(
+      "Warning: OpenClaw lock rollback could not restore the trusted posture",
+    );
+    expect(output).not.toContain("CRITICAL: OpenClaw lock rollback");
+    expect(output).not.toContain(
+      "OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox",
+    );
+  });
+
+  it("uses the invoked nemohermes alias in staged recovery commands (#6126)", () => {
+    const harness = createHarness({
+      failOpenClawGuardActions: ["lock"],
+      invokedAs: "nemohermes",
+    });
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /startup-not-ready/,
+    );
+
+    const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw", "nemohermes");
+    expect(output).not.toContain("`nemoclaw openclaw shields up`");
+    expect(output).not.toContain("`nemoclaw openclaw rebuild --yes`");
+  });
+
+  it("retains critical recovery for non-transient OpenClaw rollback failures (#6126)", () => {
+    const harness = createHarness({
+      failOpenClawGuardActions: ["lock"],
+      openClawGuardFailure: {
+        code: "unsafe-config-path",
+        path: "/sandbox/.openclaw/openclaw.json",
+        detail: "canonical config path is not a safe regular file",
+      },
+    });
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /unsafe-config-path/,
+    );
+
+    const output = harness.errorSpy.mock.calls.flat().map(String).join("\n");
+    expect(output).toContain(
+      "CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox.",
+    );
+    expect(output).not.toContain(
+      "Warning: OpenClaw lock rollback could not restore the trusted posture",
+    );
+  });
+
+  it("retains critical recovery for structural startup-not-ready diagnostics (#6126)", () => {
+    const harness = createHarness({
+      failOpenClawGuardActions: ["lock"],
+      openClawGuardFailure: {
+        code: "startup-not-ready",
+        path: "/run/nemoclaw/openclaw-config-ready.json",
+        detail: "installed config guard requires NemoClaw PID 1",
+      },
+    });
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /requires NemoClaw PID 1/,
+    );
+
+    const output = harness.errorSpy.mock.calls.flat().map(String).join("\n");
+    expect(output).toContain(
+      "CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox.",
+    );
+    expect(output).not.toContain(
+      "Warning: OpenClaw lock rollback could not restore the trusted posture",
+    );
+  });
+
+  it("retains critical recovery when a transient diagnostic is followed by another issue (#6126)", () => {
+    const harness = createHarness({
+      failOpenClawGuardActions: ["lock"],
+      openClawGuardFailures: [
+        {
+          code: "startup-not-ready",
+          path: "/run/nemoclaw/openclaw-config-ready.json",
+          detail: "OpenClaw startup is not ready for host config mutations",
+        },
+        {
+          code: "unsafe-config-path",
+          path: "/sandbox/.openclaw/openclaw.json",
+          detail: "canonical config path is not a safe regular file",
+        },
+      ],
+    });
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /unsafe-config-path/,
+    );
+
+    const output = harness.errorSpy.mock.calls.flat().map(String).join("\n");
+    expect(output).toContain(
+      "CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox.",
+    );
+    expect(output).not.toContain(
+      "Warning: OpenClaw lock rollback could not restore the trusted posture",
+    );
+  });
+
+  it("reports staged driver-neutral recovery when drift remediation cannot re-lock (#6126)", () => {
+    const harness = createHarness({ failOpenClawGuardActions: ["lock"] });
+    const stateDir = path.join(tmpDir, ".nemoclaw", "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, "shields-openclaw.json"),
+      JSON.stringify({
+        shieldsDown: false,
+        chattrApplied: false,
+        fileHashes: {
+          "/sandbox/.openclaw/openclaw.json": "a".repeat(64),
+          "/sandbox/.openclaw/.config-hash": "a".repeat(64),
+        },
+      }),
+    );
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /startup-not-ready/,
+    );
+
+    const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw");
+    expect(output).toContain("Config remains drifted — manual intervention required");
   });
 
   it("retains the bounded auto-restore owner when manual shields-up fails", () => {

--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -40,6 +40,7 @@ type ShieldsHarness = {
 let tmpDir: string;
 
 type HarnessOptions = {
+  directSandboxUnavailable?: boolean;
   dockerExecFileSync?: (argv: unknown) => string;
   failOpenClawGuardActions?: Array<"lock" | "unlock">;
   invokedAs?: "nemoclaw" | "nemohermes";
@@ -62,6 +63,10 @@ type HarnessOptions = {
   };
   run?: (cmd: unknown) => { status: number };
 };
+
+function throwHarnessError(error: Error): never {
+  throw error;
+}
 
 function createHarness(options: HarnessOptions = {}): ShieldsHarness {
   vi.stubEnv("NEMOCLAW_INVOKED_AS", options.invokedAs ?? "nemoclaw");
@@ -106,14 +111,23 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
   });
   vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "openclaw", openshellDriver: "docker" });
   vi.spyOn(registry, "listSandboxes").mockReturnValue({ sandboxes: [{ name: "openclaw" }] });
+  const directSandboxUnavailableError = new Error(
+    "No running direct OpenShell sandbox container found for 'openclaw' (driver: docker). Expected a running container named openshell-openclaw or openshell-openclaw-*. Is the sandbox running?",
+  );
+  vi.spyOn(privilegedExec, "isDirectSandboxFallbackUnavailableError").mockReturnValue(
+    Boolean(options.directSandboxUnavailable),
+  );
   vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockImplementation(
-    (_sandboxName: unknown, cmd: unknown) => [
-      "exec",
-      "--user",
-      "root",
-      "openshell-openclaw",
-      ...(Array.isArray(cmd) ? cmd.map(String) : []),
-    ],
+    (_sandboxName: unknown, cmd: unknown) =>
+      options.directSandboxUnavailable
+        ? throwHarnessError(directSandboxUnavailableError)
+        : [
+            "exec",
+            "--user",
+            "root",
+            "openshell-openclaw",
+            ...(Array.isArray(cmd) ? cmd.map(String) : []),
+          ],
   );
   vi.spyOn(dockerExec, "dockerSpawnSync").mockImplementation((argv: unknown) => {
     const args = Array.isArray(argv) ? argv.map(String) : [];
@@ -708,6 +722,20 @@ describe("shields command flow", () => {
     const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw", "nemohermes");
     expect(output).not.toContain("`nemoclaw openclaw shields up`");
     expect(output).not.toContain("`nemoclaw openclaw rebuild --yes`");
+  });
+
+  it("reports staged recovery when a stopped sandbox prevents config relock (#6126)", () => {
+    const harness = createHarness({ directSandboxUnavailable: true });
+
+    expect(() => harness.shieldsUp("openclaw", { throwOnError: true })).toThrow(
+      /No running direct OpenShell sandbox container found/,
+    );
+
+    const output = expectStagedDriverNeutralRecovery(harness.errorSpy, "openclaw");
+    expect(output).toContain(
+      "Warning: OpenClaw lock rollback could not restore the trusted posture",
+    );
+    expect(output).not.toContain("CRITICAL: OpenClaw lock rollback");
   });
 
   it("retains critical recovery for non-transient OpenClaw rollback failures (#6126)", () => {

--- a/src/lib/shields/flow.test.ts
+++ b/src/lib/shields/flow.test.ts
@@ -119,36 +119,36 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
     const args = Array.isArray(argv) ? argv.map(String) : [];
     const action = ["preflight", "lock", "unlock"].find((candidate) => args.includes(candidate));
     const openClawGuard = args.some((arg) => arg.endsWith("openclaw-config-guard.py"));
-    if (
+    const shouldFailOpenClawGuard = Boolean(
       openClawGuard &&
-      (action === "lock" || action === "unlock") &&
-      options.failOpenClawGuardActions?.includes(action)
-    ) {
-      const failures = options.openClawGuardFailures ?? [
-        options.openClawGuardFailure ?? {
-          code: "startup-not-ready",
-          path: "/run/nemoclaw/openclaw-config-ready.json",
-          detail: "OpenClaw startup is not ready for host config mutations",
-        },
-      ];
-      return {
-        status: 1,
-        signal: null,
-        stdout: `${failures
-          .map((failure) => JSON.stringify({ type: "issue", ...failure }))
-          .join("\n")}\n${JSON.stringify({ type: "result", action, status: "failed" })}\n`,
-        stderr: "",
-        pid: 0,
-        output: [],
-      } as never;
-    }
-    openClawPosture =
-      openClawGuard && action === "lock"
+        (action === "lock" || action === "unlock") &&
+        options.failOpenClawGuardActions?.includes(action),
+    );
+    const failures = options.openClawGuardFailures ?? [
+      options.openClawGuardFailure ?? {
+        code: "startup-not-ready",
+        path: "/run/nemoclaw/openclaw-config-ready.json",
+        detail: "OpenClaw startup is not ready for host config mutations",
+      },
+    ];
+    const failureResult = {
+      status: 1,
+      signal: null,
+      stdout: `${failures
+        .map((failure) => JSON.stringify({ type: "issue", ...failure }))
+        .join("\n")}\n${JSON.stringify({ type: "result", action, status: "failed" })}\n`,
+      stderr: "",
+      pid: 0,
+      output: [],
+    };
+    openClawPosture = shouldFailOpenClawGuard
+      ? openClawPosture
+      : openClawGuard && action === "lock"
         ? "locked"
         : openClawGuard && action === "unlock"
           ? "mutable"
           : openClawPosture;
-    return {
+    const successResult = {
       status: 0,
       signal: null,
       stdout: action
@@ -168,7 +168,8 @@ function createHarness(options: HarnessOptions = {}): ShieldsHarness {
       stderr: "",
       pid: 0,
       output: [],
-    } as never;
+    };
+    return (shouldFailOpenClawGuard ? failureResult : successResult) as never;
   });
   vi.spyOn(dockerExec, "dockerExecFileSync").mockImplementation((argv: unknown) => {
     const args = Array.isArray(argv) ? argv.map(String) : [];

--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -1089,7 +1089,7 @@ describe("NC-2227-05: shields timer marker behavior", () => {
   });
 });
 
-describe("#6126: shields relock recovery hint is driver-neutral", () => {
+describe("shields relock recovery hint stays driver-neutral (#6126)", () => {
   const loadHint = async () => {
     const sourceModulePath = path.join(process.cwd(), "src", "lib", "shields", "index.ts");
     const { manualRelockRecoveryHint } = await import(sourceModulePath);

--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -1088,3 +1088,22 @@ describe("NC-2227-05: shields timer marker behavior", () => {
     expect(isShieldsDown("openclaw")).toBe(false);
   });
 });
+
+describe("#6126: shields relock recovery hint is driver-neutral", () => {
+  const loadHint = async () => {
+    const sourceModulePath = path.join(process.cwd(), "src", "lib", "shields", "index.ts");
+    const { manualRelockRecoveryHint } = await import(sourceModulePath);
+    return manualRelockRecoveryHint as (sandboxName: string) => string;
+  };
+
+  it("does not tell docker/vm-driver users to kubectl exec (there is no k8s control plane)", async () => {
+    const hint = (await loadHint())("my-assistant");
+    expect(hint).not.toMatch(/kubectl/i);
+  });
+
+  it("offers recoveries valid on every driver and names the sandbox", async () => {
+    const hint = (await loadHint())("my-assistant");
+    expect(hint).toContain("nemoclaw my-assistant shields up");
+    expect(hint).toContain("nemoclaw my-assistant rebuild --yes");
+  });
+});

--- a/src/lib/shields/index.test.ts
+++ b/src/lib/shields/index.test.ts
@@ -1088,22 +1088,3 @@ describe("NC-2227-05: shields timer marker behavior", () => {
     expect(isShieldsDown("openclaw")).toBe(false);
   });
 });
-
-describe("shields relock recovery hint stays driver-neutral (#6126)", () => {
-  const loadHint = async () => {
-    const sourceModulePath = path.join(process.cwd(), "src", "lib", "shields", "index.ts");
-    const { manualRelockRecoveryHint } = await import(sourceModulePath);
-    return manualRelockRecoveryHint as (sandboxName: string) => string;
-  };
-
-  it("does not tell docker/vm-driver users to kubectl exec (there is no k8s control plane)", async () => {
-    const hint = (await loadHint())("my-assistant");
-    expect(hint).not.toMatch(/kubectl/i);
-  });
-
-  it("offers recoveries valid on every driver and names the sandbox", async () => {
-    const hint = (await loadHint())("my-assistant");
-    expect(hint).toContain("nemoclaw my-assistant shields up");
-    expect(hint).toContain("nemoclaw my-assistant rebuild --yes");
-  });
-});

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -30,6 +30,7 @@ const {
   dockerSpawnSync,
 }: typeof import("../adapters/docker/exec") = require("../adapters/docker/exec");
 const {
+  isDirectSandboxFallbackUnavailableError,
   privilegedSandboxExecArgv,
 }: typeof import("../sandbox/privileged-exec") = require("../sandbox/privileged-exec");
 const {
@@ -315,6 +316,9 @@ function stopTimedOutShieldsDownTree(ownerPid: number, ownerStartIdentity: strin
  * Keep this driver-neutral because docker and VM sandboxes have no Kubernetes
  * control plane. Rebuild remains an escalation after the sandbox-ready retry
  * rather than an equivalent first step. (#6126)
+ *
+ * Recovery is: confirm readiness and retry `<cli> <sandbox> shields up`; only
+ * then escalate to `<cli> <sandbox> rebuild --yes` if the retry still fails.
  */
 function printManualRelockRecoveryHint(sandboxName: string): void {
   console.error(
@@ -331,9 +335,24 @@ function printManualRelockRecoveryHint(sandboxName: string): void {
 const OPENCLAW_STARTUP_NOT_READY_DIAGNOSTIC =
   /^(?:top-level config rollback failed: )?Config not locked: OpenClaw config guard lock \[startup-not-ready\] \/run\/nemoclaw\/openclaw-config-ready\.json: OpenClaw startup is not ready for host config mutations$/;
 
-function isOpenClawStartupNotReadyFailure(value: unknown): boolean {
+function isOpenClawReadinessFailure(value: unknown): boolean {
   const message = value instanceof Error ? value.message : String(value);
-  return OPENCLAW_STARTUP_NOT_READY_DIAGNOSTIC.test(message);
+  return (
+    isDirectSandboxFallbackUnavailableError(value) ||
+    OPENCLAW_STARTUP_NOT_READY_DIAGNOSTIC.test(message)
+  );
+}
+
+type OpenClawRollbackIssue = {
+  message: string;
+  readinessFailure: boolean;
+};
+
+function openClawRollbackIssue(prefix: string, error: unknown): OpenClawRollbackIssue {
+  return {
+    message: `${prefix}: ${error instanceof Error ? error.message : String(error)}`,
+    readinessFailure: isOpenClawReadinessFailure(error),
+  };
 }
 
 function privilegedSandboxExec(sandboxName: string, cmd: string[], timeout = 15000): void {
@@ -2021,13 +2040,13 @@ function lockAgentConfigUnderMutationLock(
         );
       }
     } else if (openClawProtocol && openClawMutationStarted) {
-      const rollbackIssues: string[] = [];
+      const rollbackIssues: OpenClawRollbackIssue[] = [];
       const restoreTop = (action: "lock" | "unlock") => {
         try {
           transitionOpenClawTopConfig(sandboxName, target, action);
         } catch (rollbackError) {
           rollbackIssues.push(
-            `top-level config rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+            openClawRollbackIssue("top-level config rollback failed", rollbackError),
           );
         }
       };
@@ -2038,11 +2057,11 @@ function lockAgentConfigUnderMutationLock(
               stateDirLockExec(sandboxName),
               target.configDir,
               rollbackLocked,
-            ),
+            ).map((message) => ({ message, readinessFailure: false })),
           );
         } catch (rollbackError) {
           rollbackIssues.push(
-            `state-directory rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+            openClawRollbackIssue("state-directory rollback failed", rollbackError),
           );
         }
       };
@@ -2057,16 +2076,17 @@ function lockAgentConfigUnderMutationLock(
         restoreTop("lock");
       }
       if (rollbackIssues.length > 0) {
+        const rollbackSummary = rollbackIssues.map(({ message }) => message).join(", ");
         if (
-          isOpenClawStartupNotReadyFailure(error) &&
-          rollbackIssues.every(isOpenClawStartupNotReadyFailure)
+          isOpenClawReadinessFailure(error) &&
+          rollbackIssues.every(({ readinessFailure }) => readinessFailure)
         ) {
           console.error(
-            `  Warning: OpenClaw lock rollback could not restore the trusted posture. Confirm the sandbox is running and ready, then retry the operation before rebuilding. ${rollbackIssues.join(", ")}`,
+            `  Warning: OpenClaw lock rollback could not restore the trusted posture. Confirm the sandbox is running and ready, then retry the operation before rebuilding. ${rollbackSummary}`,
           );
         } else {
           console.error(
-            `  CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox. ${rollbackIssues.join(", ")}`,
+            `  CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox. ${rollbackSummary}`,
           );
         }
       }

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -24,6 +24,7 @@ const path = require("path");
 const { fork } = require("child_process");
 const { randomBytes } = require("crypto");
 const { run, runCapture, validateName } = require("../runner");
+const { CLI_NAME }: typeof import("../cli/branding") = require("../cli/branding");
 const {
   dockerExecFileSync,
   dockerSpawnSync,
@@ -308,13 +309,31 @@ function stopTimedOutShieldsDownTree(ownerPid: number, ownerStartIdentity: strin
 // sandbox container is running.
 // ---------------------------------------------------------------------------
 
-// Recovery hint printed when shields cannot restore lockdown and leaves the
-// agent config mutable. It must stay driver-neutral: the docker and vm drivers
-// run per-sandbox direct containers with no k8s control plane, so a "kubectl
-// exec" instruction is invalid there — and the docker driver is the default on
-// v0.0.71. Both recoveries below are valid on every driver. (#6126)
-function manualRelockRecoveryHint(sandboxName: string): string {
-  return `  Recovery: re-run \`nemoclaw ${sandboxName} shields up\`, or rebuild a known-good baseline with \`nemoclaw ${sandboxName} rebuild --yes\`.`;
+/**
+ * Print recovery guidance when shields cannot restore lockdown.
+ *
+ * Keep this driver-neutral because docker and VM sandboxes have no Kubernetes
+ * control plane. Rebuild remains an escalation after the sandbox-ready retry
+ * rather than an equivalent first step. (#6126)
+ */
+function printManualRelockRecoveryHint(sandboxName: string): void {
+  console.error(
+    `  Recovery: confirm the sandbox is running and ready, then retry \`${CLI_NAME} ${sandboxName} shields up\`.`,
+  );
+  console.error(
+    `  If the retry still fails, rebuild a known-good baseline with \`${CLI_NAME} ${sandboxName} rebuild --yes\`.`,
+  );
+}
+
+// The guard also uses startup-not-ready for structural PID 1 incompatibility.
+// Match the complete transient diagnostic so a different detail or an
+// additional issue cannot downgrade an unsafe rollback from CRITICAL.
+const OPENCLAW_STARTUP_NOT_READY_DIAGNOSTIC =
+  /^(?:top-level config rollback failed: )?Config not locked: OpenClaw config guard lock \[startup-not-ready\] \/run\/nemoclaw\/openclaw-config-ready\.json: OpenClaw startup is not ready for host config mutations$/;
+
+function isOpenClawStartupNotReadyFailure(value: unknown): boolean {
+  const message = value instanceof Error ? value.message : String(value);
+  return OPENCLAW_STARTUP_NOT_READY_DIAGNOSTIC.test(message);
 }
 
 function privilegedSandboxExec(sandboxName: string, cmd: string[], timeout = 15000): void {
@@ -1486,8 +1505,8 @@ function assertNoLegacyStateLayout(sandboxName: string, configDir: string): void
 // user and the gateway UID can write the mutable config tree. Hermes keeps its
 // tighter single-user layout.
 //
-// Note on chattr: best-effort — it may silently fail if kubectl exec
-// lacks CAP_LINUX_IMMUTABLE or if the file was never immutable. That's fine:
+// Note on chattr: best-effort — the privileged sandbox exec may lack
+// CAP_LINUX_IMMUTABLE, or the file may never have been immutable. That's fine:
 // the file becomes writable through the permissive policy (disables Landlock
 // read_only) + chown/chmod below.
 // ---------------------------------------------------------------------------
@@ -1814,9 +1833,9 @@ function repairMutableConfigPerms(sandboxName: string): MutableConfigRepairResul
 //   2. UNIX permissions — 444 root:root (mandatory, verified here)
 //   3. chattr +i immutable bit — defense-in-depth (best-effort)
 //
-// Layer 3 is best-effort because kubectl exec may lack
-// CAP_LINUX_IMMUTABLE. Layers 1+2 are sufficient. We still attempt it
-// in case the runtime environment supports it.
+// Layer 3 is best-effort because the privileged sandbox exec may lack
+// CAP_LINUX_IMMUTABLE. Layers 1+2 are sufficient. We still attempt it in case
+// the runtime environment supports it.
 // ---------------------------------------------------------------------------
 
 function captureSealHashes(sandboxName: string, filesToHash: string[]): { [path: string]: string } {
@@ -2038,9 +2057,18 @@ function lockAgentConfigUnderMutationLock(
         restoreTop("lock");
       }
       if (rollbackIssues.length > 0) {
-        console.error(
-          `  CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox. ${rollbackIssues.join(", ")}`,
-        );
+        if (
+          isOpenClawStartupNotReadyFailure(error) &&
+          rollbackIssues.every(isOpenClawStartupNotReadyFailure)
+        ) {
+          console.error(
+            `  Warning: OpenClaw lock rollback could not restore the trusted posture. Confirm the sandbox is running and ready, then retry the operation before rebuilding. ${rollbackIssues.join(", ")}`,
+          );
+        } else {
+          console.error(
+            `  CRITICAL: OpenClaw lock rollback could not restore the trusted posture. Restore from a trusted backup and recreate the sandbox. ${rollbackIssues.join(", ")}`,
+          );
+        }
       }
     }
     throw error;
@@ -2217,7 +2245,7 @@ function rollbackShieldsDown(
     console.error("  Lockdown restored. Config was never left unguarded.");
   } else {
     console.error("  Config remains unlocked — manual intervention required.");
-    console.error(manualRelockRecoveryHint(sandboxName));
+    printManualRelockRecoveryHint(sandboxName);
   }
 }
 
@@ -2858,6 +2886,7 @@ function shieldsUpWithoutHostLock(
       const message = relock.error ?? "Config re-lock did not re-confirm after settle window";
       console.error(`  ERROR: ${message}`);
       console.error("  Config remains drifted — manual intervention required.");
+      printManualRelockRecoveryHint(sandboxName);
       return failShieldsCommand(message, opts.throwOnError);
     }
     const lockResult: { chattrApplied: boolean; fileHashes: { [path: string]: string } } =
@@ -2921,7 +2950,7 @@ function shieldsUpWithoutHostLock(
     if (!activation.ok) {
       console.error(`  ERROR: ${activation.error ?? "unknown restore error"}`);
       console.error("  Config remains unlocked — manual intervention required.");
-      console.error(manualRelockRecoveryHint(sandboxName));
+      printManualRelockRecoveryHint(sandboxName);
       return failShieldsCommand(activation.error ?? "unknown restore error", opts.throwOnError);
     }
     if (activation.fileHashes && typeof activation.chattrApplied === "boolean") {
@@ -2932,7 +2961,7 @@ function shieldsUpWithoutHostLock(
     }
   } else {
     // 2b. Lock config file to read-only.
-    //     Uses kubectl exec to bypass Landlock (same as shields down).
+    //     Uses the registry-scoped privileged sandbox exec to bypass Landlock.
     //     Each operation runs independently and the result is verified.
     //     If verification fails, config remains unlocked — we do not lie about state.
     console.log(`  Locking ${target.agentName} config (${target.configPath})...`);
@@ -2949,7 +2978,7 @@ function shieldsUpWithoutHostLock(
       const message = err instanceof Error ? err.message : String(err);
       console.error(`  ERROR: ${message}`);
       console.error("  Config remains unlocked — manual intervention required.");
-      console.error(manualRelockRecoveryHint(sandboxName));
+      printManualRelockRecoveryHint(sandboxName);
       return failShieldsCommand(message, opts.throwOnError);
     }
     saveShieldsState(sandboxName, {
@@ -3240,7 +3269,6 @@ export {
   killTimer,
   lockAgentConfig,
   MAX_TIMEOUT_SECONDS,
-  manualRelockRecoveryHint,
   parseDuration,
   prepareAutoRestoreTransitionTakeover,
   repairMutableConfigPerms,

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -308,6 +308,15 @@ function stopTimedOutShieldsDownTree(ownerPid: number, ownerStartIdentity: strin
 // sandbox container is running.
 // ---------------------------------------------------------------------------
 
+// Recovery hint printed when shields cannot restore lockdown and leaves the
+// agent config mutable. It must stay driver-neutral: the docker and vm drivers
+// run per-sandbox direct containers with no k8s control plane, so a "kubectl
+// exec" instruction is invalid there — and the docker driver is the default on
+// v0.0.71. Both recoveries below are valid on every driver. (#6126)
+function manualRelockRecoveryHint(sandboxName: string): string {
+  return `  Recovery: re-run \`nemoclaw ${sandboxName} shields up\`, or rebuild a known-good baseline with \`nemoclaw ${sandboxName} rebuild --yes\`.`;
+}
+
 function privilegedSandboxExec(sandboxName: string, cmd: string[], timeout = 15000): void {
   dockerExecFileSync(privilegedSandboxExecArgv(sandboxName, cmd, false, true), {
     stdio: ["ignore", "pipe", "pipe"],
@@ -2208,9 +2217,7 @@ function rollbackShieldsDown(
     console.error("  Lockdown restored. Config was never left unguarded.");
   } else {
     console.error("  Config remains unlocked — manual intervention required.");
-    console.error(
-      `  Re-lock manually via kubectl exec, then run: nemoclaw ${sandboxName} shields up`,
-    );
+    console.error(manualRelockRecoveryHint(sandboxName));
   }
 }
 
@@ -2914,9 +2921,7 @@ function shieldsUpWithoutHostLock(
     if (!activation.ok) {
       console.error(`  ERROR: ${activation.error ?? "unknown restore error"}`);
       console.error("  Config remains unlocked — manual intervention required.");
-      console.error(
-        `  Re-lock manually via kubectl exec, then run: nemoclaw ${sandboxName} shields up`,
-      );
+      console.error(manualRelockRecoveryHint(sandboxName));
       return failShieldsCommand(activation.error ?? "unknown restore error", opts.throwOnError);
     }
     if (activation.fileHashes && typeof activation.chattrApplied === "boolean") {
@@ -2944,9 +2949,7 @@ function shieldsUpWithoutHostLock(
       const message = err instanceof Error ? err.message : String(err);
       console.error(`  ERROR: ${message}`);
       console.error("  Config remains unlocked — manual intervention required.");
-      console.error(
-        `  Re-lock manually via kubectl exec, then run: nemoclaw ${sandboxName} shields up`,
-      );
+      console.error(manualRelockRecoveryHint(sandboxName));
       return failShieldsCommand(message, opts.throwOnError);
     }
     saveShieldsState(sandboxName, {
@@ -3237,6 +3240,7 @@ export {
   killTimer,
   lockAgentConfig,
   MAX_TIMEOUT_SECONDS,
+  manualRelockRecoveryHint,
   parseDuration,
   prepareAutoRestoreTransitionTakeover,
   repairMutableConfigPerms,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replace the invalid `kubectl` relock hint with staged, driver-neutral recovery for every shields branch that can leave OpenClaw config unlocked or drifted. The guidance now asks operators to confirm the sandbox is running and ready, retry `shields up`, and rebuild only if that retry fails, while preserving CRITICAL severity for structural, unsafe, or mixed rollback failures.

## Related Issue

Fixes #6126

## Changes

- Print recovery commands through the invoked `nemoclaw` or `nemohermes` CLI name instead of hardcoding a Kubernetes-only path.
- Cover shields-down rollback, snapshot restore, initial shields-up locking, and drift remediation with the same retry-before-rebuild sequence.
- Treat only the exact transient startup-not-ready diagnostic and the typed direct-container-unavailable error as readiness failures, recording that classification before rollback errors are rendered to text.
- Require both the primary error and every rollback issue to be readiness-classified before using Warning severity; structural PID 1, unsafe-path, state-guard, and mixed failures remain CRITICAL.
- Add flow-level regressions for all four recovery branches, CLI alias rendering, transient rollback, structural failure, and mixed unsafe failure.
- Cover the stopped-sandbox/direct-container readiness path and keep the shared flow harness free of new `if` statements.
- Update the canonical and generated command references with the staged recovery sequence.
- Keep rebuild an explicit operator escalation: `rebuild --yes` is destructive, so a failed readiness probe must never trigger it automatically.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent final review verified all four recovery branches and the typed stopped-container path. Readiness is captured on original error objects before stringification; Warning severity requires the primary error and every rollback issue to be readiness-classified, while structural, unsafe, state-guard, and mixed diagnostics retain CRITICAL recovery guidance.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Evidence

- Normal commit hooks passed under `umask 022`, including repository checks and full CLI/integration coverage; normal push hooks passed CLI type-checking and version synchronization.
- The final follow-up passes 19/19 flow tests plus 29/29 shields index tests, including stopped-container readiness and unsafe/mixed CRITICAL regressions.
- Biome, CLI type-checking, test-title style, test-size budget, project-overlap checks, and `git diff --check` passed.
- `npm run docs` completed with 0 errors and 2 pre-existing warnings; generated agent variants are current.
- Source boundary and accepted risk: sandbox/container readiness belongs to the OpenShell runtime and can change outside NemoClaw's transaction. The config guard correctly refuses mutation when that boundary is unavailable. NemoClaw cannot safely repair it by automatically running destructive `rebuild --yes`, so recovery remains an explicit readiness check, bounded retry, then operator-approved rebuild. This staged workaround can be removed when the runtime exposes a trusted primitive that proves or restores readiness before a safe retry without recreating the sandbox.
- The command-flow tests exercise the public shields boundary with controlled guard/container failures; the required exact-head `shields-config` live job supplies runtime regression coverage but intentionally does not inject destructive failure states.
- `flow.test.ts` remains one cohesive lifecycle/rollback harness at 982 lines, below the repository's 1500-line test budget. Splitting these seven recovery cases would duplicate the same timer, policy, registry, privileged-exec, branding, and audit setup rather than isolate a distinct subsystem.

---
Signed-off-by: Jason Ma <jama@nvidia.com>
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shields recovery messaging when the sandbox config remains unlocked or has drifted: operators are prompted to confirm the sandbox is running/ready, then retry the shields-up command; if it still fails, they’re instructed to rebuild a known-good baseline with `rebuild --yes`.
  * Updated handling for “startup not ready” so these cases emit a warning with an explicit confirm-and-retry recommendation rather than escalating unnecessarily.
* **Documentation**
  * Refreshed `shields up` troubleshooting guidance across command references to match the new confirm-and-retry flow and the `rebuild --yes` fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->