### PR TITLE
refactor(onboard): separate sandbox intent from effects

### DIFF
--- a/src/lib/onboard/sandbox-create-intent-types.ts
+++ b/src/lib/onboard/sandbox-create-intent-types.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MessagingTokenDef } from "./messaging-prep";
+import type { MessagingChannel } from "./messaging-state";
+import type { SandboxGpuCreateConfig } from "./sandbox-gpu-create";
+
+type PrepareInitialSandboxCreatePolicy =
+  typeof import("./initial-policy").prepareInitialSandboxCreatePolicy;
+
+export type SandboxCreateMessagingProviderRequest = {
+  readonly name: string;
+  readonly envKey: string;
+  readonly providerType?: string;
+  readonly credentialConfigured: boolean;
+  readonly channel: string | null;
+};
+
+export type SandboxCreatePolicyRequest = {
+  readonly basePolicyPath: string;
+  readonly activeMessagingChannels: readonly string[];
+  readonly options: {
+    readonly directGpu: boolean;
+    readonly dockerGpuPatch: boolean;
+    readonly additionalPresets: readonly string[];
+    readonly agentName?: string | null;
+    readonly policyTier: string | null;
+  };
+};
+
+/**
+ * Serializable intent for the create-time sandbox contributions. When built
+ * through `prepareSandboxCreatePlan`, messaging credential values are
+ * represented only by their logical environment-key bindings and presence.
+ *
+ * This is deliberately separate from the execution plan, which contains
+ * temporary paths and cleanup callbacks. Its serializable shape is for
+ * internal inspection and testing only; it is not a persistence,
+ * machine-event, or public API contract.
+ */
+export type SandboxCreateIntent = {
+  readonly sandboxName: string;
+  readonly activeMessagingChannels: readonly string[];
+  readonly messagingProviderRequests: readonly SandboxCreateMessagingProviderRequest[];
+  readonly reusableMessagingProviders: readonly string[];
+  readonly extraProviders: readonly string[];
+  readonly hermesToolGateways: readonly string[];
+  readonly policy: SandboxCreatePolicyRequest;
+  readonly gpuCreateArgs: readonly string[];
+  readonly useDockerGpuPatch: boolean;
+  readonly sandboxGpuLogMessage: string | null;
+  readonly disabledChannelNames: readonly string[];
+};
+
+export type ResolveSandboxCreateIntentInput = {
+  basePolicyPath: string;
+  sandboxName: string;
+  channels: MessagingChannel[];
+  enabledChannels: string[] | null;
+  disabledChannelNames: ReadonlySet<string>;
+  messagingProviderRequests: readonly SandboxCreateMessagingProviderRequest[];
+  primaryMessagingCredentialEnvKeys: readonly string[];
+  reusableMessagingChannels: readonly string[];
+  reusableMessagingProviders: readonly string[];
+  extraProviders?: readonly string[];
+  hermesToolGateways: readonly string[];
+  sandboxGpuConfig: SandboxGpuCreateConfig;
+  gpuCreateArgs: readonly string[];
+  useDockerGpuPatch: boolean;
+  sandboxGpuLogMessage: string | null;
+  agentName?: string | null;
+  policyTier: string | null;
+};
+
+export type MaterializeSandboxCreatePlanInput = {
+  intent: SandboxCreateIntent;
+  buildCtx: string;
+  messagingTokenDefs: MessagingTokenDef[];
+  appendResourceFlags(createArgs: string[]): void;
+  runProviderPreDeleteCleanup(): void;
+  upsertMessagingProviders(
+    tokenDefs: MessagingTokenDef[],
+    options: { replaceExisting: true },
+  ): string[];
+  getHermesToolGatewayProviderName(sandboxName: string): string;
+  prepareInitialSandboxCreatePolicy?: PrepareInitialSandboxCreatePolicy;
+};

--- a/src/lib/onboard/sandbox-create-plan.test.ts
+++ b/src/lib/onboard/sandbox-create-plan.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
-
+import type { MessagingTokenDef } from "./messaging-prep";
 import {
   materializeSandboxCreatePlan,
   prepareSandboxCreatePlan,
@@ -40,6 +40,58 @@ const channels = [
     help: "WhatsApp",
   },
 ];
+
+function expectCredentialBindingFailure({
+  expectedMessage,
+  materializedTokenDefs,
+  plannedTokenDef,
+}: {
+  expectedMessage: string;
+  materializedTokenDefs: MessagingTokenDef[];
+  plannedTokenDef: MessagingTokenDef;
+}): void {
+  const intent = resolveSandboxCreateIntent({
+    basePolicyPath: "/repo/policy.yaml",
+    sandboxName: "sandbox",
+    channels,
+    enabledChannels: ["telegram"],
+    disabledChannelNames: new Set(),
+    messagingProviderRequests: resolveSandboxCreateMessagingProviderRequests(
+      [plannedTokenDef],
+      () => "telegram",
+    ),
+    primaryMessagingCredentialEnvKeys: [plannedTokenDef.envKey],
+    reusableMessagingChannels: [],
+    reusableMessagingProviders: [],
+    hermesToolGateways: [],
+    sandboxGpuConfig,
+    gpuCreateArgs: [],
+    useDockerGpuPatch: false,
+    sandboxGpuLogMessage: null,
+    policyTier: null,
+  });
+  const preparePolicy = vi.fn(() => ({ policyPath: "/tmp/policy.yaml", appliedPresets: [] }));
+  const appendResources = vi.fn();
+  const cleanupProviders = vi.fn();
+  const upsertProviders = vi.fn(() => []);
+
+  expect(() =>
+    materializeSandboxCreatePlan({
+      intent,
+      buildCtx: "/tmp/nemoclaw-build-1",
+      messagingTokenDefs: materializedTokenDefs,
+      prepareInitialSandboxCreatePolicy: preparePolicy,
+      appendResourceFlags: appendResources,
+      runProviderPreDeleteCleanup: cleanupProviders,
+      upsertMessagingProviders: upsertProviders,
+      getHermesToolGatewayProviderName: vi.fn(),
+    }),
+  ).toThrow(expectedMessage);
+  expect(preparePolicy).not.toHaveBeenCalled();
+  expect(appendResources).not.toHaveBeenCalled();
+  expect(cleanupProviders).not.toHaveBeenCalled();
+  expect(upsertProviders).not.toHaveBeenCalled();
+}
 
 describe("resolveSandboxCreateIntent", () => {
   it("turns credential-bearing inputs into secretless provider requests", () => {
@@ -220,54 +272,56 @@ describe("resolveSandboxCreateIntent", () => {
   });
 
   it("rejects changed credential availability before running effects", () => {
-    const originalTokenDefs = [
-      {
+    expectCredentialBindingFailure({
+      plannedTokenDef: {
         name: "sandbox-telegram-bridge",
         envKey: "TELEGRAM_BOT_TOKEN",
         token: null,
       },
-    ];
-    const intent = resolveSandboxCreateIntent({
-      basePolicyPath: "/repo/policy.yaml",
-      sandboxName: "sandbox",
-      channels,
-      enabledChannels: ["telegram"],
-      disabledChannelNames: new Set(),
-      messagingProviderRequests: resolveSandboxCreateMessagingProviderRequests(
-        originalTokenDefs,
-        () => "telegram",
-      ),
-      primaryMessagingCredentialEnvKeys: ["TELEGRAM_BOT_TOKEN"],
-      reusableMessagingChannels: [],
-      reusableMessagingProviders: [],
-      hermesToolGateways: [],
-      sandboxGpuConfig,
-      gpuCreateArgs: [],
-      useDockerGpuPatch: false,
-      sandboxGpuLogMessage: null,
-      policyTier: null,
+      materializedTokenDefs: [
+        {
+          name: "sandbox-telegram-bridge",
+          envKey: "TELEGRAM_BOT_TOKEN",
+          token: "new-secret",
+        },
+      ],
+      expectedMessage:
+        "Cannot materialize sandbox create intent; credential availability changed for provider 'sandbox-telegram-bridge'.",
     });
-    const preparePolicy = vi.fn(() => ({ policyPath: "/tmp/policy.yaml", appliedPresets: [] }));
-    const appendResources = vi.fn();
-    const cleanupProviders = vi.fn();
-    const upsertProviders = vi.fn(() => []);
+  });
 
-    expect(() =>
-      materializeSandboxCreatePlan({
-        intent,
-        buildCtx: "/tmp/nemoclaw-build-1",
-        messagingTokenDefs: [{ ...originalTokenDefs[0], token: "new-secret" }],
-        prepareInitialSandboxCreatePolicy: preparePolicy,
-        appendResourceFlags: appendResources,
-        runProviderPreDeleteCleanup: cleanupProviders,
-        upsertMessagingProviders: upsertProviders,
-        getHermesToolGatewayProviderName: vi.fn(),
-      }),
-    ).toThrow("credential availability changed");
-    expect(preparePolicy).not.toHaveBeenCalled();
-    expect(appendResources).not.toHaveBeenCalled();
-    expect(cleanupProviders).not.toHaveBeenCalled();
-    expect(upsertProviders).not.toHaveBeenCalled();
+  it("rejects a missing credential binding before running effects", () => {
+    expectCredentialBindingFailure({
+      plannedTokenDef: {
+        name: "sandbox-telegram-bridge",
+        envKey: "TELEGRAM_BOT_TOKEN",
+        token: "telegram-secret",
+      },
+      materializedTokenDefs: [],
+      expectedMessage:
+        "Cannot materialize sandbox create intent; missing credential binding 'TELEGRAM_BOT_TOKEN' for provider 'sandbox-telegram-bridge'.",
+    });
+  });
+
+  it("rejects a changed provider type before running effects", () => {
+    expectCredentialBindingFailure({
+      plannedTokenDef: {
+        name: "sandbox-brave-search",
+        envKey: "BRAVE_API_KEY",
+        token: "brave-secret",
+        providerType: "brave-search",
+      },
+      materializedTokenDefs: [
+        {
+          name: "sandbox-brave-search",
+          envKey: "BRAVE_API_KEY",
+          token: "brave-secret",
+          providerType: "generic",
+        },
+      ],
+      expectedMessage:
+        "Cannot materialize sandbox create intent; provider type changed for 'sandbox-brave-search'.",
+    });
   });
 });
 

--- a/src/lib/onboard/sandbox-create-plan.test.ts
+++ b/src/lib/onboard/sandbox-create-plan.test.ts
@@ -3,7 +3,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { prepareSandboxCreatePlan } from "./sandbox-create-plan";
+import {
+  materializeSandboxCreatePlan,
+  prepareSandboxCreatePlan,
+  resolveSandboxCreateIntent,
+  resolveSandboxCreateMessagingProviderRequests,
+} from "./sandbox-create-plan";
 import type { SandboxGpuCreateConfig } from "./sandbox-gpu-create";
 
 const sandboxGpuConfig: SandboxGpuCreateConfig = {
@@ -36,6 +41,236 @@ const channels = [
   },
 ];
 
+describe("resolveSandboxCreateIntent", () => {
+  it("turns credential-bearing inputs into secretless provider requests", () => {
+    const requests = resolveSandboxCreateMessagingProviderRequests(
+      [
+        {
+          name: "sandbox-telegram-bridge",
+          envKey: "TELEGRAM_BOT_TOKEN",
+          token: "telegram-super-secret",
+        },
+        {
+          name: "sandbox-brave-search",
+          envKey: "BRAVE_API_KEY",
+          token: null,
+          providerType: "brave-search",
+        },
+      ],
+      (envKey) => (envKey === "TELEGRAM_BOT_TOKEN" ? "telegram" : null),
+    );
+
+    expect(requests).toEqual([
+      {
+        name: "sandbox-telegram-bridge",
+        envKey: "TELEGRAM_BOT_TOKEN",
+        credentialConfigured: true,
+        channel: "telegram",
+      },
+      {
+        name: "sandbox-brave-search",
+        envKey: "BRAVE_API_KEY",
+        providerType: "brave-search",
+        credentialConfigured: false,
+        channel: null,
+      },
+    ]);
+    expect(JSON.stringify(requests)).not.toContain("telegram-super-secret");
+  });
+
+  it("resolves deterministic serializable intent without execution artifacts", () => {
+    const input = {
+      basePolicyPath: "/repo/policy.yaml",
+      sandboxName: "sandbox",
+      channels,
+      enabledChannels: ["telegram", "slack", "whatsapp"],
+      disabledChannelNames: new Set(["slack"]),
+      messagingProviderRequests: [
+        {
+          name: "sandbox-telegram-bridge",
+          envKey: "TELEGRAM_BOT_TOKEN",
+          credentialConfigured: true,
+          channel: "telegram",
+        },
+        {
+          name: "sandbox-slack-bridge",
+          envKey: "SLACK_BOT_TOKEN",
+          credentialConfigured: true,
+          channel: "slack",
+        },
+      ],
+      primaryMessagingCredentialEnvKeys: ["TELEGRAM_BOT_TOKEN", "SLACK_BOT_TOKEN"],
+      reusableMessagingChannels: ["discord", "slack"],
+      reusableMessagingProviders: ["sandbox-existing-discord", "sandbox-slack-bridge"],
+      extraProviders: ["custom-provider", "custom-provider", ""],
+      hermesToolGateways: ["github"],
+      sandboxGpuConfig,
+      gpuCreateArgs: ["--gpu", "--gpu-device", "nvidia.com/gpu=0"],
+      useDockerGpuPatch: false,
+      sandboxGpuLogMessage: "gpu note",
+      agentName: "hermes",
+      policyTier: "balanced",
+    };
+
+    const first = resolveSandboxCreateIntent(input);
+    const second = resolveSandboxCreateIntent(input);
+
+    expect(first).toEqual(second);
+    expect(first.activeMessagingChannels).toEqual(["telegram", "discord", "whatsapp"]);
+    expect(first.messagingProviderRequests.map(({ name }) => name)).toEqual([
+      "sandbox-telegram-bridge",
+      "sandbox-slack-bridge",
+    ]);
+    expect(first.reusableMessagingProviders).toEqual(["sandbox-existing-discord"]);
+    expect(first.extraProviders).toEqual(["custom-provider"]);
+    expect(first.policy).toEqual({
+      basePolicyPath: "/repo/policy.yaml",
+      activeMessagingChannels: ["telegram", "discord", "whatsapp"],
+      options: {
+        directGpu: true,
+        dockerGpuPatch: false,
+        additionalPresets: ["github"],
+        agentName: "hermes",
+        policyTier: "balanced",
+      },
+    });
+    expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+    expect(JSON.stringify(first)).not.toContain("/tmp/");
+  });
+
+  it("materializes policy and provider effects after resolving intent", () => {
+    const tokenDefs = [
+      {
+        name: "sandbox-telegram-bridge",
+        envKey: "TELEGRAM_BOT_TOKEN",
+        token: "telegram-super-secret",
+      },
+    ];
+    const intent = resolveSandboxCreateIntent({
+      basePolicyPath: "/repo/policy.yaml",
+      sandboxName: "sandbox",
+      channels,
+      enabledChannels: ["telegram"],
+      disabledChannelNames: new Set(),
+      messagingProviderRequests: resolveSandboxCreateMessagingProviderRequests(
+        tokenDefs,
+        () => "telegram",
+      ),
+      primaryMessagingCredentialEnvKeys: ["TELEGRAM_BOT_TOKEN"],
+      reusableMessagingChannels: [],
+      reusableMessagingProviders: ["sandbox-existing-discord"],
+      extraProviders: ["custom-provider"],
+      hermesToolGateways: ["github"],
+      sandboxGpuConfig,
+      gpuCreateArgs: ["--gpu"],
+      useDockerGpuPatch: false,
+      sandboxGpuLogMessage: null,
+      agentName: "hermes",
+      policyTier: "balanced",
+    });
+    const serializedIntent = JSON.stringify(intent);
+    const events: string[] = [];
+
+    const result = materializeSandboxCreatePlan({
+      intent,
+      buildCtx: "/tmp/nemoclaw-build-1",
+      messagingTokenDefs: tokenDefs,
+      prepareInitialSandboxCreatePolicy: vi.fn(() => {
+        events.push("policy");
+        return { policyPath: "/tmp/policy.yaml", appliedPresets: ["telegram"] };
+      }),
+      appendResourceFlags: (args) => {
+        events.push("resources");
+        args.push("--memory", "16g");
+      },
+      runProviderPreDeleteCleanup: () => events.push("cleanup"),
+      upsertMessagingProviders: vi.fn((receivedTokenDefs) => {
+        events.push("upsert");
+        expect(receivedTokenDefs).toEqual(tokenDefs);
+        return ["sandbox-telegram-bridge"];
+      }),
+      getHermesToolGatewayProviderName: (sandboxName) => {
+        events.push("hermes");
+        return `${sandboxName}-hermes-tools`;
+      },
+    });
+
+    expect(events).toEqual(["policy", "resources", "cleanup", "upsert", "hermes"]);
+    expect(result.createArgs).toEqual([
+      "--from",
+      "/tmp/nemoclaw-build-1/Dockerfile",
+      "--name",
+      "sandbox",
+      "--policy",
+      "/tmp/policy.yaml",
+      "--gpu",
+      "--memory",
+      "16g",
+      "--provider",
+      "sandbox-telegram-bridge",
+      "--provider",
+      "sandbox-existing-discord",
+      "--provider",
+      "sandbox-hermes-tools",
+      "--provider",
+      "custom-provider",
+    ]);
+    expect(serializedIntent).not.toContain("telegram-super-secret");
+    expect(JSON.stringify(intent)).toBe(serializedIntent);
+  });
+
+  it("rejects changed credential availability before running effects", () => {
+    const originalTokenDefs = [
+      {
+        name: "sandbox-telegram-bridge",
+        envKey: "TELEGRAM_BOT_TOKEN",
+        token: null,
+      },
+    ];
+    const intent = resolveSandboxCreateIntent({
+      basePolicyPath: "/repo/policy.yaml",
+      sandboxName: "sandbox",
+      channels,
+      enabledChannels: ["telegram"],
+      disabledChannelNames: new Set(),
+      messagingProviderRequests: resolveSandboxCreateMessagingProviderRequests(
+        originalTokenDefs,
+        () => "telegram",
+      ),
+      primaryMessagingCredentialEnvKeys: ["TELEGRAM_BOT_TOKEN"],
+      reusableMessagingChannels: [],
+      reusableMessagingProviders: [],
+      hermesToolGateways: [],
+      sandboxGpuConfig,
+      gpuCreateArgs: [],
+      useDockerGpuPatch: false,
+      sandboxGpuLogMessage: null,
+      policyTier: null,
+    });
+    const preparePolicy = vi.fn(() => ({ policyPath: "/tmp/policy.yaml", appliedPresets: [] }));
+    const appendResources = vi.fn();
+    const cleanupProviders = vi.fn();
+    const upsertProviders = vi.fn(() => []);
+
+    expect(() =>
+      materializeSandboxCreatePlan({
+        intent,
+        buildCtx: "/tmp/nemoclaw-build-1",
+        messagingTokenDefs: [{ ...originalTokenDefs[0], token: "new-secret" }],
+        prepareInitialSandboxCreatePolicy: preparePolicy,
+        appendResourceFlags: appendResources,
+        runProviderPreDeleteCleanup: cleanupProviders,
+        upsertMessagingProviders: upsertProviders,
+        getHermesToolGatewayProviderName: vi.fn(),
+      }),
+    ).toThrow("credential availability changed");
+    expect(preparePolicy).not.toHaveBeenCalled();
+    expect(appendResources).not.toHaveBeenCalled();
+    expect(cleanupProviders).not.toHaveBeenCalled();
+    expect(upsertProviders).not.toHaveBeenCalled();
+  });
+});
+
 describe("prepareSandboxCreatePlan", () => {
   it("builds create args, policy, providers, and active channels in onboard order", () => {
     const events: string[] = [];
@@ -62,9 +297,21 @@ describe("prepareSandboxCreatePlan", () => {
       enabledChannels: ["telegram", "whatsapp"],
       disabledChannelNames: new Set(),
       messagingTokenDefs: [
-        { envKey: "TELEGRAM_BOT_TOKEN", token: "telegram-token" },
-        { envKey: "SLACK_APP_TOKEN", token: "slack-app-token" },
-        { envKey: "SLACK_BOT_TOKEN", token: "slack-bot-token" },
+        {
+          name: "sandbox-telegram-bridge",
+          envKey: "TELEGRAM_BOT_TOKEN",
+          token: "telegram-token",
+        },
+        {
+          name: "sandbox-slack-app-bridge",
+          envKey: "SLACK_APP_TOKEN",
+          token: "slack-app-token",
+        },
+        {
+          name: "sandbox-slack-bridge",
+          envKey: "SLACK_BOT_TOKEN",
+          token: "slack-bot-token",
+        },
       ],
       reusableMessagingChannels: ["discord"],
       reusableMessagingProviders: ["sandbox-existing-discord"],
@@ -200,7 +447,13 @@ describe("prepareSandboxCreatePlan", () => {
       channels,
       enabledChannels: ["slack", "whatsapp"],
       disabledChannelNames: new Set(["whatsapp"]),
-      messagingTokenDefs: [{ envKey: "SLACK_APP_TOKEN", token: "slack-app-token" }],
+      messagingTokenDefs: [
+        {
+          name: "sandbox-slack-app-bridge",
+          envKey: "SLACK_APP_TOKEN",
+          token: "slack-app-token",
+        },
+      ],
       reusableMessagingChannels: [],
       reusableMessagingProviders: [],
       hermesToolGateways: [],
@@ -283,7 +536,13 @@ describe("prepareSandboxCreatePlan", () => {
       channels,
       enabledChannels: ["telegram"],
       disabledChannelNames: new Set(),
-      messagingTokenDefs: [{ envKey: "TELEGRAM_BOT_TOKEN", token: "telegram" }],
+      messagingTokenDefs: [
+        {
+          name: "sandbox-telegram-bridge",
+          envKey: "TELEGRAM_BOT_TOKEN",
+          token: "telegram",
+        },
+      ],
       reusableMessagingChannels: [],
       reusableMessagingProviders: [],
       extraProviders: ["sandbox-telegram-bridge", "tavily-search"],

--- a/src/lib/onboard/sandbox-create-plan.ts
+++ b/src/lib/onboard/sandbox-create-plan.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  type MessagingCredentialMetadata,
   listMessagingCredentialMetadata,
+  type MessagingCredentialMetadata,
 } from "../messaging/channels";
 import type { InitialSandboxPolicy } from "./initial-policy";
+import type { MessagingTokenDef } from "./messaging-prep";
 import type { MessagingChannel } from "./messaging-state";
 import { resolveQrSelectedChannels } from "./messaging-state";
 import { buildSandboxGpuCreateArgs, type SandboxGpuCreateConfig } from "./sandbox-gpu-create";
@@ -32,12 +33,6 @@ function readPolicyTierEnv(): string | null {
   const trimmed = raw.trim().toLowerCase();
   return KNOWN_POLICY_TIER_NAMES.has(trimmed) ? trimmed : null;
 }
-
-type MessagingTokenDef = {
-  name?: string;
-  envKey: string;
-  token: string | null;
-};
 
 type ResolveDockerGpuSandboxCreatePlan =
   typeof import("./docker-gpu-sandbox-create").resolveDockerGpuSandboxCreatePlan;
@@ -86,6 +81,84 @@ export type SandboxCreatePlan = {
   sandboxGpuLogMessage: string | null;
 };
 
+export type SandboxCreateMessagingProviderRequest = {
+  readonly name: string;
+  readonly envKey: string;
+  readonly providerType?: string;
+  readonly credentialConfigured: boolean;
+  readonly channel: string | null;
+};
+
+export type SandboxCreatePolicyRequest = {
+  readonly basePolicyPath: string;
+  readonly activeMessagingChannels: readonly string[];
+  readonly options: {
+    readonly directGpu: boolean;
+    readonly dockerGpuPatch: boolean;
+    readonly additionalPresets: readonly string[];
+    readonly agentName?: string | null;
+    readonly policyTier: string | null;
+  };
+};
+
+/**
+ * Serializable intent for the create-time sandbox contributions. When built
+ * through {@link prepareSandboxCreatePlan}, messaging credential values are
+ * represented only by their logical environment-key bindings and presence.
+ *
+ * This is deliberately separate from {@link SandboxCreatePlan}, which is an
+ * execution artifact containing temporary paths and cleanup callbacks. Its
+ * serializable shape is for internal inspection and testing only; it is not a
+ * persistence, machine-event, or public API contract.
+ */
+export type SandboxCreateIntent = {
+  readonly sandboxName: string;
+  readonly activeMessagingChannels: readonly string[];
+  readonly messagingProviderRequests: readonly SandboxCreateMessagingProviderRequest[];
+  readonly reusableMessagingProviders: readonly string[];
+  readonly extraProviders: readonly string[];
+  readonly hermesToolGateways: readonly string[];
+  readonly policy: SandboxCreatePolicyRequest;
+  readonly gpuCreateArgs: readonly string[];
+  readonly useDockerGpuPatch: boolean;
+  readonly sandboxGpuLogMessage: string | null;
+  readonly disabledChannelNames: readonly string[];
+};
+
+export type ResolveSandboxCreateIntentInput = {
+  basePolicyPath: string;
+  sandboxName: string;
+  channels: MessagingChannel[];
+  enabledChannels: string[] | null;
+  disabledChannelNames: ReadonlySet<string>;
+  messagingProviderRequests: readonly SandboxCreateMessagingProviderRequest[];
+  primaryMessagingCredentialEnvKeys: readonly string[];
+  reusableMessagingChannels: readonly string[];
+  reusableMessagingProviders: readonly string[];
+  extraProviders?: readonly string[];
+  hermesToolGateways: readonly string[];
+  sandboxGpuConfig: SandboxGpuCreateConfig;
+  gpuCreateArgs: readonly string[];
+  useDockerGpuPatch: boolean;
+  sandboxGpuLogMessage: string | null;
+  agentName?: string | null;
+  policyTier: string | null;
+};
+
+export type MaterializeSandboxCreatePlanInput = {
+  intent: SandboxCreateIntent;
+  buildCtx: string;
+  messagingTokenDefs: MessagingTokenDef[];
+  appendResourceFlags(createArgs: string[]): void;
+  runProviderPreDeleteCleanup(): void;
+  upsertMessagingProviders(
+    tokenDefs: MessagingTokenDef[],
+    options: { replaceExisting: true },
+  ): string[];
+  getHermesToolGatewayProviderName(sandboxName: string): string;
+  prepareInitialSandboxCreatePolicy?: PrepareInitialSandboxCreatePolicy;
+};
+
 function getDockerGpuSandboxCreatePlan(
   ...args: Parameters<ResolveDockerGpuSandboxCreatePlan>
 ): ReturnType<ResolveDockerGpuSandboxCreatePlan> {
@@ -109,25 +182,18 @@ function filterEnabledChannelNames(
   return channelNames.filter((channelName) => !disabledChannelNames.has(channelName));
 }
 
-function filterMessagingTokenDefsByEnabledChannel(
-  messagingTokenDefs: MessagingTokenDef[],
+function filterMessagingProviderRequestsByEnabledChannel(
+  requests: readonly SandboxCreateMessagingProviderRequest[],
   disabledChannelNames: ReadonlySet<string>,
-  getMessagingChannelForEnvKey: (envKey: string) => string | null,
-): MessagingTokenDef[] {
-  return messagingTokenDefs.filter(({ envKey }) => {
-    const channel = getMessagingChannelForEnvKey(envKey);
-    return !channel || !disabledChannelNames.has(channel);
-  });
+): SandboxCreateMessagingProviderRequest[] {
+  return requests.filter(({ channel }) => !channel || !disabledChannelNames.has(channel));
 }
 
 function resolveTokenProviderChannelMap(
-  messagingTokenDefs: MessagingTokenDef[],
-  getMessagingChannelForEnvKey: (envKey: string) => string | null,
+  requests: readonly SandboxCreateMessagingProviderRequest[],
 ): Map<string, string> {
   const providerChannels = new Map<string, string>();
-  for (const { envKey, name } of messagingTokenDefs) {
-    if (!name) continue;
-    const channel = getMessagingChannelForEnvKey(envKey);
+  for (const { channel, name } of requests) {
     if (channel) providerChannels.set(name, channel);
   }
   return providerChannels;
@@ -148,19 +214,19 @@ function resolveActiveMessagingChannels({
   channels,
   disabledChannelNames,
   enabledChannels,
-  getMessagingChannelForEnvKey,
-  messagingTokenDefs,
+  messagingProviderRequests,
+  primaryMessagingCredentialEnvKeys,
   reusableMessagingChannels,
 }: Pick<
-  PrepareSandboxCreatePlanInput,
+  ResolveSandboxCreateIntentInput,
   | "channels"
   | "disabledChannelNames"
   | "enabledChannels"
-  | "getMessagingChannelForEnvKey"
-  | "messagingTokenDefs"
+  | "messagingProviderRequests"
+  | "primaryMessagingCredentialEnvKeys"
   | "reusableMessagingChannels"
 >): string[] {
-  const primaryCredentialEnvKeys = getPrimaryCredentialEnvKeys();
+  const primaryCredentialEnvKeys = new Set(primaryMessagingCredentialEnvKeys);
   const qrSelectedChannels = resolveQrSelectedChannels(
     channels,
     enabledChannels,
@@ -169,10 +235,9 @@ function resolveActiveMessagingChannels({
   return filterEnabledChannelNames(
     [
       ...new Set([
-        ...messagingTokenDefs
-          .filter(({ token }) => !!token)
-          .flatMap(({ envKey }) => {
-            const channel = getMessagingChannelForEnvKey(envKey);
+        ...messagingProviderRequests
+          .filter(({ credentialConfigured }) => credentialConfigured)
+          .flatMap(({ channel, envKey }) => {
             return channel && primaryCredentialEnvKeys.has(envKey) ? [channel] : [];
           }),
         ...reusableMessagingChannels,
@@ -211,6 +276,187 @@ function compareCredentialsForPrimarySelection(
   );
 }
 
+export function resolveSandboxCreateMessagingProviderRequests(
+  messagingTokenDefs: readonly MessagingTokenDef[],
+  getMessagingChannelForEnvKey: (envKey: string) => string | null,
+): SandboxCreateMessagingProviderRequest[] {
+  return messagingTokenDefs.map(({ name, envKey, providerType, token }) => ({
+    name,
+    envKey,
+    ...(providerType ? { providerType } : {}),
+    credentialConfigured: Boolean(token),
+    channel: getMessagingChannelForEnvKey(envKey),
+  }));
+}
+
+export function resolveSandboxCreateIntent({
+  basePolicyPath,
+  sandboxName,
+  channels,
+  enabledChannels,
+  disabledChannelNames,
+  messagingProviderRequests,
+  primaryMessagingCredentialEnvKeys,
+  reusableMessagingChannels,
+  reusableMessagingProviders,
+  extraProviders,
+  hermesToolGateways,
+  sandboxGpuConfig,
+  gpuCreateArgs,
+  useDockerGpuPatch,
+  sandboxGpuLogMessage,
+  agentName,
+  policyTier,
+}: ResolveSandboxCreateIntentInput): SandboxCreateIntent {
+  const enabledMessagingProviderRequests = filterMessagingProviderRequestsByEnabledChannel(
+    messagingProviderRequests,
+    disabledChannelNames,
+  );
+  const providerChannels = resolveTokenProviderChannelMap(messagingProviderRequests);
+  const activeMessagingChannels = resolveActiveMessagingChannels({
+    channels,
+    disabledChannelNames,
+    enabledChannels,
+    messagingProviderRequests: enabledMessagingProviderRequests,
+    primaryMessagingCredentialEnvKeys,
+    reusableMessagingChannels,
+  });
+  const enabledReusableMessagingProviders = filterMessagingProvidersByEnabledChannel(
+    [...new Set(reusableMessagingProviders)],
+    providerChannels,
+    disabledChannelNames,
+  );
+
+  return {
+    sandboxName,
+    activeMessagingChannels,
+    messagingProviderRequests: messagingProviderRequests.map((request) => ({ ...request })),
+    reusableMessagingProviders: enabledReusableMessagingProviders,
+    extraProviders: [...new Set(extraProviders ?? [])].filter(Boolean),
+    hermesToolGateways: [...hermesToolGateways],
+    policy: {
+      basePolicyPath,
+      activeMessagingChannels: [...activeMessagingChannels],
+      options: {
+        directGpu: sandboxGpuConfig.sandboxGpuEnabled,
+        dockerGpuPatch: useDockerGpuPatch,
+        additionalPresets: [...hermesToolGateways],
+        ...(agentName !== undefined ? { agentName } : {}),
+        policyTier,
+      },
+    },
+    gpuCreateArgs: [...gpuCreateArgs],
+    useDockerGpuPatch,
+    sandboxGpuLogMessage,
+    disabledChannelNames: [...disabledChannelNames],
+  };
+}
+
+function messagingProviderRequestKey(
+  request: Pick<SandboxCreateMessagingProviderRequest, "name" | "envKey">,
+): string {
+  return `${request.name}\u0000${request.envKey}`;
+}
+
+function bindMessagingTokenDefs(
+  intent: SandboxCreateIntent,
+  messagingTokenDefs: readonly MessagingTokenDef[],
+): MessagingTokenDef[] {
+  const enabledRequests = filterMessagingProviderRequestsByEnabledChannel(
+    intent.messagingProviderRequests,
+    new Set(intent.disabledChannelNames),
+  );
+  const tokenDefsByRequest = new Map(
+    messagingTokenDefs.map((tokenDef) => [messagingProviderRequestKey(tokenDef), tokenDef]),
+  );
+
+  return enabledRequests.map((request) => {
+    const tokenDef = tokenDefsByRequest.get(messagingProviderRequestKey(request));
+    if (!tokenDef) {
+      throw new Error(
+        `Cannot materialize sandbox create intent; missing credential binding '${request.envKey}' for provider '${request.name}'.`,
+      );
+    }
+    if (Boolean(tokenDef.token) !== request.credentialConfigured) {
+      throw new Error(
+        `Cannot materialize sandbox create intent; credential availability changed for provider '${request.name}'.`,
+      );
+    }
+    if ((tokenDef.providerType || undefined) !== request.providerType) {
+      throw new Error(
+        `Cannot materialize sandbox create intent; provider type changed for '${request.name}'.`,
+      );
+    }
+    return tokenDef;
+  });
+}
+
+export function materializeSandboxCreatePlan({
+  intent,
+  buildCtx,
+  messagingTokenDefs,
+  appendResourceFlags,
+  runProviderPreDeleteCleanup,
+  upsertMessagingProviders,
+  getHermesToolGatewayProviderName,
+  prepareInitialSandboxCreatePolicy = getInitialSandboxCreatePolicy,
+}: MaterializeSandboxCreatePlanInput): SandboxCreatePlan {
+  const enabledMessagingTokenDefs = bindMessagingTokenDefs(intent, messagingTokenDefs);
+  const initialSandboxPolicy = prepareInitialSandboxCreatePolicy(
+    intent.policy.basePolicyPath,
+    [...intent.policy.activeMessagingChannels],
+    {
+      directGpu: intent.policy.options.directGpu,
+      dockerGpuPatch: intent.policy.options.dockerGpuPatch,
+      additionalPresets: [...intent.policy.options.additionalPresets],
+      agentName: intent.policy.options.agentName,
+      policyTier: intent.policy.options.policyTier,
+    },
+  );
+  const createArgs = [
+    "--from",
+    `${buildCtx}/Dockerfile`,
+    "--name",
+    intent.sandboxName,
+    "--policy",
+    initialSandboxPolicy.policyPath,
+    ...intent.gpuCreateArgs,
+  ];
+
+  appendResourceFlags(createArgs);
+  runProviderPreDeleteCleanup();
+  const providerChannels = resolveTokenProviderChannelMap(intent.messagingProviderRequests);
+  const messagingProviders = filterMessagingProvidersByEnabledChannel(
+    [
+      ...new Set([
+        ...upsertMessagingProviders(enabledMessagingTokenDefs, { replaceExisting: true }),
+        ...intent.reusableMessagingProviders,
+      ]),
+    ],
+    providerChannels,
+    new Set(intent.disabledChannelNames),
+  );
+  for (const provider of messagingProviders) {
+    createArgs.push("--provider", provider);
+  }
+  if (intent.hermesToolGateways.length > 0) {
+    createArgs.push("--provider", getHermesToolGatewayProviderName(intent.sandboxName));
+  }
+  for (const provider of intent.extraProviders) {
+    if (messagingProviders.includes(provider)) continue;
+    createArgs.push("--provider", provider);
+  }
+
+  return {
+    activeMessagingChannels: [...intent.activeMessagingChannels],
+    initialSandboxPolicy,
+    createArgs,
+    messagingProviders,
+    useDockerGpuPatch: intent.useDockerGpuPatch,
+    sandboxGpuLogMessage: intent.sandboxGpuLogMessage,
+  };
+}
+
 export function prepareSandboxCreatePlan({
   basePolicyPath,
   buildCtx,
@@ -234,78 +480,48 @@ export function prepareSandboxCreatePlan({
   policyTier = readPolicyTierEnv(),
   deps = {},
 }: PrepareSandboxCreatePlanInput): SandboxCreatePlan {
-  const enabledMessagingTokenDefs = filterMessagingTokenDefsByEnabledChannel(
-    messagingTokenDefs,
-    disabledChannelNames,
-    getMessagingChannelForEnvKey,
-  );
-  const providerChannels = resolveTokenProviderChannelMap(
-    messagingTokenDefs,
-    getMessagingChannelForEnvKey,
-  );
-  const activeMessagingChannels = resolveActiveMessagingChannels({
-    channels,
-    disabledChannelNames,
-    enabledChannels,
-    getMessagingChannelForEnvKey,
-    messagingTokenDefs: enabledMessagingTokenDefs,
-    reusableMessagingChannels,
-  });
   const { useDockerGpuPatch, logMessage: sandboxGpuLogMessage } = (
     deps.resolveDockerGpuSandboxCreatePlan ?? getDockerGpuSandboxCreatePlan
   )(sandboxGpuConfig, { dockerDriverGateway });
-  const initialSandboxPolicy = (
-    deps.prepareInitialSandboxCreatePolicy ?? getInitialSandboxCreatePolicy
-  )(basePolicyPath, activeMessagingChannels, {
-    directGpu: sandboxGpuConfig.sandboxGpuEnabled,
-    dockerGpuPatch: useDockerGpuPatch,
-    additionalPresets: hermesToolGateways,
+  const gpuCreateArgs = (deps.buildSandboxGpuCreateArgs ?? buildSandboxGpuCreateArgs)(
+    sandboxGpuConfig,
+    {
+      suppressGpuFlag: useDockerGpuPatch,
+    },
+  );
+  const messagingProviderRequests = resolveSandboxCreateMessagingProviderRequests(
+    messagingTokenDefs,
+    getMessagingChannelForEnvKey,
+  );
+  const intent = resolveSandboxCreateIntent({
+    basePolicyPath,
+    sandboxName,
+    channels,
+    enabledChannels,
+    disabledChannelNames,
+    messagingProviderRequests,
+    primaryMessagingCredentialEnvKeys: [...getPrimaryCredentialEnvKeys()],
+    reusableMessagingChannels,
+    reusableMessagingProviders,
+    extraProviders,
+    hermesToolGateways,
+    sandboxGpuConfig,
+    gpuCreateArgs,
+    useDockerGpuPatch,
+    sandboxGpuLogMessage,
     agentName,
     policyTier,
   });
-  const createArgs = [
-    "--from",
-    `${buildCtx}/Dockerfile`,
-    "--name",
-    sandboxName,
-    "--policy",
-    initialSandboxPolicy.policyPath,
-    ...(deps.buildSandboxGpuCreateArgs ?? buildSandboxGpuCreateArgs)(sandboxGpuConfig, {
-      suppressGpuFlag: useDockerGpuPatch,
-    }),
-  ];
 
-  appendResourceFlags(createArgs);
-  runProviderPreDeleteCleanup();
-  const messagingProviders = filterMessagingProvidersByEnabledChannel(
-    [
-      ...new Set([
-        ...upsertMessagingProviders(enabledMessagingTokenDefs, { replaceExisting: true }),
-        ...reusableMessagingProviders,
-      ]),
-    ],
-    providerChannels,
-    disabledChannelNames,
-  );
-  for (const provider of messagingProviders) {
-    createArgs.push("--provider", provider);
-  }
-  if (hermesToolGateways.length > 0) {
-    createArgs.push("--provider", getHermesToolGatewayProviderName(sandboxName));
-  }
-  const dedupedExtraProviders = [...new Set(extraProviders ?? [])].filter(
-    (name) => name && !messagingProviders.includes(name),
-  );
-  for (const provider of dedupedExtraProviders) {
-    createArgs.push("--provider", provider);
-  }
-
-  return {
-    activeMessagingChannels,
-    initialSandboxPolicy,
-    createArgs,
-    messagingProviders,
-    useDockerGpuPatch,
-    sandboxGpuLogMessage,
-  };
+  return materializeSandboxCreatePlan({
+    intent,
+    buildCtx,
+    messagingTokenDefs,
+    appendResourceFlags,
+    runProviderPreDeleteCleanup,
+    upsertMessagingProviders,
+    getHermesToolGatewayProviderName,
+    prepareInitialSandboxCreatePolicy:
+      deps.prepareInitialSandboxCreatePolicy ?? getInitialSandboxCreatePolicy,
+  });
 }

--- a/src/lib/onboard/sandbox-create-plan.ts
+++ b/src/lib/onboard/sandbox-create-plan.ts
@@ -9,7 +9,21 @@ import type { InitialSandboxPolicy } from "./initial-policy";
 import type { MessagingTokenDef } from "./messaging-prep";
 import type { MessagingChannel } from "./messaging-state";
 import { resolveQrSelectedChannels } from "./messaging-state";
+import type {
+  MaterializeSandboxCreatePlanInput,
+  ResolveSandboxCreateIntentInput,
+  SandboxCreateIntent,
+  SandboxCreateMessagingProviderRequest,
+} from "./sandbox-create-intent-types";
 import { buildSandboxGpuCreateArgs, type SandboxGpuCreateConfig } from "./sandbox-gpu-create";
+
+export type {
+  MaterializeSandboxCreatePlanInput,
+  ResolveSandboxCreateIntentInput,
+  SandboxCreateIntent,
+  SandboxCreateMessagingProviderRequest,
+  SandboxCreatePolicyRequest,
+} from "./sandbox-create-intent-types";
 
 // Known canonical policy tier names. Kept inline so the create-time path
 // validates the env value without pulling `../policy/tiers` (which transitively
@@ -79,84 +93,6 @@ export type SandboxCreatePlan = {
   messagingProviders: string[];
   useDockerGpuPatch: boolean;
   sandboxGpuLogMessage: string | null;
-};
-
-export type SandboxCreateMessagingProviderRequest = {
-  readonly name: string;
-  readonly envKey: string;
-  readonly providerType?: string;
-  readonly credentialConfigured: boolean;
-  readonly channel: string | null;
-};
-
-export type SandboxCreatePolicyRequest = {
-  readonly basePolicyPath: string;
-  readonly activeMessagingChannels: readonly string[];
-  readonly options: {
-    readonly directGpu: boolean;
-    readonly dockerGpuPatch: boolean;
-    readonly additionalPresets: readonly string[];
-    readonly agentName?: string | null;
-    readonly policyTier: string | null;
-  };
-};
-
-/**
- * Serializable intent for the create-time sandbox contributions. When built
- * through {@link prepareSandboxCreatePlan}, messaging credential values are
- * represented only by their logical environment-key bindings and presence.
- *
- * This is deliberately separate from {@link SandboxCreatePlan}, which is an
- * execution artifact containing temporary paths and cleanup callbacks. Its
- * serializable shape is for internal inspection and testing only; it is not a
- * persistence, machine-event, or public API contract.
- */
-export type SandboxCreateIntent = {
-  readonly sandboxName: string;
-  readonly activeMessagingChannels: readonly string[];
-  readonly messagingProviderRequests: readonly SandboxCreateMessagingProviderRequest[];
-  readonly reusableMessagingProviders: readonly string[];
-  readonly extraProviders: readonly string[];
-  readonly hermesToolGateways: readonly string[];
-  readonly policy: SandboxCreatePolicyRequest;
-  readonly gpuCreateArgs: readonly string[];
-  readonly useDockerGpuPatch: boolean;
-  readonly sandboxGpuLogMessage: string | null;
-  readonly disabledChannelNames: readonly string[];
-};
-
-export type ResolveSandboxCreateIntentInput = {
-  basePolicyPath: string;
-  sandboxName: string;
-  channels: MessagingChannel[];
-  enabledChannels: string[] | null;
-  disabledChannelNames: ReadonlySet<string>;
-  messagingProviderRequests: readonly SandboxCreateMessagingProviderRequest[];
-  primaryMessagingCredentialEnvKeys: readonly string[];
-  reusableMessagingChannels: readonly string[];
-  reusableMessagingProviders: readonly string[];
-  extraProviders?: readonly string[];
-  hermesToolGateways: readonly string[];
-  sandboxGpuConfig: SandboxGpuCreateConfig;
-  gpuCreateArgs: readonly string[];
-  useDockerGpuPatch: boolean;
-  sandboxGpuLogMessage: string | null;
-  agentName?: string | null;
-  policyTier: string | null;
-};
-
-export type MaterializeSandboxCreatePlanInput = {
-  intent: SandboxCreateIntent;
-  buildCtx: string;
-  messagingTokenDefs: MessagingTokenDef[];
-  appendResourceFlags(createArgs: string[]): void;
-  runProviderPreDeleteCleanup(): void;
-  upsertMessagingProviders(
-    tokenDefs: MessagingTokenDef[],
-    options: { replaceExisting: true },
-  ): string[];
-  getHermesToolGatewayProviderName(sandboxName: string): string;
-  prepareInitialSandboxCreatePolicy?: PrepareInitialSandboxCreatePolicy;
 };
 
 function getDockerGpuSandboxCreatePlan(
@@ -355,7 +291,8 @@ export function resolveSandboxCreateIntent({
 function messagingProviderRequestKey(
   request: Pick<SandboxCreateMessagingProviderRequest, "name" | "envKey">,
 ): string {
-  return `${request.name}\u0000${request.envKey}`;
+  // Tuple encoding stays collision-free even if either value contains a separator.
+  return JSON.stringify([request.name, request.envKey]);
 }
 
 function bindMessagingTokenDefs(
@@ -382,7 +319,10 @@ function bindMessagingTokenDefs(
         `Cannot materialize sandbox create intent; credential availability changed for provider '${request.name}'.`,
       );
     }
-    if ((tokenDef.providerType || undefined) !== request.providerType) {
+    // Default providers omit this field; normalize an empty or missing binding
+    // to the intent's `undefined` representation before comparing.
+    const boundProviderType = tokenDef.providerType || undefined;
+    if (boundProviderType !== request.providerType) {
       throw new Error(
         `Cannot materialize sandbox create intent; provider type changed for '${request.name}'.`,
       );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Separates create-time onboarding intent resolution from effectful materialization while preserving the existing `prepareSandboxCreatePlan` entry point and runtime behavior. This establishes a typed internal seam for later FSM work without persisting temporary paths, cleanup callbacks, or messaging credential values.

## Changes
<!-- Bullet list of key changes. -->

- Add a deterministic `SandboxCreateIntent` resolver with explicit credential metadata, policy inputs, GPU arguments, and provider contributions.
- Materialize temporary policy files, resource flags, provider cleanup/upserts, and concrete create arguments in a separate effectful phase.
- Keep the serializable intent contract in a dedicated type-only module so the execution path remains focused.
- Reject changed credential availability or provider type before any materialization effects run.
- Preserve provider ordering, channel filtering, policy-tier behavior, and the existing compatibility wrapper.
- Add characterization coverage for serialization, credential-value exclusion, effect ordering, stale bindings, disabled channels, GPU behavior, and provider deduplication.
- Keep FSM/session capture out of scope: recreate still reaches this seam after the existing destructive boundary, which requires a separate migration.
- Local verification used Node.js 22: 39 focused tests pass, CLI typecheck/build and repository checks pass, and GitHub verifies all three signed commits. The repository-wide `test-cli` hook was attempted, then skipped for the commits because macOS lacks GNU `script -qec` and Docker; a separate CLI run reached 5,335 passing tests with 18 unrelated timeout failures in untouched files.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal behavior-preserving refactor with no CLI, prompt, output, persistence, event, or public API change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: reviewed credential-value exclusion, binding validation, and side-effect ordering; focused tests assert no effects run for stale bindings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation during sandbox creation so mismatched or missing messaging credential bindings are detected early, preventing partial side effects.
  * Improved determinism and correctness of messaging provider request generation and the resulting provider wiring order.

* **Refactor**
  * Reworked sandbox creation into a two-stage flow: deriving a serializable “intent” and then materializing it into final creation arguments and providers.
  * Updated messaging provider and active channel resolution to be request-driven, with consistent ordering and Hermes gateway integration.

* **Tests**
  * Expanded and added coverage for intent resolution, credential-binding failure behavior, deterministic output, and effect ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->