### PR TITLE
refactor(e2e): consolidate fake provider protocol utilities

### DIFF
--- a/test/e2e/fixtures/http-protocol.ts
+++ b/test/e2e/fixtures/http-protocol.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+import type http from "node:http";
+
+// Protocol mechanics only. Choosing fake versus hosted/public inference remains
+// the inference-mode concern tracked by #5745.
+
+export async function readRequestBody(req: http.IncomingMessage): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+export function writeJsonResponse(
+  res: http.ServerResponse,
+  status: number,
+  payload: unknown,
+): void {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+export function writeSseBody(res: http.ServerResponse, body: string): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "content-length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+export function writeSseEvents(
+  res: http.ServerResponse,
+  events: ReadonlyArray<readonly [string | undefined, unknown]>,
+  done = false,
+): void {
+  res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+  for (const [name, payload] of events) {
+    if (name) res.write(`event: ${name}\n`);
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  }
+  res.end(done ? "data: [DONE]\n\n" : undefined);
+}
+
+export async function listenServer(
+  server: http.Server,
+  port = 0,
+  host = "0.0.0.0",
+): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("test server did not bind to a TCP port");
+  return address.port;
+}
+
+export function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+}

--- a/test/e2e/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e/live/hermes-inference-switch-helpers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import http, { type Server } from "node:http";
+import http from "node:http";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -18,6 +18,11 @@ import {
 import { expect } from "../fixtures/e2e-test.ts";
 import type { FakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
 import { DEFAULT_HOSTED_INFERENCE_MODEL } from "../fixtures/hosted-inference.ts";
+import {
+  closeServer,
+  writeJsonResponse as jsonResponse,
+  writeSseEvents,
+} from "../fixtures/http-protocol.ts";
 import {
   inferenceResponseModel,
   inferenceSetAttemptCount,
@@ -234,34 +239,16 @@ export async function cleanupHermesSwitch(
   );
 }
 
-function jsonResponse(res: http.ServerResponse, status: number, payload: unknown): void {
-  const body = JSON.stringify(payload);
-  res.writeHead(status, {
-    "content-type": "application/json",
-    "content-length": Buffer.byteLength(body),
-  });
-  res.end(body);
-}
-
 function sseResponse(res: http.ServerResponse, events: Array<[string, unknown]>): void {
-  res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
-  for (const [name, payload] of events) {
-    res.write(`event: ${name}\n`);
-    res.write(`data: ${JSON.stringify(payload)}\n\n`);
-  }
-  res.end();
+  writeSseEvents(res, events);
 }
 
 function openAiSseResponse(res: http.ServerResponse, chunks: unknown[]): void {
-  res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
-  for (const chunk of chunks) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-  res.end("data: [DONE]\n\n");
-}
-
-function closeServer(server: Server): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
+  writeSseEvents(
+    res,
+    chunks.map((chunk) => [undefined, chunk] as const),
+    true,
+  );
 }
 
 async function startMockAnthropicProvider(): Promise<MockCompatibleAnthropicProvider> {

--- a/test/e2e/live/mcp-bridge-servers.ts
+++ b/test/e2e/live/mcp-bridge-servers.ts
@@ -9,6 +9,12 @@ import type { AddressInfo } from "node:net";
 import os from "node:os";
 
 import type { CleanupRegistry } from "../fixtures/cleanup.ts";
+import {
+  closeServer,
+  writeJsonResponse as jsonResponse,
+  listenServer as listenOnRandomPort,
+  readRequestBody,
+} from "../fixtures/http-protocol.ts";
 
 type TestServer = http.Server | https.Server;
 
@@ -103,48 +109,12 @@ const MCP_EMPTY_RESULT_BY_METHOD: Record<string, unknown> = {
   "messages/listen": {},
 };
 
-function jsonResponse(res: http.ServerResponse, status: number, payload: unknown): void {
-  const body = JSON.stringify(payload);
-  res.writeHead(status, {
-    "Content-Type": "application/json",
-    "Content-Length": Buffer.byteLength(body),
-  });
-  res.end(body);
-}
-
-async function readRequestBody(req: http.IncomingMessage): Promise<string> {
-  return await new Promise((resolve) => {
-    let body = "";
-    req.setEncoding("utf8");
-    req.on("data", (chunk: string) => {
-      body += chunk;
-    });
-    req.on("end", () => resolve(body));
-  });
-}
-
 function requireTcpPort(server: TestServer, label: string): number {
   const address = server.address();
   if (!address || typeof address === "string") {
     throw new Error(`${label} did not bind to a TCP port`);
   }
   return (address as AddressInfo).port;
-}
-
-function closeServer(server: TestServer): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-}
-
-async function listenOnRandomPort(server: TestServer): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "0.0.0.0", () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
 }
 
 function delay(ms: number): Promise<void> {

--- a/test/e2e/live/messaging-compatible-endpoint.test.ts
+++ b/test/e2e/live/messaging-compatible-endpoint.test.ts
@@ -12,12 +12,18 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
-import type { AddressInfo } from "node:net";
 import path from "node:path";
 
 import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { type SandboxClient, validateSandboxName } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
+import {
+  closeServer,
+  writeJsonResponse as jsonResponse,
+  listenServer,
+  readRequestBody,
+  writeSseBody as sseResponse,
+} from "../fixtures/http-protocol.ts";
 import { shouldRunLiveE2E } from "../fixtures/live-project-gate.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import {
@@ -92,34 +98,6 @@ function redactionValues(): string[] {
   return [COMPATIBLE_KEY, TELEGRAM_TOKEN, process.env.GITHUB_TOKEN].filter(
     (value): value is string => typeof value === "string" && value.length > 0,
   );
-}
-
-function jsonResponse(res: http.ServerResponse, status: number, payload: unknown): void {
-  const body = JSON.stringify(payload);
-  res.writeHead(status, {
-    "Content-Type": "application/json",
-    "Content-Length": Buffer.byteLength(body),
-  });
-  res.end(body);
-}
-
-function sseResponse(res: http.ServerResponse, body: string): void {
-  res.writeHead(200, {
-    "Content-Type": "text/event-stream",
-    "Content-Length": Buffer.byteLength(body),
-  });
-  res.end(body);
-}
-
-function readRequestBody(req: http.IncomingMessage): Promise<string> {
-  return new Promise((resolve) => {
-    let body = "";
-    req.setEncoding("utf8");
-    req.on("data", (chunk: string) => {
-      body += chunk;
-    });
-    req.on("end", () => resolve(body));
-  });
 }
 
 function parseJsonBody(raw: string): Record<string, unknown> {
@@ -268,27 +246,12 @@ async function startCompatibleMock(
     jsonResponse(res, 404, { error: { message: "not found" } });
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(port, "0.0.0.0", () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
-
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("compatible endpoint mock did not bind to a TCP port");
-  }
-  const boundPort = (address as AddressInfo).port;
+  const boundPort = await listenServer(server, port);
   const mock = {
     requests,
     hopHeaderLogs,
     localBaseUrl: `http://127.0.0.1:${boundPort}/v1`,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      }),
+    close: () => closeServer(server),
   };
 
   for (let attempt = 1; attempt <= 30; attempt += 1) {

--- a/test/e2e/support/e2e-http-protocol.test.ts
+++ b/test/e2e/support/e2e-http-protocol.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import http from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  closeServer,
+  listenServer,
+  readRequestBody,
+  writeJsonResponse,
+  writeSseEvents,
+} from "../fixtures/http-protocol.ts";
+
+describe("fake provider HTTP protocol", () => {
+  it("reads request bodies and writes JSON responses", async () => {
+    let body = "";
+    const server = http.createServer(async (req, res) => {
+      body = await readRequestBody(req);
+      writeJsonResponse(res, 201, { ok: true });
+    });
+    const port = await listenServer(server, 0, "127.0.0.1");
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}`, { method: "POST", body: "payload" });
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(body).toBe("payload");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("writes named and data-only SSE events with a done marker", async () => {
+    const server = http.createServer((_req, res) =>
+      writeSseEvents(
+        res,
+        [
+          ["message", { text: "one" }],
+          [undefined, { text: "two" }],
+        ],
+        true,
+      ),
+    );
+    const port = await listenServer(server, 0, "127.0.0.1");
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}`);
+      const text = await response.text();
+      expect(response.headers.get("content-type")).toBe("text/event-stream");
+      expect(text).toContain('event: message\ndata: {"text":"one"}');
+      expect(text).toContain("data: [DONE]");
+    } finally {
+      await closeServer(server);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Consolidate shared fake-provider HTTP mechanics—request bodies, JSON/SSE responses, and deterministic server listen/close—without changing mock-versus-hosted inference selection (#5745).

Closes #6349
Parent epic: #6346
Related: #5745

## Changes

- Add reusable request-body, JSON response, raw/named SSE, listen, and close primitives.
- Migrate messaging-compatible, MCP bridge, and Hermes inference-switch mock servers.
- Preserve scenario-specific request logs, streaming shapes, auth checks, and cleanup.
- Document the protocol-only boundary with #5745.
- Add focused real-server protocol tests.

## Verification

- [x] Signed/Verified commit and all hooks passed
- [x] `npm run build:cli`
- [x] `npm run typecheck:cli`
- [x] `npm run lint`
- [x] Protocol and migrated-helper support tests: 23 passed
- [x] No production provider behavior or inference-mode policy changed

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared HTTP test helpers for reading request bodies, writing JSON responses, and sending SSE streams.
  * Updated end-to-end tests to use the shared helpers for server setup, response handling, and cleanup.
  * Added coverage for HTTP request/response behavior, including JSON and streaming event responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->