### PR TITLE
perf(test): run policy and messaging tests in-process

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -6,7 +6,7 @@
     "src/lib/inference/nim.test.ts": 2068,
     "src/lib/onboard/preflight.test.ts": 1904,
     "test/channels-add-preset.test.ts": 1871,
-    "test/generate-openclaw-config.test.ts": 1945,
+    "test/generate-openclaw-config.test.ts": 1941,
     "test/install-preflight.test.ts": 3934,
     "test/nemoclaw-start.test.ts": 4827,
     "test/onboard-messaging.test.ts": 2062,

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -17,7 +17,7 @@ import {
   applyMessagingBuildPhase,
   readMessagingBuildPlanFromEnv,
 } from "../src/lib/messaging/applier/build/messaging-build-applier.mts";
-import { withLegacyMessagingPlanEnv } from "./messaging-plan-test-helper";
+import { withLegacyMessagingPlanEnvDirect } from "./messaging-plan-test-helper";
 
 const SCRIPT_PATH = path.join(import.meta.dirname, "..", "scripts", "generate-openclaw-config.mts");
 const SCRIPT_ARGS = ["--experimental-strip-types", SCRIPT_PATH];
@@ -50,14 +50,17 @@ function ensureFakeOpenClaw(): string {
 
 function buildTestEnv(envOverrides: Record<string, string> = {}): Record<string, string> {
   ensureFakeOpenClaw();
-  const env = {
+  return {
     PATH: `${tmpDir}:${process.env.PATH || "/usr/bin:/bin"}`,
     ...BASE_ENV,
     ...envOverrides,
     HOME: tmpDir,
   };
-  return withLegacyMessagingPlanEnv(env, "openclaw");
 }
+
+const CHANNELS_ENV = "NEMOCLAW_MESSAGING_CHANNELS_B64";
+const messagingEnv = (channels: string, env: Record<string, string> = {}) =>
+  withLegacyMessagingPlanEnvDirect(buildTestEnv({ ...env, [CHANNELS_ENV]: channels }), "openclaw");
 
 function runConfigScriptRaw(envOverrides: Record<string, string> = {}) {
   const env = buildTestEnv(envOverrides);
@@ -108,6 +111,9 @@ function runConfigScript(envOverrides: Record<string, string> = {}): any {
   return JSON.parse(fs.readFileSync(configPath, "utf-8"));
 }
 
+const runMessagingConfig = async (channels: string, env: Record<string, string> = {}) =>
+  runConfigScript(await messagingEnv(channels, env));
+
 function runConfigSubprocess(envOverrides: Record<string, string> = {}): any {
   const env = buildTestEnv(envOverrides);
   const result = spawnSync("node", SCRIPT_ARGS, {
@@ -133,6 +139,9 @@ function buildBaseConfigDirect(envOverrides: Record<string, string> = {}): any {
   return withConfigEnv(envOverrides, () => buildConfig());
 }
 
+const buildMessagingBaseConfig = async (channels: string, env: Record<string, string> = {}) =>
+  buildBaseConfigDirect(await messagingEnv(channels, env));
+
 function buildConfigDirect(envOverrides: Record<string, string> = {}): any {
   const env = buildTestEnv(envOverrides);
   return withEnv(env, () => {
@@ -145,6 +154,9 @@ function buildConfigDirect(envOverrides: Record<string, string> = {}): any {
     return config;
   });
 }
+
+const buildMessagingConfig = async (channels: string, env: Record<string, string> = {}) =>
+  buildConfigDirect(await messagingEnv(channels, env));
 
 function expectBuildConfigError(envOverrides: Record<string, string>, message: string | RegExp) {
   expect(() => buildConfigDirect(envOverrides)).toThrow(message);
@@ -412,22 +424,22 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(origins).not.toContain("https://ilinkai.wechat.com.com");
   });
 
-  it("leaves messaging render to the messaging build applier", () => {
+  it("leaves messaging render to the messaging build applier", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
-    const config = buildBaseConfigDirect({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await buildMessagingBaseConfig(channels);
     expect(config.channels.telegram).toBeUndefined();
   });
 
-  it("parses messaging channels from base64", () => {
+  it("parses messaging channels from base64", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
-    const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await runMessagingConfig(channels);
     expect(config.channels).toBeDefined();
     expect(config.channels.telegram).toBeDefined();
   });
 
-  it("emits a tokenless WhatsApp config block for QR-paired channels", () => {
+  it("emits a tokenless WhatsApp config block for QR-paired channels", async () => {
     const channels = Buffer.from(JSON.stringify(["whatsapp"])).toString("base64");
-    const config = buildConfigDirect({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await buildMessagingConfig(channels);
     expect(config.channels.whatsapp).toBeDefined();
     expect(config.channels.whatsapp.enabled).toBe(true);
     expect(config.plugins.entries.whatsapp).toEqual({ enabled: true });
@@ -439,9 +451,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(account.appToken).toBeUndefined();
   });
 
-  it("keeps WhatsApp config alongside token-based channels in the same run", () => {
+  it("keeps WhatsApp config alongside token-based channels in the same run", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "whatsapp"])).toString("base64");
-    const config = buildConfigDirect({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await buildMessagingConfig(channels);
     expect(config.channels.telegram.enabled).toBe(true);
     expect(config.plugins.entries.telegram).toEqual({ enabled: true });
     expect(config.channels.telegram.accounts.default.botToken).toBe(
@@ -453,44 +465,39 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.whatsapp.accounts.default.botToken).toBeUndefined();
   });
 
-  it("emits groups with requireMention when TELEGRAM_REQUIRE_MENTION is true (#3022)", () => {
+  it("emits groups with requireMention when TELEGRAM_REQUIRE_MENTION is true (#3022)", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
     const telegramConfig = Buffer.from(JSON.stringify({ requireMention: true })).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_TELEGRAM_CONFIG_B64: telegramConfig,
     });
     expect(config.channels.telegram.accounts.default.groupPolicy).toBe("open");
     expect(config.channels.telegram.groups).toEqual({ "*": { requireMention: true } });
   });
 
-  it("keeps groupPolicy open with no groups stanza when requireMention is false (#3022)", () => {
+  it("keeps groupPolicy open with no groups stanza when requireMention is false (#3022)", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
     const telegramConfig = Buffer.from(JSON.stringify({ requireMention: false })).toString(
       "base64",
     );
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_TELEGRAM_CONFIG_B64: telegramConfig,
     });
     expect(config.channels.telegram.accounts.default.groupPolicy).toBe("open");
     expect(config.channels.telegram.groups).toBeUndefined();
   });
 
-  it("defaults Telegram group replies to require mentions when telegramConfig is empty (#3022)", () => {
+  it("defaults Telegram group replies to require mentions when telegramConfig is empty (#3022)", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
-    });
+    const config = await runMessagingConfig(channels);
     expect(config.channels.telegram.accounts.default.groupPolicy).toBe("open");
     expect(config.channels.telegram.groups).toEqual({ "*": { requireMention: true } });
   });
 
-  it("emits OpenClaw-valid Discord guild allowlist config when guilds are provided", () => {
+  it("emits OpenClaw-valid Discord guild allowlist config when guilds are provided", async () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
     const legacyGuilds = { "1234567890": { enabled: true, requireMention: true } };
-    const config = buildConfigDirect({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await buildMessagingConfig(channels, {
       NEMOCLAW_DISCORD_GUILDS_B64: Buffer.from(JSON.stringify(legacyGuilds)).toString("base64"),
     });
 
@@ -501,13 +508,12 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.guilds["1234567890"].enabled).toBeUndefined();
   });
 
-  it("applies WeChat post-agent-install build-file outputs through the messaging applier", () => {
+  it("applies WeChat post-agent-install build-file outputs through the messaging applier", async () => {
     const channels = Buffer.from(JSON.stringify(["wechat"])).toString("base64");
     const wechatConfig = Buffer.from(
       JSON.stringify({ accountId: "primary", baseUrl: "https://ilinkai.wechat.com", userId: "u1" }),
     ).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_WECHAT_CONFIG_B64: wechatConfig,
     });
 
@@ -524,11 +530,11 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels?.wechat).toBeUndefined();
   });
 
-  it("omits channels.openclaw-weixin when no accountId was captured", () => {
+  it("omits channels.openclaw-weixin when no accountId was captured", async () => {
     // No QR-login result → seed step bails on the empty accountId and
     // leaves openclaw.json untouched, so the bridge stays dormant.
     const channels = Buffer.from(JSON.stringify(["wechat"])).toString("base64");
-    const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await runMessagingConfig(channels);
     expect(config.channels?.["openclaw-weixin"]).toBeUndefined();
     expect(config.channels?.wechat).toBeUndefined();
   });
@@ -568,9 +574,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     }
   });
 
-  it("emits canonical placeholders and proxy routing for non-Slack channels", () => {
+  it("emits canonical placeholders and proxy routing for non-Slack channels", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
-    const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await runMessagingConfig(channels);
     expect(config.proxy).toMatchObject({
       enabled: true,
       proxyUrl: "http://10.200.0.1:3128",
@@ -590,10 +596,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("routes Discord gateway traffic through OpenClaw's managed proxy (#3894)", () => {
+  it("routes Discord gateway traffic through OpenClaw's managed proxy (#3894)", async () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_PROXY_HOST: "10.201.0.9",
       NEMOCLAW_PROXY_PORT: "43128",
     });
@@ -610,10 +615,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("does not write a Discord account proxy when the managed proxy is configured", () => {
+  it("does not write a Discord account proxy when the managed proxy is configured", async () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_PROXY_PORT: "43128",
     });
 
@@ -621,10 +625,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("can defer OpenClaw managed proxy config for build-time doctor", () => {
+  it("can defer OpenClaw managed proxy config for build-time doctor", async () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_OPENCLAW_MANAGED_PROXY: "0",
     });
 
@@ -632,10 +635,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("ignores the OpenShell loopback proxy env var when using OpenClaw managed proxy", () => {
+  it("ignores the OpenShell loopback proxy env var when using OpenClaw managed proxy", async () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       OPENSHELL_LOOPBACK_PROXY_URL: "http://127.0.0.1:45211",
       NEMOCLAW_DISCORD_PROXY_PORT: "43129",
     });
@@ -644,10 +646,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("keeps Telegram on the OpenShell proxy while Discord relies on the managed proxy", () => {
+  it("keeps Telegram on the OpenShell proxy while Discord relies on the managed proxy", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_PROXY_HOST: "10.201.0.9",
       NEMOCLAW_PROXY_PORT: "43128",
     });
@@ -657,9 +658,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.channels.discord.accounts.default.proxy).toBeUndefined();
   });
 
-  it("emits Bolt-shape placeholders for Slack so the SDK's prefix regex passes", () => {
+  it("emits Bolt-shape placeholders for Slack so the SDK's prefix regex passes", async () => {
     const channels = Buffer.from(JSON.stringify(["slack"])).toString("base64");
-    const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await runMessagingConfig(channels);
     expect(config.channels.slack.enabled).toBe(true);
     expect(config.plugins.entries.slack).toEqual({ enabled: true });
     const slack = config.channels.slack.accounts.default;
@@ -671,7 +672,7 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(slack.appToken).toMatch(/^xapp-[A-Za-z0-9_-]+$/);
   });
 
-  it("marks Telegram and Discord channels enabled so OpenClaw loads the bridges (#4314, #4390)", () => {
+  it("marks Telegram and Discord channels enabled so OpenClaw loads the bridges (#4314, #4390)", async () => {
     // Regression: OpenClaw 2026.5.22 no longer auto-starts a channel bridge
     // from the account-level enabled flag alone. The Slack mitigation in
     // PR #4222 added `channels.slack.enabled: true`; #4314 / #4390 reported
@@ -679,19 +680,18 @@ describe("generate-openclaw-config.mts: config generation", () => {
     // too. Bake the top-level enabled marker for every credential-backed
     // messaging channel.
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
-    const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await runMessagingConfig(channels);
     expect(config.channels.telegram.enabled).toBe(true);
     expect(config.channels.discord.enabled).toBe(true);
     expect(config.channels.telegram.accounts.default.enabled).toBe(true);
     expect(config.channels.discord.accounts.default.enabled).toBe(true);
   });
 
-  it("uses Telegram allowed IDs for direct-message allowlisting (#4553)", () => {
+  it("uses Telegram allowed IDs for direct-message allowlisting (#4553)", async () => {
     const allowedUsers = ["8388960805", "8388960806"];
     const channels = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
     const allowedIds = Buffer.from(JSON.stringify({ telegram: allowedUsers })).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: allowedIds,
     });
     const telegram = config.channels.telegram.accounts.default;
@@ -702,12 +702,11 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(telegram.allowFrom).toEqual(allowedUsers);
   });
 
-  it("uses Slack allowed IDs for DMs and channel mention allowlisting (#3729)", () => {
+  it("uses Slack allowed IDs for DMs and channel mention allowlisting (#3729)", async () => {
     const allowedUsers = ["U01ABC2DEF3", "U04GHI5JKL6"];
     const channels = Buffer.from(JSON.stringify(["slack"])).toString("base64");
     const allowedIds = Buffer.from(JSON.stringify({ slack: allowedUsers })).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: allowedIds,
     });
     const slack = config.channels.slack.accounts.default;
@@ -726,14 +725,13 @@ describe("generate-openclaw-config.mts: config generation", () => {
     });
   });
 
-  it("uses Slack allowed channels to scope channel @mentions", () => {
+  it("uses Slack allowed channels to scope channel @mentions", async () => {
     const allowedUsers = ["U01ABC2DEF3", "U04GHI5JKL6"];
     const allowedChannels = ["C012AB3CD", "C987ZY6XW"];
     const channels = Buffer.from(JSON.stringify(["slack"])).toString("base64");
     const allowedIds = Buffer.from(JSON.stringify({ slack: allowedUsers })).toString("base64");
     const slackConfig = Buffer.from(JSON.stringify({ allowedChannels })).toString("base64");
-    const config = runConfigScript({
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channels,
+    const config = await runMessagingConfig(channels, {
       NEMOCLAW_MESSAGING_ALLOWED_IDS_B64: allowedIds,
       NEMOCLAW_SLACK_CONFIG_B64: slackConfig,
     });
@@ -1779,9 +1777,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.plugins.entries.xai).toBeUndefined();
   });
 
-  it("enables the discord plugin entry when Discord is configured (#4246)", () => {
+  it("enables the discord plugin entry when Discord is configured (#4246)", async () => {
     const channels = Buffer.from(JSON.stringify(["discord"])).toString("base64");
-    const config = runConfigScript({ NEMOCLAW_MESSAGING_CHANNELS_B64: channels });
+    const config = await runMessagingConfig(channels);
     expect(config.plugins.entries.discord).toEqual({ enabled: true });
   });
 
@@ -1853,20 +1851,18 @@ describe("generate-openclaw-config.mts: empty-string env vars fall back to defau
     expect(config.gateway.controlUi.allowedOrigins).toEqual(["http://127.0.0.1:18789"]);
   });
 
-  it("treats empty NEMOCLAW_PROXY_HOST as unset and uses the documented default", () => {
+  it("treats empty NEMOCLAW_PROXY_HOST as unset and uses the documented default", async () => {
     const channelB64 = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
-    const cfg = runConfigScript({
+    const cfg = await runMessagingConfig(channelB64, {
       NEMOCLAW_PROXY_HOST: "",
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channelB64,
     });
     expect(cfg.channels.telegram.accounts.default.proxy).toBe("http://10.200.0.1:3128");
   });
 
-  it("treats empty NEMOCLAW_PROXY_PORT as unset and uses the documented default", () => {
+  it("treats empty NEMOCLAW_PROXY_PORT as unset and uses the documented default", async () => {
     const channelB64 = Buffer.from(JSON.stringify(["telegram"])).toString("base64");
-    const cfg = runConfigScript({
+    const cfg = await runMessagingConfig(channelB64, {
       NEMOCLAW_PROXY_PORT: "",
-      NEMOCLAW_MESSAGING_CHANNELS_B64: channelB64,
     });
     expect(cfg.channels.telegram.accounts.default.proxy).toBe("http://10.200.0.1:3128");
   });

--- a/test/onboard-preset-diff.test.ts
+++ b/test/onboard-preset-diff.test.ts
@@ -8,176 +8,100 @@
 // previously-applied ones that are no longer selected.
 
 import assert from "node:assert/strict";
-import { type SpawnSyncReturns, spawnSync } from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 
-const repoRoot = path.join(import.meta.dirname, "..");
+import { parsePolicyPresetEnv } from "../src/lib/core/url-utils";
+import {
+  type SetupPolicySelectionDeps,
+  type SetupPolicySelectionOptions,
+  setupPoliciesWithSelection,
+} from "../src/lib/onboard/policy-selection";
+import * as policy from "../src/lib/policy";
+import * as tiers from "../src/lib/policy/tiers";
 
-function runScript(scriptBody: string): SpawnSyncReturns<string> {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-preset-diff-"));
-  const scriptPath = path.join(tmpDir, "script.js");
-  fs.writeFileSync(scriptPath, scriptBody);
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (
-      key.startsWith("DISCORD_") ||
-      key.startsWith("SLACK_") ||
-      key.startsWith("TELEGRAM_") ||
-      // Teams credentials span both prefixes: the core bot credentials use
-      // `MSTEAMS_*` (MSTEAMS_APP_ID/APP_PASSWORD/TENANT_ID/PORT) while a couple
-      // of config keys use `TEAMS_*` (TEAMS_ALLOWED_USERS/REQUIRE_MENTION).
-      // Scrub both so a real `MSTEAMS_*` token can't activate Teams in the child.
-      key.startsWith("TEAMS_") ||
-      key.startsWith("MSTEAMS_") ||
-      key.startsWith("WECHAT_") ||
-      key.startsWith("WHATSAPP_")
-    ) {
-      delete env[key];
-    }
-  }
-  const result = spawnSync(process.execPath, [scriptPath], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    env: {
-      ...env,
-      HOME: tmpDir,
-      NEMOCLAW_NON_INTERACTIVE: "1",
-    },
-    timeout: 15000,
-  });
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-  return result;
-}
+vi.mock("../src/lib/onboard/policy-context-seed", () => ({
+  seedInitialPolicyContext: vi.fn(),
+}));
+
+const builtInPresets = policy.listPresets();
+const builtInPresetNames = new Set(builtInPresets.map((preset) => preset.name));
+
+type PolicyScenarioOptions = {
+  tierEnv?: string;
+  policyMode?: string;
+  policyPresets?: string;
+  alreadyApplied?: string[];
+  selectionOptions?: SetupPolicySelectionOptions;
+};
+
+type PolicyScenarioResult = {
+  chosen: string[];
+  appliedCalls: string[];
+  removedCalls: string[];
+  finalApplied: string[];
+};
 
 /**
- * Build a preamble that:
- *   - seeds `applied` to simulate the user's prior onboard (Balanced defaults)
- *   - tracks every applyPreset / removePreset call so the test can assert
- *     exactly what the preset-diff logic did
- *   - stubs the heavy I/O surfaces the same way policy-tiers-onboard.test.ts does
+ * Exercise the typed policy-selection seam with in-memory policy state. The
+ * production selection, tier, support, clamping, and channel-merging logic stays
+ * real; only sandbox readiness and gateway mutation are replaced with fakes.
  */
-function buildPreamble({
-  tierEnv = "balanced",
-  policyMode = "custom",
-  policyPresets = "npm",
-  alreadyApplied = ["npm", "pypi", "huggingface", "brew", "brave"],
-} = {}): string {
-  const credPath = JSON.stringify(path.join(repoRoot, "src", "lib", "credentials", "store.ts"));
-  const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-  const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-  const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
-  const resolveOpenshellPath = JSON.stringify(
-    path.join(repoRoot, "src", "lib", "adapters", "openshell", "resolve.ts"),
-  );
-  const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-
-  return String.raw`
-// All stubs MUST be installed before requiring onboard so its module-level
-// destructuring picks up the patched functions.
-Object.defineProperty(process, "platform", { value: "darwin" });
-
-const resolver = require(${resolveOpenshellPath});
-resolver.resolveOpenshell = () => "/fake/openshell";
-
-const runner = require(${runnerPath});
-runner.run = () => {};
-runner.runCapture = (command) => {
-  const text = Array.isArray(command) ? command.join(" ") : String(command);
-  if (text.includes("sandbox list")) return "test-sb Ready";
-  return "Running";
-};
-
-const credentials = require(${credPath});
-credentials.prompt = async (msg) => { throw new Error("unexpected prompt: " + msg); };
-credentials.ensureApiKey = async () => {};
-credentials.getCredential = () => null;
-
-const registry = require(${registryPath});
-const updates = [];
-registry.registerSandbox = () => true;
-registry.updateSandbox = (_name, fields) => { updates.push(fields); return true; };
-registry.getSandbox = () => ({ name: "test-sb", model: null, provider: null, policies: ${JSON.stringify(alreadyApplied)} });
-
-const policies = require(${policiesPath});
-const appliedCalls = [];
-const removedCalls = [];
-let appliedState = ${JSON.stringify(alreadyApplied)}.slice();
-policies.getAppliedPresets = () => appliedState.slice();
-policies.applyPreset = (_name, preset) => {
-  appliedCalls.push(preset);
-  if (!appliedState.includes(preset)) appliedState.push(preset);
-  // Mirror production contract: real applyPreset returns true on success
-  // and false on recoverable errors (unknown preset, malformed YAML, etc).
-  return true;
-};
-policies.applyPresets = (_name, presets) => {
-  for (const preset of presets) {
-    appliedCalls.push(preset);
-    if (!appliedState.includes(preset)) appliedState.push(preset);
-  }
-  return true;
-};
-policies.removePreset = (_name, preset) => {
-  removedCalls.push(preset);
-  appliedState = appliedState.filter((p) => p !== preset);
-  return true;
-};
-
-process.env.NEMOCLAW_POLICY_TIER = ${JSON.stringify(tierEnv)};
-process.env.NEMOCLAW_POLICY_MODE = ${JSON.stringify(policyMode)};
-process.env.NEMOCLAW_POLICY_PRESETS = ${JSON.stringify(policyPresets)};
-
-const { setupPoliciesWithSelection } = require(${onboardPath});
-`;
-}
-
-/**
- * Run one `setupPoliciesWithSelection` scenario end-to-end in a child process:
- * build the stub preamble, drive the call with `selectionOptions`, and return
- * the parsed `{ chosen, appliedCalls, removedCalls, finalApplied }` payload after
- * asserting the script ran cleanly. Collapses the identical preamble + IIFE +
- * run/parse boilerplate each scenario would otherwise repeat; callers keep only
- * their scenario-specific assertions.
- */
-function runPolicyScenario({
+async function runPolicyScenario({
   tierEnv,
   policyMode,
   policyPresets,
   alreadyApplied,
   selectionOptions = {},
-}: {
-  tierEnv?: string;
-  policyMode?: string;
-  policyPresets?: string;
-  alreadyApplied?: string[];
-  selectionOptions?: Record<string, unknown>;
-} = {}): {
-  chosen: string[];
-  appliedCalls: string[];
-  removedCalls: string[];
-  finalApplied: string[];
-} {
-  const script =
-    buildPreamble({ tierEnv, policyMode, policyPresets, alreadyApplied }) +
-    String.raw`
-console.log = () => {};
-(async () => {
-  try {
-    const chosen = await setupPoliciesWithSelection("test-sb", ${JSON.stringify(selectionOptions)});
-    process.stdout.write(JSON.stringify({ chosen, appliedCalls, removedCalls, finalApplied: appliedState }) + "\n");
-  } catch (err) {
-    process.stdout.write(JSON.stringify({ error: err.message }) + "\n");
-  }
-})();
-`;
-  const result = runScript(script);
-  assert.equal(result.status, 0, result.stderr);
-  const payload = JSON.parse(result.stdout.trim());
-  assert.ok(!payload.error, `unexpected error: ${payload.error}`);
-  return payload;
+}: PolicyScenarioOptions = {}): Promise<PolicyScenarioResult> {
+  const effectiveTier = tierEnv ?? "balanced";
+  const effectiveApplied = alreadyApplied ?? ["npm", "pypi", "huggingface", "brew", "brave"];
+  const customPresets = effectiveApplied
+    .filter((name) => !builtInPresetNames.has(name))
+    .map((name) => ({ name }));
+  const appliedCalls: string[] = [];
+  const removedCalls: string[] = [];
+  let appliedState = [...effectiveApplied];
+  const env: NodeJS.ProcessEnv = {
+    NEMOCLAW_NON_INTERACTIVE: "1",
+    NEMOCLAW_POLICY_TIER: effectiveTier,
+    NEMOCLAW_POLICY_MODE: policyMode ?? "custom",
+    NEMOCLAW_POLICY_PRESETS: policyPresets ?? "npm",
+  };
+
+  const deps: SetupPolicySelectionDeps = {
+    policies: {
+      setupPolicyPresetSupported: policy.setupPolicyPresetSupported,
+      listSetupPolicyPresets: (_sandboxName, options = {}) => [
+        ...policy.filterSetupPolicyPresets(builtInPresets, options),
+        ...customPresets,
+      ],
+      listCustomPresets: () => customPresets,
+      getAppliedPresets: () => [...appliedState],
+      clampSetupPolicyPresetNames: policy.clampSetupPolicyPresetNames,
+    },
+    tiers,
+    localInferenceProviders: ["ollama-local", "vllm-local"],
+    step: () => undefined,
+    note: () => undefined,
+    isNonInteractive: () => true,
+    waitForSandboxReady: () => true,
+    syncPresetSelection: (_sandboxName, current, selected) => {
+      const currentSet = new Set(current);
+      const selectedSet = new Set(selected);
+      removedCalls.push(...current.filter((name) => !selectedSet.has(name)));
+      appliedCalls.push(...selected.filter((name) => !currentSet.has(name)));
+      appliedState = [...selected];
+    },
+    selectPolicyTier: async () => effectiveTier,
+    selectTierPresetsAndAccess: async () => {
+      throw new Error("unexpected interactive policy selection");
+    },
+    parsePolicyPresetEnv,
+    env,
+  };
+
+  const chosen = await setupPoliciesWithSelection(deps, "test-sb", selectionOptions);
+  return { chosen, appliedCalls, removedCalls, finalApplied: appliedState };
 }
 
 describe("setupPoliciesWithSelection preset diff (#2177)", () => {
@@ -185,8 +109,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // defaults (applies 5 presets), second with NEMOCLAW_POLICY_PRESETS=npm —
   // expects the final sandbox to have ONLY npm. Previously-applied presets
   // must be removed.
-  it("non-interactive narrow selection removes previously-applied presets", () => {
-    const payload = runPolicyScenario({ policyMode: "custom", policyPresets: "npm" });
+  it("non-interactive narrow selection removes previously-applied presets", async () => {
+    const payload = await runPolicyScenario({ policyMode: "custom", policyPresets: "npm" });
 
     // User asked for only npm.
     assert.deepEqual(payload.chosen, ["npm"]);
@@ -213,8 +137,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // onboard. Tier defaults are recomputed against the current provider, so a
   // user-added preset such as `local-inference` is not in `suggestions` on a
   // cloud-provider sandbox — without the additive guard it would be removed.
-  it("non-interactive suggested re-onboard preserves user-added presets", () => {
-    const payload = runPolicyScenario({
+  it("non-interactive suggested re-onboard preserves user-added presets", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       // Balanced defaults plus a manually-added preset.
@@ -252,8 +176,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // recorded on the sandbox alongside built-in presets. They must survive a
   // non-interactive re-onboard the same way named built-ins do — even though
   // they do not appear in `policies.listPresets()`.
-  it("non-interactive suggested re-onboard preserves custom presets", () => {
-    const payload = runPolicyScenario({
+  it("non-interactive suggested re-onboard preserves custom presets", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       alreadyApplied: ["npm", "pypi", "huggingface", "brew", "brave", "my-internal-api"],
@@ -271,8 +195,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     );
   });
 
-  it("non-interactive suggested re-onboard removes unsupported Brave preset", () => {
-    const payload = runPolicyScenario({
+  it("non-interactive suggested re-onboard removes unsupported Brave preset", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       alreadyApplied: ["npm", "pypi", "huggingface", "brew", "brave", "my-internal-api"],
@@ -298,8 +222,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     ]);
   });
 
-  it("resume selection removes unsupported Brave preset", () => {
-    const payload = runPolicyScenario({
+  it("resume selection removes unsupported Brave preset", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       alreadyApplied: ["npm", "brave"],
@@ -311,8 +235,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     assert.deepEqual(payload.finalApplied, ["npm"]);
   });
 
-  it("resume selection preserves the Slack policy required by a recorded Slack channel", () => {
-    const payload = runPolicyScenario({
+  it("resume selection preserves the Slack policy required by a recorded Slack channel", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       alreadyApplied: ["slack"],
@@ -328,8 +252,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     assert.deepEqual(payload.finalApplied.slice().sort(), ["npm", "pypi", "slack"]);
   });
 
-  it("custom non-interactive selection preserves the Slack policy required by Slack messaging", () => {
-    const payload = runPolicyScenario({
+  it("custom non-interactive selection preserves the Slack policy required by Slack messaging", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "custom",
       policyPresets: "npm,pypi",
       alreadyApplied: ["slack"],
@@ -353,8 +277,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // `policy-list` shows `○ discord` even though Discord was configured during
   // onboard. The Slack tests above pass purely because Slack happens to be
   // requiredAtCreate; these tests guard the channels that are not.
-  it("resume selection applies the Discord policy required by a configured Discord channel (#5967)", () => {
-    const payload = runPolicyScenario({
+  it("resume selection applies the Discord policy required by a configured Discord channel (#5967)", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       // Discord is not injected at create time, so it is absent from the
@@ -371,8 +295,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     assert.deepEqual(payload.finalApplied.slice().sort(), ["discord", "npm", "pypi"]);
   });
 
-  it("custom non-interactive selection applies the Discord policy required by Discord messaging (#5967)", () => {
-    const payload = runPolicyScenario({
+  it("custom non-interactive selection applies the Discord policy required by Discord messaging (#5967)", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "custom",
       policyPresets: "npm,pypi",
       alreadyApplied: [],
@@ -387,8 +311,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     assert.deepEqual(payload.finalApplied.slice().sort(), ["discord", "npm", "pypi"]);
   });
 
-  it("custom non-interactive selection removes disabled Discord while honoring the explicit preset list (#5967)", () => {
-    const payload = runPolicyScenario({
+  it("custom non-interactive selection removes disabled Discord while honoring the explicit preset list (#5967)", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "custom",
       policyPresets: "npm",
       alreadyApplied: ["npm", "pypi", "discord"],
@@ -406,8 +330,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // exercising it end-to-end through the real `setupPoliciesWithSelection` path
   // guards the security-critical egress-policy application for a second, distinct
   // non-required channel (not just Discord).
-  it("resume selection applies the Telegram policy required by a configured Telegram channel (#5967)", () => {
-    const payload = runPolicyScenario({
+  it("resume selection applies the Telegram policy required by a configured Telegram channel (#5967)", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "suggested",
       policyPresets: "",
       alreadyApplied: [],
@@ -422,8 +346,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     assert.deepEqual(payload.finalApplied.slice().sort(), ["npm", "pypi", "telegram"]);
   });
 
-  it("custom non-interactive selection removes disabled Telegram while honoring the explicit preset list (#5967)", () => {
-    const payload = runPolicyScenario({
+  it("custom non-interactive selection removes disabled Telegram while honoring the explicit preset list (#5967)", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "custom",
       policyPresets: "npm",
       alreadyApplied: ["npm", "pypi", "telegram"],
@@ -441,8 +365,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // case guards the egress-policy application for every shipped channel — not
   // only the two already covered above (#5967).
   for (const channel of ["teams", "whatsapp", "wechat"]) {
-    it(`resume selection applies the ${channel} policy required by a configured ${channel} channel (#5967)`, () => {
-      const payload = runPolicyScenario({
+    it(`resume selection applies the ${channel} policy required by a configured ${channel} channel (#5967)`, async () => {
+      const payload = await runPolicyScenario({
         policyMode: "suggested",
         policyPresets: "",
         alreadyApplied: [],
@@ -457,8 +381,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
       assert.deepEqual(payload.finalApplied.slice().sort(), ["npm", "pypi", channel].sort());
     });
 
-    it(`custom non-interactive selection removes disabled ${channel} while honoring the explicit preset list (#5967)`, () => {
-      const payload = runPolicyScenario({
+    it(`custom non-interactive selection removes disabled ${channel} while honoring the explicit preset list (#5967)`, async () => {
+      const payload = await runPolicyScenario({
         policyMode: "custom",
         policyPresets: "npm",
         alreadyApplied: ["npm", "pypi", channel],
@@ -471,8 +395,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     });
   }
 
-  it("custom non-interactive selection removes disabled Slack while honoring the explicit preset list", () => {
-    const payload = runPolicyScenario({
+  it("custom non-interactive selection removes disabled Slack while honoring the explicit preset list", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "custom",
       policyPresets: "npm",
       alreadyApplied: ["npm", "pypi", "slack"],
@@ -484,8 +408,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
     assert.deepEqual(payload.finalApplied, ["npm"]);
   });
 
-  it("suggested non-interactive selection removes disabled Slack from tier defaults", () => {
-    const payload = runPolicyScenario({
+  it("suggested non-interactive selection removes disabled Slack from tier defaults", async () => {
+    const payload = await runPolicyScenario({
       tierEnv: "open",
       policyMode: "suggested",
       policyPresets: "",
@@ -506,8 +430,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
 
   // Widening the selection (user re-enables a preset they'd previously dropped)
   // must apply the new one and not re-apply things that are already applied.
-  it("non-interactive widen selection applies only new presets", () => {
-    const payload = runPolicyScenario({
+  it("non-interactive widen selection applies only new presets", async () => {
+    const payload = await runPolicyScenario({
       policyMode: "custom",
       policyPresets: "npm,pypi",
       alreadyApplied: ["npm"],

--- a/test/policy-preset-sync.test.ts
+++ b/test/policy-preset-sync.test.ts
@@ -28,7 +28,7 @@ function runScript(scriptBody: string): SpawnSyncReturns<string> {
 }
 
 describe("policy preset sync", () => {
-  it("batches only all-built-in additions and preserves mixed preset order", () => {
+  it("batches built-in additions and preserves mixed and removal order", () => {
     const policiesPath = JSON.stringify(path.join(repoRoot, "src", "lib", "policy", "index.ts"));
     const syncPath = JSON.stringify(
       path.join(repoRoot, "src", "lib", "onboard", "policy-preset-sync.ts"),
@@ -44,6 +44,7 @@ policies.removePreset = (_sandbox, name) => { calls.push("remove:" + name); retu
 const { syncPresetSelection } = require(${syncPath});
 syncPresetSelection("test-sb", [], ["npm", "pypi"]);
 syncPresetSelection("test-sb", [], ["npm", "custom", "pypi"]);
+syncPresetSelection("test-sb", ["slack", "npm", "pypi"], ["npm"]);
 process.stdout.write(JSON.stringify(calls) + "\n");
 `;
 
@@ -54,6 +55,8 @@ process.stdout.write(JSON.stringify(calls) + "\n");
       "single:npm",
       "single:custom",
       "single:pypi",
+      "remove:slack",
+      "remove:pypi",
     ]);
   });
 });

--- a/test/presets-checkbox.test.ts
+++ b/test/presets-checkbox.test.ts
@@ -1,16 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
-import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { execTimeout } from "./helpers/timeouts";
-
-const REPO_ROOT = path.join(import.meta.dirname, "..");
-const ONBOARD_PATH = JSON.stringify(path.join(REPO_ROOT, "src", "lib", "onboard.ts"));
-const CREDENTIALS_PATH = JSON.stringify(
-  path.join(REPO_ROOT, "src", "lib", "credentials", "store.ts"),
-);
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPolicySelectionPromptHelpers,
+  type PolicySelectionPromptDeps,
+} from "../src/lib/onboard/policy-selection-prompts";
 
 type Preset = {
   name: string;
@@ -29,140 +24,159 @@ const SAMPLE_PRESETS: Preset[] = [
 ];
 
 /**
- * Parse the JSON result from the last non-empty line of stdout.
- * The subprocess writes console.log output (preset listing, messages) to
- * stdout before the final JSON line, so we must look at only the last line.
- */
-function parseResult(stdout: string): string[] {
-  const lines = stdout.trim().split("\n").filter(Boolean);
-  const parsed: Array<string | null> = JSON.parse(lines[lines.length - 1]);
-  return Array.isArray(parsed)
-    ? parsed.filter((entry): entry is string => typeof entry === "string")
-    : [];
-}
-
-/**
- * Run presetsCheckboxSelector in a subprocess where neither stdin nor stdout
- * is a TTY (spawnSync uses pipes), forcing the non-TTY fallback path.
+ * Run presetsCheckboxSelector with neither stdin nor stdout marked as a TTY,
+ * forcing the non-TTY fallback path.
  *
  * `promptResponse` is what the stubbed prompt() returns — i.e., whatever the
  * user would have typed at the "Select presets" prompt.
  */
-function runCheckboxSelector(
+async function runCheckboxSelector(
   promptResponse: string,
   { presets = SAMPLE_PRESETS, initialSelected = [] }: SelectorOptions = {},
 ) {
-  // Stub credentials.prompt BEFORE requiring onboard so the destructured
-  // binding inside onboard.js picks up the stub at load time.
-  const script = String.raw`
-const credentials = require(${CREDENTIALS_PATH});
-credentials.prompt = () => Promise.resolve(${JSON.stringify(promptResponse)});
-const { presetsCheckboxSelector } = require(${ONBOARD_PATH});
-
-const presets = JSON.parse(process.env.NEMOCLAW_TEST_PRESETS);
-const initialSelected = JSON.parse(process.env.NEMOCLAW_TEST_INITIAL || "[]");
-
-presetsCheckboxSelector(presets, initialSelected)
-  .then((result) => {
-    process.stdout.write(JSON.stringify(result) + "\n");
-  })
-  .catch((err) => {
-    process.stderr.write(String(err) + "\n");
-    process.exit(1);
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+    stdout.push(args.map(String).join(" "));
   });
-`;
+  const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    stderr.push(args.map(String).join(" "));
+  });
+  const prompt = vi.fn(async () => promptResponse);
 
-  return spawnSync(process.execPath, ["-e", script], {
-    cwd: REPO_ROOT,
-    encoding: "utf-8",
-    timeout: execTimeout(5_000),
-    env: {
-      ...process.env,
-      NEMOCLAW_TEST_PRESETS: JSON.stringify(presets),
-      NEMOCLAW_TEST_INITIAL: JSON.stringify(initialSelected),
-      NO_COLOR: "1",
+  const deps: PolicySelectionPromptDeps = {
+    tiers: {
+      listTiers: () => [],
+      getTier: () => null,
     },
-  });
+    policyTierEnv: {
+      resolvePolicyTierFromEnv: () => "balanced",
+    },
+    isNonInteractive: () => false,
+    note: () => undefined,
+    prompt,
+    selectFromNumberedMenuOrExit: () => {
+      throw new Error("unexpected numbered-menu selection");
+    },
+    makeOnboardCancelExit: (_rollback, cleanup) => () => cleanup(),
+    sandboxCancelRollback: { markCancelled: () => undefined },
+    useColor: false,
+    stdin: {
+      isTTY: false,
+      on: () => undefined,
+      pause: () => undefined,
+      removeListener: () => undefined,
+      resume: () => undefined,
+      setEncoding: () => undefined,
+      setRawMode: () => undefined,
+    },
+    stdout: {
+      isTTY: false,
+      write: () => true,
+    },
+    processEvents: {
+      once: () => undefined,
+      removeListener: () => undefined,
+    },
+  };
+
+  try {
+    const selection = await createPolicySelectionPromptHelpers(deps).presetsCheckboxSelector(
+      presets,
+      initialSelected,
+    );
+    return {
+      status: 0,
+      selection,
+      stdout: `${stdout.join("\n")}\n`,
+      stderr: stderr.length > 0 ? `${stderr.join("\n")}\n` : "",
+      prompt,
+    };
+  } finally {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  }
 }
 
 describe("presetsCheckboxSelector (non-TTY path)", () => {
   describe("zero presets", () => {
-    it("returns [] immediately without calling prompt", () => {
-      const result = runCheckboxSelector("should-not-matter", { presets: [] });
+    it("returns [] immediately without calling prompt", async () => {
+      const result = await runCheckboxSelector("should-not-matter", { presets: [] });
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual([]);
+      expect(result.selection).toEqual([]);
+      expect(result.prompt).not.toHaveBeenCalled();
     });
 
-    it("prints a friendly message when no presets exist", () => {
-      const result = runCheckboxSelector("", { presets: [] });
+    it("prints a friendly message when no presets exist", async () => {
+      const result = await runCheckboxSelector("", { presets: [] });
       expect(result.stdout).toContain("No policy presets are available.");
     });
   });
 
   describe("empty input", () => {
-    it("returns [] when the user presses Enter without typing", () => {
-      const result = runCheckboxSelector("");
+    it("returns [] when the user presses Enter without typing", async () => {
+      const result = await runCheckboxSelector("");
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual([]);
+      expect(result.selection).toEqual([]);
     });
 
-    it("prints 'Skipping policy presets.' on empty input", () => {
-      const result = runCheckboxSelector("  ");
+    it("prints 'Skipping policy presets.' on empty input", async () => {
+      const result = await runCheckboxSelector("  ");
       expect(result.stdout).toContain("Skipping policy presets.");
     });
   });
 
   describe("valid input", () => {
-    it("returns a single named preset", () => {
-      const result = runCheckboxSelector("npm");
+    it("returns a single named preset", async () => {
+      const result = await runCheckboxSelector("npm");
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual(["npm"]);
+      expect(result.selection).toEqual(["npm"]);
     });
 
-    it("returns multiple comma-separated presets in order", () => {
-      const result = runCheckboxSelector("npm, pypi");
+    it("returns multiple comma-separated presets in order", async () => {
+      const result = await runCheckboxSelector("npm, pypi");
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual(["npm", "pypi"]);
+      expect(result.selection).toEqual(["npm", "pypi"]);
     });
 
-    it("trims whitespace around each name", () => {
-      const result = runCheckboxSelector("  npm  ,  slack  ");
+    it("trims whitespace around each name", async () => {
+      const result = await runCheckboxSelector("  npm  ,  slack  ");
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual(["npm", "slack"]);
+      expect(result.selection).toEqual(["npm", "slack"]);
     });
   });
 
   describe("unknown preset names", () => {
-    it("drops unknown names and returns only valid ones", () => {
-      const result = runCheckboxSelector("npm, typo");
+    it("drops unknown names and returns only valid ones", async () => {
+      const result = await runCheckboxSelector("npm, typo");
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual(["npm"]);
+      expect(result.selection).toEqual(["npm"]);
     });
 
-    it("warns about each unknown name on stderr", () => {
+    it("warns about each unknown name on stderr", async () => {
       // console.error() → stderr; console.log() → stdout
-      const result = runCheckboxSelector("npm, typo, alsowrong");
+      const result = await runCheckboxSelector("npm, typo, alsowrong");
       expect(result.stderr).toContain("Unknown preset name ignored: typo");
       expect(result.stderr).toContain("Unknown preset name ignored: alsowrong");
     });
 
-    it("returns [] when all names are unknown", () => {
-      const result = runCheckboxSelector("bad1, bad2");
+    it("returns [] when all names are unknown", async () => {
+      const result = await runCheckboxSelector("bad1, bad2");
       expect(result.status).toBe(0);
-      expect(parseResult(result.stdout)).toEqual([]);
+      expect(result.selection).toEqual([]);
     });
   });
 
   describe("preset listing output", () => {
-    it("prints all preset names in the listing", () => {
-      const result = runCheckboxSelector("");
+    it("prints all preset names in the listing", async () => {
+      const result = await runCheckboxSelector("");
       expect(result.stdout).toContain("npm");
       expect(result.stdout).toContain("pypi");
       expect(result.stdout).toContain("slack");
     });
 
-    it("marks initialSelected presets as checked ([✓]) and others as unchecked ([ ])", () => {
-      const result = runCheckboxSelector("", { initialSelected: ["npm"] });
+    it("marks initialSelected presets as checked ([✓]) and others as unchecked ([ ])", async () => {
+      const result = await runCheckboxSelector("", { initialSelected: ["npm"] });
       expect(result.stdout).toContain("[✓]");
       expect(result.stdout).toContain("[ ]");
       // npm line should have the check, pypi should not
@@ -173,17 +187,17 @@ describe("presetsCheckboxSelector (non-TTY path)", () => {
       expect(pypiLine).toContain("[ ]");
     });
 
-    it("shows descriptions alongside names", () => {
-      const result = runCheckboxSelector("");
+    it("shows descriptions alongside names", async () => {
+      const result = await runCheckboxSelector("");
       expect(result.stdout).toContain("npm and Yarn registry access");
       expect(result.stdout).toContain("Python Package Index (PyPI) access");
     });
   });
 
   describe("NO_COLOR respected", () => {
-    it("uses plain [✓] marker when NO_COLOR is set", () => {
-      const result = runCheckboxSelector("", { initialSelected: ["npm"] });
-      // NO_COLOR is set in the test env; no ANSI escape codes expected
+    it("uses plain [✓] marker when NO_COLOR is set", async () => {
+      const result = await runCheckboxSelector("", { initialSelected: ["npm"] });
+      // Color output is disabled through the injected dependency.
       expect(result.stdout).not.toContain("\x1b[");
     });
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Replace unit-shaped policy and messaging test subprocesses with the repository's existing in-process planner and typed dependency seams. The focused Node 22 benchmark falls from 26.02s to 2.82s wall time while preserving all 163 scenarios and the two genuine executable-boundary checks.

## Related Issue
Addresses #6245.

## Changes
- build legacy OpenClaw messaging plans in-process for 24 config scenarios instead of launching `npx tsx` per scenario
- exercise policy selection and non-TTY preset prompts directly with isolated in-memory dependencies, removing another 31 Node child launches
- retain the two real config-generator executable checks and strengthen the concrete policy-sync test with ordered removal coverage
- ratchet the legacy `generate-openclaw-config` test-file budget from 1,945 to 1,941 lines after compacting the harness
- reduce the supported-Node-22 focused benchmark from 26.02s to 2.82s wall time (89.2%) and test execution from 24.16s to 0.92s

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-harness-only optimization; no user-facing configuration, behavior, or output contract changes
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Node 22 focused run: 3 files, 163/163 passed; concrete policy-sync removal test: 1/1 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run locally; final-head CI will run the complete coverage corpus
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preset selection behavior so additions and removals are handled more reliably in mixed scenarios.
  * Kept generated configuration output consistent while tightening the expected size budget.

* **Tests**
  * Expanded coverage for preset descriptions, non-interactive selection flows, and messaging-related configuration generation.
  * Updated test harnesses to validate behavior more directly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->