### PR TITLE
docs(release): correct v0.0.75 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -18,15 +18,19 @@ For more detailed release notes, refer to the [NemoClaw GitHub announcements](ht
 
 ## v0.0.75
 
-NemoClaw v0.0.75 hardens sandbox upgrade and prepared-backup recovery, custom endpoint inference routing, and local gateway credential handling.
+NemoClaw v0.0.75 upgrades the bundled OpenClaw runtime to `2026.6.10` and improves sandbox upgrade and prepared-backup recovery, custom endpoint inference routing, and local Docker-driver sandbox JWT handling.
 
+- The bundled OpenClaw runtime upgrades to `2026.6.10` with reviewed package pins, fail-closed archive and patch validation, safer same-device pairing repair, and stricter rebuild route and credential recovery.
+  For more information, refer to the [OpenClaw 2026.6.10 Dependency Review](https://github.com/NVIDIA/NemoClaw/blob/main/docs/security/openclaw-2026.6.10-dependency-review.md).
 - Upgrading an existing install now recovers a previously onboarded sandbox instead of failing when the recreated gateway has not yet reconfigured its inference route.
-  Prepared-backup recovery restores gateway state before the rebuild and defers the live route check to onboarding, in-place upgrades recover gateway-orphaned sandboxes, and a same-name `--fresh` re-onboard preserves the newly selected LangChain Deep Agents Code routing.
+  Prepared-backup recovery defers the live route check to authoritative onboarding, which restores and verifies the gateway provider and inference route before sandbox recreation; in-place upgrades recover gateway-orphaned sandboxes, and a same-name `--fresh` re-onboard preserves the newly selected LangChain Deep Agents Code routing.
   For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands) and [Troubleshooting](../reference/troubleshooting).
-- Custom Anthropic-compatible inference now uses the OpenAI frontend, and OpenAI-only agents keep the `/v1` base URL when pointed at an Anthropic-compatible endpoint, so switching a managed sandbox to a compatible endpoint routes and reports the provider and model correctly.
-  For more information, refer to [NemoClaw Inference Options](../inference/inference-options) and [NemoClaw CLI Commands Reference](../reference/commands).
-- Local docker-driver gateway credentials no longer expire, which keeps a long-running local sandbox reachable without a manual gateway restart, and Hermes runtime and managed MCP state reconcile after a runtime change while Hermes installs accept a pinned base platform digest.
-  For more information, refer to [Use a Local Inference Server](../inference/use-local-inference) and [Set Up MCP Servers](../manage-sandboxes/set-up-mcp-servers).
+- Hermes custom Anthropic-compatible inference now uses the OpenAI frontend, and OpenAI-only agents keep the `/v1` base URL when pointed at an Anthropic-compatible endpoint, so switching a managed sandbox to a compatible endpoint routes and reports the provider and model correctly.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options) and [Switch Inference Providers](../inference/switch-inference-providers).
+- Local Docker-driver sandbox JWTs now use OpenShell's non-expiring local contract, which keeps a long-running local sandbox reachable without a manual gateway restart.
+  For more information, refer to [OpenShell 0.0.71 Gateway Authentication Review](../security/openshell-0.0.71-gateway-auth-review).
+- Hermes runtime and managed MCP state reconcile after a runtime change, and Hermes installs accept a pinned base platform digest.
+  For more information, refer to [Set Up MCP Servers](../manage-sandboxes/set-up-mcp-servers) and [NemoClaw CLI Commands Reference](../reference/commands).
 - OpenClaw local CLI pairing restores its previous connection path so a local sandbox reconnects without re-pairing.
   For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands).
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Correct the v0.0.75 release-note entry merged in #6371 before the release tag is cut.
This follow-up restores the omitted OpenClaw `2026.6.10` upgrade and narrows three claims to the runtime contracts that actually shipped.

## Changes
<!-- Bullet list of key changes. -->
- #5595 -> `docs/about/release-notes.mdx`: add the bundled OpenClaw `2026.6.10` upgrade and its reviewed package, pairing, and recovery boundaries.
- #6370 -> `docs/about/release-notes.mdx`: state that authoritative onboarding restores the gateway provider and inference route during rebuild, before sandbox recreation.
- #6335 and #6298 -> `docs/about/release-notes.mdx`: scope the OpenAI frontend to Hermes while retaining the separate OpenAI-only-agent behavior.
- #6304 -> `docs/about/release-notes.mdx`: name the non-expiring local Docker-driver sandbox JWT contract precisely and link its gateway-auth review.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: prose-only release-note corrections with no runtime behavior or code samples.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: tests are not applicable; `npm run docs` passed with 0 errors and 2 pre-existing warnings.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: 0 errors and 2 pre-existing warnings (missing authenticated redirects check and existing light-theme accent contrast).
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `v0.0.75` release notes with clearer wording and expanded details.
  * Added more specific notes about the runtime upgrade, sandbox recovery behavior, and routing safeguards.
  * Refined the description of inference routing behavior and local Docker-driver sandbox authentication handling.
  * Adjusted the linked references and final release-note wording for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->