### PR TITLE
fix(release): grant PR label write permission

### DIFF
--- a/.github/workflows/label-merged-pr-release-target.yaml
+++ b/.github/workflows/label-merged-pr-release-target.yaml
@@ -18,7 +18,9 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  # GITHUB_TOKEN requires PR write access when the issues labels endpoint
+  # targets a pull request; issues:write alone returns 403.
+  pull-requests: write
 
 jobs:
   label-release-target:

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -179,7 +179,7 @@ describe("merged PR release target workflow", () => {
     expect(workflow.permissions).toEqual({
       contents: "read",
       issues: "write",
-      "pull-requests": "read",
+      "pull-requests": "write",
     });
     expect(job.if).toBe(
       "${{ github.event_name != 'pull_request_target' || github.event.pull_request.merged == true }}",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix the merged-PR release-label workflow's `403 Resource not accessible by integration` by granting the `GITHUB_TOKEN` write access to pull requests. The workflow retains `issues: write` for creating missing labels and remains metadata-only with no checkout or PR-code execution.

## Changes

- Change `pull-requests` permission from `read` to `write`, as required when the issues labels endpoint targets a pull request.
- Document why both issue-label and pull-request write scopes are needed.
- Update the workflow contract test to enforce the corrected least-privilege permission set.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Documentation review confirmed this is an internal token-scope correction with no user-facing behavior or release-policy change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The [live 403](https://github.com/NVIDIA/NemoClaw/actions/runs/28748844248/job/85244319791) and the repository's existing E2E advisor permission precedent confirm the required scope; the privileged workflow remains pinned, metadata-only, and checkout-free.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/label-merged-pr-release-target-workflow.test.ts` — 21 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pull request labeling in merged release target workflows, so label and target updates now complete successfully.
  * Kept repository content access unchanged while enabling the needed pull request write access for these workflow actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->