### PR TITLE
test(onboard): reject blank WhatsApp seed

### DIFF
--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -491,6 +491,29 @@ describe("setupMessagingChannels", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
+  it.each([
+    undefined,
+    "",
+    "   ",
+  ])("keeps credentialless WhatsApp disabled when its optional allowlist is %p", async (allowedIds) => {
+    if (allowedIds === undefined) delete process.env.WHATSAPP_ALLOWED_IDS;
+    else process.env.WHATSAPP_ALLOWED_IDS = allowedIds;
+    process.env[MESSAGING_SETUP_APPLIER_ENV_KEY] = "stale-plan";
+    const notes: string[] = [];
+
+    const result = await setupMessagingChannels(null, null, {
+      note: (message) => notes.push(message),
+      isNonInteractive: () => true,
+    });
+
+    expect(result).toEqual([]);
+    expect(notes).toEqual([
+      "  [non-interactive] No complete messaging channel inputs configured. Skipping.",
+    ]);
+    expect(process.env[MESSAGING_SETUP_APPLIER_ENV_KEY]).toBeUndefined();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
   it("validates detected non-interactive Slack inputs before returning enabled channels", async () => {
     process.env.SLACK_BOT_TOKEN = "not-a-slack-token";
     process.env.SLACK_APP_TOKEN = "xapp-existing-token";
@@ -664,6 +687,17 @@ describe("detectMessagingChannelsFromEnv", () => {
     process.env.WHATSAPP_ALLOWED_IDS = "15551234567";
 
     expect(detectMessagingChannelsFromEnv(null)).toContain("whatsapp");
+  });
+
+  it.each([
+    undefined,
+    "",
+    "   ",
+  ])("does not detect credentialless WhatsApp when its optional allowlist is %p", (allowedIds) => {
+    if (allowedIds === undefined) delete process.env.WHATSAPP_ALLOWED_IDS;
+    else process.env.WHATSAPP_ALLOWED_IDS = allowedIds;
+
+    expect(detectMessagingChannelsFromEnv(null)).not.toContain("whatsapp");
   });
 
   it("does not detect channels for unsupported named agents even when env inputs are complete", () => {

--- a/src/lib/onboard/messaging-channel-setup.test.ts
+++ b/src/lib/onboard/messaging-channel-setup.test.ts
@@ -34,6 +34,16 @@ vi.mock("../messaging/channels/slack/hooks/credential-validation", () => ({
 
 const ORIGINAL_ENV = { ...process.env };
 const manifestRegistry = createBuiltInChannelManifestRegistry();
+const BLANK_WHATSAPP_SEED_CASES = [
+  { label: "unset", environment: {} },
+  { label: "empty", environment: { WHATSAPP_ALLOWED_IDS: "" } },
+  { label: "whitespace-only", environment: { WHATSAPP_ALLOWED_IDS: "   " } },
+] as const;
+
+function applyWhatsAppSeedEnvironment(environment: Readonly<Record<string, string>>): void {
+  delete process.env.WHATSAPP_ALLOWED_IDS;
+  Object.assign(process.env, environment);
+}
 
 function manifests(...channelIds: string[]) {
   return channelIds.map((channelId) => {
@@ -491,13 +501,12 @@ describe("setupMessagingChannels", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
-  it.each([
-    undefined,
-    "",
-    "   ",
-  ])("keeps credentialless WhatsApp disabled when its optional allowlist is %p", async (allowedIds) => {
-    if (allowedIds === undefined) delete process.env.WHATSAPP_ALLOWED_IDS;
-    else process.env.WHATSAPP_ALLOWED_IDS = allowedIds;
+  it.each(
+    BLANK_WHATSAPP_SEED_CASES,
+  )("keeps credentialless WhatsApp disabled when its optional allowlist is $label", async ({
+    environment,
+  }) => {
+    applyWhatsAppSeedEnvironment(environment);
     process.env[MESSAGING_SETUP_APPLIER_ENV_KEY] = "stale-plan";
     const notes: string[] = [];
 
@@ -689,13 +698,12 @@ describe("detectMessagingChannelsFromEnv", () => {
     expect(detectMessagingChannelsFromEnv(null)).toContain("whatsapp");
   });
 
-  it.each([
-    undefined,
-    "",
-    "   ",
-  ])("does not detect credentialless WhatsApp when its optional allowlist is %p", (allowedIds) => {
-    if (allowedIds === undefined) delete process.env.WHATSAPP_ALLOWED_IDS;
-    else process.env.WHATSAPP_ALLOWED_IDS = allowedIds;
+  it.each(
+    BLANK_WHATSAPP_SEED_CASES,
+  )("does not detect credentialless WhatsApp when its optional allowlist is $label", ({
+    environment,
+  }) => {
+    applyWhatsAppSeedEnvironment(environment);
 
     expect(detectMessagingChannelsFromEnv(null)).not.toContain("whatsapp");
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds the negative coverage requested during review of #6241. WhatsApp remains disabled when its optional allowlist seed is unset, empty, or whitespace-only, both during environment detection and noninteractive setup.

## Changes

- Cover unset, empty, and whitespace-only `WHATSAPP_ALLOWED_IDS` in `detectMessagingChannelsFromEnv`.
- Cover the same values through noninteractive `setupMessagingChannels`.
- Assert the skipped setup clears a stale serialized messaging plan and does not prompt.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-only follow-up; user-facing behavior and documentation are unchanged from #6241.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: test-only assertions verify blank optional input cannot enable a messaging channel and stale noninteractive state is cleared.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior — all 33 `messaging-channel-setup` tests pass.
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for WhatsApp onboarding behavior when allowed IDs are missing or blank.
  * Verified that non-interactive setup skips invalid WhatsApp configuration, clears any saved setup state, and avoids prompting.
  * Added checks to ensure WhatsApp is not detected from empty or whitespace-only environment values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->