### PR TITLE
docs: prepare v0.0.73 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,31 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.73
+
+NemoClaw v0.0.73 improves custom endpoint safety, Linux GPU onboarding, agent-aware policy validation, upgrade recovery, LangChain Deep Agents Code inference, and operator documentation.
+
+- Custom endpoint handling now fails closed before downstream handoff when an HTTPS endpoint relies on DNS and NemoClaw cannot pin the validated peer across the OpenShell runtime boundary.
+  Public HTTP endpoints continue to use DNS-pinned IP URLs, and HTTPS IP-literal endpoints remain accepted.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands), [NemoClaw Inference Options](../inference/inference-options), and [Troubleshooting](../reference/troubleshooting).
+- GPU sandbox onboarding now uses OpenShell native GPU injection by default on ordinary native Linux hosts with usable CDI.
+  Docker Desktop WSL and Jetson/Tegra retain the compatibility path, which preserves the OpenShell supervisor boundary, captures bounded redacted diagnostics, and attempts rollback when a recreated container fails.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands), [Troubleshooting](../reference/troubleshooting), and [Use a Local Inference Server](../inference/use-local-inference).
+- Messaging policy presets now respect agent support before `policy-add` changes state.
+  Terminal runtimes such as LangChain Deep Agents Code reject unsupported channel presets before endpoint disclosure or confirmation, matching the existing `channels add` boundary.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands), [Messaging Channels](../manage-sandboxes/messaging-channels), and [Platform Support and Launch Claims](../reference/platform-support).
+- Pre-upgrade backups can skip a running sandbox whose in-sandbox SSH endpoint is unreachable when `NEMOCLAW_SKIP_UNREACHABLE_SANDBOX_BACKUP=1` is set.
+  Installer-driven upgrades restore skipped sandboxes from the latest validated backup, while standalone `backup-all` runs only skip the failure and do not schedule a restore.
+  Any uncommitted state since the latest successful backup is not preserved.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands), [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), and [Host Files and State](../reference/host-files-and-state).
+- LangChain Deep Agents Code now reaches `inference.local` through the managed OpenShell proxy across interactive, login-shell, direct-exec, and connect-probe paths.
+  The runtime normalizes proxy environment state, clears inherited bypass settings, and keeps credential-shaped values out of persisted proxy configuration.
+  Rebuild existing LangChain Deep Agents Code sandboxes after upgrading so they receive the corrected image scripts.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](../../openclaw/get-started/quickstart-langchain-deepagents-code) and [Troubleshooting](../reference/troubleshooting).
+- Setup and recovery guidance now covers the Docker CLI requirement for Homebrew Colima, Cursor terminal restrictions on Windows, stale Kubernetes namespace cleanup, OpenShell and OpenClaw gateway startup order, and stopped-container recovery.
+  The new Host Files and State reference explains files under `~/.nemoclaw/` and which registry and backup state uninstall preserves.
+  For more information, refer to [Prerequisites](../get-started/prerequisites), [Prepare Windows for NemoClaw](../get-started/prerequisites/windows-preparation), [Host Files and State](../reference/host-files-and-state), and [Troubleshooting](../reference/troubleshooting).
+
 ## v0.0.72
 
 NemoClaw v0.0.72 improves installer recovery, sandbox diagnostics, inference setup, credential handling, and custom policy safety.

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -34,6 +34,8 @@ nemoclaw onboard --agent langchain
 The image installs a hash-locked, pinned Deep Agents Code release with NVIDIA provider support.
 NemoClaw writes `/sandbox/.deepagents/config.toml` with an OpenAI-compatible provider pointed at `https://inference.local/v1`, uses a scoped placeholder API key for that managed route, and sets `use_responses_api = false` for Chat Completions compatibility.
 NemoClaw/OpenShell keeps real provider credentials in credential handling and does not write them into the Deep Agents config file.
+Deep Agents Code reaches `inference.local` through the managed OpenShell L7 proxy rather than direct sandbox DNS.
+The image launcher normalizes the runtime proxy environment for interactive, login-shell, and direct-exec paths and removes inherited proxy credentials and bypass entries before `dcode` starts.
 
 ## Choose the Default Sandbox
 
@@ -130,6 +132,8 @@ nemo-deepagents <sandbox-name> snapshot create --name before-change
 
 `status` reports the selected harness as a terminal runtime and prints the interactive/headless command shape.
 If `status` reports `Runtime health: degraded` with an OOM kill count, rebuild the sandbox to restore the terminal runtime.
+Proxy launchers and startup scripts are baked into the sandbox image.
+After upgrading NemoClaw from a release with older Deep Agents Code routing, rebuild each existing sandbox before troubleshooting `inference.local` connectivity.
 There is no dashboard port or long-running gateway process for this harness.
 
 ## Next Steps

--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -89,6 +89,7 @@ For public HTTP URLs, NemoClaw stores the validated IP address so a downstream r
 NemoClaw rejects DNS-backed HTTPS URLs in these paths because it cannot pin the downstream peer address while preserving TLS SNI and host validation across the OpenShell runtime boundary.
 Use an HTTPS IP-literal endpoint with a certificate valid for that address, or a public HTTP endpoint only when your deployment permits non-TLS traffic.
 Managed provider defaults that do not supply an explicit custom endpoint through these paths are unaffected.
+NemoClaw accepts `http://host.openshell.internal:<port>` only with an explicit port from `1024` through `65535`; this narrow exception supports NemoClaw's sandbox-to-host inference routes and is not a general private-endpoint bypass.
 
 <Note>
 NVIDIA Endpoints and Hermes Provider use independent model catalogs, so a model can remain available through one provider after it leaves the other's curated list.

--- a/docs/inference/inference-options.mdx
+++ b/docs/inference/inference-options.mdx
@@ -81,6 +81,15 @@ NemoClaw neither displays nor accepts an unsafe `NEMOCLAW_MODEL` value as the ma
 | Local Ollama | Routes to a local Ollama instance on `localhost:11434`. NemoClaw detects installed models, offers starter models if none are present, pulls and warms the selected model, and validates it. | Selected during onboarding. For more information, refer to [Use a Local Inference Server](use-local-inference). |
 | Model Router | Starts a host-side router on port `4000`, registers it as an OpenAI-compatible provider, and keeps the sandbox pointed at `inference.local`. Set `NEMOCLAW_PROVIDER=routed` for non-interactive setup. | The router pool defines the model names. |
 
+### Custom Endpoint URL Validation
+
+Explicit endpoint URLs that NemoClaw saves through Hermes Provider setup, `inference set`, host-side `config set`, or a direct blueprint run must pass host-side SSRF validation.
+NemoClaw rejects loopback, link-local, private, and internal addresses, including public hostnames that resolve to a private address.
+For public HTTP URLs, NemoClaw stores the validated IP address so a downstream runtime cannot repeat DNS resolution and reach a different address.
+NemoClaw rejects DNS-backed HTTPS URLs in these paths because it cannot pin the downstream peer address while preserving TLS SNI and host validation across the OpenShell runtime boundary.
+Use an HTTPS IP-literal endpoint with a certificate valid for that address, or a public HTTP endpoint only when your deployment permits non-TLS traffic.
+Managed provider defaults that do not supply an explicit custom endpoint through these paths are unaffected.
+
 <Note>
 NVIDIA Endpoints and Hermes Provider use independent model catalogs, so a model can remain available through one provider after it leaves the other's curated list.
 Curated-list updates affect new onboarding choices and do not rewrite existing sandbox configurations.

--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -1681,7 +1681,8 @@ Supported provider names are `nvidia-prod`, `nvidia-nim`, `nvidia-router`, `open
 Use `--no-verify` only when OpenShell cannot verify the provider at switch time but you have already confirmed the provider and credential.
 When switching to `compatible-endpoint` or `compatible-anthropic-endpoint` from a different provider family, pass `--endpoint-url` with the trusted custom provider URL so NemoClaw can persist durable rebuild metadata.
 NemoClaw rejects loopback, link-local, private, and internal endpoint addresses, including public hostnames that resolve to a private address.
-For public HTTP URLs, NemoClaw stores the validated IP address to prevent DNS rebinding; HTTPS URLs keep their hostname after DNS validation.
+For public HTTP URLs, NemoClaw stores the validated IP address to prevent DNS rebinding.
+DNS-backed HTTPS URLs are rejected because NemoClaw cannot pin the downstream peer address while preserving TLS SNI and host validation across the OpenShell runtime boundary; HTTPS IP-literal URLs remain supported.
 NemoClaw accepts `http://host.openshell.internal:<port>` only with an explicit port from `1024` through `65535`; this narrow exception supports NemoClaw's sandbox-to-host inference routes and is not a general private-endpoint bypass.
 `--credential-env` and `--inference-api` may also be supplied for the compatible provider metadata; supported API values are `openai-completions`, `anthropic-messages`, and `openai-responses`.
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2068,7 +2068,8 @@ Supported provider names are `nvidia-prod`, `nvidia-nim`, `nvidia-router`, `open
 Use `--no-verify` only when OpenShell cannot verify the provider at switch time but you have already confirmed the provider and credential.
 When switching to `compatible-endpoint` or `compatible-anthropic-endpoint` from a different provider family, pass `--endpoint-url` with the trusted custom provider URL so NemoClaw can persist durable rebuild metadata.
 NemoClaw rejects loopback, link-local, private, and internal endpoint addresses, including public hostnames that resolve to a private address.
-For public HTTP URLs, NemoClaw stores the validated IP address to prevent DNS rebinding; HTTPS URLs keep their hostname after DNS validation.
+For public HTTP URLs, NemoClaw stores the validated IP address to prevent DNS rebinding.
+DNS-backed HTTPS URLs are rejected because NemoClaw cannot pin the downstream peer address while preserving TLS SNI and host validation across the OpenShell runtime boundary; HTTPS IP-literal URLs remain supported.
 NemoClaw accepts `http://host.openshell.internal:<port>` only with an explicit port from `1024` through `65535`; this narrow exception supports NemoClaw's sandbox-to-host inference routes and is not a general private-endpoint bypass.
 `--credential-env` and `--inference-api` may also be supplied for the compatible provider metadata; supported API values are `openai-completions`, `anthropic-messages`, and `openai-responses`.
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1380,6 +1380,16 @@ Sandboxes created with OpenShell versions older than 0.0.24 can become unreachab
 Running `$$nemoclaw onboard` automatically upgrades OpenShell to 0.0.24 or later during the preflight check.
 After the upgrade, recreate the sandbox with `$$nemoclaw onboard`.
 
+### DNS-backed HTTPS endpoint is not supported
+
+NemoClaw rejects an explicit custom endpoint when it resolves a public HTTPS hostname but cannot pin the same peer address across the downstream OpenShell runtime boundary while preserving TLS SNI and host validation.
+This can appear during a direct blueprint run, Hermes Provider custom-endpoint setup, `$$nemoclaw inference set`, or a host-side `config set` write.
+
+Use an HTTPS IP-literal endpoint whose certificate is valid for that address.
+If your deployment permits non-TLS provider traffic, you can instead use a public HTTP endpoint that NemoClaw can rewrite to a DNS-pinned address.
+Do not bypass the check with a private or internal address or by editing the persisted sandbox config directly.
+For the full endpoint rules, refer to [Inference Options](../inference/inference-options#custom-endpoint-url-validation).
+
 ### Agent cannot reach external hosts through a proxy
 
 NemoClaw uses a default proxy address of `10.200.0.1:3128` (the OpenShell-injected gateway).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR prepares the user-facing documentation for v0.0.73 before the release plan is frozen.
It adds release notes for the merged runtime changes and closes documentation gaps around DNS-backed HTTPS endpoint validation and LangChain Deep Agents Code proxy recovery.

## Changes
- Add the `v0.0.73` release-note section with links to the detailed command, inference, recovery, lifecycle, platform, and setup documentation.
- Correct the custom endpoint guidance so DNS-backed HTTPS rejection and the supported alternatives match the fail-closed runtime behavior.
- Document the managed `inference.local` proxy boundary and rebuild requirement for existing LangChain Deep Agents Code sandboxes.
- Add troubleshooting guidance for the DNS-backed HTTPS validation error.
- Validate with `npm run docs:sync-agent-variants` and `npm run docs`; Fern completed with 0 errors and 2 existing warnings.
- Source summary:
  - [#6139](https://github.com/NVIDIA/NemoClaw/pull/6139) -> `docs/about/release-notes.mdx`, `docs/inference/inference-options.mdx`, `docs/reference/commands.mdx`, `docs/reference/commands-nemohermes.mdx`, and `docs/reference/troubleshooting.mdx`: Document fail-closed DNS-backed HTTPS endpoint handling and recovery options.
  - [#6142](https://github.com/NVIDIA/NemoClaw/pull/6142) -> `docs/about/release-notes.mdx`: Summarize native OpenShell GPU injection and compatibility-path diagnostics.
  - [#6197](https://github.com/NVIDIA/NemoClaw/pull/6197) -> `docs/about/release-notes.mdx`: Summarize agent-aware messaging preset rejection.
  - [#6199](https://github.com/NVIDIA/NemoClaw/pull/6199) -> `docs/about/release-notes.mdx`: Summarize the unreachable-sandbox backup opt-in, restore behavior, and data-loss boundary.
  - [#6204](https://github.com/NVIDIA/NemoClaw/pull/6204) and [#6206](https://github.com/NVIDIA/NemoClaw/pull/6206) -> `docs/about/release-notes.mdx` and `docs/get-started/quickstart-langchain-deepagents-code.mdx`: Document the corrected managed proxy contract and required sandbox rebuild.
  - [#6213](https://github.com/NVIDIA/NemoClaw/pull/6213) -> `docs/about/release-notes.mdx`: Summarize the merged setup, recovery, and host-state documentation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation-only release preparation; the Fern docs build validates the changed pages and routes.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [ ] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **v0.0.73** release notes section with six highlights at the top of the changelog.
  * Expanded **Custom Endpoint URL Validation** guidance in inference option docs, including explicit acceptance/rejection rules for HTTP vs DNS-backed HTTPS and how validated IPs are stored.
  * Updated command references (`nemohermes inference set`, `$$nemoclaw inference set`) to match the new validation behavior.
  * Added troubleshooting documentation for unsupported **DNS-backed HTTPS endpoints**, plus clarified Deep Agents Code routing and post-upgrade sandbox rebuild guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->