### PR TITLE
perf(test): batch e2e selector workflow checks

### DIFF
--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -740,21 +740,51 @@ jobs:
   });
 
   it(
-    "keeps each free-standing target out of the registry matrix",
+    "keeps each free-standing selector out of the registry matrix",
     testTimeoutOptions(420_000),
     () => {
+      const hermesSelector = "hermes-e2e";
       const inventory = readFreeStandingJobsInventory();
+      const nonHermesJobs = inventory.allowedJobs.filter((job) => job !== hermesSelector);
+      const nonHermesTargets = [...inventory.targetToJob.keys()].filter(
+        (target) => target !== hermesSelector,
+      );
+
+      expect(nonHermesJobs).not.toHaveLength(0);
+      expect(nonHermesTargets).not.toHaveLength(0);
+      expect(inventory.allowedJobs).toContain(hermesSelector);
+      expect(inventory.targetToJob.get(hermesSelector)).toBe(hermesSelector);
+
+      expect(
+        generateMatrixForDispatch({ JOBS: nonHermesJobs.join(","), TARGETS: "" }),
+      ).toMatchObject({
+        hermes_selected: "false",
+        matrix: "[]",
+      });
+      expect(generateMatrixForDispatch({ JOBS: hermesSelector, TARGETS: "" })).toMatchObject({
+        hermes_selected: "true",
+        matrix: "[]",
+      });
+      expect(
+        generateMatrixForDispatch({ JOBS: "", TARGETS: nonHermesTargets.join(",") }),
+      ).toMatchObject({
+        hermes_selected: "false",
+        matrix: "[]",
+      });
+      expect(generateMatrixForDispatch({ JOBS: "", TARGETS: hermesSelector })).toMatchObject({
+        hermes_selected: "true",
+        matrix: "[]",
+      });
+
       for (const job of inventory.allowedJobs) {
-        expect(generateMatrixForDispatch({ JOBS: job, TARGETS: "" })).toMatchObject({
-          hermes_selected: job === "hermes-e2e" ? "true" : "false",
-          matrix: "[]",
+        expect(evaluateE2eWorkflowDispatchSelectors({ jobs: job })).toMatchObject({
+          valid: true,
+          liveTargetsRun: false,
+          selectedFreeStandingJobs: [job],
+          registryTargets: [],
         });
       }
       for (const [target, job] of inventory.targetToJob) {
-        expect(generateMatrixForDispatch({ JOBS: "", TARGETS: target })).toMatchObject({
-          hermes_selected: target === "hermes-e2e" ? "true" : "false",
-          matrix: "[]",
-        });
         expect(evaluateE2eWorkflowDispatchSelectors({ targets: target })).toMatchObject({
           valid: true,
           liveTargetsRun: false,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Batch the exhaustive E2E selector workflow checks instead of cold-starting the same Bash/TSX/Python path once for every job and target. The focused workflow test falls from 68.64 seconds to 7.36 seconds locally while retaining individual selector parity and the real extracted-workflow shell boundary.

## Related Issue

Contributes to #6245.

## Changes

- Replace 144 individual workflow-shell evaluations with four inventory-driven batches: non-Hermes jobs, Hermes, non-Hermes targets, and Hermes target.
- Preserve direct assertions for every individual job and target mapping.
- Assert nonempty batches plus the Hermes self-mapping before invoking the shell, preventing accidental default-dispatch coverage.
- Keep the real workflow matrix script, inventory CLI, output-file handling, and summary generation in the test boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only changes internal E2E support-test execution; product behavior, selector syntax, workflow configuration, and live E2E behavior are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/e2e-workflow.test.ts` (17/17 passed; 68.64s baseline to 7.36s final wall time); `npm run test:projects:check`; `npm run test:titles:check`; `npm run test-size:check`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end workflow coverage to better verify selector behavior for `hermes-e2e` and non-`hermes` jobs/targets.
  * Added checks that matrix generation returns no entries in the relevant mixed cases, while confirming the `hermes_selected` flag is set correctly.
  * Expanded dispatch validation to ensure job-based runs still behave correctly when registry targets are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->