### PR TITLE
test(docs): track canonical sandbox hardening route

### DIFF
--- a/test/repro-5088-best-practices-layers.test.ts
+++ b/test/repro-5088-best-practices-layers.test.ts
@@ -1,23 +1,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 
 // Regression for issue #5088: docs/security/best-practices.mdx described
 // "four layers" in the intro, the Mermaid diagram, and the at-a-glance table,
 // but the body documents five layer sections (it adds Gateway Authentication).
-// It also linked Sandbox Hardening through the wrong directory
-// (manage-sandboxes/ rather than the canonical deployment/ path).
+// It also keeps the Sandbox Hardening link on the canonical
+// manage-sandboxes/ route rather than the retired deployment/ path.
 const REPO_ROOT = path.dirname(import.meta.dirname);
 const DOC = path.join(REPO_ROOT, "docs", "security", "best-practices.mdx");
 const text = fs.readFileSync(DOC, "utf-8");
 
 describe("best-practices.mdx security-layer consistency (#5088)", () => {
-  it("links Sandbox Hardening via the canonical deployment path", () => {
-    expect(text).not.toMatch(/manage-sandboxes\/sandbox-hardening/);
-    expect(text).toMatch(/\.\.\/deployment\/sandbox-hardening/);
+  it("links Sandbox Hardening via the canonical manage-sandboxes path", () => {
+    expect(text).toMatch(/\.\.\/manage-sandboxes\/sandbox-hardening/);
+    expect(text).not.toMatch(/\.\.\/deployment\/sandbox-hardening/);
   });
 
   it("intro and at-a-glance agree with the body's five layer sections", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Updates the #5088 documentation regression test after #6151 moved Sandbox Hardening to the canonical `manage-sandboxes` route. Current `main` deterministically fails CLI shard 5 because the test still requires the retired `deployment` path.

## Changes

- Require `../manage-sandboxes/sandbox-hardening` in the best-practices regression test.
- Reject the retired `../deployment/sandbox-hardening` route.
- Apply the repository's current import ordering to the touched test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: #6151 already changed the user-facing route; this PR only reconciles its regression test.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated regression coverage to ensure the “Sandbox Hardening” link points to the current sandbox management route.
  * Confirmed the retired deployment link is no longer used.
  * Kept existing checks for “Gateway Authentication” and the “five layers” wording unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->