### PR TITLE
feat(hermes): bump Hermes Agent to v2026.7.1 and enable Slack Block Kit

### DIFF
--- a/.github/actions/resolve-hermes-base-image/action.yaml
+++ b/.github/actions/resolve-hermes-base-image/action.yaml
@@ -14,6 +14,11 @@ runs:
 
         image="ghcr.io/nvidia/nemoclaw/hermes-sandbox-base"
         min_glibc="2.39"
+        expected_hermes_version="$(sed -nE 's/^ARG HERMES_SEMVER=([0-9]+\.[0-9]+\.[0-9]+)$/\1/p' agents/hermes/Dockerfile.base)"
+        if [[ ! "$expected_hermes_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Could not read one valid HERMES_SEMVER from agents/hermes/Dockerfile.base"
+          exit 1
+        fi
 
         glibc_version() {
           docker run --rm --entrypoint /usr/bin/ldd "$1" --version 2>/dev/null \
@@ -24,6 +29,13 @@ runs:
         glibc_ok() {
           local have="$1"
           [[ -n "$have" ]] && [[ "$(printf '%s\n%s\n' "$min_glibc" "$have" | sort -V | head -n 1)" == "$min_glibc" ]]
+        }
+
+        hermes_version() {
+          local ref="$1"
+          docker run --rm --entrypoint /usr/local/bin/hermes "$ref" --version 2>/dev/null \
+            | sed -nE 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p; s/^([0-9]+\.[0-9]+\.[0-9]+)$/\1/p' \
+            | head -n 1
         }
 
         # Build-time package/import guard only. Authenticated HTTPS execution is
@@ -50,7 +62,7 @@ runs:
         }
 
         try_image() {
-          local ref="$1" version digest_ref
+          local ref="$1" version hermes_semver digest_ref
           if ! docker pull "$ref" >/dev/null 2>&1; then
             return 1
           fi
@@ -62,6 +74,11 @@ runs:
           version="$(glibc_version "$digest_ref" || true)"
           if ! glibc_ok "$version"; then
             echo "::warning::Hermes sandbox base image ${ref} has glibc ${version:-unknown}; need >= ${min_glibc}"
+            return 1
+          fi
+          hermes_semver="$(hermes_version "$digest_ref" || true)"
+          if [[ "$hermes_semver" != "$expected_hermes_version" ]]; then
+            echo "::warning::Hermes sandbox base image ${ref} has Hermes ${hermes_semver:-unknown}; need ${expected_hermes_version}"
             return 1
           fi
           if ! layout_ok "$digest_ref"; then
@@ -107,6 +124,11 @@ runs:
         version="$(glibc_version nemoclaw-hermes-base-local || true)"
         if ! glibc_ok "$version"; then
           echo "::error::Local Hermes sandbox base image has glibc ${version:-unknown}; need >= ${min_glibc}"
+          exit 1
+        fi
+        local_hermes_version="$(hermes_version nemoclaw-hermes-base-local || true)"
+        if [[ "$local_hermes_version" != "$expected_hermes_version" ]]; then
+          echo "::error::Local Hermes sandbox base image has Hermes ${local_hermes_version:-unknown}; need ${expected_hermes_version}"
           exit 1
         fi
         if ! layout_ok nemoclaw-hermes-base-local; then

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -175,7 +175,7 @@ RUN chmod 755 /usr/local/bin/nemoclaw-start /usr/local/lib/nemoclaw/sandbox-init
 RUN test -x /usr/local/lib/nemoclaw/validate-hermes-env-secret-boundary.py \
     || { echo "ERROR: validate-hermes-env-secret-boundary.py missing or not executable" >&2; exit 1; }
 
-# Hermes v0.17.0 computes `sessions list` preview from the first user message,
+# Hermes v0.18.0 computes `sessions list` preview from the first user message,
 # while #5254's user-facing expectation is that the existing row reflects the
 # latest resumed/continued one-shot turn. Patch only the pinned query shape and
 # prove the SessionDB list contract at build time so a Hermes update cannot
@@ -203,7 +203,7 @@ PY
 # chain tampering of the build context (an attacker rewriting the file has to
 # also rewrite the Dockerfile-committed hash, which reviewers gate). Regenerate
 # with `sha256sum agents/hermes/{hermes-wrapper.py,validate-env-secret-boundary.py}`.
-ARG NEMOCLAW_HERMES_WRAPPER_SHA256=34ef50ea993c776f28312bcf659e908eeae3c07e4094a49e513cb320eee6538f
+ARG NEMOCLAW_HERMES_WRAPPER_SHA256=ec8b0e4d6254175929d5a02240acd6af25e94774a30b36ba5c6f5a69c32fb9d7
 ARG NEMOCLAW_HERMES_VALIDATOR_SHA256=970d7ff03bc409ff1d5ca46bfdbd2a42ac28a32a810ccc147a508301bff38496
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
@@ -232,10 +232,10 @@ RUN hermes_version_output="$(/usr/local/bin/hermes --version)" \
         echo "ERROR: could not parse Hermes semver from: $hermes_version_output" >&2; \
         exit 1; \
     fi \
-    && if [ "$hermes_semver" != "0.17.0" ] \
+    && if [ "$hermes_semver" != "0.18.0" ] \
         && { grep -q '_translate_resumed_oneshot' /usr/local/lib/nemoclaw/hermes-wrapper.py \
           || grep -q 'EXPECTED_OCCURRENCES' /usr/local/lib/nemoclaw/patch-hermes-session-list-preview.py; }; then \
-        echo "ERROR: installed Hermes ${hermes_semver} but Hermes v0.17.0 compatibility workarounds are still installed; re-review #5254 workaround removal before upgrading Hermes" >&2; \
+        echo "ERROR: installed Hermes ${hermes_semver} but Hermes v0.18.0 compatibility workarounds are still installed; re-review #5254 workaround removal before upgrading Hermes" >&2; \
         exit 1; \
     fi
 # This runs before `/usr/local/bin/hermes` is moved to `hermes.real`, so the

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -28,11 +28,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # pyproject.toml, HERMES_TARBALL_SHA256 the GitHub tarball checksum, and
 # HERMES_NPM_INTEGRITY the `npm view hermes-agent@<semver> dist.integrity`
 # sha512 used as a registry cross-check at build time.
-# Calver tag v2026.6.19 = Hermes Agent v0.17.0.
-ARG HERMES_VERSION=v2026.6.19
-ARG HERMES_SEMVER=0.17.0
-ARG HERMES_TARBALL_SHA256=69b805ec0a7a7be880068ba8a3b17479d7ba29f0cac0a2e9c6692c02f346ba91
-ARG HERMES_NPM_INTEGRITY=sha512-PzSJiYqmwpTudmakYs2oCJ57OW3VwEJYf8buTuKvuRvcYEUf/KOTu2dD6pLf2XYgDKErpvcDaoSAJ1nGCyvzAA==
+# Calver tag v2026.7.1 = Hermes Agent v0.18.0.
+ARG HERMES_VERSION=v2026.7.1
+ARG HERMES_SEMVER=0.18.0
+ARG HERMES_TARBALL_SHA256=ec8a380629cc2f3f2102dd92cad50c4ded706fe59c0e359a05681166a0ae2991
+ARG HERMES_NPM_INTEGRITY=sha512-fS+8MsE69shNPmFnKDrE1a+KUDEEXgbyN/QM7J+2nh294gTjh2wCknk2tfMsD03GhSxl7YwyDmp6e5HLYzw8yA==
 ARG HERMES_UV_EXTRAS="anthropic messaging web pty mcp"
 ARG UV_VERSION=0.11.8
 

--- a/agents/hermes/config/hermes-config.ts
+++ b/agents/hermes/config/hermes-config.ts
@@ -90,7 +90,7 @@ export function buildHermesConfig(
   };
 
   const config: Record<string, unknown> = {
-    _config_version: 30,
+    _config_version: 32,
     _nemoclaw_upstream: upstream,
     model: modelConfig,
     providers: {
@@ -104,6 +104,10 @@ export function buildHermesConfig(
     agent: {
       max_turns: 60,
       reasoning_effort: "medium",
+      // Config v30→32 migrations switch the old implicit/auto behavior off.
+      // Generated configs start at v32, so persist the same migrated value
+      // instead of skipping directly to Hermes' legacy "auto" default.
+      verify_on_stop: false,
     },
     tools: {
       tool_search: {

--- a/agents/hermes/hermes-wrapper.py
+++ b/agents/hermes/hermes-wrapper.py
@@ -289,9 +289,9 @@ _VALUE_FLAGS = {
     "--resume": "--resume",
 }
 # Keep this allowlist aligned with the top-level flags accepted by the pinned
-# Hermes Agent CLI in agents/hermes/Dockerfile.base (HERMES_VERSION=v2026.6.19,
-# HERMES_SEMVER=0.17.0) and agents/hermes/manifest.yaml (expected_version
-# "0.17.0"). Unknown flags deliberately fail closed by passing the original argv
+# Hermes Agent CLI in agents/hermes/Dockerfile.base (HERMES_VERSION=v2026.7.1,
+# HERMES_SEMVER=0.18.0) and agents/hermes/manifest.yaml (expected_version
+# "0.18.0"). Unknown flags deliberately fail closed by passing the original argv
 # through to upstream Hermes.
 _BOOLEAN_FLAGS = {
     "--worktree",

--- a/agents/hermes/manifest.yaml
+++ b/agents/hermes/manifest.yaml
@@ -16,9 +16,9 @@ homepage: "https://github.com/NousResearch/hermes-agent"
 install_method: curl  # curl install.sh | bash
 binary_path: /usr/local/bin/hermes
 version_command: "hermes --version"
-expected_version: "0.17.0"
-# Hermes reports semver from `hermes --version` (e.g. `0.17.0`) even though its
-# GitHub release cadence is calendar-based (`v2026.6.19`). Declaring the
+expected_version: "0.18.0"
+# Hermes reports semver from `hermes --version` (e.g. `0.18.0`) even though its
+# GitHub release cadence is calendar-based (`v2026.7.1`). Declaring the
 # scheme keeps the staleness check off the shape heuristic when a manifest
 # could otherwise straddle both schemes (#6049).
 version_scheme: semver

--- a/agents/hermes/patch-session-list-preview.py
+++ b/agents/hermes/patch-session-list-preview.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Patch pinned Hermes v0.17.0 session-list previews to show the latest user turn.
+"""Patch pinned Hermes v0.18.0 session-list previews to show the latest user turn.
 
 Source-of-truth note for this localized Hermes runtime patch:
-  - Invalid state: Hermes v0.17.0 computes `sessions list` preview text from
+  - Invalid state: Hermes v0.18.0 computes `sessions list` preview text from
     the first user message, but #5254's resumed/continued one-shot UX expects
     the original row to reflect the latest appended turn.
   - Value being patched: pinned/prebuilt `/opt/hermes/hermes_state.py`

--- a/docs/manage-sandboxes/messaging-channels.mdx
+++ b/docs/manage-sandboxes/messaging-channels.mdx
@@ -101,6 +101,10 @@ When both Slack allowlists are set, NemoClaw requires the mention to come from o
 Channel messages still require an explicit bot mention.
 When a Slack channel `@mention` is denied by these allowlists, NemoClaw sends a denial notice back to the sender instead of dropping the message silently.
 During sandbox startup, NemoClaw normalizes OpenShell credential placeholders into the environment shape expected by the Slack runtime, so post-rebuild Slack starts use the gateway-managed tokens instead of literal placeholder strings.
+<AgentOnly variant="hermes">
+NemoClaw enables Hermes rich Slack rendering. Final responses can use Slack Block Kit, including native table blocks for Markdown table output.
+This rendering change uses the existing Slack credentials and does not require additional scopes or a new app installation.
+</AgentOnly>
 Slack Socket Mode allows one active connection per app-level token.
 If another sandbox on the same gateway already uses the same Slack app token, onboarding and `channels add slack` warn before continuing in interactive mode and abort in non-interactive mode.
 Use `--force` only when you intentionally want to move the Slack Socket Mode session to the new sandbox.

--- a/src/lib/agent/base-image-hermes-resolution.test.ts
+++ b/src/lib/agent/base-image-hermes-resolution.test.ts
@@ -83,6 +83,7 @@ describe("Hermes base-image resolver integration", () => {
     ]);
     const captureByEntrypoint = new Map([
       ["/opt/hermes/.venv/bin/python", "nemoclaw-hermes-mcp-runtime-ok"],
+      ["/usr/local/bin/hermes", "Hermes Agent v0.18.0 (2026.7.1)"],
       ["/usr/bin/ldd", "ldd (GNU libc) 2.41"],
     ]);
 
@@ -135,5 +136,24 @@ describe("Hermes base-image resolver integration", () => {
     expect(() => createAgentSandbox(makeAgent())).toThrow(
       `Hermes final image does not accept base image ref '${platformRef}'`,
     );
+  });
+
+  it("reuses a validated pinned platform-digest resolution hint", () => {
+    const initial = createAgentSandbox(makeAgent());
+    createdBuildContexts.push(initial.buildCtx);
+    const hint = initial.baseImageResolutionMetadata;
+    if (!hint) throw new Error("expected pinned resolution metadata");
+
+    dockerMocks.imageInspect.mockImplementation((ref: string) => {
+      if (ref === trackedRef) throw new Error("pinned candidate should not be re-resolved");
+      return { status: ref === platformRef ? 0 : 1 };
+    });
+
+    const reused = createAgentSandbox(makeAgent(), {
+      resolutionHint: hint,
+    });
+    createdBuildContexts.push(reused.buildCtx);
+
+    expect(reused.baseImageResolutionMetadata).toEqual(hint);
   });
 });

--- a/src/lib/agent/base-image-hermes-resolution.test.ts
+++ b/src/lib/agent/base-image-hermes-resolution.test.ts
@@ -142,15 +142,15 @@ describe("Hermes base-image resolver integration", () => {
     const initial = createAgentSandbox(makeAgent());
     createdBuildContexts.push(initial.buildCtx);
     const hint = initial.baseImageResolutionMetadata;
-    if (!hint) throw new Error("expected pinned resolution metadata");
+    expect(hint).not.toBeNull();
 
     dockerMocks.imageInspect.mockImplementation((ref: string) => {
-      if (ref === trackedRef) throw new Error("pinned candidate should not be re-resolved");
+      expect(ref).not.toBe(trackedRef);
       return { status: ref === platformRef ? 0 : 1 };
     });
 
     const reused = createAgentSandbox(makeAgent(), {
-      resolutionHint: hint,
+      resolutionHint: hint ?? undefined,
     });
     createdBuildContexts.push(reused.buildCtx);
 

--- a/src/lib/agent/base-image-hermes.test.ts
+++ b/src/lib/agent/base-image-hermes.test.ts
@@ -15,16 +15,13 @@ describe("agent base image provisioning", () => {
 
   it("probes resolved Hermes bases for the pinned version and native MCP runtime", () => {
     withMockedDocker(({ ensureAgentBaseImage, dockerCaptureMock, resolveSandboxBaseImageMock }) => {
-      dockerCaptureMock.mockImplementation((args: string[]) => {
-        const entrypoint = args[3];
-        if (entrypoint === "/usr/local/bin/hermes") {
-          return "Hermes Agent v0.18.0 (2026.7.1)";
-        }
-        if (entrypoint === "/opt/hermes/.venv/bin/python") {
-          return "nemoclaw-hermes-mcp-runtime-ok";
-        }
-        return "";
-      });
+      const compatibleOutputByEntrypoint = new Map([
+        ["/usr/local/bin/hermes", "Hermes Agent v0.18.0 (2026.7.1)"],
+        ["/opt/hermes/.venv/bin/python", "nemoclaw-hermes-mcp-runtime-ok"],
+      ]);
+      dockerCaptureMock.mockImplementation(
+        (args: string[]) => compatibleOutputByEntrypoint.get(args[3]) ?? "",
+      );
       ensureAgentBaseImage(makeAgent());
       const options = resolveSandboxBaseImageMock.mock.calls[0]?.[0] as {
         validateImage?: (imageRef: string) => boolean;
@@ -60,12 +57,9 @@ describe("agent base image provisioning", () => {
       );
 
       dockerCaptureMock.mockClear();
-      dockerCaptureMock.mockImplementation((args: string[]) => {
-        if (args[3] === "/usr/local/bin/hermes") {
-          return "Hermes Agent v0.18.0 (2026.7.1)";
-        }
-        return args[3] === "/opt/hermes/.venv/bin/python" ? "nemoclaw-hermes-mcp-runtime-ok" : "";
-      });
+      dockerCaptureMock.mockImplementation(
+        (args: string[]) => compatibleOutputByEntrypoint.get(args[3]) ?? "",
+      );
       expect(
         options.validateImage?.(
           `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:${"a".repeat(64)}`,

--- a/src/lib/agent/base-image-hermes.test.ts
+++ b/src/lib/agent/base-image-hermes.test.ts
@@ -13,29 +13,71 @@ describe("agent base image provisioning", () => {
     vi.restoreAllMocks();
   });
 
-  it("probes resolved Hermes bases for the native MCP Streamable HTTP runtime", () => {
+  it("probes resolved Hermes bases for the pinned version and native MCP runtime", () => {
     withMockedDocker(({ ensureAgentBaseImage, dockerCaptureMock, resolveSandboxBaseImageMock }) => {
+      dockerCaptureMock.mockImplementation((args: string[]) => {
+        const entrypoint = args[3];
+        if (entrypoint === "/usr/local/bin/hermes") {
+          return "Hermes Agent v0.18.0 (2026.7.1)";
+        }
+        if (entrypoint === "/opt/hermes/.venv/bin/python") {
+          return "nemoclaw-hermes-mcp-runtime-ok";
+        }
+        return "";
+      });
       ensureAgentBaseImage(makeAgent());
       const options = resolveSandboxBaseImageMock.mock.calls[0]?.[0] as {
         validateImage?: (imageRef: string) => boolean;
       };
 
-      expect(options.validateImage?.("hermes-base:test")).toBe(true);
+      const compatibleLocalRef = "nemoclaw-hermes-sandbox-base-local:test";
+      expect(options.validateImage?.(compatibleLocalRef)).toBe(true);
+      expect(dockerCaptureMock).toHaveBeenCalledWith(
+        ["run", "--rm", "--entrypoint", "/usr/local/bin/hermes", compatibleLocalRef, "--version"],
+        { ignoreError: true, timeout: 20_000 },
+      );
       expect(dockerCaptureMock).toHaveBeenCalledWith(
         [
           "run",
           "--rm",
           "--entrypoint",
           "/opt/hermes/.venv/bin/python",
-          "hermes-base:test",
+          compatibleLocalRef,
           "-c",
           expect.stringContaining("_MCP_HTTP_AVAILABLE"),
         ],
         { ignoreError: true, timeout: 20_000 },
       );
 
-      dockerCaptureMock.mockReturnValue("");
-      expect(options.validateImage?.("hermes-base:stale")).toBe(false);
+      dockerCaptureMock.mockImplementation((args: string[]) =>
+        args[3] === "/usr/local/bin/hermes" ? "Hermes Agent v0.17.0 (2026.6.19)" : "",
+      );
+      const staleLocalRef = "nemoclaw-hermes-sandbox-base-local:stale";
+      expect(options.validateImage?.(staleLocalRef)).toBe(false);
+      expect(dockerCaptureMock).not.toHaveBeenCalledWith(
+        expect.arrayContaining([staleLocalRef, "/opt/hermes/.venv/bin/python"]),
+        expect.anything(),
+      );
+
+      dockerCaptureMock.mockClear();
+      dockerCaptureMock.mockImplementation((args: string[]) => {
+        if (args[3] === "/usr/local/bin/hermes") {
+          return "Hermes Agent v0.18.0 (2026.7.1)";
+        }
+        return args[3] === "/opt/hermes/.venv/bin/python" ? "nemoclaw-hermes-mcp-runtime-ok" : "";
+      });
+      expect(
+        options.validateImage?.(
+          `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:${"a".repeat(64)}`,
+        ),
+      ).toBe(true);
+      expect(dockerCaptureMock).toHaveBeenCalled();
+
+      dockerCaptureMock.mockClear();
+      expect(options.validateImage?.("ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest")).toBe(
+        false,
+      );
+      expect(dockerCaptureMock).not.toHaveBeenCalled();
     });
   });
 
@@ -162,22 +204,14 @@ describe("agent base image provisioning", () => {
         expect(() => ensureAgentBaseImage(makeAgent())).toThrow(
           "Hermes final image does not accept base image ref",
         );
-        expect(resolveSandboxBaseImageMock).toHaveBeenCalledWith(
-          expect.objectContaining({
-            localTag: "localhost:5000/custom/hermes:latest",
-            env: expect.objectContaining({
-              [envVar]: "localhost:5000/custom/hermes:latest",
-              NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
-            }),
-          }),
-        );
+        expect(resolveSandboxBaseImageMock).not.toHaveBeenCalled();
       });
     } finally {
       prior === undefined ? delete process.env[envVar] : (process.env[envVar] = prior);
     }
   });
 
-  it("fails closed when no MCP-capable Hermes base image can be resolved", () => {
+  it("fails closed when no version-matched, MCP-capable Hermes base image can be resolved", () => {
     withMockedDocker(
       ({
         ensureAgentBaseImage,

--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -71,7 +71,7 @@ describe("agent base image provisioning", () => {
             forceRefresh: true,
             rootDir: root,
             validateImage: expect.any(Function),
-            validationDescription: "the required MCP Streamable HTTP runtime",
+            validationDescription: "Hermes 0.18.0 with the required MCP Streamable HTTP runtime",
           }),
         );
         expect(dockerImageInspectMock).not.toHaveBeenCalled();
@@ -123,7 +123,7 @@ describe("agent base image provisioning", () => {
               NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
             }),
             validateImage: expect.any(Function),
-            validationDescription: "the required MCP Streamable HTTP runtime",
+            validationDescription: "Hermes 0.18.0 with the required MCP Streamable HTTP runtime",
           }),
         );
         expect(dockerImageInspectMock).not.toHaveBeenCalled();

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -14,6 +14,7 @@ import {
   dockerRmi,
   dockerTag,
 } from "../adapters/docker";
+import { parseVersionFromText } from "../adapters/openshell/client";
 import { ROOT } from "../runner";
 import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../sandbox/build-context";
 import {
@@ -157,13 +158,35 @@ export function hermesBaseImageSupportsMcp(imageRef: string): boolean {
   return output.trim() === HERMES_MCP_RUNTIME_PROBE_OK;
 }
 
+/**
+ * Require a resolved Hermes base to match the manifest pin as well as the
+ * optional-runtime contract. A reviewed remote digest can remain valid as an
+ * image artifact after Dockerfile.base advances, so capability probes alone
+ * are not enough to keep a stale Hermes runtime out of a new final image.
+ */
+function hermesBaseImageIsCompatible(imageRef: string, expectedVersion: string | null): boolean {
+  if (!expectedVersion) return false;
+  const versionOutput = dockerCapture(
+    ["run", "--rm", "--entrypoint", "/usr/local/bin/hermes", imageRef, "--version"],
+    { ignoreError: true, timeout: 20_000 },
+  );
+  if (parseVersionFromText(versionOutput, "hermes --version") !== expectedVersion) return false;
+  return hermesBaseImageSupportsMcp(imageRef);
+}
+
 function createAgentBaseImageResolutionOptions(
   agent: AgentDefinition,
   dockerfilePath: string,
   options: EnsureAgentBaseImageOptions,
 ): ResolveBaseImageOptions {
   const imageName = `ghcr.io/nvidia/nemoclaw/${agent.name}-sandbox-base`;
-  const validateImage = agent.name === "hermes" ? hermesBaseImageSupportsMcp : undefined;
+  const validateImage =
+    agent.name === "hermes"
+      ? (imageRef: string) =>
+          (HERMES_OFFICIAL_BASE_DIGEST_REF.test(imageRef) ||
+            hermesFinalDockerfileAcceptsBase(agent, imageRef)) &&
+          hermesBaseImageIsCompatible(imageRef, agent.expectedVersion)
+      : undefined;
   const pinnedRemoteRef = getHermesPinnedRemoteBaseRef(agent) ?? undefined;
   return {
     imageName,
@@ -179,7 +202,9 @@ function createAgentBaseImageResolutionOptions(
     preferPinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
     validateImage,
     validationDescription:
-      agent.name === "hermes" ? "the required MCP Streamable HTTP runtime" : undefined,
+      agent.name === "hermes"
+        ? `Hermes ${agent.expectedVersion ?? "<missing>"} with the required MCP Streamable HTTP runtime`
+        : undefined,
   };
 }
 
@@ -278,6 +303,11 @@ export function ensureAgentBaseImage(
   }
 
   const explicitOverride = process.env[overrideEnvVar]?.trim();
+  if (explicitOverride && !hermesFinalDockerfileAcceptsBase(agent, explicitOverride)) {
+    throw new Error(
+      `Hermes final image does not accept base image ref '${explicitOverride}'; use the tracked official digest or a repository-built local base`,
+    );
+  }
   const resolved = explicitOverride
     ? resolveExactImage(explicitOverride)
     : resolveSandboxBaseImage(resolutionOptions);

--- a/src/lib/messaging/channels/manifests.test.ts
+++ b/src/lib/messaging/channels/manifests.test.ts
@@ -532,6 +532,19 @@ describe("built-in channel manifests", () => {
       "SLACK_ALLOWED_USERS={{allowedIds.slack.csv}}",
       "SLACK_ALLOWED_CHANNELS={{slackConfig.allowedChannels.csv}}",
     ]);
+    expect(findRender(slackManifest, "slack-hermes-platform")).toEqual({
+      id: "slack-hermes-platform",
+      kind: "json-fragment",
+      agent: "hermes",
+      target: "~/.hermes/config.yaml",
+      fragment: {
+        path: "platforms.slack",
+        value: {
+          enabled: true,
+          extra: { rich_blocks: true },
+        },
+      },
+    });
     expect(renderJson(slackManifest)).toContain('"path":"channels.slack"');
     expect(renderJson(slackManifest)).toContain('"accounts"');
     expect(renderJson(slackManifest)).toContain("allowedIds.slack.channels");

--- a/src/lib/messaging/channels/slack/manifest.ts
+++ b/src/lib/messaging/channels/slack/manifest.ts
@@ -168,6 +168,9 @@ export const slackManifest = {
         path: "platforms.slack",
         value: {
           enabled: true,
+          extra: {
+            rich_blocks: true,
+          },
         },
       },
     },

--- a/test/e2e/live/hermes-slack-e2e-helpers.ts
+++ b/test/e2e/live/hermes-slack-e2e-helpers.ts
@@ -312,6 +312,11 @@ else:
         errors.append("platforms.slack missing or not a mapping")
     elif slack.get("enabled") is not True:
         errors.append(f"platforms.slack.enabled is not true ({slack!r})")
+    elif (
+        not isinstance(slack.get("extra"), dict)
+        or slack["extra"].get("rich_blocks") is not True
+    ):
+        errors.append(f"platforms.slack.extra.rich_blocks is not true ({slack!r})")
 if "SLACK_BOT_TOKEN" in config_text or "SLACK_APP_TOKEN" in config_text:
     errors.append("config.yaml contains Slack token env keys")
 if errors:

--- a/test/generate-hermes-config.test.ts
+++ b/test/generate-hermes-config.test.ts
@@ -378,7 +378,8 @@ describe("agents/hermes/generate-config.ts", () => {
   it("generates API server config without messaging platform token blocks", () => {
     const { config, envFile } = runConfigScript();
 
-    expect(config._config_version).toBe(30);
+    expect(config._config_version).toBe(32);
+    expect(config.agent?.verify_on_stop).toBe(false);
     expect(config.display).toMatchObject({
       compact: false,
       tool_progress: "all",
@@ -873,7 +874,10 @@ describe("agents/hermes/generate-config.ts", () => {
 
     expect(config.telegram).toEqual({ require_mention: true });
     expect(config.platforms.telegram).toEqual({ enabled: true });
-    expect(config.platforms.slack).toEqual({ enabled: true });
+    expect(config.platforms.slack).toEqual({
+      enabled: true,
+      extra: { rich_blocks: true },
+    });
     expectRemotePlatformToolsets(config.platform_toolsets.telegram);
     expectRemotePlatformToolsets(config.platform_toolsets.slack);
     expect(envFile).toContain("TELEGRAM_BOT_TOKEN=openshell:resolve:env:TELEGRAM_BOT_TOKEN\n");
@@ -900,7 +904,10 @@ describe("agents/hermes/generate-config.ts", () => {
       NEMOCLAW_MESSAGING_CHANNELS_B64: encodeJson(["slack"]),
     });
 
-    expect(config.platforms.slack).toEqual({ enabled: true });
+    expect(config.platforms.slack).toEqual({
+      enabled: true,
+      extra: { rich_blocks: true },
+    });
     expect(config.platforms.api_server.enabled).toBe(true);
   });
 

--- a/test/helpers/base-image-test-harness.ts
+++ b/test/helpers/base-image-test-harness.ts
@@ -48,7 +48,7 @@ export function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefini
     stateFiles: [],
     userManagedFiles: [],
     versionCommand: "hermes --version",
-    expectedVersion: "2026.4.30",
+    expectedVersion: "0.18.0",
     hasDevicePairing: false,
     phoneHomeHosts: [],
     dockerfileBasePath: "/test/root/agents/hermes/Dockerfile.base",

--- a/test/hermes-doctor-config-hash.test.ts
+++ b/test/hermes-doctor-config-hash.test.ts
@@ -38,7 +38,7 @@ describe("Hermes doctor and config hash boundary", () => {
     try {
       fs.mkdirSync(path.dirname(hermesBin), { recursive: true });
       fs.mkdirSync(path.dirname(wrapper), { recursive: true });
-      fs.writeFileSync(hermesBin, "#!/usr/bin/env bash\nprintf 'hermes v0.18.0\\n'\n", {
+      fs.writeFileSync(hermesBin, "#!/usr/bin/env bash\nprintf 'hermes v0.19.0\\n'\n", {
         mode: 0o755,
       });
       fs.writeFileSync(wrapper, "# wrapper fixture without resumed oneshot marker\n");
@@ -52,7 +52,7 @@ describe("Hermes doctor and config hash boundary", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
-        "Hermes v0.17.0 compatibility workarounds are still installed",
+        "Hermes v0.18.0 compatibility workarounds are still installed",
       );
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -1249,6 +1249,9 @@ describe("pull request and main workflow contracts", () => {
     expect(runs).toContain("docker image inspect");
     expect(runs).toContain("${image}@sha256:");
     expect(runs).toContain("mcp_client_imports_ok");
+    expect(runs).toContain("expected_hermes_version");
+    expect(runs).toContain("hermes_version");
+    expect(runs).toContain("HERMES_SEMVER");
     expect(runs).toContain("Build-time package/import guard only");
     expect(runs).toContain("_MCP_HTTP_AVAILABLE");
     expect(runs).toContain("layout_ok");
@@ -1290,6 +1293,10 @@ describe("pull request and main workflow contracts", () => {
           "    process.exit(0);",
           "  }",
           '  if (entrypoint === "sh") process.exit(0);',
+          '  if (entrypoint === "/usr/local/bin/hermes") {',
+          '    process.stdout.write("Hermes Agent v0.18.0 (2026.7.1)\\n");',
+          "    process.exit(0);",
+          "  }",
           '  if (entrypoint === "/opt/hermes/.venv/bin/python") {',
           "    process.exit(image === process.env.REMOTE_DIGEST ? 42 : 0);",
           "  }",

--- a/test/update-hermes-agent-script.test.ts
+++ b/test/update-hermes-agent-script.test.ts
@@ -16,7 +16,7 @@ const HERMES_BASE_DOCKERFILE = path.join(
   "Dockerfile.base",
 );
 const HERMES_MANIFEST = path.join(import.meta.dirname, "..", "agents", "hermes", "manifest.yaml");
-const TARGET_TAG = "v2026.6.19";
+const TARGET_TAG = "v2026.7.1";
 
 const CURRENT_INSTALLED_BASE = [
   "# Calver tag v2026.6.5 = Hermes Agent v0.16.0.",
@@ -88,7 +88,7 @@ printf 'fake archive' > "$output"
     );
     writeExecutable(
       path.join(fakeBin, "tar"),
-      "#!/usr/bin/env bash\nprintf 'version = \"0.17.0\"\\n'\n",
+      "#!/usr/bin/env bash\nprintf 'version = \"0.18.0\"\\n'\n",
     );
     writeExecutable(path.join(fakeBin, "npm"), "#!/usr/bin/env bash\nprintf 'sha512-test\\n'\n");
     writeExecutable(
@@ -107,7 +107,7 @@ esac
 set -euo pipefail
 printf '%s|%s\\n' "\${NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF:-}" "$*" >> "$FAKE_NEMOHERMES_LOG"
 if [[ "$*" == "hermes exec -- hermes --version" ]]; then
-  printf '0.17.0\\n'
+  printf '0.18.0\\n'
 fi
 `,
     );
@@ -130,7 +130,7 @@ fi
       expect(run.status, `${run.stdout}\n${run.stderr}`).toBe(0);
       expect(fs.readFileSync(dockerLog, "utf8")).toContain(`tag ${baseRef} ${pinnedRef}`);
       expect(fs.readFileSync(nemohermesLog, "utf8")).toContain(`${pinnedRef}|hermes rebuild`);
-      expect(run.stdout).toContain("OK: sandbox reports Hermes Agent v0.17.0");
+      expect(run.stdout).toContain("OK: sandbox reports Hermes Agent v0.18.0");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Hermes v0.18.0 is the first release with Slack Block Kit rendering and native table blocks, so this upgrade enables rich Slack responses and native Markdown-table rendering in NemoClaw's Hermes integration. Building on #5594, it pins Hermes v2026.7.1 / 0.18.0, enables `platforms.slack.extra.rich_blocks`, and prevents stale v0.17 bases from silently defeating the upgrade. Before merge, the v0.18 multi-architecture base must be published and the immutable final-image digest repinned; this draft safely falls back to a local v0.18 base build until then.

## Related Issue

Refs #5591

## Changes

- Upgrade the Hermes release, semver, tarball checksum, npm integrity, manifest, and update-script fixtures to v2026.7.1 / 0.18.0.
- Enable Hermes Slack rich blocks for [Block Kit rendering](https://github.com/NousResearch/hermes-agent/commit/b080b93ad87428221f7bf40360d11fc13e837727) and [native table blocks](https://github.com/NousResearch/hermes-agent/commit/7c7b489813184c54dc3d57a0a7d1c37182c4d8ff), first released in [Hermes v2026.7.1](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.1).
- Advance generated Hermes config to schema 32 and preserve the migrated `agent.verify_on_stop: false` behavior.
- Retarget and retain the #5254 resumed one-shot compatibility workarounds required by Hermes v0.18.0.
- Require exact Hermes-version and MCP-runtime checks when resolving base images while preserving immutable-digest provenance and cached pinned-platform reuse.
- Document rich Slack rendering and add focused config, messaging, base-image, workflow, and live-E2E assertions.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review requested via this draft; the base-image digest repin is intentionally pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 30 focused CLI tests, 6 update-script tests, and 5 focused config/workflow tests passed; pin validation and Python compilation also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run locally; draft CI will provide the broad gate and sandbox-image coverage.
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Will Curran <wcurran@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes now supports richer Slack rendering, including formatted block-based output for tables.
  * Updated Hermes compatibility to the latest release version.

* **Bug Fixes**
  * Base image selection now rejects incompatible Hermes images more reliably.
  * Hermes configuration validation is stricter, helping prevent mismatched setups during startup and upgrades.

* **Documentation**
  * Added guidance for Hermes-specific Slack rendering behavior in sandbox messaging docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->