### PR TITLE
perf(test): reduce subprocess isolation in rebuild and setup tests

### DIFF
--- a/agents/hermes/config/generate.ts
+++ b/agents/hermes/config/generate.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type HermesBuildSettings, readHermesBuildSettings } from "./build-env.ts";
+import { buildHermesConfig, finalizeHermesPlatformToolsets } from "./hermes-config.ts";
+import { buildHermesEnvLines } from "./hermes-env.ts";
+import { discoverModelSpecificSetups } from "./model-specific-setup.ts";
+import { type WrittenHermesConfig, writeHermesConfigFiles } from "./write-config.ts";
+
+export type GenerateHermesConfigOptions = {
+  env: NodeJS.ProcessEnv;
+  scriptDir: string;
+  homeDir?: string;
+  log?: (message: string) => void;
+};
+
+export type GeneratedHermesConfig = {
+  settings: HermesBuildSettings;
+  config: Record<string, unknown>;
+  envLines: string[];
+  written: WrittenHermesConfig;
+};
+
+/** Generate the immutable Hermes config files from an explicit build environment. */
+export function generateHermesConfig({
+  env,
+  scriptDir,
+  homeDir,
+  log = console.log,
+}: GenerateHermesConfigOptions): GeneratedHermesConfig {
+  const settings = readHermesBuildSettings(env);
+  discoverModelSpecificSetups(
+    "hermes",
+    {
+      model: settings.model,
+      providerKey: settings.providerKey,
+      inferenceApi: settings.inferenceApi,
+      baseUrl: settings.baseUrl,
+    },
+    { env, scriptDir },
+  );
+
+  const config = buildHermesConfig(settings);
+  const envLines = buildHermesEnvLines(settings);
+  finalizeHermesPlatformToolsets(config, settings);
+  const written = writeHermesConfigFiles(config, envLines, homeDir);
+
+  log(`[config] Wrote ${written.configPath} (model=${settings.model}, provider=custom)`);
+  log(`[config] Wrote ${written.envPath} (${written.envEntryCount} entries)`);
+
+  return { settings, config, envLines, written };
+}

--- a/agents/hermes/config/generate.ts
+++ b/agents/hermes/config/generate.ts
@@ -40,8 +40,8 @@ export function generateHermesConfig({
     { env, scriptDir },
   );
 
-  const config = buildHermesConfig(settings);
-  const envLines = buildHermesEnvLines(settings);
+  const config = buildHermesConfig(settings, env);
+  const envLines = buildHermesEnvLines(settings, env);
   finalizeHermesPlatformToolsets(config, settings);
   const written = writeHermesConfigFiles(config, envLines, homeDir);
 

--- a/agents/hermes/config/hermes-config.ts
+++ b/agents/hermes/config/hermes-config.ts
@@ -40,7 +40,10 @@ function hermesApiMode(inferenceApi: string): string | null {
   }
 }
 
-export function buildHermesConfig(settings: HermesBuildSettings): Record<string, unknown> {
+export function buildHermesConfig(
+  settings: HermesBuildSettings,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, unknown> {
   const remotePlatformToolsets = buildHermesRemotePlatformToolsets(settings);
   const modelProviderName = "custom";
   const pickerProviderName = settings.upstreamProvider || "nemoclaw-inference";
@@ -167,7 +170,7 @@ export function buildHermesConfig(settings: HermesBuildSettings): Record<string,
 
   const managedToolGatewayPresets = effectiveManagedToolGatewayPresets(settings);
   if (managedToolGatewayPresets.length > 0) {
-    const matrix = loadManagedToolGatewayMatrix();
+    const matrix = loadManagedToolGatewayMatrix(env);
     for (const preset of managedToolGatewayPresets) {
       const entry = matrix[preset];
       if (!entry) {

--- a/agents/hermes/config/hermes-env.ts
+++ b/agents/hermes/config/hermes-env.ts
@@ -9,7 +9,10 @@ import {
 
 const TAVILY_API_KEY_PLACEHOLDER = "openshell:resolve:env:TAVILY_API_KEY";
 
-export function buildHermesEnvLines(settings: HermesBuildSettings): string[] {
+export function buildHermesEnvLines(
+  settings: HermesBuildSettings,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
   const envLines = ["API_SERVER_PORT=18642", "API_SERVER_HOST=127.0.0.1"];
 
   for (const { envKey, placeholder } of settings.messagingCredentialPlaceholders) {
@@ -23,7 +26,7 @@ export function buildHermesEnvLines(settings: HermesBuildSettings): string[] {
   const managedToolGatewayPresets = effectiveManagedToolGatewayPresets(settings);
   if (managedToolGatewayPresets.length === 0) return envLines;
 
-  const matrix = loadManagedToolGatewayMatrix();
+  const matrix = loadManagedToolGatewayMatrix(env);
   envLines.push("NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER=1");
   for (const preset of managedToolGatewayPresets) {
     const entry = matrix[preset];

--- a/agents/hermes/config/managed-tool-gateway.ts
+++ b/agents/hermes/config/managed-tool-gateway.ts
@@ -25,10 +25,12 @@ export function effectiveManagedToolGatewayPresets(
   );
 }
 
-export function loadManagedToolGatewayMatrix(): ManagedToolGatewayMatrix {
+export function loadManagedToolGatewayMatrix(
+  env: NodeJS.ProcessEnv = process.env,
+): ManagedToolGatewayMatrix {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const candidates = [
-    process.env.NEMOCLAW_HERMES_TOOL_GATEWAY_MATRIX_PATH,
+    env.NEMOCLAW_HERMES_TOOL_GATEWAY_MATRIX_PATH,
     join(scriptDir, "hermes-managed-tool-gateway-matrix.json"),
     join(scriptDir, "../hermes-managed-tool-gateway-matrix.json"),
     join(scriptDir, "../host/managed-tool-gateway-matrix.json"),

--- a/agents/hermes/generate-config.ts
+++ b/agents/hermes/generate-config.ts
@@ -13,35 +13,16 @@
 //   - Base environment entries used by Hermes inside OpenShell
 //   - Agent defaults (terminal, memory, skills, display)
 
-import { readHermesBuildSettings } from "./config/build-env.ts";
-import { buildHermesEnvLines } from "./config/hermes-env.ts";
-import { buildHermesConfig, finalizeHermesPlatformToolsets } from "./config/hermes-config.ts";
-import { discoverModelSpecificSetups } from "./config/model-specific-setup.ts";
-import { writeHermesConfigFiles } from "./config/write-config.ts";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { generateHermesConfig } from "./config/generate.ts";
 
-function main(): void {
-  const settings = readHermesBuildSettings(process.env);
-  discoverModelSpecificSetups(
-    "hermes",
-    {
-      model: settings.model,
-      providerKey: settings.providerKey,
-      inferenceApi: settings.inferenceApi,
-      baseUrl: settings.baseUrl,
-    },
-    {
-      env: process.env,
-      scriptDir: import.meta.dirname,
-    },
-  );
-
-  const config = buildHermesConfig(settings);
-  const envLines = buildHermesEnvLines(settings);
-  finalizeHermesPlatformToolsets(config, settings);
-  const written = writeHermesConfigFiles(config, envLines);
-
-  console.log(`[config] Wrote ${written.configPath} (model=${settings.model}, provider=custom)`);
-  console.log(`[config] Wrote ${written.envPath} (${written.envEntryCount} entries)`);
+export function main(): void {
+  generateHermesConfig({ env: process.env, scriptDir: import.meta.dirname });
 }
 
-main();
+function isMainModule(): boolean {
+  return process.argv[1] ? import.meta.url === pathToFileURL(resolve(process.argv[1])).href : false;
+}
+
+if (isMainModule()) main();

--- a/src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts
@@ -101,6 +101,25 @@ describe("ensureRebuildAgentBaseImage", () => {
     });
   });
 
+  it("reports a forced Hermes base-image failure before rebuild can continue", () => {
+    const { ensureAgentBaseImage } = setup();
+    ensureAgentBaseImage.mockImplementation(() => {
+      throw new Error("Failed to build Hermes Agent base image (exit 23)");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { ensureRebuildAgentBaseImage } = loadRebuildFlowHelpers();
+
+    expect(() => ensureRebuildAgentBaseImage("hermes", makeBail())).toThrow(
+      "Failed to build Hermes Agent base image (exit 23)",
+    );
+
+    const output = error.mock.calls.flat().join("\n");
+    expect(output).toContain("Rebuild preflight failed");
+    expect(output).toContain("agent base image could not be built");
+    expect(output).toContain("Failed to build Hermes Agent base image (exit 23)");
+    expect(output).toContain("Sandbox is untouched");
+  });
+
   it("forwards force refresh with the sandbox-specific hint (#4680)", () => {
     const { agent, ensureAgentBaseImage } = setup();
     const { ensureRebuildAgentBaseImage } = loadRebuildFlowHelpers();

--- a/src/lib/actions/sandbox/rebuild-flow-helpers.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow-helpers.test.ts
@@ -182,27 +182,6 @@ describe("rebuild agent base image preflight", () => {
     expect(result).toEqual({ ok: true, imageRef, overrideEnvVar });
   });
 
-  it("reports a forced Hermes base-image failure before rebuild can continue", () => {
-    const agentDefs = requireDist("../../agent/defs.js");
-    const agentOnboard = requireDist("../../agent/onboard.js");
-    vi.spyOn(agentDefs, "loadAgent").mockReturnValue({ name: "hermes" });
-    vi.spyOn(agentOnboard, "ensureAgentBaseImage").mockImplementation(() => {
-      throw new Error("Failed to build Hermes Agent base image (exit 23)");
-    });
-    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const { ensureRebuildAgentBaseImage } = loadRebuildFlowHelpers();
-
-    expect(() => ensureRebuildAgentBaseImage("hermes", makeBail())).toThrow(
-      "Failed to build Hermes Agent base image (exit 23)",
-    );
-
-    const output = error.mock.calls.flat().join("\n");
-    expect(output).toContain("Rebuild preflight failed");
-    expect(output).toContain("agent base image could not be built");
-    expect(output).toContain("Failed to build Hermes Agent base image (exit 23)");
-    expect(output).toContain("Sandbox is untouched");
-  });
-
   it("resolves an explicit caller override instead of replacing it during preflight", () => {
     process.env[overrideEnvVar] = "nemoclaw-hermes-sandbox-base-local:caller";
     const mutableRef = "nemoclaw-hermes-sandbox-base-local:resolved";

--- a/src/lib/actions/sandbox/rebuild-flow-helpers.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow-helpers.test.ts
@@ -182,6 +182,27 @@ describe("rebuild agent base image preflight", () => {
     expect(result).toEqual({ ok: true, imageRef, overrideEnvVar });
   });
 
+  it("reports a forced Hermes base-image failure before rebuild can continue", () => {
+    const agentDefs = requireDist("../../agent/defs.js");
+    const agentOnboard = requireDist("../../agent/onboard.js");
+    vi.spyOn(agentDefs, "loadAgent").mockReturnValue({ name: "hermes" });
+    vi.spyOn(agentOnboard, "ensureAgentBaseImage").mockImplementation(() => {
+      throw new Error("Failed to build Hermes Agent base image (exit 23)");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { ensureRebuildAgentBaseImage } = loadRebuildFlowHelpers();
+
+    expect(() => ensureRebuildAgentBaseImage("hermes", makeBail())).toThrow(
+      "Failed to build Hermes Agent base image (exit 23)",
+    );
+
+    const output = error.mock.calls.flat().join("\n");
+    expect(output).toContain("Rebuild preflight failed");
+    expect(output).toContain("agent base image could not be built");
+    expect(output).toContain("Failed to build Hermes Agent base image (exit 23)");
+    expect(output).toContain("Sandbox is untouched");
+  });
+
   it("resolves an explicit caller override instead of replacing it during preflight", () => {
     process.env[overrideEnvVar] = "nemoclaw-hermes-sandbox-base-local:caller";
     const mutableRef = "nemoclaw-hermes-sandbox-base-local:resolved";

--- a/src/lib/actions/sandbox/rebuild-flow.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { registerRebuildFlowCredentialPreflightTests } from "../../../../test/helpers/rebuild-flow-credential-preflight-cases";
 import { registerRebuildFlowLifecycleTests } from "../../../../test/helpers/rebuild-flow-lifecycle-cases";
 import { registerRebuildFlowRecoveryTests } from "../../../../test/helpers/rebuild-flow-recovery-cases";
 import { registerRebuildFlowTargetCredentialsTests } from "../../../../test/helpers/rebuild-flow-target-credentials-cases";
@@ -9,6 +10,7 @@ import { registerRebuildFlowTargetSessionTests } from "../../../../test/helpers/
 
 registerRebuildFlowLifecycleTests();
 registerRebuildFlowRecoveryTests();
+registerRebuildFlowCredentialPreflightTests();
 registerRebuildFlowTargetSessionTests();
 registerRebuildFlowTargetCredentialsTests();
 registerRebuildFlowTargetImageTests();

--- a/src/lib/actions/sandbox/rebuild-preflight-confirmation.test.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-confirmation.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as openshellResolve from "../../adapters/openshell/resolve";
+import {
+  confirmSandboxRebuildIfNeeded,
+  countActiveSandboxSessionsForRebuild,
+} from "./rebuild-preflight-confirmation";
+import { isSingleAgentRebuildSupported } from "./rebuild-preflight-guards";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("rebuild confirmation", () => {
+  it("accepts trimmed case-insensitive affirmative input", async () => {
+    const prompt = vi.fn(async () => " YES ");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(confirmSandboxRebuildIfNeeded(false, 0, prompt)).resolves.toBe(true);
+
+    expect(prompt).toHaveBeenCalledWith("  Proceed? [y/N]: ");
+    expect(log).not.toHaveBeenCalledWith("  Cancelled.");
+  });
+
+  it("prints active-session risk before asking for confirmation", async () => {
+    const prompt = vi.fn(async () => "n");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(confirmSandboxRebuildIfNeeded(false, 2, prompt)).resolves.toBe(false);
+
+    const output = log.mock.calls.flat().join("\n");
+    expect(output).toContain("Active SSH sessions detected (2 connections)");
+    expect(output).toContain("terminate all active sessions with a Broken pipe error");
+    expect(output.indexOf("Active SSH sessions detected")).toBeLessThan(
+      output.indexOf("Cancelled."),
+    );
+  });
+
+  it("omits the active-session warning when detection yields no sessions", async () => {
+    const prompt = vi.fn(async () => "n");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(confirmSandboxRebuildIfNeeded(false, 0, prompt)).resolves.toBe(false);
+
+    const output = log.mock.calls.flat().join("\n");
+    expect(output).not.toContain("Active SSH");
+    expect(output).toContain("Cancelled.");
+  });
+
+  it("does not prompt when confirmation is skipped", async () => {
+    const prompt = vi.fn(async () => "n");
+    await expect(confirmSandboxRebuildIfNeeded(true, 3, prompt)).resolves.toBe(true);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+});
+
+describe("rebuild preflight guards", () => {
+  it("rejects a multi-agent sandbox before later rebuild work", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const bail = (message: string): never => {
+      throw new Error(message);
+    };
+
+    expect(() =>
+      isSingleAgentRebuildSupported(
+        { name: "alpha", agents: [{ name: "openclaw" }, { name: "hermes" }] } as never,
+        bail,
+      ),
+    ).toThrow("Multi-agent sandbox rebuild is not yet supported");
+
+    const output = error.mock.calls.flat().join("\n");
+    expect(output).toContain("Multi-agent sandbox rebuild is not yet supported");
+    expect(output).toContain("Back up state manually");
+  });
+
+  it("treats an unavailable OpenShell session detector as zero active sessions", () => {
+    vi.spyOn(openshellResolve, "resolveOpenshell").mockReturnValue(null);
+    expect(countActiveSandboxSessionsForRebuild("alpha")).toBe(0);
+  });
+});

--- a/src/lib/actions/sandbox/rebuild-preflight-confirmation.test.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-confirmation.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as openshellResolve from "../../adapters/openshell/resolve";
+import * as sandboxSession from "../../state/sandbox-session";
 import {
   confirmSandboxRebuildIfNeeded,
   countActiveSandboxSessionsForRebuild,
@@ -77,6 +78,15 @@ describe("rebuild preflight guards", () => {
 
   it("treats an unavailable OpenShell session detector as zero active sessions", () => {
     vi.spyOn(openshellResolve, "resolveOpenshell").mockReturnValue(null);
+    expect(countActiveSandboxSessionsForRebuild("alpha")).toBe(0);
+  });
+
+  it("treats a session detector failure as zero active sessions", () => {
+    vi.spyOn(openshellResolve, "resolveOpenshell").mockReturnValue("/usr/bin/openshell");
+    vi.spyOn(sandboxSession, "getActiveSandboxSessions").mockImplementation(() => {
+      throw new Error("session detector unavailable");
+    });
+
     expect(countActiveSandboxSessionsForRebuild("alpha")).toBe(0);
   });
 });

--- a/src/lib/actions/sandbox/rebuild-preflight-confirmation.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-confirmation.ts
@@ -69,9 +69,10 @@ export function getRebuildAgentDisplayName(sandboxName: string): string {
   return agentRuntime.getAgentDisplayName(agentRuntime.getSessionAgent(sandboxName));
 }
 
-async function confirmSandboxRebuildIfNeeded(
+export async function confirmSandboxRebuildIfNeeded(
   skipConfirm: boolean,
   activeSessionCount: number,
+  prompt: typeof askPrompt = askPrompt,
 ): Promise<boolean> {
   if (skipConfirm) return true;
   if (activeSessionCount > 0) {
@@ -89,7 +90,7 @@ async function confirmSandboxRebuildIfNeeded(
   console.log("    2. Destroy and recreate the sandbox with the current image");
   console.log("    3. Restore workspace state into the new sandbox");
   console.log("");
-  const answer = await askPrompt("  Proceed? [y/N]: ");
+  const answer = await prompt("  Proceed? [y/N]: ");
   if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
     console.log("  Cancelled.");
     return false;

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 import { generateHermesConfig } from "../agents/hermes/config/generate.ts";
 import { HERMES_PROXY_API_KEY_PLACEHOLDER } from "../src/lib/hermes-proxy-api-key";
@@ -191,6 +191,29 @@ function writeRegistryManifest(
   return path.join(blueprintDir, "model-specific-setup");
 }
 
+function writeManagedToolGatewayMatrixFixture(
+  filename: string,
+  provider: string,
+  envValue: string,
+): string {
+  const matrixPath = path.join(tmpDir, filename);
+  fs.writeFileSync(
+    matrixPath,
+    JSON.stringify({
+      "nous-audio": {
+        service: provider,
+        config: {
+          tts: { provider, use_gateway: true },
+          stt: { provider, use_gateway: true },
+        },
+        envKey: "FIXTURE_AUDIO_GATEWAY_URL",
+        envValue,
+      },
+    }),
+  );
+  return matrixPath;
+}
+
 function copyConfigGeneratorFixture(fixtureRoot: string): string {
   const fixtureScriptPath = path.join(fixtureRoot, "agents", "hermes", "generate-config.ts");
   const fixtureConfigDir = path.join(fixtureRoot, "agents", "hermes", "config");
@@ -262,23 +285,53 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("agents/hermes/generate-config.ts", () => {
   it(
-    "runs as a strip-types executable and leaves messaging render to the build applier",
+    "matches direct generation as a strip-types executable with an explicit gateway matrix",
     async () => {
+      const matrixPath = writeManagedToolGatewayMatrixFixture(
+        "managed-tool-gateway-matrix.json",
+        "fixture-audio",
+        "https://matrix.example.test/audio",
+      );
+      const decoyMatrixPath = writeManagedToolGatewayMatrixFixture(
+        "decoy-managed-tool-gateway-matrix.json",
+        "decoy-audio",
+        "https://decoy.example.test/audio",
+      );
+      vi.stubEnv("NEMOCLAW_HERMES_TOOL_GATEWAY_MATRIX_PATH", decoyMatrixPath);
       const env = await buildHermesTestEnvDirect({
         NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram"]),
       });
-      const result = runConfigScriptRaw({
+      const overrides = {
+        NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram"]),
         NEMOCLAW_MESSAGING_PLAN_B64: env.NEMOCLAW_MESSAGING_PLAN_B64,
+        NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER: "1",
+        NEMOCLAW_HERMES_TOOL_GATEWAY_PRESETS_B64: encodeJson(["nous-audio"]),
+        NEMOCLAW_HERMES_TOOL_GATEWAY_MATRIX_PATH: matrixPath,
+      };
+      const directEnv = buildHermesTestEnv(overrides);
+      fs.mkdirSync(path.join(tmpDir, ".hermes"), { recursive: true });
+      generateHermesConfig({
+        env: directEnv,
+        scriptDir: SCRIPT_DIR,
+        homeDir: tmpDir,
+        log: () => {},
       });
+      const direct = readGeneratedConfig();
+      fs.rmSync(path.join(tmpDir, ".hermes"), { recursive: true, force: true });
+
+      const result = runConfigScriptRaw(overrides);
       expect(result.status, result.stderr).toBe(0);
-      const hermesDir = path.join(tmpDir, ".hermes");
-      const config = YAML.parse(fs.readFileSync(path.join(hermesDir, "config.yaml"), "utf-8"));
-      const envFile = fs.readFileSync(path.join(hermesDir, ".env"), "utf-8");
+      const { config, envFile } = readGeneratedConfig();
+      expect(config).toEqual(direct.config);
+      expect(envFile).toBe(direct.envFile);
+      expect(config.tts).toEqual({ provider: "fixture-audio", use_gateway: true });
+      expect(envFile).toContain("FIXTURE_AUDIO_GATEWAY_URL=https://matrix.example.test/audio\n");
       expect(config.platforms.telegram).toBeUndefined();
       expect(envFile).not.toContain("TELEGRAM_BOT_TOKEN=");
     },

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -7,21 +7,20 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import YAML from "yaml";
+import { generateHermesConfig } from "../agents/hermes/config/generate.ts";
 import { HERMES_PROXY_API_KEY_PLACEHOLDER } from "../src/lib/hermes-proxy-api-key";
+import {
+  applyMessagingBuildPhase,
+  readMessagingBuildPlanFromEnv,
+} from "../src/lib/messaging/applier/build/messaging-build-applier.mts";
 import { testTimeout } from "./helpers/timeouts";
-import { withLegacyMessagingPlanEnv } from "./messaging-plan-test-helper";
+import {
+  withLegacyMessagingPlanEnv,
+  withLegacyMessagingPlanEnvDirect,
+} from "./messaging-plan-test-helper";
 
 const SCRIPT_PATH = path.join(import.meta.dirname, "..", "agents", "hermes", "generate-config.ts");
-const APPLIER_PATH = path.join(
-  import.meta.dirname,
-  "..",
-  "src",
-  "lib",
-  "messaging",
-  "applier",
-  "build",
-  "messaging-build-applier.mts",
-);
+const SCRIPT_DIR = path.dirname(SCRIPT_PATH);
 const CONFIG_MODULE_DIR = path.join(import.meta.dirname, "..", "agents", "hermes", "config");
 
 const BASE_ENV: Record<string, string> = {
@@ -67,62 +66,93 @@ function encodeJson(value: unknown): string {
 }
 
 function buildHermesTestEnv(envOverrides: Record<string, string> = {}): Record<string, string> {
-  return withLegacyMessagingPlanEnv(
-    {
-      PATH: process.env.PATH || "/usr/bin:/bin",
-      ...BASE_ENV,
-      ...envOverrides,
-      HOME: tmpDir,
-    },
-    "hermes",
+  return withLegacyMessagingPlanEnv(buildHermesTestEnvBase(envOverrides), "hermes");
+}
+
+function buildHermesTestEnvBase(envOverrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    PATH: process.env.PATH || "/usr/bin:/bin",
+    ...BASE_ENV,
+    ...envOverrides,
+    HOME: tmpDir,
+  };
+}
+
+function buildHermesTestEnvDirect(
+  envOverrides: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  return withLegacyMessagingPlanEnvDirect(buildHermesTestEnvBase(envOverrides), "hermes");
+}
+
+function withEnv<T>(env: Record<string, string>, fn: () => T): T {
+  const originalEnv = { ...process.env };
+  try {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, env);
+    return fn();
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  }
+}
+
+function readGeneratedConfig(): { config: Record<string, any>; envFile: string } {
+  const hermesDir = path.join(tmpDir, ".hermes");
+  return {
+    config: YAML.parse(fs.readFileSync(path.join(hermesDir, "config.yaml"), "utf-8")),
+    envFile: fs.readFileSync(path.join(hermesDir, ".env"), "utf-8"),
+  };
+}
+
+function generateBaseConfig(envOverrides: Record<string, string> = {}): {
+  config: Record<string, any>;
+  envFile: string;
+} {
+  fs.mkdirSync(path.join(tmpDir, ".hermes"), { recursive: true });
+  const env = buildHermesTestEnv(envOverrides);
+  withEnv(env, () =>
+    generateHermesConfig({
+      env,
+      scriptDir: SCRIPT_DIR,
+      homeDir: tmpDir,
+      log: () => {},
+    }),
   );
+  return readGeneratedConfig();
 }
 
 function runConfigScript(envOverrides: Record<string, string> = {}): {
   config: Record<string, any>;
   envFile: string;
 } {
+  return generateConfigWithMessaging(buildHermesTestEnv(envOverrides));
+}
+
+async function runConfigScriptWithMessaging(
+  envOverrides: Record<string, string> = {},
+): Promise<{ config: Record<string, any>; envFile: string }> {
+  return generateConfigWithMessaging(await buildHermesTestEnvDirect(envOverrides));
+}
+
+function generateConfigWithMessaging(env: Record<string, string>): {
+  config: Record<string, any>;
+  envFile: string;
+} {
   fs.mkdirSync(path.join(tmpDir, ".hermes"), { recursive: true });
-  const env = buildHermesTestEnv(envOverrides);
-  const result = runConfigScriptRaw(envOverrides);
-
-  if (result.status !== 0) {
-    throw new Error(
-      `Script failed (exit ${result.status}):
-stdout: ${result.stdout}
-stderr: ${result.stderr}`,
-    );
-  }
-
-  const applierResult = spawnSync(
-    process.execPath,
-    [
-      "--experimental-strip-types",
-      APPLIER_PATH,
-      "--agent",
-      "hermes",
-      "--phase",
-      "post-agent-install",
-    ],
-    {
-      encoding: "utf-8",
+  withEnv(env, () => {
+    generateHermesConfig({
       env,
-      timeout: 10_000,
-    },
-  );
-  if (applierResult.status !== 0) {
-    throw new Error(
-      `Messaging applier failed (exit ${applierResult.status}):
-stdout: ${applierResult.stdout}
-stderr: ${applierResult.stderr}`,
+      scriptDir: SCRIPT_DIR,
+      homeDir: tmpDir,
+      log: () => {},
+    });
+    applyMessagingBuildPhase(
+      readMessagingBuildPlanFromEnv(env, "hermes"),
+      "post-agent-install",
+      env,
     );
-  }
-
-  const hermesDir = path.join(tmpDir, ".hermes");
-  return {
-    config: YAML.parse(fs.readFileSync(path.join(hermesDir, "config.yaml"), "utf-8")),
-    envFile: fs.readFileSync(path.join(hermesDir, ".env"), "utf-8"),
-  };
+  });
+  return readGeneratedConfig();
 }
 
 function runConfigScriptRaw(
@@ -141,6 +171,13 @@ function runConfigScriptRaw(
       timeout: 10_000,
     },
   );
+}
+
+function expectGenerationError(
+  envOverrides: Record<string, string>,
+  message: string | RegExp,
+): void {
+  expect(() => generateBaseConfig(envOverrides)).toThrow(message);
 }
 
 function writeRegistryManifest(
@@ -230,10 +267,13 @@ afterEach(() => {
 
 describe("agents/hermes/generate-config.ts", () => {
   it(
-    "leaves messaging render to the messaging build applier",
-    () => {
-      const result = runConfigScriptRaw({
+    "runs as a strip-types executable and leaves messaging render to the build applier",
+    async () => {
+      const env = await buildHermesTestEnvDirect({
         NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram"]),
+      });
+      const result = runConfigScriptRaw({
+        NEMOCLAW_MESSAGING_PLAN_B64: env.NEMOCLAW_MESSAGING_PLAN_B64,
       });
       expect(result.status, result.stderr).toBe(0);
       const hermesDir = path.join(tmpDir, ".hermes");
@@ -276,9 +316,10 @@ describe("agents/hermes/generate-config.ts", () => {
   });
 
   it("rejects unknown tool-disclosure modes", () => {
-    const result = runConfigScriptRaw({ NEMOCLAW_TOOL_DISCLOSURE: "sometimes" });
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("NEMOCLAW_TOOL_DISCLOSURE must be progressive or direct");
+    expectGenerationError(
+      { NEMOCLAW_TOOL_DISCLOSURE: "sometimes" },
+      "NEMOCLAW_TOOL_DISCLOSURE must be progressive or direct",
+    );
   });
 
   it("generates API server config without messaging platform token blocks", () => {
@@ -354,25 +395,21 @@ describe("agents/hermes/generate-config.ts", () => {
   });
 
   it("fails fast for unsupported web-search provider values", () => {
-    const result = runConfigScriptRaw({
-      NEMOCLAW_WEB_SEARCH_ENABLED: "1",
-      NEMOCLAW_WEB_SEARCH_PROVIDER: "search.example.com",
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(`${result.stderr}\n${result.stdout}`).toContain(
+    expectGenerationError(
+      {
+        NEMOCLAW_WEB_SEARCH_ENABLED: "1",
+        NEMOCLAW_WEB_SEARCH_PROVIDER: "search.example.com",
+      },
       'Hermes NEMOCLAW_WEB_SEARCH_PROVIDER must be "tavily"',
     );
   });
 
   it("fails closed when Brave is requested for Hermes", () => {
-    const result = runConfigScriptRaw({
-      NEMOCLAW_WEB_SEARCH_ENABLED: "1",
-      NEMOCLAW_WEB_SEARCH_PROVIDER: "brave",
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(`${result.stderr}\n${result.stdout}`).toContain(
+    expectGenerationError(
+      {
+        NEMOCLAW_WEB_SEARCH_ENABLED: "1",
+        NEMOCLAW_WEB_SEARCH_PROVIDER: "brave",
+      },
       'Hermes NEMOCLAW_WEB_SEARCH_PROVIDER must be "tavily"',
     );
   });
@@ -501,12 +538,8 @@ describe("agents/hermes/generate-config.ts", () => {
   });
 
   it("fails fast for unsupported Hermes inference API values", () => {
-    const result = runConfigScriptRaw({
-      NEMOCLAW_INFERENCE_API: "graphql",
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(`${result.stderr}\n${result.stdout}`).toContain(
+    expectGenerationError(
+      { NEMOCLAW_INFERENCE_API: "graphql" },
       "Unsupported Hermes inference API: graphql",
     );
   });
@@ -526,8 +559,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(config.model.api_key).toBe(HERMES_PROXY_API_KEY_PLACEHOLDER);
   });
 
-  it("preserves Hermes remote platform toolsets while keeping CLI defaults unpinned", () => {
-    const { config } = runConfigScript({
+  it("preserves Hermes remote platform toolsets while keeping CLI defaults unpinned", async () => {
+    const { config } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson([
         "discord",
         "slack",
@@ -607,19 +640,17 @@ describe("agents/hermes/generate-config.ts", () => {
   });
 
   it("fails fast for unknown managed-tool gateway presets", () => {
-    const result = runConfigScriptRaw({
-      NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER: "1",
-      NEMOCLAW_HERMES_TOOL_GATEWAY_PRESETS_B64: encodeJson(["nous-web", "nous-typo"]),
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(`${result.stderr}\n${result.stdout}`).toContain(
+    expectGenerationError(
+      {
+        NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER: "1",
+        NEMOCLAW_HERMES_TOOL_GATEWAY_PRESETS_B64: encodeJson(["nous-web", "nous-typo"]),
+      },
       "Unknown Hermes managed-tool gateway preset: nous-typo",
     );
   });
 
-  it("emits only resolver placeholders for secret-shaped Hermes env keys", () => {
-    const { envFile } = runConfigScript({
+  it("emits only resolver placeholders for secret-shaped Hermes env keys", async () => {
+    const { envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson([
         "discord",
         "slack",
@@ -646,8 +677,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("OPENAI_API_KEY=");
   });
 
-  it("writes Discord settings in Hermes' top-level schema and keeps tokens in .env", () => {
-    const { config, envFile } = runConfigScript({
+  it("writes Discord settings in Hermes' top-level schema and keeps tokens in .env", async () => {
+    const { config, envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["discord"]),
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
         discord: ["1005536447329222676"],
@@ -699,19 +730,17 @@ describe("agents/hermes/generate-config.ts", () => {
       buildSteps: [],
     };
 
-    const result = runConfigScriptRaw({
+    const { envFile } = generateBaseConfig({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson([]),
       NEMOCLAW_MESSAGING_PLAN_B64: encodeJson(plan),
     });
-    const envFile = fs.readFileSync(path.join(tmpDir, ".hermes", ".env"), "utf-8");
 
-    expect(result.status, result.stderr).toBe(0);
     expect(envFile).toContain("DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN\n");
     expect(findRawSecretEnvEntries(envFile)).toEqual([]);
   });
 
-  it("preserves the Discord all-messages reply mode from onboarding", () => {
-    const { config } = runConfigScript({
+  it("preserves the Discord all-messages reply mode from onboarding", async () => {
+    const { config } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["discord"]),
       NEMOCLAW_DISCORD_GUILDS_B64: encodeJson({
         "1491590992753590594": {
@@ -723,8 +752,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(config.discord.require_mention).toBe(false);
   });
 
-  it("allows Discord server members when no explicit user allowlist is configured", () => {
-    const { envFile } = runConfigScript({
+  it("allows Discord server members when no explicit user allowlist is configured", async () => {
+    const { envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["discord"]),
       NEMOCLAW_DISCORD_GUILDS_B64: encodeJson({
         "1491590992753590594": {
@@ -737,8 +766,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("DISCORD_ALLOWED_USERS=");
   });
 
-  it("does not allow all Discord users for empty guild config keys", () => {
-    const { envFile } = runConfigScript({
+  it("does not allow all Discord users for empty guild config keys", async () => {
+    const { envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["discord"]),
       NEMOCLAW_DISCORD_GUILDS_B64: encodeJson({
         " ": {
@@ -751,8 +780,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("DISCORD_ALLOWED_USERS=");
   });
 
-  it("enables Slack under platforms and keeps Telegram top-level only when messaging tokens are configured", () => {
-    const { config, envFile } = runConfigScript({
+  it("enables Slack under platforms and keeps Telegram top-level only when messaging tokens are configured", async () => {
+    const { config, envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram", "slack"]),
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
         telegram: ["123456789"],
@@ -791,8 +820,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(Object.keys(config.platforms)).toEqual(["api_server"]);
   });
 
-  it("enables Slack under platforms even when the slack token allowlist is empty", () => {
-    const { config } = runConfigScript({
+  it("enables Slack under platforms even when the slack token allowlist is empty", async () => {
+    const { config } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["slack"]),
     });
 
@@ -800,7 +829,7 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(config.platforms.api_server.enabled).toBe(true);
   });
 
-  it("bridges captured WeChat metadata to Hermes' WEIXIN_* env contract", () => {
+  it("bridges captured WeChat metadata to Hermes' WEIXIN_* env contract", async () => {
     // Hermes' adapter reads WEIXIN_TOKEN + WEIXIN_ACCOUNT_ID (plus optional
     // WEIXIN_BASE_URL, WEIXIN_ALLOWED_USERS) per
     // https://hermes-agent.nousresearch.com/docs/user-guide/messaging/weixin.
@@ -808,7 +837,7 @@ describe("agents/hermes/generate-config.ts", () => {
     // WECHAT_BOT_TOKEN in the OpenShell credential store; the placeholder
     // must reference that name so L7 egress can resolve it without a
     // host-side credential rename.
-    const { config, envFile } = runConfigScript({
+    const { config, envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["wechat"]),
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
         wechat: ["bot_other_friend"],
@@ -840,8 +869,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).toContain("WEIXIN_ALLOWED_USERS=operator_self_id,bot_other_friend\n");
   });
 
-  it("enables Hermes WhatsApp without provider tokens", () => {
-    const { config, envFile } = runConfigScript({
+  it("enables Hermes WhatsApp without provider tokens", async () => {
+    const { config, envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["whatsapp"]),
     });
 
@@ -854,8 +883,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("openshell:resolve:env:WHATSAPP");
   });
 
-  it("emits Hermes WhatsApp allowed users when configured", () => {
-    const { envFile } = runConfigScript({
+  it("emits Hermes WhatsApp allowed users when configured", async () => {
+    const { envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["whatsapp"]),
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: encodeJson({
         whatsapp: ["15551234567", "15557654321"],
@@ -865,8 +894,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).toContain("WHATSAPP_ALLOWED_USERS=15551234567,15557654321\n");
   });
 
-  it("omits WeChat env when captured account metadata is incomplete", () => {
-    const { config, envFile } = runConfigScript({
+  it("omits WeChat env when captured account metadata is incomplete", async () => {
+    const { config, envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["wechat"]),
       NEMOCLAW_WECHAT_CONFIG_B64: encodeJson({
         baseUrl: "https://ilinkai.wechat.com",
@@ -879,8 +908,8 @@ describe("agents/hermes/generate-config.ts", () => {
     expect(envFile).not.toContain("WEIXIN_ACCOUNT_ID=");
   });
 
-  it("defaults Telegram behavior config when requireMention is non-canonical", () => {
-    const { config, envFile } = runConfigScript({
+  it("defaults Telegram behavior config when requireMention is non-canonical", async () => {
+    const { config, envFile } = await runConfigScriptWithMessaging({
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["telegram"]),
       NEMOCLAW_TELEGRAM_CONFIG_B64: encodeJson({ requireMention: "true" }),
     });
@@ -1003,22 +1032,16 @@ describe("agents/hermes/generate-config.ts", () => {
       },
     });
 
-    const result = runConfigScriptRaw({
-      NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR: registryDir,
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("unknown effects for agent 'hermes': openclawCompat");
+    expectGenerationError(
+      { NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR: registryDir },
+      "unknown effects for agent 'hermes': openclawCompat",
+    );
   });
 
   it("rejects empty match objects and invalid explicit registry overrides", () => {
     const missingRegistry = path.join(tmpDir, "missing-registry");
-    const missingRegistryResult = runConfigScriptRaw({
-      NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR: missingRegistry,
-    });
-
-    expect(missingRegistryResult.status).not.toBe(0);
-    expect(missingRegistryResult.stderr).toContain(
+    expectGenerationError(
+      { NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR: missingRegistry },
       "NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR must point to an existing directory",
     );
 
@@ -1033,11 +1056,9 @@ describe("agents/hermes/generate-config.ts", () => {
       },
     });
 
-    const emptyMatchResult = runConfigScriptRaw({
-      NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR: registryDir,
-    });
-
-    expect(emptyMatchResult.status).not.toBe(0);
-    expect(emptyMatchResult.stderr).toContain("field 'match' must be a non-empty object");
+    expectGenerationError(
+      { NEMOCLAW_MODEL_SPECIFIC_SETUP_DIR: registryDir },
+      "field 'match' must be a non-empty object",
+    );
   });
 });

--- a/test/helpers/rebuild-flow-credential-preflight-cases.ts
+++ b/test/helpers/rebuild-flow-credential-preflight-cases.ts
@@ -1,0 +1,391 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { createRebuildFlowHarness, installRebuildFlowTestHooks } from "./rebuild-flow-test-harness";
+
+type Harness = ReturnType<typeof createRebuildFlowHarness>;
+
+const MODEL = "test/model";
+
+function configureSession(
+  harness: Harness,
+  provider: string,
+  credentialEnv: string | null,
+  overrides: Record<string, unknown> = {},
+): void {
+  Object.assign(harness.session, {
+    sandboxName: "alpha",
+    provider,
+    model: MODEL,
+    credentialEnv,
+    ...overrides,
+  });
+}
+
+function providerRuntime(
+  registeredProviders: readonly string[],
+  credentialKeys: Record<string, string> = {},
+) {
+  return (args: string[]) => {
+    if (args[0] !== "provider" || args[1] !== "get") {
+      return { status: 0, output: "", stdout: "", stderr: "" };
+    }
+    const provider = args[2];
+    if (!registeredProviders.includes(provider)) {
+      return { status: 1, output: "", stdout: "", stderr: "provider missing" };
+    }
+    const credentialEnv = credentialKeys[provider] ?? "NVIDIA_INFERENCE_API_KEY";
+    const output = [
+      `Name: ${provider}`,
+      "Type: openai",
+      `Credential keys: ${credentialEnv}`,
+      "Config keys: OPENAI_BASE_URL",
+    ].join("\n");
+    return { status: 0, output, stdout: output, stderr: "" };
+  };
+}
+
+function diagnostics(harness: Harness): string {
+  return harness.errorSpy.mock.calls.flat().map(String).join("\n");
+}
+
+function makeMessagingPlan() {
+  return {
+    schemaVersion: 1,
+    sandboxName: "alpha",
+    agent: "hermes",
+    workflow: "onboard",
+    channels: [
+      {
+        channelId: "discord",
+        displayName: "discord",
+        authMode: "token-paste",
+        active: true,
+        selected: true,
+        configured: true,
+        disabled: false,
+        inputs: [],
+        hooks: [],
+      },
+    ],
+    disabledChannels: [],
+    credentialBindings: [],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  };
+}
+
+export function registerRebuildFlowCredentialPreflightTests(): void {
+  describe("rebuildSandbox flow: credential preflight", () => {
+    installRebuildFlowTestHooks();
+
+    it("aborts before backup when the target provider and credential are missing", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          provider: "nvidia-prod",
+          model: MODEL,
+          credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime([]),
+      });
+      configureSession(harness, "nvidia-prod", "NVIDIA_INFERENCE_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: nvidia-prod");
+
+      const output = diagnostics(harness);
+      expect(output).toContain("provider 'nvidia-prod' is not registered in OpenShell");
+      expect(output).toContain("NVIDIA_INFERENCE_API_KEY");
+      expect(output).not.toContain("provider credential not found");
+      expect(output).not.toContain("export NVIDIA_INFERENCE_API_KEY=<your-key>");
+      expect(output).toContain("Sandbox is untouched");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+      expect(harness.onboardSpy).not.toHaveBeenCalled();
+    });
+
+    it("continues when canonical hydration supplies a saved provider credential", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          provider: "nvidia-prod",
+          model: MODEL,
+          credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        },
+        hydrateCredentialEnv: (credentialEnv) =>
+          credentialEnv === "NVIDIA_INFERENCE_API_KEY" ? "saved-provider-key" : null,
+        runOpenshell: providerRuntime(["nvidia-prod"]),
+      });
+      configureSession(harness, "nvidia-prod", "NVIDIA_INFERENCE_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.hydrateCredentialEnvSpy).toHaveBeenCalledWith("NVIDIA_INFERENCE_API_KEY");
+      expect(harness.backupSandboxStateSpy).toHaveBeenCalledOnce();
+    });
+
+    it("does not let a host credential bypass a missing gateway provider", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          provider: "nvidia-prod",
+          model: MODEL,
+          credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        },
+        hydrateCredentialEnv: () => "host-provider-key",
+        runOpenshell: providerRuntime([]),
+      });
+      configureSession(harness, "nvidia-prod", "NVIDIA_INFERENCE_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: nvidia-prod");
+
+      expect(diagnostics(harness)).not.toContain("missing from gateway; recreating it");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+
+    it("copies the staged Hermes messaging plan into the rebuild resume session", async () => {
+      const plan = makeMessagingPlan();
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          agent: "hermes",
+          provider: "nvidia-prod",
+          model: MODEL,
+          credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        },
+        buildMessagingRebuildPlan: () => plan,
+        hydrateCredentialEnv: () => "saved-provider-key",
+        runOpenshell: providerRuntime(["nvidia-prod"]),
+      });
+      configureSession(harness, "nvidia-prod", "NVIDIA_INFERENCE_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.session.agent).toBe("hermes");
+      expect(
+        (harness.session.messagingPlan as typeof plan).channels.map((channel) => channel.channelId),
+      ).toEqual(["discord"]);
+      expect(harness.onboardSpy).toHaveBeenCalledOnce();
+    });
+
+    it("stops before backup when the agent base-image preflight fails", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { agent: "hermes" },
+        baseImagePreflight: { ok: false, imageRef: null, overrideEnvVar: null },
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.ensureRebuildAgentBaseImageSpy).toHaveBeenCalledOnce();
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+      expect(harness.onboardSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips credential hydration for local inference", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider: "ollama-local", model: MODEL, credentialEnv: null },
+        hydrateCredentialEnv: () => {
+          throw new Error("local inference must not hydrate a credential");
+        },
+      });
+      configureSession(harness, "ollama-local", null);
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.hydrateCredentialEnvSpy).not.toHaveBeenCalled();
+      expect(harness.backupSandboxStateSpy).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+      "ollama-local",
+      "vllm-local",
+    ])("migrates a legacy %s target away from OPENAI_API_KEY (#2519)", async (provider) => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider, model: MODEL, credentialEnv: "OPENAI_API_KEY" },
+      });
+      configureSession(harness, provider, "OPENAI_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      const output = harness.logSpy.mock.calls.flat().map(String).join("\n");
+      expect(output).toContain("GH #2519");
+      expect(output).toContain(provider);
+      expect(harness.session.credentialEnv).toBeNull();
+      expect(harness.backupSandboxStateSpy).toHaveBeenCalledOnce();
+    });
+
+    it("fails closed when a matching session omits the remote target credential", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider: "openai-api", model: MODEL, credentialEnv: null },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime([]),
+      });
+      configureSession(harness, "openai-api", null);
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: openai-api");
+
+      expect(diagnostics(harness)).toContain("OPENAI_API_KEY");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+
+    it("uses the registry target instead of a stale provider in the matching session", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider: "openai-api", model: MODEL, credentialEnv: null },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime(["nvidia-prod"]),
+      });
+      configureSession(harness, "nvidia-prod", null);
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: openai-api");
+
+      expect(diagnostics(harness)).toContain("provider 'openai-api' is not registered");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not let a mismatched stale local session bypass the remote target preflight", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider: "openai-api", model: MODEL, credentialEnv: null },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime([]),
+      });
+      configureSession(harness, "ollama-local", "OPENAI_API_KEY", {
+        sandboxName: "other-local-sandbox",
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: openai-api");
+
+      const output = diagnostics(harness);
+      expect(output).toContain("OPENAI_API_KEY");
+      expect(output).not.toContain("GH #2519");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+
+    it("applies the same missing-provider preflight to non-NVIDIA remotes", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { provider: "openai-api", model: MODEL },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime([]),
+      });
+      configureSession(harness, "openai-api", "OPENAI_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: openai-api");
+
+      expect(diagnostics(harness)).toContain("OPENAI_API_KEY");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+
+    it("reuses a registered Hermes OAuth provider without a host OpenAI key", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          agent: "hermes",
+          provider: "hermes-provider",
+          model: MODEL,
+          credentialEnv: "OPENAI_API_KEY",
+          hermesAuthMethod: "oauth",
+        },
+        hermesCredentialKeys: ["OPENAI_API_KEY"],
+        hermesProviderExists: true,
+        hydrateCredentialEnv: () => null,
+      });
+      configureSession(harness, "hermes-provider", "OPENAI_API_KEY", {
+        hermesAuthMethod: "oauth",
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(diagnostics(harness)).not.toContain("Missing credential: OPENAI_API_KEY");
+      expect(harness.backupSandboxStateSpy).toHaveBeenCalledOnce();
+    });
+
+    it("reuses a registered nvidia-prod provider without a host key", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          provider: "nvidia-prod",
+          model: MODEL,
+          credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime(["nvidia-prod"]),
+      });
+      configureSession(harness, "nvidia-prod", "NVIDIA_INFERENCE_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(diagnostics(harness)).not.toContain("Missing credential: NVIDIA_INFERENCE_API_KEY");
+      expect(harness.backupSandboxStateSpy).toHaveBeenCalledOnce();
+    });
+
+    it("rejects nvidia-prod when both gateway registration and host key are missing", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          provider: "nvidia-prod",
+          model: MODEL,
+          credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+        },
+        hydrateCredentialEnv: () => null,
+        runOpenshell: providerRuntime([]),
+      });
+      configureSession(harness, "nvidia-prod", "NVIDIA_INFERENCE_API_KEY");
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing gateway provider: nvidia-prod");
+
+      expect(diagnostics(harness)).toContain("Sandbox is untouched");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects missing Hermes OAuth state before backup", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: {
+          agent: "hermes",
+          provider: "hermes-provider",
+          model: MODEL,
+          credentialEnv: "OPENAI_API_KEY",
+          hermesAuthMethod: "oauth",
+        },
+        hermesProviderExists: false,
+        hydrateCredentialEnv: () => null,
+      });
+      configureSession(harness, "hermes-provider", "OPENAI_API_KEY", {
+        hermesAuthMethod: "oauth",
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Missing Hermes Provider credentials");
+
+      const output = diagnostics(harness);
+      expect(output).toContain("Hermes Provider is not registered in OpenShell");
+      expect(output).toContain("credentials must be stored in OpenShell");
+      expect(output).not.toContain("Missing credential: OPENAI_API_KEY");
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+    });
+  });
+}

--- a/test/helpers/rebuild-flow-lifecycle-cases.ts
+++ b/test/helpers/rebuild-flow-lifecycle-cases.ts
@@ -12,6 +12,26 @@ import {
 export function registerRebuildFlowLifecycleTests(): void {
   describe("rebuildSandbox flow: lifecycle", () => {
     installRebuildFlowTestHooks();
+
+    it("rejects a multi-agent sandbox before backup, onboard, or deletion", async () => {
+      const harness = createRebuildFlowHarness({
+        sandboxEntry: { agents: [{ name: "openclaw" }, { name: "hermes" }] },
+      });
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("Multi-agent sandbox rebuild is not yet supported");
+
+      expect(harness.backupSandboxStateSpy).not.toHaveBeenCalled();
+      expect(harness.onboardSpy).not.toHaveBeenCalled();
+      expect(harness.removeSandboxRegistryEntryWithReceiptSpy).not.toHaveBeenCalled();
+      expect(
+        harness.runOpenshellSpy.mock.calls.some(
+          ([args]) => Array.isArray(args) && args.join(" ") === "sandbox delete alpha",
+        ),
+      ).toBe(false);
+    });
+
     it("backs up, recreates, restores, reapplies policy, and relocks on a successful OpenClaw rebuild", async () => {
       const mcpEntry = {
         server: "github",

--- a/test/helpers/rebuild-flow-test-harness.ts
+++ b/test/helpers/rebuild-flow-test-harness.ts
@@ -41,6 +41,7 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   const agentDefs = requireDist("../../agent/defs.js");
   const agentRuntime = requireDist("../../agent/runtime.js");
   const onboardMod = requireDist("../../onboard.js");
+  const onboardCredentialEnv = requireDist("../../onboard/credential-env.js");
   const hermesProviderAuth = requireDist("../../hermes-provider-auth.js");
   const onboardSession = requireDist("../../state/onboard-session.js");
   const registry = requireDist("../../state/registry.js");
@@ -137,6 +138,24 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   vi.spyOn(agentDefs, "loadAgent").mockReturnValue(agentDef);
   vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue({ name: "openclaw" });
   vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw");
+  const defaultHydrateCredentialEnv =
+    onboardCredentialEnv.hydrateCredentialEnv.bind(onboardCredentialEnv);
+  const hydrateCredentialEnvSpy = vi
+    .spyOn(onboardMod, "hydrateCredentialEnv")
+    .mockImplementation((...args: unknown[]) => {
+      const credentialEnv = String(args[0] ?? "");
+      return overrides.hydrateCredentialEnv
+        ? overrides.hydrateCredentialEnv(credentialEnv)
+        : defaultHydrateCredentialEnv(credentialEnv);
+    });
+  vi.spyOn(onboardCredentialEnv, "hydrateCredentialEnv").mockImplementation(
+    (...args: unknown[]) => {
+      const credentialEnv = String(args[0] ?? "");
+      return overrides.hydrateCredentialEnv
+        ? overrides.hydrateCredentialEnv(credentialEnv)
+        : defaultHydrateCredentialEnv(credentialEnv);
+    },
+  );
   vi.spyOn(hermesProviderAuth, "inspectHermesProviderBinding").mockReturnValue({
     exists: overrides.hermesProviderExists ?? true,
     credentialKeys:
@@ -427,6 +446,7 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     ensureRebuildAgentBaseImageSpy,
     ensureTargetGatewaySpy,
     ensureValidatedBraveSearchCredentialSpy,
+    hydrateCredentialEnvSpy,
     logSpy,
     markStepFailedSpy,
     onboardSpy,

--- a/test/helpers/rebuild-flow-test-support.ts
+++ b/test/helpers/rebuild-flow-test-support.ts
@@ -80,6 +80,7 @@ export type RebuildFlowOverrides = {
   ensureValidatedWebSearchCredential?: () => Promise<unknown>;
   hermesCredentialKeys?: string[] | null;
   hermesProviderExists?: boolean;
+  hydrateCredentialEnv?: (credentialEnv: string) => string | null;
   customImagePreflight?: RebuildImagePreflightResult;
   defaultSelectionRevision?: number;
   preDeleteDefaultSelectionRevision?: number;
@@ -97,6 +98,7 @@ export type RebuildFlowHarness = {
   ensureRebuildAgentBaseImageSpy: MockInstance;
   ensureTargetGatewaySpy: MockInstance;
   ensureValidatedBraveSearchCredentialSpy: MockInstance;
+  hydrateCredentialEnvSpy: MockInstance;
   logSpy: MockInstance;
   markStepFailedSpy: MockInstance;
   onboardSpy: MockInstance;

--- a/test/messaging-plan-test-helper.ts
+++ b/test/messaging-plan-test-helper.ts
@@ -74,6 +74,53 @@ export function withLegacyMessagingPlanEnv(
   };
 }
 
+/** Build a legacy messaging plan in-process for tests that do not need a process boundary. */
+export async function withLegacyMessagingPlanEnvDirect(
+  env: Record<string, string>,
+  agent: MessagingPlanAgent,
+): Promise<Record<string, string>> {
+  if (env.NEMOCLAW_MESSAGING_PLAN_B64) return env;
+  const channels = decodeJsonEnv<string[]>(env, "NEMOCLAW_MESSAGING_CHANNELS_B64", []);
+  if (!Array.isArray(channels) || channels.length === 0) return env;
+
+  const normalizedEnv = {
+    ...env,
+    ...legacyMessagingConfigEnv(env),
+  };
+  const {
+    createBuiltInChannelManifestRegistry,
+    createBuiltInMessagingHookRegistry,
+    createBuiltInRenderTemplateResolver,
+    MessagingSetupApplier,
+    MessagingWorkflowPlanner,
+  } = await import("../src/lib/messaging/index.ts");
+  const plan = await withProcessEnv(normalizedEnv, () =>
+    new MessagingWorkflowPlanner(
+      createBuiltInChannelManifestRegistry(),
+      createBuiltInMessagingHookRegistry({
+        wechat: {
+          seedOpenClawAccount: {
+            now: () => "2026-01-01T00:00:00.000Z",
+          },
+        },
+      }),
+      createBuiltInRenderTemplateResolver(),
+    ).buildPlan({
+      sandboxName: "test-sandbox",
+      agent,
+      workflow: "rebuild",
+      isInteractive: false,
+      configuredChannels: [...new Set(channels)],
+      credentialAvailability: credentialAvailability(),
+    }),
+  );
+
+  return {
+    ...env,
+    NEMOCLAW_MESSAGING_PLAN_B64: MessagingSetupApplier.encodePlan(plan),
+  };
+}
+
 export function buildMessagingPlanB64(
   env: Record<string, string>,
   agent: MessagingPlanAgent,
@@ -225,6 +272,18 @@ function decodeJsonEnv<T>(env: Record<string, string>, name: string, fallback: T
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function withProcessEnv<T>(env: Record<string, string>, run: () => Promise<T>): Promise<T> {
+  const originalEnv = { ...process.env };
+  try {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, env);
+    return await run();
+  } finally {
+    for (const key of Object.keys(process.env)) delete process.env[key];
+    Object.assign(process.env, originalEnv);
+  }
 }
 
 function credentialAvailability(): Record<string, boolean> {

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -75,7 +75,7 @@ function createPromptHarness({
     },
     selectFromNumberedMenuOrExit: (_rawChoice, defaultIdx, options) => {
       const selected = options[defaultIdx - 1];
-      if (selected === undefined) throw new Error("numbered menu default is out of range");
+      assert.ok(selected !== undefined, "numbered menu default is out of range");
       return selected;
     },
     makeOnboardCancelExit: (_rollback, cleanup) => () => cleanup(),

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -1,23 +1,38 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Integration tests for the tier selector in the onboarding wizard.
-// Verifies that selectPolicyTier and setupPoliciesWithSelection wire correctly.
+// Policy-tier behavior is exercised directly through the typed selection
+// seams. Only the two adapter contracts whose behavior includes real process
+// exit ordering remain isolated in child processes.
 
 import assert from "node:assert/strict";
 import { type SpawnSyncReturns, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it } from "vitest";
+import { afterEach, describe, it, type MockInstance, vi } from "vitest";
+
+import { parsePolicyPresetEnv } from "../src/lib/core/url-utils";
+import {
+  type SetupPolicySelectionDeps,
+  type SetupPolicySelectionOptions,
+  setupPoliciesWithSelection,
+} from "../src/lib/onboard/policy-selection";
+import {
+  createPolicySelectionPromptHelpers,
+  type PolicySelectionPromptDeps,
+} from "../src/lib/onboard/policy-selection-prompts";
+import { resolvePolicyTierFromEnv } from "../src/lib/onboard/policy-tier-env";
+import * as policy from "../src/lib/policy";
+import * as tiers from "../src/lib/policy/tiers";
+
+vi.mock("../src/lib/onboard/policy-context-seed", () => ({
+  seedInitialPolicyContext: vi.fn(),
+}));
 
 const repoRoot = path.join(import.meta.dirname, "..");
 
-/**
- * Run a small inline Node script that mocks out the minimal dependencies of
- * onboard.js, calls the given async expression, and prints a JSON payload.
- */
-function runScript(
+function runAdapterScript(
   scriptBody: string,
   envOverrides: Record<string, string | undefined> = {},
 ): SpawnSyncReturns<string> {
@@ -43,113 +58,136 @@ function runScript(
   return result;
 }
 
-/**
- * Build a minimal mock preamble that stubs out the heavy I/O dependencies of
- * onboard.js so we can require it without a real openshell installation.
- *
- * Sets NEMOCLAW_POLICY_TIER, NEMOCLAW_POLICY_MODE, and NEMOCLAW_POLICY_PRESETS
- * before the require so non-interactive paths read the right values.
- */
-function buildPreamble({
-  tierEnv = "balanced",
-  policyMode = "skip",
-  policyPresets = "",
-  stubOpenshellBin = false,
-  runCaptureReturn = "",
-} = {}): string {
-  const credPath = JSON.stringify(path.join(repoRoot, "src", "lib", "credentials", "store.ts"));
-  const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-  const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-  const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-  const resolveOpenshellPath = JSON.stringify(
-    path.join(repoRoot, "src", "lib", "adapters", "openshell", "resolve.ts"),
-  );
-
-  // Both stubs must run before onboard.js is required — onboard destructures
-  // resolveOpenshell and runCapture at require time, so later overrides are
-  // too late for anything onboard calls internally.
-  const openshellStub = stubOpenshellBin
-    ? `require(${resolveOpenshellPath}).resolveOpenshell = () => "/usr/bin/true";`
-    : "";
-
-  return String.raw`
-const credentials = require(${credPath});
-const runner = require(${runnerPath});
-const registry = require(${registryPath});
-
-Object.defineProperty(process, "platform", { value: "darwin" });
-
-// Stub heavy I/O
-credentials.prompt = async (msg) => { throw new Error("unexpected prompt: " + msg); };
-credentials.ensureApiKey = async () => {};
-credentials.getCredential = () => null;
-runner.run = () => {};
-runner.runCapture = (command) => {
-  const text = Array.isArray(command) ? command.join(" ") : String(command);
-  if (text.includes("sandbox list")) return "test-sb Ready";
-  return ${JSON.stringify(runCaptureReturn)};
-};
-${openshellStub}
-
-const updates = [];
-registry.registerSandbox = () => true;
-registry.updateSandbox = (_name, fields) => { updates.push(fields); return true; };
-registry.getSandbox = () => ({ name: "test-sb", model: null, provider: null });
-
-// Set env vars before requiring onboard so module-level code sees them
-process.env.NEMOCLAW_POLICY_TIER = ${JSON.stringify(tierEnv)};
-process.env.NEMOCLAW_POLICY_MODE = ${JSON.stringify(policyMode)};
-process.env.NEMOCLAW_POLICY_PRESETS = ${JSON.stringify(policyPresets)};
-
-const { selectPolicyTier, setupPoliciesWithSelection } = require(${onboardPath});
-`;
+function createPromptHarness({
+  notes = [],
+  nonInteractive = true,
+}: {
+  notes?: string[];
+  nonInteractive?: boolean;
+} = {}) {
+  const deps: PolicySelectionPromptDeps = {
+    tiers,
+    policyTierEnv: { resolvePolicyTierFromEnv },
+    isNonInteractive: () => nonInteractive,
+    note: (message) => notes.push(message),
+    prompt: async (question) => {
+      throw new Error(`unexpected prompt: ${question}`);
+    },
+    selectFromNumberedMenuOrExit: (_rawChoice, defaultIdx, options) => {
+      const selected = options[defaultIdx - 1];
+      if (selected === undefined) throw new Error("numbered menu default is out of range");
+      return selected;
+    },
+    makeOnboardCancelExit: (_rollback, cleanup) => () => cleanup(),
+    sandboxCancelRollback: { markCancelled: () => undefined },
+    useColor: false,
+  };
+  return { helpers: createPolicySelectionPromptHelpers(deps), notes };
 }
 
-describe("policy tier onboarding integration", () => {
-  it("selectPolicyTier returns selected tier name in non-interactive mode", () => {
-    const script =
-      buildPreamble({ tierEnv: "balanced" }) +
-      String.raw`
-// Suppress note() output so stdout is clean JSON
-console.log = () => {};
-(async () => {
-  const tier = await selectPolicyTier();
-  process.stdout.write(JSON.stringify({ tier }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.tier, "balanced");
-  });
+type TestPreset = { name: string; description?: string; access?: string };
 
-  it("rejects unknown NEMOCLAW_POLICY_TIER with a clear error and non-zero exit (#3741)", () => {
-    const script =
-      buildPreamble({ tierEnv: "invalid_tier" }) +
-      String.raw`
-console.log = () => {};
-(async () => {
-  await selectPolicyTier();
-  process.stdout.write("UNEXPECTED_SUCCESS\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(99); });
-`;
-    const result = runScript(script);
-    assert.equal(
-      result.status,
-      1,
-      `expected exit 1 from process.exit, got ${result.status}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
-    );
-    assert.match(
-      result.stderr,
-      /Unknown policy tier: invalid_tier\. Valid: restricted, balanced, open/,
-      `stderr must list the accepted tiers verbatim; got: ${result.stderr}`,
-    );
-    assert.ok(
-      !result.stdout.includes("UNEXPECTED_SUCCESS"),
-      "selectPolicyTier should have exited before returning",
-    );
-  });
+type SetupHarnessOptions = {
+  tierName?: string;
+  policyMode?: string;
+  policyPresets?: string;
+  currentApplied?: string[];
+  customPresets?: TestPreset[];
+  recordedPolicyTier?: string | null;
+  env?: NodeJS.ProcessEnv;
+};
 
+function createSetupHarness({
+  tierName = "balanced",
+  policyMode = "suggested",
+  policyPresets = "",
+  currentApplied = [],
+  customPresets = [],
+  recordedPolicyTier = null,
+  env = {},
+}: SetupHarnessOptions = {}) {
+  const notes: string[] = [];
+  const syncCalls: Array<{
+    sandboxName: string;
+    current: string[];
+    selected: string[];
+    accessByName?: Record<string, string>;
+  }> = [];
+  const appliedCalls: string[] = [];
+  const removedCalls: string[] = [];
+  const tierUpdates: Array<{ sandboxName: string; policyTier: string }> = [];
+
+  const deps: SetupPolicySelectionDeps = {
+    policies: {
+      setupPolicyPresetSupported: policy.setupPolicyPresetSupported,
+      listSetupPolicyPresets: (_sandboxName, options = {}) => [
+        ...policy.filterSetupPolicyPresets(
+          policy.listPresets({ agent: options.agent ?? null }),
+          options,
+        ),
+        ...customPresets,
+      ],
+      listCustomPresets: () => customPresets,
+      getAppliedPresets: () => [...currentApplied],
+      clampSetupPolicyPresetNames: policy.clampSetupPolicyPresetNames,
+    },
+    tiers,
+    localInferenceProviders: ["ollama-local", "vllm-local"],
+    step: () => undefined,
+    note: (message) => notes.push(message),
+    isNonInteractive: () => true,
+    waitForSandboxReady: () => true,
+    syncPresetSelection: (sandboxName, current, selected, accessByName) => {
+      syncCalls.push({
+        sandboxName,
+        current: [...current],
+        selected: [...selected],
+        ...(accessByName ? { accessByName: { ...accessByName } } : {}),
+      });
+      const selectedSet = new Set(selected);
+      const currentSet = new Set(current);
+      removedCalls.push(...current.filter((name) => !selectedSet.has(name)));
+      appliedCalls.push(...selected.filter((name) => !currentSet.has(name)));
+    },
+    selectPolicyTier: async () => tierName,
+    setPolicyTier: (sandboxName, policyTier) => {
+      tierUpdates.push({ sandboxName, policyTier });
+    },
+    getRecordedPolicyTier: () => recordedPolicyTier,
+    selectTierPresetsAndAccess: async (selectedTier, presets, extraSelected) => {
+      const promptHarness = createPromptHarness();
+      return promptHarness.helpers.selectTierPresetsAndAccess(selectedTier, presets, extraSelected);
+    },
+    parsePolicyPresetEnv,
+    env: {
+      NEMOCLAW_POLICY_MODE: policyMode,
+      NEMOCLAW_POLICY_PRESETS: policyPresets,
+      ...env,
+    },
+  };
+
+  return { appliedCalls, deps, notes, removedCalls, syncCalls, tierUpdates };
+}
+
+async function runPolicySetup(
+  harnessOptions: SetupHarnessOptions = {},
+  selectionOptions: SetupPolicySelectionOptions = {},
+) {
+  const harness = createSetupHarness(harnessOptions);
+  const applied = await setupPoliciesWithSelection(harness.deps, "test-sb", selectionOptions);
+  return { ...harness, applied };
+}
+
+function warningText(spy: MockInstance): string {
+  return spy.mock.calls.map((args) => args.map(String).join(" ")).join("\n");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("policy tier onboarding adapter contracts", () => {
   it("rejects unknown NEMOCLAW_POLICY_TIER before usage notice or preflight (#3741)", () => {
     const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
     const script = String.raw`
@@ -190,7 +228,7 @@ process.exit = (code = 0) => {
   }
 })();
 `;
-    const result = runScript(script);
+    const result = runAdapterScript(script);
     assert.equal(result.status, 1, result.stderr);
     const payload = JSON.parse(result.stdout.trim().split(/\n/).at(-1) || "{}");
     assert.equal(payload.exitCode, 1);
@@ -237,1254 +275,471 @@ process.exit = (code = 0) => {
   }
 })();
 `;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: undefined });
+    const result = runAdapterScript(script, { NEMOCLAW_NON_INTERACTIVE: undefined });
     assert.equal(result.status, 1, result.stderr);
     assert.doesNotMatch(result.stderr, /Unknown policy tier: invalid_tier/);
     assert.match(result.stderr, /Interactive onboarding requires a TTY/);
     assert.ok(!result.stdout.includes("UNEXPECTED_SUCCESS"));
   });
 
-  it("treats whitespace-only NEMOCLAW_POLICY_TIER as the balanced default", () => {
-    const script =
-      buildPreamble({ tierEnv: "   " }) +
-      String.raw`
+  it("persists the selected tier through the onboard registry adapter", () => {
+    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+    const policyPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
+    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
+    const refreshPath = JSON.stringify(
+      path.join(repoRoot, "src", "lib", "actions", "sandbox", "policy-context-refresh.ts"),
+    );
+    const script = String.raw`
+const registry = require(${registryPath});
+const updates = [];
+registry.getSandbox = () => ({ name: "test-sb", model: null, provider: null });
+registry.updateSandbox = (_name, fields) => { updates.push(fields); return true; };
+
+process.env.NEMOCLAW_NON_INTERACTIVE = "1";
+process.env.NEMOCLAW_POLICY_TIER = "open";
+process.env.NEMOCLAW_POLICY_MODE = "skip";
+process.env.NEMOCLAW_POLICY_PRESETS = "";
+
+const { setupPoliciesWithSelection } = require(${onboardPath});
+const policies = require(${policyPath});
+policies.getAppliedPresets = () => [];
+require(${refreshPath}).refreshSandboxPolicyContextFile = () => ({ status: "ok" });
 console.log = () => {};
+
 (async () => {
-  const tier = await selectPolicyTier();
-  process.stdout.write(JSON.stringify({ tier }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
+  try {
+    const applied = await setupPoliciesWithSelection("test-sb", {});
+    process.stdout.write(JSON.stringify({ applied, updates }) + "\n");
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ error: err.message, stack: err.stack, updates }) + "\n");
+  }
+})();
 `;
-    const result = runScript(script);
+    const result = runAdapterScript(script);
     assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.tier, "balanced");
+    const payload = JSON.parse(result.stdout.trim().split(/\n/).at(-1) || "{}");
+    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
+    assert.deepEqual(payload.applied, []);
+    assert.equal(
+      payload.updates.find((update: { policyTier?: string }) => update.policyTier !== undefined)
+        ?.policyTier,
+      "open",
+    );
+  });
+});
+
+describe("policy tier selection", () => {
+  it("returns the selected tier name in non-interactive mode", async () => {
+    vi.stubEnv("NEMOCLAW_POLICY_TIER", "balanced");
+    const { helpers } = createPromptHarness();
+
+    assert.equal(await helpers.selectPolicyTier(), "balanced");
+  });
+
+  it("rejects unknown NEMOCLAW_POLICY_TIER with a clear error and exit code 1 (#3741)", () => {
+    vi.stubEnv("NEMOCLAW_POLICY_TIER", "invalid_tier");
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args) => errors.push(args.join(" ")));
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${String(code)})`);
+    }) as never);
+
+    assert.throws(() => resolvePolicyTierFromEnv(), /process\.exit\(1\)/);
+    assert.equal(exit.mock.calls[0]?.[0], 1);
+    assert.match(
+      errors.join("\n"),
+      /Unknown policy tier: invalid_tier\. Valid: restricted, balanced, open/,
+    );
+  });
+
+  it("treats whitespace-only NEMOCLAW_POLICY_TIER as the balanced default", async () => {
+    vi.stubEnv("NEMOCLAW_POLICY_TIER", "   ");
+    const { helpers } = createPromptHarness();
+
+    assert.equal(await helpers.selectPolicyTier(), "balanced");
   });
 
   it("restricted tier produces an empty preset list", () => {
-    const tiersPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "tiers.ts"));
-    const script =
-      buildPreamble({ tierEnv: "restricted" }) +
-      String.raw`
-console.log = () => {};
-(async () => {
-  const tier = await selectPolicyTier();
-  const tiers = require(${tiersPath});
-  const presets = tiers.resolveTierPresets(tier);
-  process.stdout.write(JSON.stringify({ tier, presets }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.tier, "restricted");
-    assert.equal(payload.presets.length, 0);
+    assert.deepEqual(tiers.resolveTierPresets("restricted"), []);
   });
 
   it("balanced tier resolves exactly the five dev presets read-write without weather", () => {
-    const tiersPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "tiers.ts"));
-    const script =
-      buildPreamble({ tierEnv: "balanced" }) +
-      String.raw`
-console.log = () => {};
-(async () => {
-  const tier = await selectPolicyTier();
-  const tiers = require(${tiersPath});
-  const presets = tiers.resolveTierPresets(tier);
-  process.stdout.write(JSON.stringify({ tier, presets }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.tier, "balanced");
-    const names: string[] = payload.presets.map((p: { name: string }) => p.name);
+    const presets = tiers.resolveTierPresets("balanced");
+    const names = presets.map((preset) => preset.name);
     assert.deepEqual(
       [...names].sort(),
       ["brave", "brew", "huggingface", "npm", "pypi"],
       "balanced tier must resolve exactly brave, brew, huggingface, npm, pypi",
     );
-    const accessByName = new Map(
-      payload.presets.map((p: { name: string; access: string }) => [p.name, p.access]),
-    );
+    const accessByName = new Map(presets.map((preset) => [preset.name, preset.access]));
     for (const name of ["npm", "pypi", "huggingface", "brew", "brave"]) {
       assert.equal(accessByName.get(name), "read-write", `${name} should be read-write`);
     }
   });
 
-  it("open tier resolves presets including at least one social/messaging preset", () => {
-    const tiersPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "tiers.ts"));
-    const script =
-      buildPreamble({ tierEnv: "open" }) +
-      String.raw`
-console.log = () => {};
-(async () => {
-  const tier = await selectPolicyTier();
-  const tiers = require(${tiersPath});
-  const presets = tiers.resolveTierPresets(tier);
-  process.stdout.write(JSON.stringify({ tier, presets }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.tier, "open");
-    const names: string[] = payload.presets.map((p: { name: string }) => p.name);
+  it("open tier resolves presets including at least one social or messaging preset", () => {
+    const names = tiers.resolveTierPresets("open").map((preset) => preset.name);
     const social = ["slack", "discord", "telegram", "whatsapp"];
-    const hasSocial = social.some((n) => names.includes(n));
     assert.ok(
-      hasSocial,
+      social.some((name) => names.includes(name)),
       `open tier must include at least one social preset, got: ${names.join(", ")}`,
     );
   });
 
-  it("a preset can be deselected via selected option in resolveTierPresets", () => {
-    const tiersPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "tiers.ts"));
-    const script =
-      buildPreamble({ tierEnv: "balanced" }) +
-      String.raw`
-(async () => {
-  const tiers = require(${tiersPath});
-  // Deselect npm — keep only the remaining names
-  const allPresets = tiers.resolveTierPresets("balanced");
-  const withoutNpm = allPresets.filter((p) => p.name !== "npm").map((p) => p.name);
-  const resolved = tiers.resolveTierPresets("balanced", { selected: withoutNpm });
-  process.stdout.write(JSON.stringify({ resolved }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(
-      !payload.resolved.map((p: { name: string }) => p.name).includes("npm"),
-      "npm should be deselected",
-    );
+  it("allows a preset to be deselected through the selected option", () => {
+    const withoutNpm = tiers
+      .resolveTierPresets("balanced")
+      .filter((preset) => preset.name !== "npm")
+      .map((preset) => preset.name);
+    const resolved = tiers.resolveTierPresets("balanced", { selected: withoutNpm });
+
+    assert.ok(!resolved.map((preset) => preset.name).includes("npm"), "npm should be deselected");
   });
 
-  it("access level can be restricted from read-write to read via override", () => {
-    const tiersPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "tiers.ts"));
-    const script =
-      buildPreamble({ tierEnv: "balanced" }) +
-      String.raw`
-(async () => {
-  const tiers = require(${tiersPath});
-  const resolved = tiers.resolveTierPresets("balanced", { overrides: { npm: "read" } });
-  const npm = resolved.find((p) => p.name === "npm");
-  const pypi = resolved.find((p) => p.name === "pypi");
-  process.stdout.write(JSON.stringify({ npmAccess: npm.access, pypiAccess: pypi.access }) + "\n");
-})().catch((err) => { process.stderr.write(err.message + "\n"); process.exit(1); });
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.equal(payload.npmAccess, "read");
-    assert.equal(payload.pypiAccess, "read-write");
+  it("allows access to be restricted from read-write to read through an override", () => {
+    const resolved = tiers.resolveTierPresets("balanced", { overrides: { npm: "read" } });
+    assert.equal(resolved.find((preset) => preset.name === "npm")?.access, "read");
+    assert.equal(resolved.find((preset) => preset.name === "pypi")?.access, "read-write");
   });
 
-  it("selectPolicyTier emits a note containing the tier name", () => {
-    const script =
-      buildPreamble({ tierEnv: "balanced" }) +
-      String.raw`
-const lines = [];
-const origLog = console.log;
-console.log = (...args) => lines.push(args.join(" "));
+  it("emits a note containing the selected tier name", async () => {
+    vi.stubEnv("NEMOCLAW_POLICY_TIER", "balanced");
+    const { helpers, notes } = createPromptHarness();
 
-(async () => {
-  try {
-    const tier = await selectPolicyTier();
-    lines.push("TIER:" + tier);
-    origLog(JSON.stringify({ lines }));
-  } catch (err) {
-    console.log = origLog;
-    origLog(JSON.stringify({ lines, error: err.message }));
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    // non-interactive note includes the tier name
+    const selected = await helpers.selectPolicyTier();
+
+    assert.equal(selected, "balanced");
     assert.ok(
-      payload.lines.some((l: string) => l.includes("balanced")),
-      `summary must mention balanced tier, got: ${JSON.stringify(payload.lines)}`,
-    );
-    assert.ok(payload.lines.some((l: string) => l.includes("TIER:balanced")));
-  });
-
-  it("selected tier is persisted to the registry via updateSandbox({ policyTier })", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({ tierEnv: "open", policyMode: "skip" }) +
-      String.raw`
-const policies = require(${policiesPath});
-policies.applyPreset = () => {};
-policies.applyPresets = () => true;
-policies.getAppliedPresets = () => [];
-
-const lines = [];
-const origLog = console.log;
-console.log = (...args) => lines.push(args.join(" "));
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {});
-    console.log = origLog;
-    origLog(JSON.stringify({ applied, updates }));
-  } catch (err) {
-    console.log = origLog;
-    origLog(JSON.stringify({ error: err.message, updates }));
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    // registry.updateSandbox must have been called with policyTier: "open"
-    const tierUpdate = payload.updates.find(
-      (u: { policyTier?: string }) => u.policyTier !== undefined,
-    );
-    assert.ok(
-      tierUpdate,
-      `updateSandbox should have been called with policyTier, updates: ${JSON.stringify(payload.updates)}`,
-    );
-    assert.equal(tierUpdate.policyTier, "open");
-    // With POLICY_MODE=skip, applied presets list is empty
-    assert.deepEqual(payload.applied, []);
-  });
-
-  it("omits Brave from policy preset selection when web search is unsupported", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { webSearchSupported: false });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("brave"),
-      `Unsupported web-search presets included Brave: ${payload.applied}`,
-    );
-    assert.ok(
-      !payload.appliedCalls.includes("brave"),
-      `Unsupported web-search flow applied Brave: ${payload.appliedCalls}`,
-    );
-    assert.ok(payload.applied.includes("pypi"), "normal dev presets should still be included");
-  });
-
-  it("removes a previously-applied Brave preset when web search is unsupported", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["brave", "npm"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { webSearchSupported: false });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("brave"),
-      `Unsupported web-search presets included Brave: ${payload.applied}`,
-    );
-    assert.ok(
-      payload.removedCalls.includes("brave"),
-      `Unsupported web-search flow did not remove Brave: ${payload.removedCalls}`,
-    );
-    assert.ok(
-      !payload.appliedCalls.includes("brave"),
-      `Unsupported web-search flow applied Brave: ${payload.appliedCalls}`,
-    );
-  });
-
-  it("removes a previously-applied built-in Brave preset when Brave search is declined", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["brave", "npm"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      webSearchConfig: null,
-      webSearchSupported: true,
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("brave"),
-      `Declined Brave search flow kept built-in Brave: ${payload.applied}`,
-    );
-    assert.ok(
-      payload.removedCalls.includes("brave"),
-      `Declined Brave search flow did not remove built-in Brave: ${payload.removedCalls}`,
-    );
-    assert.ok(
-      !payload.appliedCalls.includes("brave"),
-      `Declined Brave search flow applied built-in Brave: ${payload.appliedCalls}`,
-    );
-  });
-
-  it("keeps explicitly requested built-in Brave when web search is supported", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "custom",
-        policyPresets: "brave,npm",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      webSearchConfig: null,
-      webSearchSupported: true,
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, ["brave", "npm"]);
-    assert.deepEqual(payload.appliedCalls, ["brave", "npm"]);
-  });
-
-  it("clamps resumed policy presets to web-search-supported presets", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["brave"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      webSearchSupported: false,
-      selectedPresets: ["brave", "npm"],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, ["npm"]);
-    assert.deepEqual(payload.appliedCalls, ["npm"]);
-    assert.deepEqual(payload.removedCalls, ["brave"]);
-  });
-
-  it("clamps an unsupported-only resumed policy preset list to empty", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["brave"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      webSearchSupported: false,
-      selectedPresets: ["brave"],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, []);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.deepEqual(payload.removedCalls, ["brave"]);
-  });
-
-  it("removes OpenClaw-only policy presets when resuming Hermes policy selection", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["openclaw-pricing"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      agent: "hermes",
-      selectedPresets: ["openclaw-pricing", "weather", "nous-web"],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, ["weather", "nous-web"]);
-    assert.deepEqual(payload.appliedCalls, ["weather", "nous-web"]);
-    assert.deepEqual(payload.removedCalls, ["openclaw-pricing"]);
-  });
-
-  it("removes Hermes Nous policy presets when resuming OpenClaw policy selection", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["nous-web"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      agent: "openclaw",
-      selectedPresets: ["nous-web", "weather", "openclaw-pricing"],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, ["weather", "openclaw-pricing"]);
-    assert.deepEqual(payload.appliedCalls, ["weather", "openclaw-pricing"]);
-    assert.deepEqual(payload.removedCalls, ["nous-web"]);
-  });
-
-  it("preserves a resumed custom preset whose name matches an unsupported built-in", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["brave"];
-policies.listCustomPresets = () => [{ name: "brave", description: "custom preset" }];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      webSearchSupported: false,
-      selectedPresets: ["brave", "npm"],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, ["brave", "npm"]);
-    assert.deepEqual(payload.appliedCalls, ["npm"]);
-    assert.deepEqual(payload.removedCalls, []);
-  });
-
-  it("preserves a non-interactive custom preset whose name matches an unsupported built-in", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["brave"];
-policies.listCustomPresets = () => [{ name: "brave", description: "custom preset" }];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { webSearchSupported: false });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(payload.applied.includes("brave"), `custom Brave was dropped: ${payload.applied}`);
-    assert.ok(
-      !payload.appliedCalls.includes("brave"),
-      `custom Brave was re-applied: ${payload.appliedCalls}`,
-    );
-    assert.deepEqual(payload.removedCalls, []);
-  });
-
-  // #2429: an unrecognised NEMOCLAW_POLICY_MODE used to hard-exit at step 8/8,
-  // leaving the already-built sandbox with zero presets. We now warn and fall
-  // back to the tier-derived suggestions so the sandbox stays usable, and hint
-  // that the user may have meant NEMOCLAW_POLICY_TIER when the value looks like
-  // a tier name.
-  it("falls back to tier suggestions when NEMOCLAW_POLICY_MODE is unknown (#2429)", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "restricted",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-policies.applyPreset = (sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-// Silence onboard's note()/console.log so stdout is pure JSON.
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {});
-    process.stdout.write(JSON.stringify({ applied, appliedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    // Warn path, not exit: tier suggestions were applied (non-empty).
-    assert.ok(
-      payload.applied.length > 0,
-      `expected fallback presets to be applied, got: ${JSON.stringify(payload.applied)}`,
-    );
-    // Warnings mention the bad value, the tier-name hint, and the fallback.
-    // They land on stderr via console.warn.
-    assert.match(result.stderr, /Unsupported NEMOCLAW_POLICY_MODE: restricted/);
-    assert.match(result.stderr, /NEMOCLAW_POLICY_TIER=restricted/);
-    assert.match(result.stderr, /Falling back to suggested presets/);
-  });
-
-  it("omits the tier-name hint for a non-tier invalid value (#2429)", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "balanced",
-        policyMode: "garbage",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-policies.applyPreset = () => true;
-policies.applyPresets = () => true;
-policies.getAppliedPresets = () => [];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {});
-    process.stdout.write(JSON.stringify({ applied }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.match(result.stderr, /Unsupported NEMOCLAW_POLICY_MODE: garbage/);
-    assert.ok(
-      !/did you mean NEMOCLAW_POLICY_TIER/.test(result.stderr),
-      `tier-name hint should not appear for non-tier values, stderr: ${result.stderr}`,
-    );
-  });
-
-  it("setupPoliciesWithSelection restricted tier applies zero presets for OpenClaw in non-interactive suggested mode", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { agent: "openclaw" });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.deepEqual(payload.applied, [], `applied set must be empty for restricted OpenClaw`);
-    assert.deepEqual(
-      payload.appliedCalls,
-      [],
-      `no policy preset should be applied on restricted OpenClaw`,
-    );
-  });
-
-  it("setupPoliciesWithSelection restricted tier does not re-add openclaw-diagnostics-otel-local when NEMOCLAW_OPENCLAW_OTEL=1", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { agent: "openclaw" });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script, {
-      NEMOCLAW_OPENCLAW_OTEL: "1",
-      NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
-    });
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("openclaw-diagnostics-otel-local"),
-      `applied set must not contain openclaw-diagnostics-otel-local; got: ${JSON.stringify(payload.applied)}`,
-    );
-    assert.ok(
-      !payload.applied.includes("openclaw-pricing"),
-      `applied set must not contain openclaw-pricing; got: ${JSON.stringify(payload.applied)}`,
-    );
-    assert.ok(
-      !payload.appliedCalls.includes("openclaw-diagnostics-otel-local"),
-      `policies.applyPreset/applyPresets must not be called for openclaw-diagnostics-otel-local; got: ${JSON.stringify(payload.appliedCalls)}`,
-    );
-    assert.ok(
-      !payload.appliedCalls.includes("openclaw-pricing"),
-      `policies.applyPreset/applyPresets must not be called for openclaw-pricing; got: ${JSON.stringify(payload.appliedCalls)}`,
-    );
-  });
-
-  it("setupPoliciesWithSelection restricted tier note matches the final applied presets when agent-required presets are suppressed", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-const lines = [];
-const origLog = console.log;
-console.log = (...args) => lines.push(args.join(" "));
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { agent: "openclaw" });
-    console.log = origLog;
-    origLog(JSON.stringify({ applied, appliedCalls, lines }));
-  } catch (err) {
-    console.log = origLog;
-    origLog(JSON.stringify({ error: err.message, lines }));
-  }
-})();
-`;
-    const result = runScript(script, {
-      NEMOCLAW_OPENCLAW_OTEL: "1",
-      NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
-    });
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    const noteLine: string | undefined = payload.lines.find((l: string) =>
-      l.includes("Restricted tier suppresses agent-required preset"),
-    );
-    assert.ok(
-      noteLine,
-      `suppression note must be printed, lines: ${JSON.stringify(payload.lines)}`,
-    );
-    const noteMentions = (name: string) => noteLine!.includes(name);
-    assert.ok(
-      noteMentions("openclaw-pricing"),
-      `note must mention openclaw-pricing, got: ${noteLine}`,
-    );
-    assert.ok(
-      noteMentions("openclaw-diagnostics-otel-local"),
-      `note must mention openclaw-diagnostics-otel-local when OTEL is enabled, got: ${noteLine}`,
-    );
-    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
-      assert.ok(
-        !payload.applied.includes(name),
-        `note says ${name} is suppressed but final applied still contains it: ${JSON.stringify(payload.applied)}`,
-      );
-      assert.ok(
-        !payload.appliedCalls.includes(name),
-        `note says ${name} is suppressed but applyPreset/applyPresets was still called: ${JSON.stringify(payload.appliedCalls)}`,
-      );
-    }
-  });
-
-  it("setupPoliciesWithSelection restricted tier removes previously-applied openclaw-pricing instead of preserving it", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["openclaw-pricing"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { agent: "openclaw" });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("openclaw-pricing"),
-      `applied target must exclude previously-applied openclaw-pricing on restricted; got: ${JSON.stringify(payload.applied)}`,
-    );
-    assert.ok(
-      payload.removedCalls.includes("openclaw-pricing"),
-      `restricted reconciliation must call removePreset for openclaw-pricing; got: ${JSON.stringify(payload.removedCalls)}`,
-    );
-  });
-
-  it("setupPoliciesWithSelection restricted tier removes previously-applied openclaw-diagnostics-otel-local when NEMOCLAW_OPENCLAW_OTEL=1", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["openclaw-diagnostics-otel-local", "openclaw-pricing"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", { agent: "openclaw" });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script, {
-      NEMOCLAW_OPENCLAW_OTEL: "1",
-      NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
-    });
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
-      assert.ok(
-        !payload.applied.includes(name),
-        `restricted reconciliation must exclude ${name}; got: ${JSON.stringify(payload.applied)}`,
-      );
-      assert.ok(
-        payload.removedCalls.includes(name),
-        `restricted reconciliation must call removePreset for ${name}; got: ${JSON.stringify(payload.removedCalls)}`,
-      );
-    }
-  });
-
-  it("setupPoliciesWithSelection restricted resume with empty recorded presets keeps target empty", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-registry.getSandbox = () => ({ name: "test-sb", policyTier: "restricted" });
-
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => [];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      agent: "openclaw",
-      selectedPresets: [],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("openclaw-pricing"),
-      `resume target must not be expanded back to openclaw-pricing on restricted; got: ${JSON.stringify(payload.applied)}`,
-    );
-    assert.ok(
-      !payload.appliedCalls.includes("openclaw-pricing"),
-      `resume must not call applyPreset/applyPresets for openclaw-pricing on restricted; got: ${JSON.stringify(payload.appliedCalls)}`,
-    );
-  });
-
-  it("setupPoliciesWithSelection restricted resume removes previously-applied openclaw-pricing", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-registry.getSandbox = () => ({ name: "test-sb", policyTier: "restricted" });
-
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["openclaw-pricing"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      agent: "openclaw",
-      selectedPresets: [],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("openclaw-pricing"),
-      `resume target must exclude previously-applied openclaw-pricing on restricted; got: ${JSON.stringify(payload.applied)}`,
-    );
-    assert.ok(
-      payload.removedCalls.includes("openclaw-pricing"),
-      `restricted resume must call removePreset for openclaw-pricing; got: ${JSON.stringify(payload.removedCalls)}`,
-    );
-  });
-
-  it("setupPoliciesWithSelection restricted resume with NEMOCLAW_OPENCLAW_OTEL=1 excludes openclaw-diagnostics-otel-local", () => {
-    const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-    const script =
-      buildPreamble({
-        tierEnv: "restricted",
-        policyMode: "suggested",
-        stubOpenshellBin: true,
-        runCaptureReturn: "Running",
-      }) +
-      String.raw`
-registry.getSandbox = () => ({ name: "test-sb", policyTier: "restricted" });
-
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-policies.applyPreset = (_sandbox, name) => { appliedCalls.push(name); return true; };
-policies.applyPresets = (_sandbox, names) => { for (const name of names) appliedCalls.push(name); return true; };
-policies.removePreset = (_sandbox, name) => { removedCalls.push(name); return true; };
-policies.getAppliedPresets = () => ["openclaw-diagnostics-otel-local"];
-
-console.log = () => {};
-
-(async () => {
-  try {
-    const applied = await setupPoliciesWithSelection("test-sb", {
-      agent: "openclaw",
-      selectedPresets: [],
-    });
-    process.stdout.write(JSON.stringify({ applied, appliedCalls, removedCalls }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-    const result = runScript(script, {
-      NEMOCLAW_OPENCLAW_OTEL: "1",
-      NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
-    });
-    assert.equal(result.status, 0, result.stderr);
-    const payload = JSON.parse(result.stdout.trim());
-    assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-    assert.ok(
-      !payload.applied.includes("openclaw-diagnostics-otel-local"),
-      `resume target must exclude openclaw-diagnostics-otel-local on restricted; got: ${JSON.stringify(payload.applied)}`,
-    );
-    assert.ok(
-      payload.removedCalls.includes("openclaw-diagnostics-otel-local"),
-      `restricted resume must call removePreset for openclaw-diagnostics-otel-local; got: ${JSON.stringify(payload.removedCalls)}`,
+      notes.some((line) => line.includes("balanced")),
+      `summary must mention balanced tier, got: ${JSON.stringify(notes)}`,
     );
   });
 });
 
+describe("policy tier setup", () => {
+  it("persists the selected tier through setPolicyTier", async () => {
+    const result = await runPolicySetup({ tierName: "open", policyMode: "skip" });
+
+    assert.deepEqual(result.tierUpdates, [{ sandboxName: "test-sb", policyTier: "open" }]);
+    assert.deepEqual(result.applied, []);
+  });
+
+  it("omits Brave from policy preset selection when web search is unsupported", async () => {
+    const result = await runPolicySetup({ tierName: "balanced" }, { webSearchSupported: false });
+
+    assert.ok(!result.applied.includes("brave"));
+    assert.ok(!result.appliedCalls.includes("brave"));
+    assert.ok(result.applied.includes("pypi"), "normal dev presets should still be included");
+  });
+
+  it("removes a previously-applied Brave preset when web search is unsupported", async () => {
+    const result = await runPolicySetup(
+      { tierName: "balanced", currentApplied: ["brave", "npm"] },
+      { webSearchSupported: false },
+    );
+
+    assert.ok(!result.applied.includes("brave"));
+    assert.ok(result.removedCalls.includes("brave"));
+    assert.ok(!result.appliedCalls.includes("brave"));
+  });
+
+  it("removes a previously-applied built-in Brave preset when Brave search is declined", async () => {
+    const result = await runPolicySetup(
+      { tierName: "balanced", currentApplied: ["brave", "npm"] },
+      { webSearchConfig: null, webSearchSupported: true },
+    );
+
+    assert.ok(!result.applied.includes("brave"));
+    assert.ok(result.removedCalls.includes("brave"));
+    assert.ok(!result.appliedCalls.includes("brave"));
+  });
+
+  it("keeps explicitly requested built-in Brave when web search is supported", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        policyMode: "custom",
+        policyPresets: "brave,npm",
+      },
+      { webSearchConfig: null, webSearchSupported: true },
+    );
+
+    assert.deepEqual(result.applied, ["brave", "npm"]);
+    assert.deepEqual(result.appliedCalls, ["brave", "npm"]);
+  });
+
+  it("clamps resumed policy presets to web-search-supported presets", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        currentApplied: ["brave"],
+      },
+      { webSearchSupported: false, selectedPresets: ["brave", "npm"] },
+    );
+
+    assert.deepEqual(result.applied, ["npm"]);
+    assert.deepEqual(result.appliedCalls, ["npm"]);
+    assert.deepEqual(result.removedCalls, ["brave"]);
+  });
+
+  it("clamps an unsupported-only resumed policy preset list to empty", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        currentApplied: ["brave"],
+      },
+      { webSearchSupported: false, selectedPresets: ["brave"] },
+    );
+
+    assert.deepEqual(result.applied, []);
+    assert.deepEqual(result.appliedCalls, []);
+    assert.deepEqual(result.removedCalls, ["brave"]);
+  });
+
+  it("removes OpenClaw-only policy presets when resuming Hermes policy selection", async () => {
+    const result = await runPolicySetup(
+      { currentApplied: ["openclaw-pricing"] },
+      {
+        agent: "hermes",
+        selectedPresets: ["openclaw-pricing", "weather", "nous-web"],
+      },
+    );
+
+    assert.deepEqual(result.applied, ["weather", "nous-web"]);
+    assert.deepEqual(result.appliedCalls, ["weather", "nous-web"]);
+    assert.deepEqual(result.removedCalls, ["openclaw-pricing"]);
+  });
+
+  it("removes Hermes Nous policy presets when resuming OpenClaw policy selection", async () => {
+    const result = await runPolicySetup(
+      { currentApplied: ["nous-web"] },
+      {
+        agent: "openclaw",
+        selectedPresets: ["nous-web", "weather", "openclaw-pricing"],
+      },
+    );
+
+    assert.deepEqual(result.applied, ["weather", "openclaw-pricing"]);
+    assert.deepEqual(result.appliedCalls, ["weather", "openclaw-pricing"]);
+    assert.deepEqual(result.removedCalls, ["nous-web"]);
+  });
+
+  it("preserves a resumed custom preset whose name matches an unsupported built-in", async () => {
+    const result = await runPolicySetup(
+      {
+        currentApplied: ["brave"],
+        customPresets: [{ name: "brave", description: "custom preset" }],
+      },
+      { webSearchSupported: false, selectedPresets: ["brave", "npm"] },
+    );
+
+    assert.deepEqual(result.applied, ["brave", "npm"]);
+    assert.deepEqual(result.appliedCalls, ["npm"]);
+    assert.deepEqual(result.removedCalls, []);
+  });
+
+  it("preserves a non-interactive custom preset whose name matches an unsupported built-in", async () => {
+    const result = await runPolicySetup(
+      {
+        currentApplied: ["brave"],
+        customPresets: [{ name: "brave", description: "custom preset" }],
+      },
+      { webSearchSupported: false },
+    );
+
+    assert.ok(result.applied.includes("brave"));
+    assert.ok(!result.appliedCalls.includes("brave"));
+    assert.deepEqual(result.removedCalls, []);
+  });
+
+  it("falls back to tier suggestions when NEMOCLAW_POLICY_MODE is unknown (#2429)", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const result = await runPolicySetup({ tierName: "balanced", policyMode: "restricted" });
+    const text = warningText(warnings);
+
+    assert.ok(result.applied.length > 0);
+    assert.match(text, /Unsupported NEMOCLAW_POLICY_MODE: restricted/);
+    assert.match(text, /NEMOCLAW_POLICY_TIER=restricted/);
+    assert.match(text, /Falling back to suggested presets/);
+  });
+
+  it("omits the tier-name hint for a non-tier invalid policy mode (#2429)", async () => {
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await runPolicySetup({ tierName: "balanced", policyMode: "garbage" });
+    const text = warningText(warnings);
+
+    assert.match(text, /Unsupported NEMOCLAW_POLICY_MODE: garbage/);
+    assert.doesNotMatch(text, /did you mean NEMOCLAW_POLICY_TIER/);
+  });
+
+  it("applies zero presets for restricted OpenClaw in non-interactive suggested mode", async () => {
+    const result = await runPolicySetup({ tierName: "restricted" }, { agent: "openclaw" });
+
+    assert.deepEqual(result.applied, []);
+    assert.deepEqual(result.appliedCalls, []);
+  });
+
+  it("does not re-add OpenClaw OTEL presets for the restricted tier", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "restricted",
+        env: {
+          NEMOCLAW_OPENCLAW_OTEL: "1",
+          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+        },
+      },
+      { agent: "openclaw" },
+    );
+
+    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
+      assert.ok(!result.applied.includes(name));
+      assert.ok(!result.appliedCalls.includes(name));
+    }
+  });
+
+  it("reports the final restricted preset suppression in its note", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "restricted",
+        env: {
+          NEMOCLAW_OPENCLAW_OTEL: "1",
+          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+        },
+      },
+      { agent: "openclaw" },
+    );
+    const noteLine = result.notes.find((line) =>
+      line.includes("Restricted tier suppresses agent-required preset"),
+    );
+
+    assert.ok(noteLine, `suppression note must be printed, lines: ${JSON.stringify(result.notes)}`);
+    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
+      assert.ok(noteLine.includes(name), `note must mention ${name}, got: ${noteLine}`);
+      assert.ok(!result.applied.includes(name));
+      assert.ok(!result.appliedCalls.includes(name));
+    }
+  });
+
+  it("removes previously-applied OpenClaw pricing for the restricted tier", async () => {
+    const result = await runPolicySetup(
+      { tierName: "restricted", currentApplied: ["openclaw-pricing"] },
+      { agent: "openclaw" },
+    );
+
+    assert.ok(!result.applied.includes("openclaw-pricing"));
+    assert.ok(result.removedCalls.includes("openclaw-pricing"));
+  });
+
+  it("removes previously-applied OpenClaw OTEL diagnostics for the restricted tier", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "restricted",
+        currentApplied: ["openclaw-diagnostics-otel-local", "openclaw-pricing"],
+        env: {
+          NEMOCLAW_OPENCLAW_OTEL: "1",
+          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+        },
+      },
+      { agent: "openclaw" },
+    );
+
+    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
+      assert.ok(!result.applied.includes(name));
+      assert.ok(result.removedCalls.includes(name));
+    }
+  });
+
+  it("keeps an empty restricted resume target empty", async () => {
+    const result = await runPolicySetup(
+      { recordedPolicyTier: "restricted" },
+      { agent: "openclaw", selectedPresets: [] },
+    );
+
+    assert.ok(!result.applied.includes("openclaw-pricing"));
+    assert.ok(!result.appliedCalls.includes("openclaw-pricing"));
+  });
+
+  it("removes previously-applied OpenClaw pricing during a restricted resume", async () => {
+    const result = await runPolicySetup(
+      { recordedPolicyTier: "restricted", currentApplied: ["openclaw-pricing"] },
+      { agent: "openclaw", selectedPresets: [] },
+    );
+
+    assert.ok(!result.applied.includes("openclaw-pricing"));
+    assert.ok(result.removedCalls.includes("openclaw-pricing"));
+  });
+
+  it("excludes OpenClaw OTEL diagnostics during a restricted resume", async () => {
+    const result = await runPolicySetup(
+      {
+        recordedPolicyTier: "restricted",
+        currentApplied: ["openclaw-diagnostics-otel-local"],
+        env: {
+          NEMOCLAW_OPENCLAW_OTEL: "1",
+          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+        },
+      },
+      { agent: "openclaw", selectedPresets: [] },
+    );
+
+    assert.ok(!result.applied.includes("openclaw-diagnostics-otel-local"));
+    assert.ok(result.removedCalls.includes("openclaw-diagnostics-otel-local"));
+  });
+});
+
 describe("selectTierPresetsAndAccess", () => {
-  const tiersPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "tiers.ts"));
-  const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-
-  function buildPresetsScript(body: string): string {
-    const credPath = JSON.stringify(path.join(repoRoot, "src", "lib", "credentials", "store.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    return String.raw`
-const credentials = require(${credPath});
-const runner = require(${runnerPath});
-const registry = require(${registryPath});
-credentials.prompt = async () => { throw new Error("unexpected prompt"); };
-credentials.ensureApiKey = async () => {};
-credentials.getCredential = () => null;
-runner.run = () => {};
-runner.runCapture = () => "";
-registry.getSandbox = () => ({ name: "test-sb", model: null, provider: null });
-process.env.NEMOCLAW_NON_INTERACTIVE = "1";
-const { selectTierPresetsAndAccess } = require(${onboardPath});
-const tiers = require(${tiersPath});
-const policies = require(${policiesPath});
-${body}
-`;
+  async function resolve(
+    tierName: string,
+    extraSelected: string[] = [],
+  ): Promise<Array<{ name: string; access: string }>> {
+    const { helpers } = createPromptHarness();
+    return helpers.selectTierPresetsAndAccess(tierName, policy.listPresets(), extraSelected);
   }
 
-  function run(body: string) {
-    return runScript(buildPresetsScript(body));
-  }
-
-  it("returns tier presets with their default access levels", () => {
-    const result = run(String.raw`
-(async () => {
-  const allPresets = policies.listPresets();
-  const resolved = await selectTierPresetsAndAccess("balanced", allPresets);
-  process.stdout.write(JSON.stringify(resolved) + "\n");
-})().catch((e) => { process.stderr.write(e.message); process.exit(1); });
-`);
-    assert.equal(result.status, 0, result.stderr);
-    const resolved: Array<{ name: string; access: string }> = JSON.parse(result.stdout.trim());
-    const names = resolved.map((p) => p.name);
+  it("returns tier presets with their default access levels", async () => {
+    const resolved = await resolve("balanced");
+    const names = resolved.map((preset) => preset.name);
     assert.ok(names.includes("npm"), "npm should be included");
     assert.ok(names.includes("brave"), "brave should be included");
     assert.ok(!names.includes("weather"), "weather should not be a balanced tier default");
     assert.ok(!names.includes("slack"), "slack should not be included in balanced");
-    for (const p of resolved) {
-      assert.equal(p.access, "read-write", `${p.name} should default to read-write`);
+    for (const preset of resolved) {
+      assert.equal(preset.access, "read-write", `${preset.name} should default to read-write`);
     }
   });
 
-  it("restricted tier returns empty array", () => {
-    const result = run(String.raw`
-(async () => {
-  const allPresets = policies.listPresets();
-  const resolved = await selectTierPresetsAndAccess("restricted", allPresets);
-  process.stdout.write(JSON.stringify(resolved) + "\n");
-})().catch((e) => { process.stderr.write(e.message); process.exit(1); });
-`);
-    assert.equal(result.status, 0, result.stderr);
-    const resolved = JSON.parse(result.stdout.trim());
-    assert.deepEqual(resolved, []);
+  it("returns an empty array for the restricted tier", async () => {
+    assert.deepEqual(await resolve("restricted"), []);
   });
 
-  it("extraSelected adds non-tier preset to initial checked set", () => {
-    const result = run(String.raw`
-(async () => {
-  const allPresets = policies.listPresets();
-  const resolved = await selectTierPresetsAndAccess("balanced", allPresets, ["slack"]);
-  process.stdout.write(JSON.stringify(resolved) + "\n");
-})().catch((e) => { process.stderr.write(e.message); process.exit(1); });
-`);
-    assert.equal(result.status, 0, result.stderr);
-    const resolved: Array<{ name: string }> = JSON.parse(result.stdout.trim());
-    const names = resolved.map((p) => p.name);
+  it("adds a non-tier preset to the initial checked set through extraSelected", async () => {
+    const names = (await resolve("balanced", ["slack"])).map((preset) => preset.name);
     assert.ok(names.includes("slack"), "slack should be included via extraSelected");
     assert.ok(names.includes("npm"), "npm (tier default) should still be included");
   });
 
-  it("extraSelected with invalid preset name is silently filtered", () => {
-    const result = run(String.raw`
-(async () => {
-  const allPresets = policies.listPresets();
-  const resolved = await selectTierPresetsAndAccess("balanced", allPresets, ["nonexistent-preset"]);
-  process.stdout.write(JSON.stringify(resolved) + "\n");
-})().catch((e) => { process.stderr.write(e.message); process.exit(1); });
-`);
-    assert.equal(result.status, 0, result.stderr);
-    const resolved: Array<{ name: string }> = JSON.parse(result.stdout.trim());
-    const names = resolved.map((p) => p.name);
+  it("silently filters an invalid extraSelected preset name", async () => {
+    const names = (await resolve("balanced", ["nonexistent-preset"])).map((preset) => preset.name);
     assert.ok(!names.includes("nonexistent-preset"), "invalid preset should be dropped");
   });
 
-  it("tier presets appear before non-tier presets in returned order", () => {
-    const result = run(String.raw`
-(async () => {
-  const allPresets = policies.listPresets();
-  const resolved = await selectTierPresetsAndAccess("balanced", allPresets, ["slack"]);
-  process.stdout.write(JSON.stringify(resolved) + "\n");
-})().catch((e) => { process.stderr.write(e.message); process.exit(1); });
-`);
-    assert.equal(result.status, 0, result.stderr);
-    const resolved: Array<{ name: string }> = JSON.parse(result.stdout.trim());
-    const names = resolved.map((p) => p.name);
+  it("returns tier presets before non-tier presets", async () => {
+    const names = (await resolve("balanced", ["slack"])).map((preset) => preset.name);
     const tierNames = ["npm", "pypi", "huggingface", "brew", "brave"];
-    const lastTierIdx = Math.max(...tierNames.map((n) => names.indexOf(n)));
+    const lastTierIdx = Math.max(...tierNames.map((name) => names.indexOf(name)));
     const slackIdx = names.indexOf("slack");
     assert.ok(slackIdx > lastTierIdx, "non-tier preset (slack) should appear after tier presets");
   });
 
-  it("each resolved preset has name and access fields", () => {
-    const result = run(String.raw`
-(async () => {
-  const allPresets = policies.listPresets();
-  const resolved = await selectTierPresetsAndAccess("open", allPresets);
-  process.stdout.write(JSON.stringify(resolved) + "\n");
-})().catch((e) => { process.stderr.write(e.message); process.exit(1); });
-`);
-    assert.equal(result.status, 0, result.stderr);
-    const resolved: Array<{ name: string; access: string }> = JSON.parse(result.stdout.trim());
+  it("returns name and access fields for every resolved preset", async () => {
+    const resolved = await resolve("open");
     assert.ok(resolved.length > 0, "open tier should have presets");
-    for (const p of resolved) {
-      assert.equal(typeof p.name, "string");
-      assert.ok(p.access === "read" || p.access === "read-write", `unexpected access: ${p.access}`);
+    for (const preset of resolved) {
+      assert.equal(typeof preset.name, "string");
+      assert.ok(
+        preset.access === "read" || preset.access === "read-write",
+        `unexpected access: ${preset.access}`,
+      );
     }
   });
 });

--- a/test/rebuild-credential-preflight.test.ts
+++ b/test/rebuild-credential-preflight.test.ts
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Tests for issue #2273: rebuild should be atomic.
+ * Thin real-process contracts for atomic rebuild (#2273).
  *
- * Verifies:
- * 1. Layer 1: Non-interactive onboard resolves credentials from
- *    ~/.nemoclaw/credentials.json when process.env is empty.
- * 2. Layer 2: Rebuild preflight aborts BEFORE destroying the sandbox
- *    when the provider credential is missing.
- * 3. Layer 3: If recreate fails after destroy, rebuild prints recovery
- *    instructions instead of silently exiting.
+ * Rebuild decision branches live in the direct rebuild-flow and focused source
+ * suites. This file intentionally retains only behavior whose contract crosses
+ * a process boundary: interactive stdin/exit, DCode liveness after a failed
+ * preflight, child-environment secret handling, and the CLI exit status.
  */
 
 import { spawnSync } from "node:child_process";
@@ -18,7 +15,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { execTimeout, testTimeout } from "./helpers/timeouts";
+import { execTimeout } from "./helpers/timeouts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const NODE_BIN = path.dirname(process.execPath);
@@ -29,89 +26,37 @@ afterEach(() => {
     try {
       fs.rmSync(dir, { recursive: true, force: true });
     } catch {
-      /* */
+      /* best effort */
     }
   }
 });
 
-function makeMessagingPlan(sandboxName: string, agent: string, channelIds: string[]) {
-  return {
-    schemaVersion: 1,
-    sandboxName,
-    agent,
-    workflow: "onboard",
-    channels: channelIds.map((channelId) => ({
-      channelId,
-      displayName: channelId,
-      authMode: "token-paste",
-      active: true,
-      selected: true,
-      configured: true,
-      disabled: false,
-      inputs: [],
-      hooks: [],
-    })),
-    disabledChannels: [],
-    credentialBindings: [],
-    networkPolicy: { presets: [], entries: [] },
-    agentRender: [],
-    buildSteps: [],
-    stateUpdates: [],
-    healthChecks: [],
-  };
-}
-
-/**
- * Create a temp HOME with a sandbox registry, onboard session, and
- * optionally a saved credential in credentials.json.
- *
- * The fake openshell binary responds to sandbox list, ssh-config, and
- * delete commands.  The fake ssh supports backup tar operations.
- */
 function createFixture(opts: {
-  sandboxName?: string;
+  agent?: string | null;
   provider?: string;
   credentialEnv?: string;
-  /** If set, save this credential in credentials.json */
   savedCredential?: { key: string; value: string };
-  /** If set, the onboard-session.json provider_selection step status */
-  providerSelectionStatus?: string;
-  agent?: string | null;
-  agents?: unknown[] | null;
   hermesAuthMethod?: string | null;
-  messagingPlanChannels?: string[] | null;
-  dockerBuildExitCode?: number;
   providerRegistered?: boolean;
-  registeredProviders?: string[];
   activeSessionCount?: number | null;
   inferenceProbeHttpStatus?: number | null;
 }) {
   const {
-    sandboxName = "my-assistant",
+    agent = null,
     provider = "nvidia-prod",
     credentialEnv = "NVIDIA_INFERENCE_API_KEY",
     savedCredential,
-    providerSelectionStatus = "complete",
-    agent = null,
-    agents = null,
     hermesAuthMethod = null,
-    messagingPlanChannels = null,
-    dockerBuildExitCode = 0,
     providerRegistered = true,
-    registeredProviders,
     activeSessionCount = 0,
     inferenceProbeHttpStatus = null,
   } = opts;
+  const sandboxName = "my-assistant";
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-2273-"));
   tmpFixtures.push(tmpDir);
   const nemoclawDir = path.join(tmpDir, ".nemoclaw");
   fs.mkdirSync(nemoclawDir, { recursive: true, mode: 0o700 });
-  const messagingPlan =
-    messagingPlanChannels && messagingPlanChannels.length > 0
-      ? makeMessagingPlan(sandboxName, agent ?? "openclaw", messagingPlanChannels)
-      : null;
 
-  // ── Registry ──────────────────────────────────────────────────
   fs.writeFileSync(
     path.join(nemoclawDir, "sandboxes.json"),
     JSON.stringify({
@@ -125,31 +70,25 @@ function createFixture(opts: {
           sandboxGpuMode: "0",
           gatewayName: "nemoclaw",
           gatewayPort: 8080,
-          dashboardPort: 18789,
+          dashboardPort: agent === "langchain-deepagents-code" ? 0 : 18789,
           fromDockerfile: null,
           policies: [],
           agent,
+          hermesAuthMethod,
           ...(agent === "langchain-deepagents-code"
             ? {
                 credentialEnv,
                 preferredInferenceApi: "openai-completions",
                 endpointUrl: "https://inference-api.nvidia.com/v1",
                 nemoclawVersion: "0.0.72",
-                dashboardPort: 0,
-                gatewayName: "nemoclaw",
-                gatewayPort: 8080,
-                sandboxGpuMode: "0",
               }
             : {}),
-          ...(agents ? { agents } : {}),
-          ...(messagingPlan ? { messaging: { schemaVersion: 1, plan: messagingPlan } } : {}),
         },
       },
     }),
     { mode: 0o600 },
   );
 
-  // ── Session ───────────────────────────────────────────────────
   fs.writeFileSync(
     path.join(nemoclawDir, "onboard-session.json"),
     JSON.stringify({
@@ -177,60 +116,24 @@ function createFixture(opts: {
       messagingPlan: null,
       metadata: { gatewayName: "nemoclaw", fromDockerfile: null },
       steps: {
-        preflight: {
-          status: "complete",
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
-        gateway: {
-          status: "complete",
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
-        sandbox: {
-          status: "complete",
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
+        preflight: { status: "complete", startedAt: null, completedAt: null, error: null },
+        gateway: { status: "complete", startedAt: null, completedAt: null, error: null },
+        sandbox: { status: "complete", startedAt: null, completedAt: null, error: null },
         provider_selection: {
-          status: providerSelectionStatus,
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
-        inference: {
           status: "complete",
           startedAt: null,
           completedAt: null,
           error: null,
         },
-        openclaw: {
-          status: "complete",
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
-        agent_setup: {
-          status: "pending",
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
-        policies: {
-          status: "complete",
-          startedAt: null,
-          completedAt: null,
-          error: null,
-        },
+        inference: { status: "complete", startedAt: null, completedAt: null, error: null },
+        openclaw: { status: "complete", startedAt: null, completedAt: null, error: null },
+        agent_setup: { status: "pending", startedAt: null, completedAt: null, error: null },
+        policies: { status: "complete", startedAt: null, completedAt: null, error: null },
       },
     }),
     { mode: 0o600 },
   );
 
-  // ── Credentials ───────────────────────────────────────────────
   if (savedCredential) {
     fs.writeFileSync(
       path.join(nemoclawDir, "credentials.json"),
@@ -239,7 +142,6 @@ function createFixture(opts: {
     );
   }
 
-  // ── Fake workspace dir for the backup tar call ────────────────
   const fakeRoot = path.join(tmpDir, "fake-sandbox-root");
   const workspaceDir = path.join(fakeRoot, "workspace");
   fs.mkdirSync(workspaceDir, { recursive: true });
@@ -248,7 +150,6 @@ function createFixture(opts: {
   const atomicityMarker = path.join(fakeRoot, "rebuild-atomicity-marker.txt");
   fs.writeFileSync(atomicityMarker, "dcode-atomicity-marker\n");
 
-  // ── Fake openshell ────────────────────────────────────────────
   const sshConfig = [
     `Host openshell-${sandboxName}`,
     "  HostName 127.0.0.1",
@@ -257,24 +158,19 @@ function createFixture(opts: {
     "  StrictHostKeyChecking no",
     "  UserKnownHostsFile /dev/null",
   ].join("\\n");
-
-  const registeredProvidersLiteral = JSON.stringify(registeredProviders ?? null);
   const hermesProviderStatePath = path.join(tmpDir, "hermes-provider-credential-key");
-  const initialHermesCredentialKey =
-    hermesAuthMethod === "api_key" ? "NOUS_API_KEY" : "OPENAI_API_KEY";
   fs.writeFileSync(
     path.join(tmpDir, "openshell"),
     `#!/usr/bin/env node
 const fs = require("fs");
 const a = process.argv.slice(2);
-const registeredProviders = ${registeredProvidersLiteral};
 const hermesProviderStatePath = ${JSON.stringify(hermesProviderStatePath)};
 const requiredFeatures = "request-body-credential-rewrite websocket-credential-rewrite allow_all_known_mcp_methods";
-if (a[0]==="-V" || a[0]==="--version")         { process.stdout.write("openshell 0.0.72\\n"); process.exit(0); }
-if (a[0]==="sandbox" && a[1]==="list")       { process.stdout.write("${sandboxName} Ready\\n"); process.exit(0); }
-if (a[0]==="sandbox" && a[1]==="ssh-config") { process.stdout.write("${sshConfig}\\n"); process.exit(0); }
-if (a[0]==="sandbox" && a[1]==="delete")     { fs.writeFileSync(${JSON.stringify(deleteMarker)}, "deleted\\n"); process.exit(0); }
-if (a[0]==="sandbox" && a[1]==="exec") {
+if (a[0] === "-V" || a[0] === "--version") { process.stdout.write("openshell 0.0.72\\n"); process.exit(0); }
+if (a[0] === "sandbox" && a[1] === "list") { process.stdout.write("${sandboxName} Ready\\n"); process.exit(0); }
+if (a[0] === "sandbox" && a[1] === "ssh-config") { process.stdout.write("${sshConfig}\\n"); process.exit(0); }
+if (a[0] === "sandbox" && a[1] === "delete") { fs.writeFileSync(${JSON.stringify(deleteMarker)}, "deleted\\n"); process.exit(0); }
+if (a[0] === "sandbox" && a[1] === "exec") {
   const command = a.join(" ");
   if (command.includes("rebuild-atomicity-marker.txt")) {
     process.stdout.write(fs.readFileSync(${JSON.stringify(atomicityMarker)}, "utf-8"));
@@ -289,27 +185,25 @@ if (a[0]==="sandbox" && a[1]==="exec") {
   }
   process.exit(0);
 }
-if (a[0]==="status")                         { process.stdout.write("Server Status\\n  Gateway: nemoclaw\\n  Status: Connected\\n"); process.exit(0); }
-if (a[0]==="gateway" && a[1]==="info")       { const i=a.indexOf("-g"); const name=i>=0?a[i+1]:"nemoclaw"; process.stdout.write("Gateway Info\\n\\nGateway: " + name + "\\n"); process.exit(0); }
-if (a[0]==="gateway" && a[1]==="select")     { process.exit(0); }
-if (a[0]==="inference" && a[1]==="get")      { process.stdout.write("Gateway inference:\\n  Provider: ${provider}\\n  Model: meta/llama-3.3-70b-instruct\\n"); process.exit(0); }
-if (a[0]==="inference" && a[1]==="set")      { process.exit(0); }
-if (a[0]==="provider" && a[1]==="get")       {
+if (a[0] === "status") { process.stdout.write("Server Status\\n  Gateway: nemoclaw\\n  Status: Connected\\n"); process.exit(0); }
+if (a[0] === "gateway" && a[1] === "info") { process.stdout.write("Gateway Info\\n\\nGateway: nemoclaw\\n"); process.exit(0); }
+if (a[0] === "gateway" && a[1] === "select") process.exit(0);
+if (a[0] === "inference" && a[1] === "get") { process.stdout.write("Gateway inference:\\n  Provider: ${provider}\\n  Model: meta/llama-3.3-70b-instruct\\n"); process.exit(0); }
+if (a[0] === "inference" && a[1] === "set") process.exit(0);
+if (a[0] === "provider" && a[1] === "get") {
   const providerName = a[2];
   const persistedHermes = providerName === "hermes-provider" && fs.existsSync(hermesProviderStatePath);
-  const exists = persistedHermes || (Array.isArray(registeredProviders)
-    ? registeredProviders.includes(providerName)
-    : ${providerRegistered ? "true" : "false"});
+  const exists = persistedHermes || ${providerRegistered ? "true" : "false"};
   if (!exists) process.exit(1);
   if (providerName === "hermes-provider") {
     const credentialKey = persistedHermes
       ? fs.readFileSync(hermesProviderStatePath, "utf8").trim()
-      : ${JSON.stringify(initialHermesCredentialKey)};
+      : ${JSON.stringify(hermesAuthMethod === "api_key" ? "NOUS_API_KEY" : "OPENAI_API_KEY")};
     process.stdout.write("Provider:\\n  Name: hermes-provider\\n  Credential keys: " + credentialKey + "\\n");
   }
   process.exit(0);
 }
-if (a[0]==="provider" && (a[1]==="create" || a[1]==="update")) {
+if (a[0] === "provider" && (a[1] === "create" || a[1] === "update")) {
   const nameIndex = a.indexOf("--name");
   const providerName = a[1] === "create" ? a[nameIndex + 1] : a[2];
   const credentialIndex = a.indexOf("--credential");
@@ -318,13 +212,14 @@ if (a[0]==="provider" && (a[1]==="create" || a[1]==="update")) {
   }
   process.exit(0);
 }
-if (a[0]==="provider")                       { process.exit(0); }
-if (a[0]==="forward" && a[1]==="list")      { process.stdout.write("SANDBOX BIND PORT PID STATUS\\n${sandboxName} 127.0.0.1 18789 4242 running\\n"); process.exit(0); }
-if (a[0]==="forward")                        { process.exit(0); }
+if (a[0] === "provider") process.exit(0);
+if (a[0] === "forward" && a[1] === "list") { process.stdout.write("SANDBOX BIND PORT PID STATUS\\n${sandboxName} 127.0.0.1 18789 4242 running\\n"); process.exit(0); }
+if (a[0] === "forward") process.exit(0);
 process.exit(0);
 `,
     { mode: 0o755 },
   );
+
   for (const component of ["openshell-gateway", "openshell-sandbox"]) {
     fs.writeFileSync(
       path.join(tmpDir, component),
@@ -337,7 +232,6 @@ process.exit(0);
     );
   }
 
-  // ── Fake ps for active SSH session detection ──────────────────
   const activeSessionLines = Array.from(
     { length: activeSessionCount ?? 0 },
     (_, index) => `${9000 + index} ssh openshell-${sandboxName}`,
@@ -352,81 +246,51 @@ process.exit(0);
     { mode: 0o755 },
   );
 
-  // ── Fake Docker ───────────────────────────────────────────────
-  // Hermes rebuild forces a base-image build before backup/delete.
-  // This fixture only exercises rebuild session state, so Docker succeeds.
   fs.writeFileSync(
     path.join(tmpDir, "docker"),
     `#!/usr/bin/env node
 const a = process.argv.slice(2);
-if (a[0]==="info") {
-  process.stdout.write(JSON.stringify({ServerVersion:"27.0.0", OperatingSystem:"Docker Engine", NCPU:8, MemTotal:17179869184}) + "\\n");
-  process.exit(0);
-}
-if (a[0]==="build") { process.exit(${dockerBuildExitCode}); }
-if (a[0]==="image" && a[1]==="inspect") {
+if (a[0] === "info") { process.stdout.write(JSON.stringify({ServerVersion:"27.0.0", OperatingSystem:"Docker Engine", NCPU:8, MemTotal:17179869184}) + "\\n"); process.exit(0); }
+if (a[0] === "build") process.exit(0);
+if (a[0] === "image" && a[1] === "inspect") {
   const formatIndex = a.indexOf("--format");
   const format = formatIndex >= 0 ? a[formatIndex + 1] : "";
   if (format === "{{.Id}}") process.stdout.write("sha256:${"a".repeat(64)}\\n");
   if (format === "{{json .RepoDigests}}") process.stdout.write("[]\\n");
   process.exit(0);
 }
-if (a[0]==="tag" || a[0]==="rmi") { process.exit(0); }
-if (a[0]==="run") {
+if (a[0] === "tag" || a[0] === "rmi") process.exit(0);
+if (a[0] === "run") {
   if (a.includes("nslookup")) process.stdout.write("Server: 127.0.0.11\\n** server can't find nemoclaw.invalid: NXDOMAIN\\n");
   else if (a.includes("/usr/bin/ldd")) process.stdout.write("ldd (GNU libc) 2.41\\n");
   else process.stdout.write("nemoclaw-hermes-mcp-runtime-ok\\n");
   process.exit(0);
 }
-if (a[0]==="inspect") { process.stdout.write("true\\n"); process.exit(0); }
-if (a[0]==="ps") { process.exit(0); }
+if (a[0] === "inspect") { process.stdout.write("true\\n"); process.exit(0); }
+if (a[0] === "ps") process.exit(0);
 process.stderr.write("unexpected docker call: " + a.join(" ") + "\\n");
 process.exit(1);
 `,
     { mode: 0o755 },
   );
 
-  // ── Fake ssh ──────────────────────────────────────────────────
   fs.writeFileSync(
     path.join(tmpDir, "ssh"),
     `#!/usr/bin/env node
+const { spawnSync } = require("child_process");
 const cmd = process.argv[process.argv.length - 1] || "";
-if (cmd.includes("[ -d")) {
-  process.stdout.write("workspace\\n");
-  process.exit(0);
-}
+if (cmd.includes("[ -d")) { process.stdout.write("workspace\\n"); process.exit(0); }
 if (cmd.includes("tar")) {
-  const { spawnSync } = require("child_process");
-  const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify("PLACEHOLDER")}, "workspace"], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (r.stdout) process.stdout.write(r.stdout);
-  process.exit(r.status || 0);
+  const result = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(fakeRoot)}, "workspace"], { stdio: ["ignore", "pipe", "pipe"] });
+  if (result.stdout) process.stdout.write(result.stdout);
+  process.exit(result.status || 0);
 }
-if (cmd.includes("rm -rf")) { process.exit(0); }
-if (cmd.includes("chown"))  { process.exit(0); }
 process.exit(0);
 `,
     { mode: 0o755 },
   );
 
-  // Patch the PLACEHOLDER in the fake ssh to point at the real fakeRoot
-  const sshScript = fs.readFileSync(path.join(tmpDir, "ssh"), "utf-8");
-  fs.writeFileSync(path.join(tmpDir, "ssh"), sshScript.replace("PLACEHOLDER", fakeRoot), {
-    mode: 0o755,
-  });
-
-  return { tmpDir, nemoclawDir, sandboxName, fakeRoot, deleteMarker };
-}
-
-function runRebuild(
-  fixture: ReturnType<typeof createFixture>,
-  extraEnv: Record<string, string> = {},
-  options: { yes?: boolean; input?: string; timeoutMs?: number } = {},
-) {
-  const args = [fixture.sandboxName, "rebuild"];
-  if (options.yes !== false) args.push("--yes");
-  return runCli(fixture, args, extraEnv, options.input, options.timeoutMs);
+  return { tmpDir, nemoclawDir, sandboxName, deleteMarker };
 }
 
 function runCli(
@@ -434,10 +298,8 @@ function runCli(
   args: string[],
   extraEnv: Record<string, string> = {},
   input?: string,
-  timeoutMs = 60_000,
 ) {
-  const argv = [path.join(REPO_ROOT, "bin", "nemoclaw.js"), ...args];
-  return spawnSync(process.execPath, argv, {
+  return spawnSync(process.execPath, [path.join(REPO_ROOT, "bin", "nemoclaw.js"), ...args], {
     cwd: REPO_ROOT,
     encoding: "utf-8",
     input,
@@ -451,607 +313,140 @@ function runCli(
       NO_COLOR: "1",
       ...extraEnv,
     },
-    timeout: execTimeout(timeoutMs),
+    timeout: execTimeout(60_000),
   });
+}
+
+function runRebuild(
+  fixture: ReturnType<typeof createFixture>,
+  extraEnv: Record<string, string> = {},
+  options: { yes?: boolean; input?: string } = {},
+) {
+  const args = [fixture.sandboxName, "rebuild"];
+  if (options.yes !== false) args.push("--yes");
+  return runCli(fixture, args, extraEnv, options.input);
 }
 
 function registryHasSandbox(fixture: ReturnType<typeof createFixture>): boolean {
-  const regPath = path.join(fixture.nemoclawDir, "sandboxes.json");
-  if (!fs.existsSync(regPath)) return false;
-  try {
-    const reg = JSON.parse(fs.readFileSync(regPath, "utf-8"));
-    return Boolean(reg.sandboxes?.[fixture.sandboxName]);
-  } catch {
-    return false;
-  }
+  const registryPath = path.join(fixture.nemoclawDir, "sandboxes.json");
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
+  return Boolean(registry.sandboxes?.[fixture.sandboxName]);
 }
 
-describe("atomic rebuild (#2273)", () => {
-  describe("Layer 2: preflight credential check", () => {
-    it("cancels interactive rebuild before credential preflight or backup on non-affirmative input", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        providerRegistered: false,
-      });
-
-      const result = runRebuild(f, {}, { yes: false, input: "n\n" });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).toBe(0);
-      expect(output).toContain("Proceed? [y/N]:");
-      expect(output).toContain("Cancelled.");
-      expect(output).not.toContain("preflight failed");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("accepts trimmed case-insensitive yes input before continuing rebuild", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-      });
-
-      const result = runRebuild(f, {}, { yes: false, input: " YES \n" });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(output).toContain("Proceed? [y/N]:");
-      expect(output).not.toContain("Cancelled.");
-      expect(output).not.toContain("preflight failed");
-      expect(output).toContain("Backing up sandbox state");
-    });
-
-    it("aborts multi-agent rebuild before prompting, preflight, or backup", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        agents: [{ name: "openclaw" }, { name: "hermes" }],
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-      });
-
-      const result = runRebuild(f, {}, { yes: false, input: "YES\n" });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("Multi-agent sandbox rebuild is not yet supported");
-      expect(output).not.toContain("Proceed? [y/N]:");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("prints active SSH session warning before interactive confirmation", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        activeSessionCount: 2,
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-      });
-
-      const result = runRebuild(f, {}, { yes: false, input: "n\n" });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).toBe(0);
-      expect(output).toContain("Active SSH sessions detected (2 connections)");
-      expect(output).toContain("terminate all active sessions with a Broken pipe error");
-      expect(output).toContain("Proceed? [y/N]:");
-      expect(output).toContain("Cancelled.");
-      expect(output).not.toContain("Backing up sandbox state");
-    });
-
-    it("omits active SSH warning when detection is unavailable", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        activeSessionCount: null,
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-      });
-
-      const result = runRebuild(f, {}, { yes: false, input: "n\n" });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).toBe(0);
-      expect(output).not.toContain("Active SSH");
-      expect(output).toContain("Proceed? [y/N]:");
-      expect(output).toContain("Cancelled.");
-      expect(output).not.toContain("Backing up sandbox state");
-    });
-
-    it("aborts rebuild BEFORE destroying sandbox when credential is missing", {
-      timeout: 60_000,
-    }, () => {
-      // No credential in env or credentials.json AND no gateway-registered
-      // provider — preflight must still abort so the sandbox is preserved.
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        providerRegistered: false,
-        // no savedCredential
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      // Should prefer the missing-provider abort over the generic missing-env fallback.
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("provider 'nvidia-prod' is not registered in OpenShell");
-      expect(output).toContain("NVIDIA_INFERENCE_API_KEY");
-      expect(output).not.toContain("provider credential not found");
-      expect(output).not.toContain("export NVIDIA_INFERENCE_API_KEY=<your-key>");
-      // Should say sandbox is untouched
-      expect(output).toContain("untouched");
-      // Sandbox should still be in the registry (not destroyed)
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("proceeds when credential is saved in credentials.json (not in env)", {
-      timeout: 60_000,
-    }, () => {
-      // Credential saved in credentials.json but NOT in process.env
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      // Should NOT show preflight failure
-      expect(output).not.toContain("preflight failed");
-      // Should proceed to backup step
-      expect(output).toContain("Backing up sandbox state");
-    });
-
-    it("preserves the Ready DCode sandbox when its stored inference route returns 401 (#6195)", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        agent: "langchain-deepagents-code",
-        provider: "compatible-endpoint",
-        credentialEnv: "COMPATIBLE_API_KEY",
-        providerRegistered: true,
-        inferenceProbeHttpStatus: 401,
-      });
-
-      const result = runRebuild(f, {
-        NEMOCLAW_PROVIDER_KEY: "obviously-invalid-ambient-credential",
-      });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("HTTP 401");
-      expect(output).toContain("Sandbox is untouched");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(output).not.toContain("Deleting old sandbox");
-      expect(output).not.toContain("Old sandbox deleted");
-      expect(output).not.toContain("Creating new sandbox with current image");
-      expect(fs.existsSync(f.deleteMarker)).toBe(false);
-      expect(registryHasSandbox(f)).toBe(true);
-
-      const liveList = spawnSync(path.join(f.tmpDir, "openshell"), ["sandbox", "list"], {
-        encoding: "utf-8",
-      });
-      expect(liveList.status).toBe(0);
-      expect(liveList.stdout).toContain(`${f.sandboxName} Ready`);
-
-      const marker = runCli(f, [
-        f.sandboxName,
-        "exec",
-        "--",
-        "cat",
-        "/sandbox/rebuild-atomicity-marker.txt",
-      ]);
-      expect(marker.status, marker.stderr).toBe(0);
-      expect(marker.stdout).toContain("dcode-atomicity-marker");
-    });
-
-    it("aborts before backup when the gateway provider is missing even with host credential", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        provider: "nvidia-prod",
-        providerRegistered: false,
-      });
-
-      const result = runRebuild(f, {
-        NVIDIA_INFERENCE_API_KEY: "nvapi-test-key-for-rebuild",
-      });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("provider 'nvidia-prod' is not registered in OpenShell");
-      expect(output).toContain("NVIDIA_INFERENCE_API_KEY");
-      expect(output).toContain("Sandbox is untouched");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(output).not.toContain("Old sandbox deleted");
-      expect(output).not.toContain("Creating new sandbox with current image");
-      expect(output).not.toContain("missing from gateway; recreating it");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("copies Hermes messaging channels from the registry into the rebuild resume session", {
-      timeout: testTimeout(120_000),
-    }, () => {
-      const f = createFixture({
-        agent: "hermes",
-        messagingPlanChannels: ["discord"],
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-      });
-
-      const result = runRebuild(f, {}, { timeoutMs: 120_000 });
-      const output = (result.stderr || "") + (result.stdout || "");
-      expect(output).toContain("Creating new sandbox with current image");
-
-      const session = JSON.parse(
-        fs.readFileSync(path.join(f.nemoclawDir, "onboard-session.json"), "utf-8"),
-      );
-      expect(session.agent).toBe("hermes");
-      expect(
-        session.messagingPlan?.channels.map((channel: { channelId: string }) => channel.channelId),
-      ).toEqual(["discord"]);
-    });
-
-    it("aborts rebuild before backup when forced Hermes base image build fails", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        agent: "hermes",
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-        dockerBuildExitCode: 23,
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("Rebuild preflight failed");
-      expect(output).toContain("agent base image could not be built");
-      expect(output).toContain("Failed to build Hermes Agent base image (exit 23)");
-      expect(output).toContain("Sandbox is untouched");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("skips credential preflight for local inference (no credentialEnv in session)", {
-      timeout: 60_000,
-    }, () => {
-      // Ollama/vLLM — no credentialEnv in session
-      const f = createFixture({
-        provider: "ollama-local",
-        credentialEnv: undefined as unknown as string,
-      });
-
-      // Patch the session to have null credentialEnv
-      const sessionPath = path.join(f.nemoclawDir, "onboard-session.json");
-      const session = JSON.parse(fs.readFileSync(sessionPath, "utf-8"));
-      session.credentialEnv = null;
-      session.provider = "ollama-local";
-      fs.writeFileSync(sessionPath, JSON.stringify(session), { mode: 0o600 });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      // Should NOT show preflight failure
-      expect(output).not.toContain("preflight failed");
-      // Should proceed to backup step
-      expect(output).toContain("Backing up sandbox state");
-    });
-
-    it.each([
-      ["ollama-local"],
-      ["vllm-local"],
-    ])("migrates a legacy %s sandbox off OPENAI_API_KEY (#2519)", (provider) => {
-      // Pre-fix sandboxes recorded credentialEnv="OPENAI_API_KEY" even
-      // though local inference never actually needed it. After the fix,
-      // the wizard records null. Rebuild must accept the legacy value,
-      // print a one-time migration notice, and proceed even when no
-      // OPENAI_API_KEY exists in env or credentials.json.
-      const f = createFixture({
-        provider,
-        credentialEnv: "OPENAI_API_KEY",
-        // no savedCredential — host has no OPENAI_API_KEY anywhere
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      // Must NOT bail with the usual missing-credential failure
-      expect(output).not.toContain("preflight failed");
-      expect(output).not.toContain("Missing credential: OPENAI_API_KEY");
-      // Must surface the migration notice so testers know the legacy
-      // behaviour was intentionally bypassed
-      expect(output).toContain("GH #2519");
-      expect(output).toContain(provider);
-      // Must continue into the backup step
-      expect(output).toContain("Backing up sandbox state");
-    }, 60_000);
-
-    it("fails closed when a matching session omits the remote target provider credential", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        provider: "openai-api",
-        credentialEnv: "OPENAI_API_KEY",
-        providerRegistered: false,
-      });
-      const sessionPath = path.join(f.nemoclawDir, "onboard-session.json");
-      const session = JSON.parse(fs.readFileSync(sessionPath, "utf-8"));
-      session.credentialEnv = null;
-      fs.writeFileSync(sessionPath, JSON.stringify(session), { mode: 0o600 });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("provider 'openai-api' is not registered in OpenShell");
-      expect(output).toContain("OPENAI_API_KEY");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(output).not.toContain("Old sandbox deleted");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("uses the target registry provider when a matching session has a stale registered provider", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        provider: "openai-api",
-        credentialEnv: "OPENAI_API_KEY",
-        registeredProviders: ["nvidia-prod"],
-      });
-      const sessionPath = path.join(f.nemoclawDir, "onboard-session.json");
-      const session = JSON.parse(fs.readFileSync(sessionPath, "utf-8"));
-      session.provider = "nvidia-prod";
-      session.credentialEnv = null;
-      fs.writeFileSync(sessionPath, JSON.stringify(session), { mode: 0o600 });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("provider 'openai-api' is not registered in OpenShell");
-      expect(output).toContain("OPENAI_API_KEY");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(output).not.toContain("Old sandbox deleted");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("does not let a mismatched stale local session bypass the target OPENAI_API_KEY preflight", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        provider: "openai-api",
-        credentialEnv: "OPENAI_API_KEY",
-        providerRegistered: false,
-      });
-      const sessionPath = path.join(f.nemoclawDir, "onboard-session.json");
-      const session = JSON.parse(fs.readFileSync(sessionPath, "utf-8"));
-      session.sandboxName = "other-local-sandbox";
-      session.provider = "ollama-local";
-      session.credentialEnv = "OPENAI_API_KEY";
-      fs.writeFileSync(sessionPath, JSON.stringify(session), { mode: 0o600 });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("provider 'openai-api' is not registered in OpenShell");
-      expect(output).toContain("OPENAI_API_KEY");
-      expect(output).not.toContain("GH #2519");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(output).not.toContain("Old sandbox deleted");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("preflight works for non-NVIDIA providers (OpenAI, Anthropic, etc.)", {
-      timeout: 60_000,
-    }, () => {
-      // OpenAI provider with no credential AND no gateway registration —
-      // should abort.
-      const f = createFixture({
-        provider: "openai-api",
-        credentialEnv: "OPENAI_API_KEY",
-        providerRegistered: false,
-        // no savedCredential
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("OPENAI_API_KEY");
-      expect(output).toContain("untouched");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("uses the registered Hermes Provider in OpenShell instead of requiring OPENAI_API_KEY", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        agent: "hermes",
-        provider: "hermes-provider",
-        credentialEnv: "OPENAI_API_KEY",
-        hermesAuthMethod: "oauth",
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(output).not.toContain("Missing credential: OPENAI_API_KEY");
-      expect(output).not.toContain("provider credential not found");
-      expect(output).toContain("Backing up sandbox state");
-    });
-
-    it("registers an exported Hermes API key in OpenShell when the provider is missing", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        agent: "hermes",
-        provider: "hermes-provider",
-        credentialEnv: "NOUS_API_KEY",
-        hermesAuthMethod: "api_key",
-        providerRegistered: false,
-      });
-
-      const result = runRebuild(f, { NOUS_API_KEY: "nous-key-from-env" });
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(output).not.toContain("Missing credential: NOUS_API_KEY");
-      expect(output).not.toContain("provider credential not found");
-      expect(output).toContain(
-        "Hermes Provider is not registered in OpenShell; registering it from the configured exported API-key environment variable before rebuild.",
-      );
-      expect(output).not.toContain("NOUS_API_KEY");
-      expect(output).not.toContain("nous-key-from-env");
-      expect(output).toContain("Backing up sandbox state");
-      expect(output).toContain("State backed up");
-    });
-
-    it("uses the registered nvidia-prod provider in OpenShell instead of requiring NVIDIA_INFERENCE_API_KEY", {
-      timeout: 60_000,
-    }, () => {
-      // After `nemohermes channels add wechat` the rebuild preflight used to
-      // abort because NVIDIA_INFERENCE_API_KEY was not set in the environment, even
-      // though `nvidia-prod` was already registered in the OpenShell
-      // gateway. Reuse the gateway-stored credential instead.
-      const f = createFixture({
-        provider: "nvidia-prod",
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        providerRegistered: true,
-        // no savedCredential — host env has no NVIDIA_INFERENCE_API_KEY
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(output).not.toContain("Missing credential: NVIDIA_INFERENCE_API_KEY");
-      expect(output).not.toContain("provider credential not found");
-      expect(output).toContain("Backing up sandbox state");
-    });
-
-    it("still aborts when nvidia-prod is missing from the gateway AND the env", {
-      timeout: 60_000,
-    }, () => {
-      // Negative gate on gateway-credential reuse: if the gateway also lost
-      // the provider (cold install, gateway state lost) and the env is
-      // empty, the preflight must still bail so the sandbox is preserved.
-      const f = createFixture({
-        provider: "nvidia-prod",
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        providerRegistered: false,
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("preflight failed");
-      expect(output).toContain("provider 'nvidia-prod' is not registered in OpenShell");
-      expect(output).toContain("NVIDIA_INFERENCE_API_KEY");
-      expect(output).not.toContain("provider credential not found");
-      expect(output).toContain("untouched");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
-
-    it("aborts Hermes OAuth rebuild before backup when the OpenShell provider is missing", {
-      timeout: 60_000,
-    }, () => {
-      const f = createFixture({
-        agent: "hermes",
-        provider: "hermes-provider",
-        credentialEnv: "OPENAI_API_KEY",
-        hermesAuthMethod: "oauth",
-        providerRegistered: false,
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      expect(result.status).not.toBe(0);
-      expect(output).toContain("Hermes Provider is not registered in OpenShell");
-      expect(output).toContain("credentials must be stored in OpenShell");
-      expect(output).not.toContain("Missing credential: OPENAI_API_KEY");
-      expect(output).not.toContain("Backing up sandbox state");
-      expect(registryHasSandbox(f)).toBe(true);
-    });
+describe("atomic rebuild process contracts (#2273)", () => {
+  it("cancels interactive rebuild through stdin without entering preflight or backup", () => {
+    const fixture = createFixture({ providerRegistered: false });
+
+    const result = runRebuild(fixture, {}, { yes: false, input: "n\n" });
+    const output = `${result.stderr || ""}${result.stdout || ""}`;
+
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("Proceed? [y/N]:");
+    expect(output).toContain("Cancelled.");
+    expect(output).not.toContain("preflight failed");
+    expect(output).not.toContain("Backing up sandbox state");
+    expect(registryHasSandbox(fixture)).toBe(true);
   });
 
-  describe("Layer 3: recovery on recreate failure", () => {
-    it("prints recovery instructions when recreate fails after destroy", {
-      timeout: 60_000,
-    }, () => {
-      // Credential IS present so preflight passes, but onboard will
-      // fail because the fake openshell doesn't support full onboard.
-      // The key thing: rebuild should catch the failure and print
-      // recovery instructions instead of silently exiting.
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        savedCredential: {
-          key: "NVIDIA_INFERENCE_API_KEY",
-          value: "nvapi-test-key-for-rebuild",
-        },
-        // Force provider_selection to re-run (not resume) so onboard
-        // actually exercises the provider flow, which will fail in our
-        // fake environment.
-        providerSelectionStatus: "pending",
-      });
-
-      const result = runRebuild(f);
-      const output = (result.stderr || "") + (result.stdout || "");
-
-      // Should show the backup was created
-      expect(output).toContain("State backed up");
-      // Should show sandbox was deleted
-      expect(output).toContain("Old sandbox deleted");
-      // Should show recovery instructions (not just die silently)
-      expect(output).toContain("Recreate failed");
-      expect(output).toContain("recover manually");
-      expect(output).toContain("onboard --resume");
-      // Should mention where the backup is
-      expect(output).toContain("rebuild-backups");
+  it("accepts trimmed case-insensitive yes input before continuing into backup", () => {
+    const fixture = createFixture({
+      savedCredential: {
+        key: "NVIDIA_INFERENCE_API_KEY",
+        value: "nvapi-test-key-for-rebuild",
+      },
     });
 
-    it("preflight failure exits non-zero when credential is missing", { timeout: 60_000 }, () => {
-      // Verifies that missing credentials cause rebuild to exit non-zero
-      // when no fallback exists in the gateway either. This is the
-      // observable CLI behavior — the preflight check fails and bail()
-      // calls process.exit with a non-zero code.
-      const f = createFixture({
-        credentialEnv: "NVIDIA_INFERENCE_API_KEY",
-        providerRegistered: false,
-        // No credential — preflight will fail and exit non-zero
-      });
+    const result = runRebuild(fixture, {}, { yes: false, input: " YES \n" });
+    const output = `${result.stderr || ""}${result.stdout || ""}`;
 
-      const result = runRebuild(f);
-      expect(result.status).not.toBe(0);
+    expect(output).toContain("Proceed? [y/N]:");
+    expect(output).not.toContain("Cancelled.");
+    expect(output).not.toContain("preflight failed");
+    expect(output).toContain("Backing up sandbox state");
+  });
+
+  it("prints an active SSH session warning before interactive confirmation and cancel", () => {
+    const fixture = createFixture({
+      activeSessionCount: 2,
+      savedCredential: {
+        key: "NVIDIA_INFERENCE_API_KEY",
+        value: "nvapi-test-key-for-rebuild",
+      },
     });
+
+    const result = runRebuild(fixture, {}, { yes: false, input: "n\n" });
+    const output = `${result.stderr || ""}${result.stdout || ""}`;
+
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("Active SSH sessions detected (2 connections)");
+    expect(output).toContain("terminate all active sessions with a Broken pipe error");
+    expect(output).toContain("Proceed? [y/N]:");
+    expect(output).toContain("Cancelled.");
+    expect(output).not.toContain("Backing up sandbox state");
+  });
+
+  it("keeps a Ready DCode sandbox usable when its stored route returns 401 (#6195)", () => {
+    const fixture = createFixture({
+      agent: "langchain-deepagents-code",
+      provider: "compatible-endpoint",
+      credentialEnv: "COMPATIBLE_API_KEY",
+      providerRegistered: true,
+      inferenceProbeHttpStatus: 401,
+    });
+
+    const result = runRebuild(fixture, {
+      NEMOCLAW_PROVIDER_KEY: "obviously-invalid-ambient-credential",
+    });
+    const output = `${result.stderr || ""}${result.stdout || ""}`;
+
+    expect(result.status).not.toBe(0);
+    expect(output).toContain("HTTP 401");
+    expect(output).toContain("Sandbox is untouched");
+    expect(output).not.toContain("Backing up sandbox state");
+    expect(output).not.toContain("Deleting old sandbox");
+    expect(output).not.toContain("Creating new sandbox with current image");
+    expect(fs.existsSync(fixture.deleteMarker)).toBe(false);
+    expect(registryHasSandbox(fixture)).toBe(true);
+
+    const marker = runCli(fixture, [
+      fixture.sandboxName,
+      "exec",
+      "--",
+      "cat",
+      "/sandbox/rebuild-atomicity-marker.txt",
+    ]);
+    expect(marker.status, marker.stderr).toBe(0);
+    expect(marker.stdout).toContain("dcode-atomicity-marker");
+  });
+
+  it("registers an exported Hermes API key without exposing its name or value", () => {
+    const fixture = createFixture({
+      agent: "hermes",
+      provider: "hermes-provider",
+      credentialEnv: "NOUS_API_KEY",
+      hermesAuthMethod: "api_key",
+      providerRegistered: false,
+    });
+
+    const result = runRebuild(fixture, { NOUS_API_KEY: "nous-key-from-env" });
+    const output = `${result.stderr || ""}${result.stdout || ""}`;
+
+    expect(output).toContain(
+      "Hermes Provider is not registered in OpenShell; registering it from the configured exported API-key environment variable before rebuild.",
+    );
+    expect(output).not.toContain("NOUS_API_KEY");
+    expect(output).not.toContain("nous-key-from-env");
+    expect(output).toContain("Backing up sandbox state");
+    expect(output).toContain("State backed up");
+  });
+
+  it("returns a nonzero CLI status when credential preflight fails", () => {
+    const fixture = createFixture({ providerRegistered: false });
+
+    const result = runRebuild(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(fs.existsSync(fixture.deleteMarker)).toBe(false);
+    expect(registryHasSandbox(fixture)).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Reduce unnecessary process isolation across the rebuild credential/preflight, Hermes config generation, and policy-tier onboarding suites while retaining representative executable and adapter contracts. This removes 128 of 140 test-launched processes across the three areas (91%) and keeps product defaults unchanged.

## Related Issue

Part of #6245

## Changes

- Move rebuild credential/preflight decision coverage into the direct rebuild-flow harness, retaining six CLI/process contracts plus the DCode liveness child.
- Add an explicit, import-safe Hermes config generation seam and build legacy messaging plans in process, retaining executable and copied-script contracts.
- Exercise policy-tier selection, prompt, env, and resolution seams directly while retaining adapter contracts for CLI rejection and registry persistence.
- Thread the explicit Hermes generation environment through managed-tool matrix loading and verify direct/executable parity against an ambient decoy.
- Reduce test-launched processes from 27 to 7 for rebuild preflight, 75 to 2 for Hermes config, and 38 to 3 for policy tiers.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal test-harness and dependency-seam refactoring only; CLI output, config shape, and user-facing behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent local reviews covered rebuild mutation ordering and interactive wiring, Hermes generation and messaging semantics, policy-tier persistence, and process-wide state restoration; all required findings were addressed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 228/228 passed in 19.97s across the eight changed and adjacent test surfaces; `npm run typecheck:cli` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — local `npm test` reached 13,096 passing tests; seven mode assertions inherited the host's `077` umask and passed 68/68 under `022`, while one E2E source-shape failure is byte-identical on `origin/main`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Benchmark

- Final six-surface run under `strace`: 43.58s for 182 tests.
- Previous rebuild credential/preflight file alone under `strace`: 115.16s.
- In the ordinary final run, rebuild credential/preflight completed in 9.44s, Hermes config in 0.39s, and policy tiers in 1.15s.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes configuration generation now uses the provided environment consistently, making generated outputs more predictable.
  * Sandbox rebuild confirmations can now be reused in more places, with support for custom prompt handling.

* **Bug Fixes**
  * Improved rebuild preflight checks and warnings for active sessions, missing credentials, and unsupported multi-agent rebuilds.
  * Hardened rebuild flows so failures surface clearer messages and avoid unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->