### PR TITLE
test: normalize fixture umask so Hermes/OpenClaw guard tests pass under permissive umask (#6448)

### DIFF
--- a/test/fixture-umask-normalization.test.ts
+++ b/test/fixture-umask-normalization.test.ts
@@ -124,41 +124,47 @@ else:
   expect(result.stdout).toContain("group/world-writable");
 });
 
-it("wires the fixture-umask setup into every non-live project before other setup files (#6448)", () => {
-  // A config-contract guard: if a future edit drops or misorders the setup for a
-  // project, the permissive-umask failures would only resurface on hosts with a
-  // permissive ambient umask (CI at 0o022 would not catch it).
+// Named vitest projects (config objects), used by the config-contract guards
+// below. A future edit that drops or misorders the setup would otherwise only
+// resurface the permissive-umask failures on hosts with a permissive ambient
+// umask (CI at 0o022 would not catch it).
+function namedVitestProjects(): { name: string; setupFiles?: string[] }[] {
   const projects = (vitestConfig.test?.projects ?? []) as ProjectEntry[];
-  const setupFilesByName = new Map(
-    projects.map((project) => [project.test?.name, project.test?.setupFiles ?? []]),
-  );
+  return projects
+    .map((project) => project.test)
+    .filter((test): test is { name: string; setupFiles?: string[] } => test?.name !== undefined);
+}
 
+it("wires the fixture-umask setup first in every npm test project (#6448)", () => {
   // The exact set of projects `npm test` runs, kept in sync with package.json's
   // `scripts.test`. Each must pin the fixture umask first. (Parsing the npm test
   // command string here would trip the repo's source-shape test budget, so the
   // list is asserted explicitly and lives next to that command.)
+  const setupFilesByName = new Map(
+    namedVitestProjects().map((test) => [test.name, test.setupFiles ?? []]),
+  );
   for (const name of NPM_TEST_PROJECTS) {
     const setupFiles = setupFilesByName.get(name);
     expect(setupFiles, name).toContain(FIXTURE_UMASK_SETUP);
     expect(setupFiles?.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
   }
+});
 
-  // Every other non-live project defined in the config must also be pinned first,
-  // so a newly added non-live project cannot silently miss the setup. Filters keep
-  // the test body linear (no branching) per the codebase-growth guardrail.
-  const namedProjects = projects
-    .map((project) => project.test)
-    .filter((test): test is { name: string; setupFiles?: string[] } => test?.name !== undefined);
-  for (const test of namedProjects.filter((entry) => !LIVE_PROJECTS.has(entry.name))) {
+it("pins the umask setup first in every non-live project and never in live ones (#6448)", () => {
+  // Independent contract from the explicit npm-test list: every non-live project
+  // defined in the config must pin the setup first (so a newly added non-live
+  // project cannot silently miss it), while the live/credential-bearing projects
+  // must never pin it (e2e-live handles real credentials and sets its own strict
+  // `umask 077` inline; e2e-branch-validation defines no setupFiles; neither has
+  // guard fixtures). Filters keep the test body linear (no branching) per the
+  // codebase-growth guardrail.
+  const projects = namedVitestProjects();
+  for (const test of projects.filter((entry) => !LIVE_PROJECTS.has(entry.name))) {
     const setupFiles = test.setupFiles ?? [];
     expect(setupFiles, test.name).toContain(FIXTURE_UMASK_SETUP);
     expect(setupFiles.indexOf(FIXTURE_UMASK_SETUP), test.name).toBe(0);
   }
-
-  // The live/credential-bearing projects must never be pinned (e2e-live handles
-  // real credentials and sets its own strict `umask 077` inline,
-  // e2e-branch-validation defines no setupFiles, and neither has guard fixtures).
-  for (const test of namedProjects.filter((entry) => LIVE_PROJECTS.has(entry.name))) {
+  for (const test of projects.filter((entry) => LIVE_PROJECTS.has(entry.name))) {
     expect(test.setupFiles ?? [], test.name).not.toContain(FIXTURE_UMASK_SETUP);
   }
 });

--- a/test/fixture-umask-normalization.test.ts
+++ b/test/fixture-umask-normalization.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+
+// Regression coverage for #6448. The shared setup file
+// test/helpers/normalize-fixture-umask.ts must force the conventional CI
+// file-creation umask (0o022) in every test worker, so Hermes/OpenClaw guard
+// fixtures are never created group/world-writable on a developer host with a
+// permissive ambient umask (e.g. 0002). Without it, the production
+// runtime-config guard fails those fixtures closed with
+// `UnsafePathError: refusing group/world-writable runtime config path`.
+
+it("pins the test worker umask to the deterministic 0o022 baseline (#6448)", () => {
+  // process.umask(mask) sets the umask and returns the previous value; setting it
+  // to the value the setup already installed is a no-op, and the returned
+  // previous value proves the setup pinned the worker to exactly 0o022 —
+  // independent of the developer's ambient umask. The exact value matters: tests
+  // assert group-readable fixture modes (e.g. a Hermes .env at 0o640) that only
+  // hold at 0o022.
+  const previous = process.umask(0o022);
+  expect(previous).toBe(0o022);
+});
+
+it("keeps in-process fixture files free of group/world write bits (#6448)", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-umask-regression-"));
+  try {
+    const file = path.join(dir, "config.yaml");
+    fs.writeFileSync(file, "model: test\n");
+    expect(fs.statSync(file).mode & 0o022).toBe(0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+it("propagates the safe umask to spawned fixture processes (#6448)", () => {
+  // Guard fixtures are written by python/bash children spawned from the worker.
+  // umask is inherited across spawn, so a child creating a normal file (which,
+  // unlike tempfile.mkstemp, respects umask) must also produce a non
+  // group/world-writable mode.
+  const result = spawnSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import os, stat, sys, tempfile",
+        "d = tempfile.mkdtemp()",
+        "p = os.path.join(d, 'config.yaml')",
+        "open(p, 'w', encoding='utf-8').write('model: test\\n')",
+        "sys.stdout.write(str(stat.S_IMODE(os.stat(p).st_mode)))",
+      ].join("\n"),
+    ],
+    { encoding: "utf-8", timeout: 5000 },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  const mode = Number.parseInt(result.stdout.trim(), 10);
+  expect(mode & 0o022).toBe(0);
+});

--- a/test/fixture-umask-normalization.test.ts
+++ b/test/fixture-umask-normalization.test.ts
@@ -111,11 +111,18 @@ else:
   expect(result.stdout).toContain("group/world-writable");
 });
 
-it("wires the fixture-umask setup into every intended project before other setup files (#6448)", () => {
+it("wires the fixture-umask setup into every npm test project before other setup files (#6448)", () => {
   // A config-contract guard: if a future edit drops or misorders the setup for a
   // project, the permissive-umask failures would only resurface on hosts with a
-  // permissive ambient umask (CI at 0o022 would not catch it). Assert membership
-  // and ordering here instead.
+  // permissive ambient umask (CI at 0o022 would not catch it). Derive the project
+  // list from package.json's `npm test` command rather than hard-coding it, so
+  // adding or removing a `--project` cannot silently drift out of this contract.
+  const testScript = JSON.parse(
+    fs.readFileSync(path.join(import.meta.dirname, "..", "package.json"), "utf-8"),
+  ).scripts.test as string;
+  const npmTestProjects = [...testScript.matchAll(/--project\s+(\S+)/g)].map((match) => match[1]);
+  expect(npmTestProjects.length).toBeGreaterThan(0);
+
   const projects = (vitestConfig.test?.projects ?? []) as ProjectEntry[];
   const setupFilesByName = new Map(
     projects.map((project) => [project.test?.name, project.test?.setupFiles ?? []]),
@@ -123,22 +130,18 @@ it("wires the fixture-umask setup into every intended project before other setup
 
   // Every project `npm test` runs must pin the fixture umask first, before any
   // fixture/source-loader setup file.
-  for (const name of [
-    "cli",
-    "integration",
-    "installer-integration",
-    "package-contract",
-    "plugin",
-    "e2e-support",
-  ]) {
+  for (const name of npmTestProjects) {
     const setupFiles = setupFilesByName.get(name);
     expect(setupFiles, name).toContain(FIXTURE_UMASK_SETUP);
     expect(setupFiles?.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
   }
 
-  // e2e-live intentionally keeps the caller's umask (it handles real credentials
-  // and sets its own strict `umask 077` inline); e2e-branch-validation defines no
-  // setupFiles. Neither has guard-fixture suites.
+  // The live/credential-bearing projects are intentionally excluded: e2e-live
+  // keeps the caller's umask (it handles real credentials and sets its own strict
+  // `umask 077` inline) and e2e-branch-validation defines no setupFiles. Neither
+  // is part of `npm test` nor has guard-fixture suites.
+  expect(npmTestProjects).not.toContain("e2e-live");
+  expect(npmTestProjects).not.toContain("e2e-branch-validation");
   expect(setupFilesByName.get("e2e-live") ?? []).not.toContain(FIXTURE_UMASK_SETUP);
   expect(setupFilesByName.get("e2e-branch-validation") ?? []).not.toContain(FIXTURE_UMASK_SETUP);
 });

--- a/test/fixture-umask-normalization.test.ts
+++ b/test/fixture-umask-normalization.test.ts
@@ -7,6 +7,19 @@ import os from "node:os";
 import path from "node:path";
 import { expect, it } from "vitest";
 
+import vitestConfig from "../vitest.config";
+
+const RUNTIME_CONFIG_GUARD = path.join(
+  import.meta.dirname,
+  "..",
+  "agents",
+  "hermes",
+  "runtime-config-guard.py",
+);
+
+type ProjectEntry = { test?: { name?: string; setupFiles?: string[] } };
+const FIXTURE_UMASK_SETUP = "test/helpers/normalize-fixture-umask.ts";
+
 // Regression coverage for #6448. The shared setup file
 // test/helpers/normalize-fixture-umask.ts must force the conventional CI
 // file-creation umask (0o022) in every test worker, so Hermes/OpenClaw guard
@@ -59,4 +72,73 @@ it("propagates the safe umask to spawned fixture processes (#6448)", () => {
   expect(result.status, result.stderr).toBe(0);
   const mode = Number.parseInt(result.stdout.trim(), 10);
   expect(mode & 0o022).toBe(0);
+});
+
+it("does not weaken the guard: an explicitly group/world-writable config is still rejected (#6448)", () => {
+  // The normalization only affects how test fixtures are created; the production
+  // guard must still fail closed on an explicitly unsafe (0o666) runtime config
+  // path. This proves the harness change did not relax the security boundary.
+  const result = spawnSync(
+    "python3",
+    [
+      "-c",
+      String.raw`
+import importlib.util, os, sys, tempfile
+
+spec = importlib.util.spec_from_file_location("guard", sys.argv[1])
+guard = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = guard
+spec.loader.exec_module(guard)
+
+d = tempfile.mkdtemp()
+os.chmod(d, 0o700)
+p = os.path.join(d, "config.yaml")
+open(p, "w", encoding="utf-8").write("model: test\n")
+os.chmod(p, 0o666)
+try:
+    guard._open_regular(p).close()
+except guard.UnsafePathError as exc:
+    sys.stdout.write("REJECTED:" + str(exc))
+else:
+    sys.stdout.write("ACCEPTED")
+`,
+      RUNTIME_CONFIG_GUARD,
+    ],
+    { encoding: "utf-8", timeout: 5000 },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stdout).toContain("REJECTED:");
+  expect(result.stdout).toContain("group/world-writable");
+});
+
+it("wires the fixture-umask setup into every intended project before other setup files (#6448)", () => {
+  // A config-contract guard: if a future edit drops or misorders the setup for a
+  // project, the permissive-umask failures would only resurface on hosts with a
+  // permissive ambient umask (CI at 0o022 would not catch it). Assert membership
+  // and ordering here instead.
+  const projects = (vitestConfig.test?.projects ?? []) as ProjectEntry[];
+  const setupFilesByName = new Map(
+    projects.map((project) => [project.test?.name, project.test?.setupFiles ?? []]),
+  );
+
+  // Every project `npm test` runs must pin the fixture umask first, before any
+  // fixture/source-loader setup file.
+  for (const name of [
+    "cli",
+    "integration",
+    "installer-integration",
+    "package-contract",
+    "plugin",
+    "e2e-support",
+  ]) {
+    const setupFiles = setupFilesByName.get(name);
+    expect(setupFiles, name).toContain(FIXTURE_UMASK_SETUP);
+    expect(setupFiles?.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
+  }
+
+  // e2e-live intentionally keeps the caller's umask (it handles real credentials
+  // and sets its own strict `umask 077` inline); e2e-branch-validation defines no
+  // setupFiles. Neither has guard-fixture suites.
+  expect(setupFilesByName.get("e2e-live") ?? []).not.toContain(FIXTURE_UMASK_SETUP);
+  expect(setupFilesByName.get("e2e-branch-validation") ?? []).not.toContain(FIXTURE_UMASK_SETUP);
 });

--- a/test/fixture-umask-normalization.test.ts
+++ b/test/fixture-umask-normalization.test.ts
@@ -143,20 +143,22 @@ it("wires the fixture-umask setup into every non-live project before other setup
     expect(setupFiles?.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
   }
 
-  // Any other non-live project defined in the config must also be pinned, so a
-  // newly added non-live project cannot silently miss the setup; the
-  // live/credential-bearing projects must never be pinned (e2e-live handles real
-  // credentials and sets its own strict `umask 077` inline, e2e-branch-validation
-  // defines no setupFiles, and neither has guard-fixture suites).
-  for (const project of projects) {
-    const name = project.test?.name;
-    if (name === undefined) continue;
-    const setupFiles = project.test?.setupFiles ?? [];
-    if (LIVE_PROJECTS.has(name)) {
-      expect(setupFiles, name).not.toContain(FIXTURE_UMASK_SETUP);
-    } else {
-      expect(setupFiles, name).toContain(FIXTURE_UMASK_SETUP);
-      expect(setupFiles.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
-    }
+  // Every other non-live project defined in the config must also be pinned first,
+  // so a newly added non-live project cannot silently miss the setup. Filters keep
+  // the test body linear (no branching) per the codebase-growth guardrail.
+  const namedProjects = projects
+    .map((project) => project.test)
+    .filter((test): test is { name: string; setupFiles?: string[] } => test?.name !== undefined);
+  for (const test of namedProjects.filter((entry) => !LIVE_PROJECTS.has(entry.name))) {
+    const setupFiles = test.setupFiles ?? [];
+    expect(setupFiles, test.name).toContain(FIXTURE_UMASK_SETUP);
+    expect(setupFiles.indexOf(FIXTURE_UMASK_SETUP), test.name).toBe(0);
+  }
+
+  // The live/credential-bearing projects must never be pinned (e2e-live handles
+  // real credentials and sets its own strict `umask 077` inline,
+  // e2e-branch-validation defines no setupFiles, and neither has guard fixtures).
+  for (const test of namedProjects.filter((entry) => LIVE_PROJECTS.has(entry.name))) {
+    expect(test.setupFiles ?? [], test.name).not.toContain(FIXTURE_UMASK_SETUP);
   }
 });

--- a/test/fixture-umask-normalization.test.ts
+++ b/test/fixture-umask-normalization.test.ts
@@ -19,6 +19,19 @@ const RUNTIME_CONFIG_GUARD = path.join(
 
 type ProjectEntry = { test?: { name?: string; setupFiles?: string[] } };
 const FIXTURE_UMASK_SETUP = "test/helpers/normalize-fixture-umask.ts";
+// Live/credential-bearing projects are intentionally not pinned to 0o022; they
+// are excluded from `npm test` and keep the caller's umask.
+const LIVE_PROJECTS = new Set(["e2e-live", "e2e-branch-validation"]);
+// The projects `npm test` runs (package.json `scripts.test`), asserted explicitly
+// because parsing that command string in a test would trip the source-shape budget.
+const NPM_TEST_PROJECTS = [
+  "cli",
+  "integration",
+  "installer-integration",
+  "package-contract",
+  "plugin",
+  "e2e-support",
+];
 
 // Regression coverage for #6448. The shared setup file
 // test/helpers/normalize-fixture-umask.ts must force the conventional CI
@@ -111,37 +124,39 @@ else:
   expect(result.stdout).toContain("group/world-writable");
 });
 
-it("wires the fixture-umask setup into every npm test project before other setup files (#6448)", () => {
+it("wires the fixture-umask setup into every non-live project before other setup files (#6448)", () => {
   // A config-contract guard: if a future edit drops or misorders the setup for a
   // project, the permissive-umask failures would only resurface on hosts with a
-  // permissive ambient umask (CI at 0o022 would not catch it). Derive the project
-  // list from package.json's `npm test` command rather than hard-coding it, so
-  // adding or removing a `--project` cannot silently drift out of this contract.
-  const testScript = JSON.parse(
-    fs.readFileSync(path.join(import.meta.dirname, "..", "package.json"), "utf-8"),
-  ).scripts.test as string;
-  const npmTestProjects = [...testScript.matchAll(/--project\s+(\S+)/g)].map((match) => match[1]);
-  expect(npmTestProjects.length).toBeGreaterThan(0);
-
+  // permissive ambient umask (CI at 0o022 would not catch it).
   const projects = (vitestConfig.test?.projects ?? []) as ProjectEntry[];
   const setupFilesByName = new Map(
     projects.map((project) => [project.test?.name, project.test?.setupFiles ?? []]),
   );
 
-  // Every project `npm test` runs must pin the fixture umask first, before any
-  // fixture/source-loader setup file.
-  for (const name of npmTestProjects) {
+  // The exact set of projects `npm test` runs, kept in sync with package.json's
+  // `scripts.test`. Each must pin the fixture umask first. (Parsing the npm test
+  // command string here would trip the repo's source-shape test budget, so the
+  // list is asserted explicitly and lives next to that command.)
+  for (const name of NPM_TEST_PROJECTS) {
     const setupFiles = setupFilesByName.get(name);
     expect(setupFiles, name).toContain(FIXTURE_UMASK_SETUP);
     expect(setupFiles?.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
   }
 
-  // The live/credential-bearing projects are intentionally excluded: e2e-live
-  // keeps the caller's umask (it handles real credentials and sets its own strict
-  // `umask 077` inline) and e2e-branch-validation defines no setupFiles. Neither
-  // is part of `npm test` nor has guard-fixture suites.
-  expect(npmTestProjects).not.toContain("e2e-live");
-  expect(npmTestProjects).not.toContain("e2e-branch-validation");
-  expect(setupFilesByName.get("e2e-live") ?? []).not.toContain(FIXTURE_UMASK_SETUP);
-  expect(setupFilesByName.get("e2e-branch-validation") ?? []).not.toContain(FIXTURE_UMASK_SETUP);
+  // Any other non-live project defined in the config must also be pinned, so a
+  // newly added non-live project cannot silently miss the setup; the
+  // live/credential-bearing projects must never be pinned (e2e-live handles real
+  // credentials and sets its own strict `umask 077` inline, e2e-branch-validation
+  // defines no setupFiles, and neither has guard-fixture suites).
+  for (const project of projects) {
+    const name = project.test?.name;
+    if (name === undefined) continue;
+    const setupFiles = project.test?.setupFiles ?? [];
+    if (LIVE_PROJECTS.has(name)) {
+      expect(setupFiles, name).not.toContain(FIXTURE_UMASK_SETUP);
+    } else {
+      expect(setupFiles, name).toContain(FIXTURE_UMASK_SETUP);
+      expect(setupFiles.indexOf(FIXTURE_UMASK_SETUP), name).toBe(0);
+    }
+  }
 });

--- a/test/helpers/normalize-fixture-umask.ts
+++ b/test/helpers/normalize-fixture-umask.ts
@@ -16,11 +16,15 @@
 // the tests before they reach their intended assertions (#6448).
 //
 // Child fixture processes (python3/bash spawned via spawnSync) inherit this
-// umask, so setting it once per worker makes every fixture file be created with
-// the same non group/world-writable modes CI already produces under its default
-// 0022 umask. We deliberately use 0o022 rather than a stricter value: it strips
-// only the group/world *write* bits the guard cares about while leaving read
-// bits untouched, so no test that depends on default read permissions changes
-// behavior. The production guard stays strict; only the test fixture creation
-// environment is normalized.
+// umask, so pinning it once per worker makes every fixture file be created with
+// the same deterministic modes CI produces.
+//
+// The value is exactly 0o022 — the conventional CI umask the fixture tests were
+// written against. Several tests assert those exact group-readable modes (for
+// example a Hermes .env at 0o640), so the baseline must be 0o022 rather than the
+// caller's ambient umask: a permissive caller (0o002) would create
+// group-writable fixtures the guard rejects, and a stricter caller (0o077) would
+// drop the group-read bit those assertions expect. This setup is intentionally
+// not applied to the live-E2E project, which handles real credentials and sets
+// its own strict `umask 077` inline where privacy matters.
 process.umask(0o022);

--- a/test/helpers/normalize-fixture-umask.ts
+++ b/test/helpers/normalize-fixture-umask.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Normalize the test worker's file-creation umask to the conventional CI value
+// (0o022) before any test runs.
+//
+// Several Hermes/OpenClaw suites build fixture files (config.yaml, .env,
+// .config-hash, strict hash files) in system temp directories and then feed
+// them to the production runtime-config guard
+// (agents/hermes/runtime-config-guard.py). That guard fails closed on
+// group/world-writable runtime config paths (`mode & 0o022`). On a fresh
+// developer checkout whose ambient umask is permissive (for example 0002 on
+// Ubuntu 24.04 / CI-like hosts), fixture files are created group-writable
+// (0o664) and the guard rejects them with
+// `UnsafePathError: refusing group/world-writable runtime config path`, failing
+// the tests before they reach their intended assertions (#6448).
+//
+// Child fixture processes (python3/bash spawned via spawnSync) inherit this
+// umask, so setting it once per worker makes every fixture file be created with
+// the same non group/world-writable modes CI already produces under its default
+// 0022 umask. We deliberately use 0o022 rather than a stricter value: it strips
+// only the group/world *write* bits the guard cares about while leaving read
+// bits untouched, so no test that depends on default read permissions changes
+// behavior. The production guard stays strict; only the test fixture creation
+// environment is normalized.
+process.umask(0o022);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,10 +34,10 @@ const typedSourceTransform = {
   },
 };
 const sourceNodeOptions = sourceLoaderNodeOptions(process.env.NODE_OPTIONS);
-// Force the conventional CI file-creation umask (0o022) in every test worker so
-// Hermes/OpenClaw guard fixtures are never created group/world-writable on a
-// developer host with a permissive ambient umask (e.g. 0002 on Ubuntu 24.04).
-// See test/helpers/normalize-fixture-umask.ts (#6448).
+// Mask group/world write bits into every test worker's umask so Hermes/OpenClaw
+// guard fixtures are never created group/world-writable on a developer host with
+// a permissive ambient umask (e.g. 0002 on Ubuntu 24.04), without relaxing a
+// stricter caller umask. See test/helpers/normalize-fixture-umask.ts (#6448).
 const fixtureUmaskSetup = "test/helpers/normalize-fixture-umask.ts";
 const integrationProjectScheduling = resolveIntegrationProjectScheduling({
   isCi,
@@ -157,7 +157,11 @@ export default defineConfig({
           // Use setupFiles rather than NODE_OPTIONS so the hook stays in-process
           // and never leaks `--require` into the real CLI subprocesses under
           // test. Mirrors the `cli` project.
-          setupFiles: [fixtureUmaskSetup, "test/helpers/onboard-script-mocks.cjs"],
+          //
+          // Intentionally excludes the fixture-umask setup: live E2E has no
+          // guard-fixture suites and handles real credentials, so it must keep
+          // the caller's umask (and sets its own strict `umask 077` inline).
+          setupFiles: ["test/helpers/onboard-script-mocks.cjs"],
           testTimeout: testTimeout(LIVE_E2E_PROJECT_TIMEOUT_MS),
           // Live targets mutate host, Docker, gateway, and sandbox state. A
           // whole-test retry reuses that state and can hide the first failure

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,11 @@ const typedSourceTransform = {
   },
 };
 const sourceNodeOptions = sourceLoaderNodeOptions(process.env.NODE_OPTIONS);
+// Force the conventional CI file-creation umask (0o022) in every test worker so
+// Hermes/OpenClaw guard fixtures are never created group/world-writable on a
+// developer host with a permissive ambient umask (e.g. 0002 on Ubuntu 24.04).
+// See test/helpers/normalize-fixture-umask.ts (#6448).
+const fixtureUmaskSetup = "test/helpers/normalize-fixture-umask.ts";
 const integrationProjectScheduling = resolveIntegrationProjectScheduling({
   isCi,
   npmLifecycleEvent: process.env.npm_lifecycle_event,
@@ -58,7 +63,7 @@ export default defineConfig({
           name: "cli",
           alias: canonicalOpenShellPolicyAlias,
           testTimeout: testTimeout(),
-          setupFiles: ["test/helpers/onboard-script-mocks.cjs"],
+          setupFiles: [fixtureUmaskSetup, "test/helpers/onboard-script-mocks.cjs"],
           include: ["src/**/*.test.ts"],
           exclude: ["**/node_modules/**", "**/.claude/**"],
         },
@@ -71,7 +76,7 @@ export default defineConfig({
           // Source-backed process fixtures can exceed the unit-test budget
           // when several coverage shards transpile and spawn them concurrently.
           testTimeout: testTimeout(15_000),
-          setupFiles: ["test/helpers/onboard-script-mocks.cjs"],
+          setupFiles: [fixtureUmaskSetup, "test/helpers/onboard-script-mocks.cjs"],
           // Integration fixtures often spawn short Node programs. Coverage
           // stays serial because concurrent source-loader forks exhaust the
           // 7 GiB CI runner. The canonical local full suite instead runs this
@@ -99,6 +104,7 @@ export default defineConfig({
         test: {
           name: "installer-integration",
           alias: canonicalOpenShellPolicyAlias,
+          setupFiles: [fixtureUmaskSetup],
           include: [
             "test/install-express-prompt.test.ts",
             "test/install-build-dependency-preflight.test.ts",
@@ -115,6 +121,7 @@ export default defineConfig({
         test: {
           name: "package-contract",
           alias: canonicalOpenShellPolicyAlias,
+          setupFiles: [fixtureUmaskSetup],
           include: ["test/package-contract/**/*.test.ts"],
         },
       },
@@ -123,6 +130,7 @@ export default defineConfig({
         test: {
           name: "plugin",
           alias: canonicalOpenShellPolicyAlias,
+          setupFiles: [fixtureUmaskSetup],
           include: ["nemoclaw/src/**/*.test.ts"],
         },
       },
@@ -134,7 +142,7 @@ export default defineConfig({
           name: "e2e-support",
           alias: canonicalOpenShellPolicyAlias,
           testTimeout: testTimeout(),
-          setupFiles: ["test/helpers/onboard-script-mocks.cjs"],
+          setupFiles: [fixtureUmaskSetup, "test/helpers/onboard-script-mocks.cjs"],
           include: ["test/e2e/support/**/*.test.ts"],
         },
       },
@@ -149,7 +157,7 @@ export default defineConfig({
           // Use setupFiles rather than NODE_OPTIONS so the hook stays in-process
           // and never leaks `--require` into the real CLI subprocesses under
           // test. Mirrors the `cli` project.
-          setupFiles: ["test/helpers/onboard-script-mocks.cjs"],
+          setupFiles: [fixtureUmaskSetup, "test/helpers/onboard-script-mocks.cjs"],
           testTimeout: testTimeout(LIVE_E2E_PROJECT_TIMEOUT_MS),
           // Live targets mutate host, Docker, gateway, and sandbox state. A
           // whole-test retry reuses that state and can hide the first failure

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,10 +34,13 @@ const typedSourceTransform = {
   },
 };
 const sourceNodeOptions = sourceLoaderNodeOptions(process.env.NODE_OPTIONS);
-// Mask group/world write bits into every test worker's umask so Hermes/OpenClaw
-// guard fixtures are never created group/world-writable on a developer host with
-// a permissive ambient umask (e.g. 0002 on Ubuntu 24.04), without relaxing a
-// stricter caller umask. See test/helpers/normalize-fixture-umask.ts (#6448).
+// Pin the file-creation umask of every non-live test worker to exactly 0o022 —
+// the conventional CI baseline — so Hermes/OpenClaw guard fixtures are created
+// with deterministic modes regardless of the developer's ambient umask (e.g. a
+// permissive 0002 on Ubuntu 24.04 would otherwise make them group-writable and
+// the guard would reject them). The live/credential-bearing E2E projects are
+// intentionally excluded below and keep their own stricter umask handling. See
+// test/helpers/normalize-fixture-umask.ts (#6448).
 const fixtureUmaskSetup = "test/helpers/normalize-fixture-umask.ts";
 const integrationProjectScheduling = resolveIntegrationProjectScheduling({
   isCi,


### PR DESCRIPTION
## Summary

On a fresh Ubuntu 24.04 developer checkout whose ambient `umask` is permissive
(e.g. `0002`), the Hermes/OpenClaw runtime-config guard test suites create
fixture files group/world-writable, so the production guard fails them closed
before their real assertions run — the "66-69 failures" reported. This pins the
test-worker file-creation `umask` to the conventional CI baseline (`0o022`) so
fixtures are created with the same deterministic modes CI already produces,
without weakening the production guard.

## Related Issue

Fixes #6448

## Changes

- Add `test/helpers/normalize-fixture-umask.ts`, a Vitest setup file that calls
  `process.umask(0o022)` once per test worker. Child `python3`/`bash` fixture
  processes spawned via `spawnSync` inherit this `umask`, so every fixture file
  (`config.yaml`, `.env`, `.config-hash`, strict hash files) is created with the
  deterministic CI modes. `0o022` is exact on purpose: tests assert group-readable
  fixture modes (e.g. a Hermes `.env` at `0o640`) that only hold at `0o022`, so
  neither a permissive caller (group-writable fixtures the guard rejects) nor a
  stricter caller (dropped group-read bit) is an acceptable baseline.
- Wire the setup into every non-live project `npm test` runs (`cli`,
  `integration`, `installer-integration`, `package-contract`, `plugin`,
  `e2e-support`) in `vitest.config.ts`. It is intentionally **not** applied to
  `e2e-live`, which has no guard-fixture suites, handles real credentials, and
  sets its own strict `umask 077` inline where privacy matters.
- Add `test/fixture-umask-normalization.test.ts` — regression coverage that
  asserts the worker `umask` is pinned to `0o022` and that both in-process and
  spawned-child fixture files are created without group/world write bits.
- The production guard `agents/hermes/runtime-config-guard.py` is unchanged and
  stays strict; only the deterministic test fixture-creation `umask` is pinned.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-harness-only change; no
  user-facing behavior or docs surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded —
  reviewer/approval link/justification: change is test-only and does **not**
  modify the production runtime-config guard or any product code; local
  high-effort `/review` and two `codex review` passes returned no actionable
  findings. The guard's strict rejection of group/world-writable runtime config
  paths is preserved verbatim, and the live-E2E credential path keeps its own
  strict `umask 077`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result:
  - `umask 0002 && npx vitest run --project cli --project integration <6 named guard suites> test/fixture-umask-normalization.test.ts` → **169/169 pass** (pre-fix: 57 fail with `UnsafePathError: refusing group/world-writable runtime config path`).
  - `umask 0077 && npx vitest run --project integration test/hermes-runtime-api-key.test.ts test/fixture-umask-normalization.test.ts` → **43/43 pass** (confirms a stricter caller umask still yields the expected `0o640` fixture modes).
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes — command/result:
  `umask 0002 && npm test` (reporter's exact command) → **0** `group/world-writable`
  guard failures across the whole suite (was 57). The remaining failures on this
  host (`dashboard-url-command` ×1 [SSH-session env], `openclaw-integrity-pin`
  ×17 [npm-registry Dockerfile harness], and 2 spawn/exec cases) are
  **pre-existing** — they fail identically on clean `upstream/main` under the
  default `umask 0022`, so they are environment-specific to this host and
  unrelated to this change or to the fixture-mode issue.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Reporter-workflow E2E note

The reporter's workflow is literally `./scripts/dev-setup.sh` then `npm test` on a
fresh Ubuntu 24.04 checkout. This change touches only test configuration and test
helpers — no product/runtime/CLI/installer code — so there is no `nemoclaw` user
command involved; the faithful before/after reproduction is the test suite itself
under a permissive `umask`, captured above (pre-fix 57 fixture-mode failures →
post-fix 0). The reporter-workflow pipeline E2E is this PR's own CI test jobs
(`cli-test-shards`, `installer-integration`, `plugin-tests`, `e2e-support`), which
run the `npm test` suites on the fixed head.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by normalizing the process umask so fixture files consistently avoid group/world-writable permissions across test workers and spawned processes.
  * Applied this normalization only to non-live test suites, intentionally leaving live scenarios unchanged.

* **Tests**
  * Added regression coverage for umask behavior in-process and in child processes.
  * Confirmed the runtime configuration guard still rejects group/world-writable runtime-config files.
  * Added checks ensuring the umask normalization setup is the first test setup entry where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->