### PR TITLE
fix(inference): serve Spark Qwen3.6 with qwen3_coder tool parser (#6457)

### DIFF
--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -227,7 +227,11 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--attention-backend flashinfer");
     expect(cmd).toContain("--moe-backend marlin");
     expect(cmd).toContain("--enable-auto-tool-choice");
-    expect(cmd).toContain("--tool-call-parser qwen3_xml");
+    // #6457: `qwen3_coder` (not `qwen3_xml`) is the validated tool-call parser
+    // for this Spark checkpoint; `qwen3_xml` mis-parses its tool-call frames and
+    // breaks Deep Agents Code tool calls with HTTP 400.
+    expect(cmd).toContain("--tool-call-parser qwen3_coder");
+    expect(cmd).not.toContain("qwen3_xml");
     expect(cmd).toContain("--reasoning-parser qwen3");
     expect(cmd).toContain("--max-model-len 262144");
     expect(cmd).toContain(

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -235,8 +235,7 @@ describe("vllm model registry", () => {
     // Exactly one tool-call parser is configured for the Spark recipe, so the
     // #6457 regression (serving this checkpoint with qwen3_xml, which mis-parses
     // its tool-call frames and fails Deep Agents Code with HTTP 400) cannot creep
-    // back in alongside qwen3_coder. Validated end-to-end on real DGX Spark (GB10):
-    // pre-fix 3/4 dcode runs hit HTTP 400, post-fix (qwen3_coder) 5/5 completed.
+    // back in alongside qwen3_coder.
     expect(cmd.match(/--tool-call-parser/g)).toHaveLength(1);
     expect(cmd).toContain("--reasoning-parser qwen3");
     expect(cmd).toContain("--max-model-len 262144");

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -209,7 +209,7 @@ describe("vllm model registry", () => {
     expect(qwen35b!.gated).toBe(false);
   });
 
-  it("builds the NVFP4 serve command from the DGX Spark model-card recipe", () => {
+  it("builds the NVFP4 serve command from the DGX Spark model-card recipe (#6457)", () => {
     const qwen35b = VLLM_MODELS.find((m) => m.envValue === "qwen3.6-35b-a3b-nvfp4");
     const cmd = buildVllmServeCommand(qwen35b!);
     // The current NVIDIA model card no longer needs Spark-specific env exports.
@@ -243,6 +243,22 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--pipeline-parallel-size 1");
     expect(cmd).toContain("--data-parallel-size 1");
     expect(cmd).not.toContain("--gpu-memory-utilization 0.7");
+  });
+
+  it("does not regress the Spark tool-call parser to qwen3_xml (#6457)", () => {
+    // #6457: served with `qwen3_xml`, this checkpoint's tool-call frames do not
+    // round-trip — vLLM logs `qwen3xml_tool_parser.py:303 Error when parsing XML
+    // elements: not well-formed` and emits truncated/extra-`}` arguments, so
+    // Deep Agents Code (`dcode -n`) tool calls fail with HTTP 400 and exit 1.
+    // Validated end-to-end on real DGX Spark (GB10): pre-fix 3/4 runs hit HTTP
+    // 400, post-fix (qwen3_coder) 5/5 runs completed with 0 parser errors.
+    const qwen35b = VLLM_MODELS.find((m) => m.envValue === "qwen3.6-35b-a3b-nvfp4");
+    const cmd = buildVllmServeCommand(qwen35b!);
+    expect(cmd).toContain("--enable-auto-tool-choice");
+    expect(cmd).toContain("--tool-call-parser qwen3_coder");
+    expect(cmd).not.toContain("qwen3_xml");
+    // Exactly one tool-call parser is configured for the Spark recipe.
+    expect(cmd.match(/--tool-call-parser/g)).toHaveLength(1);
   });
 });
 

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -232,6 +232,12 @@ describe("vllm model registry", () => {
     // breaks Deep Agents Code tool calls with HTTP 400.
     expect(cmd).toContain("--tool-call-parser qwen3_coder");
     expect(cmd).not.toContain("qwen3_xml");
+    // Exactly one tool-call parser is configured for the Spark recipe, so the
+    // #6457 regression (serving this checkpoint with qwen3_xml, which mis-parses
+    // its tool-call frames and fails Deep Agents Code with HTTP 400) cannot creep
+    // back in alongside qwen3_coder. Validated end-to-end on real DGX Spark (GB10):
+    // pre-fix 3/4 dcode runs hit HTTP 400, post-fix (qwen3_coder) 5/5 completed.
+    expect(cmd.match(/--tool-call-parser/g)).toHaveLength(1);
     expect(cmd).toContain("--reasoning-parser qwen3");
     expect(cmd).toContain("--max-model-len 262144");
     expect(cmd).toContain(
@@ -243,22 +249,6 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--pipeline-parallel-size 1");
     expect(cmd).toContain("--data-parallel-size 1");
     expect(cmd).not.toContain("--gpu-memory-utilization 0.7");
-  });
-
-  it("does not regress the Spark tool-call parser to qwen3_xml (#6457)", () => {
-    // #6457: served with `qwen3_xml`, this checkpoint's tool-call frames do not
-    // round-trip — vLLM logs `qwen3xml_tool_parser.py:303 Error when parsing XML
-    // elements: not well-formed` and emits truncated/extra-`}` arguments, so
-    // Deep Agents Code (`dcode -n`) tool calls fail with HTTP 400 and exit 1.
-    // Validated end-to-end on real DGX Spark (GB10): pre-fix 3/4 runs hit HTTP
-    // 400, post-fix (qwen3_coder) 5/5 runs completed with 0 parser errors.
-    const qwen35b = VLLM_MODELS.find((m) => m.envValue === "qwen3.6-35b-a3b-nvfp4");
-    const cmd = buildVllmServeCommand(qwen35b!);
-    expect(cmd).toContain("--enable-auto-tool-choice");
-    expect(cmd).toContain("--tool-call-parser qwen3_coder");
-    expect(cmd).not.toContain("qwen3_xml");
-    // Exactly one tool-call parser is configured for the Spark recipe.
-    expect(cmd.match(/--tool-call-parser/g)).toHaveLength(1);
   });
 });
 

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -200,8 +200,21 @@ export const VLLM_MODELS: readonly VllmModelDef[] = [
       "--async-scheduling",
       "--enable-prefix-caching",
       "--enable-auto-tool-choice",
+      // `qwen3_coder`, not `qwen3_xml` (#6457). On DGX Spark this checkpoint's
+      // tool-call frames do not round-trip through vLLM's `qwen3_xml` parser:
+      // it logs `qwen3xml_tool_parser.py:303 Error when parsing XML elements:
+      // not well-formed (invalid token)` and emits truncated/extra-`}` tool
+      // arguments, so Deep Agents Code headless (`dcode -n`) tool calls fail
+      // intermittently with `POST /v1/chat/completions 400 Bad Request`
+      // (`json.decoder.JSONDecodeError: Extra data`) and `dcode` exits 1. The
+      // `qwen3_coder` parser matches this Qwen3.6-family checkpoint's emitted
+      // tool-call format — the same parser the other Qwen3.6 recipes in this
+      // registry already use (Qwen3.6-27B-FP8, Nemotron-3-Nano-4B) — and was
+      // validated end-to-end on real DGX Spark (GB10) hardware: 5/5 `dcode -n`
+      // runs completed with 0 parse errors and 0 HTTP 400s, versus HTTP 400 on
+      // 3/4 runs with `qwen3_xml`.
       "--tool-call-parser",
-      "qwen3_xml",
+      "qwen3_coder",
       "--reasoning-parser",
       "qwen3",
       "--speculative-config",

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -201,18 +201,16 @@ export const VLLM_MODELS: readonly VllmModelDef[] = [
       "--enable-prefix-caching",
       "--enable-auto-tool-choice",
       // `qwen3_coder`, not `qwen3_xml` (#6457). On DGX Spark this checkpoint's
-      // tool-call frames do not round-trip through vLLM's `qwen3_xml` parser:
-      // it logs `qwen3xml_tool_parser.py:303 Error when parsing XML elements:
-      // not well-formed (invalid token)` and emits truncated/extra-`}` tool
+      // tool-call frames do not round-trip through vLLM's `qwen3_xml` parser: it
+      // logs `qwen3xml_tool_parser.py:303 Error when parsing XML elements: not
+      // well-formed (invalid token)` and emits truncated/extra-`}` tool
       // arguments, so Deep Agents Code headless (`dcode -n`) tool calls fail
-      // intermittently with `POST /v1/chat/completions 400 Bad Request`
-      // (`json.decoder.JSONDecodeError: Extra data`) and `dcode` exits 1. The
-      // `qwen3_coder` parser matches this Qwen3.6-family checkpoint's emitted
-      // tool-call format — the same parser the other Qwen3.6 recipes in this
-      // registry already use (Qwen3.6-27B-FP8, Nemotron-3-Nano-4B) — and was
-      // validated end-to-end on real DGX Spark (GB10) hardware: 5/5 `dcode -n`
-      // runs completed with 0 parse errors and 0 HTTP 400s, versus HTTP 400 on
-      // 3/4 runs with `qwen3_xml`.
+      // with `POST /v1/chat/completions 400 Bad Request`
+      // (`json.decoder.JSONDecodeError: Extra data`) and `dcode` exits 1.
+      // `qwen3_coder` matches this Qwen3.6-family checkpoint's emitted tool-call
+      // format — the parser the other Qwen3.6 recipes in this registry already
+      // use (Qwen3.6-27B-FP8, Nemotron-3-Nano-4B). Validated end-to-end on real
+      // DGX Spark (GB10); see PR verification notes for the `dcode -n` transcript.
       "--tool-call-parser",
       "qwen3_coder",
       "--reasoning-parser",


### PR DESCRIPTION
## Summary

On DGX Spark, the managed local-vLLM default model `nvidia/Qwen3.6-35B-A3B-NVFP4` was served with `--tool-call-parser qwen3_xml`, which mis-parses this checkpoint's tool-call frames and makes LangChain Deep Agents Code (`dcode -n`) fail with HTTP 400 during tool calls. This switches the Spark recipe to `--tool-call-parser qwen3_coder` — the parser the other Qwen3.6-family recipes in this registry already use — validated end-to-end on real DGX Spark (GB10) hardware.

## Related Issue

Fixes #6457

## Changes

- `src/lib/inference/vllm-models.ts`: change the DGX Spark `nvidia/Qwen3.6-35B-A3B-NVFP4` serve recipe from `--tool-call-parser qwen3_xml` to `--tool-call-parser qwen3_coder`, with a comment documenting the failure mode and the on-hardware validation.
- `src/lib/inference/vllm-models.test.ts`: update the Spark serve-command contract to pin `qwen3_coder` and assert `qwen3_xml` is absent.

## Root cause

vLLM's `qwen3_xml` tool-call parser does not round-trip this checkpoint's tool-call output. The server logs `WARNING [qwen3xml_tool_parser.py:303] Error when parsing XML elements: not well-formed (invalid token)` and produces truncated / extra-`}` tool arguments, so Deep Agents Code tool calls intermittently return `POST /v1/chat/completions 400 Bad Request` (`json.decoder.JSONDecodeError: Extra data`), the agent reports `tool.result ... has no correlated tool.use args; sending empty tool_args`, and `dcode` exits 1. `qwen3_coder` matches this Qwen3.6-family checkpoint's emitted tool-call format (already used by the `Qwen3.6-27B-FP8` and `Nemotron-3-Nano-4B` recipes here).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: internal serve-flag correction; no user-facing doc/config surface changes (managed model/profile is auto-selected on Spark).
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: `codex review --uncommitted` — no discrete correctness issues; single serve-flag value change in the inference model registry, validated end-to-end on DGX Spark (see Verification).

## Verification

E2E run on real DGX Spark (GB10, aarch64, Ubuntu; NVIDIA GB10 / compute cap 12.1) using the current worktree CLI (`node ./bin/nemoclaw.js`) and the reporter workflow. The managed vLLM container is launched by the fixed CLI code; post-fix the running container shows `--tool-call-parser qwen3_coder`.

Onboard (fixed worktree CLI), then the reporter command — both run via the worktree binary:
```
node ./bin/nemoclaw.js onboard --non-interactive --agent langchain-deepagents-code \
  --name dcode6457 --gpu --yes --yes-i-accept-third-party-software --fresh --recreate-sandbox
# (NEMOCLAW_PROVIDER=install-vllm → DGX Spark default nvidia/Qwen3.6-35B-A3B-NVFP4)

node ./bin/nemoclaw.js dcode6457 exec -- dcode -n "Work in /sandbox/work/deepagent-journey. Read task.md and complete it exactly. Run the requested tests before finishing."
```

**Pre-fix (`qwen3_xml`, current main):** 3 of 4 runs exit 1 with the reporter's exact failure:
```
🔧 Calling tool: read_file / ls
tool.result for chatcmpl-tool-... has no correlated tool.use args; sending empty tool_args
langgraph.pregel.remote.RemoteException: {'error': 'BadRequestError', 'message': 'An internal error occurred'}
# vLLM log:
WARNING [qwen3xml_tool_parser.py:303] Error when parsing XML elements: not well-formed (invalid token): line 6, column 1
json.decoder.JSONDecodeError: Extra data: line 1 column 44 (char 43)
POST /v1/chat/completions HTTP/1.1 400 Bad Request
DCODE_EXIT=1
```

**Post-fix (`qwen3_coder`, this PR) — clean onboard via the fixed CLI, then reporter command 5×:**
```
🔧 read_file → ls → edit_file → shell → execute → read_file
"The bug has been fixed ... changed return a - b to return a + b"
✓ Task completed   POSTFIX_DCODE_EXIT=0
RUN 1..4: exit=0 parse_or_400_delta=0 empty_tool_args=0 remote_exc=0 task_completed=1
```
5/5 post-fix runs completed with exit 0 and zero parser errors or HTTP 400s.

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run src/lib/inference/vllm-models.test.ts src/lib/inference/vllm.test.ts` → 56 passed; full `--project cli` lane green.
- [x] Applicable broad gate passed — command/result: `npx vitest run --project cli` passed (all files ✓); change is confined to the inference model registry.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call handling for the `nvidia/Qwen3.6-35B-A3B-NVFP4` model by switching to the correct vLLM tool-call parser, preventing malformed/truncated tool-call arguments and reducing intermittent HTTP 400 failures.

* **Tests**
  * Updated the DGX Spark serve-command regression coverage to confirm `qwen3_xml` is not used and that `--tool-call-parser` is present exactly once with the expected `qwen3_coder` setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->