### PR TITLE
fix(cli): preserve Hermes light terminal hints

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -71,37 +71,6 @@ describe("connectSandbox flow", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("marks Hermes connect sessions as light-mode when launched from light macOS Terminal.app", async () => {
-    vi.stubEnv("TERM_PROGRAM", "Apple_Terminal");
-    vi.stubEnv("COLORFGBG", "0;15");
-    vi.stubEnv("HERMES_TUI_LIGHT", "");
-    const harness = createConnectHarness({
-      agentName: "hermes",
-      sessionAgent: {
-        name: "hermes",
-        runtime: { kind: "terminal", interactive_command: "hermes" },
-      },
-    });
-
-    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
-
-    const connectCall = harness.spawnSyncSpy.mock.calls.find(
-      ([command, args]) =>
-        command === "openshell" &&
-        Array.isArray(args) &&
-        args.join(" ") === "sandbox connect alpha",
-    );
-    expect(connectCall?.[2]).toEqual(
-      expect.objectContaining({
-        env: expect.objectContaining({
-          COLORFGBG: "0;15",
-          HERMES_TUI_LIGHT: "1",
-          TERM_PROGRAM: "Apple_Terminal",
-        }),
-      }),
-    );
-  });
-
   it("restores the terminal and prints reconnect guidance when SSH disconnects", async () => {
     const setRawModeSpy = vi.fn();
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -71,6 +71,37 @@ describe("connectSandbox flow", () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
+  it("marks Hermes connect sessions as light-mode when launched from light macOS Terminal.app", async () => {
+    vi.stubEnv("TERM_PROGRAM", "Apple_Terminal");
+    vi.stubEnv("COLORFGBG", "0;15");
+    vi.stubEnv("HERMES_TUI_LIGHT", "");
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: {
+        name: "hermes",
+        runtime: { kind: "terminal", interactive_command: "hermes" },
+      },
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
+
+    const connectCall = harness.spawnSyncSpy.mock.calls.find(
+      ([command, args]) =>
+        command === "openshell" &&
+        Array.isArray(args) &&
+        args.join(" ") === "sandbox connect alpha",
+    );
+    expect(connectCall?.[2]).toEqual(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          COLORFGBG: "0;15",
+          HERMES_TUI_LIGHT: "1",
+          TERM_PROGRAM: "Apple_Terminal",
+        }),
+      }),
+    );
+  });
+
   it("restores the terminal and prints reconnect guidance when SSH disconnects", async () => {
     const setRawModeSpy = vi.fn();
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });

--- a/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
+++ b/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
@@ -24,14 +24,10 @@ describe("Hermes sandbox connect light terminal environment", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
-    if (originalStdoutIsTty === undefined) {
-      Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: undefined });
-    } else {
-      Object.defineProperty(process.stdout, "isTTY", {
-        configurable: true,
-        value: originalStdoutIsTty,
-      });
-    }
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: originalStdoutIsTty,
+    });
     delete process.env.NEMOCLAW_TEST_NO_SLEEP;
     delete require.cache[requireDist.resolve(connectModulePath)];
   });

--- a/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
+++ b/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+import {
+  connectModulePath,
+  createConnectHarness,
+  requireDist,
+} from "../../../../test/support/connect-flow-test-harness";
+
+describe("Hermes sandbox connect light terminal environment", () => {
+  let exitSpy: MockInstance;
+  const originalStdoutIsTty = process.stdout.isTTY;
+
+  beforeEach(() => {
+    process.env.NEMOCLAW_TEST_NO_SLEEP = "1";
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    if (originalStdoutIsTty === undefined) {
+      Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: undefined });
+    } else {
+      Object.defineProperty(process.stdout, "isTTY", {
+        configurable: true,
+        value: originalStdoutIsTty,
+      });
+    }
+    delete process.env.NEMOCLAW_TEST_NO_SLEEP;
+    delete require.cache[requireDist.resolve(connectModulePath)];
+  });
+
+  it("marks Hermes connect sessions as light-mode when launched from light macOS Terminal.app (#6380)", async () => {
+    vi.stubEnv("TERM_PROGRAM", "Apple_Terminal");
+    vi.stubEnv("COLORFGBG", "0;15");
+    vi.stubEnv("HERMES_TUI_LIGHT", "");
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: {
+        name: "hermes",
+        runtime: { kind: "terminal", interactive_command: "hermes" },
+      },
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
+
+    const connectCall = harness.spawnSyncSpy.mock.calls.find(
+      ([command, args]) =>
+        command === "openshell" &&
+        Array.isArray(args) &&
+        args.join(" ") === "sandbox connect alpha",
+    );
+    expect(connectCall?.[2]).toEqual(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          COLORFGBG: "0;15",
+          HERMES_TUI_LIGHT: "1",
+          TERM_PROGRAM: "Apple_Terminal",
+        }),
+      }),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -17,6 +17,7 @@ import * as agentRuntime from "../../agent/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { D, G, R, YW } from "../../cli/terminal-style";
 import { spawnExitCode } from "../../core/process-exit";
+import { buildSandboxConnectEnv } from "../../domain/sandbox/connect-env";
 import { getNamedGatewayLifecycleState } from "../../gateway-runtime-action";
 import {
   parseGatewayInference,
@@ -149,45 +150,6 @@ const SANDBOX_CONNECT_FLAGS = new Set([
   "--help",
   "-h",
 ]);
-
-const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
-const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
-
-function hasExplicitBoolean(value: string | undefined): boolean {
-  const normalized = String(value ?? "")
-    .trim()
-    .toLowerCase();
-  return TRUE_VALUES.has(normalized) || FALSE_VALUES.has(normalized);
-}
-
-function hostTerminalLooksLight(env: NodeJS.ProcessEnv): boolean {
-  const colorfgbg = String(env.COLORFGBG ?? "").trim();
-  if (colorfgbg) {
-    const lastField = colorfgbg.split(";").at(-1) ?? "";
-    if (/^\d+$/.test(lastField)) {
-      const bg = Number(lastField);
-      if (bg === 7 || bg === 15) return true;
-      if (bg >= 0 && bg < 16) return false;
-    }
-  }
-  return String(env.TERM_PROGRAM ?? "").trim() === "Apple_Terminal";
-}
-
-export function buildSandboxConnectEnv(
-  agent: { name?: string } | null | undefined,
-  env: NodeJS.ProcessEnv = process.env,
-): NodeJS.ProcessEnv {
-  const nextEnv = { ...env };
-  if (
-    agent?.name === "hermes" &&
-    !hasExplicitBoolean(nextEnv.HERMES_TUI_LIGHT) &&
-    !String(nextEnv.HERMES_TUI_THEME ?? "").trim() &&
-    hostTerminalLooksLight(nextEnv)
-  ) {
-    nextEnv.HERMES_TUI_LIGHT = "1";
-  }
-  return nextEnv;
-}
 
 export function isSandboxConnectFlag(arg: string | undefined): boolean {
   return typeof arg === "string" && SANDBOX_CONNECT_FLAGS.has(arg);

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -1093,7 +1093,7 @@ export async function connectSandbox(
   const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
     stdio: "inherit",
     cwd: ROOT,
-    env: buildSandboxConnectEnv(agent),
+    env: buildSandboxConnectEnv(agent, process.env),
   });
   exitWithConnectSpawnResult(sandboxName, result);
 }

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -150,6 +150,45 @@ const SANDBOX_CONNECT_FLAGS = new Set([
   "-h",
 ]);
 
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
+
+function hasExplicitBoolean(value: string | undefined): boolean {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return TRUE_VALUES.has(normalized) || FALSE_VALUES.has(normalized);
+}
+
+function hostTerminalLooksLight(env: NodeJS.ProcessEnv): boolean {
+  const colorfgbg = String(env.COLORFGBG ?? "").trim();
+  if (colorfgbg) {
+    const lastField = colorfgbg.split(";").at(-1) ?? "";
+    if (/^\d+$/.test(lastField)) {
+      const bg = Number(lastField);
+      if (bg === 7 || bg === 15) return true;
+      if (bg >= 0 && bg < 16) return false;
+    }
+  }
+  return String(env.TERM_PROGRAM ?? "").trim() === "Apple_Terminal";
+}
+
+export function buildSandboxConnectEnv(
+  agent: { name?: string } | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const nextEnv = { ...env };
+  if (
+    agent?.name === "hermes" &&
+    !hasExplicitBoolean(nextEnv.HERMES_TUI_LIGHT) &&
+    !String(nextEnv.HERMES_TUI_THEME ?? "").trim() &&
+    hostTerminalLooksLight(nextEnv)
+  ) {
+    nextEnv.HERMES_TUI_LIGHT = "1";
+  }
+  return nextEnv;
+}
+
 export function isSandboxConnectFlag(arg: string | undefined): boolean {
   return typeof arg === "string" && SANDBOX_CONNECT_FLAGS.has(arg);
 }
@@ -1092,7 +1131,7 @@ export async function connectSandbox(
   const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
     stdio: "inherit",
     cwd: ROOT,
-    env: process.env,
+    env: buildSandboxConnectEnv(agent),
   });
   exitWithConnectSpawnResult(sandboxName, result);
 }

--- a/src/lib/domain/sandbox/connect-env.test.ts
+++ b/src/lib/domain/sandbox/connect-env.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { buildSandboxConnectEnv } from "./connect-env";
+
+describe("sandbox connect environment helpers", () => {
+  it("marks Hermes connect sessions as light when COLORFGBG reports a light background (#6380)", () => {
+    expect(
+      buildSandboxConnectEnv(
+        { name: "hermes" },
+        { COLORFGBG: "0;15", TERM_PROGRAM: "Apple_Terminal" },
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        COLORFGBG: "0;15",
+        HERMES_TUI_LIGHT: "1",
+        TERM_PROGRAM: "Apple_Terminal",
+      }),
+    );
+  });
+
+  it("does not force Hermes light mode when COLORFGBG reports a dark background (#6380)", () => {
+    expect(
+      buildSandboxConnectEnv(
+        { name: "hermes" },
+        { COLORFGBG: "0;0", TERM_PROGRAM: "Apple_Terminal" },
+      ),
+    ).not.toHaveProperty("HERMES_TUI_LIGHT");
+  });
+
+  it("preserves explicit Hermes light-mode overrides (#6380)", () => {
+    for (const value of ["0", "false", "no", "off"]) {
+      expect(
+        buildSandboxConnectEnv({ name: "hermes" }, { COLORFGBG: "0;15", HERMES_TUI_LIGHT: value })
+          .HERMES_TUI_LIGHT,
+      ).toBe(value);
+    }
+  });
+
+  it("preserves explicit Hermes theme overrides (#6380)", () => {
+    expect(
+      buildSandboxConnectEnv({ name: "hermes" }, { COLORFGBG: "0;15", HERMES_TUI_THEME: "dark" }),
+    ).not.toHaveProperty("HERMES_TUI_LIGHT");
+  });
+
+  it("does not set Hermes light mode for non-Hermes agents (#6380)", () => {
+    expect(buildSandboxConnectEnv({ name: "openclaw" }, { COLORFGBG: "0;15" })).not.toHaveProperty(
+      "HERMES_TUI_LIGHT",
+    );
+  });
+
+  it("does not infer light mode from Apple Terminal without usable COLORFGBG (#6380)", () => {
+    expect(
+      buildSandboxConnectEnv({ name: "hermes" }, { TERM_PROGRAM: "Apple_Terminal" }),
+    ).not.toHaveProperty("HERMES_TUI_LIGHT");
+    expect(
+      buildSandboxConnectEnv(
+        { name: "hermes" },
+        { COLORFGBG: "not-a-color", TERM_PROGRAM: "Apple_Terminal" },
+      ),
+    ).not.toHaveProperty("HERMES_TUI_LIGHT");
+  });
+});

--- a/src/lib/domain/sandbox/connect-env.ts
+++ b/src/lib/domain/sandbox/connect-env.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
+
+function hasExplicitBoolean(value: string | undefined): boolean {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return TRUE_VALUES.has(normalized) || FALSE_VALUES.has(normalized);
+}
+
+function hostTerminalLooksLight(env: NodeJS.ProcessEnv): boolean {
+  const colorfgbg = String(env.COLORFGBG ?? "").trim();
+  if (!colorfgbg) return false;
+
+  const lastField = colorfgbg.split(";").at(-1) ?? "";
+  const bg = Number(lastField);
+  if (!Number.isInteger(bg) || bg < 0 || bg > 15) return false;
+  return bg === 7 || bg === 15;
+}
+
+export function buildSandboxConnectEnv(
+  agent: { name?: string } | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const nextEnv = { ...env };
+  if (
+    agent?.name === "hermes" &&
+    !hasExplicitBoolean(nextEnv.HERMES_TUI_LIGHT) &&
+    !String(nextEnv.HERMES_TUI_THEME ?? "").trim() &&
+    hostTerminalLooksLight(nextEnv)
+  ) {
+    nextEnv.HERMES_TUI_LIGHT = "1";
+  }
+  return nextEnv;
+}

--- a/src/lib/domain/sandbox/connect-env.ts
+++ b/src/lib/domain/sandbox/connect-env.ts
@@ -23,7 +23,7 @@ function hostTerminalLooksLight(env: NodeJS.ProcessEnv): boolean {
 
 export function buildSandboxConnectEnv(
   agent: { name?: string } | null | undefined,
-  env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
   const nextEnv = { ...env };
   if (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Preserve light-terminal hints when connecting to Hermes sandboxes so Hermes can select its readable light TUI theme on macOS Terminal.app.

Fixes #6380.

## Related Issue
Fixes #6380

## Changes
- Derive `HERMES_TUI_LIGHT=1` for Hermes `sandbox connect` sessions when the host terminal reports a light background and no explicit Hermes TUI theme/light override is set.
- Keep the light-mode detection in a pure domain helper and require positive `COLORFGBG` light-background evidence instead of inferring light mode from `TERM_PROGRAM` alone.
- Preserve user overrides for `HERMES_TUI_LIGHT` and `HERMES_TUI_THEME`.
- Add focused regression and boundary tests for macOS Terminal.app with `COLORFGBG=0;15`, dark backgrounds, explicit overrides, malformed inputs, and non-Hermes agents.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: behavior is an automatic connect-time environment bridge with no user-facing command or configuration change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `NPM_CONFIG_CACHE=/tmp/nemoclaw-6380-npm-cache npx vitest run --project cli src/lib/domain/sandbox/connect-env.test.ts src/lib/actions/sandbox/connect-hermes-light-theme.test.ts src/lib/actions/sandbox/connect-flow.test.ts` passed, 20 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `NPM_CONFIG_CACHE=/tmp/nemoclaw-6380-npm-cache npm test` was run and failed with 53 failures outside the touched connect files, including installer locale/timeouts, macOS `/private` path expectations, bash/BASHPID environment issues, Deep Agents Python `fcntl` support, policy-denial hint tests, and shields timing failures.
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:
- Red regression run before the fix confirmed the new Hermes light-terminal test failed because `HERMES_TUI_LIGHT` remained empty.
- Red domain follow-up run confirmed `src/lib/domain/sandbox/connect-env.test.ts` failed before the domain helper existed.
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-6380-npm-cache npm run typecheck:cli` passed.
- `NPM_CONFIG_CACHE=/tmp/nemoclaw-6380-npm-cache npx prek run --all-files` passed.
- `git diff --check` passed.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sandbox connect environment handling by automatically enabling Hermes light-mode UI when terminal color settings indicate a light background.
  * Explicit light/theme selections still take priority, preventing unwanted overrides.
* **Tests**
  * Added Vitest coverage for Hermes light-mode inference (including macOS Terminal behavior) and for theme/light override precedence across multiple environment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->