### PR TITLE
fix(ci): resolve macOS/bash 3.2 vitest failures on main

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1797,7 +1797,7 @@ seal_hermes_restart_inputs() {
   HERMES_RESTART_SEALED=0
   install_hermes_restart_seal_traps
   if ! output="$(
-    "${_HERMES_GUARD_TIMEOUT[@]}" "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" seal-restart \
+    ${_HERMES_GUARD_TIMEOUT[@]+"${_HERMES_GUARD_TIMEOUT[@]}"} "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" seal-restart \
       --hermes-dir "$HERMES_DIR" \
       --hash-file "$HERMES_HASH_FILE" \
       --state-file "$HERMES_RESTART_SEAL_STATE" \
@@ -1814,7 +1814,7 @@ seal_hermes_restart_inputs() {
     # gateway.
     original_failure_code="$HERMES_RESTART_FAILURE_CODE"
     if owner_output="$(
-      "${_HERMES_GUARD_TIMEOUT[@]}" "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" inspect-mutation-owner \
+      ${_HERMES_GUARD_TIMEOUT[@]+"${_HERMES_GUARD_TIMEOUT[@]}"} "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" inspect-mutation-owner \
         --hermes-dir "$HERMES_DIR" \
         --state-file "$HERMES_RESTART_SEAL_STATE" \
         --lock-token "$GATEWAY_CONTROL_NONCE" 2>&1
@@ -1857,7 +1857,7 @@ unseal_hermes_restart_inputs() {
   HERMES_RESTART_UNSEALING=1
   trap 'HERMES_RESTART_SIGNAL_PENDING=1' SIGTERM SIGINT HUP
   if ! output="$(
-    "${_HERMES_GUARD_TIMEOUT[@]}" "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" unseal-restart \
+    ${_HERMES_GUARD_TIMEOUT[@]+"${_HERMES_GUARD_TIMEOUT[@]}"} "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" unseal-restart \
       --hermes-dir "$HERMES_DIR" \
       --state-file "$HERMES_RESTART_SEAL_STATE" 2>&1
   )"; then
@@ -1991,7 +1991,7 @@ recover_startup_hermes_mutation() {
 
   while [ -e "$HERMES_CONFIG_MUTATION_LOCK" ] || [ -e "$HERMES_RESTART_SEAL_STATE" ]; do
     if ! owner_output="$(
-      "${_HERMES_GUARD_TIMEOUT[@]}" "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" inspect-mutation-owner \
+      ${_HERMES_GUARD_TIMEOUT[@]+"${_HERMES_GUARD_TIMEOUT[@]}"} "$_HERMES_PYTHON" -I "$_HERMES_RUNTIME_CONFIG_GUARD" inspect-mutation-owner \
         --hermes-dir "$HERMES_DIR" \
         --state-file "$HERMES_RESTART_SEAL_STATE" 2>&1
     )"; then
@@ -2475,13 +2475,13 @@ hermes_managed_controller_is_live() {
   first_start="$(gateway_control_pid_start_identity "$pid")" || return 1
   first_state="$(gateway_control_pid_state "$pid")" || return 1
   first_uids="$(awk '/^Uid:/ { print $2 ":" $3 ":" $4 ":" $5; exit }' "${proc_root}/${pid}/status")" || return 1
-  mapfile -d '' -t first_argv <"${proc_root}/${pid}/cmdline" || return 1
+  while IFS= read -r -d "" elem; do first_argv+=("$elem"); done <"${proc_root}/${pid}/cmdline" || return 1
   hermes_managed_controller_argv_is_expected "${first_argv[@]}" || return 1
 
   second_start="$(gateway_control_pid_start_identity "$pid")" || return 1
   second_state="$(gateway_control_pid_state "$pid")" || return 1
   second_uids="$(awk '/^Uid:/ { print $2 ":" $3 ":" $4 ":" $5; exit }' "${proc_root}/${pid}/status")" || return 1
-  mapfile -d '' -t second_argv <"${proc_root}/${pid}/cmdline" || return 1
+  while IFS= read -r -d "" elem; do second_argv+=("$elem"); done <"${proc_root}/${pid}/cmdline" || return 1
   hermes_managed_controller_argv_is_expected "${second_argv[@]}" || return 1
 
   [ "$first_start" = "$expected_start_identity" ] \
@@ -2499,7 +2499,6 @@ hermes_managed_gateway_exit_was_host_authorized() {
   local marker dir_metadata marker_metadata
   local version marker_pid marker_start_identity controller_pid controller_start_identity extra
   local trailing=""
-  local marker_fd
 
   case "$pid" in
     '' | 0 | 1 | *[!0-9]*) return 1 ;;
@@ -2518,18 +2517,17 @@ hermes_managed_gateway_exit_was_host_authorized() {
   marker_metadata="$(stat -c '%u:%g %a %h' "$marker" 2>/dev/null || true)"
   [ "$marker_metadata" = "0:0 444 1" ] || return 1
 
-  exec {marker_fd}<"$marker" || return 1
-  if ! IFS=' ' read -r \
-    version marker_pid marker_start_identity controller_pid controller_start_identity extra \
-    <&"$marker_fd"; then
-    exec {marker_fd}<&-
-    return 1
-  fi
-  if IFS= read -r trailing <&"$marker_fd" || [ -n "$trailing" ]; then
-    exec {marker_fd}<&-
-    return 1
-  fi
-  exec {marker_fd}<&-
+  # bash 4.1+ named FDs ({var}<file) are not available on bash 3.2 (macOS).
+  # Use a grouped redirect instead — variables assigned inside {} remain in scope.
+  {
+    if ! IFS=' ' read -r \
+      version marker_pid marker_start_identity controller_pid controller_start_identity extra; then
+      return 1
+    fi
+    if IFS= read -r trailing || [ -n "$trailing" ]; then
+      return 1
+    fi
+  } <"$marker" || return 1
 
   [ "$version" = "v1" ] \
     && [ "$marker_pid" = "$pid" ] \

--- a/scripts/gateway-control.sh
+++ b/scripts/gateway-control.sh
@@ -8,6 +8,9 @@ set -eu
 # it must not inherit command resolution from the container environment. Use a
 # fixed interpreter and trusted system PATH before invoking any external tool.
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# Byte-exact character class matching — macOS UTF-8 locale makes [a-f] case-
+# insensitive, which would allow uppercase hex nonces to pass the [!0-9a-f] check.
+export LC_ALL=C
 
 INSTALLED_CONTROL_HELPER="/usr/local/bin/nemoclaw-gateway-control"
 if [ "$0" = "$INSTALLED_CONTROL_HELPER" ]; then

--- a/scripts/gateway-control.sh
+++ b/scripts/gateway-control.sh
@@ -8,9 +8,10 @@ set -eu
 # it must not inherit command resolution from the container environment. Use a
 # fixed interpreter and trusted system PATH before invoking any external tool.
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-# Byte-exact character class matching — macOS UTF-8 locale makes [a-f] case-
-# insensitive, which would allow uppercase hex nonces to pass the [!0-9a-f] check.
-export LC_ALL=C
+# Nonce validation below uses an explicit locale-independent character class
+# ([!0123456789abcdef]) rather than the range [a-f], whose case-sensitivity
+# varies by locale (macOS UTF-8 folds [a-f] case-insensitively), keeping the
+# lowercase-only hex nonce check byte-exact without relying on LC_ALL.
 
 INSTALLED_CONTROL_HELPER="/usr/local/bin/nemoclaw-gateway-control"
 if [ "$0" = "$INSTALLED_CONTROL_HELPER" ]; then
@@ -43,7 +44,7 @@ case "$ACTION" in
   *) fail "SUPERVISOR_INVALID_ACTION" ;;
 esac
 case "$NONCE" in
-  *[!0-9a-f]* | '') fail "SUPERVISOR_INVALID_NONCE" ;;
+  *[!0123456789abcdef]* | '') fail "SUPERVISOR_INVALID_NONCE" ;;
 esac
 [ "${#NONCE}" -eq 64 ] || fail "SUPERVISOR_INVALID_NONCE"
 [ "$CONTROL_CALLER_UID" -eq 0 ] || fail "PRIVILEGED_CONTROL_UNAVAILABLE"

--- a/scripts/lib/gateway-supervisor.sh
+++ b/scripts/lib/gateway-supervisor.sh
@@ -6,6 +6,9 @@
 # The request directory is root-only. Requests are written by the host through
 # the registry-scoped privileged Docker exec path; sandbox processes cannot
 # submit or alter them.
+# Byte-exact character class matching — macOS UTF-8 locale makes [a-f] case-
+# insensitive, which would allow uppercase hex nonces to bypass the nonce check.
+export LC_ALL=C
 
 NEMOCLAW_GATEWAY_CONTROL_DIR="${NEMOCLAW_GATEWAY_CONTROL_DIR:-/run/nemoclaw/gateway-control}"
 NEMOCLAW_GATEWAY_CONTROL_REQUEST="${NEMOCLAW_GATEWAY_CONTROL_DIR}/request"

--- a/scripts/lib/gateway-supervisor.sh
+++ b/scripts/lib/gateway-supervisor.sh
@@ -6,9 +6,11 @@
 # The request directory is root-only. Requests are written by the host through
 # the registry-scoped privileged Docker exec path; sandbox processes cannot
 # submit or alter them.
-# Byte-exact character class matching — macOS UTF-8 locale makes [a-f] case-
-# insensitive, which would allow uppercase hex nonces to bypass the nonce check.
-export LC_ALL=C
+# Nonce validation below uses an explicit locale-independent character class
+# ([!0123456789abcdef]) rather than the range [a-f], whose case-sensitivity
+# varies by locale (macOS UTF-8 folds [a-f] case-insensitively). This keeps the
+# lowercase-only hex nonce check byte-exact without exporting LC_ALL from a
+# sourced library into the Hermes runtime.
 
 NEMOCLAW_GATEWAY_CONTROL_DIR="${NEMOCLAW_GATEWAY_CONTROL_DIR:-/run/nemoclaw/gateway-control}"
 NEMOCLAW_GATEWAY_CONTROL_REQUEST="${NEMOCLAW_GATEWAY_CONTROL_DIR}/request"
@@ -59,7 +61,7 @@ gateway_control_take_request() {
   fi
   [ "$version" = "v1" ] || return 1
   case "$nonce" in
-    *[!0-9a-f]* | '') return 1 ;;
+    *[!0123456789abcdef]* | '') return 1 ;;
   esac
   [ "${#nonce}" -eq 64 ] || return 1
   case "$action" in

--- a/test/e2e/fixtures/redaction.ts
+++ b/test/e2e/fixtures/redaction.ts
@@ -64,6 +64,8 @@ export const TOKEN_PREFIX_PATTERNS: RegExp[] = [
   /\bbot\d{8,10}:[A-Za-z0-9_-]{35}\b/g,
   /\b\d{8,10}:[A-Za-z0-9_-]{35}\b/g,
   /\b[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g,
+  // Tavily
+  /tvly-[A-Za-z0-9_-]{10,}/g,
 ];
 
 export const CONTEXT_PATTERNS: RegExp[] = [

--- a/test/gateway-supervisor-control.test.ts
+++ b/test/gateway-supervisor-control.test.ts
@@ -158,6 +158,7 @@ describe("gateway supervisor tracked PID handling", () => {
   it("terminates only the exact tracked child PID", () => {
     const result = runSupervisorLibrary(
       [
+        "set +m",
         "sleep 30 & target_pid=$!",
         "sleep 30 & sibling_pid=$!",
         'cleanup_children() { kill "$target_pid" "$sibling_pid" 2>/dev/null || true; }',
@@ -172,7 +173,9 @@ describe("gateway supervisor tracked PID handling", () => {
     );
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
+    // macOS bash 3.2 reports SIGTERM job-control notifications to stderr
+    // (e.g. "Terminated: 15  sleep 30") despite set +m; filter them out.
+    expect(result.stderr.replace(/^[^\n]*(?:Terminated|Killed)[^\n]*\n?/gm, "")).toBe("");
     expect(result.stdout).toMatch(/^\d+$/);
   });
 
@@ -341,6 +344,7 @@ describe("root-only gateway control helper", () => {
           temporaryDirectory("nemoclaw-gateway-helper-invalid-"),
           "absent",
         ),
+        NEMOCLAW_TEST_GATEWAY_CONTROL_CALLER_UID: "0",
       },
     });
 

--- a/test/gateway-supervisor-control.test.ts
+++ b/test/gateway-supervisor-control.test.ts
@@ -175,7 +175,7 @@ describe("gateway supervisor tracked PID handling", () => {
     expect(result.status).toBe(0);
     // macOS bash 3.2 reports SIGTERM job-control notifications to stderr
     // (e.g. "Terminated: 15  sleep 30") despite set +m; filter them out.
-    expect(result.stderr.replace(/^[^\n]*(?:Terminated|Killed)[^\n]*\n?/gm, "")).toBe("");
+    expect(result.stderr.replace(/^(?:Terminated|Killed): \d+[^\n]*\n?/gm, "")).toBe("");
     expect(result.stdout).toMatch(/^\d+$/);
   });
 


### PR DESCRIPTION
## Summary

Five pre-existing test failures on the `macos-vitest` CI workflow (confirmed present before #6060) traced to bash 3.x incompatibilities, a macOS UTF-8 locale issue, and a missing fixture sync. This PR fixes all five root causes.

Supersedes #6137 (that PR's branch was accidentally cut from a security feature branch, pulling in unrelated files into the diff; this is a clean rebase onto main with the same two commits plus a CodeRabbit fix).

## Related Issue

Investigation of CI run [28539883104](https://github.com/NVIDIA/NemoClaw/actions/runs/28539883104); failures also present in run [28534214317](https://github.com/NVIDIA/NemoClaw/actions/runs/28534214317) (before #6060), confirming #6060 is not the cause.

## Changes

- **`agents/hermes/start.sh`** — three bash 3.2 compatibility fixes:
  - Replace bash 4.1+ named-FD `exec {var}<file` with a `{ } < file` grouped redirect; variables assigned inside `{}` remain in function scope
  - Replace `mapfile -d '' -t` (bash 4.x only) with `while IFS= read -r -d "" elem; do arr+=("$elem"); done`
  - Guard `${_HERMES_GUARD_TIMEOUT[@]}` with `${arr[@]+"${arr[@]}"}` so `set -u` does not abort the script when the array is empty (bash 3.2 treats empty `[@]` as unbound)
- **`scripts/gateway-control.sh`** — add `export LC_ALL=C` so `[a-f]` character-class ranges in `case` patterns are byte-exact; macOS `en_US.UTF-8` makes `[a-f]` case-insensitive, allowing uppercase hex nonces to pass the `*[!0-9a-f]*` check
- **`scripts/lib/gateway-supervisor.sh`** — same `LC_ALL=C` fix for the sourced library's nonce validation path
- **`test/gateway-supervisor-control.test.ts`** — pin `NEMOCLAW_TEST_GATEWAY_CONTROL_CALLER_UID=0` in the nonce-rejection test so it does not depend on the CI runner's UID; tighten macOS bash 3.2 SIGTERM filter from broad word-match to exact `Terminated: <digits>` / `Killed: <digits>` format so unrelated stderr still fails the assertion
- **`test/e2e/fixtures/redaction.ts`** — add `tvly-` Tavily token pattern missing since #6134, fixing the `e2e-redaction-parity` `Array(16)` vs `Array(17)` mismatch

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable — justification: shell compatibility and test fixes, no user-facing behavior change
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging) — `gateway-control.sh` and `gateway-supervisor.sh` handle nonce validation
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — the `LC_ALL=C` fix tightens nonce validation (rejects uppercase hex on macOS that was previously accepted); `gateway_control_stop_tracked_pid` behavior is unchanged

## Verification

- [x] Git hooks passed during commit and push
- [x] Targeted tests pass for changed behavior
  - `test/gateway-supervisor-control.test.ts`: 22/22 ✓
  - `test/hermes-managed-exit-authorization.test.ts`: all ✓ (was 8 failures before)
  - `test/e2e/support/e2e-redaction-parity.test.ts`: 3/3 ✓
  - `test/hermes-gateway-supervisor-recovery.test.ts`: 41/42 (1 local flake — PID 4242 alive on dev machine; unrelated to these changes, passes on CI fresh runners)
- [x] No secrets, API keys, or credentials committed

**Remaining failures not addressed in this PR** (different root class, need separate investigation):
- `install-preflight.test.ts` — environment-specific
- `deepagents-code-tui-startup-check.test.ts` — needs investigation
- `platform-parity-cloud-experimental.test.ts` — needs investigation
- WSL `runtime-recovery-preload.test.ts`, `rebuild-config-hash.test.ts` — different class of failure

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway nonce validation to reliably accept only lowercase hex characters, independent of locale and macOS environments.
  * Fixed managed gateway startup, recovery, and live-status monitoring to be compatible with older Bash versions.
  * Tightened controller/marker parsing to reduce incorrect authorization or status detection.
  * Expanded secret redaction to cover additional Tavily-shaped tokens, improving protection in logs and text output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->