### PR TITLE
ci(main): install deps before Hermes secret-boundary Vitest (#6143)

### DIFF
--- a/.github/workflows/sandbox-images-and-e2e.yaml
+++ b/.github/workflows/sandbox-images-and-e2e.yaml
@@ -71,6 +71,15 @@ jobs:
       - name: Resolve Hermes base image
         uses: ./.github/actions/resolve-hermes-base-image
 
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
       - name: Build Hermes production image
         run: docker build -f agents/hermes/Dockerfile --build-arg BASE_IMAGE=${{ env.HERMES_BASE_IMAGE }} -t nemoclaw-hermes-production .
 
@@ -101,15 +110,6 @@ jobs:
           name: hermes-sandbox-secret-boundary-log
           path: /tmp/nemoclaw-hermes-sandbox-secret-boundary.log
           if-no-files-found: ignore
-
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
 
       - name: Run Hermes root entrypoint smoke Vitest test
         env:


### PR DESCRIPTION
## Summary
The `build-hermes-sandbox-image` job in `.github/workflows/sandbox-images-and-e2e.yaml` ran the Hermes sandbox secret-boundary Vitest test (`npx vitest`) **before** the `Set up Node` and `Install root dependencies` steps. On a clean hosted runner there is no root `node_modules`, so `npx` pulled an ad-hoc `vitest` that could not resolve `vitest/config` from the repo's `vitest.config.ts`, failing the job with `Cannot find module 'vitest/config'`. This moves the Node setup + install steps ahead of the first Vitest invocation.

## Related Issue
Fixes #6143

## Changes
- Move `Set up Node` and `Install root dependencies` (`npm ci --ignore-scripts`) to run immediately after `Resolve Hermes base image`, before `Build Hermes production image` and both Hermes Vitest steps.
- New step order: Checkout → Resolve base image → Set up Node → Install deps → Build/verify Hermes image → secret-boundary Vitest → root-entrypoint smoke Vitest.
- Net diff is a pure reorder (9 insertions / 9 deletions); no step content changed. The ordering regressed in #5756 (commit `8120223922bf`).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [x] Tests not applicable — justification: CI workflow step reorder; correctness is a CI-runner behavior (dependencies present before Vitest), validated by the job's own run plus a host A/B below. No unit-testable surface.
- [x] Docs not applicable — justification: internal CI workflow only; no user-facing surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: touches only CI step ordering in one workflow job; the Hermes secret-boundary and smoke tests, their env, and commands are unchanged — only the position of the standard `setup-node` + `npm ci` steps moved earlier.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push
- [x] Targeted validation: YAML parses; prek hooks (`check yaml`, whitespace, etc.) pass on the file; step order confirmed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed

### Host A/B verification (`local-jama@10.176.198.59`)
Reproduced the exact failure and confirmed the fix's premise without running the heavy live Docker test:
- **Before `npm install`** (simulating the old ordering — Vitest with no root `node_modules`): `npx vitest list … hermes-sandbox-secret-boundary.test.ts` fails with `Cannot find module 'vitest/config'` — matches the reported CI error.
- **After `npm install`** (the new ordering — deps present first): the same `vitest list` resolves `vitest.config.ts` and discovers the test with no ad-hoc `npx` install.

(Results pasted in the completion notification.) Definitive check: this PR's own `build-hermes-sandbox-image` job on a fresh runner.

---
Signed-off-by: Jason Ma <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sandbox image and end-to-end pipeline to prepare dependencies earlier in the run, helping the job execute more smoothly and consistently.
  * Streamlined setup steps in the workflow by removing duplicate preparation later in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->