### PR TITLE
fix(docker): relax vLLM pull stall watchdog

### DIFF
--- a/src/lib/adapters/docker/pull.test.ts
+++ b/src/lib/adapters/docker/pull.test.ts
@@ -107,7 +107,7 @@ describe("docker pull progress watchdog", () => {
     });
   });
 
-  it("does not kill a quiet large-image pull after the old 120s idle window", async () => {
+  it("allows quiet pull finalization within the 15 minute stall timeout", async () => {
     vi.useFakeTimers();
     const child = new FakeChild();
     const pull = dockerPullWithProgressWatchdog("example/image:latest", {
@@ -125,6 +125,25 @@ describe("docker pull progress watchdog", () => {
       timedOut: false,
       timeoutKind: null,
     });
+  });
+
+  it("kills a quiet pull after the default 15 minute stall timeout", async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    const pull = dockerPullWithProgressWatchdog("example/image:latest", {
+      suppressOutput: true,
+      spawnImpl: () => child,
+    });
+
+    child.stderr.emit("data", Buffer.from("abc123def: Pull complete\n"));
+    await vi.advanceTimersByTimeAsync(16 * 60_000);
+
+    await expect(pull).resolves.toMatchObject({
+      status: 124,
+      timedOut: true,
+      timeoutKind: "stall",
+    });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
   it("kills a pull when output repeats without forward progress", async () => {

--- a/src/lib/adapters/docker/pull.test.ts
+++ b/src/lib/adapters/docker/pull.test.ts
@@ -107,6 +107,26 @@ describe("docker pull progress watchdog", () => {
     });
   });
 
+  it("does not kill a quiet large-image pull after the old 120s idle window", async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    const pull = dockerPullWithProgressWatchdog("example/image:latest", {
+      suppressOutput: true,
+      spawnImpl: () => child,
+    });
+
+    child.stderr.emit("data", Buffer.from("abc123def: Pull complete\n"));
+    await vi.advanceTimersByTimeAsync(121_000);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    child.emit("close", 0, null);
+    await expect(pull).resolves.toMatchObject({
+      status: 0,
+      timedOut: false,
+      timeoutKind: null,
+    });
+  });
+
   it("kills a pull when output repeats without forward progress", async () => {
     vi.useFakeTimers();
     const child = new FakeChild();

--- a/src/lib/adapters/docker/pull.test.ts
+++ b/src/lib/adapters/docker/pull.test.ts
@@ -146,6 +146,26 @@ describe("docker pull progress watchdog", () => {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
+  it("respects a custom stall timeout", async () => {
+    vi.useFakeTimers();
+    const child = new FakeChild();
+    const pull = dockerPullWithProgressWatchdog("example/image:latest", {
+      suppressOutput: true,
+      stallTimeoutMs: 5 * 60_000,
+      spawnImpl: () => child,
+    });
+
+    child.stderr.emit("data", Buffer.from("abc123def: Pull complete\n"));
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    await expect(pull).resolves.toMatchObject({
+      status: 124,
+      timedOut: true,
+      timeoutKind: "stall",
+    });
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
   it("kills a pull when output repeats without forward progress", async () => {
     vi.useFakeTimers();
     const child = new FakeChild();

--- a/src/lib/adapters/docker/pull.test.ts
+++ b/src/lib/adapters/docker/pull.test.ts
@@ -116,7 +116,7 @@ describe("docker pull progress watchdog", () => {
     });
 
     child.stderr.emit("data", Buffer.from("abc123def: Pull complete\n"));
-    await vi.advanceTimersByTimeAsync(15 * 60_000 - 1_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000 - 10_000);
     expect(child.kill).not.toHaveBeenCalled();
 
     child.emit("close", 0, null);

--- a/src/lib/adapters/docker/pull.test.ts
+++ b/src/lib/adapters/docker/pull.test.ts
@@ -116,7 +116,7 @@ describe("docker pull progress watchdog", () => {
     });
 
     child.stderr.emit("data", Buffer.from("abc123def: Pull complete\n"));
-    await vi.advanceTimersByTimeAsync(121_000);
+    await vi.advanceTimersByTimeAsync(15 * 60_000 - 1_000);
     expect(child.kill).not.toHaveBeenCalled();
 
     child.emit("close", 0, null);

--- a/src/lib/adapters/docker/pull.ts
+++ b/src/lib/adapters/docker/pull.ts
@@ -12,7 +12,7 @@ export function dockerPull(imageRef: string, opts: DockerRunOptions = {}): Docke
   return dockerRun(["pull", imageRef], opts);
 }
 
-export const DEFAULT_DOCKER_PULL_STALL_TIMEOUT_MS = 120 * 1000;
+export const DEFAULT_DOCKER_PULL_STALL_TIMEOUT_MS = 15 * 60 * 1000;
 export const DEFAULT_DOCKER_PULL_MAX_TIMEOUT_MS = 12 * 60 * 60 * 1000;
 const DOCKER_PULL_OUTPUT_TAIL_LINES = 200;
 const DOCKER_PULL_PROGRESS_STATE_LIMIT = 512;

--- a/src/lib/adapters/docker/pull.ts
+++ b/src/lib/adapters/docker/pull.ts
@@ -12,7 +12,11 @@ export function dockerPull(imageRef: string, opts: DockerRunOptions = {}): Docke
   return dockerRun(["pull", imageRef], opts);
 }
 
-export const DEFAULT_DOCKER_PULL_STALL_TIMEOUT_MS = 15 * 60 * 1000;
+// DGX Spark vLLM pulls can spend several minutes quiet while Docker finalizes
+// large NGC layers. Keep the stall watchdog above the reported ~5.5 minute
+// successful control pull, while the separate max timeout still bounds total
+// wall-clock runtime.
+const DEFAULT_DOCKER_PULL_STALL_TIMEOUT_MS = 15 * 60 * 1000;
 export const DEFAULT_DOCKER_PULL_MAX_TIMEOUT_MS = 12 * 60 * 60 * 1000;
 const DOCKER_PULL_OUTPUT_TAIL_LINES = 200;
 const DOCKER_PULL_PROGRESS_STATE_LIMIT = 512;

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -227,6 +227,9 @@ function dockerPrereqsOk(): { ok: boolean; reason?: string } {
 
 export async function pullImage(profile: VllmProfile): Promise<{ ok: boolean; reason?: string }> {
   emit(`Pulling vLLM image: ${profile.image}`);
+  // Docker can be quiet while finalizing large layers on every supported vLLM
+  // profile, so all profiles intentionally share the 15-minute stall default.
+  // The profile-specific maximum still bounds the complete pull operation.
   const result = await dockerPullWithProgressWatchdog(profile.image, {
     maxTimeoutMs: profile.pullTimeoutSec * 1000,
     logLine: emit,


### PR DESCRIPTION
Fixes #6399

## Problem

Fresh DGX Spark installs can spend more than 120 seconds without a new recognized `docker pull` progress line while Docker finishes a large managed vLLM image pull. The existing stall watchdog treated that quiet period as a failure and killed a pull that can otherwise complete successfully.

## Solution

Increase the default Docker pull stall watchdog window from 120 seconds to 15 minutes while keeping the existing 12-hour maximum safety budget. This keeps protection against genuinely stuck pulls but avoids aborting valid large-image pulls during quiet Docker finalization periods.

## Verification

- `npx vitest run --project cli src/lib/adapters/docker/pull.test.ts`
- `npx vitest run --project cli src/lib/inference/vllm.test.ts`
- `git diff --check`
- `npm run typecheck:cli`

## Notes

A live DGX Spark cold-pull repro was not run from this workstation; the regression test covers the reported boundary where the old 120-second idle window killed the pull after Docker had emitted pull progress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default Docker image pull watchdog “stall” timeout to **15 minutes** to reduce premature termination of quiet pulls that produce minimal output during finalization.
* **Tests**
  * Added Vitest coverage for quiet Docker pulls, verifying successful completion within the stall window (no termination signal sent) and that pulls are terminated with the expected timeout behavior both for the default setting and a custom **5-minute** stall timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Chengjie Wang <chengjiew@nvidia.com>
