### PR TITLE
perf(test): remove mocked recovery waits

### DIFF
--- a/test/process-recovery-forward-failure.test.ts
+++ b/test/process-recovery-forward-failure.test.ts
@@ -15,6 +15,7 @@ const { checkAndRecoverSandboxProcesses } = requireSource(
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 function withFakeOpenshellBinary<T>(fn: () => T): T {
@@ -131,6 +132,8 @@ beta  127.0.0.1  18789  12345  running`,
     const childProcess = requireSource("node:child_process");
     let teamsForwardStarted = false;
 
+    // Forward visibility is fixed by mocks, so the production settle window is unnecessary.
+    vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 0,
       stdout: "__NEMOCLAW_SANDBOX_EXEC_STARTED__\nRUNNING\n",

--- a/test/process-recovery.test.ts
+++ b/test/process-recovery.test.ts
@@ -371,6 +371,8 @@ hermes-box  127.0.0.1  18789  12345  running`;
       return { status: 0, stdout: "GATEWAY_PID=4242\n", stderr: "" };
     });
 
+    // The gateway retry is under test; host-forward readiness is fully mocked.
+    vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
     process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS = "2";
     process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS = "0";
     process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS = "0";
@@ -455,6 +457,8 @@ hermes-box  127.0.0.1  18789  12345  running`;
       stderr,
     }));
 
+    // Preserve managed recovery retries without sleeping between mocked supervisor attempts.
+    vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS", "0");
     vi.spyOn(childProcess, "spawnSync").mockImplementation(
       (_command: unknown, rawArgs: unknown) => {
         const shellCommand = getSandboxExecShellCommand(rawArgs);
@@ -847,6 +851,8 @@ hermes-box  127.0.0.1  8642  12346  running`;
       stderr: "",
     }));
 
+    // Forward visibility is fixed by mocks, so the production settle window is unnecessary.
+    vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 0,
       stdout: "__NEMOCLAW_SANDBOX_EXEC_STARTED__\nRUNNING\n",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
This PR removes production-length recovery waits from four fully mocked integration scenarios by setting the existing delay controls to zero within those tests. Production defaults and the dedicated forward-release timing contracts remain unchanged; on Node 22, the focused pair fell from 16.15s to 1.65s wall time.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Refs #6245

## Changes
<!-- Bullet list of key changes. -->
- Preserve mocked Hermes supervisor retries without sleeping between attempts.
- Skip the production forward-visibility window in three scenarios whose outcomes are fully controlled by mocks.
- Restore stubbed environment values after the forward-failure tests.
- Reduce the four affected assertions from 15.028s combined to 22ms while retaining the explicit 1000ms delayed-release and 150ms fail-closed tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test-only timing cleanup; production defaults, configuration, and user-visible behavior are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Node 22.16.0; `npx --yes --package=node@22.16.0 node ./node_modules/vitest/vitest.mjs run --project integration test/process-recovery.test.ts test/process-recovery-forward-failure.test.ts --reporter=verbose`; 29/29 passed in 1.06s Vitest time (1.65s wall).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated recovery test coverage to run faster and more reliably by removing unnecessary wait times in mocked scenarios.
  * Improved test isolation by resetting environment stubs after each test.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->