### PR TITLE
docs: add v0.0.77 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,23 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.77
+
+NemoClaw v0.0.77 hardens LangChain Deep Agents Code packaging, tracing, and guided setup. The release publishes and validates the current Deep Agents sandbox base image, reduces telemetry credential exposure, reports the upstream provider selected during onboarding, and reuses a reviewed local credential form in starter prompts.
+
+- LangChain Deep Agents Code base-image handling now rejects stale published, cached, or overridden base images when the installed Deep Agents Code version does not match the managed manifest and dependency lock.
+  This prevents an obsolete base from reaching final-image construction silently.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart) and [Architecture Details](../reference/architecture).
+- The managed Deep Agents runtime disables LangGraph CLI analytics and reports the upstream provider selected during NemoClaw onboarding in the TUI status bar, launch banner, and model-identity prompt.
+  The runtime still uses the OpenAI-compatible adapter internally for inference routing.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart) and [NemoClaw Inference Options](../inference/inference-options).
+- Managed Deep Agents observability now applies a bounded, best-effort scrub pass to recognized credential-shaped values before OTLP trace export.
+  Treat exported traces as sensitive application data and keep collector-side filtering or redaction controls in place for unrecognized sensitive content.
+  For more information, refer to [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart), [Credential Storage](../security/credential-storage), and [Security Best Practices](../security/best-practices).
+- Starter prompts now reuse a checked-in local credential form with loopback-only submission, a restrictive content security policy, redacted confirmation output, and no external resources.
+  This gives coding agents one reviewed credential-capture path instead of asking them to generate credential forms or collect secrets in chat.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart) and [Use NemoClaw Agent Prompts, Docs MCP Server, and Skills with Your AI Coding Agent](../resources/agent-skills).
+
 ## v0.0.76
 
 NemoClaw v0.0.76 adds opt-in OTLP observability and a dedicated documentation guide for LangChain Deep Agents Code, makes Nemotron 3 Ultra the managed NVIDIA Endpoints default for Deep Agents Code, contains shared-gateway inference-route conflicts, and improves upgrade recovery, MCP diagnostics, local inference, messaging, and day-two commands.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds the v0.0.77 release-note section from the shipped release announcement and release commit range.
This is post-release docs recovery, so the PR is labeled for the next patch release train.

## Changes
- Added `v0.0.77` to `docs/about/release-notes.mdx` with links to the deeper Deep Agents, architecture, inference, security, and agent-docs pages.
- Source summary:
- #6469 -> `docs/about/release-notes.mdx`: Documents Deep Agents Code base-image publication and stale-version validation.
- #6471 -> `docs/about/release-notes.mdx`: Documents the managed runtime disabling LangGraph CLI analytics.
- #6462 -> `docs/about/release-notes.mdx`: Documents the TUI, launch banner, and model-identity provider display behavior.
- #6460 -> `docs/about/release-notes.mdx`: Documents bounded, best-effort OTLP trace credential scrubbing and the remaining collector-side redaction requirement.
- #6423 -> `docs/about/release-notes.mdx`: Documents the checked-in loopback-only local credential form used by starter prompts.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: release-note prose only, no runtime behavior or code samples changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: tests not applicable for release-note prose only.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Verification note: `npm run docs` passed. `fern check --warnings` reports the existing light-mode accent color contrast warning: `2.41:1`, expected at least `3:1`.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release-notes entry for **v0.0.77** at the top of the changelog.
  * Highlighted improved package validation, tighter handling of telemetry and trace data, and safer starter prompt behavior with stronger redaction and local-only submission.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->