### PR TITLE
fix(installer): skip unreachable running sandboxes in pre-upgrade backup

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1400,7 +1400,8 @@ nemohermes backup-all
 The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
 
 A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run.
-Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
+Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` (exactly — other values like `true`, `yes`, or `0` are not accepted) to skip such sandboxes and continue the upgrade.
+Skipped sandboxes are recovered from their latest validated backup during onboarding; any uncommitted state since that backup will be lost.
 
 ### `nemohermes <name> snapshot create`
 

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1399,7 +1399,8 @@ nemohermes backup-all
 
 The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
 
-A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run. Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
+A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run.
+Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
 
 ### `nemohermes <name> snapshot create`
 

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1390,6 +1390,8 @@ nemohermes backup-all
 
 The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
 
+A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run. Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
+
 ### `nemohermes <name> snapshot create`
 
 Create a timestamped snapshot of sandbox state.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1401,7 +1401,9 @@ The installer calls `backup-all` automatically before onboarding to protect agai
 
 A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run.
 Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` (exactly — other values like `true`, `yes`, or `0` are not accepted) to skip such sandboxes and continue the upgrade.
-Skipped sandboxes are recovered from their latest validated backup during onboarding; any uncommitted state since that backup will be lost.
+When the installer invokes `backup-all` before an OpenShell upgrade, skipped sandboxes are automatically restored from their latest validated backup during post-upgrade onboarding.
+Standalone `nemohermes backup-all` invocations only skip the failure — they do not schedule a subsequent restore.
+Any uncommitted state since the last successful backup will be lost.
 
 ### `nemohermes <name> snapshot create`
 
@@ -2137,6 +2139,7 @@ The following flags change defaults for commands that manage existing sandboxes.
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `nemohermes <name> connect` and `nemohermes <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 | `NEMOCLAW_SHIELDS_ACCEPT_LEGACY_BASELINE` | `1` to opt in | Allows advanced immutable-config verification to trust the current on-disk bytes for older or partial content baselines. Use only after you have rebuilt or manually inspected the sandbox state and accepted that the baseline is operator-approved. |
 | `NEMOCLAW_SHIELDS_SETTLE_MS` | milliseconds (default `750`, clamped to `0` to `10000`) | Settle window NemoClaw waits after re-applying a config lockdown (during shields auto-restore and `nemohermes <name> shields up` drift remediation) before re-confirming the lock still holds. Detects when an in-sandbox reconciler changes config file permissions after lockdown and re-applies the lock; if NemoClaw cannot re-confirm the lock within the retry budget, shields stay down. This narrows the window in which a reconciler can revert permissions rather than eliminating it. The best-effort `chattr +i` immutable bit remains the only fully durable lock. Raise it on hosts where the gateway settles slowly. |
+| `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP` | Exactly `1` to opt in (`true`, `yes`, `0` are not accepted) | Applies to the installer's automatic pre-upgrade `nemohermes backup-all` and to manual `nemohermes backup-all` runs. Skips running sandboxes whose in-sandbox SSH endpoint does not answer so the upgrade proceeds instead of aborting. Skipped sandboxes are restored from their latest validated backup during the installer's post-upgrade onboarding; any uncommitted state since that backup is lost. Standalone `nemohermes backup-all` invocations only skip the failure — they do not schedule a subsequent restore. |
 | `NEMOCLAW_UNINSTALL_DESTROY_USER_DATA` | `1` to opt in | Acknowledges data loss during `nemohermes uninstall` and removes the otherwise-preserved entries (`rebuild-backups/`, `backups/`, `sandboxes.json`) under `~/.nemoclaw/`. Equivalent to passing the `--destroy-user-data` flag; the global `Proceed?` confirmation still applies unless `--yes` is also passed. |
 
 ### Legacy `nemohermes setup`

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1769,7 +1769,8 @@ $$nemoclaw backup-all
 The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
 
 A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run.
-Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
+Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` (exactly — other values like `true`, `yes`, or `0` are not accepted) to skip such sandboxes and continue the upgrade.
+Skipped sandboxes are recovered from their latest validated backup during onboarding; any uncommitted state since that backup will be lost.
 
 ### `$$nemoclaw <name> snapshot create`
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1759,6 +1759,8 @@ $$nemoclaw backup-all
 
 The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
 
+A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run. Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
+
 ### `$$nemoclaw <name> snapshot create`
 
 Create a timestamped snapshot of sandbox state.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1770,7 +1770,9 @@ The installer calls `backup-all` automatically before onboarding to protect agai
 
 A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run.
 Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` (exactly — other values like `true`, `yes`, or `0` are not accepted) to skip such sandboxes and continue the upgrade.
-Skipped sandboxes are recovered from their latest validated backup during onboarding; any uncommitted state since that backup will be lost.
+When the installer invokes `backup-all` before an OpenShell upgrade, skipped sandboxes are automatically restored from their latest validated backup during post-upgrade onboarding.
+Standalone `$$nemoclaw backup-all` invocations only skip the failure — they do not schedule a subsequent restore.
+Any uncommitted state since the last successful backup will be lost.
 
 ### `$$nemoclaw <name> snapshot create`
 
@@ -2622,6 +2624,7 @@ The following flags change defaults for commands that manage existing sandboxes.
 | `NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR` | `1` to enable | Skips the automatic DNS-proxy repair for stale `inference.local` routes during `$$nemoclaw <name> connect` and `$$nemoclaw <name> connect --probe-only`. Use only as a troubleshooting escape hatch. |
 | `NEMOCLAW_SHIELDS_ACCEPT_LEGACY_BASELINE` | `1` to opt in | Allows advanced immutable-config verification to trust the current on-disk bytes for older or partial content baselines. Use only after you have rebuilt or manually inspected the sandbox state and accepted that the baseline is operator-approved. |
 | `NEMOCLAW_SHIELDS_SETTLE_MS` | milliseconds (default `750`, clamped to `0` to `10000`) | Settle window NemoClaw waits after re-applying a config lockdown (during shields auto-restore and `$$nemoclaw <name> shields up` drift remediation) before re-confirming the lock still holds. Detects when an in-sandbox reconciler changes config file permissions after lockdown and re-applies the lock; if NemoClaw cannot re-confirm the lock within the retry budget, shields stay down. This narrows the window in which a reconciler can revert permissions rather than eliminating it. The best-effort `chattr +i` immutable bit remains the only fully durable lock. Raise it on hosts where the gateway settles slowly. |
+| `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP` | Exactly `1` to opt in (`true`, `yes`, `0` are not accepted) | Applies to the installer's automatic pre-upgrade `$$nemoclaw backup-all` and to manual `$$nemoclaw backup-all` runs. Skips running sandboxes whose in-sandbox SSH endpoint does not answer so the upgrade proceeds instead of aborting. Skipped sandboxes are restored from their latest validated backup during the installer's post-upgrade onboarding; any uncommitted state since that backup is lost. Standalone `$$nemoclaw backup-all` invocations only skip the failure — they do not schedule a subsequent restore. |
 | `NEMOCLAW_UNINSTALL_DESTROY_USER_DATA` | `1` to opt in | Acknowledges data loss during `$$nemoclaw uninstall` and removes the otherwise-preserved entries (`rebuild-backups/`, `backups/`, `sandboxes.json`) under `~/.nemoclaw/`. Equivalent to passing the `--destroy-user-data` flag; the global `Proceed?` confirmation still applies unless `--yes` is also passed. |
 
 <AgentOnly variant="openclaw">

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1768,7 +1768,8 @@ $$nemoclaw backup-all
 
 The installer calls `backup-all` automatically before onboarding to protect against data loss during OpenShell upgrades.
 
-A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run. Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
+A running sandbox whose in-sandbox SSH endpoint does not answer fails its backup and aborts the run.
+Set `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip such sandboxes and continue the upgrade; they are recovered from their latest validated backup during onboarding.
 
 ### `$$nemoclaw <name> snapshot create`
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1907,7 +1907,7 @@ preinstall_backup_and_retire_legacy_gateway() {
     if legacy_openshell_gateway_upgrade_needed "$old_openshell_version"; then
       error "Pre-upgrade backup failed. Aborting before retiring the legacy OpenShell gateway."
     fi
-    error "Pre-upgrade backup failed. If the failures are running sandboxes whose in-sandbox SSH endpoint is unreachable, rerun the installer with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 to continue and recover them after the upgrade; otherwise restore the affected sandbox or stop its container, then rerun '${_CLI_BIN} backup-all'."
+    error "Pre-upgrade backup failed. If the failures are running sandboxes whose in-sandbox SSH endpoint is unreachable, rerun the installer with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 to continue and recover them after the upgrade (any uncommitted state since the last successful backup will be lost); otherwise restore the affected sandbox or stop its container, then rerun '${_CLI_BIN} backup-all'."
   fi
   export NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE=1
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1722,18 +1722,14 @@ resolve_prepared_cli_runner() {
 }
 
 run_preupgrade_backup() {
-  local old_cli_runner="$1" old_openshell_version="$2"
+  local old_cli_runner="$1"
 
   if "$old_cli_runner" backup-all 2>&1; then
     return 0
   fi
 
-  if ! legacy_openshell_gateway_upgrade_needed "$old_openshell_version"; then
-    return 1
-  fi
-
   warn "Pre-upgrade backup with the existing ${_CLI_BIN} CLI failed."
-  warn "Retrying with the current ${_CLI_DISPLAY} CLI before retiring the legacy OpenShell gateway."
+  warn "Retrying with the current ${_CLI_DISPLAY} CLI, which supports NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP."
   if ! prepare_current_cli_for_preupgrade_backup; then
     warn "Could not prepare the current ${_CLI_DISPLAY} CLI for backup retry."
     return 1
@@ -1907,7 +1903,7 @@ preinstall_backup_and_retire_legacy_gateway() {
   fi
 
   info "Backing up ${sandbox_count} sandbox(es) before upgrading OpenShell…"
-  if ! run_preupgrade_backup "$old_cli_runner" "$old_openshell_version"; then
+  if ! run_preupgrade_backup "$old_cli_runner"; then
     if legacy_openshell_gateway_upgrade_needed "$old_openshell_version"; then
       error "Pre-upgrade backup failed. Aborting before retiring the legacy OpenShell gateway."
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1911,7 +1911,7 @@ preinstall_backup_and_retire_legacy_gateway() {
     if legacy_openshell_gateway_upgrade_needed "$old_openshell_version"; then
       error "Pre-upgrade backup failed. Aborting before retiring the legacy OpenShell gateway."
     fi
-    error "Pre-upgrade backup failed. Fix the OpenShell gateway state, rerun '${_CLI_BIN} backup-all', then rerun the installer."
+    error "Pre-upgrade backup failed. If the failures are running sandboxes whose in-sandbox SSH endpoint is unreachable, rerun the installer with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 to continue and recover them after the upgrade; otherwise restore the affected sandbox or stop its container, then rerun '${_CLI_BIN} backup-all'."
   fi
   export NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE=1
 

--- a/src/lib/actions/maintenance.test.ts
+++ b/src/lib/actions/maintenance.test.ts
@@ -54,7 +54,7 @@ vi.mock("../domain/maintenance/images", () => ({
   parseSandboxImageRows: vi.fn().mockReturnValue([]),
 }));
 
-import { backupAll } from "./maintenance";
+import { backupAll, shouldSkipUnreachableSandboxBackup } from "./maintenance";
 
 describe("backupAll", () => {
   beforeEach(() => {
@@ -185,5 +185,96 @@ describe("backupAll", () => {
     });
 
     await expect(backupAll()).rejects.toThrow(/binary/);
+  });
+
+  it("skips a running but SSH-unreachable sandbox when NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }, { name: "sb-good" }],
+      defaultSandbox: null,
+    });
+    mocks.backupSandboxState.mockImplementation((name: string) =>
+      name === "sb-bad"
+        ? {
+            success: false,
+            unreachable: true,
+            backedUpDirs: [],
+            failedDirs: ["memories"],
+            backedUpFiles: [],
+            failedFiles: [],
+          }
+        : {
+            success: true,
+            backedUpDirs: ["dir1"],
+            failedDirs: [],
+            backedUpFiles: [],
+            failedFiles: [],
+            manifest: { backupPath: "/backups/sb-good/timestamp" },
+          },
+    );
+
+    process.env.NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP = "1";
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await backupAll();
+
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("Skipped 'sb-bad'");
+    expect(output).toContain("1 backed up, 0 failed, 1 skipped");
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    delete process.env.NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP;
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("fails with actionable guidance when a running sandbox is unreachable and the skip flag is unset", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      sandboxes: [{ name: "sb-bad" }],
+      defaultSandbox: null,
+    });
+    mocks.parseReadySandboxNames.mockReturnValue(new Set(["sb-bad"]));
+    mocks.captureSandboxListWithGatewayRecovery.mockResolvedValue({
+      result: { status: 0, output: "sb-bad\n" },
+    });
+    mocks.backupSandboxState.mockImplementation(() => ({
+      success: false,
+      unreachable: true,
+      backedUpDirs: [],
+      failedDirs: ["memories"],
+      backedUpFiles: [],
+      failedFiles: [],
+    }));
+
+    delete process.env.NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await expect(backupAll()).rejects.toThrow("exit:1");
+
+    const errorOutput = errorSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(errorOutput).toContain("NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1");
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+describe("shouldSkipUnreachableSandboxBackup", () => {
+  it("is true only for exactly '1'", () => {
+    expect(
+      shouldSkipUnreachableSandboxBackup({ NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP: "1" }),
+    ).toBe(true);
+    expect(
+      shouldSkipUnreachableSandboxBackup({ NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP: "0" }),
+    ).toBe(false);
+    expect(
+      shouldSkipUnreachableSandboxBackup({ NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP: "true" }),
+    ).toBe(false);
+    expect(shouldSkipUnreachableSandboxBackup({})).toBe(false);
   });
 });

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -131,7 +131,7 @@ export async function backupAll(): Promise<void> {
       if (result.unreachable) {
         if (skipUnreachable) {
           console.log(
-            `  ${YW}⚠${R} Skipped '${sb.name}' (running but SSH-unreachable; NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 set)`,
+            `  ${YW}⚠${R} Skipped '${sb.name}' (running but SSH-unreachable; NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 set). Any uncommitted state since the last successful backup will be lost.`,
           );
           skipped++;
           continue;
@@ -155,7 +155,7 @@ export async function backupAll(): Promise<void> {
         `  ${unreachableRunning} running sandbox(es) could not be backed up because their in-sandbox SSH endpoint did not answer.`,
       );
       console.error(
-        `  To upgrade now and recover them afterwards from their latest validated backup, re-run with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1.`,
+        `  To upgrade now and recover them afterwards from their latest validated backup, re-run with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1. Any uncommitted state since the last successful backup will be lost.`,
       );
       console.error(
         `  To preserve their current state first, stop the affected container (so it is skipped as not running) or restore its gateway health, then run '${CLI_NAME} backup-all' again.`,

--- a/src/lib/actions/maintenance.ts
+++ b/src/lib/actions/maintenance.ts
@@ -31,6 +31,10 @@ const R = useColor ? "\x1b[0m" : "";
 const RD = useColor ? "\x1b[1;31m" : "";
 const YW = useColor ? "\x1b[1;33m" : "";
 
+export function shouldSkipUnreachableSandboxBackup(env: NodeJS.ProcessEnv): boolean {
+  return env.NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP === "1";
+}
+
 export async function backupAll(): Promise<void> {
   const { sandboxes } = registry.listSandboxes();
   if (sandboxes.length === 0) {
@@ -63,9 +67,11 @@ export async function backupAll(): Promise<void> {
   }
   const readyNames = parseReadySandboxNames(liveList.output || "");
 
+  const skipUnreachable = shouldSkipUnreachableSandboxBackup(process.env);
   let backed = 0;
   let failed = 0;
   let skipped = 0;
+  let unreachableRunning = 0;
   for (const sb of sandboxes) {
     if (!readyNames.has(sb.name)) {
       console.log(`  ${D}Skipping '${sb.name}' (not running)${R}`);
@@ -122,6 +128,16 @@ export async function backupAll(): Promise<void> {
       );
       backed++;
     } else {
+      if (result.unreachable) {
+        if (skipUnreachable) {
+          console.log(
+            `  ${YW}⚠${R} Skipped '${sb.name}' (running but SSH-unreachable; NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 set)`,
+          );
+          skipped++;
+          continue;
+        }
+        unreachableRunning++;
+      }
       const failedItems = [...result.failedDirs, ...result.failedFiles];
       console.error(`  ${RD}✗${R} ${sb.name}: backup failed (${failedItems.join(", ")})`);
       failed++;
@@ -133,6 +149,18 @@ export async function backupAll(): Promise<void> {
     console.log(`  Backups stored in: ~/.nemoclaw/rebuild-backups/`);
   }
   if (failed > 0) {
+    if (unreachableRunning > 0) {
+      console.error("");
+      console.error(
+        `  ${unreachableRunning} running sandbox(es) could not be backed up because their in-sandbox SSH endpoint did not answer.`,
+      );
+      console.error(
+        `  To upgrade now and recover them afterwards from their latest validated backup, re-run with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1.`,
+      );
+      console.error(
+        `  To preserve their current state first, stop the affected container (so it is skipped as not running) or restore its gateway health, then run '${CLI_NAME} backup-all' again.`,
+      );
+    }
     process.exit(1);
   }
 }

--- a/src/lib/state/sandbox.test.ts
+++ b/src/lib/state/sandbox.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { isSshTransportFailure } from "./sandbox";
+
+describe("isSshTransportFailure", () => {
+  it("treats an ssh transport failure exit code (255) as unreachable", () => {
+    expect(isSshTransportFailure({ status: 255 })).toBe(true);
+  });
+
+  it("treats a timed-out or signal-killed probe (null status) as unreachable", () => {
+    expect(isSshTransportFailure({ status: null })).toBe(true);
+  });
+
+  it("treats a spawn error as unreachable", () => {
+    expect(isSshTransportFailure({ status: null, error: new Error("spawn ETIMEDOUT") })).toBe(true);
+  });
+
+  it("does not treat a reachable non-zero remote exit as unreachable", () => {
+    expect(isSshTransportFailure({ status: 1 })).toBe(false);
+    expect(isSshTransportFailure({ status: 2 })).toBe(false);
+  });
+
+  it("does not treat a successful probe as unreachable", () => {
+    expect(isSshTransportFailure({ status: 0 })).toBe(false);
+  });
+});

--- a/src/lib/state/sandbox.test.ts
+++ b/src/lib/state/sandbox.test.ts
@@ -26,4 +26,17 @@ describe("isSshTransportFailure", () => {
   it("does not treat a successful probe as unreachable", () => {
     expect(isSshTransportFailure({ status: 0 })).toBe(false);
   });
+
+  it("treats SIGHUP/SIGPIPE terminated probes as transport failures", () => {
+    // spawnSync surfaces signal-killed processes with status=null + signal set.
+    // Match connect.ts by naming the transport-level signals explicitly.
+    expect(isSshTransportFailure({ status: null, signal: "SIGHUP" })).toBe(true);
+    expect(isSshTransportFailure({ status: null, signal: "SIGPIPE" })).toBe(true);
+  });
+
+  it("does not treat a reachable exit accompanied by a benign signal as unreachable", () => {
+    // A remote exit-1 with a stale/benign signal field must still be classified
+    // by exit code, not by the signal field.
+    expect(isSshTransportFailure({ status: 1, signal: "SIGINT" })).toBe(false);
+  });
 });

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -121,6 +121,7 @@ export interface BackupResult {
   error?: string;
   backedUpFiles: string[];
   failedFiles: string[];
+  unreachable?: boolean;
 }
 
 export interface RestoreResult {
@@ -1018,6 +1019,12 @@ function restoreStateFile(
  * Back up all state directories from a running sandbox.
  * Uses the agent manifest to determine which directories contain state.
  */
+export function isSshTransportFailure(result: { status: number | null; error?: Error }): boolean {
+  if (result.error) return true;
+  if (result.status === null) return true;
+  return result.status === 255;
+}
+
 export function backupSandboxState(sandboxName: string, options: BackupOptions = {}): BackupResult {
   const sb = registry.getSandbox(sandboxName);
   const agentName = sb?.agent || "openclaw";
@@ -1168,6 +1175,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         );
         return {
           success: false,
+          unreachable: isSshTransportFailure(existResult),
           manifest,
           backedUpDirs,
           failedDirs: [...stateDirs],

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -121,6 +121,9 @@ export interface BackupResult {
   error?: string;
   backedUpFiles: string[];
   failedFiles: string[];
+  // Set when a failure stems from an SSH transport failure against a running
+  // sandbox (see isSshTransportFailure), as opposed to an audit rejection or
+  // a partial tar read error.
   unreachable?: boolean;
 }
 
@@ -1114,6 +1117,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
   const failedDirs: string[] = [];
   const backedUpFiles: string[] = [];
   const failedFiles: string[] = [];
+  let unreachable = false;
 
   if (stateDirs.length === 0 && stateFiles.length === 0) {
     _log("WARNING: Agent manifest declares no state_dirs or state_files — nothing to back up");
@@ -1222,6 +1226,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
           _log(`FAILED: Pre-backup audit command failed — ${detail}`);
           return {
             success: false,
+            unreachable: isSshTransportFailure(auditResult),
             manifest,
             backedUpDirs,
             failedDirs: [...existingDirs],
@@ -1289,6 +1294,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         _log(
           `SSH+tar download: exit=${result.status}, stdout=${result.stdout ? result.stdout.length + " bytes" : "null"}, stderr=${(result.stderr?.toString() || "").substring(0, 200)}`,
         );
+        if (isSshTransportFailure(result)) unreachable = true;
 
         // GNU tar exit codes: 0 = success, 1 = files changed during archive,
         // 2 = errors (e.g. permission denied) but archive still written to stdout.
@@ -1393,6 +1399,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
 
   return {
     success: failedDirs.length === 0 && failedFiles.length === 0,
+    unreachable,
     manifest,
     backedUpDirs,
     failedDirs,

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -1034,20 +1034,11 @@ function restoreStateFile(
  * Back up all state directories from a running sandbox.
  * Uses the agent manifest to determine which directories contain state.
  */
-export function isSshTransportFailure(result: {
-  status: number | null;
-  error?: Error;
-  signal?: NodeJS.Signals | null;
-}): boolean {
-  if (result.error) return true;
-  // Signal termination (e.g. SIGHUP/SIGPIPE from a dying gateway) reports
-  // status=null; match connect.ts and treat these as transport-level
-  // failures explicitly so the diagnostic path is unambiguous. Any other
-  // null-status result (timeout, killed) is also transport-level.
-  if (result.signal === "SIGHUP" || result.signal === "SIGPIPE") return true;
-  if (result.status === null) return true;
-  return result.status === 255;
-}
+
+// isSshTransportFailure is re-exported here for backwards compatibility with
+// callers that imported it from this module before it moved to ./ssh-transport.
+// Prefer importing directly from ./ssh-transport in new code.
+export { isSshTransportFailure } from "./ssh-transport";
 
 export function backupSandboxState(sandboxName: string, options: BackupOptions = {}): BackupResult {
   const sb = registry.getSandbox(sandboxName);

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -1022,8 +1022,17 @@ function restoreStateFile(
  * Back up all state directories from a running sandbox.
  * Uses the agent manifest to determine which directories contain state.
  */
-export function isSshTransportFailure(result: { status: number | null; error?: Error }): boolean {
+export function isSshTransportFailure(result: {
+  status: number | null;
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+}): boolean {
   if (result.error) return true;
+  // Signal termination (e.g. SIGHUP/SIGPIPE from a dying gateway) reports
+  // status=null; match connect.ts and treat these as transport-level
+  // failures explicitly so the diagnostic path is unambiguous. Any other
+  // null-status result (timeout, killed) is also transport-level.
+  if (result.signal === "SIGHUP" || result.signal === "SIGPIPE") return true;
   if (result.status === null) return true;
   return result.status === 255;
 }

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -39,6 +39,7 @@ import {
   shouldMergeOpenClawConfigStateFile,
 } from "./openclaw-config-restore-input.js";
 import type { CustomPolicyEntry } from "./registry.js";
+import { isSshTransportFailure } from "./ssh-transport.js";
 import * as registry from "./registry.js";
 import { runTarListing } from "./tar-listing.js";
 
@@ -1035,10 +1036,10 @@ function restoreStateFile(
  * Uses the agent manifest to determine which directories contain state.
  */
 
-// isSshTransportFailure is re-exported here for backwards compatibility with
-// callers that imported it from this module before it moved to ./ssh-transport.
-// Prefer importing directly from ./ssh-transport in new code.
-export { isSshTransportFailure } from "./ssh-transport";
+// isSshTransportFailure lives in ./ssh-transport now. Re-exported here for
+// backwards compatibility with callers that used to import it from this
+// module. Prefer importing directly from ./ssh-transport in new code.
+export { isSshTransportFailure };
 
 export function backupSandboxState(sandboxName: string, options: BackupOptions = {}): BackupResult {
   const sb = registry.getSandbox(sandboxName);

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -848,13 +848,25 @@ function buildStateFileBackupCommand(dir: string, spec: StateFileSpec): string {
   ].join("; ");
 }
 
+type StateFileBackupOutcome = "backed_up" | "missing" | "failed";
+
+interface StateFileBackupResult {
+  outcome: StateFileBackupOutcome;
+  // Set on "failed" when the SSH probe itself failed at the transport level
+  // (exit 255, signal-killed, spawn error). The caller (backupSandboxState)
+  // propagates this into BackupResult.unreachable so that
+  // NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 activates for state-file
+  // failures too, not only the initial dir probe. See #6188.
+  unreachable: boolean;
+}
+
 function backupStateFile(
   configFile: string,
   sandboxName: string,
   dir: string,
   spec: StateFileSpec,
   backupPath: string,
-): "backed_up" | "missing" | "failed" {
+): StateFileBackupResult {
   const command = buildStateFileBackupCommand(dir, spec);
   _log(`Backing up state file ${spec.path} (${spec.strategy})`);
   const result = spawnSync("ssh", [...sshArgs(configFile, sandboxName), command], {
@@ -863,14 +875,14 @@ function backupStateFile(
     maxBuffer: 256 * 1024 * 1024,
   });
 
-  if (result.status === 2) return "missing";
+  if (result.status === 2) return { outcome: "missing", unreachable: false };
   if (result.status !== 0 || result.error || result.signal || !result.stdout) {
     const detail =
       (result.stderr?.toString() || "").trim() ||
       result.error?.message ||
       (result.signal ? `signal ${result.signal}` : `exit ${String(result.status)}`);
     _log(`FAILED: state file backup ${spec.path}: ${detail.substring(0, 200)}`);
-    return "failed";
+    return { outcome: "failed", unreachable: isSshTransportFailure(result) };
   }
 
   const localPath = path.join(backupPath, spec.path);
@@ -880,7 +892,7 @@ function backupStateFile(
   rejectSymlinksOnPath(localPath);
   writeFileSync(localPath, result.stdout);
   chmodSync(localPath, 0o600);
-  return "backed_up";
+  return { outcome: "backed_up", unreachable: false };
 }
 
 export function buildStateFileRestoreCommand(
@@ -1139,6 +1151,10 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
   const sshConfig = getSshConfig(sandboxName);
   if (!sshConfig) {
     _log("FAILED: Could not get SSH config");
+    // For a sandbox the registry reported as running, an unreachable
+    // `openshell sandbox ssh-config` lookup is a transport-level failure —
+    // treat it the same as the initial dir probe and propagate `unreachable`
+    // so NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 can activate. (#6188)
     return {
       success: false,
       manifest,
@@ -1146,6 +1162,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
       failedDirs: [...stateDirs],
       backedUpFiles,
       failedFiles: stateFiles.map((f) => f.path),
+      unreachable: true,
     };
   }
   _log(`SSH config obtained (${sshConfig.length} bytes)`);
@@ -1370,10 +1387,14 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
 
     for (const spec of stateFiles) {
       const result = backupStateFile(configFile, sandboxName, dir, spec, backupPath);
-      if (result === "backed_up") {
+      if (result.outcome === "backed_up") {
         backedUpFiles.push(spec.path);
-      } else if (result === "failed") {
+      } else if (result.outcome === "failed") {
         failedFiles.push(spec.path);
+        // Any transport-level failure at the state-file phase must promote to
+        // the sandbox-level unreachable flag so the skip flag can activate
+        // for state-file failures — not only the initial dir probe. (#6188)
+        if (result.unreachable) unreachable = true;
       }
     }
   } finally {

--- a/src/lib/state/ssh-transport.test.ts
+++ b/src/lib/state/ssh-transport.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isSshTransportFailure } from "./sandbox";
+import { isSshTransportFailure } from "./ssh-transport";
 
 describe("isSshTransportFailure", () => {
   it("treats an ssh transport failure exit code (255) as unreachable", () => {

--- a/src/lib/state/ssh-transport.ts
+++ b/src/lib/state/ssh-transport.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure classifiers for SSH probe outcomes into transport-level failures
+ * (unreachable) vs application-level failures (reachable but exit-non-zero).
+ *
+ * A "transport-level" failure means the SSH tunnel itself could not carry
+ * data — the process never reached a shell that could return a real exit
+ * code. Typical shapes reported by `spawnSync("ssh", …)`:
+ *
+ *   - `error` set on the result (spawn-time failure: ENOENT, EACCES, …)
+ *   - `status === 255` (ssh's own transport-error convention)
+ *   - `status === null` with a signal (killed by SIGHUP/SIGPIPE from a
+ *     dying gateway) or with no signal (timed out / SIGTERM)
+ *
+ * Callers use this to promote a sandbox-level `unreachable` flag so the
+ * NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 opt-in can activate. See #6188.
+ */
+export function isSshTransportFailure(result: {
+  status: number | null;
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+}): boolean {
+  if (result.error) return true;
+  // Signal termination (e.g. SIGHUP/SIGPIPE from a dying gateway) reports
+  // status=null; match connect.ts and treat these as transport-level
+  // failures explicitly so the diagnostic path is unambiguous. Any other
+  // null-status result (timeout, killed) is also transport-level.
+  if (result.signal === "SIGHUP" || result.signal === "SIGPIPE") return true;
+  if (result.status === null) return true;
+  return result.status === 255;
+}

--- a/test/install-openshell-upgrade-prompt.test.ts
+++ b/test/install-openshell-upgrade-prompt.test.ts
@@ -229,9 +229,7 @@ describe("install.sh OpenShell 0.0.37 gateway upgrade prompt", () => {
     expect(result.status).toBe(0);
     expect(result.stdout + result.stderr).toContain("Retrying with the current NemoClaw CLI");
     expect(result.stdout).toContain("RESTORE=1");
-    expect(cliLog.split(/\r?\n/)).toContain("old:backup-all");
-    expect(cliLog.split(/\r?\n/)).toContain("prepare-current");
-    expect(cliLog.split(/\r?\n/)).toContain("current:backup-all");
+    expect(cliLog).toMatch(/old:backup-all[\s\S]*prepare-current[\s\S]*current:backup-all/);
     expect(openshellLog).toBe("");
   });
 

--- a/test/install-openshell-upgrade-prompt.test.ts
+++ b/test/install-openshell-upgrade-prompt.test.ts
@@ -210,11 +210,28 @@ describe("install.sh OpenShell 0.0.37 gateway upgrade prompt", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stdout + result.stderr).toContain(
-      "Fix the OpenShell gateway state, rerun 'nemoclaw backup-all', then rerun the installer.",
+      "If the failures are running sandboxes whose in-sandbox SSH endpoint is unreachable, rerun the installer with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 to continue and recover them after the upgrade; otherwise restore the affected sandbox or stop its container, then rerun 'nemoclaw backup-all'.",
     );
     expect(cliLog.split(/\r?\n/)).toContain("old:backup-all");
     expect(cliLog).not.toContain("--help");
-    expect(cliLog).not.toContain("prepare-current");
+    expect(cliLog.split(/\r?\n/)).toContain("prepare-current");
+    expect(openshellLog).toBe("");
+  });
+
+  it("retries current-gateway backup with the current CLI when the old CLI fails", () => {
+    const { result, cliLog, openshellLog } = runPreinstallUpgradeGuard(
+      {
+        NON_INTERACTIVE: "1",
+      },
+      { backupSucceeds: false, fallbackAvailable: true, openshellVersion: "0.0.37" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toContain("Retrying with the current NemoClaw CLI");
+    expect(result.stdout).toContain("RESTORE=1");
+    expect(cliLog.split(/\r?\n/)).toContain("old:backup-all");
+    expect(cliLog.split(/\r?\n/)).toContain("prepare-current");
+    expect(cliLog.split(/\r?\n/)).toContain("current:backup-all");
     expect(openshellLog).toBe("");
   });
 

--- a/test/install-openshell-upgrade-prompt.test.ts
+++ b/test/install-openshell-upgrade-prompt.test.ts
@@ -64,6 +64,10 @@ exit 0
     currentCli,
     `#!/usr/bin/env bash
 printf 'current:%s\\n' "$*" >> "${cliLog}"
+# Record the skip env var so the installer-integration test can prove the
+# installer propagates NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP into the
+# current-CLI child. See #6188 / PRA-9.
+printf 'skip-env=%s\\n' "\${NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP:-}" >> "${cliLog}"
 if [ "$1" = "--version" ]; then
   printf 'nemoclaw v0.1.0\\n'
   exit 0
@@ -210,7 +214,7 @@ describe("install.sh OpenShell 0.0.37 gateway upgrade prompt", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stdout + result.stderr).toContain(
-      "If the failures are running sandboxes whose in-sandbox SSH endpoint is unreachable, rerun the installer with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 to continue and recover them after the upgrade; otherwise restore the affected sandbox or stop its container, then rerun 'nemoclaw backup-all'.",
+      "If the failures are running sandboxes whose in-sandbox SSH endpoint is unreachable, rerun the installer with NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1 to continue and recover them after the upgrade (any uncommitted state since the last successful backup will be lost); otherwise restore the affected sandbox or stop its container, then rerun 'nemoclaw backup-all'.",
     );
     expect(cliLog.split(/\r?\n/)).toContain("old:backup-all");
     expect(cliLog).not.toContain("--help");
@@ -231,6 +235,28 @@ describe("install.sh OpenShell 0.0.37 gateway upgrade prompt", () => {
     expect(result.stdout).toContain("RESTORE=1");
     expect(cliLog).toMatch(/old:backup-all[\s\S]*prepare-current[\s\S]*current:backup-all/);
     expect(openshellLog).toBe("");
+  });
+
+  it("propagates NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP into the current-CLI backup retry (#6188)", () => {
+    // The skip flag is consumed by the CLI's backup-all path (maintenance.ts's
+    // shouldSkipUnreachableSandboxBackup). The installer's job is to pass the
+    // env var through unchanged when it retries with the current CLI so the
+    // skip logic can actually activate. This asserts the env var reaches the
+    // current-CLI child process — verified via the current-mock, which echoes
+    // it into cli.log. See advisor PRA-9.
+    const { result, cliLog } = runPreinstallUpgradeGuard(
+      {
+        NON_INTERACTIVE: "1",
+        NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP: "1",
+      },
+      { backupSucceeds: false, fallbackAvailable: true, openshellVersion: "0.0.37" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("RESTORE=1");
+    // The current-CLI child must see the skip env var. Empty value (unset) or
+    // a truthy value that's not exactly "1" would defeat the CLI-side check.
+    expect(cliLog).toMatch(/current:backup-all[\s\S]*skip-env=1/);
   });
 
   it("continues after the user manually prepared the old gateway state", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Pre-upgrade `backup-all` aborted the `curl | bash` installer whenever a running sandbox's in-sandbox SSH endpoint did not answer, with no override, looping the upgrade forever. This classifies such a sandbox as unreachable and adds `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` to skip it so the upgrade proceeds and onboarding recovers it from its latest validated backup.

## Related Issue
Fixes #6188

## Changes
- `src/lib/state/sandbox.ts`: add `unreachable` to `BackupResult` and set it on an SSH transport-level dir-check failure (exit 255, timeout, spawn error) via a new `isSshTransportFailure` predicate.
- `src/lib/actions/maintenance.ts`: an unreachable running sandbox is skipped when `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1`, otherwise it still fails but prints actionable guidance before exit.
- `scripts/install.sh`: reword the pre-upgrade backup abort to name the override and the recovery path.
- `docs/reference/commands.mdx`: document the flag in the `backup-all` section.
- Tests: `maintenance.test.ts` gains skip-with-flag, fail-with-guidance, and flag truth-table cases; new `sandbox.test.ts` covers `isSshTransportFailure`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `backup-all` now detects running sandboxes with an unreachable in-sandbox SSH endpoint and can skip them when `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1`.
  * Skipped sandboxes are recovered during onboarding from the latest validated backup; any uncommitted state since then is not preserved.
* **Bug Fixes**
  * Improved failure handling and remediation when SSH transport/unreachability occurs, including clearer guidance and installer/upgrade retry behavior.
* **Documentation**
  * Updated `nemoclaw` and `nemohermes` `backup-all` docs to state the default abort behavior and the skip flag’s exact `=1` requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->