### PR TITLE
docs(release): add v0.0.75 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -18,7 +18,7 @@ For more detailed release notes, refer to the [NemoClaw GitHub announcements](ht
 
 ## v0.0.75
 
-NemoClaw v0.0.75 hardens sandbox upgrade and prepared-backup recovery, custom endpoint inference routing, and local gateway credential handling, alongside a large test-performance effort that shortens the suite without changing runtime behavior.
+NemoClaw v0.0.75 hardens sandbox upgrade and prepared-backup recovery, custom endpoint inference routing, and local gateway credential handling.
 
 - Upgrading an existing install now recovers a previously onboarded sandbox instead of failing when the recreated gateway has not yet reconfigured its inference route.
   Prepared-backup recovery restores gateway state before the rebuild and defers the live route check to onboarding, in-place upgrades recover gateway-orphaned sandboxes, and a same-name `--fresh` re-onboard preserves the newly selected LangChain Deep Agents Code routing.

--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,20 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.75
+
+NemoClaw v0.0.75 hardens sandbox upgrade and prepared-backup recovery, custom endpoint inference routing, and local gateway credential handling, alongside a large test-performance effort that shortens the suite without changing runtime behavior.
+
+- Upgrading an existing install now recovers a previously onboarded sandbox instead of failing when the recreated gateway has not yet reconfigured its inference route.
+  Prepared-backup recovery restores gateway state before the rebuild and defers the live route check to onboarding, in-place upgrades recover gateway-orphaned sandboxes, and a same-name `--fresh` re-onboard preserves the newly selected LangChain Deep Agents Code routing.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands) and [Troubleshooting](../reference/troubleshooting).
+- Custom Anthropic-compatible inference now uses the OpenAI frontend, and OpenAI-only agents keep the `/v1` base URL when pointed at an Anthropic-compatible endpoint, so switching a managed sandbox to a compatible endpoint routes and reports the provider and model correctly.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options) and [NemoClaw CLI Commands Reference](../reference/commands).
+- Local docker-driver gateway credentials no longer expire, which keeps a long-running local sandbox reachable without a manual gateway restart, and Hermes runtime and managed MCP state reconcile after a runtime change while Hermes installs accept a pinned base platform digest.
+  For more information, refer to [Use a Local Inference Server](../inference/use-local-inference) and [Set Up MCP Servers](../manage-sandboxes/set-up-mcp-servers).
+- OpenClaw local CLI pairing restores its previous connection path so a local sandbox reconnects without re-pairing.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands).
+
 ## v0.0.74
 
 NemoClaw v0.0.74 upgrades the OpenShell policy boundary, adds managed MCP and progressive tool disclosure, strengthens the experimental LangChain Deep Agents Code integration, and improves onboarding, local inference, messaging, recovery, and contributor workflows.


### PR DESCRIPTION
## Summary
Add the v0.0.75 release-notes entry for the release train, summarizing the user-facing fixes merged since v0.0.74. Release-prep docs for the `nemoclaw-maintainer-cut-release-tag` gate.

## Related Issue
Release prep for v0.0.75. Remove this section if none.

## Changes
- `docs/about/release-notes.mdx`: add the `## v0.0.75` section (themed intro + grouped bullets with source-page links), matching the existing v0.0.74 style.

### Source summary (doc-impacting PRs → doc page)
- #6370 -> `docs/about/release-notes.mdx`: prepared-backup recovery restores gateway state and defers the live route check to onboarding, so upgrade recovery no longer fails on an unset gateway route.
- #6305 -> `docs/about/release-notes.mdx`: in-place upgrades recover gateway-orphaned sandboxes.
- #6332 -> `docs/about/release-notes.mdx`: same-name `--fresh` re-onboard preserves fresh LangChain Deep Agents Code routing.
- #6335 -> `docs/about/release-notes.mdx`: custom Anthropic-compatible inference uses the OpenAI frontend.
- #6298 -> `docs/about/release-notes.mdx`: OpenAI-only agents keep the `/v1` base URL on Anthropic-compatible endpoints.
- #6304 -> `docs/about/release-notes.mdx`: local docker-driver gateway credentials no longer expire.
- #6261 -> `docs/about/release-notes.mdx`: Hermes runtime and managed MCP state reconcile after a runtime change.
- #6318 -> `docs/about/release-notes.mdx`: Hermes installs accept a pinned base platform digest.
- #6291 -> `docs/about/release-notes.mdx`: OpenClaw local CLI pairing restores its previous connection path.

Test-performance, CI, and chore commits since v0.0.74 are excluded as non-user-facing.

## Type of Change
- [x] Doc only (prose changes, no code sample modifications)

## Quality Gates
- [x] Tests not applicable — justification: documentation-only change (release notes prose).
- [x] Docs updated for user-facing behavior changes

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] `npm run docs` builds without warnings introduced by this change — command/result: "Found 0 errors and 2 warnings" (the 2 warnings pre-exist this change).
- [x] Doc pages follow the style guide (active voice, no numbered/colon titles, correct NVIDIA/NemoClaw/OpenShell capitalization; skip-terms avoided).
- [x] No secrets, API keys, or credentials committed

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **v0.0.75** section to the release notes, highlighting improved sandbox upgrade hardening and prepared-backup recovery, updated inference routing for Anthropic-compatible endpoints, longer-lasting local gateway credential handling, and restored CLI pairing reconnection without re-pairing. Also includes cross-links to related NemoClaw CLI and documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->