### PR TITLE
fix(dcode): route inference.local through managed proxy

### DIFF
--- a/agents/langchain-deepagents-code/Dockerfile
+++ b/agents/langchain-deepagents-code/Dockerfile
@@ -33,10 +33,7 @@ RUN chmod 444 /opt/nemoclaw-deepagents-code/generate-config.ts /opt/nemoclaw-dee
     && rm -f /usr/local/bin/dcode /usr/local/bin/deepagents-code /opt/venv/bin/dcode /opt/venv/bin/deepagents-code \
     && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/dcode \
     && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/dcode.real \
-    && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/deepagents-code \
-    && /usr/local/bin/dcode --version \
-    && /usr/local/bin/dcode.real --version \
-    && /usr/local/bin/deepagents-code --version
+    && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/deepagents-code
 
 ARG NEMOCLAW_MODEL=nvidia/nemotron-3-super-120b-a12b
 ARG NEMOCLAW_PROVIDER_KEY=inference
@@ -48,6 +45,18 @@ ARG NEMOCLAW_DARWIN_VM_COMPAT=0
 ARG NEMOCLAW_PROXY_HOST=10.200.0.1
 ARG NEMOCLAW_PROXY_PORT=3128
 
+# The launcher and startup script read these root-owned files instead of
+# trusting process-level environment overrides for inference routing. Invoking
+# each launcher validates the build args before the image can complete.
+RUN install -d -m 0755 /usr/local/share/nemoclaw \
+    && printf '%s\n' "$NEMOCLAW_PROXY_HOST" > /usr/local/share/nemoclaw/dcode-proxy-host \
+    && printf '%s\n' "$NEMOCLAW_PROXY_PORT" > /usr/local/share/nemoclaw/dcode-proxy-port \
+    && chown root:root /usr/local/share/nemoclaw/dcode-proxy-host /usr/local/share/nemoclaw/dcode-proxy-port \
+    && chmod 0444 /usr/local/share/nemoclaw/dcode-proxy-host /usr/local/share/nemoclaw/dcode-proxy-port \
+    && /usr/local/bin/dcode --version \
+    && /usr/local/bin/dcode.real --version \
+    && /usr/local/bin/deepagents-code --version
+
 ENV HOME=/sandbox \
     VIRTUAL_ENV=/opt/venv \
     PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin" \
@@ -57,8 +66,6 @@ ENV HOME=/sandbox \
     NEMOCLAW_INFERENCE_BASE_URL=${NEMOCLAW_INFERENCE_BASE_URL} \
     NEMOCLAW_INFERENCE_API=${NEMOCLAW_INFERENCE_API} \
     NEMOCLAW_BUILD_ID=${NEMOCLAW_BUILD_ID} \
-    NEMOCLAW_PROXY_HOST=${NEMOCLAW_PROXY_HOST} \
-    NEMOCLAW_PROXY_PORT=${NEMOCLAW_PROXY_PORT} \
     DEEPAGENTS_CODE_NO_UPDATE_CHECK=1 \
     DEEPAGENTS_CODE_AUTO_UPDATE=0 \
     DEEPAGENTS_CODE_OPENAI_API_KEY=nemoclaw-managed-inference \

--- a/agents/langchain-deepagents-code/Dockerfile
+++ b/agents/langchain-deepagents-code/Dockerfile
@@ -23,16 +23,17 @@ RUN set -eu; \
 COPY agents/langchain-deepagents-code/generate-config.ts /opt/nemoclaw-deepagents-code/generate-config.ts
 COPY agents/langchain-deepagents-code/patch-managed-deepagents-code.py /opt/nemoclaw-deepagents-code/patch-managed-deepagents-code.py
 COPY agents/langchain-deepagents-code/dcode-wrapper.sh /usr/local/lib/nemoclaw/dcode-wrapper.sh
+COPY agents/langchain-deepagents-code/dcode-launcher.sh /usr/local/lib/nemoclaw/dcode-launcher.sh
 COPY agents/langchain-deepagents-code/start.sh /usr/local/bin/nemoclaw-start
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 RUN chmod 444 /opt/nemoclaw-deepagents-code/generate-config.ts /opt/nemoclaw-deepagents-code/patch-managed-deepagents-code.py \
-    && chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/dcode-wrapper.sh \
+    && chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/dcode-wrapper.sh /usr/local/lib/nemoclaw/dcode-launcher.sh \
     && chmod -R a+rX /opt/nemoclaw-blueprint \
     && python3 /opt/nemoclaw-deepagents-code/patch-managed-deepagents-code.py \
     && rm -f /usr/local/bin/dcode /usr/local/bin/deepagents-code /opt/venv/bin/dcode /opt/venv/bin/deepagents-code \
-    && install -m 0755 /usr/local/lib/nemoclaw/dcode-wrapper.sh /usr/local/bin/dcode \
-    && install -m 0755 /usr/local/lib/nemoclaw/dcode-wrapper.sh /usr/local/bin/dcode.real \
-    && install -m 0755 /usr/local/lib/nemoclaw/dcode-wrapper.sh /usr/local/bin/deepagents-code \
+    && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/dcode \
+    && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/dcode.real \
+    && install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/deepagents-code \
     && /usr/local/bin/dcode --version \
     && /usr/local/bin/dcode.real --version \
     && /usr/local/bin/deepagents-code --version
@@ -44,6 +45,8 @@ ARG NEMOCLAW_INFERENCE_BASE_URL=https://inference.local/v1
 ARG NEMOCLAW_INFERENCE_API=openai-completions
 ARG NEMOCLAW_BUILD_ID=default
 ARG NEMOCLAW_DARWIN_VM_COMPAT=0
+ARG NEMOCLAW_PROXY_HOST=10.200.0.1
+ARG NEMOCLAW_PROXY_PORT=3128
 
 ENV HOME=/sandbox \
     VIRTUAL_ENV=/opt/venv \
@@ -54,6 +57,8 @@ ENV HOME=/sandbox \
     NEMOCLAW_INFERENCE_BASE_URL=${NEMOCLAW_INFERENCE_BASE_URL} \
     NEMOCLAW_INFERENCE_API=${NEMOCLAW_INFERENCE_API} \
     NEMOCLAW_BUILD_ID=${NEMOCLAW_BUILD_ID} \
+    NEMOCLAW_PROXY_HOST=${NEMOCLAW_PROXY_HOST} \
+    NEMOCLAW_PROXY_PORT=${NEMOCLAW_PROXY_PORT} \
     DEEPAGENTS_CODE_NO_UPDATE_CHECK=1 \
     DEEPAGENTS_CODE_AUTO_UPDATE=0 \
     DEEPAGENTS_CODE_OPENAI_API_KEY=nemoclaw-managed-inference \

--- a/agents/langchain-deepagents-code/dcode-launcher.sh
+++ b/agents/langchain-deepagents-code/dcode-launcher.sh
@@ -11,12 +11,52 @@ export HOME=/sandbox
 export PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Raw OpenShell exec processes do not inherit the entrypoint's environment or
-# source shell startup files. Rebuild the managed proxy contract here so
-# `nemoclaw <sandbox> exec -- dcode` cannot retain the sandbox-create host proxy
-# seed (including NO_PROXY=inference.local). Host/port are non-secret image ENV
-# values patched at build time and validated again before use.
-PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
-PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+# source shell startup files. Rebuild the proxy-only dcode contract here so a
+# direct exec cannot retain the host seed and bypass the managed proxy for a
+# direct inference.local DNS lookup. This stays at the agent runtime boundary
+# because the shared seed is still required for OpenShell host-side chaining.
+# Remove it only when OpenShell normalizes every sandbox exec/login process or
+# dcode no longer uses inference.local.
+readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw/dcode-proxy-host"
+readonly MANAGED_PROXY_PORT_FILE="/usr/local/share/nemoclaw/dcode-proxy-port"
+readonly MANAGED_PROXY_OWNER_UID=0
+
+managed_proxy_file_metadata() {
+  local file="$1"
+  local metadata
+  if metadata="$(stat -c '%u:%a' "$file" 2>/dev/null)"; then
+    printf '%s' "$metadata"
+  else
+    stat -f '%u:%Lp' "$file" 2>/dev/null
+  fi
+}
+
+read_managed_proxy_value() {
+  local file="$1"
+  local name="$2"
+  local metadata
+  local value
+  if [ ! -f "$file" ] || [ -L "$file" ] || [ ! -r "$file" ]; then
+    printf 'Missing or unsafe trusted managed proxy %s file.\n' "$name" >&2
+    return 1
+  fi
+  metadata="$(managed_proxy_file_metadata "$file")" || {
+    printf 'Cannot inspect trusted managed proxy %s file.\n' "$name" >&2
+    return 1
+  }
+  if [ "$metadata" != "${MANAGED_PROXY_OWNER_UID}:444" ]; then
+    printf 'Unsafe ownership or mode on trusted managed proxy %s file.\n' "$name" >&2
+    return 1
+  fi
+  value="$(<"$file")"
+  printf '%s' "$value"
+}
+
+# Onboard validates the build args and the Dockerfile stores them in root-owned
+# files. Runtime env is untrusted and cannot override those image-baked values.
+PROXY_HOST="$(read_managed_proxy_value "$MANAGED_PROXY_HOST_FILE" "host")"
+PROXY_PORT="$(read_managed_proxy_value "$MANAGED_PROXY_PORT_FILE" "port")"
+unset NEMOCLAW_PROXY_HOST NEMOCLAW_PROXY_PORT
 
 is_valid_proxy_host() {
   local value="$1"

--- a/agents/langchain-deepagents-code/dcode-launcher.sh
+++ b/agents/langchain-deepagents-code/dcode-launcher.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Proxy-normalizing launcher for every managed Deep Agents Code entry point.
+
+set -euo pipefail
+
+readonly MANAGED_DCODE_WRAPPER="/usr/local/lib/nemoclaw/dcode-wrapper.sh"
+export HOME=/sandbox
+export PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Raw OpenShell exec processes do not inherit the entrypoint's environment or
+# source shell startup files. Rebuild the managed proxy contract here so
+# `nemoclaw <sandbox> exec -- dcode` cannot retain the sandbox-create host proxy
+# seed (including NO_PROXY=inference.local). Host/port are non-secret image ENV
+# values patched at build time and validated again before use.
+PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
+PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+
+is_valid_proxy_host() {
+  local value="$1"
+  [[ "$value" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+is_valid_proxy_port() {
+  local value="$1"
+  [[ "$value" =~ ^[0-9]{1,5}$ ]] || return 1
+  ((10#$value >= 1 && 10#$value <= 65535))
+}
+
+if ! is_valid_proxy_host "$PROXY_HOST"; then
+  printf '%s\n' 'Invalid NEMOCLAW_PROXY_HOST for the managed runtime proxy.' >&2
+  exit 1
+fi
+if ! is_valid_proxy_port "$PROXY_PORT"; then
+  printf '%s\n' 'Invalid NEMOCLAW_PROXY_PORT for the managed runtime proxy.' >&2
+  exit 1
+fi
+
+_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"
+_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"
+export HTTP_PROXY="$_PROXY_URL"
+export HTTPS_PROXY="$_PROXY_URL"
+export NO_PROXY="$_NO_PROXY_VAL"
+export http_proxy="$_PROXY_URL"
+export https_proxy="$_PROXY_URL"
+export no_proxy="$_NO_PROXY_VAL"
+
+exec "$MANAGED_DCODE_WRAPPER" "$@"

--- a/agents/langchain-deepagents-code/start.sh
+++ b/agents/langchain-deepagents-code/start.sh
@@ -19,6 +19,27 @@ export OPENAI_BASE_URL="${OPENAI_BASE_URL:-https://inference.local/v1}"
 # and inference.local must stay on the proxy path instead of resolving via DNS.
 PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
 PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+
+is_valid_proxy_host() {
+  local value="$1"
+  [[ "$value" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+is_valid_proxy_port() {
+  local value="$1"
+  [[ "$value" =~ ^[0-9]{1,5}$ ]] || return 1
+  ((10#$value >= 1 && 10#$value <= 65535))
+}
+
+if ! is_valid_proxy_host "$PROXY_HOST"; then
+  printf '%s\n' 'Invalid NEMOCLAW_PROXY_HOST for the managed runtime proxy.' >&2
+  exit 1
+fi
+if ! is_valid_proxy_port "$PROXY_PORT"; then
+  printf '%s\n' 'Invalid NEMOCLAW_PROXY_PORT for the managed runtime proxy.' >&2
+  exit 1
+fi
+
 _PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"
 _NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"
 export HTTP_PROXY="$_PROXY_URL"

--- a/agents/langchain-deepagents-code/start.sh
+++ b/agents/langchain-deepagents-code/start.sh
@@ -13,42 +13,26 @@ export DEEPAGENTS_CODE_AUTO_UPDATE=0
 export DEEPAGENTS_CODE_OPENAI_API_KEY="${DEEPAGENTS_CODE_OPENAI_API_KEY:-nemoclaw-managed-inference}"
 export OPENAI_BASE_URL="${OPENAI_BASE_URL:-https://inference.local/v1}"
 
+# OpenShell's sandbox-create environment may contain a host/corporate proxy and
+# a NO_PROXY seed that includes inference.local. That seed is only for
+# host-side proxy chaining. Runtime traffic must use OpenShell's managed proxy,
+# and inference.local must stay on the proxy path instead of resolving via DNS.
+PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
+PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+_PROXY_URL="http://${PROXY_HOST}:${PROXY_PORT}"
+_NO_PROXY_VAL="localhost,127.0.0.1,::1,${PROXY_HOST}"
+export HTTP_PROXY="$_PROXY_URL"
+export HTTPS_PROXY="$_PROXY_URL"
+export NO_PROXY="$_NO_PROXY_VAL"
+export http_proxy="$_PROXY_URL"
+export https_proxy="$_PROXY_URL"
+export no_proxy="$_NO_PROXY_VAL"
+
 write_export_if_set() {
   local name="$1"
   local value="${!name:-}"
   [ -n "$value" ] || return 0
   printf 'export %s=%q\n' "$name" "$value"
-}
-
-is_credential_bearing_url() {
-  local value="$1"
-  case "$value" in
-    *://*@*) return 0 ;;
-    *:*@*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-write_proxy_export_pair() {
-  local primary="$1"
-  local secondary="$2"
-  local name
-  local value
-  local has_credentials=0
-  for name in "$primary" "$secondary"; do
-    value="${!name:-}"
-    [ -n "$value" ] || continue
-    if is_credential_bearing_url "$value"; then
-      printf 'Skipping %s in Deep Agents Code runtime env because the proxy URL contains credentials.\n' "$name" >&2
-      has_credentials=1
-    fi
-  done
-  if [ "$has_credentials" -eq 1 ]; then
-    unset "$primary" "$secondary"
-    return 0
-  fi
-  write_export_if_set "$primary"
-  write_export_if_set "$secondary"
 }
 
 prepare_runtime_env() {
@@ -64,9 +48,11 @@ prepare_runtime_env() {
     printf '%s\n' 'export DEEPAGENTS_CODE_OPENAI_API_KEY="${DEEPAGENTS_CODE_OPENAI_API_KEY:-nemoclaw-managed-inference}"'
     # shellcheck disable=SC2016
     printf '%s\n' 'export OPENAI_BASE_URL="${OPENAI_BASE_URL:-https://inference.local/v1}"'
-    write_proxy_export_pair HTTP_PROXY http_proxy
-    write_proxy_export_pair HTTPS_PROXY https_proxy
+    write_export_if_set HTTP_PROXY
+    write_export_if_set HTTPS_PROXY
     write_export_if_set NO_PROXY
+    write_export_if_set http_proxy
+    write_export_if_set https_proxy
     write_export_if_set no_proxy
     write_export_if_set SSL_CERT_FILE
     write_export_if_set REQUESTS_CA_BUNDLE

--- a/agents/langchain-deepagents-code/start.sh
+++ b/agents/langchain-deepagents-code/start.sh
@@ -13,12 +13,60 @@ export DEEPAGENTS_CODE_AUTO_UPDATE=0
 export DEEPAGENTS_CODE_OPENAI_API_KEY="${DEEPAGENTS_CODE_OPENAI_API_KEY:-nemoclaw-managed-inference}"
 export OPENAI_BASE_URL="${OPENAI_BASE_URL:-https://inference.local/v1}"
 
-# OpenShell's sandbox-create environment may contain a host/corporate proxy and
-# a NO_PROXY seed that includes inference.local. That seed is only for
-# host-side proxy chaining. Runtime traffic must use OpenShell's managed proxy,
-# and inference.local must stay on the proxy path instead of resolving via DNS.
-PROXY_HOST="${NEMOCLAW_PROXY_HOST:-10.200.0.1}"
-PROXY_PORT="${NEMOCLAW_PROXY_PORT:-3128}"
+# Invalid state: OpenShell's sandbox-create environment contains the host proxy
+# seed, including NO_PROXY=inference.local, so dcode bypasses the managed proxy
+# and attempts direct DNS resolution that is not part of the dcode contract.
+# Source boundary: that seed remains correct for OpenShell's host-side proxy
+# chaining; this agent-owned runtime boundary is the first safe place to replace
+# it without changing OpenClaw, Hermes, or global OpenShell route provisioning.
+# Source-fix constraint: inference.local is an L7 managed-proxy route, so adding
+# sandbox DNS/hosts state or changing the shared seed would widen this fix and
+# break the host chaining contract. Direct DNS/hosts resolution is not required.
+# Regression: focused tests and the live check cover login-shell, direct dcode,
+# and connect paths when the direct DNS/hosts lookup is absent.
+# Removal condition: remove this normalization only when OpenShell guarantees
+# the managed proxy and normalized NO_PROXY for every sandbox exec/login process,
+# or when dcode no longer uses inference.local.
+readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw/dcode-proxy-host"
+readonly MANAGED_PROXY_PORT_FILE="/usr/local/share/nemoclaw/dcode-proxy-port"
+readonly MANAGED_PROXY_OWNER_UID=0
+
+managed_proxy_file_metadata() {
+  local file="$1"
+  local metadata
+  if metadata="$(stat -c '%u:%a' "$file" 2>/dev/null)"; then
+    printf '%s' "$metadata"
+  else
+    stat -f '%u:%Lp' "$file" 2>/dev/null
+  fi
+}
+
+read_managed_proxy_value() {
+  local file="$1"
+  local name="$2"
+  local metadata
+  local value
+  if [ ! -f "$file" ] || [ -L "$file" ] || [ ! -r "$file" ]; then
+    printf 'Missing or unsafe trusted managed proxy %s file.\n' "$name" >&2
+    return 1
+  fi
+  metadata="$(managed_proxy_file_metadata "$file")" || {
+    printf 'Cannot inspect trusted managed proxy %s file.\n' "$name" >&2
+    return 1
+  }
+  if [ "$metadata" != "${MANAGED_PROXY_OWNER_UID}:444" ]; then
+    printf 'Unsafe ownership or mode on trusted managed proxy %s file.\n' "$name" >&2
+    return 1
+  fi
+  value="$(<"$file")"
+  printf '%s' "$value"
+}
+
+# Fail closed if the root-owned image contract is missing. Process-level
+# NEMOCLAW_PROXY_* values are not a trusted runtime routing source.
+PROXY_HOST="$(read_managed_proxy_value "$MANAGED_PROXY_HOST_FILE" "host")"
+PROXY_PORT="$(read_managed_proxy_value "$MANAGED_PROXY_PORT_FILE" "port")"
+unset NEMOCLAW_PROXY_HOST NEMOCLAW_PROXY_PORT
 
 is_valid_proxy_host() {
   local value="$1"

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -236,6 +236,72 @@ describe("connectSandbox flow", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it("runs the dcode inference route probe through its login-shell proxy contract (#6191)", async () => {
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+    });
+    const registry = requireDist("../../src/lib/state/registry.js");
+    registry.getSandbox.mockReturnValue({
+      name: "alpha",
+      agent: "langchain-deepagents-code",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      gpuEnabled: false,
+      policies: [],
+    });
+    harness.captureOpenshellSpy.mockImplementation((args: unknown) => {
+      const argv = Array.isArray(args) ? args : [];
+      if (argv[0] === "sandbox" && argv[1] === "list") {
+        return { status: 0, output: "alpha Ready" };
+      }
+      if (argv[0] === "inference" && argv[1] === "get") {
+        return {
+          status: 0,
+          output:
+            "Gateway inference:\n  Provider: nvidia-prod\n  Model: nvidia/nemotron-3-super-120b-a12b\n",
+        };
+      }
+      if (argv[0] === "sandbox" && argv[1] === "exec") {
+        return { status: 0, output: "OK 200" };
+      }
+      return { status: 0, output: "" };
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
+
+    expect(harness.captureOpenshellSpy).toHaveBeenCalledWith(
+      [
+        "sandbox",
+        "exec",
+        "--name",
+        "alpha",
+        "--",
+        "env",
+        "-u",
+        "HTTP_PROXY",
+        "-u",
+        "HTTPS_PROXY",
+        "-u",
+        "http_proxy",
+        "-u",
+        "https_proxy",
+        "-u",
+        "NO_PROXY",
+        "-u",
+        "no_proxy",
+        "HOME=/sandbox",
+        "bash",
+        "-lc",
+        expect.stringContaining("https://inference.local/v1/models"),
+      ],
+      expect.objectContaining({ ignoreError: true }),
+    );
+  });
+
   it("stops before opening SSH when the sandbox list reports a terminal failure phase", async () => {
     const harness = createConnectHarness({ listOutput: "alpha Error" });
 

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -253,22 +253,21 @@ describe("connectSandbox flow", () => {
       gpuEnabled: false,
       policies: [],
     });
-    harness.captureOpenshellSpy.mockImplementation((args: unknown) => {
-      const argv = Array.isArray(args) ? args : [];
-      if (argv[0] === "sandbox" && argv[1] === "list") {
-        return { status: 0, output: "alpha Ready" };
-      }
-      if (argv[0] === "inference" && argv[1] === "get") {
-        return {
+    const responses = new Map([
+      ["sandbox list", { status: 0, output: "alpha Ready" }],
+      [
+        "inference get",
+        {
           status: 0,
           output:
             "Gateway inference:\n  Provider: nvidia-prod\n  Model: nvidia/nemotron-3-super-120b-a12b\n",
-        };
-      }
-      if (argv[0] === "sandbox" && argv[1] === "exec") {
-        return { status: 0, output: "OK 200" };
-      }
-      return { status: 0, output: "" };
+        },
+      ],
+      ["sandbox exec", { status: 0, output: "OK 200" }],
+    ]);
+    harness.captureOpenshellSpy.mockImplementation((args: unknown) => {
+      const argv = Array.isArray(args) ? args : [];
+      return responses.get(`${String(argv[0])} ${String(argv[1])}`) ?? { status: 0, output: "" };
     });
 
     await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");

--- a/src/lib/actions/sandbox/connect-route-repair.test.ts
+++ b/src/lib/actions/sandbox/connect-route-repair.test.ts
@@ -36,12 +36,70 @@ vi.mock("./gateway-state", () => ({
 }));
 
 import {
+  buildSandboxInferenceRouteProbeArgs,
+  type ManagedInferenceRouteResetDeps,
   repairSandboxInferenceRouteWithDeps,
   resetManagedInferenceRouteWithDeps,
-  type ManagedInferenceRouteResetDeps,
   type SandboxInferenceRouteProbe,
   type SandboxInferenceRouteRepairDeps,
 } from "./connect";
+
+const INFERENCE_ROUTE_PROBE_SCRIPT = [
+  "OUT=/tmp/nemoclaw-inference-route-probe.out",
+  "HTTP_CODE=$(curl -sk -o \"$OUT\" -w '%{http_code}' --connect-timeout 3 --max-time 8 https://inference.local/v1/models 2>/dev/null) || HTTP_CODE=000",
+  'case "$HTTP_CODE" in 000|5*) printf \'BROKEN %s \' "$HTTP_CODE"; head -c 160 "$OUT" 2>/dev/null || true ;; *) printf \'OK %s\' "$HTTP_CODE" ;; esac',
+].join("; ");
+
+describe("sandbox connect inference route probe argv", () => {
+  it("uses the dcode login-shell proxy contract without inherited proxy variables (#6191)", () => {
+    const args = buildSandboxInferenceRouteProbeArgs("deep-code", {
+      name: "langchain-deepagents-code",
+    });
+
+    expect(args).toEqual([
+      "sandbox",
+      "exec",
+      "--name",
+      "deep-code",
+      "--",
+      "env",
+      "-u",
+      "HTTP_PROXY",
+      "-u",
+      "HTTPS_PROXY",
+      "-u",
+      "http_proxy",
+      "-u",
+      "https_proxy",
+      "-u",
+      "NO_PROXY",
+      "-u",
+      "no_proxy",
+      "HOME=/sandbox",
+      "bash",
+      "-lc",
+      INFERENCE_ROUTE_PROBE_SCRIPT,
+    ]);
+    expect(args.every((arg) => !/[\r\n]/.test(arg))).toBe(true);
+  });
+
+  it.each([
+    null,
+    { name: "openclaw" },
+    { name: "hermes" },
+  ])("preserves the plain sh probe for non-dcode agents (%j)", (agent) => {
+    expect(buildSandboxInferenceRouteProbeArgs("alpha", agent)).toEqual([
+      "sandbox",
+      "exec",
+      "--name",
+      "alpha",
+      "--",
+      "sh",
+      "-c",
+      INFERENCE_ROUTE_PROBE_SCRIPT,
+    ]);
+  });
+});
 
 const healthy = (detail = "OK 200"): SandboxInferenceRouteProbe => ({
   healthy: true,

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -13,6 +13,7 @@ import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "../../adapters/openshell/timeouts";
+import type { AgentDefinition } from "../../agent/defs";
 import * as agentRuntime from "../../agent/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { D, G, R, YW } from "../../cli/terminal-style";
@@ -92,6 +93,8 @@ type InferenceRouteProbeOptions = {
   attempts?: number;
   delayMs?: number;
 };
+
+type InferenceRouteProbeAgent = Pick<AgentDefinition, "name"> | null;
 
 export type SandboxInferenceRouteRepairResult = {
   healthy: boolean;
@@ -257,7 +260,7 @@ function runSandboxConnectProbe(sandboxName: string): void {
       agent,
       agentName,
       capture: captureOpenshell,
-      ensureInferenceRoute: ensureSandboxInferenceRoute,
+      ensureInferenceRoute: (name, options) => ensureSandboxInferenceRoute(name, agent, options),
       sandboxName,
     });
     return;
@@ -286,7 +289,7 @@ function runSandboxConnectProbe(sandboxName: string): void {
     );
   }
   if (processCheck.wasRunning) {
-    ensureSandboxInferenceRoute(sandboxName, { quiet: true });
+    ensureSandboxInferenceRoute(sandboxName, agent, { quiet: true });
     // Defense-in-depth scope-upgrade approval on the probe-only / `recover`
     // path (#4504): the gateway is up, so deterministically clear any pending
     // allowlisted CLI/webchat scope upgrade. Best-effort; never throws.
@@ -301,13 +304,13 @@ function runSandboxConnectProbe(sandboxName: string): void {
     return;
   }
   if (processCheck.recovered) {
-    ensureSandboxInferenceRoute(sandboxName, { quiet: true });
+    ensureSandboxInferenceRoute(sandboxName, agent, { quiet: true });
     // Same defense-in-depth approval after a recovery (#4504); best-effort.
     runConnectAutoPairApprovalPass(sandboxName);
     console.log(`  Probe complete: recovered ${agentName} gateway in '${sandboxName}'.`);
     return;
   }
-  ensureSandboxInferenceRoute(sandboxName, { quiet: true });
+  ensureSandboxInferenceRoute(sandboxName, agent, { quiet: true });
   console.error(
     `  Probe failed: ${agentName} gateway is not running in '${sandboxName}' and automatic recovery failed.`,
   );
@@ -382,8 +385,43 @@ function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {
   }
 }
 
+const INFERENCE_ROUTE_PROBE_SCRIPT = [
+  "OUT=/tmp/nemoclaw-inference-route-probe.out",
+  "HTTP_CODE=$(curl -sk -o \"$OUT\" -w '%{http_code}' --connect-timeout 3 --max-time 8 https://inference.local/v1/models 2>/dev/null) || HTTP_CODE=000",
+  'case "$HTTP_CODE" in 000|5*) printf \'BROKEN %s \' "$HTTP_CODE"; head -c 160 "$OUT" 2>/dev/null || true ;; *) printf \'OK %s\' "$HTTP_CODE" ;; esac',
+].join("; ");
+
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+
+export function buildSandboxInferenceRouteProbeArgs(
+  sandboxName: string,
+  agent: InferenceRouteProbeAgent,
+): string[] {
+  const command =
+    agent?.name === "langchain-deepagents-code"
+      ? [
+          "env",
+          ...PROXY_ENV_KEYS.flatMap((key) => ["-u", key]),
+          "HOME=/sandbox",
+          "bash",
+          "-lc",
+          INFERENCE_ROUTE_PROBE_SCRIPT,
+        ]
+      : ["sh", "-c", INFERENCE_ROUTE_PROBE_SCRIPT];
+
+  return ["sandbox", "exec", "--name", sandboxName, "--", ...command];
+}
+
 function probeSandboxInferenceRoute(
   sandboxName: string,
+  agent: InferenceRouteProbeAgent,
   { attempts = 1, delayMs = 0 }: InferenceRouteProbeOptions = {},
 ): SandboxInferenceRouteProbe {
   let lastProbe: SandboxInferenceRouteProbe | null = null;
@@ -393,23 +431,10 @@ function probeSandboxInferenceRoute(
     // Keep the shell string inside the sandbox: curl write-out, body capture,
     // and status classification must run as one bounded probe. sandboxName
     // remains an argv value, so no user input is interpolated into the script.
-    const probe = captureOpenshell(
-      [
-        "sandbox",
-        "exec",
-        "--name",
-        sandboxName,
-        "--",
-        "sh",
-        "-c",
-        [
-          "OUT=/tmp/nemoclaw-inference-route-probe.out",
-          "HTTP_CODE=$(curl -sk -o \"$OUT\" -w '%{http_code}' --connect-timeout 3 --max-time 8 https://inference.local/v1/models 2>/dev/null) || HTTP_CODE=000",
-          'case "$HTTP_CODE" in 000|5*) printf \'BROKEN %s \' "$HTTP_CODE"; head -c 160 "$OUT" 2>/dev/null || true ;; *) printf \'OK %s\' "$HTTP_CODE" ;; esac',
-        ].join("; "),
-      ],
-      { ignoreError: true, timeout: OPENSHELL_INFERENCE_ROUTE_PROBE_TIMEOUT_MS },
-    );
+    const probe = captureOpenshell(buildSandboxInferenceRouteProbeArgs(sandboxName, agent), {
+      ignoreError: true,
+      timeout: OPENSHELL_INFERENCE_ROUTE_PROBE_TIMEOUT_MS,
+    });
     const detail = probe.output.trim();
     lastProbe = {
       healthy: probe.status === 0 && /^OK\s+[0-9]{3}\b/.test(detail),
@@ -452,6 +477,7 @@ function buildInferenceSetArgs(provider: string, model: string): string[] {
 function reapplyVmInferenceRoute(
   sandboxName: string,
   sb: SandboxEntry | null,
+  agent: InferenceRouteProbeAgent,
 ): SandboxInferenceRouteProbe | null {
   const inference = sb ? registry.getSandboxEntryInference(sb) : null;
   if (inference?.kind !== "configured") return null;
@@ -459,7 +485,7 @@ function reapplyVmInferenceRoute(
     ignoreError: true,
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
-  return probeSandboxInferenceRoute(sandboxName);
+  return probeSandboxInferenceRoute(sandboxName, agent);
 }
 
 export function repairSandboxInferenceRouteWithDeps(
@@ -599,6 +625,7 @@ export function repairSandboxInferenceRouteWithDeps(
 function repairSandboxInferenceRouteIfNeeded(
   sandboxName: string,
   sb: SandboxEntry | null,
+  agent: InferenceRouteProbeAgent,
   { quiet = false }: { quiet?: boolean } = {},
 ): SandboxInferenceRouteRepairResult {
   return repairSandboxInferenceRouteWithDeps(
@@ -607,10 +634,10 @@ function repairSandboxInferenceRouteIfNeeded(
     { quiet },
     {
       isRepairDisabled: () => process.env.NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR === "1",
-      probe: probeSandboxInferenceRoute,
+      probe: (name, options) => probeSandboxInferenceRoute(name, agent, options),
       shouldApplyVmDnsMonkeypatch,
       applyVmDnsMonkeypatch: applyOpenShellVmDnsMonkeypatch,
-      reapplyVmInferenceRoute,
+      reapplyVmInferenceRoute: (name, sandbox) => reapplyVmInferenceRoute(name, sandbox, agent),
       repairLegacyDnsProxy: (name, isQuiet) =>
         runSetupDnsProxy(
           { gatewayName: resolveSandboxGatewayName(sb), sandboxName: name },
@@ -717,6 +744,7 @@ export function resetManagedInferenceRouteWithDeps(
 function resetManagedInferenceRoute(
   sandboxName: string,
   sb: SandboxEntry,
+  agent: InferenceRouteProbeAgent,
   { detail, quiet = false }: { detail: string; quiet?: boolean },
 ): boolean {
   return resetManagedInferenceRouteWithDeps(
@@ -730,7 +758,7 @@ function resetManagedInferenceRoute(
           ignoreError: true,
           timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
         }),
-      probe: probeSandboxInferenceRoute,
+      probe: (name, options) => probeSandboxInferenceRoute(name, agent, options),
       printUnrecoverableInferenceRoute,
     },
   );
@@ -738,6 +766,7 @@ function resetManagedInferenceRoute(
 
 function ensureSandboxInferenceRoute(
   sandboxName: string,
+  agent: InferenceRouteProbeAgent,
   { quiet = false }: { quiet?: boolean } = {},
 ): SandboxInferenceRouteEnsureResult {
   let sb: SandboxEntry | null = null;
@@ -788,9 +817,9 @@ function ensureSandboxInferenceRoute(
         );
       }
     }
-    const repairResult = repairSandboxInferenceRouteIfNeeded(sandboxName, sb, { quiet });
+    const repairResult = repairSandboxInferenceRouteIfNeeded(sandboxName, sb, agent, { quiet });
     if (!repairResult.healthy && repairResult.repairAttempted) {
-      const resetResult = resetManagedInferenceRoute(sandboxName, sb, {
+      const resetResult = resetManagedInferenceRoute(sandboxName, sb, agent, {
         detail: repairResult.detail,
         quiet,
       });
@@ -814,9 +843,10 @@ function ensureSandboxInferenceRoute(
 
 function ensureSandboxInferenceRouteOrExit(
   sandboxName: string,
+  agent: InferenceRouteProbeAgent,
   { quiet = false }: { quiet?: boolean } = {},
 ): SandboxEntry | null {
-  const result = ensureSandboxInferenceRoute(sandboxName, { quiet });
+  const result = ensureSandboxInferenceRoute(sandboxName, agent, { quiet });
   if (result.routeHealthy === false) {
     process.exit(1);
   }
@@ -1088,7 +1118,8 @@ export async function connectSandbox(
   // When the user has multiple sandboxes with different providers, the
   // cluster-wide inference.local route may still point at the other provider.
   // After the sandbox is Ready, verify and recover the route before SSH.
-  sb = ensureSandboxInferenceRouteOrExit(sandboxName);
+  const agent = agentRuntime.getSessionAgent(sandboxName);
+  sb = ensureSandboxInferenceRouteOrExit(sandboxName, agent);
   maybeEnsureHermesToolGatewayBroker(sb);
 
   // ── Auto-pair late scope-upgrade approval (#4263) ───────────────
@@ -1112,10 +1143,7 @@ export async function connectSandbox(
   ) {
     console.log("");
     const agentName = sb?.agent || "openclaw";
-    const terminalCommand = agentRuntime.getTerminalCommand(
-      agentRuntime.getSessionAgent(sandboxName),
-      "interactive",
-    );
+    const terminalCommand = agentRuntime.getTerminalCommand(agent, "interactive");
     const agentCmd = terminalCommand ?? (agentName === "openclaw" ? "openclaw tui" : agentName);
     console.log(`  ${G}✓${R} Connecting to sandbox '${sandboxName}'`);
     console.log(

--- a/src/lib/actions/sandbox/terminal-connect-probe.test.ts
+++ b/src/lib/actions/sandbox/terminal-connect-probe.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+import type { AgentDefinition } from "../../agent/defs";
+import { runTerminalAgentConnectProbe } from "./terminal-connect-probe";
+
+const dcodeAgent = {
+  name: "langchain-deepagents-code",
+  runtime: {
+    kind: "terminal",
+    headless_command: "dcode -n",
+    interactive_command: "dcode",
+  },
+} as AgentDefinition;
+
+describe("terminal-agent connect inference route", () => {
+  let errorSpy: MockInstance;
+  let exitSpy: MockInstance;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fails dcode probe-only before smoke checks when inference.local stays broken (#6191)", () => {
+    const capture = vi.fn();
+    const ensureInferenceRoute = vi.fn(() => ({ routeHealthy: false }));
+
+    expect(() =>
+      runTerminalAgentConnectProbe({
+        agent: dcodeAgent,
+        agentName: "LangChain Deep Agents Code",
+        capture: capture as never,
+        ensureInferenceRoute,
+        sandboxName: "deep-code",
+      }),
+    ).toThrow("process.exit(1)");
+
+    expect(ensureInferenceRoute).toHaveBeenCalledWith("deep-code", { quiet: true });
+    expect(capture).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "  Probe failed: LangChain Deep Agents Code could not reach the managed inference.local route in 'deep-code'.",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/lib/actions/sandbox/terminal-connect-probe.ts
+++ b/src/lib/actions/sandbox/terminal-connect-probe.ts
@@ -10,7 +10,7 @@ import { redact } from "../../runner";
 export type EnsureTerminalInferenceRoute = (
   sandboxName: string,
   options: { quiet: true },
-) => unknown;
+) => { routeHealthy: boolean | null };
 
 export function runTerminalAgentConnectProbe({
   agent,
@@ -25,7 +25,13 @@ export function runTerminalAgentConnectProbe({
   ensureInferenceRoute: EnsureTerminalInferenceRoute;
   sandboxName: string;
 }): void {
-  ensureInferenceRoute(sandboxName, { quiet: true });
+  const routeResult = ensureInferenceRoute(sandboxName, { quiet: true });
+  if (agent.name === "langchain-deepagents-code" && routeResult.routeHealthy === false) {
+    console.error(
+      `  Probe failed: ${agentName} could not reach the managed inference.local route in '${sandboxName}'.`,
+    );
+    process.exit(1);
+  }
   const smokeResult = runAgentSmokeCommands(sandboxName, agent, capture);
   if (!smokeResult.ok) {
     console.error(

--- a/src/lib/onboard/dockerfile-patch.ts
+++ b/src/lib/onboard/dockerfile-patch.ts
@@ -246,9 +246,9 @@ export function patchStagedDockerfile(
     );
   }
   // Honor NEMOCLAW_PROXY_HOST / NEMOCLAW_PROXY_PORT exported in the host
-  // shell so the sandbox-side nemoclaw-start.sh sees them via $ENV at runtime.
-  // Without this, the host export is silently dropped at image build time and
-  // the sandbox falls back to the default 10.200.0.1:3128 proxy. See #1409.
+  // shell. Agent Dockerfiles consume these validated build args; dcode pins
+  // them into root-owned image files so untrusted runtime env cannot redirect
+  // its managed inference traffic. See #1409 and #6191.
   const proxyHostEnv = process.env.NEMOCLAW_PROXY_HOST;
   if (proxyHostEnv && isValidProxyHost(proxyHostEnv)) {
     dockerfile = dockerfile.replace(

--- a/src/lib/onboard/sandbox-create-launch.ts
+++ b/src/lib/onboard/sandbox-create-launch.ts
@@ -58,14 +58,11 @@ export function prepareSandboxCreateLaunch(input: SandboxCreateLaunchInput): San
     dropCredentialBearingProxyUrls: input.agent?.name === "langchain-deepagents-code",
   });
 
-  // Propagate NEMOCLAW_PROXY_HOST / NEMOCLAW_PROXY_PORT to the runtime
-  // sandbox container. patchStagedDockerfile() already substitutes them
-  // into the build-time Dockerfile ARG/ENV, but `openshell sandbox create
-  // -- env ... nemoclaw-start` only forwards the explicitly listed env vars;
-  // image-baked ENV does not propagate into the running pod. Without
-  // this, nemoclaw-start.sh falls back to the default 10.200.0.1:3128
-  // and `HTTPS_PROXY` inside the sandbox ignores the host override. The
-  // build-time substitution and runtime env stay in sync as a result.
+  // Propagate NEMOCLAW_PROXY_HOST / NEMOCLAW_PROXY_PORT to runtime containers
+  // that consume them from sandbox-create env. patchStagedDockerfile() also
+  // substitutes the validated build args; dcode pins that build-time source in
+  // root-owned image files instead of trusting this runtime copy. Keep both
+  // paths in sync for the other agent images that still consume runtime env.
   // Fixes #2424. Uses the shared isValidProxyHost / isValidProxyPort
   // helpers so build-time and runtime validation stay aligned.
   const sandboxProxyHost = env.NEMOCLAW_PROXY_HOST;

--- a/test/dcode-start-keepalive.test.ts
+++ b/test/dcode-start-keepalive.test.ts
@@ -3,6 +3,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -16,9 +17,40 @@ const START_SCRIPT = path.join(
 
 // start.sh hardcodes this runtime-env path; clean it up so the test is hermetic.
 const RUNTIME_ENV_FILE = "/tmp/nemoclaw-proxy-env.sh";
+const tempDirs: string[] = [];
+
+function makeStartFixture(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-keepalive-"));
+  const scriptPath = path.join(tempDir, "start.sh");
+  const hostFile = path.join(tempDir, "trusted-proxy-host");
+  const portFile = path.join(tempDir, "trusted-proxy-port");
+  const fixture = fs
+    .readFileSync(START_SCRIPT, "utf8")
+    .replace(
+      'readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw/dcode-proxy-host"',
+      `readonly MANAGED_PROXY_HOST_FILE="${hostFile}"`,
+    )
+    .replace(
+      'readonly MANAGED_PROXY_PORT_FILE="/usr/local/share/nemoclaw/dcode-proxy-port"',
+      `readonly MANAGED_PROXY_PORT_FILE="${portFile}"`,
+    )
+    .replace(
+      "readonly MANAGED_PROXY_OWNER_UID=0",
+      `readonly MANAGED_PROXY_OWNER_UID=${process.getuid?.() ?? 0}`,
+    );
+  fs.writeFileSync(hostFile, "10.200.0.1\n");
+  fs.writeFileSync(portFile, "3128\n");
+  fs.chmodSync(hostFile, 0o444);
+  fs.chmodSync(portFile, 0o444);
+  fs.writeFileSync(scriptPath, fixture);
+  fs.chmodSync(scriptPath, 0o755);
+  tempDirs.push(tempDir);
+  return scriptPath;
+}
 
 afterEach(() => {
   fs.rmSync(RUNTIME_ENV_FILE, { force: true });
+  for (const tempDir of tempDirs.splice(0)) fs.rmSync(tempDir, { force: true, recursive: true });
 });
 
 describe("Deep Agents Code sandbox entrypoint keep-alive (#5717)", () => {
@@ -33,7 +65,8 @@ describe("Deep Agents Code sandbox entrypoint keep-alive (#5717)", () => {
     // script directly (not via `bash`) so this also exercises the real ENTRYPOINT
     // contract — the image runs /usr/local/bin/nemoclaw-start directly, so a
     // broken shebang or execute bit would also be caught here.
-    const result = spawnSync(START_SCRIPT, [], {
+    expect(fs.statSync(START_SCRIPT).mode & 0o111).not.toBe(0);
+    const result = spawnSync(makeStartFixture(), [], {
       input: "",
       timeout: 3000,
       encoding: "utf-8",
@@ -47,7 +80,7 @@ describe("Deep Agents Code sandbox entrypoint keep-alive (#5717)", () => {
   });
 
   it("execs an explicitly supplied command instead of idling", () => {
-    const result = spawnSync(START_SCRIPT, ["printf", "RAN_CMD"], {
+    const result = spawnSync(makeStartFixture(), ["printf", "RAN_CMD"], {
       input: "",
       timeout: 3000,
       encoding: "utf-8",

--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -44,34 +44,22 @@ sandbox_login_exec() {
     HOME=/sandbox bash -lc "$1" 2>&1
 }
 
-sandbox_login_proxy_contract() {
-  # This command is evaluated by the login shell inside the sandbox.
-  # shellcheck disable=SC2016
-  sandbox_login_exec '
-set -euo pipefail
-contract_fail() {
-  printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_FAIL:$1"
-  exit 1
+sandbox_direct_dcode() {
+  openshell sandbox exec --name "$SANDBOX_NAME" --timeout "$HEADLESS_TIMEOUT" -- dcode "$@" 2>&1
 }
-[ "${HOME:-}" = /sandbox ] || contract_fail home
-proxy_url="${HTTP_PROXY:-}"
-case "$proxy_url" in
-  http://*:* ) ;;
-  *) contract_fail proxy-shape ;;
-esac
-case "$proxy_url" in
-  *"@"*) contract_fail proxy-credentials ;;
-esac
-[ "$proxy_url" = "${HTTPS_PROXY:-}" ] || contract_fail https-proxy
-[ "$proxy_url" = "${http_proxy:-}" ] || contract_fail lower-http-proxy
-[ "$proxy_url" = "${https_proxy:-}" ] || contract_fail lower-https-proxy
-proxy_host="${proxy_url#http://}"
-proxy_host="${proxy_host%:*}"
-expected_no_proxy="localhost,127.0.0.1,::1,${proxy_host}"
-[ "${NO_PROXY:-}" = "$expected_no_proxy" ] || contract_fail no-proxy
-[ "${no_proxy:-}" = "$expected_no_proxy" ] || contract_fail lower-no-proxy
-printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_OK"
-'
+
+nemoclaw_connect_probe() {
+  "${NEMOCLAW_CLI_BIN:-nemoclaw}" "$SANDBOX_NAME" connect --probe-only 2>&1
+}
+
+sandbox_login_proxy_contract() {
+  # OpenShell rejects CR/LF in any exec argv element, so keep this remote login
+  # command on one physical line. inference.local is intentionally absent from
+  # NO_PROXY: the managed proxy, not direct DNS/hosts resolution, routes it.
+  local contract_command
+  # shellcheck disable=SC2016
+  contract_command='set -euo pipefail; contract_fail() { printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_FAIL:$1"; exit 1; }; [ "${HOME:-}" = /sandbox ] || contract_fail home; proxy_url="${HTTP_PROXY:-}"; case "$proxy_url" in http://*:*) ;; *) contract_fail proxy-shape ;; esac; case "$proxy_url" in *"@"*) contract_fail proxy-credentials ;; esac; [ "$proxy_url" = "${HTTPS_PROXY:-}" ] || contract_fail https-proxy; [ "$proxy_url" = "${http_proxy:-}" ] || contract_fail lower-http-proxy; [ "$proxy_url" = "${https_proxy:-}" ] || contract_fail lower-https-proxy; proxy_host="${proxy_url#http://}"; proxy_host="${proxy_host%:*}"; expected_no_proxy="localhost,127.0.0.1,::1,${proxy_host}"; [ "${NO_PROXY:-}" = "$expected_no_proxy" ] || contract_fail no-proxy; [ "${no_proxy:-}" = "$expected_no_proxy" ] || contract_fail lower-no-proxy; printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_OK"'
+  sandbox_login_exec "$contract_command"
 }
 
 sandbox_artifact_scan_command() {
@@ -228,13 +216,36 @@ main() {
     fail_test "login-shell dcode -n did not exit 0 with PONG (${classification}, exit ${dcode_exit:-unknown})"
   fi
 
-  # 5. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.
+  # 5. The public direct-exec path reaches inference without shell startup files.
+  if direct_output="$(sandbox_direct_dcode -n "Reply with exactly one word: PONG")"; then
+    direct_exit=0
+  else
+    direct_exit=$?
+  fi
+  direct_headless_output="${direct_output}
+DCODE_EXIT:${direct_exit}"
+  if direct_classification="$(classify_headless_output "$direct_exit" "$direct_headless_output")"; then
+    pass "direct-exec dcode -n reached managed inference with ${direct_classification} (exit ${direct_exit})"
+  else
+    fail_test "direct-exec dcode -n did not exit 0 with PONG (${direct_classification}, exit ${direct_exit})"
+  fi
+
+  # 6. The user-facing connect readiness path accepts the same managed route.
+  if connect_output="$(nemoclaw_connect_probe)"; then
+    pass "nemoclaw connect --probe-only accepted the managed inference route"
+  else
+    fail_test "nemoclaw connect --probe-only rejected the managed inference route"
+  fi
+
+  # 7. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.
   leak_scan="$(sandbox_exec "$(sandbox_artifact_scan_command)" || true)"
   combined="${config_output}
 ${leak_scan}
 ${proxy_contract_output}
 ${route_output}
-${headless_output}"
+${headless_output}
+${direct_headless_output}
+${connect_output}"
   if printf '%s' "$combined" | contains_secret; then
     fail_test "secret-shaped value found in config/env/output (redacted from log)"
   else

--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -55,10 +55,12 @@ nemoclaw_connect_probe() {
 sandbox_login_proxy_contract() {
   # OpenShell rejects CR/LF in any exec argv element, so keep this remote login
   # command on one physical line. inference.local is intentionally absent from
-  # NO_PROXY: the managed proxy, not direct DNS/hosts resolution, routes it.
+  # NO_PROXY: OpenShell does not need to provision inference.local DNS/hosts
+  # into the sandbox because its managed proxy owns this L7 route. Adding
+  # inference.local here would bypass that proxy and force a direct DNS lookup.
   local contract_command
   # shellcheck disable=SC2016
-  contract_command='set -euo pipefail; contract_fail() { printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_FAIL:$1"; exit 1; }; [ "${HOME:-}" = /sandbox ] || contract_fail home; proxy_url="${HTTP_PROXY:-}"; case "$proxy_url" in http://*:*) ;; *) contract_fail proxy-shape ;; esac; case "$proxy_url" in *"@"*) contract_fail proxy-credentials ;; esac; [ "$proxy_url" = "${HTTPS_PROXY:-}" ] || contract_fail https-proxy; [ "$proxy_url" = "${http_proxy:-}" ] || contract_fail lower-http-proxy; [ "$proxy_url" = "${https_proxy:-}" ] || contract_fail lower-https-proxy; proxy_host="${proxy_url#http://}"; proxy_host="${proxy_host%:*}"; expected_no_proxy="localhost,127.0.0.1,::1,${proxy_host}"; [ "${NO_PROXY:-}" = "$expected_no_proxy" ] || contract_fail no-proxy; [ "${no_proxy:-}" = "$expected_no_proxy" ] || contract_fail lower-no-proxy; printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_OK"'
+  contract_command='set -euo pipefail; contract_fail() { printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_FAIL:$1"; exit 1; }; proxy_file_metadata() { stat -c "%u:%a" "$1" 2>/dev/null || stat -f "%u:%Lp" "$1" 2>/dev/null; }; [ "${HOME:-}" = /sandbox ] || contract_fail home; for file in /usr/local/share/nemoclaw/dcode-proxy-host /usr/local/share/nemoclaw/dcode-proxy-port; do [ -f "$file" ] && [ ! -L "$file" ] && [ "$(proxy_file_metadata "$file")" = "0:444" ] || contract_fail proxy-file-trust; done; proxy_url="${HTTP_PROXY:-}"; case "$proxy_url" in http://*:*) ;; *) contract_fail proxy-shape ;; esac; case "$proxy_url" in *"@"*) contract_fail proxy-credentials ;; esac; [ "$proxy_url" = "${HTTPS_PROXY:-}" ] || contract_fail https-proxy; [ "$proxy_url" = "${http_proxy:-}" ] || contract_fail lower-http-proxy; [ "$proxy_url" = "${https_proxy:-}" ] || contract_fail lower-https-proxy; proxy_host="${proxy_url#http://}"; proxy_host="${proxy_host%:*}"; expected_no_proxy="localhost,127.0.0.1,::1,${proxy_host}"; [ "${NO_PROXY:-}" = "$expected_no_proxy" ] || contract_fail no-proxy; [ "${no_proxy:-}" = "$expected_no_proxy" ] || contract_fail lower-no-proxy; printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_OK"'
   sandbox_login_exec "$contract_command"
 }
 
@@ -189,7 +191,22 @@ main() {
     fail_test "config.toml does not use the managed placeholder API key env reference (captured config redacted from log)"
   fi
 
-  # 2. The login shell loaded the exact normalized proxy contract from .profile.
+  # 2. Record whether direct DNS/hosts is absent. When it is, the following
+  # login, direct-exec, and connect successes prove they do not depend on it;
+  # a present route is informational and is not credited as that proof.
+  dns_hosts_output="$(sandbox_exec "if ! command -v getent >/dev/null 2>&1 || ! command -v timeout >/dev/null 2>&1; then printf '%s\\n' NEMOCLAW_DCODE_DNS_PROBE_UNAVAILABLE; elif timeout 5 getent hosts inference.local >/dev/null 2>&1; then printf '%s\\n' NEMOCLAW_DCODE_DNS_PRESENT; else status=\$?; if [ \"\$status\" -eq 124 ]; then printf '%s\\n' NEMOCLAW_DCODE_DNS_PROBE_TIMEOUT; else printf '%s\\n' NEMOCLAW_DCODE_DNS_ABSENT; fi; fi")"
+  if printf '%s\n' "$dns_hosts_output" | grep -Fxq "NEMOCLAW_DCODE_DNS_ABSENT"; then
+    direct_dns_state=absent
+    pass "direct inference.local DNS/hosts is absent; exercising the proxy-only contract"
+  elif printf '%s\n' "$dns_hosts_output" | grep -Fxq "NEMOCLAW_DCODE_DNS_PRESENT"; then
+    direct_dns_state=present
+    info "direct inference.local DNS/hosts is present; proxy independence is not inferred from this observation"
+  else
+    direct_dns_state=unknown
+    fail_test "could not observe the direct inference.local DNS/hosts state"
+  fi
+
+  # 3. The login shell loaded the exact normalized proxy contract from .profile.
   proxy_contract_output="$(sandbox_login_proxy_contract || true)"
   if printf '%s\n' "$proxy_contract_output" | grep -Fxq "NEMOCLAW_DCODE_PROXY_ENV_OK"; then
     pass "login shell loaded the normalized managed proxy environment"
@@ -198,8 +215,8 @@ main() {
     fail_test "login shell did not load the normalized managed proxy environment (${proxy_contract_reason:-unknown contract mismatch})"
   fi
 
-  # 3. The managed route is reachable through the normalized login-shell proxy.
-  route_output="$(sandbox_login_exec "curl -sS -o /dev/null -w 'HTTP_CODE:%{http_code}' --max-time 30 https://inference.local/v1/models" || true)"
+  # 4. The managed route is reachable through the normalized login-shell proxy.
+  route_output="$(sandbox_login_exec "curl -sS -o /dev/null -w 'HTTP_CODE:%{http_code}' --proxy \"\${HTTPS_PROXY}\" --noproxy \"\${NO_PROXY}\" --max-time 30 https://inference.local/v1/models" || true)"
   route_code="$(printf '%s' "$route_output" | sed -n 's/.*HTTP_CODE:\([0-9][0-9][0-9]\).*/\1/p' | tail -n1)"
   if [ "$route_code" = "200" ]; then
     pass "login-shell proxy reached https://inference.local/v1/models"
@@ -207,16 +224,16 @@ main() {
     fail_test "login-shell proxy did not receive HTTP 200 from https://inference.local/v1/models (HTTP ${route_code:-000})"
   fi
 
-  # 4. The same login-shell path runs dcode and returns PONG.
+  # 5. The same login-shell path runs dcode and returns PONG.
   headless_output="$(sandbox_login_exec "cd /sandbox && timeout ${HEADLESS_TIMEOUT} dcode -n 'Reply with exactly one word: PONG'; echo \"DCODE_EXIT:\$?\"" || true)"
   dcode_exit="$(printf '%s' "$headless_output" | sed -n 's/.*DCODE_EXIT:\([0-9]\+\).*/\1/p' | tail -n1)"
   if classification="$(classify_headless_output "${dcode_exit:-unknown}" "$headless_output")"; then
-    pass "login-shell dcode -n reached managed inference with ${classification} (exit ${dcode_exit:-unknown})"
+    pass "login-shell dcode -n reached managed inference with ${classification} (exit ${dcode_exit:-unknown}; direct DNS/hosts ${direct_dns_state})"
   else
     fail_test "login-shell dcode -n did not exit 0 with PONG (${classification}, exit ${dcode_exit:-unknown})"
   fi
 
-  # 5. The public direct-exec path reaches inference without shell startup files.
+  # 6. The public direct-exec path reaches inference without shell startup files.
   if direct_output="$(sandbox_direct_dcode -n "Reply with exactly one word: PONG")"; then
     direct_exit=0
   else
@@ -225,24 +242,25 @@ main() {
   direct_headless_output="${direct_output}
 DCODE_EXIT:${direct_exit}"
   if direct_classification="$(classify_headless_output "$direct_exit" "$direct_headless_output")"; then
-    pass "direct-exec dcode -n reached managed inference with ${direct_classification} (exit ${direct_exit})"
+    pass "direct-exec dcode -n reached managed inference with ${direct_classification} (exit ${direct_exit}; direct DNS/hosts ${direct_dns_state})"
   else
     fail_test "direct-exec dcode -n did not exit 0 with PONG (${direct_classification}, exit ${direct_exit})"
   fi
 
-  # 6. The user-facing connect readiness path accepts the same managed route.
+  # 7. The user-facing connect readiness path accepts the same managed route.
   if connect_output="$(nemoclaw_connect_probe)"; then
     connect_exit=0
-    pass "nemoclaw connect --probe-only accepted the managed inference route"
+    pass "nemoclaw connect --probe-only accepted the managed inference route (direct DNS/hosts ${direct_dns_state})"
   else
     connect_exit=$?
     fail_test "nemoclaw connect --probe-only rejected the managed inference route (exit ${connect_exit})"
   fi
 
-  # 7. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.
+  # 8. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.
   leak_scan="$(sandbox_exec "$(sandbox_artifact_scan_command)" || true)"
   combined="${config_output}
 ${leak_scan}
+${dns_hosts_output}
 ${proxy_contract_output}
 ${route_output}
 ${headless_output}

--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -6,10 +6,10 @@
 #
 # Headless `dcode -n "<prompt>"`, run inside a built Deep Agents Code sandbox,
 # must route through the managed https://inference.local/v1 endpoint using the
-# placeholder OpenAI-compatible key NemoClaw writes into config.toml, and either
-# return a response or a deterministic, actionable provider/model error (never a
-# hang or ambiguous failure). No real provider/proxy credentials may appear in
-# config.toml, .env, .mcp.json, /tmp/nemoclaw-proxy-env.sh, or the captured output.
+# placeholder OpenAI-compatible key NemoClaw writes into config.toml. The login
+# shell path must return PONG with exit 0; provider, connection, DNS, timeout, and
+# ambiguous failures are not acceptable. No real provider/proxy credentials may
+# appear in config.toml, .env, .mcp.json, /tmp/nemoclaw-proxy-env.sh, or output.
 
 set -euo pipefail
 
@@ -30,6 +30,35 @@ pass() {
 
 sandbox_exec() {
   openshell sandbox exec --name "$SANDBOX_NAME" -- bash -c "$1" 2>&1
+}
+
+sandbox_login_exec() {
+  openshell sandbox exec --name "$SANDBOX_NAME" -- bash -lc "$1" 2>&1
+}
+
+sandbox_login_proxy_contract() {
+  # This command is evaluated by the login shell inside the sandbox.
+  # shellcheck disable=SC2016
+  sandbox_login_exec '
+set -euo pipefail
+proxy_url="${HTTP_PROXY:-}"
+case "$proxy_url" in
+  http://*:* ) ;;
+  *) exit 1 ;;
+esac
+case "$proxy_url" in
+  *"@"*) exit 1 ;;
+esac
+[ "$proxy_url" = "${HTTPS_PROXY:-}" ]
+[ "$proxy_url" = "${http_proxy:-}" ]
+[ "$proxy_url" = "${https_proxy:-}" ]
+proxy_host="${proxy_url#http://}"
+proxy_host="${proxy_host%:*}"
+expected_no_proxy="localhost,127.0.0.1,::1,${proxy_host}"
+[ "${NO_PROXY:-}" = "$expected_no_proxy" ]
+[ "${no_proxy:-}" = "$expected_no_proxy" ]
+printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_OK"
+'
 }
 
 sandbox_artifact_scan_command() {
@@ -71,8 +100,12 @@ is_local_execution_failure() {
   grep -Eiq '(^|[[:space:]])(usage:|Traceback|SyntaxError|ImportError|ModuleNotFoundError|No module named|command not found|No such file or directory|Permission denied|invalid option)([[:space:]]|$)|DCODE_EXIT:12[67]'
 }
 
+is_inference_connection_failure() {
+  grep -Eiq 'APIConnectionError|APITimeoutError|ConnectError|ConnectTimeout|ReadTimeout|Could not resolve host|Name or service not known|Temporary failure in name resolution|getaddrinfo.*(ENOTFOUND|EAI_AGAIN|failed|error)|nodename nor servname provided|DNS (lookup|resolution) (failed|error)|connection (timed out|refused)|request timed out'
+}
+
 is_actionable_inference_error() {
-  grep -Eiq 'inference\.local|provider|model|NVIDIA|OpenAI|API key|authentication|authorization|unauthorized|forbidden|rate[ -]?limit|quota|HTTP[[:space:]]*(401|403|404|429|5[0-9]{2})|status[[:space:]]*(401|403|404|429|5[0-9]{2})'
+  grep -Eiq 'API key|authentication|authorization|unauthorized|forbidden|rate[ -]?limit|quota|HTTP[[:space:]]*(401|403|404|429|5[0-9]{2})|status[[:space:]]*(401|403|404|429|5[0-9]{2})|(inference\.local|provider|model|NVIDIA|OpenAI).*(error|failed|failure|invalid|unavailable)|(error|failed|failure|invalid|unavailable).*(inference\.local|provider|model|NVIDIA|OpenAI)'
 }
 
 classify_headless_output() {
@@ -86,6 +119,19 @@ classify_headless_output() {
     return 1
   fi
 
+  if [ "$dcode_exit" != "0" ]; then
+    if printf '%s' "$payload" | is_local_execution_failure; then
+      printf '%s\n' "local-execution-failure"
+    elif printf '%s' "$payload" | is_inference_connection_failure; then
+      printf '%s\n' "inference-connection-failure"
+    elif printf '%s' "$payload" | is_actionable_inference_error; then
+      printf '%s\n' "actionable-inference-error"
+    else
+      printf '%s\n' "nonzero-exit"
+    fi
+    return 1
+  fi
+
   if [ -z "$(printf '%s' "$payload" | tr -d '[:space:]')" ]; then
     printf '%s\n' "empty-output"
     return 1
@@ -96,13 +142,18 @@ classify_headless_output() {
     return 1
   fi
 
-  if printf '%s' "$payload" | grep -Eiq '(^|[^[:alnum:]_])PONG([^[:alnum:]_]|$)'; then
-    printf '%s\n' "pong"
-    return 0
+  if printf '%s' "$payload" | is_inference_connection_failure; then
+    printf '%s\n' "inference-connection-failure"
+    return 1
   fi
 
   if printf '%s' "$payload" | is_actionable_inference_error; then
     printf '%s\n' "actionable-inference-error"
+    return 1
+  fi
+
+  if printf '%s' "$payload" | grep -Eiq '(^|[^[:alnum:]_])PONG([^[:alnum:]_]|$)'; then
+    printf '%s\n' "pong"
     return 0
   fi
 
@@ -137,19 +188,38 @@ main() {
     fail_test "config.toml does not use the managed placeholder API key env reference (captured config redacted from log)"
   fi
 
-  # 2. Headless dcode -n returns PONG or a deterministic, actionable inference error.
-  headless_output="$(sandbox_exec "cd /sandbox && timeout ${HEADLESS_TIMEOUT} dcode -n 'Reply with exactly one word: PONG'; echo \"DCODE_EXIT:\$?\"")"
-  dcode_exit="$(printf '%s' "$headless_output" | sed -n 's/.*DCODE_EXIT:\([0-9]\+\).*/\1/p' | tail -n1)"
-  if classification="$(classify_headless_output "${dcode_exit:-unknown}" "$headless_output")"; then
-    pass "dcode -n reached managed inference with ${classification} (exit ${dcode_exit:-unknown})"
+  # 2. The login shell loaded the exact normalized proxy contract from .profile.
+  proxy_contract_output="$(sandbox_login_proxy_contract || true)"
+  if printf '%s\n' "$proxy_contract_output" | grep -Fxq "NEMOCLAW_DCODE_PROXY_ENV_OK"; then
+    pass "login shell loaded the normalized managed proxy environment"
   else
-    fail_test "dcode -n did not produce PONG or an allowlisted provider/model/inference error (${classification}, exit ${dcode_exit:-unknown})"
+    fail_test "login shell did not load the normalized managed proxy environment"
   fi
 
-  # 3. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.
+  # 3. The managed route is reachable through the normalized login-shell proxy.
+  route_output="$(sandbox_login_exec "curl -sS -o /dev/null -w 'HTTP_CODE:%{http_code}' --max-time 30 https://inference.local/v1/models" || true)"
+  route_code="$(printf '%s' "$route_output" | sed -n 's/.*HTTP_CODE:\([0-9][0-9][0-9]\).*/\1/p' | tail -n1)"
+  if [ "$route_code" = "200" ]; then
+    pass "login-shell proxy reached https://inference.local/v1/models"
+  else
+    fail_test "login-shell proxy did not receive HTTP 200 from https://inference.local/v1/models (HTTP ${route_code:-000})"
+  fi
+
+  # 4. The same login-shell path runs dcode and returns PONG.
+  headless_output="$(sandbox_login_exec "cd /sandbox && timeout ${HEADLESS_TIMEOUT} dcode -n 'Reply with exactly one word: PONG'; echo \"DCODE_EXIT:\$?\"")"
+  dcode_exit="$(printf '%s' "$headless_output" | sed -n 's/.*DCODE_EXIT:\([0-9]\+\).*/\1/p' | tail -n1)"
+  if classification="$(classify_headless_output "${dcode_exit:-unknown}" "$headless_output")"; then
+    pass "login-shell dcode -n reached managed inference with ${classification} (exit ${dcode_exit:-unknown})"
+  else
+    fail_test "login-shell dcode -n did not exit 0 with PONG (${classification}, exit ${dcode_exit:-unknown})"
+  fi
+
+  # 5. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.
   leak_scan="$(sandbox_exec "$(sandbox_artifact_scan_command)" || true)"
   combined="${config_output}
 ${leak_scan}
+${proxy_contract_output}
+${route_output}
 ${headless_output}"
   if printf '%s' "$combined" | contains_secret; then
     fail_test "secret-shaped value found in config/env/output (redacted from log)"

--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -49,7 +49,7 @@ sandbox_direct_dcode() {
 }
 
 nemoclaw_connect_probe() {
-  "${NEMOCLAW_CLI_BIN:-nemoclaw}" "$SANDBOX_NAME" connect --probe-only 2>&1
+  "${NEMOCLAW_CLI_BIN:-${REPO:-.}/bin/nemoclaw.js}" "$SANDBOX_NAME" connect --probe-only 2>&1
 }
 
 sandbox_login_proxy_contract() {
@@ -232,9 +232,11 @@ DCODE_EXIT:${direct_exit}"
 
   # 6. The user-facing connect readiness path accepts the same managed route.
   if connect_output="$(nemoclaw_connect_probe)"; then
+    connect_exit=0
     pass "nemoclaw connect --probe-only accepted the managed inference route"
   else
-    fail_test "nemoclaw connect --probe-only rejected the managed inference route"
+    connect_exit=$?
+    fail_test "nemoclaw connect --probe-only rejected the managed inference route (exit ${connect_exit})"
   fi
 
   # 7. No real secrets in managed config, runtime env files, artifacts, logs, or captured output.

--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -220,7 +220,7 @@ main() {
   fi
 
   # 4. The same login-shell path runs dcode and returns PONG.
-  headless_output="$(sandbox_login_exec "cd /sandbox && timeout ${HEADLESS_TIMEOUT} dcode -n 'Reply with exactly one word: PONG'; echo \"DCODE_EXIT:\$?\"")"
+  headless_output="$(sandbox_login_exec "cd /sandbox && timeout ${HEADLESS_TIMEOUT} dcode -n 'Reply with exactly one word: PONG'; echo \"DCODE_EXIT:\$?\"" || true)"
   dcode_exit="$(printf '%s' "$headless_output" | sed -n 's/.*DCODE_EXIT:\([0-9]\+\).*/\1/p' | tail -n1)"
   if classification="$(classify_headless_output "${dcode_exit:-unknown}" "$headless_output")"; then
     pass "login-shell dcode -n reached managed inference with ${classification} (exit ${dcode_exit:-unknown})"

--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -10,6 +10,8 @@
 # shell path must return PONG with exit 0; provider, connection, DNS, timeout, and
 # ambiguous failures are not acceptable. No real provider/proxy credentials may
 # appear in config.toml, .env, .mcp.json, /tmp/nemoclaw-proxy-env.sh, or output.
+# Direct DNS/hosts resolution is intentionally not required: OpenShell's managed
+# proxy routes inference.local when the request follows the normalized path.
 
 set -euo pipefail
 
@@ -33,7 +35,13 @@ sandbox_exec() {
 }
 
 sandbox_login_exec() {
-  openshell sandbox exec --name "$SANDBOX_NAME" -- bash -lc "$1" 2>&1
+  # OpenShell exec sessions may carry their own environment. Remove it so this
+  # probe can only recover the proxy contract through /sandbox/.profile, then
+  # pin HOME so bash selects the sandbox user's trusted login startup file.
+  openshell sandbox exec --name "$SANDBOX_NAME" -- env \
+    -u HTTP_PROXY -u HTTPS_PROXY -u NO_PROXY \
+    -u http_proxy -u https_proxy -u no_proxy \
+    HOME=/sandbox bash -lc "$1" 2>&1
 }
 
 sandbox_login_proxy_contract() {
@@ -41,22 +49,27 @@ sandbox_login_proxy_contract() {
   # shellcheck disable=SC2016
   sandbox_login_exec '
 set -euo pipefail
+contract_fail() {
+  printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_FAIL:$1"
+  exit 1
+}
+[ "${HOME:-}" = /sandbox ] || contract_fail home
 proxy_url="${HTTP_PROXY:-}"
 case "$proxy_url" in
   http://*:* ) ;;
-  *) exit 1 ;;
+  *) contract_fail proxy-shape ;;
 esac
 case "$proxy_url" in
-  *"@"*) exit 1 ;;
+  *"@"*) contract_fail proxy-credentials ;;
 esac
-[ "$proxy_url" = "${HTTPS_PROXY:-}" ]
-[ "$proxy_url" = "${http_proxy:-}" ]
-[ "$proxy_url" = "${https_proxy:-}" ]
+[ "$proxy_url" = "${HTTPS_PROXY:-}" ] || contract_fail https-proxy
+[ "$proxy_url" = "${http_proxy:-}" ] || contract_fail lower-http-proxy
+[ "$proxy_url" = "${https_proxy:-}" ] || contract_fail lower-https-proxy
 proxy_host="${proxy_url#http://}"
 proxy_host="${proxy_host%:*}"
 expected_no_proxy="localhost,127.0.0.1,::1,${proxy_host}"
-[ "${NO_PROXY:-}" = "$expected_no_proxy" ]
-[ "${no_proxy:-}" = "$expected_no_proxy" ]
+[ "${NO_PROXY:-}" = "$expected_no_proxy" ] || contract_fail no-proxy
+[ "${no_proxy:-}" = "$expected_no_proxy" ] || contract_fail lower-no-proxy
 printf "%s\n" "NEMOCLAW_DCODE_PROXY_ENV_OK"
 '
 }
@@ -193,7 +206,8 @@ main() {
   if printf '%s\n' "$proxy_contract_output" | grep -Fxq "NEMOCLAW_DCODE_PROXY_ENV_OK"; then
     pass "login shell loaded the normalized managed proxy environment"
   else
-    fail_test "login shell did not load the normalized managed proxy environment"
+    proxy_contract_reason="$(printf '%s\n' "$proxy_contract_output" | sed -n 's/^NEMOCLAW_DCODE_PROXY_ENV_FAIL:\([a-z-]*\)$/\1/p' | tail -n1)"
+    fail_test "login shell did not load the normalized managed proxy environment (${proxy_contract_reason:-unknown contract mismatch})"
   fi
 
   # 3. The managed route is reachable through the normalized login-shell proxy.

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -251,7 +251,6 @@ describe("LangChain Deep Agents Code image contracts", () => {
     const outputLines = output.trimEnd().split("\n");
     const envFileLines = envFileText.trimEnd().split("\n");
     expect(envFileText).toContain(`export PATH="${DCODE_CANONICAL_PATH}"`);
-    expect(envFileText.match(/\/usr\/local\/bin/g)).toHaveLength(1);
     for (const name of PROXY_URL_ENV_NAMES) {
       expect(outputLines).toContain(`RUNTIME_${name}=${managedProxy}`);
       expect(outputLines).toContain(`SOURCED_${name}=${managedProxy}`);
@@ -338,6 +337,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
 
   it("keeps all Deep Agents Code entry points behind the managed wrapper boundary", () => {
     const dockerfile = readAgentFile("Dockerfile");
+    const launcher = readAgentFile("dcode-launcher.sh");
     const wrapper = readAgentFile("dcode-wrapper.sh");
     const policy = readAgentFile("policy-additions.yaml");
 
@@ -349,11 +349,12 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(wrapper).toContain("unset DEEPAGENTS_CODE_SHELL_ALLOW_LIST");
     expect(wrapper).not.toContain("NEMOCLAW_DEEPAGENTS_CODE_SHELL_ALLOW_LIST");
     expect(dockerfile).toContain(
-      "install -m 0755 /usr/local/lib/nemoclaw/dcode-wrapper.sh /usr/local/bin/dcode.real",
+      "install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/dcode.real",
     );
     expect(dockerfile).toContain(
-      "install -m 0755 /usr/local/lib/nemoclaw/dcode-wrapper.sh /usr/local/bin/deepagents-code",
+      "install -m 0755 /usr/local/lib/nemoclaw/dcode-launcher.sh /usr/local/bin/deepagents-code",
     );
+    expect(launcher).toContain('exec "$MANAGED_DCODE_WRAPPER" "$@"');
     expect(dockerfile).not.toContain("dcode.upstream");
     expect(wrapper).toContain("exec python3 -m deepagents_code");
     expect(wrapper).toContain('reject_managed_override "sandbox isolation"');
@@ -631,6 +632,14 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(headlessCheck).toContain('HOME=/sandbox bash -lc "$1"');
     expect(headlessCheck).toContain('bash -lc "$1"');
     expect(headlessCheck).toContain("NEMOCLAW_DCODE_PROXY_ENV_OK");
+    expect(headlessCheck).toContain("local contract_command");
+    expect(headlessCheck).toContain('sandbox_login_exec "$contract_command"');
+    expect(headlessCheck).toContain("sandbox_direct_dcode");
+    expect(headlessCheck).toContain('-- dcode "$@"');
+    expect(headlessCheck).toContain("nemoclaw_connect_probe");
+    expect(headlessCheck).toContain("connect --probe-only 2>&1");
+    expect(headlessCheck).toContain("direct-exec dcode -n reached managed inference");
+    expect(headlessCheck).toContain("connect --probe-only accepted the managed inference route");
     expect(headlessCheck).toContain('sandbox_login_exec "cd /sandbox');
     expect(headlessCheck).not.toContain('sandbox_login_exec ". /tmp/nemoclaw-proxy-env.sh');
     expect(headlessCheck).toContain("https://inference.local/v1/models");
@@ -731,6 +740,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
       return runHeadlessCheckHelper(
         [
           "sandbox_login_exec() {",
+          "  case \"$1\" in *$'\\n'*|*$'\\r'*) return 97 ;; esac",
           '  env -u HTTP_PROXY -u HTTPS_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u no_proxy HOME="$TEST_LOGIN_HOME" bash -lc "$1"',
           "}",
           "if sandbox_login_proxy_contract >/dev/null 2>&1; then printf pass; else printf fail; fi",

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -637,6 +637,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(headlessCheck).toContain("sandbox_direct_dcode");
     expect(headlessCheck).toContain('-- dcode "$@"');
     expect(headlessCheck).toContain("nemoclaw_connect_probe");
+    expect(headlessCheck).toContain("${NEMOCLAW_CLI_BIN:-${REPO:-.}/bin/nemoclaw.js}");
     expect(headlessCheck).toContain("connect --probe-only 2>&1");
     expect(headlessCheck).toContain("direct-exec dcode -n reached managed inference");
     expect(headlessCheck).toContain("connect --probe-only accepted the managed inference route");

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -117,10 +117,24 @@ function makeStartScriptFixture(tempDir: string): {
 } {
   const envFile = path.join(tempDir, "proxy-env.sh");
   const scriptPath = path.join(tempDir, "start.sh");
+  const hostFile = path.join(tempDir, "trusted-proxy-host");
+  const portFile = path.join(tempDir, "trusted-proxy-port");
   const original = readAgentFile("start.sh");
   expect(original).toContain("local target=/tmp/nemoclaw-proxy-env.sh");
   expect(original).toContain('tmp="$(mktemp /tmp/nemoclaw-proxy-env.XXXXXX)"');
   const fixture = original
+    .replace(
+      'readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw/dcode-proxy-host"',
+      `readonly MANAGED_PROXY_HOST_FILE="${hostFile}"`,
+    )
+    .replace(
+      'readonly MANAGED_PROXY_PORT_FILE="/usr/local/share/nemoclaw/dcode-proxy-port"',
+      `readonly MANAGED_PROXY_PORT_FILE="${portFile}"`,
+    )
+    .replace(
+      "readonly MANAGED_PROXY_OWNER_UID=0",
+      `readonly MANAGED_PROXY_OWNER_UID=${process.getuid?.() ?? 0}`,
+    )
     .replace("local target=/tmp/nemoclaw-proxy-env.sh", `local target="${envFile}"`)
     .replace(
       'tmp="$(mktemp /tmp/nemoclaw-proxy-env.XXXXXX)"',
@@ -130,6 +144,10 @@ function makeStartScriptFixture(tempDir: string): {
   expect(fixture).toContain(`tmp="$(mktemp "${tempDir}/nemoclaw-proxy-env.XXXXXX")"`);
   expect(fixture).not.toContain("local target=/tmp/nemoclaw-proxy-env.sh");
   expect(fixture).not.toContain('tmp="$(mktemp /tmp/nemoclaw-proxy-env.XXXXXX)"');
+  fs.writeFileSync(hostFile, "10.200.0.1\n", "utf8");
+  fs.writeFileSync(portFile, "3128\n", "utf8");
+  fs.chmodSync(hostFile, 0o444);
+  fs.chmodSync(portFile, 0o444);
   fs.writeFileSync(scriptPath, fixture, "utf8");
   fs.chmodSync(scriptPath, 0o755);
   return { envFile, scriptPath };
@@ -168,8 +186,12 @@ function runStartScriptProxyProbe(
   };
 }
 
-function runHeadlessCheckHelper(snippet: string, env: NodeJS.ProcessEnv = {}): string {
-  return execFileSync("bash", ["-c", `source "$1"; ${snippet}`, "bash", headlessCheckPath], {
+function runHeadlessCheckHelper(
+  snippet: string,
+  env: NodeJS.ProcessEnv = {},
+  sourcePath = headlessCheckPath,
+): string {
+  return execFileSync("bash", ["-c", `source "$1"; ${snippet}`, "bash", sourcePath], {
     encoding: "utf8",
     env: { ...process.env, ...env },
   });
@@ -273,66 +295,6 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(combined).not.toContain("corp-user");
     expect(combined).not.toContain("corp-password");
     expect(combined).not.toContain("corp.internal");
-  });
-
-  it("honors managed proxy host and port overrides in commands and shell sessions (#6191)", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-start-"));
-    const { envFile, scriptPath } = makeStartScriptFixture(tempDir);
-
-    const { envFileText, output } = runStartScriptProxyProbe(scriptPath, envFile, {
-      HTTP_PROXY: "http://host-user:host-password@host-proxy.example:8118",
-      NO_PROXY: "localhost,inference.local",
-      NEMOCLAW_PROXY_HOST: "managed-proxy.internal",
-      NEMOCLAW_PROXY_PORT: "65535",
-    });
-
-    const managedProxy = "http://managed-proxy.internal:65535";
-    const managedNoProxy = "localhost,127.0.0.1,::1,managed-proxy.internal";
-    const outputLines = output.trimEnd().split("\n");
-    const envFileLines = envFileText.trimEnd().split("\n");
-    for (const name of PROXY_URL_ENV_NAMES) {
-      expect(outputLines).toContain(`RUNTIME_${name}=${managedProxy}`);
-      expect(outputLines).toContain(`SOURCED_${name}=${managedProxy}`);
-      expect(envFileLines).toContain(`export ${name}=${managedProxy}`);
-    }
-    for (const name of NO_PROXY_ENV_NAMES) {
-      expect(outputLines).toContain(`RUNTIME_${name}=${managedNoProxy}`);
-      expect(outputLines).toContain(`SOURCED_${name}=${managedNoProxy}`);
-      expect(envFileLines).toContain(`export ${name}=${managedNoProxy.replaceAll(",", "\\,")}`);
-    }
-    const combined = `${output}\n${envFileText}`;
-    expect(combined).not.toContain("host-proxy.example");
-    expect(combined).not.toContain("host-user");
-    expect(combined).not.toContain("host-password");
-  });
-
-  it("rejects unsafe managed proxy overrides before persisting shell state (#6191)", () => {
-    const rejectedOverrides = [
-      { NEMOCLAW_PROXY_HOST: "corp-user:corp-password@proxy.example" },
-      { NEMOCLAW_PROXY_HOST: "proxy example" },
-      { NEMOCLAW_PROXY_HOST: "proxy.example\ninjected" },
-      { NEMOCLAW_PROXY_HOST: "proxy.example/path" },
-      { NEMOCLAW_PROXY_PORT: "not-a-port" },
-      { NEMOCLAW_PROXY_PORT: "0" },
-      { NEMOCLAW_PROXY_PORT: "65536" },
-      { NEMOCLAW_PROXY_PORT: "000001" },
-    ];
-
-    for (const overrides of rejectedOverrides) {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-start-invalid-"));
-      const { envFile, scriptPath } = makeStartScriptFixture(tempDir);
-      const result = spawnSync("bash", [scriptPath, "true"], {
-        env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...overrides },
-        encoding: "utf8",
-      });
-
-      expect(result.status).not.toBe(0);
-      expect(fs.existsSync(envFile)).toBe(false);
-      const output = `${result.stdout}\n${result.stderr}`;
-      for (const value of Object.values(overrides)) {
-        expect(output).not.toContain(value);
-      }
-    }
   });
 
   it("keeps all Deep Agents Code entry points behind the managed wrapper boundary", () => {
@@ -724,6 +686,22 @@ describe("LangChain Deep Agents Code image contracts", () => {
   it("accepts only the normalized login-shell proxy contract (#6191)", () => {
     const validate = (proxyUrl: string, noProxy: string, lowerProxy = proxyUrl) => {
       const loginHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-login-"));
+      const hostFile = path.join(loginHome, "trusted-proxy-host");
+      const portFile = path.join(loginHome, "trusted-proxy-port");
+      const checkFixture = path.join(loginHome, "headless-check.sh");
+      fs.writeFileSync(hostFile, "10.200.0.1\n", "utf8");
+      fs.writeFileSync(portFile, "3128\n", "utf8");
+      fs.chmodSync(hostFile, 0o444);
+      fs.chmodSync(portFile, 0o444);
+      fs.writeFileSync(
+        checkFixture,
+        fs
+          .readFileSync(headlessCheckPath, "utf8")
+          .replaceAll("/usr/local/share/nemoclaw/dcode-proxy-host", hostFile)
+          .replaceAll("/usr/local/share/nemoclaw/dcode-proxy-port", portFile)
+          .replace('= "0:444"', `= "${process.getuid?.() ?? 0}:444"`),
+        "utf8",
+      );
       fs.writeFileSync(
         path.join(loginHome, ".profile"),
         [
@@ -747,6 +725,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
           "if sandbox_login_proxy_contract >/dev/null 2>&1; then printf pass; else printf fail; fi",
         ].join("\n"),
         { TEST_LOGIN_HOME: loginHome },
+        checkFixture,
       );
     };
 

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -135,6 +135,39 @@ function makeStartScriptFixture(tempDir: string): {
   return { envFile, scriptPath };
 }
 
+const PROXY_URL_ENV_NAMES = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] as const;
+const NO_PROXY_ENV_NAMES = ["NO_PROXY", "no_proxy"] as const;
+
+function runStartScriptProxyProbe(
+  scriptPath: string,
+  envFile: string,
+  env: NodeJS.ProcessEnv,
+): { envFileText: string; output: string } {
+  const probe = [
+    ...[...PROXY_URL_ENV_NAMES, ...NO_PROXY_ENV_NAMES].map(
+      (name) => `printf 'RUNTIME_${name}=%s\\n' "\${${name}-__unset__}"`,
+    ),
+    "unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy",
+    '. "$NEMOCLAW_TEST_PROXY_ENV"',
+    ...[...PROXY_URL_ENV_NAMES, ...NO_PROXY_ENV_NAMES].map(
+      (name) => `printf 'SOURCED_${name}=%s\\n' "\${${name}-__unset__}"`,
+    ),
+  ].join("\n");
+  const result = spawnSync("bash", [scriptPath, "bash", "-c", probe], {
+    env: {
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      ...env,
+      NEMOCLAW_TEST_PROXY_ENV: envFile,
+    },
+    encoding: "utf8",
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return {
+    envFileText: fs.readFileSync(envFile, "utf8"),
+    output: `${result.stdout}\n${result.stderr}`,
+  };
+}
+
 function runHeadlessCheckHelper(snippet: string, env: NodeJS.ProcessEnv = {}): string {
   return execFileSync("bash", ["-c", `source "$1"; ${snippet}`, "bash", headlessCheckPath], {
     encoding: "utf8",
@@ -182,7 +215,8 @@ describe("LangChain Deep Agents Code image contracts", () => {
     const startScript = readAgentFile("start.sh");
 
     expect(startScript).toContain('chmod 400 "$tmp"');
-    expect(startScript).toContain("write_proxy_export_pair HTTPS_PROXY https_proxy");
+    expect(startScript).toContain("write_export_if_set HTTPS_PROXY");
+    expect(startScript).not.toContain("write_proxy_export_pair");
     expect(startScript).not.toContain("write_export_if_set DEEPAGENTS_CODE_SHELL_ALLOW_LIST");
     expect(startScript).not.toContain("NEMOCLAW_DEEPAGENTS_CODE_SHELL_ALLOW_LIST");
     expect(startScript).not.toMatch(
@@ -190,73 +224,81 @@ describe("LangChain Deep Agents Code image contracts", () => {
     );
   });
 
-  it("serializes non-credential proxy URLs into the shell env file", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-start-"));
-    const { envFile, scriptPath } = makeStartScriptFixture(tempDir);
+  it("sources the managed runtime environment in interactive and login shells (#6191)", () => {
+    const baseDockerfile = readAgentFile("Dockerfile.base");
+    const sourceLine = "[ -f /tmp/nemoclaw-proxy-env.sh ] && . /tmp/nemoclaw-proxy-env.sh";
 
-    execFileSync("bash", [scriptPath, "sh", "-c", 'cat "$NEMOCLAW_TEST_PROXY_ENV"'], {
-      env: {
-        NEMOCLAW_TEST_PROXY_ENV: envFile,
-        PATH: process.env.PATH ?? "/usr/bin:/bin",
-        HTTP_PROXY: "http://proxy.example:8080",
-        https_proxy: "https://safe-proxy.example:8443",
-      },
-      encoding: "utf8",
-    });
-
-    const envFileText = fs.readFileSync(envFile, "utf8");
-    expect(envFileText).toContain(`export PATH="${DCODE_CANONICAL_PATH}"`);
-    expect(envFileText.match(/\/usr\/local\/bin/g)).toHaveLength(1);
-    expect(envFileText).toContain("export HTTP_PROXY=http://proxy.example:8080");
-    expect(envFileText).toContain("export https_proxy=https://safe-proxy.example:8443");
+    expect(baseDockerfile.split(sourceLine)).toHaveLength(3);
+    expect(baseDockerfile).toContain("> /sandbox/.bashrc");
+    expect(baseDockerfile).toContain("> /sandbox/.profile");
   });
 
-  it("omits and unsets credential-bearing proxy URLs", () => {
+  it("replaces inherited host proxy values with the managed runtime proxy (#6191)", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-start-"));
     const { envFile, scriptPath } = makeStartScriptFixture(tempDir);
 
-    const output = execFileSync(
-      "bash",
-      [
-        scriptPath,
-        "sh",
-        "-c",
-        [
-          'cat "$NEMOCLAW_TEST_PROXY_ENV"',
-          'printf "\\nENV_HTTP_PROXY=%s\\n" "${HTTP_PROXY-__unset__}"',
-          'printf "ENV_http_proxy=%s\\n" "${http_proxy-__unset__}"',
-          'printf "ENV_HTTPS_PROXY=%s\\n" "${HTTPS_PROXY-__unset__}"',
-          'printf "ENV_https_proxy=%s\\n" "${https_proxy-__unset__}"',
-        ].join("; "),
-      ],
-      {
-        env: {
-          NEMOCLAW_TEST_PROXY_ENV: envFile,
-          PATH: process.env.PATH ?? "/usr/bin:/bin",
-          HTTP_PROXY: "http://proxy.example:8080",
-          HTTPS_PROXY: "https://user:pass@proxy.example:8443",
-          http_proxy: "http://user:pass@proxy.example:8080",
-          https_proxy: "https://safe-proxy.example:8443",
-          NEMOCLAW_DEEPAGENTS_CODE_SHELL_ALLOW_LIST: "all",
-        },
-        encoding: "utf8",
-      },
-    );
+    const { envFileText, output } = runStartScriptProxyProbe(scriptPath, envFile, {
+      HTTP_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
+      HTTPS_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
+      NO_PROXY: "corp.internal,inference.local",
+      http_proxy: "http://lower-user:lower-password@lower-proxy.example:8080",
+      https_proxy: "http://lower-user:lower-password@lower-proxy.example:8080",
+      no_proxy: "corp.internal,inference.local",
+    });
 
-    const envFileText = fs.readFileSync(envFile, "utf8");
-    expect(envFileText).not.toContain("HTTP_PROXY");
-    expect(envFileText).not.toContain("HTTPS_PROXY");
-    expect(envFileText).not.toContain("http_proxy");
-    expect(envFileText).not.toContain("https_proxy");
-    expect(envFileText).not.toContain("NEMOCLAW_DEEPAGENTS_CODE_SHELL_ALLOW_LIST");
-    expect(envFileText).not.toContain("DEEPAGENTS_CODE_SHELL_ALLOW_LIST");
-    expect(output).toContain("ENV_HTTP_PROXY=__unset__");
-    expect(output).toContain("ENV_http_proxy=__unset__");
-    expect(output).toContain("ENV_HTTPS_PROXY=__unset__");
-    expect(output).toContain("ENV_https_proxy=__unset__");
-    expect(envFileText).not.toContain("user:pass");
-    expect(envFileText).not.toContain("user:pass@proxy.example:8443");
-    expect(envFileText).not.toContain("user:pass@proxy.example:8080");
+    const managedProxy = "http://10.200.0.1:3128";
+    const managedNoProxy = "localhost,127.0.0.1,::1,10.200.0.1";
+    const outputLines = output.trimEnd().split("\n");
+    const envFileLines = envFileText.trimEnd().split("\n");
+    expect(envFileText).toContain(`export PATH="${DCODE_CANONICAL_PATH}"`);
+    expect(envFileText.match(/\/usr\/local\/bin/g)).toHaveLength(1);
+    for (const name of PROXY_URL_ENV_NAMES) {
+      expect(outputLines).toContain(`RUNTIME_${name}=${managedProxy}`);
+      expect(outputLines).toContain(`SOURCED_${name}=${managedProxy}`);
+      expect(envFileLines).toContain(`export ${name}=${managedProxy}`);
+    }
+    for (const name of NO_PROXY_ENV_NAMES) {
+      expect(outputLines).toContain(`RUNTIME_${name}=${managedNoProxy}`);
+      expect(outputLines).toContain(`SOURCED_${name}=${managedNoProxy}`);
+      expect(envFileLines).toContain(`export ${name}=${managedNoProxy.replaceAll(",", "\\,")}`);
+    }
+    const combined = `${output}\n${envFileText}`;
+    expect(combined).not.toContain("corp-proxy.example");
+    expect(combined).not.toContain("lower-proxy.example");
+    expect(combined).not.toContain("corp-user");
+    expect(combined).not.toContain("corp-password");
+    expect(combined).not.toContain("corp.internal");
+  });
+
+  it("honors managed proxy host and port overrides in commands and shell sessions (#6191)", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-start-"));
+    const { envFile, scriptPath } = makeStartScriptFixture(tempDir);
+
+    const { envFileText, output } = runStartScriptProxyProbe(scriptPath, envFile, {
+      HTTP_PROXY: "http://host-user:host-password@host-proxy.example:8118",
+      NO_PROXY: "localhost,inference.local",
+      NEMOCLAW_PROXY_HOST: "192.168.64.1",
+      NEMOCLAW_PROXY_PORT: "8080",
+    });
+
+    const managedProxy = "http://192.168.64.1:8080";
+    const managedNoProxy = "localhost,127.0.0.1,::1,192.168.64.1";
+    const outputLines = output.trimEnd().split("\n");
+    const envFileLines = envFileText.trimEnd().split("\n");
+    for (const name of PROXY_URL_ENV_NAMES) {
+      expect(outputLines).toContain(`RUNTIME_${name}=${managedProxy}`);
+      expect(outputLines).toContain(`SOURCED_${name}=${managedProxy}`);
+      expect(envFileLines).toContain(`export ${name}=${managedProxy}`);
+    }
+    for (const name of NO_PROXY_ENV_NAMES) {
+      expect(outputLines).toContain(`RUNTIME_${name}=${managedNoProxy}`);
+      expect(outputLines).toContain(`SOURCED_${name}=${managedNoProxy}`);
+      expect(envFileLines).toContain(`export ${name}=${managedNoProxy.replaceAll(",", "\\,")}`);
+    }
+    const combined = `${output}\n${envFileText}`;
+    expect(combined).not.toContain("host-proxy.example");
+    expect(combined).not.toContain("host-user");
+    expect(combined).not.toContain("host-password");
   });
 
   it("keeps all Deep Agents Code entry points behind the managed wrapper boundary", () => {
@@ -547,6 +589,15 @@ describe("LangChain Deep Agents Code image contracts", () => {
 
     expect(headlessCheck).toContain("test -d /sandbox/.deepagents && command -v dcode");
     expect(headlessCheck).toContain("dcode -n 'Reply with exactly one word: PONG'");
+    expect(headlessCheck).toContain("sandbox_login_exec");
+    expect(headlessCheck).toContain("sandbox_login_proxy_contract");
+    expect(headlessCheck).toContain('bash -lc "$1"');
+    expect(headlessCheck).toContain("NEMOCLAW_DCODE_PROXY_ENV_OK");
+    expect(headlessCheck).toContain('sandbox_login_exec "cd /sandbox');
+    expect(headlessCheck).not.toContain('sandbox_login_exec ". /tmp/nemoclaw-proxy-env.sh');
+    expect(headlessCheck).toContain("https://inference.local/v1/models");
+    expect(headlessCheck).toContain("HTTP_CODE:%{http_code}");
+    expect(headlessCheck).toContain('[ "$route_code" = "200" ]');
     expect(headlessCheck).toContain("https://inference\\.local(/v1)?");
     expect(headlessCheck).toContain("references_managed_placeholder_key");
     expect(headlessCheck).toContain(
@@ -585,7 +636,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
     ).toBe("key");
   });
 
-  it("classifies Deep Agents Code headless output without accepting local failures", () => {
+  it("requires exit zero and PONG from Deep Agents Code headless inference (#6191)", () => {
     const classify = (exitCode: string, output: string) =>
       runHeadlessCheckHelper(
         [
@@ -601,13 +652,51 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(classify("0", "PONG\nDCODE_EXIT:0")).toBe("pass:pong");
     expect(
       classify("1", "OpenAI provider returned HTTP 401 for inference.local\nDCODE_EXIT:1"),
-    ).toBe("pass:actionable-inference-error");
+    ).toBe("fail:actionable-inference-error");
+    expect(classify("1", "PONG\nDCODE_EXIT:1")).toBe("fail:nonzero-exit");
+    expect(classify("1", "openai.APIConnectionError\nDCODE_EXIT:1")).toBe(
+      "fail:inference-connection-failure",
+    );
+    expect(classify("1", "Could not resolve host inference.local\nDCODE_EXIT:1")).toBe(
+      "fail:inference-connection-failure",
+    );
+    expect(classify("0", "OpenAI provider unavailable\nDCODE_EXIT:0")).toBe(
+      "fail:actionable-inference-error",
+    );
     expect(classify("124", "still waiting\nDCODE_EXIT:124")).toBe("fail:timeout");
     expect(classify("1", "usage: dcode [-h]\nDCODE_EXIT:1")).toBe("fail:local-execution-failure");
     expect(classify("1", "Traceback (most recent call last):\nDCODE_EXIT:1")).toBe(
       "fail:local-execution-failure",
     );
-    expect(classify("1", "something happened\nDCODE_EXIT:1")).toBe("fail:ambiguous-output");
+    expect(classify("0", "something happened\nDCODE_EXIT:0")).toBe("fail:ambiguous-output");
+    expect(classify("1", "something happened\nDCODE_EXIT:1")).toBe("fail:nonzero-exit");
+  });
+
+  it("accepts only the normalized login-shell proxy contract (#6191)", () => {
+    const validate = (proxyUrl: string, noProxy: string, lowerProxy = proxyUrl) =>
+      runHeadlessCheckHelper(
+        [
+          'sandbox_login_exec() { bash --noprofile --norc -c "$1"; }',
+          'export HTTP_PROXY="$TEST_PROXY_URL" HTTPS_PROXY="$TEST_PROXY_URL"',
+          'export http_proxy="$TEST_LOWER_PROXY_URL" https_proxy="$TEST_LOWER_PROXY_URL"',
+          'export NO_PROXY="$TEST_NO_PROXY" no_proxy="$TEST_NO_PROXY"',
+          "if sandbox_login_proxy_contract >/dev/null 2>&1; then printf pass; else printf fail; fi",
+        ].join("; "),
+        {
+          TEST_LOWER_PROXY_URL: lowerProxy,
+          TEST_NO_PROXY: noProxy,
+          TEST_PROXY_URL: proxyUrl,
+        },
+      );
+
+    const managedProxy = "http://10.200.0.1:3128";
+    const managedNoProxy = "localhost,127.0.0.1,::1,10.200.0.1";
+    expect(validate(managedProxy, managedNoProxy)).toBe("pass");
+    expect(validate(managedProxy, `${managedNoProxy},inference.local`)).toBe("fail");
+    expect(validate("http://corp-user:corp-password@proxy.example:8080", managedNoProxy)).toBe(
+      "fail",
+    );
+    expect(validate(managedProxy, managedNoProxy, "http://other-proxy.example:3128")).toBe("fail");
   });
 
   it("rejects unsafe headless timeout values before sandbox execution", () => {

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -262,6 +262,12 @@ describe("LangChain Deep Agents Code image contracts", () => {
       expect(outputLines).toContain(`SOURCED_${name}=${managedNoProxy}`);
       expect(envFileLines).toContain(`export ${name}=${managedNoProxy.replaceAll(",", "\\,")}`);
     }
+    expect(
+      outputLines.filter((line) => /^(?:RUNTIME|SOURCED)_(?:NO_PROXY|no_proxy)=/.test(line)),
+    ).not.toEqual(expect.arrayContaining([expect.stringContaining("inference.local")]));
+    expect(envFileLines.filter((line) => /^export (?:NO_PROXY|no_proxy)=/.test(line))).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("inference.local")]),
+    );
     const combined = `${output}\n${envFileText}`;
     expect(combined).not.toContain("corp-proxy.example");
     expect(combined).not.toContain("lower-proxy.example");
@@ -636,6 +642,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
       'api_key_env[[:space:]]*=[[:space:]]*"DEEPAGENTS_CODE_OPENAI_API_KEY"',
     );
     expect(headlessCheck).toContain("classify_headless_output");
+    expect(headlessCheck).toMatch(/headless_output=.*sandbox_login_exec.*\|\| true\)"/);
     expect(headlessCheck).toContain("DEEPAGENTS_HEADLESS_TIMEOUT must be a positive integer");
     expect(headlessCheck).toContain("nvapi-");
     expect(headlessCheck).toContain("nvcf-");
@@ -705,21 +712,32 @@ describe("LangChain Deep Agents Code image contracts", () => {
   });
 
   it("accepts only the normalized login-shell proxy contract (#6191)", () => {
-    const validate = (proxyUrl: string, noProxy: string, lowerProxy = proxyUrl) =>
-      runHeadlessCheckHelper(
+    const validate = (proxyUrl: string, noProxy: string, lowerProxy = proxyUrl) => {
+      const loginHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-login-"));
+      fs.writeFileSync(
+        path.join(loginHome, ".profile"),
         [
-          'sandbox_login_exec() { HOME=/sandbox bash --noprofile --norc -c "$1"; }',
-          'export HTTP_PROXY="$TEST_PROXY_URL" HTTPS_PROXY="$TEST_PROXY_URL"',
-          'export http_proxy="$TEST_LOWER_PROXY_URL" https_proxy="$TEST_LOWER_PROXY_URL"',
-          'export NO_PROXY="$TEST_NO_PROXY" no_proxy="$TEST_NO_PROXY"',
-          "if sandbox_login_proxy_contract >/dev/null 2>&1; then printf pass; else printf fail; fi",
-        ].join("; "),
-        {
-          TEST_LOWER_PROXY_URL: lowerProxy,
-          TEST_NO_PROXY: noProxy,
-          TEST_PROXY_URL: proxyUrl,
-        },
+          "export HOME=/sandbox",
+          `export HTTP_PROXY=${JSON.stringify(proxyUrl)}`,
+          `export HTTPS_PROXY=${JSON.stringify(proxyUrl)}`,
+          `export http_proxy=${JSON.stringify(lowerProxy)}`,
+          `export https_proxy=${JSON.stringify(lowerProxy)}`,
+          `export NO_PROXY=${JSON.stringify(noProxy)}`,
+          `export no_proxy=${JSON.stringify(noProxy)}`,
+          "",
+        ].join("\n"),
+        "utf8",
       );
+      return runHeadlessCheckHelper(
+        [
+          "sandbox_login_exec() {",
+          '  env -u HTTP_PROXY -u HTTPS_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u no_proxy HOME="$TEST_LOGIN_HOME" bash -lc "$1"',
+          "}",
+          "if sandbox_login_proxy_contract >/dev/null 2>&1; then printf pass; else printf fail; fi",
+        ].join("\n"),
+        { TEST_LOGIN_HOME: loginHome },
+      );
+    };
 
     const managedProxy = "http://10.200.0.1:3128";
     const managedNoProxy = "localhost,127.0.0.1,::1,10.200.0.1";

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -277,12 +277,12 @@ describe("LangChain Deep Agents Code image contracts", () => {
     const { envFileText, output } = runStartScriptProxyProbe(scriptPath, envFile, {
       HTTP_PROXY: "http://host-user:host-password@host-proxy.example:8118",
       NO_PROXY: "localhost,inference.local",
-      NEMOCLAW_PROXY_HOST: "192.168.64.1",
-      NEMOCLAW_PROXY_PORT: "8080",
+      NEMOCLAW_PROXY_HOST: "managed-proxy.internal",
+      NEMOCLAW_PROXY_PORT: "65535",
     });
 
-    const managedProxy = "http://192.168.64.1:8080";
-    const managedNoProxy = "localhost,127.0.0.1,::1,192.168.64.1";
+    const managedProxy = "http://managed-proxy.internal:65535";
+    const managedNoProxy = "localhost,127.0.0.1,::1,managed-proxy.internal";
     const outputLines = output.trimEnd().split("\n");
     const envFileLines = envFileText.trimEnd().split("\n");
     for (const name of PROXY_URL_ENV_NAMES) {
@@ -299,6 +299,35 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(combined).not.toContain("host-proxy.example");
     expect(combined).not.toContain("host-user");
     expect(combined).not.toContain("host-password");
+  });
+
+  it("rejects unsafe managed proxy overrides before persisting shell state (#6191)", () => {
+    const rejectedOverrides = [
+      { NEMOCLAW_PROXY_HOST: "corp-user:corp-password@proxy.example" },
+      { NEMOCLAW_PROXY_HOST: "proxy example" },
+      { NEMOCLAW_PROXY_HOST: "proxy.example\ninjected" },
+      { NEMOCLAW_PROXY_HOST: "proxy.example/path" },
+      { NEMOCLAW_PROXY_PORT: "not-a-port" },
+      { NEMOCLAW_PROXY_PORT: "0" },
+      { NEMOCLAW_PROXY_PORT: "65536" },
+      { NEMOCLAW_PROXY_PORT: "000001" },
+    ];
+
+    for (const overrides of rejectedOverrides) {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-start-invalid-"));
+      const { envFile, scriptPath } = makeStartScriptFixture(tempDir);
+      const result = spawnSync("bash", [scriptPath, "true"], {
+        env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...overrides },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(fs.existsSync(envFile)).toBe(false);
+      const output = `${result.stdout}\n${result.stderr}`;
+      for (const value of Object.values(overrides)) {
+        expect(output).not.toContain(value);
+      }
+    }
   });
 
   it("keeps all Deep Agents Code entry points behind the managed wrapper boundary", () => {
@@ -591,6 +620,9 @@ describe("LangChain Deep Agents Code image contracts", () => {
     expect(headlessCheck).toContain("dcode -n 'Reply with exactly one word: PONG'");
     expect(headlessCheck).toContain("sandbox_login_exec");
     expect(headlessCheck).toContain("sandbox_login_proxy_contract");
+    expect(headlessCheck).toContain("-u HTTP_PROXY -u HTTPS_PROXY -u NO_PROXY");
+    expect(headlessCheck).toContain("-u http_proxy -u https_proxy -u no_proxy");
+    expect(headlessCheck).toContain('HOME=/sandbox bash -lc "$1"');
     expect(headlessCheck).toContain('bash -lc "$1"');
     expect(headlessCheck).toContain("NEMOCLAW_DCODE_PROXY_ENV_OK");
     expect(headlessCheck).toContain('sandbox_login_exec "cd /sandbox');
@@ -676,7 +708,7 @@ describe("LangChain Deep Agents Code image contracts", () => {
     const validate = (proxyUrl: string, noProxy: string, lowerProxy = proxyUrl) =>
       runHeadlessCheckHelper(
         [
-          'sandbox_login_exec() { bash --noprofile --norc -c "$1"; }',
+          'sandbox_login_exec() { HOME=/sandbox bash --noprofile --norc -c "$1"; }',
           'export HTTP_PROXY="$TEST_PROXY_URL" HTTPS_PROXY="$TEST_PROXY_URL"',
           'export http_proxy="$TEST_LOWER_PROXY_URL" https_proxy="$TEST_LOWER_PROXY_URL"',
           'export NO_PROXY="$TEST_NO_PROXY" no_proxy="$TEST_NO_PROXY"',

--- a/test/langchain-deepagents-code-proxy-launcher.test.ts
+++ b/test/langchain-deepagents-code-proxy-launcher.test.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const agentDir = path.join(process.cwd(), "agents", "langchain-deepagents-code");
+const PROXY_URL_ENV_NAMES = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] as const;
+const NO_PROXY_ENV_NAMES = ["NO_PROXY", "no_proxy"] as const;
+
+function readAgentFile(name: string): string {
+  return fs.readFileSync(path.join(agentDir, name), "utf8");
+}
+
+function makeLauncherProxyProbeFixture(tempDir: string): string {
+  const launcherPath = path.join(tempDir, "dcode-launcher.sh");
+  const probePath = path.join(tempDir, "managed-dcode-probe.sh");
+  const probe = [
+    "#!/usr/bin/env bash",
+    "for name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do",
+    '  printf \'LAUNCHER_%s=%s\\n\' "$name" "${!name-__unset__}"',
+    "done",
+    "",
+  ].join("\n");
+  const fixture = readAgentFile("dcode-launcher.sh").replace(
+    'readonly MANAGED_DCODE_WRAPPER="/usr/local/lib/nemoclaw/dcode-wrapper.sh"',
+    `readonly MANAGED_DCODE_WRAPPER="${probePath}"`,
+  );
+  fs.writeFileSync(probePath, probe, "utf8");
+  fs.writeFileSync(launcherPath, fixture, "utf8");
+  fs.chmodSync(probePath, 0o755);
+  fs.chmodSync(launcherPath, 0o755);
+  return launcherPath;
+}
+
+function runLauncher(
+  launcherPath: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): SpawnSyncReturns<string> {
+  return spawnSync("bash", [launcherPath, ...args], {
+    env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("Deep Agents Code direct-exec proxy launcher", () => {
+  it("normalizes proxy state for direct dcode launcher execution (#6191)", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-direct-proxy-"));
+    const launcherPath = makeLauncherProxyProbeFixture(tempDir);
+    const result = runLauncher(launcherPath, ["-n", "PONG"], {
+      HTTP_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
+      HTTPS_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
+      NO_PROXY: "corp.internal,inference.local",
+      http_proxy: "http://lower-user:lower-password@lower-proxy.example:8080",
+      https_proxy: "http://lower-user:lower-password@lower-proxy.example:8080",
+      no_proxy: "corp.internal,inference.local",
+      NEMOCLAW_PROXY_HOST: "managed-proxy.internal",
+      NEMOCLAW_PROXY_PORT: "65535",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const lines = result.stdout.trimEnd().split("\n");
+    const managedProxy = "http://managed-proxy.internal:65535";
+    const managedNoProxy = "localhost,127.0.0.1,::1,managed-proxy.internal";
+    for (const name of PROXY_URL_ENV_NAMES) {
+      expect(lines).toContain(`LAUNCHER_${name}=${managedProxy}`);
+    }
+    for (const name of NO_PROXY_ENV_NAMES) {
+      expect(lines).toContain(`LAUNCHER_${name}=${managedNoProxy}`);
+    }
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(output).not.toContain("inference.local");
+    expect(output).not.toContain("corp-proxy.example");
+    expect(output).not.toContain("corp-user");
+    expect(output).not.toContain("corp-password");
+  });
+
+  it("bakes validated proxy overrides into direct dcode execution paths (#6191)", () => {
+    const dockerfile = readAgentFile("Dockerfile");
+    const launcher = readAgentFile("dcode-launcher.sh");
+
+    expect(dockerfile).toContain("ARG NEMOCLAW_PROXY_HOST=10.200.0.1");
+    expect(dockerfile).toContain("ARG NEMOCLAW_PROXY_PORT=3128");
+    expect(dockerfile).toContain("NEMOCLAW_PROXY_HOST=${NEMOCLAW_PROXY_HOST}");
+    expect(dockerfile).toContain("NEMOCLAW_PROXY_PORT=${NEMOCLAW_PROXY_PORT}");
+    expect(launcher).toContain(
+      'export PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"',
+    );
+    expect(launcher).toContain('export HTTPS_PROXY="$_PROXY_URL"');
+    expect(launcher).toContain('export no_proxy="$_NO_PROXY_VAL"');
+  });
+
+  it("rejects unsafe direct dcode proxy overrides before managed code runs (#6191)", () => {
+    const rejectedOverrides = [
+      { NEMOCLAW_PROXY_HOST: "corp-user:corp-password@proxy.example" },
+      { NEMOCLAW_PROXY_HOST: "proxy.example/path" },
+      { NEMOCLAW_PROXY_PORT: "0" },
+      { NEMOCLAW_PROXY_PORT: "65536" },
+    ];
+
+    for (const overrides of rejectedOverrides) {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-launch-invalid-"));
+      const launcherPath = makeLauncherProxyProbeFixture(tempDir);
+      const result = runLauncher(launcherPath, ["-n", "PONG"], overrides);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).not.toContain("LAUNCHER_");
+      for (const value of Object.values(overrides)) {
+        expect(`${result.stdout}\n${result.stderr}`).not.toContain(value);
+      }
+    }
+  });
+});

--- a/test/langchain-deepagents-code-proxy-launcher.test.ts
+++ b/test/langchain-deepagents-code-proxy-launcher.test.ts
@@ -7,33 +7,110 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { isValidProxyHost, isValidProxyPort } from "../src/lib/onboard/dockerfile-patch.ts";
+
 const agentDir = path.join(process.cwd(), "agents", "langchain-deepagents-code");
+const headlessCheckPath = path.join(
+  process.cwd(),
+  "test",
+  "e2e",
+  "e2e-cloud-experimental",
+  "checks",
+  "07-deepagents-code-headless-inference.sh",
+);
 const PROXY_URL_ENV_NAMES = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] as const;
 const NO_PROXY_ENV_NAMES = ["NO_PROXY", "no_proxy"] as const;
+const DEFAULT_MANAGED_PROXY = { host: "10.200.0.1", port: "3128" } as const;
+const TEST_OWNER_UID = process.getuid?.() ?? 0;
 
 function readAgentFile(name: string): string {
   return fs.readFileSync(path.join(agentDir, name), "utf8");
 }
 
-function makeLauncherProxyProbeFixture(tempDir: string): string {
+function writeManagedProxyFiles(
+  tempDir: string,
+  managedProxy: { host: string; port: string },
+): void {
+  const hostFile = path.join(tempDir, "trusted-proxy-host");
+  const portFile = path.join(tempDir, "trusted-proxy-port");
+  fs.rmSync(hostFile, { force: true });
+  fs.rmSync(portFile, { force: true });
+  fs.writeFileSync(hostFile, `${managedProxy.host}\n`);
+  fs.writeFileSync(portFile, `${managedProxy.port}\n`);
+  fs.chmodSync(hostFile, 0o444);
+  fs.chmodSync(portFile, 0o444);
+}
+
+function makeLauncherProxyProbeFixture(
+  tempDir: string,
+  managedProxy: { host: string; port: string } = DEFAULT_MANAGED_PROXY,
+): string {
   const launcherPath = path.join(tempDir, "dcode-launcher.sh");
   const probePath = path.join(tempDir, "managed-dcode-probe.sh");
+  const hostFile = path.join(tempDir, "trusted-proxy-host");
+  const portFile = path.join(tempDir, "trusted-proxy-port");
   const probe = [
     "#!/usr/bin/env bash",
-    "for name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do",
+    "for name in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy NEMOCLAW_PROXY_HOST NEMOCLAW_PROXY_PORT; do",
     '  printf \'LAUNCHER_%s=%s\\n\' "$name" "${!name-__unset__}"',
     "done",
     "",
   ].join("\n");
-  const fixture = readAgentFile("dcode-launcher.sh").replace(
-    'readonly MANAGED_DCODE_WRAPPER="/usr/local/lib/nemoclaw/dcode-wrapper.sh"',
-    `readonly MANAGED_DCODE_WRAPPER="${probePath}"`,
-  );
+  const fixture = readAgentFile("dcode-launcher.sh")
+    .replace(
+      'readonly MANAGED_DCODE_WRAPPER="/usr/local/lib/nemoclaw/dcode-wrapper.sh"',
+      `readonly MANAGED_DCODE_WRAPPER="${probePath}"`,
+    )
+    .replace(
+      'readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw/dcode-proxy-host"',
+      `readonly MANAGED_PROXY_HOST_FILE="${hostFile}"`,
+    )
+    .replace(
+      'readonly MANAGED_PROXY_PORT_FILE="/usr/local/share/nemoclaw/dcode-proxy-port"',
+      `readonly MANAGED_PROXY_PORT_FILE="${portFile}"`,
+    )
+    .replace(
+      "readonly MANAGED_PROXY_OWNER_UID=0",
+      `readonly MANAGED_PROXY_OWNER_UID=${TEST_OWNER_UID}`,
+    );
   fs.writeFileSync(probePath, probe, "utf8");
   fs.writeFileSync(launcherPath, fixture, "utf8");
+  writeManagedProxyFiles(tempDir, managedProxy);
   fs.chmodSync(probePath, 0o755);
   fs.chmodSync(launcherPath, 0o755);
   return launcherPath;
+}
+
+function makeStartProxyProbeFixture(
+  tempDir: string,
+  managedProxy: { host: string; port: string } = DEFAULT_MANAGED_PROXY,
+): { envFile: string; scriptPath: string } {
+  const envFile = path.join(tempDir, "proxy-env.sh");
+  const scriptPath = path.join(tempDir, "start.sh");
+  const hostFile = path.join(tempDir, "trusted-proxy-host");
+  const portFile = path.join(tempDir, "trusted-proxy-port");
+  const fixture = readAgentFile("start.sh")
+    .replace(
+      'readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw/dcode-proxy-host"',
+      `readonly MANAGED_PROXY_HOST_FILE="${hostFile}"`,
+    )
+    .replace(
+      'readonly MANAGED_PROXY_PORT_FILE="/usr/local/share/nemoclaw/dcode-proxy-port"',
+      `readonly MANAGED_PROXY_PORT_FILE="${portFile}"`,
+    )
+    .replace(
+      "readonly MANAGED_PROXY_OWNER_UID=0",
+      `readonly MANAGED_PROXY_OWNER_UID=${TEST_OWNER_UID}`,
+    )
+    .replace("local target=/tmp/nemoclaw-proxy-env.sh", `local target="${envFile}"`)
+    .replace(
+      'tmp="$(mktemp /tmp/nemoclaw-proxy-env.XXXXXX)"',
+      `tmp="$(mktemp "${tempDir}/nemoclaw-proxy-env.XXXXXX")"`,
+    );
+  fs.writeFileSync(scriptPath, fixture, "utf8");
+  writeManagedProxyFiles(tempDir, managedProxy);
+  fs.chmodSync(scriptPath, 0o755);
+  return { envFile, scriptPath };
 }
 
 function runLauncher(
@@ -47,10 +124,20 @@ function runLauncher(
   });
 }
 
+function shellValidatorAccepts(source: string, name: string, value: string): boolean {
+  const match = source.match(new RegExp(`${name}\\(\\) \\{[\\s\\S]*?\\n\\}`));
+  expect(match, `${name} must exist`).not.toBeNull();
+  const definition = match?.[0] ?? "";
+  return spawnSync("bash", ["-c", `${definition}\n${name} "$1"`, "bash", value]).status === 0;
+}
+
 describe("Deep Agents Code direct-exec proxy launcher", () => {
   it("normalizes proxy state for direct dcode launcher execution (#6191)", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-direct-proxy-"));
-    const launcherPath = makeLauncherProxyProbeFixture(tempDir);
+    const launcherPath = makeLauncherProxyProbeFixture(tempDir, {
+      host: "managed-proxy.internal",
+      port: "65535",
+    });
     const result = runLauncher(launcherPath, ["-n", "PONG"], {
       HTTP_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
       HTTPS_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
@@ -58,8 +145,6 @@ describe("Deep Agents Code direct-exec proxy launcher", () => {
       http_proxy: "http://lower-user:lower-password@lower-proxy.example:8080",
       https_proxy: "http://lower-user:lower-password@lower-proxy.example:8080",
       no_proxy: "corp.internal,inference.local",
-      NEMOCLAW_PROXY_HOST: "managed-proxy.internal",
-      NEMOCLAW_PROXY_PORT: "65535",
     });
 
     expect(result.status, result.stderr).toBe(0);
@@ -79,14 +164,21 @@ describe("Deep Agents Code direct-exec proxy launcher", () => {
     expect(output).not.toContain("corp-password");
   });
 
-  it("bakes validated proxy overrides into direct dcode execution paths (#6191)", () => {
+  it("pins validated proxy overrides into direct dcode execution paths (#6191)", () => {
     const dockerfile = readAgentFile("Dockerfile");
     const launcher = readAgentFile("dcode-launcher.sh");
 
     expect(dockerfile).toContain("ARG NEMOCLAW_PROXY_HOST=10.200.0.1");
     expect(dockerfile).toContain("ARG NEMOCLAW_PROXY_PORT=3128");
-    expect(dockerfile).toContain("NEMOCLAW_PROXY_HOST=${NEMOCLAW_PROXY_HOST}");
-    expect(dockerfile).toContain("NEMOCLAW_PROXY_PORT=${NEMOCLAW_PROXY_PORT}");
+    expect(dockerfile).toContain("printf '%s\\n' \"$NEMOCLAW_PROXY_HOST\"");
+    expect(dockerfile).toContain("printf '%s\\n' \"$NEMOCLAW_PROXY_PORT\"");
+    expect(dockerfile).toContain("chmod 0444 /usr/local/share/nemoclaw/dcode-proxy-host");
+    expect(dockerfile).toContain("chown root:root /usr/local/share/nemoclaw/dcode-proxy-host");
+    expect(dockerfile).not.toContain("    NEMOCLAW_PROXY_HOST=${NEMOCLAW_PROXY_HOST}");
+    expect(dockerfile).not.toContain("    NEMOCLAW_PROXY_PORT=${NEMOCLAW_PROXY_PORT}");
+    expect(launcher).toContain('readonly MANAGED_PROXY_HOST_FILE="/usr/local/share/nemoclaw');
+    expect(launcher).toContain("Runtime env is untrusted and cannot override");
+    expect(launcher).toContain('"${MANAGED_PROXY_OWNER_UID}:444"');
     expect(launcher).toContain(
       'export PATH="/usr/local/bin:/opt/venv/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"',
     );
@@ -94,23 +186,169 @@ describe("Deep Agents Code direct-exec proxy launcher", () => {
     expect(launcher).toContain('export no_proxy="$_NO_PROXY_VAL"');
   });
 
+  it("does not let runtime config override the image-baked dcode proxy (#6191)", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-trusted-proxy-"));
+    const trustedProxy = { host: "trusted-proxy.internal", port: "3129" };
+    const launcherPath = makeLauncherProxyProbeFixture(tempDir, trustedProxy);
+    const { envFile, scriptPath } = makeStartProxyProbeFixture(tempDir, trustedProxy);
+    const untrustedEnv = {
+      HTTP_PROXY: "http://corp-user:corp-password@corp-proxy.example:8080",
+      NO_PROXY: "corp.internal,inference.local",
+      NEMOCLAW_PROXY_HOST: "attacker-proxy.internal",
+      NEMOCLAW_PROXY_PORT: "4444",
+    };
+    const launcherResult = runLauncher(launcherPath, ["-n", "PONG"], untrustedEnv);
+    const startResult = spawnSync(
+      "bash",
+      [
+        scriptPath,
+        "bash",
+        "-c",
+        'printf \'START_PROXY=%s|%s|%s|%s\\n\' "$HTTPS_PROXY" "$NO_PROXY" "${NEMOCLAW_PROXY_HOST-__unset__}" "${NEMOCLAW_PROXY_PORT-__unset__}"',
+      ],
+      {
+        env: { PATH: process.env.PATH ?? "/usr/bin:/bin", ...untrustedEnv },
+        encoding: "utf8",
+      },
+    );
+
+    expect(launcherResult.status, launcherResult.stderr).toBe(0);
+    expect(startResult.status, startResult.stderr).toBe(0);
+    const envFileText = fs.readFileSync(envFile, "utf8");
+    expect(startResult.stdout).toContain(
+      "START_PROXY=http://trusted-proxy.internal:3129|localhost,127.0.0.1,::1,trusted-proxy.internal|__unset__|__unset__",
+    );
+    expect(envFileText).toContain("export HTTPS_PROXY=http://trusted-proxy.internal:3129");
+    expect(envFileText).toContain(
+      "export NO_PROXY=localhost\\,127.0.0.1\\,::1\\,trusted-proxy.internal",
+    );
+    const combined = `${launcherResult.stdout}\n${launcherResult.stderr}\n${startResult.stdout}\n${startResult.stderr}\n${envFileText}`;
+    expect(combined).toContain("http://trusted-proxy.internal:3129");
+    expect(combined).toContain("localhost,127.0.0.1,::1,trusted-proxy.internal");
+    expect(combined).not.toContain("attacker-proxy.internal");
+    expect(combined).not.toContain("corp-proxy.example");
+    expect(combined).not.toContain("corp-password");
+  });
+
+  it("fails closed when the image-baked dcode proxy contract is missing (#6191)", () => {
+    for (const missingFile of ["trusted-proxy-host", "trusted-proxy-port"]) {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-missing-proxy-"));
+      const launcherPath = makeLauncherProxyProbeFixture(tempDir);
+      const { scriptPath } = makeStartProxyProbeFixture(tempDir);
+      fs.unlinkSync(path.join(tempDir, missingFile));
+      const launcherResult = runLauncher(launcherPath, ["-n", "PONG"], {
+        NEMOCLAW_PROXY_HOST: "attacker-proxy.internal",
+        NEMOCLAW_PROXY_PORT: "4444",
+      });
+      const startResult = spawnSync("bash", [scriptPath, "true"], {
+        env: {
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          NEMOCLAW_PROXY_HOST: "attacker-proxy.internal",
+          NEMOCLAW_PROXY_PORT: "4444",
+        },
+        encoding: "utf8",
+      });
+
+      expect(launcherResult.status).not.toBe(0);
+      expect(startResult.status).not.toBe(0);
+      const combined = `${launcherResult.stdout}\n${launcherResult.stderr}\n${startResult.stdout}\n${startResult.stderr}`;
+      expect(combined).toContain("trusted managed proxy");
+      expect(combined).not.toContain("attacker-proxy.internal");
+    }
+  });
+
+  it("rejects writable image-baked dcode proxy files (#6191)", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-proxy-mode-"));
+    const launcherPath = makeLauncherProxyProbeFixture(tempDir);
+    const { scriptPath } = makeStartProxyProbeFixture(tempDir);
+    fs.chmodSync(path.join(tempDir, "trusted-proxy-host"), 0o644);
+    const launcherResult = runLauncher(launcherPath, ["-n", "PONG"], {});
+    const startResult = spawnSync("bash", [scriptPath, "true"], {
+      env: { PATH: process.env.PATH ?? "/usr/bin:/bin" },
+      encoding: "utf8",
+    });
+
+    expect(launcherResult.status).not.toBe(0);
+    expect(startResult.status).not.toBe(0);
+    expect(`${launcherResult.stderr}\n${startResult.stderr}`).toContain(
+      "Unsafe ownership or mode on trusted managed proxy host file",
+    );
+  });
+
+  it("keeps dcode shell proxy validators aligned with onboard validation (#6191)", () => {
+    const start = readAgentFile("start.sh");
+    const launcher = readAgentFile("dcode-launcher.sh");
+    const hostSamples = [
+      "10.200.0.1",
+      "managed-proxy.internal",
+      "proxy_name",
+      "http://proxy.internal",
+      "user:password@proxy.internal",
+      "proxy.internal/path",
+      "proxy internal",
+      "proxy.internal\ninjected",
+      "",
+    ];
+    const portSamples = ["1", "3128", "65535", "00001", "0", "65536", "000001", "12a", ""];
+
+    for (const value of hostSamples) {
+      const expected = isValidProxyHost(value);
+      expect(shellValidatorAccepts(start, "is_valid_proxy_host", value), value).toBe(expected);
+      expect(shellValidatorAccepts(launcher, "is_valid_proxy_host", value), value).toBe(expected);
+    }
+    for (const value of portSamples) {
+      const expected = isValidProxyPort(value);
+      expect(shellValidatorAccepts(start, "is_valid_proxy_port", value), value).toBe(expected);
+      expect(shellValidatorAccepts(launcher, "is_valid_proxy_port", value), value).toBe(expected);
+    }
+  });
+
+  it("documents the proxy-only source boundary and removal condition (#6191)", () => {
+    const start = readAgentFile("start.sh");
+    const launcher = readAgentFile("dcode-launcher.sh");
+    const headlessCheck = fs.readFileSync(headlessCheckPath, "utf8");
+
+    for (const marker of [
+      "# Invalid state:",
+      "# Source boundary:",
+      "# Source-fix constraint:",
+      "# Regression:",
+      "# Removal condition:",
+    ]) {
+      expect(start).toContain(marker);
+    }
+    expect(start).toContain("Direct DNS/hosts resolution is not required");
+    expect(launcher).toContain("Remove it only when OpenShell normalizes every sandbox exec/login");
+    expect(headlessCheck).toContain("getent hosts inference.local >/dev/null 2>&1");
+    expect(headlessCheck).toContain("direct inference.local DNS/hosts is absent");
+    expect(headlessCheck).toContain('stat -c "%u:%a"');
+    expect(headlessCheck).toContain("direct-exec dcode -n reached managed inference");
+    expect(headlessCheck).toContain("connect --probe-only accepted the managed inference route");
+  });
+
   it("rejects unsafe direct dcode proxy overrides before managed code runs (#6191)", () => {
     const rejectedOverrides = [
-      { NEMOCLAW_PROXY_HOST: "corp-user:corp-password@proxy.example" },
-      { NEMOCLAW_PROXY_HOST: "proxy.example/path" },
-      { NEMOCLAW_PROXY_PORT: "0" },
-      { NEMOCLAW_PROXY_PORT: "65536" },
+      { host: "corp-user:corp-password@proxy.example", port: "3128" },
+      { host: "proxy.example/path", port: "3128" },
+      { host: "10.200.0.1", port: "0" },
+      { host: "10.200.0.1", port: "65536" },
     ];
 
-    for (const overrides of rejectedOverrides) {
+    for (const managedProxy of rejectedOverrides) {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-launch-invalid-"));
-      const launcherPath = makeLauncherProxyProbeFixture(tempDir);
-      const result = runLauncher(launcherPath, ["-n", "PONG"], overrides);
+      const launcherPath = makeLauncherProxyProbeFixture(tempDir, managedProxy);
+      const { scriptPath } = makeStartProxyProbeFixture(tempDir, managedProxy);
+      const result = runLauncher(launcherPath, ["-n", "PONG"], {});
+      const startResult = spawnSync("bash", [scriptPath, "true"], {
+        env: { PATH: process.env.PATH ?? "/usr/bin:/bin" },
+        encoding: "utf8",
+      });
 
       expect(result.status).not.toBe(0);
+      expect(startResult.status).not.toBe(0);
       expect(result.stdout).not.toContain("LAUNCHER_");
-      for (const value of Object.values(overrides)) {
-        expect(`${result.stdout}\n${result.stderr}`).not.toContain(value);
+      for (const value of Object.values(managedProxy)) {
+        expect(`${result.stdout}\n${result.stderr}\n${startResult.stderr}`).not.toContain(value);
       }
     }
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR restores LangChain Deep Agents Code inference by replacing the sandbox-create host proxy seed with OpenShell's managed runtime proxy before dcode runs. It keeps `inference.local` on the proxy path instead of allowing direct DNS resolution, without changing OpenShell route provisioning or other agent runtimes.

## Related Issue
Fixes #6191.

## Changes
- Pin the validated `NEMOCLAW_PROXY_HOST` / `NEMOCLAW_PROXY_PORT` build values in root-owned, read-only image files. The dcode startup and direct-exec launcher reject missing, linked, writable, or non-root-owned files and ignore process-level proxy-host overrides.
- Normalize uppercase and lowercase HTTP proxy variables for every dcode entry path, set runtime bypasses to loopback plus the managed proxy host only, and persist the same normalized values for interactive and login shells. Inherited corporate proxy URLs, credentials, and `inference.local` bypass entries are not retained.
- Make the dcode-only `connect --probe-only` route check use the login-shell proxy contract and fail if route repair still reports `inference.local` unhealthy. OpenClaw, Hermes, and unknown-agent probe behavior is unchanged.
- Add focused coverage for inherited credential-bearing proxies, exact `NO_PROXY` values, trusted host/port overrides, hostile runtime overrides, file ownership/mode, validator parity, login-shell persistence, direct dcode execution, and broken-route connect behavior.
- Require the live Deep Agents check to observe direct DNS state, verify the trusted proxy files, force the managed proxy for `https://inference.local/v1/models`, and return `PONG` with dcode exit 0 through both login-shell and direct-exec paths. Connection, DNS, timeout, provider, and ambiguous failures fail the check.
- An empty `getent hosts inference.local` is intentionally valid for dcode. Direct DNS or `/etc/hosts` provisioning is outside this fix because OpenShell's managed L7 proxy owns the route; the sandbox-create host proxy seed remains unchanged for host-side chaining.
- Existing Deep Agents Code sandboxes must be rebuilt after upgrading because the corrected startup and launcher scripts are baked into the image.
- Exact-head [`ubuntu-repo-cloud-langchain-deepagents-code` E2E](https://github.com/NVIDIA/NemoClaw/actions/runs/28616070748) passed at `22d42e2fa26d17bb8f64d45eb9ba853c8feb9e51`: onboarding and Ready state, absent direct DNS, managed `/v1/models` HTTP 200, login/direct `PONG`, `connect --probe-only`, and clean teardown all passed.
- Reporter-class macOS/Colima and DGX Spark confirmation remains pending. A local macOS/Colima attempt stopped before sandbox creation on provider HTTP 401 and cleaned up its isolated gateway state; any DGX Provisioning/GPU lifecycle failure remains a separate blocker.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification: New regression coverage was required and added.
- [ ] Tests not applicable — justification: Tests apply and were added.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the managed `inference.local` contract and rebuild workflow already documented in the Deep Agents quickstart, inference options, troubleshooting, and sandbox lifecycle pages.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending maintainer sensitive-path review; no waiver claimed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: No acceptance claimed. The local repo-wide `test-cli` coverage hook hit unrelated baseline subprocess-loader and timeout failures; targeted suites, scoped hooks, and exact-head GitHub CI/E2E are authoritative for this change.

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Deep Agents Code launcher that normalizes managed proxy settings (host/port, `HTTP_PROXY`/`HTTPS_PROXY`, and `NO_PROXY`) before running entry points.
  * Introduced agent-aware inference route probing during sandbox connect.

* **Bug Fixes**
  * Hardened proxy environment contract with stricter host/port validation and consistent `NO_PROXY` behavior across uppercase/lowercase.
  * Reduced risk of proxy credential leakage in outputs and generated artifacts.

* **Tests**
  * Expanded end-to-end and unit coverage to enforce the login-shell proxy contract, probe wiring, and improved inference connection/error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
