### PR TITLE
docs: include late v0.0.78 source-fetching fix

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -18,12 +18,15 @@ For more detailed release notes, refer to the [NemoClaw GitHub announcements](ht
 
 ## v0.0.78
 
-NemoClaw v0.0.78 adds opt-in thread-scoped auto-approval for managed LangChain Deep Agents Code, authoritative agent-visible inference health, round-trippable policy export, and stronger recovery for local inference, custom images, managed MCP, remote dashboards, and credential capture.
+NemoClaw v0.0.78 adds opt-in thread-scoped auto-approval and policy-routed repository reads for managed LangChain Deep Agents Code, authoritative agent-visible inference health, round-trippable policy export, and stronger recovery for local inference, custom images, managed MCP, remote dashboards, and credential capture.
 
 - Managed LangChain Deep Agents Code sandboxes keep auto-approval disabled by default and can enable the `thread-opt-in` capability through a named transactional rebuild.
   Each thread must still opt in through the TUI or `dcode -y`, and approval state resets across process, thread, and agent transitions without bypassing OpenShell controls.
   Managed Nemotron 3 Ultra aliases now load through a version-pinned first-party profile plugin, preserve required nonempty tool-call content, and reject the observed literal `[content]` execute placeholder before shell dispatch.
   For more information, refer to [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart), [Security Best Practices](../security/best-practices), [Model Capability Audit](../inference/model-capability-audit), and [NemoClaw CLI Commands Reference](../reference/commands).
+- Managed LangChain Deep Agents Code `fetch_url` requests now use NemoClaw's policy proxy, allowing GitHub file links and repository source to resolve inside the sandbox while keeping initial and redirected destinations inside the managed egress boundary.
+  The baseline GitHub policy permits only GET and HEAD requests to `raw.githubusercontent.com` from the listed managed binaries.
+  For more information, refer to [Network Policies](../reference/network-policies).
 - `status`, `doctor`, and `connect` now treat the agent-visible `https://inference.local/v1/models` route as authoritative and return nonzero or fail closed when trusted evidence is unavailable.
   Deep Agents probes reject login-shell preambles and multiline contamination while preserving configured observability through a side-effect-free managed execution path.
   For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands), [Monitor Sandbox Activity](../monitoring/monitor-sandbox-activity), and [Troubleshooting](../reference/troubleshooting).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This follow-up keeps the v0.0.78 release notes synchronized with PR #6495, which merged after the original release-prep docs refresh. The deeper network-policy reference already documents the exact endpoint, methods, and managed binaries.

## Changes
- #6495 -> `docs/about/release-notes.mdx`: Add policy-routed repository reads to the v0.0.78 lead and explain that managed Deep Agents Code `fetch_url` uses NemoClaw's policy proxy with read-only `raw.githubusercontent.com` access.
- Reviewed #6534 against the existing backup/restore and lifecycle documentation; no additional prose is needed because it restores the documented contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: release-note prose only; no code sample or generated behavior changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — tests are not applicable to prose-only release notes
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 pre-existing Fern warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to reflect new opt-in thread-scoped auto-approval and policy-routed repository reads.
  * Added notes about sandboxed `fetch_url` handling for GitHub source access and the allowed GitHub request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->