### PR TITLE
docs(contributing): clarify extension terminology checklist

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,6 +138,20 @@ Run targeted tests once per relevant change set only when the change also touche
 Reserve `npm test` for broad runtime or test-harness changes.
 Reserve `npm run check` for repo-wide validation or coverage-baseline changes.
 
+## Extensibility Terminology Checklist
+
+Use this checklist when you write or review docs for contribution surfaces, messaging channels, managed packages, policies, manifests, or future extension concepts.
+It gives contributors a quick terminology check without replacing the extension taxonomy and SDK readiness decision record from PR #6508.
+
+- Use `lifecycle contribution` for a NemoClaw-managed addition to sandbox setup, policy, configuration, onboarding, rebuild, recovery, or documentation flows.
+- Use `managed agent package` for a reviewed package that NemoClaw installs or configures for an agent through a trusted built-in path.
+- Use `agent-native plugin` only for plugins owned by OpenClaw, Hermes, Deep Agents Code, or another agent runtime.
+- Treat `NemoClaw plugin SDK` as a reserved future public SDK concept, not a current product surface.
+- Do not describe managed packages, policy presets, channel manifests, or compatibility manifests as a current NemoClaw plugin SDK.
+- Keep the ownership boundaries separate: #5998 covers the VoiceClaw managed-package and messaging-channel integration path, #6097 covers internal messaging channel organization, #3915 covers future observability extension work, #6201 covers OpenClaw voice-call plugin and provider work, and #6207 covers OpenShell sandbox and networking contracts.
+- Do not combine those issue scopes or reclassify one boundary as another.
+- Do not promise SDK, registry, CLI, semantic-versioning, migration, or compatibility commitments unless a separate accepted decision and implementation already provide them.
+
 ## Writing Conventions
 
 ### Format

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -148,6 +148,7 @@ It gives contributors a quick terminology check without replacing the extension 
 - Use `agent-native plugin` only for plugins owned by OpenClaw, Hermes, Deep Agents Code, or another agent runtime.
 - Treat `NemoClaw plugin SDK` as a reserved future public SDK concept, not a current product surface.
 - Do not describe managed packages, policy presets, channel manifests, or compatibility manifests as a current NemoClaw plugin SDK.
+- State that NemoClaw does not currently run arbitrary third-party code through a public plugin SDK; managed agent packages must stay reviewed and installed through trusted built-in paths.
 - Keep the ownership boundaries separate: #5998 covers the VoiceClaw managed-package and messaging-channel integration path, #6097 covers internal messaging channel organization, #3915 covers future observability extension work, #6201 covers OpenClaw voice-call plugin and provider work, and #6207 covers OpenShell sandbox and networking contracts.
 - Do not combine those issue scopes or reclassify one boundary as another.
 - Do not promise SDK, registry, CLI, semantic-versioning, migration, or compatibility commitments unless a separate accepted decision and implementation already provide them.


### PR DESCRIPTION
## Summary
- Clarify the contributor-facing extensibility terminology checklist in `docs/CONTRIBUTING.md`.
- Reference PR #6508 as the separate decision record without duplicating it.
- Keep ownership boundaries for #5998, #6097, #3915, #6201, and #6207 separate.

## Verification
- Broker validation `docs` passed.
- Final broker repository status shows only `docs/CONTRIBUTING.md` changed.

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

Request broker-controlled commit, push, and draft PR creation.