### PR TITLE
test(e2e): validate Hermes MCP hash state

### DIFF
--- a/test/e2e/live/hermes-gpu-startup-integrity.ts
+++ b/test/e2e/live/hermes-gpu-startup-integrity.ts
@@ -76,18 +76,23 @@ def parse_hash(data, label):
         text = data.decode("ascii")
     except UnicodeDecodeError:
         fail(f"{label} is not ASCII")
-    if not text.endswith("\\n"):
-        fail(f"{label} is missing its final newline")
-    lines = text.splitlines()
+    parts = text.split("\\n")
+    if len(parts) != 4 or parts[-1] != "":
+        fail(f"{label} does not contain exactly three records")
+    lines = parts[:2]
     expected_paths = (str(config_path), str(env_path))
-    if len(lines) != len(expected_paths):
-        fail(f"{label} does not contain exactly two records")
     digests = []
     for line, expected_path in zip(lines, expected_paths):
         match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
         if match is None or match.group(2) != expected_path:
-            fail(f"{label} contains an unexpected record")
+            fail(f"{label} contains an unexpected file record")
         digests.append(match.group(1))
+    state_match = re.fullmatch(
+        r"# nemoclaw-hermes-mcp-state-v1 intended=([0-9a-f]{64}) applied=([0-9a-f]{64})",
+        parts[2],
+    )
+    if state_match is None:
+        fail(f"{label} contains an unexpected MCP state record")
     return tuple(digests)
 
 def digest(data):

--- a/test/e2e/support/hermes-gpu-startup-integrity.test.ts
+++ b/test/e2e/support/hermes-gpu-startup-integrity.test.ts
@@ -22,6 +22,7 @@ interface IntegrityFixture {
 }
 
 const roots: string[] = [];
+const MCP_STATE_RECORD = `# nemoclaw-hermes-mcp-state-v1 intended=${"1".repeat(64)} applied=${"2".repeat(64)}`;
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
@@ -38,7 +39,18 @@ function writeHash(
   envPath: string,
   env: string,
 ): void {
-  fs.writeFileSync(hashPath, `${digest(config)}  ${configPath}\n${digest(env)}  ${envPath}\n`);
+  fs.writeFileSync(
+    hashPath,
+    `${digest(config)}  ${configPath}\n${digest(env)}  ${envPath}\n${MCP_STATE_RECORD}\n`,
+  );
+}
+
+function readHashRecords(hashPath: string): string[] {
+  return fs.readFileSync(hashPath, "utf-8").split("\n").slice(0, -1);
+}
+
+function writeHashRecords(hashPath: string, records: readonly string[]): void {
+  fs.writeFileSync(hashPath, `${records.join("\n")}\n`);
 }
 
 function createFixture(): IntegrityFixture {
@@ -96,7 +108,7 @@ function runProof(fixture: IntegrityFixture, extraEnv: NodeJS.ProcessEnv = {}) {
 }
 
 describe("Hermes managed startup integrity proof", () => {
-  it("accepts a current compatibility hash and one generated API key beyond the strict base", () => {
+  it("accepts canonical file and MCP state records with one generated API key beyond the strict base (#6427)", () => {
     const fixture = createFixture();
     const rawStrictCheck = spawnSync("sha256sum", ["-c", fixture.strictHashPath, "--status"], {
       encoding: "utf-8",
@@ -109,6 +121,68 @@ describe("Hermes managed startup integrity proof", () => {
     const proof = runProof(fixture);
     expect(proof.status, proof.stderr).toBe(0);
     expect(proof.stdout).toBe("OK\n");
+  });
+
+  it("rejects a missing Hermes MCP state record (#6427)", () => {
+    const fixture = createFixture();
+    const [configRecord, envRecord] = readHashRecords(fixture.compatHashPath);
+    writeHashRecords(fixture.compatHashPath, [configRecord!, envRecord!]);
+
+    const proof = runProof(fixture);
+    expect(proof.status).not.toBe(0);
+    expect(proof.stderr).toContain(
+      "Hermes compatibility hash does not contain exactly three records",
+    );
+  });
+
+  it("rejects a malformed Hermes MCP state record (#6427)", () => {
+    const fixture = createFixture();
+    const [configRecord, envRecord] = readHashRecords(fixture.compatHashPath);
+    writeHashRecords(fixture.compatHashPath, [
+      configRecord!,
+      envRecord!,
+      `# nemoclaw-hermes-mcp-state-v1 intended=${"1".repeat(64)} applied=invalid`,
+    ]);
+
+    const proof = runProof(fixture);
+    expect(proof.status).not.toBe(0);
+    expect(proof.stderr).toContain(
+      "Hermes compatibility hash contains an unexpected MCP state record",
+    );
+  });
+
+  it("rejects duplicate Hermes MCP state records (#6427)", () => {
+    const fixture = createFixture();
+    const records = readHashRecords(fixture.compatHashPath);
+    writeHashRecords(fixture.compatHashPath, [...records, MCP_STATE_RECORD]);
+
+    const proof = runProof(fixture);
+    expect(proof.status).not.toBe(0);
+    expect(proof.stderr).toContain(
+      "Hermes compatibility hash does not contain exactly three records",
+    );
+  });
+
+  it("rejects a reordered Hermes MCP state record (#6427)", () => {
+    const fixture = createFixture();
+    const [configRecord, envRecord, stateRecord] = readHashRecords(fixture.compatHashPath);
+    writeHashRecords(fixture.compatHashPath, [stateRecord!, configRecord!, envRecord!]);
+
+    const proof = runProof(fixture);
+    expect(proof.status).not.toBe(0);
+    expect(proof.stderr).toContain("Hermes compatibility hash contains an unexpected file record");
+  });
+
+  it("rejects unexpected records after the Hermes MCP state record (#6427)", () => {
+    const fixture = createFixture();
+    const records = readHashRecords(fixture.compatHashPath);
+    writeHashRecords(fixture.compatHashPath, [...records, "unexpected"]);
+
+    const proof = runProof(fixture);
+    expect(proof.status).not.toBe(0);
+    expect(proof.stderr).toContain(
+      "Hermes compatibility hash does not contain exactly three records",
+    );
   });
 
   it("rejects non-key environment drift even when the compatibility hash accepts it", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Update the Hermes GPU startup integrity proof to validate the three-record hash format introduced by the MCP state reconciliation contract. This prevents a healthy GPU sandbox from failing solely because the proof still expected the obsolete two-record form.

## Related Issue
Fixes #6427

## Changes
- Require two ordered canonical SHA-256 file records followed by one canonical Hermes MCP intended/applied state record.
- Update strict and compatibility hash fixtures to emit the production three-record form.
- Add fail-closed coverage for missing, malformed, duplicate, reordered, and unexpected MCP hash records.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test-only correction aligns the GPU proof with the existing production hash contract; user-facing behavior is unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/hermes-gpu-startup-integrity.test.ts` (12 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for Hermes startup integrity files to better detect malformed or unexpected integrity records.
  * Improved error handling when integrity proof content is missing, duplicated, reordered, or includes unexpected extra data.

* **Tests**
  * Added end-to-end coverage for valid startup integrity proofs and multiple failure cases involving MCP state records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->