### PR TITLE
test(e2e): cover v0.0.55 gateway upgrades

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3223,10 +3223,23 @@ jobs:
         run: bash .github/scripts/docker-auth-cleanup.sh
 
   openshell-gateway-upgrade:
+    name: OpenShell gateway upgrade (${{ matrix.legacy.id }})
     needs: generate-matrix
     if: ${{ (github.event_name != 'workflow_dispatch' || (inputs.jobs == '' && inputs.targets == '')) || contains(format(',{0},', inputs.jobs), ',openshell-gateway-upgrade,') || contains(format(',{0},', inputs.targets), ',openshell-gateway-upgrade,') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        legacy:
+          - id: v0.0.36
+            nemoclaw_ref: v0.0.36
+            openshell_version: 0.0.36
+            openclaw_version: 2026.4.24
+          - id: v0.0.55
+            nemoclaw_ref: v0.0.55
+            openshell_version: 0.0.44
+            openclaw_version: 2026.5.22
     env:
       E2E_JOB: "1"
       E2E_TARGET_ID: "openshell-gateway-upgrade"
@@ -3236,6 +3249,9 @@ jobs:
       NEMOCLAW_NON_INTERACTIVE: "1"
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_GATEWAY_UPGRADE_SURVIVOR_NAME: "e2e-gateway-upgrade-survivor"
+      NEMOCLAW_OLD_NEMOCLAW_REF: ${{ matrix.legacy.nemoclaw_ref }}
+      NEMOCLAW_OLD_OPENSHELL_VERSION: ${{ matrix.legacy.openshell_version }}
+      NEMOCLAW_OLD_OPENCLAW_VERSION: ${{ matrix.legacy.openclaw_version }}
       OPENSHELL_GATEWAY: "nemoclaw"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -3248,10 +3264,9 @@ jobs:
         uses: NVIDIA/NemoClaw/.github/actions/prepare-e2e@50281ee84c4a6fc759da95ea28fc0b7d9c378a28
 
       - name: Run OpenShell gateway upgrade live Vitest test
-        # This
-        # preserves the legacy ubuntu-latest + Docker/OpenShell runner lane,
-        # old installer/current installer upgrade boundary, survivor sandbox
-        # restore checks, and hermetic macOS installer regressions.
+        # This preserves the legacy ubuntu-latest + Docker/OpenShell runner
+        # lane while covering both the original v0.0.36 fixture and the exact
+        # v0.0.55/OpenShell 0.0.44 source shape from upgrade regression #6114.
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -3264,6 +3279,8 @@ jobs:
       - name: Upload OpenShell gateway upgrade artifacts
         if: always()
         uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
+        with:
+          name: e2e-openshell-gateway-upgrade-${{ matrix.legacy.id }}
 
       - name: Clean up Docker auth
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3234,10 +3234,14 @@ jobs:
         legacy:
           - id: v0.0.36
             nemoclaw_ref: v0.0.36
+            nemoclaw_commit: "3351fbdd4eb7d9b80ec471545083956327da2b10"
+            installer_sha256: "0c42400a0d3867739f1d75d612e069967be4506e169974bbbebf14b7af39144f"
             openshell_version: 0.0.36
             openclaw_version: 2026.4.24
           - id: v0.0.55
             nemoclaw_ref: v0.0.55
+            nemoclaw_commit: "95d483fe2b6569d68e59493c60f19df09a068e8f"
+            installer_sha256: "ff8cf448e4d17b00421545a1f333262b615b1b0aa236d0cc5aeaf4e2cae2d897"
             openshell_version: 0.0.44
             openclaw_version: 2026.5.22
     env:
@@ -3250,6 +3254,8 @@ jobs:
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_GATEWAY_UPGRADE_SURVIVOR_NAME: "e2e-gateway-upgrade-survivor"
       NEMOCLAW_OLD_NEMOCLAW_REF: ${{ matrix.legacy.nemoclaw_ref }}
+      NEMOCLAW_OLD_NEMOCLAW_COMMIT: ${{ matrix.legacy.nemoclaw_commit }}
+      NEMOCLAW_OLD_INSTALLER_SHA256: ${{ matrix.legacy.installer_sha256 }}
       NEMOCLAW_OLD_OPENSHELL_VERSION: ${{ matrix.legacy.openshell_version }}
       NEMOCLAW_OLD_OPENCLAW_VERSION: ${{ matrix.legacy.openclaw_version }}
       OPENSHELL_GATEWAY: "nemoclaw"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3236,12 +3236,14 @@ jobs:
             nemoclaw_ref: v0.0.36
             nemoclaw_commit: "3351fbdd4eb7d9b80ec471545083956327da2b10"
             installer_sha256: "0c42400a0d3867739f1d75d612e069967be4506e169974bbbebf14b7af39144f"
+            sandbox_base_image_ref: "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:104151ffadc2ff0b6c815e3c95c2783ced61aee0d0f83fc327cc02be9b7e14e6"
             openshell_version: 0.0.36
             openclaw_version: 2026.4.24
           - id: v0.0.55
             nemoclaw_ref: v0.0.55
             nemoclaw_commit: "95d483fe2b6569d68e59493c60f19df09a068e8f"
             installer_sha256: "ff8cf448e4d17b00421545a1f333262b615b1b0aa236d0cc5aeaf4e2cae2d897"
+            sandbox_base_image_ref: "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:104151ffadc2ff0b6c815e3c95c2783ced61aee0d0f83fc327cc02be9b7e14e6"
             openshell_version: 0.0.44
             openclaw_version: 2026.5.22
     env:
@@ -3256,6 +3258,7 @@ jobs:
       NEMOCLAW_OLD_NEMOCLAW_REF: ${{ matrix.legacy.nemoclaw_ref }}
       NEMOCLAW_OLD_NEMOCLAW_COMMIT: ${{ matrix.legacy.nemoclaw_commit }}
       NEMOCLAW_OLD_INSTALLER_SHA256: ${{ matrix.legacy.installer_sha256 }}
+      NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF: ${{ matrix.legacy.sandbox_base_image_ref }}
       NEMOCLAW_OLD_OPENSHELL_VERSION: ${{ matrix.legacy.openshell_version }}
       NEMOCLAW_OLD_OPENCLAW_VERSION: ${{ matrix.legacy.openclaw_version }}
       OPENSHELL_GATEWAY: "nemoclaw"

--- a/test/e2e/live/openshell-gateway-upgrade-helpers.ts
+++ b/test/e2e/live/openshell-gateway-upgrade-helpers.ts
@@ -6,6 +6,46 @@ import { shellQuote } from "../fixtures/clients/command.ts";
 const COMMON_INSTALLER_ARGS = ["--non-interactive", "--yes-i-accept-third-party-software"];
 const GATEWAY_VOLUME_PREFIX = "openshell-cluster-nemoclaw";
 
+export interface LegacyGatewayUpgradeFixture {
+  nemoclawRef: string;
+  nemoclawCommit: string;
+  installerSha256: string;
+  openclawVersion: string;
+  sandboxBaseImageRef: string;
+}
+
+export function validateLegacyGatewayUpgradeFixture(fixture: LegacyGatewayUpgradeFixture): {
+  sandboxBaseDigest: string;
+} {
+  if (!/^v\d+\.\d+\.\d+$/.test(fixture.nemoclawRef)) {
+    throw new Error(`NEMOCLAW_OLD_NEMOCLAW_REF must be a release tag; got ${fixture.nemoclawRef}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(fixture.nemoclawCommit)) {
+    throw new Error(
+      `NEMOCLAW_OLD_NEMOCLAW_COMMIT must be a full lowercase commit SHA; got ${fixture.nemoclawCommit}`,
+    );
+  }
+  if (!/^[0-9a-f]{64}$/.test(fixture.installerSha256)) {
+    throw new Error(
+      `NEMOCLAW_OLD_INSTALLER_SHA256 must be a lowercase SHA-256 digest; got ${fixture.installerSha256}`,
+    );
+  }
+  if (!/^\d{4}\.\d{1,2}\.\d{1,2}$/.test(fixture.openclawVersion)) {
+    throw new Error(
+      `NEMOCLAW_OLD_OPENCLAW_VERSION must use the YYYY.M.D release format; got ${fixture.openclawVersion}`,
+    );
+  }
+  const sandboxBaseDigest = fixture.sandboxBaseImageRef.match(
+    /^[^@\s]+@sha256:([0-9a-f]{64})$/,
+  )?.[1];
+  if (!sandboxBaseDigest) {
+    throw new Error(
+      `NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF must be digest-pinned; got ${fixture.sandboxBaseImageRef}`,
+    );
+  }
+  return { sandboxBaseDigest };
+}
+
 export function oldGatewayUpgradeInstallerArgs(installer: string): string[] {
   return [installer, ...COMMON_INSTALLER_ARGS, "--fresh"];
 }

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -673,7 +673,7 @@ runLinuxOpenShellGatewayUpgrade(
       id: "openshell-gateway-upgrade",
       runner: "vitest",
       boundary: [
-        "real old install.sh fetched from v0.0.36",
+        `real old install.sh fetched from ${OLD_NEMOCLAW_REF}`,
         "real Docker/OpenShell gateway and OpenClaw sandbox",
         "exact-name confirmation for the known-managed legacy fixture",
         "current scripts/install.sh gateway upgrade path",
@@ -682,6 +682,8 @@ runLinuxOpenShellGatewayUpgrade(
       ],
       oldNemoclawRef: OLD_NEMOCLAW_REF,
       oldOpenShellVersion: OLD_OPENSHELL_VERSION,
+      oldOpenClawVersion: OLD_OPENCLAW_VERSION,
+      oldSandboxBaseImageRef: OLD_SANDBOX_BASE_IMAGE_REF,
       currentOpenShellVersion: CURRENT_OPENSHELL_VERSION,
       survivorSandbox: SURVIVOR_SANDBOX,
     });

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -154,7 +154,6 @@ import sys
 path = Path(sys.argv[1])
 version = sys.argv[2]
 text = path.read_text(encoding="utf-8")
-marker = "RUN set -eu; \\\n    MIN_VER=$(grep -m 1 'min_openclaw_version'"
 injection = (
     "# E2E old-upgrade fixture: force the historical OpenClaw before the old Dockerfile's version gate.\n"
     "RUN rm -rf /usr/local/lib/node_modules/openclaw /usr/local/bin/openclaw \\\n"
@@ -162,9 +161,18 @@ injection = (
     "    && openclaw --version\n\n"
 )
 if injection not in text:
-    if marker not in text:
-        raise SystemExit(f"{path}: old OpenClaw version gate not found")
-    text = text.replace(marker, injection + marker, 1)
+    arg_markers = [
+        line for line in text.splitlines(keepends=True)
+        if line.startswith("ARG OPENCLAW_VERSION=")
+    ]
+    if len(arg_markers) == 1:
+        marker = arg_markers[0]
+        text = text.replace(marker, marker + "\n" + injection, 1)
+    else:
+        marker = "RUN set -eu; \\\n    MIN_VER=$(grep -m 1 'min_openclaw_version'"
+        if marker not in text:
+            raise SystemExit(f"{path}: old OpenClaw version gate not found")
+        text = text.replace(marker, injection + marker, 1)
     path.write_text(text, encoding="utf-8")
 print(f"INFO: Forced OpenClaw {version} in old upgrade fixture Dockerfile", flush=True)
 NEMOCLAW_OLD_DOCKERFILE_PIN_PY

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -447,7 +447,7 @@ chmod 755 ${shellQuote(oldInstaller)}`,
   );
   const expectedHead = await bash(
     host,
-    `git ls-remote https://github.com/NVIDIA/NemoClaw.git refs/tags/${shellQuote(OLD_NEMOCLAW_REF)} | awk '{print $1}'`,
+    `resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}^{}`)} | awk '{print $1}'); if [ -z "$resolved" ]; then resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}`)} | awk '{print $1}'); fi; printf '%s\n' "$resolved"`,
     { artifactName: "old-source-expected-head", timeoutMs: 60_000 },
   );
   expectExitZero(sourceHead, "read old source head");

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -168,6 +168,10 @@ if injection not in text:
     if len(arg_markers) == 1:
         marker = arg_markers[0]
         text = text.replace(marker, marker + "\n" + injection, 1)
+    elif len(arg_markers) > 1:
+        raise SystemExit(
+            f"{path}: found {len(arg_markers)} OpenClaw version ARGs; expected exactly one"
+        )
     else:
         marker = "RUN set -eu; \\\n    MIN_VER=$(grep -m 1 'min_openclaw_version'"
         if marker not in text:

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -200,15 +200,17 @@ NEMOCLAW_OLD_PAYLOAD_PIN_PY
 
 function createOldDockerWrapper(artifacts: ArtifactSink): string {
   const wrapperDir = artifacts.pathFor("old-docker-wrapper");
+  const logFile = artifacts.pathFor("old-docker-wrapper.log");
+  const realDocker = process.env.NEMOCLAW_REAL_DOCKER ?? "/usr/bin/docker";
   fs.mkdirSync(wrapperDir, { recursive: true, mode: 0o700 });
   writeExecutable(
     path.join(wrapperDir, "docker"),
     `#!/usr/bin/env bash
 set -euo pipefail
-real_docker="\${NEMOCLAW_REAL_DOCKER:-/usr/bin/docker}"
-base_ref="\${NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF:?}"
-old_openclaw="\${NEMOCLAW_OLD_OPENCLAW_VERSION:?}"
-log_file="\${NEMOCLAW_OLD_DOCKER_WRAPPER_LOG:?}"
+real_docker=${shellQuote(realDocker)}
+base_ref=${shellQuote(OLD_SANDBOX_BASE_IMAGE_REF)}
+old_openclaw=${shellQuote(OLD_OPENCLAW_VERSION)}
+log_file=${shellQuote(logFile)}
 base_tag="ghcr.io/nvidia/nemoclaw/sandbox-base:latest"
 if [ "\${1:-}" = "pull" ]; then
   for arg in "$@"; do

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -17,6 +17,7 @@
 
 import { Buffer } from "node:buffer";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -35,6 +36,7 @@ import {
   currentGatewayUpgradeInstallerArgs,
   oldGatewayUpgradeInstallerArgs,
   upgradeGatewayCleanupScript,
+  validateLegacyGatewayUpgradeFixture,
 } from "./openshell-gateway-upgrade-helpers.ts";
 
 const INSTALL_OPENSHELL = path.join(REPO_ROOT, "scripts", "install-openshell.sh");
@@ -47,12 +49,24 @@ const STATE_DIR = path.join(
 );
 const PID_FILE = path.join(STATE_DIR, "openshell-gateway.pid");
 const OLD_NEMOCLAW_REF = process.env.NEMOCLAW_OLD_NEMOCLAW_REF ?? "v0.0.36";
+const OLD_NEMOCLAW_COMMIT =
+  process.env.NEMOCLAW_OLD_NEMOCLAW_COMMIT ?? "3351fbdd4eb7d9b80ec471545083956327da2b10";
+const OLD_INSTALLER_SHA256 =
+  process.env.NEMOCLAW_OLD_INSTALLER_SHA256 ??
+  "0c42400a0d3867739f1d75d612e069967be4506e169974bbbebf14b7af39144f";
 const OLD_OPENSHELL_VERSION = process.env.NEMOCLAW_OLD_OPENSHELL_VERSION ?? "0.0.36";
 const CURRENT_OPENSHELL_VERSION = process.env.NEMOCLAW_CURRENT_OPENSHELL_VERSION ?? "0.0.72";
 const OLD_SANDBOX_BASE_IMAGE_REF =
   process.env.NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF ??
   "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:104151ffadc2ff0b6c815e3c95c2783ced61aee0d0f83fc327cc02be9b7e14e6";
 const OLD_OPENCLAW_VERSION = process.env.NEMOCLAW_OLD_OPENCLAW_VERSION ?? "2026.4.24";
+const { sandboxBaseDigest: OLD_SANDBOX_BASE_DIGEST } = validateLegacyGatewayUpgradeFixture({
+  nemoclawRef: OLD_NEMOCLAW_REF,
+  nemoclawCommit: OLD_NEMOCLAW_COMMIT,
+  installerSha256: OLD_INSTALLER_SHA256,
+  openclawVersion: OLD_OPENCLAW_VERSION,
+  sandboxBaseImageRef: OLD_SANDBOX_BASE_IMAGE_REF,
+});
 const SURVIVOR_SANDBOX =
   process.env.NEMOCLAW_GATEWAY_UPGRADE_SURVIVOR_NAME ??
   [
@@ -115,10 +129,6 @@ function escapeRegExpLiteral(value: string): string {
   return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
-function extractSha256Digest(imageRef: string): string | null {
-  return imageRef.match(/@sha256:([0-9a-f]{64})$/i)?.[1].toLowerCase() ?? null;
-}
-
 function expectFullGitSha(result: ShellProbeResult, label: string): string {
   expectExitZero(result, label);
   const sha = result.stdout.trim();
@@ -148,6 +158,10 @@ async function bash(
   });
 }
 
+// The frozen release installers are the source of truth, but their embedded
+// Dockerfiles predate the fixture pins needed for a deterministic upgrade test.
+// Keep this adapter scoped to the v0.0.36/v0.0.55 lanes and retire it with
+// those historical lanes; changing the tagged release payloads is not viable.
 function patchOldInstallerFixture(installer: string): void {
   const needle = '  legacy_script="${source_root}/install.sh"\n';
   const hook =
@@ -391,11 +405,18 @@ async function installOldNemoclawAndClaw(
 
   const download = await bash(
     host,
-    `curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/${shellQuote(OLD_NEMOCLAW_REF)}/install.sh -o ${shellQuote(oldInstaller)}
-chmod 755 ${shellQuote(oldInstaller)}`,
+    `curl -fsSL https://raw.githubusercontent.com/NVIDIA/NemoClaw/${shellQuote(OLD_NEMOCLAW_COMMIT)}/install.sh -o ${shellQuote(oldInstaller)}`,
     { artifactName: "download-old-installer", timeoutMs: 90_000 },
   );
   expectExitZero(download, `download old ${OLD_NEMOCLAW_REF} installer`);
+  const downloadedInstallerSha256 = createHash("sha256")
+    .update(fs.readFileSync(oldInstaller))
+    .digest("hex");
+  expect(
+    downloadedInstallerSha256,
+    `downloaded ${OLD_NEMOCLAW_REF} installer must match its pinned SHA-256`,
+  ).toBe(OLD_INSTALLER_SHA256);
+  fs.chmodSync(oldInstaller, 0o755);
   patchOldInstallerFixture(oldInstaller);
 
   const installEnv = liveEnv({
@@ -408,8 +429,8 @@ chmod 755 ${shellQuote(oldInstaller)}`,
     NEMOCLAW_OLD_DOCKER_WRAPPER_LOG: oldDockerLog,
     NEMOCLAW_ACCEPT_EXPERIMENTAL_OPENSHELL_UPGRADE: "1",
     NEMOCLAW_BOOTSTRAP_PAYLOAD: "1",
-    NEMOCLAW_INSTALL_REF: OLD_NEMOCLAW_REF,
-    NEMOCLAW_INSTALL_TAG: OLD_NEMOCLAW_REF,
+    NEMOCLAW_INSTALL_REF: OLD_NEMOCLAW_COMMIT,
+    NEMOCLAW_INSTALL_TAG: OLD_NEMOCLAW_COMMIT,
     NEMOCLAW_PROVIDER: "custom",
     NEMOCLAW_ENDPOINT_URL: fakeBaseUrl,
     NEMOCLAW_MODEL: "test-model",
@@ -435,14 +456,10 @@ chmod 755 ${shellQuote(oldInstaller)}`,
   );
 
   const oldLog = fs.readFileSync(oldInstallLog, "utf8");
-  const oldSandboxBaseDigest = extractSha256Digest(OLD_SANDBOX_BASE_IMAGE_REF);
-  if (oldSandboxBaseDigest) {
-    const oldSandboxBasePinPrefix = `sha256:${oldSandboxBaseDigest}`.slice(0, 19);
-    expect(
-      oldLog,
-      `old fixture must pin sandbox base image ${OLD_SANDBOX_BASE_IMAGE_REF}`,
-    ).toContain(`Pinning base image to ${oldSandboxBasePinPrefix}`);
-  }
+  const oldSandboxBasePinPrefix = `sha256:${OLD_SANDBOX_BASE_DIGEST}`.slice(0, 19);
+  expect(oldLog, `old fixture must pin sandbox base image ${OLD_SANDBOX_BASE_IMAGE_REF}`).toContain(
+    `Pinning base image to ${oldSandboxBasePinPrefix}`,
+  );
   const oldOpenClawVersionPattern = escapeRegExpLiteral(OLD_OPENCLAW_VERSION);
   const wrongOldOpenClaw = oldLog.match(
     new RegExp(
@@ -474,22 +491,8 @@ chmod 755 ${shellQuote(oldInstaller)}`,
 git -C "$HOME/.nemoclaw/source" rev-parse --verify HEAD`,
     { artifactName: "old-source-head", timeoutMs: 30_000 },
   );
-  const expectedHead = await bash(
-    host,
-    `resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}^{}`)} | awk '{print $1}')
-if ! [[ "$resolved" =~ ^[0-9a-f]{40}$ ]]; then
-  resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}`)} | awk '{print $1}')
-fi
-if ! [[ "$resolved" =~ ^[0-9a-f]{40}$ ]]; then
-  printf 'ERROR: expected %s to resolve to a full commit SHA, got %q\n' ${shellQuote(OLD_NEMOCLAW_REF)} "$resolved" >&2
-  exit 1
-fi
-printf '%s\n' "$resolved"`,
-    { artifactName: "old-source-expected-head", timeoutMs: 60_000 },
-  );
   const actualSourceHead = expectFullGitSha(sourceHead, "read old source head");
-  const expectedSourceHead = expectFullGitSha(expectedHead, "read expected old tag head");
-  expect(actualSourceHead).toBe(expectedSourceHead);
+  expect(actualSourceHead).toBe(OLD_NEMOCLAW_COMMIT);
 
   await waitForSurvivorReady(host, "old-install");
   const list = await bash(host, `nemoclaw list`, {
@@ -726,6 +729,8 @@ runLinuxOpenShellGatewayUpgrade(
         "NemoClaw registry and durable workspace restore",
       ],
       oldNemoclawRef: OLD_NEMOCLAW_REF,
+      oldNemoclawCommit: OLD_NEMOCLAW_COMMIT,
+      oldInstallerSha256: OLD_INSTALLER_SHA256,
       oldOpenShellVersion: OLD_OPENSHELL_VERSION,
       oldOpenClawVersion: OLD_OPENCLAW_VERSION,
       oldSandboxBaseImageRef: OLD_SANDBOX_BASE_IMAGE_REF,

--- a/test/e2e/live/openshell-gateway-upgrade.test.ts
+++ b/test/e2e/live/openshell-gateway-upgrade.test.ts
@@ -115,6 +115,19 @@ function escapeRegExpLiteral(value: string): string {
   return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
+function extractSha256Digest(imageRef: string): string | null {
+  return imageRef.match(/@sha256:([0-9a-f]{64})$/i)?.[1].toLowerCase() ?? null;
+}
+
+function expectFullGitSha(result: ShellProbeResult, label: string): string {
+  expectExitZero(result, label);
+  const sha = result.stdout.trim();
+  expect(sha, `${label} must produce a full git commit SHA:\n${resultText(result)}`).toMatch(
+    /^[0-9a-f]{40}$/,
+  );
+  return sha;
+}
+
 async function bash(
   host: HostCliClient,
   script: string,
@@ -389,6 +402,7 @@ chmod 755 ${shellQuote(oldInstaller)}`,
     PATH: `${wrapperDir}:${process.env.PATH ?? "/usr/bin:/bin"}`,
     COMPATIBLE_API_KEY: "dummy",
     NEMOCLAW_REAL_DOCKER: process.env.NEMOCLAW_REAL_DOCKER ?? "/usr/bin/docker",
+    NEMOCLAW_SANDBOX_BASE_IMAGE_REF: OLD_SANDBOX_BASE_IMAGE_REF,
     NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF: OLD_SANDBOX_BASE_IMAGE_REF,
     NEMOCLAW_OLD_OPENCLAW_VERSION: OLD_OPENCLAW_VERSION,
     NEMOCLAW_OLD_DOCKER_WRAPPER_LOG: oldDockerLog,
@@ -421,6 +435,14 @@ chmod 755 ${shellQuote(oldInstaller)}`,
   );
 
   const oldLog = fs.readFileSync(oldInstallLog, "utf8");
+  const oldSandboxBaseDigest = extractSha256Digest(OLD_SANDBOX_BASE_IMAGE_REF);
+  if (oldSandboxBaseDigest) {
+    const oldSandboxBasePinPrefix = `sha256:${oldSandboxBaseDigest}`.slice(0, 19);
+    expect(
+      oldLog,
+      `old fixture must pin sandbox base image ${OLD_SANDBOX_BASE_IMAGE_REF}`,
+    ).toContain(`Pinning base image to ${oldSandboxBasePinPrefix}`);
+  }
   const oldOpenClawVersionPattern = escapeRegExpLiteral(OLD_OPENCLAW_VERSION);
   const wrongOldOpenClaw = oldLog.match(
     new RegExp(
@@ -448,17 +470,26 @@ chmod 755 ${shellQuote(oldInstaller)}`,
 
   const sourceHead = await bash(
     host,
-    `if [ -d "$HOME/.nemoclaw/source/.git" ]; then git -C "$HOME/.nemoclaw/source" rev-parse HEAD; fi`,
+    `test -d "$HOME/.nemoclaw/source/.git"
+git -C "$HOME/.nemoclaw/source" rev-parse --verify HEAD`,
     { artifactName: "old-source-head", timeoutMs: 30_000 },
   );
   const expectedHead = await bash(
     host,
-    `resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}^{}`)} | awk '{print $1}'); if [ -z "$resolved" ]; then resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}`)} | awk '{print $1}'); fi; printf '%s\n' "$resolved"`,
+    `resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}^{}`)} | awk '{print $1}')
+if ! [[ "$resolved" =~ ^[0-9a-f]{40}$ ]]; then
+  resolved=$(git ls-remote https://github.com/NVIDIA/NemoClaw.git ${shellQuote(`refs/tags/${OLD_NEMOCLAW_REF}`)} | awk '{print $1}')
+fi
+if ! [[ "$resolved" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'ERROR: expected %s to resolve to a full commit SHA, got %q\n' ${shellQuote(OLD_NEMOCLAW_REF)} "$resolved" >&2
+  exit 1
+fi
+printf '%s\n' "$resolved"`,
     { artifactName: "old-source-expected-head", timeoutMs: 60_000 },
   );
-  expectExitZero(sourceHead, "read old source head");
-  expectExitZero(expectedHead, "read expected old tag head");
-  expect(sourceHead.stdout.trim()).toBe(expectedHead.stdout.trim());
+  const actualSourceHead = expectFullGitSha(sourceHead, "read old source head");
+  const expectedSourceHead = expectFullGitSha(expectedHead, "read expected old tag head");
+  expect(actualSourceHead).toBe(expectedSourceHead);
 
   await waitForSurvivorReady(host, "old-install");
   const list = await bash(host, `nemoclaw list`, {

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -82,6 +82,24 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
     expect(() =>
       validateLegacyGatewayUpgradeFixture({
         ...fixture,
+        nemoclawRef: "v0.0.55; echo injected",
+      }),
+    ).toThrow(/NEMOCLAW_OLD_NEMOCLAW_REF/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
+        nemoclawCommit: fixture.nemoclawCommit.toUpperCase(),
+      }),
+    ).toThrow(/NEMOCLAW_OLD_NEMOCLAW_COMMIT/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
+        installerSha256: fixture.installerSha256.toUpperCase(),
+      }),
+    ).toThrow(/NEMOCLAW_OLD_INSTALLER_SHA256/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
         openclawVersion: '2026.5.22" && echo injected #',
       }),
     ).toThrow(/NEMOCLAW_OLD_OPENCLAW_VERSION/);

--- a/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
+++ b/test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts
@@ -15,6 +15,7 @@ import {
   currentGatewayUpgradeInstallerArgs,
   oldGatewayUpgradeInstallerArgs,
   upgradeGatewayCleanupScript,
+  validateLegacyGatewayUpgradeFixture,
 } from "../live/openshell-gateway-upgrade-helpers.ts";
 
 describe("OpenShell gateway upgrade workflow boundary", () => {
@@ -63,6 +64,33 @@ describe("OpenShell gateway upgrade workflow boundary", () => {
       "--non-interactive",
       "--yes-i-accept-third-party-software",
     ]);
+  });
+
+  it("rejects mutable or injectable historical fixture inputs before use (#6114)", () => {
+    const fixture = {
+      nemoclawRef: "v0.0.55",
+      nemoclawCommit: "95d483fe2b6569d68e59493c60f19df09a068e8f",
+      installerSha256: "ff8cf448e4d17b00421545a1f333262b615b1b0aa236d0cc5aeaf4e2cae2d897",
+      openclawVersion: "2026.5.22",
+      sandboxBaseImageRef:
+        "ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:104151ffadc2ff0b6c815e3c95c2783ced61aee0d0f83fc327cc02be9b7e14e6",
+    };
+
+    expect(validateLegacyGatewayUpgradeFixture(fixture)).toEqual({
+      sandboxBaseDigest: "104151ffadc2ff0b6c815e3c95c2783ced61aee0d0f83fc327cc02be9b7e14e6",
+    });
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
+        openclawVersion: '2026.5.22" && echo injected #',
+      }),
+    ).toThrow(/NEMOCLAW_OLD_OPENCLAW_VERSION/);
+    expect(() =>
+      validateLegacyGatewayUpgradeFixture({
+        ...fixture,
+        sandboxBaseImageRef: "ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+      }),
+    ).toThrow(/NEMOCLAW_OLD_SANDBOX_BASE_IMAGE_REF/);
   });
 
   it("reclaims only the owned gateway volume namespace", () => {


### PR DESCRIPTION
## Summary

- run the existing live OpenShell gateway upgrade test as a two-case matrix
- retain the v0.0.36 legacy fixture
- add the exact v0.0.55 / OpenShell 0.0.44 / OpenClaw 2026.5.22 source shape from #6114
- publish version-specific artifacts and record the selected legacy versions in test metadata

## Related Issue

Follow-up coverage for #6114 and NVBug 6401602.

## Type of Change

- [x] Test and CI coverage
- [ ] Product code change
- [ ] Documentation only

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing live E2E implementation reused to avoid duplicate upgrade logic
- [x] Sensitive upgrade and recovery path covered by a real installer, gateway, sandbox, process, and workspace-survival boundary
- [x] No secrets, API keys, or credentials committed

## Verification

- focused e2e-support Vitest tests: 7 passed
- local e2e-live target: 3 passed, Linux live case skipped on macOS as designed
- workflow inventory validation passed
- actionlint passed after ignoring pre-existing custom runner label warnings
- npm run check:diff passed
- targeted live upgrade matrix: v0.0.36 and v0.0.55 both passed ([run 28873726294](https://github.com/NVIDIA/NemoClaw/actions/runs/28873726294))

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live end-to-end upgrade test reliability by handling varying legacy installer layouts during OpenClaw injection.
  * Made legacy upgrade tag/head verification more robust with dereferenced-tag-first resolution and fallback.
  * Refreshed upgrade assertions and expanded the upgrade payload with dynamic legacy reference/version and sandbox/base image details.
* **Chores**
  * Updated the end-to-end upgrade workflow to run across two legacy fixture variants, with clearer per-variant job naming and variant-specific artifact labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->