### PR TITLE
fix(onboard): drop stale disabled web-search providers

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2749,7 +2749,7 @@ async function createSandboxWithBaseImageResolution(
     messagingTokenDefs,
     reusableMessagingChannels,
     reusableMessagingProviders,
-    extraProviders: registry.listExtraProviders(),
+    ...sandboxCreatePlan.extraProviderSelection(registry.listExtraProviders(), webSearchConfig),
     hermesToolGateways,
     sandboxGpuConfig: effectiveSandboxGpuConfig,
     dockerDriverGateway,

--- a/src/lib/onboard/sandbox-create-plan.test.ts
+++ b/src/lib/onboard/sandbox-create-plan.test.ts
@@ -589,6 +589,46 @@ describe("prepareSandboxCreatePlan", () => {
     expect(providerArgs).toEqual(["tavily-search", "custom-provider"]);
   });
 
+  it("keeps only the selected managed web-search extra provider", () => {
+    const result = prepareSandboxCreatePlan({
+      basePolicyPath: "/repo/policy.yaml",
+      buildCtx: "/tmp/nemoclaw-build-1",
+      sandboxName: "sandbox",
+      channels,
+      enabledChannels: [],
+      disabledChannelNames: new Set(),
+      messagingTokenDefs: [],
+      reusableMessagingChannels: [],
+      reusableMessagingProviders: [],
+      extraProviders: ["brave-search", "tavily-search", "custom-provider"],
+      webSearchConfig: { fetchEnabled: true, provider: "brave" },
+      hermesToolGateways: [],
+      sandboxGpuConfig,
+      dockerDriverGateway: true,
+      appendResourceFlags: vi.fn(),
+      runProviderPreDeleteCleanup: vi.fn(),
+      upsertMessagingProviders: vi.fn(() => []),
+      getMessagingChannelForEnvKey: () => null,
+      getHermesToolGatewayProviderName: vi.fn(),
+      deps: {
+        resolveDockerGpuSandboxCreatePlan: vi.fn(() => ({
+          useDockerGpuPatch: false,
+          logMessage: null,
+        })),
+        prepareInitialSandboxCreatePolicy: vi.fn(() => ({
+          policyPath: "/tmp/policy.yaml",
+          appliedPresets: [],
+        })),
+        buildSandboxGpuCreateArgs: vi.fn(() => []),
+      },
+    });
+
+    const providerArgs = result.createArgs
+      .map((arg, index) => (arg === "--provider" ? result.createArgs[index + 1] : null))
+      .filter((value): value is string => value !== null);
+    expect(providerArgs).toEqual(["brave-search", "custom-provider"]);
+  });
+
   it("does not duplicate an extra provider that is already a messaging provider", () => {
     const result = prepareSandboxCreatePlan({
       basePolicyPath: "/repo/policy.yaml",

--- a/src/lib/onboard/sandbox-create-plan.ts
+++ b/src/lib/onboard/sandbox-create-plan.ts
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  WEB_SEARCH_PROVIDERS,
+  type WebSearchConfig,
+  webSearchProviderForConfig,
+} from "../inference/web-search";
+import {
   listMessagingCredentialMetadata,
   type MessagingCredentialMetadata,
 } from "../messaging/channels";
@@ -32,6 +37,9 @@ export type {
 // tier there requires updating this set so an explicit tier env value reaches
 // the create-time policy decision.
 const KNOWN_POLICY_TIER_NAMES = new Set(["restricted", "balanced", "open"]);
+const MANAGED_WEB_SEARCH_EXTRA_PROVIDERS = new Set(
+  WEB_SEARCH_PROVIDERS.map((provider) => `${provider}-search`),
+);
 
 function readPolicyTierEnv(): string | null {
   // Only trust the env value in non-interactive mode. Interactive flows let the
@@ -70,6 +78,11 @@ export type PrepareSandboxCreatePlanInput = {
   reusableMessagingChannels: string[];
   reusableMessagingProviders: string[];
   extraProviders?: readonly string[];
+  /**
+   * Undefined keeps generic planner callers unchanged. Null is an
+   * authoritative onboard/rebuild decision to disable managed web search.
+   */
+  webSearchConfig?: WebSearchConfig | null;
   hermesToolGateways: string[];
   sandboxGpuConfig: SandboxGpuCreateConfig;
   dockerDriverGateway: boolean;
@@ -96,6 +109,13 @@ export type SandboxCreatePlan = {
   useDockerGpuPatch: boolean;
   sandboxGpuLogMessage: string | null;
 };
+
+export function extraProviderSelection(
+  extraProviders: readonly string[],
+  webSearchConfig: WebSearchConfig | null,
+): Pick<PrepareSandboxCreatePlanInput, "extraProviders" | "webSearchConfig"> {
+  return { extraProviders, webSearchConfig };
+}
 
 function getDockerGpuSandboxCreatePlan(
   ...args: Parameters<ResolveDockerGpuSandboxCreatePlan>
@@ -146,6 +166,21 @@ function filterMessagingProvidersByEnabledChannel(
     const channel = providerChannels.get(providerName);
     return !channel || !disabledChannelNames.has(channel);
   });
+}
+
+function normalizeExtraProvidersForWebSearch(
+  extraProviders: readonly string[] | undefined,
+  webSearchConfig: WebSearchConfig | null | undefined,
+): string[] {
+  const normalized = [...new Set(extraProviders ?? [])].filter(Boolean);
+  if (webSearchConfig === undefined) return normalized;
+  const selectedWebSearchProvider = webSearchConfig
+    ? `${webSearchProviderForConfig(webSearchConfig)}-search`
+    : null;
+  return normalized.filter(
+    (provider) =>
+      !MANAGED_WEB_SEARCH_EXTRA_PROVIDERS.has(provider) || provider === selectedWebSearchProvider,
+  );
 }
 
 function resolveActiveMessagingChannels({
@@ -411,6 +446,7 @@ export function prepareSandboxCreatePlan({
   reusableMessagingChannels,
   reusableMessagingProviders,
   extraProviders,
+  webSearchConfig,
   hermesToolGateways,
   sandboxGpuConfig,
   dockerDriverGateway,
@@ -446,7 +482,7 @@ export function prepareSandboxCreatePlan({
     primaryMessagingCredentialEnvKeys: [...getPrimaryCredentialEnvKeys()],
     reusableMessagingChannels,
     reusableMessagingProviders,
-    extraProviders,
+    extraProviders: normalizeExtraProvidersForWebSearch(extraProviders, webSearchConfig),
     hermesToolGateways,
     sandboxGpuConfig,
     gpuCreateArgs,

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -1877,7 +1877,7 @@ const { createSandbox } = require(${onboardPath});
       entry.command.includes("sandbox create"),
     );
     assert.ok(createCommand, "expected sandbox create command");
-    assert.match(createCommand.command, /(?=.*nemoclaw-start)(?=.*--provider tavily-search)/);
+    assert.match(createCommand.command, /^(?=.*nemoclaw-start)(?!.*--provider tavily-search)/s);
     assert.doesNotMatch(createCommand.command, /--upload/);
     assert.doesNotMatch(createCommand.command, /OPENCLAW_CONFIG_PATH/);
     assert.doesNotMatch(createCommand.command, /NVIDIA_INFERENCE_API_KEY=/);


### PR DESCRIPTION
## Summary
- treat `webSearchConfig: null` as an authoritative managed web-search disable when preparing sandbox create providers
- filter stale `brave-search` / `tavily-search` extra providers while preserving unrelated custom extra providers
- update sandbox create coverage so a stale `tavily-search` registry entry no longer reaches `openshell sandbox create` when web search is disabled

## Tests
- `npm run build:cli`
- `npx vitest run src/lib/onboard/sandbox-create-plan.test.ts test/onboard.test.ts`
- `npx vitest run test/onboard.test.ts -t "builds the sandbox without uploading an external OpenClaw config file"`
- `npm run check:diff`

## DCO
- [x] I certify that this contribution is submitted under the Developer Certificate of Origin and the commit is signed off with `Signed-off-by`.

Closes #6501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox plan generation to correctly honor web search configuration.
  * When web search is explicitly disabled, web-search-related providers are excluded from generated provider flags.
  * Provider selection for web search is now derived from the chosen configuration.
* **Tests**
  * Added coverage for selecting the managed web-search provider while excluding other web-search providers.
  * Tightened sandbox creation command assertions to ensure only the expected provider flags are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->