### PR TITLE
perf(test): retire rebuild gateway loader seam

### DIFF
--- a/scripts/checks/test-create-require-budget.ts
+++ b/scripts/checks/test-create-require-budget.ts
@@ -23,7 +23,6 @@ export const CLI_CREATE_REQUIRE_FILES = [
   "src/lib/actions/sandbox/gateway-state-hints.test.ts",
   "src/lib/actions/sandbox/process-recovery-lock.test.ts",
   "src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts",
-  "src/lib/actions/sandbox/rebuild-gateway-drift.test.ts",
   "src/lib/actions/sandbox/rebuild-local-provider-recreate.test.ts",
   "src/lib/actions/sandbox/rebuild-resume-config.test.ts",
   "src/lib/actions/sandbox/rebuild-resume-reasoning.test.ts",

--- a/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
+++ b/src/lib/actions/sandbox/rebuild-gateway-drift.test.ts
@@ -1,31 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createRequire } from "node:module";
-
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
-import type { OpenShellStateRpcIssue } from "../../adapters/openshell/gateway-drift";
+import * as gatewayDrift from "../../adapters/openshell/gateway-drift";
+import * as openshellRuntime from "../../adapters/openshell/runtime";
+import * as gatewayRuntime from "../../gateway-runtime-action";
+import * as dockerDriverRecovery from "../../onboard/docker-driver-sandbox-recovery";
+import * as registry from "../../state/registry";
+import { type RebuildSandboxEntry, resolveRebuildLiveState } from "./rebuild-flow-helpers";
+import {
+  checkRebuildGatewaySchemaPreflight,
+  runRebuildGatewayIntentPreflight,
+} from "./rebuild-preflight-guards";
 
-type RebuildSandbox = typeof import("./rebuild")["rebuildSandbox"];
-
-const requireDist = createRequire(import.meta.url);
-const gatewayDrift = requireDist("../../adapters/openshell/gateway-drift.js");
-const openshellRuntime = requireDist("../../adapters/openshell/runtime.js");
-const gatewayRuntime = requireDist("../../gateway-runtime-action.js");
-const registry = requireDist("../../state/registry.js");
-const resolve = requireDist("../../adapters/openshell/resolve.js");
-const sandboxSession = requireDist("../../state/sandbox-session.js");
-const onboardSession = requireDist("../../state/onboard-session.js");
-const sandboxVersion = requireDist("../../sandbox/version.js");
-const agentRuntime = requireDist("../../agent/runtime.js");
-const rebuildUsageNotice = requireDist("./rebuild-usage-notice.js");
-const rebuildImagePreflight = requireDist("./rebuild-custom-image-preflight.js");
-const { rebuildSandbox } = requireDist("./rebuild.js") as {
-  rebuildSandbox: RebuildSandbox;
-};
-
-const driftIssue: OpenShellStateRpcIssue = {
+const driftIssue: gatewayDrift.OpenShellStateRpcIssue = {
   kind: "image_drift",
   drift: {
     containerName: "openshell-cluster-nemoclaw",
@@ -35,37 +24,45 @@ const driftIssue: OpenShellStateRpcIssue = {
   },
 };
 
-function mockExit() {
-  return vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
-    throw new Error(`process.exit(${code ?? 0})`);
-  }) as never);
+const recoveryStates = [
+  "missing_named",
+  "named_unhealthy",
+  "named_unreachable",
+  "connected_other",
+] as const;
+
+function makeSandboxEntry(gatewayName = "nemoclaw", gatewayPort = 8080): RebuildSandboxEntry {
+  return {
+    name: "alpha",
+    provider: "ollama-local",
+    model: "nvidia/nemotron",
+    policies: [],
+    nimContainer: null,
+    agent: null,
+    nemoclawVersion: "0.1.0",
+    dashboardPort: 18789,
+    gatewayName,
+    gatewayPort,
+  };
+}
+
+function bail(message: string): never {
+  throw new Error(message);
 }
 
 describe("rebuild gateway drift preflight", () => {
-  let exitSpy: ReturnType<typeof mockExit>;
-  let errorSpy: MockInstance;
-  let spies: MockInstance[];
-  let checkAgentVersionSpy: MockInstance;
-  let detectPreflightIssueSpy: MockInstance;
   let captureOpenshellSpy: MockInstance;
   let runOpenshellSpy: MockInstance;
-  let printIssueSpy: MockInstance;
   let recoverNamedGatewayRuntimeSpy: MockInstance;
+  let getNamedGatewayLifecycleStateSpy: MockInstance;
+  let recoverDockerDriverSandboxSpy: MockInstance;
+  let errorSpy: MockInstance;
+  let logSpy: MockInstance;
 
-  beforeEach(async () => {
-    spies = [];
-    exitSpy = mockExit();
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    printIssueSpy = vi
-      .spyOn(gatewayDrift, "printOpenShellStateRpcIssue")
-      .mockImplementation(() => undefined);
-    detectPreflightIssueSpy = vi
-      .spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue")
-      .mockReturnValue(driftIssue);
-    checkAgentVersionSpy = vi
-      .spyOn(sandboxVersion, "checkAgentVersion")
-      .mockReturnValue({ expectedVersion: "0.1.0", sandboxVersion: "0.0.1" } as never);
+  beforeEach(() => {
+    vi.spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue").mockReturnValue(null);
+    vi.spyOn(gatewayDrift, "detectOpenShellStateRpcResultIssue").mockReturnValue(null);
+    vi.spyOn(gatewayDrift, "printOpenShellStateRpcIssue").mockImplementation(() => undefined);
     captureOpenshellSpy = vi
       .spyOn(openshellRuntime, "captureOpenshell")
       .mockReturnValue({ status: 0, output: "alpha Ready" });
@@ -76,65 +73,48 @@ describe("rebuild gateway drift preflight", () => {
       .spyOn(gatewayRuntime, "recoverNamedGatewayRuntime")
       .mockResolvedValue({
         recovered: true,
+        attempted: true,
         before: { state: "healthy_named" },
         after: { state: "healthy_named" },
-      });
-
-    spies.push(
-      detectPreflightIssueSpy,
-      vi.spyOn(gatewayDrift, "detectOpenShellStateRpcResultIssue").mockReturnValue(null),
-      captureOpenshellSpy,
-      runOpenshellSpy,
-      recoverNamedGatewayRuntimeSpy,
-      printIssueSpy,
-      vi.spyOn(registry, "getSandbox").mockReturnValue({
-        name: "alpha",
-        provider: "ollama-local",
-        model: "nvidia/nemotron",
-        policies: [],
-        nimContainer: null,
-        agent: null,
-        nemoclawVersion: "0.1.0",
-        dashboardPort: 18789,
-        gatewayName: "nemoclaw",
-        gatewayPort: 8080,
-      } as never),
-      vi.spyOn(registry, "updateSandbox").mockReturnValue(true),
-      vi.spyOn(resolve, "resolveOpenshell").mockReturnValue(null),
-      vi.spyOn(sandboxSession, "getActiveSandboxSessions").mockReturnValue({
-        detected: false,
-        sessions: [],
-      }),
-      vi.spyOn(onboardSession, "loadSession").mockReturnValue(null),
-      vi.spyOn(onboardSession, "acquireOnboardLock").mockReturnValue({ acquired: true }),
-      vi.spyOn(onboardSession, "releaseOnboardLock").mockImplementation(() => undefined),
-      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null),
-      vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw"),
-      vi
-        .spyOn(requireDist("../../onboard.js"), "preflightAuthoritativeRebuildTarget")
-        .mockResolvedValue(undefined),
-      vi
-        .spyOn(rebuildImagePreflight, "preflightRebuildImage")
-        .mockResolvedValue({ ok: true, imageTag: null }),
-      vi.spyOn(rebuildUsageNotice, "ensureRebuildUsageNoticeAccepted").mockResolvedValue(true),
-      checkAgentVersionSpy,
-    );
+      } as never);
+    getNamedGatewayLifecycleStateSpy = vi
+      .spyOn(gatewayRuntime, "getNamedGatewayLifecycleState")
+      .mockReturnValue({ state: "healthy_named", activeGateway: "nemoclaw", status: "" } as never);
+    recoverDockerDriverSandboxSpy = vi
+      .spyOn(dockerDriverRecovery, "recoverDockerDriverSandbox")
+      .mockReturnValue({ recovered: false, via: null });
+    vi.spyOn(registry, "getSandbox").mockReturnValue(makeSandboxEntry() as never);
+    vi.spyOn(registry, "load").mockReturnValue({
+      sandboxes: { alpha: makeSandboxEntry() },
+    } as never);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    for (const spy of spies) spy.mockRestore();
-    exitSpy.mockRestore();
-    errorSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
-  it("fails before version or liveness RPCs when gateway image drift is detected", async () => {
-    await expect(rebuildSandbox("alpha", ["--yes"])).rejects.toThrow("process.exit(1)");
+  it("rejects gateway image drift before confirming rebuild intent", async () => {
+    vi.mocked(gatewayDrift.detectOpenShellStateRpcPreflightIssue).mockReturnValue(driftIssue);
+    const confirmIntent = vi.fn();
 
-    expect(printIssueSpy).toHaveBeenCalledWith(
-      driftIssue,
-      expect.objectContaining({ command: "nemoclaw alpha rebuild" }),
-    );
-    expect(checkAgentVersionSpy).not.toHaveBeenCalled();
+    await expect(
+      runRebuildGatewayIntentPreflight({
+        checkGatewaySchema: () =>
+          checkRebuildGatewaySchemaPreflight("alpha", makeSandboxEntry(), bail),
+        confirmIntent,
+      }),
+    ).rejects.toThrow("OpenShell gateway schema mismatch.");
+
+    expect(gatewayDrift.detectOpenShellStateRpcPreflightIssue).toHaveBeenCalledWith({
+      gatewayName: "nemoclaw",
+    });
+    expect(gatewayDrift.printOpenShellStateRpcIssue).toHaveBeenCalledWith(driftIssue, {
+      action: "rebuilding sandbox 'alpha'",
+      command: "nemoclaw alpha rebuild",
+    });
+    expect(confirmIntent).not.toHaveBeenCalled();
     expect(captureOpenshellSpy).not.toHaveBeenCalled();
     expect(recoverNamedGatewayRuntimeSpy).not.toHaveBeenCalled();
   });
@@ -150,277 +130,119 @@ describe("rebuild gateway drift preflight", () => {
       recordedPort: 9000,
       activeGateway: "nemoclaw",
     },
-  ])("refuses stale recovery when '$activeGateway' is active instead of recorded gateway '$recordedGateway' (#4497)", async ({
+  ])("refuses stale recovery when $activeGateway is active instead of recorded gateway $recordedGateway (#4497)", async ({
     recordedGateway,
     recordedPort,
     activeGateway,
   }) => {
-    detectPreflightIssueSpy.mockReturnValue(null);
-    vi.mocked(registry.getSandbox).mockReturnValue({
-      name: "alpha",
-      provider: "ollama-local",
-      model: "nvidia/nemotron",
-      policies: [],
-      nimContainer: null,
-      agent: null,
-      nemoclawVersion: "0.1.0",
-      dashboardPort: 18789,
-      gatewayName: recordedGateway,
-      gatewayPort: recordedPort,
+    const entry = makeSandboxEntry(recordedGateway, recordedPort);
+    vi.mocked(registry.getSandbox).mockReturnValue(entry as never);
+    captureOpenshellSpy
+      .mockReturnValueOnce({ status: 0, output: "" })
+      .mockReturnValueOnce({ status: 1, output: "Error:   × Not Found: sandbox not found" })
+      .mockReturnValueOnce({ status: 1, output: "Error:   × Not Found: sandbox not found" });
+    getNamedGatewayLifecycleStateSpy.mockReturnValue({
+      state: "connected_other",
+      activeGateway,
+      status: `Gateway: ${activeGateway}\nStatus: Connected`,
     } as never);
-    const openshellResults: Record<string, { status: number; output: string }> = {
-      "sandbox list": { status: 0, output: "" },
-      "sandbox get": {
-        status: 1,
-        output: "Error:   × Not Found: sandbox not found",
-      },
-    };
-    captureOpenshellSpy.mockImplementation(
-      (args: string[]) => openshellResults[args.slice(0, 2).join(" ")] ?? { status: 0, output: "" },
-    );
-    const getNamedGatewayLifecycleStateSpy = vi
-      .spyOn(gatewayRuntime, "getNamedGatewayLifecycleState")
-      .mockReturnValue({
-        state: "connected_other",
-        activeGateway,
-        status: `Gateway: ${activeGateway}\nStatus: Connected`,
-      } as never);
-    const backupSandboxStateSpy = vi
-      .spyOn(requireDist("../../state/sandbox.js"), "backupSandboxState")
-      .mockImplementation(() => {
-        throw new Error("unexpected backup");
-      });
-    const removeSandboxRegistryEntrySpy = vi
-      .spyOn(requireDist("./destroy.js"), "removeSandboxRegistryEntryWithReceipt")
-      .mockImplementation(() => {
-        throw new Error("unexpected registry removal");
-      });
-    const onboardSpy = vi
-      .spyOn(requireDist("../../onboard.js"), "onboard")
-      .mockImplementation(async () => {
-        throw new Error("unexpected onboard");
-      });
-    spies.push(
-      getNamedGatewayLifecycleStateSpy,
-      backupSandboxStateSpy,
-      removeSandboxRegistryEntrySpy,
-      onboardSpy,
-    );
+    const behaviorLog = vi.fn();
 
-    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
+    await expect(resolveRebuildLiveState("alpha", entry, behaviorLog, bail)).rejects.toThrow(
       "Could not confirm live state",
     );
 
-    const output = errorSpy.mock.calls.flat().join("\n");
-    expect(output).toContain("NOT been removed");
-    expect(output).toContain(`openshell gateway select ${recordedGateway}`);
     expect(getNamedGatewayLifecycleStateSpy).toHaveBeenCalledWith(recordedGateway);
     expect(runOpenshellSpy).toHaveBeenCalledWith(
       ["gateway", "select", recordedGateway],
       expect.objectContaining({ ignoreError: true }),
     );
-    expect(backupSandboxStateSpy).not.toHaveBeenCalled();
-    expect(runOpenshellSpy).not.toHaveBeenCalledWith(
-      ["sandbox", "delete", "alpha"],
+    const output = errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("NOT been removed");
+    expect(output).toContain(`openshell gateway select ${recordedGateway}`);
+    expect(registry.load).not.toHaveBeenCalled();
+    expect(recoverDockerDriverSandboxSpy).not.toHaveBeenCalled();
+    expect([...logSpy.mock.calls, ...behaviorLog.mock.calls].flat().join("\n")).not.toContain(
+      "No live workspace state to back up",
+    );
+  });
+
+  it.each([
+    { gatewayName: "nemoclaw", gatewayPort: 8080 },
+    { gatewayName: "nemoclaw-12345", gatewayPort: 12345 },
+  ])("recovers $gatewayName and returns stale state after confirming the sandbox is absent (#4497)", async ({
+    gatewayName,
+    gatewayPort,
+  }) => {
+    const entry = makeSandboxEntry(gatewayName, gatewayPort);
+    const registrySnapshot = { sandboxes: { alpha: entry } };
+    vi.mocked(registry.getSandbox).mockReturnValue(entry as never);
+    vi.mocked(registry.load).mockReturnValue(registrySnapshot as never);
+    captureOpenshellSpy
+      .mockReturnValueOnce({
+        status: 1,
+        output: "client error (Connect): Connection refused",
+      })
+      .mockReturnValueOnce({ status: 0, output: "beta Ready" })
+      .mockReturnValueOnce({ status: 1, output: "Error:   × Not Found: sandbox not found" });
+    getNamedGatewayLifecycleStateSpy.mockReturnValue({
+      state: "healthy_named",
+      activeGateway: gatewayName,
+      status: `Gateway: ${gatewayName}\nStatus: Connected`,
+    } as never);
+    const behaviorLog = vi.fn();
+
+    const result = await resolveRebuildLiveState("alpha", entry, behaviorLog, bail);
+
+    expect(result).toEqual({
+      staleRecovery: true,
+      staleRegistrySnapshot: registrySnapshot,
+    });
+    expect(result?.staleRegistrySnapshot).not.toBe(registrySnapshot);
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledTimes(2);
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenNthCalledWith(1, {
+      gatewayName,
+      recoverableStates: recoveryStates,
+    });
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenNthCalledWith(2, {
+      gatewayName,
+      recoverableStates: recoveryStates,
+    });
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(1, ["sandbox", "list"]);
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(2, ["sandbox", "list"]);
+    expect(captureOpenshellSpy).toHaveBeenNthCalledWith(
+      3,
+      ["sandbox", "get", "alpha"],
       expect.anything(),
     );
-    expect(removeSandboxRegistryEntrySpy).not.toHaveBeenCalled();
-    expect(onboardSpy).not.toHaveBeenCalled();
+    expect(getNamedGatewayLifecycleStateSpy).toHaveBeenCalledWith(gatewayName);
+    expect(recoverDockerDriverSandboxSpy).toHaveBeenCalledWith("alpha");
+    expect(registry.load).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls.flat().join("\n")).toContain("absent from the live OpenShell gateway");
+    expect(behaviorLog.mock.calls.flat().join("\n")).toContain("Stale-sandbox recovery");
   });
 
-  it("recovers the named gateway and retries the liveness query before entering stale recovery", async () => {
-    detectPreflightIssueSpy.mockReturnValue(null);
-    // First `sandbox list` fails (gateway down) and triggers recovery; the retry
-    // shows only 'beta', so 'alpha' is absent. Before treating that as stale,
-    // rebuild reconciles against the NAMED gateway, which reports a healthy
-    // nemoclaw (status Connected + gateway info), confirming the sandbox is
-    // genuinely gone (#4497).
-    let listCalls = 0;
-    captureOpenshellSpy.mockImplementation((args: string[]) => {
-      if (args[0] === "sandbox" && args[1] === "list") {
-        listCalls += 1;
-        return listCalls === 1
-          ? { status: 1, output: "client error (Connect): Connection refused" }
-          : { status: 0, output: "beta Ready" };
-      }
-      if (args[0] === "status") {
-        return {
-          status: 0,
-          output: "Server Status\n\n  Gateway: nemoclaw\n  Status: Connected\n",
-        };
-      }
-      if (args[0] === "gateway" && args[1] === "info") {
-        return { status: 0, output: "Gateway Info\n\nGateway: nemoclaw\n" };
-      }
-      if (args[0] === "sandbox" && args[1] === "get") {
-        return { status: 1, output: "Error:   × Not Found: sandbox not found" };
-      }
-      return { status: 0, output: "" };
+  it("fails without a sandbox-list retry after a generic query error", async () => {
+    const entry = makeSandboxEntry();
+    captureOpenshellSpy.mockReturnValueOnce({
+      status: 1,
+      output: "unknown option: sandbox list",
     });
 
-    // The reconcile confirms the stale state, so rather than dead-ending at
-    // "Cannot back up state", rebuild skips backup and recreates from the
-    // preserved registry metadata. Stub the destructive steps + recreate handoff
-    // so the path stays hermetic, and assert the recreate failure surfaces the
-    // stale-recovery message instead of "not running".
-    const destroy = requireDist("./destroy.js");
-    const onboardMod = requireDist("../../onboard.js");
-    spies.push(
-      vi.spyOn(destroy, "removeSandboxRegistryEntryWithReceipt").mockReturnValue(null),
-      vi.spyOn(onboardMod, "onboard").mockRejectedValue(new Error("recreate-stub")),
-    );
-
-    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
-      /stale-sandbox recovery/,
-    );
-
-    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
-      gatewayName: "nemoclaw",
-      recoverableStates: [
-        "missing_named",
-        "named_unhealthy",
-        "named_unreachable",
-        "connected_other",
-      ],
-    });
-    // The liveness query ran twice (initial failure + post-recovery retry).
-    expect(listCalls).toBe(2);
-  });
-
-  it("recovers the persisted non-default gateway when the sandbox is bound to nemoclaw-<port>", async () => {
-    detectPreflightIssueSpy.mockReturnValue(null);
-    // Reseed the sandbox lookup to expose a non-default gateway binding
-    // (gatewayPort=12345 → gateway name `nemoclaw-12345`). The stale-recovery
-    // path must address that gateway, not the default `nemoclaw`, otherwise a
-    // sandbox onboarded against `NEMOCLAW_GATEWAY_PORT=12345` would try to
-    // recover the wrong (and possibly nonexistent) default gateway.
-    for (const spy of spies) spy.mockRestore();
-    spies.length = 0;
-    let listCalls = 0;
-    detectPreflightIssueSpy = vi
-      .spyOn(gatewayDrift, "detectOpenShellStateRpcPreflightIssue")
-      .mockReturnValue(null);
-    captureOpenshellSpy = vi.spyOn(openshellRuntime, "captureOpenshell").mockImplementation(((
-      args: string[],
-    ) => {
-      if (args[0] === "sandbox" && args[1] === "list") {
-        listCalls += 1;
-        return listCalls === 1
-          ? { status: 1, output: "client error (Connect): Connection refused" }
-          : { status: 0, output: "beta Ready" };
-      }
-      if (args[0] === "status") {
-        return {
-          status: 0,
-          output: "Server Status\n\n  Gateway: nemoclaw-12345\n  Status: Connected\n",
-        };
-      }
-      if (args[0] === "gateway" && args[1] === "info") {
-        return { status: 0, output: "Gateway Info\n\nGateway: nemoclaw-12345\n" };
-      }
-      if (args[0] === "sandbox" && args[1] === "get") {
-        return { status: 1, output: "Error:   × Not Found: sandbox not found" };
-      }
-      return { status: 0, output: "" };
-    }) as never);
-    runOpenshellSpy = vi
-      .spyOn(openshellRuntime, "runOpenshell")
-      .mockReturnValue({ status: 0, output: "" } as never);
-    recoverNamedGatewayRuntimeSpy = vi
-      .spyOn(gatewayRuntime, "recoverNamedGatewayRuntime")
-      .mockResolvedValue({
-        recovered: true,
-        before: { state: "healthy_named" },
-        after: { state: "healthy_named" },
-      });
-    checkAgentVersionSpy = vi
-      .spyOn(sandboxVersion, "checkAgentVersion")
-      .mockReturnValue({ expectedVersion: "0.1.0", sandboxVersion: "0.0.1" } as never);
-    printIssueSpy = vi
-      .spyOn(gatewayDrift, "printOpenShellStateRpcIssue")
-      .mockImplementation(() => undefined);
-
-    const destroy = requireDist("./destroy.js");
-    const onboardMod = requireDist("../../onboard.js");
-    spies.push(
-      detectPreflightIssueSpy,
-      vi.spyOn(gatewayDrift, "detectOpenShellStateRpcResultIssue").mockReturnValue(null),
-      captureOpenshellSpy,
-      runOpenshellSpy,
-      recoverNamedGatewayRuntimeSpy,
-      printIssueSpy,
-      vi.spyOn(registry, "getSandbox").mockReturnValue({
-        name: "alpha",
-        provider: "ollama-local",
-        model: "nvidia/nemotron",
-        policies: [],
-        nimContainer: null,
-        agent: null,
-        gatewayName: "nemoclaw-12345",
-        gatewayPort: 12345,
-        nemoclawVersion: "0.1.0",
-        dashboardPort: 18789,
-      } as never),
-      vi.spyOn(registry, "updateSandbox").mockReturnValue(true),
-      vi.spyOn(resolve, "resolveOpenshell").mockReturnValue(null),
-      vi.spyOn(sandboxSession, "getActiveSandboxSessions").mockReturnValue({
-        detected: false,
-        sessions: [],
-      }),
-      vi.spyOn(onboardSession, "loadSession").mockReturnValue(null),
-      vi.spyOn(onboardSession, "acquireOnboardLock").mockReturnValue({ acquired: true }),
-      vi.spyOn(onboardSession, "releaseOnboardLock").mockImplementation(() => undefined),
-      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null),
-      vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw"),
-      vi.spyOn(onboardMod, "preflightAuthoritativeRebuildTarget").mockResolvedValue(undefined),
-      vi
-        .spyOn(rebuildImagePreflight, "preflightRebuildImage")
-        .mockResolvedValue({ ok: true, imageTag: null }),
-      vi.spyOn(rebuildUsageNotice, "ensureRebuildUsageNoticeAccepted").mockResolvedValue(true),
-      checkAgentVersionSpy,
-      vi.spyOn(destroy, "removeSandboxRegistryEntryWithReceipt").mockReturnValue(null),
-      vi.spyOn(onboardMod, "onboard").mockRejectedValue(new Error("recreate-stub")),
-    );
-    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
-      /stale-sandbox recovery/,
-    );
-
-    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
-      gatewayName: "nemoclaw-12345",
-      recoverableStates: [
-        "missing_named",
-        "named_unhealthy",
-        "named_unreachable",
-        "connected_other",
-      ],
-    });
-    expect(listCalls).toBe(2);
-  });
-
-  it("does not retry gateway recovery for generic sandbox list failures", async () => {
-    detectPreflightIssueSpy.mockReturnValue(null);
-    captureOpenshellSpy.mockReturnValue({ status: 1, output: "unknown option: sandbox list" });
-
-    await expect(rebuildSandbox("alpha", ["--yes"], { throwOnError: true })).rejects.toThrow(
+    await expect(resolveRebuildLiveState("alpha", entry, vi.fn(), bail)).rejects.toThrow(
       "Failed to query running sandboxes from OpenShell.",
     );
 
-    const listRecoveryCalls = recoverNamedGatewayRuntimeSpy.mock.calls.filter(
-      ([options]) => options.recoverableStates !== undefined,
-    );
-    expect(listRecoveryCalls).toEqual([
-      [
-        {
-          gatewayName: "nemoclaw",
-          recoverableStates: [
-            "missing_named",
-            "named_unhealthy",
-            "named_unreachable",
-            "connected_other",
-          ],
-        },
-      ],
-    ]);
-    expect(captureOpenshellSpy).toHaveBeenCalledTimes(1);
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledOnce();
+    expect(recoverNamedGatewayRuntimeSpy).toHaveBeenCalledWith({
+      gatewayName: "nemoclaw",
+      recoverableStates: recoveryStates,
+    });
+    expect(captureOpenshellSpy).toHaveBeenCalledOnce();
+    expect(captureOpenshellSpy).toHaveBeenCalledWith(["sandbox", "list"]);
+    expect(getNamedGatewayLifecycleStateSpy).not.toHaveBeenCalled();
+    expect(recoverDockerDriverSandboxSpy).not.toHaveBeenCalled();
+    expect(registry.load).not.toHaveBeenCalled();
+    expect(errorSpy.mock.calls.flat().join("\n")).toContain("Failed to query running sandboxes");
   });
 });

--- a/src/lib/actions/sandbox/rebuild-preflight-guards.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-guards.ts
@@ -32,6 +32,14 @@ export function checkRebuildGatewaySchemaPreflight(
   return true;
 }
 
+export async function runRebuildGatewayIntentPreflight<T>(options: {
+  checkGatewaySchema: () => boolean;
+  confirmIntent: () => Promise<T | null>;
+}): Promise<T | null> {
+  if (!options.checkGatewaySchema()) return null;
+  return options.confirmIntent();
+}
+
 export function getRebuildSandboxEntryOrBail(
   sandboxName: string,
   bail: RebuildBail,

--- a/src/lib/actions/sandbox/rebuild-preflight-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-phase.ts
@@ -36,6 +36,7 @@ import {
   checkRebuildGatewaySchemaPreflight,
   getRebuildSandboxEntryOrBail,
   isSingleAgentRebuildSupported,
+  runRebuildGatewayIntentPreflight,
 } from "./rebuild-preflight-guards";
 import { prepareRebuildTargetPreflights } from "./rebuild-preflight-target-phase";
 import { disposePreparedBuildContext } from "./rebuild-prepared-image-context";
@@ -116,19 +117,13 @@ export async function runRebuildPreflightPhase(
   let preparedImage: PreparedRebuildImage | null = null;
   let retainPreparedImage = false;
   try {
-    if (
-      !isDcodeRebuildAgent(rebuildAgent) &&
-      !checkRebuildGatewaySchemaPreflight(sandboxName, sandboxEntry, bail)
-    ) {
-      return null;
-    }
-    const versionCheck = await confirmRebuildIntent(
-      sandboxName,
-      agentName,
-      skipConfirm,
-      activeSessionCount,
-      bail,
-    );
+    const versionCheck = await runRebuildGatewayIntentPreflight({
+      checkGatewaySchema: () =>
+        isDcodeRebuildAgent(rebuildAgent) ||
+        checkRebuildGatewaySchemaPreflight(sandboxName, sandboxEntry, bail),
+      confirmIntent: () =>
+        confirmRebuildIntent(sandboxName, agentName, skipConfirm, activeSessionCount, bail),
+    });
     if (!versionCheck) return null;
 
     const releaseOnboardLock = acquireRebuildOnboardLock(sandboxName, bail);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Replace the remaining CommonJS full-rebuild loader seam in the gateway-drift suite with native, focused source tests. Preserve the rebuild-specific fail-closed ordering through a dependency-light schema/intent composition boundary while keeping production behavior unchanged.

## Related Issue
Refs #6245
Refs #6237

## Changes
- Rewrite all six `rebuild-gateway-drift.test.ts` cases against native gateway-schema and live-state seams instead of loading and mocking the complete `rebuildSandbox` graph through `createRequire`.
- Keep the real #4497 named-gateway classifier matrix for both default and persisted non-default gateway mismatches.
- Route rebuild preflight through an ordered schema/intent helper so gateway drift still aborts before version confirmation, liveness, locking, or destructive phases.
- Preserve real CLI/process contracts in the existing gateway-drift and stale-recovery integration suites.
- Tighten the exact-path `createRequire` ratchet from 28 to 27 CLI test files; support paths remain at 8.
- Reduce matched CI file time from 22,348.070ms on the exact main base to 2,744.496ms on the final head (87.72% lower, 8.14× faster), while preserving all 6/6 cases; collection fell 80.26% and test bodies fell 99.70%.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal test-loader and preflight composition refactor only; CLI commands, output, errors, flags, defaults, DCode handling, state, and recovery behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent final-diff review verified the fail-closed schema-before-confirmation ordering, real wrong-gateway classifier coverage, mock isolation, unchanged DCode short-circuit semantics, and retained process/destructive-boundary contracts; no actionable findings remain.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect that behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 135/135 focused CLI tests passed across gateway classification, sandbox-list recovery, rebuild preflight, DCode, and the broader rebuild flow; 14/14 integration/process-contract tests passed for stale recovery, real gateway drift, and the loader ratchet; CLI typecheck passed.
- [x] Required focused live E2Es passed — `gateway-drift-preflight` and `sandbox-rebuild` both passed in run 28887907635; the typed DCode target separately validated the changed no-mutation rejection but encountered post-lifecycle inference-route instability on two attempts, documented in the final PR comment.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: final-head five-shard CI, merged coverage, static/type checks, package lanes, and aggregate checks passed in run 28887585117.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rebuild preflight now more reliably checks gateway state before continuing, helping prevent unsafe confirmation flows.
  * Rebuild recovery handling was tightened so stale or mismatched sandbox states are handled more consistently, with clearer failure behavior when checks cannot be completed.
* **Tests**
  * Updated coverage for rebuild preflight and recovery scenarios to reflect the new flow and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->