### PR TITLE
fix(onboard): differentiate NXDOMAIN/REFUSED container DNS from unreachable (#6149)

### DIFF
--- a/src/lib/onboard/bridge-dns-preflight.test.ts
+++ b/src/lib/onboard/bridge-dns-preflight.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { setOnboardBrandingAgent } from "./branding";
 import {
   printContainerDnsRemediation,
+  printContainerDnsResolutionFailedRemediation,
   printDockerBridgeContainerStartFailure,
 } from "./bridge-dns-preflight";
 
@@ -222,5 +223,47 @@ describe("printDockerBridgeContainerStartFailure", () => {
     const blob = messages.join("\n");
     expect(blob).toContain("Docker Desktop > Settings > Resources > WSL integration");
     expect(blob).toContain("enable integration for this distro");
+  });
+});
+
+describe("printContainerDnsResolutionFailedRemediation (#6149)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const capture = (host: { platform: string; isWsl: boolean }): string => {
+    const messages: string[] = [];
+    const errSpy = vi.spyOn(console, "error").mockImplementation((arg?: unknown) => {
+      messages.push(String(arg ?? ""));
+    });
+    printContainerDnsResolutionFailedRemediation(
+      host as unknown as Parameters<typeof printContainerDnsResolutionFailedRemediation>[0],
+    );
+    errSpy.mockRestore();
+    return messages.join("\n");
+  };
+
+  it("names registry.npmjs.org and frames the resolver as reachable-but-refused, not UDP:53-blocked", () => {
+    const blob = capture({ platform: "linux", isWsl: false });
+    expect(blob).toContain("registry.npmjs.org");
+    expect(blob).toMatch(/reachable/i);
+    expect(blob).toMatch(/NXDOMAIN\/REFUSED/);
+    expect(blob).toContain("#6149");
+    // Must NOT emit the servers_unreachable (UDP:53-blocked) remediation, whose
+    // distinctive markers are the systemd-resolved stub listener and the #2101
+    // npm-hang framing.
+    expect(blob).not.toContain("DNSStubListenerExtra");
+    expect(blob).not.toContain("Exit handler never called");
+  });
+
+  it("suggests the Linux daemon.json path on native Linux", () => {
+    const blob = capture({ platform: "linux", isWsl: false });
+    expect(blob).toContain("/etc/docker/daemon.json");
+  });
+
+  it("suggests the Docker Desktop path on macOS instead of the Linux daemon.json path", () => {
+    const blob = capture({ platform: "darwin", isWsl: false });
+    expect(blob).toContain("Docker Desktop");
+    expect(blob).not.toContain("/etc/docker/daemon.json");
   });
 });

--- a/src/lib/onboard/bridge-dns-preflight.ts
+++ b/src/lib/onboard/bridge-dns-preflight.ts
@@ -75,6 +75,7 @@ function printDaemonJsonDnsPatch(opts: DaemonJsonDnsPatchOpts): void {
   ].join(" ");
   console.error(`${indent}${sudoPrefix}sh -c '${shBody.replace(/'/g, "'\"'\"'")}'`);
 }
+
 import {
   BUSYBOX_PROBE_IMAGE,
   DEFAULT_HOST_DNS_PROBE_HOSTNAME,
@@ -252,6 +253,10 @@ export function assertDockerBridgeAndContainerDnsHealthy(host: Host, nonInteract
     console.error("  ✗ Container DNS probe did not complete.");
   } else if (dns.reason === "image_pull_failed") {
     console.error("  ✗ Docker could not resolve or pull the DNS probe image.");
+  } else if (dns.reason === "resolution_failed") {
+    console.error(
+      "  ✗ Container DNS server is reachable but rejected the query (NXDOMAIN/REFUSED).",
+    );
   } else {
     console.error("  ✗ DNS resolution from inside a docker container failed.");
   }
@@ -261,7 +266,16 @@ export function assertDockerBridgeAndContainerDnsHealthy(host: Host, nonInteract
     }
   }
   console.error("");
-  printContainerDnsRemediation(host);
+  // `servers_unreachable` (UDP:53 dropped) and `resolution_failed` (the resolver
+  // answered but returned NXDOMAIN/REFUSED) need different fixes: the former is
+  // the #2101 systemd-resolved/daemon.json remediation, the latter is a resolver
+  // config problem. Routing both to the UDP:53 block sent NXDOMAIN/REFUSED users
+  // down an irrelevant path (#6149).
+  if (dns.reason === "resolution_failed") {
+    printContainerDnsResolutionFailedRemediation(host);
+  } else {
+    printContainerDnsRemediation(host);
+  }
   process.exit(1);
 }
 
@@ -439,6 +453,44 @@ export function printHostDnsRemediation(
     `    node -e "require('node:dns').resolve('${hostname}', (e,a)=>{if(e)throw e;console.log(a)})"`,
   );
   console.error(`    curl -sS https://${hostname}/v1/models -o /dev/null && echo reachable`);
+}
+
+/**
+ * Remediation for the `resolution_failed` container-DNS reason: the docker
+ * DNS server *answered* the probe (so it is reachable) but returned
+ * NXDOMAIN/REFUSED for the name. The sandbox build's `npm ci` would then fail
+ * to resolve registry.npmjs.org. This is a different failure from
+ * `servers_unreachable` (UDP:53 dropped), so it must NOT print the
+ * systemd-resolved / UDP:53 remediation, which recommends changes that are
+ * irrelevant when the resolver is already reachable (#6149).
+ */
+export function printContainerDnsResolutionFailedRemediation(
+  host: Pick<Host, "platform" | "isWsl">,
+): void {
+  console.error("  The DNS server your docker daemon uses is reachable — it answered the probe —");
+  console.error("  but it refused or could not resolve the name (NXDOMAIN/REFUSED). The sandbox");
+  console.error("  build runs `npm ci` inside a container and must resolve registry.npmjs.org, so");
+  console.error("  onboarding cannot continue until that name resolves. See issue #6149.");
+  console.error("");
+  console.error("  This is NOT the UDP:53-blocked case — your resolver is up. Check its config:");
+  console.error("");
+  console.error(
+    "  1. If the docker daemon points at a local/forwarding resolver (dnsmasq, Pi-hole,",
+  );
+  console.error("     unbound, systemd-resolved), make sure it forwards public names and has no");
+  console.error("     blocklist/ACL rejecting registry.npmjs.org (e.g. a dnsmasq");
+  console.error("     `address=/registry.npmjs.org/` or `server=` override, or a REFUSED ACL).");
+  console.error("  2. Confirm the resolver's own upstream is healthy and not returning");
+  console.error("     NXDOMAIN/REFUSED for public names.");
+  const daemonJsonHint =
+    host.platform === "linux" && !host.isWsl
+      ? "/etc/docker/daemon.json, then restart docker"
+      : "your docker daemon.json (Docker Desktop → Settings → Docker Engine on macOS/Windows), then restart it";
+  console.error("  3. Or point the docker daemon at a DNS server that resolves public names — add");
+  console.error(`     { "dns": ["<working-dns-ip>"] } in ${daemonJsonHint}.`);
+  console.error("");
+  console.error("  Verify the fix worked:");
+  console.error(`    docker run --rm ${BUSYBOX_PROBE_IMAGE} nslookup registry.npmjs.org`);
 }
 
 export function printContainerDnsRemediation(host: Host): void {


### PR DESCRIPTION
## Summary
Onboard preflight printed a single generic message plus the UDP:53-blocked / systemd-resolved remediation for **every** fatal container-DNS failure. That block fits `servers_unreachable` (UDP:53 dropped, the #2101 case) but is misleading for `resolution_failed`, where the DNS server is reachable and answered with NXDOMAIN/REFUSED — the systemd-resolved advice is irrelevant when the resolver is already up. This routes the two cases to distinct messages/remediations.

## Related Issue
Fixes #6149

## Changes
- `assertDockerBridgeAndContainerDnsHealthy`: add a distinct headline for `dns.reason === "resolution_failed"` ("Container DNS server is reachable but rejected the query (NXDOMAIN/REFUSED)") and route it to a new remediation; `servers_unreachable` and other reasons keep `printContainerDnsRemediation`.
- New exported `printContainerDnsResolutionFailedRemediation(host)`: frames the resolver as reachable-but-refused, names `registry.npmjs.org` (the name the sandbox build's `npm ci` must resolve), and points at the upstream resolver config (dnsmasq/Pi-hole/unbound/systemd-resolved forwarding, blocklists/ACLs, or a daemon.json `dns` override) instead of the UDP:53 block. Platform-aware daemon.json hint (Linux path vs Docker Desktop UI).
- Unit tests for the new remediation (names registry.npmjs.org, reachable-but-refused framing, does NOT emit the `servers_unreachable` UDP:53/systemd-resolved markers, platform-aware daemon.json hint).

Note: the probe (`probeContainerDns`) already classifies `resolution_failed` vs `servers_unreachable` distinctly (`preflight.ts`); only the printer lumped them together, so this is a printer-only change with no probe/logic change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [x] Docs not applicable — justification: preflight error-message wording only; no documented command/flag surface changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: onboarding/preflight change is limited to which user-facing remediation text is printed for an already-classified fatal DNS reason; the probe classification, the fatal/inconclusive decision (`isFatalContainerDnsProbeFailure`), and the exit behavior are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push
- [x] Targeted tests pass: `bridge-dns-preflight.test.ts` (12) + `preflight.test.ts` (131); typecheck, biome, repository-checks (test-title-style/import boundaries) all clean.
- [x] No secrets, API keys, or credentials committed

### Host verification (`local-jama@10.176.198.59`)
Built the branch and drove the real preflight code path with an injected probe result for each reason, asserting the printed remediation. Results pasted in the completion notification. Host workspace removed afterward.

---
Signed-off-by: Jason Ma <jama@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker/container DNS diagnostics to better distinguish between DNS queries that are refused and those blocked at UDP port 53.
  * Added clearer, platform-specific remediation guidance for affected setups, including Linux and macOS.
  * Updated the error message to more clearly indicate when the registry DNS server is reachable but rejects the query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->