### PR TITLE
refactor(e2e): centralize command result helpers

### DIFF
--- a/test/e2e/fixtures/clients/command.ts
+++ b/test/e2e/fixtures/clients/command.ts
@@ -13,7 +13,17 @@ export interface CommandRunner {
   run(command: TrustedShellCommand, options?: ShellProbeRunOptions): Promise<ShellProbeResult>;
 }
 
-export function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
+export interface CommandResultText {
+  stdout: string;
+  stderr: string;
+}
+
+export interface CommandExitResult extends CommandResultText {
+  exitCode: number | null;
+  signal?: NodeJS.Signals | null;
+}
+
+export function resultText(result: CommandResultText): string {
   return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
@@ -40,12 +50,12 @@ export function outputContainsReadySandbox(
     });
 }
 
-export function assertExitZero(result: ShellProbeResult, label: string): void {
+export function assertExitZero(result: CommandExitResult, label: string): void {
   if (result.exitCode === 0) return;
   const fallback = result.signal
     ? `signal=${result.signal}`
     : `exit=${result.exitCode ?? "unknown"}`;
-  const detail = result.stderr.trim() || result.stdout.trim() || fallback;
+  const detail = resultText(result).trim() || fallback;
   throw new Error(`${label} failed: ${detail}`);
 }
 

--- a/test/e2e/fixtures/clients/index.ts
+++ b/test/e2e/fixtures/clients/index.ts
@@ -3,25 +3,27 @@
 
 export {
   assertExitZero,
+  type CommandExitResult,
+  type CommandResultText,
+  type CommandRunner,
   outputContainsSandbox,
   resultText,
   shellQuote,
-  type CommandRunner,
 } from "./command.ts";
 export { GatewayClient } from "./gateway.ts";
 export { HostCliClient } from "./host.ts";
 export {
   ProviderClient,
-  trustedProviderEndpoint,
   type ProviderJsonRequestOptions,
   type ProviderJsonResponse,
   type TrustedProviderEndpoint,
+  trustedProviderEndpoint,
 } from "./provider.ts";
 export {
   SandboxClient,
   sandboxAccessEnv,
-  trustedSandboxShellScript,
   type TrustedSandboxShellScript,
+  trustedSandboxShellScript,
   validateSandboxName,
 } from "./sandbox.ts";
 export { StateClient } from "./state.ts";

--- a/test/e2e/fixtures/phases/onboarding.ts
+++ b/test/e2e/fixtures/phases/onboarding.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { ArtifactSink } from "../artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../availability-env.ts";
-import { artifactLabel, assertExitZero } from "../clients/command.ts";
+import { artifactLabel, assertExitZero, resultText } from "../clients/command.ts";
 import type { HostCliClient } from "../clients/host.ts";
 import { validateSandboxName } from "../clients/sandbox.ts";
 import {
@@ -130,10 +130,6 @@ exit 1
 
 function prependPath(pathEntry: string, currentPath?: string): string {
   return currentPath ? `${pathEntry}:${currentPath}` : pathEntry;
-}
-
-function resultText(result: ShellProbeResult): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function redactExplicitValues(text: string, values: string[]): string {

--- a/test/e2e/live/bedrock-runtime-compatible-anthropic.test.ts
+++ b/test/e2e/live/bedrock-runtime-compatible-anthropic.test.ts
@@ -11,7 +11,11 @@ import os from "node:os";
 import path from "node:path";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { shellQuote } from "../fixtures/clients/command.ts";
+import {
+  assertExitZero as expectExitZero,
+  resultText,
+  shellQuote,
+} from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -98,10 +102,6 @@ interface MockBedrockRuntime {
   close(): Promise<void>;
 }
 
-function resultText(result: CommandText): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
-
 function redactedResultText(
   result: Pick<RawRunResult, "redactedStdout" | "redactedStderr">,
 ): string {
@@ -110,10 +110,6 @@ function redactedResultText(
 
 function evidenceTail(text: string): string {
   return text.slice(-4_000);
-}
-
-function expectExitZero(result: CommandText & { exitCode: number | null }, label: string): void {
-  expect(result.exitCode, `${label} failed:\n${resultText(result)}`).toBe(0);
 }
 
 function isMissingSandboxCleanupOutput(text: string): boolean {

--- a/test/e2e/live/cloud-inference-provider-skip.ts
+++ b/test/e2e/live/cloud-inference-provider-skip.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { resultText } from "../fixtures/clients/command.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
@@ -36,10 +37,6 @@ export interface PreContractExternalProviderSkipEvidence {
   artifacts: ShellProbeResult["artifacts"];
   sourceBoundary: typeof PRE_CONTRACT_EXTERNAL_PROVIDER_SOURCE_BOUNDARY;
   removalCondition: typeof PRE_CONTRACT_EXTERNAL_PROVIDER_REMOVAL_CONDITION;
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function tailForEvidence(text: string, maxLength = 1600): string {

--- a/test/e2e/live/cloud-inference.test.ts
+++ b/test/e2e/live/cloud-inference.test.ts
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -69,10 +70,6 @@ function positiveInteger(value: string | undefined, fallback: number): number {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 async function writePreContractExternalProviderSkip(

--- a/test/e2e/live/cloud-onboard.test.ts
+++ b/test/e2e/live/cloud-onboard.test.ts
@@ -4,8 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { type HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -34,10 +34,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 async function cleanup(

--- a/test/e2e/live/concurrent-gateway-ports.test.ts
+++ b/test/e2e/live/concurrent-gateway-ports.test.ts
@@ -11,8 +11,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import type { SandboxClient } from "../fixtures/clients/sandbox.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
@@ -41,10 +41,6 @@ validateSandboxName(SANDBOX_B);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {

--- a/test/e2e/live/credential-migration.test.ts
+++ b/test/e2e/live/credential-migration.test.ts
@@ -4,8 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -34,10 +34,6 @@ validateSandboxName(SANDBOX_NAME);
 const runCredentialMigrationTest = shouldRunLiveE2E() ? test : test.skip;
 
 type CommandResult = { stdout: string; stderr: string; exitCode: number | null };
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function testEnv(home: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const base = buildAvailabilityProbeEnv();

--- a/test/e2e/live/credential-sanitization.test.ts
+++ b/test/e2e/live/credential-sanitization.test.ts
@@ -12,9 +12,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import YAML from "yaml";
-
 import {
   isCredentialField,
   isSensitiveFile,
@@ -22,6 +20,7 @@ import {
   stripCredentials,
 } from "../../../src/lib/security/credential-filter.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -43,10 +42,6 @@ type Blueprint = {
   digest?: unknown;
   components?: { sandbox?: { image?: unknown } };
 };
-
-function resultText(result: CommandText): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function testEnv(home: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const base = buildAvailabilityProbeEnv();

--- a/test/e2e/live/diagnostics.test.ts
+++ b/test/e2e/live/diagnostics.test.ts
@@ -12,8 +12,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { requireHostedInferenceConfig } from "../fixtures/hosted-inference.ts";
@@ -35,10 +35,6 @@ type RawCommandResult = {
   stderr: string;
   error?: Error;
 };
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function rawResultText(result: Pick<RawCommandResult, "stdout" | "stderr">): string {
   return [result.stdout, result.stderr].filter(Boolean).join("\n");

--- a/test/e2e/live/double-onboard.test.ts
+++ b/test/e2e/live/double-onboard.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import type { SandboxClient } from "../fixtures/clients/sandbox.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
@@ -43,10 +44,6 @@ validateSandboxName(ALT_GATEWAY_NAME);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {

--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -4,10 +4,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { type HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -62,10 +62,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     ...securityPostureModeEnv(),
     ...extra,
   };
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 async function repoNemoclaw(

--- a/test/e2e/live/gpu-double-onboard.test.ts
+++ b/test/e2e/live/gpu-double-onboard.test.ts
@@ -4,9 +4,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { type HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -37,10 +37,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 async function nemoclaw(

--- a/test/e2e/live/hermes-e2e.test.ts
+++ b/test/e2e/live/hermes-e2e.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { shellQuote } from "../fixtures/clients/command.ts";
+import { resultText, shellQuote } from "../fixtures/clients/command.ts";
 import { trustedProviderEndpoint } from "../fixtures/clients/provider.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -55,10 +55,6 @@ interface OpenAiChoiceLike {
 
 interface OpenAiChatLike {
   choices?: OpenAiChoiceLike[];
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function truthyEnv(value: string | undefined): boolean {

--- a/test/e2e/live/inference-routing.test.ts
+++ b/test/e2e/live/inference-routing.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import type { SandboxClient } from "../fixtures/clients/sandbox.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
@@ -75,10 +76,6 @@ interface RawRunOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly redactionValues?: readonly string[];
   readonly timeoutMs?: number;
-}
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function redactedResultText(

--- a/test/e2e/live/issue-4434-tui-unreachable-inference.test.ts
+++ b/test/e2e/live/issue-4434-tui-unreachable-inference.test.ts
@@ -3,9 +3,9 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { isGatewayManagedCompatibleInference } from "../fixtures/ci-compatible-inference.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
@@ -63,10 +63,6 @@ const runIssue4434LiveTest =
     : test.skip;
 
 type CommandResultText = { stdout: string; stderr: string };
-
-function resultText(result: CommandResultText): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function shellSingleQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;

--- a/test/e2e/live/issue-4462-scope-upgrade-approval.test.ts
+++ b/test/e2e/live/issue-4462-scope-upgrade-approval.test.ts
@@ -4,8 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { type HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -42,10 +42,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 interface FreshAgentGatewaySnapshot {

--- a/test/e2e/live/launchable-smoke.test.ts
+++ b/test/e2e/live/launchable-smoke.test.ts
@@ -5,10 +5,10 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { assertExitZero as expectExitZero } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -79,10 +79,6 @@ async function runBash(
     redactionValues: options.redactionValues,
     timeoutMs: options.timeoutMs,
   });
-}
-
-function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
 }
 
 function parseChatContent(raw: string): string {

--- a/test/e2e/live/mcp-bridge-hermes-lifecycle.ts
+++ b/test/e2e/live/mcp-bridge-hermes-lifecycle.ts
@@ -4,8 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { assertExitZero as expectExitZero, resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect } from "../fixtures/e2e-test.ts";
@@ -16,17 +16,6 @@ const HOST_SECRET = MCP_BRIDGE_TEST_CREDENTIALS.host;
 const ROTATED_HOST_SECRET = MCP_BRIDGE_TEST_CREDENTIALS.rotatedHost;
 const INSPECTION_CONTROL_MARKER = "MCP_INSPECT_FORGED_CONTROL_LINE";
 const REGISTRY_FILE = path.join(process.env.HOME ?? os.homedir(), ".nemoclaw", "sandboxes.json");
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
-
-function expectExitZero(
-  result: { exitCode: number | null; stdout: string; stderr: string },
-  label: string,
-): void {
-  expect(result.exitCode, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
-}
 
 export async function assertHermesConfig(
   sandbox: SandboxClient,

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -4,9 +4,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import YAML from "yaml";
-
 import {
   buildDeepAgentsMcpStatusCommand,
   buildHermesMcpStatusCommand,
@@ -17,6 +15,7 @@ import { parseOpenShellPolicy } from "../../../src/lib/policy/merge";
 import type { McpBridgeEntry } from "../../../src/lib/state/registry";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { CleanupRegistry } from "../fixtures/cleanup.ts";
+import { assertExitZero as expectExitZero, resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -74,14 +73,6 @@ const MCP_MUTATION_TIMEOUT_MS: Record<McpAdapter, number> = {
   "hermes-config": 12 * 60_000,
   mcporter: 3 * 60_000,
 };
-
-function resultText(result: ShellProbeResult): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
-
-function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
-}
 
 function expectExitNonZero(result: ShellProbeResult, label: string, pattern: RegExp): void {
   expect(

--- a/test/e2e/live/messaging-compatible-endpoint.test.ts
+++ b/test/e2e/live/messaging-compatible-endpoint.test.ts
@@ -14,6 +14,7 @@ import fs from "node:fs";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
+import { resultText } from "../fixtures/clients/command.ts";
 
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
@@ -79,10 +80,6 @@ interface CompatibleMock {
 }
 
 type ProcessResult = { exitCode?: number | null; stdout: string; stderr: string };
-
-function resultText(result: ProcessResult): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/e2e/live/messaging-providers-helpers.ts
+++ b/test/e2e/live/messaging-providers-helpers.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { shellQuote } from "../fixtures/clients/command.ts";
+import { assertExitZero as expectExitZero, shellQuote } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -18,6 +18,8 @@ import {
 import { expect } from "../fixtures/e2e-test.ts";
 import { buildProcessTokenProbe } from "../fixtures/process-token-probe.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+
+export { expectExitZero };
 
 export const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 export const CLI_ENTRYPOINT = path.join(REPO_ROOT, "bin", "nemoclaw.js");
@@ -400,10 +402,6 @@ export function buildSandboxShellInvocation(script: string): string[] {
     );
   }
   return invocation;
-}
-
-export function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label}\n${outputText(result)}`).toBe(0);
 }
 
 export function check(condition: boolean, message: string): void {

--- a/test/e2e/live/model-router-provider-routed-inference.test.ts
+++ b/test/e2e/live/model-router-provider-routed-inference.test.ts
@@ -3,8 +3,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import {
@@ -33,10 +33,6 @@ interface ChatCompletionResponse {
     message?: { content?: unknown };
     text?: unknown;
   }>;
-}
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function sleep(ms: number): Promise<void> {

--- a/test/e2e/live/network-policy-transient-provider.ts
+++ b/test/e2e/live/network-policy-transient-provider.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { resultText } from "../fixtures/clients/command.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const TRANSIENT_PROVIDER_VALIDATION_RE =
@@ -9,10 +10,6 @@ const TRANSIENT_PROVIDER_DETAIL_RE =
   /timed? out|timeout|curl failed \(exit (7|28|35|52|56)\)|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|failed to connect|error sending request|HTTP (429|502|503|504)|returned HTTP (429|502|503|504)|too many requests|rate[- ]?limit|quota|temporar/i;
 const LOCAL_VALIDATION_FAILURE_RE =
   /invalid .*credential|invalid .*api[_ -]?key|authorization failed|authentication failed|denied by network policy|policy .*failed|routing .*failed|route .*failed|proxy .*failed|hop-by-hop|header stripping/i;
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 export function isTransientProviderValidationFailure(
   result: Pick<ShellProbeResult, "stdout" | "stderr">,

--- a/test/e2e/live/onboard-negative-paths.test.ts
+++ b/test/e2e/live/onboard-negative-paths.test.ts
@@ -3,8 +3,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 
@@ -21,10 +21,6 @@ const STACK_TRACE_PATTERNS = [/(^|\s)(TypeError|ReferenceError|SyntaxError):/m, 
 process.env.NEMOCLAW_CLI_BIN ??= path.join(REPO_ROOT, "bin", "nemoclaw.js");
 
 const liveTest = process.env.NEMOCLAW_RUN_LIVE_E2E === "1" ? test : test.skip;
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function hasStackTrace(text: string): boolean {
   return STACK_TRACE_PATTERNS.some((pattern) => pattern.test(text));

--- a/test/e2e/live/onboard-repair.test.ts
+++ b/test/e2e/live/onboard-repair.test.ts
@@ -4,8 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { type HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -34,10 +34,6 @@ function env(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     OPENSHELL_GATEWAY: "nemoclaw",
     ...extra,
   };
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 async function nemoclaw(

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -17,7 +17,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { shellQuote } from "../fixtures/clients/command.ts";
+import { resultText, shellQuote } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -144,10 +144,6 @@ function expectMockBaselineAuthentication(
   baseline
     ? expect(baseline.requests()).toContainEqual(expectedRequest)
     : expect(baseline).toBeUndefined();
-}
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function stripAnsi(value: string): string {

--- a/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
@@ -3,8 +3,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
@@ -26,10 +26,6 @@ const EXDEV_PATTERNS = [
   /cross-device link not permitted/i,
 ];
 const liveTest = shouldRunLiveE2E() ? test : test.skip;
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function liveEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {

--- a/test/e2e/live/openclaw-skill-cli.test.ts
+++ b/test/e2e/live/openclaw-skill-cli.test.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { shellQuote } from "../fixtures/clients/command.ts";
+import { resultText, shellQuote } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -35,10 +35,6 @@ const SANDBOX_EXEC_TIMEOUT_MS = 120_000;
 validateSandboxName(SANDBOX_NAME);
 
 const runOpenClawSkillCliTest = shouldRunLiveE2E() ? test : test.skip;
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function isEndpointRateLimited(text: string): boolean {
   return /HTTP 429|rate limit|too many requests/i.test(text);

--- a/test/e2e/live/openshell-allowed-ips-rebinding.ts
+++ b/test/e2e/live/openshell-allowed-ips-rebinding.ts
@@ -4,14 +4,13 @@
 import fs from "node:fs";
 import { createServer, type Server } from "node:http";
 import path from "node:path";
-
 import YAML from "yaml";
-
 import { isPrivateIp } from "../../../nemoclaw/src/blueprint/private-networks.ts";
 import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { parseOpenShellPolicy } from "../../../src/lib/policy/merge";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect } from "../fixtures/e2e-test.ts";
@@ -41,10 +40,6 @@ type RawOpenShellEndpoint = Record<string, unknown> & {
 
 function isMapping(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function resultText(result: Pick<ShellProbeResult, "stderr" | "stdout">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 function parseRawPolicy(yaml: string): RawOpenShellPolicy {

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -23,6 +23,7 @@ import path from "node:path";
 import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { type ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { assertExitZero as expectExitZero } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { resultText } from "../fixtures/clients/index.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
@@ -105,10 +106,6 @@ function shellLoginPrefix(): string {
     "fi",
     'export PATH="$HOME/.local/bin:$PATH"',
   ].join("\n");
-}
-
-function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label} failed:\n${resultText(result)}`).toBe(0);
 }
 
 function expectOutputContains(result: ShellProbeResult, value: string, label: string): void {

--- a/test/e2e/live/phase6-messaging-helpers.ts
+++ b/test/e2e/live/phase6-messaging-helpers.ts
@@ -4,7 +4,11 @@
 import path from "node:path";
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { shellQuote } from "../fixtures/clients/command.ts";
+import {
+  assertExitZero as expectExitZero,
+  resultText,
+  shellQuote,
+} from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -16,6 +20,8 @@ import { expect } from "../fixtures/e2e-test.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { isNvidiaEndpointRateLimitFailure } from "./messaging-providers-helpers.ts";
 
+export { expectExitZero, resultText };
+
 export const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
 export const CLI = process.env.NEMOCLAW_CLI_BIN ?? path.join(REPO_ROOT, "bin", "nemoclaw.js");
 
@@ -26,10 +32,6 @@ export type AgentKind = "openclaw" | "hermes";
 
 export function stripAnsi(value: string): string {
   return value.replace(/\u001b\[[0-9;]*m/g, "");
-}
-
-export function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
 }
 
 export { shellQuote };
@@ -70,10 +72,6 @@ export async function bestEffort(run: () => Promise<unknown>): Promise<void> {
   } catch {
     // Cleanup and diagnostics must not hide primary test failures.
   }
-}
-
-export function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label}\n${resultText(result)}`).toBe(0);
 }
 
 export async function precleanSandbox(

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { assertExitZero as expectExitZero } from "../fixtures/clients/command.ts";
 import { type HostCliClient, resultText } from "../fixtures/clients/index.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -156,10 +157,6 @@ function expectedHermesVersion(): string {
     expect.any(String),
   );
   return match![1].trim();
-}
-
-function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label} failed:\n${resultText(result)}`).toBe(0);
 }
 
 function expectEqual(actual: string | undefined, expected: string, message: string): void {

--- a/test/e2e/live/rebuild-openclaw.test.ts
+++ b/test/e2e/live/rebuild-openclaw.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { assertExitZero as expectExitZero, resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -71,14 +72,6 @@ interface GatewayTokenRotationResult {
   hashReferencesConfig: boolean;
   hashChanged: boolean;
   hashValid: boolean;
-}
-
-function resultText(result: ShellProbeResult): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
-
-function expectExitZero(result: ShellProbeResult, label: string): void {
-  expect(result.exitCode, `${label} failed:\n${resultText(result)}`).toBe(0);
 }
 
 function isRetryableOnboardEndpointFailure(result: ShellProbeResult): boolean {

--- a/test/e2e/live/runtime-overrides.test.ts
+++ b/test/e2e/live/runtime-overrides.test.ts
@@ -65,7 +65,7 @@ function run(command: string, args: string[]): CommandResult {
   );
 }
 
-function resultText(result: CommandResult): string {
+function spawnResultText(result: CommandResult): string {
   return [
     `status=${result.status}`,
     result.error ? `error=${result.error.message}` : "",
@@ -77,7 +77,7 @@ function resultText(result: CommandResult): string {
 }
 
 function formatLog(label: string, result: CommandResult): string {
-  return [`## ${label}`, resultText(result)].join("\n");
+  return [`## ${label}`, spawnResultText(result)].join("\n");
 }
 
 function firstProvider(config: OpenClawConfig): ProviderConfig {
@@ -176,7 +176,7 @@ function captureConfig(
   }
 
   throw new Error(
-    `${label} config capture failed after 3 attempts\n${lastError?.message ?? ""}\n${lastResult ? resultText(lastResult) : ""}`,
+    `${label} config capture failed after 3 attempts\n${lastError?.message ?? ""}\n${lastResult ? spawnResultText(lastResult) : ""}`,
   );
 }
 
@@ -195,7 +195,7 @@ function runConfigHashCheck(
     env,
     'cd /sandbox/.openclaw && if sha256sum -c .config-hash --status; then printf "OK\\n" >&3; else printf "FAIL\\n" >&3; fi; sleep 0.1',
   );
-  expect(result.status, resultText(result)).toBe(0);
+  expect(result.status, spawnResultText(result)).toBe(0);
   return result.stdout.trim();
 }
 
@@ -232,7 +232,7 @@ function buildImage(dockerLog: string[], image: string): void {
     REPO_ROOT,
   ]);
   dockerLog.push(formatLog(`build ${image}`, build));
-  expect(build.status, resultText(build)).toBe(0);
+  expect(build.status, spawnResultText(build)).toBe(0);
 }
 
 runtimeOverridesTest(
@@ -267,7 +267,7 @@ runtimeOverridesTest(
           reason: DOCKER_REQUIRED_MESSAGE,
         });
         if (process.env.GITHUB_ACTIONS === "true") {
-          throw new Error(`${DOCKER_REQUIRED_MESSAGE}\n${resultText(docker)}`);
+          throw new Error(`${DOCKER_REQUIRED_MESSAGE}\n${spawnResultText(docker)}`);
         }
         skip(DOCKER_REQUIRED_MESSAGE);
       }

--- a/test/e2e/live/sandbox-operations.test.ts
+++ b/test/e2e/live/sandbox-operations.test.ts
@@ -11,9 +11,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { assertExitZero as expectExitZero, resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -34,17 +34,9 @@ const liveTest = process.env.NEMOCLAW_RUN_LIVE_E2E === "1" ? test : test.skip;
 type ProcessResult = { exitCode: number | null; stdout: string; stderr: string };
 type CleanupRegistry = { add(name: string, run: () => Promise<void> | void): void };
 
-function resultText(result: ProcessResult): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
-
 function outputContainsSandbox(result: ProcessResult, sandboxName: string): boolean {
   const escaped = sandboxName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`(^|\\s)${escaped}(\\s|$)`, "m").test(resultText(result));
-}
-
-function expectExitZero(result: ProcessResult, label: string): void {
-  expect(result.exitCode, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
 }
 
 async function onboardSandbox(

--- a/test/e2e/live/sandbox-operations.test.ts
+++ b/test/e2e/live/sandbox-operations.test.ts
@@ -13,7 +13,11 @@ import os from "node:os";
 import path from "node:path";
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
-import { assertExitZero as expectExitZero, resultText } from "../fixtures/clients/command.ts";
+import {
+  assertExitZero as expectExitZero,
+  outputContainsSandbox,
+  resultText,
+} from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -31,13 +35,7 @@ const REGISTRY_FILE = path.join(process.env.HOME ?? os.homedir(), ".nemoclaw", "
 const GATEWAY_CONTAINER = "openshell-cluster-nemoclaw";
 const liveTest = process.env.NEMOCLAW_RUN_LIVE_E2E === "1" ? test : test.skip;
 
-type ProcessResult = { exitCode: number | null; stdout: string; stderr: string };
 type CleanupRegistry = { add(name: string, run: () => Promise<void> | void): void };
-
-function outputContainsSandbox(result: ProcessResult, sandboxName: string): boolean {
-  const escaped = sandboxName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(^|\\s)${escaped}(\\s|$)`, "m").test(resultText(result));
-}
 
 async function onboardSandbox(
   host: HostCliClient,

--- a/test/e2e/live/sandbox-rebuild.test.ts
+++ b/test/e2e/live/sandbox-rebuild.test.ts
@@ -4,8 +4,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import {
@@ -37,10 +37,6 @@ const STATUS_TIMEOUT_MS = 60_000;
 const ONBOARD_TIMEOUT_MS = TEST_TIMEOUT_MS;
 const REBUILD_TIMEOUT_MS = TEST_TIMEOUT_MS;
 const MARKER_CONTENT = `REBUILD_E2E_${Date.now()}`;
-
-function resultText(result: ShellProbeResult): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function sandboxRebuildEnv(apiKey: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {

--- a/test/e2e/live/sandbox-rlimits-connect.test.ts
+++ b/test/e2e/live/sandbox-rlimits-connect.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
@@ -13,10 +14,6 @@ const runConnectRlimitTest =
   shouldRunLiveE2E() && process.env.NEMOCLAW_E2E_CONNECT_RLIMITS === "1" ? test : test.skip;
 
 validateSandboxName(SANDBOX_NAME);
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function numericProbe(text: string, key: string): number {
   const match = text.match(new RegExp(`${key}=(\\d+)`));

--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -13,8 +13,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import {
   type SandboxClient,
@@ -45,10 +45,6 @@ const TIMER_POLL_TIMEOUT_MS = 75_000;
 const TIMER_POLL_INTERVAL_MS = 5_000;
 
 validateSandboxName(SANDBOX_NAME);
-
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/e2e/live/skill-agent.test.ts
+++ b/test/e2e/live/skill-agent.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import {
   type SandboxClient,
   trustedSandboxShellScript,
@@ -55,10 +56,6 @@ const RETRY_SLEEP_MS =
   Number.parseInt(process.env.E2E_SKILL_AGENT_RETRY_SLEEP_SEC ?? "15", 10) * 1_000;
 
 process.env.NEMOCLAW_CLI_BIN ??= CLI_ENTRYPOINT;
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/e2e/live/snapshot-commands.test.ts
+++ b/test/e2e/live/snapshot-commands.test.ts
@@ -12,8 +12,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
@@ -34,9 +34,6 @@ const MARKER_FILE = "/sandbox/.openclaw/workspace/snapshot-marker.txt";
 const SECOND_MARKER = "/sandbox/.openclaw/workspace/snapshot-marker-2.txt";
 const LIVE_TIMEOUT_MS = 30 * 60_000;
 const INSTALL_ATTEMPTS = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true" ? 3 : 1;
-function resultText(result: Pick<ShellProbeResult, "stdout" | "stderr">): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function commandEnv(apiKey?: string): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {

--- a/test/e2e/live/token-rotation.test.ts
+++ b/test/e2e/live/token-rotation.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { testTimeoutOptions } from "../../helpers/timeouts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import { resultText } from "../fixtures/clients/command.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
@@ -59,10 +60,6 @@ type RegistrySandboxEntry = {
     };
   };
 };
-
-function resultText(result: { stdout: string; stderr: string }): string {
-  return [result.stdout, result.stderr].filter(Boolean).join("\n");
-}
 
 function stripAnsi(value: string): string {
   return value.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");

--- a/test/e2e/support/e2e-clients.test.ts
+++ b/test/e2e/support/e2e-clients.test.ts
@@ -715,6 +715,18 @@ describe("E2E fixture clients", () => {
     );
   });
 
+  it("assertExitZero accepts lightweight command results and retains both output streams", () => {
+    const result = {
+      exitCode: 2,
+      stdout: "standard output",
+      stderr: "standard error",
+    };
+
+    expect(() => assertExitZero(result, "lightweight command")).toThrow(
+      "lightweight command failed: standard output\nstandard error",
+    );
+  });
+
   it("exports the shared shell quoting helper", () => {
     expect(shellQuote("can't run; rm -rf /")).toBe("'can'\\''t run; rm -rf /'");
   });

--- a/test/e2e/support/e2e-command-helper-adoption.test.ts
+++ b/test/e2e/support/e2e-command-helper-adoption.test.ts
@@ -11,11 +11,18 @@ const LOCAL_COMMAND_HELPER =
   /^(?:export\s+)?(?:function\s+(?:resultText|expectExitZero)\s*\(|const\s+(?:resultText|expectExitZero)\s*=)/m;
 
 function typescriptFiles(root: string): string[] {
-  return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+  const files: string[] = [];
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     const target = path.join(root, entry.name);
-    if (entry.isDirectory()) return typescriptFiles(target);
-    return entry.isFile() && entry.name.endsWith(".ts") ? [target] : [];
-  });
+    const nestedFiles = entry.isDirectory() ? typescriptFiles(target) : [];
+    files.push(...nestedFiles);
+
+    const currentFile = entry.isFile() && entry.name.endsWith(".ts") ? [target] : [];
+    files.push(...currentFile);
+  }
+
+  return files;
 }
 
 describe("E2E command helper adoption", () => {

--- a/test/e2e/support/e2e-command-helper-adoption.test.ts
+++ b/test/e2e/support/e2e-command-helper-adoption.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 
 const LIVE_ROOT = path.resolve(import.meta.dirname, "../live");
 const LOCAL_COMMAND_HELPER =
-  /^(?:export\s+)?(?:function\s+(?:resultText|expectExitZero)\s*\(|const\s+(?:resultText|expectExitZero)\s*=)/m;
+  /^\s*(?:export\s+)?(?:async\s+)?(?:function\s*\*?\s+(?:resultText|expectExitZero)\s*\(|(?:const|let|var)\s+(?:resultText|expectExitZero)\b\s*(?::[^=]+)?=)/m;
 
 function typescriptFiles(root: string): string[] {
   const files: string[] = [];

--- a/test/e2e/support/e2e-command-helper-adoption.test.ts
+++ b/test/e2e/support/e2e-command-helper-adoption.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const LIVE_ROOT = path.resolve(import.meta.dirname, "../live");
+const LOCAL_COMMAND_HELPER =
+  /^(?:export\s+)?(?:function\s+(?:resultText|expectExitZero)\s*\(|const\s+(?:resultText|expectExitZero)\s*=)/m;
+
+function typescriptFiles(root: string): string[] {
+  return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(root, entry.name);
+    if (entry.isDirectory()) return typescriptFiles(target);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [target] : [];
+  });
+}
+
+describe("E2E command helper adoption", () => {
+  it("keeps live targets on the shared command result helpers", () => {
+    const violations = typescriptFiles(LIVE_ROOT)
+      .filter((file) => LOCAL_COMMAND_HELPER.test(fs.readFileSync(file, "utf8")))
+      .map((file) => path.relative(LIVE_ROOT, file));
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Centralize the live Vitest E2E command-result formatter and zero-exit assertion on the existing fixture client helpers. This removes the equivalent local helper copies exposed by the post-migration audit and adds a ratchet against reintroducing them.

## Related Issue

Closes #6355
Parent epic: #6346

## Changes

- Generalize the shared command-result types so lightweight subprocess results can use `resultText` and `assertExitZero` without casts.
- Replace equivalent local helpers across live targets and the onboarding phase with shared imports.
- Preserve the existing Phase 6 helper APIs through re-exports while moving their implementation to the fixture client.
- Rename the richer runtime-overrides spawn formatter instead of changing its intentionally different diagnostics.
- Add an E2E support guard that rejects new local `resultText` or `expectExitZero` definitions in live targets.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-harness-only refactor with no user-facing behavior
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-command-helper-adoption.test.ts test/e2e/support/e2e-clients.test.ts test/e2e/support/messaging-providers-runtime-proofs.test.ts test/e2e/support/openclaw-discord-pairing-helpers.test.ts` (79 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional local verification:

- `npm run build:cli`
- `npm run typecheck`
- `npm run lint`
- Full `e2e-support` run reached 87 passing files; the unchanged main-branch shell-quote source-of-truth check currently reports `openshell-gateway-upgrade-helpers.ts`, and that test plus source file are unchanged by this PR.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized end-to-end command output formatting across flows for more consistent, readable failure messages.
  * Improved exit-status failure details by deriving them from unified command output and aligning accepted result shapes.

* **Tests**
  * Updated many end-to-end tests to use shared command-result and exit-check helpers instead of local duplicates.
  * Added coverage for exit-check behavior with lightweight command results.
  * Added a guard test to prevent future live tests from reintroducing local helper implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->