### PR TITLE
fix(cli): release sandbox forwards on full stop

### DIFF
--- a/src/lib/tunnel/services-sandbox.test.ts
+++ b/src/lib/tunnel/services-sandbox.test.ts
@@ -242,6 +242,49 @@ describe("stopAll with sandbox channels", () => {
     logSpy.mockRestore();
   });
 
+  it("releases managed host forwards for the selected sandbox on deprecated full stop", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    spawnSyncSpy
+      .mockReturnValueOnce({ status: 1, stdout: "" })
+      .mockReturnValueOnce({ status: 1 })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: [
+          "SANDBOX   BIND        PORT   PID    STATUS",
+          "test-sb   127.0.0.1   8642   1234   running",
+          "other-sb  127.0.0.1   18789  1235   running",
+          "test-sb   127.0.0.1   18790  1236   active",
+        ].join("\n"),
+      })
+      .mockReturnValue({ status: 0 });
+
+    stopAll({ pidDir, sandboxName: "test-sb", releaseGatewayPort: true });
+
+    expect(spawnSyncSpy).toHaveBeenCalledWith(
+      "/usr/local/bin/openshell",
+      ["forward", "list"],
+      expect.objectContaining({ timeout: 15_000 }),
+    );
+    expect(spawnSyncSpy).toHaveBeenCalledWith(
+      "/usr/local/bin/openshell",
+      ["forward", "stop", "8642", "test-sb"],
+      expect.objectContaining({ timeout: 30_000 }),
+    );
+    expect(spawnSyncSpy).toHaveBeenCalledWith(
+      "/usr/local/bin/openshell",
+      ["forward", "stop", "18790", "test-sb"],
+      expect.objectContaining({ timeout: 30_000 }),
+    );
+    expect(spawnSyncSpy).not.toHaveBeenCalledWith(
+      "/usr/local/bin/openshell",
+      ["forward", "stop", "18789", "test-sb"],
+      expect.any(Object),
+    );
+    const output = logSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("Released 2 managed host forward(s) for sandbox test-sb");
+    logSpy.mockRestore();
+  });
+
   it("warns when no sandbox name is available", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const savedNemoclaw = process.env.NEMOCLAW_SANDBOX;

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -17,10 +17,15 @@ import {
 import { basename, join } from "node:path";
 import { dockerSpawnSync } from "../adapters/docker";
 import { resolveOpenshell } from "../adapters/openshell/resolve";
+import {
+  OPENSHELL_OPERATION_TIMEOUT_MS,
+  OPENSHELL_PROBE_TIMEOUT_MS,
+} from "../adapters/openshell/timeouts";
 import { renderBox } from "../cli/banner";
 import { AGENT_PRODUCT_NAME, CLI_DISPLAY_NAME, CLI_NAME } from "../cli/branding";
 import { isRecord } from "../core/json-types";
 import { DASHBOARD_PORT } from "../core/ports";
+import { getOccupiedPorts } from "../onboard/dashboard-port";
 import { buildSubprocessEnv } from "../subprocess-env";
 import { registerTunnelOrigin } from "./allowed-origins";
 import * as gatewayStop from "./gateway-stop";
@@ -459,7 +464,7 @@ export function showStatus(opts: ServiceOptions = {}): void {
  * post-stop process scan is empty.
  */
 export function stopSandboxChannels(sandboxName: string): void {
-  info(`Stopping in-sandbox OpenClaw gateway (sandbox: ${sandboxName})...`);
+  info(`Stopping in-sandbox ${AGENT_PRODUCT_NAME} gateway (sandbox: ${sandboxName})...`);
 
   const privilegedResult = stopSandboxChannelsViaKubectl(sandboxName);
   if (reportStopResult(privilegedResult)) return;
@@ -587,6 +592,39 @@ function reportStopResult(result: StopAttemptResult | null): boolean {
   return true;
 }
 
+function stopSandboxForwards(sandboxName: string): void {
+  const openshell = resolveOpenshell();
+  if (!openshell) {
+    warn("openshell not found — cannot release managed host forwards.");
+    return;
+  }
+
+  const listResult = spawnSync(openshell, ["forward", "list"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: OPENSHELL_PROBE_TIMEOUT_MS,
+  });
+  if (listResult.status !== 0) {
+    warn("Could not list OpenShell forwards — managed host forwards may still be running.");
+    return;
+  }
+
+  const output = listResult.stdout ?? "";
+  const ports = [...getOccupiedPorts(output).entries()]
+    .filter(([, owner]) => owner === sandboxName)
+    .map(([port]) => port);
+  for (const port of ports) {
+    spawnSync(openshell, ["forward", "stop", port, sandboxName], {
+      encoding: "utf-8",
+      stdio: "ignore",
+      timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
+    });
+  }
+  if (ports.length > 0) {
+    info(`Released ${String(ports.length)} managed host forward(s) for sandbox ${sandboxName}.`);
+  }
+}
+
 export function stopAll(opts: ServiceOptions = {}): void {
   // Stop the in-sandbox OpenClaw gateway (and its messaging channels).
   const rawSandboxName =
@@ -625,6 +663,9 @@ export function stopAll(opts: ServiceOptions = {}): void {
   stopService(pidDir, "cloudflared");
 
   if (opts.releaseGatewayPort) {
+    if (sandboxName) {
+      stopSandboxForwards(sandboxName);
+    }
     gatewayStop.releaseGatewayPortForStop(sandboxName, { info, warn });
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR makes deprecated full stop release OpenShell forwards owned by the selected sandbox before releasing the host gateway. It fixes `nemohermes stop` leaving the Hermes API forward on port 8642 alive and makes the in-sandbox gateway stop message use the active agent product name.

## Related Issue
Fixes #6392

## Changes
- Enumerate live `openshell forward list` entries during legacy full stop and stop only forwards owned by the selected sandbox using `forward stop <port> <sandbox>`.
- Keep foreign sandbox forwards untouched even when they use nearby managed ports.
- Replace hard-coded `OpenClaw gateway` stop-starting copy with the active agent product name.
- Add regression coverage for releasing Hermes-style port `8642` and another owned forward while preserving another sandbox's forward.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: existing help already states deprecated full stop releases the managed gateway port; this PR aligns implementation with that documented behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review; stop is sandbox-scoped by `openshell forward list` ownership and uses `forward stop <port> <sandbox>` to avoid collateral teardown.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm test -- src/lib/tunnel/services-sandbox.test.ts src/lib/tunnel/services-gateway-ownership.test.ts src/lib/tunnel/service-command.test.ts` passed, 3 files / 36 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway port release so stopping one sandbox now clears only that sandbox’s managed host forwards, including active ports, without affecting others.
  * Updated stop behavior to use the product name consistently in status messages.
  * Added clearer logging when forwarded ports are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->