### PR TITLE
perf(test): coordinate source loader cache misses

### DIFF
--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -10,18 +10,19 @@ const path = require("node:path");
 const ts = require("typescript");
 
 const sourceLoader = path.join(__dirname, "register-source-require.ts");
-const { outputText } = ts.transpileModule(fs.readFileSync(sourceLoader, "utf8"), {
-  compilerOptions: {
-    esModuleInterop: true,
-    module: ts.ModuleKind.CommonJS,
-    target: ts.ScriptTarget.ES2022,
-  },
-  fileName: sourceLoader,
-});
-const sourceLoaderModule = new Module(sourceLoader, module);
-sourceLoaderModule.filename = sourceLoader;
-sourceLoaderModule.paths = module.paths;
-sourceLoaderModule._compile(outputText, sourceLoader);
+
+Module._extensions[".ts"] = (targetModule, filename) => {
+  const { outputText } = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  });
+  targetModule._compile(outputText, filename);
+};
+require(sourceLoader);
 
 function normalizeCommand(command) {
   return (Array.isArray(command) ? command.join(" ") : String(command)).replace(/'/g, "");

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -10,8 +10,18 @@ const path = require("node:path");
 const ts = require("typescript");
 
 const sourceLoader = path.join(__dirname, "register-source-require.ts");
+const sourceLoaderCache = path.join(__dirname, "source-require-cache.ts");
+const bootstrapSources = new Set([sourceLoader, sourceLoaderCache]);
+const previousTypeScriptLoader = Module._extensions[".ts"];
 
 Module._extensions[".ts"] = (targetModule, filename) => {
+  if (!bootstrapSources.has(filename)) {
+    if (previousTypeScriptLoader) {
+      previousTypeScriptLoader(targetModule, filename);
+      return;
+    }
+    throw new Error(`Unexpected TypeScript bootstrap dependency: ${filename}`);
+  }
   const { outputText } = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
     compilerOptions: {
       esModuleInterop: true,

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -10,21 +10,28 @@ const path = require("node:path");
 const ts = require("typescript");
 
 const sourceLoader = path.join(__dirname, "register-source-require.ts");
-const sourceLoaderCache = path.join(__dirname, "source-require-cache.ts");
-const bootstrapSources = new Set([sourceLoader, sourceLoaderCache]);
+const bootstrapTypeScriptFiles = new Set([
+  path.resolve(sourceLoader),
+  path.resolve(__dirname, "source-require-cache.ts"),
+]);
 const previousTypeScriptLoader = Module._extensions[".ts"];
 
 Module._extensions[".ts"] = (targetModule, filename) => {
-  if (!bootstrapSources.has(filename)) {
+  if (!bootstrapTypeScriptFiles.has(path.resolve(filename))) {
     if (previousTypeScriptLoader) {
       previousTypeScriptLoader(targetModule, filename);
       return;
     }
-    throw new Error(`Unexpected TypeScript bootstrap dependency: ${filename}`);
+    throw new Error(`Refusing to bootstrap unexpected TypeScript module: ${filename}`);
   }
+
+  // Loading source-require-cache.ts is what lets the real hook read tsconfig.src.json,
+  // so this first hop intentionally uses minimal emit options instead of that config.
   const { outputText } = ts.transpileModule(fs.readFileSync(filename, "utf8"), {
     compilerOptions: {
       esModuleInterop: true,
+      inlineSourceMap: true,
+      inlineSources: true,
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES2022,
     },

--- a/test/helpers/register-source-require.ts
+++ b/test/helpers/register-source-require.ts
@@ -4,6 +4,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import Module from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import ts from "typescript";
@@ -47,7 +48,7 @@ fs.mkdirSync(cacheDir, { recursive: true });
 const cacheWaitMs = envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS", 5_000);
 const cachePollMs = Math.max(1, envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS", 25));
 const cacheLockStaleMs = envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS", 30_000);
-const statsPath = process.env.NEMOCLAW_SOURCE_REQUIRE_STATS;
+const statsPath = sourceRequireStatsPath(process.env.NEMOCLAW_SOURCE_REQUIRE_STATS);
 
 const stats = {
   cacheHits: 0,
@@ -68,6 +69,61 @@ function envInt(name: string, fallback: number): number {
   if (raw === undefined) return fallback;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (!path.isAbsolute(relative) && !relative.startsWith(`..${path.sep}`) && relative !== "..")
+  );
+}
+
+function sourceRequireStatsPath(configuredPath: string | undefined): string | undefined {
+  if (!configuredPath) return undefined;
+  const resolved = path.resolve(configuredPath);
+  return [repoRoot, os.tmpdir()].some((root) => isWithin(path.resolve(root), resolved))
+    ? resolved
+    : undefined;
+}
+
+function openSourceRequireStats(statsPath: string): number | null {
+  const parent = path.dirname(statsPath);
+  let canonicalParent: string;
+  try {
+    canonicalParent = fs.realpathSync.native(parent);
+  } catch {
+    return null;
+  }
+  const canonicalPath = path.join(canonicalParent, path.basename(statsPath));
+  const withinAllowedRoot = [repoRoot, os.tmpdir()].some((root) => {
+    try {
+      return isWithin(fs.realpathSync.native(root), canonicalPath);
+    } catch {
+      return false;
+    }
+  });
+  if (!withinAllowedRoot) return null;
+
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(
+      statsPath,
+      fs.constants.O_APPEND |
+        fs.constants.O_CREAT |
+        fs.constants.O_WRONLY |
+        fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+  } catch {
+    return null;
+  }
+  const stat = fs.fstatSync(descriptor);
+  if (!stat.isFile() || stat.nlink !== 1) {
+    fs.closeSync(descriptor);
+    return null;
+  }
+  return descriptor;
 }
 
 function nowMs(): number {
@@ -326,6 +382,7 @@ function compileWithCache(filename: string, source: string, cachePath: string): 
 if (statsPath) {
   process.once("exit", () => {
     if (stats.files === 0) return;
+    let descriptor: number | null = null;
     try {
       const row = {
         ...stats,
@@ -335,10 +392,12 @@ if (statsPath) {
         pid: process.pid,
         rssMb: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
       };
-      fs.mkdirSync(path.dirname(statsPath), { recursive: true });
-      fs.appendFileSync(statsPath, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+      descriptor = openSourceRequireStats(statsPath);
+      if (descriptor !== null) fs.appendFileSync(descriptor, `${JSON.stringify(row)}\n`);
     } catch {
       // Diagnostics are best-effort and must not fail an otherwise successful test process.
+    } finally {
+      if (descriptor !== null) fs.closeSync(descriptor);
     }
   });
 }

--- a/test/helpers/register-source-require.ts
+++ b/test/helpers/register-source-require.ts
@@ -167,7 +167,8 @@ function readLockSnapshot(lockPath: string): LockSnapshot | null {
   try {
     descriptor = fs.openSync(lockPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ELOOP") return null;
     throw error;
   }
 
@@ -372,7 +373,11 @@ function compileWithCache(filename: string, source: string, cachePath: string): 
 
   try {
     const outputText = transpileSource(source, filename);
-    writeAtomic(cachePath, outputText);
+    try {
+      writeAtomic(cachePath, outputText);
+    } catch {
+      // The compiled output is still valid when best-effort cache persistence fails.
+    }
     return outputText;
   } finally {
     fs.rmSync(lockPath, { force: true });

--- a/test/helpers/register-source-require.ts
+++ b/test/helpers/register-source-require.ts
@@ -5,10 +5,25 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import Module from "node:module";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import ts from "typescript";
+
+import {
+  loadSourceRequireCompilerOptions,
+  sourceRequireCacheDir,
+  sourceRequireCachePath,
+} from "./source-require-cache";
 
 type CommonJsModule = NodeModule & {
   _compile(source: string, filename: string): void;
+};
+
+type LockSnapshot = {
+  contents: string;
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  size: number;
 };
 
 type ResolveFilename = (
@@ -23,45 +38,310 @@ const moduleRuntime = Module as unknown as {
   _resolveFilename: ResolveFilename;
 };
 const repoRoot = path.resolve(__dirname, "../..");
-const configPath = path.join(repoRoot, "tsconfig.src.json");
-const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
-
-if (configFile.error) {
-  throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
-}
-
-const parsedConfig = ts.parseJsonConfigFileContent(
-  configFile.config,
-  ts.sys,
-  repoRoot,
-  {},
-  configPath,
-);
-if (parsedConfig.errors.length > 0) {
-  throw new Error(
-    parsedConfig.errors
-      .map((error) => ts.flattenDiagnosticMessageText(error.messageText, "\n"))
-      .join("\n"),
-  );
-}
-
-const compilerOptions: ts.CompilerOptions = {
-  ...parsedConfig.options,
-  declaration: false,
-  declarationMap: false,
-  inlineSourceMap: true,
-  inlineSources: true,
-  noEmit: false,
-  outDir: undefined,
-  rootDir: undefined,
-  sourceMap: false,
-};
+const compilerOptions = loadSourceRequireCompilerOptions(repoRoot);
 // Keep the cross-process transpilation cache in this checkout's dependency
 // tree. A shared, predictable directory under the OS temp root could be
 // replaced by another local user before a test process reads from it.
-const cacheDir = path.join(repoRoot, "node_modules", ".cache", "nemoclaw-source-require");
-const compilerFingerprint = JSON.stringify({ compilerOptions, typescript: ts.version });
+const cacheDir = sourceRequireCacheDir(repoRoot);
 fs.mkdirSync(cacheDir, { recursive: true });
+const cacheWaitMs = envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS", 5_000);
+const cachePollMs = Math.max(1, envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS", 25));
+const cacheLockStaleMs = envInt("NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS", 30_000);
+const statsPath = process.env.NEMOCLAW_SOURCE_REQUIRE_STATS;
+
+const stats = {
+  cacheHits: 0,
+  cacheMisses: 0,
+  compileMs: 0,
+  duplicateFallbacks: 0,
+  files: 0,
+  lockWaits: 0,
+  readCacheMs: 0,
+  staleLocks: 0,
+  transforms: 0,
+  transformMs: 0,
+  waitMs: 0,
+};
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function nowMs(): number {
+  return performance.now();
+}
+
+const sleepBuffer = new SharedArrayBuffer(4);
+const sleepArray = new Int32Array(sleepBuffer);
+
+function sleepSync(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(sleepArray, 0, 0, ms);
+}
+
+function readCachedOutput(cachePath: string): string | null {
+  const start = nowMs();
+  try {
+    const output = fs.readFileSync(cachePath, "utf8");
+    stats.readCacheMs += nowMs() - start;
+    return output;
+  } catch (error) {
+    stats.readCacheMs += nowMs() - start;
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return null;
+  }
+}
+
+function writeAtomic(cachePath: string, outputText: string): void {
+  const temporaryPath = `${cachePath}.${process.pid}.${crypto.randomUUID()}`;
+  fs.writeFileSync(temporaryPath, outputText, { flag: "wx", mode: 0o600 });
+  try {
+    fs.renameSync(temporaryPath, cachePath);
+  } catch (error) {
+    fs.rmSync(temporaryPath, { force: true });
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+}
+
+function readLockSnapshot(lockPath: string): LockSnapshot | null {
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(lockPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+
+  try {
+    const before = fs.fstatSync(descriptor);
+    const contents = fs.readFileSync(descriptor, "utf8");
+    const after = fs.fstatSync(descriptor);
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.mtimeMs !== after.mtimeMs ||
+      before.size !== after.size
+    ) {
+      return null;
+    }
+    return {
+      contents,
+      dev: after.dev,
+      ino: after.ino,
+      mtimeMs: after.mtimeMs,
+      size: after.size,
+    };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function parseLockOwner(contents: string): { pid?: number } {
+  try {
+    const parsed = JSON.parse(contents);
+    return typeof parsed?.pid === "number" && Number.isInteger(parsed.pid) && parsed.pid > 0
+      ? { pid: parsed.pid }
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function tryAcquireLock(lockPath: string, filename: string): boolean {
+  try {
+    fs.writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        filename,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        startedAtMs: Date.now(),
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    return false;
+  }
+}
+
+function sameLockIdentity(left: LockSnapshot, right: LockSnapshot | null): boolean {
+  return (
+    right !== null &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeMs === right.mtimeMs &&
+    left.size === right.size &&
+    left.contents === right.contents
+  );
+}
+
+function staleLockClaimPath(lockPath: string, snapshot: LockSnapshot): string {
+  const identity = crypto
+    .createHash("sha256")
+    .update(String(snapshot.dev))
+    .update("\0")
+    .update(String(snapshot.ino))
+    .update("\0")
+    .update(String(snapshot.mtimeMs))
+    .update("\0")
+    .update(String(snapshot.size))
+    .update("\0")
+    .update(snapshot.contents)
+    .digest("hex")
+    .slice(0, 24);
+  return `${lockPath}.reclaim-${identity}`;
+}
+
+function reclaimStaleLock(lockPath: string): boolean {
+  if (cacheLockStaleMs <= 0) return false;
+  const snapshot = readLockSnapshot(lockPath);
+  if (snapshot === null || Date.now() - snapshot.mtimeMs < cacheLockStaleMs) return false;
+  const { pid } = parseLockOwner(snapshot.contents);
+  if (pid !== undefined && processIsRunning(pid)) return false;
+
+  // A hard link is an atomic claim on this exact lock inode. Contenders that
+  // observed the same stale lock derive the same claim path, so only one can
+  // unlink it. If the lock was replaced before linkSync, the identity check
+  // below rejects the replacement without removing it.
+  const claimPath = staleLockClaimPath(lockPath, snapshot);
+  try {
+    fs.linkSync(lockPath, claimPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST" || code === "ENOENT") return false;
+    throw error;
+  }
+
+  try {
+    const claimed = readLockSnapshot(claimPath);
+    if (!sameLockIdentity(snapshot, claimed) || claimed === null) return false;
+    let current: fs.Stats;
+    try {
+      current = fs.lstatSync(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
+    if (current.dev !== claimed.dev || current.ino !== claimed.ino) return false;
+    fs.unlinkSync(lockPath);
+    stats.staleLocks += 1;
+    return true;
+  } finally {
+    fs.rmSync(claimPath, { force: true });
+  }
+}
+
+function transpileSource(source: string, filename: string): string {
+  const start = nowMs();
+  const result = ts.transpileModule(source, {
+    compilerOptions,
+    fileName: filename,
+    reportDiagnostics: true,
+  });
+  stats.transformMs += nowMs() - start;
+  stats.transforms += 1;
+  const errors = result.diagnostics?.filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (errors && errors.length > 0) {
+    throw new Error(
+      errors
+        .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+        .join("\n"),
+    );
+  }
+  return result.outputText;
+}
+
+function waitForCache(cachePath: string): string | null {
+  if (cacheWaitMs <= 0) return null;
+  const start = nowMs();
+  const deadline = start + cacheWaitMs;
+  stats.lockWaits += 1;
+
+  while (nowMs() < deadline) {
+    const output = readCachedOutput(cachePath);
+    if (output !== null) {
+      stats.waitMs += nowMs() - start;
+      return output;
+    }
+    sleepSync(Math.min(cachePollMs, Math.max(0, deadline - nowMs())));
+  }
+  stats.waitMs += nowMs() - start;
+  return null;
+}
+
+function compileWithCache(filename: string, source: string, cachePath: string): string {
+  const cached = readCachedOutput(cachePath);
+  if (cached !== null) {
+    stats.cacheHits += 1;
+    return cached;
+  }
+  stats.cacheMisses += 1;
+
+  const lockPath = `${cachePath}.lock`;
+  let ownsLock = tryAcquireLock(lockPath, filename);
+  if (!ownsLock && reclaimStaleLock(lockPath)) {
+    const cachedAfterReclaim = readCachedOutput(cachePath);
+    if (cachedAfterReclaim !== null) {
+      stats.cacheHits += 1;
+      return cachedAfterReclaim;
+    }
+    ownsLock = tryAcquireLock(lockPath, filename);
+  }
+
+  if (!ownsLock) {
+    const waited = waitForCache(cachePath);
+    if (waited !== null) {
+      stats.cacheHits += 1;
+      return waited;
+    }
+    stats.duplicateFallbacks += 1;
+    return transpileSource(source, filename);
+  }
+
+  try {
+    const outputText = transpileSource(source, filename);
+    writeAtomic(cachePath, outputText);
+    return outputText;
+  } finally {
+    fs.rmSync(lockPath, { force: true });
+  }
+}
+
+if (statsPath) {
+  process.once("exit", () => {
+    if (stats.files === 0) return;
+    try {
+      const row = {
+        ...stats,
+        cacheDir,
+        cachePollMs,
+        label: process.env.NEMOCLAW_SOURCE_REQUIRE_STATS_LABEL ?? null,
+        pid: process.pid,
+        rssMb: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
+      };
+      fs.mkdirSync(path.dirname(statsPath), { recursive: true });
+      fs.appendFileSync(statsPath, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+    } catch {
+      // Diagnostics are best-effort and must not fail an otherwise successful test process.
+    }
+  });
+}
 
 const resolveFilename = moduleRuntime._resolveFilename;
 moduleRuntime._resolveFilename = function resolveSourceFilename(request, parent, isMain, options) {
@@ -82,46 +362,11 @@ moduleRuntime._resolveFilename = function resolveSourceFilename(request, parent,
 };
 
 moduleRuntime._extensions[".ts"] = (module, filename) => {
+  const compileStart = nowMs();
+  stats.files += 1;
   const source = fs.readFileSync(filename, "utf8");
-  const cacheKey = crypto
-    .createHash("sha256")
-    .update(filename)
-    .update("\0")
-    .update(source)
-    .update("\0")
-    .update(compilerFingerprint)
-    .digest("hex");
-  const cachePath = path.join(cacheDir, `${cacheKey}.cjs`);
-  let outputText: string;
-
-  try {
-    outputText = fs.readFileSync(cachePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    const result = ts.transpileModule(source, {
-      compilerOptions,
-      fileName: filename,
-      reportDiagnostics: true,
-    });
-    const errors = result.diagnostics?.filter(
-      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
-    );
-    if (errors && errors.length > 0) {
-      throw new Error(
-        errors
-          .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
-          .join("\n"),
-      );
-    }
-    outputText = result.outputText;
-    const temporaryPath = `${cachePath}.${process.pid}.${crypto.randomUUID()}`;
-    fs.writeFileSync(temporaryPath, outputText, { flag: "wx", mode: 0o600 });
-    try {
-      fs.renameSync(temporaryPath, cachePath);
-    } catch (error) {
-      fs.rmSync(temporaryPath, { force: true });
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-    }
-  }
+  const cachePath = sourceRequireCachePath({ compilerOptions, filename, repoRoot, source });
+  const outputText = compileWithCache(filename, source, cachePath);
+  stats.compileMs += nowMs() - compileStart;
   module._compile(outputText, filename);
 };

--- a/test/helpers/source-require-cache.ts
+++ b/test/helpers/source-require-cache.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from "node:crypto";
+import path from "node:path";
+import ts from "typescript";
+
+export function loadSourceRequireCompilerOptions(repoRoot: string): ts.CompilerOptions {
+  const configPath = path.join(repoRoot, "tsconfig.src.json");
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+
+  if (configFile.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    repoRoot,
+    {},
+    configPath,
+  );
+  if (parsedConfig.errors.length > 0) {
+    throw new Error(
+      parsedConfig.errors
+        .map((error) => ts.flattenDiagnosticMessageText(error.messageText, "\n"))
+        .join("\n"),
+    );
+  }
+
+  return {
+    ...parsedConfig.options,
+    declaration: false,
+    declarationMap: false,
+    inlineSourceMap: true,
+    inlineSources: true,
+    noEmit: false,
+    outDir: undefined,
+    rootDir: undefined,
+    sourceMap: false,
+  };
+}
+
+export function sourceRequireCacheDir(repoRoot: string): string {
+  return path.join(repoRoot, "node_modules", ".cache", "nemoclaw-source-require");
+}
+
+export function sourceRequireCompilerFingerprint(compilerOptions: ts.CompilerOptions): string {
+  return JSON.stringify({ compilerOptions, typescript: ts.version });
+}
+
+export function sourceRequireCachePath(options: {
+  compilerOptions: ts.CompilerOptions;
+  filename: string;
+  repoRoot: string;
+  source: string;
+}): string {
+  const cacheKey = crypto
+    .createHash("sha256")
+    .update(options.filename)
+    .update("\0")
+    .update(options.source)
+    .update("\0")
+    .update(sourceRequireCompilerFingerprint(options.compilerOptions))
+    .digest("hex");
+  return path.join(sourceRequireCacheDir(options.repoRoot), `${cacheKey}.cjs`);
+}

--- a/test/source-require-loader.test.ts
+++ b/test/source-require-loader.test.ts
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  nodeOptionsWithoutSourceLoader,
+  SOURCE_REQUIRE_HOOK,
+} from "./helpers/source-loader-options";
+import {
+  sourceRequireCachePath as buildSourceRequireCachePath,
+  loadSourceRequireCompilerOptions,
+} from "./helpers/source-require-cache";
+
+type SourceRequireStats = {
+  cacheHits: number;
+  cacheMisses: number;
+  cachePollMs: number;
+  duplicateFallbacks: number;
+  files: number;
+  label: string | null;
+  staleLocks: number;
+  transforms: number;
+};
+
+const roots: string[] = [];
+const cacheArtifacts: string[] = [];
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const compilerOptions = loadSourceRequireCompilerOptions(REPO_ROOT);
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  for (const artifact of cacheArtifacts.splice(0)) {
+    fs.rmSync(artifact, { force: true });
+  }
+});
+
+function runFixtureRequire(
+  fixturePath: string,
+  statsPath: string,
+  env: Record<string, string> = {},
+): void {
+  const script = `
+require(${JSON.stringify(SOURCE_REQUIRE_HOOK)});
+const fixture = require(${JSON.stringify(fixturePath)});
+process.exitCode = fixture.value === 42 ? 0 : 7;
+`;
+  const result = spawnSync(process.execPath, ["-e", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NEMOCLAW_SOURCE_REQUIRE_STATS: statsPath,
+      NEMOCLAW_SOURCE_REQUIRE_STATS_LABEL: "source-require-loader-test",
+      NODE_OPTIONS: nodeOptionsWithoutSourceLoader(process.env.NODE_OPTIONS),
+      ...env,
+    },
+    timeout: 10_000,
+  });
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+}
+
+function exitedChildPid(): number {
+  const result = spawnSync(process.execPath, ["-e", ""], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  expect(result.pid).toBeGreaterThan(0);
+  return result.pid;
+}
+
+function sourceRequireCachePath(filename: string): string {
+  return buildSourceRequireCachePath({
+    compilerOptions,
+    filename,
+    repoRoot: REPO_ROOT,
+    source: fs.readFileSync(filename, "utf8"),
+  });
+}
+
+function trackCacheArtifacts(filename: string): { cachePath: string; lockPath: string } {
+  const cachePath = sourceRequireCachePath(filename);
+  const lockPath = `${cachePath}.lock`;
+  cacheArtifacts.push(cachePath, lockPath);
+  return { cachePath, lockPath };
+}
+
+function readStats(statsPath: string): SourceRequireStats[] {
+  return fs
+    .readFileSync(statsPath, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line) as SourceRequireStats);
+}
+
+describe("source require loader", () => {
+  it("emits opt-in cache statistics and reuses a cross-process cache entry (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    trackCacheArtifacts(fs.realpathSync(fixturePath));
+
+    const env = { NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS: "0" };
+    runFixtureRequire(fixturePath, statsPath, env);
+    runFixtureRequire(fixturePath, statsPath, env);
+
+    const rows = readStats(statsPath);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      cacheHits: 0,
+      cacheMisses: 1,
+      cachePollMs: 1,
+      files: 1,
+      label: "source-require-loader-test",
+      transforms: 1,
+    });
+    expect(rows[1]).toMatchObject({
+      cacheHits: 1,
+      cacheMisses: 0,
+      cachePollMs: 1,
+      files: 1,
+      label: "source-require-loader-test",
+      transforms: 0,
+    });
+  });
+
+  it("reclaims dead cache locks before falling back to duplicate transpilation (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-stale-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    const fixtureRealPath = fs.realpathSync(fixturePath);
+
+    const { cachePath, lockPath } = trackCacheArtifacts(fixtureRealPath);
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.rmSync(cachePath, { force: true });
+    fs.writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        filename: fixtureRealPath,
+        pid: exitedChildPid(),
+        startedAtMs: Date.now() - 60_000,
+      })}\n`,
+      { mode: 0o600 },
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
+
+    runFixtureRequire(fixtureRealPath, statsPath, {
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS: "1",
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS: "1",
+    });
+
+    const [row] = readStats(statsPath);
+    expect(row).toMatchObject({
+      cacheMisses: 1,
+      duplicateFallbacks: 0,
+      staleLocks: 1,
+      transforms: 1,
+    });
+    expect(fs.existsSync(cachePath)).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(
+      fs
+        .readdirSync(path.dirname(cachePath))
+        .filter((entry) => entry.startsWith(`${path.basename(lockPath)}.reclaim-`)),
+    ).toEqual([]);
+  });
+
+  it("keeps stats output best-effort when the destination cannot be appended (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-stats-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    trackCacheArtifacts(fs.realpathSync(fixturePath));
+
+    runFixtureRequire(fixturePath, root);
+  });
+});

--- a/test/source-require-loader.test.ts
+++ b/test/source-require-loader.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -23,6 +24,7 @@ type SourceRequireStats = {
   duplicateFallbacks: number;
   files: number;
   label: string | null;
+  lockWaits: number;
   staleLocks: number;
   transforms: number;
 };
@@ -45,9 +47,11 @@ function runFixtureRequire(
   fixturePath: string,
   statsPath: string,
   env: Record<string, string> = {},
+  readyPath?: string,
 ): void {
   const script = `
 require(${JSON.stringify(SOURCE_REQUIRE_HOOK)});
+${readyPath ? `require("node:fs").writeFileSync(${JSON.stringify(readyPath)}, "ready\\n");` : ""}
 const fixture = require(${JSON.stringify(fixturePath)});
 process.exitCode = fixture.value === 42 ? 0 : 7;
 `;
@@ -97,6 +101,17 @@ function readStats(statsPath: string): SourceRequireStats[] {
     .trim()
     .split(/\r?\n/)
     .map((line) => JSON.parse(line) as SourceRequireStats);
+}
+
+function waitForFile(filename: string, timeoutMs = 2_000): void {
+  const deadline = Date.now() + timeoutMs;
+  const sleepBuffer = new SharedArrayBuffer(4);
+  const sleepArray = new Int32Array(sleepBuffer);
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filename)) return;
+    Atomics.wait(sleepArray, 0, 0, 5);
+  }
+  throw new Error(`Timed out waiting for ${filename}`);
 }
 
 describe("source require loader", () => {
@@ -174,6 +189,143 @@ describe("source require loader", () => {
         .readdirSync(path.dirname(cachePath))
         .filter((entry) => entry.startsWith(`${path.basename(lockPath)}.reclaim-`)),
     ).toEqual([]);
+  });
+
+  it("waits for a live lock owner to publish the cache without duplicate transpilation (#6237)", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-wait-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    const readyPath = path.join(root, "publisher-ready");
+    const consumerReadyPath = path.join(root, "consumer-ready");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    const fixtureRealPath = fs.realpathSync(fixturePath);
+
+    const { cachePath, lockPath } = trackCacheArtifacts(fixtureRealPath);
+    const publisherCachePath = `${cachePath}.publisher`;
+    cacheArtifacts.push(publisherCachePath);
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.rmSync(cachePath, { force: true });
+    const publisherScript = `
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(lockPath)}, JSON.stringify({ pid: process.pid }) + "\\n", {
+  flag: "wx",
+  mode: 0o600,
+});
+fs.writeFileSync(${JSON.stringify(readyPath)}, "ready\\n");
+const deadline = Date.now() + 5000;
+const publishWhenConsumerIsReady = () => {
+  if (fs.existsSync(${JSON.stringify(consumerReadyPath)})) {
+    setTimeout(() => {
+      fs.writeFileSync(${JSON.stringify(publisherCachePath)}, "exports.value = 42;\\n", {
+        flag: "wx",
+        mode: 0o600,
+      });
+      fs.renameSync(${JSON.stringify(publisherCachePath)}, ${JSON.stringify(cachePath)});
+    }, 100);
+    setTimeout(() => fs.rmSync(${JSON.stringify(lockPath)}, { force: true }), 200);
+    return;
+  }
+  if (Date.now() >= deadline) {
+    process.exitCode = 2;
+    return;
+  }
+  setTimeout(publishWhenConsumerIsReady, 5);
+};
+publishWhenConsumerIsReady();
+`;
+    const publisher = spawn(process.execPath, ["-e", publisherScript], {
+      env: {
+        ...process.env,
+        NODE_OPTIONS: nodeOptionsWithoutSourceLoader(process.env.NODE_OPTIONS),
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let publisherStderr = "";
+    publisher.stderr?.setEncoding("utf8");
+    publisher.stderr?.on("data", (chunk: string) => {
+      publisherStderr += chunk;
+    });
+
+    try {
+      waitForFile(readyPath);
+      runFixtureRequire(
+        fixtureRealPath,
+        statsPath,
+        {
+          NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS: "5",
+          NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS: "2000",
+        },
+        consumerReadyPath,
+      );
+      const [code, signal] =
+        publisher.exitCode !== null || publisher.signalCode !== null
+          ? [publisher.exitCode, publisher.signalCode]
+          : await once(publisher, "exit");
+      expect({ code, signal, stderr: publisherStderr }).toMatchObject({ code: 0, signal: null });
+    } finally {
+      if (publisher.exitCode === null && publisher.signalCode === null) publisher.kill();
+    }
+
+    const [row] = readStats(statsPath);
+    expect(row).toMatchObject({
+      cacheHits: 1,
+      cacheMisses: 1,
+      duplicateFallbacks: 0,
+      lockWaits: 1,
+      staleLocks: 0,
+      transforms: 0,
+    });
+  });
+
+  it("preserves a stale-looking live lock and falls back after the bounded wait (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-live-lock-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    const fixtureRealPath = fs.realpathSync(fixturePath);
+
+    const { cachePath, lockPath } = trackCacheArtifacts(fixtureRealPath);
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.rmSync(cachePath, { force: true });
+    fs.writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid })}\n`, { mode: 0o600 });
+    const staleTime = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
+
+    runFixtureRequire(fixtureRealPath, statsPath, {
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS: "1",
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS: "1",
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS: "5",
+    });
+
+    const [row] = readStats(statsPath);
+    expect(row).toMatchObject({
+      cacheHits: 0,
+      cacheMisses: 1,
+      duplicateFallbacks: 1,
+      lockWaits: 1,
+      staleLocks: 0,
+      transforms: 1,
+    });
+    expect(fs.existsSync(cachePath)).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it("rejects a symlinked stats destination inside an allowed directory (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-stats-link-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const targetPath = path.join(root, "target.jsonl");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    fs.writeFileSync(targetPath, "sentinel\n");
+    fs.symlinkSync(targetPath, statsPath);
+    trackCacheArtifacts(fs.realpathSync(fixturePath));
+
+    runFixtureRequire(fixturePath, statsPath);
+
+    expect(fs.readFileSync(targetPath, "utf8")).toBe("sentinel\n");
   });
 
   it("keeps stats output best-effort when the destination cannot be appended (#6237)", () => {

--- a/test/source-require-loader.test.ts
+++ b/test/source-require-loader.test.ts
@@ -48,8 +48,10 @@ function runFixtureRequire(
   statsPath: string,
   env: Record<string, string> = {},
   readyPath?: string,
+  beforeHook = "",
 ): void {
   const script = `
+${beforeHook}
 require(${JSON.stringify(SOURCE_REQUIRE_HOOK)});
 ${readyPath ? `require("node:fs").writeFileSync(${JSON.stringify(readyPath)}, "ready\\n");` : ""}
 const fixture = require(${JSON.stringify(fixturePath)});
@@ -107,11 +109,10 @@ function waitForFile(filename: string, timeoutMs = 2_000): void {
   const deadline = Date.now() + timeoutMs;
   const sleepBuffer = new SharedArrayBuffer(4);
   const sleepArray = new Int32Array(sleepBuffer);
-  while (Date.now() < deadline) {
-    if (fs.existsSync(filename)) return;
+  while (!fs.existsSync(filename) && Date.now() < deadline) {
     Atomics.wait(sleepArray, 0, 0, 5);
   }
-  throw new Error(`Timed out waiting for ${filename}`);
+  expect(fs.existsSync(filename), `Timed out waiting for ${filename}`).toBe(true);
 }
 
 describe("source require loader", () => {
@@ -123,10 +124,17 @@ describe("source require loader", () => {
     fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
     trackCacheArtifacts(fs.realpathSync(fixturePath));
 
-    const env = { NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS: "0" };
+    const diagnosticSentinel = "source-require-environment-sentinel";
+    const env = {
+      NEMOCLAW_SOURCE_REQUIRE_CACHE_POLL_MS: "0",
+      SOURCE_REQUIRE_TEST_SENTINEL: diagnosticSentinel,
+    };
     runFixtureRequire(fixturePath, statsPath, env);
     runFixtureRequire(fixturePath, statsPath, env);
 
+    const statsOutput = fs.readFileSync(statsPath, "utf8");
+    expect(statsOutput).not.toContain(diagnosticSentinel);
+    expect(statsOutput).not.toContain("export const value");
     const rows = readStats(statsPath);
     expect(rows).toHaveLength(2);
     expect(rows[0]).toMatchObject({
@@ -264,7 +272,7 @@ publishWhenConsumerIsReady();
           : await once(publisher, "exit");
       expect({ code, signal, stderr: publisherStderr }).toMatchObject({ code: 0, signal: null });
     } finally {
-      if (publisher.exitCode === null && publisher.signalCode === null) publisher.kill();
+      publisher.kill();
     }
 
     const [row] = readStats(statsPath);
@@ -312,6 +320,94 @@ publishWhenConsumerIsReady();
     expect(fs.existsSync(lockPath)).toBe(true);
   });
 
+  it("does not unlink a replacement lock during stale-lock reclamation (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-replaced-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    const fixtureRealPath = fs.realpathSync(fixturePath);
+    const { cachePath, lockPath } = trackCacheArtifacts(fixtureRealPath);
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.rmSync(cachePath, { force: true });
+    fs.writeFileSync(lockPath, `${JSON.stringify({ filename: fixtureRealPath })}\n`, {
+      mode: 0o600,
+    });
+    const staleTime = new Date(Date.now() - 60_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
+    const replacementContents = `${JSON.stringify({
+      filename: fixtureRealPath,
+      pid: process.pid,
+      replacement: true,
+    })}\n`;
+
+    runFixtureRequire(
+      fixtureRealPath,
+      statsPath,
+      {
+        NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS: "1",
+        NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS: "5",
+      },
+      undefined,
+      `
+const fs = require("node:fs");
+const originalLinkSync = fs.linkSync;
+let replaced = false;
+fs.linkSync = function replaceSourceRequireLock(existingPath, claimPath) {
+  if (!replaced && existingPath === ${JSON.stringify(lockPath)}) {
+    replaced = true;
+    fs.rmSync(existingPath, { force: true });
+    fs.writeFileSync(existingPath, ${JSON.stringify(replacementContents)}, { mode: 0o600 });
+  }
+  return originalLinkSync.call(this, existingPath, claimPath);
+};
+`,
+    );
+
+    const [row] = readStats(statsPath);
+    expect(row).toMatchObject({
+      cacheMisses: 1,
+      duplicateFallbacks: 1,
+      staleLocks: 0,
+      transforms: 1,
+    });
+    expect(fs.readFileSync(lockPath, "utf8")).toBe(replacementContents);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not follow symlinked cache locks before duplicate fallback (#6237)",
+    () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-symlink-"));
+      roots.push(root);
+      const fixturePath = path.join(root, "fixture.ts");
+      const statsPath = path.join(root, "stats.jsonl");
+      const targetPath = path.join(root, "lock-target");
+      fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+      fs.writeFileSync(targetPath, "do not follow\n");
+      const fixtureRealPath = fs.realpathSync(fixturePath);
+      const { cachePath, lockPath } = trackCacheArtifacts(fixtureRealPath);
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.rmSync(cachePath, { force: true });
+      fs.symlinkSync(targetPath, lockPath);
+
+      runFixtureRequire(fixtureRealPath, statsPath, {
+        NEMOCLAW_SOURCE_REQUIRE_CACHE_LOCK_STALE_MS: "1",
+        NEMOCLAW_SOURCE_REQUIRE_CACHE_WAIT_MS: "5",
+      });
+
+      const [row] = readStats(statsPath);
+      expect(row).toMatchObject({
+        cacheMisses: 1,
+        duplicateFallbacks: 1,
+        staleLocks: 0,
+        transforms: 1,
+      });
+      expect(fs.lstatSync(lockPath).isSymbolicLink()).toBe(true);
+      expect(fs.readFileSync(targetPath, "utf8")).toBe("do not follow\n");
+      expect(fs.existsSync(cachePath)).toBe(false);
+    },
+  );
+
   it("rejects a symlinked stats destination inside an allowed directory (#6237)", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-stats-link-"));
     roots.push(root);
@@ -328,6 +424,63 @@ publishWhenConsumerIsReady();
     expect(fs.readFileSync(targetPath, "utf8")).toBe("sentinel\n");
   });
 
+  it("limits bootstrap transpilation to source-mapped loader helpers (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-bootstrap-"));
+    roots.push(root);
+    const unexpectedPath = path.join(root, "unexpected.ts");
+    fs.writeFileSync(unexpectedPath, "export const unexpected = true;\n");
+    const script = `
+const Module = require("node:module");
+const path = require("node:path");
+const expected = new Set([
+  path.resolve(${JSON.stringify(path.join(import.meta.dirname, "helpers", "register-source-require.ts"))}),
+  path.resolve(${JSON.stringify(path.join(import.meta.dirname, "helpers", "source-require-cache.ts"))}),
+]);
+const compiled = [];
+const originalCompile = Module.prototype._compile;
+Module.prototype._compile = function recordBootstrapSource(source, filename) {
+  if (expected.has(path.resolve(filename))) {
+    compiled.push({ filename: path.resolve(filename), sourceMapped: source.includes("sourceMappingURL=data:application/json;base64") });
+  }
+  return originalCompile.call(this, source, filename);
+};
+let rejectedUnexpected = false;
+Object.defineProperty(Module._extensions, ".ts", {
+  configurable: true,
+  get() {
+    return undefined;
+  },
+  set(handler) {
+    try {
+      handler({ _compile() { throw new Error("unexpected module was compiled"); } }, ${JSON.stringify(unexpectedPath)});
+    } catch (error) {
+      rejectedUnexpected = String(error).includes("Refusing to bootstrap unexpected TypeScript module");
+    }
+    Object.defineProperty(Module._extensions, ".ts", {
+      configurable: true,
+      enumerable: true,
+      value: handler,
+      writable: true,
+    });
+  },
+});
+require(${JSON.stringify(SOURCE_REQUIRE_HOOK)});
+if (!rejectedUnexpected || compiled.length !== 2 || compiled.some((entry) => !entry.sourceMapped)) {
+  console.error(JSON.stringify({ compiled, rejectedUnexpected }));
+  process.exitCode = 9;
+}
+`;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: nodeOptionsWithoutSourceLoader(process.env.NODE_OPTIONS),
+      },
+      timeout: 10_000,
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
   it("keeps stats output best-effort when the destination cannot be appended (#6237)", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-stats-"));
     roots.push(root);
@@ -336,5 +489,49 @@ publishWhenConsumerIsReady();
     trackCacheArtifacts(fs.realpathSync(fixturePath));
 
     runFixtureRequire(fixturePath, root);
+  });
+
+  it("returns transpiled output when cache persistence fails (#6237)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-write-"));
+    roots.push(root);
+    const fixturePath = path.join(root, "fixture.ts");
+    const statsPath = path.join(root, "stats.jsonl");
+    fs.writeFileSync(fixturePath, "export const value: number = 42;\n");
+    const fixtureRealPath = fs.realpathSync(fixturePath);
+    const { cachePath, lockPath } = trackCacheArtifacts(fixtureRealPath);
+    fs.rmSync(cachePath, { force: true });
+
+    runFixtureRequire(
+      fixtureRealPath,
+      statsPath,
+      {},
+      undefined,
+      `
+const fs = require("node:fs");
+const originalRenameSync = fs.renameSync;
+fs.renameSync = function renameSourceRequireCache(from, to) {
+  if (to === ${JSON.stringify(cachePath)}) {
+    const error = new Error("synthetic cache write failure");
+    error.code = "EACCES";
+    throw error;
+  }
+  return originalRenameSync.call(this, from, to);
+};
+`,
+    );
+
+    const [row] = readStats(statsPath);
+    expect(row).toMatchObject({
+      cacheMisses: 1,
+      duplicateFallbacks: 0,
+      transforms: 1,
+    });
+    expect(fs.existsSync(cachePath)).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(
+      fs
+        .readdirSync(path.dirname(cachePath))
+        .filter((entry) => entry.startsWith(`${path.basename(cachePath)}.`)),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Coordinate cross-process TypeScript source-loader cache misses so parallel test workers reuse compiled output instead of duplicating work, while safely reclaiming stale locks and emitting opt-in diagnostics.
This is a related mitigation for #6237 and does not claim to fix or close the issue.
This supersedes #6483 and preserves original implementation credit for Ho Lim in the commit and PR description.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Related mitigation for #6237.
This PR does not fix or close the issue.

## Changes
<!-- Bullet list of key changes. -->

- Extract reusable compiler-option, fingerprint, cache-directory, and cache-path helpers for the source require loader.
- Coordinate cache misses with exclusive lock files, bounded waiting, atomic cache writes, and duplicate-transpile fallback.
- Reclaim stale locks only after checking lock identity and confirming that the recorded owner is no longer running.
- Add opt-in cache timing and hit/miss statistics without allowing diagnostic writes to fail test processes.
- Update the CommonJS onboarding test bootstrap and add coverage for cross-process reuse, stale-lock recovery, and best-effort statistics.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Independent documentation review found that this test-only loader and cache optimization does not change user-facing commands, configuration, runtime behavior, or supported workflows.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — `npx prek run --from-ref origin/main --to-ref HEAD` and the normal pre-push gates passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `test/source-require-loader.test.ts` and `test/gateway-drift-preflight.test.ts` passed (4 tests); `src/lib/actions/sandbox/rebuild-gateway-drift.test.ts` passed (6 tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: No broad full-suite claim; focused TypeScript compilation of the three changed or new TypeScript files passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the TypeScript “source require” loader in cross-process, filesystem-backed test runs.
  * Expanded coverage for shared cache reuse across runs and lock-file coordination, including stale/dead lock reclamation behavior.
  * Added validation that bootstrapping compilation is restricted to expected loader modules, with safeguards against unexpected TypeScript compilation.
  * Added checks for cache/lock timing output (JSONL stats), symlink handling, and graceful fallback when cache persistence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->