### PR TITLE
fix(dcode): publish and validate sandbox base image

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -25,6 +25,7 @@ on:
       - "Dockerfile.base"
       - "agents/hermes/Dockerfile.base"
       - "agents/langchain-deepagents-code/Dockerfile.base"
+      - "agents/langchain-deepagents-code/manifest.yaml"
       - "agents/langchain-deepagents-code/requirements.lock"
       # Dockerfile.base validates min_openclaw_version from this file at build time.
       - "nemoclaw-blueprint/blueprint.yaml"
@@ -48,6 +49,9 @@ env:
   IMAGE_NAME: nvidia/nemoclaw/sandbox-base
 
 jobs:
+  # Keep one job per package so build failures, reruns, and published tags stay
+  # independently observable. Consolidating the existing publishers into a
+  # matrix is a separate release-workflow refactor, not part of #6456.
   build-and-push:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
@@ -57,10 +61,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -71,7 +75,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
@@ -128,10 +132,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -142,7 +146,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:
@@ -176,10 +180,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -190,7 +194,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 8
         with:

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Build and push the sandbox base image to GHCR.
+# Build and push the sandbox base images to GHCR.
 #
 # Triggers:
-#   - Push to main when Dockerfile.base or the blueprint minimum version changes
+#   - Push to main when a base-image workflow input changes
 #   - Manual dispatch for ad-hoc rebuilds
 #
 # The base image contains the expensive, rarely-changing layers (apt, gosu,
@@ -19,8 +19,13 @@ on:
     tags:
       - "v*"
     paths:
+      # Re-run when this workflow gains or changes a publisher so the new path
+      # takes effect immediately after merge instead of waiting for another tag.
+      - ".github/workflows/base-image.yaml"
       - "Dockerfile.base"
       - "agents/hermes/Dockerfile.base"
+      - "agents/langchain-deepagents-code/Dockerfile.base"
+      - "agents/langchain-deepagents-code/requirements.lock"
       # Dockerfile.base validates min_openclaw_version from this file at build time.
       - "nemoclaw-blueprint/blueprint.yaml"
   workflow_dispatch:
@@ -155,6 +160,54 @@ jobs:
         with:
           context: .
           file: agents/hermes/Dockerfile.base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-push-langchain-deepagents-code:
+    if: github.repository == 'NVIDIA/NemoClaw'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+        with:
+          images: ${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag
+            type=sha,prefix=,format=short
+
+      - name: Validate Deep Agents Code production Docker build args
+        run: scripts/check-production-build-args.sh
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: agents/langchain-deepagents-code/Dockerfile.base
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -101,6 +101,13 @@ describe("agent base image provisioning", () => {
         [
           "run",
           "--rm",
+          "--network",
+          "none",
+          "--cap-drop",
+          "ALL",
+          "--security-opt",
+          "no-new-privileges",
+          "--read-only",
           "--entrypoint",
           "/opt/venv/bin/python3",
           "dcode-base:current",
@@ -113,9 +120,24 @@ describe("agent base image provisioning", () => {
 
       dockerCaptureMock.mockReturnValue("0.1.12");
       expect(options.validateImage?.("dcode-base:stale")).toBe(false);
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      dockerCaptureMock.mockReturnValue("");
+      expect(options.validateImage?.("dcode-base:unreadable")).toBe(false);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "dcode-base:unreadable returned no Deep Agents Code version output",
+        ),
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("deepagents-code==0.1.34"));
+      warn.mockRestore();
+
       expect(resolveSandboxBaseImageMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          inputPaths: ["/test/root/agents/langchain-deepagents-code/requirements.lock"],
+          inputPaths: [
+            "/test/root/agents/langchain-deepagents-code/manifest.yaml",
+            "/test/root/agents/langchain-deepagents-code/requirements.lock",
+          ],
           validateImage: expect.any(Function),
           validationDescription: "deepagents-code==0.1.34",
         }),
@@ -134,7 +156,9 @@ describe("agent base image provisioning", () => {
             dockerfileBasePath: "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
           }),
         ),
-      ).toThrow("LangChain Deep Agents Code manifest is missing expected_version");
+      ).toThrow(
+        "Agent 'langchain-deepagents-code' (LangChain Deep Agents Code) manifest is missing expected_version required for base-image validation",
+      );
       expect(resolveSandboxBaseImageMock).not.toHaveBeenCalled();
     });
   });

--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -80,6 +80,65 @@ describe("agent base image provisioning", () => {
     );
   });
 
+  it("rejects Deep Agents Code base images that drift from the manifest version (#6456)", () => {
+    withMockedDocker(({ ensureAgentBaseImage, dockerCaptureMock, resolveSandboxBaseImageMock }) => {
+      ensureAgentBaseImage(
+        makeAgent({
+          name: "langchain-deepagents-code",
+          displayName: "LangChain Deep Agents Code",
+          expectedVersion: "0.1.34",
+          dockerfileBasePath: "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
+          dockerfilePath: "/test/root/agents/langchain-deepagents-code/Dockerfile",
+        }),
+      );
+      const options = resolveSandboxBaseImageMock.mock.calls[0]?.[0] as {
+        validateImage?: (imageRef: string) => boolean;
+      };
+
+      dockerCaptureMock.mockReturnValue("0.1.34");
+      expect(options.validateImage?.("dcode-base:current")).toBe(true);
+      expect(dockerCaptureMock).toHaveBeenLastCalledWith(
+        [
+          "run",
+          "--rm",
+          "--entrypoint",
+          "/opt/venv/bin/python3",
+          "dcode-base:current",
+          "-I",
+          "-c",
+          'import importlib.metadata; print(importlib.metadata.version("deepagents-code"))',
+        ],
+        { ignoreError: true, timeout: 20_000 },
+      );
+
+      dockerCaptureMock.mockReturnValue("0.1.12");
+      expect(options.validateImage?.("dcode-base:stale")).toBe(false);
+      expect(resolveSandboxBaseImageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputPaths: ["/test/root/agents/langchain-deepagents-code/requirements.lock"],
+          validateImage: expect.any(Function),
+          validationDescription: "deepagents-code==0.1.34",
+        }),
+      );
+    });
+  });
+
+  it("fails closed when the Deep Agents Code manifest omits its base-image version", () => {
+    withMockedDocker(({ ensureAgentBaseImage, resolveSandboxBaseImageMock }) => {
+      expect(() =>
+        ensureAgentBaseImage(
+          makeAgent({
+            name: "langchain-deepagents-code",
+            displayName: "LangChain Deep Agents Code",
+            expectedVersion: null,
+            dockerfileBasePath: "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
+          }),
+        ),
+      ).toThrow("LangChain Deep Agents Code manifest is missing expected_version");
+      expect(resolveSandboxBaseImageMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("rebuilds an agent base image when rebuild flow forces local Dockerfile.base refresh", () => {
     withMockedDocker(
       ({

--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -80,8 +80,8 @@ describe("agent base image provisioning", () => {
     );
   });
 
-  it("rejects Deep Agents Code base images that drift from the manifest version (#6456)", () => {
-    withMockedDocker(({ ensureAgentBaseImage, dockerCaptureMock, resolveSandboxBaseImageMock }) => {
+  it("configures Deep Agents Code base-image validation from the manifest (#6456)", () => {
+    withMockedDocker(({ ensureAgentBaseImage, resolveSandboxBaseImageMock }) => {
       ensureAgentBaseImage(
         makeAgent({
           name: "langchain-deepagents-code",
@@ -91,47 +91,6 @@ describe("agent base image provisioning", () => {
           dockerfilePath: "/test/root/agents/langchain-deepagents-code/Dockerfile",
         }),
       );
-      const options = resolveSandboxBaseImageMock.mock.calls[0]?.[0] as {
-        validateImage?: (imageRef: string) => boolean;
-      };
-
-      dockerCaptureMock.mockReturnValue("0.1.34");
-      expect(options.validateImage?.("dcode-base:current")).toBe(true);
-      expect(dockerCaptureMock).toHaveBeenLastCalledWith(
-        [
-          "run",
-          "--rm",
-          "--network",
-          "none",
-          "--cap-drop",
-          "ALL",
-          "--security-opt",
-          "no-new-privileges",
-          "--read-only",
-          "--entrypoint",
-          "/opt/venv/bin/python3",
-          "dcode-base:current",
-          "-I",
-          "-c",
-          'import importlib.metadata; print(importlib.metadata.version("deepagents-code"))',
-        ],
-        { ignoreError: true, timeout: 20_000 },
-      );
-
-      dockerCaptureMock.mockReturnValue("0.1.12");
-      expect(options.validateImage?.("dcode-base:stale")).toBe(false);
-
-      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-      dockerCaptureMock.mockReturnValue("");
-      expect(options.validateImage?.("dcode-base:unreadable")).toBe(false);
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "dcode-base:unreadable returned no Deep Agents Code version output",
-        ),
-      );
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining("deepagents-code==0.1.34"));
-      warn.mockRestore();
-
       expect(resolveSandboxBaseImageMock).toHaveBeenCalledWith(
         expect.objectContaining({
           inputPaths: [

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -27,10 +27,10 @@ import {
   type SandboxBaseImageResolution,
   type SandboxBaseImageResolutionMetadata,
 } from "../sandbox-base-image";
+import { createDeepAgentsCodeBaseImageResolutionOptions } from "./deep-agents-code-base-image";
 import type { AgentDefinition } from "./defs";
 
 const HERMES_MCP_RUNTIME_PROBE_OK = "nemoclaw-hermes-mcp-runtime-ok";
-const DEEPAGENTS_CODE_DISTRIBUTION = "deepagents-code";
 // Matches the official Hermes base repository for both Dockerfile manifest-list
 // pins and Docker-normalized platform manifest digests.
 const HERMES_OFFICIAL_BASE_DIGEST_REF =
@@ -158,80 +158,23 @@ export function hermesBaseImageSupportsMcp(imageRef: string): boolean {
   return output.trim() === HERMES_MCP_RUNTIME_PROBE_OK;
 }
 
-/**
- * Reject a published or cached Deep Agents Code base whose installed package
- * does not match the active manifest. The final image patchers intentionally
- * require this exact source pairing, so accepting a merely runnable older base
- * only defers the failure until the expensive final-image build (#6456).
- */
-function deepAgentsCodeBaseImageMatchesVersion(imageRef: string, expectedVersion: string): boolean {
-  const output = dockerCapture(
-    [
-      "run",
-      "--rm",
-      "--network",
-      "none",
-      "--cap-drop",
-      "ALL",
-      "--security-opt",
-      "no-new-privileges",
-      "--read-only",
-      "--entrypoint",
-      "/opt/venv/bin/python3",
-      imageRef,
-      "-I",
-      "-c",
-      `import importlib.metadata; print(importlib.metadata.version("${DEEPAGENTS_CODE_DISTRIBUTION}"))`,
-    ],
-    { ignoreError: true, timeout: 20_000 },
-  );
-  const installedVersion = output.trim();
-  if (!installedVersion) {
-    console.warn(
-      `  Warning: ${imageRef} returned no Deep Agents Code version output; ` +
-        `rejecting the base image (expected ${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion}).`,
-    );
-    return false;
-  }
-  return installedVersion === expectedVersion;
-}
-
 function createAgentBaseImageResolutionOptions(
   agent: AgentDefinition,
   dockerfilePath: string,
   options: EnsureAgentBaseImageOptions,
 ): ResolveBaseImageOptions {
   const imageName = `ghcr.io/nvidia/nemoclaw/${agent.name}-sandbox-base`;
-  const deepAgentsCodeExpectedVersion =
-    agent.name === "langchain-deepagents-code" ? agent.expectedVersion : null;
-  if (agent.name === "langchain-deepagents-code" && !deepAgentsCodeExpectedVersion) {
-    throw new Error(
-      `Agent '${agent.name}' (${agent.displayName}) manifest is missing expected_version ` +
-        "required for base-image validation",
-    );
-  }
-  const validateImage =
+  const validationOptions =
     agent.name === "hermes"
-      ? hermesBaseImageSupportsMcp
-      : deepAgentsCodeExpectedVersion
-        ? (imageRef: string) =>
-            deepAgentsCodeBaseImageMatchesVersion(imageRef, deepAgentsCodeExpectedVersion)
-        : undefined;
+      ? {
+          validateImage: hermesBaseImageSupportsMcp,
+          validationDescription: "the required MCP Streamable HTTP runtime",
+        }
+      : createDeepAgentsCodeBaseImageResolutionOptions(agent, dockerfilePath);
   const pinnedRemoteRef = getHermesPinnedRemoteBaseRef(agent) ?? undefined;
   return {
     imageName,
     dockerfilePath,
-    // The shared resolver intentionally retains its existing global
-    // Dockerfile.base/blueprint inputs in addition to these agent inputs. That
-    // conservative invalidation applies to every agent; decoupling the cache
-    // policy is a separate cross-agent change rather than part of #6456.
-    inputPaths:
-      agent.name === "langchain-deepagents-code"
-        ? [
-            path.join(path.dirname(dockerfilePath), "manifest.yaml"),
-            path.join(path.dirname(dockerfilePath), "requirements.lock"),
-          ]
-        : undefined,
     localTag: buildLocalBaseTag(`nemoclaw-${agent.name}-sandbox-base-local`, ROOT),
     envVar: getAgentSandboxBaseImageEnvVar(agent.name),
     label: `${agent.displayName} sandbox base image`,
@@ -241,13 +184,7 @@ function createAgentBaseImageResolutionOptions(
     rootDir: ROOT,
     pinnedRemoteRef,
     preferPinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
-    validateImage,
-    validationDescription:
-      agent.name === "hermes"
-        ? "the required MCP Streamable HTTP runtime"
-        : deepAgentsCodeExpectedVersion
-          ? `${DEEPAGENTS_CODE_DISTRIBUTION}==${deepAgentsCodeExpectedVersion}`
-          : undefined,
+    ...validationOptions,
   };
 }
 

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -169,6 +169,13 @@ function deepAgentsCodeBaseImageMatchesVersion(imageRef: string, expectedVersion
     [
       "run",
       "--rm",
+      "--network",
+      "none",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--read-only",
       "--entrypoint",
       "/opt/venv/bin/python3",
       imageRef,
@@ -178,7 +185,15 @@ function deepAgentsCodeBaseImageMatchesVersion(imageRef: string, expectedVersion
     ],
     { ignoreError: true, timeout: 20_000 },
   );
-  return output.trim() === expectedVersion;
+  const installedVersion = output.trim();
+  if (!installedVersion) {
+    console.warn(
+      `  Warning: ${imageRef} returned no Deep Agents Code version output; ` +
+        `rejecting the base image (expected ${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion}).`,
+    );
+    return false;
+  }
+  return installedVersion === expectedVersion;
 }
 
 function createAgentBaseImageResolutionOptions(
@@ -190,7 +205,10 @@ function createAgentBaseImageResolutionOptions(
   const deepAgentsCodeExpectedVersion =
     agent.name === "langchain-deepagents-code" ? agent.expectedVersion : null;
   if (agent.name === "langchain-deepagents-code" && !deepAgentsCodeExpectedVersion) {
-    throw new Error("LangChain Deep Agents Code manifest is missing expected_version");
+    throw new Error(
+      `Agent '${agent.name}' (${agent.displayName}) manifest is missing expected_version ` +
+        "required for base-image validation",
+    );
   }
   const validateImage =
     agent.name === "hermes"
@@ -203,9 +221,16 @@ function createAgentBaseImageResolutionOptions(
   return {
     imageName,
     dockerfilePath,
+    // The shared resolver intentionally retains its existing global
+    // Dockerfile.base/blueprint inputs in addition to these agent inputs. That
+    // conservative invalidation applies to every agent; decoupling the cache
+    // policy is a separate cross-agent change rather than part of #6456.
     inputPaths:
       agent.name === "langchain-deepagents-code"
-        ? [path.join(path.dirname(dockerfilePath), "requirements.lock")]
+        ? [
+            path.join(path.dirname(dockerfilePath), "manifest.yaml"),
+            path.join(path.dirname(dockerfilePath), "requirements.lock"),
+          ]
         : undefined,
     localTag: buildLocalBaseTag(`nemoclaw-${agent.name}-sandbox-base-local`, ROOT),
     envVar: getAgentSandboxBaseImageEnvVar(agent.name),

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -30,6 +30,7 @@ import {
 import type { AgentDefinition } from "./defs";
 
 const HERMES_MCP_RUNTIME_PROBE_OK = "nemoclaw-hermes-mcp-runtime-ok";
+const DEEPAGENTS_CODE_DISTRIBUTION = "deepagents-code";
 // Matches the official Hermes base repository for both Dockerfile manifest-list
 // pins and Docker-normalized platform manifest digests.
 const HERMES_OFFICIAL_BASE_DIGEST_REF =
@@ -157,17 +158,55 @@ export function hermesBaseImageSupportsMcp(imageRef: string): boolean {
   return output.trim() === HERMES_MCP_RUNTIME_PROBE_OK;
 }
 
+/**
+ * Reject a published or cached Deep Agents Code base whose installed package
+ * does not match the active manifest. The final image patchers intentionally
+ * require this exact source pairing, so accepting a merely runnable older base
+ * only defers the failure until the expensive final-image build (#6456).
+ */
+function deepAgentsCodeBaseImageMatchesVersion(imageRef: string, expectedVersion: string): boolean {
+  const output = dockerCapture(
+    [
+      "run",
+      "--rm",
+      "--entrypoint",
+      "/opt/venv/bin/python3",
+      imageRef,
+      "-I",
+      "-c",
+      `import importlib.metadata; print(importlib.metadata.version("${DEEPAGENTS_CODE_DISTRIBUTION}"))`,
+    ],
+    { ignoreError: true, timeout: 20_000 },
+  );
+  return output.trim() === expectedVersion;
+}
+
 function createAgentBaseImageResolutionOptions(
   agent: AgentDefinition,
   dockerfilePath: string,
   options: EnsureAgentBaseImageOptions,
 ): ResolveBaseImageOptions {
   const imageName = `ghcr.io/nvidia/nemoclaw/${agent.name}-sandbox-base`;
-  const validateImage = agent.name === "hermes" ? hermesBaseImageSupportsMcp : undefined;
+  const deepAgentsCodeExpectedVersion =
+    agent.name === "langchain-deepagents-code" ? agent.expectedVersion : null;
+  if (agent.name === "langchain-deepagents-code" && !deepAgentsCodeExpectedVersion) {
+    throw new Error("LangChain Deep Agents Code manifest is missing expected_version");
+  }
+  const validateImage =
+    agent.name === "hermes"
+      ? hermesBaseImageSupportsMcp
+      : deepAgentsCodeExpectedVersion
+        ? (imageRef: string) =>
+            deepAgentsCodeBaseImageMatchesVersion(imageRef, deepAgentsCodeExpectedVersion)
+        : undefined;
   const pinnedRemoteRef = getHermesPinnedRemoteBaseRef(agent) ?? undefined;
   return {
     imageName,
     dockerfilePath,
+    inputPaths:
+      agent.name === "langchain-deepagents-code"
+        ? [path.join(path.dirname(dockerfilePath), "requirements.lock")]
+        : undefined,
     localTag: buildLocalBaseTag(`nemoclaw-${agent.name}-sandbox-base-local`, ROOT),
     envVar: getAgentSandboxBaseImageEnvVar(agent.name),
     label: `${agent.displayName} sandbox base image`,
@@ -179,7 +218,11 @@ function createAgentBaseImageResolutionOptions(
     preferPinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
     validateImage,
     validationDescription:
-      agent.name === "hermes" ? "the required MCP Streamable HTTP runtime" : undefined,
+      agent.name === "hermes"
+        ? "the required MCP Streamable HTTP runtime"
+        : deepAgentsCodeExpectedVersion
+          ? `${DEEPAGENTS_CODE_DISTRIBUTION}==${deepAgentsCodeExpectedVersion}`
+          : undefined,
   };
 }
 

--- a/src/lib/agent/deep-agents-code-base-image.test.ts
+++ b/src/lib/agent/deep-agents-code-base-image.test.ts
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeAgent } from "../../../test/helpers/base-image-test-harness";
+
+const mocks = vi.hoisted(() => ({
+  dockerCapture: vi.fn(),
+}));
+
+vi.mock("../adapters/docker", () => ({
+  dockerCapture: mocks.dockerCapture,
+}));
+
+import {
+  createDeepAgentsCodeBaseImageResolutionOptions,
+  deepAgentsCodeBaseImageMatchesVersion,
+} from "./deep-agents-code-base-image";
+
+describe("Deep Agents Code base image compatibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts only the exact installed distribution version (#6456)", () => {
+    mocks.dockerCapture.mockReturnValueOnce("0.1.34\n").mockReturnValueOnce("0.1.12\n");
+
+    expect(deepAgentsCodeBaseImageMatchesVersion("dcode-base:current", "0.1.34")).toBe(true);
+    expect(deepAgentsCodeBaseImageMatchesVersion("dcode-base:stale", "0.1.34")).toBe(false);
+  });
+
+  it("binds the manifest version and source files into resolution options (#6456)", () => {
+    const options = createDeepAgentsCodeBaseImageResolutionOptions(
+      makeAgent({
+        name: "langchain-deepagents-code",
+        displayName: "LangChain Deep Agents Code",
+        expectedVersion: "9.8.7",
+      }),
+      "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
+    );
+    mocks.dockerCapture.mockReturnValue("9.8.7");
+
+    expect(options).toMatchObject({
+      inputPaths: [
+        "/test/root/agents/langchain-deepagents-code/manifest.yaml",
+        "/test/root/agents/langchain-deepagents-code/requirements.lock",
+      ],
+      validationDescription: "deepagents-code==9.8.7",
+    });
+    expect(options?.validateImage?.("dcode-base:manifest-version")).toBe(true);
+  });
+
+  it("runs the version probe in a locked-down container (#6456)", () => {
+    mocks.dockerCapture.mockReturnValue("0.1.34");
+
+    deepAgentsCodeBaseImageMatchesVersion("dcode-base:current", "0.1.34");
+
+    expect(mocks.dockerCapture).toHaveBeenCalledWith(
+      [
+        "run",
+        "--rm",
+        "--network",
+        "none",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--entrypoint",
+        "/opt/venv/bin/python3",
+        "dcode-base:current",
+        "-I",
+        "-c",
+        'import importlib.metadata; print(importlib.metadata.version("deepagents-code"))',
+      ],
+      { ignoreError: true, timeout: 20_000 },
+    );
+  });
+
+  it("warns and fails closed when the probe returns no version (#6456)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mocks.dockerCapture.mockReturnValue("");
+
+    expect(deepAgentsCodeBaseImageMatchesVersion("dcode-base:unreadable", "0.1.34")).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("dcode-base:unreadable returned no Deep Agents Code version output"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("the container or metadata probe may have failed"),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("deepagents-code==0.1.34"));
+    warn.mockRestore();
+  });
+});

--- a/src/lib/agent/deep-agents-code-base-image.ts
+++ b/src/lib/agent/deep-agents-code-base-image.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+import { dockerCapture } from "../adapters/docker";
+import type { ResolveBaseImageOptions } from "../sandbox-base-image";
+import type { AgentDefinition } from "./defs";
+
+const DEEPAGENTS_CODE_DISTRIBUTION = "deepagents-code";
+
+type DeepAgentsCodeResolutionOptions = Pick<
+  ResolveBaseImageOptions,
+  "inputPaths" | "validateImage" | "validationDescription"
+>;
+
+/**
+ * Reject a published or cached Deep Agents Code base whose installed package
+ * does not match the active manifest. The final image patchers intentionally
+ * require this exact source pairing, so accepting a merely runnable older base
+ * only defers the failure until the expensive final-image build (#6456).
+ */
+export function deepAgentsCodeBaseImageMatchesVersion(
+  imageRef: string,
+  expectedVersion: string,
+): boolean {
+  const output = dockerCapture(
+    [
+      "run",
+      "--rm",
+      "--network",
+      "none",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--read-only",
+      "--entrypoint",
+      "/opt/venv/bin/python3",
+      imageRef,
+      "-I",
+      "-c",
+      `import importlib.metadata; print(importlib.metadata.version("${DEEPAGENTS_CODE_DISTRIBUTION}"))`,
+    ],
+    { ignoreError: true, timeout: 20_000 },
+  );
+  const installedVersion = output.trim();
+  if (!installedVersion) {
+    console.warn(
+      `  Warning: ${imageRef} returned no Deep Agents Code version output; ` +
+        "the container or metadata probe may have failed. " +
+        `Rejecting the base image (expected ${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion}).`,
+    );
+    return false;
+  }
+  return installedVersion === expectedVersion;
+}
+
+export function createDeepAgentsCodeBaseImageResolutionOptions(
+  agent: AgentDefinition,
+  dockerfilePath: string,
+): DeepAgentsCodeResolutionOptions | undefined {
+  if (agent.name !== "langchain-deepagents-code") return undefined;
+  const expectedVersion = agent.expectedVersion;
+  if (!expectedVersion) {
+    throw new Error(
+      `Agent '${agent.name}' (${agent.displayName}) manifest is missing expected_version ` +
+        "required for base-image validation",
+    );
+  }
+  const agentRoot = path.dirname(dockerfilePath);
+  return {
+    // Retain the resolver's pre-existing global inputs alongside these agent
+    // inputs. Per-agent cache-policy isolation is a separate cross-agent change.
+    inputPaths: [path.join(agentRoot, "manifest.yaml"), path.join(agentRoot, "requirements.lock")],
+    validateImage: (imageRef) => deepAgentsCodeBaseImageMatchesVersion(imageRef, expectedVersion),
+    validationDescription: `${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion}`,
+  };
+}

--- a/src/lib/sandbox-base-image-agent-resolution.test.ts
+++ b/src/lib/sandbox-base-image-agent-resolution.test.ts
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dockerMocks = vi.hoisted(() => ({
+  build: vi.fn(),
+  capture: vi.fn(),
+  imageInspect: vi.fn(),
+  imageInspectFormat: vi.fn(),
+  infoFormat: vi.fn(),
+  pull: vi.fn(),
+}));
+const sourceMocks = vi.hoisted(() => ({
+  inputsDirty: vi.fn(),
+  inputsChanged: vi.fn(),
+}));
+
+vi.mock("./adapters/docker", () => ({
+  dockerBuild: dockerMocks.build,
+  dockerCapture: dockerMocks.capture,
+  dockerImageInspect: dockerMocks.imageInspect,
+  dockerImageInspectFormat: dockerMocks.imageInspectFormat,
+  dockerInfoFormat: dockerMocks.infoFormat,
+  dockerPull: dockerMocks.pull,
+}));
+
+vi.mock("./trace", () => ({
+  addTraceEvent: vi.fn(),
+}));
+
+vi.mock("./sandbox-base-image/source-identity", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./sandbox-base-image/source-identity")>()),
+  baseImageInputsDirty: sourceMocks.inputsDirty,
+  baseImageInputsChangedSinceMain: sourceMocks.inputsChanged,
+}));
+
+import { resolveSandboxBaseImage } from "./sandbox-base-image";
+
+const IMAGE_NAME = "ghcr.io/nvidia/nemoclaw/sandbox-base";
+
+function resolutionOptions() {
+  return {
+    imageName: IMAGE_NAME,
+    dockerfilePath: path.join(process.cwd(), "Dockerfile.base"),
+    localTag: "nemoclaw-sandbox-base-local:test",
+    rootDir: process.cwd(),
+    env: {
+      ...process.env,
+      GITHUB_SHA: "1234567890abcdef1234567890abcdef12345678",
+    },
+    requireOpenshellSandboxAbi: false,
+  };
+}
+
+describe("agent-specific sandbox base-image resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dockerMocks.infoFormat.mockReturnValue("linux/amd64\n");
+    sourceMocks.inputsDirty.mockReturnValue(false);
+    sourceMocks.inputsChanged.mockReturnValue(false);
+  });
+
+  it("tracks agent dependency locks in dirty and main-divergence checks (#6456)", () => {
+    dockerMocks.imageInspect.mockReturnValue({ status: 1 });
+    dockerMocks.pull.mockReturnValue({ status: 1 });
+    const options = resolutionOptions();
+    const lockfile = path.join(
+      process.cwd(),
+      "agents",
+      "langchain-deepagents-code",
+      "requirements.lock",
+    );
+
+    expect(
+      resolveSandboxBaseImage({
+        ...options,
+        inputPaths: [lockfile],
+        env: {
+          ...options.env,
+          NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
+        },
+      }),
+    ).toBeNull();
+    expect(sourceMocks.inputsDirty).toHaveBeenCalledWith(process.cwd(), expect.any(Object), [
+      options.dockerfilePath,
+      lockfile,
+    ]);
+    expect(sourceMocks.inputsChanged).toHaveBeenCalledWith(process.cwd(), expect.any(Object), [
+      options.dockerfilePath,
+      lockfile,
+    ]);
+  });
+
+  it("rejects a pulled base when custom runtime validation fails (#6456)", () => {
+    const options = resolutionOptions();
+    const staleRef = `${IMAGE_NAME}:stale-dcode`;
+    const validateImage = vi.fn(() => false);
+    dockerMocks.imageInspect.mockReturnValue({ status: 1 });
+    dockerMocks.pull.mockReturnValue({ status: 0 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      resolveSandboxBaseImage({
+        ...options,
+        envVar: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF",
+        env: {
+          ...options.env,
+          NEMOCLAW_SANDBOX_BASE_IMAGE_REF: staleRef,
+          NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
+        },
+        validateImage,
+        validationDescription: "deepagents-code==0.1.34",
+      }),
+    ).toBeNull();
+    expect(dockerMocks.pull).toHaveBeenCalledWith(staleRef, {
+      ignoreError: true,
+      suppressOutput: true,
+    });
+    expect(validateImage).toHaveBeenCalledWith(staleRef);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("deepagents-code==0.1.34"));
+    expect(dockerMocks.build).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -265,6 +265,37 @@ describe("sandbox base-image warm resolution", () => {
     ]);
   });
 
+  it("rejects a pulled base when custom runtime validation fails (#6456)", () => {
+    const options = resolutionOptions();
+    const staleRef = `${IMAGE_NAME}:stale-dcode`;
+    const validateImage = vi.fn(() => false);
+    dockerMocks.imageInspect.mockReturnValue({ status: 1 });
+    dockerMocks.pull.mockReturnValue({ status: 0 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      resolveSandboxBaseImage({
+        ...options,
+        envVar: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF",
+        env: {
+          ...options.env,
+          NEMOCLAW_SANDBOX_BASE_IMAGE_REF: staleRef,
+          NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
+        },
+        validateImage,
+        validationDescription: "deepagents-code==0.1.34",
+      }),
+    ).toBeNull();
+    expect(dockerMocks.pull).toHaveBeenCalledWith(staleRef, {
+      ignoreError: true,
+      suppressOutput: true,
+    });
+    expect(validateImage).toHaveBeenCalledWith(staleRef);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("deepagents-code==0.1.34"));
+    expect(dockerMocks.build).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("fails closed instead of trusting an existing local tag when base inputs are dirty (#4680)", () => {
     sourceMocks.inputsDirty.mockReturnValue(true);
     dockerMocks.imageInspect.mockReturnValue({ status: 0 });

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -234,6 +234,37 @@ describe("sandbox base-image warm resolution", () => {
     });
   });
 
+  it("tracks agent dependency locks in dirty and main-divergence checks (#6456)", () => {
+    dockerMocks.imageInspect.mockReturnValue({ status: 1 });
+    dockerMocks.pull.mockReturnValue({ status: 1 });
+    const options = resolutionOptions();
+    const lockfile = path.join(
+      process.cwd(),
+      "agents",
+      "langchain-deepagents-code",
+      "requirements.lock",
+    );
+
+    expect(
+      resolveSandboxBaseImage({
+        ...options,
+        inputPaths: [lockfile],
+        env: {
+          ...options.env,
+          NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
+        },
+      }),
+    ).toBeNull();
+    expect(sourceMocks.inputsDirty).toHaveBeenCalledWith(process.cwd(), expect.any(Object), [
+      options.dockerfilePath,
+      lockfile,
+    ]);
+    expect(sourceMocks.inputsChanged).toHaveBeenCalledWith(process.cwd(), expect.any(Object), [
+      options.dockerfilePath,
+      lockfile,
+    ]);
+  });
+
   it("fails closed instead of trusting an existing local tag when base inputs are dirty (#4680)", () => {
     sourceMocks.inputsDirty.mockReturnValue(true);
     dockerMocks.imageInspect.mockReturnValue({ status: 0 });

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -234,68 +234,6 @@ describe("sandbox base-image warm resolution", () => {
     });
   });
 
-  it("tracks agent dependency locks in dirty and main-divergence checks (#6456)", () => {
-    dockerMocks.imageInspect.mockReturnValue({ status: 1 });
-    dockerMocks.pull.mockReturnValue({ status: 1 });
-    const options = resolutionOptions();
-    const lockfile = path.join(
-      process.cwd(),
-      "agents",
-      "langchain-deepagents-code",
-      "requirements.lock",
-    );
-
-    expect(
-      resolveSandboxBaseImage({
-        ...options,
-        inputPaths: [lockfile],
-        env: {
-          ...options.env,
-          NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
-        },
-      }),
-    ).toBeNull();
-    expect(sourceMocks.inputsDirty).toHaveBeenCalledWith(process.cwd(), expect.any(Object), [
-      options.dockerfilePath,
-      lockfile,
-    ]);
-    expect(sourceMocks.inputsChanged).toHaveBeenCalledWith(process.cwd(), expect.any(Object), [
-      options.dockerfilePath,
-      lockfile,
-    ]);
-  });
-
-  it("rejects a pulled base when custom runtime validation fails (#6456)", () => {
-    const options = resolutionOptions();
-    const staleRef = `${IMAGE_NAME}:stale-dcode`;
-    const validateImage = vi.fn(() => false);
-    dockerMocks.imageInspect.mockReturnValue({ status: 1 });
-    dockerMocks.pull.mockReturnValue({ status: 0 });
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-    expect(
-      resolveSandboxBaseImage({
-        ...options,
-        envVar: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF",
-        env: {
-          ...options.env,
-          NEMOCLAW_SANDBOX_BASE_IMAGE_REF: staleRef,
-          NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "0",
-        },
-        validateImage,
-        validationDescription: "deepagents-code==0.1.34",
-      }),
-    ).toBeNull();
-    expect(dockerMocks.pull).toHaveBeenCalledWith(staleRef, {
-      ignoreError: true,
-      suppressOutput: true,
-    });
-    expect(validateImage).toHaveBeenCalledWith(staleRef);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("deepagents-code==0.1.34"));
-    expect(dockerMocks.build).not.toHaveBeenCalled();
-    warn.mockRestore();
-  });
-
   it("fails closed instead of trusting an existing local tag when base inputs are dirty (#4680)", () => {
     sourceMocks.inputsDirty.mockReturnValue(true);
     dockerMocks.imageInspect.mockReturnValue({ status: 0 });

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -265,7 +265,7 @@ export function resolveSandboxBaseImage(
     if (!options.requireOpenshellSandboxAbi && !options.validateImage) return null;
   } else {
     const rootDir = options.rootDir || ROOT;
-    const inputPaths = [options.dockerfilePath];
+    const inputPaths = [options.dockerfilePath, ...(options.inputPaths ?? [])];
     const preferPinnedRemoteRef = options.preferPinnedRemoteRef === true;
     if (baseImageInputsDirty(rootDir, env, inputPaths)) return resolveChangedInputs();
 

--- a/src/lib/sandbox-base-image/resolution-key.test.ts
+++ b/src/lib/sandbox-base-image/resolution-key.test.ts
@@ -55,6 +55,19 @@ describe("sandbox base-image resolution key", () => {
     expect(createSandboxBaseImageResolutionKey(options(root))).not.toBe(before);
   });
 
+  it("changes when an agent-specific dependency lock changes (#6456)", () => {
+    const root = fixture();
+    const lockfile = path.join(root, "agents", "langchain-deepagents-code", "requirements.lock");
+    fs.mkdirSync(path.dirname(lockfile), { recursive: true });
+    fs.writeFileSync(lockfile, "deepagents-code==0.1.34\n");
+    const keyedOptions = { ...options(root), inputPaths: [lockfile] };
+    const before = createSandboxBaseImageResolutionKey(keyedOptions);
+
+    fs.writeFileSync(lockfile, "deepagents-code==0.1.34\ntransitive-dependency==2.0.0\n");
+
+    expect(createSandboxBaseImageResolutionKey(keyedOptions)).not.toBe(before);
+  });
+
   it("isolates explicit base-image overrides (#4680)", () => {
     const root = fixture();
     const base = { ...options(root), envVar: "NEMOCLAW_SANDBOX_BASE_IMAGE_REF" };

--- a/src/lib/sandbox-base-image/resolution-key.ts
+++ b/src/lib/sandbox-base-image/resolution-key.ts
@@ -18,9 +18,13 @@ import {
   SANDBOX_BASE_RESOLUTION_SCHEMA,
 } from "./types";
 
-function hashBaseImageInputs(rootDir: string, dockerfilePath: string): string {
+function hashBaseImageInputs(
+  rootDir: string,
+  dockerfilePath: string,
+  inputPaths: string[] = [],
+): string {
   const hash = crypto.createHash("sha256");
-  const paths = normalizeBaseImageInputPaths(rootDir, [dockerfilePath]).sort();
+  const paths = normalizeBaseImageInputPaths(rootDir, [dockerfilePath, ...inputPaths]).sort();
   for (const relativePath of paths) {
     hash.update(relativePath);
     hash.update("\0");
@@ -55,7 +59,7 @@ export function createSandboxBaseImageResolutionKey(options: ResolveBaseImageOpt
     versionTags: getVersionedBaseImageTags(rootDir, env),
     sourceTags: getSourceShortShaTags(rootDir, env),
     localTag: options.localTag,
-    inputFingerprint: hashBaseImageInputs(rootDir, options.dockerfilePath),
+    inputFingerprint: hashBaseImageInputs(rootDir, options.dockerfilePath, options.inputPaths),
     platform: dockerPlatform(),
     requireOpenshellSandboxAbi: options.requireOpenshellSandboxAbi === true,
     minGlibcVersion: options.minGlibcVersion || OPENSHELL_SANDBOX_MIN_GLIBC,

--- a/src/lib/sandbox-base-image/types.ts
+++ b/src/lib/sandbox-base-image/types.ts
@@ -38,6 +38,7 @@ export type SandboxBaseImageResolutionMetadata = {
 export type ResolveBaseImageOptions = {
   imageName: string;
   dockerfilePath: string;
+  inputPaths?: string[];
   localTag: string;
   envVar?: string;
   label?: string;

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -28,21 +28,67 @@ type Workflow = {
 };
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflow = YAML.parse(
+  fs.readFileSync(path.join(repoRoot, ".github", "workflows", "base-image.yaml"), "utf8"),
+) as Workflow;
+const dcodeManifest = YAML.parse(
+  fs.readFileSync(
+    path.join(repoRoot, "agents", "langchain-deepagents-code", "manifest.yaml"),
+    "utf8",
+  ),
+) as { expected_version?: string };
+const dcodeRequirementsLock = fs.readFileSync(
+  path.join(repoRoot, "agents", "langchain-deepagents-code", "requirements.lock"),
+  "utf8",
+);
+
+const publishers = [
+  {
+    jobName: "build-and-push",
+    image: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",
+    dockerfile: "Dockerfile.base",
+    guardName: "Validate production Docker build args",
+  },
+  {
+    jobName: "build-and-push-hermes",
+    image: "${{ env.REGISTRY }}/nvidia/nemoclaw/hermes-sandbox-base",
+    dockerfile: "agents/hermes/Dockerfile.base",
+    guardName: "Validate Hermes production Docker build args",
+  },
+  {
+    jobName: "build-and-push-langchain-deepagents-code",
+    image: "${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+    dockerfile: "agents/langchain-deepagents-code/Dockerfile.base",
+    guardName: "Validate Deep Agents Code production Docker build args",
+  },
+] as const;
 
 describe("Deep Agents Code base-image publication", () => {
-  it("publishes the multi-arch base image whenever its inputs change (#6456)", () => {
-    const workflow = YAML.parse(
-      fs.readFileSync(path.join(repoRoot, ".github", "workflows", "base-image.yaml"), "utf8"),
-    ) as Workflow;
+  it("triggers its publisher whenever the DCode base inputs change (#6456)", () => {
     expect(workflow.on?.push?.paths).toEqual(
       expect.arrayContaining([
         ".github/workflows/base-image.yaml",
         "agents/langchain-deepagents-code/Dockerfile.base",
+        "agents/langchain-deepagents-code/manifest.yaml",
         "agents/langchain-deepagents-code/requirements.lock",
       ]),
     );
+  });
 
-    const job = workflow.jobs?.["build-and-push-langchain-deepagents-code"];
+  it("keeps DCode manifest expected_version in sync with the base-image lockfile and workflow trigger", () => {
+    const lockedVersion = dcodeRequirementsLock.match(/^deepagents-code==([^\s\\]+)/m)?.[1];
+    expect(lockedVersion).toBeDefined();
+    expect(dcodeManifest.expected_version).toBe(lockedVersion);
+    expect(workflow.on?.push?.paths).toContain("agents/langchain-deepagents-code/manifest.yaml");
+  });
+
+  it.each(publishers)("keeps $jobName as an independently guarded multi-arch publisher (#6456)", ({
+    jobName,
+    image,
+    dockerfile,
+    guardName,
+  }) => {
+    const job = workflow.jobs?.[jobName];
     expect(job).toMatchObject({
       if: "github.repository == 'NVIDIA/NemoClaw'",
       "runs-on": "ubuntu-latest",
@@ -52,15 +98,16 @@ describe("Deep Agents Code base-image publication", () => {
     const step = (name: string) => steps.find((candidate) => candidate.name === name);
     const metadata = step("Extract metadata");
     expect(metadata?.with).toMatchObject({
-      images: "${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+      images: image,
       tags: expect.stringContaining("type=ref,event=tag"),
     });
     expect(metadata?.with?.tags).toEqual(expect.stringContaining("type=raw,value=latest"));
     expect(metadata?.with?.tags).toEqual(expect.stringContaining("type=sha,prefix=,format=short"));
+    for (const actionStep of steps.filter((candidate) => candidate.uses?.startsWith("docker/"))) {
+      expect(actionStep.uses).toMatch(/^docker\/[^@]+@[0-9a-f]{40}$/);
+    }
 
-    const guardIndex = steps.findIndex(
-      (candidate) => candidate.name === "Validate Deep Agents Code production Docker build args",
-    );
+    const guardIndex = steps.findIndex((candidate) => candidate.name === guardName);
     const buildIndex = steps.findIndex((candidate) => candidate.name === "Build and push");
     expect(guardIndex).toBeGreaterThanOrEqual(0);
     expect(guardIndex).toBeLessThan(buildIndex);
@@ -69,7 +116,7 @@ describe("Deep Agents Code base-image publication", () => {
       uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
       with: {
         context: ".",
-        file: "agents/langchain-deepagents-code/Dockerfile.base",
+        file: dockerfile,
         platforms: "linux/amd64,linux/arm64",
         push: true,
         tags: "${{ steps.meta.outputs.tags }}",

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+type WorkflowStep = {
+  name?: string;
+  id?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  if?: string;
+  "runs-on"?: string;
+  "timeout-minutes"?: number;
+  steps?: WorkflowStep[];
+};
+
+type Workflow = {
+  on?: { push?: { paths?: string[] } };
+  jobs?: Record<string, WorkflowJob>;
+};
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+describe("Deep Agents Code base-image publication", () => {
+  it("publishes the multi-arch base image whenever its inputs change (#6456)", () => {
+    const workflow = YAML.parse(
+      fs.readFileSync(path.join(repoRoot, ".github", "workflows", "base-image.yaml"), "utf8"),
+    ) as Workflow;
+    expect(workflow.on?.push?.paths).toEqual(
+      expect.arrayContaining([
+        ".github/workflows/base-image.yaml",
+        "agents/langchain-deepagents-code/Dockerfile.base",
+        "agents/langchain-deepagents-code/requirements.lock",
+      ]),
+    );
+
+    const job = workflow.jobs?.["build-and-push-langchain-deepagents-code"];
+    expect(job).toMatchObject({
+      if: "github.repository == 'NVIDIA/NemoClaw'",
+      "runs-on": "ubuntu-latest",
+      "timeout-minutes": 45,
+    });
+    const steps = job?.steps ?? [];
+    const step = (name: string) => steps.find((candidate) => candidate.name === name);
+    const metadata = step("Extract metadata");
+    expect(metadata?.with).toMatchObject({
+      images: "${{ env.REGISTRY }}/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+      tags: expect.stringContaining("type=ref,event=tag"),
+    });
+    expect(metadata?.with?.tags).toEqual(expect.stringContaining("type=raw,value=latest"));
+    expect(metadata?.with?.tags).toEqual(expect.stringContaining("type=sha,prefix=,format=short"));
+
+    const guardIndex = steps.findIndex(
+      (candidate) => candidate.name === "Validate Deep Agents Code production Docker build args",
+    );
+    const buildIndex = steps.findIndex((candidate) => candidate.name === "Build and push");
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(guardIndex).toBeLessThan(buildIndex);
+    expect(steps[guardIndex]?.run).toContain("scripts/check-production-build-args.sh");
+    expect(steps[buildIndex]).toMatchObject({
+      uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+      with: {
+        context: ".",
+        file: "agents/langchain-deepagents-code/Dockerfile.base",
+        platforms: "linux/amd64,linux/arm64",
+        push: true,
+        tags: "${{ steps.meta.outputs.tags }}",
+        labels: "${{ steps.meta.outputs.labels }}",
+      },
+    });
+  });
+});

--- a/test/openclaw-dependency-review.test.ts
+++ b/test/openclaw-dependency-review.test.ts
@@ -482,13 +482,17 @@ grep -Fq -- '--phase post-agent-install' Dockerfile
       baseImages.jobs["build-and-push-hermes"] as WorkflowJob,
       "Validate Hermes production Docker build args",
     );
+    expectBuildPushGuard(
+      baseImages.jobs["build-and-push-langchain-deepagents-code"] as WorkflowJob,
+      "Validate Deep Agents Code production Docker build args",
+    );
 
     const discoveredBuilds = [
       ...findProductionBuildGuardCoverage("pr-self-hosted", prSelfHosted),
       ...findProductionBuildGuardCoverage("sandbox-images-and-e2e", sandboxImages),
       ...findProductionBuildGuardCoverage("base-image", baseImages),
     ];
-    expect(discoveredBuilds.map(({ label }) => label)).toHaveLength(7);
+    expect(discoveredBuilds.map(({ label }) => label)).toHaveLength(8);
     expect(discoveredBuilds.filter(({ guarded }) => !guarded)).toEqual([]);
 
     const productionWorkflowContract = JSON.stringify({ prSelfHosted, sandboxImages, baseImages });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Publishes the LangChain Deep Agents Code sandbox base image from the same main/tag workflow used by the other supported agents, closing the release-pipeline gap that left v0.0.76 resolving an obsolete `deepagents-code` 0.1.12 base. Base resolution now verifies the installed DCode distribution against the active manifest and fingerprints both the manifest and dependency lock so version or transitive dependency drift fails closed before final-image construction.

## Related Issue
Refs #6456. Keep the issue open until the exact-main image run succeeds, the new GHCR package is public, and a clean ARM64 v0.0.76 install is revalidated.

## Changes
- Add a guarded, multi-architecture GHCR publisher for `langchain-deepagents-code-sandbox-base` with `latest`, release-tag, and short-SHA metadata.
- Trigger base-image publication when the workflow, DCode base Dockerfile, manifest, or dependency lock changes, so merging this fix immediately publishes `latest`.
- Reject published, cached, or overridden DCode bases unless `/opt/venv` contains the manifest-required `deepagents-code` version; the metadata-only probe is networkless, capability-dropped, no-new-privileges, and read-only.
- Include the DCode manifest and dependency lock in base-resolution identity plus dirty/main-divergence checks, preventing version and transitive lock changes from reusing stale images.
- Pin every Docker action in the package-writing workflow to an immutable commit.
- Add focused resolver, workflow, source-invariant, and build-guard regression coverage for #6456.

## Design Notes
- The invalid state is a published or cached DCode image whose installed `deepagents-code` version differs from `manifest.yaml` `expected_version`. The manifest is the runtime acceptance contract and `requirements.lock` is the immutable image-build input; they serve different consumers and cannot safely be collapsed in this release fix. Their named invariant test runs in every PR's integration CI, so drift is merge-blocking. Remove the duplicated-field guard only when build tooling generates both consumers from one authoritative source.
- Global `Dockerfile.base` and blueprint inputs intentionally remain in every agent resolution key under the resolver's pre-existing conservative policy. #6456 adds the DCode manifest/lock inputs without redefining cross-agent invalidation; removal requires a dedicated per-agent cache-policy design with migration and regression coverage.
- DCode validation and DCode-specific resolution options are isolated in `deep-agents-code-base-image.ts`; the shared base-image module only selects those options. Hermes remains separate because it validates a different capability contract.
- On exact head `29c17cd5`, `base-image.ts` is 378 lines versus 373 on `main`, and the generic resolver test is 452 lines versus 452 on `main`; the prior monolith findings are resolved by the focused DCode module and agent-resolution test file.
- `dockerCapture` exposes stdout, not an exit-status result. Empty output therefore means the container or metadata probe may have failed and is rejected with a warning; a non-empty wrong version follows the distinct stale-version path. Expanding the Docker adapter result type is outside this publication fix.
- `/opt/venv/bin/python3` is the DCode base Dockerfile's declared virtual-environment interpreter. Using the absolute path avoids `PATH` ambiguity; a future layout change intentionally fails closed, and the exact-head DCode onboarding E2E exercises the real image contract.
- The `deepagents-code` distribution identifier comes from the top-level hash-locked requirement and is checked against the manifest version by required integration CI; any future package rename fails closed.
- Coverage deliberately splits the two public contracts: focused DCode tests exercise manifest-to-validator binding, while the agent-resolution suite proves a pulled image is rejected when its supplied validator fails. Exact-head DCode onboarding and sandbox-rebuild E2E supply the composed runtime check.
- The composed override/cache contract is covered at stable public seams: the DCode helper test binds the manifest version to the locked-down probe, the agent provisioning test passes that validator to resolution, the resolver test rejects an overridden candidate when validation fails, and the resolution-metadata test revalidates a cached hint before reuse. Exact-head DCode onboarding E2E validates the assembled runtime path; duplicating those private seams in one synthetic test would add coupling without a new behavior assertion.
- Manifest/lock synchronization is CI-enforced: `test/dcode-base-image-workflow.test.ts` is in the integration project, `.github/actions/ci-cli-coverage-shard/action.yaml` runs both `--project cli` and `--project integration` for code PRs, and the required aggregate `cli-tests` check passed on this exact head.
- Missing in-repo agent inputs are retained by normalization and hashed as `<missing>` by the resolution key. Only empty, repository-root, or out-of-repository paths are rejected, which is the intentional path-traversal boundary rather than silent missing-file handling.
- The metadata probe has no network, capabilities, privilege escalation, writable root filesystem, or host mounts. Keeping the image's default user avoids requiring arbitrary override images to define a `sandbox` account; the command is read-only and fail-closed.
- Image references are non-secret resolver inputs and are intentionally included in validation diagnostics so operators can identify a bad explicit override or cached tag; secret-bearing process output still passes through the existing runner redaction boundary.
- Separate publisher jobs intentionally preserve package-specific failures, reruns, and tag observability. Converting all existing publishers to a matrix changes the release contract across three packages and is a separate workflow refactor, not prerequisite work for #6456.
- `packages: write` is the minimum permission needed to publish the requested GHCR image and is pre-existing for this dedicated workflow; the only other workflow permission is `contents: read`, publisher jobs are repository-guarded, and all Docker actions are immutable-pinned.
- PR #5755 is already conflicting with current `main`; its checkout dependency bump must rebase independently. PR #6469 remains mergeable and does not need to absorb that unrelated dependency update.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: restores the documented hash-locked DCode runtime and stale-base fallback contracts without changing commands, flags, configuration, defaults, or policy.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending human review of base-image selection and release publication on this exact head.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact head `29c17cd5`: changed resolver/base-image/workflow suites passed 56/56; the parent DCode image contract suites passed 83/83; JS-config and CLI typechecks, `npm run checks`, YAML/Biome validation, normal hooks, secret scan, import/shape checks, and test-size budgets passed. Exact-head [E2E run 28948929160](https://github.com/NVIDIA/NemoClaw/actions/runs/28948929160) passed DCode cloud onboarding and sandbox rebuild.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded automated image publishing to cover an additional agent base image and related dependency updates.
  * Base image rebuilds now respond to more relevant file changes, helping keep published images current.

* **Bug Fixes**
  * Improved base image validation so outdated images are rejected more reliably.
  * Resolution logic now tracks dependency lockfile changes, reducing stale image reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
