### PR TITLE
perf(e2e): start hosted proofs in parallel

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2613,11 +2613,8 @@ jobs:
         run: bash .github/scripts/docker-auth-cleanup.sh
 
   full-e2e:
-    # Keep the load-sensitive agent-mediated proof out of the peak hosted
-    # lifecycle burst. always() preserves targeted dispatch when the
-    # unselected dependencies are skipped.
-    needs: [generate-matrix, token-rotation, channels-stop-start]
-    if: ${{ always() && ((github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',full-e2e,') || contains(format(',{0},', inputs.targets), ',full-e2e,')) }}
+    needs: generate-matrix
+    if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',full-e2e,') || contains(format(',{0},', inputs.targets), ',full-e2e,') }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
@@ -3539,10 +3536,8 @@ jobs:
 
   # The #2603/#3145 OpenClaw websocket protocol/history contract.
   openclaw-tui-chat-correlation:
-    # Run the strict hosted-correlation proof after the serialized full agent
-    # proof. always() preserves targeted dispatch when dependencies are skipped.
-    needs: [generate-matrix, token-rotation, channels-stop-start, full-e2e]
-    if: ${{ always() && ((github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',openclaw-tui-chat-correlation,') || contains(format(',{0},', inputs.targets), ',openclaw-tui-chat-correlation,')) }}
+    needs: generate-matrix
+    if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',openclaw-tui-chat-correlation,') || contains(format(',{0},', inputs.targets), ',openclaw-tui-chat-correlation,') }}
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:

--- a/test/e2e-release-gate-workflow.test.ts
+++ b/test/e2e-release-gate-workflow.test.ts
@@ -10,21 +10,16 @@ import { readYaml, type WorkflowJob } from "./helpers/e2e-workflow-contract";
 const e2eWorkflow = readYaml<{ jobs: Record<string, WorkflowJob> }>(".github/workflows/e2e.yaml");
 
 describe("release gate workflow resource contracts", () => {
-  it("serializes hosted agent proofs after peak hosted lifecycle jobs", () => {
+  it("starts hosted agent proofs in the first wave after matrix generation", () => {
     const fullJob = e2eWorkflow.jobs["full-e2e"];
     const tuiJob = e2eWorkflow.jobs["openclaw-tui-chat-correlation"];
-    const peakDependencies = ["generate-matrix", "token-rotation", "channels-stop-start"];
 
-    expect(fullJob.needs).toEqual(expect.arrayContaining(peakDependencies));
-    expect(fullJob.needs).toHaveLength(peakDependencies.length);
-    expect(fullJob.if).toContain("always()");
+    expect(fullJob.needs).toBe("generate-matrix");
+    expect(fullJob.if).not.toContain("always()");
     expect(fullJob.if).toContain(",full-e2e,");
-    const tuiDependencies = [...peakDependencies, "full-e2e"];
-    expect(tuiJob.needs).toEqual(expect.arrayContaining(tuiDependencies));
-    expect(tuiJob.needs).toHaveLength(tuiDependencies.length);
-    expect(tuiJob.if).toContain("always()");
+    expect(tuiJob.needs).toBe("generate-matrix");
+    expect(tuiJob.if).not.toContain("always()");
     expect(tuiJob.if).toContain(",openclaw-tui-chat-correlation,");
-    for (const dependency of tuiDependencies) expect(e2eWorkflow.jobs).toHaveProperty(dependency);
   });
 
   it("budgets cold Ollama pulls in the consolidated GPU lane", () => {

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -78,6 +78,40 @@ describe("e2e workflow boundary", () => {
     expect(validateE2eWorkflowBoundary()).toEqual([]);
   });
 
+  it("starts hosted OpenClaw proofs in the first wave after matrix generation", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-workflow-"));
+    const workflowPath = path.join(tmp, "workflow.yaml");
+    const workflow = readWorkflow() as {
+      jobs: Record<string, { needs?: string | string[] }>;
+    };
+    const serializedDependencies = {
+      "full-e2e": ["generate-matrix", "token-rotation", "channels-stop-start"],
+      "openclaw-tui-chat-correlation": [
+        "generate-matrix",
+        "token-rotation",
+        "channels-stop-start",
+        "full-e2e",
+      ],
+    };
+
+    for (const [jobName, dependencies] of Object.entries(serializedDependencies)) {
+      expect(workflow.jobs[jobName]?.needs).toBe("generate-matrix");
+      workflow.jobs[jobName]!.needs = dependencies;
+    }
+    fs.writeFileSync(workflowPath, YAML.stringify(workflow));
+
+    try {
+      expect(validateE2eWorkflowBoundary(workflowPath)).toEqual(
+        expect.arrayContaining([
+          "full-e2e job must depend on generate-matrix",
+          "openclaw-tui-chat-correlation job must depend on generate-matrix",
+        ]),
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("rejects free-standing E2E artifact uploads from raw temp paths", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-workflow-"));
     const workflowPath = path.join(tmp, "workflow.yaml");

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -53,10 +53,8 @@ const COMMON_SECRET_ENV_NAMES = [
   "GITHUB_TOKEN",
 ];
 const FREE_STANDING_SELECTOR_SPECIAL_CASES = new Set([
-  "full-e2e",
   "hermes-e2e",
   "hermes-root-entrypoint-smoke",
-  "openclaw-tui-chat-correlation",
 ]);
 const PUBLIC_NVIDIA_ENDPOINT_KEY_JOBS = new Set([
   "device-auth-health",
@@ -517,39 +515,6 @@ function validateGatewayGuardRecoveryJob(errors: string[], jobs: WorkflowRecord)
   const jobEnv = asRecord(job.env);
   if (jobEnv.NEMOCLAW_E2E_USE_HOSTED_INFERENCE !== "1") {
     errors.push("gateway-guard-recovery job must enable hosted-compatible inference mode");
-  }
-}
-
-function validateSerializedHostedAgentProofs(errors: string[], jobs: WorkflowRecord): void {
-  const specs = [
-    {
-      jobName: "full-e2e",
-      dependencies: ["generate-matrix", "token-rotation", "channels-stop-start"],
-    },
-    {
-      jobName: "openclaw-tui-chat-correlation",
-      dependencies: ["generate-matrix", "token-rotation", "channels-stop-start", "full-e2e"],
-    },
-  ] as const;
-
-  for (const { dependencies, jobName } of specs) {
-    const job = asRecord(jobs[jobName]);
-    const needs = Array.isArray(job.needs) ? job.needs : [];
-    if (
-      needs.length !== dependencies.length ||
-      dependencies.some((dependency) => !needs.includes(dependency))
-    ) {
-      errors.push(`${jobName} job must wait for ${dependencies.join(", ")}`);
-    }
-    const condition = stringValue(job.if);
-    if (!condition.includes("always()")) {
-      errors.push(`${jobName} job must remain runnable after skipped dependencies`);
-    }
-    for (const selector of ["inputs.jobs", "inputs.targets", `,${jobName},`]) {
-      if (!condition.includes(selector)) {
-        errors.push(`${jobName} job selector must include ${selector}`);
-      }
-    }
   }
 }
 
@@ -3861,7 +3826,6 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
   validateUpgradeStaleSandboxJob(errors, jobs);
   validateTokenRotationJob(errors, jobs);
   validateMessagingCompatibleEndpointJob(errors, jobs);
-  validateSerializedHostedAgentProofs(errors, jobs);
   validateFreeStandingJobSelector(errors, jobs, "gateway-guard-recovery", "gateway-guard-recovery");
   validateGatewayGuardRecoveryJob(errors, jobs);
   validateFreeStandingJobSelector(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Starts the hosted full E2E and OpenClaw TUI correlation proofs in the first wave after matrix generation. This removes the artificial `channels-stop-start -> full-e2e -> TUI` critical path while preserving selective dispatch.

## Changes

- Make `full-e2e` and `openclaw-tui-chat-correlation` depend only on `generate-matrix`.
- Use the shared free-standing job selector contract instead of bespoke `always()` conditions.
- Remove the dedicated serialization validator and selector exceptions.
- Add regression coverage that rejects reintroducing serialized dependencies.
- Reduce the branch by 12 net lines, including 5 fewer workflow YAML lines.

## Parallel Safety and Runtime Validation

- GitHub gives each job its own hosted runner and Docker/OpenShell state.
- The jobs use distinct sandbox identifiers: `e2e-full`, `e2e-openclaw-tui-corr`, and `e2e-channels-stop-start-{openclaw,hermes}`. Their tests clean up only their own sandbox and gateway on that runner.
- Artifact roots are disjoint: `full-e2e`, `openclaw-tui-chat-correlation`, and `channels-stop-start/${agent}`.
- None consumes outputs or persisted state from `token-rotation`, `channels-stop-start`, or another hosted proof; `generate-matrix` is their only dependency.
- Selective run [28645490321](https://github.com/NVIDIA/NemoClaw/actions/runs/28645490321) omits `token-rotation` and proves first-wave scheduling: matrix completed at 07:29:03Z; TUI/Hermes channels started at 07:29:05Z; full E2E/OpenClaw channels started at 07:29:07Z.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal CI scheduling and workflow-contract behavior only; no product or user workflow changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior — 20 E2E-support workflow tests and 3 release-gate integration tests pass; CLI typecheck and YAML/Biome checks pass.
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
