### PR TITLE
fix(policy): restore Tavily egress for managed Python

### DIFF
--- a/nemoclaw-blueprint/policies/presets/tavily.yaml
+++ b/nemoclaw-blueprint/policies/presets/tavily.yaml
@@ -17,6 +17,8 @@ network_policies:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
     binaries:
+      # OpenShell attributes Deep Agents Code Tavily requests to its managed Python venv.
+      - { path: /opt/venv/bin/python3* }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/tavily.yaml
+++ b/nemoclaw-blueprint/policies/presets/tavily.yaml
@@ -17,7 +17,8 @@ network_policies:
           - allow: { method: GET, path: "/**" }
           - allow: { method: POST, path: "/**" }
     binaries:
-      # OpenShell attributes Deep Agents Code Tavily requests to its managed Python venv.
+      # OpenShell attributes Deep Agents Code Tavily requests to this managed
+      # Python venv, which its strict Landlock policy mounts read-only.
       - { path: /opt/venv/bin/python3* }
       - { path: /usr/local/bin/node }
       - { path: /usr/bin/node }

--- a/nemoclaw-blueprint/provider-profiles/tavily.yaml
+++ b/nemoclaw-blueprint/provider-profiles/tavily.yaml
@@ -20,6 +20,8 @@ endpoints:
     access: read-write
     enforcement: enforce
 binaries:
+  # OpenShell attributes Deep Agents Code Tavily requests to its managed Python venv.
+  - /opt/venv/bin/python3*
   - /usr/local/bin/node
   - /usr/bin/node
   - /usr/local/bin/curl

--- a/nemoclaw-blueprint/provider-profiles/tavily.yaml
+++ b/nemoclaw-blueprint/provider-profiles/tavily.yaml
@@ -20,7 +20,8 @@ endpoints:
     access: read-write
     enforcement: enforce
 binaries:
-  # OpenShell attributes Deep Agents Code Tavily requests to its managed Python venv.
+  # OpenShell attributes Deep Agents Code Tavily requests to this managed
+  # Python venv, which its strict Landlock policy mounts read-only.
   - /opt/venv/bin/python3*
   - /usr/local/bin/node
   - /usr/bin/node

--- a/test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
@@ -10,6 +10,8 @@ SANDBOX_NAME="${SANDBOX_NAME:-${NEMOCLAW_SANDBOX_NAME:-e2e-cloud-onboard}}"
 PREFIX="09-deepagents-code-tavily-opt-in"
 REPO="${REPO:-$(pwd)}"
 CLI="${NEMOCLAW_E2E_CLI:-${REPO}/bin/nemoclaw.js}"
+PROJECT_VENV="/sandbox/.nemoclaw-e2e-project-venv"
+PROJECT_PYTHON="${PROJECT_VENV}/bin/python3"
 
 ok() { printf '%s\n' "${PREFIX}: OK ($*)"; }
 info() { printf '%s\n' "${PREFIX}: $*"; }
@@ -175,6 +177,20 @@ elif echo "$SYSTEM_PROBE_OUTPUT" | grep -q "REACHED:"; then
   fail_test "system Python reached Tavily unexpectedly after policy-add: $SYSTEM_PROBE_OUTPUT"
 else
   fail_test "system Python Tavily probe lacked denial evidence after policy-add: $SYSTEM_PROBE_OUTPUT"
+fi
+
+PROJECT_OUT="$(sandbox_exec "if ! test -x ${PROJECT_PYTHON@Q}; then python3 -m venv --copies ${PROJECT_VENV@Q}; fi; test -x ${PROJECT_PYTHON@Q} && readlink -f ${PROJECT_PYTHON@Q}" || true)"
+if echo "$PROJECT_OUT" | grep -Fxq "$PROJECT_PYTHON"; then
+  PROJECT_PROBE_OUTPUT="$(python_probe "https://api.tavily.com/" "$PROJECT_PYTHON" || true)"
+  if echo "$PROJECT_PROBE_OUTPUT" | grep -q "BLOCKED:" && ! echo "$PROJECT_PROBE_OUTPUT" | grep -q "REACHED:"; then
+    pass "project venv Python under /sandbox remains blocked from Tavily after policy-add"
+  elif echo "$PROJECT_PROBE_OUTPUT" | grep -q "REACHED:"; then
+    fail_test "project venv Python reached Tavily unexpectedly after policy-add: $PROJECT_PROBE_OUTPUT"
+  else
+    fail_test "project venv Python Tavily probe lacked denial evidence after policy-add: $PROJECT_PROBE_OUTPUT"
+  fi
+else
+  fail_test "project venv under /sandbox did not expose a usable python3 executable: $PROJECT_OUT"
 fi
 
 printf '%s\n' "${PREFIX}: $PASSED passed, $FAILED failed"

--- a/test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/09-deepagents-code-tavily-opt-in.sh
@@ -93,13 +93,14 @@ PY
 
 python_probe() {
   local url="$1"
+  local python_bin="${2:-python3}"
   local encoded remote_cmd
   if [ -n "${NEMOCLAW_E2E_TAVILY_PROBE_FIXTURE+x}" ]; then
     printf '%s\n' "$NEMOCLAW_E2E_TAVILY_PROBE_FIXTURE"
     return 0
   fi
   encoded="$(python_probe_source | base64 | tr -d '\n')"
-  remote_cmd="python3 -c \"\$(printf '%s' ${encoded@Q} | base64 -d)\" ${url@Q}"
+  remote_cmd="${python_bin@Q} -c \"\$(printf '%s' ${encoded@Q} | base64 -d)\" ${url@Q}"
   sandbox_exec "$remote_cmd"
 }
 
@@ -165,6 +166,15 @@ elif echo "$PROBE_OUTPUT" | grep -q "BLOCKED:"; then
   fail_test "managed Deep Agents Code python is still policy-blocked after policy-add: $PROBE_OUTPUT"
 else
   fail_test "Tavily probe lacked reachability evidence after policy-add: $PROBE_OUTPUT"
+fi
+
+SYSTEM_PROBE_OUTPUT="$(python_probe "https://api.tavily.com/" "/usr/bin/python3" || true)"
+if echo "$SYSTEM_PROBE_OUTPUT" | grep -q "BLOCKED:" && ! echo "$SYSTEM_PROBE_OUTPUT" | grep -q "REACHED:"; then
+  pass "system Python remains blocked from Tavily after policy-add"
+elif echo "$SYSTEM_PROBE_OUTPUT" | grep -q "REACHED:"; then
+  fail_test "system Python reached Tavily unexpectedly after policy-add: $SYSTEM_PROBE_OUTPUT"
+else
+  fail_test "system Python Tavily probe lacked denial evidence after policy-add: $SYSTEM_PROBE_OUTPUT"
 fi
 
 printf '%s\n' "${PREFIX}: $PASSED passed, $FAILED failed"

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -528,6 +528,10 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tavilyOptInCheck).toContain(
       "system Python remains blocked from Tavily after policy-add",
     );
+    expect(tavilyOptInCheck).toContain("/sandbox/.nemoclaw-e2e-project-venv");
+    expect(tavilyOptInCheck).toContain(
+      "project venv Python under /sandbox remains blocked from Tavily after policy-add",
+    );
     expect(cloudExperimentalChecksForOnboarding("cloud-langchain-deepagents-code")).toEqual([
       "test/e2e/e2e-cloud-experimental/checks/05-deepagents-code-landlock-readonly.sh",
       "test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh",

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -520,10 +520,14 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(tavilyOptInCheck).toContain("https://api.tavily.com/");
     expect(tavilyOptInCheck).toContain("python_probe_source");
     expect(tavilyOptInCheck).toContain("base64 | tr -d");
-    expect(tavilyOptInCheck).toContain("python3 -c");
+    expect(tavilyOptInCheck).toContain("${python_bin@Q} -c");
     expect(tavilyOptInCheck).toContain("NEMOCLAW_E2E_TAVILY_SELF_TEST");
     expect(tavilyOptInCheck).toContain("/opt/venv/");
     expect(tavilyOptInCheck).toContain("managed Deep Agents Code python can reach Tavily");
+    expect(tavilyOptInCheck).toContain('python_probe "https://api.tavily.com/" "/usr/bin/python3"');
+    expect(tavilyOptInCheck).toContain(
+      "system Python remains blocked from Tavily after policy-add",
+    );
     expect(cloudExperimentalChecksForOnboarding("cloud-langchain-deepagents-code")).toEqual([
       "test/e2e/e2e-cloud-experimental/checks/05-deepagents-code-landlock-readonly.sh",
       "test/e2e/e2e-cloud-experimental/checks/06-deepagents-code-python-egress.sh",

--- a/test/tavily-preset.test.ts
+++ b/test/tavily-preset.test.ts
@@ -45,6 +45,7 @@ describe("tavily opt-in preset", () => {
       },
     ]);
     expect(policy?.binaries).toEqual([
+      { path: "/opt/venv/bin/python3*" },
       { path: "/usr/local/bin/node" },
       { path: "/usr/bin/node" },
       { path: "/usr/local/bin/curl" },

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -505,6 +505,7 @@ describe("Tavily Search provider profile", () => {
 
   it("limits the binary allowlist to runtimes the Tavily client actually uses", () => {
     expect(profile.binaries).toEqual([
+      "/opt/venv/bin/python3*",
       "/usr/local/bin/node",
       "/usr/bin/node",
       "/usr/local/bin/curl",

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -33,6 +33,10 @@ const TAVILY_POLICY_PRESET_PATH = new URL(
   "../nemoclaw-blueprint/policies/presets/tavily.yaml",
   import.meta.url,
 );
+const DEEPAGENTS_POLICY_PATH = new URL(
+  "../agents/langchain-deepagents-code/policy-additions.yaml",
+  import.meta.url,
+);
 const PERMISSIVE_POLICY_PATH = new URL(
   "../nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
   import.meta.url,
@@ -91,6 +95,7 @@ type PolicyEntry = {
 
 type SandboxPolicy = {
   version?: number;
+  filesystem_policy?: { read_only?: string[] };
   network_policies?: Record<string, PolicyEntry>;
 };
 
@@ -484,6 +489,7 @@ describe("Brave Search provider profile", () => {
 describe("Tavily Search provider profile", () => {
   const profile = loadYaml<ProviderProfile>(TAVILY_PROVIDER_PROFILE_PATH);
   const preset = loadYaml<PolicyPreset>(TAVILY_POLICY_PRESET_PATH);
+  const deepAgentsPolicy = loadYaml<SandboxPolicy>(DEEPAGENTS_POLICY_PATH);
 
   it("routes TAVILY_API_KEY through a bearer authorization header", () => {
     expect(profile.id).toBe("tavily");
@@ -521,6 +527,15 @@ describe("Tavily Search provider profile", () => {
   it("keeps its binary allowlist aligned with the Tavily policy preset", () => {
     const presetBinaries = preset.network_policies?.tavily?.binaries?.map(({ path }) => path);
     expect(profile.binaries).toEqual(presetBinaries);
+  });
+
+  it("anchors managed Python access to Deep Agents Code's read-only venv", () => {
+    const managedPython = "/opt/venv/bin/python3*";
+    const managedInferenceBinaries = deepAgentsPolicy.network_policies?.managed_inference?.binaries;
+
+    expect(deepAgentsPolicy.filesystem_policy?.read_only).toContain("/opt/venv");
+    expect(managedInferenceBinaries).toContainEqual({ path: managedPython });
+    expect(profile.binaries).toContain(managedPython);
   });
 });
 

--- a/test/validate-blueprint.test.ts
+++ b/test/validate-blueprint.test.ts
@@ -29,6 +29,10 @@ const TAVILY_PROVIDER_PROFILE_PATH = new URL(
   "../nemoclaw-blueprint/provider-profiles/tavily.yaml",
   import.meta.url,
 );
+const TAVILY_POLICY_PRESET_PATH = new URL(
+  "../nemoclaw-blueprint/policies/presets/tavily.yaml",
+  import.meta.url,
+);
 const PERMISSIVE_POLICY_PATH = new URL(
   "../nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
   import.meta.url,
@@ -479,6 +483,7 @@ describe("Brave Search provider profile", () => {
 
 describe("Tavily Search provider profile", () => {
   const profile = loadYaml<ProviderProfile>(TAVILY_PROVIDER_PROFILE_PATH);
+  const preset = loadYaml<PolicyPreset>(TAVILY_POLICY_PRESET_PATH);
 
   it("routes TAVILY_API_KEY through a bearer authorization header", () => {
     expect(profile.id).toBe("tavily");
@@ -511,6 +516,11 @@ describe("Tavily Search provider profile", () => {
       "/usr/local/bin/curl",
       "/usr/bin/curl",
     ]);
+  });
+
+  it("keeps its binary allowlist aligned with the Tavily policy preset", () => {
+    const presetBinaries = preset.network_policies?.tavily?.binaries?.map(({ path }) => path);
+    expect(profile.binaries).toEqual(presetBinaries);
   });
 });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore the managed Deep Agents Code Python interpreter to the Tavily policy and provider-profile allowlists. PR #5969 removed Python while tightening the Tavily boundary, which left `policy-add tavily` successful but Python-originated Tavily requests blocked by OpenShell with HTTP 403.

## Changes

- Add `/opt/venv/bin/python3*` to `nemoclaw-blueprint/policies/presets/tavily.yaml`.
- Add the same managed interpreter path to `nemoclaw-blueprint/provider-profiles/tavily.yaml` so both enforcement layers agree.
- Document that the wildcard relies on Deep Agents Code's strict Landlock policy mounting `/opt/venv` read-only.
- Keep system Python and writable project-venv paths excluded.
- Add exact allowlist, profile/preset alignment, and managed-venv trust-boundary contracts.
- Extend the live Tavily opt-in check: managed Python must reach Tavily, while `/usr/bin/python3` and `/sandbox/.../bin/python3` must remain blocked.

### Source-boundary rationale

- **Invalid state:** the documented `policy-add tavily` flow succeeds, but OpenShell attributes Deep Agents Code requests to `/opt/venv/bin/python3*`, so Tavily remains blocked unless that managed interpreter is present in both enforcement layers.
- **Source boundary:** the existing user-facing source of truth is the shared Tavily preset plus its provider profile; both must remain aligned while `policy-add tavily` is the supported opt-in command.
- **Constraint:** moving Tavily into an agent-default policy would change opt-in semantics during a release-blocking regression fix. This PR therefore restores the narrow read-only managed path without adding system or writable project Python.
- **Regression coverage:** exact allowlists, profile/preset equality, the Deep Agents read-only `/opt/venv` contract, and live positive/negative process-attribution probes.
- **Removal condition:** remove the shared managed path only when `policy-add tavily` is redesigned or deprecated in favor of an agent-scoped opt-in mechanism with equivalent runtime coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing Deep Agents documentation already states that OpenShell attributes Tavily calls to the managed Python interpreter; this restores the documented behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending maintainer review; the change restores only `/opt/venv/bin/python3*`, not system or writable project Python paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes — the diff-scoped fallback passed formatting, schema, repository, and secret-scan hooks; its broad integration lane requires Linux utilities/semantics unavailable on this macOS host, so CI remains authoritative.
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <36614+apurvvkumaria@users.noreply.github.com>
