### PR TITLE
fix(messaging): tolerate verbose npm metadata output

### DIFF
--- a/src/lib/messaging/applier/build/messaging-build-applier.mts
+++ b/src/lib/messaging/applier/build/messaging-build-applier.mts
@@ -138,6 +138,8 @@ export const OPENCLAW_MESSAGING_PLUGIN_ARCHIVE_PROVENANCE_POLICY = Object.freeze
   registryTarballUrl: "must-match-committed-url",
 } as const);
 
+const NPM_METADATA_MAX_BUFFER = 16 * 1024 * 1024;
+
 type HermesUvPackageInstall = {
   readonly spec: string;
 };
@@ -1160,6 +1162,7 @@ function npmViewString(packageSpec: string, field: string, env: Env): string {
   const result = spawnSync("npm", ["view", packageSpec, field], {
     encoding: "utf-8",
     env: env as NodeJS.ProcessEnv,
+    maxBuffer: NPM_METADATA_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.error) throw result.error;
@@ -1211,6 +1214,7 @@ function packNpmArchive(
   const result = spawnSync("npm", ["pack", packageSpec, "--pack-destination", rootDir, "--json"], {
     encoding: "utf-8",
     env: env as NodeJS.ProcessEnv,
+    maxBuffer: NPM_METADATA_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.error) {

--- a/test/messaging-build-applier.test.ts
+++ b/test/messaging-build-applier.test.ts
@@ -614,6 +614,74 @@ describe("messaging-build-applier.mts: agent-install", () => {
     }
   });
 
+  it("tolerates verbose npm metadata output when installing the Teams plugin", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-teams-npm-buffer-"));
+    const tracePath = path.join(tmp, "openclaw.trace");
+    fs.writeFileSync(
+      path.join(tmp, "npm"),
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        "const path = require('node:path');",
+        "const [command, packageSpec, fieldOrFlag, destination] = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.OPENCLAW_TRACE, `npm|${command}|${packageSpec}|${fieldOrFlag || ''}\\n`);",
+        "process.stderr.write('npm notice verbose teams metadata '.repeat(50000));",
+        "if (command === 'view' && packageSpec === '@openclaw/msteams@2026.6.10' && fieldOrFlag === 'dist.integrity') {",
+        "  process.stdout.write(`${process.env.OPENCLAW_MSTEAMS_2026_6_10_INTEGRITY}\\n`);",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'view' && packageSpec === '@openclaw/msteams@2026.6.10' && fieldOrFlag === 'dist.tarball') {",
+        "  process.stdout.write('https://registry.npmjs.org/@openclaw/msteams/-/msteams-2026.6.10.tgz\\n');",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'pack' && packageSpec === '@openclaw/msteams@2026.6.10') {",
+        "  const packFile = 'msteams-2026.6.10.tgz';",
+        "  fs.writeFileSync(path.join(destination, packFile), 'fake plugin tarball');",
+        "  process.stdout.write(JSON.stringify([{ filename: packFile, integrity: process.env.OPENCLAW_MSTEAMS_2026_6_10_INTEGRITY }]) + '\\n');",
+        "  process.exit(0);",
+        "}",
+        "process.exit(1);",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(tmp, "openclaw"),
+      [
+        "#!/bin/sh",
+        'printf \'openclaw|%s|%s|%s|%s\\n\' "$1" "$2" "$3" "$4" >> "$OPENCLAW_TRACE"',
+        "exit 0",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      const env = await withLegacyMessagingPlanEnvDirect(
+        {
+          PATH: `${tmp}:${TEST_PATH}`,
+          OPENCLAW_TRACE: tracePath,
+          OPENCLAW_MSTEAMS_2026_6_10_INTEGRITY,
+          OPENCLAW_VERSION: "2026.6.10",
+          NEMOCLAW_MESSAGING_CHANNELS_B64: channelsB64(["teams"]),
+          NEMOCLAW_TEAMS_CONFIG_B64: teamsConfigB64(),
+        },
+        "openclaw",
+      );
+      const plan = readMessagingBuildPlanFromEnv(env, "openclaw");
+
+      expect(applyMessagingBuildPhase(plan, "agent-install", env)).toEqual([]);
+      const trace = fs.readFileSync(tracePath, "utf-8");
+      expect(trace).toContain("npm|view|@openclaw/msteams@2026.6.10|dist.integrity");
+      expect(trace).toContain("npm|view|@openclaw/msteams@2026.6.10|dist.tarball");
+      expect(trace).toContain("npm|pack|@openclaw/msteams@2026.6.10|--pack-destination");
+      expect(trace).toContain("openclaw|plugins|install|");
+      expect(trace).toContain("msteams-2026.6.10.tgz|--pin");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed before installing reviewed OpenClaw plugins absent from active channel manifests", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-package-plan-"));
     const tracePath = path.join(tmp, "openclaw.trace");

--- a/test/messaging-build-applier.test.ts
+++ b/test/messaging-build-applier.test.ts
@@ -614,7 +614,7 @@ describe("messaging-build-applier.mts: agent-install", () => {
     }
   });
 
-  it("tolerates verbose npm metadata output when installing the Teams plugin", async () => {
+  it("tolerates verbose npm metadata output when installing the Teams plugin (#6389)", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openclaw-teams-npm-buffer-"));
     const tracePath = path.join(tmp, "openclaw.trace");
     fs.writeFileSync(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR prevents the OpenClaw messaging build applier from failing with `spawnSync npm ENOBUFS` when npm emits verbose metadata output while installing the Teams plugin. The fix gives the buffered `npm view` and `npm pack --json` calls an explicit bounded buffer while keeping the reviewed archive validation and local archive install flow unchanged.

## Related Issue
Fixes #6389

## Changes
- Adds a 16 MiB buffer limit for buffered npm metadata/archive calls in `src/lib/messaging/applier/build/messaging-build-applier.mts`.
- Adds a Teams plugin regression in `test/messaging-build-applier.test.ts` that emits more than Node's default sync buffer during `npm view`/`npm pack`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal build robustness fix; no CLI or docs contract changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: focused messaging build-applier tests and diff-scoped hooks passed; trusted archive validation remains unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `NPM_CONFIG_CACHE=/tmp/nemoclaw-6389-npm-cache npx vitest run test/messaging-build-applier.test.ts` passed, 26 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of plugin installation when npm produces extremely verbose metadata output by increasing the command output buffering used during package metadata retrieval and verified archive creation.
  * Reduced the chance of installation failures in noisy npm environments.

* **Tests**
  * Added a functional test that simulates highly verbose npm `view`/`pack` output and verifies the expected install flow and pinned tarball behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->