### PR TITLE
ci(release): label merged PRs with release targets

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json
@@ -609,8 +609,9 @@
     "release": {
       "item_kinds": ["issue", "pull_request"],
       "pattern": "^v\\d+\\.\\d+\\.\\d+$",
-      "positive_signals": ["maintainer selected PR for daily work", "open PR activated for day queue", "issue tracked as daily release attention signal", "issue flagged as needing PR work for daily release"],
-      "negative_signals": ["readiness claim", "automatic bump", "issue treated as release inclusion"]
+      "positive_signals": ["maintainer selected PR for daily work", "open PR activated for day queue", "authorized post-merge assignment to a containing release or the next patch release", "issue tracked as daily release attention signal", "issue flagged as needing PR work for daily release"],
+      "negative_signals": ["readiness claim", "unverified automatic assignment outside an authorized workflow", "issue treated as release inclusion"],
+      "application_policy": "Authorized post-merge automation may add the earliest containing release label, or the next patch label when no release contains a PR merged to main. It must preserve existing version labels."
     },
     "agent_owned": {
       "item_kinds": ["issue", "pull_request"],
@@ -631,6 +632,7 @@
     "human_review_required_when_outside_authorization_context": true,
     "agent_owned_label_writes_allowed_when_authorized": true,
     "release_labels_on_issues_allowed": true,
+    "post_merge_release_labeling_allowed": true,
     "release_label_is_readiness_claim": false
   }
 }

--- a/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.md
@@ -191,7 +191,7 @@ Do not combine:
 
 ### Release Train
 
-Daily `v0.0.x` labels activate PRs for daily release work. Issues may use a daily label as a tracking or attention signal, but issue labels do not determine release inclusion. See `release-train.md`.
+Daily `v0.0.x` labels activate open PRs for daily release work. After a PR merges to `main`, authorized post-merge automation adds its earliest containing release label, or the next patch label after the highest strict-ancestor release when no tag contains it yet. This gives every landed PR release attribution, is additive, and does not remove earlier version labels. Issues may use a daily label as a tracking or attention signal, but issue labels do not determine release inclusion. See `release-train.md`.
 
 ### Agent-Owned
 

--- a/.agents/skills/nemoclaw-maintainer-policies/references/project-workflow.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/project-workflow.md
@@ -63,12 +63,13 @@ Standup converts the recommendation into assignments. Every recommended item sho
 
 ## Release Labels In Project Context
 
-Daily `v0.0.x` labels have different meanings by item kind:
+Daily `v0.0.x` labels have different meanings by item kind and PR state:
 
-- On PRs, the label activates the PR for daily release work. Merged PRs carrying the daily label are candidates for the daily release cutoff.
+- On open PRs, the label activates the PR for daily release work. Open labeled PRs that merge by cutoff are candidates for that release.
+- After a PR merges to `main`, authorized automation adds the earliest containing release label, or the next patch label when no release tag contains the merge yet. This is historical release attribution, not evidence that the PR was activated or ready before merge.
 - On issues, the label is an attention, regression-tracking, or "needs PR for this daily release" signal. It does not include the issue in the release by itself.
 
-Open labeled PRs and issues that miss a tagged release are automatically moved to the next patch label during post-tag housekeeping. Remove a version label without replacement only when the item is deferred, superseded, closed, or no longer part of the daily release cycle.
+Open labeled PRs and issues that miss a tagged release are automatically moved to the next patch label during post-tag housekeeping. Merged PR labels remain as additive release attribution. Remove a version label without replacement only when an open item is deferred, superseded, closed, or no longer part of the daily release cycle.
 
 ## Issue Templates
 

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -9,12 +9,15 @@ Daily release labels coordinate release work. They do not classify issues and th
 
 - PRs own the release-inclusion meaning of daily version labels.
 - Engineers and agents may add the current `v0.0.x` label to open PRs to activate them for day work.
+- After a PR merges to `main`, the trusted post-merge workflow records it automatically. If a release tag already contains the merge, the workflow uses the earliest containing release; otherwise it finds the highest strict-ancestor release tag and adds its next patch label.
+- Post-merge assignment is additive and idempotent. It creates the next release label with the canonical metadata when needed and never removes an existing version label.
+- A scheduled and manually dispatchable reconciliation pass repairs missed or failed merge events across the current train and completed releases tagged within the seven-day retention window.
 - Issues may also carry daily version labels when they need a PR, fix, or regression follow-up for the daily tag.
 - Applying a daily version label is not a readiness claim.
 - Release includes PRs that both carry the daily version label and are merged by cutoff.
 - Issue version labels are tracking signals only; an issue label does not include work in the release without a merged labeled PR.
 - Open PRs and issues that miss a tagged release carry forward automatically by moving from the released version label to the next patch label.
-- A PR or issue leaves the daily release cycle only when its version label is removed without a replacement.
+- An open PR or issue leaves the daily release cycle only when its version label is removed without a replacement. Merged PR labels record release attribution and remain subject to the history and pruning rules below.
 - Version labels are pruned after seven days only after durable release history is preserved and no open PR still carries or depends on the old label.
 
 ## Release-Prep Docs
@@ -71,7 +74,7 @@ Old version labels may be deleted only when all conditions are true:
 
 1. The label is older than seven days.
 2. Durable release history has been preserved in tags, release notes, Agent Feed artifacts, or equivalent reports.
-3. No open PR or issue still carries or depends on the old label after post-tag housekeeping.
+3. No open PR or issue still carries or depends on the old label after post-tag housekeeping, and the label is outside the post-merge reconciliation window.
 4. The current authorization context explicitly allows label pruning.
 
 Pruning is a cleanup operation, not part of ordinary daily triage.

--- a/.github/workflows/label-merged-pr-release-target.yaml
+++ b/.github/workflows/label-merged-pr-release-target.yaml
@@ -1,0 +1,375 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Automation / Label Merged PR Release Target
+
+# pull_request_target runs in the base repo context, giving the token write
+# access even for fork PRs. This workflow is safe because it only reads trusted
+# repository metadata and edits labels. Do NOT add a checkout step or execute
+# PR-sourced code here.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [closed]
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  label-release-target:
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Apply release target to merged PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const RELEASE_LABEL_COLOR = '1d76db';
+            const RELEASE_LABEL_DESCRIPTION = 'Release target';
+            const RELEASE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)$/;
+            const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+            const RECONCILIATION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+            const ensuredLabels = new Set();
+
+            function validateSha(value, description) {
+              if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
+                throw new Error(`Invalid ${description}: ${value}`);
+              }
+              return value;
+            }
+
+            function nextPatchLabel(release) {
+              const [major, minor, patch] = release.parts;
+              if (patch === Number.MAX_SAFE_INTEGER) {
+                throw new Error(`Cannot increment release tag ${release.name} safely`);
+              }
+              return `v${major}.${minor}.${patch + 1}`;
+            }
+
+            async function loadReleaseTags() {
+              const listedTags = await github.paginate(github.rest.repos.listTags, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+              const releaseTags = [];
+              const seenTags = new Set();
+
+              for (const tag of listedTags) {
+                const match = RELEASE_TAG_PATTERN.exec(tag.name ?? '');
+                if (!match || seenTags.has(tag.name)) continue;
+                const parts = match.slice(1).map((part) => Number(part));
+                if (!parts.every((part) => Number.isSafeInteger(part))) {
+                  throw new Error(`Release tag exceeds the supported numeric range: ${tag.name}`);
+                }
+                seenTags.add(tag.name);
+                releaseTags.push({ name: tag.name, parts });
+              }
+
+              releaseTags.sort((left, right) => {
+                for (let index = 0; index < 3; index += 1) {
+                  if (left.parts[index] > right.parts[index]) return -1;
+                  if (left.parts[index] < right.parts[index]) return 1;
+                }
+                return 0;
+              });
+
+              if (releaseTags.length === 0) {
+                throw new Error('No strict semver release tags were found');
+              }
+              return releaseTags;
+            }
+
+            async function peelReleaseTag(release) {
+              if (release.commit) return release.commit;
+              const reference = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${release.name}`,
+              });
+              if (reference.data.object.type !== 'tag') {
+                throw new Error(`Release tag ${release.name} must be annotated`);
+              }
+
+              const annotatedTag = await github.rest.git.getTag({
+                owner,
+                repo,
+                tag_sha: reference.data.object.sha,
+              });
+              const releaseCommit = annotatedTag.data.object.sha;
+              if (annotatedTag.data.object.type !== 'commit') {
+                throw new Error(`Release tag ${release.name} does not peel to a commit`);
+              }
+              release.commit = validateSha(releaseCommit, `commit for release tag ${release.name}`);
+              release.taggedAt = Date.parse(annotatedTag.data.tagger?.date ?? '');
+              if (!Number.isFinite(release.taggedAt)) {
+                throw new Error(`Release tag ${release.name} has an invalid tagger date`);
+              }
+              return release.commit;
+            }
+
+            async function compareRelation(base, head) {
+              const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${base}...${head}`,
+                per_page: 1,
+              });
+              const { status, ahead_by: aheadBy, behind_by: behindBy } = comparison.data;
+              if (aheadBy > 0 && behindBy === 0) return 'ahead';
+              if (behindBy > 0 && aheadBy === 0) return 'behind';
+              if (aheadBy === 0 && behindBy === 0 && status === 'identical') return 'identical';
+              throw new Error(`Release comparison ${base}...${head} is not linear: ${status}`);
+            }
+
+            async function resolveTargetForMerge(mergeSha, releaseTags) {
+              let containingRelease;
+              for (const release of releaseTags) {
+                const releaseCommit = await peelReleaseTag(release);
+                const relation = await compareRelation(releaseCommit, mergeSha);
+
+                if (relation === 'behind' || relation === 'identical') {
+                  containingRelease = release;
+                  continue;
+                }
+                if (containingRelease) {
+                  return {
+                    label: containingRelease.name,
+                    boundary: `containing release ${containingRelease.name}`,
+                  };
+                }
+                return {
+                  label: nextPatchLabel(release),
+                  boundary: `release predecessor ${release.name}`,
+                };
+              }
+
+              if (containingRelease) {
+                return {
+                  label: containingRelease.name,
+                  boundary: `containing release ${containingRelease.name}`,
+                };
+              }
+              throw new Error(`No release tag is linearly related to merge ${mergeSha}`);
+            }
+
+            function releaseLabels(pullRequest) {
+              return (pullRequest.labels ?? [])
+                .map((label) => label?.name)
+                .filter((name) => typeof name === 'string' && RELEASE_TAG_PATTERN.test(name));
+            }
+
+            async function ensureReleaseLabel(targetLabel) {
+              if (ensuredLabels.has(targetLabel)) return;
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: targetLabel });
+              } catch (error) {
+                if (error?.status !== 404) throw error;
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: targetLabel,
+                    color: RELEASE_LABEL_COLOR,
+                    description: RELEASE_LABEL_DESCRIPTION,
+                  });
+                  core.info(`Created release target label ${targetLabel}`);
+                } catch (createError) {
+                  if (createError?.status !== 422) throw createError;
+                  await github.rest.issues.getLabel({ owner, repo, name: targetLabel });
+                  core.info(`Release target label ${targetLabel} was created concurrently`);
+                }
+              }
+              ensuredLabels.add(targetLabel);
+            }
+
+            async function applyTarget(pullRequest, targetLabel, boundary) {
+              const prNumber = pullRequest?.number;
+              if (!Number.isInteger(prNumber) || prNumber <= 0) {
+                throw new Error(`Invalid merged pull request number: ${prNumber}`);
+              }
+
+              const existingReleaseLabels = releaseLabels(pullRequest);
+              if (existingReleaseLabels.includes(targetLabel)) {
+                core.info(`PR #${prNumber} already has release target ${targetLabel}`);
+                return;
+              }
+              const otherReleaseLabels = existingReleaseLabels.filter(
+                (label) => label !== targetLabel,
+              );
+              if (otherReleaseLabels.length > 0) {
+                core.warning(
+                  `PR #${prNumber} already has release label(s) ${otherReleaseLabels.join(', ')}; preserving them and adding ${targetLabel}`,
+                );
+              }
+
+              await ensureReleaseLabel(targetLabel);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [targetLabel],
+              });
+              core.info(`Added ${targetLabel} to PR #${prNumber} from ${boundary}`);
+            }
+
+            async function listCommitsBetween(base, head) {
+              const commits = [];
+              let page = 1;
+              let totalCommits;
+
+              while (true) {
+                const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                  owner,
+                  repo,
+                  basehead: `${base}...${head}`,
+                  per_page: 100,
+                  page,
+                });
+                const { status, ahead_by: aheadBy, behind_by: behindBy } = comparison.data;
+                if (behindBy > 0 || (status !== 'ahead' && status !== 'identical')) {
+                  throw new Error(`Release range ${base}...${head} is not forward-only: ${status}`);
+                }
+
+                totalCommits ??= comparison.data.total_commits;
+                const pageCommits = comparison.data.commits ?? [];
+                commits.push(...pageCommits);
+                if (commits.length >= totalCommits || pageCommits.length === 0) break;
+                page += 1;
+              }
+              return commits;
+            }
+
+            async function collectIntervalPullRequests(interval) {
+              const pullRequestsByNumber = new Map();
+              const commits = await listCommitsBetween(interval.base, interval.head);
+              for (const commit of commits) {
+                const pullRequests = await github.paginate(
+                  github.rest.repos.listPullRequestsAssociatedWithCommit,
+                  {
+                    owner,
+                    repo,
+                    commit_sha: commit.sha,
+                    per_page: 100,
+                  },
+                );
+                for (const pullRequest of pullRequests) {
+                  if (
+                    !pullRequest.merged_at ||
+                    pullRequest.base?.ref !== 'main' ||
+                    pullRequest.merge_commit_sha !== commit.sha
+                  ) {
+                    continue;
+                  }
+                  pullRequestsByNumber.set(pullRequest.number, pullRequest);
+                }
+              }
+              return [...pullRequestsByNumber.values()];
+            }
+
+            async function applyInterval(interval, processed) {
+              const pullRequests = await collectIntervalPullRequests(interval);
+              for (const pullRequest of pullRequests) {
+                const key = `${interval.label}:${pullRequest.number}`;
+                if (processed.has(key)) continue;
+                processed.add(key);
+                await applyTarget(pullRequest, interval.label, interval.boundary);
+              }
+            }
+
+            async function refreshLatestRelease(expectedName, expectedCommit) {
+              const releaseTags = await loadReleaseTags();
+              const latest = releaseTags[0];
+              const latestCommit = await peelReleaseTag(latest);
+              return {
+                changed: latest.name !== expectedName || latestCommit !== expectedCommit,
+                latest,
+                latestCommit,
+                releaseTags,
+              };
+            }
+
+            async function reconcileReleaseTargets(releaseTags, restartCount = 0) {
+              const latestRelease = releaseTags[0];
+              const latestCommit = await peelReleaseTag(latestRelease);
+              const processed = new Set();
+              const reconciliationCutoff = Date.now() - RECONCILIATION_WINDOW_MS;
+
+              for (let index = 0; index < releaseTags.length - 1; index += 1) {
+                const newer = releaseTags[index];
+                const older = releaseTags[index + 1];
+                await peelReleaseTag(newer);
+                if (newer.taggedAt < reconciliationCutoff) break;
+                await applyInterval(
+                  {
+                    base: await peelReleaseTag(older),
+                    head: await peelReleaseTag(newer),
+                    label: newer.name,
+                    boundary: `containing release ${newer.name}`,
+                  },
+                  processed,
+                );
+              }
+
+              const refreshed = await refreshLatestRelease(latestRelease.name, latestCommit);
+              if (refreshed.changed) {
+                if (restartCount >= 2) {
+                  throw new Error('Newest release tag kept changing during reconciliation');
+                }
+                core.warning('Newest release tag changed; restarting reconciliation');
+                return reconcileReleaseTargets(refreshed.releaseTags, restartCount + 1);
+              }
+
+              const main = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
+              const mainCommit = validateSha(main.data.commit.sha, 'main commit SHA');
+              const currentInterval = {
+                base: refreshed.latestCommit,
+                head: mainCommit,
+                label: nextPatchLabel(refreshed.latest),
+                boundary: `release predecessor ${refreshed.latest.name}`,
+              };
+              const currentPullRequests = await collectIntervalPullRequests(currentInterval);
+              const verified = await refreshLatestRelease(
+                refreshed.latest.name,
+                refreshed.latestCommit,
+              );
+              if (verified.changed) {
+                if (restartCount >= 2) {
+                  throw new Error('Newest release tag kept changing during reconciliation');
+                }
+                core.warning('Newest release tag changed; restarting reconciliation');
+                return reconcileReleaseTargets(verified.releaseTags, restartCount + 1);
+              }
+
+              for (const pullRequest of currentPullRequests) {
+                const key = `${currentInterval.label}:${pullRequest.number}`;
+                if (processed.has(key)) continue;
+                processed.add(key);
+                await applyTarget(
+                  pullRequest,
+                  currentInterval.label,
+                  currentInterval.boundary,
+                );
+              }
+              core.info(`Reconciled ${processed.size} merged PR release target(s)`);
+            }
+
+            const releaseTags = await loadReleaseTags();
+            if (context.eventName === 'pull_request_target') {
+              const pullRequest = context.payload.pull_request;
+              const mergeSha = validateSha(
+                pullRequest?.merge_commit_sha,
+                `merge commit SHA for PR #${pullRequest?.number}`,
+              );
+              const target = await resolveTargetForMerge(mergeSha, releaseTags);
+              await applyTarget(pullRequest, target.label, target.boundary);
+            } else {
+              await reconcileReleaseTargets(releaseTags);
+            }

--- a/.github/workflows/label-merged-pr-release-target.yaml
+++ b/.github/workflows/label-merged-pr-release-target.yaml
@@ -30,8 +30,10 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            // Keep this privileged workflow inline so it never checks out or executes
-            // repository or PR code. Tests execute this exact pinned-action script.
+            // This intentionally deviates from the shell+gh pull_request_target pattern.
+            // Extracting it to TypeScript would require this privileged job to check out
+            // and execute repository files. The pinned action supplies Octokit without a
+            // checkout, and tests execute this exact inline script.
             const RELEASE_LABEL_COLOR = '1d76db';
             const RELEASE_LABEL_DESCRIPTION = 'Release target';
             const RELEASE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)$/;
@@ -56,6 +58,9 @@ jobs:
               }
               if (!Array.isArray(pullRequest.labels)) {
                 throw new Error('Invalid pull_request_target payload: labels must be an array');
+              }
+              if (pullRequest.merged !== true) {
+                throw new Error('Invalid pull_request_target payload: merged must be true');
               }
               return {
                 mergeSha: validateSha(
@@ -187,9 +192,11 @@ jobs:
                 .filter((name) => typeof name === 'string' && RELEASE_TAG_PATTERN.test(name));
             }
 
-            // The label name is the idempotency key. A concurrent run may create it
-            // after our 404, so a 422 is verified by re-reading the label. This is
-            // covered by the concurrent-creation regression test.
+            // Invalid state: another run creates the same label after our 404, yielding
+            // a 422. The source boundary is GitHub's Labels API, which has no atomic
+            // create-or-get operation, so this workflow verifies the winner by re-reading
+            // the label. The concurrent-creation regression test covers the workaround;
+            // remove it when the API offers an atomic equivalent.
             async function ensureReleaseLabel(targetLabel) {
               if (ensuredLabels.has(targetLabel)) return;
               try {

--- a/.github/workflows/label-merged-pr-release-target.yaml
+++ b/.github/workflows/label-merged-pr-release-target.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            // Keep this privileged workflow inline so it never checks out or executes
+            // repository or PR code. Tests execute this exact pinned-action script.
             const RELEASE_LABEL_COLOR = '1d76db';
             const RELEASE_LABEL_DESCRIPTION = 'Release target';
             const RELEASE_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)$/;
@@ -43,6 +45,25 @@ jobs:
                 throw new Error(`Invalid ${description}: ${value}`);
               }
               return value;
+            }
+
+            function validatePullRequest(pullRequest) {
+              if (!pullRequest || typeof pullRequest !== 'object') {
+                throw new Error('Invalid pull_request_target payload: pull_request is missing');
+              }
+              if (!Number.isInteger(pullRequest.number) || pullRequest.number <= 0) {
+                throw new Error(`Invalid merged pull request number: ${pullRequest.number}`);
+              }
+              if (!Array.isArray(pullRequest.labels)) {
+                throw new Error('Invalid pull_request_target payload: labels must be an array');
+              }
+              return {
+                mergeSha: validateSha(
+                  pullRequest.merge_commit_sha,
+                  `merge commit SHA for PR #${pullRequest.number}`,
+                ),
+                pullRequest,
+              };
             }
 
             function nextPatchLabel(release) {
@@ -166,6 +187,9 @@ jobs:
                 .filter((name) => typeof name === 'string' && RELEASE_TAG_PATTERN.test(name));
             }
 
+            // The label name is the idempotency key. A concurrent run may create it
+            // after our 404, so a 422 is verified by re-reading the label. This is
+            // covered by the concurrent-creation regression test.
             async function ensureReleaseLabel(targetLabel) {
               if (ensuredLabels.has(targetLabel)) return;
               try {
@@ -361,15 +385,14 @@ jobs:
               core.info(`Reconciled ${processed.size} merged PR release target(s)`);
             }
 
-            const releaseTags = await loadReleaseTags();
             if (context.eventName === 'pull_request_target') {
-              const pullRequest = context.payload.pull_request;
-              const mergeSha = validateSha(
-                pullRequest?.merge_commit_sha,
-                `merge commit SHA for PR #${pullRequest?.number}`,
+              const { mergeSha, pullRequest } = validatePullRequest(
+                context.payload.pull_request,
               );
+              const releaseTags = await loadReleaseTags();
               const target = await resolveTargetForMerge(mergeSha, releaseTags);
               await applyTarget(pullRequest, target.label, target.boundary);
             } else {
+              const releaseTags = await loadReleaseTags();
               await reconcileReleaseTargets(releaseTags);
             }

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from "node:assert/strict";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { readYaml, type WorkflowJob } from "./helpers/e2e-workflow-contract";
@@ -60,7 +62,7 @@ function createHarness(tags: TagFixture[], pullRequestLabels: string[] = []) {
   });
   const getRef = vi.fn(async ({ ref }: { ref: string }) => {
     const fixture = fixtureByName.get(ref.replace(/^tags\//u, ""));
-    if (!fixture) throw new Error(`Unexpected tag ref: ${ref}`);
+    assert(fixture, `Unexpected tag ref: ${ref}`);
     return {
       data: {
         object: {
@@ -72,7 +74,7 @@ function createHarness(tags: TagFixture[], pullRequestLabels: string[] = []) {
   });
   const getTag = vi.fn(async ({ tag_sha: tagSha }: { tag_sha: string }) => {
     const fixture = fixtureByObjectSha.get(tagSha);
-    if (!fixture) throw new Error(`Unexpected tag object: ${tagSha}`);
+    assert(fixture, `Unexpected tag object: ${tagSha}`);
     return {
       data: {
         object: {
@@ -86,8 +88,8 @@ function createHarness(tags: TagFixture[], pullRequestLabels: string[] = []) {
   const compareCommitsWithBasehead = vi.fn(async ({ basehead }: { basehead: string }) => {
     const [base, head] = basehead.split("...");
     const fixture = fixtureByCommitSha.get(base);
-    if (!fixture) throw new Error(`Unexpected comparison base: ${base}`);
-    if (head !== MERGE_SHA) throw new Error(`Unexpected comparison head: ${head}`);
+    assert(fixture, `Unexpected comparison base: ${base}`);
+    assert.equal(head, MERGE_SHA, `Unexpected comparison head: ${head}`);
     const status = fixture.status ?? "ahead";
     return {
       data: {
@@ -341,29 +343,30 @@ describe("merged PR release target workflow", () => {
     harness.getBranch.mockResolvedValueOnce({ data: { commit: { sha: mainCommit } } });
     harness.compareCommitsWithBasehead.mockImplementation(
       async ({ basehead }: { basehead: string }) => {
-        if (basehead === `${latest.commitSha}...${mainCommit}`) {
-          return {
-            data: {
-              status: "ahead",
-              ahead_by: 1,
-              behind_by: 0,
-              total_commits: 1,
-              commits: [{ sha: MERGE_SHA }],
-            },
-          };
+        switch (basehead) {
+          case `${latest.commitSha}...${mainCommit}`:
+            return {
+              data: {
+                status: "ahead",
+                ahead_by: 1,
+                behind_by: 0,
+                total_commits: 1,
+                commits: [{ sha: MERGE_SHA }],
+              },
+            };
+          case `${previous.commitSha}...${latest.commitSha}`:
+            return {
+              data: {
+                status: "ahead",
+                ahead_by: 1,
+                behind_by: 0,
+                total_commits: 1,
+                commits: [{ sha: completedReleaseCommit }],
+              },
+            };
+          default:
+            throw new Error(`Unexpected reconciliation comparison: ${basehead}`);
         }
-        if (basehead === `${previous.commitSha}...${latest.commitSha}`) {
-          return {
-            data: {
-              status: "ahead",
-              ahead_by: 1,
-              behind_by: 0,
-              total_commits: 1,
-              commits: [{ sha: completedReleaseCommit }],
-            },
-          };
-        }
-        throw new Error(`Unexpected reconciliation comparison: ${basehead}`);
       },
     );
     harness.listPullRequestsAssociatedWithCommit.mockImplementation(
@@ -410,9 +413,11 @@ describe("merged PR release target workflow", () => {
     harness.getBranch.mockResolvedValueOnce({ data: { commit: { sha: mainCommit } } });
     harness.compareCommitsWithBasehead.mockImplementation(
       async ({ basehead }: { basehead: string }) => {
-        if (basehead !== `${latest.commitSha}...${mainCommit}`) {
-          throw new Error(`Unexpected expired release comparison: ${basehead}`);
-        }
+        assert.equal(
+          basehead,
+          `${latest.commitSha}...${mainCommit}`,
+          `Unexpected expired release comparison: ${basehead}`,
+        );
         return {
           data: {
             status: "identical",
@@ -446,32 +451,31 @@ describe("merged PR release target workflow", () => {
     harness.getBranch.mockResolvedValue({ data: { commit: { sha: mainCommit } } });
     harness.compareCommitsWithBasehead.mockImplementation(
       async ({ basehead }: { basehead: string }) => {
-        if (basehead === `${v11.commitSha}...${mainCommit}`) {
-          return {
-            data: {
-              status: "ahead",
-              ahead_by: 1,
-              behind_by: 0,
-              total_commits: 1,
-              commits: [{ sha: MERGE_SHA }],
-            },
-          };
+        switch (basehead) {
+          case `${v11.commitSha}...${mainCommit}`:
+            return {
+              data: {
+                status: "ahead",
+                ahead_by: 1,
+                behind_by: 0,
+                total_commits: 1,
+                commits: [{ sha: MERGE_SHA }],
+              },
+            };
+          case `${v10.commitSha}...${v11.commitSha}`:
+          case `${v09.commitSha}...${v10.commitSha}`:
+            return {
+              data: {
+                status: "ahead",
+                ahead_by: 1,
+                behind_by: 0,
+                total_commits: 1,
+                commits: [{ sha: "c".repeat(40) }],
+              },
+            };
+          default:
+            throw new Error(`Unexpected tag-change comparison: ${basehead}`);
         }
-        if (
-          basehead === `${v10.commitSha}...${v11.commitSha}` ||
-          basehead === `${v09.commitSha}...${v10.commitSha}`
-        ) {
-          return {
-            data: {
-              status: "ahead",
-              ahead_by: 1,
-              behind_by: 0,
-              total_commits: 1,
-              commits: [{ sha: "c".repeat(40) }],
-            },
-          };
-        }
-        throw new Error(`Unexpected tag-change comparison: ${basehead}`);
       },
     );
     harness.listPullRequestsAssociatedWithCommit.mockImplementation(

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -190,6 +190,33 @@ describe("merged PR release target workflow", () => {
     expect(job.steps?.some((step) => typeof step.run === "string")).toBe(false);
   });
 
+  it.each([
+    ["pull request", undefined, "pull_request is missing"],
+    [
+      "PR number",
+      { labels: [], merge_commit_sha: MERGE_SHA, number: 0 },
+      "Invalid merged pull request number: 0",
+    ],
+    [
+      "labels",
+      { labels: null, merge_commit_sha: MERGE_SHA, number: 123 },
+      "labels must be an array",
+    ],
+    [
+      "merge SHA",
+      { labels: [], merge_commit_sha: "not-a-sha", number: 123 },
+      "Invalid merge commit SHA for PR #123",
+    ],
+  ])("rejects malformed %s metadata before calling GitHub", async (_field, pullRequest, error) => {
+    const harness = createHarness([{ name: "v0.0.10", status: "ahead" }]);
+    Object.assign(harness.context.payload, { pull_request: pullRequest });
+
+    await expect(runScript(harness)).rejects.toThrow(error);
+
+    expect(harness.listTags).not.toHaveBeenCalled();
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
   it("uses numeric semver order and ignores non-release tags", async () => {
     const harness = createHarness([
       { name: "v0.0.9", status: "ahead" },
@@ -503,5 +530,31 @@ describe("merged PR release target workflow", () => {
     expect(harness.addLabels).toHaveBeenCalledWith(
       expect.objectContaining({ issue_number: 123, labels: ["v0.0.12"] }),
     );
+  });
+
+  it("stops after two reconciliation restarts when release tags keep changing", async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const harness = createHarness(
+      ["v0.0.13", "v0.0.12", "v0.0.11", "v0.0.10", "v0.0.9"].map((name) => ({
+        name,
+        taggedAt: eightDaysAgo,
+      })),
+    );
+    const [v13, v12, v11, v10, v09] = harness.fixtures;
+    harness.context.eventName = "schedule";
+    harness.listTags
+      .mockResolvedValueOnce({ data: [v10, v09] })
+      .mockResolvedValueOnce({ data: [v11, v10, v09] })
+      .mockResolvedValueOnce({ data: [v12, v11, v10, v09] })
+      .mockResolvedValueOnce({ data: [v13, v12, v11, v10, v09] });
+
+    await expect(runScript(harness)).rejects.toThrow(
+      "Newest release tag kept changing during reconciliation",
+    );
+
+    expect(harness.listTags).toHaveBeenCalledTimes(4);
+    expect(harness.warning).toHaveBeenCalledTimes(2);
+    expect(harness.getBranch).not.toHaveBeenCalled();
+    expect(harness.addLabels).not.toHaveBeenCalled();
   });
 });

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -130,6 +130,7 @@ function createHarness(tags: TagFixture[], pullRequestLabels: string[] = []) {
       pull_request: {
         labels: pullRequestLabels.map((name) => ({ name })),
         merge_commit_sha: MERGE_SHA,
+        merged: true,
         number: 123,
       },
       repository: { default_branch: "main" },
@@ -194,18 +195,23 @@ describe("merged PR release target workflow", () => {
     ["pull request", undefined, "pull_request is missing"],
     [
       "PR number",
-      { labels: [], merge_commit_sha: MERGE_SHA, number: 0 },
+      { labels: [], merge_commit_sha: MERGE_SHA, merged: true, number: 0 },
       "Invalid merged pull request number: 0",
     ],
     [
       "labels",
-      { labels: null, merge_commit_sha: MERGE_SHA, number: 123 },
+      { labels: null, merge_commit_sha: MERGE_SHA, merged: true, number: 123 },
       "labels must be an array",
     ],
     [
       "merge SHA",
-      { labels: [], merge_commit_sha: "not-a-sha", number: 123 },
+      { labels: [], merge_commit_sha: "not-a-sha", merged: true, number: 123 },
       "Invalid merge commit SHA for PR #123",
+    ],
+    [
+      "merged state",
+      { labels: [], merge_commit_sha: MERGE_SHA, merged: false, number: 123 },
+      "merged must be true",
     ],
   ])("rejects malformed %s metadata before calling GitHub", async (_field, pullRequest, error) => {
     const harness = createHarness([{ name: "v0.0.10", status: "ahead" }]);

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -1,0 +1,503 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { readYaml, type WorkflowJob } from "./helpers/e2e-workflow-contract";
+
+const AsyncFunction = Object.getPrototypeOf(async () => undefined).constructor as new (
+  ...parameters: string[]
+) => (...args: unknown[]) => Promise<unknown>;
+
+type AutoLabelWorkflow = {
+  on?: {
+    pull_request_target?: {
+      branches?: string[];
+      types?: string[];
+    };
+    schedule?: Array<{ cron: string }>;
+    workflow_dispatch?: unknown;
+  };
+  permissions?: Record<string, string>;
+  jobs: Record<string, WorkflowJob>;
+};
+
+type ComparisonStatus = "ahead" | "behind" | "diverged" | "identical";
+
+type TagFixture = {
+  name: string;
+  refType?: "commit" | "tag";
+  peeledType?: "commit" | "tag";
+  taggedAt?: string;
+  status?: ComparisonStatus;
+  aheadBy?: number;
+  behindBy?: number;
+};
+
+const WORKFLOW_PATH = ".github/workflows/label-merged-pr-release-target.yaml";
+const MERGE_SHA = "f".repeat(40);
+const workflow = readYaml<AutoLabelWorkflow>(WORKFLOW_PATH);
+const job = workflow.jobs["label-release-target"];
+const actionStep = job.steps?.find((step) => step.name === "Apply release target to merged PRs");
+const script = actionStep?.with?.script;
+
+function sha(index: number): string {
+  return index.toString(16).padStart(40, "0");
+}
+
+function createHarness(tags: TagFixture[], pullRequestLabels: string[] = []) {
+  const fixtures = tags.map((tag, index) => ({
+    ...tag,
+    objectSha: sha(index * 2 + 1),
+    commitSha: sha(index * 2 + 2),
+  }));
+  const fixtureByName = new Map(fixtures.map((fixture) => [fixture.name, fixture]));
+  const fixtureByObjectSha = new Map(fixtures.map((fixture) => [fixture.objectSha, fixture]));
+  const fixtureByCommitSha = new Map(fixtures.map((fixture) => [fixture.commitSha, fixture]));
+
+  const listTags = vi.fn().mockResolvedValue({
+    data: fixtures.map(({ name }) => ({ name })),
+  });
+  const getRef = vi.fn(async ({ ref }: { ref: string }) => {
+    const fixture = fixtureByName.get(ref.replace(/^tags\//u, ""));
+    if (!fixture) throw new Error(`Unexpected tag ref: ${ref}`);
+    return {
+      data: {
+        object: {
+          sha: fixture.objectSha,
+          type: fixture.refType ?? "tag",
+        },
+      },
+    };
+  });
+  const getTag = vi.fn(async ({ tag_sha: tagSha }: { tag_sha: string }) => {
+    const fixture = fixtureByObjectSha.get(tagSha);
+    if (!fixture) throw new Error(`Unexpected tag object: ${tagSha}`);
+    return {
+      data: {
+        object: {
+          sha: fixture.commitSha,
+          type: fixture.peeledType ?? "commit",
+        },
+        tagger: { date: fixture.taggedAt ?? new Date().toISOString() },
+      },
+    };
+  });
+  const compareCommitsWithBasehead = vi.fn(async ({ basehead }: { basehead: string }) => {
+    const [base, head] = basehead.split("...");
+    const fixture = fixtureByCommitSha.get(base);
+    if (!fixture) throw new Error(`Unexpected comparison base: ${base}`);
+    if (head !== MERGE_SHA) throw new Error(`Unexpected comparison head: ${head}`);
+    const status = fixture.status ?? "ahead";
+    return {
+      data: {
+        status,
+        ahead_by: fixture.aheadBy ?? (status === "ahead" ? 1 : 0),
+        behind_by: fixture.behindBy ?? (status === "behind" ? 1 : 0),
+      },
+    };
+  });
+  const getLabel = vi.fn().mockResolvedValue({ data: { name: "release-target" } });
+  const createLabel = vi.fn().mockResolvedValue({ data: {} });
+  const addLabels = vi.fn().mockResolvedValue({ data: [] });
+  const getBranch = vi.fn().mockResolvedValue({ data: { commit: { sha: MERGE_SHA } } });
+  const listPullRequestsAssociatedWithCommit = vi.fn().mockResolvedValue({ data: [] });
+  const info = vi.fn();
+  const warning = vi.fn();
+  const paginate = vi.fn(async (endpoint: (args: unknown) => Promise<{ data: unknown }>, args) => {
+    const response = await endpoint(args);
+    return response.data;
+  });
+
+  const github = {
+    paginate,
+    rest: {
+      git: { getRef, getTag },
+      issues: { addLabels, createLabel, getLabel },
+      repos: {
+        compareCommitsWithBasehead,
+        getBranch,
+        listPullRequestsAssociatedWithCommit,
+        listTags,
+      },
+    },
+  };
+  const context = {
+    eventName: "pull_request_target",
+    payload: {
+      pull_request: {
+        labels: pullRequestLabels.map((name) => ({ name })),
+        merge_commit_sha: MERGE_SHA,
+        number: 123,
+      },
+      repository: { default_branch: "main" },
+    },
+    repo: { owner: "NVIDIA", repo: "NemoClaw" },
+  };
+  const core = { info, warning };
+
+  return {
+    addLabels,
+    compareCommitsWithBasehead,
+    context,
+    core,
+    createLabel,
+    fixtures,
+    getBranch,
+    getLabel,
+    getRef,
+    getTag,
+    github,
+    info,
+    listPullRequestsAssociatedWithCommit,
+    listTags,
+    paginate,
+    warning,
+  };
+}
+
+async function runScript(harness: ReturnType<typeof createHarness>): Promise<void> {
+  expect(script).toEqual(expect.any(String));
+  await new AsyncFunction("github", "context", "core", script as string)(
+    harness.github,
+    harness.context,
+    harness.core,
+  );
+}
+
+describe("merged PR release target workflow", () => {
+  it("keeps fork-safe labeling inside the trusted metadata boundary", () => {
+    expect(workflow.on?.pull_request_target).toEqual({
+      branches: ["main"],
+      types: ["closed"],
+    });
+    expect(workflow.on?.schedule).toEqual([{ cron: "17 */6 * * *" }]);
+    expect(workflow.on).toHaveProperty("workflow_dispatch");
+    expect(workflow.permissions).toEqual({
+      contents: "read",
+      issues: "write",
+      "pull-requests": "read",
+    });
+    expect(job.if).toBe(
+      "${{ github.event_name != 'pull_request_target' || github.event.pull_request.merged == true }}",
+    );
+    expect(job["timeout-minutes"]).toBe(10);
+    expect(actionStep?.uses).toMatch(/^actions\/github-script@[0-9a-f]{40}$/u);
+    expect(job.steps).toHaveLength(1);
+    expect(job.steps?.some((step) => step.uses?.startsWith("actions/checkout@"))).toBe(false);
+    expect(job.steps?.some((step) => typeof step.run === "string")).toBe(false);
+  });
+
+  it("uses numeric semver order and ignores non-release tags", async () => {
+    const harness = createHarness([
+      { name: "v0.0.9", status: "ahead" },
+      { name: "latest" },
+      { name: "v0.0.10", status: "ahead" },
+      { name: "v0.0.11-rc.1" },
+    ]);
+
+    await runScript(harness);
+
+    expect(harness.paginate).toHaveBeenCalledWith(harness.listTags, {
+      owner: "NVIDIA",
+      repo: "NemoClaw",
+      per_page: 100,
+    });
+    expect(harness.listTags).toHaveBeenCalledWith({
+      owner: "NVIDIA",
+      repo: "NemoClaw",
+      per_page: 100,
+    });
+    expect(harness.getRef).toHaveBeenCalledTimes(1);
+    expect(harness.getRef).toHaveBeenCalledWith(expect.objectContaining({ ref: "tags/v0.0.10" }));
+    expect(harness.addLabels).toHaveBeenCalledWith({
+      owner: "NVIDIA",
+      repo: "NemoClaw",
+      issue_number: 123,
+      labels: ["v0.0.11"],
+    });
+  });
+
+  it("assigns a PR at a tag boundary to that release", async () => {
+    const harness = createHarness([
+      { name: "v0.0.10", status: "identical" },
+      { name: "v0.0.9", status: "ahead" },
+    ]);
+
+    await runScript(harness);
+
+    expect(harness.compareCommitsWithBasehead).toHaveBeenCalledTimes(2);
+    expect(harness.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ["v0.0.10"] }),
+    );
+  });
+
+  it("assigns a non-patch release tag that contains the merge", async () => {
+    const harness = createHarness([
+      { name: "v1.0.0", status: "identical" },
+      { name: "v0.9.9", status: "ahead" },
+    ]);
+
+    await runScript(harness);
+
+    expect(harness.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ["v1.0.0"] }));
+  });
+
+  it("uses ancestry when a newer release tag appears after the merge", async () => {
+    const harness = createHarness([
+      { name: "v0.0.11", status: "behind" },
+      { name: "v0.0.10", status: "ahead" },
+    ]);
+
+    await runScript(harness);
+
+    expect(harness.compareCommitsWithBasehead).toHaveBeenCalledTimes(2);
+    expect(harness.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ["v0.0.11"] }),
+    );
+  });
+
+  it("creates a missing release label and preserves older release labels", async () => {
+    const harness = createHarness([{ name: "v1.2.3", status: "ahead" }], ["v1.2.2"]);
+    harness.getLabel.mockRejectedValueOnce({ status: 404 });
+
+    await runScript(harness);
+
+    expect(harness.createLabel).toHaveBeenCalledWith({
+      owner: "NVIDIA",
+      repo: "NemoClaw",
+      name: "v1.2.4",
+      color: "1d76db",
+      description: "Release target",
+    });
+    expect(harness.warning).toHaveBeenCalledWith(expect.stringContaining("preserving them"));
+    expect(harness.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ["v1.2.4"] }));
+  });
+
+  it("verifies a release label created by a concurrent run", async () => {
+    const harness = createHarness([{ name: "v1.2.3", status: "ahead" }]);
+    harness.getLabel
+      .mockRejectedValueOnce({ status: 404 })
+      .mockResolvedValueOnce({ data: { name: "v1.2.4" } });
+    harness.createLabel.mockRejectedValueOnce({ status: 422 });
+
+    await runScript(harness);
+
+    expect(harness.getLabel).toHaveBeenCalledTimes(2);
+    expect(harness.addLabels).toHaveBeenCalledWith(expect.objectContaining({ labels: ["v1.2.4"] }));
+  });
+
+  it("leaves an already-correct PR unchanged", async () => {
+    const harness = createHarness([{ name: "v1.2.3", status: "ahead" }], ["v1.2.4"]);
+
+    await runScript(harness);
+
+    expect(harness.getLabel).not.toHaveBeenCalled();
+    expect(harness.createLabel).not.toHaveBeenCalled();
+    expect(harness.addLabels).not.toHaveBeenCalled();
+    expect(harness.info).toHaveBeenCalledWith("PR #123 already has release target v1.2.4");
+  });
+
+  it("rejects lightweight release tags", async () => {
+    const harness = createHarness([{ name: "v1.2.3", refType: "commit", status: "ahead" }]);
+
+    await expect(runScript(harness)).rejects.toThrow("Release tag v1.2.3 must be annotated");
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
+  it("fails rather than guessing across divergent release history", async () => {
+    const harness = createHarness([
+      { name: "v1.2.3", status: "diverged", aheadBy: 1, behindBy: 1 },
+    ]);
+
+    await expect(runScript(harness)).rejects.toThrow("is not linear: diverged");
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
+  it("fails rather than overflowing the next patch version", async () => {
+    const harness = createHarness([{ name: `v1.2.${Number.MAX_SAFE_INTEGER}`, status: "ahead" }]);
+
+    await expect(runScript(harness)).rejects.toThrow(
+      `Cannot increment release tag v1.2.${Number.MAX_SAFE_INTEGER} safely`,
+    );
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
+  it("propagates label API failures without applying a partial write", async () => {
+    const harness = createHarness([{ name: "v1.2.3", status: "ahead" }]);
+    harness.getLabel.mockRejectedValueOnce({ status: 403, message: "forbidden" });
+
+    await expect(runScript(harness)).rejects.toMatchObject({ status: 403 });
+    expect(harness.createLabel).not.toHaveBeenCalled();
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
+  it("repairs missed labels across the current and latest completed releases", async () => {
+    const harness = createHarness([{ name: "v0.0.10" }, { name: "v0.0.9" }]);
+    const mainCommit = "e".repeat(40);
+    const completedReleaseCommit = "d".repeat(40);
+    const [latest, previous] = harness.fixtures;
+    harness.context.eventName = "schedule";
+    harness.getBranch.mockResolvedValueOnce({ data: { commit: { sha: mainCommit } } });
+    harness.compareCommitsWithBasehead.mockImplementation(
+      async ({ basehead }: { basehead: string }) => {
+        if (basehead === `${latest.commitSha}...${mainCommit}`) {
+          return {
+            data: {
+              status: "ahead",
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: 1,
+              commits: [{ sha: MERGE_SHA }],
+            },
+          };
+        }
+        if (basehead === `${previous.commitSha}...${latest.commitSha}`) {
+          return {
+            data: {
+              status: "ahead",
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: 1,
+              commits: [{ sha: completedReleaseCommit }],
+            },
+          };
+        }
+        throw new Error(`Unexpected reconciliation comparison: ${basehead}`);
+      },
+    );
+    harness.listPullRequestsAssociatedWithCommit.mockImplementation(
+      async ({ commit_sha: commitSha }: { commit_sha: string }) => ({
+        data: [
+          commitSha === MERGE_SHA
+            ? {
+                base: { ref: "main" },
+                labels: [],
+                merge_commit_sha: MERGE_SHA,
+                merged_at: "2026-07-04T00:00:00Z",
+                number: 123,
+              }
+            : {
+                base: { ref: "main" },
+                labels: [{ name: "v0.0.10" }],
+                merge_commit_sha: completedReleaseCommit,
+                merged_at: "2026-07-03T00:00:00Z",
+                number: 122,
+              },
+        ],
+      }),
+    );
+
+    await runScript(harness);
+
+    expect(harness.listPullRequestsAssociatedWithCommit).toHaveBeenCalledTimes(2);
+    expect(harness.addLabels).toHaveBeenCalledTimes(1);
+    expect(harness.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 123, labels: ["v0.0.11"] }),
+    );
+    expect(harness.info).toHaveBeenCalledWith("Reconciled 2 merged PR release target(s)");
+  });
+
+  it("does not recreate completed release labels outside the retention window", async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const harness = createHarness([
+      { name: "v0.0.10", taggedAt: eightDaysAgo },
+      { name: "v0.0.9", taggedAt: eightDaysAgo },
+    ]);
+    const mainCommit = "e".repeat(40);
+    const [latest] = harness.fixtures;
+    harness.context.eventName = "schedule";
+    harness.getBranch.mockResolvedValueOnce({ data: { commit: { sha: mainCommit } } });
+    harness.compareCommitsWithBasehead.mockImplementation(
+      async ({ basehead }: { basehead: string }) => {
+        if (basehead !== `${latest.commitSha}...${mainCommit}`) {
+          throw new Error(`Unexpected expired release comparison: ${basehead}`);
+        }
+        return {
+          data: {
+            status: "identical",
+            ahead_by: 0,
+            behind_by: 0,
+            total_commits: 0,
+            commits: [],
+          },
+        };
+      },
+    );
+
+    await runScript(harness);
+
+    expect(harness.compareCommitsWithBasehead).toHaveBeenCalledTimes(1);
+    expect(harness.getRef).toHaveBeenCalledTimes(3);
+    expect(harness.listPullRequestsAssociatedWithCommit).not.toHaveBeenCalled();
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
+  it("restarts reconciliation when a release tag lands during the audit", async () => {
+    const harness = createHarness([{ name: "v0.0.11" }, { name: "v0.0.10" }, { name: "v0.0.9" }]);
+    const mainCommit = "e".repeat(40);
+    const [v11, v10, v09] = harness.fixtures;
+    harness.context.eventName = "schedule";
+    harness.listTags
+      .mockResolvedValueOnce({ data: [{ name: v10.name }, { name: v09.name }] })
+      .mockResolvedValue({
+        data: [{ name: v11.name }, { name: v10.name }, { name: v09.name }],
+      });
+    harness.getBranch.mockResolvedValue({ data: { commit: { sha: mainCommit } } });
+    harness.compareCommitsWithBasehead.mockImplementation(
+      async ({ basehead }: { basehead: string }) => {
+        if (basehead === `${v11.commitSha}...${mainCommit}`) {
+          return {
+            data: {
+              status: "ahead",
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: 1,
+              commits: [{ sha: MERGE_SHA }],
+            },
+          };
+        }
+        if (
+          basehead === `${v10.commitSha}...${v11.commitSha}` ||
+          basehead === `${v09.commitSha}...${v10.commitSha}`
+        ) {
+          return {
+            data: {
+              status: "ahead",
+              ahead_by: 1,
+              behind_by: 0,
+              total_commits: 1,
+              commits: [{ sha: "c".repeat(40) }],
+            },
+          };
+        }
+        throw new Error(`Unexpected tag-change comparison: ${basehead}`);
+      },
+    );
+    harness.listPullRequestsAssociatedWithCommit.mockImplementation(
+      async ({ commit_sha: commitSha }: { commit_sha: string }) => ({
+        data:
+          commitSha === MERGE_SHA
+            ? [
+                {
+                  base: { ref: "main" },
+                  labels: [],
+                  merge_commit_sha: MERGE_SHA,
+                  merged_at: "2026-07-04T00:00:00Z",
+                  number: 123,
+                },
+              ]
+            : [],
+      }),
+    );
+
+    await runScript(harness);
+
+    expect(harness.warning).toHaveBeenCalledWith(
+      "Newest release tag changed; restarting reconciliation",
+    );
+    expect(harness.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 123, labels: ["v0.0.12"] }),
+    );
+  });
+});

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -86,6 +86,30 @@ describe("maintainer skills follow canonical workflow policy", () => {
     ).toBe(true);
   });
 
+  it("records every merged main PR against its ancestry-derived release target", () => {
+    const policy = read(".agents/skills/nemoclaw-maintainer-policies/references/release-train.md");
+    const taxonomy = JSON.parse(
+      read(".agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json"),
+    ) as {
+      label_families: {
+        release: { application_policy: string; positive_signals: string[] };
+      };
+      quality_rules: { post_merge_release_labeling_allowed: boolean };
+    };
+
+    expect(policy).toContain("After a PR merges to `main`");
+    expect(policy).toContain("earliest containing release");
+    expect(policy).toContain("completed releases tagged within the seven-day retention window");
+    expect(policy).toContain("never removes an existing version label");
+    expect(taxonomy.label_families.release.positive_signals).toContain(
+      "authorized post-merge assignment to a containing release or the next patch release",
+    );
+    expect(taxonomy.label_families.release.application_policy).toContain(
+      "preserve existing version labels",
+    );
+    expect(taxonomy.quality_rules.post_merge_release_labeling_allowed).toBe(true);
+  });
+
   it("requires exact-SHA E2E evidence or itemized maintainer exceptions before tagging", () => {
     const dailyFlow = read(".agents/skills/nemoclaw-maintainer-policies/references/daily-flow.md");
     const evening = read(".agents/skills/nemoclaw-maintainer-evening/SKILL.md");

--- a/test/maintainer-skills-policy.test.ts
+++ b/test/maintainer-skills-policy.test.ts
@@ -88,6 +88,9 @@ describe("maintainer skills follow canonical workflow policy", () => {
 
   it("records every merged main PR against its ancestry-derived release target", () => {
     const policy = read(".agents/skills/nemoclaw-maintainer-policies/references/release-train.md");
+    const projectWorkflow = read(
+      ".agents/skills/nemoclaw-maintainer-policies/references/project-workflow.md",
+    );
     const taxonomy = JSON.parse(
       read(".agents/skills/nemoclaw-maintainer-policies/references/label-taxonomy.json"),
     ) as {
@@ -101,6 +104,9 @@ describe("maintainer skills follow canonical workflow policy", () => {
     expect(policy).toContain("earliest containing release");
     expect(policy).toContain("completed releases tagged within the seven-day retention window");
     expect(policy).toContain("never removes an existing version label");
+    expect(projectWorkflow).toContain("On open PRs");
+    expect(projectWorkflow).toContain("After a PR merges to `main`");
+    expect(projectWorkflow).toContain("historical release attribution");
     expect(taxonomy.label_families.release.positive_signals).toContain(
       "authorized post-merge assignment to a containing release or the next patch release",
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Automatically label every pull request merged into `main` with its ancestry-derived release target. This records the earliest containing release when a tag already includes the merge, or the next patch after the latest release tag while the train is still open.

## Changes

- Add a metadata-only `pull_request_target` workflow that creates and applies release labels without checking out PR code.
- Reconcile missed merge events every six hours and on manual dispatch across the current train and the seven-day completed-release window.
- Cover semver ordering, tag ancestry, idempotence, concurrent label creation, reconciliation, and tag-race behavior with executable workflow tests.
- Document the automated post-merge attribution rules in the canonical maintainer policy and label taxonomy.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is internal GitHub maintainer automation; the canonical maintainer policy references are updated, with no user-facing runtime or documentation behavior change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent workflow-security and maintainer release-semantics reviews completed locally with no actionable findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/label-merged-pr-release-target-workflow.test.ts test/maintainer-skills-policy.test.ts` — 32 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic semver “release target” labeling for merged pull requests.
  * Added scheduled reconciliation to apply any missed release-target labels.

* **Bug Fixes**
  * Improved post-merge release attribution to be additive/idempotent while preserving existing version labels.
  * Strengthened validation (e.g., malformed metadata, lightweight tags, unsupported histories) and safe handling when the next patch label can’t be determined.
  * Added concurrency-safe label creation and reconciliation retry when release tags change.

* **Documentation**
  * Updated release-train, project workflow, and taxonomy rules, including the post-merge labeling permission flag.

* **Tests**
  * Added comprehensive workflow and policy behavior tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->