### PR TITLE
docs: fix sandbox hardening links

### DIFF
--- a/docs/reference/enterprise-readiness.mdx
+++ b/docs/reference/enterprise-readiness.mdx
@@ -83,7 +83,7 @@ Each row links to deeper documentation and, when a concrete fix is in progress, 
 
 <AgentOnly variant="openclaw">
 For remote deployment specifics, refer to [Deploy to Remote GPU Instances](../deployment/deploy-to-remote-gpu) and [Brev Web UI](../deployment/brev-web-ui).
-For container-level hardening beyond the entrypoint defaults, refer to [Sandbox Hardening](../deployment/sandbox-hardening).
+For container-level hardening beyond the entrypoint defaults, refer to [Sandbox Hardening](../manage-sandboxes/sandbox-hardening).
 </AgentOnly>
 <AgentOnly variant="hermes">
 For remote deployment and Brev specifics, refer to the Brev section of the [Troubleshooting](troubleshooting#brev) guide.

--- a/docs/security/best-practices.mdx
+++ b/docs/security/best-practices.mdx
@@ -322,7 +322,7 @@ The container runtime spawns a `$$nemoclaw connect` shell outside that tree, so 
 
 <AgentOnly variant="openclaw">
 For additional protection, pass `--cap-drop=ALL` with `docker run` or Compose.
-Refer to [Sandbox Hardening](../deployment/sandbox-hardening).
+Refer to [Sandbox Hardening](../manage-sandboxes/sandbox-hardening).
 </AgentOnly>
 
 | Aspect | Detail |
@@ -658,7 +658,7 @@ The following patterns weaken security without providing meaningful benefit.
 - [Customize the Network Policy](../network-policy/customize-network-policy) for static and dynamic policy changes.
 - [Approve or Deny Network Requests](../network-policy/approve-network-requests) for the operator approval flow.
 <AgentOnly variant="openclaw">
-- [Sandbox Hardening](../deployment/sandbox-hardening) for container-level security measures.
+- [Sandbox Hardening](../manage-sandboxes/sandbox-hardening) for container-level security measures.
 </AgentOnly>
 - [Inference Options](../inference/inference-options) for provider configuration details.
 - [How It Works](../about/how-it-works) for the protection layer architecture.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes stale Sandbox Hardening links that still routed through the old deployment path.
The affected docs now point to the current `manage-sandboxes/sandbox-hardening` route.

## Related Issue
Fixes #6093.

## Changes
- Updated `docs/security/best-practices.mdx` to use the current Sandbox Hardening route in both OpenClaw-only references.
- Updated `docs/reference/enterprise-readiness.mdx` to use the current Sandbox Hardening route.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: link-only documentation route fix.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: link-only docs route fix; no runtime behavior, security controls, policy, credentials, or sandbox defaults changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs:sync-agent-variants && npm run docs` passed with 0 errors. Fern reported 1 existing hidden warning.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several “Sandbox Hardening” links in the security and enterprise-readiness docs to point to the current guide location.
  * Improved navigation from related security guidance so readers can find sandbox hardening information more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->