### PR TITLE
feat(cli): show a concrete example in the unknown sandbox action error

### DIFF
--- a/src/lib/cli/public-dispatch.ts
+++ b/src/lib/cli/public-dispatch.ts
@@ -320,6 +320,7 @@ async function runPublicTranslationResult(
     case "unknownPublicAction":
       console.error(`  Unknown action: ${result.action}`);
       console.error(`  Valid actions: ${validSandboxActionsText()}`);
+      console.error(`  Example: ${CLI_NAME} ${opts.sandboxName ?? "<name>"} connect`);
       process.exit(1);
   }
 }

--- a/test/cli/unknown-sandbox-action.test.ts
+++ b/test/cli/unknown-sandbox-action.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { runWithEnv, testTimeoutOptions, writeSandboxRegistry } from "./helpers";
+
+describe("unknown sandbox action guidance (#755)", () => {
+  it("lists valid actions and a concrete example command", testTimeoutOptions(15_000), () => {
+    // The unknown-action path only triggers once the first token resolves to
+    // a registered sandbox; otherwise dispatch reports an unknown command.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-unknown-action-"));
+    writeSandboxRegistry(home, "alpha");
+
+    // `2>&1` folds stderr into the captured output; the guidance is written to
+    // stderr before the command exits non-zero.
+    const r = runWithEnv("alpha definitely-not-an-action 2>&1", { HOME: home });
+
+    expect(r.code).not.toBe(0);
+    expect(r.out).toContain("Unknown action: definitely-not-an-action");
+    expect(r.out).toContain("Valid actions:");
+    // The concrete example uses the sandbox name the user actually typed.
+    expect(r.out).toContain("alpha connect");
+  });
+});


### PR DESCRIPTION
## Summary

The unknown-action error for sandbox commands listed the valid actions but no concrete example. This appends an example command that uses the sandbox name the user typed, e.g. `nemoclaw <name> connect`, satisfying the last unmet acceptance criterion in #755 (unknown sandbox actions should list valid actions *and* a concrete example).

## Related Issue

Refs #755

## Changes

- `src/lib/cli/public-dispatch.ts`: the `unknownPublicAction` branch now prints `  Example: <cli> <name> connect` after the valid-actions list, matching the existing `Did you mean:` / command-order hint patterns already in that file.
- `test/cli/unknown-sandbox-action.test.ts`: new test asserting an unknown sandbox action reports the valid actions and the concrete example.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable — justification: CLI error-output only; no user-facing docs affected.

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push
- [x] Targeted tests pass for changed behavior
- [x] No secrets, API keys, or credentials committed

Ran: `npx @biomejs/biome check` (pass), `npm run typecheck` (pass), `npm run build:cli`, and `vitest run test/cli/unknown-sandbox-action.test.ts` (pass).

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI guidance when an unknown sandbox action is entered.
  * The error message now includes a clearer example command, using the sandbox name when available.
  * Added test coverage to confirm the CLI shows the expected error, valid actions, and example usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->