### PR TITLE
test(e2e): prevent process-token probe self-matches

### DIFF
--- a/test/e2e/fixtures/process-token-probe.ts
+++ b/test/e2e/fixtures/process-token-probe.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { shellQuote } from "./clients/command.ts";
+
+export function buildProcessTokenProbe(token: string, procRoot = "/proc"): string {
+  if (token.length === 0) {
+    throw new Error("process token probe requires a nonempty token");
+  }
+  if (token.includes("\0")) {
+    throw new Error("process token probe does not accept NUL bytes");
+  }
+
+  const encodedToken = Buffer.from(token, "utf8").toString("base64");
+  return `set +x
+set +v
+set +a
+set +f
+export LC_ALL=C
+unset nemoclaw_process_probe_token nemoclaw_process_probe_pid nemoclaw_process_probe_root
+unset nemoclaw_process_probe_path nemoclaw_process_probe_entry nemoclaw_process_probe_cmdline
+command -v base64 >/dev/null 2>&1 || exit 2
+command -v tr >/dev/null 2>&1 || exit 2
+if ! nemoclaw_process_probe_token="$({
+  printf '%s' ${shellQuote(encodedToken)} | base64 -d && printf '%s' .
+})"; then
+  exit 2
+fi
+nemoclaw_process_probe_token="\${nemoclaw_process_probe_token%.}"
+nemoclaw_process_probe_pid=$$
+nemoclaw_process_probe_root=${shellQuote(procRoot)}
+for nemoclaw_process_probe_path in "$nemoclaw_process_probe_root"/[0-9]*/cmdline; do
+  nemoclaw_process_probe_entry="\${nemoclaw_process_probe_path%/cmdline}"
+  nemoclaw_process_probe_entry="\${nemoclaw_process_probe_entry##*/}"
+  case "$nemoclaw_process_probe_entry" in
+    ""|*[!0-9]*) continue ;;
+  esac
+  [ "$nemoclaw_process_probe_entry" = "$nemoclaw_process_probe_pid" ] && continue
+  [ -r "$nemoclaw_process_probe_path" ] || continue
+  if ! nemoclaw_process_probe_cmdline="$({ tr '\\000' '\\377' < "$nemoclaw_process_probe_path"; } 2>/dev/null)"; then
+    [ -r "$nemoclaw_process_probe_path" ] || continue
+    exit 2
+  fi
+  case "$nemoclaw_process_probe_cmdline" in
+    *"$nemoclaw_process_probe_token"*)
+      printf 'FOUND pid=%s\n' "$nemoclaw_process_probe_entry"
+      exit 0
+      ;;
+  esac
+done
+printf '%s\n' ABSENT`;
+}

--- a/test/e2e/live/hermes-discord.test.ts
+++ b/test/e2e/live/hermes-discord.test.ts
@@ -10,6 +10,7 @@ import type { HostCliClient, SandboxClient } from "../fixtures/clients/index.ts"
 import { sandboxAccessEnv, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
+import { buildProcessTokenProbe } from "../fixtures/process-token-probe.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { type FakeDockerApi, startFakeDockerApi } from "./messaging-providers-helpers.ts";
 import {
@@ -345,7 +346,7 @@ async function rawTokenSurfaceProbe(
     surface === "env"
       ? `token="$(printf %s ${shellQuote(tokenB64)} | base64 -d)"\nif env 2>/dev/null | grep -Fq "$token"; then echo FOUND_TOKEN; elif env 2>/dev/null | grep -q '^DISCORD_PROXY='; then echo FOUND_DISCORD_PROXY; else echo ABSENT; fi`
       : surface === "process"
-        ? `token="$(printf %s ${shellQuote(tokenB64)} | base64 -d)"\nif cat /proc/[0-9]*/cmdline 2>/dev/null | tr '\\0' '\\n' | grep -Fq "$token"; then echo FOUND_TOKEN; else echo ABSENT; fi`
+        ? buildProcessTokenProbe(token)
         : `token="$(printf %s ${shellQuote(tokenB64)} | base64 -d)"\nhit="$(grep -rFlm1 -F "$token" /sandbox /home /etc /tmp /var 2>/dev/null | head -1 || true)"\nif [ -n "$hit" ]; then printf 'FOUND_TOKEN %s\\n' "$hit"; else echo ABSENT; fi`;
   return sandboxEncodedSh(sandbox, SANDBOX_NAME, script, [], {
     artifactName,

--- a/test/e2e/live/messaging-providers-helpers.ts
+++ b/test/e2e/live/messaging-providers-helpers.ts
@@ -16,6 +16,7 @@ import {
   validateSandboxName,
 } from "../fixtures/clients/sandbox.ts";
 import { expect } from "../fixtures/e2e-test.ts";
+import { buildProcessTokenProbe } from "../fixtures/process-token-probe.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 export const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
@@ -508,8 +509,7 @@ export async function rawTokenSurfaceProbe(
       ? `token="$(printf '%s' ${shellQuote(tokenB64)} | base64 -d)"
 if env 2>/dev/null | grep -Fq "$token"; then echo FOUND; else echo ABSENT; fi`
       : surface === "process"
-        ? `token="$(printf '%s' ${shellQuote(tokenB64)} | base64 -d)"
-if cat /proc/[0-9]*/cmdline 2>/dev/null | tr '\\0' '\\n' | grep -Fq "$token"; then echo FOUND; else echo ABSENT; fi`
+        ? buildProcessTokenProbe(token)
         : `token="$(printf '%s' ${shellQuote(tokenB64)} | base64 -d)"
 match="$(grep -rIlm1 -F "$token" /sandbox /home /etc /tmp /var 2>/dev/null | head -1 || true)"
 if [ -n "$match" ]; then printf '%s\n' "$match"; else echo ABSENT; fi`;

--- a/test/e2e/support/process-token-probe.test.ts
+++ b/test/e2e/support/process-token-probe.test.ts
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { shellQuote } from "../fixtures/clients/command.ts";
+import { buildProcessTokenProbe } from "../fixtures/process-token-probe.ts";
+
+function withFakeProcRoot<T>(run: (procRoot: string) => T): T {
+  const procRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-process-token-probe-"));
+  try {
+    return run(procRoot);
+  } finally {
+    fs.rmSync(procRoot, { recursive: true, force: true });
+  }
+}
+
+function writeCmdline(procRoot: string, pid: string, args: string[]): void {
+  const procDir = path.join(procRoot, pid);
+  fs.mkdirSync(procDir);
+  fs.writeFileSync(path.join(procDir, "cmdline"), Buffer.from(`${args.join("\0")}\0`));
+}
+
+function runProbe(script: string): SpawnSyncReturns<string> {
+  return spawnSync("sh", ["-c", script], { encoding: "utf8" });
+}
+
+function expectProbeResult(result: SpawnSyncReturns<string>, expected: string): void {
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stdout.trim()).toBe(expected);
+  expect(result.stderr).toBe("");
+}
+
+function probeDiagnosticsContainToken(
+  script: string,
+  result: SpawnSyncReturns<string>,
+  token: string,
+): boolean {
+  return [script, result.stdout, result.stderr, result.error?.message ?? ""].some((value) =>
+    value.includes(token),
+  );
+}
+
+describe("process token probe", () => {
+  it("rejects token values that cannot be scanned literally", () => {
+    expect(() => buildProcessTokenProbe("")).toThrow("requires a nonempty token");
+    expect(() => buildProcessTokenProbe("contains\0nul")).toThrow("does not accept NUL bytes");
+  });
+
+  it("ignores its encoded command and excludes the scanner shell PID", () =>
+    withFakeProcRoot((procRoot) => {
+      const token = `scanner-self-secret-${process.pid}`;
+      const encodedToken = Buffer.from(token, "utf8").toString("base64");
+      const scanner = buildProcessTokenProbe(token, procRoot);
+      writeCmdline(procRoot, "101", ["sh", "-c", scanner]);
+
+      const selfCmdline = `${shellQuote(procRoot)}/$$/cmdline`;
+      const script = `mkdir -p ${shellQuote(procRoot)}/$$
+printf 'sh\\000-c\\000' > ${selfCmdline}
+printf '%s' ${shellQuote(encodedToken)} | base64 -d >> ${selfCmdline}
+printf '\\000' >> ${selfCmdline}
+${scanner}`;
+      const result = runProbe(script);
+
+      expect(scanner).toContain(encodedToken);
+      expect(scanner).toContain('case "$nemoclaw_process_probe_cmdline" in');
+      expect(scanner).not.toContain("grep");
+      expectProbeResult(result, "ABSENT");
+      expect(probeDiagnosticsContainToken(scanner, result, token)).toBe(false);
+      fs.rmSync(path.join(procRoot, String(result.pid)), { recursive: true, force: true });
+
+      const traced = spawnSync("sh", ["-x", "-c", scanner], { encoding: "utf8" });
+      expect(traced.status, traced.stderr).toBe(0);
+      expect(traced.stdout.trim()).toBe("ABSENT");
+      expect(probeDiagnosticsContainToken(scanner, traced, token)).toBe(false);
+    }));
+
+  it("reports the PID whose NUL-separated command line contains the literal token", () =>
+    withFakeProcRoot((procRoot) => {
+      const token = `literal-process-secret-${process.pid}\n`;
+      const scanner = buildProcessTokenProbe(token, procRoot);
+      writeCmdline(procRoot, "1111", ["node", "worker.js", `--token=${token.slice(0, -1)}`, ""]);
+      writeCmdline(procRoot, "4242", ["node", "worker.js", `--token=${token}`]);
+
+      const result = runProbe(scanner);
+
+      expectProbeResult(result, "FOUND pid=4242");
+      expect(probeDiagnosticsContainToken(scanner, result, token)).toBe(false);
+
+      const noglob = spawnSync("sh", ["-f", "-c", scanner], { encoding: "utf8" });
+      expectProbeResult(noglob, "FOUND pid=4242");
+    }));
+
+  it("ignores missing and disappearing proc entries", () =>
+    withFakeProcRoot((procRoot) => {
+      fs.mkdirSync(path.join(procRoot, "1001"));
+      fs.mkdirSync(path.join(procRoot, "1002"));
+      fs.symlinkSync(
+        path.join(procRoot, "already-disappeared"),
+        path.join(procRoot, "1002", "cmdline"),
+      );
+
+      const result = runProbe(buildProcessTokenProbe("missing-entry-secret", procRoot));
+
+      expectProbeResult(result, "ABSENT");
+    }));
+
+  it("tolerates inspect-time disappearance but fails closed on transform errors", () =>
+    withFakeProcRoot((procRoot) => {
+      const token = `disappearing-process-secret-${process.pid}`;
+      const scanner = buildProcessTokenProbe(token, procRoot);
+      writeCmdline(procRoot, "2002", ["worker", token]);
+      const cmdlinePath = path.join(procRoot, "2002", "cmdline");
+      const shimDir = path.join(procRoot, "bin");
+      const trShim = path.join(shimDir, "tr");
+      fs.mkdirSync(shimDir);
+      fs.writeFileSync(
+        trShim,
+        `#!/bin/sh
+case "$NEMOCLAW_TEST_TR_MODE" in
+  disappear) rm -f "$NEMOCLAW_TEST_TR_PATH" ;;
+esac
+exit 1
+`,
+        { mode: 0o755 },
+      );
+      const env = {
+        ...process.env,
+        PATH: `${shimDir}:${process.env.PATH ?? ""}`,
+        NEMOCLAW_TEST_TR_PATH: cmdlinePath,
+      };
+
+      const disappeared = spawnSync("sh", ["-c", scanner], {
+        encoding: "utf8",
+        env: { ...env, NEMOCLAW_TEST_TR_MODE: "disappear" },
+      });
+      expectProbeResult(disappeared, "ABSENT");
+
+      fs.writeFileSync(cmdlinePath, Buffer.from(`worker\0${token}\0`));
+      const transformFailure = spawnSync("sh", ["-c", scanner], {
+        encoding: "utf8",
+        env: { ...env, NEMOCLAW_TEST_TR_MODE: "fail" },
+      });
+      expect(transformFailure.status).toBe(2);
+      expect(transformFailure.stdout).toBe("");
+      expect(transformFailure.stderr).toBe("");
+    }));
+
+  it("matches shell metacharacters literally without command injection", () =>
+    withFakeProcRoot((procRoot) => {
+      const marker = path.join(procRoot, "injected");
+      const token = `meta-*?[ab];$(touch ${marker})`;
+      const decoy = `meta-XYa;$(touch ${marker})`;
+      const scanner = buildProcessTokenProbe(token, procRoot);
+      writeCmdline(procRoot, "1111", ["worker", decoy]);
+      writeCmdline(procRoot, "4242", ["worker", token]);
+
+      const result = runProbe(scanner);
+
+      expectProbeResult(result, "FOUND pid=4242");
+      expect(fs.existsSync(marker)).toBe(false);
+      expect(probeDiagnosticsContainToken(scanner, result, token)).toBe(false);
+    }));
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Prevents the messaging-provider and Hermes Discord raw-token process probes from matching their own external matcher process. The shared test-only scanner keeps genuine command-line leak detection strict while emitting only `ABSENT` or the matching PID.

## Changes
- Add a shared E2E process-token scanner that keeps the decoded token unexported, excludes its own PID, tolerates disappearing `/proc` entries, and compares literally with the shell built-in `case`.
- Use the scanner in the `messaging-providers` and `hermes-discord` process branches without changing their environment or filesystem leak checks.
- Add fake-`/proc` regression coverage for encoded self-commands, genuine NUL-separated cmdlines, scanner PID exclusion, disappearing entries, shell metacharacters, xtrace/noglob state, and fail-closed transform errors.
- Differential Linux proof with no NemoClaw product process: the old scanner self-matched 28/100 runs; the new scanner returned `ABSENT`; after deliberately placing the token in one process argv, the new scanner returned that exact PID.
- Before-fix evidence: [main E2E run 28558629411, attempt 1](https://github.com/NVIDIA/NemoClaw/actions/runs/28558629411/attempts/1) failed `messaging-providers` after `retry x2` with Slack bot, Slack app, and WeChat process probes reporting `FOUND`.
- After-fix evidence: [exact-head selective E2E run 28563521798](https://github.com/NVIDIA/NemoClaw/actions/runs/28563521798) passed `hermes-discord` and `messaging-providers` on workflow attempt 1 with no Vitest retry marker. Artifacts `8028519602` and `8028523225` show the Hermes probe and all seven messaging process probes returned `ABSENT`, exit code 0, no timeout, and empty stderr.
- Local verification passed for the focused `e2e-support` test (6/6), `npm run typecheck:cli`, `npm run test-conditionals:scan -- --top 25`, repository checks, gitleaks, source-shape budget, test-size budget, commitlint, and pre-push typecheck/version sync. The full integration hook is not claimed because this macOS host has BSD `script`, while an unchanged integration test requires util-linux `script -qec`; Linux CI remains required.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal E2E probe behavior only; no product, workflow interface, or user-facing behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending GitHub maintainer review; two independent local reviews found no remaining blocker
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
