### PR TITLE
fix(sandbox): repair docker inference host alias

### DIFF
--- a/src/lib/actions/sandbox/connect-route-repair.test.ts
+++ b/src/lib/actions/sandbox/connect-route-repair.test.ts
@@ -82,6 +82,7 @@ function makeRepairDeps(
     logs: [] as string[],
     errors: [] as string[],
     legacyRepairs: [] as Array<{ sandboxName: string; quiet: boolean }>,
+    directHostRepairs: [] as string[],
     monkeypatches: [] as string[],
     reapplications: [] as string[],
     probeOptions: [] as Array<object | undefined>,
@@ -104,6 +105,10 @@ function makeRepairDeps(
     repairLegacyDnsProxy: vi.fn((sandboxName, quiet) => {
       calls.legacyRepairs.push({ sandboxName, quiet });
       return { exitCode: 0 };
+    }),
+    repairDirectContainerHosts: vi.fn((sandboxName) => {
+      calls.directHostRepairs.push(sandboxName);
+      return { ok: true, changed: true, detail: "added inference.local -> 172.17.0.1" };
     }),
     log: (message) => calls.logs.push(message),
     error: (message) => calls.errors.push(message),
@@ -192,8 +197,8 @@ describe("sandbox connect route repair unit flow", () => {
     expect(calls.reapplications).toEqual([]);
   });
 
-  it("uses inference route reapply instead of legacy DNS repair for docker sandboxes", () => {
-    const { calls, deps } = makeRepairDeps([broken(), healthy()]);
+  it("repairs docker-driver /etc/hosts before falling back to inference route reapply", () => {
+    const { calls, deps } = makeRepairDeps([broken(), broken(), healthy()]);
 
     const result = repairSandboxInferenceRouteWithDeps(
       "docker-box",
@@ -205,8 +210,36 @@ describe("sandbox connect route repair unit flow", () => {
     expect(result.healthy).toBe(true);
     expect(result.repairAttempted).toBe(true);
     expect(calls.legacyRepairs).toEqual([]);
+    expect(calls.directHostRepairs).toEqual(["docker-box"]);
     expect(calls.reapplications).toEqual(["docker-box"]);
+    expect(calls.errors).toContain(
+      "  Warning: inference.local is still unavailable after /etc/hosts repair.",
+    );
     expect(calls.logs).toContain("  inference.local route repaired.");
+  });
+
+  it("accepts docker-driver /etc/hosts repair when it restores inference.local", () => {
+    const { calls, deps } = makeRepairDeps([broken(), healthy()]);
+
+    const result = repairSandboxInferenceRouteWithDeps(
+      "docker-box",
+      sandbox({ openshellDriver: "docker" }),
+      {},
+      deps,
+    );
+
+    expect(result).toEqual({
+      healthy: true,
+      repairAttempted: true,
+      detail: "OK 200",
+    });
+    expect(calls.directHostRepairs).toEqual(["docker-box"]);
+    expect(calls.legacyRepairs).toEqual([]);
+    expect(calls.reapplications).toEqual([]);
+    expect(calls.probeOptions).toEqual([undefined, { attempts: 3, delayMs: 2000 }]);
+    expect(calls.logs).toContain(
+      "  inference.local is unavailable inside 'docker-box'. Repairing /etc/hosts...",
+    );
   });
 
   it("lets the VM monkeypatch satisfy the route before inference reapply", () => {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -13,6 +13,7 @@ import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "../../adapters/openshell/timeouts";
+import { dockerSpawnSync } from "../../adapters/docker/exec";
 import * as agentRuntime from "../../agent/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { D, G, R, YW } from "../../cli/terminal-style";
@@ -30,6 +31,7 @@ import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import { isWsl } from "../../platform";
 import { ROOT } from "../../runner";
 import * as sandboxVersion from "../../sandbox/version";
+import { privilegedSandboxExecArgv } from "../../sandbox/privileged-exec";
 import {
   isSandboxReady,
   isTerminalSandboxPhase,
@@ -111,6 +113,10 @@ export type SandboxInferenceRouteRepairResult = {
 export type SandboxInferenceRouteRepairDeps = {
   isRepairDisabled?: () => boolean;
   probe: (sandboxName: string, options?: InferenceRouteProbeOptions) => SandboxInferenceRouteProbe;
+  repairDirectContainerHosts?: (
+    sandboxName: string,
+    sb: SandboxEntry | null,
+  ) => DirectInferenceHostsRepairResult;
   shouldApplyVmDnsMonkeypatch: (sb: SandboxEntry | null) => boolean;
   applyVmDnsMonkeypatch: (
     sandboxName: string,
@@ -138,6 +144,12 @@ export type ManagedInferenceRouteResetDeps = {
   printUnrecoverableInferenceRoute: (sandboxName: string, route: string, detail: string) => void;
   log?: (message: string) => void;
   error?: (message: string) => void;
+};
+
+type DirectInferenceHostsRepairResult = {
+  ok: boolean;
+  changed: boolean;
+  detail: string;
 };
 
 const INFERENCE_ROUTE_POST_REPAIR_PROBE_ATTEMPTS = 3;
@@ -397,6 +409,66 @@ function shouldUseLegacyDnsProxyRepair(sb: SandboxEntry | null): boolean {
   return driver !== "vm" && driver !== "docker";
 }
 
+function shouldRepairDirectInferenceHosts(sb: SandboxEntry | null): boolean {
+  return sb?.openshellDriver === "docker";
+}
+
+function repairDirectContainerInferenceHosts(
+  sandboxName: string,
+  sb: SandboxEntry | null,
+): DirectInferenceHostsRepairResult {
+  if (!shouldRepairDirectInferenceHosts(sb)) {
+    return { ok: true, changed: false, detail: "not a docker-driver sandbox" };
+  }
+
+  const script = [
+    'hostname="inference.local"',
+    "if awk -v h=\"$hostname\" '{ for (i = 2; i <= NF; i++) if ($i == h) found = 1 } END { exit found ? 0 : 1 }' /etc/hosts; then",
+    '  echo "present"',
+    "  exit 0",
+    "fi",
+    'target="$(awk \'$2 == "host.openshell.internal" { print $1; exit }\' /etc/hosts 2>/dev/null || true)"',
+    'if [ -z "$target" ] && command -v getent >/dev/null 2>&1; then',
+    "  target=\"$(getent hosts host.openshell.internal 2>/dev/null | awk 'NR == 1 { print $1; exit }')\"",
+    "fi",
+    'if [ -z "$target" ]; then',
+    "  target=\"$(ip route show default 2>/dev/null | awk 'NR == 1 { print $3; exit }')\"",
+    "fi",
+    'case "$target" in',
+    '  ""|*[!0-9A-Fa-f:.]*) echo "could not resolve a safe gateway address for inference.local" >&2; exit 1 ;;',
+    "esac",
+    'printf "\\n%s\\t%s\\n" "$target" "$hostname" >> /etc/hosts',
+    'echo "added $hostname -> $target"',
+  ].join("\n");
+
+  try {
+    const result = dockerSpawnSync(
+      privilegedSandboxExecArgv(sandboxName, ["sh", "-eu", "-c", script], false, true),
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+        timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+      },
+    );
+    const output = String(result.stdout || result.stderr || "").trim();
+    if (result.status !== 0) {
+      return {
+        ok: false,
+        changed: false,
+        detail: output || `docker exec exited with status ${String(result.status)}`,
+      };
+    }
+    return {
+      ok: true,
+      changed: /^added\b/.test(output),
+      detail: output || "present",
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, changed: false, detail };
+  }
+}
+
 function buildInferenceSetArgs(provider: string, model: string): string[] {
   const args = ["inference", "set", "--provider", provider, "--model", model, "--no-verify"];
   if (["compatible-endpoint", "ollama-local", "vllm-local"].includes(provider)) {
@@ -439,6 +511,41 @@ export function repairSandboxInferenceRouteWithDeps(
   }
 
   if (!shouldUseLegacyDnsProxyRepair(sb)) {
+    if (shouldRepairDirectInferenceHosts(sb)) {
+      if (!quiet) {
+        log("");
+        log(`  inference.local is unavailable inside '${sandboxName}'. Repairing /etc/hosts...`);
+      }
+      const hostsRepair = deps.repairDirectContainerHosts?.(sandboxName, sb) ?? {
+        ok: true,
+        changed: false,
+        detail: "direct-container host repair unavailable",
+      };
+      const hostsProbe = hostsRepair.ok
+        ? deps.probe(sandboxName, {
+            attempts: INFERENCE_ROUTE_POST_REPAIR_PROBE_ATTEMPTS,
+            delayMs: INFERENCE_ROUTE_POST_REPAIR_PROBE_DELAY_MS,
+          })
+        : null;
+      if (hostsProbe?.healthy) {
+        if (!quiet) {
+          log("  inference.local route repaired.");
+        }
+        return {
+          healthy: true,
+          repairAttempted: true,
+          detail: hostsProbe.detail,
+        };
+      }
+      if (!quiet) {
+        if (!hostsRepair.ok) {
+          error(`  Warning: could not repair inference.local in /etc/hosts: ${hostsRepair.detail}`);
+        } else if (hostsProbe?.broken) {
+          error("  Warning: inference.local is still unavailable after /etc/hosts repair.");
+        }
+      }
+    }
+
     if (deps.shouldApplyVmDnsMonkeypatch(sb)) {
       if (!quiet) {
         log("");
@@ -566,6 +673,7 @@ function repairSandboxInferenceRouteIfNeeded(
     {
       isRepairDisabled: () => process.env.NEMOCLAW_DISABLE_INFERENCE_ROUTE_REPAIR === "1",
       probe: (name, options) => probeSandboxInferenceRoute(name, agent, options),
+      repairDirectContainerHosts: repairDirectContainerInferenceHosts,
       shouldApplyVmDnsMonkeypatch,
       applyVmDnsMonkeypatch: applyOpenShellVmDnsMonkeypatch,
       reapplyVmInferenceRoute: (name, sandbox) => reapplyVmInferenceRoute(name, sandbox, agent),


### PR DESCRIPTION
## Summary
Repair Docker-driver sandbox connect recovery when `inference.local` is missing from the direct container's `/etc/hosts`, which can happen when the NemoClaw gateway is running on a non-default port.

## Related Issue
Fixes #6310

## Changes
- Adds a Docker-driver-only connect-time repair that idempotently injects `inference.local` into the direct sandbox container `/etc/hosts` before reapplying the OpenShell inference route.
- Reuses the sandbox's existing `host.openshell.internal` mapping when present, with the default gateway as fallback.
- Keeps the existing route reapply fallback when host alias repair does not restore the probe.
- Adds route repair regression coverage for alias-only recovery and fallback behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: runtime repair behavior only; no CLI surface or user workflow text changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: focused change is limited to Docker-driver sandbox connect inference repair; privileged exec uses the existing registered-sandbox direct-container resolver and a constant shell script with no user-controlled interpolation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [ ] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `NPM_CONFIG_CACHE=/tmp/nemoclaw-6310-npm-cache npx vitest run --project cli src/lib/actions/sandbox/connect-route-repair.test.ts`: 1 file passed, 13 tests passed.
- [x] Applicable broad gate passed — `npm run typecheck:cli`: passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional local checks:
- `git diff --check`: passed.
- `npx @biomejs/biome lint src/lib/actions/sandbox/connect.ts src/lib/actions/sandbox/connect-route-repair.test.ts`: checked 2 files, no fixes applied.

Known limitations:
- I did not run a live Jetson/OpenShell Docker-driver repro in this environment; the proof is a focused regression test around the connect-time repair boundary.
- Full `npm test` / `npm run check:diff` were not run due scope; targeted behavior, typecheck, lint, and whitespace checks passed.

---
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an additional repair path for sandbox connectivity that can automatically restore local service resolution in supported environments.

* **Bug Fixes**
  * Improved recovery when a sandbox can’t reach the inference endpoint by trying a more direct fix before falling back to the existing repair flow.
  * Added clearer logging and success handling for cases where the connection is restored immediately or still needs further recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->