### PR TITLE
docs(commands): fix broken plugin link and drop hardcoded agent versions

### DIFF
--- a/docs/reference/commands-nemohermes.mdx
+++ b/docs/reference/commands-nemohermes.mdx
@@ -796,7 +796,7 @@ Expected output:
 
 ```text
 ...
-    Agent:    Hermes v2026.5.16
+    Agent:    Hermes v<version>
 ...
 ```
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -985,7 +985,7 @@ Expected output:
 
 ```text
 ...
-    Agent:    OpenClaw v2026.5.27
+    Agent:    OpenClaw v<version>
 ...
 ```
 
@@ -1011,7 +1011,7 @@ Expected output:
 
 ```text
 ...
-    Agent:    Hermes v2026.5.16
+    Agent:    Hermes v<version>
 ...
 ```
 
@@ -1664,7 +1664,7 @@ Skill names must contain only alphanumeric characters, dots, hyphens, and unders
 <AgentOnly variant="openclaw">
 
 OpenClaw plugins are a different kind of extension.
-To install an OpenClaw plugin, refer to [Install OpenClaw Plugins](../manage-sandboxes/install-openclaw-plugins).
+To install an OpenClaw plugin, refer to [Install OpenClaw Plugins](../deployment/install-openclaw-plugins).
 For OpenClaw, the command uploads the skill to the OpenClaw state directory and mirrors it into `$HOME/.openclaw/skills/<name>` when the agent home directory differs from the state directory.
 That mirror makes skills listed by `openclaw skills list` available at session startup.
 If mirror creation fails, NemoClaw prints a warning so you can reinstall or inspect the home directory permissions.


### PR DESCRIPTION
## Summary

Fixes a broken internal link and stale hardcoded agent-version examples in the CLI commands reference. QA flagged that the OpenClaw plugin link 404s and that the status-output examples pin specific OpenClaw/Hermes versions that go stale on every pin bump.

## Related Issue

Fixes #5445

## Changes

- Repoint the OpenClaw plugin link in `docs/reference/commands.mdx` from the non-existent `../manage-sandboxes/install-openclaw-plugins` to `../deployment/install-openclaw-plugins` (matches `docs/index.yml` nav and `docs/about/release-notes.mdx`).
- Replace hardcoded example versions `OpenClaw v2026.5.27` and `Hermes v2026.5.16` with a `v<version>` placeholder consistent with the other `<name>`/`<version>` placeholders on the page.
- Regenerate the derived `docs/reference/commands-nemohermes.mdx` via `npm run docs:sync-agent-variants` (generated from `commands.mdx`; not hand-edited).

## Type of Change

- [x] Doc only (prose changes, no code sample modifications)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [x] Tests not applicable — justification: docs-only change (broken link + example text); no runtime behavior.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable

## Verification

Reporter workflow is docs navigation (open the page, click the plugin link, read the status-output example) — not a CLI command. There is no `nemoclaw`/`nemohermes` runtime surface for a docs link/text change, so a worktree CLI transcript (`./bin/nemoclaw.js ...`) is not applicable; the equivalent reporter-workflow E2E for a docs internal link is the Fern link resolution check below (`fern check` fails on unresolved internal links). The `docs-only-checks` CI job on this PR is the named pipeline E2E for these changes.

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — justification: docs-only; ran the reporter-workflow docs checks below.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — `npm run docs:strict` reported 0 errors; the 2 warnings are pre-existing and unrelated (unauthenticated redirect check skipped; light-mode accent contrast ratio).
- [x] Doc pages follow the style guide (doc changes only)

Reporter-workflow / pipeline E2E transcript (docs checks from this worktree):

```
$ rg -n "v2026\.5\.27|v2026\.5\.16" docs/ --glob '!**/_build/**'      # no matches (stale versions gone)
$ rg -n "manage-sandboxes/install-openclaw-plugins" docs/ --glob '!**/_build/**'   # no matches (broken link gone)
$ npm run docs:check-agent-variants   # commands-nemohermes.mdx in sync
$ npm run docs:strict                 # fern check: Found 0 errors and 2 warnings (validates internal link resolves)
```

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>
