### PR TITLE
test(e2e): keep proxy env backup in sandbox

### DIFF
--- a/test/e2e/live/issue-2478-crash-loop-recovery.test.ts
+++ b/test/e2e/live/issue-2478-crash-loop-recovery.test.ts
@@ -27,6 +27,8 @@ const CRASH_CYCLES = positiveInteger(process.env.NEMOCLAW_E2E_CRASH_CYCLES, 5);
 const SOAK_SECONDS = positiveInteger(process.env.NEMOCLAW_E2E_SOAK_SECONDS, 300);
 const COMPATIBLE_MODEL = process.env.NEMOCLAW_COMPAT_MODEL ?? "test-model";
 const COMPATIBLE_AUTH_VALUE = ["nemoclaw", "e2e", "compatible", "mock"].join("-");
+const PROXY_ENV_PATH = "/tmp/nemoclaw-proxy-env.sh";
+const PROXY_ENV_BACKUP_PATH = "/tmp/.issue-2478-proxy-env.sh.backup";
 const ONBOARD_ARGS = [
   "onboard",
   "--non-interactive",
@@ -290,36 +292,7 @@ async function killOpenclawTreeForRecovery(
   expect(result.exitCode, result.stderr).toBe(0);
 }
 
-async function snapshotProxyEnv(
-  sandbox: {
-    exec(
-      name: string,
-      command: string[],
-      options?: Record<string, unknown>,
-    ): Promise<{ exitCode: number | null; stdout: string; stderr: string }>;
-  },
-  sandboxName: string,
-): Promise<{ b64: string; size: number }> {
-  const result = await sandbox.exec(
-    sandboxName,
-    [
-      "sh",
-      "-c",
-      "base64 < /tmp/nemoclaw-proxy-env.sh && printf '\\nSIZE=' && wc -c < /tmp/nemoclaw-proxy-env.sh",
-    ],
-    { artifactName: "snapshot-proxy-env", env: probeEnv(), timeoutMs: 30_000 },
-  );
-  expect(result.exitCode, result.stderr).toBe(0);
-  const match = result.stdout.match(/([A-Za-z0-9+/=\n]+)\nSIZE=(\d+)/);
-  expect(match, `unexpected proxy-env snapshot output: ${result.stdout}`).not.toBeNull();
-  const b64 = match?.[1]?.replace(/\s+/g, "") ?? "";
-  const size = Number(match?.[2] ?? 0);
-  expect(b64.length, "proxy-env snapshot must not be empty").toBeGreaterThan(0);
-  expect(size, "proxy-env snapshot size must be positive").toBeGreaterThan(0);
-  return { b64, size };
-}
-
-async function removeProxyEnv(
+async function moveProxyEnvToBackup(
   sandbox: {
     exec(
       name: string,
@@ -329,15 +302,17 @@ async function removeProxyEnv(
   },
   sandboxName: string,
 ): Promise<void> {
-  const result = await sandbox.exec(sandboxName, ["rm", "-f", "/tmp/nemoclaw-proxy-env.sh"], {
-    artifactName: "remove-proxy-env",
-    env: probeEnv(),
-    timeoutMs: 30_000,
-  });
+  // This scenario restarts only the process tree, so a same-directory rename
+  // survives the recovery phase while preserving the file bytes and metadata.
+  const result = await sandbox.exec(
+    sandboxName,
+    ["mv", "-f", PROXY_ENV_PATH, PROXY_ENV_BACKUP_PATH],
+    { artifactName: "backup-proxy-env", env: probeEnv(), timeoutMs: 30_000 },
+  );
   expect(result.exitCode, result.stderr).toBe(0);
 }
 
-async function proxyEnvHasGuardMarkers(
+async function restoreProxyEnvFromBackup(
   sandbox: {
     exec(
       name: string,
@@ -346,49 +321,13 @@ async function proxyEnvHasGuardMarkers(
     ): Promise<{ exitCode: number | null; stdout: string; stderr: string }>;
   },
   sandboxName: string,
-  artifactName: string,
-): Promise<boolean> {
-  const result = await sandbox.exec(
-    sandboxName,
-    ["sh", "-c", "cat /tmp/nemoclaw-proxy-env.sh 2>/dev/null || true"],
-    { artifactName, env: probeEnv(), timeoutMs: 30_000 },
-  );
-  return (
-    result.stdout.includes("nemoclaw-sandbox-safety-net") &&
-    result.stdout.includes("nemoclaw-ciao-network-guard")
-  );
-}
-
-async function restoreProxyEnv(
-  sandbox: {
-    exec(
-      name: string,
-      command: string[],
-      options?: Record<string, unknown>,
-    ): Promise<{ exitCode: number | null; stdout: string; stderr: string }>;
-  },
-  sandboxName: string,
-  snapshot: { b64: string; size: number },
 ): Promise<void> {
   const result = await sandbox.exec(
     sandboxName,
-    [
-      "sh",
-      "-c",
-      `rm -f /tmp/nemoclaw-proxy-env.sh 2>/dev/null || true; (printf '%s' '${snapshot.b64}' | base64 -d > /tmp/nemoclaw-proxy-env.sh 2>/dev/null && chmod 444 /tmp/nemoclaw-proxy-env.sh) || true; wc -c < /tmp/nemoclaw-proxy-env.sh 2>/dev/null || true`,
-    ],
+    ["mv", "-f", PROXY_ENV_BACKUP_PATH, PROXY_ENV_PATH],
     { artifactName: "restore-proxy-env", env: probeEnv(), timeoutMs: 30_000 },
   );
   expect(result.exitCode, result.stderr).toBe(0);
-
-  const restoredSize = Number(result.stdout.trim() || 0);
-  if (restoredSize === snapshot.size) return;
-  if (await proxyEnvHasGuardMarkers(sandbox, sandboxName, "restore-proxy-env-guard-markers"))
-    return;
-
-  expect(restoredSize, "restored proxy-env byte size or recovered guard markers").toBe(
-    snapshot.size,
-  );
 }
 
 async function waitForRecoveryWarning(
@@ -532,8 +471,7 @@ test("issue-2478: gateway recovery preserves guard chain and avoids crash loop",
     previousPid = nextPid!;
   }
 
-  const snapshot = await snapshotProxyEnv(sandbox, instance.sandboxName);
-  await removeProxyEnv(sandbox, instance.sandboxName);
+  await moveProxyEnvToBackup(sandbox, instance.sandboxName);
   await killOpenclawTreeForRecovery(
     sandbox,
     instance.sandboxName,
@@ -545,7 +483,7 @@ test("issue-2478: gateway recovery preserves guard chain and avoids crash loop",
   expect(negativePid, "missing proxy-env warning path should still respawn gateway").not.toBeNull();
   await gateway.expectGuardChainActive(instance);
 
-  await restoreProxyEnv(sandbox, instance.sandboxName, snapshot);
+  await restoreProxyEnvFromBackup(sandbox, instance.sandboxName);
   await killOpenclawTreeForRecovery(
     sandbox,
     instance.sandboxName,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replace the issue-2478 E2E test's host-side Base64 snapshot transport with an atomic sandbox-local backup and restore. This removes the OpenShell single-argument size dependency while preserving the proxy environment's exact bytes, ownership, and mode across the process-only recovery scenario.

## Related Issue

Refs #2478. Related to #6020 and #5595, which currently carry chunk-based workarounds for the same E2E failure.

## Changes

- Move `/tmp/nemoclaw-proxy-env.sh` to a hidden backup in the same sandbox before exercising the missing-file recovery path.
- Atomically move the backup back to the canonical path before the restored-path restart and soak.
- Remove Base64 encoding, captured proxy configuration output, host round-trips, chunking, and argument-size coupling.
- Keep the backup in `/tmp` because this scenario restarts only the process tree; it does not recreate the sandbox or wipe `/tmp`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the exact `issue-2478-crash-loop-recovery` live target exercises the backup, missing-file recovery, restore, five crash cycles, and five-minute stability soak.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-harness-only implementation; no command, default, runtime behavior, public API, target ID, or documented E2E interface changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: human review pending; no waiver requested.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: the broad local `test-cli` hook was not used as evidence after an unrelated host-toolchain failure; required CI remains authoritative.

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Test Evidence

- Full focused live E2E: 1/1 passed in 709.49s with 5 crash cycles, atomic backup/restore, 20 stable PID samples, 5 successful inference probes, and 0 inference failures.
- Focused smoke: 1/1 passed in 270.21s with 1 crash cycle and a 15-second soak.
- `npm run typecheck:cli`
- `npm run checks`
- `npm run source-shape:check`
- `npm run test-size:check`
- `npx @biomejs/biome check test/e2e/live/issue-2478-crash-loop-recovery.test.ts`
- Pre-push CLI TypeScript and package-version checks passed.

---
Signed-off-by: Apurv Kumaria <36614+apurvvkumaria@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end crash-loop recovery coverage by making the proxy environment file backup and restore flow more reliable.
  * The test now uses a simpler file move approach to preserve state across recovery steps, reducing flakiness during recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->