### PR TITLE
fix(hermes): require pinned sandbox base image

### DIFF
--- a/src/lib/agent/base-image-hermes.test.ts
+++ b/src/lib/agent/base-image-hermes.test.ts
@@ -63,6 +63,7 @@ describe("agent base image provisioning", () => {
         expect.objectContaining({
           pinnedRemoteRef: trackedRef?.[1],
           preferPinnedRemoteRef: true,
+          requirePinnedRemoteRef: true,
         }),
       );
 

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -158,6 +158,7 @@ function createAgentBaseImageResolutionOptions(
     rootDir: ROOT,
     pinnedRemoteRef,
     preferPinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
+    requirePinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
     validateImage,
     validationDescription:
       agent.name === "hermes" ? "the required MCP Streamable HTTP runtime" : undefined,

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -377,6 +377,35 @@ describe("sandbox base-image warm resolution", () => {
     expect(dockerMocks.build).not.toHaveBeenCalled();
   });
 
+  it("skips non-pinned automatic remote candidates when the caller requires the pinned ref", () => {
+    const sourceShaRef = `${IMAGE_NAME}:12345678`;
+    dockerMocks.imageInspect.mockImplementation((ref: string) => ({
+      status: ref === sourceShaRef || ref === "nemoclaw-sandbox-base-local:test" ? 0 : 1,
+    }));
+    dockerMocks.pull.mockReturnValue({ status: 1 });
+
+    const resolved = resolveSandboxBaseImage({
+      ...resolutionOptions(),
+      pinnedRemoteRef: REF,
+      preferPinnedRemoteRef: true,
+      requirePinnedRemoteRef: true,
+    });
+
+    expect(resolved).toMatchObject({
+      ref: "nemoclaw-sandbox-base-local:test",
+      source: "local",
+    });
+    expect(dockerMocks.imageInspect).toHaveBeenCalledWith(REF, {
+      ignoreError: true,
+      suppressOutput: true,
+    });
+    expect(dockerMocks.imageInspect).toHaveBeenCalledWith(sourceShaRef, {
+      ignoreError: true,
+      suppressOutput: true,
+    });
+    expect(dockerMocks.build).not.toHaveBeenCalled();
+  });
+
   it("rebuilds changed inputs before using a Dockerfile-pinned baseline (#4680)", () => {
     sourceMocks.inputsChanged.mockReturnValue(true);
     dockerMocks.imageInspect.mockReturnValue({ status: 1 });

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -141,8 +141,21 @@ function resolvePulledCandidate(
   }
 
   const repoDigest = getRepoDigest(imageName, imageRef);
+  const resolvedRef = repoDigest?.ref || imageRef;
+  if (
+    options.requirePinnedRemoteRef === true &&
+    source !== "override" &&
+    source !== "pinned" &&
+    resolvedRef !== options.pinnedRemoteRef
+  ) {
+    addTraceEvent("nemoclaw.sandbox_base_image.remote_candidate_rejected", {
+      source,
+      reason: "not_pinned_remote_ref",
+    });
+    return null;
+  }
   return {
-    ref: repoDigest?.ref || imageRef,
+    ref: resolvedRef,
     digest: repoDigest?.digest || null,
     source,
     glibcVersion,
@@ -302,7 +315,11 @@ export function resolveSandboxBaseImage(
     if (resolved) return finish(resolved);
   }
 
-  if (options.requireOpenshellSandboxAbi || options.validateImage) {
+  if (
+    options.requireOpenshellSandboxAbi ||
+    options.validateImage ||
+    options.requirePinnedRemoteRef
+  ) {
     const local = resolveLocalCandidate(options);
     return local ? finish(local) : null;
   }

--- a/src/lib/sandbox-base-image/types.ts
+++ b/src/lib/sandbox-base-image/types.ts
@@ -46,6 +46,7 @@ export type ResolveBaseImageOptions = {
   env?: NodeJS.ProcessEnv;
   pinnedRemoteRef?: string;
   preferPinnedRemoteRef?: boolean;
+  requirePinnedRemoteRef?: boolean;
   validateImage?: (imageRef: string) => boolean;
   validationDescription?: string;
   resolutionHint?: SandboxBaseImageResolutionMetadata | null;


### PR DESCRIPTION
## Summary
Hermes sandbox onboarding now requires automatic remote base-image resolution to use the Dockerfile-pinned official Hermes base digest. If the pinned digest is unavailable or incompatible, the resolver skips moving version/source/latest remote candidates and falls back to a validated local base instead of handing an incompatible remote digest to the final Hermes Dockerfile.

## Related Issue
Fixes #6308

## Changes
- Added `requirePinnedRemoteRef` to the sandbox base-image resolver contract.
- Rejected non-pinned automatic remote candidates when that contract is enabled, while preserving explicit override handling.
- Enabled the pinned-only remote contract for Hermes base-image resolution.
- Added regression coverage for pinned-only remote fallback and Hermes resolver options.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal base-image resolution behavior only; no user-facing commands or docs changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: targeted sandbox base-image resolver tests and Hermes base-image tests passed locally; maintainer review requested via this PR.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [ ] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/sandbox-base-image-resolution.test.ts` passed; `npx vitest run --project cli src/lib/agent/base-image-hermes.test.ts src/lib/agent/base-image.test.ts` passed.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run build:cli` passed; `git diff --check` passed. Full `npm test` not run because the focused resolver/build checks cover this narrow change and the repo test script also requires plugin dependency setup outside this fix boundary.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes base image resolution now more strictly prefers the pinned remote image when available.

* **Bug Fixes**
  * Remote image selection now avoids unpinned candidates when a pinned reference is required.
  * Base image resolution can fall back to a local image more reliably when the pinned remote image can’t be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->