### PR TITLE
refactor(e2e): track sandbox and gateway cleanup as resources

### DIFF
--- a/test/e2e/fixtures/cleanup.ts
+++ b/test/e2e/fixtures/cleanup.ts
@@ -14,6 +14,12 @@ export interface CleanupResult {
 type CleanupFn = () => Promise<void> | void;
 type RedactFn = (text: string) => string;
 
+export interface CleanupHost {
+  cleanupSandbox(name: string): Promise<void>;
+  cleanupGatewayRegistration(name: string): Promise<void>;
+  cleanupForward(port: number): Promise<void>;
+}
+
 interface CleanupEntry {
   name: string;
   run: CleanupFn;
@@ -32,6 +38,22 @@ export class CleanupRegistry {
       throw new Error("cleanup name is required");
     }
     this.entries.push({ name, run });
+  }
+
+  trackSandbox(host: CleanupHost, name: string): void {
+    this.add(`destroy sandbox ${name}`, () => host.cleanupSandbox(name));
+  }
+
+  trackGateway(host: CleanupHost, name: string): void {
+    this.add(`remove gateway ${name}`, () => host.cleanupGatewayRegistration(name));
+  }
+
+  trackForward(host: CleanupHost, port: number): void {
+    this.add(`stop forward ${port}`, () => host.cleanupForward(port));
+  }
+
+  trackDisposable(name: string, dispose: CleanupFn): void {
+    this.add(name, dispose);
   }
 
   async runAll(): Promise<CleanupResult> {

--- a/test/e2e/fixtures/clients/host.ts
+++ b/test/e2e/fixtures/clients/host.ts
@@ -21,7 +21,8 @@ const GATEWAY_ALREADY_ABSENT =
   /gateway[^\n]*(?:does not exist|not found)|No (?:active )?gateway|No gateway metadata found/i;
 const GATEWAY_REMOVE_UNSUPPORTED =
   /unrecognized subcommand ['"]remove['"]|unknown command ['"]remove['"]/i;
-const FORWARD_ALREADY_ABSENT = /no (?:active )?forward|forward .* not found|not running/i;
+const FORWARD_ALREADY_ABSENT =
+  /no (?:active )?forward|forward[^\n]*(?:not found|not running)|forward stop[^\n]*not running/i;
 
 export class HostCliClient {
   private readonly runner: CommandRunner;

--- a/test/e2e/fixtures/clients/host.ts
+++ b/test/e2e/fixtures/clients/host.ts
@@ -21,6 +21,7 @@ const GATEWAY_ALREADY_ABSENT =
   /gateway[^\n]*(?:does not exist|not found)|No (?:active )?gateway|No gateway metadata found/i;
 const GATEWAY_REMOVE_UNSUPPORTED =
   /unrecognized subcommand ['"]remove['"]|unknown command ['"]remove['"]/i;
+const FORWARD_ALREADY_ABSENT = /no (?:active )?forward|forward .* not found|not running/i;
 
 export class HostCliClient {
   private readonly runner: CommandRunner;
@@ -149,6 +150,15 @@ export class HostCliClient {
     });
     if (destroy.exitCode === 0 || GATEWAY_ALREADY_ABSENT.test(resultText(destroy))) return;
     assertExitZero(destroy, `cleanup gateway registration ${gatewayName}`);
+  }
+
+  async cleanupForward(port: number, options: ShellProbeRunOptions = {}): Promise<void> {
+    const result = await this.command("openshell", ["forward", "stop", String(port)], {
+      ...options,
+      artifactName: options.artifactName ?? `cleanup-forward-${port}`,
+    });
+    if (result.exitCode === 0 || FORWARD_ALREADY_ABSENT.test(resultText(result))) return;
+    assertExitZero(result, `cleanup forward ${port}`);
   }
 
   async bestEffortCleanupSandbox(

--- a/test/e2e/live/sandbox-operations.test.ts
+++ b/test/e2e/live/sandbox-operations.test.ts
@@ -13,6 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import { containsInteger42Answer } from "../../helpers/e2e-answer-assertions.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
+import type { CleanupRegistry } from "../fixtures/cleanup.ts";
 import {
   assertExitZero as expectExitZero,
   outputContainsSandbox,
@@ -34,8 +35,6 @@ const SANDBOX_B = "e2e-sbx-b";
 const REGISTRY_FILE = path.join(process.env.HOME ?? os.homedir(), ".nemoclaw", "sandboxes.json");
 const GATEWAY_CONTAINER = "openshell-cluster-nemoclaw";
 
-type CleanupRegistry = { add(name: string, run: () => Promise<void> | void): void };
-
 async function onboardSandbox(
   host: HostCliClient,
   cleanup: CleanupRegistry,
@@ -44,7 +43,7 @@ async function onboardSandbox(
   hosted: HostedInferenceConfig,
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<ShellProbeResult> {
-  cleanup.add(`destroy sandbox ${sandboxName}`, () => host.cleanupSandbox(sandboxName));
+  cleanup.trackSandbox(host, sandboxName);
   const result = await host.nemoclaw(
     ["onboard", "--non-interactive", "--yes", "--yes-i-accept-third-party-software"],
     {

--- a/test/e2e/support/e2e-cleanup-resources.test.ts
+++ b/test/e2e/support/e2e-cleanup-resources.test.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { type CleanupHost, CleanupRegistry } from "../fixtures/cleanup.ts";
+
+describe("cleanup resources", () => {
+  it("tears down acquired resources in reverse order", async () => {
+    const calls: string[] = [];
+    const host: CleanupHost = {
+      cleanupSandbox: async (name) => {
+        calls.push(`sandbox:${name}`);
+      },
+      cleanupGatewayRegistration: async (name) => {
+        calls.push(`gateway:${name}`);
+      },
+      cleanupForward: async (port) => {
+        calls.push(`forward:${port}`);
+      },
+    };
+    const cleanup = new CleanupRegistry();
+    cleanup.trackGateway(host, "nemoclaw");
+    cleanup.trackSandbox(host, "e2e-resource");
+    cleanup.trackForward(host, 18789);
+
+    const result = await cleanup.runAll();
+    expect(calls).toEqual(["forward:18789", "sandbox:e2e-resource", "gateway:nemoclaw"]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("supports partial setup and runs each registration only once", async () => {
+    let calls = 0;
+    const cleanup = new CleanupRegistry();
+    cleanup.trackDisposable("close acquired server", () => {
+      calls += 1;
+    });
+
+    expect((await cleanup.runAll()).passed).toEqual(["close acquired server"]);
+    expect(await cleanup.runAll()).toEqual({ passed: [], failures: [] });
+    expect(calls).toBe(1);
+  });
+
+  it("redacts failures and continues cleanup", async () => {
+    const calls: string[] = [];
+    const cleanup = new CleanupRegistry((text) => text.replaceAll("secret", "[REDACTED]"));
+    cleanup.trackDisposable("later secret cleanup", () => {
+      calls.push("later");
+    });
+    cleanup.trackDisposable("failing secret cleanup", () => {
+      throw new Error("secret failure");
+    });
+
+    const result = await cleanup.runAll();
+    expect(calls).toEqual(["later"]);
+    expect(result).toEqual({
+      passed: ["later [REDACTED] cleanup"],
+      failures: [{ name: "failing [REDACTED] cleanup", message: "[REDACTED] failure" }],
+    });
+  });
+});

--- a/test/e2e/support/e2e-clients.test.ts
+++ b/test/e2e/support/e2e-clients.test.ts
@@ -183,6 +183,31 @@ describe("E2E fixture clients", () => {
     ]);
   });
 
+  it("host client stops a forward and accepts an already-absent forward", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue({ exitCode: 0 });
+    runner.enqueue({ exitCode: 1, stderr: "No active forward" });
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await host.cleanupForward(18789);
+    await host.cleanupForward(18789);
+
+    expect(runner.calls.map((call) => call.args)).toEqual([
+      ["forward", "stop", "18789"],
+      ["forward", "stop", "18789"],
+    ]);
+  });
+
+  it("host client surfaces unexpected forward cleanup failures", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue({ exitCode: 1, stderr: "permission denied" });
+    const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
+
+    await expect(host.cleanupForward(18789)).rejects.toThrow(
+      "cleanup forward 18789 failed: permission denied",
+    );
+  });
+
   it("host client does not hide a current gateway remove failure behind the legacy verb", async () => {
     const runner = new FakeRunner();
     runner.enqueue({ exitCode: 1, stderr: "permission denied" });

--- a/test/e2e/support/e2e-clients.test.ts
+++ b/test/e2e/support/e2e-clients.test.ts
@@ -183,28 +183,31 @@ describe("E2E fixture clients", () => {
     ]);
   });
 
-  it("host client stops a forward and accepts an already-absent forward", async () => {
+  it.each([
+    "No active forward",
+    "forward 18789 not found",
+    "forward stop failed: not running",
+  ])("host client accepts canonical already-absent forward output: %s", async (stderr) => {
     const runner = new FakeRunner();
-    runner.enqueue({ exitCode: 0 });
-    runner.enqueue({ exitCode: 1, stderr: "No active forward" });
+    runner.enqueue({ exitCode: 1, stderr });
     const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
 
     await host.cleanupForward(18789);
-    await host.cleanupForward(18789);
 
-    expect(runner.calls.map((call) => call.args)).toEqual([
-      ["forward", "stop", "18789"],
-      ["forward", "stop", "18789"],
-    ]);
+    expect(runner.calls.map((call) => call.args)).toEqual([["forward", "stop", "18789"]]);
   });
 
-  it("host client surfaces unexpected forward cleanup failures", async () => {
+  it.each([
+    "permission denied",
+    "daemon not running",
+    "some unrelated error: not running",
+  ])("host client surfaces unexpected forward cleanup failure: %s", async (stderr) => {
     const runner = new FakeRunner();
-    runner.enqueue({ exitCode: 1, stderr: "permission denied" });
+    runner.enqueue({ exitCode: 1, stderr });
     const host = new HostCliClient(runner, { cliPath: "nemoclaw" });
 
     await expect(host.cleanupForward(18789)).rejects.toThrow(
-      "cleanup forward 18789 failed: permission denied",
+      `cleanup forward 18789 failed: ${stderr}`,
     );
   });
 


### PR DESCRIPTION
## Summary

Extend the existing cleanup registry and host client with typed sandbox, gateway, forward, and disposable resource registration. Idempotent command semantics stay in `HostCliClient`; reverse-order execution, redaction, and failure aggregation stay in `CleanupRegistry`.

Refs #6352 (resource-tracking foundation; remaining cleanup-site migrations stay tracked there)
Parent epic: #6346

## Changes

- Add `trackSandbox`, `trackGateway`, `trackForward`, and `trackDisposable`.
- Add idempotent `HostCliClient.cleanupForward`, including already-absent detection and real failure propagation.
- Adopt sandbox tracking in the shared sandbox-operations acquisition helper.
- Add tests for reverse ordering, partial setup/idempotency, redacted failure reporting, absent forwards, and unexpected forward failures.

## Scope note

This PR intentionally does not complete issue 6352. It lands the typed cleanup resource APIs, forward cleanup semantics, and a proving sandbox tracking call site; remaining bestEffort / gateway / forward cleanup-site migrations continue under #6352.

## Verification

- [x] Signed/Verified commit; all commit and push hooks passed
- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] `npm run lint`
- [x] Cleanup/client support tests: 46 passed
- [x] No user-facing docs or secrets

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end teardown handling for temporary resources by adding host-based cleanup registration (sandbox, gateway, and forwarded ports).
  * Forwarded-port cleanup now treats “already absent/not running” output as success to avoid false failures.
  * Cleanup continues after errors, while keeping reverse teardown order and returning redacted failure details.
* **Tests**
  * Added an E2E suite validating cleanup-resource semantics (ordering, partial setup, error continuation, and redaction).
  * Added E2E cases for forward-stop success and clearer failure messaging (including permission-related errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

