### PR TITLE
fix(rebuild): preserve legacy OpenClaw restores

### DIFF
--- a/src/lib/state/sandbox-recreated-openclaw-restore.test.ts
+++ b/src/lib/state/sandbox-recreated-openclaw-restore.test.ts
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { OpenClawImagePluginInstall } from "./openclaw-plugin-restore.js";
+import { restoreRecreatedSandboxState } from "./sandbox.js";
+
+const OPENCLAW_DIR = "/sandbox/.openclaw";
+
+function imageInstall(id: string, extensionDir: string): OpenClawImagePluginInstall {
+  const installPath = `${OPENCLAW_DIR}/extensions/${extensionDir}`;
+  return { id, installPath, loadPaths: [installPath] };
+}
+
+function writeExecutable(filePath: string, source: string): void {
+  fs.writeFileSync(filePath, source, { mode: 0o755 });
+}
+
+function extensionDir(install: OpenClawImagePluginInstall): string | null {
+  const prefix = `${OPENCLAW_DIR}/extensions/`;
+  return install.installPath.startsWith(prefix) ? install.installPath.slice(prefix.length) : null;
+}
+
+function runRestoreScenario(options: {
+  backupConfig: Record<string, unknown>;
+  backupExtensionDirs: string[];
+  freshConfig: Record<string, unknown>;
+  freshPluginInstalls: OpenClawImagePluginInstall[];
+  previousPluginInstalls?: OpenClawImagePluginInstall[];
+}): {
+  cleanupCommand: string | undefined;
+  freshMarkers: Record<string, string>;
+  restore: ReturnType<typeof restoreRecreatedSandboxState>;
+  restoredConfig: Record<string, any>;
+  staleUserExtensionExists: boolean;
+  userExtensionMarker: string;
+} {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-recreated-restore-"));
+  const previousOpenshellBin = process.env.NEMOCLAW_OPENSHELL_BIN;
+  const previousPath = process.env.PATH;
+  try {
+    const binDir = path.join(fixture, "bin");
+    const openclawDir = path.join(fixture, "sandbox-root", ".openclaw");
+    const extensionsDir = path.join(openclawDir, "extensions");
+    const backupPath = path.join(fixture, "backup");
+    const backupExtensionsDir = path.join(backupPath, "extensions");
+    const sshLog = path.join(fixture, "ssh-log.jsonl");
+    const freshExtensionDirs = [
+      "nemoclaw",
+      ...options.freshPluginInstalls
+        .map(extensionDir)
+        .filter((entry): entry is string => entry !== null),
+    ];
+    fs.mkdirSync(binDir, { recursive: true });
+
+    for (const extensionName of freshExtensionDirs) {
+      const target = path.join(extensionsDir, extensionName);
+      fs.mkdirSync(target, { recursive: true });
+      fs.writeFileSync(path.join(target, "marker.txt"), `fresh-${extensionName}\n`);
+    }
+    fs.mkdirSync(path.join(extensionsDir, "stale-user-extension"), { recursive: true });
+    fs.writeFileSync(path.join(extensionsDir, "stale-user-extension", "marker.txt"), "stale\n");
+
+    for (const extensionName of ["nemoclaw", ...options.backupExtensionDirs]) {
+      const target = path.join(backupExtensionsDir, extensionName);
+      fs.mkdirSync(target, { recursive: true });
+      fs.writeFileSync(path.join(target, "marker.txt"), `old-${extensionName}\n`);
+    }
+    fs.mkdirSync(path.join(backupExtensionsDir, "user-extension"), { recursive: true });
+    fs.writeFileSync(path.join(backupExtensionsDir, "user-extension", "marker.txt"), "restored\n");
+
+    fs.mkdirSync(backupPath, { recursive: true });
+    fs.writeFileSync(path.join(backupPath, "openclaw.json"), JSON.stringify(options.backupConfig));
+    fs.writeFileSync(path.join(openclawDir, "openclaw.json"), JSON.stringify(options.freshConfig));
+    const manifest: Record<string, unknown> = {
+      version: 1,
+      sandboxName: "alpha",
+      timestamp: "2026-07-08T12-00-00-000Z",
+      agentType: "openclaw",
+      agentVersion: null,
+      expectedVersion: null,
+      stateDirs: ["extensions"],
+      backedUpDirs: ["extensions"],
+      stateFiles: [{ path: "openclaw.json", strategy: "copy" }],
+      dir: OPENCLAW_DIR,
+      backupPath,
+      blueprintDigest: null,
+    };
+    if (options.previousPluginInstalls !== undefined) {
+      manifest.openclawImagePluginInstalls = options.previousPluginInstalls;
+    }
+    fs.writeFileSync(path.join(backupPath, "rebuild-manifest.json"), JSON.stringify(manifest));
+
+    const openshell = path.join(binDir, "openshell");
+    writeExecutable(
+      openshell,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "sandbox" && args[1] === "ssh-config") {
+  process.stdout.write("Host openshell-alpha\\n  HostName 127.0.0.1\\n  User sandbox\\n");
+}
+process.exit(0);
+`,
+    );
+    writeExecutable(
+      path.join(binDir, "ssh"),
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const cmd = process.argv[process.argv.length - 1] || "";
+const openclawDir = ${JSON.stringify(openclawDir)};
+const extensionsDir = ${JSON.stringify(extensionsDir)};
+fs.appendFileSync(${JSON.stringify(sshLog)}, JSON.stringify({ cmd }) + "\\n");
+function readStdin() {
+  const chunks = [];
+  for (;;) {
+    const buffer = Buffer.alloc(65536);
+    const count = fs.readSync(0, buffer, 0, buffer.length, null);
+    if (count === 0) break;
+    chunks.push(buffer.subarray(0, count));
+  }
+  return Buffer.concat(chunks);
+}
+if (cmd.includes("${OPENCLAW_DIR}/extensions") && cmd.includes("-exec rm -rf")) {
+  const preserved = new Set(${JSON.stringify(freshExtensionDirs)});
+  for (const entry of fs.readdirSync(extensionsDir)) {
+    if (!preserved.has(entry)) fs.rmSync(path.join(extensionsDir, entry), { recursive: true, force: true });
+  }
+  process.exit(0);
+}
+if (cmd.includes("tar --no-same-owner -xf -")) {
+  const result = spawnSync("tar", ["--no-same-owner", "-xf", "-", "-C", openclawDir], {
+    input: readStdin(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  process.exit(result.status || 0);
+}
+if (cmd.includes("chown") || cmd.includes("[ -d ")) process.exit(0);
+if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
+  process.stdout.write(fs.readFileSync(path.join(openclawDir, "openclaw.json")));
+  process.exit(0);
+}
+if (cmd.includes("openclaw.json") && cmd.includes(".nemoclaw-restore")) {
+  fs.writeFileSync(path.join(openclawDir, "openclaw.json"), readStdin());
+  process.exit(0);
+}
+process.exit(1);
+`,
+    );
+
+    process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    const restore = restoreRecreatedSandboxState("alpha", backupPath, {
+      targetAgentType: "openclaw",
+      freshOpenClawImagePluginInstalls: options.freshPluginInstalls,
+    });
+    const loggedCommands = fs
+      .readFileSync(sshLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line).cmd as string);
+
+    return {
+      cleanupCommand: loggedCommands.find((command) => command.includes("-exec rm -rf")),
+      freshMarkers: Object.fromEntries(
+        freshExtensionDirs.map((name) => [
+          name,
+          fs.readFileSync(path.join(extensionsDir, name, "marker.txt"), "utf8"),
+        ]),
+      ),
+      restore,
+      restoredConfig: JSON.parse(fs.readFileSync(path.join(openclawDir, "openclaw.json"), "utf8")),
+      staleUserExtensionExists: fs.existsSync(path.join(extensionsDir, "stale-user-extension")),
+      userExtensionMarker: fs.readFileSync(
+        path.join(extensionsDir, "user-extension", "marker.txt"),
+        "utf8",
+      ),
+    };
+  } finally {
+    if (previousOpenshellBin === undefined) delete process.env.NEMOCLAW_OPENSHELL_BIN;
+    else process.env.NEMOCLAW_OPENSHELL_BIN = previousOpenshellBin;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+}
+
+function expectSuccessfulRestore(result: ReturnType<typeof runRestoreScenario>): void {
+  expect(result.restore).toEqual({
+    success: true,
+    restoredDirs: ["extensions"],
+    failedDirs: [],
+    restoredFiles: ["openclaw.json"],
+    failedFiles: [],
+  });
+  expect(result.staleUserExtensionExists).toBe(false);
+  expect(result.userExtensionMarker).toBe("restored\n");
+}
+
+describe("recreated OpenClaw state restore", () => {
+  it.each([
+    { provenance: "missing legacy", previousPluginInstalls: undefined },
+    { provenance: "known-empty", previousPluginInstalls: [] },
+  ])("restores config and extensions with $provenance previous provenance", ({
+    previousPluginInstalls,
+  }) => {
+    const weather = imageInstall("weather", "weather");
+    const result = runRestoreScenario({
+      previousPluginInstalls,
+      freshPluginInstalls: [weather],
+      backupExtensionDirs: ["weather"],
+      backupConfig: {
+        gateway: { auth: { token: "stale-token" } },
+        mcpServers: { filesystem: { command: "npx" } },
+        plugins: { entries: { "user-plugin": { enabled: true } } },
+      },
+      freshConfig: {
+        gateway: { auth: { token: "fresh-token" } },
+        plugins: {
+          entries: { weather: { enabled: true, config: { revision: "fresh" } } },
+          load: { paths: weather.loadPaths },
+        },
+      },
+    });
+
+    expectSuccessfulRestore(result);
+    expect(result.freshMarkers).toEqual({
+      nemoclaw: "fresh-nemoclaw\n",
+      weather: "fresh-weather\n",
+    });
+    expect(result.restoredConfig.gateway.auth.token).toBe("fresh-token");
+    expect(result.restoredConfig.mcpServers.filesystem.command).toBe("npx");
+    expect(result.restoredConfig.plugins.entries).toEqual({
+      "user-plugin": { enabled: true },
+      weather: { enabled: true, config: { revision: "fresh" } },
+    });
+    expect(result.cleanupCommand).toContain("! -name 'nemoclaw'");
+    expect(result.cleanupCommand).toContain("! -name 'weather'");
+  });
+
+  it("reconciles populated previous and fresh image-plugin provenance during config restore", () => {
+    const previousWeather = imageInstall("weather", "weather-v1");
+    const freshWeather = imageInstall("weather", "weather-v2");
+    const userPluginPath = `${OPENCLAW_DIR}/extensions/user-plugin`;
+    const result = runRestoreScenario({
+      previousPluginInstalls: [previousWeather],
+      freshPluginInstalls: [freshWeather],
+      backupExtensionDirs: ["weather-v1"],
+      backupConfig: {
+        gateway: { auth: { token: "stale-token" } },
+        channels: {
+          weather: { enabled: false, token: "stale-image-token" },
+          "user-channel": { room: "keep" },
+        },
+        plugins: {
+          entries: {
+            weather: { enabled: false, config: { revision: "stale" } },
+            "user-plugin": { enabled: true },
+          },
+          installs: { weather: { installPath: previousWeather.installPath } },
+          load: { paths: [previousWeather.installPath, userPluginPath] },
+          slots: { memory: "weather", contextEngine: "user-plugin" },
+        },
+      },
+      freshConfig: {
+        gateway: { auth: { token: "fresh-token" } },
+        channels: { weather: { enabled: true, endpoint: "fresh" } },
+        plugins: {
+          entries: { weather: { enabled: true, config: { revision: "fresh" } } },
+          load: { paths: freshWeather.loadPaths },
+          slots: { memory: "weather" },
+        },
+      },
+    });
+
+    expectSuccessfulRestore(result);
+    expect(result.freshMarkers).toEqual({
+      nemoclaw: "fresh-nemoclaw\n",
+      "weather-v2": "fresh-weather-v2\n",
+    });
+    expect(result.restoredConfig.gateway.auth.token).toBe("fresh-token");
+    expect(result.restoredConfig.channels).toEqual({
+      weather: { enabled: true, endpoint: "fresh" },
+      "user-channel": { room: "keep" },
+    });
+    expect(result.restoredConfig.plugins.entries).toEqual({
+      "user-plugin": { enabled: true },
+      weather: { enabled: true, config: { revision: "fresh" } },
+    });
+    expect(result.restoredConfig.plugins.load.paths).toEqual([
+      freshWeather.installPath,
+      userPluginPath,
+    ]);
+    expect(result.restoredConfig.plugins.slots).toEqual({
+      contextEngine: "user-plugin",
+      memory: "weather",
+    });
+    expect(result.restoredConfig.plugins.installs).toBeUndefined();
+  });
+});

--- a/src/lib/state/sandbox-recreated-openclaw-restore.test.ts
+++ b/src/lib/state/sandbox-recreated-openclaw-restore.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { restoreEnvBulk } from "../../../test/helpers/env-test-helpers.js";
 import type { OpenClawImagePluginInstall } from "./openclaw-plugin-restore.js";
 import { restoreRecreatedSandboxState } from "./sandbox.js";
 
@@ -90,10 +91,10 @@ function runRestoreScenario(options: {
       dir: OPENCLAW_DIR,
       backupPath,
       blueprintDigest: null,
+      ...(options.previousPluginInstalls !== undefined
+        ? { openclawImagePluginInstalls: options.previousPluginInstalls }
+        : {}),
     };
-    if (options.previousPluginInstalls !== undefined) {
-      manifest.openclawImagePluginInstalls = options.previousPluginInstalls;
-    }
     fs.writeFileSync(path.join(backupPath, "rebuild-manifest.json"), JSON.stringify(manifest));
 
     const openshell = path.join(binDir, "openshell");
@@ -183,10 +184,7 @@ process.exit(1);
       ),
     };
   } finally {
-    if (previousOpenshellBin === undefined) delete process.env.NEMOCLAW_OPENSHELL_BIN;
-    else process.env.NEMOCLAW_OPENSHELL_BIN = previousOpenshellBin;
-    if (previousPath === undefined) delete process.env.PATH;
-    else process.env.PATH = previousPath;
+    restoreEnvBulk({ NEMOCLAW_OPENSHELL_BIN: previousOpenshellBin, PATH: previousPath });
     fs.rmSync(fixture, { recursive: true, force: true });
   }
 }

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -1549,6 +1549,15 @@ function restoreSandboxStateInternal(
     freshOpenClawImagePluginInstalls !== undefined
       ? manifest.openclawImagePluginInstalls
       : undefined;
+  // Fresh provenance is still authoritative for preserving image-managed
+  // extension directories during recreation. Config reconciliation, however,
+  // needs a complete before/after pair. Legacy and stock-image backups do not
+  // carry the previous baseline, so preserve their historical config-merge
+  // behavior by passing neither side of the pair to openclaw.json restore.
+  const configFreshOpenClawImagePluginInstalls =
+    previousOpenClawImagePluginInstalls !== undefined
+      ? freshOpenClawImagePluginInstalls
+      : undefined;
   try {
     const pluginRestorePlan = planOpenClawPluginRestore({
       agentType: manifest.agentType,
@@ -1710,7 +1719,7 @@ function restoreSandboxStateInternal(
           backupPath,
           shouldMergeOpenClawConfigStateFile(manifest.agentType, dir, spec),
           options.stateFileRestorePolicy,
-          freshOpenClawImagePluginInstalls,
+          configFreshOpenClawImagePluginInstalls,
           previousOpenClawImagePluginInstalls,
         )
       ) {

--- a/test/e2e/live/device-auth-health.test.ts
+++ b/test/e2e/live/device-auth-health.test.ts
@@ -40,9 +40,13 @@ test("device auth health probes treat 401 as live instead of offline (#2342)", {
   timeout: LIVE_TIMEOUT_MS,
 }, async ({ artifacts, cleanup, host, sandbox, skip }) => {
   const installLog = artifacts.pathFor("phase-1-install-device-auth-health.log");
+  // The sandbox cannot reach runner loopback, so expose the fixture through
+  // OpenShell's host bridge while keeping readiness checks local to the runner.
   const inference = await startFakeOpenAiCompatibleServer({
     apiKey: INFERENCE_API_KEY,
+    host: "0.0.0.0",
     model: INFERENCE_MODEL,
+    publicHost: "host.openshell.internal",
     requireAuth: true,
   });
   cleanup.add("close device-auth compatible inference fixture", async () => {

--- a/test/e2e/live/rebuild-openclaw.test.ts
+++ b/test/e2e/live/rebuild-openclaw.test.ts
@@ -693,6 +693,9 @@ print(json.dumps({'seeded': saved == os.environ['PRE_REBUILD_GATEWAY_TOKEN'], 'h
       },
     );
     expectExitZero(rebuild, "nemoclaw rebuild");
+    const rebuildText = resultText(rebuild);
+    expect(rebuildText).toContain(`Sandbox '${SANDBOX_NAME}' rebuilt successfully`);
+    expect(rebuildText).not.toContain("post-restore steps were incomplete");
 
     // Phase 7: state preservation, upgrade, token rotation, backup hygiene, and
     // policy-preset preservation assertions.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR fixes the two deterministic failure families that blocked the v0.0.78 release candidate. It restores legacy and stock OpenClaw backups without weakening authoritative custom-image provenance checks, makes the device-auth fixture reachable from inside OpenShell sandboxes, and prevents incomplete rebuilds from appearing green in E2E.

## Changes
- Preserve fresh image-managed extension directories while passing plugin provenance to the `openclaw.json` merge only when the backup contains the corresponding previous baseline.
- Cover missing, known-empty, and populated previous-provenance restore paths, including stale image-owned configuration removal and fresh/user-owned state preservation.
- Bind the device-auth fake inference service to the runner host bridge and advertise `host.openshell.internal` to the sandbox.
- Require the rebuild E2E to observe the explicit success message and reject incomplete post-restore completion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the runtime fix restores the documented backup/restore contract without changing commands, configuration, defaults, migrations, or operator actions; the remaining changes are test-only.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: focused correctness review confirmed that missing legacy provenance takes the compatibility path, authoritative empty and populated provenance still reconcile, marked custom-image manifests remain fail-closed, and the random-port fake server follows the existing OpenShell host-bridge test pattern.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project cli src/lib/state/sandbox-recreated-openclaw-restore.test.ts src/lib/state/openclaw-config-restore-input.test.ts src/lib/state/openclaw-config-merge.test.ts src/lib/state/openclaw-plugin-restore.test.ts` (68 passed)
  - `npx vitest run --project integration test/snapshot-openclaw-managed-extensions.test.ts --reporter=verbose` (6 passed)
  - `npx vitest run --project e2e-support test/e2e/support/device-auth-health-helpers.test.ts test/e2e/support/rebuild-openclaw-old-base-context.test.ts` (7 passed)
  - `npm run typecheck:cli` and `npm run test:projects:check` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox restore so recreated OpenClaw environments reliably restore `openclaw.json` configuration and extension/plugin state from rebuild artifacts.
  * Prevent restore from attempting configuration reconciliation when prior plugin-install provenance is incomplete, and correctly reconciles differing provenance when present.
  * Ensured stale user extensions are cleaned up during restore and extension markers are restored as expected.
  * Improved live health-check connectivity by adjusting sandbox network/bridge host settings.
  * Rebuild now produces clearer success output and avoids “post-restore steps were incomplete” messaging.

* **Tests**
  * Added coverage for restore reconciliation and strengthened e2e rebuild output assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->