### PR TITLE
fix(sandbox): respawn gateway after watchdog SIGTERM instead of exiting PID 1

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -4812,10 +4812,11 @@ if [ "$(id -u)" -ne 0 ]; then
     # non-zero, defeating the respawn loop entirely.
     RC=0
     EXITED_GATEWAY_PID="$GATEWAY_PID"
+    EXITED_GATEWAY_START_IDENTITY="$GATEWAY_PID_START_IDENTITY"
     wait "$EXITED_GATEWAY_PID" || RC=$?
     mark_openclaw_gateway_stopped
     if [ "$RC" -eq 0 ] \
-      && ! consume_gateway_watchdog_kill "${EXITED_GATEWAY_PID}:${GATEWAY_PID_START_IDENTITY}"; then
+      && ! consume_gateway_watchdog_kill "${EXITED_GATEWAY_PID}:${EXITED_GATEWAY_START_IDENTITY}"; then
       exit 0
     fi
     NOW=$(date +%s)
@@ -5084,6 +5085,7 @@ while :; do
   fi
 
   EXITED_GATEWAY_PID="$GATEWAY_PID"
+  EXITED_GATEWAY_START_IDENTITY="$GATEWAY_PID_START_IDENTITY"
   REAP_STATUS=0
   openclaw_reap_exited_gateway || REAP_STATUS=$?
   if [ "$REAP_STATUS" -eq 3 ]; then
@@ -5099,7 +5101,7 @@ while :; do
     continue
   fi
   if [ "$RC" -eq 0 ] \
-    && ! consume_gateway_watchdog_kill "${EXITED_GATEWAY_PID}:${GATEWAY_PID_START_IDENTITY}"; then
+    && ! consume_gateway_watchdog_kill "${EXITED_GATEWAY_PID}:${EXITED_GATEWAY_START_IDENTITY}"; then
     exit 0
   fi
   NOW=$(date +%s)

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -254,6 +254,7 @@ NEMOCLAW_CMD=("$@")
 # Internal test seam shared by the PID writer and watchdog. This is deliberately
 # not documented as a public env API; production always keeps the default path.
 GATEWAY_PID_FILE=/tmp/nemoclaw-gateway.pid
+GATEWAY_WATCHDOG_KILL_FILE="${_NEMOCLAW_GATEWAY_WATCHDOG_KILL_FILE:-/tmp/nemoclaw-gateway-watchdog-kill}"
 
 # A numeric PID is not a process identity: Linux may reuse it immediately
 # after the child is reaped.  Capture `/proc/<pid>/stat` field 22 (starttime)
@@ -358,6 +359,19 @@ record_gateway_pid() {
 
 clear_gateway_pid_record() {
   printf '' | _nemoclaw_safe_replace_tmp_file "$GATEWAY_PID_FILE" 600 "" best-effort 2>/dev/null || true
+}
+
+record_gateway_watchdog_kill() {
+  printf '%s\n' "${1:-}" \
+    | _nemoclaw_safe_replace_tmp_file "$GATEWAY_WATCHDOG_KILL_FILE" 600 "" best-effort 2>/dev/null || true
+}
+
+consume_gateway_watchdog_kill() {
+  local expected="$1" marked=""
+  [ -f "$GATEWAY_WATCHDOG_KILL_FILE" ] || return 1
+  IFS= read -r marked <"$GATEWAY_WATCHDOG_KILL_FILE" 2>/dev/null || true
+  rm -f "$GATEWAY_WATCHDOG_KILL_FILE" 2>/dev/null || true
+  [ -n "$marked" ] && [ "$marked" = "$expected" ]
 }
 
 _chat_ui_url_port() {
@@ -4122,6 +4136,7 @@ start_gateway_serving_watchdog() {
       # _NEMOCLAW_GATEWAY_LOG is a test seam; production always appends to
       # /tmp/gateway.log alongside the gateway's own output.
       echo "$msg" >>"${_NEMOCLAW_GATEWAY_LOG:-/tmp/gateway.log}" 2>/dev/null || true
+      record_gateway_watchdog_kill "$tracked_identity"
       kill -TERM "$pid" 2>/dev/null || true
       for _ in 1 2 3 4 5 6 7 8 9 10; do
         openclaw_supervised_pid_is_live "$pid" "$start_identity" || break
@@ -4799,7 +4814,8 @@ if [ "$(id -u)" -ne 0 ]; then
     EXITED_GATEWAY_PID="$GATEWAY_PID"
     wait "$EXITED_GATEWAY_PID" || RC=$?
     mark_openclaw_gateway_stopped
-    if [ "$RC" -eq 0 ]; then
+    if [ "$RC" -eq 0 ] \
+      && ! consume_gateway_watchdog_kill "${EXITED_GATEWAY_PID}:${GATEWAY_PID_START_IDENTITY}"; then
       exit 0
     fi
     NOW=$(date +%s)
@@ -5082,7 +5098,8 @@ while :; do
     handle_openclaw_gateway_control_request || true
     continue
   fi
-  if [ "$RC" -eq 0 ]; then
+  if [ "$RC" -eq 0 ] \
+    && ! consume_gateway_watchdog_kill "${EXITED_GATEWAY_PID}:${GATEWAY_PID_START_IDENTITY}"; then
     exit 0
   fi
   NOW=$(date +%s)

--- a/test/gateway-watchdog-kill-marker.test.ts
+++ b/test/gateway-watchdog-kill-marker.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const START_SCRIPT = path.resolve(HERE, "..", "scripts", "nemoclaw-start.sh");
+
+function requireNonNegative(value: number, message: string): number {
+  return value >= 0
+    ? value
+    : (() => {
+        throw new Error(message);
+      })();
+}
+
+function extractShellFunction(scriptPath: string, name: string): string {
+  const body = readFileSync(scriptPath, "utf8");
+  const startMarker = `${name}() {`;
+  const start = requireNonNegative(
+    body.indexOf(startMarker),
+    `function ${name} not found in ${scriptPath}`,
+  );
+  const lines = body.slice(start).split("\n");
+  const endIndex = requireNonNegative(
+    lines.findIndex((line, index) => index > 0 && line === "}"),
+    `function ${name} missing closing brace in ${scriptPath}`,
+  );
+  return lines.slice(0, endIndex + 1).join("\n");
+}
+
+function runMarkerScenario(scenario: string): { status: number; stdout: string } {
+  const helper = extractShellFunction(START_SCRIPT, "_nemoclaw_safe_replace_tmp_file");
+  const record = extractShellFunction(START_SCRIPT, "record_gateway_watchdog_kill");
+  const consume = extractShellFunction(START_SCRIPT, "consume_gateway_watchdog_kill");
+  const harness = `
+${helper}
+${record}
+${consume}
+GATEWAY_WATCHDOG_KILL_FILE="$(mktemp -u "\${TMPDIR:-/tmp}/nemoclaw-wd-kill.XXXXXX")"
+${scenario}
+`;
+  const result = spawnSync("bash", ["-c", harness], { encoding: "utf-8", timeout: 10_000 });
+  return { status: result.status ?? -1, stdout: (result.stdout ?? "").trim() };
+}
+
+describe("gateway watchdog kill marker", () => {
+  it("respawns (match) when the consumed identity equals the recorded one", () => {
+    const { status } = runMarkerScenario(
+      `record_gateway_watchdog_kill "123:456"\nconsume_gateway_watchdog_kill "123:456"`,
+    );
+    expect(status).toBe(0);
+  });
+
+  it("does not match a different gateway identity", () => {
+    const { status } = runMarkerScenario(
+      `record_gateway_watchdog_kill "123:456"\nconsume_gateway_watchdog_kill "999:000"`,
+    );
+    expect(status).toBe(1);
+  });
+
+  it("does not match when no marker was recorded", () => {
+    const { status } = runMarkerScenario(`consume_gateway_watchdog_kill "123:456"`);
+    expect(status).toBe(1);
+  });
+
+  it("does not match an empty recorded identity", () => {
+    const { status } = runMarkerScenario(
+      `record_gateway_watchdog_kill ""\nconsume_gateway_watchdog_kill "123:456"`,
+    );
+    expect(status).toBe(1);
+  });
+
+  it("matches only once — a second consume of the same identity misses", () => {
+    const { status } = runMarkerScenario(
+      `record_gateway_watchdog_kill "123:456"\nconsume_gateway_watchdog_kill "123:456"\nconsume_gateway_watchdog_kill "123:456"`,
+    );
+    expect(status).toBe(1);
+  });
+
+  it("clears the marker on a matching consume", () => {
+    const { stdout } = runMarkerScenario(
+      `record_gateway_watchdog_kill "123:456"\nconsume_gateway_watchdog_kill "123:456"\ntest -f "$GATEWAY_WATCHDOG_KILL_FILE" && echo PRESENT || echo ABSENT`,
+    );
+    expect(stdout).toBe("ABSENT");
+  });
+
+  it("clears a stale marker even when the identity does not match", () => {
+    const { stdout } = runMarkerScenario(
+      `record_gateway_watchdog_kill "123:456"\nconsume_gateway_watchdog_kill "999:000"\ntest -f "$GATEWAY_WATCHDOG_KILL_FILE" && echo PRESENT || echo ABSENT`,
+    );
+    expect(stdout).toBe("ABSENT");
+  });
+});

--- a/test/gateway-watchdog-kill-marker.test.ts
+++ b/test/gateway-watchdog-kill-marker.test.ts
@@ -96,4 +96,31 @@ describe("gateway watchdog kill marker", () => {
     );
     expect(stdout).toBe("ABSENT");
   });
+
+  it("respawns when the loop snapshots the start identity before it is cleared", () => {
+    const { status } = runMarkerScenario(
+      [
+        `GATEWAY_PID_START_IDENTITY="456"`,
+        `EXITED_GATEWAY_PID="123"`,
+        `EXITED_GATEWAY_START_IDENTITY="$GATEWAY_PID_START_IDENTITY"`,
+        `record_gateway_watchdog_kill "123:456"`,
+        `GATEWAY_PID_START_IDENTITY=""`,
+        `consume_gateway_watchdog_kill "\${EXITED_GATEWAY_PID}:\${EXITED_GATEWAY_START_IDENTITY}"`,
+      ].join("\n"),
+    );
+    expect(status).toBe(0);
+  });
+
+  it("misses the marker when the loop reads the identity after it is cleared", () => {
+    const { status } = runMarkerScenario(
+      [
+        `GATEWAY_PID_START_IDENTITY="456"`,
+        `EXITED_GATEWAY_PID="123"`,
+        `record_gateway_watchdog_kill "123:456"`,
+        `GATEWAY_PID_START_IDENTITY=""`,
+        `consume_gateway_watchdog_kill "\${EXITED_GATEWAY_PID}:\${GATEWAY_PID_START_IDENTITY}"`,
+      ].join("\n"),
+    );
+    expect(status).toBe(1);
+  });
 });

--- a/test/gateway-watchdog-kill-marker.test.ts
+++ b/test/gateway-watchdog-kill-marker.test.ts
@@ -49,6 +49,43 @@ ${scenario}
   return { status: result.status ?? -1, stdout: (result.stdout ?? "").trim() };
 }
 
+function extractRespawnCriticalSection(scriptPath: string): string {
+  const body = readFileSync(scriptPath, "utf8");
+  const startMarker = '    RC=0\n    EXITED_GATEWAY_PID="$GATEWAY_PID"';
+  const start = requireNonNegative(
+    body.indexOf(startMarker),
+    `non-root respawn critical section not found in ${scriptPath}`,
+  );
+  const endMarker = "    NOW=$(date +%s)";
+  const end = requireNonNegative(
+    body.indexOf(endMarker, start),
+    `non-root respawn critical section end not found in ${scriptPath}`,
+  );
+  return body.slice(start, end).trimEnd();
+}
+
+function runRespawnCriticalSection(setup: string): { status: number; stdout: string } {
+  const helper = extractShellFunction(START_SCRIPT, "_nemoclaw_safe_replace_tmp_file");
+  const record = extractShellFunction(START_SCRIPT, "record_gateway_watchdog_kill");
+  const consume = extractShellFunction(START_SCRIPT, "consume_gateway_watchdog_kill");
+  const section = extractRespawnCriticalSection(START_SCRIPT);
+  const harness = `
+${helper}
+${record}
+${consume}
+wait() { return "\${STUB_WAIT_RC:-0}"; }
+mark_openclaw_gateway_stopped() { GATEWAY_PID=0; GATEWAY_PID_START_IDENTITY=""; }
+GATEWAY_WATCHDOG_KILL_FILE="$(mktemp -u "\${TMPDIR:-/tmp}/nemoclaw-wd-kill.XXXXXX")"
+GATEWAY_PID="123"
+GATEWAY_PID_START_IDENTITY="456"
+${setup}
+${section}
+echo RESPAWN
+`;
+  const result = spawnSync("bash", ["-c", harness], { encoding: "utf-8", timeout: 10_000 });
+  return { status: result.status ?? -1, stdout: (result.stdout ?? "").trim() };
+}
+
 describe("gateway watchdog kill marker", () => {
   it("respawns (match) when the consumed identity equals the recorded one", () => {
     const { status } = runMarkerScenario(
@@ -97,30 +134,18 @@ describe("gateway watchdog kill marker", () => {
     expect(stdout).toBe("ABSENT");
   });
 
-  it("respawns when the loop snapshots the start identity before it is cleared", () => {
-    const { status } = runMarkerScenario(
-      [
-        `GATEWAY_PID_START_IDENTITY="456"`,
-        `EXITED_GATEWAY_PID="123"`,
-        `EXITED_GATEWAY_START_IDENTITY="$GATEWAY_PID_START_IDENTITY"`,
-        `record_gateway_watchdog_kill "123:456"`,
-        `GATEWAY_PID_START_IDENTITY=""`,
-        `consume_gateway_watchdog_kill "\${EXITED_GATEWAY_PID}:\${EXITED_GATEWAY_START_IDENTITY}"`,
-      ].join("\n"),
-    );
-    expect(status).toBe(0);
+  it("respawns via the real loop when the watchdog recorded the exiting identity", () => {
+    const { stdout } = runRespawnCriticalSection(`record_gateway_watchdog_kill "123:456"`);
+    expect(stdout).toBe("RESPAWN");
   });
 
-  it("misses the marker when the loop reads the identity after it is cleared", () => {
-    const { status } = runMarkerScenario(
-      [
-        `GATEWAY_PID_START_IDENTITY="456"`,
-        `EXITED_GATEWAY_PID="123"`,
-        `record_gateway_watchdog_kill "123:456"`,
-        `GATEWAY_PID_START_IDENTITY=""`,
-        `consume_gateway_watchdog_kill "\${EXITED_GATEWAY_PID}:\${GATEWAY_PID_START_IDENTITY}"`,
-      ].join("\n"),
-    );
-    expect(status).toBe(1);
+  it("tears down via the real loop on a genuine operator clean exit with no marker", () => {
+    const { stdout } = runRespawnCriticalSection("");
+    expect(stdout).toBe("");
+  });
+
+  it("tears down via the real loop when the marker identity does not match the exit", () => {
+    const { stdout } = runRespawnCriticalSection(`record_gateway_watchdog_kill "123:999"`);
+    expect(stdout).toBe("");
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The in-sandbox OpenClaw gateway exits spontaneously on v0.0.71 and the sandbox is torn down, so the TUI and slash commands fail with "OpenClaw gateway is not running inside the sandbox (sandbox likely restarted)" and recovery also fails. This restores the respawn supervisor's intent so a watchdog-driven gateway kill relaunches the gateway instead of stopping PID 1.

## Related Issue

Fixes #6107

## Changes

- The serving watchdog SIGTERMs a gateway that has dropped its HTTP listener so the respawn loop can relaunch it, but OpenClaw exits 0 on a graceful SIGTERM. Both PID-1 respawn loops treated a clean rc=0 exit as an operator-requested shutdown and called `exit 0`, tearing down the whole sandbox.
- The watchdog now records an identity-scoped kill marker (`<pid>:<start-identity>`) immediately before its `kill -TERM`.
- Both respawn loops (root and non-root) exit PID 1 on rc=0 only when the exit was not a watchdog kill; a watchdog-induced clean exit respawns, while a genuine operator clean exit still stops the sandbox.
- The marker is consumed once and scoped to the exact pid and start identity, so a stale marker cannot force an unwanted respawn and self-clears on a non-matching read.
- New unit coverage for the marker record/consume helpers (`test/gateway-watchdog-kill-marker.test.ts`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway shutdown handling: intentional watchdog-triggered listener loss no longer stops the whole container when the event is recognized as safe.
  * Added a configurable watchdog kill-marker mechanism (via an environment setting) to ensure the gateway can restart without false container exits.
* **Tests**
  * Added automated coverage for kill-marker matching/mismatching, missing/empty marker cases, and single-use consumption.
  * Validated respawn vs. teardown behavior for timing-sensitive gateway watchdog scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->