### PR TITLE
docs: clarify inference sandbox prerequisite

### DIFF
--- a/docs/inference/switch-inference-providers.mdx
+++ b/docs/inference/switch-inference-providers.mdx
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 title: "Switch Inference Models at Runtime"
 sidebar-title: "Switch Inference Providers"
-description: "Change the active inference model without restarting the sandbox."
-description-agent: "Changes the active inference model without restarting the sandbox. Use when switching inference providers, changing the model runtime, or reconfiguring inference routing."
+description: "Change the active inference model for a running sandbox without restarting it."
+description-agent: "Changes the active inference model for a running sandbox without restarting it. Use when switching inference providers, changing the model runtime, or reconfiguring inference routing."
 keywords: ["switch nemoclaw inference model", "change inference runtime"]
 content:
   type: "how_to"
@@ -18,8 +18,14 @@ You do not need to restart the sandbox.
 
 ## Prerequisites
 
-- A running NemoClaw sandbox.
+- A running NemoClaw sandbox created or resumed with `$$nemoclaw onboard`.
+- A selected default sandbox, or pass `--sandbox <name>` to each `$$nemoclaw inference set` command when more than one sandbox is registered.
 - The OpenShell CLI on your `PATH`, which NemoClaw uses internally.
+
+<Note>
+If you run `$$nemoclaw inference set` before NemoClaw has a selected sandbox, the CLI exits with `No sandbox selected`.
+Run `$$nemoclaw onboard` first, then retry the switch.
+</Note>
 
 ## Find the Provider Name
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Clarifies that `nemoclaw inference set` requires a running, selected NemoClaw sandbox before switching providers. This prevents new users from copying the first switch command and immediately hitting `No sandbox selected`.

## Related Issue
Fixes #6092

## Changes
- Updates the Switch Inference Providers page metadata to describe running-sandbox scope.
- Expands prerequisites to tell users to run `$$nemoclaw onboard` and use `--sandbox <name>` when needed.
- Adds a note explaining the `No sandbox selected` error and recovery path before the first `inference set` example.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only prerequisite clarification with no runtime behavior change.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification note: `npm run docs` completed with 0 errors, but Fern reported 1 hidden warning, so the warning-free docs checkbox is intentionally left unchecked.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the guide for switching the active inference model in a running sandbox.
  * Updated prerequisites to list the required setup more explicitly, including selecting a sandbox or providing one with the command.
  * Added a note about the “No sandbox selected” message and the steps to retry after onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->