### PR TITLE
perf(test): coordinate source loader cache misses

### DIFF
--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -10,18 +10,19 @@ const path = require("node:path");
 const ts = require("typescript");
 
 const sourceLoader = path.join(__dirname, "register-source-require.ts");
-const { outputText } = ts.transpileModule(fs.readFileSync(sourceLoader, "utf8"), {
-  compilerOptions: {
-    esModuleInterop: true,
-    module: ts.ModuleKind.CommonJS,
-    target: ts.ScriptTarget.ES2022,
-  },
-  fileName: sourceLoader,
-});
-const sourceLoaderModule = new Module(sourceLoader, module);
-sourceLoaderModule.filename = sourceLoader;
-sourceLoaderModule.paths = module.paths;
-sourceLoaderModule._compile(outputText, sourceLoader);
+
+Module._extensions[".ts"] = (targetModule, filename) => {
+  const { outputText } = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  });
+  targetModule._compile(outputText, filename);
+};
+require(sourceLoader);
 
 function normalizeCommand(command) {
   return (Array.isArray(command) ? command.join(" ") : String(command)).replace(/'/g, "");

--- a/test/helpers/register-source-require.ts
+++ b/test/helpers/register-source-require.ts
@@ -5,7 +5,14 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import Module from "node:module";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import ts from "typescript";
+
+import {
+  loadSourceRequireCompilerOptions,
+  sourceRequireCacheDir,
+  sourceRequireCachePath,
+} from "./source-require-cache";
 
 type CommonJsModule = NodeModule & {
   _compile(source: string, filename: string): void;
@@ -23,45 +30,229 @@ const moduleRuntime = Module as unknown as {
   _resolveFilename: ResolveFilename;
 };
 const repoRoot = path.resolve(__dirname, "../..");
-const configPath = path.join(repoRoot, "tsconfig.src.json");
-const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
-
-if (configFile.error) {
-  throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
-}
-
-const parsedConfig = ts.parseJsonConfigFileContent(
-  configFile.config,
-  ts.sys,
-  repoRoot,
-  {},
-  configPath,
-);
-if (parsedConfig.errors.length > 0) {
-  throw new Error(
-    parsedConfig.errors
-      .map((error) => ts.flattenDiagnosticMessageText(error.messageText, "\n"))
-      .join("\n"),
-  );
-}
-
-const compilerOptions: ts.CompilerOptions = {
-  ...parsedConfig.options,
-  declaration: false,
-  declarationMap: false,
-  inlineSourceMap: true,
-  inlineSources: true,
-  noEmit: false,
-  outDir: undefined,
-  rootDir: undefined,
-  sourceMap: false,
-};
+const compilerOptions = loadSourceRequireCompilerOptions(repoRoot);
 // Keep the cross-process transpilation cache in this checkout's dependency
 // tree. A shared, predictable directory under the OS temp root could be
 // replaced by another local user before a test process reads from it.
-const cacheDir = path.join(repoRoot, "node_modules", ".cache", "nemoclaw-source-require");
-const compilerFingerprint = JSON.stringify({ compilerOptions, typescript: ts.version });
+const cacheDir = sourceRequireCacheDir(repoRoot);
 fs.mkdirSync(cacheDir, { recursive: true });
+const cacheWaitMs = envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS", 5_000);
+const cachePollMs = Math.max(1, envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS", 25));
+const cacheLockStaleMs = envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS", 30_000);
+const statsPath = process.env.NEMOCLAW_SOURCE_REQUIRE_STATS;
+
+const stats = {
+  cacheHits: 0,
+  cacheMisses: 0,
+  compileMs: 0,
+  duplicateFallbacks: 0,
+  files: 0,
+  lockWaits: 0,
+  readCacheMs: 0,
+  staleLocks: 0,
+  transforms: 0,
+  transformMs: 0,
+  waitMs: 0,
+};
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function nowMs(): number {
+  return performance.now();
+}
+
+const sleepBuffer = new SharedArrayBuffer(4);
+const sleepArray = new Int32Array(sleepBuffer);
+
+function sleepSync(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(sleepArray, 0, 0, ms);
+}
+
+function readCachedOutput(cachePath: string): string | null {
+  const start = nowMs();
+  try {
+    const output = fs.readFileSync(cachePath, "utf8");
+    stats.readCacheMs += nowMs() - start;
+    return output;
+  } catch (error) {
+    stats.readCacheMs += nowMs() - start;
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return null;
+  }
+}
+
+function writeAtomic(cachePath: string, outputText: string): void {
+  const temporaryPath = `${cachePath}.${process.pid}.${crypto.randomUUID()}`;
+  fs.writeFileSync(temporaryPath, outputText, { flag: "wx", mode: 0o600 });
+  try {
+    fs.renameSync(temporaryPath, cachePath);
+  } catch (error) {
+    fs.rmSync(temporaryPath, { force: true });
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+}
+
+function parseLockOwner(contents: string): { pid?: number } {
+  try {
+    const parsed = JSON.parse(contents);
+    return typeof parsed?.pid === "number" && Number.isInteger(parsed.pid) && parsed.pid > 0
+      ? { pid: parsed.pid }
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function lockOwnerContents(filename: string): string {
+  return `${JSON.stringify({
+    filename,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    startedAtMs: Date.now(),
+  })}\n`;
+}
+
+function tryAcquireLock(lockPath: string, filename: string): boolean {
+  try {
+    fs.writeFileSync(lockPath, lockOwnerContents(filename), { flag: "wx", mode: 0o600 });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    return false;
+  }
+}
+
+function reclaimStaleLock(lockPath: string, filename: string): boolean {
+  if (cacheLockStaleMs <= 0) return false;
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(lockPath, "r+");
+    const stat = fs.fstatSync(fd);
+    const contents = fs.readFileSync(fd, "utf8");
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs < cacheLockStaleMs) return false;
+    const { pid } = parseLockOwner(contents);
+    if (pid !== undefined && processIsRunning(pid)) return false;
+
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, lockOwnerContents(filename), 0, "utf8");
+    stats.staleLocks += 1;
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function transpileSource(source: string, filename: string): string {
+  const start = nowMs();
+  const result = ts.transpileModule(source, {
+    compilerOptions,
+    fileName: filename,
+    reportDiagnostics: true,
+  });
+  stats.transformMs += nowMs() - start;
+  stats.transforms += 1;
+  const errors = result.diagnostics?.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (errors && errors.length > 0) {
+    throw new Error(
+      errors
+        .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+        .join("\n"),
+    );
+  }
+  return result.outputText;
+}
+
+function waitForCache(cachePath: string): string | null {
+  if (cacheWaitMs <= 0) return null;
+  const start = nowMs();
+  const deadline = start + cacheWaitMs;
+  stats.lockWaits += 1;
+
+  while (nowMs() < deadline) {
+    const output = readCachedOutput(cachePath);
+    if (output !== null) {
+      stats.waitMs += nowMs() - start;
+      return output;
+    }
+    sleepSync(Math.min(cachePollMs, Math.max(0, deadline - nowMs())));
+  }
+  stats.waitMs += nowMs() - start;
+  return null;
+}
+
+function compileWithCache(filename: string, source: string, cachePath: string): string {
+  const cached = readCachedOutput(cachePath);
+  if (cached !== null) {
+    stats.cacheHits += 1;
+    return cached;
+  }
+  stats.cacheMisses += 1;
+
+  const lockPath = `${cachePath}.lock`;
+  let ownsLock = tryAcquireLock(lockPath, filename);
+  if (!ownsLock) {
+    const cachedAfterContention = readCachedOutput(cachePath);
+    if (cachedAfterContention !== null) {
+      stats.cacheHits += 1;
+      return cachedAfterContention;
+    }
+    ownsLock = reclaimStaleLock(lockPath, filename);
+  }
+
+  if (!ownsLock) {
+    const waited = waitForCache(cachePath);
+    if (waited !== null) {
+      stats.cacheHits += 1;
+      return waited;
+    }
+    stats.duplicateFallbacks += 1;
+    return transpileSource(source, filename);
+  }
+
+  try {
+    const outputText = transpileSource(source, filename);
+    writeAtomic(cachePath, outputText);
+    return outputText;
+  } finally {
+    fs.rmSync(lockPath, { force: true });
+  }
+}
+
+if (statsPath) {
+  process.once("exit", () => {
+    if (stats.files === 0) return;
+    const row = {
+      ...stats,
+      cacheDir,
+      label: process.env.NEMOCLAW_SOURCE_REQUIRE_STATS_LABEL ?? null,
+      pid: process.pid,
+      rssMb: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
+    };
+    fs.mkdirSync(path.dirname(statsPath), { recursive: true });
+    fs.appendFileSync(statsPath, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+  });
+}
 
 const resolveFilename = moduleRuntime._resolveFilename;
 moduleRuntime._resolveFilename = function resolveSourceFilename(request, parent, isMain, options) {
@@ -82,46 +273,11 @@ moduleRuntime._resolveFilename = function resolveSourceFilename(request, parent,
 };
 
 moduleRuntime._extensions[".ts"] = (module, filename) => {
+  const compileStart = nowMs();
+  stats.files += 1;
   const source = fs.readFileSync(filename, "utf8");
-  const cacheKey = crypto
-    .createHash("sha256")
-    .update(filename)
-    .update("\0")
-    .update(source)
-    .update("\0")
-    .update(compilerFingerprint)
-    .digest("hex");
-  const cachePath = path.join(cacheDir, `${cacheKey}.cjs`);
-  let outputText: string;
-
-  try {
-    outputText = fs.readFileSync(cachePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    const result = ts.transpileModule(source, {
-      compilerOptions,
-      fileName: filename,
-      reportDiagnostics: true,
-    });
-    const errors = result.diagnostics?.filter(
-      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
-    );
-    if (errors && errors.length > 0) {
-      throw new Error(
-        errors
-          .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
-          .join("\n"),
-      );
-    }
-    outputText = result.outputText;
-    const temporaryPath = `${cachePath}.${process.pid}.${crypto.randomUUID()}`;
-    fs.writeFileSync(temporaryPath, outputText, { flag: "wx", mode: 0o600 });
-    try {
-      fs.renameSync(temporaryPath, cachePath);
-    } catch (error) {
-      fs.rmSync(temporaryPath, { force: true });
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-    }
-  }
+  const cachePath = sourceRequireCachePath({ compilerOptions, filename, repoRoot, source });
+  const outputText = compileWithCache(filename, source, cachePath);
+  stats.compileMs += nowMs() - compileStart;
   module._compile(outputText, filename);
 };

--- a/test/helpers/source-require-cache.ts
+++ b/test/helpers/source-require-cache.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+import path from "node:path";
+import ts from "typescript";
+
+export function loadSourceRequireCompilerOptions(repoRoot: string): ts.CompilerOptions {
+  const configPath = path.join(repoRoot, "tsconfig.src.json");
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+
+  if (configFile.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    repoRoot,
+    {},
+    configPath,
+  );
+  if (parsedConfig.errors.length > 0) {
+    throw new Error(
+      parsedConfig.errors
+        .map((error) => ts.flattenDiagnosticMessageText(error.messageText, "\n"))
+        .join("\n"),
+    );
+  }
+
+  return {
+    ...parsedConfig.options,
+    declaration: false,
+    declarationMap: false,
+    inlineSourceMap: true,
+    inlineSources: true,
+    noEmit: false,
+    outDir: undefined,
+    rootDir: undefined,
+    sourceMap: false,
+  };
+}
+
+export function sourceRequireCacheDir(repoRoot: string): string {
+  return path.join(repoRoot, "node_modules", ".cache", "nemoclaw-source-require");
+}
+
+export function sourceRequireCompilerFingerprint(compilerOptions: ts.CompilerOptions): string {
+  return JSON.stringify({ compilerOptions, typescript: ts.version });
+}
+
+export function sourceRequireCachePath(options: {
+  compilerOptions: ts.CompilerOptions;
+  filename: string;
+  repoRoot: string;
+  source: string;
+}): string {
+  const cacheKey = crypto
+    .createHash("sha256")
+    .update(options.filename)
+    .update("\0")
+    .update(options.source)
+    .update("\0")
+    .update(sourceRequireCompilerFingerprint(options.compilerOptions))
+    .digest("hex");
+  return path.join(sourceRequireCacheDir(options.repoRoot), `${cacheKey}.cjs`);
+}

--- a/test/source-require-loader.test.ts
+++ b/test/source-require-loader.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  nodeOptionsWithoutSourceLoader,
+  SOURCE_REQUIRE_HOOK,
+} from "./helpers/source-loader-options";
+import {
+  sourceRequireCachePath as buildSourceRequireCachePath,
+  loadSourceRequireCompilerOptions,
+} from "./helpers/source-require-cache";
+
+type SourceRequireStats = {
+  cacheHits: number;
+  cacheMisses: number;
+  duplicateFallbacks: number;
+  files: number;
+  label: string | null;
+  staleLocks: number;
+  transforms: number;
+};
+
+const roots: string[] = [];
+const cacheArtifacts: string[] = [];
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const compilerOptions = loadSourceRequireCompilerOptions(REPO_ROOT);
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  for (const artifact of cacheArtifacts.splice(0)) {
+    fs.rmSync(artifact, { force: true });
+  }
+});
+
+function runFixtureRequire(
+  fixturePath: string,
+  statsPath: string,
+  env: Record<string, string> = {},
+): void {
+  const script = `
+require(${JSON.stringify(SOURCE_REQUIRE_HOOK)});
+const fixture = require(${JSON.stringify(fixturePath)});
+process.exitCode = fixture.value === 42 ? 0 : 7;
+`;
+  const result = spawnSync(process.execPath, ["-e", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NEMOCLAW_SOURCE_REQUIRE_STATS: statsPath,
+      NEMOCLAW_SOURCE_REQUIRE_STATS_LABEL: "source-require-loader-test",
+      NODE_OPTIONS: nodeOptionsWithoutSourceLoader(process.env.NODE_OPTIONS),
+      ...env,
+    },
+    timeout: 10_000,
+  });
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+}
+
+function exitedChildPid(): number {
+  const result = spawnSync(process.execPath, ["-e", ""], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  expect(result.pid).toBeGreaterThan(0);
+  return result.pid;
+}
+
+function sourceRequireCachePath(filename: string): string {
+  return buildSourceRequireCachePath({
+    compilerOptions,
+    filename,
+    repoRoot: REPO_ROOT,
+    source: fs.readFileSync(filename, "utf8"),
+  });
+}
+
+function readStats(statsPath: string): SourceRequireStats[] {
+  return fs
+    .readFileSync(statsPath, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line) as SourceRequireStats);
+}
+
+describe("source require loader", () => {
+  it("emits opt-in cache statistics and reuses a cross-process cache entry", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    cacheArtifacts.push(sourceRequireCachePath(fs.realpathSync(fixturePath)));
+
+    runFixtureRequire(fixturePath, statsPath);
+    runFixtureRequire(fixturePath, statsPath);
+
+    const rows = readStats(statsPath);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      cacheHits: 0,
+      cacheMisses: 1,
+      files: 1,
+      label: "source-require-loader-test",
+      transforms: 1,
+    });
+    expect(rows[1]).toMatchObject({
+      cacheHits: 1,
+      cacheMisses: 0,
+      files: 1,
+      label: "source-require-loader-test",
+      transforms: 0,
+    });
+  });
+
+  it("reclaims dead cache locks before falling back to duplicate transpilation", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-stale-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    const fixtureRealPath = fs.realpathSync(fixturePath);
+
+    const cachePath = sourceRequireCachePath(fixtureRealPath);
+    const lockPath = `${cachePath}.lock`;
+    cacheArtifacts.push(cachePath, lockPath);
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.rmSync(cachePath, { force: true });
+    fs.writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        filename: fixtureRealPath,
+        pid: exitedChildPid(),
+        startedAtMs: Date.now() - 60_000,
+      })}\n`,
+      { mode: 0o600 },
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
+
+    runFixtureRequire(fixtureRealPath, statsPath, {
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS: "1",
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS: "1",
+    });
+
+    const [row] = readStats(statsPath);
+    expect(row).toMatchObject({
+      cacheMisses: 1,
+      duplicateFallbacks: 0,
+      staleLocks: 1,
+      transforms: 1,
+    });
+    expect(fs.existsSync(cachePath)).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- coordinate cross-process source-require cache misses with a per-cache-entry lock so parallel Vitest workers do not all transpile the same cold TypeScript file
- add opt-in `NEMOCLAW_SOURCE_REQUIRE_STATS` JSONL output for source-loader cache, wait, transform, and memory diagnostics
- cover the hook with a child-process regression test that proves a second process reuses the compiled cache entry

## Impact
- Parallel smoke with 8 child processes requiring the same cold TypeScript fixture: 1 transform, 7 cache hits, 7 lock waits, 0 duplicate fallbacks, 2073 ms elapsed.
- Cold `--shard=2/5` stats on this machine: 103 source-loader processes, 32,030 `.ts` loads, 31,565 cache hits, 465 transforms, 31 lock waits, 0 duplicate fallbacks.

## Validation
- `npx vitest run --project integration test/source-require-loader.test.ts`
- `npx vitest run --project integration test/source-require-loader.test.ts test/gateway-drift-preflight.test.ts --project cli src/lib/actions/sandbox/rebuild-gateway-drift.test.ts`
- `npx vitest run --project cli --project integration test/gateway-drift-preflight.test.ts src/lib/actions/sandbox/rebuild-gateway-drift.test.ts --coverage --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli/issue-6237-after --coverage.include="bin/**/*.js" --coverage.include="src/**/*.ts" --coverage.exclude="test/**/*.js" --coverage.exclude="test/**/*.ts"`
- `npx @biomejs/biome check test/helpers/register-source-require.ts test/source-require-loader.test.ts`
- `npm run test-size:check`
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run check:diff`

## Shard attempt
- Also ran the #6237-style cold `--shard=2/5` coverage command with source-loader stats enabled. It completed without source-loader hook timeouts.
- That local macOS run still failed 4 unrelated shell-runtime integration cases because this environment lacks Linux/GNU shell assumptions (`BASHPID`, `timeout`, and bash arrays in sourced scripts).

Refs #6237.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-process compiled-output caching to improve source-loading performance.
  * Introduced optional JSONL statistics output (timings, cache hits/misses) for monitoring.
* **Bug Fixes**
  * Reduced redundant recompilation by coordinating cache creation across concurrent processes.
  * Improved handling of stale cache locks to maintain cache correctness.
* **Tests**
  * Added Vitest coverage for cache hit/miss transitions and stale-lock reclamation, including deterministic cache targeting and stats validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: Ho Lim <subhoya@gmail.com>
