### PR TITLE
feat(cli): add shell completion command for bash, zsh, and fish

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -132,6 +132,35 @@ Print the installed NemoClaw CLI version.
 $$nemoclaw --version
 ```
 
+### `$$nemoclaw completion`
+
+Generate a tab-completion script for Bash, Zsh, or Fish from the commands and flags available in the installed CLI.
+The script completes public global commands, the sandbox-first `$$nemoclaw <name> ...` grammar, flags, shell choices, and locally registered sandbox names.
+If you omit the shell name, `$$nemoclaw completion` detects the target from `$SHELL` and defaults to Bash when it cannot identify Zsh or Fish.
+The generated script is bound to the CLI name that created it, so install a separate script for each CLI alias you use.
+It loads sandbox names from the local registry the first time completion runs and caches them for the rest of that shell session.
+
+For Bash, source the generated script and add the same line to `~/.bashrc` for future sessions.
+
+```bash
+source <($$nemoclaw completion bash)
+```
+
+For Zsh, source the generated script and add the same line to `~/.zshrc` for future sessions.
+
+```zsh
+source <($$nemoclaw completion zsh)
+```
+
+For Fish, write the generated script to Fish's completions directory.
+
+```fish
+mkdir -p ~/.config/fish/completions
+$$nemoclaw completion fish > ~/.config/fish/completions/$$nemoclaw.fish
+```
+
+Start a new shell session to refresh the cached sandbox names after creating or removing a sandbox.
+
 ### `$$nemoclaw resources`
 
 Display host hardware inventory and configured sandbox resource profiles.
@@ -159,31 +188,6 @@ Expected output:
 openclaw                   Gateway-based AI agent with plugin ecosystem (openclaw.ai)
 hermes                     Self-improving AI agent with learning loop (Nous Research)
 langchain-deepagents-code  Terminal coding agent built on the Deep Agents SDK
-```
-
-### `$$nemoclaw completion`
-
-Generate a shell completion script for bash, zsh, or fish.
-Tab completion covers global commands, registered sandbox names, sandbox subcommands, and per-command flags.
-Sandbox names are resolved at completion time from `$$nemoclaw list --json`, so new sandboxes appear without regenerating the script.
-When the shell argument is omitted, the target shell is detected from the `SHELL` environment variable and defaults to bash.
-
-For bash, add to `~/.bashrc` or `~/.bash_profile`:
-
-```bash
-source <($$nemoclaw completion bash)
-```
-
-For zsh, add to `~/.zshrc`:
-
-```bash
-source <($$nemoclaw completion zsh)
-```
-
-For fish, install the script once:
-
-```bash
-$$nemoclaw completion fish > ~/.config/fish/completions/nemoclaw.fish
 ```
 
 ### `$$nemoclaw onboard`

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -161,6 +161,31 @@ hermes                     Self-improving AI agent with learning loop (Nous Rese
 langchain-deepagents-code  Terminal coding agent built on the Deep Agents SDK
 ```
 
+### `$$nemoclaw completion`
+
+Generate a shell completion script for bash, zsh, or fish.
+Tab completion covers global commands, registered sandbox names, sandbox subcommands, and per-command flags.
+Sandbox names are resolved at completion time from `$$nemoclaw list --json`, so new sandboxes appear without regenerating the script.
+When the shell argument is omitted, the target shell is detected from the `SHELL` environment variable and defaults to bash.
+
+For bash, add to `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+source <($$nemoclaw completion bash)
+```
+
+For zsh, add to `~/.zshrc`:
+
+```bash
+source <($$nemoclaw completion zsh)
+```
+
+For fish, install the script once:
+
+```bash
+$$nemoclaw completion fish > ~/.config/fish/completions/nemoclaw.fish
+```
+
 ### `$$nemoclaw onboard`
 
 Run the interactive setup wizard (recommended for new installs).

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Args } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
 
-import { runCompletionAction } from "../lib/actions/completion";
+import { runCompletionAction, runCompletionSandboxNamesAction } from "../lib/actions/completion";
 import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
 
 export default class CompletionCommand extends NemoClawCommand {
@@ -31,9 +31,19 @@ export default class CompletionCommand extends NemoClawCommand {
       required: false,
     }),
   };
+  static flags = {
+    "list-sandbox-names": Flags.boolean({
+      description: "List registered sandbox names for shell completion",
+      hidden: true,
+    }),
+  };
 
   public async run(): Promise<void> {
-    const { args } = await this.parse(CompletionCommand);
-    runCompletionAction(args.shell);
+    const { args, flags } = await this.parse(CompletionCommand);
+    if (flags["list-sandbox-names"]) {
+      runCompletionSandboxNamesAction();
+      return;
+    }
+    runCompletionAction(args.shell, this.config.commands, this.config.bin);
   }
 }

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Args } from "@oclif/core";
+
+import { runCompletionAction } from "../lib/actions/completion";
+import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
+
+export default class CompletionCommand extends NemoClawCommand {
+  static id = "completion";
+  static strict = true;
+  static summary = "Generate shell completion script";
+  static description =
+    "Output a shell completion script for nemoclaw. Source it in your shell profile to enable tab completion for commands, flags, and sandbox names.";
+  static usage = ["completion [bash|zsh|fish]"];
+  static examples = [
+    "# Bash (add to ~/.bashrc or ~/.bash_profile):",
+    "source <(<%= config.bin %> completion bash)",
+    "",
+    "# Zsh (add to ~/.zshrc):",
+    "source <(<%= config.bin %> completion zsh)",
+    "",
+    "# Fish (install permanently):",
+    "<%= config.bin %> completion fish > ~/.config/fish/completions/<%= config.bin %>.fish",
+  ];
+
+  static args = {
+    shell: Args.string({
+      description: "Target shell: bash, zsh, or fish. Auto-detected from $SHELL when omitted.",
+      options: ["bash", "zsh", "fish"],
+      required: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(CompletionCommand);
+    runCompletionAction(args.shell);
+  }
+}

--- a/src/lib/actions/completion.test.ts
+++ b/src/lib/actions/completion.test.ts
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { detectShell, generateCompletionScript, runCompletionAction } from "./completion";
+
+describe("detectShell", () => {
+  it("detects zsh from SHELL", () => {
+    expect(detectShell("/bin/zsh")).toBe("zsh");
+  });
+
+  it("detects fish from SHELL", () => {
+    expect(detectShell("/usr/local/bin/fish")).toBe("fish");
+  });
+
+  it("defaults to bash", () => {
+    expect(detectShell("/bin/bash")).toBe("bash");
+    expect(detectShell(undefined)).toBe("bash");
+    expect(detectShell("")).toBe("bash");
+  });
+});
+
+describe("generateCompletionScript", () => {
+  it("emits a bash completion function", () => {
+    const script = generateCompletionScript("bash");
+    expect(script).toContain("_nemoclaw()");
+    expect(script).toContain("complete -F _nemoclaw nemoclaw");
+  });
+
+  it("emits a zsh compdef", () => {
+    const script = generateCompletionScript("zsh");
+    expect(script).toContain("#compdef nemoclaw");
+  });
+
+  it("emits fish completions", () => {
+    const script = generateCompletionScript("fish");
+    expect(script).toContain("__nemoclaw_sandboxes");
+  });
+
+  it("reads sandbox names from list --json in every shell", () => {
+    expect(generateCompletionScript("bash")).toContain("nemoclaw list --json");
+    expect(generateCompletionScript("zsh")).toContain("nemoclaw list --json");
+    expect(generateCompletionScript("fish")).toContain("nemoclaw list --json");
+  });
+
+  it("includes the same sandbox subcommands in fish as in bash", () => {
+    const bash = generateCompletionScript("bash");
+    const fish = generateCompletionScript("fish");
+    const probes = ["gateway-token", "policy-explain", "share:mount", "config:rotate-token"];
+    for (const subcommand of probes) {
+      expect(bash).toContain(subcommand);
+      expect(fish).toContain(subcommand);
+    }
+  });
+
+  it("offers the same per-command flags in all three shells", () => {
+    const bash = generateCompletionScript("bash");
+    const zsh = generateCompletionScript("zsh");
+    const fish = generateCompletionScript("fish");
+    const longFlagProbes = [
+      "--sandbox",
+      "--agent",
+      "--non-interactive",
+      "--type",
+      "--credential",
+      "--config",
+      "--from-existing",
+      "--quick",
+      "--output",
+      "--force",
+      "--dry-run",
+      "--json",
+    ];
+    for (const flag of longFlagProbes) {
+      expect(bash).toContain(flag);
+      expect(zsh).toContain(flag);
+      // fish spells long flags as `-l <name>` without the dashes
+      expect(fish).toContain(`-l ${flag.slice(2)}`);
+    }
+  });
+
+  it("completes shell names for the completion command in all three shells", () => {
+    expect(generateCompletionScript("bash")).toContain("bash zsh fish");
+    expect(generateCompletionScript("zsh")).toContain("'bash' 'zsh' 'fish'");
+    expect(generateCompletionScript("fish")).toContain(
+      "__fish_seen_subcommand_from completion' -a 'bash zsh fish'",
+    );
+  });
+});
+
+describe("runCompletionAction", () => {
+  it("writes the script for an explicit shell", () => {
+    const written: string[] = [];
+    runCompletionAction("zsh", { write: (s) => written.push(s) });
+    expect(written).toHaveLength(1);
+    expect(written[0]).toContain("#compdef nemoclaw");
+  });
+
+  it("auto-detects the shell from the env dep when omitted", () => {
+    const written: string[] = [];
+    runCompletionAction(undefined, {
+      write: (s) => written.push(s),
+      shellEnv: "/usr/local/bin/fish",
+    });
+    expect(written[0]).toContain("# nemoclaw fish completion");
+  });
+
+  it("falls back to bash for unknown shells", () => {
+    const written: string[] = [];
+    runCompletionAction(undefined, { write: (s) => written.push(s), shellEnv: "/bin/tcsh" });
+    expect(written[0]).toContain("complete -F _nemoclaw nemoclaw");
+  });
+});

--- a/src/lib/actions/completion.test.ts
+++ b/src/lib/actions/completion.test.ts
@@ -1,114 +1,186 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Config as OclifConfig } from "@oclif/core";
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
-import { detectShell, generateCompletionScript, runCompletionAction } from "./completion";
+import {
+  buildCompletionModel,
+  type CompletionCommandMetadata,
+  detectShell,
+  generateCompletionScript,
+  runCompletionAction,
+  runCompletionSandboxNamesAction,
+} from "./completion";
 
-describe("detectShell", () => {
-  it("detects zsh from SHELL", () => {
-    expect(detectShell("/bin/zsh")).toBe("zsh");
+const COMMANDS = [
+  {
+    args: {},
+    flags: {
+      agent: { hidden: false, name: "agent", type: "option" },
+      help: { char: "h", hidden: false, name: "help", type: "boolean" },
+    },
+    hidden: false,
+    id: "onboard",
+  },
+  {
+    args: {},
+    flags: { type: { hidden: false, name: "type", type: "option" } },
+    hidden: false,
+    id: "credentials:add",
+  },
+  {
+    args: {
+      shell: { name: "shell", options: ["bash", "zsh", "fish"] },
+    },
+    flags: {
+      "list-sandbox-names": {
+        hidden: true,
+        name: "list-sandbox-names",
+        type: "boolean",
+      },
+    },
+    hidden: false,
+    id: "completion",
+  },
+  { args: {}, flags: {}, hidden: false, id: "resources" },
+  {
+    args: {},
+    flags: { json: { hidden: false, name: "json", type: "boolean" } },
+    hidden: false,
+    id: "sandbox:status",
+  },
+  {
+    args: {},
+    flags: { quiet: { char: "q", hidden: false, name: "quiet", type: "boolean" } },
+    hidden: false,
+    id: "sandbox:gateway:token",
+  },
+  { args: {}, flags: {}, hidden: false, id: "sandbox:channels:add" },
+  { args: {}, flags: {}, hidden: true, id: "internal:secret" },
+] as unknown as CompletionCommandMetadata[];
+
+function findCase(
+  model: ReturnType<typeof buildCompletionModel>,
+  scope: "global" | "sandbox",
+  key: string,
+) {
+  return model[scope].find((entry) => entry.key === `${scope}:${key}`);
+}
+
+describe("buildCompletionModel", () => {
+  it("derives public routes and flags from oclif metadata", () => {
+    const model = buildCompletionModel(COMMANDS);
+
+    expect(findCase(model, "global", "")?.candidates).toEqual([
+      "completion",
+      "credentials",
+      "onboard",
+      "resources",
+    ]);
+    expect(findCase(model, "global", "credentials")?.candidates).toEqual(["add"]);
+    expect(findCase(model, "global", "credentials add")?.flags).toEqual(["--type"]);
+    expect(findCase(model, "global", "completion")?.argOptions).toEqual(["bash", "fish", "zsh"]);
+    expect(findCase(model, "sandbox", "")?.candidates).toEqual([
+      "channels",
+      "gateway-token",
+      "status",
+    ]);
+    expect(findCase(model, "sandbox", "gateway-token")?.flags).toEqual(["--quiet", "-q"]);
+    expect(JSON.stringify(model)).not.toContain("internal:secret");
+    expect(JSON.stringify(model)).not.toContain("credentials:add");
   });
 
-  it("detects fish from SHELL", () => {
-    expect(detectShell("/usr/local/bin/fish")).toBe("fish");
-  });
+  it("tracks the repository's discovered oclif and public-route registries", async () => {
+    const config = await OclifConfig.load(process.cwd());
+    const model = buildCompletionModel(config.commands);
 
-  it("defaults to bash", () => {
-    expect(detectShell("/bin/bash")).toBe("bash");
-    expect(detectShell(undefined)).toBe("bash");
-    expect(detectShell("")).toBe("bash");
+    expect(findCase(model, "global", "")?.candidates).toEqual(
+      expect.arrayContaining(["help", "resources", "uninstall", "use", "version"]),
+    );
+    expect(findCase(model, "global", "")?.flags).toEqual(
+      expect.arrayContaining(["--help", "--version", "-h", "-v"]),
+    );
+    expect(findCase(model, "global", "inference")?.candidates).toEqual(
+      expect.arrayContaining(["get", "set"]),
+    );
+    expect(findCase(model, "sandbox", "sessions")?.candidates).toEqual(
+      expect.arrayContaining(["delete", "export", "list", "reset"]),
+    );
+    expect(findCase(model, "sandbox", "gateway")?.candidates).toContain("restart");
+    expect(findCase(model, "sandbox", "gateway-token")?.flags).toContain("--quiet");
   });
 });
 
 describe("generateCompletionScript", () => {
-  it("emits a bash completion function", () => {
-    const script = generateCompletionScript("bash");
-    expect(script).toContain("_nemoclaw()");
-    expect(script).toContain("complete -F _nemoclaw nemoclaw");
+  it.each([
+    "bash",
+    "zsh",
+    "fish",
+  ] as const)("generates %s from the same metadata model", (shell) => {
+    const script = generateCompletionScript(shell, COMMANDS, "nemoclaw");
+    expect(script).toContain("credentials add");
+    expect(script).toContain("gateway-token");
+    expect(script).toContain("completion --list-sandbox-names");
+    expect(script).not.toContain("nemoclaw list --json");
+    expect(script).not.toContain("credentials:add");
   });
 
-  it("emits a zsh compdef", () => {
-    const script = generateCompletionScript("zsh");
-    expect(script).toContain("#compdef nemoclaw");
+  it("uses the active oclif binary name", () => {
+    const script = generateCompletionScript("bash", COMMANDS, "nemo-deepagents");
+    expect(script).toContain("complete -F _nemo_deepagents 'nemo-deepagents'");
+    expect(script).toContain("'nemo-deepagents' completion --list-sandbox-names");
   });
 
-  it("emits fish completions", () => {
-    const script = generateCompletionScript("fish");
-    expect(script).toContain("__nemoclaw_sandboxes");
-  });
-
-  it("reads sandbox names from list --json in every shell", () => {
-    expect(generateCompletionScript("bash")).toContain("nemoclaw list --json");
-    expect(generateCompletionScript("zsh")).toContain("nemoclaw list --json");
-    expect(generateCompletionScript("fish")).toContain("nemoclaw list --json");
-  });
-
-  it("includes the same sandbox subcommands in fish as in bash", () => {
-    const bash = generateCompletionScript("bash");
-    const fish = generateCompletionScript("fish");
-    const probes = ["gateway-token", "policy-explain", "share:mount", "config:rotate-token"];
-    for (const subcommand of probes) {
-      expect(bash).toContain(subcommand);
-      expect(fish).toContain(subcommand);
-    }
-  });
-
-  it("offers the same per-command flags in all three shells", () => {
-    const bash = generateCompletionScript("bash");
-    const zsh = generateCompletionScript("zsh");
-    const fish = generateCompletionScript("fish");
-    const longFlagProbes = [
-      "--sandbox",
-      "--agent",
-      "--non-interactive",
-      "--type",
-      "--credential",
-      "--config",
-      "--from-existing",
-      "--quick",
-      "--output",
-      "--force",
-      "--dry-run",
-      "--json",
-    ];
-    for (const flag of longFlagProbes) {
-      expect(bash).toContain(flag);
-      expect(zsh).toContain(flag);
-      // fish spells long flags as `-l <name>` without the dashes
-      expect(fish).toContain(`-l ${flag.slice(2)}`);
-    }
-  });
-
-  it("completes shell names for the completion command in all three shells", () => {
-    expect(generateCompletionScript("bash")).toContain("bash zsh fish");
-    expect(generateCompletionScript("zsh")).toContain("'bash' 'zsh' 'fish'");
-    expect(generateCompletionScript("fish")).toContain(
-      "__fish_seen_subcommand_from completion' -a 'bash zsh fish'",
+  it("loads and caches sandbox names in the generated Bash script", () => {
+    const script = generateCompletionScript("bash", COMMANDS, "nemoclaw");
+    const result = spawnSync(
+      "bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        `${script}
+nemoclaw() { printf 'beta\\nalpha\\n'; }
+_nemoclaw_load_sandboxes
+printf '%s|%s\\n' "$__nemoclaw_sandbox_cache" "$__nemoclaw_sandbox_cache_loaded"`,
+      ],
+      { encoding: "utf8" },
     );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("beta\nalpha|1\n");
   });
 });
 
-describe("runCompletionAction", () => {
-  it("writes the script for an explicit shell", () => {
+describe("completion actions", () => {
+  it("detects the target shell and defaults to bash", () => {
+    expect(detectShell("/bin/zsh")).toBe("zsh");
+    expect(detectShell("/usr/local/bin/fish")).toBe("fish");
+    expect(detectShell("/bin/tcsh")).toBe("bash");
+    expect(detectShell(undefined)).toBe("bash");
+  });
+
+  it("writes the selected generated script", () => {
     const written: string[] = [];
-    runCompletionAction("zsh", { write: (s) => written.push(s) });
+    runCompletionAction(undefined, COMMANDS, "nemoclaw", {
+      shellEnv: "/bin/zsh",
+      write: (output) => written.push(output),
+    });
     expect(written).toHaveLength(1);
     expect(written[0]).toContain("#compdef nemoclaw");
   });
 
-  it("auto-detects the shell from the env dep when omitted", () => {
+  it("emits sorted registry names without running the full list command", () => {
     const written: string[] = [];
-    runCompletionAction(undefined, {
-      write: (s) => written.push(s),
-      shellEnv: "/usr/local/bin/fish",
+    runCompletionSandboxNamesAction({
+      listRegisteredSandboxes: () => ({
+        defaultSandbox: "beta",
+        sandboxes: [{ name: "beta" }, { name: "alpha" }],
+      }),
+      write: (output) => written.push(output),
     });
-    expect(written[0]).toContain("# nemoclaw fish completion");
-  });
-
-  it("falls back to bash for unknown shells", () => {
-    const written: string[] = [];
-    runCompletionAction(undefined, { write: (s) => written.push(s), shellEnv: "/bin/tcsh" });
-    expect(written[0]).toContain("complete -F _nemoclaw nemoclaw");
+    expect(written).toEqual(["alpha\nbeta\n"]);
   });
 });

--- a/src/lib/actions/completion.ts
+++ b/src/lib/actions/completion.ts
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shell completion script generation for `nemoclaw completion`. Script
+ * templates and shell detection live here so the command class stays a
+ * thin argv adapter, and the generators can be unit tested without
+ * invoking oclif. The stdout write is behind an injectable dep.
+ *
+ * Command names, sandbox subcommands, and per-command flags are each
+ * defined once and rendered into all three shells, so the shells cannot
+ * drift from one another.
+ */
+
+export type CompletionShell = "bash" | "zsh" | "fish";
+
+const GLOBAL_COMMANDS = [
+  "onboard",
+  "list",
+  "status",
+  "completion",
+  "credentials",
+  "credentials:add",
+  "credentials:list",
+  "credentials:reset",
+  "inference:get",
+  "inference:set",
+  "agents:list",
+  "backup-all",
+  "upgrade-sandboxes",
+  "setup-spark",
+  "debug",
+  "gc",
+  "update",
+  "version",
+  "help",
+];
+
+/**
+ * Shell snippet that lists registered sandbox names by parsing
+ * `nemoclaw list --json` with node (always installed for a Node CLI).
+ * The human-readable table emitted by plain `nemoclaw list` is not a
+ * stable interface, so completion must not scrape it.
+ */
+const LIST_SANDBOXES_SNIPPET =
+  "nemoclaw list --json 2>/dev/null | node -e '" +
+  'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{' +
+  "try{(JSON.parse(d).sandboxes||[]).forEach(s=>s&&s.name&&console.log(s.name))}catch(e){}})' 2>/dev/null";
+
+const SANDBOX_SUBCOMMANDS = [
+  "status",
+  "logs",
+  "exec",
+  "agent",
+  "connect",
+  "destroy",
+  "rebuild",
+  "recover",
+  "download",
+  "doctor",
+  "dashboard-url",
+  "gateway-token",
+  "inference:get",
+  "inference:set",
+  "policy-add",
+  "policy-remove",
+  "policy-list",
+  "policy-explain",
+  "channels:add",
+  "channels:remove",
+  "channels:list",
+  "channels:start",
+  "channels:stop",
+  "channels:status",
+  "hosts-add",
+  "hosts-remove",
+  "hosts-list",
+  "snapshot:create",
+  "snapshot:list",
+  "snapshot:restore",
+  "shields:up",
+  "shields:down",
+  "shields:status",
+  "skill:install",
+  "skill:remove",
+  "mcp",
+  "share:mount",
+  "share:unmount",
+  "share:status",
+  "config:get",
+  "config:set",
+  "config:rotate-token",
+  "sessions:reset",
+  "tunnel:start",
+  "tunnel:stop",
+  "tunnel:status",
+];
+
+interface FlagSpec {
+  /** Long form including dashes, e.g. "--sandbox". */
+  long: string;
+  /** Optional short form including dash, e.g. "-y". */
+  short?: string;
+  /** Human description, shown by zsh and fish. */
+  description?: string;
+  /** Placeholder label when the flag takes a value, e.g. "name". */
+  value?: string;
+  /** Set to complete the value as a filesystem path (zsh only). */
+  file?: boolean;
+}
+
+/**
+ * Per-command flag table — the single source of truth rendered into the
+ * bash `case` entries, zsh `_arguments` calls, and fish `complete` lines.
+ */
+const COMMAND_FLAG_TABLE: Array<{ commands: string[]; flags: FlagSpec[] }> = [
+  {
+    commands: ["credentials:add", "credentials"],
+    flags: [
+      { long: "--type", description: "Credential type", value: "type" },
+      { long: "--credential", description: "Env var name", value: "name" },
+      { long: "--config", description: "Key=value config", value: "kv" },
+      { long: "--from-existing" },
+    ],
+  },
+  {
+    commands: ["credentials:reset"],
+    flags: [{ long: "--yes", short: "-y", description: "Skip confirmation" }],
+  },
+  {
+    commands: ["status", "list", "inference:get", "inference:set"],
+    flags: [{ long: "--json", description: "JSON output" }],
+  },
+  {
+    commands: ["onboard"],
+    flags: [
+      { long: "--sandbox", description: "Sandbox name", value: "name" },
+      { long: "--agent", description: "Agent runtime", value: "agent" },
+      { long: "--non-interactive", description: "Skip interactive prompts" },
+      { long: "--yes", short: "-y", description: "Skip confirmation" },
+    ],
+  },
+  {
+    commands: ["debug"],
+    flags: [
+      { long: "--quick", description: "Quick diagnostics only" },
+      { long: "--output", short: "-o", description: "Output file", value: "file", file: true },
+      { long: "--sandbox", description: "Sandbox name", value: "name" },
+    ],
+  },
+  {
+    commands: ["gc"],
+    flags: [
+      { long: "--yes", short: "-y", description: "Skip confirmation" },
+      { long: "--force", description: "Skip confirmation" },
+      { long: "--dry-run", description: "Preview without applying" },
+    ],
+  },
+];
+
+const COMPLETION_SHELLS = ["bash", "zsh", "fish"];
+
+function bashFlagWords(flags: FlagSpec[]): string {
+  const words = flags.flatMap((f) => (f.short ? [f.long, f.short] : [f.long]));
+  return [...words, "--help"].join(" ");
+}
+
+function bashFlagCases(): string {
+  const entries = COMMAND_FLAG_TABLE.map(({ commands, flags }) => {
+    const pattern = commands.join("|");
+    return `    ${pattern})
+      COMPREPLY=( $(compgen -W "${bashFlagWords(flags)}" -- "\${cur}") )
+      ;;`;
+  });
+  entries.push(`    completion)
+      COMPREPLY=( $(compgen -W "${COMPLETION_SHELLS.join(" ")}" -- "\${cur}") )
+      ;;`);
+  return entries.join("\n");
+}
+
+function zshFlagArgs(flags: FlagSpec[]): string {
+  const args = flags.flatMap((f) => {
+    const desc = f.description ? `[${f.description}]` : "";
+    const value = f.file ? ":file:_files" : f.value ? `:${f.value}` : "";
+    const long = `'${f.long}${desc}${value}'`;
+    return f.short ? [long, `'${f.short}${desc}${value}'`] : [long];
+  });
+  return [...args, "'--help'"].join(" ");
+}
+
+function zshFlagCases(): string {
+  const entries = COMMAND_FLAG_TABLE.map(({ commands, flags }) => {
+    const pattern = commands.join("|");
+    return `    ${pattern})
+      _arguments ${zshFlagArgs(flags)}
+      ;;`;
+  });
+  entries.push(`    completion)
+      local -a shells; shells=(${COMPLETION_SHELLS.map((s) => `'${s}'`).join(" ")})
+      _describe 'shell' shells
+      ;;`);
+  return entries.join("\n");
+}
+
+function fishFlagLines(): string {
+  const lines = COMMAND_FLAG_TABLE.flatMap(({ commands, flags }) => {
+    const condition = `__fish_seen_subcommand_from ${commands.join(" ")}`;
+    return flags.map((f) => {
+      const parts = [`complete -c nemoclaw -n '${condition}'`, `-l ${f.long.slice(2)}`];
+      if (f.short) parts.push(`-s ${f.short.slice(1)}`);
+      if (f.description) parts.push(`-d '${f.description}'`);
+      if (f.value) parts.push("-r");
+      return parts.join(" ");
+    });
+  });
+  lines.push(
+    `complete -c nemoclaw -n '__fish_seen_subcommand_from completion' -a '${COMPLETION_SHELLS.join(" ")}'`,
+  );
+  return lines.join("\n");
+}
+
+function bashScript(): string {
+  const globals = GLOBAL_COMMANDS.join(" ");
+  const subcommands = SANDBOX_SUBCOMMANDS.join(" ");
+  return `# nemoclaw bash completion
+# Source this file or add to ~/.bash_completion.d/
+# Usage: source <(nemoclaw completion bash)
+
+_nemoclaw() {
+  local cur prev words cword
+  _init_completion 2>/dev/null || {
+    COMPREPLY=()
+    cur="\${COMP_WORDS[COMP_CWORD]}"
+    prev="\${COMP_WORDS[COMP_CWORD-1]}"
+    words=("\${COMP_WORDS[@]}")
+    cword=\${COMP_CWORD}
+  }
+
+  local global_cmds="${globals}"
+  local sandbox_cmds="${subcommands}"
+
+  # Fetch sandbox names (cached for the lifetime of this completion call)
+  local sandboxes
+  sandboxes=$(${LIST_SANDBOXES_SNIPPET}) || sandboxes=""
+
+  if [[ \${cword} -eq 1 ]]; then
+    # Complete global commands and registered sandbox names
+    COMPREPLY=( $(compgen -W "\${global_cmds} \${sandboxes}" -- "\${cur}") )
+    return 0
+  fi
+
+  local first="\${words[1]}"
+
+  # If the first token is a known sandbox name, complete sandbox subcommands
+  if echo "\${sandboxes}" | grep -qx "\${first}"; then
+    COMPREPLY=( $(compgen -W "\${sandbox_cmds}" -- "\${cur}") )
+    return 0
+  fi
+
+  # Flag completion for global commands (generated from the shared flag table)
+  case "\${first}" in
+${bashFlagCases()}
+    *)
+      COMPREPLY=( $(compgen -W "--help" -- "\${cur}") )
+      ;;
+  esac
+  return 0
+}
+
+complete -F _nemoclaw nemoclaw
+`;
+}
+
+function zshScript(): string {
+  const globals = GLOBAL_COMMANDS.map((c) => `'${c}'`).join("\n    ");
+  const subcommands = SANDBOX_SUBCOMMANDS.map((c) => `'${c}'`).join("\n    ");
+  return `#compdef nemoclaw
+# nemoclaw zsh completion
+# Usage: source <(nemoclaw completion zsh)
+# Or add to a file in \$fpath, e.g. /usr/local/share/zsh/site-functions/_nemoclaw
+
+_nemoclaw() {
+  local -a global_cmds sandbox_cmds sandboxes
+  global_cmds=(
+    ${globals}
+  )
+  sandbox_cmds=(
+    ${subcommands}
+  )
+  sandboxes=( \${(f)"\$(${LIST_SANDBOXES_SNIPPET})"} )
+
+  if (( CURRENT == 2 )); then
+    _alternative \\
+      'global:global command:compadd -a global_cmds' \\
+      'sandbox:sandbox name:compadd -a sandboxes'
+    return
+  fi
+
+  local first=\${words[2]}
+
+  # If second token is a sandbox name, complete its subcommands
+  if (( \${sandboxes[(I)\${first}]} )); then
+    _describe 'sandbox subcommand' sandbox_cmds
+    return
+  fi
+
+  # Flag completion for known global commands (generated from the shared flag table)
+  case \${first} in
+${zshFlagCases()}
+    *)
+      _arguments '--help'
+      ;;
+  esac
+}
+
+_nemoclaw "\$@"
+`;
+}
+
+function fishScript(): string {
+  const globals = GLOBAL_COMMANDS.map(
+    (c) => `complete -c nemoclaw -n '__fish_use_subcommand' -a '${c}'`,
+  ).join("\n");
+  const subcommands = SANDBOX_SUBCOMMANDS.join(" ");
+  return `# nemoclaw fish completion
+# Usage: nemoclaw completion fish > ~/.config/fish/completions/nemoclaw.fish
+
+${globals}
+
+# Sandbox subcommands (when first arg is a sandbox name)
+set -l sandbox_subcommands ${subcommands}
+
+# Dynamic sandbox names
+function __nemoclaw_sandboxes
+  ${LIST_SANDBOXES_SNIPPET}
+end
+
+complete -c nemoclaw -n '__fish_use_subcommand' -a '(__nemoclaw_sandboxes)' -d 'Sandbox'
+complete -c nemoclaw -n '__fish_seen_subcommand_from (__nemoclaw_sandboxes)' -a "$sandbox_subcommands"
+
+# Global flags
+complete -c nemoclaw -l help -s h -d 'Show help'
+
+# Per-command flags (generated from the shared flag table)
+${fishFlagLines()}
+`;
+}
+
+const SCRIPT_GENERATORS: Record<CompletionShell, () => string> = {
+  bash: bashScript,
+  zsh: zshScript,
+  fish: fishScript,
+};
+
+/**
+ * Resolve the target shell from an explicit argument or the SHELL
+ * environment variable, defaulting to bash.
+ */
+export function detectShell(shellEnv: string | undefined): CompletionShell {
+  const shell = shellEnv ?? "";
+  if (shell.includes("zsh")) return "zsh";
+  if (shell.includes("fish")) return "fish";
+  return "bash";
+}
+
+/** Generate the completion script for the given shell. */
+export function generateCompletionScript(shell: CompletionShell): string {
+  return SCRIPT_GENERATORS[shell]();
+}
+
+export interface CompletionActionDeps {
+  write?: (script: string) => void;
+  shellEnv?: string;
+}
+
+/**
+ * Emit the completion script for the requested (or detected) shell.
+ */
+export function runCompletionAction(
+  shell: string | undefined,
+  deps: CompletionActionDeps = {},
+): void {
+  const write = deps.write ?? ((script: string) => process.stdout.write(script));
+  const resolved =
+    shell === "bash" || shell === "zsh" || shell === "fish"
+      ? shell
+      : detectShell(deps.shellEnv ?? process.env.SHELL);
+  write(generateCompletionScript(resolved));
+}

--- a/src/lib/actions/completion.ts
+++ b/src/lib/actions/completion.ts
@@ -1,361 +1,358 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Shell completion script generation for `nemoclaw completion`. Script
- * templates and shell detection live here so the command class stays a
- * thin argv adapter, and the generators can be unit tested without
- * invoking oclif. The stdout write is behind an injectable dep.
- *
- * Command names, sandbox subcommands, and per-command flags are each
- * defined once and rendered into all three shells, so the shells cannot
- * drift from one another.
- */
+import { globalRouteTokenVariants, sandboxRouteTokens } from "../cli/public-route-metadata";
+import { listSandboxes } from "../state/registry";
 
 export type CompletionShell = "bash" | "zsh" | "fish";
 
-const GLOBAL_COMMANDS = [
-  "onboard",
-  "list",
-  "status",
-  "completion",
-  "credentials",
-  "credentials:add",
-  "credentials:list",
-  "credentials:reset",
-  "inference:get",
-  "inference:set",
-  "agents:list",
-  "backup-all",
-  "upgrade-sandboxes",
-  "setup-spark",
-  "debug",
-  "gc",
-  "update",
-  "version",
-  "help",
-];
-
-/**
- * Shell snippet that lists registered sandbox names by parsing
- * `nemoclaw list --json` with node (always installed for a Node CLI).
- * The human-readable table emitted by plain `nemoclaw list` is not a
- * stable interface, so completion must not scrape it.
- */
-const LIST_SANDBOXES_SNIPPET =
-  "nemoclaw list --json 2>/dev/null | node -e '" +
-  'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{' +
-  "try{(JSON.parse(d).sandboxes||[]).forEach(s=>s&&s.name&&console.log(s.name))}catch(e){}})' 2>/dev/null";
-
-const SANDBOX_SUBCOMMANDS = [
-  "status",
-  "logs",
-  "exec",
-  "agent",
-  "connect",
-  "destroy",
-  "rebuild",
-  "recover",
-  "download",
-  "doctor",
-  "dashboard-url",
-  "gateway-token",
-  "inference:get",
-  "inference:set",
-  "policy-add",
-  "policy-remove",
-  "policy-list",
-  "policy-explain",
-  "channels:add",
-  "channels:remove",
-  "channels:list",
-  "channels:start",
-  "channels:stop",
-  "channels:status",
-  "hosts-add",
-  "hosts-remove",
-  "hosts-list",
-  "snapshot:create",
-  "snapshot:list",
-  "snapshot:restore",
-  "shields:up",
-  "shields:down",
-  "shields:status",
-  "skill:install",
-  "skill:remove",
-  "mcp",
-  "share:mount",
-  "share:unmount",
-  "share:status",
-  "config:get",
-  "config:set",
-  "config:rotate-token",
-  "sessions:reset",
-  "tunnel:start",
-  "tunnel:stop",
-  "tunnel:status",
-];
-
-interface FlagSpec {
-  /** Long form including dashes, e.g. "--sandbox". */
-  long: string;
-  /** Optional short form including dash, e.g. "-y". */
-  short?: string;
-  /** Human description, shown by zsh and fish. */
-  description?: string;
-  /** Placeholder label when the flag takes a value, e.g. "name". */
-  value?: string;
-  /** Set to complete the value as a filesystem path (zsh only). */
-  file?: boolean;
-}
-
-/**
- * Per-command flag table — the single source of truth rendered into the
- * bash `case` entries, zsh `_arguments` calls, and fish `complete` lines.
- */
-const COMMAND_FLAG_TABLE: Array<{ commands: string[]; flags: FlagSpec[] }> = [
-  {
-    commands: ["credentials:add", "credentials"],
-    flags: [
-      { long: "--type", description: "Credential type", value: "type" },
-      { long: "--credential", description: "Env var name", value: "name" },
-      { long: "--config", description: "Key=value config", value: "kv" },
-      { long: "--from-existing" },
-    ],
-  },
-  {
-    commands: ["credentials:reset"],
-    flags: [{ long: "--yes", short: "-y", description: "Skip confirmation" }],
-  },
-  {
-    commands: ["status", "list", "inference:get", "inference:set"],
-    flags: [{ long: "--json", description: "JSON output" }],
-  },
-  {
-    commands: ["onboard"],
-    flags: [
-      { long: "--sandbox", description: "Sandbox name", value: "name" },
-      { long: "--agent", description: "Agent runtime", value: "agent" },
-      { long: "--non-interactive", description: "Skip interactive prompts" },
-      { long: "--yes", short: "-y", description: "Skip confirmation" },
-    ],
-  },
-  {
-    commands: ["debug"],
-    flags: [
-      { long: "--quick", description: "Quick diagnostics only" },
-      { long: "--output", short: "-o", description: "Output file", value: "file", file: true },
-      { long: "--sandbox", description: "Sandbox name", value: "name" },
-    ],
-  },
-  {
-    commands: ["gc"],
-    flags: [
-      { long: "--yes", short: "-y", description: "Skip confirmation" },
-      { long: "--force", description: "Skip confirmation" },
-      { long: "--dry-run", description: "Preview without applying" },
-    ],
-  },
-];
-
-const COMPLETION_SHELLS = ["bash", "zsh", "fish"];
-
-function bashFlagWords(flags: FlagSpec[]): string {
-  const words = flags.flatMap((f) => (f.short ? [f.long, f.short] : [f.long]));
-  return [...words, "--help"].join(" ");
-}
-
-function bashFlagCases(): string {
-  const entries = COMMAND_FLAG_TABLE.map(({ commands, flags }) => {
-    const pattern = commands.join("|");
-    return `    ${pattern})
-      COMPREPLY=( $(compgen -W "${bashFlagWords(flags)}" -- "\${cur}") )
-      ;;`;
-  });
-  entries.push(`    completion)
-      COMPREPLY=( $(compgen -W "${COMPLETION_SHELLS.join(" ")}" -- "\${cur}") )
-      ;;`);
-  return entries.join("\n");
-}
-
-function zshFlagArgs(flags: FlagSpec[]): string {
-  const args = flags.flatMap((f) => {
-    const desc = f.description ? `[${f.description}]` : "";
-    const value = f.file ? ":file:_files" : f.value ? `:${f.value}` : "";
-    const long = `'${f.long}${desc}${value}'`;
-    return f.short ? [long, `'${f.short}${desc}${value}'`] : [long];
-  });
-  return [...args, "'--help'"].join(" ");
-}
-
-function zshFlagCases(): string {
-  const entries = COMMAND_FLAG_TABLE.map(({ commands, flags }) => {
-    const pattern = commands.join("|");
-    return `    ${pattern})
-      _arguments ${zshFlagArgs(flags)}
-      ;;`;
-  });
-  entries.push(`    completion)
-      local -a shells; shells=(${COMPLETION_SHELLS.map((s) => `'${s}'`).join(" ")})
-      _describe 'shell' shells
-      ;;`);
-  return entries.join("\n");
-}
-
-function fishFlagLines(): string {
-  const lines = COMMAND_FLAG_TABLE.flatMap(({ commands, flags }) => {
-    const condition = `__fish_seen_subcommand_from ${commands.join(" ")}`;
-    return flags.map((f) => {
-      const parts = [`complete -c nemoclaw -n '${condition}'`, `-l ${f.long.slice(2)}`];
-      if (f.short) parts.push(`-s ${f.short.slice(1)}`);
-      if (f.description) parts.push(`-d '${f.description}'`);
-      if (f.value) parts.push("-r");
-      return parts.join(" ");
-    });
-  });
-  lines.push(
-    `complete -c nemoclaw -n '__fish_seen_subcommand_from completion' -a '${COMPLETION_SHELLS.join(" ")}'`,
-  );
-  return lines.join("\n");
-}
-
-function bashScript(): string {
-  const globals = GLOBAL_COMMANDS.join(" ");
-  const subcommands = SANDBOX_SUBCOMMANDS.join(" ");
-  return `# nemoclaw bash completion
-# Source this file or add to ~/.bash_completion.d/
-# Usage: source <(nemoclaw completion bash)
-
-_nemoclaw() {
-  local cur prev words cword
-  _init_completion 2>/dev/null || {
-    COMPREPLY=()
-    cur="\${COMP_WORDS[COMP_CWORD]}"
-    prev="\${COMP_WORDS[COMP_CWORD-1]}"
-    words=("\${COMP_WORDS[@]}")
-    cword=\${COMP_CWORD}
-  }
-
-  local global_cmds="${globals}"
-  local sandbox_cmds="${subcommands}"
-
-  # Fetch sandbox names (cached for the lifetime of this completion call)
-  local sandboxes
-  sandboxes=$(${LIST_SANDBOXES_SNIPPET}) || sandboxes=""
-
-  if [[ \${cword} -eq 1 ]]; then
-    # Complete global commands and registered sandbox names
-    COMPREPLY=( $(compgen -W "\${global_cmds} \${sandboxes}" -- "\${cur}") )
-    return 0
-  fi
-
-  local first="\${words[1]}"
-
-  # If the first token is a known sandbox name, complete sandbox subcommands
-  if echo "\${sandboxes}" | grep -qx "\${first}"; then
-    COMPREPLY=( $(compgen -W "\${sandbox_cmds}" -- "\${cur}") )
-    return 0
-  fi
-
-  # Flag completion for global commands (generated from the shared flag table)
-  case "\${first}" in
-${bashFlagCases()}
-    *)
-      COMPREPLY=( $(compgen -W "--help" -- "\${cur}") )
-      ;;
-  esac
-  return 0
-}
-
-complete -F _nemoclaw nemoclaw
-`;
-}
-
-function zshScript(): string {
-  const globals = GLOBAL_COMMANDS.map((c) => `'${c}'`).join("\n    ");
-  const subcommands = SANDBOX_SUBCOMMANDS.map((c) => `'${c}'`).join("\n    ");
-  return `#compdef nemoclaw
-# nemoclaw zsh completion
-# Usage: source <(nemoclaw completion zsh)
-# Or add to a file in \$fpath, e.g. /usr/local/share/zsh/site-functions/_nemoclaw
-
-_nemoclaw() {
-  local -a global_cmds sandbox_cmds sandboxes
-  global_cmds=(
-    ${globals}
-  )
-  sandbox_cmds=(
-    ${subcommands}
-  )
-  sandboxes=( \${(f)"\$(${LIST_SANDBOXES_SNIPPET})"} )
-
-  if (( CURRENT == 2 )); then
-    _alternative \\
-      'global:global command:compadd -a global_cmds' \\
-      'sandbox:sandbox name:compadd -a sandboxes'
-    return
-  fi
-
-  local first=\${words[2]}
-
-  # If second token is a sandbox name, complete its subcommands
-  if (( \${sandboxes[(I)\${first}]} )); then
-    _describe 'sandbox subcommand' sandbox_cmds
-    return
-  fi
-
-  # Flag completion for known global commands (generated from the shared flag table)
-  case \${first} in
-${zshFlagCases()}
-    *)
-      _arguments '--help'
-      ;;
-  esac
-}
-
-_nemoclaw "\$@"
-`;
-}
-
-function fishScript(): string {
-  const globals = GLOBAL_COMMANDS.map(
-    (c) => `complete -c nemoclaw -n '__fish_use_subcommand' -a '${c}'`,
-  ).join("\n");
-  const subcommands = SANDBOX_SUBCOMMANDS.join(" ");
-  return `# nemoclaw fish completion
-# Usage: nemoclaw completion fish > ~/.config/fish/completions/nemoclaw.fish
-
-${globals}
-
-# Sandbox subcommands (when first arg is a sandbox name)
-set -l sandbox_subcommands ${subcommands}
-
-# Dynamic sandbox names
-function __nemoclaw_sandboxes
-  ${LIST_SANDBOXES_SNIPPET}
-end
-
-complete -c nemoclaw -n '__fish_use_subcommand' -a '(__nemoclaw_sandboxes)' -d 'Sandbox'
-complete -c nemoclaw -n '__fish_seen_subcommand_from (__nemoclaw_sandboxes)' -a "$sandbox_subcommands"
-
-# Global flags
-complete -c nemoclaw -l help -s h -d 'Show help'
-
-# Per-command flags (generated from the shared flag table)
-${fishFlagLines()}
-`;
-}
-
-const SCRIPT_GENERATORS: Record<CompletionShell, () => string> = {
-  bash: bashScript,
-  zsh: zshScript,
-  fish: fishScript,
+type CompletionArgMetadata = {
+  options?: readonly string[];
 };
 
-/**
- * Resolve the target shell from an explicit argument or the SHELL
- * environment variable, defaulting to bash.
- */
+type CompletionFlagMetadata = {
+  allowNo?: boolean;
+  char?: string;
+  hidden?: boolean;
+};
+
+export type CompletionCommandMetadata = {
+  args?: Record<string, CompletionArgMetadata>;
+  flags?: Record<string, CompletionFlagMetadata>;
+  hidden?: boolean;
+  id: string;
+};
+
+type CompletionNode = {
+  argOptions: Set<string>;
+  children: Map<string, CompletionNode>;
+  flags: Set<string>;
+};
+
+export type CompletionCase = {
+  argOptions: string[];
+  candidates: string[];
+  flags: string[];
+  key: string;
+};
+
+export type CompletionModel = {
+  global: CompletionCase[];
+  sandbox: CompletionCase[];
+};
+
+function createNode(): CompletionNode {
+  return { argOptions: new Set(), children: new Map(), flags: new Set() };
+}
+
+function sorted(values: Iterable<string>): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function addCommandMetadata(node: CompletionNode, command: CompletionCommandMetadata): void {
+  for (const [name, flag] of Object.entries(command.flags ?? {})) {
+    if (flag.hidden) continue;
+    node.flags.add(`--${name}`);
+    if (flag.char) node.flags.add(`-${flag.char}`);
+    if (flag.allowNo) node.flags.add(`--no-${name}`);
+  }
+
+  for (const arg of Object.values(command.args ?? {})) {
+    for (const option of arg.options ?? []) node.argOptions.add(option);
+  }
+}
+
+function addRoute(
+  root: CompletionNode,
+  route: readonly string[],
+  command: CompletionCommandMetadata,
+): void {
+  const tokens = route.filter(Boolean);
+  if (tokens.length === 0) return;
+
+  if (tokens.length === 1 && tokens[0]?.startsWith("-")) {
+    root.flags.add(tokens[0]);
+    return;
+  }
+
+  let node = root;
+  for (const token of tokens) {
+    let child = node.children.get(token);
+    if (!child) {
+      child = createNode();
+      node.children.set(token, child);
+    }
+    node = child;
+  }
+  addCommandMetadata(node, command);
+}
+
+function flattenTree(root: CompletionNode, mode: "global" | "sandbox"): CompletionCase[] {
+  const cases: CompletionCase[] = [];
+
+  function visit(node: CompletionNode, path: string[]): void {
+    cases.push({
+      argOptions: sorted(node.argOptions),
+      candidates: sorted(node.children.keys()),
+      flags: sorted(node.flags),
+      key: `${mode}:${path.join(" ")}`,
+    });
+    for (const token of sorted(node.children.keys())) {
+      const child = node.children.get(token);
+      if (child) visit(child, [...path, token]);
+    }
+  }
+
+  visit(root, []);
+  return cases;
+}
+
+/** Build the public completion trees directly from oclif's discovered command metadata. */
+export function buildCompletionModel(
+  commands: readonly CompletionCommandMetadata[],
+): CompletionModel {
+  const globalRoot = createNode();
+  const sandboxRoot = createNode();
+
+  for (const command of commands) {
+    // Root help/version adapters are hidden from native oclif topics but remain
+    // intentional public routes. Other hidden/internal commands stay private.
+    if (command.hidden && !command.id.startsWith("root:")) continue;
+    for (const route of globalRouteTokenVariants(command.id)) {
+      addRoute(globalRoot, route, command);
+    }
+    const sandboxRoute = sandboxRouteTokens(command.id);
+    if (sandboxRoute) addRoute(sandboxRoot, sandboxRoute, command);
+  }
+
+  return {
+    global: flattenTree(globalRoot, "global"),
+    sandbox: flattenTree(sandboxRoot, "sandbox"),
+  };
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function shellIdentifier(binName: string): string {
+  if (!/^[a-zA-Z0-9._-]+$/.test(binName)) {
+    throw new Error(`Unsupported completion binary name: ${binName}`);
+  }
+  return binName.replaceAll(/[^a-zA-Z0-9_]/g, "_");
+}
+
+function escapeDoubleQuotedCase(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("$", "\\$");
+}
+
+function bashCases(model: CompletionModel): string {
+  return [...model.global, ...model.sandbox]
+    .map((entry) => {
+      const regular = [...entry.candidates, ...entry.argOptions].join(" ");
+      return `    "${escapeDoubleQuotedCase(entry.key)}")
+      if [[ "$cur" == -* ]]; then
+        candidates="${entry.flags.join(" ")}"
+      else
+        candidates="${regular}"
+      fi
+      ;;`;
+    })
+    .join("\n");
+}
+
+function bashScript(model: CompletionModel, binName: string): string {
+  const id = shellIdentifier(binName);
+  const bin = shellSingleQuote(binName);
+  const cache = `__${id}_sandbox_cache`;
+  const loaded = `${cache}_loaded`;
+
+  return `# ${binName} bash completion
+# Source this file or add it to your bash completion directory.
+
+_${id}_load_sandboxes() {
+  if [[ $${loaded} != 1 ]]; then
+    ${cache}="$(${bin} completion --list-sandbox-names 2>/dev/null)"
+    ${loaded}=1
+  fi
+}
+
+_${id}() {
+  local cur mode prefix first sandbox candidates
+  local -a words
+  local cword start i
+  COMPREPLY=()
+  words=("\${COMP_WORDS[@]}")
+  cword=\${COMP_CWORD}
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  mode=global
+  start=1
+  _${id}_load_sandboxes
+
+  if (( cword > 1 )); then
+    first="\${words[1]}"
+    while IFS= read -r sandbox; do
+      if [[ -n "$sandbox" && "$sandbox" == "$first" ]]; then
+        mode=sandbox
+        start=2
+        break
+      fi
+    done <<< "$${cache}"
+  fi
+
+  prefix=""
+  for ((i = start; i < cword; i++)); do
+    prefix+="\${prefix:+ }\${words[i]}"
+  done
+
+  candidates=""
+  case "$mode:$prefix" in
+${bashCases(model)}
+  esac
+
+  if (( cword == 1 )) && [[ "$cur" != -* ]]; then
+    candidates="$candidates $${cache}"
+  fi
+  COMPREPLY=( $(compgen -W "$candidates" -- "$cur") )
+}
+
+complete -F _${id} ${bin}
+`;
+}
+
+function zshWords(values: readonly string[]): string {
+  return values.map(shellSingleQuote).join(" ");
+}
+
+function zshCases(model: CompletionModel): string {
+  return [...model.global, ...model.sandbox]
+    .map((entry) => {
+      const regular = [...entry.candidates, ...entry.argOptions];
+      return `    ${shellSingleQuote(entry.key)})
+      if [[ "$cur" == -* ]]; then
+        candidates=(${zshWords(entry.flags)})
+      else
+        candidates=(${zshWords(regular)})
+      fi
+      ;;`;
+    })
+    .join("\n");
+}
+
+function zshScript(model: CompletionModel, binName: string): string {
+  const id = shellIdentifier(binName);
+  const bin = shellSingleQuote(binName);
+  const cache = `__${id}_sandbox_cache`;
+  const loaded = `${cache}_loaded`;
+
+  return `#compdef ${binName}
+# ${binName} zsh completion
+
+typeset -g ${loaded}=0
+typeset -ga ${cache}
+
+_${id}_load_sandboxes() {
+  if (( ! ${loaded} )); then
+    ${cache}=("\${(@f)\"$(${bin} completion --list-sandbox-names 2>/dev/null)\"}")
+    ${loaded}=1
+  fi
+}
+
+_${id}() {
+  local cur mode prefix first
+  local -a candidates
+  integer start i
+  cur="\${words[CURRENT]}"
+  mode=global
+  start=2
+  _${id}_load_sandboxes
+
+  if (( CURRENT > 2 )); then
+    first="\${words[2]}"
+    if (( \${${cache}[(Ie)$first]} )); then
+      mode=sandbox
+      start=3
+    fi
+  fi
+
+  prefix=""
+  for ((i = start; i < CURRENT; i++)); do
+    prefix+="\${prefix:+ }\${words[i]}"
+  done
+
+  candidates=()
+  case "$mode:$prefix" in
+${zshCases(model)}
+  esac
+
+  if (( CURRENT == 2 )) && [[ "$cur" != -* ]]; then
+    candidates+=("\${${cache}[@]}")
+  fi
+  (( \${#candidates[@]} )) && _describe 'completion' candidates
+}
+
+compdef _${id} ${bin}
+`;
+}
+
+function fishCaseBody(entry: CompletionCase): string {
+  const regular = [...entry.candidates, ...entry.argOptions];
+  const flags = entry.flags.length > 0 ? `printf '%s\\n' ${zshWords(entry.flags)}` : "true";
+  const values = regular.length > 0 ? `printf '%s\\n' ${zshWords(regular)}` : "true";
+  return `    case ${shellSingleQuote(entry.key)}
+      if string match -q -- '-*' "$cur"
+        ${flags}
+      else
+        ${values}
+      end`;
+}
+
+function fishScript(model: CompletionModel, binName: string): string {
+  const id = shellIdentifier(binName);
+  const bin = shellSingleQuote(binName);
+  const cache = `__${id}_sandbox_cache`;
+  const loaded = `${cache}_loaded`;
+  const cases = [...model.global, ...model.sandbox].map(fishCaseBody).join("\n");
+
+  return `# ${binName} fish completion
+
+function __${id}_sandboxes
+  if not set -q ${loaded}
+    set -g ${cache} (command ${bin} completion --list-sandbox-names 2>/dev/null)
+    set -g ${loaded} 1
+  end
+  printf '%s\\n' $${cache}
+end
+
+function __${id}_complete
+  set -l tokens (commandline -opc)
+  set -l cur (commandline -ct)
+  set -e tokens[1]
+  set -l mode global
+  set -l start 1
+
+  if test (count $tokens) -gt 0
+    if contains -- $tokens[1] (__${id}_sandboxes)
+      set mode sandbox
+      set start 2
+    end
+  end
+
+  set -l prefix (string join ' ' $tokens[$start..-1])
+  switch "$mode:$prefix"
+${cases}
+  end
+
+  if test "$mode" = global; and test (count $tokens) -eq 0; and not string match -q -- '-*' "$cur"
+    __${id}_sandboxes
+  end
+end
+
+complete -c ${bin} -f -a '(__${id}_complete)'
+`;
+}
+
+/** Resolve the target shell from an explicit argument or the SHELL environment. */
 export function detectShell(shellEnv: string | undefined): CompletionShell {
   const shell = shellEnv ?? "";
   if (shell.includes("zsh")) return "zsh";
@@ -363,27 +360,45 @@ export function detectShell(shellEnv: string | undefined): CompletionShell {
   return "bash";
 }
 
-/** Generate the completion script for the given shell. */
-export function generateCompletionScript(shell: CompletionShell): string {
-  return SCRIPT_GENERATORS[shell]();
+/** Generate a shell script from oclif's currently discovered command metadata. */
+export function generateCompletionScript(
+  shell: CompletionShell,
+  commands: readonly CompletionCommandMetadata[],
+  binName: string,
+): string {
+  const model = buildCompletionModel(commands);
+  if (shell === "zsh") return zshScript(model, binName);
+  if (shell === "fish") return fishScript(model, binName);
+  return bashScript(model, binName);
 }
 
 export interface CompletionActionDeps {
-  write?: (script: string) => void;
+  listRegisteredSandboxes?: typeof listSandboxes;
   shellEnv?: string;
+  write?: (output: string) => void;
 }
 
-/**
- * Emit the completion script for the requested (or detected) shell.
- */
+/** Emit the generated script for the requested (or detected) shell. */
 export function runCompletionAction(
   shell: string | undefined,
+  commands: readonly CompletionCommandMetadata[],
+  binName: string,
   deps: CompletionActionDeps = {},
 ): void {
-  const write = deps.write ?? ((script: string) => process.stdout.write(script));
+  const write = deps.write ?? ((output: string) => process.stdout.write(output));
   const resolved =
     shell === "bash" || shell === "zsh" || shell === "fish"
       ? shell
       : detectShell(deps.shellEnv ?? process.env.SHELL);
-  write(generateCompletionScript(resolved));
+  write(generateCompletionScript(resolved, commands, binName));
+}
+
+/** Emit only local registry names for the lightweight dynamic completion path. */
+export function runCompletionSandboxNamesAction(deps: CompletionActionDeps = {}): void {
+  const write = deps.write ?? ((output: string) => process.stdout.write(output));
+  const readRegistry = deps.listRegisteredSandboxes ?? listSandboxes;
+  const names = readRegistry()
+    .sandboxes.map((sandbox) => sandbox.name)
+    .sort();
+  write(names.length > 0 ? `${names.join("\n")}\n` : "");
 }

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -25,6 +25,14 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
       order: 40,
     },
   ],
+  completion: [
+    {
+      group: "Getting Started",
+      order: 2.5,
+      description: "Generate a shell completion script (bash, zsh, or fish)",
+      flags: "[bash|zsh|fish]",
+    },
+  ],
   "credentials:add": [
     {
       group: "Credentials",

--- a/src/lib/cli/public-display-defaults.ts
+++ b/src/lib/cli/public-display-defaults.ts
@@ -28,8 +28,7 @@ const PUBLIC_DISPLAY_LAYOUT: Record<string, readonly PublicDisplayLayout[]> = {
   completion: [
     {
       group: "Getting Started",
-      order: 2.5,
-      description: "Generate a shell completion script (bash, zsh, or fish)",
+      order: 1.75,
       flags: "[bash|zsh|fish]",
     },
   ],

--- a/test/package-contract/cli/command-registry.test.ts
+++ b/test/package-contract/cli/command-registry.test.ts
@@ -188,10 +188,11 @@ describe("command-registry", () => {
   });
 
   describe("globalCommandTokens()", () => {
-    it("returns the exact set of 26 tokens matching the global dispatch commands", () => {
+    it("returns the exact set of 27 tokens matching the global dispatch commands", () => {
       const tokens = globalCommandTokens();
       const expected = new Set([
         "agents",
+        "completion",
         "onboard",
         "update",
         "list",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds `nemoclaw completion [bash|zsh|fish]` for global commands, the public sandbox-first grammar, flags, shell choices, and registered sandbox names. The completion tree is generated from oclif's discovered command metadata and NemoClaw's public-route helpers, so it stays aligned with the CLI instead of maintaining a second command registry.

Replaces #6267, which was closed with unrelated history.

## Changes

- Generate global and sandbox-first command trees from `this.config.commands`, `globalRouteTokenVariants`, and `sandboxRouteTokens`.
- Derive long/short flags and fixed argument choices from oclif metadata for Bash, Zsh, and Fish.
- Read sandbox names through a hidden, local-registry-only completion path instead of the full `list --json` workflow.
- Cache sandbox names for the current shell session so Fish and repeated tab completion do not rerun registry reads.
- Bind generated scripts to the active CLI alias (`nemoclaw`, `nemohermes`, or `nemo-deepagents`).
- Register and document the new public command.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every new maintainer commit is signed
- [x] Commit and push hooks pass
- [x] Targeted tests pass: 37 CLI and package-contract tests
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Repository checks, source-shape guard, and test-size guard pass
- [x] Bash and Zsh generated-script syntax checks pass
- [x] Bash command, flag, and sandbox-first completion behavior passes
- [x] Docs CLI parity passes (77/77 commands plus flag parity)
- [x] Docs variant, route, and Fern checks pass (0 errors; 2 existing warnings)
- [x] No secrets, API keys, or credentials committed

## Contributor credit

The original implementation and every maintainer-authored follow-up commit retain `sauravdev` as a co-author.

---
Signed-off-by: sauravdev <saurava@nvidia.com>
