### PR TITLE
ci(coverage): ratchet CLI thresholds

### DIFF
--- a/ci/coverage-threshold-cli.json
+++ b/ci/coverage-threshold-cli.json
@@ -1,6 +1,6 @@
 {
-  "lines": 33.2,
-  "functions": 29.8,
-  "branches": 23.4,
-  "statements": 32.7
+  "lines": 70.9,
+  "functions": 71.5,
+  "branches": 62.9,
+  "statements": 70.5
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Rebaseline the nominal CLI coverage thresholds to the current observed coverage level after the test-performance series. The values use the lower of two successful identical-tree runs and retain the checker’s existing one-percentage-point variance allowance.

## Related Issue
Refs #6237

## Changes
- Raise line coverage from 33.2% to 70.9% and function coverage from 29.8% to 71.5%.
- Raise branch coverage from 23.4% to 62.9% and statement coverage from 32.7% to 70.5%.
- Leave plugin thresholds and the existing one-point tolerance unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the aggregate CLI coverage job runs the unchanged ratchet checker against this JSON; successful identical-tree runs reported minima of 70.99% lines, 71.59% functions, 62.95% branches, and 70.50% statements.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal CI baseline data only; contributor commands and user-facing behavior are unchanged, and documentation review found no update needed.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that affect that behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: the unchanged ratchet path passed on post-merge main with all four actual metrics at or above the new values; all 68 permission-sensitive cases from the local broad run passed under CI's standard `022` umask.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: final-head CI passed all five CLI coverage shards and the merged `cli-tests` ratchet with 70.50% statements, 62.98% branches, 71.61% functions, and 71.01% lines.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
