### PR TITLE
perf(e2e): seed WhatsApp before channel lifecycle checks

### DIFF
--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -61,7 +61,7 @@ Refer to [Commands](../reference/commands) for details.
 | Discord | `DISCORD_BOT_TOKEN` | `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `DISCORD_REQUIRE_MENTION` |
 | Slack | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `SLACK_ALLOWED_USERS` for DM and channel `@mention` user allowlisting, `SLACK_ALLOWED_CHANNELS` for channel ID allowlisting |
 | WeChat (experimental) | None. Captured through host-side QR scan during `$$nemoclaw onboard` | `WECHAT_ALLOWED_IDS` for DM allowlisting |
-| WhatsApp (experimental) | None. Pair through QR after rebuild | None |
+| WhatsApp (experimental) | None. Pair through QR after rebuild | `WHATSAPP_ALLOWED_IDS` for Hermes sender allowlisting and non-interactive channel selection |
 | Microsoft Teams (experimental) | `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, `MSTEAMS_TENANT_ID` | `TEAMS_ALLOWED_USERS` for direct-message Microsoft Entra ID object ID allowlisting, `MSTEAMS_PORT` for the local webhook port, `TEAMS_REQUIRE_MENTION` for OpenClaw group and channel mention mode |
 
 Telegram uses a bot token from [BotFather](https://t.me/BotFather).
@@ -171,6 +171,8 @@ Keep the terminal in the foreground until you see `✓ WeChat login confirmed`.
 WhatsApp (experimental) uses QR pairing instead of a host-side token, so the wizard does not prompt.
 It prints pairing instructions and you complete the pairing inside the sandbox after rebuild.
 NemoClaw also selects the matching network policy preset during policy setup so the channel can reach its provider API.
+For non-interactive onboarding, set `WHATSAPP_ALLOWED_IDS` to a nonempty comma-separated sender list to select WhatsApp for either agent.
+Hermes also uses these values as its WhatsApp sender allowlist.
 
 For scripted setup, export the credentials and optional settings for the channels you want to enable before you run onboarding:
 
@@ -183,6 +185,7 @@ export SLACK_BOT_TOKEN="<your-slack-bot-token>"
 export SLACK_APP_TOKEN="<your-slack-app-token>"
 export SLACK_ALLOWED_USERS="<your-slack-member-id>"
 export SLACK_ALLOWED_CHANNELS="<your-slack-channel-id>"
+export WHATSAPP_ALLOWED_IDS="<your-whatsapp-sender-id>"
 export MSTEAMS_APP_ID="<your-teams-app-id>"
 export MSTEAMS_APP_PASSWORD="<your-teams-client-secret>"
 export MSTEAMS_TENANT_ID="<your-teams-tenant-id>"

--- a/src/lib/messaging/utils.ts
+++ b/src/lib/messaging/utils.ts
@@ -107,10 +107,12 @@ export function formatSupportedMessagingAgentIds(
 export function resolveMessagingManifestSeed(
   manifests: readonly ChannelManifest[],
   existingChannels: readonly string[] | null | undefined,
-  hasChannelRequiredInputs: (manifest: ChannelManifest) => boolean,
+  hasChannelConfiguredInputs: (manifest: ChannelManifest) => boolean,
   { includeAllExisting = false }: { readonly includeAllExisting?: boolean } = {},
 ): string[] {
-  const seeded = new Set(manifests.filter(hasChannelRequiredInputs).map((manifest) => manifest.id));
+  const seeded = new Set(
+    manifests.filter(hasChannelConfiguredInputs).map((manifest) => manifest.id),
+  );
   if (!Array.isArray(existingChannels)) return Array.from(seeded);
 
   const manifestById = new Map(manifests.map((manifest) => [manifest.id, manifest]));
@@ -134,6 +136,24 @@ export function hasMessagingManifestRequiredInputs(
     if (!input.envKey) return false;
     return hasResolvedInputValue(resolveInput(input));
   });
+}
+
+/**
+ * Return whether environment-backed inputs explicitly select a channel.
+ *
+ * Credentialed channels require every required input. Credentialless channels
+ * such as WhatsApp have no required input, so any configured optional input is
+ * the explicit signal that non-interactive onboarding should select them.
+ */
+export function hasMessagingManifestConfiguredInputs(
+  manifest: ChannelManifest,
+  resolveInput: MessagingInputResolver,
+): boolean {
+  const requiredInputs = manifest.inputs.filter((input) => input.required);
+  if (requiredInputs.length > 0) {
+    return hasMessagingManifestRequiredInputs(manifest, resolveInput);
+  }
+  return manifest.inputs.some((input) => hasResolvedInputValue(resolveInput(input)));
 }
 
 function hasResolvedInputValue(value: string | null): boolean {

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -461,6 +461,36 @@ describe("setupMessagingChannels", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
+  it("seeds credentialless WhatsApp from its optional allowlist input in non-interactive mode", async () => {
+    process.env.WHATSAPP_ALLOWED_IDS = "15551234567,15557654321";
+    const notes: string[] = [];
+
+    const result = await setupMessagingChannels(null, null, {
+      note: (message) => notes.push(message),
+      isNonInteractive: () => true,
+      sandboxName: "whatsapp-seed",
+    });
+
+    expect(result).toEqual(["whatsapp"]);
+    expect(notes).toEqual(["  [non-interactive] Messaging channel inputs detected: whatsapp"]);
+    expect(MessagingSetupApplier.requirePlanFromEnv()).toMatchObject({
+      sandboxName: "whatsapp-seed",
+      channels: [
+        {
+          channelId: "whatsapp",
+          active: true,
+          inputs: [
+            {
+              inputId: "allowedIds",
+              value: "15551234567,15557654321",
+            },
+          ],
+        },
+      ],
+    });
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
   it("validates detected non-interactive Slack inputs before returning enabled channels", async () => {
     process.env.SLACK_BOT_TOKEN = "not-a-slack-token";
     process.env.SLACK_APP_TOKEN = "xapp-existing-token";
@@ -628,6 +658,12 @@ describe("detectMessagingChannelsFromEnv", () => {
     process.env.TELEGRAM_BOT_TOKEN = "123456:ABC-test-token";
 
     expect(detectMessagingChannelsFromEnv(null)).toContain("telegram");
+  });
+
+  it("detects credentialless WhatsApp when WHATSAPP_ALLOWED_IDS is supplied", () => {
+    process.env.WHATSAPP_ALLOWED_IDS = "15551234567";
+
+    expect(detectMessagingChannelsFromEnv(null)).toContain("whatsapp");
   });
 
   it("does not detect channels for unsupported named agents even when env inputs are complete", () => {

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -10,7 +10,7 @@ import {
   createBuiltInMessagingHookRegistry,
   createBuiltInRenderTemplateResolver,
   getMessagingManifestAvailabilityContext,
-  hasMessagingManifestRequiredInputs,
+  hasMessagingManifestConfiguredInputs,
   MessagingHostStateApplier,
   MessagingSetupApplier,
   MessagingWorkflowPlanner,
@@ -59,11 +59,13 @@ const getMessagingInputValue = (input: ChannelInputSpec): string | null => {
 };
 
 /**
- * Detect which built-in messaging channels currently have complete required
- * inputs in the process environment, using the same manifest input rules as
- * {@link setupMessagingChannels}. Pure and side-effect free: it only reads env
- * via the manifest input resolvers so callers can compare current env inputs
- * against a reused/stale sandbox messaging plan before treating that plan as
+ * Detect which built-in messaging channels are explicitly configured in the
+ * process environment, using the same manifest input rules as
+ * {@link setupMessagingChannels}. Credentialed channels require all required
+ * inputs; credentialless channels are explicitly selected by any configured
+ * optional input. Pure and side-effect free: it only reads env via the manifest
+ * input resolvers so callers can compare current env inputs against a
+ * reused/stale sandbox messaging plan before treating that plan as
  * authoritative. NEMOCLAW_POLICY_PRESETS is intentionally ignored — policy
  * presets are not messaging channel selection.
  */
@@ -75,7 +77,7 @@ export function detectMessagingChannelsFromEnv(agent: AgentDefinition | null = n
   );
   const availableChannels = manifestRegistry.listAvailable(availabilityContext);
   return availableChannels
-    .filter((manifest) => hasMessagingManifestRequiredInputs(manifest, getMessagingInputValue))
+    .filter((manifest) => hasMessagingManifestConfiguredInputs(manifest, getMessagingInputValue))
     .map((manifest) => manifest.id);
 }
 
@@ -105,10 +107,10 @@ export async function setupMessagingChannels(
     manifestRegistry.list(),
   );
   const availableChannels = manifestRegistry.listAvailable(availabilityContext);
-  const hasManifestRequiredInputs = (manifest: ChannelManifest) =>
-    hasMessagingManifestRequiredInputs(manifest, getMessagingInputValue);
+  const hasManifestConfiguredInputs = (manifest: ChannelManifest) =>
+    hasMessagingManifestConfiguredInputs(manifest, getMessagingInputValue);
   const seedFromState = (includeAllExisting = false): string[] =>
-    resolveMessagingManifestSeed(availableChannels, existingChannels, hasManifestRequiredInputs, {
+    resolveMessagingManifestSeed(availableChannels, existingChannels, hasManifestConfiguredInputs, {
       includeAllExisting,
     });
 
@@ -133,7 +135,7 @@ export async function setupMessagingChannels(
   const input = process.stdin as MessagingSelectorInput;
   const output = process.stderr as MessagingSelectorOutput;
   const statusForChannel = (manifest: ChannelManifest): string =>
-    hasManifestRequiredInputs(manifest) ? " (configured)" : "";
+    hasManifestConfiguredInputs(manifest) ? " (configured)" : "";
 
   if (availableChannels.length > 0) {
     if (!input.isTTY || !output.isTTY || typeof input.setRawMode !== "function") {

--- a/test/e2e/live/channels-stop-start-helpers.ts
+++ b/test/e2e/live/channels-stop-start-helpers.ts
@@ -83,6 +83,7 @@ function phase6TokenEnv(tokens: Phase6Tokens): NodeJS.ProcessEnv {
     WECHAT_USER_ID: process.env.WECHAT_USER_ID ?? "wxid_e2e_operator",
     WECHAT_ALLOWED_IDS:
       process.env.WECHAT_ALLOWED_IDS ?? process.env.WECHAT_USER_ID ?? "wxid_e2e_operator",
+    WHATSAPP_ALLOWED_IDS: process.env.WHATSAPP_ALLOWED_IDS ?? "15551234567,15557654321",
   };
   if (tokens.telegram.includes("fake")) env.NEMOCLAW_SKIP_TELEGRAM_REACHABILITY = "1";
   if (
@@ -193,22 +194,28 @@ function expectPlanChannelState(channelId: string, expected: ChannelState): void
   ).toBe(false);
 }
 
-function expectChannelInputs(): void {
+function requireEnvValue(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key];
+  if (!value) throw new Error(`${key} must be configured for the channels stop/start target`);
+  return value;
+}
+
+function expectChannelInputs(env: NodeJS.ProcessEnv): void {
   const expected: Record<string, Record<string, string>> = {
     telegram: {
-      allowedIds: process.env.TELEGRAM_ALLOWED_IDS ?? "123456789,987654321",
-      requireMention: process.env.TELEGRAM_REQUIRE_MENTION ?? "0",
+      allowedIds: requireEnvValue(env, "TELEGRAM_ALLOWED_IDS"),
+      requireMention: requireEnvValue(env, "TELEGRAM_REQUIRE_MENTION"),
     },
     discord: {
-      serverId: process.env.DISCORD_SERVER_ID ?? "1491590992753590594",
-      userId: process.env.DISCORD_USER_ID ?? "1005536447329222676",
-      requireMention: process.env.DISCORD_REQUIRE_MENTION ?? "0",
+      serverId: requireEnvValue(env, "DISCORD_SERVER_ID"),
+      userId: requireEnvValue(env, "DISCORD_USER_ID"),
+      requireMention: requireEnvValue(env, "DISCORD_REQUIRE_MENTION"),
     },
-    slack: { allowedUsers: process.env.SLACK_ALLOWED_USERS ?? "U0123456789,U09ABCDEFGH" },
+    slack: { allowedUsers: requireEnvValue(env, "SLACK_ALLOWED_USERS") },
     wechat: {
-      allowedIds:
-        process.env.WECHAT_ALLOWED_IDS ?? process.env.WECHAT_USER_ID ?? "wxid_e2e_operator",
+      allowedIds: requireEnvValue(env, "WECHAT_ALLOWED_IDS"),
     },
+    whatsapp: { allowedIds: requireEnvValue(env, "WHATSAPP_ALLOWED_IDS") },
   };
   for (const [channelId, inputs] of Object.entries(expected)) {
     const channel = planChannel(channelId);
@@ -381,7 +388,7 @@ async function runChannelCommand(
   host: import("../fixtures/clients/host.ts").HostCliClient,
   env: NodeJS.ProcessEnv,
   redactions: string[],
-  action: "add" | "stop" | "start",
+  action: "stop" | "start",
   channel: string,
 ): Promise<void> {
   const result = await host.command(
@@ -395,10 +402,7 @@ async function runChannelCommand(
     },
   );
   expectExitZero(result, `channels ${action} ${channel}`);
-  const expectedText =
-    action === "add"
-      ? `Enabled ${channel} channel`
-      : `Marked ${channel} ${action === "stop" ? "disabled" : "enabled"}`;
+  const expectedText = `Marked ${channel} ${action === "stop" ? "disabled" : "enabled"}`;
   expect(resultText(result)).toContain(expectedText);
 }
 
@@ -482,19 +486,7 @@ export async function runChannelsStopStartTarget({
     `sandbox-list-channels-stop-start-${AGENT}`,
   );
 
-  if (!planChannel("whatsapp")) {
-    await runChannelCommand(host, env, redactions, "add", "whatsapp");
-    const rebuild = await rebuildSandbox(
-      host,
-      SANDBOX_NAME,
-      env,
-      redactions,
-      `rebuild-add-whatsapp-${AGENT}`,
-    );
-    expectExitZero(rebuild, "rebuild after adding WhatsApp");
-  }
-
-  expectChannelInputs();
+  expectChannelInputs(env);
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
   await expectAgentConfig(sandbox, "present", redactions);
   await expectProvidersExist(host, env, redactions, "baseline");
@@ -506,7 +498,7 @@ export async function runChannelsStopStartTarget({
   }
 
   for (const channel of CHANNELS) await runChannelCommand(host, env, redactions, "stop", channel);
-  expectChannelInputs();
+  expectChannelInputs(env);
   for (const channel of CHANNELS) expectPlanChannelState(channel, "disabled");
   const stopRebuild = await rebuildSandbox(
     host,
@@ -527,7 +519,7 @@ export async function runChannelsStopStartTarget({
   }
 
   for (const channel of CHANNELS) await runChannelCommand(host, env, redactions, "start", channel);
-  expectChannelInputs();
+  expectChannelInputs(env);
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
   const startRebuild = await rebuildSandbox(
     host,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Seeds credentialless WhatsApp during initial non-interactive messaging setup when `WHATSAPP_ALLOWED_IDS` is configured. The channels stop/start target no longer needs a separate `channels add whatsapp` plus image rebuild before exercising lifecycle persistence.

## Changes

- Add a manifest-generic configured-input predicate: credentialed channels still require every required input, while credentialless channels can be explicitly selected by a configured optional input.
- Detect and select WhatsApp from `WHATSAPP_ALLOWED_IDS` during non-interactive onboarding.
- Seed the WhatsApp allowlist in the initial channels stop/start environment and assert it from that authoritative environment.
- Remove the conditional WhatsApp add/rebuild cycle while preserving stop/rebuild and start/rebuild coverage.
- Document the WhatsApp non-interactive selection signal and Hermes sender allowlist.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the shared predicate preserves complete-required-input checks for credentialed channels; focused tests cover WhatsApp selection, plan contents, and unsupported-agent behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior — 46 focused messaging tests pass; CLI typecheck, Biome, and diff checks pass.
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — 0 errors; 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp can now be selected and configured using `WHATSAPP_ALLOWED_IDS` as an optional setting.
  * Messaging channel setup now recognizes channels when optional configuration is present, improving setup for credentialless channel types.

* **Documentation**
  * Updated WhatsApp onboarding guidance and channel requirements to include the new sender allowlist setting.

* **Tests**
  * Added coverage for WhatsApp detection, non-interactive setup, and start/stop channel flows with the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->