### PR TITLE
[codex] restore Tavily egress for managed Python

### DIFF
--- a/nemoclaw-blueprint/policies/presets/tavily.yaml
+++ b/nemoclaw-blueprint/policies/presets/tavily.yaml
@@ -17,6 +17,8 @@ network_policies:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
     binaries:
+      # OpenShell attributes Deep Agents Code Tavily requests to its managed Python venv.
+      - { path: /opt/venv/bin/python3* }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/provider-profiles/tavily.yaml
+++ b/nemoclaw-blueprint/provider-profiles/tavily.yaml
@@ -20,6 +20,8 @@ endpoints:
     access: read-write
     enforcement: enforce
 binaries:
+  # OpenShell attributes Deep Agents Code Tavily requests to its managed Python venv.
+  - /opt/venv/bin/python3*
   - /usr/local/bin/node
   - /usr/bin/node
   - /usr/local/bin/curl

--- a/test/tavily-preset.test.ts
+++ b/test/tavily-preset.test.ts
@@ -45,6 +45,7 @@ describe("tavily opt-in preset", () => {
       },
     ]);
     expect(policy?.binaries).toEqual([
+      { path: "/opt/venv/bin/python3*" },
       { path: "/usr/local/bin/node" },
       { path: "/usr/bin/node" },
       { path: "/usr/local/bin/curl" },

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -505,6 +505,7 @@ describe("Tavily Search provider profile", () => {
 
   it("limits the binary allowlist to runtimes the Tavily client actually uses", () => {
     expect(profile.binaries).toEqual([
+      "/opt/venv/bin/python3*",
       "/usr/local/bin/node",
       "/usr/bin/node",
       "/usr/local/bin/curl",


### PR DESCRIPTION
## Summary

Restore `/opt/venv/bin/python3*` to the Tavily policy preset and provider-profile binary allowlists, and lock the managed interpreter into both exact allowlist tests.

## Root cause

PR #5969 tightened the Tavily binary allowlist by removing Python. Deep Agents Code runs from the managed `/opt/venv` environment, and OpenShell attributes its Tavily requests to that Python interpreter. As a result, `policy-add tavily` applied successfully but the actual request remained blocked with `403 Forbidden`.

Failed release-gate job: https://github.com/NVIDIA/NemoClaw/actions/runs/28533929538/job/84591431680

The fix intentionally restores only the managed interpreter path. It does not reopen system Python paths.

## Changes

- Add `/opt/venv/bin/python3*` to the Tavily policy preset.
- Add `/opt/venv/bin/python3*` to the Tavily provider profile.
- Document the OpenShell process-attribution reason beside both allowlists.
- Update the preset and provider-profile contract tests.

## Impact

Deep Agents Code can reach `api.tavily.com` after the operator explicitly applies the Tavily policy and attaches the Tavily provider, while Tavily remains denied by default and system Python interpreters remain excluded.

## Validation

```text
npx vitest run test/tavily-preset.test.ts test/validate-blueprint.test.ts --reporter=default

Test Files  2 passed (2)
Tests       67 passed (67)
```

A rerun of `ubuntu-repo-cloud-langchain-deepagents-code` is still required for live validation.
