### PR TITLE
fix(onboard): preserve pending route reservation across resume

### DIFF
--- a/src/lib/onboard/tool-disclosure-flow.test.ts
+++ b/src/lib/onboard/tool-disclosure-flow.test.ts
@@ -130,4 +130,42 @@ describe("onboard tool-disclosure flow", () => {
     expect(mocks.updateSession).not.toHaveBeenCalled();
     expect(mocks.removeSandbox).not.toHaveBeenCalled();
   });
+
+  it("keeps a pending route reservation for the current sandbox so a resumed onboard can recover", () => {
+    const result = prepareSandboxToolDisclosure(
+      "alpha",
+      null,
+      false,
+      () => ({
+        existingEntry: {
+          name: "alpha",
+          toolDisclosure: "progressive",
+          pendingRouteReservation: true,
+        },
+        preservedMcpState: undefined,
+        liveExists: false,
+      }),
+      "progressive",
+    );
+
+    expect(result).toMatchObject({ effectiveToolDisclosure: "progressive" });
+    expect(mocks.updateSession).toHaveBeenCalledOnce();
+    expect(mocks.removeSandbox).not.toHaveBeenCalled();
+  });
+
+  it("still clears a stale registry entry that has no live sandbox and no pending reservation", () => {
+    prepareSandboxToolDisclosure(
+      "beta",
+      null,
+      false,
+      () => ({
+        existingEntry: { name: "beta", toolDisclosure: "progressive" },
+        preservedMcpState: undefined,
+        liveExists: false,
+      }),
+      "progressive",
+    );
+
+    expect(mocks.removeSandbox).toHaveBeenCalledWith("beta");
+  });
 });

--- a/src/lib/onboard/tool-disclosure-flow.ts
+++ b/src/lib/onboard/tool-disclosure-flow.ts
@@ -63,7 +63,14 @@ export function prepareSandboxToolDisclosure(
   // Keep inspection and validation ahead of every mutation. Splitting these
   // steps across lifecycle callbacks would require a transaction object to
   // preserve this fail-closed ordering for registry and session state.
-  if (existingEntry && !liveExists && !preservedMcpState) registry.removeSandbox(sandboxName);
+  if (
+    existingEntry &&
+    !liveExists &&
+    !preservedMcpState &&
+    existingEntry.pendingRouteReservation !== true
+  ) {
+    registry.removeSandbox(sandboxName);
+  }
   onboardSession.updateSession((session) => {
     session.toolDisclosure = mode;
     return session;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`onboard --resume` aborted with `sandbox route reservation '<name>' disappeared while onboarding was in progress` and could never recover after onboarding was interrupted or failed during sandbox creation. The sandbox step removed the current run's own pending route reservation before creating the container, so an interrupted or failed create left no reservation for the resumed run to find, and the recommended `--resume` looped forever. This spares `pendingRouteReservation` rows for the current sandbox so the reservation survives the interrupt and the resumed run recovers.

## Related Issue

Fixes #6562
Fixes #6563

## Changes

- `src/lib/onboard/tool-disclosure-flow.ts`: skip the pre-create registry removal when the existing entry is the current sandbox's pending route reservation (`pendingRouteReservation === true`); genuinely stale entries with no live sandbox and no reservation are still cleared.
- `src/lib/onboard/tool-disclosure-flow.test.ts`: cover that a pending reservation is preserved so a resumed onboard can recover, and that a stale non-reservation entry with no live sandbox is still removed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox tool disclosure handling so existing pending route reservations are preserved instead of being cleared too early.
  * Prevented stale sandbox entries from being removed when there is no live sandbox, but a reservation is still pending.
  * Added coverage for session and registry update behavior to ensure the new handling remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->