### PR TITLE
refactor(e2e): extract file snapshot and JSON state helpers

### DIFF
--- a/test/e2e/fixtures/file-state.ts
+++ b/test/e2e/fixtures/file-state.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type FileSnapshot =
+  | { exists: false }
+  | {
+      exists: true;
+      content: string;
+    };
+
+export function snapshotFile(file: string): FileSnapshot {
+  return fs.existsSync(file)
+    ? { exists: true, content: fs.readFileSync(file, "utf8") }
+    : { exists: false };
+}
+
+export function restoreFile(file: string, snapshot: FileSnapshot): void {
+  if (!snapshot.exists) {
+    fs.rmSync(file, { force: true });
+    return;
+  }
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, snapshot.content, "utf8");
+}
+
+export function readJsonFile<T>(file: string): T {
+  return JSON.parse(fs.readFileSync(file, "utf8")) as T;
+}
+
+/** Returns the fallback only when the file is absent; malformed JSON still throws. */
+export function readJsonFileOr<T>(file: string, fallback: T): T {
+  return fs.existsSync(file) ? readJsonFile<T>(file) : fallback;
+}
+
+/** Returns the fallback when the file is absent or its JSON cannot be parsed. */
+export function readJsonFileOrFallback<T>(file: string, fallback: T): T {
+  try {
+    return readJsonFileOr(file, fallback);
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeJsonFile(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/test/e2e/fixtures/file-state.ts
+++ b/test/e2e/fixtures/file-state.ts
@@ -39,8 +39,11 @@ export function readJsonFileOr<T>(file: string, fallback: T): T {
 export function readJsonFileOrFallback<T>(file: string, fallback: T): T {
   try {
     return readJsonFileOr(file, fallback);
-  } catch {
-    return fallback;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return fallback;
+    }
+    throw error;
   }
 }
 

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -11,6 +11,12 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { type HostCliClient, resultText } from "../fixtures/clients/index.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import {
+  readJsonFileOr,
+  restoreFile,
+  snapshotFile,
+  writeJsonFile,
+} from "../fixtures/file-state.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import { listCredentialLeakPaths } from "../fixtures/phases/state-validation.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
@@ -69,11 +75,6 @@ const SANDBOX_CREATE_TIMEOUT_MS = 10 * 60_000;
 const REBUILD_TIMEOUT_MS = 45 * 60_000;
 const LIVE_TIMEOUT_MS = 100 * 60_000;
 
-interface FileSnapshot {
-  exists: boolean;
-  content?: string;
-}
-
 interface RegistryData {
   sandboxes?: Record<string, Record<string, unknown>>;
   defaultSandbox?: string;
@@ -121,32 +122,8 @@ function testEnv(apiKey?: string, extra: NodeJS.ProcessEnv = {}): NodeJS.Process
   });
 }
 
-function snapshotFile(file: string): FileSnapshot {
-  return fs.existsSync(file)
-    ? { exists: true, content: fs.readFileSync(file, "utf8") }
-    : { exists: false };
-}
-
 function fail(message: string): never {
   throw new Error(message);
-}
-
-function restoreFile(file: string, snapshot: FileSnapshot): void {
-  snapshot.exists ? restoreExistingFile(file, snapshot) : fs.rmSync(file, { force: true });
-}
-
-function restoreExistingFile(file: string, snapshot: FileSnapshot): void {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, snapshot.content ?? "", "utf8");
-}
-
-function readJsonFile<T>(file: string, fallback: T): T {
-  return fs.existsSync(file) ? (JSON.parse(fs.readFileSync(file, "utf8")) as T) : fallback;
-}
-
-function writeJsonFile(file: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
 function expectedHermesVersion(): string {
@@ -251,7 +228,7 @@ async function waitForSandboxReady(host: HostCliClient, apiKey: string): Promise
 }
 
 function seedRegistryAndSession(dashboardPort: number): SessionArtifactSummary {
-  const registry = readJsonFile<RegistryData>(REGISTRY_FILE, {});
+  const registry = readJsonFileOr<RegistryData>(REGISTRY_FILE, {});
   registry.sandboxes = registry.sandboxes ?? {};
 
   const credentialHash = createHash("sha256").update(DISCORD_FAKE_TOKEN).digest("hex");
@@ -361,7 +338,7 @@ function registryVersion(): unknown {
 }
 
 function registrySandbox(): Record<string, unknown> {
-  const sandbox = readJsonFile<RegistryData>(REGISTRY_FILE, {}).sandboxes?.[SANDBOX_NAME];
+  const sandbox = readJsonFileOr<RegistryData>(REGISTRY_FILE, {}).sandboxes?.[SANDBOX_NAME];
   expect(sandbox, `registry entry missing for ${SANDBOX_NAME}`).toBeDefined();
   return sandbox as Record<string, unknown>;
 }

--- a/test/e2e/live/rebuild-openclaw.test.ts
+++ b/test/e2e/live/rebuild-openclaw.test.ts
@@ -10,6 +10,13 @@ import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import {
+  readJsonFile,
+  readJsonFileOr,
+  restoreFile,
+  snapshotFile,
+  writeJsonFile,
+} from "../fixtures/file-state.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { createOldBaseBuildContext } from "./rebuild-openclaw-old-base-context.ts";
@@ -89,36 +96,6 @@ function isRetryableOnboardEndpointFailure(result: ShellProbeResult): boolean {
       text,
     )
   );
-}
-
-function readJsonFile<T>(file: string, fallback: T): T {
-  if (!fs.existsSync(file)) return fallback;
-  return JSON.parse(fs.readFileSync(file, "utf8")) as T;
-}
-
-function writeJsonFile(file: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-interface FileSnapshot {
-  exists: boolean;
-  content?: string;
-}
-
-function snapshotFile(file: string): FileSnapshot {
-  return fs.existsSync(file)
-    ? { exists: true, content: fs.readFileSync(file, "utf8") }
-    : { exists: false };
-}
-
-function restoreFile(file: string, snapshot: FileSnapshot): void {
-  if (!snapshot.exists) {
-    fs.rmSync(file, { force: true });
-    return;
-  }
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, snapshot.content ?? "", "utf8");
 }
 
 function sleep(ms: number): Promise<void> {
@@ -225,7 +202,7 @@ function seedRegistryAndSession(dashboardPort: number): void {
   // so `nemoclaw <name> rebuild --yes` exercises the user-visible rebuild
   // boundary. Remove this local seeding once a first-class old-version lifecycle
   // fixture/profile exists.
-  const registry = readJsonFile<{
+  const registry = readJsonFileOr<{
     sandboxes?: Record<string, Record<string, unknown>>;
     defaultSandbox?: string;
   }>(REGISTRY_FILE, {});
@@ -252,7 +229,7 @@ function seedRegistryAndSession(dashboardPort: number): void {
   const now = new Date().toISOString();
   const complete = { status: "complete", startedAt: now, completedAt: now, error: null };
   const pending = { status: "pending", startedAt: null, completedAt: null, error: null };
-  const session = readJsonFile<Record<string, unknown>>(SESSION_FILE, {});
+  const session = readJsonFileOr<Record<string, unknown>>(SESSION_FILE, {});
   Object.assign(session, {
     sandboxName: SANDBOX_NAME,
     status: "complete",
@@ -279,7 +256,7 @@ function seedRegistryAndSession(dashboardPort: number): void {
 }
 
 function registrySandbox(): Record<string, unknown> {
-  const data = readJsonFile<{ sandboxes?: Record<string, Record<string, unknown>> }>(
+  const data = readJsonFileOr<{ sandboxes?: Record<string, Record<string, unknown>> }>(
     REGISTRY_FILE,
     {},
   );
@@ -304,7 +281,7 @@ function latestRebuildBackupDir(): string {
 function latestRebuildManifest(backupDir: string): Record<string, unknown> {
   const manifestPath = path.join(backupDir, "rebuild-manifest.json");
   expect(fs.existsSync(manifestPath), `backup manifest missing: ${manifestPath}`).toBe(true);
-  return JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+  return readJsonFile<Record<string, unknown>>(manifestPath);
 }
 
 function backupCredentialLeakPaths(backupDir: string, oldGatewayToken: string): string[] {
@@ -628,7 +605,7 @@ print(json.dumps({'seeded': saved == os.environ['PRE_REBUILD_GATEWAY_TOKEN'], 'h
     expect(preRebuildConfigHash).toContain("openclaw.json");
 
     seedRegistryAndSession(phase1DashboardPort as number);
-    const sessionAfterSeed = readJsonFile<Record<string, unknown>>(SESSION_FILE, {});
+    const sessionAfterSeed = readJsonFileOr<Record<string, unknown>>(SESSION_FILE, {});
     const seededSteps = sessionAfterSeed.steps as Record<string, { status?: string }> | undefined;
     const seededSandbox = registrySandbox();
     await artifacts.writeJson("phase-4-registry-session-summary.json", {

--- a/test/e2e/live/upgrade-stale-sandbox-helpers.ts
+++ b/test/e2e/live/upgrade-stale-sandbox-helpers.ts
@@ -10,6 +10,12 @@ import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { resultText } from "../fixtures/clients/index.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect } from "../fixtures/e2e-test.ts";
+import {
+  readJsonFileOrFallback,
+  restoreFile,
+  snapshotFile,
+  writeJsonFile,
+} from "../fixtures/file-state.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
@@ -34,11 +40,6 @@ export const OLD_BASE_TAG = `nemoclaw-old-base:${SANDBOX_NAME.toLowerCase().repl
 const REGISTRY_FILE = path.join(os.homedir(), ".nemoclaw", "sandboxes.json");
 const SESSION_FILE = path.join(os.homedir(), ".nemoclaw", "onboard-session.json");
 const INSTALL_ATTEMPTS = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true" ? 3 : 1;
-
-interface FileSnapshot {
-  exists: boolean;
-  content?: string;
-}
 
 function assertSafeSandboxName(): void {
   if (!SANDBOX_NAME.startsWith(TEST_SANDBOX_PREFIX)) {
@@ -67,32 +68,6 @@ export async function bestEffort(run: () => Promise<unknown>): Promise<void> {
   } catch {
     // Cleanup must not mask the primary assertion failure.
   }
-}
-
-function readJsonFile<T>(file: string, fallback: T): T {
-  try {
-    return fs.existsSync(file) ? (JSON.parse(fs.readFileSync(file, "utf8")) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function writeJsonFile(file: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-function snapshotFile(file: string): FileSnapshot {
-  return fs.existsSync(file)
-    ? { exists: true, content: fs.readFileSync(file, "utf8") }
-    : { exists: false };
-}
-
-function restoreFile(file: string, snapshot: FileSnapshot): void {
-  snapshot.exists || fs.rmSync(file, { force: true });
-  if (!snapshot.exists) return;
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, snapshot.content ?? "", "utf8");
 }
 
 function createOldBaseBuildContext(): string {
@@ -125,7 +100,7 @@ function createOldBaseBuildContext(): string {
 }
 
 export function writeStaleRegistryEntry(): void {
-  const session = readJsonFile<Record<string, unknown>>(SESSION_FILE, {});
+  const session = readJsonFileOrFallback<Record<string, unknown>>(SESSION_FILE, {});
   const envProvider =
     process.env.NEMOCLAW_PROVIDER === "custom"
       ? "compatible-endpoint"
@@ -139,7 +114,7 @@ export function writeStaleRegistryEntry(): void {
     process.env.NEMOCLAW_MODEL ||
     process.env.NEMOCLAW_COMPAT_MODEL ||
     "nvidia/nvidia/nemotron-3-ultra";
-  const registry = readJsonFile<{
+  const registry = readJsonFileOrFallback<{
     sandboxes?: Record<string, Record<string, unknown>>;
     defaultSandbox?: string;
   }>(REGISTRY_FILE, {});

--- a/test/e2e/support/e2e-file-state.test.ts
+++ b/test/e2e/support/e2e-file-state.test.ts
@@ -77,4 +77,13 @@ describe("E2E file state", () => {
       });
     });
   });
+
+  it("does not hide non-parse JSON read failures", () => {
+    withTempDir((root) => {
+      const directory = path.join(root, "state-directory.json");
+      fs.mkdirSync(directory);
+
+      expect(() => readJsonFileOrFallback(directory, { source: "unused" })).toThrow();
+    });
+  });
 });

--- a/test/e2e/support/e2e-file-state.test.ts
+++ b/test/e2e/support/e2e-file-state.test.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  readJsonFile,
+  readJsonFileOr,
+  readJsonFileOrFallback,
+  restoreFile,
+  snapshotFile,
+  writeJsonFile,
+} from "../fixtures/file-state.ts";
+
+function withTempDir(run: (root: string) => void): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-file-state-"));
+  try {
+    run(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("E2E file state", () => {
+  it("distinguishes absent, empty, and populated snapshots during restore", () => {
+    withTempDir((root) => {
+      const file = path.join(root, "nested", "state.txt");
+      const absent = snapshotFile(file);
+      expect(absent).toEqual({ exists: false });
+
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, "", "utf8");
+      const empty = snapshotFile(file);
+      expect(empty).toEqual({ exists: true, content: "" });
+
+      fs.writeFileSync(file, "changed", "utf8");
+      restoreFile(file, empty);
+      expect(fs.readFileSync(file, "utf8")).toBe("");
+
+      fs.writeFileSync(file, "created", "utf8");
+      restoreFile(file, absent);
+      expect(fs.existsSync(file)).toBe(false);
+    });
+  });
+
+  it("writes stable formatted JSON and creates nested parent directories", () => {
+    withTempDir((root) => {
+      const file = path.join(root, "nested", "deeper", "state.json");
+      writeJsonFile(file, { enabled: true, count: 2 });
+
+      expect(fs.readFileSync(file, "utf8")).toBe(
+        `${JSON.stringify({ enabled: true, count: 2 }, null, 2)}\n`,
+      );
+      expect(readJsonFile<{ enabled: boolean; count: number }>(file)).toEqual({
+        enabled: true,
+        count: 2,
+      });
+    });
+  });
+
+  it("makes missing and malformed JSON fallback behavior explicit", () => {
+    withTempDir((root) => {
+      const missing = path.join(root, "missing.json");
+      const malformed = path.join(root, "malformed.json");
+      fs.writeFileSync(malformed, "{not-json", "utf8");
+
+      expect(readJsonFileOr(missing, { source: "missing-fallback" })).toEqual({
+        source: "missing-fallback",
+      });
+      expect(() => readJsonFileOr(malformed, { source: "unused" })).toThrow(SyntaxError);
+      expect(readJsonFileOrFallback(malformed, { source: "parse-fallback" })).toEqual({
+        source: "parse-fallback",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extract the repeated synchronous file snapshot/restore and JSON state helpers used by the stateful rebuild E2E scenarios. The shared utility preserves the existing absent-file, empty-file, malformed-JSON, parent-directory, and formatted-newline behavior.

## Related Issue

Closes #6348
Parent epic: #6346

## Changes

- Add a discriminated `FileSnapshot` type that cannot confuse an absent file with an empty one.
- Add shared snapshot, restore, strict JSON read, missing-file fallback, parse-error fallback, and formatted JSON write helpers.
- Keep malformed JSON behavior explicit through separate `readJsonFileOr` and `readJsonFileOrFallback` APIs.
- Migrate rebuild-openclaw, rebuild-hermes, and stale-sandbox upgrade state handling.
- Add focused support tests for absent, empty, populated, malformed, and nested-path cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable — justification: test-state utility only
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass — `e2e-file-state.test.ts` (3 passed)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed

Additional local verification:

- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run lint`


## Advisor / Merge Coordination Notes

- **Overlapping E2E refactor PRs:** PR #6358 and PR #6357 touch the same rebuild/stale-sandbox live test files. This PR should land first because it only extracts shared file-state helpers; the overlapping PRs can then rebase and keep using `test/e2e/fixtures/file-state.ts`. Any conflicts are expected to be mechanical import/helper-call conflicts, not runtime behavior conflicts.
- **`readJsonFileOrFallback` semantics:** The malformed-JSON fallback is intentional only for stale-sandbox E2E setup state where prior test runs may leave incomplete registry/session JSON. The helper catches only `SyntaxError`; non-parse I/O/read failures still propagate, and `test/e2e/support/e2e-file-state.test.ts` covers that negative case.
- **Sensitive-path waiver:** Changes are test-only under `test/e2e/**`; no production credential, policy, onboarding, inference, runner, sandbox runtime, or messaging code is modified. Maintainer approval by `cv` is recorded on this PR.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared E2E file-state utilities for snapshot/restore and JSON read/write, with consistent pretty-printed JSON output and a trailing newline.
  * Introduced two JSON fallback behaviors: fallback only when a file is missing, or fallback when the file is missing and/or contains malformed JSON.
* **Tests**
  * Added E2E coverage for restore behavior (absent vs. empty), nested directory handling for writes, and the JSON fallback/throw rules.
* **Chores**
  * Updated multiple live E2E tests to reuse the shared file-state utilities instead of local helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
