### PR TITLE
docs(skills): verify release announcements

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -165,7 +165,7 @@ This writes:
 
 If `notes-data.json` has `status: "partial"` or non-empty `pullRequestWarnings`, report the warnings and ask the maintainer whether to fetch/fill the missing PR metadata before drafting.
 
-Draft release notes from `notes-data.json` using the style from `nemoclaw-maintainer-release-notes`. Save only Markdown, outside the checkout root:
+Load and follow `nemoclaw-maintainer-release-notes`, then use its output as the draft. Save only Markdown, outside the checkout root:
 
 ```text
 <release-dir>/release-note-draft.md
@@ -189,12 +189,11 @@ Ask the maintainer to publish the draft in the `Announcements` Discussion catego
 
 ### Step 8: Verify Announcement and Hand Off Sharing
 
-Open the maintainer-provided Discussion URL using a read-only GitHub or web capability. Verify:
+Before making any network request, reject the maintainer-provided URL unless it exactly matches `https://github.com/NVIDIA/NemoClaw/discussions/<positive-integer>` with no query string or fragment. Only then open it using a read-only GitHub or web capability and verify:
 
-- the URL belongs to `github.com/NVIDIA/NemoClaw/discussions/<number>`;
 - the title is `NemoClaw <new-version> is out`;
 - the category is `Announcements`;
-- the body describes the released tag and substantially matches the local release-note draft;
+- the body preserves the draft's three lead paragraphs, category headings, every included PR link, comparison URL, and external contributor usernames; formatting-only edits are acceptable;
 - the comparison link targets `<previous-version>...<new-version>` and visible PR links target `github.com/NVIDIA/NemoClaw/pull/<number>`.
 
 If the Announcement is valid, return its URL with the release artifacts and mark the release workflow complete. Remind the maintainer to share that Discussion URL in the appropriate external channels. Do not create a duplicate Announcement.
@@ -209,5 +208,5 @@ If the Announcement is valid, return its URL with the release artifacts and mark
 - `lkg` changed: stop and escalate to a release admin.
 - Post-tag housekeeping fails: report the error and list items still carrying the released label. After the failure is fixed, rerun the same bump command; already-moved items no longer match the source label.
 - Announcement is not published yet: keep Step 7 in progress and return the draft path and suggested title; the tag and housekeeping remain complete.
-- Announcement title, category, body, or links are wrong: ask the maintainer to edit the existing Discussion, then verify the same URL again. Do not create a replacement.
+- Announcement title, category, body, or links are wrong: ask the maintainer to edit the existing Discussion, then verify the same URL again. Do not create a replacement. After three failed verification attempts for the same Discussion, stop and escalate to a release admin.
 - Announcement cannot be inspected: report the read failure and ask the maintainer to confirm access or provide a public URL; do not mark Step 8 complete.

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemoclaw-maintainer-cut-release-tag
-description: Creates deterministic NemoClaw semver release tags on origin/main, handles release housekeeping, and drafts release notes. Use when cutting a release, tagging a version, shipping a build, creating vX.Y.Z tags, or preparing release announcements.
+description: Creates deterministic NemoClaw semver release tags on origin/main, handles release housekeeping, drafts release notes, and verifies the maintainer-published Announcement. Use when cutting a release, tagging a version, shipping a build, creating vX.Y.Z tags, publishing release announcements, or completing release communication.
 user_invocable: true
 ---
 
@@ -11,7 +11,7 @@ user_invocable: true
 
 Use the release scripts for normal release operations. Do not run raw `git tag`, `git push`, `gh api`, or version-bump commands by hand for the normal release flow.
 
-The release is one annotated semver tag on an already-merged `origin/main` commit. The GitHub workflow moves `latest`; release admins promote `lkg` manually after validation. After the tag and `latest` are verified, automatically move remaining open issues/PRs from the released version label to the next patch label, then draft release notes for the maintainer to post.
+The release is one annotated semver tag on an already-merged `origin/main` commit. The GitHub workflow moves `latest`; release admins promote `lkg` manually after validation. After the tag and `latest` are verified, automatically move remaining open issues/PRs from the released version label to the next patch label, draft release notes, then verify the maintainer-published Announcement before final handoff.
 
 ## Hard Rules
 
@@ -24,6 +24,7 @@ The release is one annotated semver tag on an already-merged `origin/main` commi
 - Never push `latest` or `lkg` from this skill.
 - Never move, delete, or force-push an existing remote semver tag unless the maintainer explicitly starts protected-tag remediation.
 - Draft release notes locally. Do not create the GitHub Discussion; the maintainer does that.
+- Do not mark the announcement step complete until the maintainer provides a valid Discussion URL and the published Announcement is verified.
 - Follow the shared [Git and GitHub Access Hard Stop](../_shared/git-github-hard-stop.md) for SSH, authentication, remote access, authorization, or permission failures.
 
 ## Workflow
@@ -38,7 +39,8 @@ Release Progress:
 - [ ] Step 4: Wait for workflow-managed latest
 - [ ] Step 5: Bump remaining open issues/PRs
 - [ ] Step 6: Generate release-note data and draft Markdown
-- [ ] Step 7: Hand off announcement steps
+- [ ] Step 7: Wait for maintainer-published Announcement
+- [ ] Step 8: Verify Announcement and hand off sharing
 ```
 
 ### Step 1: Generate Release Plan
@@ -171,7 +173,7 @@ Draft release notes from `notes-data.json` using the style from `nemoclaw-mainta
 
 Do not create or update a GitHub Discussion.
 
-### Step 7: Hand Off Announcement
+### Step 7: Wait for Maintainer-Published Announcement
 
 Return:
 
@@ -181,8 +183,21 @@ Return:
 - `cut-result.json`, `latest-result.json`, and `notes-data.json` paths,
 - Markdown draft path,
 - issue/PR housekeeping summary,
-- suggested discussion title: `NemoClaw <new-version> is out`,
-- reminder: maintainer creates the Announcement discussion and shares its link in external channels.
+- suggested discussion title: `NemoClaw <new-version> is out`.
+
+Ask the maintainer to publish the draft in the `Announcements` Discussion category and return the resulting Discussion URL. Do not create or update the Discussion. Keep Step 7 in progress until the maintainer provides the URL.
+
+### Step 8: Verify Announcement and Hand Off Sharing
+
+Open the maintainer-provided Discussion URL using a read-only GitHub or web capability. Verify:
+
+- the URL belongs to `github.com/NVIDIA/NemoClaw/discussions/<number>`;
+- the title is `NemoClaw <new-version> is out`;
+- the category is `Announcements`;
+- the body describes the released tag and substantially matches the local release-note draft;
+- the comparison link targets `<previous-version>...<new-version>` and visible PR links target `github.com/NVIDIA/NemoClaw/pull/<number>`.
+
+If the Announcement is valid, return its URL with the release artifacts and mark the release workflow complete. Remind the maintainer to share that Discussion URL in the appropriate external channels. Do not create a duplicate Announcement.
 
 ## Recovery
 
@@ -193,3 +208,6 @@ Return:
 - `latest` workflow rejects a rollback: keep `latest` unchanged, inspect the plan target commit, and regenerate the plan for the current `origin/main` tip if appropriate.
 - `lkg` changed: stop and escalate to a release admin.
 - Post-tag housekeeping fails: report the error and list items still carrying the released label. After the failure is fixed, rerun the same bump command; already-moved items no longer match the source label.
+- Announcement is not published yet: keep Step 7 in progress and return the draft path and suggested title; the tag and housekeeping remain complete.
+- Announcement title, category, body, or links are wrong: ask the maintainer to edit the existing Discussion, then verify the same URL again. Do not create a replacement.
+- Announcement cannot be inspected: report the read failure and ask the maintainer to confirm access or provide a public URL; do not mark Step 8 complete.

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -171,6 +171,8 @@ Load and follow `nemoclaw-maintainer-release-notes`, then use its output as the 
 <release-dir>/release-note-draft.md
 ```
 
+Before continuing to Step 7, verify the draft has exactly three lead paragraphs, categorized shipped changes, one what-changed-and-why-it-matters bullet with a visible `#NNNN` link for every included change, and thanks for external contributors only.
+
 Do not create or update a GitHub Discussion.
 
 ### Step 7: Wait for Maintainer-Published Announcement


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Extend the release-tag maintainer skill through Announcement publication and verification. The release workflow now remains open until a maintainer supplies a valid Discussion URL and the published title, category, body, and links are checked read-only.

## Changes
<!-- Bullet list of key changes. -->

- Add explicit Announcement publication and verification steps to the release checklist.
- Keep Discussion creation and editing with the maintainer while requiring the resulting URL before completion.
- Define read-only checks for the repository, title, category, release body, comparison range, and PR links.
- Add recovery guidance for missing, incorrect, duplicate-prone, or inaccessible Announcements.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check all that apply. For any "covered by existing tests", "not applicable", or waiver entry, add a brief justification on the same line or in the Changes section. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: guidance-only skill workflow; validated with repository skill checks and a fresh forward-test.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal maintainer workflow only; documentation impact review found no CLI, runtime, configuration, or user-doc routing change.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each item you ran and confirmed. Leave unchecked items you skipped. Doc-only changes do not require npm test unless you ran it. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Git hooks passed during commit and push, or `npx prek run --from-ref main --to-ref HEAD` passes
- [x] Targeted tests pass for changed behavior
- [ ] Full `npm test` passes (broad runtime changes only)
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in the PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the release-tag cut guidance so completion is gated on a maintainer-published GitHub Discussion announcement verification.
  * Added strict checks for a valid Discussion URL and for the announcement’s title, category, body content, and release/PR comparison links to match the prepared draft (allowing formatting-only differences).
  * Updated recovery steps for unpublished announcements, incorrect announcement details (edit and re-verify up to repeated attempts), and unreadable Discussion content (request access or provide a public URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->