### PR TITLE
refactor(e2e): centralize host address discovery for sandbox callbacks

### DIFF
--- a/test/e2e/fixtures/host-address.ts
+++ b/test/e2e/fixtures/host-address.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { buildAvailabilityProbeEnv } from "./availability-env.ts";
+import { assertExitZero } from "./clients/command.ts";
 import type { HostCliClient } from "./clients/host.ts";
 import type { ShellProbeResult } from "./shell-probe.ts";
 
@@ -49,5 +50,6 @@ export async function discoverHostAddress(
     ],
     { artifactName, env: buildAvailabilityProbeEnv(), timeoutMs: 30_000 },
   );
+  assertExitZero(probe, "host address discovery");
   return { ...parseHostAddressProbe(probe.stdout), probe };
 }

--- a/test/e2e/fixtures/host-address.ts
+++ b/test/e2e/fixtures/host-address.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { buildAvailabilityProbeEnv } from "./availability-env.ts";
+import type { HostCliClient } from "./clients/host.ts";
+import type { ShellProbeResult } from "./shell-probe.ts";
+
+export type HostAddressSource =
+  | "route"
+  | "hostname"
+  | "darwin-interface"
+  | "darwin-ifconfig"
+  | "loopback";
+export interface HostAddressResult {
+  address: string;
+  source: HostAddressSource;
+  probe: ShellProbeResult;
+}
+
+export function parseHostAddressProbe(
+  output: string,
+): Pick<HostAddressResult, "address" | "source"> {
+  const match = output.trim().match(/^(route|hostname|darwin-interface|darwin-ifconfig)\s+(\S+)/);
+  return match
+    ? { source: match[1] as HostAddressSource, address: match[2] }
+    : { source: "loopback", address: "127.0.0.1" };
+}
+
+export async function discoverHostAddress(
+  host: HostCliClient,
+  artifactName = "host-address-for-sandbox",
+): Promise<HostAddressResult> {
+  const probe = await host.command(
+    "bash",
+    [
+      "-lc",
+      [
+        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
+        'if [ -n "$ip_addr" ]; then echo "route $ip_addr"; exit 0; fi',
+        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
+        'if [ -n "$ip_addr" ]; then echo "hostname $ip_addr"; exit 0; fi',
+        'if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then',
+        ' for iface in en0 en1 bridge100; do ip_addr="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"; if [ -n "$ip_addr" ]; then echo "darwin-interface $ip_addr"; exit 0; fi; done',
+        " ip_addr=\"$(ifconfig 2>/dev/null | awk '/inet / && $2 !~ /^127\\./ {print $2; exit}')\"",
+        ' if [ -n "$ip_addr" ]; then echo "darwin-ifconfig $ip_addr"; exit 0; fi',
+        "fi",
+        "echo loopback 127.0.0.1",
+      ].join("\n"),
+    ],
+    { artifactName, env: buildAvailabilityProbeEnv(), timeoutMs: 30_000 },
+  );
+  return { ...parseHostAddressProbe(probe.stdout), probe };
+}

--- a/test/e2e/fixtures/host-address.ts
+++ b/test/e2e/fixtures/host-address.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isIP } from "node:net";
+
 import { buildAvailabilityProbeEnv } from "./availability-env.ts";
 import { assertExitZero } from "./clients/command.ts";
 import type { HostCliClient } from "./clients/host.ts";
@@ -22,9 +24,18 @@ export function parseHostAddressProbe(
   output: string,
 ): Pick<HostAddressResult, "address" | "source"> {
   const match = output.trim().match(/^(route|hostname|darwin-interface|darwin-ifconfig)\s+(\S+)/);
-  return match
-    ? { source: match[1] as HostAddressSource, address: match[2] }
-    : { source: "loopback", address: "127.0.0.1" };
+  if (!match) {
+    return { source: "loopback", address: "127.0.0.1" };
+  }
+
+  const address = match[2];
+  if (isIP(address) !== 4) {
+    throw new Error(
+      `host address discovery returned invalid IPv4 address from ${match[1]}: ${address}`,
+    );
+  }
+
+  return { source: match[1] as HostAddressSource, address };
 }
 
 export async function discoverHostAddress(

--- a/test/e2e/fixtures/host-address.ts
+++ b/test/e2e/fixtures/host-address.ts
@@ -23,19 +23,24 @@ export interface HostAddressResult {
 export function parseHostAddressProbe(
   output: string,
 ): Pick<HostAddressResult, "address" | "source"> {
-  const match = output.trim().match(/^(route|hostname|darwin-interface|darwin-ifconfig)\s+(\S+)/);
-  if (!match) {
+  const trimmed = output.trim();
+  const match = trimmed.match(/^(route|hostname|darwin-interface|darwin-ifconfig)\s+(\S+)$/);
+  if (match) {
+    const address = match[2];
+    if (isIP(address) !== 4) {
+      throw new Error(
+        `host address discovery returned invalid IPv4 address from ${match[1]}: ${address}`,
+      );
+    }
+
+    return { source: match[1] as HostAddressSource, address };
+  }
+
+  if (trimmed === "loopback 127.0.0.1") {
     return { source: "loopback", address: "127.0.0.1" };
   }
 
-  const address = match[2];
-  if (isIP(address) !== 4) {
-    throw new Error(
-      `host address discovery returned invalid IPv4 address from ${match[1]}: ${address}`,
-    );
-  }
-
-  return { source: match[1] as HostAddressSource, address };
+  throw new Error(`host address discovery returned unrecognized probe output: ${trimmed}`);
 }
 
 export async function discoverHostAddress(

--- a/test/e2e/live/mcp-bridge-sandbox.ts
+++ b/test/e2e/live/mcp-bridge-sandbox.ts
@@ -4,6 +4,7 @@
 import { shellQuote } from "../../../src/lib/core/shell-quote";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
+import { discoverHostAddress } from "../fixtures/host-address.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 const MCP_CURL_HTTP_CODE_MARKER = "NEMOCLAW_MCP_CURL_HTTP_CODE=";
@@ -11,25 +12,7 @@ const MCP_CURL_HTTP_CODE_MARKER = "NEMOCLAW_MCP_CURL_HTTP_CODE=";
 export type McpDnsRebindingAdapter = "mcporter" | "hermes-config" | "deepagents-config";
 
 export async function hostAddressForSandbox(host: HostCliClient): Promise<string> {
-  const probe = await host.command(
-    "bash",
-    [
-      "-lc",
-      [
-        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "echo 127.0.0.1",
-      ].join("\n"),
-    ],
-    {
-      artifactName: "host-ip-for-mcp-compatible-endpoint",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  return probe.stdout.trim().split(/\s+/)[0] || "127.0.0.1";
+  return (await discoverHostAddress(host)).address;
 }
 
 export {

--- a/test/e2e/live/messaging-compatible-endpoint.test.ts
+++ b/test/e2e/live/messaging-compatible-endpoint.test.ts
@@ -26,7 +26,6 @@ import {
   readRequestBody,
   writeSseBody as sseResponse,
 } from "../fixtures/http-protocol.ts";
-import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import { CLI_DIST_ENTRYPOINT, CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import {

--- a/test/e2e/live/messaging-compatible-endpoint.test.ts
+++ b/test/e2e/live/messaging-compatible-endpoint.test.ts
@@ -18,6 +18,7 @@ import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import { discoverHostAddress } from "../fixtures/host-address.ts";
 import {
   closeServer,
   writeJsonResponse as jsonResponse,
@@ -25,6 +26,7 @@ import {
   readRequestBody,
   writeSseBody as sseResponse,
 } from "../fixtures/http-protocol.ts";
+import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import { CLI_DIST_ENTRYPOINT, CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/paths.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import {
@@ -264,33 +266,7 @@ async function startCompatibleMock(
 }
 
 async function hostAddressForSandbox(host: HostCliClient): Promise<string> {
-  const probe = await host.command(
-    "bash",
-    [
-      "-lc",
-      [
-        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        'if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then',
-        "  for iface in en0 en1 bridge100; do",
-        '    ip_addr="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"',
-        '    if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "  done",
-        "  ip_addr=\"$(ifconfig 2>/dev/null | awk '/inet / && $2 !~ /^127\\./ {print $2; exit}')\"",
-        '  if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "fi",
-        "echo 127.0.0.1",
-      ].join("\n"),
-    ],
-    {
-      artifactName: "host-ip-for-compatible-endpoint",
-      env: commandEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  return probe.stdout.trim().split(/\s+/)[0] || "127.0.0.1";
+  return (await discoverHostAddress(host)).address;
 }
 
 async function sourceCliAvailable(host: HostCliClient): Promise<boolean> {

--- a/test/e2e/live/onboard-resume.test.ts
+++ b/test/e2e/live/onboard-resume.test.ts
@@ -13,6 +13,8 @@ import {
   type FakeOpenAiCompatibleServer,
   startFakeOpenAiCompatibleServer,
 } from "../fixtures/fake-openai-compatible.ts";
+import { discoverHostAddress } from "../fixtures/host-address.ts";
+import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import { CLI_ENTRYPOINT } from "../fixtures/paths.ts";
 
 // Disruption-recovery contract — regression for #446.
@@ -108,33 +110,7 @@ function containsExactJsonToken(value: unknown, token: string): boolean {
 }
 
 async function hostAddressForSandbox(host: HostCliClient): Promise<string> {
-  const probe = await host.command(
-    "bash",
-    [
-      "-lc",
-      [
-        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        'if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then',
-        "  for iface in en0 en1 bridge100; do",
-        '    ip_addr="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"',
-        '    if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "  done",
-        "  ip_addr=\"$(ifconfig 2>/dev/null | awk '/inet / && $2 !~ /^127\\./ {print $2; exit}')\"",
-        '  if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "fi",
-        "echo 127.0.0.1",
-      ].join("\n"),
-    ],
-    {
-      artifactName: "host-ip-for-onboard-resume-compatible-endpoint",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  return probe.stdout.trim().split(/\s+/)[0] || "127.0.0.1";
+  return (await discoverHostAddress(host)).address;
 }
 
 function expectHermeticCompatibleInferenceUsed(fake: FakeOpenAiCompatibleServer): void {

--- a/test/e2e/live/onboard-resume.test.ts
+++ b/test/e2e/live/onboard-resume.test.ts
@@ -14,7 +14,6 @@ import {
   startFakeOpenAiCompatibleServer,
 } from "../fixtures/fake-openai-compatible.ts";
 import { discoverHostAddress } from "../fixtures/host-address.ts";
-import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import { CLI_ENTRYPOINT } from "../fixtures/paths.ts";
 
 // Disruption-recovery contract — regression for #446.

--- a/test/e2e/live/openshell-allowed-ips-rebinding.ts
+++ b/test/e2e/live/openshell-allowed-ips-rebinding.ts
@@ -14,6 +14,7 @@ import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, trustedSandboxShellScript } from "../fixtures/clients/sandbox.ts";
 import { expect } from "../fixtures/e2e-test.ts";
+import { discoverHostAddress } from "../fixtures/host-address.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import {
   type DnsRebindingHostsFixture,
@@ -141,26 +142,7 @@ export function buildRawOpenShellAllowedIpsRebindingProbeScript(targetUrl: strin
 }
 
 async function hostAddressForSandbox(host: HostCliClient): Promise<string> {
-  const probe = await host.command(
-    "bash",
-    [
-      "-lc",
-      [
-        'ip_addr="$(ip route get 1.1.1.1 2>/dev/null | awk \'{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}\')"',
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "ip_addr=\"$(hostname -I 2>/dev/null | awk '{print $1}')\"",
-        'if [ -n "$ip_addr" ]; then echo "$ip_addr"; exit 0; fi',
-        "echo 127.0.0.1",
-      ].join("\n"),
-    ],
-    {
-      artifactName: "raw-openshell-rebinding-host-address",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(probe.exitCode, resultText(probe)).toBe(0);
-  return probe.stdout.trim();
+  return (await discoverHostAddress(host)).address;
 }
 
 async function closeServer(server: Server): Promise<void> {

--- a/test/e2e/support/e2e-host-address.test.ts
+++ b/test/e2e/support/e2e-host-address.test.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { parseHostAddressProbe } from "../fixtures/host-address.ts";
+
+describe("host address discovery", () => {
+  it.each([
+    ["route 10.0.0.2\n", { source: "route", address: "10.0.0.2" }],
+    ["hostname 192.168.1.5\n", { source: "hostname", address: "192.168.1.5" }],
+    ["darwin-interface 192.168.64.1\n", { source: "darwin-interface", address: "192.168.64.1" }],
+    ["darwin-ifconfig 10.1.2.3\n", { source: "darwin-ifconfig", address: "10.1.2.3" }],
+    ["", { source: "loopback", address: "127.0.0.1" }],
+  ])("parses %j", (output, expected) => expect(parseHostAddressProbe(output)).toEqual(expected));
+});

--- a/test/e2e/support/e2e-host-address.test.ts
+++ b/test/e2e/support/e2e-host-address.test.ts
@@ -15,6 +15,12 @@ describe("host address discovery", () => {
     ["", { source: "loopback", address: "127.0.0.1" }],
   ])("parses %j", (output, expected) => expect(parseHostAddressProbe(output)).toEqual(expected));
 
+  it("rejects malformed known-source host address output", () => {
+    expect(() => parseHostAddressProbe("route not-an-ip\n")).toThrow(
+      /invalid IPv4 address from route: not-an-ip/,
+    );
+  });
+
   it("rejects failed host probes before parsing fallback output", async () => {
     const runner: CommandRunner = {
       run: async (command) => ({

--- a/test/e2e/support/e2e-host-address.test.ts
+++ b/test/e2e/support/e2e-host-address.test.ts
@@ -12,8 +12,14 @@ describe("host address discovery", () => {
     ["hostname 192.168.1.5\n", { source: "hostname", address: "192.168.1.5" }],
     ["darwin-interface 192.168.64.1\n", { source: "darwin-interface", address: "192.168.64.1" }],
     ["darwin-ifconfig 10.1.2.3\n", { source: "darwin-ifconfig", address: "10.1.2.3" }],
-    ["", { source: "loopback", address: "127.0.0.1" }],
+    ["loopback 127.0.0.1\n", { source: "loopback", address: "127.0.0.1" }],
   ])("parses %j", (output, expected) => expect(parseHostAddressProbe(output)).toEqual(expected));
+
+  it("rejects successful unrecognized host address probe output", () => {
+    expect(() => parseHostAddressProbe("garbage 10.0.0.2\n")).toThrow(
+      /unrecognized probe output: garbage 10\.0\.0\.2/,
+    );
+  });
 
   it("rejects malformed known-source host address output", () => {
     expect(() => parseHostAddressProbe("route not-an-ip\n")).toThrow(

--- a/test/e2e/support/e2e-host-address.test.ts
+++ b/test/e2e/support/e2e-host-address.test.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { parseHostAddressProbe } from "../fixtures/host-address.ts";
+import { type CommandRunner } from "../fixtures/clients/command.ts";
+import { HostCliClient } from "../fixtures/clients/host.ts";
+import { discoverHostAddress, parseHostAddressProbe } from "../fixtures/host-address.ts";
 
 describe("host address discovery", () => {
   it.each([
@@ -12,4 +14,22 @@ describe("host address discovery", () => {
     ["darwin-ifconfig 10.1.2.3\n", { source: "darwin-ifconfig", address: "10.1.2.3" }],
     ["", { source: "loopback", address: "127.0.0.1" }],
   ])("parses %j", (output, expected) => expect(parseHostAddressProbe(output)).toEqual(expected));
+
+  it("rejects failed host probes before parsing fallback output", async () => {
+    const runner: CommandRunner = {
+      run: async (command) => ({
+        command: [command.command, ...command.args],
+        exitCode: 127,
+        signal: null,
+        timedOut: false,
+        stdout: "loopback 127.0.0.1\n",
+        stderr: "bash: command not found\n",
+        artifacts: { stdout: "stdout.txt", stderr: "stderr.txt", result: "result.json" },
+      }),
+    };
+
+    await expect(discoverHostAddress(new HostCliClient(runner))).rejects.toThrow(
+      /host address discovery failed/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Centralize the repeated multi-platform host-address probe used by sandbox callback tests and return typed discovery evidence, including an explicit loopback fallback source.

Closes #6351
Parent epic: #6346

## Changes

- Add typed route/hostname/macOS/loopback host-address discovery with command evidence.
- Preserve Linux then macOS discovery ordering.
- Migrate onboard-resume, messaging-compatible-endpoint, allowed-IP rebinding, and MCP bridge callers.
- Add route, hostname, macOS-interface, macOS-ifconfig, and fallback parser tests.

## Verification

- [x] Signed/Verified commit and all hooks passed
- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] Host-address support tests: 5 passed
- [x] No production networking behavior changed

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared end-to-end host address discovery utilities that run a host probe, extract the resolved address/source, and fall back to loopback (`127.0.0.1`) when no routable value is detected.
* **Bug Fixes**
  * Updated live end-to-end tests to use the shared discovery helper instead of ad-hoc shell probing, improving reliability across OS/network scenarios.
* **Tests**
  * Added an end-to-end suite covering multiple probe output formats and validating failure behavior when the probe command errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->