### PR TITLE
fix(installer): remove nemohermes shim on uninstall

### DIFF
--- a/src/lib/actions/uninstall/run-plan.test.ts
+++ b/src/lib/actions/uninstall/run-plan.test.ts
@@ -60,6 +60,43 @@ describe("uninstall run plan", () => {
     );
   });
 
+  it("removes the nemohermes shim when it is an installer-managed symlink (#6098)", () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-hermes-shim-"));
+    const userBin = path.join(tmpHome, ".local", "bin");
+    fs.mkdirSync(userBin, { recursive: true });
+    const nemohermsShimPath = path.join(userBin, "nemohermes");
+    fs.symlinkSync("/dev/null", nemohermsShimPath);
+
+    const removed: string[] = [];
+    try {
+      runUninstallPlan(
+        { assumeYes: true, deleteModels: false, keepOpenShell: true },
+        {
+          commandExists: () => false,
+          env: {
+            HOME: tmpHome,
+            NEMOCLAW_AGENT: "hermes",
+            TMPDIR: tmpHome,
+          } as NodeJS.ProcessEnv,
+          existsSync: (target) => fs.existsSync(target),
+          isTty: false,
+          log: () => {},
+          rmSync: vi.fn((target: fs.PathLike, opts?: fs.RmOptions) => {
+            removed.push(String(target));
+            fs.rmSync(target, opts);
+          }),
+          run: vi.fn(() => ok()),
+          runDocker: () => ok(""),
+        },
+      );
+
+      expect(removed).toContain(nemohermsShimPath);
+      expect(fs.existsSync(nemohermsShimPath)).toBe(false);
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   it("applies a non-destructive uninstall run with fake tools", () => {
     const logs: string[] = [];
     const run = vi.fn((_command: string, args: string[]) => {

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -686,6 +686,13 @@ function removeNemoclawCli(paths: UninstallPaths, runtime: UninstallRuntime): vo
       `Leaving ${paths.nemoclawShimPath} in place because it is not an installer-managed shim.`,
     );
   }
+  const agentShim = classifyShimPath(paths.nemohermsShimPath);
+  if (agentShim.remove) removePath(paths.nemohermsShimPath, runtime);
+  else if (agentShim.kind === "preserve-foreign-file") {
+    runtime.warn(
+      `Leaving ${paths.nemohermsShimPath} in place because it is not an installer-managed shim.`,
+    );
+  }
   removeNvmLeftovers(paths, runtime);
   removeAliases(paths, runtime);
 }

--- a/src/lib/domain/uninstall/paths.test.ts
+++ b/src/lib/domain/uninstall/paths.test.ts
@@ -27,6 +27,7 @@ describe("uninstall paths", () => {
     expect(paths.openshellConfigDir).toBe(path.join("/home/test", ".config", "openshell"));
     expect(paths.nemoclawConfigDir).toBe(path.join("/home/test", ".config", "nemoclaw"));
     expect(paths.nemoclawShimPath).toBe(path.join("/home/test", ".local", "bin", "nemoclaw"));
+    expect(paths.nemohermsShimPath).toBe(path.join("/home/test", ".local", "bin", "nemohermes"));
     expect(paths.openshellInstallPaths).toEqual([
       ...OPENSHELL_MANAGED_BINARIES.map((binary) => path.join("/usr/local/bin", binary)),
       ...OPENSHELL_MANAGED_BINARIES.map((binary) => path.join("/xdg/bin", binary)),

--- a/src/lib/domain/uninstall/paths.ts
+++ b/src/lib/domain/uninstall/paths.ts
@@ -31,6 +31,7 @@ export interface UninstallPaths {
   managedSwapMarkerPath: string;
   nemoclawConfigDir: string;
   nemoclawShimPath: string;
+  nemohermsShimPath: string;
   nemoclawStateDir: string;
   gatewayLocalStateDir: string;
   openshellConfigDir: string;
@@ -59,6 +60,7 @@ export function defaultUninstallPaths(options: UninstallPathOptions): UninstallP
     managedSwapMarkerPath: path.join(options.home, ".nemoclaw", "managed_swap"),
     nemoclawConfigDir: path.join(options.home, ".config", "nemoclaw"),
     nemoclawShimPath: path.join(options.home, ".local", "bin", "nemoclaw"),
+    nemohermsShimPath: path.join(options.home, ".local", "bin", "nemohermes"),
     nemoclawStateDir: path.join(options.home, ".nemoclaw"),
     gatewayLocalStateDir: path.join(options.home, ".local", "state", "nemoclaw"),
     openshellConfigDir: path.join(options.home, ".config", "openshell"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw uninstall` removed the `nemoclaw` shim at `~/.local/bin/nemoclaw` but left the sibling `nemohermes` shim installed by the Hermes variant untouched, so `nemohermes` kept resolving as a command after a clean uninstall. This PR adds `nemohermsShimPath` to `UninstallPaths` and extends `removeNemoclawCli()` to classify and remove it using the same installer-shim guard already applied to the `nemoclaw` shim.

## Related Issue

Fixes #6098

## Changes

- `src/lib/domain/uninstall/paths.ts` — add `nemohermsShimPath: string` to `UninstallPaths` interface and populate it as `~/.local/bin/nemohermes` in `defaultUninstallPaths()`
- `src/lib/actions/uninstall/run-plan.ts` — after the existing `nemoclaw` shim block in `removeNemoclawCli()`, add a matching classify-then-remove block for `paths.nemohermsShimPath`, including the `preserve-foreign-file` warning for non-installer-managed files
- `src/lib/domain/uninstall/paths.test.ts` — assert `nemohermsShimPath === ~/.local/bin/nemohermes`
- `src/lib/actions/uninstall/run-plan.test.ts` — red→green test: creates a real symlink at `tmpHome/.local/bin/nemohermes`, runs `runUninstallPlan`, asserts `rmSync` is called for it and the symlink is gone

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs not applicable — justification: uninstall behavior change; no user-facing docs reference the `nemohermes` shim removal path
- [ ] Docs updated for user-facing behavior changes
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstall now also removes the installer-managed `nemohermes` command shim when appropriate.
  * Preserved foreign shims are now left in place with a warning instead of being removed.
  * Default uninstall path handling now includes the `nemohermes` shim location under the user’s local bin directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->