### PR TITLE
perf(test): reduce CLI dispatch process isolation

### DIFF
--- a/test/cli/credentials-command.test.ts
+++ b/test/cli/credentials-command.test.ts
@@ -1,9 +1,30 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import CredentialsAddCommand from "../../src/commands/credentials/add";
+import CredentialsListCommand from "../../src/commands/credentials/list";
+import { runCredentialsAddAction } from "../../src/lib/actions/credentials-add";
 import { run, runWithInput } from "./helpers";
+
+vi.mock("../../src/lib/actions/global", () => ({
+  forgetExtraProvider: vi.fn(),
+  recordExtraProvider: vi.fn(),
+  recoverNamedGatewayRuntime: vi.fn().mockResolvedValue({ recovered: true }),
+  runOpenshellProviderCommand: vi.fn(),
+}));
+
+function validateAdd(overrides: Partial<Parameters<typeof runCredentialsAddAction>[0]> = {}) {
+  return runCredentialsAddAction({
+    provider: "tavily-search",
+    type: "tavily",
+    credentials: [],
+    configPairs: [],
+    fromExisting: false,
+    ...overrides,
+  });
+}
 
 describe("credentials CLI dispatch", () => {
   it("credentials help exits 0 and shows credential subcommands", () => {
@@ -16,21 +37,19 @@ describe("credentials CLI dispatch", () => {
     expect(r.out).toContain("credentials reset");
   });
 
-  it("credentials list --help exits 0 and shows list usage", () => {
-    const r = run("credentials list --help");
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("credentials list");
-    expect(r.out).toContain("List provider credentials");
+  it("credentials list declares its help usage and description", () => {
+    expect(CredentialsListCommand.usage).toContain("credentials list");
+    expect(CredentialsListCommand.description).toContain("List provider credentials");
   });
 
-  it("credentials add --help exits 0 and shows add usage", () => {
-    const r = run("credentials add --help");
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("credentials add");
-    expect(r.out).toContain("Register a provider credential");
-    expect(r.out).toContain("--type");
-    expect(r.out).toContain("--credential");
-    expect(r.out).toContain("--from-existing");
+  it("credentials add declares its help usage, description, and flags", () => {
+    expect(CredentialsAddCommand.usage).toContain(
+      "credentials add <PROVIDER> --type <TYPE> [--credential ENV_NAME] [--config K=V] [--from-existing]",
+    );
+    expect(CredentialsAddCommand.description).toContain("Register a provider credential");
+    expect(Object.keys(CredentialsAddCommand.flags)).toEqual(
+      expect.arrayContaining(["type", "credential", "from-existing"]),
+    );
   });
 
   it("credentials add without provider uses oclif required-arg validation", () => {
@@ -40,22 +59,28 @@ describe("credentials CLI dispatch", () => {
     expect(r.out).toContain("provider  OpenShell provider name");
   });
 
-  it("credentials add without --type uses oclif required-flag validation", () => {
-    const r = run("credentials add tavily-search --credential TAVILY_API_KEY");
-    expect(r.code).toBe(2);
-    expect(r.out).toContain("Missing required flag type");
+  it("credentials add requires the type flag in its parser metadata", () => {
+    expect(CredentialsAddCommand.flags.type.required).toBe(true);
   });
 
-  it("credentials add without --credential or --from-existing fails with explicit guidance", () => {
-    const r = run("credentials add tavily-search --type tavily");
-    expect(r.code).not.toBe(0);
-    expect(r.out).toContain("At least one --credential KEY or --from-existing is required.");
+  it("credentials add without --credential or --from-existing fails with explicit guidance", async () => {
+    const result = await validateAdd();
+    expect(result.exitCode).not.toBe(0);
+    expect(result.failureLines.join("\n")).toContain(
+      "At least one --credential KEY or --from-existing is required.",
+    );
   });
 
-  it("credentials add rejects --from-existing combined with --credential", () => {
-    const r = run("credentials add foo --type generic --from-existing --credential FOO_TOKEN");
-    expect(r.code).not.toBe(0);
-    expect(r.out).toContain("--from-existing cannot be combined with --credential.");
+  it("credentials add rejects --from-existing combined with --credential", async () => {
+    const result = await validateAdd({
+      provider: "foo",
+      credentials: ["FOO_TOKEN"],
+      fromExisting: true,
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.failureLines.join("\n")).toContain(
+      "--from-existing cannot be combined with --credential.",
+    );
   });
 
   it("credentials add rejects inline KEY=VALUE credentials without echoing the value", () => {
@@ -67,26 +92,23 @@ describe("credentials CLI dispatch", () => {
     expect(r.out).not.toContain("tvly-secret-12345");
   });
 
-  it("credentials add rejects --credential values that are not uppercase env names", () => {
-    const r = run("credentials add tavily-search --type tavily --credential tavily-api-key");
-    expect(r.code).not.toBe(0);
-    expect(r.out).toContain("--credential must be a valid env variable name");
-    expect(r.out).not.toContain("tavily-api-key");
+  it("credentials add rejects --credential values that are not uppercase env names", async () => {
+    const result = await validateAdd({
+      credentials: ["tavily-api-key"],
+    });
+    const output = result.failureLines.join("\n");
+    expect(result.exitCode).not.toBe(0);
+    expect(output).toContain("--credential must be a valid env variable name");
+    expect(output).not.toContain("tavily-api-key");
   });
 
-  it("credentials add never echoes a secret-shaped --credential value", () => {
-    const r = run(
-      "credentials add tavily-search --type tavily --credential tvly-secret-leaked-9999",
-    );
-    expect(r.code).not.toBe(0);
-    expect(r.out).not.toContain("tvly-secret-leaked-9999");
-  });
-
-  it("credentials reset without provider uses oclif required-arg validation", () => {
-    const r = run("credentials reset --yes");
-    expect(r.code).toBe(2);
-    expect(r.out).toContain("Missing 1 required arg");
-    expect(r.out).toContain("provider  OpenShell provider name");
+  it("credentials add never echoes a secret-shaped --credential value", async () => {
+    const secretShapedCredential = "tvly-secret-leaked-9999";
+    const result = await validateAdd({
+      credentials: [secretShapedCredential],
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.failureLines.join("\n")).not.toContain(secretShapedCredential);
   });
 
   it("credentials reset without provider ignores poisoned stdin", () => {

--- a/test/cli/dispatch-basics.test.ts
+++ b/test/cli/dispatch-basics.test.ts
@@ -9,8 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { help } from "../../src/lib/actions/root-help.js";
 import { normalizeArgv } from "../../src/lib/cli/argv-normalizer.js";
-import { globalCommandTokens, sandboxActionTokens } from "../../src/lib/cli/command-registry.js";
-import { translatePublicGlobalArgv } from "../../src/lib/cli/public-argv-translation.js";
+import { globalCommandTokens } from "../../src/lib/cli/command-registry.js";
 
 import {
   CLI,
@@ -162,13 +161,12 @@ describe("CLI dispatch", () => {
     expect(r.out).not.toContain("Sandbox 'agents' does not exist");
   });
 
-  it("agents list routes to the registered global list command", () => {
-    expect(translatePublicGlobalArgv("agents", ["list"])).toEqual({
-      kind: "nativeArgv",
-      commandId: "agents:list",
-      args: [],
-      argv: ["agents", "list"],
-    });
+  it("agents list exits 0 and lists global agent runtimes", () => {
+    const r = run("agents list");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("openclaw");
+    expect(r.out).toContain("hermes");
+    expect(r.out).toContain("langchain-deepagents-code");
   });
 
   it("exits 0 for --help", () => {
@@ -253,11 +251,36 @@ describe("CLI dispatch", () => {
     }
   });
 
-  it("lists inference among registered sandbox actions (#5977)", () => {
+  it("lists inference among Valid actions when reporting an unknown sandbox action (#5977)", () => {
     // The reporter-facing action list is derived from registered sandbox
     // commands; the new sandbox-scoped inference route must appear there so
     // users discover it instead of hitting the old dead end.
-    expect(sandboxActionTokens()).toContain("inference");
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-inference-valid-actions-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      ["#!/usr/bin/env bash", "exit 1"].join("\n"),
+      { mode: 0o755 },
+    );
+    writeSandboxRegistry(home, "alpha");
+
+    try {
+      const r = runWithEnv(
+        "alpha bogus-action-5977",
+        {
+          HOME: home,
+          PATH: `${localBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_HEALTH_POLL_COUNT: "0",
+        },
+        execTimeout(30_000),
+      );
+      expect(r.code).toBe(1);
+      expect(r.out).toContain("Unknown action: bogus-action-5977");
+      expect(r.out).toMatch(/Valid actions:.*\binference\b/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it("points OpenShell-only commands at openshell instead of sandbox connect (#3388)", () => {

--- a/test/cli/dispatch-basics.test.ts
+++ b/test/cli/dispatch-basics.test.ts
@@ -5,7 +5,12 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { help } from "../../src/lib/actions/root-help.js";
+import { normalizeArgv } from "../../src/lib/cli/argv-normalizer.js";
+import { globalCommandTokens, sandboxActionTokens } from "../../src/lib/cli/command-registry.js";
+import { translatePublicGlobalArgv } from "../../src/lib/cli/public-argv-translation.js";
 
 import {
   CLI,
@@ -15,6 +20,10 @@ import {
   testTimeoutOptions,
   writeSandboxRegistry,
 } from "./helpers";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("CLI dispatch", () => {
   it("config get validates flags and values before dispatch", async () => {
@@ -120,38 +129,30 @@ describe("CLI dispatch", () => {
     },
   );
 
-  it("help exits 0 and shows sections", () => {
-    const r = run("help");
-    expect(r.code).toBe(0);
-    expect(r.out.includes("Getting Started")).toBeTruthy();
-    expect(r.out.includes("Sandbox Management")).toBeTruthy();
-    expect(r.out.includes("Policy Presets")).toBeTruthy();
-    expect(r.out.includes("Compatibility Commands")).toBeTruthy();
-    expect(r.out).toContain("nemoclaw upgrade-sandboxes");
-    expect(r.out).toContain("(--check, --auto, --yes|-y)");
-    expect(r.out).toContain("nemoclaw update");
-    expect(r.out).toContain("(--check, --fresh, --yes|-y)");
-    expect(r.out).toContain("nemoclaw gc");
-    expect(r.out).toContain("(--yes|-y|--force, --dry-run)");
-    expect(r.out).toContain("nemoclaw onboard");
-    expect(r.out).toContain(
+  it("help shows registered command sections", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    help();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Getting Started");
+    expect(output).toContain("Sandbox Management");
+    expect(output).toContain("Policy Presets");
+    expect(output).toContain("Compatibility Commands");
+    expect(output).toContain("nemoclaw upgrade-sandboxes");
+    expect(output).toContain("(--check, --auto, --yes|-y)");
+    expect(output).toContain("nemoclaw update");
+    expect(output).toContain("(--check, --fresh, --yes|-y)");
+    expect(output).toContain("nemoclaw gc");
+    expect(output).toContain("(--yes|-y|--force, --dry-run)");
+    expect(output).toContain("nemoclaw onboard");
+    expect(output).toContain(
       "Configure inference endpoint and credentials (--agent to choose runtime)",
     );
-    expect(r.out).toContain("nemoclaw agents list");
-    expect(r.out).toContain("List available agent runtimes for onboard --agent");
-    expect(r.out).toContain("nemoclaw onboard --from");
-    expect(r.out).toContain("Use a custom Dockerfile for the sandbox image");
-  });
-
-  it("onboard help lists installed agent runtime names in the --agent description", () => {
-    const r = run("onboard --help");
-    expect(r.code).toBe(0);
-    expect(r.out).toContain(
-      "Agent runtime to onboard (openclaw, hermes, langchain-deepagents-code;",
-    );
-    expect(r.out).toContain("aliases: nemohermes → hermes;");
-    expect(r.out).toContain("nemo-deepagents/dcode/deepagents/deepagents-code/langchain →");
-    expect(r.out).toContain("langchain-deepagents-code)");
+    expect(output).toContain("nemoclaw agents list");
+    expect(output).toContain("List available agent runtimes for onboard --agent");
+    expect(output).toContain("nemoclaw onboard --from");
+    expect(output).toContain("Use a custom Dockerfile for the sandbox image");
   });
 
   it("agents parent shows command help instead of sandbox lookup", () => {
@@ -161,12 +162,13 @@ describe("CLI dispatch", () => {
     expect(r.out).not.toContain("Sandbox 'agents' does not exist");
   });
 
-  it("agents list exits 0 and lists global agent runtimes", () => {
-    const r = run("agents list");
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("openclaw");
-    expect(r.out).toContain("hermes");
-    expect(r.out).toContain("langchain-deepagents-code");
+  it("agents list routes to the registered global list command", () => {
+    expect(translatePublicGlobalArgv("agents", ["list"])).toEqual({
+      kind: "nativeArgv",
+      commandId: "agents:list",
+      args: [],
+      argv: ["agents", "list"],
+    });
   });
 
   it("exits 0 for --help", () => {
@@ -179,8 +181,13 @@ describe("CLI dispatch", () => {
     expect(r.out.trim()).toMatch(/^nemoclaw v/);
   });
 
-  it("exits 0 for -h", () => {
-    expect(run("-h").code).toBe(0);
+  it("normalizes -h as a root-help alias", () => {
+    expect(
+      normalizeArgv(["-h"], {
+        globalCommands: globalCommandTokens(),
+        isSandboxConnectFlag: () => false,
+      }),
+    ).toEqual({ kind: "rootHelp" });
   });
 
   it("no args exits 0 (shows help)", () => {
@@ -246,36 +253,11 @@ describe("CLI dispatch", () => {
     }
   });
 
-  it("lists inference among Valid actions when reporting an unknown sandbox action (#5977)", () => {
+  it("lists inference among registered sandbox actions (#5977)", () => {
     // The reporter-facing action list is derived from registered sandbox
     // commands; the new sandbox-scoped inference route must appear there so
     // users discover it instead of hitting the old dead end.
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-inference-valid-actions-"));
-    const localBin = path.join(home, "bin");
-    fs.mkdirSync(localBin, { recursive: true });
-    fs.writeFileSync(
-      path.join(localBin, "openshell"),
-      ["#!/usr/bin/env bash", "exit 1"].join("\n"),
-      { mode: 0o755 },
-    );
-    writeSandboxRegistry(home, "alpha");
-
-    try {
-      const r = runWithEnv(
-        "alpha bogus-action-5977",
-        {
-          HOME: home,
-          PATH: `${localBin}:${process.env.PATH || ""}`,
-          NEMOCLAW_HEALTH_POLL_COUNT: "0",
-        },
-        execTimeout(30_000),
-      );
-      expect(r.code).toBe(1);
-      expect(r.out).toContain("Unknown action: bogus-action-5977");
-      expect(r.out).toMatch(/Valid actions:.*\binference\b/);
-    } finally {
-      fs.rmSync(home, { recursive: true, force: true });
-    }
+    expect(sandboxActionTokens()).toContain("inference");
   });
 
   it("points OpenShell-only commands at openshell instead of sandbox connect (#3388)", () => {

--- a/test/cli/onboard-compatibility.test.ts
+++ b/test/cli/onboard-compatibility.test.ts
@@ -6,7 +6,6 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import DeployCliCommand from "../../src/commands/deploy";
 import OnboardCliCommand from "../../src/commands/onboard";
 import SetupCliCommand from "../../src/commands/setup";
 import SetupSparkCliCommand from "../../src/commands/setup-spark";
@@ -19,7 +18,6 @@ vi.mock("../../src/lib/agent/defs", () => ({
 }));
 
 vi.mock("../../src/lib/actions/global", () => ({
-  runDeployAction: vi.fn().mockResolvedValue(undefined),
   runOnboardAction: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -257,13 +255,12 @@ describe("CLI onboard compatibility", () => {
     expect(r.out.includes("Cannot resume non-interactive onboard")).toBeTruthy();
   });
 
-  it("setup-spark exposes native deprecated-alias help metadata", () => {
-    expect(SetupSparkCliCommand.state).toBe("deprecated");
-    expect(SetupSparkCliCommand.deprecationOptions.message).toContain(
-      "Deprecated: 'nemoclaw setup-spark' is now 'nemoclaw onboard'",
-    );
-    expect(SetupSparkCliCommand.usage).toEqual(["setup-spark [flags]"]);
-    expect(SetupSparkCliCommand.flags).toHaveProperty("resume");
+  it("setup-spark --help exits 0 and shows native deprecated-alias usage", () => {
+    const r = run("setup-spark --help");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Deprecated: 'nemoclaw setup-spark' is now 'nemoclaw onboard'");
+    expect(r.out).toContain("$ nemoclaw setup-spark [flags]");
+    expect(r.out).not.toContain("Unknown onboard option");
   });
 
   it("setup-spark is a deprecated compatibility alias for onboard", async () => {
@@ -282,8 +279,10 @@ describe("CLI onboard compatibility", () => {
     );
   });
 
-  it("deploy exposes deprecated compatibility help metadata", () => {
-    expect(DeployCliCommand.usage).toEqual(["deploy [instance-name]"]);
-    expect(DeployCliCommand.summary).toBe("Deprecated Brev-specific bootstrap path");
+  it("deploy --help exits 0 and shows deprecated usage", () => {
+    const r = run("deploy --help");
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("deploy [instance-name]");
+    expect(r.out).toContain("Deprecated Brev-specific bootstrap path");
   });
 });

--- a/test/cli/onboard-compatibility.test.ts
+++ b/test/cli/onboard-compatibility.test.ts
@@ -4,9 +4,27 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DeployCliCommand from "../../src/commands/deploy";
+import OnboardCliCommand from "../../src/commands/onboard";
+import SetupCliCommand from "../../src/commands/setup";
+import SetupSparkCliCommand from "../../src/commands/setup-spark";
+import { runOnboardAction } from "../../src/lib/actions/global";
 
 import { PARSER_EXIT_CODE, run, runWithEnv } from "./helpers";
+
+vi.mock("../../src/lib/agent/defs", () => ({
+  listAgents: vi.fn(() => ["openclaw", "hermes", "langchain-deepagents-code"]),
+}));
+
+vi.mock("../../src/lib/actions/global", () => ({
+  runDeployAction: vi.fn().mockResolvedValue(undefined),
+  runOnboardAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+const rootDir = process.cwd();
+let previousExitCode: typeof process.exitCode;
 
 function writeOpenShellVersionStub(localBin: string): void {
   fs.writeFileSync(
@@ -65,7 +83,19 @@ function writeIncompleteResumeSession(nemoclawDir: string): void {
 }
 
 describe("CLI onboard compatibility", () => {
+  beforeEach(() => {
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+  });
+
   it("onboard --help exits 0 and shows usage", () => {
+    // Keep one real executable help contract so command discovery, oclif rendering,
+    // and the CommonJS launcher remain covered together.
     const r = run("onboard --help");
     expect(r.code).toBe(0);
     expect(r.out).toContain("USAGE");
@@ -73,58 +103,94 @@ describe("CLI onboard compatibility", () => {
     expect(r.out).toContain("--from <Dockerfile>");
     expect(r.out).toContain("--yes");
     expect(r.out).toContain("--sandbox-gpu-device=<value>");
+    expect(r.out).toContain(
+      "Agent runtime to onboard (openclaw, hermes, langchain-deepagents-code;",
+    );
+    expect(r.out).toContain("aliases: nemohermes → hermes;");
+    expect(r.out).toContain("nemo-deepagents/dcode/deepagents/deepagents-code/langchain →");
+    expect(r.out).toContain("langchain-deepagents-code)");
   });
 
   it("unknown onboard option exits 1", () => {
+    // Keep one real parser-exit contract to pin launcher argv and exit-code propagation.
     const r = run("onboard --non-interactiv");
     expect(r.code).toBe(PARSER_EXIT_CODE);
     expect(r.out).toContain("Nonexistent flag: --non-interactiv");
   });
 
-  it("accepts onboard --resume in CLI parsing", () => {
-    const r = run("onboard --resume --non-interactiv");
-    expect(r.code).toBe(PARSER_EXIT_CODE);
-    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
-  });
-
-  it("accepts the third-party software flag in onboard CLI parsing", () => {
-    const r = run("onboard --yes-i-accept-third-party-software --non-interactiv");
-    expect(r.code).toBe(PARSER_EXIT_CODE);
-    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
-  });
-
-  it("accepts install automation --yes in onboard CLI parsing", () => {
-    const r = run("onboard --resume --non-interactive --yes-i-accept-third-party-software --yes");
-    expect(r.code).toBe(1);
-    expect(r.out.includes("No resumable onboarding session was found")).toBeTruthy();
-    expect(r.out).not.toContain("Nonexistent flag: --yes");
-  });
-
-  it("lets oclif reject conflicting sandbox GPU flags", () => {
-    const r = run(
-      "onboard --sandbox-gpu --no-sandbox-gpu --non-interactive --yes-i-accept-third-party-software --yes",
+  it("accepts onboard --resume in CLI parsing", async () => {
+    await expect(OnboardCliCommand.run(["--resume", "--non-interactiv"], rootDir)).rejects.toThrow(
+      "Nonexistent flag: --non-interactiv",
     );
-    expect(r.code).toBe(PARSER_EXIT_CODE);
-    expect(r.out).toContain("--no-sandbox-gpu=true cannot also be provided");
-    expect(r.out).toContain("--sandbox-gpu");
+    expect(runOnboardAction).not.toHaveBeenCalled();
   });
 
-  it("lets oclif enforce the sandbox GPU device dependency", () => {
-    const r = run(
-      "onboard --sandbox-gpu-device nvidia.com/gpu=0 --no-sandbox-gpu --non-interactive --yes-i-accept-third-party-software --yes",
+  it("accepts the third-party software flag in onboard CLI parsing", async () => {
+    await expect(
+      OnboardCliCommand.run(["--yes-i-accept-third-party-software", "--non-interactiv"], rootDir),
+    ).rejects.toThrow("Nonexistent flag: --non-interactiv");
+    expect(runOnboardAction).not.toHaveBeenCalled();
+  });
+
+  it("accepts install automation --yes in onboard CLI parsing", async () => {
+    await OnboardCliCommand.run(
+      ["--resume", "--non-interactive", "--yes-i-accept-third-party-software", "--yes"],
+      rootDir,
     );
-    expect(r.code).toBe(PARSER_EXIT_CODE);
-    expect(r.out).toContain("must be provided when using --sandbox-gpu-device");
-    expect(r.out).toContain("--sandbox-gpu");
+
+    expect(runOnboardAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "non-interactive": true,
+        resume: true,
+        "yes-i-accept-third-party-software": true,
+        yes: true,
+      }),
+    );
   });
 
-  it("lets oclif reject privileged control UI ports", () => {
-    const r = run("onboard --control-ui-port 80");
-    expect(r.code).toBe(PARSER_EXIT_CODE);
-    expect(r.out).toContain("Expected an integer greater than or equal to 1024 but received: 80");
+  it("lets oclif reject conflicting sandbox GPU flags", async () => {
+    await expect(
+      OnboardCliCommand.run(
+        [
+          "--sandbox-gpu",
+          "--no-sandbox-gpu",
+          "--non-interactive",
+          "--yes-i-accept-third-party-software",
+          "--yes",
+        ],
+        rootDir,
+      ),
+    ).rejects.toThrow(/--no-sandbox-gpu=true cannot also be provided.*--sandbox-gpu/s);
+    expect(runOnboardAction).not.toHaveBeenCalled();
+  });
+
+  it("lets oclif enforce the sandbox GPU device dependency", async () => {
+    await expect(
+      OnboardCliCommand.run(
+        [
+          "--sandbox-gpu-device",
+          "nvidia.com/gpu=0",
+          "--no-sandbox-gpu",
+          "--non-interactive",
+          "--yes-i-accept-third-party-software",
+          "--yes",
+        ],
+        rootDir,
+      ),
+    ).rejects.toThrow(/must be provided when using --sandbox-gpu-device: --sandbox-gpu/);
+    expect(runOnboardAction).not.toHaveBeenCalled();
+  });
+
+  it("lets oclif reject privileged control UI ports", async () => {
+    await expect(OnboardCliCommand.run(["--control-ui-port", "80"], rootDir)).rejects.toThrow(
+      "Expected an integer greater than or equal to 1024 but received: 80",
+    );
+    expect(runOnboardAction).not.toHaveBeenCalled();
   });
 
   it("setup --help exits 0 and shows native deprecated-alias usage", () => {
+    // Keep one real alias-help rendering contract; the other aliases can use their
+    // command metadata and typed action seam directly.
     const r = run("setup --help");
     expect(r.code).toBe(0);
     expect(r.out).toContain("Deprecated: 'nemoclaw setup' is now 'nemoclaw onboard'");
@@ -132,20 +198,31 @@ describe("CLI onboard compatibility", () => {
     expect(r.out).not.toContain("Unknown onboard option");
   });
 
-  it("setup rejects unknown options through oclif", () => {
-    const r = run("setup --non-interactiv");
-    expect(r.code).toBe(PARSER_EXIT_CODE);
-    expect(r.out).toContain("Nonexistent flag: --non-interactiv");
+  it("setup rejects unknown options through oclif", async () => {
+    await expect(SetupCliCommand.run(["--non-interactiv"], rootDir)).rejects.toThrow(
+      "Nonexistent flag: --non-interactiv",
+    );
+    expect(runOnboardAction).not.toHaveBeenCalled();
   });
 
-  it("setup forwards --resume into the shared onboard action", () => {
-    const r = run("setup --resume --non-interactive --yes-i-accept-third-party-software --yes");
-    expect(r.code).toBe(1);
-    expect(r.out).toContain("Deprecated: 'nemoclaw setup' is now 'nemoclaw onboard'");
-    expect(r.out.includes("No resumable onboarding session was found")).toBeTruthy();
+  it("setup forwards --resume into the shared onboard action", async () => {
+    await SetupCliCommand.run(
+      ["--resume", "--non-interactive", "--yes-i-accept-third-party-software", "--yes"],
+      rootDir,
+    );
+
+    expect(runOnboardAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "non-interactive": true,
+        resume: true,
+        "yes-i-accept-third-party-software": true,
+        yes: true,
+      }),
+    );
   });
 
   it("resume rejection clarifies --resume semantics and points to onboard (#2281)", () => {
+    // Keep the real executable/runtime exit contract for the user-facing diagnostic.
     const r = run("onboard --resume --non-interactive --yes-i-accept-third-party-software --yes");
     expect(r.code).toBe(1);
     expect(r.out.includes("No resumable onboarding session was found")).toBeTruthy();
@@ -156,31 +233,9 @@ describe("CLI onboard compatibility", () => {
     expect(r.out.includes("nemoclaw onboard")).toBeTruthy();
   });
 
-  it("refuses non-interactive --resume when the sandbox step never completed and no name is provided (#2753)", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-resume-no-name-"));
-    const localBin = path.join(home, "bin");
-    const nemoclawDir = path.join(home, ".nemoclaw");
-    fs.mkdirSync(localBin, { recursive: true });
-    fs.mkdirSync(nemoclawDir, { recursive: true });
-    // Fake openshell so preflight passes and we reach the resume sandbox-name
-    // init where the new guard lives.
-    writeOpenShellVersionStub(localBin);
-    // Simulates a pre-fix on-disk session that recorded only provider/model
-    // (with #2753's onboard fix, sandboxName is no longer written here either).
-    writeIncompleteResumeSession(nemoclawDir);
-
-    const r = runWithEnv("onboard --resume --non-interactive --yes-i-accept-third-party-software", {
-      HOME: home,
-      PATH: `${localBin}:${process.env.PATH || ""}`,
-      NEMOCLAW_SANDBOX_NAME: "",
-    });
-
-    expect(r.code).toBe(1);
-    expect(r.out.includes("Cannot resume non-interactive onboard")).toBeTruthy();
-    expect(r.out.includes("--name <sandbox>")).toBeTruthy();
-  });
-
   it("does not let whitespace-only NEMOCLAW_SANDBOX_NAME satisfy the resume guard (#2753)", () => {
+    // Preserve one full environment-ingest boundary: HOME/session discovery,
+    // whitespace normalization, OpenShell executable lookup, and final exit.
     // The env-var ingest pipeline trims and rejects whitespace-only values
     // before populating requestedSandboxName, so the guard sees no recovered
     // name and fires correctly.
@@ -202,27 +257,33 @@ describe("CLI onboard compatibility", () => {
     expect(r.out.includes("Cannot resume non-interactive onboard")).toBeTruthy();
   });
 
-  it("setup-spark --help exits 0 and shows native deprecated-alias usage", () => {
-    const r = run("setup-spark --help");
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("Deprecated: 'nemoclaw setup-spark' is now 'nemoclaw onboard'");
-    expect(r.out).toContain("$ nemoclaw setup-spark [flags]");
-    expect(r.out).not.toContain("Unknown onboard option");
-  });
-
-  it("setup-spark is a deprecated compatibility alias for onboard", () => {
-    const r = run(
-      "setup-spark --resume --non-interactive --yes-i-accept-third-party-software --yes",
+  it("setup-spark exposes native deprecated-alias help metadata", () => {
+    expect(SetupSparkCliCommand.state).toBe("deprecated");
+    expect(SetupSparkCliCommand.deprecationOptions.message).toContain(
+      "Deprecated: 'nemoclaw setup-spark' is now 'nemoclaw onboard'",
     );
-    expect(r.code).toBe(1);
-    expect(r.out).toContain("Deprecated: 'nemoclaw setup-spark' is now 'nemoclaw onboard'");
-    expect(r.out.includes("No resumable onboarding session was found")).toBeTruthy();
+    expect(SetupSparkCliCommand.usage).toEqual(["setup-spark [flags]"]);
+    expect(SetupSparkCliCommand.flags).toHaveProperty("resume");
   });
 
-  it("deploy --help exits 0 and shows deprecated usage", () => {
-    const r = run("deploy --help");
-    expect(r.code).toBe(0);
-    expect(r.out).toContain("deploy [instance-name]");
-    expect(r.out).toContain("Deprecated Brev-specific bootstrap path");
+  it("setup-spark is a deprecated compatibility alias for onboard", async () => {
+    await SetupSparkCliCommand.run(
+      ["--resume", "--non-interactive", "--yes-i-accept-third-party-software", "--yes"],
+      rootDir,
+    );
+
+    expect(runOnboardAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "non-interactive": true,
+        resume: true,
+        "yes-i-accept-third-party-software": true,
+        yes: true,
+      }),
+    );
+  });
+
+  it("deploy exposes deprecated compatibility help metadata", () => {
+    expect(DeployCliCommand.usage).toEqual(["deploy [instance-name]"]);
+    expect(DeployCliCommand.summary).toBe("Deprecated Brev-specific bootstrap path");
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Moves repeated CLI help, parser, alias, and validation assertions in three integration suites onto existing source seams while retaining representative executable contracts. This removes 21 cold CLI helper launches; final focused evidence totals 12.48s of test execution versus 49.92s of prior CI file execution, a directional cross-runner comparison pending final-head CI.

## Related Issue

Related to #6245.

## Changes

- Exercise root help, parser metadata, command metadata, and credential validation directly where process behavior is not the contract.
- Keep real CLI launches for executable discovery, rendered help, agent runtime listing, argv and exit propagation, secret-bearing arguments, poisoned stdin, environment ingestion, registry recovery, deprecated compatibility help, and user-facing failure diagnostics.
- Reduce cold CLI helper calls from 51 to 30 across `dispatch-basics`, `credentials-command`, and `onboard-compatibility`, without changing production or shared test-harness code.
- Mock runtime-only bridges in direct tests and restore `process.exitCode` so the faster coverage does not introduce collection bloat or worker-state leakage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test execution strategy only; no command, flag, default, configuration, API, policy, output, or recovery behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent local review found no remaining actionable findings; secret redaction, poisoned stdin, executable help/parser exits, resume diagnostics, and environment-ingest contracts remain real processes
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: credentials passed 11/11 (1.69s test execution); the post-review dispatch/onboard run passed 37/37 in 11.58s total (10.79s test execution)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this focused three-file batch; final-head CI remains authoritative for full coverage
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CLI credential tests to validate command metadata (usage/description, required flag types), and to assert action-result failures for missing/complicting options without exposing secret-like values.
  * Refined help/argv coverage to verify normalization and logged help sections rather than relying on full CLI stdout/exit-code checks.
  * Strengthened onboarding compatibility tests by running commands directly, improving mock/restoration behavior, adding resume-guard coverage for whitespace sandbox names, and verifying deprecated alias option forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->