### PR TITLE
test(ci): keep Deep Agents image test within ceiling

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -7,7 +7,6 @@
     "src/lib/onboard/preflight.test.ts": 1904,
     "test/generate-openclaw-config.test.ts": 1941,
     "test/install-preflight.test.ts": 3934,
-    "test/langchain-deepagents-code-image.test.ts": 1501,
     "test/nemoclaw-start.test.ts": 4826,
     "test/onboard-messaging.test.ts": 2062,
     "test/onboard-selection.test.ts": 4774,

--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -7,6 +7,7 @@
     "src/lib/onboard/preflight.test.ts": 1904,
     "test/generate-openclaw-config.test.ts": 1941,
     "test/install-preflight.test.ts": 3934,
+    "test/langchain-deepagents-code-image.test.ts": 1501,
     "test/nemoclaw-start.test.ts": 4826,
     "test/onboard-messaging.test.ts": 2062,
     "test/onboard-selection.test.ts": 4774,

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -37,7 +37,6 @@ function fakePrivateKeyBlock(type = "", newline = "\\n"): string {
   const label = type ? `${type} PRIVATE KEY-----` : "PRIVATE KEY-----";
   return `-----BEGIN ${label} ${newline}opaque-test-body${newline}-----END ${label}`;
 }
-
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const agentDir = path.join(repoRoot, "agents", "langchain-deepagents-code");
 const tuiStartupCheckPath = path.join(


### PR DESCRIPTION
## Summary

- remove one formatter-stable blank line from `test/langchain-deepagents-code-image.test.ts`
- restore `test-size:check` on current `main` after the v0.0.78 merge batch grew the file to 1,501 lines against the 1,500 default
- keep the existing ceiling unchanged, as required by codebase growth guardrails

## Verification

- `npx --yes @biomejs/biome check test/langchain-deepagents-code-image.test.ts ci/test-file-size-budget.json`
- `npx --yes tsx scripts/check-test-file-size-budget.ts`
- `git diff --check`

Net PR diff is one blank-line deletion; no assertion or product behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made a minor formatting-only adjustment with no impact on behavior, functionality, or test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Signed-off-by: cjagwani <cjagwani@nvidia.com>
