### PR TITLE
ci(codeql): repair and guard action version sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      # CodeQL steps exchange state and reject mixed action versions.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -41,7 +41,7 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
 
   shellcheck:
     name: ShellCheck SARIF

--- a/test/code-scanning-workflow.test.ts
+++ b/test/code-scanning-workflow.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { readYaml, type Workflow } from "./helpers/e2e-workflow-contract";
+
+type DependabotUpdate = {
+  "package-ecosystem"?: string;
+  directory?: string;
+  groups?: Record<string, { patterns?: string[] }>;
+};
+
+const workflow = readYaml<Workflow>(".github/workflows/code-scanning.yaml");
+const dependabot = readYaml<{ updates?: DependabotUpdate[] }>(".github/dependabot.yml");
+
+const codeqlActionPrefix = "github/codeql-action/";
+
+describe("Code scanning workflow dependency updates", () => {
+  it("keeps every CodeQL action on one immutable revision", () => {
+    const codeqlActions = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .map((step) => step.uses)
+      .filter((uses): uses is string => uses?.startsWith(codeqlActionPrefix) ?? false);
+
+    expect(
+      codeqlActions.map((uses) => uses.slice(codeqlActionPrefix.length).split("@")[0]).sort(),
+    ).toEqual(["analyze", "init", "upload-sarif"]);
+
+    const revisions = codeqlActions.map((uses) => uses.split("@")[1]);
+    expect(revisions).toHaveLength(3);
+    for (const revision of revisions) {
+      expect(revision).toMatch(/^[0-9a-f]{40}$/);
+    }
+    expect(new Set(revisions).size).toBe(1);
+  });
+
+  it("groups CodeQL action updates so Dependabot keeps the shared revision synchronized", () => {
+    const githubActionsUpdate = dependabot.updates?.find(
+      (update) => update["package-ecosystem"] === "github-actions" && update.directory === "/",
+    );
+    const groups = Object.values(githubActionsUpdate?.groups ?? {});
+
+    expect(groups.some((group) => group.patterns?.includes("github/codeql-action/*"))).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Repair the mixed CodeQL Action versions that broke the `Security / Code Scanning` workflow, then prevent the same failure from recurring by grouping CodeQL Dependabot updates and enforcing one shared immutable revision in CI. This is a prevention-complete superset of the repair-only #6524, which appeared while this change was in progress.

## Changes
<!-- Bullet list of key changes. -->

- Align `github/codeql-action/analyze` with the v4.37.0 revision already used by `init` and `upload-sarif`.
- Group `github/codeql-action/*` dependencies so Dependabot updates all CodeQL components atomically.
- Add an integration contract test that requires all three CodeQL components, full SHA pins, one shared revision, and the Dependabot group.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal CI dependency management only; installation, runtime behavior, commands, configuration, and user-facing policy schemas are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The focused workflow review confirmed that triggers, permissions, languages, queries, and SARIF behavior are unchanged; only the reviewed CodeQL SHA is aligned, with a regression contract added.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/code-scanning-workflow.test.ts` passed (2 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this is a focused workflow/configuration contract change covered by the targeted test and normal hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Code Scanning’s GitHub Actions configuration to keep CodeQL action versions aligned and pinned consistently.
  * Improved dependency update grouping so related CodeQL updates stay synchronized.

* **Tests**
  * Added checks to verify the Code Scanning workflow uses only the expected CodeQL actions and immutable revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->