### PR TITLE
refactor(shields): isolate mutable config repair

### DIFF
--- a/scripts/lib/normalize_mutable_config_perms.py
+++ b/scripts/lib/normalize_mutable_config_perms.py
@@ -808,6 +808,9 @@ def lock_recovery_baseline(
                 BASELINE_NAME, dir_fd=root_fd, follow_symlinks=False
             )
         except FileNotFoundError:
+            # Expected before the first successful post-override capture. There
+            # is no recovery source to lock yet, and normal startup must remain
+            # quiet; capture mode creates the baseline through a fresh inode.
             before = None
 
         if before is not None:

--- a/src/lib/actions/sandbox/exec.ts
+++ b/src/lib/actions/sandbox/exec.ts
@@ -129,6 +129,15 @@ function repairFailureDetail(
  * `nemoclaw <sandbox> exec` command boundary. OpenShell executes the requested
  * process directly, so the sandbox entrypoint's one-shot cleanup does not run
  * on this path. Hermes and custom agents are deliberately left unchanged.
+ *
+ * Each production inspect/repair call takes the cross-process, timer-bound
+ * shields transition lock and rechecks posture while holding it. The repair is
+ * idempotent, so two CLI processes may interleave only between those protected
+ * steps: they can repeat a repair or make one caller report conservative drift,
+ * but host-side repair mutations cannot overlap or weaken shields-up. A
+ * process-local mutex would not serialize separate CLI invocations, while a
+ * lock inside the sandbox-owned config tree would put lock authority on the
+ * wrong trust side.
  */
 export function cleanupOpenClawAfterExec(
   sandboxName: string,

--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -85,6 +85,9 @@ const {
   inspectMutableConfigPerms: inspectMutableConfigPermsCore,
   repairMutableConfigPerms: repairMutableConfigPermsCore,
 }: typeof import("./mutable-config-perms") = require("./mutable-config-perms");
+const {
+  normalizeMutableOpenClawConfig,
+}: typeof import("./mutable-config-repair") = require("./mutable-config-repair");
 type MutableConfigPermsInspection = import("./mutable-config-perms").MutableConfigPermsInspection;
 type MutableConfigRepairResult = import("./mutable-config-perms").MutableConfigRepairResult;
 type ProcessIdentity = import("./timer-control").ProcessIdentity;
@@ -98,7 +101,6 @@ const HERMES_RUNTIME_CONFIG_GUARD = "/usr/local/lib/nemoclaw/hermes-runtime-conf
 const HERMES_PYTHON = "/opt/hermes/.venv/bin/python";
 const HERMES_RESTART_SEAL_STATE = "/run/nemoclaw/hermes-restart-seal.json";
 const HERMES_CONFIG_HASH = "/etc/nemoclaw/hermes.config-hash";
-const MUTABLE_CONFIG_NORMALIZER = "/usr/local/lib/nemoclaw/normalize_mutable_config_perms.py";
 const STATE_DIR_GUARD_TIMEOUT_MS = 15 * 60 * 1000;
 const OPENCLAW_CONFIG_GUARD_TIMEOUT_MS = 6 * 60 * 1000;
 const HERMES_CONFIG_GUARD_TIMEOUT_MS = 11 * 60 * 1000;
@@ -321,28 +323,6 @@ function privilegedSandboxExecCapture(sandboxName: string, cmd: string[], timeou
     stdio: ["ignore", "pipe", "pipe"],
     timeout,
   }).trim();
-}
-
-function sandboxIdentityId(sandboxName: string, flag: "-u" | "-g"): string {
-  const id = privilegedSandboxExecCapture(sandboxName, ["/usr/bin/id", flag, "sandbox"]);
-  if (!/^[1-9][0-9]*$/.test(id)) {
-    const kind = flag === "-u" ? "UID" : "GID";
-    throw new Error(`sandbox identity lookup returned an invalid ${kind}`);
-  }
-  return id;
-}
-
-function normalizeMutableOpenClawConfig(sandboxName: string, configDir: string): void {
-  const sandboxUid = sandboxIdentityId(sandboxName, "-u");
-  const sandboxGid = sandboxIdentityId(sandboxName, "-g");
-  privilegedSandboxExec(sandboxName, [
-    "/usr/bin/python3",
-    "-I",
-    MUTABLE_CONFIG_NORMALIZER,
-    configDir,
-    sandboxUid,
-    sandboxGid,
-  ]);
 }
 
 function hermesShieldsGuardArgs(

--- a/src/lib/shields/mutable-config-repair.test.ts
+++ b/src/lib/shields/mutable-config-repair.test.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const NORMALIZER = "/usr/local/lib/nemoclaw/normalize_mutable_config_perms.py";
+const requireSource = createRequire(import.meta.url);
+
+type DockerExecModule = typeof import("../adapters/docker/exec");
+type MutableConfigRepairModule = typeof import("./mutable-config-repair");
+type PrivilegedExecModule = typeof import("../sandbox/privileged-exec");
+
+let dockerExec: DockerExecModule;
+let normalizeMutableOpenClawConfig: MutableConfigRepairModule["normalizeMutableOpenClawConfig"];
+let privilegedExec: PrivilegedExecModule;
+
+function mockPrivilegedArgv() {
+  return vi
+    .spyOn(privilegedExec, "privilegedSandboxExecArgv")
+    .mockImplementation((_sandboxName, cmd) => ["privileged", ...cmd]);
+}
+
+describe("mutable OpenClaw config repair", () => {
+  beforeEach(() => {
+    delete require.cache[requireSource.resolve("./mutable-config-repair.js")];
+    dockerExec = requireSource("../adapters/docker/exec.js");
+    privilegedExec = requireSource("../sandbox/privileged-exec.js");
+    ({ normalizeMutableOpenClawConfig } = requireSource("./mutable-config-repair.js"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete require.cache[requireSource.resolve("./mutable-config-repair.js")];
+  });
+
+  it("sanitizes every privileged identity and normalizer invocation", () => {
+    const privilegedArgv = mockPrivilegedArgv();
+    const dockerExecFileSync = vi
+      .spyOn(dockerExec, "dockerExecFileSync")
+      .mockReturnValueOnce("1000\n")
+      .mockReturnValueOnce("1001\n")
+      .mockReturnValue("");
+
+    normalizeMutableOpenClawConfig("alpha", "/sandbox/.openclaw");
+
+    expect(privilegedArgv.mock.calls).toEqual([
+      ["alpha", ["/usr/bin/id", "-u", "sandbox"], false, true],
+      ["alpha", ["/usr/bin/id", "-g", "sandbox"], false, true],
+      [
+        "alpha",
+        ["/usr/bin/python3", "-I", NORMALIZER, "/sandbox/.openclaw", "1000", "1001"],
+        false,
+        true,
+      ],
+    ]);
+    expect(dockerExecFileSync).toHaveBeenCalledTimes(3);
+    expect(dockerExecFileSync.mock.calls.map(([argv]) => argv)).toEqual([
+      ["privileged", "/usr/bin/id", "-u", "sandbox"],
+      ["privileged", "/usr/bin/id", "-g", "sandbox"],
+      ["privileged", "/usr/bin/python3", "-I", NORMALIZER, "/sandbox/.openclaw", "1000", "1001"],
+    ]);
+    expect(dockerExecFileSync.mock.calls.map(([, options]) => options)).toEqual([
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
+    ]);
+  });
+
+  it("rejects an invalid sandbox UID before the GID or normalizer runs", () => {
+    const privilegedArgv = mockPrivilegedArgv();
+    const dockerExecFileSync = vi.spyOn(dockerExec, "dockerExecFileSync").mockReturnValue("0\n");
+
+    expect(() => normalizeMutableOpenClawConfig("alpha", "/sandbox/.openclaw")).toThrow(
+      "sandbox identity lookup returned an invalid UID",
+    );
+    expect(privilegedArgv).toHaveBeenCalledOnce();
+    expect(privilegedArgv).toHaveBeenCalledWith(
+      "alpha",
+      ["/usr/bin/id", "-u", "sandbox"],
+      false,
+      true,
+    );
+    expect(dockerExecFileSync).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an invalid sandbox GID before the normalizer runs", () => {
+    const privilegedArgv = mockPrivilegedArgv();
+    const dockerExecFileSync = vi
+      .spyOn(dockerExec, "dockerExecFileSync")
+      .mockReturnValueOnce("1000\n")
+      .mockReturnValueOnce("not-a-gid\n");
+
+    expect(() => normalizeMutableOpenClawConfig("alpha", "/sandbox/.openclaw")).toThrow(
+      "sandbox identity lookup returned an invalid GID",
+    );
+    expect(privilegedArgv).toHaveBeenCalledTimes(2);
+    expect(privilegedArgv).not.toHaveBeenCalledWith(
+      "alpha",
+      expect.arrayContaining([NORMALIZER]),
+      false,
+      true,
+    );
+    expect(dockerExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates a trusted normalizer execution failure", () => {
+    const privilegedArgv = mockPrivilegedArgv();
+    const failure = new Error("docker exec failed");
+    const dockerExecFileSync = vi
+      .spyOn(dockerExec, "dockerExecFileSync")
+      .mockReturnValueOnce("1000\n")
+      .mockReturnValueOnce("1001\n")
+      .mockImplementationOnce(() => {
+        throw failure;
+      });
+
+    expect(() => normalizeMutableOpenClawConfig("alpha", "/sandbox/.openclaw")).toThrow(failure);
+    expect(privilegedArgv).toHaveBeenLastCalledWith(
+      "alpha",
+      ["/usr/bin/python3", "-I", NORMALIZER, "/sandbox/.openclaw", "1000", "1001"],
+      false,
+      true,
+    );
+    expect(dockerExecFileSync).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/shields/mutable-config-repair.test.ts
+++ b/src/lib/shields/mutable-config-repair.test.ts
@@ -6,6 +6,7 @@ import { createRequire } from "node:module";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const NORMALIZER = "/usr/local/lib/nemoclaw/normalize_mutable_config_perms.py";
+const NORMALIZER_WATCHDOG = ["/usr/bin/timeout", "--signal=TERM", "--kill-after=5s", "15s"];
 const requireSource = createRequire(import.meta.url);
 
 type DockerExecModule = typeof import("../adapters/docker/exec");
@@ -35,7 +36,7 @@ describe("mutable OpenClaw config repair", () => {
     delete require.cache[requireSource.resolve("./mutable-config-repair.js")];
   });
 
-  it("sanitizes every privileged identity and normalizer invocation", () => {
+  it("sanitizes identity probes and watchdogs the privileged normalizer", () => {
     const privilegedArgv = mockPrivilegedArgv();
     const dockerExecFileSync = vi
       .spyOn(dockerExec, "dockerExecFileSync")
@@ -50,7 +51,15 @@ describe("mutable OpenClaw config repair", () => {
       ["alpha", ["/usr/bin/id", "-g", "sandbox"], false, true],
       [
         "alpha",
-        ["/usr/bin/python3", "-I", NORMALIZER, "/sandbox/.openclaw", "1000", "1001"],
+        [
+          ...NORMALIZER_WATCHDOG,
+          "/usr/bin/python3",
+          "-I",
+          NORMALIZER,
+          "/sandbox/.openclaw",
+          "1000",
+          "1001",
+        ],
         false,
         true,
       ],
@@ -59,12 +68,21 @@ describe("mutable OpenClaw config repair", () => {
     expect(dockerExecFileSync.mock.calls.map(([argv]) => argv)).toEqual([
       ["privileged", "/usr/bin/id", "-u", "sandbox"],
       ["privileged", "/usr/bin/id", "-g", "sandbox"],
-      ["privileged", "/usr/bin/python3", "-I", NORMALIZER, "/sandbox/.openclaw", "1000", "1001"],
+      [
+        "privileged",
+        ...NORMALIZER_WATCHDOG,
+        "/usr/bin/python3",
+        "-I",
+        NORMALIZER,
+        "/sandbox/.openclaw",
+        "1000",
+        "1001",
+      ],
     ]);
     expect(dockerExecFileSync.mock.calls.map(([, options]) => options)).toEqual([
       { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
       { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
-      { stdio: ["ignore", "pipe", "pipe"], timeout: 15000 },
+      { stdio: ["ignore", "pipe", "pipe"], timeout: 25000 },
     ]);
   });
 
@@ -119,7 +137,15 @@ describe("mutable OpenClaw config repair", () => {
     expect(() => normalizeMutableOpenClawConfig("alpha", "/sandbox/.openclaw")).toThrow(failure);
     expect(privilegedArgv).toHaveBeenLastCalledWith(
       "alpha",
-      ["/usr/bin/python3", "-I", NORMALIZER, "/sandbox/.openclaw", "1000", "1001"],
+      [
+        ...NORMALIZER_WATCHDOG,
+        "/usr/bin/python3",
+        "-I",
+        NORMALIZER,
+        "/sandbox/.openclaw",
+        "1000",
+        "1001",
+      ],
       false,
       true,
     );

--- a/src/lib/shields/mutable-config-repair.ts
+++ b/src/lib/shields/mutable-config-repair.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const dockerExec: typeof import("../adapters/docker/exec") = require("../adapters/docker/exec");
+const privilegedExecModule: typeof import("../sandbox/privileged-exec") = require("../sandbox/privileged-exec");
+
+const MUTABLE_CONFIG_NORMALIZER = "/usr/local/lib/nemoclaw/normalize_mutable_config_perms.py";
+
+function runPrivileged(sandboxName: string, cmd: string[], timeout = 15000): void {
+  dockerExec.dockerExecFileSync(
+    privilegedExecModule.privilegedSandboxExecArgv(sandboxName, cmd, false, true),
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout,
+    },
+  );
+}
+
+function privilegedExecCapture(sandboxName: string, cmd: string[], timeout = 15000): string {
+  return dockerExec
+    .dockerExecFileSync(
+      privilegedExecModule.privilegedSandboxExecArgv(sandboxName, cmd, false, true),
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout,
+      },
+    )
+    .trim();
+}
+
+function sandboxIdentityId(sandboxName: string, flag: "-u" | "-g"): string {
+  const id = privilegedExecCapture(sandboxName, ["/usr/bin/id", flag, "sandbox"]);
+  if (!/^[1-9][0-9]*$/.test(id)) {
+    const kind = flag === "-u" ? "UID" : "GID";
+    throw new Error(`sandbox identity lookup returned an invalid ${kind}`);
+  }
+  return id;
+}
+
+/** Apply the mutable OpenClaw contract through the image's trusted helper. */
+export function normalizeMutableOpenClawConfig(sandboxName: string, configDir: string): void {
+  const sandboxUid = sandboxIdentityId(sandboxName, "-u");
+  const sandboxGid = sandboxIdentityId(sandboxName, "-g");
+  runPrivileged(sandboxName, [
+    "/usr/bin/python3",
+    "-I",
+    MUTABLE_CONFIG_NORMALIZER,
+    configDir,
+    sandboxUid,
+    sandboxGid,
+  ]);
+}

--- a/src/lib/shields/mutable-config-repair.ts
+++ b/src/lib/shields/mutable-config-repair.ts
@@ -5,6 +5,13 @@ const dockerExec: typeof import("../adapters/docker/exec") = require("../adapter
 const privilegedExecModule: typeof import("../sandbox/privileged-exec") = require("../sandbox/privileged-exec");
 
 const MUTABLE_CONFIG_NORMALIZER = "/usr/local/lib/nemoclaw/normalize_mutable_config_perms.py";
+const MUTABLE_CONFIG_NORMALIZER_HOST_TIMEOUT_MS = 25000;
+const MUTABLE_CONFIG_NORMALIZER_WATCHDOG = [
+  "/usr/bin/timeout",
+  "--signal=TERM",
+  "--kill-after=5s",
+  "15s",
+] as const;
 
 function runPrivileged(sandboxName: string, cmd: string[], timeout = 15000): void {
   dockerExec.dockerExecFileSync(
@@ -30,6 +37,8 @@ function privilegedExecCapture(sandboxName: string, cmd: string[], timeout = 150
 
 function sandboxIdentityId(sandboxName: string, flag: "-u" | "-g"): string {
   const id = privilegedExecCapture(sandboxName, ["/usr/bin/id", flag, "sandbox"]);
+  // Keep the ownership target non-root so privileged repair cannot become a
+  // confused-deputy path.
   if (!/^[1-9][0-9]*$/.test(id)) {
     const kind = flag === "-u" ? "UID" : "GID";
     throw new Error(`sandbox identity lookup returned an invalid ${kind}`);
@@ -41,12 +50,20 @@ function sandboxIdentityId(sandboxName: string, flag: "-u" | "-g"): string {
 export function normalizeMutableOpenClawConfig(sandboxName: string, configDir: string): void {
   const sandboxUid = sandboxIdentityId(sandboxName, "-u");
   const sandboxGid = sandboxIdentityId(sandboxName, "-g");
-  runPrivileged(sandboxName, [
-    "/usr/bin/python3",
-    "-I",
-    MUTABLE_CONFIG_NORMALIZER,
-    configDir,
-    sandboxUid,
-    sandboxGid,
-  ]);
+  // The in-sandbox watchdog signals the Python process group and reaps its
+  // direct child before the longer host-side Docker timeout can release the
+  // shields transition lock.
+  runPrivileged(
+    sandboxName,
+    [
+      ...MUTABLE_CONFIG_NORMALIZER_WATCHDOG,
+      "/usr/bin/python3",
+      "-I",
+      MUTABLE_CONFIG_NORMALIZER,
+      configDir,
+      sandboxUid,
+      sandboxGid,
+    ],
+    MUTABLE_CONFIG_NORMALIZER_HOST_TIMEOUT_MS,
+  );
 }

--- a/src/lib/shields/openclaw-transition.test.ts
+++ b/src/lib/shields/openclaw-transition.test.ts
@@ -138,7 +138,7 @@ describe("OpenClaw shields top-config transaction", () => {
       switch (argv[0]) {
         case "/usr/bin/id":
           return "1000\n";
-        case "/usr/bin/python3":
+        case "/usr/bin/timeout":
           return "";
         default:
           throw new Error(`unexpected privileged command: ${argv.join(" ")}`);
@@ -156,6 +156,10 @@ describe("OpenClaw shields top-config transaction", () => {
       ["/usr/bin/id", "-u", "sandbox"],
       ["/usr/bin/id", "-g", "sandbox"],
       [
+        "/usr/bin/timeout",
+        "--signal=TERM",
+        "--kill-after=5s",
+        "15s",
         "/usr/bin/python3",
         "-I",
         "/usr/local/lib/nemoclaw/normalize_mutable_config_perms.py",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This follow-up extracts the direct mutable OpenClaw repair invocation from the oversized shields module after #6060 merged. It preserves the trusted-helper command, identity validation, timeouts, and runtime behavior while documenting the existing cross-process lock and first-start recovery-baseline semantics requested by automated review.

## Related Issue

Follow-up to #6060 and #6047.

## Changes

- Move sandbox UID/GID lookup and the trusted mutable-config normalizer invocation into `src/lib/shields/mutable-config-repair.ts`.
- Keep runtime dependency lookup compatible with the existing Vitest spies and module cache behavior.
- Document why the timer-bound host lock is the correct cross-process serialization boundary for post-`exec` repair.
- Document why a missing recovery baseline is expected and intentionally quiet before the first successful post-override capture.
- Pin the extracted privilege boundary with focused tests for sanitized UID/GID probes, exact normalizer argv, invalid identity short-circuiting, and Docker execution failures.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the existing shields-transition, mutable-permission, and post-`exec` cleanup suites exercise the unchanged public path, identity validation, and trusted-helper invocation.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is a behavior-preserving extraction plus implementation comments; the #6060 command and troubleshooting docs remain accurate.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent read-only review found no security or correctness blocker; helper path, argv, timeout, UID/GID validation, cross-process transition lock, and fail-closed behavior are unchanged from merged #6060.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Evidence

- `npx prek run --from-ref origin/main --to-ref HEAD` passed under the repository-required `umask 022`, including the full CLI/integration coverage hook.
- The normal push hook passed CLI type-checking and version synchronization.
- Focused shields-transition, mutable-config-permission, extracted-repair, and post-`exec` cleanup tests passed 49/49; CLI type-checking, Biome, Python parsing, test-title style, file-size budget, and `git diff --check` passed.
- The extracted-repair tests prove `stdin=false` and `sanitizeEnvironment=true` on every privileged call, reject invalid UID/GID values before normalization, assert forwarded Docker argv/options, and propagate normalizer execution failures.
- The documentation-writer audit found no doc change necessary; `npm run docs` completed with 0 errors and 2 pre-existing warnings.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mutable configuration-permission repair to run the normalization step inside a privileged sandbox, including sandbox identity discovery and validation (UID/GID) before changes are applied.
  - Added a time-bound execution wrapper around the normalization command to prevent long-running operations.
- **Refactor**
  - Moved the mutable-config permission normalization into a dedicated, reusable module invoked by the existing repair workflow.
- **Tests**
  - Added coverage for identity validation failures, error propagation, and the exact privileged command invocation sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->