### PR TITLE
fix(observability): scrub credential-shaped values from dcode trace spans

### DIFF
--- a/agents/langchain-deepagents-code/nemoclaw_observability.py
+++ b/agents/langchain-deepagents-code/nemoclaw_observability.py
@@ -126,6 +126,52 @@ def _safe_identifier(value: Any, fallback: str) -> str:
     return normalized or fallback
 
 
+_REDACTED_SECRET_VALUE = "<redacted-secret>"
+_STANDALONE_SECRET_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"nvapi-[A-Za-z0-9_-]{10,}",
+        r"nvcf-[A-Za-z0-9_-]{10,}",
+        r"ghp_[A-Za-z0-9_-]{10,}",
+        r"github_pat_[A-Za-z0-9_]{30,}",
+        r"sk-proj-[A-Za-z0-9_-]{10,}",
+        r"sk-ant-[A-Za-z0-9_-]{10,}",
+        r"sk-[A-Za-z0-9_-]{20,}",
+        r"(?:xox[bpas]|xapp)-[A-Za-z0-9-]{10,}",
+        r"A(?:K|S)IA[A-Z0-9]{16}",
+        r"hf_[A-Za-z0-9]{10,}",
+        r"glpat-[A-Za-z0-9_-]{10,}",
+        r"gsk_[A-Za-z0-9]{10,}",
+        r"pypi-[A-Za-z0-9_-]{10,}",
+        r"\bbot\d{8,10}:[A-Za-z0-9_-]{35}\b",
+        r"\b\d{8,10}:[A-Za-z0-9_-]{35}\b",
+        r"\b[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b",
+        r"tvly-[A-Za-z0-9_-]{10,}",
+        r"lsv2_(?:pt|sk)_[A-Za-z0-9]{10,}(?:_[A-Za-z0-9]+)*",
+        r"(?s)-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )?PRIVATE KEY-----",
+    )
+)
+_ANCHORED_SECRET_PATTERNS = (
+    re.compile(r"(Bearer\s+)[A-Za-z0-9_.+/=-]{10,}", re.IGNORECASE),
+    re.compile(
+        r"((?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['\"]?)"
+        r"[A-Za-z0-9_.+/=-]{10,}",
+        re.IGNORECASE,
+    ),
+)
+_ANCHORED_SECRET_REPLACEMENT = rf"\g<1>{_REDACTED_SECRET_VALUE}"
+
+
+def _scrub_secret_values(value: str) -> str:
+    """Best-effort redaction of recognized credential-shaped tokens in text."""
+    scrubbed = value
+    for pattern in _STANDALONE_SECRET_PATTERNS:
+        scrubbed = pattern.sub(_REDACTED_SECRET_VALUE, scrubbed)
+    for pattern in _ANCHORED_SECRET_PATTERNS:
+        scrubbed = pattern.sub(_ANCHORED_SECRET_REPLACEMENT, scrubbed)
+    return scrubbed
+
+
 def _bounded_string(value: str, budget: _CaptureBudget | None = None) -> str:
     limit = min(len(value), _MAX_CAPTURE_STRING_CHARS)
     if budget is not None:
@@ -209,7 +255,7 @@ def _capture_jsonable(
     if type(value) is float:
         return value if math.isfinite(value) else "<non-finite float>"
     if type(value) is str:
-        return _bounded_string(value, budget)
+        return _bounded_string(_scrub_secret_values(value), budget)
     if type(value) in (bytes, bytearray):
         return f"<{len(value)} bytes>"
     if type(value) is dict:

--- a/agents/langchain-deepagents-code/nemoclaw_observability.py
+++ b/agents/langchain-deepagents-code/nemoclaw_observability.py
@@ -122,11 +122,25 @@ def _safe_identifier(value: Any, fallback: str) -> str:
     """Sanitize and cap identifiers at 128 characters before Relay receives them."""
     if type(value) is not str:
         return fallback
-    normalized = _SCOPE_NAME_UNSAFE.sub("_", value[:_MAX_SCOPE_NAME_CHARS]).strip("_")
-    return normalized or fallback
+    bounded = value[:_MAX_SCOPE_NAME_CHARS]
+    scrubbed = _scrub_secret_values(
+        bounded, source_was_truncated=len(value) > _MAX_SCOPE_NAME_CHARS
+    )
+    normalized = _SCOPE_NAME_UNSAFE.sub("_", scrubbed).strip("_")
+    return normalized[:_MAX_SCOPE_NAME_CHARS] or fallback
 
 
 _REDACTED_SECRET_VALUE = "<redacted-secret>"
+# SECURITY -- Invalid state: Relay legitimately carries raw model and tool
+# content, but NemoClaw's managed exporter must not emit recognized credential
+# shapes from that content. This isolated Python package cannot import the
+# canonical TypeScript groups in src/lib/security/secret-patterns.ts, so these
+# expressions mirror them at NemoClaw's final span-projection boundary. Host
+# collector processors remain defense in depth, not the source fix. The parity
+# regression in test/langchain-deepagents-code-secret-pattern-parity.test.ts and
+# the real Relay wire assertions in validate-observability.py guard this mirror.
+# Remove it only when a shared Python artifact or upstream pre-export hook can
+# enforce the same managed redaction contract before OTLP serialization.
 _STANDALONE_SECRET_PATTERNS = tuple(
     re.compile(pattern)
     for pattern in (
@@ -152,7 +166,11 @@ _STANDALONE_SECRET_PATTERNS = tuple(
     )
 )
 _ANCHORED_SECRET_PATTERNS = (
-    re.compile(r"(Bearer\s+)[A-Za-z0-9_.+/=-]{10,}", re.IGNORECASE),
+    re.compile(
+        r"(Bearer[\t\n\v\f\r \u00a0\u1680\u2000-\u200a\u2028\u2029"
+        r"\u202f\u205f\u3000\ufeff]+)[A-Za-z0-9_.+/=-]{10,}",
+        re.IGNORECASE,
+    ),
     re.compile(
         r"((?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['\"]?)"
         r"[A-Za-z0-9_.+/=-]{10,}",
@@ -160,27 +178,76 @@ _ANCHORED_SECRET_PATTERNS = (
     ),
 )
 _ANCHORED_SECRET_REPLACEMENT = rf"\g<1>{_REDACTED_SECRET_VALUE}"
+_UNTERMINATED_PRIVATE_KEY_PATTERN = re.compile(
+    r"(?s)-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----.*\Z"
+)
+_TRUNCATED_SECRET_PATTERNS = tuple(
+    re.compile(pattern, flags)
+    for pattern, flags in (
+        (
+            r"(?:nvapi-|nvcf-|ghp_|github_pat_|sk-proj-|sk-ant-|sk-|"
+            r"(?:xox[bpas]|xapp)-|hf_|glpat-|gsk_|pypi-|tvly-|"
+            r"lsv2_(?:pt|sk)_)[A-Za-z0-9_-]*\Z",
+            0,
+        ),
+        (r"A(?:K|S)IA[A-Z0-9]*\Z", 0),
+        (r"(?:bot)?\d{1,10}:[A-Za-z0-9_-]*\Z", 0),
+        (
+            r"[A-Za-z0-9]{1,24}\.[A-Za-z0-9_-]{0,6}"
+            r"(?:\.[A-Za-z0-9_-]*)?\Z",
+            0,
+        ),
+        (
+            r"(?:Bearer[\t\n\v\f\r \u00a0\u1680\u2000-\u200a\u2028\u2029"
+            r"\u202f\u205f\u3000\ufeff]+|"
+            r"(?:_KEY|API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[=: ]['\"]?)"
+            r"[A-Za-z0-9_.+/=-]*\Z",
+            re.IGNORECASE,
+        ),
+    )
+)
 
 
-def _scrub_secret_values(value: str) -> str:
+def _scrub_secret_values(
+    value: str, *, source_was_truncated: bool = False
+) -> str:
     """Best-effort redaction of recognized credential-shaped tokens in text."""
     scrubbed = value
     for pattern in _STANDALONE_SECRET_PATTERNS:
         scrubbed = pattern.sub(_REDACTED_SECRET_VALUE, scrubbed)
     for pattern in _ANCHORED_SECRET_PATTERNS:
         scrubbed = pattern.sub(_ANCHORED_SECRET_REPLACEMENT, scrubbed)
+    # Bounding can cut a private-key block before its END marker. Once a BEGIN
+    # marker is present, redact the remaining bounded segment rather than emit a
+    # partial key body.
+    scrubbed = _UNTERMINATED_PRIVATE_KEY_PATTERN.sub(
+        _REDACTED_SECRET_VALUE, scrubbed
+    )
+    if source_was_truncated:
+        for pattern in _TRUNCATED_SECRET_PATTERNS:
+            scrubbed = pattern.sub(_REDACTED_SECRET_VALUE, scrubbed)
     return scrubbed
 
 
-def _bounded_string(value: str, budget: _CaptureBudget | None = None) -> str:
+def _bounded_string(
+    value: str,
+    budget: _CaptureBudget | None = None,
+    *,
+    scrub_secrets: bool = False,
+) -> str:
     limit = min(len(value), _MAX_CAPTURE_STRING_CHARS)
     if budget is not None:
         limit = min(limit, budget.remaining_string_chars)
         budget.remaining_string_chars -= limit
+    bounded_source = value if limit == len(value) else value[:limit]
+    if scrub_secrets:
+        bounded_source = _scrub_secret_values(
+            bounded_source, source_was_truncated=limit < len(value)
+        )
     bounded = (
-        value
+        bounded_source
         if limit == len(value)
-        else f"{value[:limit]}...[truncated {len(value) - limit} chars]"
+        else f"{bounded_source}...[truncated {len(value) - limit} chars]"
     )
     # Relay's native JSON bridge requires valid UTF-8. Replace unpaired UTF-16
     # surrogates without rejecting the application value or mutating it in place.
@@ -233,6 +300,18 @@ def _opaque_capture_marker(_value: Any) -> dict[str, str]:
     return {"_omitted_type": "opaque"}
 
 
+def _unique_capture_key(candidate: str, captured: dict[str, Any]) -> str:
+    """Keep redacted or bounded mapping keys distinct without exposing originals."""
+    if candidate not in captured:
+        return candidate
+    for index in range(2, _MAX_CAPTURE_ITEMS + 2):
+        suffix = f"#{index}"
+        unique = f"{candidate[: _MAX_CAPTURE_STRING_CHARS - len(suffix)]}{suffix}"
+        if unique not in captured:
+            return unique
+    return f"_duplicate_key_{len(captured)}"
+
+
 def _capture_jsonable(
     value: Any,
     *,
@@ -255,7 +334,7 @@ def _capture_jsonable(
     if type(value) is float:
         return value if math.isfinite(value) else "<non-finite float>"
     if type(value) is str:
-        return _bounded_string(_scrub_secret_values(value), budget)
+        return _bounded_string(value, budget, scrub_secrets=True)
     if type(value) in (bytes, bytearray):
         return f"<{len(value)} bytes>"
     if type(value) is dict:
@@ -276,7 +355,9 @@ def _capture_jsonable(
             if type(key) is not str:
                 omitted_items += 1
                 continue
-            bounded_key = _bounded_string(key, budget)
+            bounded_key = _unique_capture_key(
+                _bounded_string(key, budget, scrub_secrets=True), captured
+            )
             captured[bounded_key] = (
                 _REDACTED_VALUE
                 if _redact_capture_key(key)

--- a/agents/langchain-deepagents-code/validate-observability.py
+++ b/agents/langchain-deepagents-code/validate-observability.py
@@ -550,6 +550,17 @@ def _assert_capture_traversal_bounds(observability: ModuleType) -> None:
         raise AssertionError("projected model response did not record truncation")
 
 
+def _assert_secret_value_redaction(observability: ModuleType) -> None:
+    probe = {"content": "My key is sk-EXAMPLE0000000000000000000000 - do not repeat."}
+    encoded = repr(observability._bounded_capture(probe))
+    if "sk-EXAMPLE0000000000000000000000" in encoded:
+        raise AssertionError("secret-shaped content value survived capture redaction")
+    if observability._REDACTED_SECRET_VALUE not in encoded:
+        raise AssertionError(
+            "secret-shaped content value was not replaced by the redaction marker"
+        )
+
+
 def _exercise_graph(observability: ModuleType, raw_graph_name: str) -> None:
     callback = observability.new_metadata_only_callback_handler()
     callback.on_chain_start(
@@ -887,6 +898,7 @@ def main() -> None:
 
         _assert_callback_manager_boundary(observability)
         _assert_capture_traversal_bounds(observability)
+        _assert_secret_value_redaction(observability)
         middleware = observability.new_relay_middleware()
         asyncio.run(
             _exercise_async_boundaries(observability, middleware, raw_names)

--- a/agents/langchain-deepagents-code/validate-observability.py
+++ b/agents/langchain-deepagents-code/validate-observability.py
@@ -52,6 +52,8 @@ _MAX_REQUEST_BODY_BYTES = 1_048_576
 _SAFE_IDENTIFIER = re.compile(r"[A-Za-z0-9_.:/-]+")
 
 _PROMPT_SECRET = "NEMOCLAW_PROMPT_SECRET"
+_CREDENTIAL_SHAPED_SECRET = "sk-EXAMPLE0000000000000000000000"
+_WIRE_PROMPT = f"{_PROMPT_SECRET}: {_CREDENTIAL_SHAPED_SECRET}"
 _MODEL_OUTPUT_SECRET = "NEMOCLAW_MODEL_OUTPUT_SECRET"
 _TOOL_ARGUMENT_SECRET = "NEMOCLAW_TOOL_ARGUMENT_SECRET"
 _TOOL_RESULT_SECRET = "NEMOCLAW_TOOL_RESULT_SECRET"
@@ -227,7 +229,7 @@ async def _exercise_async_boundaries(
         {"authorization": _PROMPT_SECRET},
         {
             "model": raw_names["model"],
-            "messages": [{"role": "user", "content": _PROMPT_SECRET}],
+            "messages": [{"role": "user", "content": _WIRE_PROMPT}],
             "model_settings": {"api_key": _DROPPED_REQUEST_SURFACE_SECRET},
             "response_format": {"schema": _DROPPED_REQUEST_SURFACE_SECRET},
             "tools": [{"description": _DROPPED_REQUEST_SURFACE_SECRET}],
@@ -237,7 +239,7 @@ async def _exercise_async_boundaries(
     async def successful_model(inner_request: Any) -> dict[str, str]:
         if inner_request.headers != {"authorization": _PROMPT_SECRET}:
             raise AssertionError("model telemetry changed execution headers")
-        if inner_request.content["messages"][0]["content"] != _PROMPT_SECRET:
+        if inner_request.content["messages"][0]["content"] != _WIRE_PROMPT:
             raise AssertionError("model telemetry changed the execution prompt")
         return {"content": _MODEL_OUTPUT_SECRET}
 
@@ -551,14 +553,153 @@ def _assert_capture_traversal_bounds(observability: ModuleType) -> None:
 
 
 def _assert_secret_value_redaction(observability: ModuleType) -> None:
-    probe = {"content": "My key is sk-EXAMPLE0000000000000000000000 - do not repeat."}
-    encoded = repr(observability._bounded_capture(probe))
-    if "sk-EXAMPLE0000000000000000000000" in encoded:
-        raise AssertionError("secret-shaped content value survived capture redaction")
-    if observability._REDACTED_SECRET_VALUE not in encoded:
-        raise AssertionError(
-            "secret-shaped content value was not replaced by the redaction marker"
+    private_key_marker = "PRIVATE" + " KEY"
+    private_key_probe = (
+        f"-----BEGIN TEST {private_key_marker}-----\nopaque-private-key-material\n"
+        f"-----END TEST {private_key_marker}-----"
+    )
+    probes = (
+        (
+            "reported OpenAI-shaped token",
+            f"My key is {_CREDENTIAL_SHAPED_SECRET} - do not repeat.",
+            _CREDENTIAL_SHAPED_SECRET,
+        ),
+        (
+            "standalone provider key",
+            "nvapi-abcdefghijklmnop",
+            "nvapi-abcdefghijklmnop",
+        ),
+        (
+            "case-insensitive bearer token",
+            "Authorization: bEaReR\ufeffopaqueRandomSessionTokenZ1234567890",
+            "opaqueRandomSessionTokenZ1234567890",
+        ),
+        (
+            "case-insensitive key assignment",
+            "Api_Key=opaqueCredentialPayloadZ1234567890",
+            "opaqueCredentialPayloadZ1234567890",
+        ),
+        (
+            "private key block",
+            private_key_probe,
+            "opaque-private-key-material",
+        ),
+    )
+    for label, value, forbidden in probes:
+        encoded = repr(observability._bounded_capture({"content": value}))
+        if forbidden in encoded:
+            raise AssertionError(f"{label} survived capture redaction")
+        if observability._REDACTED_SECRET_VALUE not in encoded:
+            raise AssertionError(f"{label} was not replaced by the redaction marker")
+
+    benign_values = (
+        "sk-too-short",
+        "Bearer short",
+        "-----BEGIN PUBLIC KEY-----\nnot-private\n-----END PUBLIC KEY-----",
+    )
+    for value in benign_values:
+        if observability._bounded_capture(value) != value:
+            raise AssertionError(f"benign near-miss was redacted: {value!r}")
+
+    original_scrubber = observability._scrub_secret_values
+    scrubbed_lengths: list[int] = []
+
+    def recording_scrubber(
+        value: str, *, source_was_truncated: bool = False
+    ) -> str:
+        scrubbed_lengths.append(len(value))
+        return original_scrubber(
+            value, source_was_truncated=source_was_truncated
         )
+
+    repeated_secret = f"{_CREDENTIAL_SHAPED_SECRET} " * 400
+    budget = observability._CaptureBudget()
+    observability._scrub_secret_values = recording_scrubber
+    try:
+        captured = observability._capture_jsonable(repeated_secret, budget=budget)
+    finally:
+        observability._scrub_secret_values = original_scrubber
+    if scrubbed_lengths != [observability._MAX_CAPTURE_STRING_CHARS]:
+        raise AssertionError(
+            "secret scrubbing did not run only on the bounded source segment"
+        )
+    expected_remaining = (
+        observability._MAX_CAPTURE_AGGREGATE_STRING_CHARS
+        - observability._MAX_CAPTURE_STRING_CHARS
+    )
+    if budget.remaining_string_chars != expected_remaining:
+        raise AssertionError("secret redaction changed source-character budget accounting")
+    truncated_chars = len(repeated_secret) - observability._MAX_CAPTURE_STRING_CHARS
+    if f"[truncated {truncated_chars} chars]" not in captured:
+        raise AssertionError("secret-heavy source did not retain its truncation marker")
+    if _CREDENTIAL_SHAPED_SECRET in captured:
+        raise AssertionError("bounded secret-heavy source retained a raw credential")
+
+    boundary_probes = (
+        ("provider prefix", _CREDENTIAL_SHAPED_SECRET),
+        ("AWS access key", "AK" + "IA" + "ABCDEFGHIJKLMNOP"),
+        (
+            "Telegram token",
+            "bot123456789:AbcDefGhiJklMnoPqrStuVwxYz012345678",
+        ),
+        (
+            "Discord token",
+            "ABCDEFGHIJKLMNOPQRSTUVWX.Abcdef.ZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+        ),
+        ("Bearer token", "Bearer ABCDEFGHIJ"),
+        ("key assignment", "Api_" + "Key" + "=" + "ABCDEFGHIJ"),
+    )
+    for label, credential in boundary_probes:
+        boundary_prefix = credential[:-3]
+        boundary_value = (
+            "x" * (observability._MAX_CAPTURE_STRING_CHARS - len(boundary_prefix))
+            + credential
+        )
+        boundary_capture = observability._bounded_capture(boundary_value)
+        if boundary_prefix in boundary_capture:
+            raise AssertionError(f"capture boundary retained a partial {label}")
+        if observability._REDACTED_SECRET_VALUE not in boundary_capture:
+            raise AssertionError(f"capture-boundary {label} lacks a redaction marker")
+
+    mapping_keys = (
+        "sk-AAAAAAAAAAAAAAAAAAAA",
+        "sk-BBBBBBBBBBBBBBBBBBBB",
+    )
+    mapping_capture = observability._bounded_capture(
+        {mapping_keys[0]: "first", mapping_keys[1]: "second"}
+    )
+    encoded_mapping = repr(mapping_capture)
+    if any(key in encoded_mapping for key in mapping_keys):
+        raise AssertionError("credential-shaped mapping key survived redaction")
+    if set(mapping_capture.values()) != {"first", "second"}:
+        raise AssertionError("redacted mapping-key collision dropped captured values")
+    if not all(
+        observability._REDACTED_SECRET_VALUE in key for key in mapping_capture
+    ):
+        raise AssertionError("credential-shaped mapping key lacks a redaction marker")
+
+    identifier = observability._safe_identifier(
+        f"tool-{mapping_keys[0]}", "unknown"
+    )
+    if mapping_keys[0] in identifier or "redacted-secret" not in identifier:
+        raise AssertionError("credential-shaped identifier survived redaction")
+    expanding_identifier_source = ("hf_aaaaaaaaaa-" * 9).rstrip("-")
+    expanding_identifier = observability._safe_identifier(
+        expanding_identifier_source, "unknown"
+    )
+    if len(expanding_identifier) > observability._MAX_SCOPE_NAME_CHARS:
+        raise AssertionError("redaction expansion exceeded the identifier bound")
+    if "hf_aaaaaaaaaa" in expanding_identifier:
+        raise AssertionError("expanded identifier retained a raw credential")
+
+    unterminated_private_key = (
+        "-----BEGIN TEST PRIVATE KEY-----\n" + "private-key-body" * 1_000
+    )
+    captured_private_key = observability._bounded_capture(unterminated_private_key)
+    if "private-key-body" in captured_private_key:
+        raise AssertionError("bounded private key prefix retained partial key material")
+    if observability._REDACTED_SECRET_VALUE not in captured_private_key:
+        raise AssertionError("bounded private key prefix lacks the redaction marker")
 
 
 def _exercise_graph(observability: ModuleType, raw_graph_name: str) -> None:
@@ -762,6 +903,11 @@ def _assert_wire_requests(
     for sentinel in captured_content:
         if sentinel.encode() not in bodies:
             raise AssertionError(f"expected captured content {sentinel} is absent from OTLP")
+    credential_bytes = _CREDENTIAL_SHAPED_SECRET.encode()
+    if credential_bytes in bodies or credential_bytes in header_values:
+        raise AssertionError("credential-shaped prompt content reached the OTLP request")
+    if observability._REDACTED_SECRET_VALUE.encode() not in bodies:
+        raise AssertionError("credential-shaped OTLP content lacks the redaction marker")
     relay_json_content = (
         observability._OUT_OF_RANGE_INTEGER,
         "before\ufffdafter",

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -246,8 +246,10 @@ They exclude request headers, `model_settings`, `response_format`, and tool defi
 Model and tool spans carry the bounded content used for debugging.
 LangGraph node scopes export only bounded node names, a static LangGraph integration label, and success or error status.
 They omit raw graph inputs and outputs, callback metadata, checkpoint payloads, and interrupt or resume values so a node span does not duplicate the full conversation and graph state.
-These controls bound payload shape and remove recognized key classes, but they do not classify arbitrary text values.
-A secret pasted into a prompt, model response, shell command, tool result, file body, or unrecognized field can still be exported.
+These controls bound payload shape and remove recognized key classes.
+As a best-effort second layer, the managed exporter also scrubs recognized credential-shaped tokens, such as provider API keys, bearer tokens, and private key blocks, from captured text values and replaces each match with a redaction marker.
+This value scrubbing is pattern-based and not exhaustive: a secret in an obfuscated or unrecognized form, or any sensitive text that does not match a known credential shape, can still be exported.
+Complete redaction depends on upstream content controls and on the redaction processors you run in the host collector.
 
 The sandbox sends OTLP/HTTP protobuf requests only to `http://host.openshell.internal:4318/v1/traces` and reports `service.name=nemoclaw-langchain-deepagents-code`.
 The OTLP library adds standard transport headers such as content type and content length, but the managed exporter cannot add operator-supplied custom or authentication headers.

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -234,12 +234,13 @@ Trace export is off by default and requires an explicit onboarding choice.
 When enabled, the managed exporter can include bounded prompts, model responses, tool arguments, tool results, operation names, model and tool names, and success or error information.
 Treat the resulting traces as sensitive application data even when your normal prompts do not contain secrets.
 
-Managed capture limits each string to 8,000 characters, each mapping or sequence to 50 items, and nesting to 8 levels.
+Managed capture selects at most 8,000 source characters from each captured string before adding truncation metadata, limits each mapping or sequence to 50 items, and limits nesting to 8 levels.
 Each captured value also has an aggregate budget of 2,048 traversed nodes and 50,000 source string characters.
 Repeated or cyclic containers are replaced with a reference-omission marker instead of being expanded again.
 After bounding a value, a JSON encoding longer than 50,000 characters is replaced by a constant opaque marker and a 16,000-character serialized preview.
 Other opaque objects are replaced by the same constant marker without reading their class name or string representation.
-It replaces binary values with their byte count and redacts recognized credential, header, cookie, password, token, checkpoint, resume, and interrupt keys.
+It replaces binary values with their byte count and bounds dictionary key names, replacing credential-shaped matches in those names with `<redacted-secret>`.
+When a dictionary key matches a recognized credential, header, cookie, password, token, checkpoint, resume, or interrupt class, it replaces the associated value with `<redacted>`.
 It also replaces original exception text with a stable redacted error.
 Model request traces include only the bounded messages and sanitized model identifier.
 They exclude request headers, `model_settings`, `response_format`, and tool definitions or schemas.
@@ -247,7 +248,8 @@ Model and tool spans carry the bounded content used for debugging.
 LangGraph node scopes export only bounded node names, a static LangGraph integration label, and success or error status.
 They omit raw graph inputs and outputs, callback metadata, checkpoint payloads, and interrupt or resume values so a node span does not duplicate the full conversation and graph state.
 These controls bound payload shape and remove recognized key classes.
-As a best-effort second layer, the managed exporter also scrubs recognized credential-shaped tokens, such as provider API keys, bearer tokens, and private key blocks, from captured text values and replaces each match with a redaction marker.
+As a best-effort second layer, the managed exporter also scrubs recognized credential-shaped tokens, such as provider API keys, bearer tokens, and private key blocks, from bounded prompt, response, tool, and other captured string content and replaces each match with `<redacted-secret>`.
+Identifier fields are scrubbed before sanitization and carry the identifier-safe text `redacted-secret` instead.
 This value scrubbing is pattern-based and not exhaustive: a secret in an obfuscated or unrecognized form, or any sensitive text that does not match a known credential shape, can still be exported.
 Complete redaction depends on upstream content controls and on the redaction processors you run in the host collector.
 

--- a/test/e2e/e2e-cloud-experimental/checks/11-deepagents-code-observability.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/11-deepagents-code-observability.sh
@@ -35,6 +35,8 @@ TOOL_NAME="nemoclaw_otlp_e2e_tool"
 TOOL_ARGUMENT="NEMOCLAW_OTLP_TOOL_ARGUMENT_SENTINEL"
 TOOL_RESULT="NEMOCLAW_OTLP_TOOL_RESULT_SENTINEL"
 AMBIENT_CANARY="NEMOCLAW_OTLP_AMBIENT_EXPORTER_CANARY"
+REDACTION_PROBE="sk-EXAMPLE0000000000000000000000"
+REDACTION_MARKER="<redacted-secret>"
 
 fail() {
   printf '%s: FAIL: %s\n' "$PREFIX" "$1" >&2
@@ -247,7 +249,7 @@ run_dcode_direct() {
     env OTEL_SERVICE_NAME="$AMBIENT_CANARY" \
     OTEL_RESOURCE_ATTRIBUTES="ambient.canary=${AMBIENT_CANARY}" \
     dcode -n \
-    "Reply with exactly ${DIRECT_RESPONSE}. Do not repeat the input marker ${DIRECT_PROMPT}." 2>&1
+    "My key is ${REDACTION_PROBE}. Reply with exactly ${DIRECT_RESPONSE}. Do not repeat the key or the input marker ${DIRECT_PROMPT}." 2>&1
 }
 
 run_dcode_login() {
@@ -341,6 +343,8 @@ for _attempt in $(seq 1 45); do
       TOOL_ARGUMENT="$TOOL_ARGUMENT" \
       TOOL_RESULT="$TOOL_RESULT" \
       AMBIENT_CANARY="$AMBIENT_CANARY" \
+      REDACTION_PROBE="$REDACTION_PROBE" \
+      REDACTION_MARKER="$REDACTION_MARKER" \
       "$TSX" "$CONTRACT_HELPER" validate-captures "$CAPTURE_DIR" 2>&1
   )"
   validation_status=$?

--- a/test/e2e/live/deepagents-observability-contract.ts
+++ b/test/e2e/live/deepagents-observability-contract.ts
@@ -26,6 +26,7 @@ const CONFIRMED_EXEC_HINT =
 export type LlmTraceExpectation = {
   label: string;
   promptMarker: string;
+  redactionMarker?: string;
   responseMarker: string;
 };
 
@@ -38,6 +39,10 @@ export type ToolTraceExpectation = {
 export type DeepAgentsTraceExpectations = {
   ambientCanary: string;
   llmExchanges: readonly LlmTraceExpectation[];
+  redaction: {
+    marker: string;
+    rawCredential: string;
+  };
   serviceName: string;
   tool: ToolTraceExpectation;
 };
@@ -78,6 +83,8 @@ function assertLlmExchange(
       hasManagedService(span, serviceName) &&
       spanKind(span) === "LLM" &&
       markerInAttributes(span, INPUT_ATTRIBUTE_KEYS, expectation.promptMarker) &&
+      (expectation.redactionMarker === undefined ||
+        markerInAttributes(span, INPUT_ATTRIBUTE_KEYS, expectation.redactionMarker)) &&
       markerInAttributes(span, OUTPUT_ATTRIBUTE_KEYS, expectation.responseMarker),
   );
   if (!match) {
@@ -113,10 +120,18 @@ export function assertDeepAgentsTraceContract(
 ): { requestCount: number; spanCount: number } {
   if (bodies.length === 0) throw new Error("no managed OTLP trace requests were captured");
   const canary = Buffer.from(expectations.ambientCanary);
+  const rawCredential = Buffer.from(expectations.redaction.rawCredential);
+  const redactionMarker = Buffer.from(expectations.redaction.marker);
+  let redactionMarkerObserved = false;
   const spans = bodies.flatMap((body, index) => {
-    if (Buffer.from(body).includes(canary)) {
+    const encoded = Buffer.from(body);
+    if (encoded.includes(canary)) {
       throw new Error("ambient exporter configuration reached OTLP");
     }
+    if (encoded.includes(rawCredential)) {
+      throw new Error("credential-shaped prompt content reached OTLP");
+    }
+    redactionMarkerObserved ||= encoded.includes(redactionMarker);
     try {
       return decodeExportTraceServiceRequest(body);
     } catch (error) {
@@ -125,6 +140,9 @@ export function assertDeepAgentsTraceContract(
       );
     }
   });
+  if (!redactionMarkerObserved) {
+    throw new Error("credential-shaped OTLP content lacks the redaction marker");
+  }
 
   for (const expectation of expectations.llmExchanges) {
     assertLlmExchange(spans, expectations.serviceName, expectation);
@@ -221,11 +239,16 @@ async function main(): Promise<void> {
       requiredEnvironment("ALLOWED_PROBE"),
       {
         ambientCanary: requiredEnvironment("AMBIENT_CANARY"),
+        redaction: {
+          marker: requiredEnvironment("REDACTION_MARKER"),
+          rawCredential: requiredEnvironment("REDACTION_PROBE"),
+        },
         serviceName: requiredEnvironment("SERVICE_NAME"),
         llmExchanges: [
           {
             label: "direct-exec",
             promptMarker: requiredEnvironment("DIRECT_PROMPT"),
+            redactionMarker: requiredEnvironment("REDACTION_MARKER"),
             responseMarker: requiredEnvironment("DIRECT_RESPONSE"),
           },
           {

--- a/test/e2e/support/deepagents-observability-contract.test.ts
+++ b/test/e2e/support/deepagents-observability-contract.test.ts
@@ -38,6 +38,8 @@ const TOOL_NAME = "nemoclaw_otlp_e2e_tool";
 const TOOL_ARGUMENT = "TOOL_ARGUMENT";
 const TOOL_RESULT = "TOOL_RESULT";
 const AMBIENT_CANARY = "AMBIENT_CANARY";
+const RAW_CREDENTIAL = "sk-EXAMPLE0000000000000000000000";
+const REDACTION_MARKER = "<redacted-secret>";
 
 function validSpans(): TestSpan[] {
   return [
@@ -45,7 +47,11 @@ function validSpans(): TestSpan[] {
       name: "direct model",
       attributes: {
         "openinference.span.kind": "LLM",
-        "input.value": JSON.stringify({ prompt: DIRECT_PROMPT, requested: DIRECT_RESPONSE }),
+        "input.value": JSON.stringify({
+          prompt: DIRECT_PROMPT,
+          redaction: REDACTION_MARKER,
+          requested: DIRECT_RESPONSE,
+        }),
         "output.value": JSON.stringify({ content: DIRECT_RESPONSE }),
       },
     },
@@ -71,9 +77,15 @@ function validSpans(): TestSpan[] {
 
 const expectations = {
   ambientCanary: AMBIENT_CANARY,
+  redaction: { marker: REDACTION_MARKER, rawCredential: RAW_CREDENTIAL },
   serviceName: SERVICE_NAME,
   llmExchanges: [
-    { label: "direct", promptMarker: DIRECT_PROMPT, responseMarker: DIRECT_RESPONSE },
+    {
+      label: "direct",
+      promptMarker: DIRECT_PROMPT,
+      redactionMarker: REDACTION_MARKER,
+      responseMarker: DIRECT_RESPONSE,
+    },
     { label: "login", promptMarker: LOGIN_PROMPT, responseMarker: LOGIN_RESPONSE },
   ],
   tool: { argumentMarker: TOOL_ARGUMENT, name: TOOL_NAME, resultMarker: TOOL_RESULT },
@@ -124,6 +136,7 @@ describe("Deep Agents OTLP trace contract", () => {
     const misplacedToolArgument = validSpans();
     misplacedToolArgument[0].attributes["input.value"] = JSON.stringify({
       prompt: DIRECT_PROMPT,
+      redaction: REDACTION_MARKER,
       requested: DIRECT_RESPONSE,
       unrelatedToolArgument: TOOL_ARGUMENT,
     });
@@ -134,6 +147,27 @@ describe("Deep Agents OTLP trace contract", () => {
     expect(() =>
       assertDeepAgentsTraceContract([traceRequest(misplacedToolArgument)], expectations),
     ).toThrow(/not associated on one managed TOOL span/);
+  });
+
+  it("requires credential-shaped content to be replaced on the OTLP wire", () => {
+    const rawCredential = validSpans();
+    rawCredential[0].attributes["input.value"] = JSON.stringify({
+      prompt: DIRECT_PROMPT,
+      rawCredential: RAW_CREDENTIAL,
+      requested: DIRECT_RESPONSE,
+    });
+    expect(() =>
+      assertDeepAgentsTraceContract([traceRequest(rawCredential)], expectations),
+    ).toThrow(/credential-shaped prompt content reached OTLP/);
+
+    const missingMarker = validSpans();
+    missingMarker[0].attributes["input.value"] = JSON.stringify({
+      prompt: DIRECT_PROMPT,
+      requested: DIRECT_RESPONSE,
+    });
+    expect(() =>
+      assertDeepAgentsTraceContract([traceRequest(missingMarker)], expectations),
+    ).toThrow(/credential-shaped OTLP content lacks the redaction marker/);
   });
 
   it("fails closed on malformed requests, wrong service identity, and ambient canaries", () => {

--- a/test/langchain-deepagents-code-secret-pattern-parity.test.ts
+++ b/test/langchain-deepagents-code-secret-pattern-parity.test.ts
@@ -22,6 +22,12 @@ const managedRuntimePath = path.join(
   "langchain-deepagents-code",
   "managed-dcode-runtime.py",
 );
+const observabilityPath = path.join(
+  repoRoot,
+  "agents",
+  "langchain-deepagents-code",
+  "nemoclaw_observability.py",
+);
 
 const canonicalPatterns: Record<CanonicalSecretPatternGroup, readonly RegExp[]> = {
   token: TOKEN_PREFIX_PATTERNS,
@@ -119,5 +125,63 @@ json.dump([managed._contains_secret_shape(value) for value in values], sys.stdou
     });
 
     expect(JSON.parse(output)).toEqual(CANONICAL_SECRET_POSITIVE_VECTORS.map(() => true));
+  });
+
+  it("scrubs every shared positive vector in managed observability (#6452)", () => {
+    const probe = `
+import importlib.util
+import json
+import sys
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("_nemoclaw_observability_parity", sys.argv[1])
+if spec is None or spec.loader is None:
+    raise RuntimeError("observability module could not be loaded")
+observability = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(observability)
+values = json.load(sys.stdin)
+json.dump([observability._scrub_secret_values(value) for value in values], sys.stdout)
+`;
+    const values = CANONICAL_SECRET_POSITIVE_VECTORS.map((vector) => vector.value);
+    const output = execFileSync("python3", ["-I", "-c", probe, observabilityPath], {
+      encoding: "utf8",
+      input: JSON.stringify(values),
+    });
+    const scrubbed = JSON.parse(output) as string[];
+
+    for (const [index, value] of values.entries()) {
+      expect(scrubbed[index], CANONICAL_SECRET_POSITIVE_VECTORS[index].label).toContain(
+        "<redacted-secret>",
+      );
+      expect(scrubbed[index], CANONICAL_SECRET_POSITIVE_VECTORS[index].label).not.toContain(value);
+    }
+  });
+
+  it("preserves benign near-misses in managed observability (#6452)", () => {
+    const probe = `
+import importlib.util
+import json
+import sys
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("_nemoclaw_observability_near_miss", sys.argv[1])
+if spec is None or spec.loader is None:
+    raise RuntimeError("observability module could not be loaded")
+observability = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(observability)
+values = json.load(sys.stdin)
+json.dump([observability._scrub_secret_values(value) for value in values], sys.stdout)
+`;
+    const values = [
+      "sk-too-short",
+      "Bearer short",
+      "-----BEGIN PUBLIC KEY-----\\nnot-private\\n-----END PUBLIC KEY-----",
+    ];
+    const output = execFileSync("python3", ["-I", "-c", probe, observabilityPath], {
+      encoding: "utf8",
+      input: JSON.stringify(values),
+    });
+
+    expect(JSON.parse(output)).toEqual(values);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deep Agents Code `--observability` trace export redacted only recognized sensitive *keys*, so credential-shaped tokens embedded in prompt or tool *content* reached OTLP spans verbatim. This adds a best-effort value-level scrubber at the managed capture boundary that replaces recognized credential shapes with a redaction marker, and updates the documented redaction contract to match. Complete redaction of arbitrary or obfuscated secrets still depends on upstream content controls and on the redaction processors operators run in the host collector.

## Related Issue

Resolves #6452

## Changes

- Add bounded value-level scrubbing at the final managed span-projection boundary, mirroring the canonical NemoClaw credential shapes without changing application values.
- Account and slice original source text before regex work; redact recognized tokens that cross the capture edge, structured mapping keys with collision-safe names, and bounded identifier fields.
- Extend validation across every canonical pattern, benign near-misses, source budgets, truncated token families, mapping-key collisions, identifier expansion, and emitted Relay OTLP protobuf bodies. The live dcode E2E now injects the reported synthetic prompt token and requires same-span marker evidence.
- Document source bounds, `<redacted>` key-class handling, `<redacted-secret>` content handling, identifier-safe redaction, residual pattern limitations, and host-collector responsibility.

**Scope note:** this is a best-effort second layer at NemoClaw's own capture boundary. The exported spans are produced by NemoClaw's managed exporter, not by dcode; full redaction of content that does not match a known credential shape is only possible with upstream content controls or host-collector redaction.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer nine-category security review completed by @ericksoa with no open findings; final approval follows exact-head CI and required live E2E
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 79 dcode image/observability integration tests passed; 12 OTLP contract-support tests passed; every canonical value pattern passed parity; exact sandbox image build validated real NeMo Relay 0.4.0 / LangGraph 1.2.6 with 13 decoded OTLP requests and the raw reported token absent
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; this is a focused dcode projection fix with targeted integration, E2E-support, real-image, and `npm run check:diff` coverage
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — command passed with 0 errors; Fern reported 2 warnings for review
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved telemetry handling by redacting more secret-like values before traces are exported.
  * Added broader protection for common credential patterns, including API keys, bearer tokens, and private key blocks.

* **Bug Fixes**
  * Reduced the chance of sensitive strings appearing in captured observability data.

* **Documentation**
  * Updated the quickstart guide to better explain how trace redaction works and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
