### PR TITLE
docs(overview): gate 'Messaging channels' to openclaw/hermes variants

### DIFF
--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -13,7 +13,17 @@ skill:
 ---
 import { AgentCli, AgentOnly } from "../_components/AgentGuide";
 
-NVIDIA NemoClaw is an open-source reference stack for running <AgentOnly variant="openclaw,hermes">always-on AI agents</AgentOnly><AgentOnly variant="deepagents">AI coding agents</AgentOnly> more safely inside OpenShell containers.
+<AgentOnly variant="openclaw,hermes">
+
+NVIDIA NemoClaw is an open-source reference stack for running always-on AI agents more safely inside OpenShell containers.
+
+</AgentOnly>
+<AgentOnly variant="deepagents">
+
+NVIDIA NemoClaw is an open-source reference stack for running AI coding agents more safely inside OpenShell containers.
+
+</AgentOnly>
+
 NemoClaw provides onboarding, lifecycle management, and agent operations for supported runtimes in OpenShell sandboxes.
 It adds policy-based privacy and security controls for agent behavior and data handling.
 These controls help agents run in clouds, on-premises environments, RTX PCs, and DGX Spark.

--- a/docs/about/overview.mdx
+++ b/docs/about/overview.mdx
@@ -13,7 +13,7 @@ skill:
 ---
 import { AgentCli, AgentOnly } from "../_components/AgentGuide";
 
-NVIDIA NemoClaw is an open-source reference stack for running always-on AI agents more safely inside OpenShell containers.
+NVIDIA NemoClaw is an open-source reference stack for running <AgentOnly variant="openclaw,hermes">always-on AI agents</AgentOnly><AgentOnly variant="deepagents">AI coding agents</AgentOnly> more safely inside OpenShell containers.
 NemoClaw provides onboarding, lifecycle management, and agent operations for supported runtimes in OpenShell sandboxes.
 It adds policy-based privacy and security controls for agent behavior and data handling.
 These controls help agents run in clouds, on-premises environments, RTX PCs, and DGX Spark.
@@ -39,9 +39,16 @@ NemoClaw provides these product capabilities.
 | AI-agent docs | Publishes Markdown docs and a small routing skill so AI coding assistants can guide setup, inference configuration, policy management, monitoring, deployment, security review, and troubleshooting. |
 | Hardened blueprint | A Dockerfile with capability drops, least-privilege network rules, and declarative policy. |
 | State management | Safe migration of agent state across machines with credential stripping and integrity verification. |
-| Messaging channels | OpenShell-managed processes connect Telegram, Discord, Slack, and similar platforms to supported messaging agents. NemoClaw configures channels during onboarding where the selected agent supports them; OpenShell supplies the native constructs, credential flow, and runtime supervision. |
 | Routed inference | Provider-routed model calls through the OpenShell gateway, transparent to the agent. Supports NVIDIA Endpoints, OpenAI, Anthropic, Google Gemini, compatible endpoints, local Ollama, local vLLM, and the Model Router. |
 | Layered protection | Network, filesystem, process, and inference controls that can be hot-reloaded or locked at creation. |
+
+<AgentOnly variant="openclaw,hermes">
+
+| Feature | Description |
+|---------|-------------|
+| Messaging channels | OpenShell-managed processes connect Telegram, Discord, Slack, and similar platforms to supported messaging agents. NemoClaw configures channels during onboarding where the selected agent supports them; OpenShell supplies the native constructs, credential flow, and runtime supervision. |
+
+</AgentOnly>
 
 ## Benefits of Using NemoClaw
 


### PR DESCRIPTION
## Summary

The Overview page's Key Features table lists **Messaging channels** for all three NemoClaw variants, but Deep Agents is a terminal coding harness with no messaging channel support (`channels add slack` is hard-rejected).

## Changes

**File:** `docs/about/overview.mdx`

1. **Intro text** — Use inline `<AgentOnly>` to show "always-on AI agents" for openclaw/hermes and "AI coding agents" for deepagents, since Deep Agents is a terminal coding harness rather than an always-on assistant.

2. **Key Features table** — Move the "Messaging channels" row out of the shared table into an `<AgentOnly variant="openclaw,hermes">` block so it only renders for variants that actually support messaging channels.

Both changes use the existing `<AgentOnly>` component already imported and used in the same file's Next Steps section.

## Note

The messaging channels row renders as a separate single-row table for openclaw/hermes users because MDX doesn't support wrapping individual table rows in JSX components. This is the same approach used in the Next Steps section and is the standard pattern for variant-gated content.

Closes #6561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the overview page’s main description to vary by product variant (e.g., “always-on AI agents” vs “AI coding agents”).
  * Adjusted the “Key Features” table ordering so “Routed inference” and “Layered protection” appear earlier.
  * Made the “Messaging channels” capability row render only for the applicable variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Signed-off-by: Kagura <kagura.agent.ai@gmail.com>
