### PR TITLE
docs(skills): add engineering behavior guidelines

### DIFF
--- a/.agents/skills/nemoclaw-contributor-engineering-guidelines/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-engineering-guidelines/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: nemoclaw-contributor-engineering-guidelines
+description: Apply NemoClaw engineering behavior guidelines while implementing, reviewing, refactoring, or diagnosing code. Use when defining success criteria, resolving material ambiguity, controlling change scope or complexity, verifying a fix, or addressing a defect found by QA so both the product root cause and the engineering detection gap are closed. Trigger keywords - engineering guidelines, implement, code review, refactor, bug fix, QA defect, escaped defect, root cause, regression test.
+---
+
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Apply NemoClaw Engineering Guidelines
+
+Use these principles for implementation, review, refactoring, and defect investigation.
+Scale the detail to the risk and ambiguity of the change; do not turn routine work into ceremony.
+Treat the root `AGENTS.md` and any narrower package `AGENTS.md` as project constraints.
+Use this skill to reason about the change; use the repository's contributor skills and commands for setup, verification, and pull request mechanics.
+
+## Make Assumptions Reviewable
+
+1. Restate the requested outcome and observable success criteria.
+2. List assumptions that materially affect behavior, security, compatibility, data, or a public contract.
+3. Separate verified facts from inferences and cite the evidence behind consequential choices.
+4. Surface meaningfully different interpretations and their tradeoffs.
+5. Ask before implementation when choosing an interpretation would change the intended outcome.
+6. For routine details that do not change the outcome, follow existing patterns and state the choice without blocking progress.
+
+Do not hide uncertainty behind an implementation choice.
+
+## Build the Smallest Sufficient Change
+
+- Implement the stated acceptance criteria and nothing speculative.
+- Prefer an existing extension point or direct solution over a new framework for one known case.
+- Add configuration, abstraction, fallback behavior, or generality only when the current requirement demonstrates the need.
+- Match the surrounding architecture and style even when another approach is personally preferable.
+- Simplify before handoff when the implementation is larger or more indirect than the behavior requires.
+
+## Keep Changes Issue-Scoped
+
+- Make every changed line traceable to the requested outcome, its verification, or cleanup caused by the change.
+- Avoid drive-by refactoring, formatting, comment rewrites, renames, and unrelated cleanup.
+- Remove imports, variables, branches, or helpers made obsolete by the current change.
+- Report unrelated debt separately instead of including it silently.
+- Explain and obtain agreement before expanding the scope beyond the issue or acceptance criteria.
+- Review the final diff against the trusted base, not only the files expected to change.
+
+## Define and Verify the Outcome
+
+1. Convert the request into observable success criteria before editing.
+2. For a defect, reproduce the failure before fixing it when feasible. If reproduction is impractical, record why and identify equivalent evidence.
+3. Choose the narrowest stable test or inspection that proves the behavior rather than the implementation detail.
+4. Make the change, run the targeted evidence, and iterate until the criteria are satisfied.
+5. Rerun evidence after later edits or automated fixes that can affect the behavior.
+6. Follow the verification commands and broad-gate boundaries in the root `AGENTS.md` and `nemoclaw-contributor-create-pr`; do not invent a duplicate or broader gate.
+
+Passing an unrelated broad suite does not replace evidence for the changed behavior.
+
+## Root-Cause Escaped Defects
+
+When QA discovers a defect, treat it as two connected failures:
+
+1. **Product failure:** the behavior was incorrect.
+2. **Detection gap:** engineering controls did not expose the incorrect behavior before QA.
+
+Perform an escape analysis proportional to the defect's risk.
+Do not require a heavyweight postmortem when a concise analysis closes the gap.
+
+1. Reproduce the reported behavior at the earliest stable boundary that can express it when doing so is feasible and safe.
+2. Establish the product root cause instead of patching only the observed input or symptom.
+3. Identify why the defect escaped. Check for an unstated invariant, incorrect assumption, missing or ineffective coverage, testing at the wrong boundary, a review blind spot, CI or environment mismatch, or insufficient diagnostics.
+4. Fix the product root cause and the smallest durable detection gap.
+5. Add regression evidence at the earliest stable boundary that would have caught the failure.
+6. Add higher-level coverage only when it protects a distinct integration boundary.
+7. Define and perform a bounded search across adjacent paths that share the failed invariant or implementation mechanism.
+8. Record the analysis without assigning individual blame, and label uncertain conclusions as inferences.
+
+Use this compact record in the issue, pull request, or handoff when the defect escaped to QA:
+
+```text
+Product failure:
+Product root cause:
+Detection gap:
+Prevention evidence:
+Adjacent check:
+```
+
+## Apply the Principles
+
+- **Ambiguous request:** Before adding a custom endpoint, establish how omitted, empty, and invalid values should behave when those choices affect the public contract.
+- **Unnecessary generality:** Extend the existing manifest for one provider instead of creating a plugin framework without a second demonstrated use case.
+- **Surgical fix:** Change the failing parser path and its regression coverage without renaming adjacent helpers or reformatting unrelated files.
+- **Verifiable outcome:** Demonstrate that the regression fails before the fix and passes after it, then run only the relevant surrounding coverage.
+- **QA escape:** If unit tests covered parsed values but QA exposed a serialization-boundary failure, fix the serialization root cause, add a contract test at that boundary, and inspect sibling serializers. Add an end-to-end test only if it protects a separate failure mode.
+
+## Final Check
+
+Before handoff, confirm:
+
+- Material assumptions and tradeoffs are visible.
+- The design is the smallest one that meets the acceptance criteria.
+- Every changed line belongs to the requested outcome.
+- Verification directly proves the changed behavior.
+- Any QA-escaped defect includes both product root cause and detection-gap evidence.
+- Unrelated findings are reported without being folded into the change.

--- a/.agents/skills/nemoclaw-contributor-engineering-guidelines/agents/openai.yaml
+++ b/.agents/skills/nemoclaw-contributor-engineering-guidelines/agents/openai.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+interface:
+  display_name: "NemoClaw Engineering Guidelines"
+  short_description: "Apply focused, verifiable engineering practices"
+  default_prompt: "Use $nemoclaw-contributor-engineering-guidelines to plan and implement this change with explicit assumptions, minimal scope, verification, and escape analysis when applicable."

--- a/.agents/skills/nemoclaw-skills-guide/SKILL.md
+++ b/.agents/skills/nemoclaw-skills-guide/SKILL.md
@@ -27,10 +27,10 @@ Covers routing human users' AI agents to the canonical NemoClaw Markdown documen
 For project maintainers.
 Covers the daily maintainer cadence (morning standup, daytime loop, evening handoff), workflow policy reference, cutting releases, drafting release notes, finding PRs to review, comparing PRs, cross-issue sweeps, triage, normalizing issue and PR title tags, performing security code reviews, and verifying whether stale bug reports still reproduce on the latest release.
 
-### `nemoclaw-contributor-*` (4 skills)
+### `nemoclaw-contributor-*` (5 skills)
 
 For contributors to the NemoClaw codebase.
-Covers trusted checkout setup and readiness checks, creating pull requests that follow the project template, monitoring CI and automated review feedback, drafting documentation updates, and onboarding new messaging channels.
+Covers shared engineering behavior for focused and verifiable changes, trusted checkout setup and readiness checks, creating pull requests that follow the project template, monitoring CI and automated review feedback, drafting documentation updates, and onboarding new messaging channels.
 
 ## Skill Catalog
 
@@ -65,6 +65,7 @@ Covers trusted checkout setup and readiness checks, creating pull requests that 
 | Skill | Summary |
 |-------|---------|
 | `nemoclaw-contributor-onboard` | Set up, repair, or verify a trusted source checkout, with explicit opt-ins for host-visible CLI exposure, the pinned agent, and runtime onboarding. |
+| `nemoclaw-contributor-engineering-guidelines` | Apply shared engineering behavior for explicit assumptions, minimal and issue-scoped changes, direct verification, and root-cause analysis of defects that escape to QA. |
 | `nemoclaw-contributor-create-pr` | Create GitHub pull requests that follow the NemoClaw PR template, including pre-PR checks, conventional commit titles, DCO sign-off, post-push CI monitoring, and CodeRabbit/PR Review Advisor follow-up. |
 | `nemoclaw-contributor-onboard-messaging-channel` | Add or review a new messaging channel with manifest-first implementation, upstream source analysis, plugin install confirmation, reachability checks, policies, docs, and tests. |
 | `nemoclaw-contributor-update-docs` | Scan recent git commits for user-facing changes and draft or update documentation pages during release prep. |
@@ -82,7 +83,7 @@ Skills are cumulative. Each role includes the skills from the roles above it:
 | Role | Skills included | Count | Start with |
 |------|----------------|-------|------------|
 | User | `nemoclaw-user-*` | 1 | `nemoclaw-user-guide` |
-| Contributor | `nemoclaw-user-*` + `nemoclaw-contributor-*` | 5 | `nemoclaw-contributor-onboard` |
-| Maintainer | All skills | 18 | `nemoclaw-maintainer-morning` |
+| Contributor | `nemoclaw-user-*` + `nemoclaw-contributor-*` | 6 | `nemoclaw-contributor-onboard` |
+| Maintainer | All skills | 19 | `nemoclaw-maintainer-morning` |
 
 After identifying the role, present the applicable skills from the Skill Catalog above and recommend the starting skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,18 @@ NemoClaw isolates agents inside OpenShell sandboxes with:
 
 Security-sensitive code paths require extra test coverage.
 
+## Engineering Behavior
+
+Apply these principles to implementation, review, refactoring, and defect investigation:
+
+- **Make assumptions reviewable.** State assumptions and meaningfully different interpretations when they affect behavior, security, compatibility, data, or a public contract. Ask before implementation when the choice would change the intended outcome.
+- **Build the smallest sufficient change.** Implement the acceptance criteria without speculative features, abstractions, configuration, or fallback behavior. Follow existing architecture and local patterns.
+- **Keep changes issue-scoped.** Make every changed line traceable to the requested outcome, its verification, or cleanup caused by the change. Report unrelated debt instead of including drive-by changes.
+- **Define and verify the outcome.** Establish observable success criteria, reproduce defects before fixing them when feasible, and use the narrowest stable evidence that proves the changed behavior.
+- **Root-cause escaped defects.** When QA finds a defect, identify both the product root cause and the engineering detection gap. Close the smallest durable gap, check adjacent code for the same failure class, and record prevention evidence without assigning individual blame.
+
+Load [`nemoclaw-contributor-engineering-guidelines`](.agents/skills/nemoclaw-contributor-engineering-guidelines/SKILL.md) for the expanded workflow and examples.
+
 ## Code Style and Conventions
 
 ### Commit Messages


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds repository-wide engineering behavior principles and a reusable contributor skill for explicit assumptions, minimal scope, direct verification, and QA escape analysis. Defects found by QA now call for both a product root cause and an engineering detection-gap analysis without imposing heavyweight RCA on routine work.

## Related Issue
Closes #6515.

## Changes
- Add five concise engineering behavior principles to `AGENTS.md`.
- Add `nemoclaw-contributor-engineering-guidelines` with working procedures, examples, and UI metadata.
- Register the skill and update contributor and cumulative counts in the NemoClaw skills guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Instructional Markdown and UI metadata only; existing structural validation automatically discovers the new skill.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal contributor and coding-agent guidance only; no end-user or Fern behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/skills-frontmatter.test.ts` passed 26 tests; the standalone skill validator also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused guidance-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
