### PR TITLE
test(sandbox): isolate version tests from the real registry

### DIFF
--- a/src/lib/sandbox/version.test.ts
+++ b/src/lib/sandbox/version.test.ts
@@ -4,7 +4,7 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock heavy dependencies that pull in the full module graph
 vi.mock("../adapters/openshell/resolve.js", () => ({
@@ -63,26 +63,45 @@ vi.mock("child_process", async (importOriginal) => {
 import { spawnSync } from "child_process";
 import { captureSandboxSshConfigCommand } from "../adapters/openshell/client.js";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "../adapters/openshell/timeouts.js";
-import * as registry from "../state/registry.js";
-import { checkAgentVersion, formatStalenessWarning } from "./version.js";
+
+// state/registry captures the registry path at module scope, so HOME must be
+// redirected before it loads. Static ESM imports are hoisted above this
+// assignment, hence the dynamic imports below; reassigning HOME from
+// beforeEach() would be too late and every registerSandbox() would land in the
+// developer's real ~/.nemoclaw/sandboxes.json (#6553).
+const TEST_HOME = mkdtempSync(join(tmpdir(), "sandbox-ver-test-"));
+const ORIGINAL_HOME = process.env.HOME;
+process.env.HOME = TEST_HOME;
+
+const registry = await import("../state/registry.js");
+const { checkAgentVersion, formatStalenessWarning } = await import("./version.js");
+
+const TEST_REGISTRY_FILE = join(TEST_HOME, ".nemoclaw", "sandboxes.json");
+
+function resetTestRegistry(): void {
+  mkdirSync(dirname(TEST_REGISTRY_FILE), { recursive: true });
+  writeFileSync(TEST_REGISTRY_FILE, JSON.stringify({ sandboxes: {}, defaultSandbox: null }));
+}
+
+afterAll(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe("registry isolation", () => {
+  it("resolves the registry inside the test HOME, never the real one (#6553)", () => {
+    expect(registry.REGISTRY_FILE).toBe(TEST_REGISTRY_FILE);
+    expect(registry.REGISTRY_FILE.startsWith(TEST_HOME)).toBe(true);
+  });
+});
 
 describe("checkAgentVersion", () => {
-  let tmpDir: string;
-  const originalHome = process.env.HOME;
-
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "sandbox-ver-test-"));
-    process.env.HOME = tmpDir;
-    mkdirSync(join(tmpDir, ".nemoclaw"), { recursive: true });
-    writeFileSync(
-      join(tmpDir, ".nemoclaw", "sandboxes.json"),
-      JSON.stringify({ sandboxes: {}, defaultSandbox: null }),
-    );
+    resetTestRegistry();
   });
 
   afterEach(() => {
-    process.env.HOME = originalHome;
-    rmSync(tmpDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
 
@@ -424,23 +443,9 @@ describe("checkAgentVersion", () => {
 });
 
 describe("formatStalenessWarning", () => {
-  let tmpDir: string;
-  const originalHome = process.env.HOME;
-
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "sandbox-warn-test-"));
-    process.env.HOME = tmpDir;
-    mkdirSync(join(tmpDir, ".nemoclaw"), { recursive: true });
-    writeFileSync(
-      join(tmpDir, ".nemoclaw", "sandboxes.json"),
-      JSON.stringify({ sandboxes: {}, defaultSandbox: null }),
-    );
+    resetTestRegistry();
     registry.registerSandbox({ name: "my-sb", agent: null });
-  });
-
-  afterEach(() => {
-    process.env.HOME = originalHome;
-    rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it("includes sandbox name, versions, and rebuild hint", () => {

--- a/src/lib/sandbox/version.test.ts
+++ b/src/lib/sandbox/version.test.ts
@@ -84,8 +84,7 @@ function resetTestRegistry(): void {
 }
 
 afterAll(() => {
-  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
-  else process.env.HOME = ORIGINAL_HOME;
+  process.env.HOME = ORIGINAL_HOME;
   rmSync(TEST_HOME, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

`src/lib/sandbox/version.test.ts` meant to isolate itself by pointing `HOME` at a temp dir, but `state/registry` resolves the registry path at module scope, so the `beforeEach` reassignment never took effect and every `registerSandbox()` wrote to the developer's real `~/.nemoclaw/sandboxes.json`. This redirects `HOME` before the module loads and adds a regression test that pins `REGISTRY_FILE` inside the test HOME.

## Related Issue

Fixes #6553

## Changes

- Redirect `HOME` at module scope and reach `state/registry` / `./version` through dynamic imports, matching the pattern already used by `test/registry.test.ts` (`createRequire`) and `test/deepagents-mcp-legacy-lifecycle.test.ts` (top-level `await import()`).
- Replace the per-test temp HOME with one file-scoped temp HOME plus a `resetTestRegistry()` helper, restoring the original `HOME` in `afterAll`.
- Add a `registry isolation` test asserting `registry.REGISTRY_FILE` resolves inside the test HOME, so a future static import fails CI instead of silently writing to a real registry.

No production code changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-only change; no user-facing behavior changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — `npm run check:diff` passed (exit 0).
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/sandbox/` → 10 files, 146 tests passed. The touched file goes from 21 to 22 tests.
- [ ] Applicable broad gate passed — justification: change is confined to one test file; no runtime or test-harness behavior is altered.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Evidence

Before the fix, running the single test file against a witness registry appended seven fixture sandboxes to it:

```text
BEFORE: precious-prod-sandbox
      Tests  21 passed (21)
AFTER:  precious-prod-sandbox,test-sb,hermes-sb,high-major-sb,low-year-sb,openclaw-sb,hermes-warn-sb,my-sb
```

After the fix, the same run leaves it untouched:

```text
BEFORE: precious-prod-sandbox
 Test Files  1 passed (1)
      Tests  22 passed (22)
AFTER:  precious-prod-sandbox
```

The new regression test has teeth: reintroducing the static import on a scratch copy makes exactly one test fail (`registry isolation > resolves the registry inside the test HOME, never the real one (#6553)`), with the rest of the file still passing.

### Note on the deeper fix

#6553 also proposes resolving the registry path lazily in `src/lib/state/registry.ts` so the ordering footgun disappears for everyone. That touches a core state module and has two in-repo consumers of the `REGISTRY_FILE` export, so I left it out of this PR. Happy to send it separately if maintainers want it.

## DCO

Signed-off-by: Hokonoken <41166525+Hokonoken@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using a temporary home directory and resetting registry data between runs.
  * Added coverage to verify resolved registry paths remain contained within the test environment.
  * Simplified version and staleness-warning test setup by removing repeated environment setup/teardown and consolidating it into shared helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->