### PR TITLE
docs: refresh release notes for v0.0.72

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,26 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.72
+
+NemoClaw v0.0.72 improves installer recovery, sandbox diagnostics, inference setup, credential handling, and custom policy safety.
+
+- Installer and upgrade flows now recover eligible non-Ready sandboxes before generic onboarding.
+  The installer runs `backup-all` when available, runs `upgrade-sandboxes --auto`, restores only validated latest backups with matching sandbox identity and managed-image provenance, and exits before onboarding if any eligible recovery is blocked or fails.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart) and [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle).
+- Day-two commands provide clearer diagnostics before work reaches a lower-level failure.
+  `channels status` prints a compact summary for configured channels and non-secret rendered-config comparisons, `credentials add` registers provider credentials by provider name and type, `status` separates host inventory from per-sandbox health, `exec` rejects newline-containing arguments with recovery guidance, and connect shells point policy-denial failures at logs.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands) and [Troubleshooting](../reference/troubleshooting).
+- Inference setup and model switching fail with safer context.
+  NVIDIA Endpoints onboarding uses a public featured-model catalog with safe bundled fallback behavior, provider-not-found errors list registered providers and point back to onboarding, Hermes Provider endpoint URLs are validated before credentials are dispatched, and curl-based probes keep API keys out of process arguments.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options), [Switch Inference Providers](../inference/switch-inference-providers), and [Security Best Practices](../security/best-practices).
+- Custom policy and sandbox credential boundaries are tighter.
+  User-supplied custom presets reject `allowed_ips` except the explicit host bridge, OpenClaw processes receive `AWS_EC2_METADATA_DISABLED=true`, Hermes runtime configuration output masks API key fields, and `exec` restores mutable OpenClaw config permissions after one-shot commands.
+  For more information, refer to [Customize the Network Policy](../network-policy/customize-network-policy), [Security Best Practices](../security/best-practices), and [NemoClaw CLI Commands Reference](../reference/commands).
+- Runtime repair covers more sandbox-specific drift.
+  OpenClaw gateway watchdog exits respawn the gateway instead of ending PID 1, Hermes upgrade checks compare agent versions in the Hermes runtime scheme, Tavily access is restored for managed Python workflows, and prompt-stdin EOF during onboarding is treated as cancellation.
+  For more information, refer to [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), [Common NemoClaw Integration Policy Examples](../network-policy/integration-policy-examples), and [NemoClaw CLI Commands Reference](../reference/commands).
+
 ## v0.0.71
 
 NemoClaw v0.0.71 improves gateway recovery, OpenShell gateway authentication, policy provenance, uninstall safety, Windows bootstrap diagnostics, messaging behavior, and inference guidance.

--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -299,6 +299,10 @@ network_policies:
 
 The top-level `preset.name` must be a lowercase RFC 1123 label (letters, digits, hyphens) and must not collide with a built-in preset name such as `slack` or `pypi`.
 Rename `preset.name` if NemoClaw refuses to apply the file because of a collision.
+User-authored presets must not declare `allowed_ips` for ordinary endpoints.
+NemoClaw rejects that field in files passed through `--from-file` or `--from-dir` because it can widen the private-address ranges that OpenShell checks during SSRF protection.
+Use hostnames, ports, protocols, methods, paths, and binary restrictions instead.
+The only exception is the `host.openshell.internal` bridge endpoint used for explicit sandbox-to-host service access.
 
 ### Apply a Single File
 


### PR DESCRIPTION
## Summary
- Add the `v0.0.72` release-note section with links to the deeper docs pages for installer recovery, command diagnostics, inference, policy, and sandbox repair changes.
- Document the custom preset `allowed_ips` guard for user-authored policy files.

## Related Issue
None.

## Source summary
- #6132 -> `docs/about/release-notes.mdx`: Summarizes installer and upgrade recovery before generic onboarding, with links to quickstart and lifecycle docs.
- #6087 -> `docs/network-policy/customize-network-policy.mdx`: Documents that user-authored custom presets reject `allowed_ips` for ordinary endpoints; also summarized in release notes.
- #5975 -> `docs/about/release-notes.mdx`: Summarizes safer curl-based inference probes that keep API keys out of process arguments.
- #6044 -> `docs/about/release-notes.mdx`: Summarizes compact `channels status` configuration reporting.
- #6096 -> `docs/about/release-notes.mdx`: Summarizes OpenClaw EC2 metadata discovery disablement and links to security guidance.
- #5980 and #5991 -> `docs/about/release-notes.mdx`: Summarizes `exec` multiline argument rejection and recovery guidance.
- #6023 -> `docs/about/release-notes.mdx`: Summarizes registered-provider diagnostics for `inference set` failures.
- #6074 -> `docs/about/release-notes.mdx`: Summarizes the refreshed NVIDIA Endpoints featured-model selection behavior.
- #5969 -> `docs/about/release-notes.mdx`: Summarizes `credentials add` provider credential registration.
- #6060 -> `docs/about/release-notes.mdx`: Summarizes mutable OpenClaw config permission restoration after `exec`.
- #6134 -> `docs/about/release-notes.mdx`: Summarizes restored Tavily access for managed Python workflows.
- #6089 -> `docs/about/release-notes.mdx`: Summarizes Hermes runtime version-scheme comparison during upgrade checks.
- #6131 -> `docs/about/release-notes.mdx`: Summarizes OpenClaw gateway watchdog recovery behavior.
- #5976 and #5990 -> `docs/about/release-notes.mdx`: Summarizes prompt stdin EOF cancellation behavior during onboarding.
- #5540 -> `docs/about/release-notes.mdx`: Summarizes clarified host-level and per-sandbox status command scope.
- #5978 and #6018 -> `docs/about/release-notes.mdx`: Summarizes policy-denial log breadcrumbs in connect shells.

## Testing
- `npm run docs:sync-agent-variants`
- `npm run docs`
- Commit hooks passed during `git commit`, including commitlint and gitleaks.
- Pre-push hook passed during `git push`, including TypeScript CLI and package/tag version sync.

## Checklist
- [x] Documentation updated.
- [x] `npm run docs` completed with 0 errors and 1 existing Fern warning.
- [x] No source code or generated build artifacts committed.

Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.72 covering improved installer recovery, clearer CLI diagnostics, safer inference setup and provider switching, better credential handling, stronger policy boundaries, and more robust runtime repair behavior.
  * Updated network policy guidance to clarify when `allowed_ips` can be used, including a specific exception for the sandbox-to-host bridge endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->