### PR TITLE
perf(test): run channel preset tests in-process

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -5,7 +5,6 @@
     "nemoclaw/src/commands/migration-state.test.ts": 1566,
     "src/lib/inference/nim.test.ts": 2068,
     "src/lib/onboard/preflight.test.ts": 1904,
-    "test/channels-add-preset.test.ts": 1871,
     "test/generate-openclaw-config.test.ts": 1941,
     "test/install-preflight.test.ts": 3934,
     "test/nemoclaw-start.test.ts": 4827,

--- a/test/channels-add-preset.test.ts
+++ b/test/channels-add-preset.test.ts
@@ -122,7 +122,6 @@ let promptSpy: MockInstance;
 let getCredentialSpy: MockInstance;
 let saveCredentialSpy: MockInstance;
 let deleteCredentialSpy: MockInstance;
-let getSandboxSpy: MockInstance;
 let updateSandboxSpy: MockInstance;
 let applyPresetSpy: MockInstance;
 let removePresetSpy: MockInstance;
@@ -147,7 +146,6 @@ let slackBotProbe: ProbeResult;
 let slackAppProbe: ProbeResult;
 let testConfig: Record<string, unknown>;
 let testLog: string;
-let execCalls: Array<{ name: string; command: string }>;
 let testHome: string;
 
 const originalBuildPlan = MessagingWorkflowPlanner.prototype.buildPlan;
@@ -194,7 +192,6 @@ beforeEach(() => {
   slackAppProbe = successfulProbe('{"ok":true,"url":"wss://wss-primary.slack.com/link"}');
   testConfig = {};
   testLog = "";
-  execCalls = [];
 
   logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
     callOrder.push(
@@ -206,7 +203,7 @@ beforeEach(() => {
     throw new ExitError(code);
   }) as never);
 
-  getSandboxSpy = vi.spyOn(registry, "getSandbox").mockImplementation(() => registryEntry);
+  vi.spyOn(registry, "getSandbox").mockImplementation(() => registryEntry);
   vi.spyOn(registry, "listSandboxes").mockImplementation(() => ({
     sandboxes: [registryEntry],
     defaultSandbox: "test-sb",
@@ -301,8 +298,7 @@ beforeEach(() => {
 
   execSpy = vi
     .spyOn(processRecovery, "executeSandboxExecCommand")
-    .mockImplementation((name, command) => {
-      execCalls.push({ name, command });
+    .mockImplementation((_name, command) => {
       return command.includes("/sandbox/.openclaw/openclaw.json")
         ? { status: 0, stdout: JSON.stringify(testConfig), stderr: "" }
         : command.includes("tail -n 400") && command.includes("/tmp/gateway.log")

--- a/test/channels-add-preset.test.ts
+++ b/test/channels-add-preset.test.ts
@@ -1,1871 +1,802 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Regression test for #3437 — `nemoclaw <sandbox> channels add <channel>`
-// must apply the channel's matching network policy preset BEFORE triggering
-// the rebuild, so the rebuild's backup manifest captures the preset and
-// the bridge has egress to its upstream API after the new sandbox boots.
 
-import assert from "node:assert/strict";
-import { type SpawnSyncReturns, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { addSandboxChannel, removeSandboxChannel } from "../src/lib/actions/sandbox/policy-channel";
+import { policyChannelDependencies } from "../src/lib/actions/sandbox/policy-channel-dependencies";
+import * as processRecovery from "../src/lib/actions/sandbox/process-recovery";
+import * as httpProbe from "../src/lib/adapters/http/probe";
+import * as runtime from "../src/lib/adapters/openshell/runtime";
+import * as store from "../src/lib/credentials/store";
+import * as gatewayRuntime from "../src/lib/gateway-runtime-action";
+import { MessagingWorkflowPlanner, type SandboxMessagingPlan } from "../src/lib/messaging";
+import {
+  getMessagingChannelConfigEnvKeys,
+  MESSAGING_CHANNEL_CONFIG_ENV_KEYS,
+} from "../src/lib/messaging-channel-config";
+import * as policies from "../src/lib/policy";
+import { getChannelTokenKeys, knownChannelNames, listChannels } from "../src/lib/sandbox/channels";
+import * as onboardSession from "../src/lib/state/onboard-session";
+import type { SandboxEntry } from "../src/lib/state/registry";
+import * as registry from "../src/lib/state/registry";
 
-const repoRoot = path.join(import.meta.dirname, "..");
-const j = (p: string) =>
-  JSON.stringify(path.join(repoRoot, "src", "lib", p.replace(/\.js$/, ".ts")));
-
-function runScript(
-  scriptBody: string,
-  extraEnv: Record<string, string> = {},
-): SpawnSyncReturns<string> {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-3437-"));
-  const scriptPath = path.join(tmpDir, "script.js");
-  fs.writeFileSync(scriptPath, scriptBody);
-  const result = spawnSync(process.execPath, [scriptPath], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-    env: {
-      ...process.env,
-      HOME: tmpDir,
-      NEMOCLAW_NON_INTERACTIVE: "1",
-      NEMOCLAW_SKIP_SLACK_AUTH_VALIDATION: "",
-      TELEGRAM_BOT_TOKEN: "test-telegram-token",
-      SLACK_BOT_TOKEN: "xoxb-slack-bot-token-for-test",
-      SLACK_APP_TOKEN: "xapp-slack-app-token-for-test",
-      DISCORD_BOT_TOKEN: "test-discord-token",
-      NEMOCLAW_SKIP_TELEGRAM_REACHABILITY: "1",
-      ...extraEnv,
-    },
-    timeout: 15000,
-  });
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-  return result;
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
 }
 
-function parseResultPayload<T extends Record<string, any> = Record<string, any>>(
-  result: SpawnSyncReturns<string>,
-): T {
-  const marker = result.stdout.lastIndexOf("__RESULT__");
-  assert.ok(marker >= 0, `no __RESULT__ marker in stdout:\n${result.stdout}`);
-  const payload = JSON.parse(result.stdout.slice(marker + "__RESULT__".length).trim()) as T;
-  assert.ok(!payload.error, `unexpected error: ${payload.error}\n${payload.stack || ""}`);
-  return payload;
-}
+type ProbeResult = ReturnType<typeof httpProbe.runCurlProbe>;
 
-// Build a preamble that:
-//   - stubs every module touched by addSandboxChannel so no real openshell,
-//     gateway, or filesystem credential write happens
-//   - records every policies.applyPreset call in `appliedCalls`
-//   - records the relative order of applyPreset vs promptAndRebuild via
-//     a console.log marker, so the test can assert the ordering invariant
-//     (apply MUST precede rebuild)
-function buildPreamble({
-  presetNamesAvailable = ["telegram", "slack", "discord", "npm", "github"],
-  applyPresetResult = true,
-  appliedPresets = [] as string[],
-  sandboxAgent = "openclaw",
-  sessionSandboxName = "test-sb",
-  sessionPolicyPresets = ["npm", "pypi", "huggingface", "brew"] as string[] | null,
-  sessionLoadThrows = false,
-  sessionUpdateThrows = false,
-  sessionMissing = false,
-  presetFileMissing = false,
-  presetMissingNetworkPolicies = false,
-  presetMalformedYaml = false,
-}: {
-  presetNamesAvailable?: string[];
-  applyPresetResult?: boolean;
-  appliedPresets?: string[];
-  sandboxAgent?: string;
-  sessionSandboxName?: string | null;
-  sessionPolicyPresets?: string[] | null;
-  sessionLoadThrows?: boolean;
-  sessionUpdateThrows?: boolean;
-  sessionMissing?: boolean;
-  presetFileMissing?: boolean;
-  presetMissingNetworkPolicies?: boolean;
-  presetMalformedYaml?: boolean;
-} = {}): string {
-  return String.raw`
-const resolver = require(${j("adapters/openshell/resolve.js")});
-resolver.resolveOpenshell = () => "/fake/openshell";
+const TEST_ENV_KEYS = new Set([
+  ...listChannels().flatMap((channel) => getChannelTokenKeys(channel)),
+  ...MESSAGING_CHANNEL_CONFIG_ENV_KEYS.flatMap((key) => getMessagingChannelConfigEnvKeys(key)),
+  "NEMOCLAW_MESSAGING_PLAN_B64",
+  "NEMOCLAW_NON_INTERACTIVE",
+  "NEMOCLAW_SKIP_SLACK_AUTH_VALIDATION",
+  "NEMOCLAW_SKIP_TELEGRAM_REACHABILITY",
+]);
+const originalProcessEnv = { ...process.env };
 
-const openshellRuntime = require(${j("adapters/openshell/runtime.js")});
-openshellRuntime.runOpenshell = () => ({ status: 0, stdout: "", stderr: "" });
-
-const processRecovery = require(${j("actions/sandbox/process-recovery.js")});
-processRecovery.executeSandboxExecCommand = () => ({ status: 0, stdout: "NEMOCLAW_CHANNEL_CLEAR_OK", stderr: "" });
-processRecovery.executeSandboxCommand = () => null;
-
-const runner = require(${j("runner.js")});
-runner.run = () => ({ status: 0, stdout: "", stderr: "" });
-runner.runCapture = () => "";
-
-const gatewayRuntime = require(${j("gateway-runtime-action.js")});
-gatewayRuntime.recoverNamedGatewayRuntime = async () => ({ recovered: true });
-
-const credentials = require(${j("credentials/store.js")});
-const savedCredentialKeys = [];
-const deletedCredentialKeys = [];
-const credentialSaveCalls = [];
-credentials.getCredential = (key) => process.env[key] || null;
-credentials.saveCredential = (key, value) => {
-  savedCredentialKeys.push(key);
-  credentialSaveCalls.push({ key, value });
-  callOrder.push("saveCredential:" + key);
-  return true;
-};
-credentials.deleteCredential = (key) => {
-  deletedCredentialKeys.push(key);
-  return true;
-};
-credentials.prompt = async (msg) => { throw new Error("unexpected prompt: " + msg); };
-
-const onboard = require(${j("onboard.js")});
-onboard.isNonInteractive = () => true;
-
-const onboardProviders = require(${j("onboard/providers.js")});
-const providerCalls = [];
-onboardProviders.upsertMessagingProviders = (defs) => {
-  providerCalls.push(...defs);
-  callOrder.push("upsertMessagingProviders");
-};
-
-const workflowPlanner = require(${j("messaging/compiler/workflow-planner.js")});
-const originalBuildPlan = workflowPlanner.MessagingWorkflowPlanner.prototype.buildPlan;
-const buildPlanCalls = [];
-workflowPlanner.MessagingWorkflowPlanner.prototype.buildPlan = async function(context) {
-  if (context.workflow === "add-channel") buildPlanCalls.push({
-    sandboxName: context.sandboxName,
-    agent: context.agent,
-    workflow: context.workflow,
-    isInteractive: context.isInteractive,
-    configuredChannels: context.configuredChannels,
-    disabledChannels: context.disabledChannels,
-    supportedChannelIds: context.supportedChannelIds,
-  });
-  return originalBuildPlan.call(this, context);
-};
-
-const registry = require(${j("state/registry.js")});
-const registryUpdates = [];
-function makeMessagingPlan(sandboxName, channelIds = [], disabledChannels = []) {
+function makeMessagingPlan(
+  sandboxName: string,
+  channelIds: string[] = [],
+  disabledChannels: string[] = [],
+  agent = "openclaw",
+): SandboxMessagingPlan {
   const disabled = new Set(disabledChannels);
-  return { schemaVersion: 1, sandboxName, agent: ${JSON.stringify(sandboxAgent)}, workflow: "onboard", channels: channelIds.map((channelId) => ({ channelId, displayName: channelId, authMode: channelId === "whatsapp" ? "in-sandbox-qr" : "token-paste", active: !disabled.has(channelId), selected: true, configured: true, disabled: disabled.has(channelId), inputs: [], hooks: [] })), disabledChannels, credentialBindings: [], networkPolicy: { presets: [], entries: [] }, agentRender: [], buildSteps: [], stateUpdates: [], healthChecks: [] };
-}
-function makeRegistryEntry(channelIds = [], disabledChannels = []) {
   return {
-    name: "test-sb",
-    agent: ${JSON.stringify(sandboxAgent)},
-    ...(channelIds.length > 0
-      ? { messaging: { schemaVersion: 1, plan: makeMessagingPlan("test-sb", channelIds, disabledChannels) } }
-      : {}),
+    schemaVersion: 1,
+    sandboxName,
+    agent: agent as SandboxMessagingPlan["agent"],
+    workflow: "onboard",
+    channels: channelIds.map((channelId) => ({
+      channelId: channelId as SandboxMessagingPlan["channels"][number]["channelId"],
+      displayName: channelId,
+      authMode: channelId === "whatsapp" ? "in-sandbox-qr" : "token-paste",
+      active: !disabled.has(channelId),
+      selected: true,
+      configured: true,
+      disabled: disabled.has(channelId),
+      inputs: [],
+      hooks: [],
+    })),
+    disabledChannels: disabledChannels as SandboxMessagingPlan["disabledChannels"],
+    credentialBindings: [],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
   };
 }
-registry.getSandbox = () => makeRegistryEntry();
-registry.updateSandbox = (name, updates) => {
-  registryUpdates.push({ name, updates });
-  return true;
-};
 
-const policies = require(${j("policy/index.js")});
-const appliedCalls = [];
-const removedCalls = [];
-const callOrder = [];
-policies.listPresets = () => ${JSON.stringify(presetNamesAvailable.map((name) => ({ name })))};
-function stubPresetContent(name) {
-  if (${JSON.stringify(presetFileMissing)}) return null;
-  if (${JSON.stringify(presetMissingNetworkPolicies)}) return "name: " + name + "\ndescription: \"stub preset without network_policies\"\n";
-  if (${JSON.stringify(presetMalformedYaml)}) return "network_policies:\n  - [unclosed\n";
-  return "network_policies:\n  " + name + ":\n    egress:\n      - host: example.com";
+function makeRegistryEntry(
+  channelIds: string[] = [],
+  disabledChannels: string[] = [],
+  agent = sandboxAgent,
+): SandboxEntry {
+  return {
+    name: "test-sb",
+    agent,
+    ...(channelIds.length > 0
+      ? {
+          messaging: {
+            schemaVersion: 1,
+            plan: makeMessagingPlan("test-sb", channelIds, disabledChannels, agent),
+          },
+        }
+      : {}),
+  } as SandboxEntry;
 }
-policies.loadPreset = (name) => stubPresetContent(name);
-policies.loadPresetForSandbox = (sandboxName, name) => { callOrder.push("loadPresetForSandbox:" + sandboxName + ":" + name); return stubPresetContent(name); };
-policies.applyPreset = (sandboxName, presetName) => {
-  appliedCalls.push({ sandboxName, presetName });
-  callOrder.push("applyPreset:" + presetName);
-  return ${JSON.stringify(applyPresetResult)};
-};
-policies.removePreset = (sandboxName, presetName) => {
-  removedCalls.push({ sandboxName, presetName });
-  callOrder.push("removePreset:" + presetName);
-  return true;
-};
-policies.getAppliedPresets = () => ${JSON.stringify(appliedPresets)};
 
-const httpProbe = require(${j("adapters/http/probe.js")});
-const slackProbeCalls = [];
-const slackProbeOk = (body = '{"ok":true}') => ({
-  ok: true,
-  httpStatus: 200,
-  curlStatus: 0,
-  body,
-  stderr: "",
-  message: "",
-});
-httpProbe.runCurlProbe = (argv) => {
-  const url = argv[argv.length - 1];
-  if (typeof url === "string" && url.includes("slack.com/api/")) {
-    slackProbeCalls.push(argv);
-    callOrder.push(url.includes("auth.test") ? "slackProbe:bot" : "slackProbe:app");
-    if (url.includes("auth.test")) return global.__slackBotProbe || slackProbeOk();
-    if (url.includes("apps.connections.open")) return global.__slackAppProbe || slackProbeOk('{"ok":true,"url":"wss://wss-primary.slack.com/link"}');
-  }
-  return slackProbeOk();
-};
+function successfulOpenshellResult(): ReturnType<typeof runtime.runOpenshell> {
+  return {
+    pid: 0,
+    output: [null, "", ""],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  };
+}
 
-// Stub onboardSession so the new policyPresets-sync helper has something
-// to read/write. The test asserts on sessionUpdates to verify the
-// helper kept session.policyPresets aligned with the registry.
-const onboardSession = require(${j("state/onboard-session.js")});
-const sessionUpdates = [];
-const sessionLoadConfig = ${JSON.stringify({
-    sessionSandboxName,
-    sessionPolicyPresets,
-    sessionLoadThrows,
-    sessionMissing,
-  })};
-const sessionUpdateThrows = ${JSON.stringify(sessionUpdateThrows)};
-let sessionState = sessionLoadConfig.sessionMissing
-  ? null
-  : {
-      sandboxName: sessionLoadConfig.sessionSandboxName,
-      policyPresets: Array.isArray(sessionLoadConfig.sessionPolicyPresets)
-        ? [...sessionLoadConfig.sessionPolicyPresets]
-        : sessionLoadConfig.sessionPolicyPresets,
-    };
-onboardSession.loadSession = () => {
-  if (sessionLoadConfig.sessionLoadThrows) throw new Error("simulated load failure");
-  return sessionState;
-};
-onboardSession.updateSession = (mutator) => {
-  if (sessionUpdateThrows) throw new Error("simulated save failure");
-  // Mirror the real updateSession contract: load → mutate → save.
-  if (!sessionState) sessionState = { sandboxName: null, policyPresets: null };
-  const next = mutator(sessionState) || sessionState;
-  sessionState = next;
-  sessionUpdates.push({
-    policyPresets: Array.isArray(next.policyPresets) ? [...next.policyPresets] : next.policyPresets,
+function successfulProbe(body = '{"ok":true}'): ProbeResult {
+  return {
+    ok: true,
+    httpStatus: 200,
+    curlStatus: 0,
+    body,
+    stderr: "",
+    message: "",
+  };
+}
+
+let logSpy: MockInstance;
+let errorSpy: MockInstance;
+let exitSpy: MockInstance;
+let promptSpy: MockInstance;
+let getCredentialSpy: MockInstance;
+let saveCredentialSpy: MockInstance;
+let deleteCredentialSpy: MockInstance;
+let getSandboxSpy: MockInstance;
+let updateSandboxSpy: MockInstance;
+let applyPresetSpy: MockInstance;
+let removePresetSpy: MockInstance;
+let loadPresetForSandboxSpy: MockInstance;
+let providerSpy: MockInstance;
+let rebuildSpy: MockInstance;
+let runOpenshellSpy: MockInstance;
+let curlProbeSpy: MockInstance;
+let execSpy: MockInstance;
+let buildPlanSpy: MockInstance;
+
+let sandboxAgent: string;
+let registryEntry: SandboxEntry;
+let appliedPresets: string[];
+let presetContent: string | null;
+let applyPresetResult: boolean;
+let sessionState: onboardSession.Session | null;
+let sessionUpdateThrows: boolean;
+let sessionUpdates: Array<{ policyPresets: string[] | null }>;
+let callOrder: string[];
+let slackBotProbe: ProbeResult;
+let slackAppProbe: ProbeResult;
+let testConfig: Record<string, unknown>;
+let testLog: string;
+let execCalls: Array<{ name: string; command: string }>;
+let testHome: string;
+
+const originalBuildPlan = MessagingWorkflowPlanner.prototype.buildPlan;
+
+function printedText(): string {
+  return [...logSpy.mock.calls, ...errorSpy.mock.calls]
+    .map((call) => call.map(String).join(" "))
+    .join("\n");
+}
+
+async function expectExit(action: () => Promise<void>): Promise<void> {
+  await expect(action()).rejects.toMatchObject({ code: 1 });
+  expect(exitSpy).toHaveBeenCalledWith(1);
+}
+
+function setSession(
+  sandboxName: string | null = "test-sb",
+  policyPresets: string[] | null = ["npm", "pypi", "huggingface", "brew"],
+): void {
+  sessionState = { sandboxName, policyPresets } as onboardSession.Session;
+}
+
+beforeEach(() => {
+  for (const key of TEST_ENV_KEYS) delete process.env[key];
+  testHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-channels-add-preset-"));
+  process.env.HOME = testHome;
+  process.env.NEMOCLAW_NON_INTERACTIVE = "1";
+  process.env.NEMOCLAW_SKIP_TELEGRAM_REACHABILITY = "1";
+  process.env.TELEGRAM_BOT_TOKEN = "test-telegram-token";
+  process.env.SLACK_BOT_TOKEN = "xoxb-slack-bot-token-for-test";
+  process.env.SLACK_APP_TOKEN = "xapp-slack-app-token-for-test";
+  process.env.DISCORD_BOT_TOKEN = "test-discord-token";
+
+  sandboxAgent = "openclaw";
+  registryEntry = makeRegistryEntry();
+  appliedPresets = [];
+  presetContent = "network_policies:\n  stub:\n    egress:\n      - host: example.com\n";
+  applyPresetResult = true;
+  setSession();
+  sessionUpdateThrows = false;
+  sessionUpdates = [];
+  callOrder = [];
+  slackBotProbe = successfulProbe();
+  slackAppProbe = successfulProbe('{"ok":true,"url":"wss://wss-primary.slack.com/link"}');
+  testConfig = {};
+  testLog = "";
+  execCalls = [];
+
+  logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    callOrder.push(
+      ...(args.map(String).join(" ").includes("Change queued") ? ["promptAndRebuild"] : []),
+    );
   });
-  return next;
-};
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code);
+  }) as never);
 
-// Tag the rebuild-prompt branch via stdout so we can compare ordering.
-// In NEMOCLAW_NON_INTERACTIVE mode, promptAndRebuild logs "Change queued."
-// and returns immediately without invoking rebuildSandbox.
-const origLog = console.log;
-console.log = (...args) => {
-  const line = args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ");
-  if (line.includes("Change queued")) callOrder.push("promptAndRebuild");
-  origLog.call(console, ...args);
-};
+  getSandboxSpy = vi.spyOn(registry, "getSandbox").mockImplementation(() => registryEntry);
+  vi.spyOn(registry, "listSandboxes").mockImplementation(() => ({
+    sandboxes: [registryEntry],
+    defaultSandbox: "test-sb",
+  }));
+  updateSandboxSpy = vi.spyOn(registry, "updateSandbox").mockReturnValue(true);
 
-const channelModule = require(${j("actions/sandbox/policy-channel.js")});
+  loadPresetForSandboxSpy = vi
+    .spyOn(policies, "loadPresetForSandbox")
+    .mockImplementation((sandboxName, presetName) => {
+      callOrder.push(`loadPresetForSandbox:${sandboxName}:${presetName}`);
+      return presetContent;
+    });
+  vi.spyOn(policies, "listPresets").mockImplementation(() =>
+    ["telegram", "slack", "discord", "whatsapp", "npm", "github"].map((name) => ({
+      name,
+      file: `${name}.yaml`,
+      description: `${name} test preset`,
+    })),
+  );
+  applyPresetSpy = vi.spyOn(policies, "applyPreset").mockImplementation((name, presetName) => {
+    callOrder.push(`applyPreset:${presetName}`);
+    return applyPresetResult;
+  });
+  removePresetSpy = vi.spyOn(policies, "removePreset").mockImplementation((_name, presetName) => {
+    callOrder.push(`removePreset:${presetName}`);
+    return true;
+  });
+  vi.spyOn(policies, "getAppliedPresets").mockImplementation(() => appliedPresets);
 
-module.exports = {
-  channelModule,
-  appliedCalls,
-  removedCalls,
-  callOrder,
-  providerCalls,
-  registryUpdates,
-  sessionUpdates,
-  buildPlanCalls,
-  savedCredentialKeys,
-  deletedCredentialKeys,
-  credentialSaveCalls,
-  slackProbeCalls,
-  getSessionState: () => sessionState,
-};
-`;
-}
+  getCredentialSpy = vi
+    .spyOn(store, "getCredential")
+    .mockImplementation((key) => process.env[key] || null);
+  saveCredentialSpy = vi.spyOn(store, "saveCredential").mockImplementation((key) => {
+    callOrder.push(`saveCredential:${key}`);
+  });
+  deleteCredentialSpy = vi.spyOn(store, "deleteCredential").mockImplementation(() => true);
+  promptSpy = vi.spyOn(store, "prompt").mockResolvedValue("y");
+
+  vi.spyOn(onboardSession, "loadSession").mockImplementation(() => sessionState);
+  vi.spyOn(onboardSession, "updateSession").mockImplementation((mutator) => {
+    sessionUpdateThrows
+      ? (() => {
+          throw new Error("simulated save failure");
+        })()
+      : undefined;
+    sessionState ??= { sandboxName: null, policyPresets: null } as onboardSession.Session;
+    const next = mutator(sessionState as onboardSession.Session) || sessionState;
+    sessionState = next as onboardSession.Session;
+    sessionUpdates.push({
+      policyPresets: Array.isArray(sessionState.policyPresets)
+        ? [...sessionState.policyPresets]
+        : sessionState.policyPresets,
+    });
+    return sessionState;
+  });
+
+  providerSpy = vi
+    .spyOn(policyChannelDependencies, "upsertMessagingProviders")
+    .mockImplementation(() => {
+      callOrder.push("upsertMessagingProviders");
+      return [];
+    });
+  rebuildSpy = vi
+    .spyOn(policyChannelDependencies, "rebuildSandbox")
+    .mockImplementation(async () => {
+      callOrder.push("rebuildSandbox");
+    });
+
+  runOpenshellSpy = vi
+    .spyOn(runtime, "runOpenshell")
+    .mockImplementation(() => successfulOpenshellResult());
+  const healthyGatewayState = {
+    state: "healthy_named",
+    status: "",
+    gatewayInfo: "",
+    activeGateway: "nemoclaw",
+  } as const;
+  vi.spyOn(gatewayRuntime, "recoverNamedGatewayRuntime").mockResolvedValue({
+    recovered: true,
+    before: healthyGatewayState,
+    after: healthyGatewayState,
+    attempted: false,
+  });
+
+  curlProbeSpy = vi.spyOn(httpProbe, "runCurlProbe").mockImplementation((argv) => {
+    const url = argv.at(-1);
+    const isBotProbe = url?.includes("auth.test") ?? false;
+    const isAppProbe = url?.includes("apps.connections.open") ?? false;
+    callOrder.push(...(isBotProbe ? ["slackProbe:bot"] : isAppProbe ? ["slackProbe:app"] : []));
+    return isBotProbe ? slackBotProbe : isAppProbe ? slackAppProbe : successfulProbe();
+  });
+
+  execSpy = vi
+    .spyOn(processRecovery, "executeSandboxExecCommand")
+    .mockImplementation((name, command) => {
+      execCalls.push({ name, command });
+      return command.includes("/sandbox/.openclaw/openclaw.json")
+        ? { status: 0, stdout: JSON.stringify(testConfig), stderr: "" }
+        : command.includes("tail -n 400") && command.includes("/tmp/gateway.log")
+          ? { status: 0, stdout: testLog, stderr: "" }
+          : { status: 0, stdout: "", stderr: "" };
+    });
+  vi.spyOn(processRecovery, "executeSandboxCommand").mockReturnValue(null);
+
+  buildPlanSpy = vi
+    .spyOn(MessagingWorkflowPlanner.prototype, "buildPlan")
+    .mockImplementation(function (this: MessagingWorkflowPlanner, context) {
+      return originalBuildPlan.call(this, context);
+    });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(testHome, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, originalProcessEnv);
+});
 
 describe("channels add applies a matching policy preset (#3437)", () => {
-  it("plans channel enrollment through the messaging manifest workflow", () => {
-    const script = `${buildPreamble()}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      buildPlanCalls: ctx.buildPlanCalls,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("plans channel enrollment through the messaging manifest workflow", async () => {
+    await addSandboxChannel("test-sb", { channel: "slack" });
 
-    assert.deepEqual(payload.buildPlanCalls, [
-      {
-        sandboxName: "test-sb",
-        agent: "openclaw",
-        workflow: "add-channel",
-        isInteractive: false,
-        configuredChannels: ["slack"],
-        disabledChannels: [],
-        supportedChannelIds: ["telegram", "discord", "wechat", "slack", "whatsapp", "teams"],
-      },
-    ]);
+    expect(buildPlanSpy).toHaveBeenCalledWith({
+      sandboxName: "test-sb",
+      agent: "openclaw",
+      workflow: "add-channel",
+      isInteractive: false,
+      configuredChannels: ["slack"],
+      disabledChannels: [],
+      supportedChannelIds: ["telegram", "discord", "wechat", "slack", "whatsapp", "teams"],
+      credentialAvailability: expect.any(Object),
+    });
   });
 
   for (const channel of ["telegram", "slack", "discord"]) {
-    it(`applies the '${channel}' preset before triggering rebuild`, () => {
-      const script = `${buildPreamble()}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: ${JSON.stringify(channel)} });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      appliedCalls: ctx.appliedCalls,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-      const result = runScript(script);
-      assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-      const payload = parseResultPayload(result);
+    it(`applies the '${channel}' preset before triggering rebuild`, async () => {
+      await addSandboxChannel("test-sb", { channel });
 
-      // Contract 1: applyPreset is called exactly once with the channel's name.
-      assert.deepEqual(
-        payload.appliedCalls,
-        [{ sandboxName: "test-sb", presetName: channel }],
-        `expected applyPreset("test-sb", "${channel}") exactly once; got ${JSON.stringify(payload.appliedCalls)}`,
-      );
-      assert.ok(payload.callOrder.includes(`loadPresetForSandbox:test-sb:${channel}`));
-
-      const applyIdx = payload.callOrder.indexOf(`applyPreset:${channel}`);
-      const rebuildIdx = payload.callOrder.indexOf("promptAndRebuild");
-      assert.ok(
-        applyIdx >= 0,
-        `applyPreset was never called (order: ${JSON.stringify(payload.callOrder)})`,
-      );
-      assert.ok(
-        rebuildIdx >= 0,
-        `promptAndRebuild was never called (order: ${JSON.stringify(payload.callOrder)})`,
-      );
-      assert.ok(
-        applyIdx < rebuildIdx,
-        `applyPreset must run before promptAndRebuild; got order: ${JSON.stringify(payload.callOrder)}`,
+      expect(applyPresetSpy).toHaveBeenCalledOnce();
+      expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", channel);
+      expect(loadPresetForSandboxSpy).toHaveBeenCalledWith("test-sb", channel);
+      expect(callOrder.indexOf(`applyPreset:${channel}`)).toBeLessThan(
+        callOrder.indexOf("promptAndRebuild"),
       );
     });
   }
 
-  it("applies the tokenless WhatsApp preset for Hermes before triggering rebuild", () => {
-    const script = `${buildPreamble({
-      presetNamesAvailable: ["telegram", "slack", "discord", "whatsapp", "npm", "github"],
-      sandboxAgent: "hermes",
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "whatsapp" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      appliedCalls: ctx.appliedCalls,
-      callOrder: ctx.callOrder,
-      providerCalls: ctx.providerCalls,
-      registryUpdates: ctx.registryUpdates,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script, {
-      WHATSAPP_BOT_TOKEN: "must-not-be-used",
-      WHATSAPP_TOKEN: "must-not-be-used",
-      WHATSAPP_SESSION_SECRET: "must-not-be-used",
-    });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("applies the tokenless WhatsApp preset for Hermes before triggering rebuild", async () => {
+    sandboxAgent = "hermes";
+    registryEntry = makeRegistryEntry([], [], "hermes");
+    process.env.WHATSAPP_BOT_TOKEN = "must-not-be-used";
+    process.env.WHATSAPP_TOKEN = "must-not-be-used";
+    process.env.WHATSAPP_SESSION_SECRET = "must-not-be-used";
 
-    assert.deepEqual(payload.providerCalls, [], "WhatsApp must not create host-side providers");
-    const messagingStateUpdate = payload.registryUpdates.find(
-      (entry: {
-        updates?: { messaging?: { plan?: { channels?: Array<{ channelId?: string }> } } };
-      }) => entry.updates?.messaging?.plan,
+    await addSandboxChannel("test-sb", { channel: "whatsapp" });
+
+    expect(providerSpy).not.toHaveBeenCalled();
+    const messagingUpdate = updateSandboxSpy.mock.calls.find(
+      (call) => (call[1] as { messaging?: unknown }).messaging,
     );
-    assert.ok(
-      messagingStateUpdate,
-      `expected a registry update that stores durable messaging state; got ${JSON.stringify(payload.registryUpdates)}`,
+    expect(updateSandboxSpy).toHaveBeenCalledOnce();
+    expect(messagingUpdate).toBeDefined();
+    expect(messagingUpdate?.[0]).toBe("test-sb");
+    const plan = (messagingUpdate?.[1] as { messaging: { plan: SandboxMessagingPlan } }).messaging
+      .plan;
+    expect(plan.channels.map((channel) => channel.channelId)).toEqual(["whatsapp"]);
+    expect(plan.agent).toBe("hermes");
+    expect(plan.credentialBindings).toEqual([]);
+    expect(messagingUpdate?.[1]).not.toHaveProperty("messagingChannels");
+    expect(messagingUpdate?.[1]).not.toHaveProperty("disabledChannels");
+    expect(applyPresetSpy).toHaveBeenCalledOnce();
+    expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", "whatsapp");
+    expect(callOrder.indexOf("applyPreset:whatsapp")).toBeLessThan(
+      callOrder.indexOf("promptAndRebuild"),
     );
-    assert.deepEqual(
-      messagingStateUpdate.updates.messaging.plan.channels.map(
-        (channel: { channelId: string }) => channel.channelId,
+  });
+
+  it("aborts tokenless WhatsApp before registry and rebuild when preset apply fails", async () => {
+    sandboxAgent = "hermes";
+    registryEntry = makeRegistryEntry([], [], "hermes");
+    applyPresetResult = false;
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "whatsapp" }));
+
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", "whatsapp");
+    expect(callOrder).not.toContain("promptAndRebuild");
+  });
+
+  it("aborts non-QR channel when policy preset YAML is missing", async () => {
+    presetContent = null;
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain(
+      "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
+    );
+  });
+
+  it("aborts non-QR channel when policy preset YAML has no network_policies section", async () => {
+    presetContent = 'name: telegram\ndescription: "stub preset without network_policies"\n';
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy).not.toHaveBeenCalled();
+    expect(deleteCredentialSpy).not.toHaveBeenCalled();
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain("has no parseable entries under 'network_policies:'");
+    expect(printedText()).toContain(
+      "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
+    );
+  });
+
+  it("aborts non-QR channel when policy preset YAML body is malformed", async () => {
+    presetContent = "network_policies:\n  - [unclosed\n";
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy).not.toHaveBeenCalled();
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain("has no parseable entries under 'network_policies:'");
+    expect(printedText()).toContain(
+      "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
+    );
+  });
+
+  it("dry-run validates the channel preset and avoids gateway, registry, and rebuild side effects", async () => {
+    await addSandboxChannel("test-sb", { channel: "telegram", dryRun: true });
+
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy).not.toHaveBeenCalled();
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain("--dry-run: would enable channel 'telegram' for 'test-sb'");
+  });
+
+  it("dry-run fails when the matching policy preset YAML is missing", async () => {
+    presetContent = null;
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram", dryRun: true }));
+
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy).not.toHaveBeenCalled();
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain(
+      "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
+    );
+  });
+
+  it("aborts QR-paired WhatsApp before registry write when its preset YAML is missing", async () => {
+    presetContent = null;
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "whatsapp" }));
+
+    expect(applyPresetSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain(
+      "Restore the preset YAML and re-run: nemoclaw test-sb channels add whatsapp",
+    );
+  });
+
+  it("rolls back providers and credentials without writing plan state when applyPreset fails", async () => {
+    applyPresetResult = false;
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", "telegram");
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(deleteCredentialSpy).toHaveBeenCalledWith("TELEGRAM_BOT_TOKEN");
+    expect(sessionUpdates).toEqual([]);
+    expect(callOrder).not.toContain("promptAndRebuild");
+  });
+
+  it("leaves plan state untouched and reports residual gateway state when detach fails", async () => {
+    applyPresetResult = false;
+    runOpenshellSpy.mockImplementation((args: string[]) =>
+      args.slice(0, 3).join(" ") === "sandbox provider detach"
+        ? { ...successfulOpenshellResult(), status: 1, stderr: "permission denied" }
+        : successfulOpenshellResult(),
+    );
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(deleteCredentialSpy).toHaveBeenCalledWith("TELEGRAM_BOT_TOKEN");
+    expect(printedText()).toContain("Rollback could not fully clean gateway-providers");
+    expect(printedText()).toContain("'nemoclaw test-sb channels remove telegram'");
+    expect(callOrder).not.toContain("promptAndRebuild");
+  });
+
+  it("restores prior channel credentials when re-add applyPreset fails on an already-enabled channel", async () => {
+    applyPresetResult = false;
+    registryEntry = makeRegistryEntry(["telegram"]);
+    getCredentialSpy.mockImplementation((key: string) =>
+      key === "TELEGRAM_BOT_TOKEN" ? "prior-telegram-token" : null,
+    );
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy).toHaveBeenCalledWith("TELEGRAM_BOT_TOKEN", "prior-telegram-token");
+    expect(providerSpy).toHaveBeenCalledTimes(2);
+    expect(
+      providerSpy.mock.calls.map(([definitions]) =>
+        definitions.map((definition: { name: string }) => definition.name),
       ),
-      ["whatsapp"],
+    ).toEqual([["test-sb-telegram-bridge"], ["test-sb-telegram-bridge"]]);
+    expect(callOrder).not.toContain("promptAndRebuild");
+    expect(printedText()).toContain("Rollback could not fully clean gateway-providers");
+  });
+
+  it("leaves prior plan state untouched even when re-upsert during re-add rollback throws", async () => {
+    applyPresetResult = false;
+    registryEntry = makeRegistryEntry(["telegram"]);
+    getCredentialSpy.mockImplementation((key: string) =>
+      key === "TELEGRAM_BOT_TOKEN" ? "prior-telegram-token" : null,
     );
-    assert.equal(messagingStateUpdate.updates.messaging.plan.agent, "hermes");
-    assert.deepEqual(messagingStateUpdate.updates.messaging.plan.credentialBindings, []);
-    assert.equal(messagingStateUpdate.updates.messagingChannels, undefined);
-    assert.equal(messagingStateUpdate.updates.disabledChannels, undefined);
-    assert.deepEqual(
-      payload.registryUpdates.map((entry: { name: string }) => entry.name),
-      ["test-sb"],
+    providerSpy
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => {
+        throw new Error("simulated gateway upsert failure during restore");
+      });
+
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "telegram" }));
+
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy).toHaveBeenCalledWith("TELEGRAM_BOT_TOKEN", "prior-telegram-token");
+    expect(printedText()).toContain("Failed to restore gateway providers for 'telegram'");
+    expect(printedText()).toContain("Rollback could not fully clean gateway-providers");
+  });
+
+  it("validates Slack credentials before registering providers", async () => {
+    await addSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(curlProbeSpy).toHaveBeenCalledTimes(2);
+    expect(curlProbeSpy.mock.calls[0][0]).toContain("https://slack.com/api/auth.test");
+    expect(curlProbeSpy.mock.calls[1][0]).toContain("https://slack.com/api/apps.connections.open");
+    expect(saveCredentialSpy.mock.calls.map((call) => call[0])).toEqual([
+      "SLACK_BOT_TOKEN",
+      "SLACK_APP_TOKEN",
+    ]);
+    expect(
+      providerSpy.mock.calls[0][0].map((definition: { envKey: string }) => definition.envKey),
+    ).toEqual(["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]);
+    expect(callOrder.indexOf("slackProbe:app")).toBeLessThan(
+      callOrder.indexOf("saveCredential:SLACK_BOT_TOKEN"),
     );
-    assert.deepEqual(
-      payload.appliedCalls,
-      [{ sandboxName: "test-sb", presetName: "whatsapp" }],
-      `expected applyPreset("test-sb", "whatsapp") exactly once; got ${JSON.stringify(payload.appliedCalls)}`,
-    );
-    const applyIdx = payload.callOrder.indexOf("applyPreset:whatsapp");
-    const rebuildIdx = payload.callOrder.indexOf("promptAndRebuild");
-    assert.ok(
-      applyIdx >= 0,
-      `applyPreset was never called (order: ${JSON.stringify(payload.callOrder)})`,
-    );
-    assert.ok(
-      rebuildIdx >= 0,
-      `promptAndRebuild was never called (order: ${JSON.stringify(payload.callOrder)})`,
-    );
-    assert.ok(
-      applyIdx < rebuildIdx,
-      `applyPreset must run before promptAndRebuild; got order: ${JSON.stringify(payload.callOrder)}`,
+    expect(callOrder.indexOf("saveCredential:SLACK_APP_TOKEN")).toBeLessThan(
+      callOrder.indexOf("upsertMessagingProviders"),
     );
   });
 
-  it("aborts tokenless WhatsApp before registry and rebuild when preset apply fails", () => {
-    const script = `${buildPreamble({
-      presetNamesAvailable: ["telegram", "slack", "discord", "whatsapp", "npm", "github"],
-      applyPresetResult: false,
-      sandboxAgent: "hermes",
-    })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "whatsapp" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("can explicitly skip live Slack validation for offline channel add", async () => {
+    process.env.NEMOCLAW_SKIP_SLACK_AUTH_VALIDATION = "1";
+    slackBotProbe = successfulProbe('{"ok":false,"error":"invalid_auth"}');
 
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.providerCalls, [], "WhatsApp must not create host-side providers");
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `preset failure must not register whatsapp locally; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.deepEqual(
-      payload.appliedCalls,
-      [{ sandboxName: "test-sb", presetName: "whatsapp" }],
-      `expected one failed applyPreset call; got ${JSON.stringify(payload.appliedCalls)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `preset failure must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
+    await addSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(curlProbeSpy).not.toHaveBeenCalled();
+    expect(saveCredentialSpy.mock.calls.map((call) => call[0])).toEqual([
+      "SLACK_BOT_TOKEN",
+      "SLACK_APP_TOKEN",
+    ]);
+    expect(
+      providerSpy.mock.calls[0][0].map((definition: { envKey: string }) => definition.envKey),
+    ).toEqual(["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]);
+    expect(callOrder.indexOf("saveCredential:SLACK_APP_TOKEN")).toBeLessThan(
+      callOrder.indexOf("upsertMessagingProviders"),
     );
   });
 
-  it("aborts non-QR channel when policy preset YAML is missing", () => {
-    const script = `${buildPreamble({ presetFileMissing: true })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("aborts Slack channel add on rejected Slack API validation before provider registration", async () => {
+    slackBotProbe = successfulProbe('{"ok":false,"error":"invalid_auth"}');
 
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(
-      payload.appliedCalls,
-      [],
-      `missing preset YAML must abort before applyPreset; got ${JSON.stringify(payload.appliedCalls)}`,
-    );
-    assert.deepEqual(
-      payload.providerCalls,
-      [],
-      `missing preset YAML must not register host-side providers; got ${JSON.stringify(payload.providerCalls)}`,
-    );
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `missing preset YAML must not register telegram in the messaging plan; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `missing preset YAML must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stderr.includes(
-        `Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram`,
-      ),
-      `expected restore-and-re-run hint on stderr; got:\n${result.stderr}`,
-    );
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "slack" }));
+
+    expect(saveCredentialSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(applyPresetSpy).not.toHaveBeenCalled();
   });
 
-  it("aborts non-QR channel when policy preset YAML has no network_policies section", () => {
-    const script = `${buildPreamble({ presetMissingNetworkPolicies: true })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    savedCredentialKeys: ctx.savedCredentialKeys,
-    deletedCredentialKeys: ctx.deletedCredentialKeys,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("aborts Slack channel add on indeterminate Slack API validation before provider registration", async () => {
+    slackBotProbe = {
+      ok: false,
+      httpStatus: 0,
+      curlStatus: 28,
+      body: "",
+      stderr: "operation timed out",
+      message: "curl failed (exit 28): operation timed out",
+    };
 
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(payload.registryUpdates, []);
-    assert.deepEqual(payload.savedCredentialKeys, []);
-    assert.deepEqual(payload.deletedCredentialKeys, []);
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `invalid preset must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stderr.includes("has no parseable entries under 'network_policies:'"),
-      `expected diagnostic about unparseable network_policies section; got:\n${result.stderr}`,
-    );
-    assert.ok(
-      result.stderr.includes(
-        "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
-      ),
-      `expected restore-and-re-run hint on stderr; got:\n${result.stderr}`,
-    );
-  });
+    await expectExit(() => addSandboxChannel("test-sb", { channel: "slack" }));
 
-  it("aborts non-QR channel when policy preset YAML body is malformed", () => {
-    const script = `${buildPreamble({ presetMalformedYaml: true })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    savedCredentialKeys: ctx.savedCredentialKeys,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(payload.registryUpdates, []);
-    assert.deepEqual(payload.savedCredentialKeys, []);
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `malformed preset must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stderr.includes("has no parseable entries under 'network_policies:'"),
-      `expected parse-failure diagnostic; got:\n${result.stderr}`,
-    );
-    assert.ok(
-      result.stderr.includes(
-        "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
-      ),
-      `expected restore-and-re-run hint on stderr; got:\n${result.stderr}`,
-    );
-  });
-
-  it("dry-run validates the channel preset and avoids gateway, registry, and rebuild side effects", () => {
-    const script = `${buildPreamble()}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram", dryRun: true });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      appliedCalls: ctx.appliedCalls,
-      callOrder: ctx.callOrder,
-      providerCalls: ctx.providerCalls,
-      registryUpdates: ctx.registryUpdates,
-      savedCredentialKeys: ctx.savedCredentialKeys,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(payload.registryUpdates, []);
-    assert.deepEqual(payload.savedCredentialKeys, []);
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `dry-run must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stdout.includes("--dry-run: would enable channel 'telegram' for 'test-sb'"),
-      `expected dry-run preview; got:\n${result.stdout}`,
-    );
-  });
-
-  it("dry-run fails when the matching policy preset YAML is missing", () => {
-    const script = `${buildPreamble({ presetFileMissing: true })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram", dryRun: true });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    savedCredentialKeys: ctx.savedCredentialKeys,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(payload.registryUpdates, []);
-    assert.deepEqual(payload.savedCredentialKeys, []);
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `dry-run preset failure must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stderr.includes(
-        "Restore the preset YAML and re-run: nemoclaw test-sb channels add telegram",
-      ),
-      `expected restore-and-re-run hint on stderr; got:\n${result.stderr}`,
-    );
-  });
-
-  it("aborts QR-paired WhatsApp before registry write when its preset YAML is missing", () => {
-    const script = `${buildPreamble({ presetFileMissing: true })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "whatsapp" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `missing whatsapp.yaml must not write messaging plan state; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `missing whatsapp preset must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stderr.includes(
-        "Restore the preset YAML and re-run: nemoclaw test-sb channels add whatsapp",
-      ),
-      `expected restore-and-re-run hint on stderr; got:\n${result.stderr}`,
-    );
-  });
-
-  it("rolls back providers and credentials without writing plan state when applyPreset fails", () => {
-    const script = `${buildPreamble({ applyPresetResult: false })}
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    savedCredentialKeys: ctx.savedCredentialKeys,
-    deletedCredentialKeys: ctx.deletedCredentialKeys,
-    sessionUpdates: ctx.sessionUpdates,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(
-      payload.appliedCalls,
-      [{ sandboxName: "test-sb", presetName: "telegram" }],
-      `expected one failed applyPreset call; got ${JSON.stringify(payload.appliedCalls)}`,
-    );
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `failed preset apply must not write messaging plan state; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.deepEqual(
-      payload.deletedCredentialKeys,
-      ["TELEGRAM_BOT_TOKEN"],
-      `expected rollback to clear persisted credentials; got ${JSON.stringify(payload.deletedCredentialKeys)}`,
-    );
-    assert.deepEqual(
-      payload.sessionUpdates,
-      [],
-      `applyPreset returned false before syncSessionPolicyPresetsWithRegistry; session must stay untouched; got ${JSON.stringify(payload.sessionUpdates)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `apply failure must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-  });
-
-  it("leaves plan state untouched and reports residual gateway state when detach fails", () => {
-    const script = `${buildPreamble({ applyPresetResult: false })}
-openshellRuntime.runOpenshell = (args) => {
-  if (Array.isArray(args) && args[0] === "sandbox" && args[1] === "provider" && args[2] === "detach") {
-    return { status: 1, stdout: "", stderr: "permission denied" };
-  }
-  return { status: 0, stdout: "", stderr: "" };
-};
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-const stderrChunks = [];
-const originalConsoleError = console.error;
-console.error = (...args) => {
-  stderrChunks.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ") + "\\n");
-  originalConsoleError.apply(console, args);
-};
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-    console.error = originalConsoleError;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    deletedCredentialKeys: ctx.deletedCredentialKeys,
-    exitCodes,
-    stderrCombined: stderrChunks.join(""),
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.appliedCalls, [{ sandboxName: "test-sb", presetName: "telegram" }]);
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `failed preset apply must leave plan-backed registry state untouched; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.deepEqual(
-      payload.deletedCredentialKeys,
-      ["TELEGRAM_BOT_TOKEN"],
-      `expected local credentials cleared before gateway rollback; got ${JSON.stringify(payload.deletedCredentialKeys)}`,
-    );
-    assert.ok(
-      payload.stderrCombined.includes("Rollback could not fully clean gateway-providers"),
-      `expected residual-state warning on stderr; got:\n${payload.stderrCombined}`,
-    );
-    assert.ok(
-      payload.stderrCombined.includes(`'nemoclaw test-sb channels remove telegram'`),
-      `expected manual cleanup hint on stderr; got:\n${payload.stderrCombined}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `rollback path must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-  });
-
-  it("restores prior channel credentials when re-add applyPreset fails on an already-enabled channel", () => {
-    const script = `${buildPreamble({ applyPresetResult: false })}
-registry.getSandbox = () => ({
-  name: "test-sb",
-  agent: "openclaw",
-  messaging: { schemaVersion: 1, plan: makeMessagingPlan("test-sb", ["telegram"]) },
-});
-credentials.getCredential = (key) => key === "TELEGRAM_BOT_TOKEN" ? "prior-telegram-token" : null;
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    deletedCredentialKeys: ctx.deletedCredentialKeys,
-    savedCredentialKeys: ctx.savedCredentialKeys,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.appliedCalls, [{ sandboxName: "test-sb", presetName: "telegram" }]);
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `re-add failure must leave prior plan-backed registry state untouched; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.ok(
-      payload.savedCredentialKeys.includes("TELEGRAM_BOT_TOKEN"),
-      `re-add failure must restore prior credentials via saveCredential; got ${JSON.stringify(payload.savedCredentialKeys)}`,
-    );
-    const upsertNames = (payload.providerCalls as Array<{ name: string }>).map((d) => d.name);
-    assert.ok(
-      upsertNames.length >= 2,
-      `expected initial and restorative upsertMessagingProviders calls; got ${JSON.stringify(payload.providerCalls)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("promptAndRebuild"),
-      `re-add failure must not prompt for rebuild; got order: ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      result.stderr.includes("Rollback could not fully clean gateway-providers"),
-      `expected residual-state warning on stderr; got:\n${result.stderr}`,
-    );
-  });
-
-  it("leaves prior plan state untouched even when re-upsert during re-add rollback throws", () => {
-    const script = `${buildPreamble({ applyPresetResult: false })}
-registry.getSandbox = () => ({
-  name: "test-sb",
-  agent: "openclaw",
-  messaging: { schemaVersion: 1, plan: makeMessagingPlan("test-sb", ["telegram"]) },
-});
-credentials.getCredential = (key) => key === "TELEGRAM_BOT_TOKEN" ? "prior-telegram-token" : null;
-let upsertCalls = 0;
-onboardProviders.upsertMessagingProviders = (defs) => {
-  upsertCalls += 1;
-  providerCalls.push(...defs);
-  if (upsertCalls >= 2) throw new Error("simulated gateway upsert failure during restore");
-};
-const ctx = module.exports;
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-    registryUpdates: ctx.registryUpdates,
-    savedCredentialKeys: ctx.savedCredentialKeys,
-    exitCodes,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(
-      payload.registryUpdates,
-      [],
-      `re-add gateway restore failure must leave prior plan-backed registry state untouched; got ${JSON.stringify(payload.registryUpdates)}`,
-    );
-    assert.ok(
-      payload.savedCredentialKeys.includes("TELEGRAM_BOT_TOKEN"),
-      `re-add failure must restore staged environment credentials; got ${JSON.stringify(payload.savedCredentialKeys)}`,
-    );
-    assert.ok(
-      result.stderr.includes("Failed to restore gateway providers for 'telegram'"),
-      `expected gateway-provider restoration warning on stderr; got:\n${result.stderr}`,
-    );
-    assert.ok(
-      result.stderr.includes("Rollback could not fully clean gateway-providers"),
-      `expected residual-state warning on stderr; got:\n${result.stderr}`,
-    );
-  });
-
-  it("validates Slack credentials before registering providers", () => {
-    const script = `${buildPreamble()}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      slackProbeCalls: ctx.slackProbeCalls,
-      credentialSaveCalls: ctx.credentialSaveCalls,
-      providerCalls: ctx.providerCalls,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.equal(payload.slackProbeCalls.length, 2, "expected bot and app Slack probes");
-    assert.ok(
-      payload.slackProbeCalls[0].includes("https://slack.com/api/auth.test"),
-      `expected auth.test first; got ${JSON.stringify(payload.slackProbeCalls)}`,
-    );
-    assert.ok(
-      payload.slackProbeCalls[1].includes("https://slack.com/api/apps.connections.open"),
-      `expected apps.connections.open second; got ${JSON.stringify(payload.slackProbeCalls)}`,
-    );
-    assert.deepEqual(
-      payload.credentialSaveCalls.map((call: { key: string }) => call.key),
-      ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
-    );
-    assert.deepEqual(
-      payload.providerCalls.map((call: { envKey: string }) => call.envKey),
-      ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
-    );
-    assert.ok(
-      payload.callOrder.indexOf("slackProbe:app") <
-        payload.callOrder.indexOf("saveCredential:SLACK_BOT_TOKEN"),
-      `Slack validation must complete before token persistence; got ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      payload.callOrder.indexOf("slackProbe:app") <
-        payload.callOrder.indexOf("upsertMessagingProviders"),
-      `Slack validation must complete before provider registration; got ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      payload.callOrder.indexOf("saveCredential:SLACK_APP_TOKEN") <
-        payload.callOrder.indexOf("upsertMessagingProviders"),
-      `token persistence should happen before provider registration; got ${JSON.stringify(payload.callOrder)}`,
-    );
-  });
-
-  it("can explicitly skip live Slack validation for offline channel add", () => {
-    const script = `${buildPreamble()}
-const ctx = module.exports;
-global.__slackBotProbe = {
-  ok: true,
-  httpStatus: 200,
-  curlStatus: 0,
-  body: '{"ok":false,"error":"invalid_auth"}',
-  stderr: "",
-  message: "",
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      slackProbeCalls: ctx.slackProbeCalls,
-      credentialSaveCalls: ctx.credentialSaveCalls,
-      providerCalls: ctx.providerCalls,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script, { NEMOCLAW_SKIP_SLACK_AUTH_VALIDATION: "1" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.slackProbeCalls, []);
-    assert.deepEqual(
-      payload.credentialSaveCalls.map((call: { key: string }) => call.key),
-      ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
-    );
-    assert.deepEqual(
-      payload.providerCalls.map((call: { envKey: string }) => call.envKey),
-      ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
-    );
-    assert.ok(
-      !payload.callOrder.some((entry: string) => entry.startsWith("slackProbe:")),
-      `offline skip mode must not probe Slack; got ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      payload.callOrder.indexOf("saveCredential:SLACK_APP_TOKEN") <
-        payload.callOrder.indexOf("upsertMessagingProviders"),
-      `token persistence should happen before provider registration; got ${JSON.stringify(payload.callOrder)}`,
-    );
-  });
-
-  it("aborts Slack channel add on rejected Slack API validation before provider registration", () => {
-    const script = `${buildPreamble()}
-const ctx = module.exports;
-global.__slackBotProbe = {
-  ok: true,
-  httpStatus: 200,
-  curlStatus: 0,
-  body: '{"ok":false,"error":"invalid_auth"}',
-  stderr: "",
-  message: "",
-};
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    exitCodes,
-    credentialSaveCalls: ctx.credentialSaveCalls,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.credentialSaveCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(payload.registryUpdates, []);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.ok(
-      !payload.callOrder.some((entry: string) => entry.startsWith("saveCredential:")),
-      `rejected Slack credentials must not be persisted; got ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("upsertMessagingProviders"),
-      `rejected Slack credentials must not register providers; got ${JSON.stringify(payload.callOrder)}`,
-    );
-  });
-
-  it("aborts Slack channel add on indeterminate Slack API validation before provider registration", () => {
-    const script = `${buildPreamble()}
-const ctx = module.exports;
-global.__slackBotProbe = {
-  ok: false,
-  httpStatus: 0,
-  curlStatus: 28,
-  body: "",
-  stderr: "operation timed out",
-  message: "curl failed (exit 28): operation timed out",
-};
-const exitCodes = [];
-const originalExit = process.exit;
-process.exit = (code) => {
-  exitCodes.push(code ?? 0);
-  throw new Error("__EXIT__" + (code ?? 0));
-};
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-  } catch (err) {
-    if (!String(err && err.message).startsWith("__EXIT__")) {
-      process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-      return;
-    }
-  } finally {
-    process.exit = originalExit;
-  }
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    exitCodes,
-    credentialSaveCalls: ctx.credentialSaveCalls,
-    providerCalls: ctx.providerCalls,
-    registryUpdates: ctx.registryUpdates,
-    appliedCalls: ctx.appliedCalls,
-    callOrder: ctx.callOrder,
-  }) + "\\n");
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-
-    assert.deepEqual(payload.exitCodes, [1]);
-    assert.deepEqual(payload.credentialSaveCalls, []);
-    assert.deepEqual(payload.providerCalls, []);
-    assert.deepEqual(payload.registryUpdates, []);
-    assert.deepEqual(payload.appliedCalls, []);
-    assert.ok(
-      !payload.callOrder.some((entry: string) => entry.startsWith("saveCredential:")),
-      `indeterminate Slack credentials must not be persisted; got ${JSON.stringify(payload.callOrder)}`,
-    );
-    assert.ok(
-      !payload.callOrder.includes("upsertMessagingProviders"),
-      `indeterminate Slack credentials must not register providers; got ${JSON.stringify(payload.callOrder)}`,
-    );
+    expect(saveCredentialSpy).not.toHaveBeenCalled();
+    expect(providerSpy).not.toHaveBeenCalled();
+    expect(updateSandboxSpy).not.toHaveBeenCalled();
+    expect(applyPresetSpy).not.toHaveBeenCalled();
   });
 });
 
-// Regression: `channels add` was updating the registry but NOT
-// session.policyPresets. A later `rebuild` re-entered onboard in resume
-// mode, read the stale session, and the policy-selection step narrowed
-// the channel's preset back away. The new sandbox booted with the
-// channel auto-launched but no matching network policy active, so the
-// bridge's Slack/Telegram/Discord WebClient hit 403s and stayed wedged
-// even after Step 5.5 of rebuild reapplied the preset from the backup
-// manifest.
-//
-// These tests pin down the invariant: after a successful preset apply
-// via channels-add, session.policyPresets must contain the channel
-// name; after a successful preset remove via channels-remove, it must
-// not. Edge cases (no session, foreign sandbox, save failure) must not
-// abort the operation.
 describe("channels add/remove keeps session.policyPresets in sync with registry", () => {
-  it("appends the channel preset to session.policyPresets after a successful add", () => {
-    const script = `${buildPreamble({
-      sessionSandboxName: "test-sb",
-      sessionPolicyPresets: ["npm", "pypi", "huggingface", "brew"],
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      sessionUpdates: ctx.sessionUpdates,
-      finalSession: ctx.getSessionState(),
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("appends the channel preset to session.policyPresets after a successful add", async () => {
+    await addSandboxChannel("test-sb", { channel: "slack" });
 
-    // Exactly one update — the helper short-circuits when the desired
-    // membership already holds, so duplicate writes would be a bug.
-    assert.equal(
-      payload.sessionUpdates.length,
-      1,
-      `expected exactly one session update; got ${JSON.stringify(payload.sessionUpdates)}`,
-    );
-    assert.deepEqual(payload.sessionUpdates[0].policyPresets, [
-      "npm",
-      "pypi",
-      "huggingface",
-      "brew",
-      "slack",
+    expect(sessionUpdates).toEqual([
+      { policyPresets: ["npm", "pypi", "huggingface", "brew", "slack"] },
     ]);
-    assert.deepEqual(payload.finalSession.policyPresets, [
-      "npm",
-      "pypi",
-      "huggingface",
-      "brew",
-      "slack",
-    ]);
+    expect(sessionState?.policyPresets).toEqual(["npm", "pypi", "huggingface", "brew", "slack"]);
   });
 
-  it("does not touch the session when it tracks a different sandbox", () => {
-    const script = `${buildPreamble({
-      sessionSandboxName: "other-sb",
-      sessionPolicyPresets: ["npm", "github"],
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      sessionUpdates: ctx.sessionUpdates,
-      finalSession: ctx.getSessionState(),
-      appliedCalls: ctx.appliedCalls,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("does not touch the session when it tracks a different sandbox", async () => {
+    setSession("other-sb", ["npm", "github"]);
 
-    // applyPreset still runs against the registry — the preset is the
-    // channel's egress contract and lives in registry, not session.
-    assert.deepEqual(payload.appliedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    // But the foreign session's policyPresets must be left untouched —
-    // otherwise we corrupt the other sandbox's resume state.
-    assert.deepEqual(
-      payload.sessionUpdates,
-      [],
-      `session belonging to a different sandbox must not be mutated; got ${JSON.stringify(payload.sessionUpdates)}`,
-    );
-    assert.deepEqual(payload.finalSession.policyPresets, ["npm", "github"]);
+    await addSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(sessionUpdates).toEqual([]);
+    expect(sessionState?.policyPresets).toEqual(["npm", "github"]);
   });
 
-  it("succeeds even when no onboard session file exists", () => {
-    const script = `${buildPreamble({ sessionMissing: true })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      sessionUpdates: ctx.sessionUpdates,
-      appliedCalls: ctx.appliedCalls,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("succeeds even when no onboard session file exists", async () => {
+    sessionState = null;
 
-    // Registry mutation still happens; only the session-sync side-effect
-    // is skipped (there is no intent record to keep aligned).
-    assert.deepEqual(payload.appliedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    assert.deepEqual(payload.sessionUpdates, []);
-    assert.ok(payload.callOrder.includes("promptAndRebuild"));
+    await addSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(sessionUpdates).toEqual([]);
+    expect(callOrder).toContain("promptAndRebuild");
   });
 
-  it("does not abort channels-add when session save fails", () => {
-    const script = `${buildPreamble({
-      sessionSandboxName: "test-sb",
-      sessionPolicyPresets: ["npm", "pypi", "huggingface", "brew"],
-      sessionUpdateThrows: true,
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.addSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      appliedCalls: ctx.appliedCalls,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("does not abort channels-add when session save fails", async () => {
+    sessionUpdateThrows = true;
 
-    // Even though session.updateSession threw, the channel add flow
-    // still completed: preset applied to registry, rebuild prompted.
-    // Session-sync is best-effort.
-    assert.deepEqual(payload.appliedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    assert.ok(payload.callOrder.includes("promptAndRebuild"));
+    await addSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(applyPresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(callOrder).toContain("promptAndRebuild");
   });
 
-  it("removes the channel preset from session.policyPresets after a successful remove", () => {
-    const script = `${buildPreamble({
-      appliedPresets: ["slack"],
-      sessionSandboxName: "test-sb",
-      sessionPolicyPresets: ["npm", "slack", "github"],
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.removeSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      removedCalls: ctx.removedCalls,
-      sessionUpdates: ctx.sessionUpdates,
-      finalSession: ctx.getSessionState(),
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("removes the channel preset from session.policyPresets after a successful remove", async () => {
+    appliedPresets = ["slack"];
+    setSession("test-sb", ["npm", "slack", "github"]);
 
-    assert.deepEqual(payload.removedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    assert.equal(
-      payload.sessionUpdates.length,
-      1,
-      `expected exactly one session update; got ${JSON.stringify(payload.sessionUpdates)}`,
-    );
-    assert.deepEqual(payload.sessionUpdates[0].policyPresets, ["npm", "github"]);
-    assert.deepEqual(payload.finalSession.policyPresets, ["npm", "github"]);
-    assert.ok(payload.callOrder.includes("promptAndRebuild"));
+    await removeSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(removePresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(sessionUpdates).toEqual([{ policyPresets: ["npm", "github"] }]);
+    expect(sessionState?.policyPresets).toEqual(["npm", "github"]);
+    expect(callOrder).toContain("promptAndRebuild");
   });
 
-  it("does not touch a foreign session during channels-remove", () => {
-    const script = `${buildPreamble({
-      appliedPresets: ["slack"],
-      sessionSandboxName: "other-sb",
-      sessionPolicyPresets: ["slack", "npm"],
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.removeSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      removedCalls: ctx.removedCalls,
-      sessionUpdates: ctx.sessionUpdates,
-      finalSession: ctx.getSessionState(),
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("does not touch a foreign session during channels-remove", async () => {
+    appliedPresets = ["slack"];
+    setSession("other-sb", ["slack", "npm"]);
 
-    assert.deepEqual(payload.removedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    assert.deepEqual(
-      payload.sessionUpdates,
-      [],
-      `session belonging to a different sandbox must not be mutated; got ${JSON.stringify(payload.sessionUpdates)}`,
-    );
-    assert.deepEqual(payload.finalSession.policyPresets, ["slack", "npm"]);
+    await removeSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(removePresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(sessionUpdates).toEqual([]);
+    expect(sessionState?.policyPresets).toEqual(["slack", "npm"]);
   });
 
-  it("succeeds during channels-remove when no onboard session file exists", () => {
-    const script = `${buildPreamble({
-      appliedPresets: ["slack"],
-      sessionMissing: true,
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.removeSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      removedCalls: ctx.removedCalls,
-      sessionUpdates: ctx.sessionUpdates,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("succeeds during channels-remove when no onboard session file exists", async () => {
+    appliedPresets = ["slack"];
+    sessionState = null;
 
-    assert.deepEqual(payload.removedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    assert.deepEqual(payload.sessionUpdates, []);
-    assert.ok(payload.callOrder.includes("promptAndRebuild"));
+    await removeSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(removePresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(sessionUpdates).toEqual([]);
+    expect(callOrder).toContain("promptAndRebuild");
   });
 
-  it("does not abort channels-remove when session save fails", () => {
-    const script = `${buildPreamble({
-      appliedPresets: ["slack"],
-      sessionSandboxName: "test-sb",
-      sessionPolicyPresets: ["npm", "slack"],
-      sessionUpdateThrows: true,
-    })}
-const ctx = module.exports;
-(async () => {
-  try {
-    await ctx.channelModule.removeSandboxChannel("test-sb", { channel: "slack" });
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({
-      removedCalls: ctx.removedCalls,
-      callOrder: ctx.callOrder,
-    }) + "\\n");
-  } catch (err) {
-    process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message, stack: err.stack }) + "\\n");
-  }
-})();
-`;
-    const result = runScript(script);
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
+  it("does not abort channels-remove when session save fails", async () => {
+    appliedPresets = ["slack"];
+    setSession("test-sb", ["npm", "slack"]);
+    sessionUpdateThrows = true;
 
-    assert.deepEqual(payload.removedCalls, [{ sandboxName: "test-sb", presetName: "slack" }]);
-    assert.ok(payload.callOrder.includes("promptAndRebuild"));
+    await removeSandboxChannel("test-sb", { channel: "slack" });
+
+    expect(removePresetSpy).toHaveBeenCalledWith("test-sb", "slack");
+    expect(callOrder).toContain("promptAndRebuild");
   });
 });
 
-// Regression: `nemoclaw <sandbox> channels add telegram` followed by a
-// rebuild produced no Telegram process, no logs, and no errors — the
-// command reported a successful rebuild but the bridge silently no-op'd
-// (#4314, #4390). After the fix the channel block is baked enabled and
-// addSandboxChannel runs a post-rebuild probe that reports either a
-// startup breadcrumb confirmation or an actionable warning. These tests
-// drive the verifier through stubbed sandbox-exec output so the contract
-// is pinned regardless of OpenClaw/OpenShell runtime availability.
 describe("channels add verifies bridge startup after rebuild (#4314, #4390)", () => {
-  function buildInteractivePreamble(): string {
-    return String.raw`
-const resolver = require(${j("adapters/openshell/resolve.js")});
-resolver.resolveOpenshell = () => "/fake/openshell";
-
-const openshellRuntime = require(${j("adapters/openshell/runtime.js")});
-openshellRuntime.runOpenshell = () => ({ status: 0, stdout: "", stderr: "" });
-
-const processRecovery = require(${j("actions/sandbox/process-recovery.js")});
-const execCalls = [];
-processRecovery.executeSandboxExecCommand = (name, command) => {
-  execCalls.push({ name, command });
-  if (typeof command === "string" && command.includes("/sandbox/.openclaw/openclaw.json")) {
-    return { status: 0, stdout: JSON.stringify(global.__testConfig || {}), stderr: "" };
-  }
-  if (
-    typeof command === "string" &&
-    command.includes("tail -n 400") &&
-    command.includes("/tmp/gateway.log")
-  ) {
-    return { status: 0, stdout: global.__testLog || "", stderr: "" };
-  }
-  return { status: 0, stdout: "", stderr: "" };
-};
-processRecovery.executeSandboxCommand = () => null;
-
-const rebuild = require(${j("actions/sandbox/rebuild-pipeline.js")});
-let rebuildCount = 0;
-rebuild.rebuildSandbox = async () => { rebuildCount += 1; };
-
-const runner = require(${j("runner.js")});
-runner.run = () => ({ status: 0, stdout: "", stderr: "" });
-runner.runCapture = () => "";
-
-const gatewayRuntime = require(${j("gateway-runtime-action.js")});
-gatewayRuntime.recoverNamedGatewayRuntime = async () => ({ recovered: true });
-
-const credentials = require(${j("credentials/store.js")});
-credentials.getCredential = (key) => process.env[key] || null;
-credentials.saveCredential = () => true;
-credentials.deleteCredential = () => true;
-credentials.prompt = async () => "y";
-
-const onboard = require(${j("onboard.js")});
-onboard.isNonInteractive = () => false;
-
-const onboardProviders = require(${j("onboard/providers.js")});
-onboardProviders.upsertMessagingProviders = () => {};
-
-const registry = require(${j("state/registry.js")});
-registry.getSandbox = () => ({
-  name: "test-sb",
-  agent: global.__testAgent || "openclaw",
-});
-registry.updateSandbox = () => true;
-
-const policies = require(${j("policy/index.js")});
-policies.listPresets = () => [{ name: "telegram" }, { name: "slack" }, { name: "discord" }];
-policies.applyPreset = () => true;
-policies.getAppliedPresets = () => [];
-
-const onboardSession = require(${j("state/onboard-session.js")});
-onboardSession.loadSession = () => ({ sandboxName: "test-sb", policyPresets: [] });
-onboardSession.updateSession = (mutator) => {
-  const s = { sandboxName: "test-sb", policyPresets: [] };
-  mutator(s);
-  return s;
-};
-
-const logs = [];
-const origLog = console.log;
-console.log = (...args) => {
-  const line = args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ");
-  logs.push(line);
-};
-
-const channelModule = require(${j("actions/sandbox/policy-channel.js")});
-
-module.exports = { channelModule, execCalls, getRebuildCount: () => rebuildCount, logs };
-`;
-  }
-
-  it("confirms the startup breadcrumb when the bridge logs the starting-provider line", () => {
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-global.__testConfig = { channels: { telegram: { enabled: true, accounts: { default: {} } } } };
-global.__testLog = [
-  "[telegram] [default] starting provider",
-  "[telegram] [default] provider ready (Bot API reachable; agent replies use inference.local)",
-].join("\\n");
-const ctx = module.exports;
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({
-    rebuildCount: ctx.getRebuildCount(),
-    execCalls: ctx.execCalls.length,
-    logs: ctx.logs,
-  }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.equal(payload.rebuildCount, 1);
-    assert.ok(
-      payload.logs.some((line: string) => line.includes("'telegram' bridge startup detected")),
-      `expected startup confirmation in logs; got:\n${payload.logs.join("\n")}`,
-    );
+  beforeEach(() => {
+    delete process.env.NEMOCLAW_NON_INTERACTIVE;
+    promptSpy.mockResolvedValue("y");
+    testConfig = { channels: { telegram: { enabled: true, accounts: { default: {} } } } };
   });
 
-  it("warns when the baked config does not mark the channel enabled", () => {
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-global.__testConfig = { channels: { telegram: { accounts: { default: {} } } } };
-global.__testLog = "";
-const ctx = module.exports;
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({ logs: ctx.logs }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.ok(
-      payload.logs.some((line: string) => line.includes("was not marked enabled in baked")),
-      `expected enabled-flag warning; got:\n${payload.logs.join("\n")}`,
-    );
+  it("confirms the startup breadcrumb when the bridge logs the starting-provider line", async () => {
+    testLog = [
+      "[telegram] [default] starting provider",
+      "[telegram] [default] provider ready (Bot API reachable; agent replies use inference.local)",
+    ].join("\n");
+
+    await addSandboxChannel("test-sb", { channel: "telegram" });
+
+    expect(rebuildSpy).toHaveBeenCalledOnce();
+    expect(printedText()).toContain("'telegram' bridge startup detected");
   });
 
-  it("warns when the gateway log shows no bridge breadcrumb yet", () => {
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-global.__testConfig = { channels: { telegram: { enabled: true, accounts: { default: {} } } } };
-global.__testLog = "";
-const ctx = module.exports;
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({ logs: ctx.logs }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.ok(
-      payload.logs.some((line: string) => line.includes("did not log a startup breadcrumb")),
-      `expected missing-breadcrumb warning; got:\n${payload.logs.join("\n")}`,
-    );
+  it("warns when the baked config does not mark the channel enabled", async () => {
+    testConfig = { channels: { telegram: { accounts: { default: {} } } } };
+
+    await addSandboxChannel("test-sb", { channel: "telegram" });
+
+    expect(printedText()).toContain("was not marked enabled in baked");
   });
 
-  it("does NOT claim success when only the no-start breadcrumb is present", () => {
-    // Regression: the original verifier matched any [<channel>] line and
-    // fell through to "bridge startup detected" even when the only log line
-    // was the preload's own "bridge did not start within Ns" diagnostic.
-    // That handed users a false-green signal for the exact failure mode
-    // #4314 reported.
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-global.__testConfig = { channels: { telegram: { enabled: true, accounts: { default: {} } } } };
-global.__testLog = "[telegram] [default] bridge did not start within 15s; check channels.telegram.enabled, plugin entries, and gateway log";
-const ctx = module.exports;
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({ logs: ctx.logs }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.ok(
-      !payload.logs.some((line: string) => line.includes("bridge startup detected")),
-      `must not claim startup detected; got:\n${payload.logs.join("\n")}`,
-    );
-    assert.ok(
-      payload.logs.some(
-        (line: string) =>
-          line.includes("logged credential/startup warnings") ||
-          line.includes("did not start within"),
-      ),
-      `expected the no-start breadcrumb to be surfaced; got:\n${payload.logs.join("\n")}`,
-    );
+  it("warns when the gateway log shows no bridge breadcrumb yet", async () => {
+    await addSandboxChannel("test-sb", { channel: "telegram" });
+
+    expect(printedText()).toContain("did not log a startup breadcrumb");
   });
 
-  it("forwards credential-placeholder warnings surfaced by the bridge", () => {
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-global.__testConfig = { channels: { telegram: { enabled: true, accounts: { default: {} } } } };
-global.__testLog = "[telegram] [default] credential placeholder mismatch: openclaw.json botToken does not match runtime TELEGRAM_BOT_TOKEN placeholder";
-const ctx = module.exports;
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({ logs: ctx.logs }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.ok(
-      payload.logs.some((line: string) => line.includes("logged credential/startup warnings")),
-      `expected credential warning summary; got:\n${payload.logs.join("\n")}`,
-    );
+  it("does NOT claim success when only the no-start breadcrumb is present", async () => {
+    testLog =
+      "[telegram] [default] bridge did not start within 15s; check channels.telegram.enabled, plugin entries, and gateway log";
+
+    await addSandboxChannel("test-sb", { channel: "telegram" });
+
+    expect(printedText()).not.toContain("bridge startup detected");
+    expect(printedText()).toMatch(/logged credential\/startup warnings|did not start within/);
   });
 
-  it("skips the OpenClaw-shaped probe for Hermes sandboxes (avoids false negatives)", () => {
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-global.__testAgent = "hermes";
-// Hermes sandboxes do not use /sandbox/.openclaw/openclaw.json; if the
-// verifier mistakenly ran it would read an empty config and warn about a
-// missing enabled flag. We confirm the absence of that misleading guidance.
-global.__testConfig = { channels: { telegram: {} } };
-global.__testLog = "";
-const ctx = module.exports;
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "telegram" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({ logs: ctx.logs, execCalls: ctx.execCalls.length }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.equal(payload.execCalls, 0, "verifier must not run any sandbox exec probes for Hermes");
-    assert.ok(
-      !payload.logs.some((line: string) => line.includes("was not marked enabled in baked")),
-      `Hermes sandbox should not see OpenClaw-shaped warning; got:\n${payload.logs.join("\n")}`,
-    );
-    assert.ok(
-      !payload.logs.some((line: string) => line.includes("bridge startup detected")),
-      `Hermes sandbox should not claim OpenClaw-style startup confirmation; got:\n${payload.logs.join("\n")}`,
-    );
+  it("forwards credential-placeholder warnings surfaced by the bridge", async () => {
+    testLog =
+      "[telegram] [default] credential placeholder mismatch: openclaw.json botToken does not match runtime TELEGRAM_BOT_TOKEN placeholder";
+
+    await addSandboxChannel("test-sb", { channel: "telegram" });
+
+    expect(printedText()).toContain("logged credential/startup warnings");
   });
 
-  it("skips the verifier for WhatsApp (QR-only) and WeChat (different runtime key)", () => {
-    const preamble = buildInteractivePreamble();
-    const script = `${preamble}
-// WhatsApp uses the in-sandbox-qr path which short-circuits before the
-// bridge probe. Extend the preset list (already stubbed in the preamble)
-// so applyPreset can match the whatsapp name.
-policies.listPresets = () => [{ name: "whatsapp" }, { name: "telegram" }, { name: "slack" }, { name: "discord" }];
-const ctx = module.exports;
-global.__testConfig = { channels: {} };
-global.__testLog = "";
-(async () => {
-  await ctx.channelModule.addSandboxChannel("test-sb", { channel: "whatsapp" });
-  process.stdout.write("\\n__RESULT__" + JSON.stringify({ logs: ctx.logs, execCalls: ctx.execCalls.length }) + "\\n");
-})().catch((err) => process.stdout.write("\\n__RESULT__" + JSON.stringify({ error: err.message }) + "\\n"));
-`;
-    const result = runScript(script, { NEMOCLAW_NON_INTERACTIVE: "" });
-    assert.equal(result.status, 0, `script failed: ${result.stderr}\n${result.stdout}`);
-    const payload = parseResultPayload(result);
-    assert.equal(payload.execCalls, 0, "verifier must not probe sandbox exec for QR-only WhatsApp");
-    assert.ok(
-      !payload.logs.some((line: string) =>
-        line.includes("was not marked enabled in baked openclaw.json"),
-      ),
-      `WhatsApp should not trigger OpenClaw-shaped warning; got:\n${payload.logs.join("\n")}`,
-    );
+  it("skips the OpenClaw-shaped probe for Hermes sandboxes (avoids false negatives)", async () => {
+    sandboxAgent = "hermes";
+    registryEntry = makeRegistryEntry([], [], "hermes");
+    testConfig = { channels: { telegram: {} } };
+
+    await addSandboxChannel("test-sb", { channel: "telegram" });
+
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(printedText()).not.toContain("was not marked enabled in baked");
+    expect(printedText()).not.toContain("bridge startup detected");
+  });
+
+  it("skips the verifier for WhatsApp's QR-only runtime", async () => {
+    testConfig = { channels: {} };
+
+    await addSandboxChannel("test-sb", { channel: "whatsapp" });
+
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(printedText()).not.toContain("was not marked enabled in baked openclaw.json");
   });
 });
 
 describe("channel preset source-of-truth", () => {
   it("every channel registered in KNOWN_CHANNELS ships a preset YAML that parsePresetPolicyKeys() accepts", () => {
-    const { knownChannelNames } = require(
-      path.join(repoRoot, "src", "lib", "sandbox", "channels.ts"),
-    ) as {
-      knownChannelNames: () => string[];
-    };
-    const { loadPreset, parsePresetPolicyKeys } = require(
-      path.join(repoRoot, "src", "lib", "policy", "index.ts"),
-    ) as {
-      loadPreset: (name: string) => string | null;
-      parsePresetPolicyKeys: (content: string | null | undefined) => string[];
-    };
     const failures: string[] = [];
     for (const name of knownChannelNames()) {
-      const content = loadPreset(name);
+      const content = policies.loadPreset(name);
       if (content === null) {
         failures.push(`${name}: preset YAML not found on disk`);
         continue;
       }
-      const keys = parsePresetPolicyKeys(content);
-      if (keys.length === 0) {
+      if (policies.parsePresetPolicyKeys(content).length === 0) {
         failures.push(`${name}: parsePresetPolicyKeys returned no entries`);
       }
     }
-    assert.deepEqual(
-      failures,
-      [],
-      `every channel in KNOWN_CHANNELS must ship a parseable preset YAML; failures: ${failures.join("; ")}`,
-    );
+
+    expect(failures).toEqual([]);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Converts the subprocess-backed `channels-add-preset` scenarios to direct calls through the public channel actions and existing injectable boundaries. All 36 behaviors remain covered while the focused local test body drops from 12.34 seconds to about 0.36 seconds.

## Related Issue
Contributes to #6245.

## Changes
- Replace 35 temporary-script and child-process scenarios with isolated in-process Vitest coverage of `addSandboxChannel` and `removeSandboxChannel`.
- Preserve policy ordering, rollback, Slack validation, session synchronization, and post-rebuild health-check assertions while isolating environment variables and mutation-lock files per test.
- Keep the real on-disk channel-preset contract and remove the obsolete 1,871-line legacy size-budget exemption after shrinking the test below 800 lines.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test execution and a CI size-budget ratchet changed; CLI and runtime behavior are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/channels-add-preset.test.ts --project integration` (36/36); `npm run test:titles:check`; `npm run test:projects:check`; `npm run test-size:check`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
