### PR TITLE
perf(test): reduce layer boundary fixture scans

### DIFF
--- a/scripts/checks/layer-import-boundaries.ts
+++ b/scripts/checks/layer-import-boundaries.ts
@@ -34,6 +34,12 @@ function isProductionTsFile(absPath: string): boolean {
 
 function* walk(dir: string): Generator<string> {
   if (!existsSync(dir)) return;
+  const rootStats = statSync(dir);
+  if (rootStats.isFile()) {
+    if (isProductionTsFile(dir)) yield dir;
+    return;
+  }
+  if (!rootStats.isDirectory()) return;
   for (const entry of readdirSync(dir)) {
     if (SKIP_DIRS.has(entry)) continue;
     const absPath = path.join(dir, entry);

--- a/test/layer-import-boundaries.test.ts
+++ b/test/layer-import-boundaries.test.ts
@@ -1,133 +1,92 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { findLayerImportBoundaryViolations } from "../scripts/checks/layer-import-boundaries";
+
 const REPO_ROOT = path.join(import.meta.dirname, "..");
-const TSX = path.join(REPO_ROOT, "node_modules", ".bin", "tsx");
-const BOUNDARY_SCRIPT = path.join(REPO_ROOT, "scripts", "checks", "layer-import-boundaries.ts");
+let fixtureCounter = 0;
 
-describe("CLI layer import boundaries", () => {
-  it("keeps domain, adapter, action, and command layers separated", () => {
-    const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
-      cwd: REPO_ROOT,
-      encoding: "utf-8",
-    });
+function fixturePath(dir: string, label: string): string {
+  fixtureCounter += 1;
+  return path.join(REPO_ROOT, dir, `__boundary-${label}-${process.pid}-${fixtureCounter}.ts`);
+}
 
-    expect(`${result.stdout}${result.stderr}`).toContain("Layer import boundaries passed.");
-    expect(result.status).toBe(0);
+function scanFixture(fixture: string, source: string) {
+  try {
+    fs.writeFileSync(fixture, source);
+    return findLayerImportBoundaryViolations(fixture);
+  } finally {
+    fs.rmSync(fixture, { force: true });
+  }
+}
+
+describe("CLI layer import boundaries (#6245)", () => {
+  it("keeps domain, adapter, action, and command layers separated (#6245)", () => {
+    expect(findLayerImportBoundaryViolations()).toEqual([]);
   });
 
-  it("collects TypeScript import-equals references", () => {
-    const fixture = path.join(
-      REPO_ROOT,
-      "src",
-      "lib",
-      "domain",
-      `__boundary-import-equals-${process.pid}.ts`,
+  it("collects TypeScript import-equals references (#6245)", () => {
+    const violations = scanFixture(
+      fixturePath("src/lib/domain", "import-equals"),
+      'import adapter = require("../adapters/openshell/client");\nexport const value = adapter;\n',
     );
-    try {
-      fs.writeFileSync(
-        fixture,
-        'import adapter = require("../adapters/openshell/client");\nexport const value = adapter;\n',
-      );
-      const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
-        cwd: REPO_ROOT,
-        encoding: "utf-8",
-      });
 
-      expect(result.status).toBe(1);
-      expect(`${result.stdout}${result.stderr}`).toContain(
-        "domain must not import src/lib/adapters/openshell/client.ts",
-      );
-    } finally {
-      fs.rmSync(fixture, { force: true });
-    }
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          detail: "domain must not import src/lib/adapters/openshell/client.ts",
+        }),
+      ]),
+    );
   });
 
-  it("keeps messaging manifests isolated from side-effect layers", () => {
-    const fixture = path.join(
-      REPO_ROOT,
-      "src",
-      "lib",
-      "messaging",
-      "manifest",
-      `__boundary-fs-${process.pid}.ts`,
+  it("keeps messaging manifests isolated from side-effect layers (#6245)", () => {
+    const violations = scanFixture(
+      fixturePath("src/lib/messaging/manifest", "fs"),
+      'import { readFileSync } from "node:fs";\nexport const value = readFileSync;\n',
     );
-    try {
-      fs.writeFileSync(
-        fixture,
-        'import { readFileSync } from "node:fs";\nexport const value = readFileSync;\n',
-      );
-      const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
-        cwd: REPO_ROOT,
-        encoding: "utf-8",
-      });
 
-      expect(result.status).toBe(1);
-      expect(`${result.stdout}${result.stderr}`).toContain(
-        "messaging manifest modules must not import node:fs",
-      );
-    } finally {
-      fs.rmSync(fixture, { force: true });
-    }
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          detail: "messaging manifest modules must not import node:fs",
+        }),
+      ]),
+    );
   });
 
-  it("blocks bare fs imports in messaging manifests", () => {
-    const fixture = path.join(
-      REPO_ROOT,
-      "src",
-      "lib",
-      "messaging",
-      "manifest",
-      `__boundary-bare-fs-${process.pid}.ts`,
+  it("blocks bare fs imports in messaging manifests (#6245)", () => {
+    const violations = scanFixture(
+      fixturePath("src/lib/messaging/manifest", "bare-fs"),
+      'import { readFile } from "fs/promises";\nexport const value = readFile;\n',
     );
-    try {
-      fs.writeFileSync(
-        fixture,
-        'import { readFile } from "fs/promises";\nexport const value = readFile;\n',
-      );
-      const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
-        cwd: REPO_ROOT,
-        encoding: "utf-8",
-      });
 
-      expect(result.status).toBe(1);
-      expect(`${result.stdout}${result.stderr}`).toContain(
-        "messaging manifest modules must not import fs",
-      );
-    } finally {
-      fs.rmSync(fixture, { force: true });
-    }
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          detail: "messaging manifest modules must not import fs",
+        }),
+      ]),
+    );
   });
 
-  it("counts only classes that extend Command as oclif command classes", () => {
-    const fixture = path.join(
-      REPO_ROOT,
-      "src",
-      "commands",
-      `__boundary-implements-${process.pid}.ts`,
+  it("counts only classes that extend Command as oclif command classes (#6245)", () => {
+    const violations = scanFixture(
+      fixturePath("src/commands", "implements"),
+      'import { Command } from "@oclif/core";\nclass NotACommand implements Command {}\n',
     );
-    try {
-      fs.writeFileSync(
-        fixture,
-        'import { Command } from "@oclif/core";\nclass NotACommand implements Command {}\n',
-      );
-      const result = spawnSync(TSX, [BOUNDARY_SCRIPT], {
-        cwd: REPO_ROOT,
-        encoding: "utf-8",
-      });
 
-      expect(result.status).toBe(1);
-      expect(`${result.stdout}${result.stderr}`).toContain(
-        "command files must define exactly one registered oclif command class; found 0",
-      );
-    } finally {
-      fs.rmSync(fixture, { force: true });
-    }
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          detail: "command files must define exactly one registered oclif command class; found 0",
+        }),
+      ]),
+    );
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
This PR speeds up layer import-boundary integration coverage by calling the checker in-process and scanning each synthetic negative fixture directly, while retaining one repository-wide positive scan. In the contributor's Node 22 local benchmark, the focused test file fell from 15.08s to 3.83s wall time (74.6%).

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Refs #6245

## Changes
<!-- Bullet list of key changes. -->
- Allow the boundary checker to accept a single production TypeScript file as its scan root.
- Replace five external `tsx` invocations with direct `findLayerImportBoundaryViolations()` calls.
- Scope the four negative cases to their synthetic fixtures and assert structured violations directly.

## Performance

Contributor-reported Node 22 measurements:

| Measurement | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Focused test wall time | 15.08s | 3.83s | 74.6% |
| Vitest duration | 13.00s | 2.70s | 79.2% |

The latest reported branch run completed in 2.59s of Vitest duration, with 1.78s of test-body time.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal test/checker performance change with no user-facing behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/layer-import-boundaries.test.ts --reporter=verbose` passed; contributor reported a 2.59s Vitest duration on Node 22.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional contributor-reported checks: `npm run checks`, `npm run build:cli`, `npm run typecheck:cli`, a focused Biome check, and `git diff --check`.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Ho Lim <subhoya@gmail.com>
