### PR TITLE
fix(cli): validate Git signing format in developer doctor

### DIFF
--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -173,19 +173,21 @@ check_git_configuration() {
   fi
 
   sign_enabled="$(git_config commit.gpgsign)"
-  sign_format="$(git_config gpg.format)"
+  if ! sign_format="$(git -C "${REPO_ROOT}" config --get gpg.format 2>/dev/null)"; then
+    sign_format="openpgp"
+  fi
   signing_key="$(git_config user.signingkey)"
   case "${sign_format}" in
-    "" | openpgp | ssh | x509)
+    openpgp | ssh | x509)
       if [ "${sign_enabled}" = "true" ] && [ -n "${signing_key}" ]; then
-        pass "Git commit signing configured (${sign_format:-openpgp})"
+        pass "Git commit signing configured (${sign_format})"
       else
         fail "Git commit signing is incomplete" \
           "Configure user.signingkey and set commit.gpgsign=true before committing."
       fi
       ;;
     *)
-      fail "Git commit signing format is unsupported (${sign_format})" \
+      fail "Git commit signing format is unsupported (${sign_format:-empty})" \
         "Set gpg.format to openpgp, ssh, or x509, or run: git config --unset gpg.format"
       ;;
   esac

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -175,12 +175,20 @@ check_git_configuration() {
   sign_enabled="$(git_config commit.gpgsign)"
   sign_format="$(git_config gpg.format)"
   signing_key="$(git_config user.signingkey)"
-  if [ "${sign_enabled}" = "true" ] && [ -n "${signing_key}" ]; then
-    pass "Git commit signing configured (${sign_format:-openpgp})"
-  else
-    fail "Git commit signing is incomplete" \
-      "Configure user.signingkey and set commit.gpgsign=true before committing."
-  fi
+  case "${sign_format}" in
+    "" | openpgp | ssh | x509)
+      if [ "${sign_enabled}" = "true" ] && [ -n "${signing_key}" ]; then
+        pass "Git commit signing configured (${sign_format:-openpgp})"
+      else
+        fail "Git commit signing is incomplete" \
+          "Configure user.signingkey and set commit.gpgsign=true before committing."
+      fi
+      ;;
+    *)
+      fail "Git commit signing format is unsupported (${sign_format})" \
+        "Set gpg.format to openpgp, ssh, or x509, or run: git config --unset gpg.format"
+      ;;
+  esac
 
   hooks_path="$(git_config core.hooksPath)"
   if [ -n "${hooks_path}" ]; then

--- a/test/dev-setup-doctor.test.ts
+++ b/test/dev-setup-doctor.test.ts
@@ -93,7 +93,10 @@ fi`,
     if [ "\${FAKE_GIT_SIGNING_MISSING:-}" = "1" ]; then exit 1; fi
     echo "true"
     ;;
-  *" config --get gpg.format "*) echo "ssh" ;;
+  *" config --get gpg.format "*)
+    if [ "\${FAKE_GIT_SIGN_FORMAT_UNSET:-}" = "1" ]; then exit 1; fi
+    echo "\${FAKE_GIT_SIGN_FORMAT:-ssh}"
+    ;;
   *" config --get user.signingkey "*)
     if [ "\${FAKE_GIT_SIGNING_MISSING:-}" = "1" ]; then exit 1; fi
     echo "test-signing-key"
@@ -252,6 +255,37 @@ describe("contributor environment doctor", () => {
     expect(result.status).toBe(1);
     expect(result.output).toContain("Git commit signing is incomplete");
     expect(result.output).toContain("Git pre-push hook is missing");
+  });
+
+  it("rejects an unsupported git signing format with a precise remediation", () => {
+    const fixture = createFixture();
+
+    const result = runDoctor(fixture, { FAKE_GIT_SIGN_FORMAT: "bogus" });
+
+    expect(result.status).toBe(1);
+    expect(result.output).not.toContain("Git commit signing configured");
+    expect(result.output).toContain("Git commit signing format is unsupported (bogus)");
+    expect(result.output).toContain(
+      "Next: Set gpg.format to openpgp, ssh, or x509, or run: git config --unset gpg.format",
+    );
+  });
+
+  it("accepts an unset git signing format and reports the openpgp default", () => {
+    const fixture = createFixture();
+
+    const result = runDoctor(fixture, { FAKE_GIT_SIGN_FORMAT_UNSET: "1" });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("Git commit signing configured (openpgp)");
+  });
+
+  it.each(["openpgp", "x509"])("accepts the %s git signing format", (format) => {
+    const fixture = createFixture();
+
+    const result = runDoctor(fixture, { FAKE_GIT_SIGN_FORMAT: format });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(`Git commit signing configured (${format})`);
   });
 
   it("reports missing commands, dependencies, artifacts, and contributor identity", () => {

--- a/test/dev-setup-doctor.test.ts
+++ b/test/dev-setup-doctor.test.ts
@@ -95,7 +95,7 @@ fi`,
     ;;
   *" config --get gpg.format "*)
     if [ "\${FAKE_GIT_SIGN_FORMAT_UNSET:-}" = "1" ]; then exit 1; fi
-    echo "\${FAKE_GIT_SIGN_FORMAT:-ssh}"
+    echo "\${FAKE_GIT_SIGN_FORMAT-ssh}"
     ;;
   *" config --get user.signingkey "*)
     if [ "\${FAKE_GIT_SIGNING_MISSING:-}" = "1" ]; then exit 1; fi
@@ -277,6 +277,17 @@ describe("contributor environment doctor", () => {
 
     expect(result.status).toBe(0);
     expect(result.output).toContain("Git commit signing configured (openpgp)");
+  });
+
+  it("rejects an explicitly empty git signing format", () => {
+    const fixture = createFixture();
+
+    const result = runDoctor(fixture, { FAKE_GIT_SIGN_FORMAT: "" });
+
+    expect(result.status).toBe(1);
+    expect(result.output).not.toContain("Git commit signing configured");
+    expect(result.output).not.toContain("Ready to create a feature branch.");
+    expect(result.output).toContain("Git commit signing format is unsupported (empty)");
   });
 
   it.each(["openpgp", "x509"])("accepts the %s git signing format", (format) => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`check_git_configuration` in `scripts/dev-setup.sh` echoed `gpg.format` back into its "Git commit signing configured" pass message without validating it, so an unsupported value (for example, `gpg.format=bogus`) still reported contributor readiness even though Git would reject that format at commit time. This PR distinguishes an absent setting (Git's `openpgp` default) from configured values, accepts only `openpgp`, `ssh`, and `x509`, and rejects explicitly empty or unsupported values with precise remediation.

## Related Issue

Fixes #6119

## Attribution

- Original implementation and PR author: Dongni Yang (`@Dongni-Yang`).
- The edge-case follow-up commit credits Dongni with `Co-authored-by: Dongni Yang <dongniy@nvidia.com>`.

## Changes

- `scripts/dev-setup.sh`: `check_git_configuration` preserves whether `gpg.format` is absent, defaults only an absent setting to `openpgp`, and accepts configured `openpgp`, `ssh`, or `x509` values. Explicitly empty or unsupported values fail with remediation. Existing `commit.gpgsign` and `user.signingkey` checks are unchanged for valid formats.
- `test/dev-setup-doctor.test.ts`: parameterizes the fake `git` fixture's `gpg.format` response and adds regression tests covering unsupported and explicitly empty formats, an unset format, and valid `openpgp`, `ssh`, and `x509` formats.

## Type of Change

<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing

<!-- What testing was done? -->
- [ ] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

Verification evidence:

- `npx vitest run --project integration test/dev-setup-doctor.test.ts` — 16/16 passing, including a red-before/green-after regression test for explicitly empty `gpg.format`.
- `npm run build:cli`, `npm run typecheck:cli`, `npm run checks`, `npm run test:titles:check`, and `npm run test-size:check` passed.
- Repository-managed shfmt, ShellCheck, Biome, repository checks, secret scanning, commitlint, and pre-push hooks passed.
- The broad local `test-cli` hook was stopped after more than 30 minutes while still progressing through unrelated integration cases. On updated head `bdf422f7`, GitHub CI completed 41 checks with no failures, including all five CLI shards, aggregate CLI tests, ShellCheck, CodeQL, sandbox-image checks, and platform E2E checks.

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [ ] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes

<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [x] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes — not applicable; this is a contributor-doctor correctness fix and existing contributor guidance remains accurate.

### Doc Changes

<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "/update-docs catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git commit signing validation during environment setup to correctly interpret signing format settings, including when unset.
  * Added clearer guidance when signing information is incomplete or when an unsupported signing format is provided.
  * Correctly accepts common signing formats and rejects empty or unsupported values with appropriate messaging.
* **Tests**
  * Expanded the environment doctor checks to cover supported, unsupported, unset, and empty signing format scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
