### PR TITLE
perf(test): reduce CommonJS loader churn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,7 +171,7 @@ repos:
         name: Repository checks
         entry: npm run checks
         language: system
-        files: ^(bin/.*\.(cjs|js|mjs)$|src/.*\.tsx?$|scripts/.*\.(cjs|js|mjs|ts|tsx)$|test/.*\.(cjs|js|mjs|ts|tsx)$|nemoclaw/src/.*\.tsx?$)
+        files: ^(bin/.*\.(cjs|js|mjs)$|src/.*\.(cts|mts|ts|tsx)$|scripts/.*\.(cjs|cts|js|mjs|mts|ts|tsx)$|test/.*\.(cjs|cts|js|mjs|mts|ts|tsx)$|nemoclaw/src/.*\.(cts|mts|ts|tsx)$)
         pass_filenames: false
         priority: 10
 

--- a/scripts/checks/run.ts
+++ b/scripts/checks/run.ts
@@ -47,6 +47,11 @@ const CHECKS: readonly CheckCommand[] = [
     args: ["scripts/checks/no-test-dist-imports.ts"],
   },
   {
+    name: "test-create-require-budget",
+    command: TSX,
+    args: ["scripts/checks/test-create-require-budget.ts"],
+  },
+  {
     name: "vitest-project-overlap",
     command: TSX,
     args: ["scripts/checks/vitest-project-overlap.ts"],

--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -93,6 +93,8 @@ export function containsCreateRequireIdentifier(
   );
   let found = false;
 
+  // Count identifiers in executable syntax, including property access, because
+  // either can introduce a loader seam. Literal text cannot invoke createRequire.
   function visit(node: ts.Node): void {
     if (found) return;
     if (ts.isIdentifier(node) && node.text === "createRequire") {

--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const CLI_TEST_ROOT = path.join(REPO_ROOT, "src");
+const TEST_SUPPORT_ROOT = path.join(REPO_ROOT, "test");
+const TEST_FILE_PATTERN = /\.test\.(?:[cm]?ts|tsx)$/;
+const TYPESCRIPT_PATTERN = /\.(?:[cm]?ts|tsx)$/;
+
+// Keep the exact paths rather than treating a scalar count as spare capacity.
+// When another CommonJS test seam is retired, removing its path is part of
+// that change; a different file cannot silently consume the freed slot.
+export const CLI_CREATE_REQUIRE_FILES = [
+  "src/lib/actions/sandbox/doctor-flow.test.ts",
+  "src/lib/actions/sandbox/doctor-system-checks.test.ts",
+  "src/lib/actions/sandbox/gateway-state-drift.test.ts",
+  "src/lib/actions/sandbox/gateway-state-hints.test.ts",
+  "src/lib/actions/sandbox/process-recovery-lock.test.ts",
+  "src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts",
+  "src/lib/actions/sandbox/rebuild-config-hash.test.ts",
+  "src/lib/actions/sandbox/rebuild-flow-helpers.test.ts",
+  "src/lib/actions/sandbox/rebuild-gateway-drift.test.ts",
+  "src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts",
+  "src/lib/actions/sandbox/rebuild-messaging-stage.test.ts",
+  "src/lib/actions/sandbox/rebuild-prepared-recovery.test.ts",
+  "src/lib/actions/sandbox/rebuild-resume-config.test.ts",
+  "src/lib/actions/sandbox/rebuild-resume-reasoning.test.ts",
+  "src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts",
+  "src/lib/actions/sandbox/rebuild-shields-finally.test.ts",
+  "src/lib/actions/sandbox/sandbox-gateway-routing.test.ts",
+  "src/lib/actions/upgrade-sandboxes-recovery.test.ts",
+  "src/lib/adapters/openshell/gateway-drift.test.ts",
+  "src/lib/gateway-runtime-action.test.ts",
+  "src/lib/hermes-provider-auth.test.ts",
+  "src/lib/inference/nim-igpu-compute-constrained.test.ts",
+  "src/lib/inference/nim.test.ts",
+  "src/lib/inference/ollama/proxy.test.ts",
+  "src/lib/inference/ollama/windows.test.ts",
+  "src/lib/onboard/sandbox-registration.test.ts",
+  "src/lib/sandbox/privileged-exec.test.ts",
+  "src/lib/shields/flow.test.ts",
+  "src/lib/shields/legacy-hermes-compat.test.ts",
+  "src/lib/shields/mutable-config-repair.test.ts",
+  "src/lib/shields/openclaw-transition.test.ts",
+  "src/lib/shields/policy-transition.test.ts",
+  "src/lib/state/onboard-session-cross-process-lock.test.ts",
+  "src/lib/state/onboard-session-tool-disclosure.test.ts",
+  "src/lib/state/onboard-session.test.ts",
+  "src/lib/state/user-managed-files-probe.test.ts",
+] as const;
+
+export const TEST_SUPPORT_CREATE_REQUIRE_FILES = [
+  "test/fixtures/strict-tool-call-probe-driver.ts",
+  "test/fixtures/uninstall-prompt-pty-driver.ts",
+  "test/helpers/base-image-test-harness.ts",
+  "test/helpers/destroy-flow-test-harness.ts",
+  "test/helpers/rebuild-flow-harness.ts",
+  "test/helpers/rebuild-flow-test-harness.ts",
+  "test/support/connect-flow-test-harness.ts",
+  "test/support/status-flow-test-harness.ts",
+] as const;
+
+function* walkTypeScriptFiles(directory: string): Generator<string> {
+  if (!existsSync(directory)) return;
+
+  for (const entry of readdirSync(directory)) {
+    const absolutePath = path.join(directory, entry);
+    const stats = statSync(absolutePath);
+    if (stats.isDirectory()) {
+      yield* walkTypeScriptFiles(absolutePath);
+    } else if (stats.isFile() && TYPESCRIPT_PATTERN.test(entry)) {
+      yield absolutePath;
+    }
+  }
+}
+
+export function containsCreateRequireIdentifier(
+  sourceText: string,
+  fileName = "example.test.ts",
+): boolean {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let found = false;
+
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (ts.isIdentifier(node) && node.text === "createRequire") {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+export function collectCliCreateRequireTests(root = CLI_TEST_ROOT): string[] {
+  return [...walkTypeScriptFiles(root)]
+    .filter((absolutePath) => TEST_FILE_PATTERN.test(absolutePath))
+    .filter((absolutePath) =>
+      containsCreateRequireIdentifier(readFileSync(absolutePath, "utf8"), absolutePath),
+    )
+    .map((absolutePath) => path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/"))
+    .sort();
+}
+
+export function collectProductionCreateRequireSources(root = CLI_TEST_ROOT): string[] {
+  return [...walkTypeScriptFiles(root)]
+    .filter((absolutePath) => !TEST_FILE_PATTERN.test(absolutePath))
+    .filter((absolutePath) =>
+      containsCreateRequireIdentifier(readFileSync(absolutePath, "utf8"), absolutePath),
+    )
+    .map((absolutePath) => path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/"))
+    .sort();
+}
+
+export function collectTestSupportCreateRequireSources(root = TEST_SUPPORT_ROOT): string[] {
+  return [...walkTypeScriptFiles(root)]
+    .filter((absolutePath) => !TEST_FILE_PATTERN.test(absolutePath))
+    .filter((absolutePath) =>
+      containsCreateRequireIdentifier(readFileSync(absolutePath, "utf8"), absolutePath),
+    )
+    .map((absolutePath) => path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/"))
+    .sort();
+}
+
+export function createRequireBudgetFailure(
+  files: readonly string[],
+  allowedFiles: readonly string[] = CLI_CREATE_REQUIRE_FILES,
+): string | null {
+  const actual = new Set(files);
+  const allowed = new Set(allowedFiles);
+  const added = [...actual].filter((file) => !allowed.has(file)).sort();
+  const removed = [...allowed].filter((file) => !actual.has(file)).sort();
+  if (added.length === 0 && removed.length === 0) return null;
+
+  const lines = ["CLI createRequire path budget failed."];
+  if (added.length > 0) {
+    lines.push(
+      "",
+      "Replace new CommonJS test seams with native imports or explicit dependencies:",
+      ...added.map((file) => `- ${file}`),
+    );
+  }
+  if (removed.length > 0) {
+    lines.push(
+      "",
+      "Remove retired paths from CLI_CREATE_REQUIRE_FILES so they cannot return:",
+      ...removed.map((file) => `- ${file}`),
+    );
+  }
+  return lines.join("\n");
+}
+
+function main(): void {
+  const productionFiles = collectProductionCreateRequireSources();
+  if (productionFiles.length > 0) {
+    console.error(
+      [
+        "Production TypeScript must not introduce createRequire boundaries.",
+        "Use static imports, explicit dependencies, or retain a genuine CommonJS boundary outside src/.",
+        "",
+        ...productionFiles.map((file) => `- ${file}`),
+      ].join("\n"),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const files = collectCliCreateRequireTests();
+  const failure = createRequireBudgetFailure(files);
+  if (failure) {
+    console.error(failure);
+    process.exitCode = 1;
+    return;
+  }
+
+  const supportFiles = collectTestSupportCreateRequireSources();
+  const supportFailure = createRequireBudgetFailure(
+    supportFiles,
+    TEST_SUPPORT_CREATE_REQUIRE_FILES,
+  );
+  if (supportFailure) {
+    console.error(
+      supportFailure
+        .replace("CLI createRequire", "Test-support createRequire")
+        .replaceAll("CLI_CREATE_REQUIRE_FILES", "TEST_SUPPORT_CREATE_REQUIRE_FILES"),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `CLI createRequire budget passed: ${files.length} CLI test file(s), ${supportFiles.length} support file(s).`,
+  );
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  main();
+}

--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -89,7 +89,7 @@ export function containsCreateRequireIdentifier(
     sourceText,
     ts.ScriptTarget.Latest,
     true,
-    ts.ScriptKind.TS,
+    fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
   );
   let found = false;
 
@@ -116,7 +116,7 @@ export function collectCliCreateRequireTests(root = CLI_TEST_ROOT): string[] {
     .sort();
 }
 
-export function collectProductionCreateRequireSources(root = CLI_TEST_ROOT): string[] {
+function collectNonTestCreateRequireSources(root: string): string[] {
   return [...walkTypeScriptFiles(root)]
     .filter((absolutePath) => !TEST_FILE_PATTERN.test(absolutePath))
     .filter((absolutePath) =>
@@ -126,14 +126,12 @@ export function collectProductionCreateRequireSources(root = CLI_TEST_ROOT): str
     .sort();
 }
 
+export function collectProductionCreateRequireSources(root = CLI_TEST_ROOT): string[] {
+  return collectNonTestCreateRequireSources(root);
+}
+
 export function collectTestSupportCreateRequireSources(root = TEST_SUPPORT_ROOT): string[] {
-  return [...walkTypeScriptFiles(root)]
-    .filter((absolutePath) => !TEST_FILE_PATTERN.test(absolutePath))
-    .filter((absolutePath) =>
-      containsCreateRequireIdentifier(readFileSync(absolutePath, "utf8"), absolutePath),
-    )
-    .map((absolutePath) => path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/"))
-    .sort();
+  return collectNonTestCreateRequireSources(root);
 }
 
 export function createRequireBudgetFailure(

--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -31,8 +31,6 @@ export const CLI_CREATE_REQUIRE_FILES = [
   "src/lib/actions/sandbox/rebuild-prepared-recovery.test.ts",
   "src/lib/actions/sandbox/rebuild-resume-config.test.ts",
   "src/lib/actions/sandbox/rebuild-resume-reasoning.test.ts",
-  "src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts",
-  "src/lib/actions/sandbox/rebuild-shields-finally.test.ts",
   "src/lib/actions/sandbox/sandbox-gateway-routing.test.ts",
   "src/lib/actions/upgrade-sandboxes-recovery.test.ts",
   "src/lib/adapters/openshell/gateway-drift.test.ts",

--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -28,7 +28,6 @@ export const CLI_CREATE_REQUIRE_FILES = [
   "src/lib/actions/sandbox/rebuild-gateway-drift.test.ts",
   "src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts",
   "src/lib/actions/sandbox/rebuild-messaging-stage.test.ts",
-  "src/lib/actions/sandbox/rebuild-prepared-recovery.test.ts",
   "src/lib/actions/sandbox/rebuild-resume-config.test.ts",
   "src/lib/actions/sandbox/rebuild-resume-reasoning.test.ts",
   "src/lib/actions/sandbox/sandbox-gateway-routing.test.ts",

--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -36,7 +36,6 @@ export const CLI_CREATE_REQUIRE_FILES = [
   "src/lib/actions/sandbox/sandbox-gateway-routing.test.ts",
   "src/lib/actions/upgrade-sandboxes-recovery.test.ts",
   "src/lib/adapters/openshell/gateway-drift.test.ts",
-  "src/lib/gateway-runtime-action.test.ts",
   "src/lib/hermes-provider-auth.test.ts",
   "src/lib/inference/nim-igpu-compute-constrained.test.ts",
   "src/lib/inference/nim.test.ts",
@@ -71,7 +70,8 @@ function* walkTypeScriptFiles(directory: string): Generator<string> {
 
   for (const entry of readdirSync(directory)) {
     const absolutePath = path.join(directory, entry);
-    const stats = statSync(absolutePath);
+    const stats = lstatSync(absolutePath);
+    if (stats.isSymbolicLink()) continue;
     if (stats.isDirectory()) {
       yield* walkTypeScriptFiles(absolutePath);
     } else if (stats.isFile() && TYPESCRIPT_PATTERN.test(entry)) {

--- a/src/lib/actions/sandbox/policy-channel-agent-gate.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-agent-gate.test.ts
@@ -14,7 +14,8 @@ import * as defs from "../../agent/defs";
 import * as store from "../../credentials/store";
 import * as policy from "../../policy";
 import * as registry from "../../state/registry";
-import { addSandboxChannel, policyChannelDependencies } from "./policy-channel";
+import { addSandboxChannel } from "./policy-channel";
+import { policyChannelDependencies } from "./policy-channel-dependencies";
 
 function agentFixture(name: string): defs.AgentDefinition {
   return { name } as defs.AgentDefinition;

--- a/src/lib/actions/sandbox/policy-channel-agent-gate.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-agent-gate.test.ts
@@ -7,31 +7,29 @@
 // Without this gate, a destructive sandbox rebuild can run and fail late at
 // Dockerfile patching.
 //
-// policy-channel.ts loads several dependencies through CommonJS `require()`.
-// Load the source module and its dependencies through the shared source hook
-// so `vi.spyOn` observes one require cache without depending on a CLI build.
-
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-const requireSource = createRequire(import.meta.url);
-const D = (p: string) => requireSource(`../../${p}`);
+import * as runtime from "../../adapters/openshell/runtime";
+import * as defs from "../../agent/defs";
+import * as store from "../../credentials/store";
+import * as policy from "../../policy";
+import * as registry from "../../state/registry";
+import { addSandboxChannel, policyChannelDependencies } from "./policy-channel";
 
-const registry = D("state/registry.js");
-const providers = D("onboard/providers.js");
-const runtime = D("adapters/openshell/runtime.js");
-const defs = D("agent/defs.js");
-const rebuild = D("actions/sandbox/rebuild.js");
-const policy = D("policy/index.js");
-const store = D("credentials/store.js");
+function agentFixture(name: string): defs.AgentDefinition {
+  return { name } as defs.AgentDefinition;
+}
 
-const { addSandboxChannel } = D("actions/sandbox/policy-channel.js") as {
-  addSandboxChannel: (
-    name: string,
-    options?: { channel?: string; dryRun?: boolean; force?: boolean },
-  ) => Promise<void>;
-};
+function successfulOpenshellResult(): ReturnType<typeof runtime.runOpenshell> {
+  return {
+    pid: 0,
+    output: [null, "", ""],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  };
+}
 
 let exitMock: MockInstance;
 let errSpy: MockInstance;
@@ -64,10 +62,8 @@ beforeEach(() => {
 
   getSandboxMock = vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "da-test" });
   updateSandboxMock = vi.spyOn(registry, "updateSandbox").mockReturnValue(true);
-  upsertMock = vi.spyOn(providers, "upsertMessagingProviders").mockImplementation(() => undefined);
-  runOpenshellMock = vi
-    .spyOn(runtime, "runOpenshell")
-    .mockReturnValue({ status: 0, stdout: "", stderr: "" });
+  upsertMock = vi.spyOn(policyChannelDependencies, "upsertMessagingProviders").mockReturnValue([]);
+  runOpenshellMock = vi.spyOn(runtime, "runOpenshell").mockReturnValue(successfulOpenshellResult());
   loadPresetForSandboxMock = vi
     .spyOn(policy, "loadPresetForSandbox")
     .mockReturnValue("network_policies:\n  stub: {}\n");
@@ -78,7 +74,7 @@ beforeEach(() => {
   getCredentialMock = vi.spyOn(store, "getCredential").mockReturnValue(null);
   saveCredentialMock = vi.spyOn(store, "saveCredential").mockImplementation(() => undefined);
   promptMock = vi.spyOn(store, "prompt").mockResolvedValue("");
-  rebuildMock = vi.spyOn(rebuild, "rebuildSandbox").mockResolvedValue(undefined);
+  rebuildMock = vi.spyOn(policyChannelDependencies, "rebuildSandbox").mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -87,9 +83,7 @@ afterEach(() => {
 
 describe("addSandboxChannel agent gate", () => {
   it("rejects an unknown agent before any preset, mutation, provider, credential, or rebuild call", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "custom-agent",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("custom-agent"));
 
     let caught: unknown;
     try {
@@ -118,9 +112,7 @@ describe("addSandboxChannel agent gate", () => {
   });
 
   it("rejects an agent that is not listed by any channel manifest before any mutation", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "future-agent",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("future-agent"));
 
     let caught: unknown;
     try {
@@ -138,9 +130,7 @@ describe("addSandboxChannel agent gate", () => {
   });
 
   it("does not gate messaging-capable agents (openclaw flows past the agent check)", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "openclaw",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("openclaw"));
 
     let caught: unknown;
     try {

--- a/src/lib/actions/sandbox/policy-channel-cleanup.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-cleanup.test.ts
@@ -7,26 +7,18 @@
 // strip the stored messaging plan from the registry, `channels pause/resume`
 // should fail closed (no throw, no plan mutation).
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-const requireDist = createRequire(import.meta.url);
-const D = (p: string) => requireDist(`../../${p}`);
+import * as defs from "../../agent/defs";
+import * as registry from "../../state/registry";
+import {
+  persistManifestChannelDisabledPlan,
+  persistManifestChannelRemovePlan,
+} from "./policy-channel";
 
-const registry = D("state/registry.js");
-const defs = D("agent/defs.js");
-
-const { persistManifestChannelDisabledPlan, persistManifestChannelRemovePlan } = D(
-  "actions/sandbox/policy-channel.js",
-) as {
-  persistManifestChannelDisabledPlan: (
-    sandboxName: string,
-    channelId: string,
-    disabled: boolean,
-  ) => Promise<unknown>;
-  persistManifestChannelRemovePlan: (sandboxName: string, channelId: string) => Promise<boolean>;
-};
+function agentFixture(name: string): defs.AgentDefinition {
+  return { name } as defs.AgentDefinition;
+}
 
 let getSandboxMock: MockInstance;
 let updateSandboxMock: MockInstance;
@@ -78,9 +70,7 @@ afterEach(() => {
 
 describe("persistManifestChannelRemovePlan with non-messaging agent (#5729)", () => {
   it("strips stale messaging state from the registry without throwing", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "custom-agent",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("custom-agent"));
     getSandboxMock.mockReturnValue(entryWithStalePlan("da-test", "discord"));
 
     const result = await persistManifestChannelRemovePlan("da-test", "discord");
@@ -90,9 +80,7 @@ describe("persistManifestChannelRemovePlan with non-messaging agent (#5729)", ()
   });
 
   it("returns true and skips registry update when no stale plan exists", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "custom-agent",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("custom-agent"));
     getSandboxMock.mockReturnValue({ name: "da-test", agent: "custom-agent" });
 
     const result = await persistManifestChannelRemovePlan("da-test", "discord");
@@ -104,9 +92,7 @@ describe("persistManifestChannelRemovePlan with non-messaging agent (#5729)", ()
 
 describe("persistManifestChannelDisabledPlan with non-messaging agent (#5729)", () => {
   it("returns null without throwing or mutating the registry when the agent does not support messaging", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "custom-agent",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("custom-agent"));
     getSandboxMock.mockReturnValue(entryWithStalePlan("da-test", "discord"));
 
     const result = await persistManifestChannelDisabledPlan("da-test", "discord", true);
@@ -116,9 +102,7 @@ describe("persistManifestChannelDisabledPlan with non-messaging agent (#5729)", 
   });
 
   it("returns null without throwing when there is no stored messaging plan", async () => {
-    vi.spyOn(defs, "loadAgent").mockReturnValue({
-      name: "custom-agent",
-    });
+    vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("custom-agent"));
     getSandboxMock.mockReturnValue({ name: "da-test", agent: "custom-agent" });
 
     const result = await persistManifestChannelDisabledPlan("da-test", "discord", true);

--- a/src/lib/actions/sandbox/policy-channel-conflict.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-conflict.test.ts
@@ -18,11 +18,8 @@ import * as onboardSession from "../../state/onboard-session";
 import type { SandboxEntry } from "../../state/registry";
 import * as registry from "../../state/registry";
 import * as messagingHostForwardLifecycle from "./messaging-host-forward-lifecycle";
-import {
-  addSandboxChannel,
-  policyChannelDependencies,
-  startSandboxChannel,
-} from "./policy-channel";
+import { addSandboxChannel, startSandboxChannel } from "./policy-channel";
+import { policyChannelDependencies } from "./policy-channel-dependencies";
 import * as processRecovery from "./process-recovery";
 
 function agentFixture(name: string): defs.AgentDefinition {

--- a/src/lib/actions/sandbox/policy-channel-conflict.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-conflict.test.ts
@@ -6,50 +6,39 @@
 // assert only on the mocked module boundaries — never on the private helper
 // names — so they survive a refactor of the internal conflict-check plumbing.
 //
-// policy-channel.ts loads several dependencies through CommonJS `require()`.
-// Load the source module and its dependencies through the shared source hook
-// so `vi.spyOn` observes one require cache without depending on a CLI build.
-//
-// isNonInteractive is destructured at module load (`const { isNonInteractive }
-// = require("../../onboard")`), so it cannot be spied after load; it reads
-// process.env.NEMOCLAW_NON_INTERACTIVE === "1" at call time, which we drive
-// directly. The real messaging/applier, sandbox/channels, and credential-hash
-// modules run unmocked so the genuine hash + conflict logic is exercised.
-
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-const requireSource = createRequire(import.meta.url);
-const D = (p: string) => requireSource(`../../${p}`);
+import * as runtime from "../../adapters/openshell/runtime";
+import * as defs from "../../agent/defs";
+import * as store from "../../credentials/store";
+import * as gatewayRuntime from "../../gateway-runtime-action";
+import * as policy from "../../policy";
+import { hashCredential } from "../../security/credential-hash";
+import * as onboardSession from "../../state/onboard-session";
+import type { SandboxEntry } from "../../state/registry";
+import * as registry from "../../state/registry";
+import * as messagingHostForwardLifecycle from "./messaging-host-forward-lifecycle";
+import {
+  addSandboxChannel,
+  policyChannelDependencies,
+  startSandboxChannel,
+} from "./policy-channel";
+import * as processRecovery from "./process-recovery";
 
-type SandboxEntry = import("../../state/registry").SandboxEntry;
+function agentFixture(name: string): defs.AgentDefinition {
+  return { name } as defs.AgentDefinition;
+}
 
-// Real source dependency modules (shared require cache with the SUT).
-const store = D("credentials/store.js");
-const registry = D("state/registry.js");
-const providers = D("onboard/providers.js");
-const runtime = D("adapters/openshell/runtime.js");
-const gatewayRuntime = D("gateway-runtime-action.js");
-const defs = D("agent/defs.js");
-const rebuild = D("actions/sandbox/rebuild.js");
-const messagingHostForwardLifecycle = D("actions/sandbox/messaging-host-forward-lifecycle.js");
-const processRecovery = D("actions/sandbox/process-recovery.js");
-const onboardSession = D("state/onboard-session.js");
-const policy = D("policy/index.js");
-const { hashCredential } = D("security/credential-hash.js") as {
-  hashCredential: (v: string) => string | null;
-};
-const { addSandboxChannel, startSandboxChannel } = D("actions/sandbox/policy-channel.js") as {
-  addSandboxChannel: (
-    name: string,
-    options?: { channel?: string; dryRun?: boolean; force?: boolean },
-  ) => Promise<void>;
-  startSandboxChannel: (
-    name: string,
-    options?: { channel?: string; dryRun?: boolean; force?: boolean },
-  ) => Promise<void>;
-};
+function successfulOpenshellResult(): ReturnType<typeof runtime.runOpenshell> {
+  return {
+    pid: 0,
+    output: [null, "", ""],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  };
+}
 
 const TELEGRAM_TOKEN = "123456:AAH-secret-bot-token-value";
 const TELEGRAM_HASH = hashCredential(TELEGRAM_TOKEN) as string;
@@ -310,15 +299,23 @@ beforeEach(() => {
     .mockReturnValue({ sandboxes: [], defaultSandbox: null });
   updateSandboxMock = vi.spyOn(registry, "updateSandbox").mockReturnValue(true);
 
-  // onboard/providers seam (gateway probe + register).
-  vi.spyOn(providers, "providerExistsInGateway").mockReturnValue(false);
-  upsertMock = vi.spyOn(providers, "upsertMessagingProviders").mockImplementation(() => undefined);
+  // Lazy legacy-provider seam: no onboarding graph is loaded for this suite.
+  upsertMock = vi.spyOn(policyChannelDependencies, "upsertMessagingProviders").mockReturnValue([]);
 
   // openshell runtime + gateway recovery.
-  runOpenshellMock = vi
-    .spyOn(runtime, "runOpenshell")
-    .mockReturnValue({ status: 0, stdout: "", stderr: "" });
-  vi.spyOn(gatewayRuntime, "recoverNamedGatewayRuntime").mockResolvedValue({ recovered: true });
+  runOpenshellMock = vi.spyOn(runtime, "runOpenshell").mockReturnValue(successfulOpenshellResult());
+  const healthyGatewayState = {
+    state: "healthy_named",
+    status: "",
+    gatewayInfo: "",
+    activeGateway: "nemoclaw",
+  } as const;
+  vi.spyOn(gatewayRuntime, "recoverNamedGatewayRuntime").mockResolvedValue({
+    recovered: true,
+    before: healthyGatewayState,
+    after: healthyGatewayState,
+    attempted: false,
+  });
 
   // Credentials store: staged token (no real prompt) + controllable prompt.
   getCredentialMock = vi.spyOn(store, "getCredential").mockReturnValue(null);
@@ -326,9 +323,7 @@ beforeEach(() => {
   vi.spyOn(store, "saveCredential").mockImplementation(() => undefined);
 
   // Agent gate: OpenClaw support is derived from channel manifests.
-  vi.spyOn(defs, "loadAgent").mockReturnValue({
-    name: "openclaw",
-  });
+  vi.spyOn(defs, "loadAgent").mockReturnValue(agentFixture("openclaw"));
 
   // Policy seam. addSandboxChannel gates on loadPreset()/parsePresetPolicyKeys()
   // up front (the channel must ship a preset with network_policies); stub both
@@ -342,7 +337,9 @@ beforeEach(() => {
   vi.spyOn(policy, "getAppliedPresets").mockReturnValue([]);
 
   // Downstream rebuild is not under test.
-  rebuildSandboxMock = vi.spyOn(rebuild, "rebuildSandbox").mockResolvedValue(undefined);
+  rebuildSandboxMock = vi
+    .spyOn(policyChannelDependencies, "rebuildSandbox")
+    .mockResolvedValue(undefined);
   ensureMessagingHostForwardAfterRebuildMock = vi
     .spyOn(messagingHostForwardLifecycle, "ensureMessagingHostForwardAfterRebuild")
     .mockReturnValue(true);
@@ -361,7 +358,9 @@ beforeEach(() => {
 
   // onboard-session for the wechat host-qr branch.
   vi.spyOn(onboardSession, "loadSession").mockReturnValue(null);
-  vi.spyOn(onboardSession, "updateSession").mockImplementation(() => undefined);
+  vi.spyOn(onboardSession, "updateSession").mockReturnValue(
+    undefined as unknown as onboardSession.Session,
+  );
 });
 
 afterEach(() => {

--- a/src/lib/actions/sandbox/policy-channel-dependencies.ts
+++ b/src/lib/actions/sandbox/policy-channel-dependencies.ts
@@ -28,7 +28,9 @@ type RebuildModule = typeof import("./rebuild");
 /**
  * Injectable, late-bound boundary around provider registration and rebuild
  * orchestration. Focused tests replace these methods with `vi.spyOn` without
- * using `createRequire` or mutating the CommonJS cache.
+ * using `createRequire` or mutating the CommonJS cache. This boundary can be
+ * removed when those graphs can be imported without eagerly loading unrelated
+ * onboarding and rebuild modules at policy-channel import time.
  */
 export const policyChannelDependencies = {
   upsertMessagingProviders(

--- a/src/lib/actions/sandbox/policy-channel-dependencies.ts
+++ b/src/lib/actions/sandbox/policy-channel-dependencies.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { runOpenshell } from "../../adapters/openshell/runtime";
+
+type MessagingProviderTokenDefinition = {
+  name: string;
+  envKey: string;
+  token: string | null;
+  providerType?: string;
+};
+
+type MessagingProviderUpsertOptions = {
+  replaceExisting?: boolean;
+  bestEffort?: boolean;
+};
+
+type LegacyOnboardProvidersModule = {
+  upsertMessagingProviders(
+    tokenDefs: MessagingProviderTokenDefinition[],
+    run: typeof runOpenshell,
+    options?: MessagingProviderUpsertOptions,
+  ): string[];
+};
+
+type RebuildModule = typeof import("./rebuild");
+
+/**
+ * Injectable, late-bound boundary around provider registration and rebuild
+ * orchestration. Focused tests replace these methods with `vi.spyOn` without
+ * using `createRequire` or mutating the CommonJS cache.
+ */
+export const policyChannelDependencies = {
+  upsertMessagingProviders(
+    tokenDefs: MessagingProviderTokenDefinition[],
+    options?: MessagingProviderUpsertOptions,
+  ): string[] {
+    const providers = require("../../onboard/providers") as LegacyOnboardProvidersModule;
+    return providers.upsertMessagingProviders(tokenDefs, runOpenshell, options);
+  },
+  rebuildSandbox(
+    sandboxName: Parameters<RebuildModule["rebuildSandbox"]>[0],
+    args: Parameters<RebuildModule["rebuildSandbox"]>[1],
+  ): ReturnType<RebuildModule["rebuildSandbox"]> {
+    const rebuild = require("./rebuild") as RebuildModule;
+    return rebuild.rebuildSandbox(sandboxName, args);
+  },
+};

--- a/src/lib/actions/sandbox/policy-channel-policy.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-policy.test.ts
@@ -1,31 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-const requireDist = createRequire(import.meta.url);
-const D = (p: string) => requireDist(`../../${p}`);
+import * as store from "../../credentials/store";
+import * as policies from "../../policy";
+import * as onboardSession from "../../state/onboard-session";
+import * as registry from "../../state/registry";
+import { addSandboxPolicy, removeSandboxPolicy } from "./policy-channel";
 
-type PresetInfo = {
-  name: string;
-  description?: string;
-};
-
-type PolicyAddOptions = {
-  preset?: string;
-  dryRun?: boolean;
-  yes?: boolean;
-  force?: boolean;
-};
-
-type PolicyRemoveOptions = {
-  preset?: string;
-  dryRun?: boolean;
-  yes?: boolean;
-  force?: boolean;
-};
+type PresetInfo = ReturnType<typeof policies.listPresets>[number];
 
 class ExitError extends Error {
   constructor(public readonly code: number | undefined) {
@@ -33,24 +17,27 @@ class ExitError extends Error {
   }
 }
 
-const store = D("credentials/store.js");
-const registry = D("state/registry.js");
-const onboardSession = D("state/onboard-session.js");
-const policies = D("policy/index.js");
-const { addSandboxPolicy, removeSandboxPolicy } = D("actions/sandbox/policy-channel.js") as {
-  addSandboxPolicy: (sandboxName: string, options?: PolicyAddOptions) => Promise<void>;
-  removeSandboxPolicy: (sandboxName: string, options?: PolicyRemoveOptions) => Promise<void>;
-};
-
 const POLICY_PRESETS: PresetInfo[] = [
-  { name: "npm", description: "npm and Yarn registry access" },
-  { name: "pypi", description: "Python Package Index access" },
-  { name: "discord", description: "Discord API access" },
-  { name: "openclaw-pricing", description: "OpenClaw pricing lookup" },
-  { name: "nous-web", description: "Nous Portal managed web search gateway" },
-  { name: "nous-code", description: "Nous Portal managed sandboxed code gateway" },
-  { name: "telegram", description: "Telegram API access" },
-  { name: "wechat", description: "WeChat API access" },
+  { file: "npm.yaml", name: "npm", description: "npm and Yarn registry access" },
+  { file: "pypi.yaml", name: "pypi", description: "Python Package Index access" },
+  { file: "discord.yaml", name: "discord", description: "Discord API access" },
+  {
+    file: "openclaw-pricing.yaml",
+    name: "openclaw-pricing",
+    description: "OpenClaw pricing lookup",
+  },
+  {
+    file: "nous-web.yaml",
+    name: "nous-web",
+    description: "Nous Portal managed web search gateway",
+  },
+  {
+    file: "nous-code.yaml",
+    name: "nous-code",
+    description: "Nous Portal managed sandboxed code gateway",
+  },
+  { file: "telegram.yaml", name: "telegram", description: "Telegram API access" },
+  { file: "wechat.yaml", name: "wechat", description: "WeChat API access" },
 ];
 
 let logSpy: MockInstance;
@@ -103,7 +90,9 @@ beforeEach(() => {
   vi.spyOn(registry, "getCustomPolicies").mockReturnValue([]);
 
   vi.spyOn(onboardSession, "loadSession").mockReturnValue(null);
-  vi.spyOn(onboardSession, "updateSession").mockImplementation(() => undefined);
+  vi.spyOn(onboardSession, "updateSession").mockReturnValue(
+    undefined as unknown as onboardSession.Session,
+  );
 
   vi.spyOn(policies, "listPresets").mockReturnValue(POLICY_PRESETS);
   vi.spyOn(policies, "listCustomPresets").mockReturnValue([]);
@@ -238,9 +227,9 @@ describe("addSandboxPolicy", () => {
   it("treats messaging channel policy presets unavailable to terminal-runtime agents as unknown before preview or prompt", async () => {
     arrangeSandbox("langchain-deepagents-code");
     vi.spyOn(policies, "listPresets").mockReturnValue([
-      { name: "npm", description: "npm and Yarn registry access" },
-      { name: "pypi", description: "Python Package Index access" },
-      { name: "tavily", description: "Tavily Search API access" },
+      { file: "npm.yaml", name: "npm", description: "npm and Yarn registry access" },
+      { file: "pypi.yaml", name: "pypi", description: "Python Package Index access" },
+      { file: "tavily.yaml", name: "tavily", description: "Tavily Search API access" },
     ]);
 
     await expect(

--- a/src/lib/actions/sandbox/policy-channel-refresh.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-refresh.test.ts
@@ -13,16 +13,24 @@
  */
 
 import * as fs from "node:fs";
-import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-const requireDist = createRequire(import.meta.url);
-const D = (p: string) => requireDist(`../../${p}`);
+import * as store from "../../credentials/store";
+import * as policies from "../../policy";
+import * as onboardSession from "../../state/onboard-session";
+import * as registry from "../../state/registry";
+import {
+  addSandboxPolicy,
+  applyChannelPresetIfAvailable,
+  removeChannelPresetIfPresent,
+  removeSandboxPolicy,
+} from "./policy-channel";
+import * as policyContextRefresh from "./policy-context-refresh";
 
-type PresetInfo = { name: string };
+type PresetInfo = ReturnType<typeof policies.listPresets>[number];
 
 class ExitError extends Error {
   constructor(public readonly code: number | undefined) {
@@ -30,24 +38,11 @@ class ExitError extends Error {
   }
 }
 
-const store = D("credentials/store.js");
-const registry = D("state/registry.js");
-const onboardSession = D("state/onboard-session.js");
-const policies = D("policy/index.js");
-const policyContextRefresh = D("actions/sandbox/policy-context-refresh.js");
-const {
-  addSandboxPolicy,
-  removeSandboxPolicy,
-  applyChannelPresetIfAvailable,
-  removeChannelPresetIfPresent,
-} = D("actions/sandbox/policy-channel.js") as {
-  addSandboxPolicy: (sandboxName: string, options?: Record<string, unknown>) => Promise<void>;
-  removeSandboxPolicy: (sandboxName: string, options?: Record<string, unknown>) => Promise<void>;
-  applyChannelPresetIfAvailable: (sandboxName: string, channelName: string) => boolean;
-  removeChannelPresetIfPresent: (sandboxName: string, channelName: string) => void;
-};
-
-const POLICY_PRESETS: PresetInfo[] = [{ name: "npm" }, { name: "pypi" }, { name: "discord" }];
+const POLICY_PRESETS: PresetInfo[] = [
+  { file: "npm.yaml", name: "npm", description: "npm and Yarn registry access" },
+  { file: "pypi.yaml", name: "pypi", description: "Python Package Index access" },
+  { file: "discord.yaml", name: "discord", description: "Discord API access" },
+];
 
 let logSpy: MockInstance;
 let errSpy: MockInstance;
@@ -86,7 +81,9 @@ beforeEach(() => {
   vi.spyOn(registry, "getCustomPolicies").mockReturnValue([]);
 
   vi.spyOn(onboardSession, "loadSession").mockReturnValue(null);
-  vi.spyOn(onboardSession, "updateSession").mockImplementation(() => undefined);
+  vi.spyOn(onboardSession, "updateSession").mockReturnValue(
+    undefined as unknown as onboardSession.Session,
+  );
 
   vi.spyOn(policies, "listPresets").mockReturnValue(POLICY_PRESETS);
   vi.spyOn(policies, "listCustomPresets").mockReturnValue([]);

--- a/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
@@ -5,12 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 
 import * as policies from "../../policy";
 import * as registry from "../../state/registry";
-import {
-  policyChannelDependencies,
-  removeSandboxChannel,
-  startSandboxChannel,
-  stopSandboxChannel,
-} from "./policy-channel";
+import { removeSandboxChannel, startSandboxChannel, stopSandboxChannel } from "./policy-channel";
+import { policyChannelDependencies } from "./policy-channel-dependencies";
 
 describe("policy channel remove/enable flows", () => {
   let exitSpy: MockInstance;

--- a/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-remove-flow.test.ts
@@ -1,21 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-const requireDist = createRequire(import.meta.url);
-const policyChannelModulePath = "./policy-channel.js";
-
-type PolicyChannelModule = typeof import("./policy-channel");
+import * as policies from "../../policy";
+import * as registry from "../../state/registry";
+import {
+  policyChannelDependencies,
+  removeSandboxChannel,
+  startSandboxChannel,
+  stopSandboxChannel,
+} from "./policy-channel";
 
 describe("policy channel remove/enable flows", () => {
   let exitSpy: MockInstance;
   let logSpy: MockInstance;
 
   beforeEach(() => {
-    delete require.cache[requireDist.resolve(policyChannelModulePath)];
     exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
       throw new Error(`process.exit(${code ?? 0})`);
     }) as never);
@@ -25,24 +26,17 @@ describe("policy channel remove/enable flows", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete require.cache[requireDist.resolve(policyChannelModulePath)];
   });
 
   it("reports remove usage and exits before touching channel state when no channel is supplied", async () => {
-    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
-
-    await expect(policyChannel.removeSandboxChannel("alpha", {})).rejects.toThrow(
-      "process.exit(1)",
-    );
+    await expect(removeSandboxChannel("alpha", {})).rejects.toThrow("process.exit(1)");
 
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it("supports a remove dry run without gateway, registry, or rebuild side effects", async () => {
-    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
-
     await expect(
-      policyChannel.removeSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+      removeSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
     ).resolves.toBeUndefined();
 
     expect(logSpy.mock.calls.flat().join("\n")).toContain(
@@ -52,14 +46,12 @@ describe("policy channel remove/enable flows", () => {
   });
 
   it("supports stop dry runs for configured channels", async () => {
-    const registry = requireDist("../../state/registry.js");
     vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "alpha" });
     vi.spyOn(registry, "getConfiguredMessagingChannelsFromEntry").mockReturnValue(["telegram"]);
     vi.spyOn(registry, "getDisabledChannels").mockReturnValue([]);
-    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
 
     await expect(
-      policyChannel.stopSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+      stopSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
     ).resolves.toBeUndefined();
 
     expect(logSpy.mock.calls.flat().join("\n")).toContain(
@@ -69,19 +61,14 @@ describe("policy channel remove/enable flows", () => {
   });
 
   it("supports start dry runs without applying a preset or persisting the enabled plan", async () => {
-    const registry = requireDist("../../state/registry.js");
-    const policies = requireDist("../../policy/index.js");
-    const rebuild = requireDist("./rebuild.js");
     vi.spyOn(registry, "getSandbox").mockReturnValue({ name: "alpha" });
     vi.spyOn(registry, "getConfiguredMessagingChannelsFromEntry").mockReturnValue(["telegram"]);
     vi.spyOn(registry, "getDisabledChannels").mockReturnValue(["telegram"]);
     const updateSandboxSpy = vi.spyOn(registry, "updateSandbox");
     const applyPresetSpy = vi.spyOn(policies, "applyPreset");
-    const rebuildSpy = vi.spyOn(rebuild, "rebuildSandbox");
-    const policyChannel = requireDist(policyChannelModulePath) as PolicyChannelModule;
-
+    const rebuildSpy = vi.spyOn(policyChannelDependencies, "rebuildSandbox");
     await expect(
-      policyChannel.startSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
+      startSandboxChannel("alpha", { channel: "telegram", dryRun: true }),
     ).resolves.toBeUndefined();
 
     expect(logSpy.mock.calls.flat().join("\n")).toContain(

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -56,52 +56,9 @@ import * as registry from "../../state/registry";
 import { isDockerRuntimeDown, printDockerRuntimeDownGuidance } from "./gateway-failure-classifier";
 import { getSandboxTargetGatewayName } from "./gateway-target";
 import { ensureMessagingHostForwardAfterRebuild } from "./messaging-host-forward-lifecycle";
+import { policyChannelDependencies } from "./policy-channel-dependencies";
 import { refreshSandboxPolicyContextFile } from "./policy-context-refresh";
 import { executeSandboxCommand, executeSandboxExecCommand } from "./process-recovery";
-
-type MessagingProviderTokenDefinition = {
-  name: string;
-  envKey: string;
-  token: string | null;
-  providerType?: string;
-};
-
-type MessagingProviderUpsertOptions = {
-  replaceExisting?: boolean;
-  bestEffort?: boolean;
-};
-
-type LegacyOnboardProvidersModule = {
-  upsertMessagingProviders(
-    tokenDefs: MessagingProviderTokenDefinition[],
-    run: typeof runOpenshell,
-    options?: MessagingProviderUpsertOptions,
-  ): string[];
-};
-
-type RebuildModule = typeof import("./rebuild");
-
-/**
- * Injectable, late-bound boundary around provider registration and rebuild
- * orchestration. Focused tests replace these methods with `vi.spyOn` without
- * using `createRequire` or mutating the CommonJS cache.
- */
-export const policyChannelDependencies = {
-  upsertMessagingProviders(
-    tokenDefs: MessagingProviderTokenDefinition[],
-    options?: MessagingProviderUpsertOptions,
-  ): string[] {
-    const providers = require("../../onboard/providers") as LegacyOnboardProvidersModule;
-    return providers.upsertMessagingProviders(tokenDefs, runOpenshell, options);
-  },
-  rebuildSandbox(
-    sandboxName: Parameters<RebuildModule["rebuildSandbox"]>[0],
-    args: Parameters<RebuildModule["rebuildSandbox"]>[1],
-  ): ReturnType<RebuildModule["rebuildSandbox"]> {
-    const rebuild = require("./rebuild") as RebuildModule;
-    return rebuild.rebuildSandbox(sandboxName, args);
-  },
-};
 
 function isNonInteractive(): boolean {
   return process.env.NEMOCLAW_NON_INTERACTIVE === "1";

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -3,10 +3,15 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
+import { runOpenshell } from "../../adapters/openshell/runtime";
 import { type AgentDefinition, loadAgent } from "../../agent/defs";
 import { CLI_DISPLAY_NAME, CLI_NAME } from "../../cli/branding";
 import { prompt as askPrompt, getCredential } from "../../credentials/store";
+import {
+  type PolicyAddOptions,
+  type PolicyRemoveOptions,
+  parsePolicyAddOptions,
+} from "../../domain/policy-channel";
 import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import {
   type ChannelManifest,
@@ -27,28 +32,13 @@ import {
   toMessagingAgentId,
   tryGetMessagingAgentId,
 } from "../../messaging";
+import { findChannelConflicts } from "../../messaging/applier/conflict-detection/registry";
 import { hydrateMessagingChannelConfig } from "../../messaging-channel-config";
-import { hashCredential } from "../../security/credential-hash";
-import { getSandboxTargetGatewayName } from "./gateway-target";
-
-const { isNonInteractive } = require("../../onboard") as { isNonInteractive: () => boolean };
-const onboardProviders = require("../../onboard/providers");
-
 import { filterSetupPolicyPresetsForAgent } from "../../onboard/agent-policy-presets";
 import { getStoredMessagingChannelConfig } from "../../onboard/messaging-config";
+import { getMessagingToken } from "../../onboard/messaging-token";
 import * as policies from "../../policy";
 import { formatPolicyListPresetRow } from "../../policy/policy-list-display";
-
-const onboardSession =
-  require("../../state/onboard-session") as typeof import("../../state/onboard-session");
-
-import { runOpenshell } from "../../adapters/openshell/runtime";
-import {
-  type PolicyAddOptions,
-  type PolicyRemoveOptions,
-  parsePolicyAddOptions,
-} from "../../domain/policy-channel";
-import { getMessagingToken } from "../../onboard/messaging-token";
 import { shellQuote } from "../../runner";
 import {
   type ChannelDef,
@@ -59,13 +49,63 @@ import {
   knownChannelNames,
   persistChannelTokens,
 } from "../../sandbox/channels";
+import { hashCredential } from "../../security/credential-hash";
 import { withSandboxMutationLock } from "../../state/mcp-lifecycle-lock";
+import * as onboardSession from "../../state/onboard-session";
 import * as registry from "../../state/registry";
 import { isDockerRuntimeDown, printDockerRuntimeDownGuidance } from "./gateway-failure-classifier";
+import { getSandboxTargetGatewayName } from "./gateway-target";
 import { ensureMessagingHostForwardAfterRebuild } from "./messaging-host-forward-lifecycle";
 import { refreshSandboxPolicyContextFile } from "./policy-context-refresh";
 import { executeSandboxCommand, executeSandboxExecCommand } from "./process-recovery";
-import { rebuildSandbox } from "./rebuild";
+
+type MessagingProviderTokenDefinition = {
+  name: string;
+  envKey: string;
+  token: string | null;
+  providerType?: string;
+};
+
+type MessagingProviderUpsertOptions = {
+  replaceExisting?: boolean;
+  bestEffort?: boolean;
+};
+
+type LegacyOnboardProvidersModule = {
+  upsertMessagingProviders(
+    tokenDefs: MessagingProviderTokenDefinition[],
+    run: typeof runOpenshell,
+    options?: MessagingProviderUpsertOptions,
+  ): string[];
+};
+
+type RebuildModule = typeof import("./rebuild");
+
+/**
+ * Injectable, late-bound boundary around provider registration and rebuild
+ * orchestration. Focused tests replace these methods with `vi.spyOn` without
+ * using `createRequire` or mutating the CommonJS cache.
+ */
+export const policyChannelDependencies = {
+  upsertMessagingProviders(
+    tokenDefs: MessagingProviderTokenDefinition[],
+    options?: MessagingProviderUpsertOptions,
+  ): string[] {
+    const providers = require("../../onboard/providers") as LegacyOnboardProvidersModule;
+    return providers.upsertMessagingProviders(tokenDefs, runOpenshell, options);
+  },
+  rebuildSandbox(
+    sandboxName: Parameters<RebuildModule["rebuildSandbox"]>[0],
+    args: Parameters<RebuildModule["rebuildSandbox"]>[1],
+  ): ReturnType<RebuildModule["rebuildSandbox"]> {
+    const rebuild = require("./rebuild") as RebuildModule;
+    return rebuild.rebuildSandbox(sandboxName, args);
+  },
+};
+
+function isNonInteractive(): boolean {
+  return process.env.NEMOCLAW_NON_INTERACTIVE === "1";
+}
 
 type ChannelMutationOptions = {
   channel?: string;
@@ -410,9 +450,6 @@ async function checkChannelAddConflict(
   }
   if (Object.keys(credentialHashes).length === 0) return true;
 
-  const { findChannelConflicts } =
-    require("../../messaging/applier") as typeof import("../../messaging/applier");
-
   let conflicts: ReturnType<typeof findChannelConflicts>;
   try {
     conflicts = findChannelConflicts(
@@ -568,7 +605,7 @@ async function applyChannelAddToGatewayAndRegistry(
     }
     // upsertMessagingProviders handles create-or-update and process.exits on
     // failure, so reaching the next line means every entry is registered.
-    onboardProviders.upsertMessagingProviders(tokenDefs, runOpenshell);
+    policyChannelDependencies.upsertMessagingProviders(tokenDefs);
   }
 }
 
@@ -696,7 +733,7 @@ async function promptAndRebuild(sandboxName: string, actionDesc: string): Promis
     );
     return false;
   }
-  await rebuildSandbox(sandboxName, ["--yes"]);
+  await policyChannelDependencies.rebuildSandbox(sandboxName, ["--yes"]);
   return true;
 }
 
@@ -1104,7 +1141,7 @@ async function rollbackChannelAdd(
           envKey,
           token,
         }));
-        onboardProviders.upsertMessagingProviders(priorTokenDefs, runOpenshell, {
+        policyChannelDependencies.upsertMessagingProviders(priorTokenDefs, {
           bestEffort: true,
         });
       } catch (err) {

--- a/src/lib/actions/sandbox/rebuild-credential-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-credential-preflight.ts
@@ -5,15 +5,13 @@ import { runOpenshell } from "../../adapters/openshell/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { R, RD } from "../../cli/terminal-style";
 import type { RebuildSandboxEntry } from "./rebuild-flow-helpers";
+import { rebuildOnboardDependencies } from "./rebuild-onboard-dependencies";
 import {
   checkRebuildGatewayProviderOrBail,
   shouldVerifyRebuildGatewayProvider,
 } from "./rebuild-provider-preflight";
 import { getRebuildCredentialEnvFromRegistry } from "./rebuild-resume-config";
 
-const onboardModule = require("../../onboard") as {
-  hydrateCredentialEnv: (name: string) => string | null;
-};
 const hermesProviderAuth = require("../../hermes-provider-auth") as {
   HERMES_PROVIDER_NAME: string;
   HERMES_INFERENCE_CREDENTIAL_ENV: string;
@@ -169,7 +167,7 @@ export function preflightRebuildCredentials(
     return true;
   }
 
-  const credentialValue = onboardModule.hydrateCredentialEnv(rebuildCredentialEnv);
+  const credentialValue = rebuildOnboardDependencies.hydrateCredentialEnv(rebuildCredentialEnv);
   log(
     `Preflight credential check: ${rebuildCredentialEnv} → ${credentialValue ? "present" : "MISSING"}`,
   );

--- a/src/lib/actions/sandbox/rebuild-onboard-dependencies.ts
+++ b/src/lib/actions/sandbox/rebuild-onboard-dependencies.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { RebuildDurableConfig } from "./rebuild-durable-config";
+import type { RebuildRecreateOnboardOpts } from "./rebuild-gpu-opt-out";
+
+type RebuildAuthoritativePreflightOptions = RebuildRecreateOnboardOpts & {
+  model: string;
+  provider: string;
+  sandboxName: string;
+};
+
+type RebuildOnboardModule = {
+  ensureValidatedWebSearchCredential: (
+    config: NonNullable<RebuildDurableConfig["webSearchConfig"]>,
+    nonInteractive?: boolean,
+  ) => Promise<unknown>;
+  hydrateCredentialEnv: (name: string) => string | null;
+  onboard: (options: RebuildRecreateOnboardOpts) => Promise<void>;
+  preflightAuthoritativeRebuildTarget: (
+    options: RebuildAuthoritativePreflightOptions,
+  ) => Promise<void>;
+};
+
+function loadOnboardModule(): RebuildOnboardModule {
+  return require("../../onboard") as RebuildOnboardModule;
+}
+
+/**
+ * Late-bound onboarding boundary for rebuild orchestration. Rebuild imports no
+ * longer initialize the full onboarding graph, and focused tests can replace
+ * these calls without mutating the CommonJS cache. Remove this boundary once
+ * the onboarding APIs are side-effect-free named imports.
+ */
+export const rebuildOnboardDependencies = {
+  ensureValidatedWebSearchCredential(
+    config: NonNullable<RebuildDurableConfig["webSearchConfig"]>,
+    nonInteractive?: boolean,
+  ): Promise<unknown> {
+    return loadOnboardModule().ensureValidatedWebSearchCredential(config, nonInteractive);
+  },
+  hydrateCredentialEnv(name: string): string | null {
+    return loadOnboardModule().hydrateCredentialEnv(name);
+  },
+  onboard(options: RebuildRecreateOnboardOpts): Promise<void> {
+    return loadOnboardModule().onboard(options);
+  },
+  preflightAuthoritativeRebuildTarget(
+    options: RebuildAuthoritativePreflightOptions,
+  ): Promise<void> {
+    return loadOnboardModule().preflightAuthoritativeRebuildTarget(options);
+  },
+};

--- a/src/lib/actions/sandbox/rebuild-prepared-recovery.test.ts
+++ b/src/lib/actions/sandbox/rebuild-prepared-recovery.test.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createRebuildFlowHarness,
@@ -10,8 +8,6 @@ import {
   snapshotEnv,
 } from "../../../../test/helpers/rebuild-flow-harness";
 
-const requireDist = createRequire(import.meta.url);
-const rebuildModulePath = "./rebuild.js";
 const restoreSandboxEnv = snapshotEnv(["NEMOCLAW_SANDBOX_NAME"]);
 
 describe("prepared rebuild recovery", () => {
@@ -21,7 +17,6 @@ describe("prepared rebuild recovery", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    delete require.cache[requireDist.resolve(rebuildModulePath)];
     restoreSandboxEnv();
   });
 

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -27,6 +27,7 @@ import {
   printMcpRebuildRetryCommand,
   restoreMcpRegistryForRebuildRetry,
 } from "./rebuild-mcp-phase";
+import { rebuildOnboardDependencies } from "./rebuild-onboard-dependencies";
 import type { RebuildRegistryRollback } from "./rebuild-registry-rollback";
 import type { RebuildResumeConfig } from "./rebuild-resume-config";
 import { printRebuildShieldsRecovery, type RebuildShieldsWindow } from "./rebuild-shields";
@@ -163,9 +164,6 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
 
   // Intercept process.exit so a failed inner onboard can preserve the backup
   // and durable retry state instead of terminating the outer transaction.
-  const { onboard } = require("../../onboard") as {
-    onboard: (options: RebuildRecreateOnboardOpts) => Promise<void>;
-  };
   let onboardFailed = false;
   let onboardExitCode = 1;
   const savedExit = process.exit;
@@ -183,7 +181,7 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
   const restoreRebuildBaseImageOverride =
     pinRebuildAgentBaseImageForRecreate(rebuildBaseImagePreflight);
   try {
-    await onboard(recreateOptions);
+    await rebuildOnboardDependencies.onboard(recreateOptions);
     log("onboard() returned successfully");
   } catch (error) {
     onboardFailed = true;

--- a/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
+++ b/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
@@ -1,23 +1,35 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
+import * as gatewayDrift from "../../adapters/openshell/gateway-drift";
+import * as resolve from "../../adapters/openshell/resolve";
+import * as openshellRuntime from "../../adapters/openshell/runtime";
+import * as agentDefs from "../../agent/defs";
+import * as agentRuntime from "../../agent/runtime";
+import * as gatewayRuntime from "../../gateway-runtime-action";
+import * as nim from "../../inference/nim";
+import * as resumeRepair from "../../onboard/resume-machine-repair";
+import * as sandboxList from "../../openshell-sandbox-list";
+import * as sandboxVersion from "../../sandbox/version";
 import type { Session } from "../../state/onboard-session";
-
-type RebuildSandbox = typeof import("./rebuild")["rebuildSandbox"];
-
-const requireDist = createRequire(import.meta.url);
-const rebuildModulePath = "./rebuild.js";
+import * as onboardSession from "../../state/onboard-session";
+import * as registry from "../../state/registry";
+import * as sandboxState from "../../state/sandbox";
+import * as sandboxSession from "../../state/sandbox-session";
+import * as destroy from "./destroy";
+import { rebuildSandbox } from "./rebuild";
+import * as rebuildImagePreflight from "./rebuild-custom-image-preflight";
+import { rebuildOnboardDependencies } from "./rebuild-onboard-dependencies";
+import * as rebuildShields from "./rebuild-shields";
+import * as rebuildUsageNotice from "./rebuild-usage-notice";
 
 function cloneSession(session: Session): Session {
   return JSON.parse(JSON.stringify(session));
 }
 
 describe("rebuild resume snapshot repair", () => {
-  let rebuildSandbox: RebuildSandbox;
   let spies: MockInstance[];
   let errorSpy: MockInstance;
   let logSpy: MockInstance;
@@ -44,30 +56,9 @@ describe("rebuild resume snapshot repair", () => {
     observed.preRepairResumable = null;
     observed.repairedMachineState = null;
     observed.sandboxEnvInsideOnboard = null;
-    delete require.cache[requireDist.resolve(rebuildModulePath)];
 
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-
-    const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
-    const gatewayRuntime = requireDist("../../gateway-runtime-action.js");
-    const openshellRuntime = requireDist("../../adapters/openshell/runtime.js");
-    const sandboxList = requireDist("../../openshell-sandbox-list.js");
-    const resolve = requireDist("../../adapters/openshell/resolve.js");
-    const agentDefs = requireDist("../../agent/defs.js");
-    const agentRuntime = requireDist("../../agent/runtime.js");
-    const onboardMod = requireDist("../../onboard.js");
-    const resumeRepair = requireDist("../../onboard/resume-machine-repair.js");
-    const onboardSession = requireDist("../../state/onboard-session.js");
-    const registry = requireDist("../../state/registry.js");
-    const sandboxSession = requireDist("../../state/sandbox-session.js");
-    const sandboxState = requireDist("../../state/sandbox.js");
-    const sandboxVersion = requireDist("../../sandbox/version.js");
-    const destroy = requireDist("./destroy.js");
-    const rebuildShields = requireDist("./rebuild-shields.js");
-    const rebuildImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
-    const rebuildUsageNotice = requireDist("./rebuild-usage-notice.js");
-    const nim = requireDist("../../inference/nim.js");
 
     session = onboardSession.createSession({
       sandboxName: "alpha",
@@ -101,11 +92,14 @@ describe("rebuild resume snapshot repair", () => {
       vi.spyOn(gatewayDrift, "detectOpenShellStateRpcResultIssue").mockReturnValue(null),
       vi.spyOn(gatewayRuntime, "recoverNamedGatewayRuntime").mockResolvedValue({
         recovered: true,
-        before: { state: "healthy_named" },
-        after: { state: "healthy_named" },
+        before: { state: "healthy_named", status: "", gatewayInfo: "", activeGateway: null },
+        after: { state: "healthy_named", status: "", gatewayInfo: "", activeGateway: null },
+        attempted: false,
       }),
       vi.spyOn(sandboxList, "captureSandboxListWithGatewayRecovery").mockResolvedValue({
         result: { status: 0, output: "alpha Ready" },
+        recoveryAttempted: false,
+        recoverySucceeded: false,
       }),
       vi.spyOn(resolve, "resolveOpenshell").mockReturnValue(null),
       vi.spyOn(agentDefs, "loadAgent").mockReturnValue({
@@ -115,7 +109,11 @@ describe("rebuild resume snapshot repair", () => {
       vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw"),
       vi.spyOn(onboardSession, "loadSession").mockImplementation(loadSession),
       vi.spyOn(onboardSession, "updateSession").mockImplementation(updateSession),
-      vi.spyOn(onboardSession, "acquireOnboardLock").mockReturnValue({ acquired: true }),
+      vi.spyOn(onboardSession, "acquireOnboardLock").mockReturnValue({
+        acquired: true,
+        lockFile: "/tmp/nemoclaw-onboard.lock",
+        stale: false,
+      }),
       vi.spyOn(onboardSession, "releaseOnboardLock").mockImplementation(() => undefined),
       vi.spyOn(onboardSession, "markStepFailed").mockImplementation(() => loadSession()),
       vi.spyOn(registry, "getSandbox").mockReturnValue({
@@ -157,33 +155,38 @@ describe("rebuild resume snapshot repair", () => {
           policyPresets: [],
         },
       } as never),
-      vi.spyOn(openshellRuntime, "runOpenshell").mockReturnValue({ status: 0, output: "" }),
-      vi.spyOn(destroy, "removeSandboxRegistryEntry").mockImplementation(() => undefined),
+      vi
+        .spyOn(openshellRuntime, "runOpenshell")
+        .mockReturnValue({ status: 0, output: "" } as never),
+      vi.spyOn(destroy, "removeSandboxRegistryEntry").mockReturnValue(true),
       vi.spyOn(nim, "stopNimContainer").mockImplementation(() => undefined),
       vi.spyOn(nim, "stopNimContainerByName").mockImplementation(() => undefined),
       vi.spyOn(nim, "detectGpu").mockReturnValue(null),
-      vi.spyOn(onboardMod, "preflightAuthoritativeRebuildTarget").mockResolvedValue(undefined),
+      vi
+        .spyOn(rebuildOnboardDependencies, "preflightAuthoritativeRebuildTarget")
+        .mockResolvedValue(undefined),
       vi.spyOn(rebuildImagePreflight, "preflightRebuildImage").mockResolvedValue({
         ok: true,
         imageTag: null,
-      }),
+      } as never),
       vi.spyOn(rebuildUsageNotice, "ensureRebuildUsageNoticeAccepted").mockResolvedValue(true),
-      vi.spyOn(onboardMod, "onboard").mockImplementation(async (options: unknown) => {
-        observed.handoffOptions = options as Record<string, unknown>;
-        const reopened = onboardSession.loadSession();
-        observed.preRepairMachineState = reopened.machine.state;
-        observed.preRepairPreflightStatus = reopened.steps.preflight.status;
-        observed.preRepairGatewayStatus = reopened.steps.gateway.status;
-        observed.preRepairStatus = reopened.status;
-        observed.preRepairResumable = reopened.resumable;
-        resumeRepair.repairResumeMachineSnapshot(reopened, "2026-06-01T00:01:00.000Z");
-        observed.repairedMachineState = reopened.machine.state;
-        observed.sandboxEnvInsideOnboard = process.env.NEMOCLAW_SANDBOX_NAME ?? null;
-        throw new Error("stop-after-resume-repair-probe");
-      }),
+      vi
+        .spyOn(rebuildOnboardDependencies, "onboard")
+        .mockImplementation(async (options: unknown) => {
+          observed.handoffOptions = options as Record<string, unknown>;
+          const reopened = onboardSession.loadSession();
+          if (!reopened) throw new Error("expected rebuild resume session");
+          observed.preRepairMachineState = reopened.machine.state;
+          observed.preRepairPreflightStatus = reopened.steps.preflight.status;
+          observed.preRepairGatewayStatus = reopened.steps.gateway.status;
+          observed.preRepairStatus = reopened.status;
+          observed.preRepairResumable = reopened.resumable;
+          resumeRepair.repairResumeMachineSnapshot(reopened, "2026-06-01T00:01:00.000Z");
+          observed.repairedMachineState = reopened.machine.state;
+          observed.sandboxEnvInsideOnboard = process.env.NEMOCLAW_SANDBOX_NAME ?? null;
+          throw new Error("stop-after-resume-repair-probe");
+        }),
     );
-
-    ({ rebuildSandbox } = requireDist(rebuildModulePath));
   });
 
   afterEach(() => {
@@ -195,10 +198,9 @@ describe("rebuild resume snapshot repair", () => {
     } else {
       process.env.NEMOCLAW_SANDBOX_NAME = originalSandboxName;
     }
-    delete require.cache[requireDist.resolve(rebuildModulePath)];
   });
 
-  it("replaces complete history with a target-scoped resume snapshot", async () => {
+  it("replaces complete history with a target-scoped resume snapshot (#6245)", async () => {
     await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
       "Recreate failed",
     );

--- a/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
+++ b/src/lib/actions/sandbox/rebuild-resume-snapshot.test.ts
@@ -174,8 +174,7 @@ describe("rebuild resume snapshot repair", () => {
         .spyOn(rebuildOnboardDependencies, "onboard")
         .mockImplementation(async (options: unknown) => {
           observed.handoffOptions = options as Record<string, unknown>;
-          const reopened = onboardSession.loadSession();
-          if (!reopened) throw new Error("expected rebuild resume session");
+          const reopened = onboardSession.loadSession() as Session;
           observed.preRepairMachineState = reopened.machine.state;
           observed.preRepairPreflightStatus = reopened.steps.preflight.status;
           observed.preRepairGatewayStatus = reopened.steps.gateway.status;

--- a/src/lib/actions/sandbox/rebuild-shields-finally.test.ts
+++ b/src/lib/actions/sandbox/rebuild-shields-finally.test.ts
@@ -1,127 +1,68 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+const phaseMocks = vi.hoisted(() => ({
+  runBackup: vi.fn(),
+  runPreflight: vi.fn(),
+  runShields: vi.fn(),
+}));
 
-type RebuildSandbox = typeof import("./rebuild")["rebuildSandbox"];
+vi.mock("./rebuild-backup-phase", () => ({
+  runRebuildBackupPhase: phaseMocks.runBackup,
+}));
 
-const requireDist = createRequire(import.meta.url);
-const rebuildModulePath = "./rebuild.js";
+vi.mock("./rebuild-preflight-phase", () => ({
+  runRebuildPreflightPhase: phaseMocks.runPreflight,
+}));
+
+vi.mock("./rebuild-shields-phase", () => ({
+  runRebuildShieldsPhase: phaseMocks.runShields,
+}));
+
+import { rebuildSandbox } from "./rebuild";
 
 describe("rebuild shields relock guard", () => {
-  let rebuildSandbox: RebuildSandbox;
-  let spies: MockInstance[];
-  let errorSpy: MockInstance;
-  let logSpy: MockInstance;
-  let relockSpy: MockInstance;
-  let sandboxListRecoverySpy: MockInstance;
   const rebuildWindow = { relocked: false, wasLocked: true };
+  const cleanupDcodePreflight = vi.fn();
+  const releaseOnboardLock = vi.fn();
+  const relockShields = vi.fn(() => {
+    rebuildWindow.relocked = true;
+    return true;
+  });
 
   beforeEach(() => {
-    spies = [];
+    vi.clearAllMocks();
     rebuildWindow.relocked = false;
-    delete require.cache[requireDist.resolve(rebuildModulePath)];
-
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-
-    const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
-    const gatewayRuntime = requireDist("../../gateway-runtime-action.js");
-    const sandboxList = requireDist("../../openshell-sandbox-list.js");
-    const resolve = requireDist("../../adapters/openshell/resolve.js");
-    const agentRuntime = requireDist("../../agent/runtime.js");
-    const onboardMod = requireDist("../../onboard.js");
-    const onboardSession = requireDist("../../state/onboard-session.js");
-    const registry = requireDist("../../state/registry.js");
-    const sandboxState = requireDist("../../state/sandbox.js");
-    const sandboxSession = requireDist("../../state/sandbox-session.js");
-    const sandboxVersion = requireDist("../../sandbox/version.js");
-    const rebuildShields = requireDist("./rebuild-shields.js");
-    const rebuildImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
-    const rebuildUsageNotice = requireDist("./rebuild-usage-notice.js");
-    const nim = requireDist("../../inference/nim.js");
-
-    relockSpy = vi
-      .spyOn(rebuildShields, "relockRebuildShieldsWindow")
-      .mockImplementation((...args: unknown[]) => {
-        const window = args[1] as typeof rebuildWindow;
-        window.relocked = true;
-        return true;
-      });
-
-    sandboxListRecoverySpy = vi.spyOn(sandboxList, "captureSandboxListWithGatewayRecovery");
-
-    spies.push(
-      vi.spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue").mockReturnValue(null),
-      vi.spyOn(gatewayDrift, "detectOpenShellStateRpcResultIssue").mockReturnValue(null),
-      vi.spyOn(gatewayRuntime, "recoverNamedGatewayRuntime").mockResolvedValue({
-        recovered: true,
-        before: { state: "connected_other" },
-        after: { state: "healthy_named" },
-      }),
-      sandboxListRecoverySpy.mockResolvedValue({
-        result: { status: 0, output: "alpha Ready" },
-      }),
-      vi.spyOn(resolve, "resolveOpenshell").mockReturnValue(null),
-      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null),
-      vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw"),
-      vi.spyOn(onboardSession, "loadSession").mockReturnValue(null),
-      vi.spyOn(onboardSession, "acquireOnboardLock").mockReturnValue({ acquired: true }),
-      vi.spyOn(onboardSession, "releaseOnboardLock").mockImplementation(() => undefined),
-      vi.spyOn(registry, "getSandbox").mockReturnValue({
-        name: "alpha",
-        provider: "ollama-local",
-        model: "nvidia/nemotron",
-        policies: [],
-        agent: null,
-        nimContainer: null,
-        nemoclawVersion: "0.1.0",
-        gatewayName: "nemoclaw-8090",
-        gatewayPort: 8090,
-        dashboardPort: 18789,
-      } as never),
-      vi.spyOn(registry, "updateSandbox").mockReturnValue(true),
-      vi.spyOn(sandboxSession, "getActiveSandboxSessions").mockReturnValue({
-        detected: false,
-        sessions: [],
-      }),
-      vi.spyOn(sandboxVersion, "checkAgentVersion").mockReturnValue({
-        expectedVersion: "0.1.0",
-        sandboxVersion: "0.0.1",
-      } as never),
-      vi.spyOn(nim, "detectGpu").mockReturnValue(null),
-      vi.spyOn(onboardMod, "preflightAuthoritativeRebuildTarget").mockResolvedValue(undefined),
-      vi.spyOn(rebuildImagePreflight, "preflightRebuildImage").mockResolvedValue({
-        ok: true,
-        imageTag: null,
-      }),
-      vi.spyOn(rebuildUsageNotice, "ensureRebuildUsageNoticeAccepted").mockResolvedValue(true),
-      vi.spyOn(rebuildShields, "openRebuildShieldsWindow").mockReturnValue(rebuildWindow),
-      relockSpy,
-      vi.spyOn(sandboxState, "backupSandboxState").mockImplementation(() => {
-        throw new Error("unexpected backup exception");
-      }),
-    );
-
-    ({ rebuildSandbox } = requireDist(rebuildModulePath));
+    phaseMocks.runPreflight.mockResolvedValue({
+      sandboxEntry: { name: "alpha", customPolicies: [] },
+      targetConfig: { durableConfig: { webSearchConfig: null } },
+      liveState: { staleRecovery: false, staleRegistrySnapshot: null },
+      recoveryManifest: null,
+      dcodePreflight: { cleanup: cleanupDcodePreflight },
+      preparedImage: null,
+      releaseOnboardLock,
+      log: vi.fn(),
+      bail: vi.fn(),
+    });
+    phaseMocks.runShields.mockReturnValue({
+      window: rebuildWindow,
+      staleSandboxWasLocked: false,
+      relock: relockShields,
+    });
+    phaseMocks.runBackup.mockImplementation(() => {
+      throw new Error("unexpected backup exception");
+    });
   });
 
-  afterEach(() => {
-    for (const spy of spies) spy.mockRestore();
-    errorSpy.mockRestore();
-    logSpy.mockRestore();
-    delete require.cache[requireDist.resolve(rebuildModulePath)];
-  });
-
-  it("relocks shields when an unexpected exception escapes after auto-unlock", async () => {
+  it("relocks shields when an unexpected rebuild phase exception escapes after auto-unlock (#6245)", async () => {
     await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
       "unexpected backup exception",
     );
 
-    expect(relockSpy).toHaveBeenCalledWith("alpha", rebuildWindow, true, expect.any(String));
-    expect(sandboxListRecoverySpy).toHaveBeenCalledWith({ gatewayName: "nemoclaw-8090" });
+    expect(phaseMocks.runBackup).toHaveBeenCalledOnce();
+    expect(relockShields).toHaveBeenCalledWith(true);
     expect(rebuildWindow.relocked).toBe(true);
-  }, 15_000);
+  });
 });

--- a/src/lib/actions/sandbox/rebuild-target-runtime.ts
+++ b/src/lib/actions/sandbox/rebuild-target-runtime.ts
@@ -23,24 +23,11 @@ import * as rebuildImagePreflight from "./rebuild-custom-image-preflight";
 import type { RebuildDurableConfig } from "./rebuild-durable-config";
 import type { RebuildSandboxEntry } from "./rebuild-flow-helpers";
 import type { RebuildRecreateOnboardOpts } from "./rebuild-gpu-opt-out";
+import { rebuildOnboardDependencies } from "./rebuild-onboard-dependencies";
 import { printRebuildPreflightFailure } from "./rebuild-preflight-error";
 import { disposePreparedBuildContext } from "./rebuild-prepared-image-context";
 import type { RebuildResumeConfig } from "./rebuild-resume-config";
 import type { RebuildTargetConfig } from "./rebuild-target-config";
-
-const onboardModule = require("../../onboard") as {
-  ensureValidatedWebSearchCredential: (
-    config: NonNullable<RebuildDurableConfig["webSearchConfig"]>,
-    nonInteractive?: boolean,
-  ) => Promise<unknown>;
-  preflightAuthoritativeRebuildTarget: (
-    options: RebuildRecreateOnboardOpts & {
-      model: string;
-      provider: string;
-      sandboxName: string;
-    },
-  ) => Promise<void>;
-};
 
 async function preflightRebuildWebSearchCredential(
   durableConfig: RebuildDurableConfig,
@@ -51,7 +38,10 @@ async function preflightRebuildWebSearchCredential(
   const provider = webSearchProviderForConfig(config);
   const label = webSearchLabelFor(provider);
   try {
-    const credential = await onboardModule.ensureValidatedWebSearchCredential(config, true);
+    const credential = await rebuildOnboardDependencies.ensureValidatedWebSearchCredential(
+      config,
+      true,
+    );
     if (typeof credential !== "string" || !credential.trim()) {
       throw new Error(`${label} credential validation did not return a usable key.`);
     }
@@ -215,7 +205,7 @@ export async function preflightAuthoritativeOnboardRuntime(
   bail: RebuildBail,
 ): Promise<boolean> {
   try {
-    await onboardModule.preflightAuthoritativeRebuildTarget({
+    await rebuildOnboardDependencies.preflightAuthoritativeRebuildTarget({
       ...recreateOptions,
       model: resumeConfig.model,
       provider: resumeConfig.provider,

--- a/src/lib/gateway-runtime-action.test.ts
+++ b/src/lib/gateway-runtime-action.test.ts
@@ -1,45 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-type GatewayRuntimeModule = typeof import("./gateway-runtime-action");
-
-const requireDist = createRequire(import.meta.url);
-const gatewayRuntimeModulePath = "./gateway-runtime-action.js";
+import * as gatewayRuntime from "./gateway-runtime-action";
 
 describe("gateway-runtime-action per-sandbox gateway routing", () => {
-  let gatewayRuntime: GatewayRuntimeModule;
   let captureSpy: MockInstance;
   let runSpy: MockInstance;
   let startGatewaySpy: MockInstance;
-  let spies: MockInstance[];
 
   beforeEach(() => {
-    spies = [];
-    delete require.cache[requireDist.resolve(gatewayRuntimeModulePath)];
-    const openshellRuntime = requireDist("./adapters/openshell/runtime.js");
-    captureSpy = vi.spyOn(openshellRuntime, "captureOpenshell");
-    runSpy = vi.spyOn(openshellRuntime, "runOpenshell");
-    spies.push(captureSpy, runSpy);
-
-    // The recovery path also pokes onboard.startGatewayForRecovery via lazy
-    // require(); stub it so the tests do not pull onboard's runtime in.
-    const onboard = requireDist("./onboard.js");
+    captureSpy = vi.spyOn(gatewayRuntime.gatewayRuntimeDependencies, "captureOpenshell");
+    runSpy = vi.spyOn(gatewayRuntime.gatewayRuntimeDependencies, "runOpenshell");
     startGatewaySpy = vi
-      .spyOn(onboard, "startGatewayForRecovery")
+      .spyOn(gatewayRuntime.gatewayRuntimeDependencies, "startGatewayForRecovery")
       .mockResolvedValue(undefined as never);
-    spies.push(startGatewaySpy);
-
-    gatewayRuntime = requireDist(gatewayRuntimeModulePath);
   });
 
   afterEach(() => {
-    for (const spy of spies) spy.mockRestore();
+    vi.restoreAllMocks();
     delete process.env.OPENSHELL_GATEWAY;
-    delete require.cache[requireDist.resolve(gatewayRuntimeModulePath)];
   });
 
   describe("getNamedGatewayLifecycleState", () => {

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -2,13 +2,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { stripAnsi } from "./adapters/openshell/client";
-import { captureOpenshell, runOpenshell } from "./adapters/openshell/runtime";
+import * as openshellRuntime from "./adapters/openshell/runtime";
 import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "./adapters/openshell/timeouts";
 import { GATEWAY_PORT } from "./core/ports";
 import { resolveGatewayName, resolveGatewayPortFromName } from "./onboard/gateway-binding";
+
+type StartGatewayForRecoveryOptions = {
+  gatewayName?: string;
+  gatewayPort?: number;
+};
+
+type LegacyOnboardModule = {
+  startGatewayForRecovery(options?: StartGatewayForRecoveryOptions): Promise<void>;
+};
+
+/**
+ * Injectable boundary for OpenShell calls and the deliberately lazy onboarding
+ * recovery path. Source-backed tests spy here without loading the onboard graph
+ * or invalidating the CommonJS module cache before every test.
+ */
+export const gatewayRuntimeDependencies = {
+  captureOpenshell(...args: Parameters<typeof openshellRuntime.captureOpenshell>) {
+    return openshellRuntime.captureOpenshell(...args);
+  },
+  runOpenshell(...args: Parameters<typeof openshellRuntime.runOpenshell>) {
+    return openshellRuntime.runOpenshell(...args);
+  },
+  async startGatewayForRecovery(options?: StartGatewayForRecoveryOptions): Promise<void> {
+    const onboard = (await import("./onboard")) as unknown as LegacyOnboardModule;
+    return onboard.startGatewayForRecovery(options);
+  },
+};
 
 /** Whether `gateway info` output names the given NemoClaw gateway. */
 function hasNamedGateway(output = "", gatewayName = "nemoclaw"): boolean {
@@ -41,16 +68,19 @@ export function getNamedGatewayLifecycleState(
   // When ignoring probe errors we must still capture stderr — OpenShell writes
   // the `Status:`/`Gateway:` lines there, and `ignoreError` would otherwise
   // drop stderr and break the healthy/connected classification.
-  const status = captureOpenshell(["status"], {
+  const status = gatewayRuntimeDependencies.captureOpenshell(["status"], {
     timeout: OPENSHELL_PROBE_TIMEOUT_MS,
     ignoreError,
     includeStderr: ignoreError,
   });
-  const gatewayInfo = captureOpenshell(["gateway", "info", "-g", gatewayName], {
-    timeout: OPENSHELL_PROBE_TIMEOUT_MS,
-    ignoreError,
-    includeStderr: ignoreError,
-  });
+  const gatewayInfo = gatewayRuntimeDependencies.captureOpenshell(
+    ["gateway", "info", "-g", gatewayName],
+    {
+      timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+      ignoreError,
+      includeStderr: ignoreError,
+    },
+  );
   const cleanStatus = stripAnsi(status.output);
   const activeGateway = getActiveGatewayName(status.output);
   const connected = /^\s*Status:\s*Connected\b/im.test(cleanStatus);
@@ -124,7 +154,7 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
     return { recovered: false, before, after: before, attempted: false };
   }
 
-  runOpenshell(["gateway", "select", gatewayName], {
+  gatewayRuntimeDependencies.runOpenshell(["gateway", "select", gatewayName], {
     ignoreError: true,
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
@@ -141,17 +171,8 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
   );
 
   if (shouldStartGateway) {
-    // Keep this lazy to avoid the deliberate onboard -> runner -> gateway
-    // recovery cycle at module-import time. Lifecycle helpers do not need to
-    // load the full onboarding graph until recovery actually starts.
-    const { startGatewayForRecovery } = (await import("./onboard")) as unknown as {
-      startGatewayForRecovery: (startOptions?: {
-        gatewayName?: string;
-        gatewayPort?: number;
-      }) => Promise<void>;
-    };
     try {
-      await startGatewayForRecovery({
+      await gatewayRuntimeDependencies.startGatewayForRecovery({
         gatewayName,
         gatewayPort: resolveGatewayPortFromName(gatewayName) ?? undefined,
       });
@@ -159,7 +180,7 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
       // Fall through to the lifecycle re-check below so we preserve the
       // existing recovery result shape and emit the correct classification.
     }
-    runOpenshell(["gateway", "select", gatewayName], {
+    gatewayRuntimeDependencies.runOpenshell(["gateway", "select", gatewayName], {
       ignoreError: true,
       timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
     });

--- a/src/lib/runner-argv.test.ts
+++ b/src/lib/runner-argv.test.ts
@@ -1,11 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "module";
 import { describe, expect, it } from "vitest";
 
-const require = createRequire(import.meta.url);
-const runner = require("./runner");
+import * as runner from "./runner";
 
 describe("run with argv array", () => {
   it("executes a simple command and returns result", () => {
@@ -52,6 +50,7 @@ describe("run with argv array", () => {
   });
 
   it("rejects string commands", () => {
+    // @ts-expect-error Exercise the runtime guard for legacy string input.
     expect(() => runner.run("echo hello", { suppressOutput: true })).toThrow(/argv array instead/);
   });
 
@@ -62,7 +61,7 @@ describe("run with argv array", () => {
     });
     // spawnSync sets result.error for missing executables
     expect(result.error).toBeDefined();
-    expect(result.error.code).toBe("ENOENT");
+    expect((result.error as NodeJS.ErrnoException).code).toBe("ENOENT");
   });
 });
 
@@ -80,6 +79,7 @@ describe("runInteractive with argv array", () => {
   });
 
   it("rejects string commands", () => {
+    // @ts-expect-error Exercise the runtime guard for legacy string input.
     expect(() => runner.runInteractive("echo hello", { suppressOutput: true })).toThrow(
       /argv array instead/,
     );
@@ -169,6 +169,7 @@ describe("runCapture with argv array", () => {
   });
 
   it("rejects string commands", () => {
+    // @ts-expect-error Exercise the runtime guard for legacy string input.
     expect(() => runner.runCapture("echo hello")).toThrow(/argv array instead/);
   });
 

--- a/src/lib/status-command-deps.test.ts
+++ b/src/lib/status-command-deps.test.ts
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-const require = createRequire(import.meta.url);
-const { buildStatusCommandDeps } =
-  require("./status-command-deps.js") as typeof import("./status-command-deps");
+import { buildStatusCommandDeps } from "./status-command-deps";
 
 function writeExecutable(target: string, body: string): void {
   fs.writeFileSync(target, body, { mode: 0o755 });

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -69,6 +69,26 @@ describe("source-loader Node options", () => {
     }
   });
 
+  it("preserves malformed source-loader assignments byte-for-byte (#6245)", () => {
+    const hook = "hook";
+    const malformedAssignments = ["--require='hook", '--require="hook', '--require=foo"bar'];
+
+    for (const malformed of malformedAssignments) {
+      expect(nodeOptionsWithoutSourceLoader(malformed, hook)).toBe(malformed);
+    }
+  });
+
+  it("removes an unquoted source-loader assignment with escaped backslashes (#6245)", () => {
+    const escapedWindowsHook = String.raw`C:\\path\\hook`;
+
+    expect(
+      nodeOptionsWithoutSourceLoader(
+        `--require=${escapedWindowsHook} --trace-warnings`,
+        escapedWindowsHook,
+      ),
+    ).toBe("--trace-warnings");
+  });
+
   it("handles mixed quotes and escaped backslashes while removing the source loader (#6245)", () => {
     const spacedWindowsHook = String.raw`C:\NemoClaw worktree\onboard-script-mocks.cjs`;
     const mixedOptions = `--conditions='development "mode"' ${sourceLoaderNodeOptions(

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -55,8 +55,22 @@ describe("source-loader Node options", () => {
   it("preserves unrelated options byte-for-byte when the source loader is absent", () => {
     const nodeOptions =
       '--require=/tmp/onboard-script-mocks.cjs.backup --conditions="development mode"';
+    const malformed = '--conditions="development mode --trace-warnings';
 
     expect(nodeOptionsWithoutSourceLoader(nodeOptions)).toBe(nodeOptions);
+    expect(nodeOptionsWithoutSourceLoader(malformed)).toBe(malformed);
+  });
+
+  it("handles mixed quotes and escaped backslashes while removing the source loader", () => {
+    const spacedWindowsHook = String.raw`C:\NemoClaw worktree\onboard-script-mocks.cjs`;
+    const mixedOptions = `--conditions='development mode' ${sourceLoaderNodeOptions(
+      undefined,
+      spacedWindowsHook,
+    )} --trace-warnings`;
+
+    expect(nodeOptionsWithoutSourceLoader(mixedOptions, spacedWindowsHook)).toBe(
+      "--conditions='development mode' --trace-warnings",
+    );
   });
 
   it("keeps unrelated preloads active without installing the TypeScript source hook", () => {

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  nodeOptionsWithoutSourceLoader,
+  SOURCE_REQUIRE_HOOK,
+  sourceLoaderNodeOptions,
+} from "../helpers/source-loader-options";
+import { runWithEnv } from "./helpers";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const directory of tempDirs) fs.rmSync(directory, { force: true, recursive: true });
+  tempDirs.clear();
+});
+
+describe("source-loader Node options", () => {
+  it("removes only the repository source-loader option wherever it appears", () => {
+    const unrelatedRequire = "--require=/tmp/keep-preload.cjs";
+    const inspect = "--inspect-port=0";
+    const assigned = `--require=${SOURCE_REQUIRE_HOOK}`;
+    const quotedAssignment = `--require=${JSON.stringify(SOURCE_REQUIRE_HOOK)}`;
+
+    expect(nodeOptionsWithoutSourceLoader(undefined)).toBe("");
+    expect(nodeOptionsWithoutSourceLoader(assigned)).toBe("");
+    expect(nodeOptionsWithoutSourceLoader(quotedAssignment)).toBe("");
+    expect(nodeOptionsWithoutSourceLoader(`--require ${SOURCE_REQUIRE_HOOK}`)).toBe("");
+    expect(nodeOptionsWithoutSourceLoader(`-r ${JSON.stringify(SOURCE_REQUIRE_HOOK)}`)).toBe("");
+    expect(
+      nodeOptionsWithoutSourceLoader(
+        `${quotedAssignment} ${inspect} ${assigned} ${unrelatedRequire}`,
+      ),
+    ).toBe(`${inspect} ${unrelatedRequire}`);
+    expect(
+      nodeOptionsWithoutSourceLoader(`${unrelatedRequire} -r=${SOURCE_REQUIRE_HOOK} ${inspect}`),
+    ).toBe(`${unrelatedRequire} ${inspect}`);
+
+    const spacedHook = "/tmp/NemoClaw worktree/onboard-script-mocks.cjs";
+    expect(
+      nodeOptionsWithoutSourceLoader(
+        `--require=${JSON.stringify(spacedHook)} ${inspect}`,
+        spacedHook,
+      ),
+    ).toBe(inspect);
+  });
+
+  it("preserves unrelated options byte-for-byte when the source loader is absent", () => {
+    const nodeOptions =
+      '--require=/tmp/onboard-script-mocks.cjs.backup --conditions="development mode"';
+
+    expect(nodeOptionsWithoutSourceLoader(nodeOptions)).toBe(nodeOptions);
+  });
+
+  it("keeps unrelated preloads active without installing the TypeScript source hook", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-node-options-"));
+    tempDirs.add(directory);
+    const marker = path.join(directory, "preload.json");
+    const preload = path.join(directory, "observe-preloads.cjs");
+    fs.writeFileSync(
+      preload,
+      [
+        'const fs = require("node:fs");',
+        'const Module = require("node:module");',
+        `fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ hasTypeScriptHook: Object.hasOwn(Module._extensions, ".ts") }));`,
+      ].join("\n"),
+    );
+
+    const result = spawnSync(process.execPath, ["-e", "process.exit(0)"], {
+      env: {
+        ...process.env,
+        NODE_OPTIONS: nodeOptionsWithoutSourceLoader(
+          `${sourceLoaderNodeOptions(undefined)} --require=${preload}`,
+        ),
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(fs.readFileSync(marker, "utf8"))).toEqual({ hasTypeScriptHook: false });
+  });
+
+  it("keeps the TypeScript source hook in the default CLI integration child", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-source-options-"));
+    tempDirs.add(directory);
+    const marker = path.join(directory, "preload.json");
+    const preload = path.join(directory, "observe-source-preload.cjs");
+    fs.writeFileSync(
+      preload,
+      [
+        'const fs = require("node:fs");',
+        'const Module = require("node:module");',
+        `fs.writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ hasTypeScriptHook: Object.hasOwn(Module._extensions, ".ts") }));`,
+      ].join("\n"),
+    );
+
+    const result = runWithEnv("--version", {
+      NODE_OPTIONS: `${sourceLoaderNodeOptions(undefined)} --require=${preload}`,
+    });
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(fs.readFileSync(marker, "utf8"))).toEqual({ hasTypeScriptHook: true });
+  });
+
+  it("quotes preload paths that contain spaces for Node", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw node options "));
+    tempDirs.add(directory);
+    const marker = path.join(directory, "loaded.txt");
+    const preload = path.join(directory, "space preload.cjs");
+    fs.writeFileSync(preload, `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "ok");`);
+
+    const result = spawnSync(process.execPath, ["-e", "process.exit(0)"], {
+      env: { ...process.env, NODE_OPTIONS: sourceLoaderNodeOptions(undefined, preload) },
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.readFileSync(marker, "utf8")).toBe("ok");
+  });
+});

--- a/test/cli/helpers.test.ts
+++ b/test/cli/helpers.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 
 describe("source-loader Node options", () => {
-  it("removes only the repository source-loader option wherever it appears", () => {
+  it("removes only the repository source-loader option wherever it appears (#6245)", () => {
     const unrelatedRequire = "--require=/tmp/keep-preload.cjs";
     const inspect = "--inspect-port=0";
     const assigned = `--require=${SOURCE_REQUIRE_HOOK}`;
@@ -52,28 +52,36 @@ describe("source-loader Node options", () => {
     ).toBe(inspect);
   });
 
-  it("preserves unrelated options byte-for-byte when the source loader is absent", () => {
+  it("preserves malformed or unrelated options byte-for-byte (#6245)", () => {
     const nodeOptions =
       '--require=/tmp/onboard-script-mocks.cjs.backup --conditions="development mode"';
-    const malformed = '--conditions="development mode --trace-warnings';
+    const malformedOptions = [
+      '--conditions="development mode --trace-warnings',
+      "--conditions='development mode --trace-warnings",
+      "--conditions=trailing\\",
+    ];
 
     expect(nodeOptionsWithoutSourceLoader(nodeOptions)).toBe(nodeOptions);
-    expect(nodeOptionsWithoutSourceLoader(malformed)).toBe(malformed);
+    for (const malformed of malformedOptions) {
+      expect(nodeOptionsWithoutSourceLoader(malformed)).toBe(malformed);
+      const loaderBeforeMalformed = `${sourceLoaderNodeOptions(undefined)} ${malformed}`;
+      expect(nodeOptionsWithoutSourceLoader(loaderBeforeMalformed)).toBe(loaderBeforeMalformed);
+    }
   });
 
-  it("handles mixed quotes and escaped backslashes while removing the source loader", () => {
+  it("handles mixed quotes and escaped backslashes while removing the source loader (#6245)", () => {
     const spacedWindowsHook = String.raw`C:\NemoClaw worktree\onboard-script-mocks.cjs`;
-    const mixedOptions = `--conditions='development mode' ${sourceLoaderNodeOptions(
+    const mixedOptions = `--conditions='development "mode"' ${sourceLoaderNodeOptions(
       undefined,
       spacedWindowsHook,
     )} --trace-warnings`;
 
     expect(nodeOptionsWithoutSourceLoader(mixedOptions, spacedWindowsHook)).toBe(
-      "--conditions='development mode' --trace-warnings",
+      `--conditions='development "mode"' --trace-warnings`,
     );
   });
 
-  it("keeps unrelated preloads active without installing the TypeScript source hook", () => {
+  it("keeps unrelated preloads active without installing the TypeScript source hook (#6245)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-node-options-"));
     tempDirs.add(directory);
     const marker = path.join(directory, "preload.json");
@@ -101,7 +109,7 @@ describe("source-loader Node options", () => {
     expect(JSON.parse(fs.readFileSync(marker, "utf8"))).toEqual({ hasTypeScriptHook: false });
   });
 
-  it("keeps the TypeScript source hook in the default CLI integration child", () => {
+  it("keeps the TypeScript source hook in the default CLI integration child (#6245)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-source-options-"));
     tempDirs.add(directory);
     const marker = path.join(directory, "preload.json");
@@ -123,7 +131,7 @@ describe("source-loader Node options", () => {
     expect(JSON.parse(fs.readFileSync(marker, "utf8"))).toEqual({ hasTypeScriptHook: true });
   });
 
-  it("quotes preload paths that contain spaces for Node", () => {
+  it("quotes preload paths that contain spaces for Node (#6245)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw node options "));
     tempDirs.add(directory);
     const marker = path.join(directory, "loaded.txt");

--- a/test/gateway-drift-preflight.test.ts
+++ b/test/gateway-drift-preflight.test.ts
@@ -8,16 +8,11 @@ import path from "node:path";
 
 import { afterAll, describe, expect, it } from "vitest";
 
+import { nodeOptionsWithoutSourceLoader } from "./helpers/source-loader-options";
 import { testTimeoutOptions } from "./helpers/timeouts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
-const SOURCE_REQUIRE_OPTION = `--require=${path.join(
-  REPO_ROOT,
-  "test",
-  "helpers",
-  "onboard-script-mocks.cjs",
-)}`;
 const ARTIFACT_ROOT = process.env.E2E_ARTIFACT_DIR;
 const WORK_ROOT = (() => {
   const parent = ARTIFACT_ROOT ?? os.tmpdir();
@@ -226,14 +221,6 @@ function prepareCase(name: string): { binDir: string; caseDir: string; home: str
   writeRegistry(home);
   writeFakeOpenshell(binDir);
   return { binDir, caseDir, home };
-}
-
-function nodeOptionsWithoutSourceLoader(nodeOptions: string | undefined): string {
-  if (!nodeOptions || nodeOptions === SOURCE_REQUIRE_OPTION) return "";
-  const sourceLoaderSuffix = ` ${SOURCE_REQUIRE_OPTION}`;
-  return nodeOptions.endsWith(sourceLoaderSuffix)
-    ? nodeOptions.slice(0, -sourceLoaderSuffix.length)
-    : nodeOptions;
 }
 
 function runCli(caseDir: string, home: string, binDir: string, args: string[]): CommandResult {

--- a/test/helpers/rebuild-flow-harness.ts
+++ b/test/helpers/rebuild-flow-harness.ts
@@ -18,6 +18,41 @@ const rebuildModulePath = "./rebuild.js";
 requireDist(rebuildModulePath);
 delete require.cache[requireDist.resolve(rebuildModulePath)];
 
+// Cache stable dependency modules outside each test's timeout. The rebuild
+// entry itself is still reloaded after these modules receive fresh spies.
+const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
+const openshellRuntime = requireDist("../../adapters/openshell/runtime.js");
+const dockerImage = requireDist("../../adapters/docker/image.js");
+const dockerInspect = requireDist("../../adapters/docker/inspect.js");
+const sandboxList = requireDist("../../openshell-sandbox-list.js");
+const resolve = requireDist("../../adapters/openshell/resolve.js");
+const agentDefs = requireDist("../../agent/defs.js");
+const agentOnboard = requireDist("../../agent/onboard.js");
+const agentRuntime = requireDist("../../agent/runtime.js");
+const gatewayRuntime = requireDist("../../gateway-runtime-action.js");
+const gatewayState = requireDist("./gateway-state.js");
+const { rebuildOnboardDependencies } = requireDist("./rebuild-onboard-dependencies.js");
+const onboardCredentialEnv = requireDist("../../onboard/credential-env.js");
+const onboardSession = requireDist("../../state/onboard-session.js");
+const registry = requireDist("../../state/registry.js");
+const sandboxState = requireDist("../../state/sandbox.js");
+const sandboxSession = requireDist("../../state/sandbox-session.js");
+const sandboxVersion = requireDist("../../sandbox/version.js");
+const destroy = requireDist("./destroy.js");
+const rebuildShields = requireDist("./rebuild-shields.js");
+const nim = requireDist("../../inference/nim.js");
+const policies = requireDist("../../policy/index.js");
+const processRecovery = requireDist("./process-recovery.js");
+const messagingHostForwardLifecycle = requireDist("./messaging-host-forward-lifecycle.js");
+const messaging = requireDist("../../messaging/index.js");
+const mcpBridge = requireDist("./mcp-bridge.js");
+const rebuildCustomImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
+const rebuildInference = requireDist("./rebuild-inference-preflight.js");
+const rebuildFlowHelpers = requireDist("./rebuild-flow-helpers.js");
+const rebuildManagedImage = requireDist("./rebuild-managed-image-preflight.js");
+const rebuildMessagingConflict = requireDist("./rebuild-messaging-conflict-preflight.js");
+const shields = requireDist("../../shields/index.js");
+
 type RebuildFlowStep = {
   status: string;
   startedAt: string | null;
@@ -219,38 +254,6 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
   const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-  const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
-  const openshellRuntime = requireDist("../../adapters/openshell/runtime.js");
-  const dockerImage = requireDist("../../adapters/docker/image.js");
-  const dockerInspect = requireDist("../../adapters/docker/inspect.js");
-  const sandboxList = requireDist("../../openshell-sandbox-list.js");
-  const resolve = requireDist("../../adapters/openshell/resolve.js");
-  const agentDefs = requireDist("../../agent/defs.js");
-  const agentOnboard = requireDist("../../agent/onboard.js");
-  const agentRuntime = requireDist("../../agent/runtime.js");
-  const gatewayRuntime = requireDist("../../gateway-runtime-action.js");
-  const gatewayState = requireDist("./gateway-state.js");
-  const { rebuildOnboardDependencies } = requireDist("./rebuild-onboard-dependencies.js");
-  const onboardSession = requireDist("../../state/onboard-session.js");
-  const registry = requireDist("../../state/registry.js");
-  const sandboxState = requireDist("../../state/sandbox.js");
-  const sandboxSession = requireDist("../../state/sandbox-session.js");
-  const sandboxVersion = requireDist("../../sandbox/version.js");
-  const destroy = requireDist("./destroy.js");
-  const rebuildShields = requireDist("./rebuild-shields.js");
-  const nim = requireDist("../../inference/nim.js");
-  const policies = requireDist("../../policy/index.js");
-  const processRecovery = requireDist("./process-recovery.js");
-  const messagingHostForwardLifecycle = requireDist("./messaging-host-forward-lifecycle.js");
-  const messaging = requireDist("../../messaging/index.js");
-  const mcpBridge = requireDist("./mcp-bridge.js");
-  const rebuildCustomImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
-  const rebuildInference = requireDist("./rebuild-inference-preflight.js");
-  const rebuildFlowHelpers = requireDist("./rebuild-flow-helpers.js");
-  const rebuildManagedImage = requireDist("./rebuild-managed-image-preflight.js");
-  const rebuildMessagingConflict = requireDist("./rebuild-messaging-conflict-preflight.js");
-  const shields = requireDist("../../shields/index.js");
 
   const session = createRebuildFlowSession(onboardSession.MACHINE_SNAPSHOT_VERSION);
   const rebuildShieldsWindow = { relocked: false, wasLocked: false };
@@ -478,6 +481,9 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     .mockImplementation(async () => {
       await overrides.onboard?.(session);
     });
+  vi.spyOn(rebuildOnboardDependencies, "hydrateCredentialEnv").mockImplementation(
+    (...args: unknown[]) => onboardCredentialEnv.hydrateCredentialEnv(String(args[0] ?? "")),
+  );
   vi.spyOn(rebuildOnboardDependencies, "preflightAuthoritativeRebuildTarget").mockResolvedValue(
     undefined,
   );

--- a/test/helpers/rebuild-flow-harness.ts
+++ b/test/helpers/rebuild-flow-harness.ts
@@ -231,7 +231,7 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   const agentRuntime = requireDist("../../agent/runtime.js");
   const gatewayRuntime = requireDist("../../gateway-runtime-action.js");
   const gatewayState = requireDist("./gateway-state.js");
-  const onboardMod = requireDist("../../onboard.js");
+  const { rebuildOnboardDependencies } = requireDist("./rebuild-onboard-dependencies.js");
   const onboardSession = requireDist("../../state/onboard-session.js");
   const registry = requireDist("../../state/registry.js");
   const sandboxState = requireDist("../../state/sandbox.js");
@@ -473,10 +473,14 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
     });
   vi.spyOn(nim, "stopNimContainer").mockImplementation(() => undefined);
   vi.spyOn(nim, "stopNimContainerByName").mockImplementation(() => undefined);
-  const onboardSpy = vi.spyOn(onboardMod, "onboard").mockImplementation(async () => {
-    await overrides.onboard?.(session);
-  });
-  vi.spyOn(onboardMod, "preflightAuthoritativeRebuildTarget").mockResolvedValue(undefined);
+  const onboardSpy = vi
+    .spyOn(rebuildOnboardDependencies, "onboard")
+    .mockImplementation(async () => {
+      await overrides.onboard?.(session);
+    });
+  vi.spyOn(rebuildOnboardDependencies, "preflightAuthoritativeRebuildTarget").mockResolvedValue(
+    undefined,
+  );
   const applyPresetSpy = vi
     .spyOn(policies, "applyPreset")
     .mockImplementation((_sandboxName: unknown, presetName: unknown) => {

--- a/test/helpers/rebuild-flow-test-harness.ts
+++ b/test/helpers/rebuild-flow-test-harness.ts
@@ -40,7 +40,7 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   const resolve = requireDist("../../adapters/openshell/resolve.js");
   const agentDefs = requireDist("../../agent/defs.js");
   const agentRuntime = requireDist("../../agent/runtime.js");
-  const onboardMod = requireDist("../../onboard.js");
+  const { rebuildOnboardDependencies } = requireDist("./rebuild-onboard-dependencies.js");
   const onboardCredentialEnv = requireDist("../../onboard/credential-env.js");
   const hermesProviderAuth = requireDist("../../hermes-provider-auth.js");
   const onboardSession = requireDist("../../state/onboard-session.js");
@@ -141,7 +141,7 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   const defaultHydrateCredentialEnv =
     onboardCredentialEnv.hydrateCredentialEnv.bind(onboardCredentialEnv);
   const hydrateCredentialEnvSpy = vi
-    .spyOn(onboardMod, "hydrateCredentialEnv")
+    .spyOn(rebuildOnboardDependencies, "hydrateCredentialEnv")
     .mockImplementation((...args: unknown[]) => {
       const credentialEnv = String(args[0] ?? "");
       return overrides.hydrateCredentialEnv
@@ -369,14 +369,16 @@ export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): 
   vi.spyOn(nim, "stopNimContainer").mockImplementation(() => undefined);
   vi.spyOn(nim, "stopNimContainerByName").mockImplementation(() => undefined);
   const onboardSpy = vi
-    .spyOn(onboardMod, "onboard")
+    .spyOn(rebuildOnboardDependencies, "onboard")
     .mockImplementation(async (...args: unknown[]) => {
       const options = args[0] as RebuildRecreateOnboardOpts;
       await overrides.onboard?.(session, options);
     });
-  vi.spyOn(onboardMod, "preflightAuthoritativeRebuildTarget").mockResolvedValue(undefined);
+  vi.spyOn(rebuildOnboardDependencies, "preflightAuthoritativeRebuildTarget").mockResolvedValue(
+    undefined,
+  );
   const ensureValidatedBraveSearchCredentialSpy = vi
-    .spyOn(onboardMod, "ensureValidatedWebSearchCredential")
+    .spyOn(rebuildOnboardDependencies, "ensureValidatedWebSearchCredential")
     .mockImplementation(
       overrides.ensureValidatedWebSearchCredential ??
         overrides.ensureValidatedBraveSearchCredential ??

--- a/test/helpers/rebuild-flow-test-harness.ts
+++ b/test/helpers/rebuild-flow-test-harness.ts
@@ -26,43 +26,45 @@ requireDist(rebuildModulePath);
 delete require.cache[requireDist.resolve(rebuildModulePath)];
 const harnessTempDirs: string[] = [];
 
+// Cache stable dependency modules outside each test's timeout. The rebuild
+// entry itself is still reloaded after these modules receive fresh spies.
+const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
+const openshellRuntime = requireDist("../../adapters/openshell/runtime.js");
+const dockerInspect = requireDist("../../adapters/docker/inspect.js");
+const sandboxList = requireDist("../../openshell-sandbox-list.js");
+const resolve = requireDist("../../adapters/openshell/resolve.js");
+const agentDefs = requireDist("../../agent/defs.js");
+const agentRuntime = requireDist("../../agent/runtime.js");
+const { rebuildOnboardDependencies } = requireDist("./rebuild-onboard-dependencies.js");
+const onboardCredentialEnv = requireDist("../../onboard/credential-env.js");
+const hermesProviderAuth = requireDist("../../hermes-provider-auth.js");
+const onboardSession = requireDist("../../state/onboard-session.js");
+const registry = requireDist("../../state/registry.js");
+const sandboxState = requireDist("../../state/sandbox.js");
+const sandboxSession = requireDist("../../state/sandbox-session.js");
+const sandboxVersion = requireDist("../../sandbox/version.js");
+const destroy = requireDist("./destroy.js");
+const gatewayState = requireDist("./gateway-state.js");
+const rebuildFlowHelpers = requireDist("./rebuild-flow-helpers.js");
+const rebuildCustomImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
+const rebuildPreparedImageContext = requireDist("./rebuild-prepared-image-context.js");
+const buildContextFingerprint = requireDist("../../adapters/fs/build-context-fingerprint.js");
+const rebuildUsageNotice = requireDist("./rebuild-usage-notice.js");
+const rebuildShields = requireDist("./rebuild-shields.js");
+const nim = requireDist("../../inference/nim.js");
+const policies = requireDist("../../policy/index.js");
+const processRecovery = requireDist("./process-recovery.js");
+const messagingHostForwardLifecycle = requireDist("./messaging-host-forward-lifecycle.js");
+const mcpBridge = requireDist("./mcp-bridge.js");
+const messaging = requireDist("../../messaging/index.js");
+const shields = requireDist("../../shields/index.js");
+
 export function createRebuildFlowHarness(overrides: RebuildFlowOverrides = {}): RebuildFlowHarness {
   delete require.cache[requireDist.resolve(rebuildModulePath)];
 
   const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
   const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-  const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
-  const openshellRuntime = requireDist("../../adapters/openshell/runtime.js");
-  const dockerInspect = requireDist("../../adapters/docker/inspect.js");
-  const sandboxList = requireDist("../../openshell-sandbox-list.js");
-  const resolve = requireDist("../../adapters/openshell/resolve.js");
-  const agentDefs = requireDist("../../agent/defs.js");
-  const agentRuntime = requireDist("../../agent/runtime.js");
-  const { rebuildOnboardDependencies } = requireDist("./rebuild-onboard-dependencies.js");
-  const onboardCredentialEnv = requireDist("../../onboard/credential-env.js");
-  const hermesProviderAuth = requireDist("../../hermes-provider-auth.js");
-  const onboardSession = requireDist("../../state/onboard-session.js");
-  const registry = requireDist("../../state/registry.js");
-  const sandboxState = requireDist("../../state/sandbox.js");
-  const sandboxSession = requireDist("../../state/sandbox-session.js");
-  const sandboxVersion = requireDist("../../sandbox/version.js");
-  const destroy = requireDist("./destroy.js");
-  const gatewayState = requireDist("./gateway-state.js");
-  const rebuildFlowHelpers = requireDist("./rebuild-flow-helpers.js");
-  const rebuildCustomImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
-  const rebuildPreparedImageContext = requireDist("./rebuild-prepared-image-context.js");
-  const buildContextFingerprint = requireDist("../../adapters/fs/build-context-fingerprint.js");
-  const rebuildUsageNotice = requireDist("./rebuild-usage-notice.js");
-  const rebuildShields = requireDist("./rebuild-shields.js");
-  const nim = requireDist("../../inference/nim.js");
-  const policies = requireDist("../../policy/index.js");
-  const processRecovery = requireDist("./process-recovery.js");
-  const messagingHostForwardLifecycle = requireDist("./messaging-host-forward-lifecycle.js");
-  const mcpBridge = requireDist("./mcp-bridge.js");
-  const messaging = requireDist("../../messaging/index.js");
-  const shields = requireDist("../../shields/index.js");
 
   const session = createRebuildFlowSession(onboardSession.MACHINE_SNAPSHOT_VERSION);
   const rebuildShieldsWindow = { relocked: false, wasLocked: false };

--- a/test/helpers/source-loader-options.ts
+++ b/test/helpers/source-loader-options.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+export const SOURCE_REQUIRE_HOOK = path.join(import.meta.dirname, "onboard-script-mocks.cjs");
+
+function splitRawNodeOptions(nodeOptions: string): string[] {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < nodeOptions.length) {
+    while (index < nodeOptions.length && /\s/.test(nodeOptions[index] ?? "")) index += 1;
+    if (index >= nodeOptions.length) break;
+
+    const start = index;
+    let quote: "'" | '"' | null = null;
+    let escaped = false;
+    while (index < nodeOptions.length) {
+      const char = nodeOptions[index] ?? "";
+      if (escaped) {
+        escaped = false;
+        index += 1;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        index += 1;
+        continue;
+      }
+      if (quote) {
+        if (char === quote) quote = null;
+        index += 1;
+        continue;
+      }
+      if (char === "'" || char === '"') {
+        quote = char;
+        index += 1;
+        continue;
+      }
+      if (/\s/.test(char)) break;
+      index += 1;
+    }
+    tokens.push(nodeOptions.slice(start, index));
+  }
+  return tokens;
+}
+
+function decodeNodeOptionToken(token: string): string {
+  const first = token[0];
+  if (token.length < 2 || (first !== "'" && first !== '"') || token.at(-1) !== first) {
+    return token;
+  }
+  if (first === '"') {
+    try {
+      return JSON.parse(token) as string;
+    } catch {
+      // Node also accepts quoted paths whose backslashes are not JSON escapes.
+    }
+  }
+  return token.slice(1, -1);
+}
+
+function isRequireFlag(token: string): boolean {
+  return token === "--require" || token === "-r";
+}
+
+function requireAssignmentValue(token: string): string | null {
+  const decoded = decodeNodeOptionToken(token);
+  for (const prefix of ["--require=", "-r="]) {
+    if (decoded.startsWith(prefix)) {
+      return decodeNodeOptionToken(decoded.slice(prefix.length));
+    }
+  }
+  return null;
+}
+
+export function sourceLoaderNodeOptions(
+  nodeOptions: string | undefined,
+  sourceHook = SOURCE_REQUIRE_HOOK,
+): string {
+  const sourceRequireOption = `--require=${JSON.stringify(sourceHook)}`;
+  return [nodeOptions, sourceRequireOption].filter(Boolean).join(" ");
+}
+
+export function nodeOptionsWithoutSourceLoader(
+  nodeOptions: string | undefined,
+  sourceHook = SOURCE_REQUIRE_HOOK,
+): string {
+  if (!nodeOptions) return "";
+  const tokens = splitRawNodeOptions(nodeOptions);
+  const retained: string[] = [];
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index] ?? "";
+    const decoded = decodeNodeOptionToken(token);
+    const nextToken = tokens[index + 1];
+    if (
+      isRequireFlag(decoded) &&
+      nextToken !== undefined &&
+      decodeNodeOptionToken(nextToken) === sourceHook
+    ) {
+      index += 1;
+      continue;
+    }
+    if (requireAssignmentValue(token) === sourceHook) continue;
+    retained.push(token);
+  }
+
+  return retained.length === tokens.length ? nodeOptions : retained.join(" ");
+}

--- a/test/helpers/source-loader-options.ts
+++ b/test/helpers/source-loader-options.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 export const SOURCE_REQUIRE_HOOK = path.join(import.meta.dirname, "onboard-script-mocks.cjs");
 
-function splitRawNodeOptions(nodeOptions: string): string[] {
+function splitRawNodeOptions(nodeOptions: string): string[] | null {
   const tokens: string[] = [];
   let index = 0;
   while (index < nodeOptions.length) {
@@ -40,6 +40,7 @@ function splitRawNodeOptions(nodeOptions: string): string[] {
       if (/\s/.test(char)) break;
       index += 1;
     }
+    if (quote || escaped) return null;
     tokens.push(nodeOptions.slice(start, index));
   }
   return tokens;
@@ -88,6 +89,7 @@ export function nodeOptionsWithoutSourceLoader(
 ): string {
   if (!nodeOptions) return "";
   const tokens = splitRawNodeOptions(nodeOptions);
+  if (!tokens) return nodeOptions;
   const retained: string[] = [];
 
   for (let index = 0; index < tokens.length; index += 1) {

--- a/test/helpers/source-loader-options.ts
+++ b/test/helpers/source-loader-options.ts
@@ -89,6 +89,8 @@ export function nodeOptionsWithoutSourceLoader(
 ): string {
   if (!nodeOptions) return "";
   const tokens = splitRawNodeOptions(nodeOptions);
+  // Preserve malformed external input as one opaque value. Partially rewriting
+  // it could corrupt unrelated flags; Node remains responsible for rejecting it.
   if (!tokens) return nodeOptions;
   const retained: string[] = [];
 

--- a/test/package-contract/cli/config-set-cli-dispatch.test.ts
+++ b/test/package-contract/cli/config-set-cli-dispatch.test.ts
@@ -93,7 +93,7 @@ describe("config set CLI dispatch", () => {
         settled = true;
       });
 
-      await vi.waitFor(() => expect(configSet).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(configSet).toHaveBeenCalledTimes(1), { timeout: 4_000 });
       expect(configSet).toHaveBeenCalledTimes(1);
       expect(configSet).toHaveBeenCalledWith("test-sandbox", {
         key: "inference.endpoints",

--- a/test/test-create-require-budget.test.ts
+++ b/test/test-create-require-budget.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 });
 
 describe("CLI createRequire budget", () => {
-  it("detects direct and namespace-qualified createRequire references", () => {
+  it("detects direct and namespace-qualified createRequire references (#6245)", () => {
     expect(
       containsCreateRequireIdentifier(
         'import { createRequire } from "node:module";\ncreateRequire(import.meta.url);',
@@ -35,7 +35,7 @@ describe("CLI createRequire budget", () => {
     ).toBe(true);
   });
 
-  it("ignores comments and string data that only mention createRequire", () => {
+  it("ignores comments and string data that only mention createRequire (#6245)", () => {
     expect(
       containsCreateRequireIdentifier(
         '// createRequire is documentation\nconst fixture = "createRequire(import.meta.url)";',
@@ -46,15 +46,18 @@ describe("CLI createRequire budget", () => {
     ).toBe(false);
   });
 
-  it("conservatively treats arbitrary createRequire properties as boundaries", () => {
+  it("conservatively treats arbitrary createRequire properties as boundaries (#6245)", () => {
+    expect(
+      containsCreateRequireIdentifier("const helper = { createRequire: () => undefined };"),
+    ).toBe(true);
     expect(containsCreateRequireIdentifier("helper.createRequire();")).toBe(true);
   });
 
-  it("treats a production createRequire identifier as a real boundary", () => {
+  it("treats a production createRequire identifier as a real boundary (#6245)", () => {
     expect(containsCreateRequireIdentifier("function createRequire() {}")).toBe(true);
   });
 
-  it("scans TypeScript module variants and non-test support files", () => {
+  it("scans TypeScript module variants and non-test support files (#6245)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-create-require-budget-"));
     tempDirs.add(directory);
     fs.writeFileSync(
@@ -69,16 +72,27 @@ describe("CLI createRequire budget", () => {
       path.join(directory, "excluded.test.tsx"),
       'import { createRequire } from "node:module";',
     );
+    fs.writeFileSync(
+      path.join(directory, "component.tsx"),
+      [
+        'import { createRequire } from "node:module";',
+        "export const fixture = <div>{createRequire(import.meta.url)}</div>;",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(directory, "jsx-text.tsx"),
+      "export const fixture = <div>createRequire</div>;",
+    );
 
     expect(
       collectProductionCreateRequireSources(directory).map((file) => path.basename(file)),
-    ).toEqual(["helper.cts", "production.mts"]);
+    ).toEqual(["component.tsx", "helper.cts", "production.mts"]);
     expect(
       collectTestSupportCreateRequireSources(directory).map((file) => path.basename(file)),
-    ).toEqual(["helper.cts", "production.mts"]);
+    ).toEqual(["component.tsx", "helper.cts", "production.mts"]);
   });
 
-  it("does not follow symlinks outside the configured scan root", () => {
+  it("does not follow symlinks outside the configured scan root (#6245)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-create-require-root-"));
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-create-require-outside-"));
     tempDirs.add(directory);
@@ -94,14 +108,14 @@ describe("CLI createRequire budget", () => {
     expect(collectTestSupportCreateRequireSources(directory)).toEqual([]);
   });
 
-  it("requires the budget to fall with the remaining file count", () => {
+  it("requires the budget to fall with the remaining file count (#6245)", () => {
     expect(createRequireBudgetFailure(["src/a.test.ts"], ["src/a.test.ts"])).toBeNull();
     expect(
       createRequireBudgetFailure(["src/a.test.ts"], ["src/a.test.ts", "src/b.test.ts"]),
     ).toContain("Remove retired paths from CLI_CREATE_REQUIRE_FILES");
   });
 
-  it("rejects a new path even when it replaces an allowed path one-for-one", () => {
+  it("rejects a new path even when it replaces an allowed path one-for-one (#6245)", () => {
     const failure = createRequireBudgetFailure(
       ["src/allowed.test.ts", "src/new.test.ts"],
       ["src/allowed.test.ts", "src/retired.test.ts"],

--- a/test/test-create-require-budget.test.ts
+++ b/test/test-create-require-budget.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  collectProductionCreateRequireSources,
+  collectTestSupportCreateRequireSources,
+  containsCreateRequireIdentifier,
+  createRequireBudgetFailure,
+} from "../scripts/checks/test-create-require-budget";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const directory of tempDirs) fs.rmSync(directory, { force: true, recursive: true });
+  tempDirs.clear();
+});
+
+describe("CLI createRequire budget", () => {
+  it("detects direct and namespace-qualified createRequire references", () => {
+    expect(
+      containsCreateRequireIdentifier(
+        'import { createRequire } from "node:module";\ncreateRequire(import.meta.url);',
+      ),
+    ).toBe(true);
+    expect(
+      containsCreateRequireIdentifier(
+        'import * as nodeModule from "node:module";\nnodeModule.createRequire(import.meta.url);',
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores comments and string data that only mention createRequire", () => {
+    expect(
+      containsCreateRequireIdentifier(
+        '// createRequire is documentation\nconst fixture = "createRequire(import.meta.url)";',
+      ),
+    ).toBe(false);
+  });
+
+  it("treats a production createRequire identifier as a real boundary", () => {
+    expect(containsCreateRequireIdentifier("function createRequire() {}")).toBe(true);
+  });
+
+  it("scans TypeScript module variants and non-test support files", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-create-require-budget-"));
+    tempDirs.add(directory);
+    fs.writeFileSync(
+      path.join(directory, "production.mts"),
+      'import { createRequire } from "node:module";',
+    );
+    fs.writeFileSync(
+      path.join(directory, "helper.cts"),
+      'import { createRequire } from "node:module";',
+    );
+    fs.writeFileSync(
+      path.join(directory, "excluded.test.tsx"),
+      'import { createRequire } from "node:module";',
+    );
+
+    expect(
+      collectProductionCreateRequireSources(directory).map((file) => path.basename(file)),
+    ).toEqual(["helper.cts", "production.mts"]);
+    expect(
+      collectTestSupportCreateRequireSources(directory).map((file) => path.basename(file)),
+    ).toEqual(["helper.cts", "production.mts"]);
+  });
+
+  it("requires the budget to fall with the remaining file count", () => {
+    expect(createRequireBudgetFailure(["src/a.test.ts"], ["src/a.test.ts"])).toBeNull();
+    expect(
+      createRequireBudgetFailure(["src/a.test.ts"], ["src/a.test.ts", "src/b.test.ts"]),
+    ).toContain("Remove retired paths from CLI_CREATE_REQUIRE_FILES");
+  });
+
+  it("rejects a new path even when it replaces an allowed path one-for-one", () => {
+    const failure = createRequireBudgetFailure(
+      ["src/allowed.test.ts", "src/new.test.ts"],
+      ["src/allowed.test.ts", "src/retired.test.ts"],
+    );
+
+    expect(failure).toContain("src/new.test.ts");
+    expect(failure).toContain("src/retired.test.ts");
+  });
+});

--- a/test/test-create-require-budget.test.ts
+++ b/test/test-create-require-budget.test.ts
@@ -41,6 +41,13 @@ describe("CLI createRequire budget", () => {
         '// createRequire is documentation\nconst fixture = "createRequire(import.meta.url)";',
       ),
     ).toBe(false);
+    expect(
+      containsCreateRequireIdentifier("const fixture = `createRequire(${notExecutable})`;"),
+    ).toBe(false);
+  });
+
+  it("conservatively treats arbitrary createRequire properties as boundaries", () => {
+    expect(containsCreateRequireIdentifier("helper.createRequire();")).toBe(true);
   });
 
   it("treats a production createRequire identifier as a real boundary", () => {
@@ -69,6 +76,22 @@ describe("CLI createRequire budget", () => {
     expect(
       collectTestSupportCreateRequireSources(directory).map((file) => path.basename(file)),
     ).toEqual(["helper.cts", "production.mts"]);
+  });
+
+  it("does not follow symlinks outside the configured scan root", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-create-require-root-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-create-require-outside-"));
+    tempDirs.add(directory);
+    tempDirs.add(outside);
+    fs.writeFileSync(
+      path.join(outside, "external.ts"),
+      'import { createRequire } from "node:module";',
+    );
+    fs.symlinkSync(outside, path.join(directory, "external"), "dir");
+    fs.symlinkSync(path.join(outside, "external.ts"), path.join(directory, "external.ts"), "file");
+
+    expect(collectProductionCreateRequireSources(directory)).toEqual([]);
+    expect(collectTestSupportCreateRequireSources(directory)).toEqual([]);
   });
 
   it("requires the budget to fall with the remaining file count", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ import {
   shouldRunBranchValidationE2E,
   shouldRunLiveE2E,
 } from "./test/e2e/fixtures/live-project-gate.ts";
+import { sourceLoaderNodeOptions } from "./test/helpers/source-loader-options";
 import { testTimeout } from "./test/helpers/timeouts";
 
 const isGithubActions = process.env.GITHUB_ACTIONS === "true";
@@ -16,7 +17,6 @@ const isCi = isGithubActions || process.env.CI === "true" || process.env.CI === 
 const LIVE_E2E_PROJECT_TIMEOUT_MS = 30 * 60 * 1000;
 const runLiveE2E = shouldRunLiveE2E();
 const runBranchValidationE2E = shouldRunBranchValidationE2E();
-const sourceRequireHook = path.resolve("test/helpers/onboard-script-mocks.cjs");
 const canonicalOpenShellPolicyBoundary = path.resolve(
   "nemoclaw/src/shared/openshell-policy-boundary.cts",
 );
@@ -31,9 +31,7 @@ const typedSourceTransform = {
     include: /\.(?:[cm]?ts|[jt]sx)$/,
   },
 };
-const sourceNodeOptions = [process.env.NODE_OPTIONS, `--require=${sourceRequireHook}`]
-  .filter(Boolean)
-  .join(" ");
+const sourceNodeOptions = sourceLoaderNodeOptions(process.env.NODE_OPTIONS);
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This removes repeated `createRequire` use and CommonJS cache manipulation from the policy-channel, gateway-runtime, and rebuild suites, replaces native-safe seams with typed imports, and keeps heavyweight provider/rebuild dependencies late-bound. It reduces CLI test files using `createRequire` from 44 to 32 and adds exact path guardrails so the remaining seams can only decrease.

## Related Issue
Refs #6245

## Changes
- Convert six policy/channel suites plus runner and status tests to native imports and typed dependency seams.
- Load policy conflict detection from its leaf module while deferring provider and rebuild graphs until their runtime paths execute.
- Replace the gateway-runtime suite's per-test onboard graph load and cache invalidation with a native, late-bound dependency seam.
- Move rebuild-to-onboard calls behind one lazy typed boundary and replace two coverage-timeout rebuild suites with native, phase-focused tests.
- Centralize source-loader `NODE_OPTIONS` quoting/removal, preserving unrelated options and limiting bypass to the explicit compiled-artifact test.
- Enforce exact `createRequire` allowlists for 32 CLI tests and 8 support files across `.ts`, `.mts`, `.cts`, and `.tsx`; production TypeScript remains prohibited and the scanner skips symlinks.
- Expand the repository-check hook matcher to cover every TypeScript module extension.
- Give the compiled CLI dispatch contract enough polling time under CI contention while retaining cleanup headroom.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal test loading, dependency injection, and repository guardrails only; no user-facing behavior or interface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent read-only reviews found no remaining runtime, test-isolation, TypeScript, guardrail, or documentation findings after follow-up.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 13 focused source/integration suites passed 147/147; the parser/guard review batch passed 16/16; all 41 rebuild suites passed 311/311, 13 credential integration tests passed, all 10 shared-harness consumer suites passed 105/105, and the three formerly timing-out suites passed 17/17 from a cold source cache with V8 coverage (67–264 ms per file); all 17 package-contract files passed 290/290; the CLI type-check and 32-CLI/8-support budget passed.
- [x] Applicable broad gate passed — CI-equivalent five-shard CLI/integration coverage merge passed 11,496 tests with zero failures; coverage passed at 71.48% lines, 72.76% functions, 64.01% branches, and 70.86% statements.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
