### PR TITLE
test(rebuild): prove live recovery boundaries

### DIFF
--- a/ci/env-var-doc-allowlist.json
+++ b/ci/env-var-doc-allowlist.json
@@ -60,6 +60,10 @@
     "reason": "Internal E2E-only sentinel that tells CI to route the repository NVIDIA_INFERENCE_API_KEY secret through the hosted inference-api.nvidia.com OpenAI-compatible endpoint. Not user-facing."
   },
   {
+    "name": "NEMOCLAW_RUN_LIVE_E2E",
+    "reason": "Repository live-E2E opt-in consumed by Vitest collection and guarded failure-injection hooks. It is a test-runner control, not a supported NemoClaw runtime configuration variable."
+  },
+  {
     "name": "NEMOCLAW_COMPAT_MODEL",
     "reason": "Internal E2E/test override for the model used by OpenAI-compatible endpoint scenarios. User-facing custom endpoint model selection is collected through onboard prompts or NEMOCLAW_MODEL."
   },

--- a/src/lib/actions/sandbox/rebuild-destroy-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-destroy-phase.ts
@@ -159,9 +159,7 @@ export async function runRebuildDestroyPhase(
   }
   maybePauseForRebuildInterruption("delete_unjournaled");
   await onDeleted();
-  // The registry row is durable rebuild intent. The inner onboard run observes
-  // that the sandbox is absent and replaces the row only after creation. Keep
-  // it for every agent so process death cannot discard recovery metadata.
+  // Keep the registry row as durable intent until inner onboard replaces it.
   log("Preserving registry entry across sandbox recreation");
   log(
     `Registry after remove: ${JSON.stringify(registry.listSandboxes().sandboxes.map((s: { name: string }) => s.name))}`,

--- a/src/lib/actions/sandbox/rebuild-e2e-interruption.test.ts
+++ b/src/lib/actions/sandbox/rebuild-e2e-interruption.test.ts
@@ -14,25 +14,26 @@ describe("rebuild E2E interruption hook", () => {
   it("is inert without the private process-death fixture boundary", () => {
     vi.stubEnv("VITEST", "true");
     vi.stubEnv("NEMOCLAW_E2E_FAILURE_INJECTION", "1");
-    vi.stubEnv("NEMOCLAW_E2E_FORCE_FAIL_AT_STEP", "rebuild_prepared");
+    vi.stubEnv("NEMOCLAW_E2E_FORCE_FAIL_AT_STEP", "rebuild_old_deleted");
     const kill = vi.spyOn(process, "kill").mockReturnValue(true);
 
-    maybePauseForRebuildInterruption("prepared");
+    maybePauseForRebuildInterruption("old_deleted");
 
     expect(kill).not.toHaveBeenCalled();
   });
 
-  it("stops only the explicitly selected checkpoint in Vitest", () => {
-    vi.stubEnv("VITEST", "true");
+  it("stops only the selected checkpoint in an explicitly guarded live E2E", () => {
+    vi.stubEnv("VITEST", undefined);
+    vi.stubEnv("NEMOCLAW_RUN_LIVE_E2E", "1");
     vi.stubEnv("HOME", "/tmp/rebuild-process-fixture");
     vi.stubEnv("NEMOCLAW_REBUILD_PROCESS_FIXTURE", "/tmp/rebuild-process-fixture");
     vi.stubEnv("NEMOCLAW_E2E_FAILURE_INJECTION", "1");
-    vi.stubEnv("NEMOCLAW_E2E_FORCE_FAIL_AT_STEP", "rebuild_prepared");
+    vi.stubEnv("NEMOCLAW_E2E_FORCE_FAIL_AT_STEP", "rebuild_old_deleted");
     const kill = vi.spyOn(process, "kill").mockReturnValue(true);
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     maybePauseForRebuildInterruption("delete_unjournaled");
-    maybePauseForRebuildInterruption("prepared");
+    maybePauseForRebuildInterruption("old_deleted");
 
     expect(kill).toHaveBeenCalledOnce();
     expect(kill).toHaveBeenCalledWith(process.pid, "SIGSTOP");

--- a/src/lib/actions/sandbox/rebuild-e2e-interruption.ts
+++ b/src/lib/actions/sandbox/rebuild-e2e-interruption.ts
@@ -4,6 +4,7 @@
 /** Testing-only process-death checkpoint; inert unless the shared E2E gate is enabled. */
 export type RebuildInterruptionPhase =
   | "delete_unjournaled"
+  | "old_deleted"
   | "prepared"
   | "replacement_created"
   | "replacement_unjournaled"
@@ -11,7 +12,7 @@ export type RebuildInterruptionPhase =
   | "state_restored";
 
 export function maybePauseForRebuildInterruption(phase: RebuildInterruptionPhase): void {
-  if (process.env.VITEST !== "true") return;
+  if (process.env.VITEST !== "true" && process.env.NEMOCLAW_RUN_LIVE_E2E !== "1") return;
   const fixtureRoot = process.env.NEMOCLAW_REBUILD_PROCESS_FIXTURE;
   if (!fixtureRoot || fixtureRoot !== process.env.HOME) return;
   if (process.env.NEMOCLAW_E2E_FAILURE_INJECTION !== "1") return;

--- a/src/lib/actions/sandbox/rebuild-pipeline.ts
+++ b/src/lib/actions/sandbox/rebuild-pipeline.ts
@@ -253,6 +253,7 @@ async function rebuildSandboxUnlocked(
         onDeleted: async () => {
           sandboxStillExists = false;
           await transaction.markDeleted();
+          maybePauseForRebuildInterruption("old_deleted");
         },
       });
       if (!mcpPreparation) return;

--- a/src/lib/actions/sandbox/rebuild-recovery-orchestrator.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recovery-orchestrator.test.ts
@@ -83,6 +83,35 @@ function makeOrchestrator(entry: SandboxEntry) {
 }
 
 describe("rebuild recovery receipt publication", () => {
+  it("starts a new transaction generation after a completed tombstone", async () => {
+    const completed = { ...record, status: "completed", phase: "completed" } as const;
+    const transaction = {
+      record: completed,
+      prepare: vi.fn(),
+      reconcileObservedDeletion: vi.fn(),
+    } as unknown as RebuildTransactionCoordinator;
+    const orchestrator = new RebuildRecoveryOrchestrator({
+      plan: null,
+      transaction,
+      recoveredTransaction: completed as RebuildTransactionRecordV1,
+      sandboxName: "alpha",
+      readRegistryEntry: () => replacement,
+      readSession: () => session,
+      bail: (message) => {
+        throw new Error(message);
+      },
+      log: vi.fn(),
+    });
+
+    await orchestrator.prepare({
+      sandboxEntry: replacement,
+      staleRecovery: false,
+    } as Parameters<RebuildRecoveryOrchestrator["prepare"]>[0]);
+
+    expect(transaction.prepare).toHaveBeenCalledOnce();
+    expect(transaction.reconcileObservedDeletion).toHaveBeenCalledOnce();
+  });
+
   it("publishes a compensation receipt only after re-verifying registry and session evidence", async () => {
     const { orchestrator, transaction } = makeOrchestrator(replacement);
 

--- a/src/lib/actions/sandbox/rebuild-recovery-orchestrator.ts
+++ b/src/lib/actions/sandbox/rebuild-recovery-orchestrator.ts
@@ -92,9 +92,8 @@ export class RebuildRecoveryOrchestrator {
         ? recoveredTransaction.intent.source.registryRecovery.entry
         : input.sandboxEntry;
 
-    if (recoveredTransaction) await transaction.reconcileObservedDeletion(input.staleRecovery);
     if (
-      !recoveredTransaction ||
+      recoveredTransaction?.status !== "active" ||
       (recoveredTransaction.phase === "prepared" && !input.staleRecovery)
     ) {
       await transaction.prepare({

--- a/src/lib/actions/sandbox/rebuild-recovery.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recovery.test.ts
@@ -53,6 +53,7 @@ describe("rebuild replacement recovery decision", () => {
   it.each([
     ["old_deleted", "absent", "source", "missing", "create"],
     ["old_deleted", "absent", "missing", "unrelated", "create"],
+    ["old_deleted", "absent", "target", "unrelated", "create"],
     ["old_deleted", "ready", "target", "matching", "adopt"],
     ["replacement_created", "ready", "replacement", "matching", "resume"],
     ["replacement_created", "absent", "replacement", "matching", "recreate"],

--- a/src/lib/actions/sandbox/rebuild-recovery.ts
+++ b/src/lib/actions/sandbox/rebuild-recovery.ts
@@ -77,7 +77,7 @@ export function decideRebuildRecovery(input: {
   const { transaction, live, registry, session } = input;
   if (transaction.phase === "old_deleted") {
     if (live === "absent") {
-      if (registry === "source" || registry === "missing") return { action: "create" };
+      if (["source", "missing", "target"].includes(registry)) return { action: "create" };
       return {
         action: "refuse",
         code:

--- a/src/lib/actions/sandbox/rebuild-transaction-boundary.test.ts
+++ b/src/lib/actions/sandbox/rebuild-transaction-boundary.test.ts
@@ -167,7 +167,7 @@ describe("rebuild transaction boundary", () => {
     });
   });
 
-  it("resumes old-deleted recovery without duplicate delete or unrelated session config", async () => {
+  it("resumes old-deleted recovery from version-enriched backup without duplicate delete", async () => {
     const interrupted = createRebuildFlowHarness({
       staleRecovery: true,
       onboard: () => {
@@ -181,7 +181,10 @@ describe("rebuild transaction boundary", () => {
       }),
     ).rejects.toThrow("Recreate failed");
 
-    const resumed = createRebuildFlowHarness({ staleRecovery: true });
+    const resumed = createRebuildFlowHarness({
+      staleRecovery: true,
+      preDeleteLatestManifest: { ...makePreparedRecoveryManifest(), snapshotVersion: 1 },
+    });
     resumed.session.toolDisclosure = "direct";
     resumed.session.preferredInferenceApi = "stale-session-api";
     await resumed.rebuildSandbox("alpha", ["--yes"], {

--- a/src/lib/actions/sandbox/rebuild-transaction-boundary.test.ts
+++ b/src/lib/actions/sandbox/rebuild-transaction-boundary.test.ts
@@ -180,9 +180,14 @@ describe("rebuild transaction boundary", () => {
         recoveryManifest: makePreparedRecoveryManifest(),
       }),
     ).rejects.toThrow("Recreate failed");
-
+    const interruptedRecord = interrupted.transactionStore.load("alpha")!;
     const resumed = createRebuildFlowHarness({
       staleRecovery: true,
+      sandboxEntry: {
+        policies: ["normalized-target"],
+        toolDisclosure: interruptedRecord.intent.target.toolDisclosure,
+        observabilityEnabled: interruptedRecord.intent.target.observabilityEnabled,
+      },
       preDeleteLatestManifest: { ...makePreparedRecoveryManifest(), snapshotVersion: 1 },
     });
     resumed.session.toolDisclosure = "direct";

--- a/src/lib/actions/sandbox/rebuild-transaction-coordinator.ts
+++ b/src/lib/actions/sandbox/rebuild-transaction-coordinator.ts
@@ -22,6 +22,13 @@ import type { RebuildTargetConfig } from "./rebuild-target-preflight";
 
 export { fingerprintRebuildRegistryEntry, fingerprintRebuildValue };
 
+function fingerprintBackupManifest({
+  snapshotVersion: _snapshotVersion,
+  ...manifest
+}: sandboxState.RebuildManifest & { snapshotVersion?: number }): string {
+  return fingerprintRebuildValue(manifest);
+}
+
 export function loadRebuildRecovery(
   store: RebuildTransactionStore,
   sandboxName: string,
@@ -45,7 +52,7 @@ export function loadRebuildRecovery(
   if (
     !recoveryManifest ||
     recoveryManifest.timestamp !== transaction.receipts.backup.manifestTimestamp ||
-    fingerprintRebuildValue(recoveryManifest) !== transaction.receipts.backup.manifestFingerprint
+    fingerprintBackupManifest(recoveryManifest) !== transaction.receipts.backup.manifestFingerprint
   ) {
     throw new Error(
       `Rebuild transaction '${transaction.transactionId}' no longer matches the latest validated backup.`,
@@ -103,7 +110,7 @@ async function prepareRebuildTransaction(args: {
   const receipts = {
     backup: {
       manifestTimestamp: args.backupManifest.timestamp,
-      manifestFingerprint: fingerprintRebuildValue(args.backupManifest),
+      manifestFingerprint: fingerprintBackupManifest(args.backupManifest),
     },
   };
   if (!args.existing || args.existing.status === "completed") {

--- a/src/lib/actions/upgrade-sandboxes-recovery.test-support.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test-support.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi } from "vitest";
+import * as coreVersion from "../core/version";
+import * as sandboxList from "../openshell-sandbox-list";
+import * as sandboxVersion from "../sandbox/version";
+import * as registry from "../state/registry";
+import * as sandboxState from "../state/sandbox";
+import { upgradeSandboxes, upgradeSandboxesDependencies } from "./upgrade-sandboxes";
+
+export function makeRecoveryManifest(sandboxName: string) {
+  const timestamp = `2026-07-01T06-50-4${sandboxName.length}-044Z`;
+  return {
+    version: 1,
+    sandboxName,
+    timestamp,
+    agentType: "openclaw",
+    agentVersion: "2026.5.27",
+    expectedVersion: "2026.5.27",
+    stateDirs: ["workspace"],
+    backedUpDirs: ["workspace"],
+    stateFiles: [],
+    dir: "/sandbox/.openclaw",
+    backupPath: `/tmp/rebuild-backups/${sandboxName}/${timestamp}`,
+    blueprintDigest: null,
+    policyPresets: [],
+    customPolicies: [],
+    snapshotVersion: 1,
+  };
+}
+
+export function createRecoveryHarness(
+  names: string[],
+  options: {
+    gatewayNames?: Record<string, string>;
+    gatewayPort?: number;
+    liveOutput?: string;
+    latestBackup?: ReturnType<typeof makeRecoveryManifest> | null;
+    registryOverrides?: Record<
+      string,
+      Partial<{
+        agent: "openclaw" | "hermes" | "langchain-deepagents-code" | null;
+        agentVersion: string | null;
+        nemoclawVersion: string | null;
+        fromDockerfile: string | null;
+      }>
+    >;
+    confirmedLegacyManagedNames?: string[] | string;
+    staleNames?: string[];
+    useRealManagedEvidence?: boolean;
+  } = {},
+) {
+  vi.stubEnv("NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE", "1");
+  vi.stubEnv(
+    "NEMOCLAW_CONFIRMED_LEGACY_MANAGED_SANDBOXES",
+    typeof options.confirmedLegacyManagedNames === "string"
+      ? options.confirmedLegacyManagedNames
+      : JSON.stringify(options.confirmedLegacyManagedNames ?? []),
+  );
+
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  vi.spyOn(upgradeSandboxesDependencies, "getGatewayPort").mockReturnValue(
+    options.gatewayPort ?? 8080,
+  );
+  vi.spyOn(coreVersion, "getVersion").mockReturnValue("0.0.71");
+  const liveListSpy = vi
+    .spyOn(sandboxList, "captureSandboxListWithGatewayPreflightOrExit")
+    .mockResolvedValue({
+      status: 0,
+      output: options.liveOutput ?? names.map((name) => `${name} Error`).join("\n"),
+    });
+  vi.spyOn(registry, "listSandboxes").mockReturnValue({
+    defaultSandbox: null,
+    sandboxes: names.map((name) => ({
+      name,
+      agent: null,
+      agentVersion: "2026.5.27",
+      gatewayName: options.gatewayNames?.[name],
+      gatewayPort: options.gatewayPort,
+      nemoclawVersion: "0.0.71",
+      ...options.registryOverrides?.[name],
+    })),
+  });
+  vi.spyOn(sandboxVersion, "checkAgentVersion").mockImplementation((...args: unknown[]) => {
+    const name = String(args[0]);
+    return {
+      sandboxVersion: options.staleNames?.includes(name) === true ? "2026.5.26" : "2026.5.27",
+      expectedVersion: "2026.5.27",
+      isStale: options.staleNames?.includes(name) === true,
+      verificationFailed: false,
+      detectionMethod: "registry",
+    };
+  });
+  const latestBackupSpy = vi
+    .spyOn(sandboxState, "getLatestBackup")
+    .mockImplementation((...args: unknown[]) =>
+      options.latestBackup === undefined
+        ? makeRecoveryManifest(String(args[0]))
+        : options.latestBackup,
+    );
+  vi.spyOn(sandboxState, "validateRebuildRecoveryManifest").mockImplementation(
+    (...args: unknown[]) => ({
+      ok: true as const,
+      manifest: args[2] as ReturnType<typeof makeRecoveryManifest>,
+    }),
+  );
+  const managedEvidenceSpy = options.useRealManagedEvidence
+    ? vi.spyOn(sandboxState, "hasPositiveManagedImageEvidence")
+    : vi.spyOn(sandboxState, "hasPositiveManagedImageEvidence").mockReturnValue(true);
+  const rebuildSpy = vi
+    .spyOn(upgradeSandboxesDependencies, "rebuildSandbox")
+    .mockResolvedValue(undefined);
+
+  return { upgradeSandboxes, rebuildSpy, latestBackupSpy, managedEvidenceSpy, liveListSpy };
+}

--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-
+import {
+  createRebuildFlowHarness,
+  installRebuildFlowTestHooks,
+} from "../../../test/helpers/rebuild-flow-test-harness";
+import { makePreparedRecoveryManifest } from "../actions/sandbox/rebuild-flow-test-fixtures";
 import * as coreVersion from "../core/version";
 import * as sandboxList from "../openshell-sandbox-list";
 import * as sandboxVersion from "../sandbox/version";
@@ -11,6 +15,8 @@ import * as sandboxState from "../state/sandbox";
 import { upgradeSandboxes, upgradeSandboxesDependencies } from "./upgrade-sandboxes";
 
 type UpgradeSandboxes = typeof upgradeSandboxes;
+
+installRebuildFlowTestHooks();
 
 function makeManifest(sandboxName: string) {
   const timestamp = `2026-07-01T06-50-4${sandboxName.length}-044Z`;
@@ -150,9 +156,9 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     }
   });
 
-  it("continues through all eligible sandboxes before reporting a recovery failure", async () => {
+  it("isolates a corrupt transaction while continuing unrelated recovery (#6437)", async () => {
     const harness = createRecoveryHarness(["alpha", "beta"]);
-    harness.rebuildSpy.mockRejectedValueOnce(new Error("alpha failed"));
+    harness.rebuildSpy.mockRejectedValueOnce(new Error("CORRUPT alpha transaction"));
     vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);
@@ -161,9 +167,57 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
 
     expect(harness.rebuildSpy).toHaveBeenCalledTimes(2);
     expect(harness.rebuildSpy.mock.calls.map((call) => call[0])).toEqual(["alpha", "beta"]);
+    expect(harness.rebuildSpy.mock.calls[1]?.[2]).toEqual({
+      throwOnError: true,
+      recoveryManifest: expect.objectContaining({ sandboxName: "beta" }),
+    });
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to recover 'alpha': alpha failed"),
+      expect.stringContaining("Failed to recover 'alpha': CORRUPT alpha transaction"),
     );
+  });
+
+  it("continues an existing old_deleted transaction through the installer runner (#6437)", async () => {
+    let onboardAttempts = 0;
+    const flow = createRebuildFlowHarness({
+      staleRecovery: true,
+      onboard: () => {
+        onboardAttempts += 1;
+        return onboardAttempts === 1
+          ? Promise.reject(new Error("interrupt before replacement receipt"))
+          : undefined;
+      },
+    });
+
+    await expect(
+      flow.rebuildSandbox("alpha", ["--yes"], {
+        throwOnError: true,
+        recoveryManifest: makePreparedRecoveryManifest(),
+      }),
+    ).rejects.toThrow("Recreate failed");
+    const interrupted = flow.transactionStore.load("alpha");
+    expect(interrupted).toMatchObject({ status: "active", phase: "old_deleted" });
+
+    const resumed = createRebuildFlowHarness({ staleRecovery: true });
+    resumed.onboardSpy.mockClear();
+    const upgrade = createRecoveryHarness(["alpha"], {
+      latestBackup: makePreparedRecoveryManifest() as ReturnType<typeof makeManifest>,
+    });
+    upgrade.rebuildSpy.mockImplementation((...args) =>
+      resumed.rebuildSandbox(args[0], args[1], {
+        ...args[2],
+        transactionStore: flow.transactionStore,
+      }),
+    );
+
+    await expect(upgrade.upgradeSandboxes({ auto: true })).resolves.toBeUndefined();
+
+    expect(flow.transactionStore.load("alpha")).toMatchObject({
+      transactionId: interrupted?.transactionId,
+      status: "completed",
+      phase: "completed",
+    });
+    expect(resumed.onboardSpy).toHaveBeenCalledOnce();
+    expect(upgrade.rebuildSpy).toHaveBeenCalledOnce();
   });
 
   it("fails closed for a probed v0.0.55 custom image with matching backup agent version", async () => {

--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -27,26 +27,6 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     }
   });
 
-  it("isolates a corrupt transaction while continuing unrelated recovery (#6437)", async () => {
-    const harness = createRecoveryHarness(["alpha", "beta"]);
-    harness.rebuildSpy.mockRejectedValueOnce(new Error("CORRUPT alpha transaction"));
-    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit(${code})`);
-    }) as never);
-
-    await expect(harness.upgradeSandboxes({ auto: true })).rejects.toThrow("process.exit(1)");
-
-    expect(harness.rebuildSpy).toHaveBeenCalledTimes(2);
-    expect(harness.rebuildSpy.mock.calls.map((call) => call[0])).toEqual(["alpha", "beta"]);
-    expect(harness.rebuildSpy.mock.calls[1]?.[2]).toEqual({
-      throwOnError: true,
-      recoveryManifest: expect.objectContaining({ sandboxName: "beta" }),
-    });
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to recover 'alpha': CORRUPT alpha transaction"),
-    );
-  });
-
   it("fails closed for a probed v0.0.55 custom image with matching backup agent version", async () => {
     const probedAgentVersion = "2026.5.27";
     const harness = createRecoveryHarness(["custom-box"], {

--- a/src/lib/actions/upgrade-sandboxes-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-recovery.test.ts
@@ -3,138 +3,9 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  createRebuildFlowHarness,
-  installRebuildFlowTestHooks,
-} from "../../../test/helpers/rebuild-flow-test-harness";
-import { makePreparedRecoveryManifest } from "../actions/sandbox/rebuild-flow-test-fixtures";
-import * as coreVersion from "../core/version";
-import * as sandboxList from "../openshell-sandbox-list";
-import * as sandboxVersion from "../sandbox/version";
-import * as registry from "../state/registry";
-import * as sandboxState from "../state/sandbox";
-import { upgradeSandboxes, upgradeSandboxesDependencies } from "./upgrade-sandboxes";
-
-type UpgradeSandboxes = typeof upgradeSandboxes;
-
-installRebuildFlowTestHooks();
-
-function makeManifest(sandboxName: string) {
-  const timestamp = `2026-07-01T06-50-4${sandboxName.length}-044Z`;
-  return {
-    version: 1,
-    sandboxName,
-    timestamp,
-    agentType: "openclaw",
-    agentVersion: "2026.5.27",
-    expectedVersion: "2026.5.27",
-    stateDirs: ["workspace"],
-    backedUpDirs: ["workspace"],
-    stateFiles: [],
-    dir: "/sandbox/.openclaw",
-    backupPath: `/tmp/rebuild-backups/${sandboxName}/${timestamp}`,
-    blueprintDigest: null,
-    policyPresets: [],
-    customPolicies: [],
-    snapshotVersion: 1,
-  };
-}
-
-function createRecoveryHarness(
-  names: string[],
-  options: {
-    gatewayNames?: Record<string, string>;
-    gatewayPort?: number;
-    liveOutput?: string;
-    latestBackup?: ReturnType<typeof makeManifest> | null;
-    registryOverrides?: Record<
-      string,
-      Partial<{
-        agent: "openclaw" | "hermes" | "langchain-deepagents-code" | null;
-        agentVersion: string | null;
-        nemoclawVersion: string | null;
-        fromDockerfile: string | null;
-      }>
-    >;
-    confirmedLegacyManagedNames?: string[] | string;
-    staleNames?: string[];
-    useRealManagedEvidence?: boolean;
-  } = {},
-): {
-  upgradeSandboxes: UpgradeSandboxes;
-  rebuildSpy: ReturnType<typeof vi.fn>;
-  latestBackupSpy: ReturnType<typeof vi.spyOn>;
-  managedEvidenceSpy: ReturnType<typeof vi.spyOn>;
-  liveListSpy: ReturnType<typeof vi.spyOn>;
-} {
-  vi.stubEnv("NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE", "1");
-  vi.stubEnv(
-    "NEMOCLAW_CONFIRMED_LEGACY_MANAGED_SANDBOXES",
-    typeof options.confirmedLegacyManagedNames === "string"
-      ? options.confirmedLegacyManagedNames
-      : JSON.stringify(options.confirmedLegacyManagedNames ?? []),
-  );
-
-  vi.spyOn(console, "log").mockImplementation(() => undefined);
-  vi.spyOn(console, "error").mockImplementation(() => undefined);
-  vi.spyOn(console, "warn").mockImplementation(() => undefined);
-  vi.spyOn(upgradeSandboxesDependencies, "getGatewayPort").mockReturnValue(
-    options.gatewayPort ?? 8080,
-  );
-  vi.spyOn(coreVersion, "getVersion").mockReturnValue("0.0.71");
-  const liveListSpy = vi
-    .spyOn(sandboxList, "captureSandboxListWithGatewayPreflightOrExit")
-    .mockResolvedValue({
-      status: 0,
-      output: options.liveOutput ?? names.map((name) => `${name} Error`).join("\n"),
-    });
-  vi.spyOn(registry, "listSandboxes").mockReturnValue({
-    defaultSandbox: null,
-    sandboxes: names.map((name) => ({
-      name,
-      agent: null,
-      agentVersion: "2026.5.27",
-      gatewayName: options.gatewayNames?.[name],
-      gatewayPort: options.gatewayPort,
-      nemoclawVersion: "0.0.71",
-      ...options.registryOverrides?.[name],
-    })),
-  });
-  vi.spyOn(sandboxVersion, "checkAgentVersion").mockImplementation((...args: unknown[]) => {
-    const name = String(args[0]);
-    return {
-      sandboxVersion: options.staleNames?.includes(name) === true ? "2026.5.26" : "2026.5.27",
-      expectedVersion: "2026.5.27",
-      isStale: options.staleNames?.includes(name) === true,
-      verificationFailed: false,
-      detectionMethod: "registry",
-    };
-  });
-  const latestBackupSpy = vi
-    .spyOn(sandboxState, "getLatestBackup")
-    .mockImplementation((...args: unknown[]) =>
-      options.latestBackup === undefined ? makeManifest(String(args[0])) : options.latestBackup,
-    );
-  vi.spyOn(sandboxState, "validateRebuildRecoveryManifest").mockImplementation(
-    (...args: unknown[]) => ({
-      ok: true as const,
-      manifest: args[2] as ReturnType<typeof makeManifest>,
-    }),
-  );
-  const managedEvidenceSpy = options.useRealManagedEvidence
-    ? vi.spyOn(sandboxState, "hasPositiveManagedImageEvidence")
-    : vi.spyOn(sandboxState, "hasPositiveManagedImageEvidence").mockReturnValue(true);
-  const rebuildSpy = vi
-    .spyOn(upgradeSandboxesDependencies, "rebuildSandbox")
-    .mockResolvedValue(undefined);
-
-  return {
-    upgradeSandboxes,
-    rebuildSpy,
-    latestBackupSpy,
-    managedEvidenceSpy,
-    liveListSpy,
-  };
-}
+  createRecoveryHarness,
+  makeRecoveryManifest,
+} from "./upgrade-sandboxes-recovery.test-support";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -176,55 +47,11 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
     );
   });
 
-  it("continues an existing old_deleted transaction through the installer runner (#6437)", async () => {
-    let onboardAttempts = 0;
-    const flow = createRebuildFlowHarness({
-      staleRecovery: true,
-      onboard: () => {
-        onboardAttempts += 1;
-        return onboardAttempts === 1
-          ? Promise.reject(new Error("interrupt before replacement receipt"))
-          : undefined;
-      },
-    });
-
-    await expect(
-      flow.rebuildSandbox("alpha", ["--yes"], {
-        throwOnError: true,
-        recoveryManifest: makePreparedRecoveryManifest(),
-      }),
-    ).rejects.toThrow("Recreate failed");
-    const interrupted = flow.transactionStore.load("alpha");
-    expect(interrupted).toMatchObject({ status: "active", phase: "old_deleted" });
-
-    const resumed = createRebuildFlowHarness({ staleRecovery: true });
-    resumed.onboardSpy.mockClear();
-    const upgrade = createRecoveryHarness(["alpha"], {
-      latestBackup: makePreparedRecoveryManifest() as ReturnType<typeof makeManifest>,
-    });
-    upgrade.rebuildSpy.mockImplementation((...args) =>
-      resumed.rebuildSandbox(args[0], args[1], {
-        ...args[2],
-        transactionStore: flow.transactionStore,
-      }),
-    );
-
-    await expect(upgrade.upgradeSandboxes({ auto: true })).resolves.toBeUndefined();
-
-    expect(flow.transactionStore.load("alpha")).toMatchObject({
-      transactionId: interrupted?.transactionId,
-      status: "completed",
-      phase: "completed",
-    });
-    expect(resumed.onboardSpy).toHaveBeenCalledOnce();
-    expect(upgrade.rebuildSpy).toHaveBeenCalledOnce();
-  });
-
   it("fails closed for a probed v0.0.55 custom image with matching backup agent version", async () => {
     const probedAgentVersion = "2026.5.27";
     const harness = createRecoveryHarness(["custom-box"], {
       latestBackup: {
-        ...makeManifest("custom-box"),
+        ...makeRecoveryManifest("custom-box"),
         agentVersion: probedAgentVersion,
       },
       registryOverrides: {
@@ -604,7 +431,7 @@ describe("upgrade-sandboxes prepared backup recovery (#6114)", () => {
       .mockImplementationOnce(() => {
         throw new Error("ENOTDIR: unreadable backup root");
       })
-      .mockImplementationOnce((name: string) => makeManifest(name));
+      .mockImplementationOnce((name: string) => makeRecoveryManifest(name));
     vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);

--- a/src/lib/actions/upgrade-sandboxes-transaction-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-transaction-recovery.test.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createRebuildFlowHarness,
+  installRebuildFlowTestHooks,
+} from "../../../test/helpers/rebuild-flow-test-harness";
+import { makePreparedRecoveryManifest } from "./sandbox/rebuild-flow-test-fixtures";
+import {
+  createRecoveryHarness,
+  makeRecoveryManifest,
+} from "./upgrade-sandboxes-recovery.test-support";
+
+installRebuildFlowTestHooks();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("upgrade-sandboxes rebuild transaction handoff (#6437)", () => {
+  it("continues an existing old_deleted transaction through the installer runner", async () => {
+    let onboardAttempts = 0;
+    const flow = createRebuildFlowHarness({
+      staleRecovery: true,
+      onboard: () => {
+        onboardAttempts += 1;
+        return onboardAttempts === 1
+          ? Promise.reject(new Error("interrupt before replacement receipt"))
+          : undefined;
+      },
+    });
+
+    await expect(
+      flow.rebuildSandbox("alpha", ["--yes"], {
+        throwOnError: true,
+        recoveryManifest: makePreparedRecoveryManifest(),
+      }),
+    ).rejects.toThrow("Recreate failed");
+    const interrupted = flow.transactionStore.load("alpha");
+    expect(interrupted).toMatchObject({ status: "active", phase: "old_deleted" });
+
+    const resumed = createRebuildFlowHarness({ staleRecovery: true });
+    resumed.onboardSpy.mockClear();
+    const upgrade = createRecoveryHarness(["alpha"], {
+      latestBackup: makePreparedRecoveryManifest() as ReturnType<typeof makeRecoveryManifest>,
+    });
+    upgrade.rebuildSpy.mockImplementation((...args) =>
+      resumed.rebuildSandbox(args[0], args[1], {
+        ...args[2],
+        transactionStore: flow.transactionStore,
+      }),
+    );
+
+    await expect(upgrade.upgradeSandboxes({ auto: true })).resolves.toBeUndefined();
+
+    expect(flow.transactionStore.load("alpha")).toMatchObject({
+      transactionId: interrupted?.transactionId,
+      status: "completed",
+      phase: "completed",
+    });
+    expect(resumed.onboardSpy).toHaveBeenCalledOnce();
+    expect(upgrade.rebuildSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/actions/upgrade-sandboxes-transaction-recovery.test.ts
+++ b/src/lib/actions/upgrade-sandboxes-transaction-recovery.test.ts
@@ -1,11 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createRebuildFlowHarness,
   installRebuildFlowTestHooks,
 } from "../../../test/helpers/rebuild-flow-test-harness";
+import { getRebuildTransactionPath, RebuildTransactionStore } from "../state/rebuild-transaction";
 import { makePreparedRecoveryManifest } from "./sandbox/rebuild-flow-test-fixtures";
 import {
   createRecoveryHarness,
@@ -13,13 +18,66 @@ import {
 } from "./upgrade-sandboxes-recovery.test-support";
 
 installRebuildFlowTestHooks();
+const transactionRoots: string[] = [];
 
 afterEach(() => {
+  for (const root of transactionRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
 
 describe("upgrade-sandboxes rebuild transaction handoff (#6437)", () => {
+  it("isolates a corrupt transaction while completing unrelated recovery", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-upgrade-transactions-"));
+    transactionRoots.push(stateDir);
+    const transactionStore = new RebuildTransactionStore({ stateDir });
+    const corruptSandbox = "corrupt-box";
+    const recoverableSandbox = "alpha";
+    const corruptPath = getRebuildTransactionPath(corruptSandbox, stateDir);
+    fs.mkdirSync(path.dirname(corruptPath), { recursive: true });
+    const corruptRecord = '{"version":999,"transactionId":"corrupt-alpha"}\n';
+    fs.writeFileSync(corruptPath, corruptRecord, { mode: 0o600 });
+
+    const upgrade = createRecoveryHarness([corruptSandbox, recoverableSandbox], {
+      latestBackup: makePreparedRecoveryManifest() as ReturnType<typeof makeRecoveryManifest>,
+    });
+    const errors: string[] = [];
+    upgrade.rebuildSpy.mockImplementation((sandboxName, args, options) => {
+      const flow = createRebuildFlowHarness({
+        sandboxEntry: { name: sandboxName },
+        sessionSandboxName: sandboxName,
+        staleRecovery: true,
+      });
+      vi.spyOn(console, "error").mockImplementation((message) => errors.push(String(message)));
+      return flow.rebuildSandbox(sandboxName, args, { ...options, transactionStore });
+    });
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    await expect(upgrade.upgradeSandboxes({ auto: true })).rejects.toThrow("process.exit(1)");
+
+    expect(upgrade.rebuildSpy.mock.calls.map((call) => call[0])).toEqual([
+      corruptSandbox,
+      recoverableSandbox,
+    ]);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/unsupported schema version 999/i),
+        expect.stringMatching(/Failed to recover 'corrupt-box'/i),
+      ]),
+    );
+    expect(errors).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/Failed to recover 'alpha'/i)]),
+    );
+    expect(fs.readFileSync(corruptPath, "utf8")).toBe(corruptRecord);
+    expect(transactionStore.load(recoverableSandbox)).toMatchObject({
+      status: "completed",
+      phase: "completed",
+      intent: { sandboxName: recoverableSandbox },
+    });
+  });
+
   it("continues an existing old_deleted transaction through the installer runner", async () => {
     let onboardAttempts = 0;
     const flow = createRebuildFlowHarness({

--- a/test/e2e/fixtures/phases/state-validation.ts
+++ b/test/e2e/fixtures/phases/state-validation.ts
@@ -4,20 +4,19 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-
-import { buildAvailabilityProbeEnv } from "../availability-env.ts";
-import type { ArtifactSink } from "../artifacts.ts";
-import {
-  resultText,
-  trustedProviderEndpoint,
-  type GatewayClient,
-  type HostCliClient,
-  type SandboxClient,
-} from "../clients/index.ts";
-import type { ShellProbeResult } from "../shell-probe.ts";
+import { shellQuote } from "../../../../src/lib/core/shell-quote";
 import { probesForState, requireExpectedState } from "../../registry/expected-states.ts";
 import type { ExpectedState, StateProbeId } from "../../registry/types.ts";
-import { shellQuote } from "../../../../src/lib/core/shell-quote";
+import type { ArtifactSink } from "../artifacts.ts";
+import { buildAvailabilityProbeEnv } from "../availability-env.ts";
+import {
+  type GatewayClient,
+  type HostCliClient,
+  resultText,
+  type SandboxClient,
+  trustedProviderEndpoint,
+} from "../clients/index.ts";
+import type { ShellProbeResult } from "../shell-probe.ts";
 import type { NemoClawInstance } from "./onboarding.ts";
 
 // Mirror of `src/lib/state/registry.ts::REGISTRY_FILE`. The fixture
@@ -216,15 +215,20 @@ export function latestRebuildBackupDir(
   sandboxName: string,
   options: RebuildBackupOptions = {},
 ): string | undefined {
+  return listRebuildBackupDirs(sandboxName, options).at(-1);
+}
+
+export function listRebuildBackupDirs(
+  sandboxName: string,
+  options: RebuildBackupOptions = {},
+): string[] {
   const sandboxRoot = path.join(options.backupRoot ?? defaultRebuildBackupsRoot(), sandboxName);
-  if (!fs.existsSync(sandboxRoot)) return undefined;
-  const latest = fs
+  if (!fs.existsSync(sandboxRoot)) return [];
+  return fs
     .readdirSync(sandboxRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort()
-    .at(-1);
-  return latest ? path.join(sandboxRoot, latest) : undefined;
+    .map((entry) => path.join(sandboxRoot, entry.name))
+    .sort();
 }
 
 export function readRebuildBackupManifest(backupDir: string): Record<string, unknown> {

--- a/test/e2e/fixtures/rebuild-recovery.ts
+++ b/test/e2e/fixtures/rebuild-recovery.ts
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync, spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ArtifactSink } from "./artifacts.ts";
+import { resultText } from "./clients/command.ts";
+import type { HostCliClient } from "./clients/host.ts";
+import type { ShellProbeRunOptions } from "./shell-probe.ts";
+
+export type LiveRebuildInterruptionPhase = "old_deleted" | "replacement_unjournaled";
+
+export interface RebuildTransactionEvidence {
+  transactionId: string;
+  sandboxName: string;
+  revision: number;
+  status: "active" | "completed";
+  phase: "old_deleted" | "completed";
+  createdAt: string;
+  completedAt: string | null;
+  receipts: { backup: boolean; oldSandboxDeletion: boolean; replacement: boolean };
+  target: {
+    gatewayName: string;
+    gatewayPort: number;
+    imageFingerprint: string;
+    configurationFingerprint: string;
+  };
+}
+
+export interface RebuildInterruptionEvidence extends RebuildTransactionEvidence {
+  interruption: LiveRebuildInterruptionPhase;
+  replacement: null | {
+    registryGatewayName: string;
+    registryGatewayPort: number;
+    sessionTransactionId: string;
+    sessionImageFingerprint: string;
+    sessionConfigurationFingerprint: string;
+    replacementFingerprint: string;
+  };
+}
+
+export interface RebuildRegistryEvidence {
+  agent: string | null;
+  defaultSandbox: string | null;
+  sandboxName: string;
+  gatewayName: string;
+  gatewayPort: number;
+  agentVersion: string;
+  nemoclawVersion: string;
+  observabilityEnabled: boolean;
+  policies: string[];
+  toolDisclosure: string;
+}
+
+export interface PausedRebuildProcess {
+  pid: number;
+  kill(): Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+interface StartInterruptedRebuildOptions {
+  artifacts: ArtifactSink;
+  artifactName: string;
+  commandPath: string;
+  env: NodeJS.ProcessEnv;
+  phase: LiveRebuildInterruptionPhase;
+  redact: (text: string) => string;
+  sandboxName: string;
+  timeoutMs: number;
+}
+
+type JsonObject = Record<string, unknown>;
+
+export async function startRebuildAtDurableBoundary(
+  options: StartInterruptedRebuildOptions,
+): Promise<PausedRebuildProcess> {
+  const home = readText(options.env.HOME, "rebuild interruption HOME");
+  const args = [options.sandboxName, "rebuild", "--yes"];
+  const child = spawn(options.commandPath, args, {
+    detached: true,
+    env: {
+      ...options.env,
+      NEMOCLAW_RUN_LIVE_E2E: "1",
+      NEMOCLAW_REBUILD_PROCESS_FIXTURE: home,
+      NEMOCLAW_E2E_FAILURE_INJECTION: "1",
+      NEMOCLAW_E2E_FORCE_FAIL_AT_STEP: `rebuild_${options.phase}`,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const marker = `[e2e] Rebuild interruption point '${options.phase}'`;
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    },
+  );
+  const writeArtifacts = async (result: { code: number | null; signal: NodeJS.Signals | null }) => {
+    const redactedStdout = options.redact(stdout);
+    const redactedStderr = options.redact(stderr);
+    await options.artifacts.writeText(`${options.artifactName}.stdout.txt`, redactedStdout);
+    await options.artifacts.writeText(`${options.artifactName}.stderr.txt`, redactedStderr);
+    await options.artifacts.writeJson(`${options.artifactName}.result.json`, {
+      command: [options.commandPath, ...args],
+      ...result,
+      stdout: redactedStdout,
+      stderr: redactedStderr,
+    });
+  };
+  let killResult: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | undefined;
+  const kill = () => {
+    killResult ??= (async () => {
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        child.kill("SIGKILL");
+      }
+      const result = await exit;
+      await writeArtifacts(result);
+      if (result.signal !== "SIGKILL") {
+        throw new Error(
+          `rebuild interruption expected SIGKILL, got code=${String(result.code)} signal=${String(result.signal)}`,
+        );
+      }
+      return result;
+    })();
+    return killResult;
+  };
+
+  try {
+    await Promise.race([
+      new Promise<void>((resolve) => {
+        const observe = () => (stderr.includes(marker) ? resolve() : undefined);
+        child.stderr.on("data", observe);
+        observe();
+      }),
+      exit.then(({ code, signal }) => {
+        throw new Error(
+          `rebuild exited before ${options.phase}: code=${String(code)} signal=${String(signal)}`,
+        );
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error(`timed out waiting for rebuild ${options.phase}`)),
+          options.timeoutMs,
+        ).unref();
+      }),
+    ]);
+    await waitForStopped(child.pid!, Math.min(options.timeoutMs, 5_000));
+  } catch (error) {
+    await kill().catch(() => undefined);
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}\n${options.redact(`${stdout}\n${stderr}`).trim()}`,
+    );
+  }
+
+  return { pid: child.pid!, kill };
+}
+
+export function readInterruptedRebuildEvidence(
+  sandboxName: string,
+  interruption: LiveRebuildInterruptionPhase,
+  home: string,
+): RebuildInterruptionEvidence {
+  const record = readObject(transactionPath(home, sandboxName), "rebuild transaction");
+  const base = projectTransaction(record, sandboxName, "active");
+  if (base.phase !== "old_deleted" || base.receipts.replacement) {
+    throw new Error("interrupted transaction is not at durable old_deleted");
+  }
+
+  let replacement: RebuildInterruptionEvidence["replacement"] = null;
+  if (interruption === "replacement_unjournaled") {
+    const registry = readObject(path.join(home, ".nemoclaw", "sandboxes.json"), "registry");
+    const entry = readObjectValue(
+      readObjectValue(registry.sandboxes, "registry.sandboxes")[sandboxName],
+      "replacement registry entry",
+    );
+    const session = readObject(path.join(home, ".nemoclaw", "onboard-session.json"), "session");
+    const correlation = readObjectValue(
+      readObjectValue(session.metadata, "session.metadata").rebuild,
+      "session.metadata.rebuild",
+    );
+    if (
+      session.sandboxName !== sandboxName ||
+      entry.name !== sandboxName ||
+      correlation.transactionId !== base.transactionId ||
+      correlation.imageFingerprint !== base.target.imageFingerprint ||
+      correlation.configurationFingerprint !== base.target.configurationFingerprint
+    ) {
+      throw new Error("replacement session correlation does not match the rebuild transaction");
+    }
+    if (
+      entry.gatewayName !== base.target.gatewayName ||
+      entry.gatewayPort !== base.target.gatewayPort
+    ) {
+      throw new Error("replacement registry gateway does not match the rebuild target");
+    }
+    replacement = {
+      registryGatewayName: readText(entry.gatewayName, "replacement gatewayName"),
+      registryGatewayPort: readInteger(entry.gatewayPort, "replacement gatewayPort"),
+      sessionTransactionId: readText(correlation.transactionId, "session transactionId"),
+      sessionImageFingerprint: readFingerprint(
+        correlation.imageFingerprint,
+        "session imageFingerprint",
+      ),
+      sessionConfigurationFingerprint: readFingerprint(
+        correlation.configurationFingerprint,
+        "session configurationFingerprint",
+      ),
+      replacementFingerprint: readFingerprint(
+        correlation.replacementFingerprint,
+        "session replacementFingerprint",
+      ),
+    };
+  }
+  return { ...base, interruption, replacement };
+}
+
+export function readCompletedRebuildEvidence(
+  sandboxName: string,
+  home: string,
+): RebuildTransactionEvidence {
+  const evidence = projectTransaction(
+    readObject(transactionPath(home, sandboxName), "rebuild transaction"),
+    sandboxName,
+    "completed",
+  );
+  if (evidence.phase !== "completed" || !evidence.receipts.replacement) {
+    throw new Error("rebuild transaction is not a completed tombstone");
+  }
+  return evidence;
+}
+
+export function readRebuildRegistryEvidence(
+  sandboxName: string,
+  home: string,
+): RebuildRegistryEvidence {
+  const registry = readObject(path.join(home, ".nemoclaw", "sandboxes.json"), "registry");
+  const entry = readObjectValue(
+    readObjectValue(registry.sandboxes, "registry.sandboxes")[sandboxName],
+    "registry sandbox entry",
+  );
+  const policies = entry.policies ?? [];
+  if (!Array.isArray(policies) || !policies.every((policy) => typeof policy === "string")) {
+    throw new Error("registry entry policies must be a string array");
+  }
+  return {
+    agent: entry.agent === null ? null : readText(entry.agent, "registry entry agent"),
+    defaultSandbox:
+      registry.defaultSandbox === null
+        ? null
+        : readText(registry.defaultSandbox, "registry.defaultSandbox"),
+    sandboxName,
+    gatewayName: readText(entry.gatewayName, "registry entry gatewayName"),
+    gatewayPort: readInteger(entry.gatewayPort, "registry entry gatewayPort"),
+    agentVersion: readText(entry.agentVersion, "registry entry agentVersion"),
+    nemoclawVersion: readText(entry.nemoclawVersion, "registry entry nemoclawVersion"),
+    observabilityEnabled: entry.observabilityEnabled === true,
+    policies: [...policies].sort(),
+    toolDisclosure: readText(entry.toolDisclosure, "registry entry toolDisclosure"),
+  };
+}
+
+export async function sandboxContainerIds(
+  host: HostCliClient,
+  sandboxName: string,
+  options: ShellProbeRunOptions = {},
+): Promise<string[]> {
+  const result = await host.command(
+    "docker",
+    [
+      "ps",
+      "-a",
+      "--filter",
+      `label=openshell.ai/sandbox-name=${sandboxName}`,
+      "--format",
+      "{{.ID}}",
+    ],
+    options,
+  );
+  if (result.exitCode !== 0) throw new Error(resultText(result));
+  return result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function projectTransaction(
+  record: JsonObject,
+  sandboxName: string,
+  status: "active" | "completed",
+): RebuildTransactionEvidence {
+  const intent = readObjectValue(record.intent, "transaction.intent");
+  const target = readObjectValue(intent.target, "transaction.intent.target");
+  const receipts = readObjectValue(record.receipts, "transaction.receipts");
+  const phase = status === "completed" ? "completed" : "old_deleted";
+  if (record.status !== status || record.phase !== phase || intent.sandboxName !== sandboxName) {
+    throw new Error(`rebuild transaction is not ${status} for ${sandboxName}`);
+  }
+  if (!receipts.backup || !receipts.oldSandboxDeletion) {
+    throw new Error("rebuild transaction is missing destructive receipts");
+  }
+  return {
+    transactionId: readText(record.transactionId, "transaction.transactionId"),
+    sandboxName,
+    revision: readInteger(record.revision, "transaction.revision"),
+    status,
+    phase,
+    createdAt: readText(record.createdAt, "transaction.createdAt"),
+    completedAt:
+      status === "completed" ? readText(record.completedAt, "transaction.completedAt") : null,
+    receipts: {
+      backup: true,
+      oldSandboxDeletion: true,
+      replacement: receipts.replacement !== undefined,
+    },
+    target: {
+      gatewayName: readText(target.gatewayName, "transaction target gatewayName"),
+      gatewayPort: readInteger(target.gatewayPort, "transaction target gatewayPort"),
+      imageFingerprint: readFingerprint(target.imageFingerprint, "transaction imageFingerprint"),
+      configurationFingerprint: readFingerprint(
+        target.configurationFingerprint,
+        "transaction configurationFingerprint",
+      ),
+    },
+  };
+}
+
+async function waitForStopped(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const state = execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
+        encoding: "utf8",
+      }).trim();
+      if (state.startsWith("T")) return;
+    } catch {
+      // The exit promise reports an early process death with captured output.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`rebuild process ${String(pid)} did not enter SIGSTOP state`);
+}
+
+function transactionPath(home: string, sandboxName: string): string {
+  const stem = crypto.createHash("sha256").update(sandboxName).digest("hex");
+  return path.join(home, ".nemoclaw", "state", "rebuild-transactions", `${stem}.json`);
+}
+
+function readObject(file: string, label: string): JsonObject {
+  return readObjectValue(JSON.parse(fs.readFileSync(file, "utf8")), label);
+}
+
+function readObjectValue(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function readText(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} is missing`);
+  return value;
+}
+
+function readInteger(value: unknown, label: string): number {
+  if (!Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value as number;
+}
+
+function readFingerprint(value: unknown, label: string): string {
+  const candidate = readText(value, label);
+  if (!/^sha256:[0-9a-f]{64}$/u.test(candidate)) {
+    throw new Error(`${label} must be a sha256 fingerprint`);
+  }
+  return candidate;
+}

--- a/test/e2e/fixtures/rebuild-recovery.ts
+++ b/test/e2e/fixtures/rebuild-recovery.ts
@@ -2,32 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, spawn } from "node:child_process";
-import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import type { Session } from "../../../src/lib/state/onboard-session";
+import {
+  getRebuildTransactionPath,
+  type RebuildTransactionDiagnosticV1,
+  type RebuildTransactionRecordV1,
+} from "../../../src/lib/state/rebuild-transaction";
+import type { SandboxRegistry } from "../../../src/lib/state/registry";
 
 import type { ArtifactSink } from "./artifacts.ts";
-import { resultText } from "./clients/command.ts";
-import type { HostCliClient } from "./clients/host.ts";
-import type { ShellProbeRunOptions } from "./shell-probe.ts";
 
 export type LiveRebuildInterruptionPhase = "old_deleted" | "replacement_unjournaled";
 
-export interface RebuildTransactionEvidence {
-  transactionId: string;
-  sandboxName: string;
-  revision: number;
-  status: "active" | "completed";
+export interface RebuildTransactionEvidence
+  extends Omit<RebuildTransactionDiagnosticV1, "failureCode" | "phase" | "updatedAt" | "version"> {
   phase: "old_deleted" | "completed";
-  createdAt: string;
-  completedAt: string | null;
-  receipts: { backup: boolean; oldSandboxDeletion: boolean; replacement: boolean };
-  target: {
-    gatewayName: string;
-    gatewayPort: number;
-    imageFingerprint: string;
-    configurationFingerprint: string;
-  };
+  target: Pick<
+    RebuildTransactionRecordV1["intent"]["target"],
+    "configurationFingerprint" | "gatewayName" | "gatewayPort" | "imageFingerprint"
+  >;
 }
 
 export interface RebuildInterruptionEvidence extends RebuildTransactionEvidence {
@@ -40,19 +35,6 @@ export interface RebuildInterruptionEvidence extends RebuildTransactionEvidence 
     sessionConfigurationFingerprint: string;
     replacementFingerprint: string;
   };
-}
-
-export interface RebuildRegistryEvidence {
-  agent: string | null;
-  defaultSandbox: string | null;
-  sandboxName: string;
-  gatewayName: string;
-  gatewayPort: number;
-  agentVersion: string;
-  nemoclawVersion: string;
-  observabilityEnabled: boolean;
-  policies: string[];
-  toolDisclosure: string;
 }
 
 export interface PausedRebuildProcess {
@@ -71,12 +53,15 @@ interface StartInterruptedRebuildOptions {
   timeoutMs: number;
 }
 
-type JsonObject = Record<string, unknown>;
+const MAX_CAPTURED_CHARACTERS = 256 * 1024;
+const MAX_ERROR_TAIL_CHARACTERS = 16 * 1024;
+const OUTPUT_TRUNCATED = "\n...[earlier output truncated]...\n";
 
 export async function startRebuildAtDurableBoundary(
   options: StartInterruptedRebuildOptions,
 ): Promise<PausedRebuildProcess> {
-  const home = readText(options.env.HOME, "rebuild interruption HOME");
+  const home = options.env.HOME;
+  if (!home) throw new Error("rebuild interruption HOME is required");
   const args = [options.sandboxName, "rebuild", "--yes"];
   const child = spawn(options.commandPath, args, {
     detached: true,
@@ -93,10 +78,10 @@ export async function startRebuildAtDurableBoundary(
   let stdout = "";
   let stderr = "";
   child.stdout.on("data", (chunk: Buffer) => {
-    stdout += chunk.toString("utf8");
+    stdout = appendCapturedOutput(stdout, chunk.toString("utf8"));
   });
   child.stderr.on("data", (chunk: Buffer) => {
-    stderr += chunk.toString("utf8");
+    stderr = appendCapturedOutput(stderr, chunk.toString("utf8"));
   });
 
   const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
@@ -159,9 +144,11 @@ export async function startRebuildAtDurableBoundary(
     await waitForStopped(child.pid!, Math.min(options.timeoutMs, 5_000));
   } catch (error) {
     await kill().catch(() => undefined);
-    throw new Error(
-      `${error instanceof Error ? error.message : String(error)}\n${options.redact(`${stdout}\n${stderr}`).trim()}`,
-    );
+    const outputTail = options
+      .redact(`${stdout}\n${stderr}`)
+      .trim()
+      .slice(-MAX_ERROR_TAIL_CHARACTERS);
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\n${outputTail}`);
   }
 
   return { pid: child.pid!, kill };
@@ -172,7 +159,9 @@ export function readInterruptedRebuildEvidence(
   interruption: LiveRebuildInterruptionPhase,
   home: string,
 ): RebuildInterruptionEvidence {
-  const record = readObject(transactionPath(home, sandboxName), "rebuild transaction");
+  const record = readJson<RebuildTransactionRecordV1>(
+    getRebuildTransactionPath(sandboxName, path.join(home, ".nemoclaw", "state")),
+  );
   const base = projectTransaction(record, sandboxName, "active");
   if (base.phase !== "old_deleted" || base.receipts.replacement) {
     throw new Error("interrupted transaction is not at durable old_deleted");
@@ -180,17 +169,14 @@ export function readInterruptedRebuildEvidence(
 
   let replacement: RebuildInterruptionEvidence["replacement"] = null;
   if (interruption === "replacement_unjournaled") {
-    const registry = readObject(path.join(home, ".nemoclaw", "sandboxes.json"), "registry");
-    const entry = readObjectValue(
-      readObjectValue(registry.sandboxes, "registry.sandboxes")[sandboxName],
-      "replacement registry entry",
-    );
-    const session = readObject(path.join(home, ".nemoclaw", "onboard-session.json"), "session");
-    const correlation = readObjectValue(
-      readObjectValue(session.metadata, "session.metadata").rebuild,
-      "session.metadata.rebuild",
-    );
+    const registry = readJson<SandboxRegistry>(path.join(home, ".nemoclaw", "sandboxes.json"));
+    const entry = registry.sandboxes[sandboxName];
+    const session = readJson<Session>(path.join(home, ".nemoclaw", "onboard-session.json"));
+    const correlation = session.metadata.rebuild;
     if (
+      !entry ||
+      !correlation ||
+      correlation.replacementFingerprint === null ||
       session.sandboxName !== sandboxName ||
       entry.name !== sandboxName ||
       correlation.transactionId !== base.transactionId ||
@@ -206,21 +192,12 @@ export function readInterruptedRebuildEvidence(
       throw new Error("replacement registry gateway does not match the rebuild target");
     }
     replacement = {
-      registryGatewayName: readText(entry.gatewayName, "replacement gatewayName"),
-      registryGatewayPort: readInteger(entry.gatewayPort, "replacement gatewayPort"),
-      sessionTransactionId: readText(correlation.transactionId, "session transactionId"),
-      sessionImageFingerprint: readFingerprint(
-        correlation.imageFingerprint,
-        "session imageFingerprint",
-      ),
-      sessionConfigurationFingerprint: readFingerprint(
-        correlation.configurationFingerprint,
-        "session configurationFingerprint",
-      ),
-      replacementFingerprint: readFingerprint(
-        correlation.replacementFingerprint,
-        "session replacementFingerprint",
-      ),
+      registryGatewayName: entry.gatewayName,
+      registryGatewayPort: entry.gatewayPort,
+      sessionTransactionId: correlation.transactionId,
+      sessionImageFingerprint: correlation.imageFingerprint,
+      sessionConfigurationFingerprint: correlation.configurationFingerprint,
+      replacementFingerprint: correlation.replacementFingerprint,
     };
   }
   return { ...base, interruption, replacement };
@@ -231,7 +208,9 @@ export function readCompletedRebuildEvidence(
   home: string,
 ): RebuildTransactionEvidence {
   const evidence = projectTransaction(
-    readObject(transactionPath(home, sandboxName), "rebuild transaction"),
+    readJson<RebuildTransactionRecordV1>(
+      getRebuildTransactionPath(sandboxName, path.join(home, ".nemoclaw", "state")),
+    ),
     sandboxName,
     "completed",
   );
@@ -241,68 +220,13 @@ export function readCompletedRebuildEvidence(
   return evidence;
 }
 
-export function readRebuildRegistryEvidence(
-  sandboxName: string,
-  home: string,
-): RebuildRegistryEvidence {
-  const registry = readObject(path.join(home, ".nemoclaw", "sandboxes.json"), "registry");
-  const entry = readObjectValue(
-    readObjectValue(registry.sandboxes, "registry.sandboxes")[sandboxName],
-    "registry sandbox entry",
-  );
-  const policies = entry.policies ?? [];
-  if (!Array.isArray(policies) || !policies.every((policy) => typeof policy === "string")) {
-    throw new Error("registry entry policies must be a string array");
-  }
-  return {
-    agent: entry.agent === null ? null : readText(entry.agent, "registry entry agent"),
-    defaultSandbox:
-      registry.defaultSandbox === null
-        ? null
-        : readText(registry.defaultSandbox, "registry.defaultSandbox"),
-    sandboxName,
-    gatewayName: readText(entry.gatewayName, "registry entry gatewayName"),
-    gatewayPort: readInteger(entry.gatewayPort, "registry entry gatewayPort"),
-    agentVersion: readText(entry.agentVersion, "registry entry agentVersion"),
-    nemoclawVersion: readText(entry.nemoclawVersion, "registry entry nemoclawVersion"),
-    observabilityEnabled: entry.observabilityEnabled === true,
-    policies: [...policies].sort(),
-    toolDisclosure: readText(entry.toolDisclosure, "registry entry toolDisclosure"),
-  };
-}
-
-export async function sandboxContainerIds(
-  host: HostCliClient,
-  sandboxName: string,
-  options: ShellProbeRunOptions = {},
-): Promise<string[]> {
-  const result = await host.command(
-    "docker",
-    [
-      "ps",
-      "-a",
-      "--filter",
-      `label=openshell.ai/sandbox-name=${sandboxName}`,
-      "--format",
-      "{{.ID}}",
-    ],
-    options,
-  );
-  if (result.exitCode !== 0) throw new Error(resultText(result));
-  return result.stdout
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter(Boolean);
-}
-
 function projectTransaction(
-  record: JsonObject,
+  record: RebuildTransactionRecordV1,
   sandboxName: string,
   status: "active" | "completed",
 ): RebuildTransactionEvidence {
-  const intent = readObjectValue(record.intent, "transaction.intent");
-  const target = readObjectValue(intent.target, "transaction.intent.target");
-  const receipts = readObjectValue(record.receipts, "transaction.receipts");
+  const { intent, receipts } = record;
+  const { target } = intent;
   const phase = status === "completed" ? "completed" : "old_deleted";
   if (record.status !== status || record.phase !== phase || intent.sandboxName !== sandboxName) {
     throw new Error(`rebuild transaction is not ${status} for ${sandboxName}`);
@@ -311,27 +235,23 @@ function projectTransaction(
     throw new Error("rebuild transaction is missing destructive receipts");
   }
   return {
-    transactionId: readText(record.transactionId, "transaction.transactionId"),
+    transactionId: record.transactionId,
     sandboxName,
-    revision: readInteger(record.revision, "transaction.revision"),
+    revision: record.revision,
     status,
     phase,
-    createdAt: readText(record.createdAt, "transaction.createdAt"),
-    completedAt:
-      status === "completed" ? readText(record.completedAt, "transaction.completedAt") : null,
+    createdAt: record.createdAt,
+    completedAt: status === "completed" ? record.completedAt : null,
     receipts: {
       backup: true,
       oldSandboxDeletion: true,
       replacement: receipts.replacement !== undefined,
     },
     target: {
-      gatewayName: readText(target.gatewayName, "transaction target gatewayName"),
-      gatewayPort: readInteger(target.gatewayPort, "transaction target gatewayPort"),
-      imageFingerprint: readFingerprint(target.imageFingerprint, "transaction imageFingerprint"),
-      configurationFingerprint: readFingerprint(
-        target.configurationFingerprint,
-        "transaction configurationFingerprint",
-      ),
+      gatewayName: target.gatewayName,
+      gatewayPort: target.gatewayPort,
+      imageFingerprint: target.imageFingerprint,
+      configurationFingerprint: target.configurationFingerprint,
     },
   };
 }
@@ -352,36 +272,12 @@ async function waitForStopped(pid: number, timeoutMs: number): Promise<void> {
   throw new Error(`rebuild process ${String(pid)} did not enter SIGSTOP state`);
 }
 
-function transactionPath(home: string, sandboxName: string): string {
-  const stem = crypto.createHash("sha256").update(sandboxName).digest("hex");
-  return path.join(home, ".nemoclaw", "state", "rebuild-transactions", `${stem}.json`);
+function appendCapturedOutput(current: string, chunk: string): string {
+  const combined = current + chunk;
+  if (combined.length <= MAX_CAPTURED_CHARACTERS) return combined;
+  return OUTPUT_TRUNCATED + combined.slice(-(MAX_CAPTURED_CHARACTERS - OUTPUT_TRUNCATED.length));
 }
 
-function readObject(file: string, label: string): JsonObject {
-  return readObjectValue(JSON.parse(fs.readFileSync(file, "utf8")), label);
-}
-
-function readObjectValue(value: unknown, label: string): JsonObject {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
-  }
-  return value as JsonObject;
-}
-
-function readText(value: unknown, label: string): string {
-  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} is missing`);
-  return value;
-}
-
-function readInteger(value: unknown, label: string): number {
-  if (!Number.isInteger(value)) throw new Error(`${label} must be an integer`);
-  return value as number;
-}
-
-function readFingerprint(value: unknown, label: string): string {
-  const candidate = readText(value, label);
-  if (!/^sha256:[0-9a-f]{64}$/u.test(candidate)) {
-    throw new Error(`${label} must be a sha256 fingerprint`);
-  }
-  return candidate;
+function readJson<T>(file: string): T {
+  return JSON.parse(fs.readFileSync(file, "utf8")) as T;
 }

--- a/test/e2e/live/sandbox-rebuild.test.ts
+++ b/test/e2e/live/sandbox-rebuild.test.ts
@@ -124,9 +124,10 @@ function registryEvidence(home: string) {
     fs.readFileSync(path.join(home, ".nemoclaw", "sandboxes.json"), "utf8"),
   ) as { defaultSandbox?: string | null };
   const policies = entry.policies;
-  if (!Array.isArray(policies) || !policies.every((policy) => typeof policy === "string")) {
-    throw new Error("registry policies must be a string array");
-  }
+  expect(
+    Array.isArray(policies) && policies.every((policy) => typeof policy === "string"),
+    "registry policies must be a string array",
+  ).toBe(true);
   return {
     agent: entry.agent ?? null,
     defaultSandbox: registry.defaultSandbox ?? null,
@@ -135,7 +136,7 @@ function registryEvidence(home: string) {
     agentVersion: entry.agentVersion,
     nemoclawVersion: entry.nemoclawVersion,
     observabilityEnabled: entry.observabilityEnabled === true,
-    policies: [...policies].sort(),
+    policies: [...(policies as string[])].sort(),
     toolDisclosure: entry.toolDisclosure,
   };
 }

--- a/test/e2e/live/sandbox-rebuild.test.ts
+++ b/test/e2e/live/sandbox-rebuild.test.ts
@@ -318,6 +318,17 @@ test(
     });
     const firstCompleted = readCompletedRebuildEvidence(SANDBOX_NAME, home);
     await artifacts.writeJson("phase-6-first-completed-tombstone.json", firstCompleted);
+    const firstReplacementContainers = await sandboxContainerIds(
+      host,
+      "phase-6-replacement-container-identity",
+    );
+    expect(firstReplacementContainers).toHaveLength(1);
+    await artifacts.writeJson("phase-6-replacement-identity.json", {
+      containerId: firstReplacementContainers[0],
+      gatewayName: firstCompleted.target.gatewayName,
+      imageFingerprint: firstCompleted.target.imageFingerprint,
+      transactionId: firstCompleted.transactionId,
+    });
 
     const updatedVersion = stateValidation.expectRegistryAgentVersionUpdated(
       SANDBOX_NAME,

--- a/test/e2e/live/sandbox-rebuild.test.ts
+++ b/test/e2e/live/sandbox-rebuild.test.ts
@@ -6,22 +6,29 @@ import os from "node:os";
 import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/command.ts";
+import type { HostCliClient } from "../fixtures/clients/host.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import {
-  latestRebuildBackupDir,
   listCredentialLeakPaths,
+  listRebuildBackupDirs,
   patchRegistrySandboxEntry,
   readRegistrySandboxEntry,
   restoreRegistryAndSession,
   snapshotRegistryAndSession,
 } from "../fixtures/phases/state-validation.ts";
+import {
+  readCompletedRebuildEvidence,
+  readInterruptedRebuildEvidence,
+  readRebuildRegistryEvidence,
+  sandboxContainerIds,
+  startRebuildAtDurableBoundary,
+} from "../fixtures/rebuild-recovery.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 
 // This dependent migration reuses the rebuild/state helper shape seeded by the
 // OpenClaw rebuild anchor while keeping the contract focused: onboard a real
-// sandbox, mark workspace state, force stale registry metadata, run the real
-// `nemoclaw <sandbox> rebuild --yes`, then verify state preservation, registry
-// refresh, and backup credential hygiene.
+// sandbox, mark workspace state, force stale registry metadata, then kill and
+// resume two real rebuild generations at the destructive recovery boundaries.
 
 const MARKER_FILE = "/sandbox/.openclaw/workspace/rebuild-marker.txt";
 const STALE_AGENT_VERSION = "0.0.1";
@@ -64,8 +71,22 @@ async function bestEffort(run: () => Promise<unknown>): Promise<void> {
   }
 }
 
+async function expectStoppedRebuild(
+  host: HostCliClient,
+  pid: number,
+  artifactName: string,
+): Promise<void> {
+  const state = await host.command("ps", ["-o", "stat=", "-p", String(pid)], {
+    artifactName,
+    env: buildAvailabilityProbeEnv(),
+    timeoutMs: 10_000,
+  });
+  expect(state.exitCode, resultText(state)).toBe(0);
+  expect(state.stdout.trim()).toMatch(/^T/u);
+}
+
 test(
-  "sandbox-rebuild: rebuild preserves marker state and refreshes registry metadata",
+  "sandbox rebuild recovers destructive process death without duplicate effects (#6437)",
   async ({
     artifacts,
     cleanup,
@@ -109,7 +130,9 @@ test(
         "real nemoclaw onboard with Docker/OpenShell",
         "openshell sandbox exec marker write/read",
         "local registry stale agentVersion mutation",
-        "real nemoclaw <sandbox> rebuild --yes",
+        "SIGSTOP/SIGKILL after durable old-sandbox deletion",
+        "SIGSTOP/SIGKILL after unjournaled replacement creation",
+        "ordinary public rebuild command recovery for both generations",
         "backup credential leak scan under ~/.nemoclaw/rebuild-backups",
       ],
     });
@@ -150,6 +173,8 @@ test(
       sandboxName: SANDBOX_NAME,
       timeoutMs: ONBOARD_TIMEOUT_MS,
     });
+    const home = process.env.HOME ?? os.homedir();
+    const initialRegistry = readRebuildRegistryEvidence(SANDBOX_NAME, home);
 
     const status = await host.nemoclaw([SANDBOX_NAME, "status"], {
       artifactName: "phase-2-status-version-detection",
@@ -184,24 +209,64 @@ test(
     expect(staleStatus.exitCode, resultText(staleStatus)).toBe(0);
     expect(resultText(staleStatus)).toMatch(/rebuild/i);
 
+    const deletedProcess = await startRebuildAtDurableBoundary({
+      artifacts,
+      artifactName: "phase-5-rebuild-interrupt-old-deleted",
+      commandPath: host.commandPath,
+      env: sandboxRebuildEnv(apiKey),
+      phase: "old_deleted",
+      redact: (text) => secrets.redact(text, [apiKey]),
+      sandboxName: SANDBOX_NAME,
+      timeoutMs: REBUILD_TIMEOUT_MS,
+    });
+    cleanup.add("kill old_deleted rebuild process", async () => {
+      await deletedProcess.kill();
+    });
+    await expectStoppedRebuild(host, deletedProcess.pid, "phase-5-stopped-process-state");
+    const deletedEvidence = readInterruptedRebuildEvidence(SANDBOX_NAME, "old_deleted", home);
+    expect(
+      await sandboxContainerIds(host, SANDBOX_NAME, {
+        artifactName: "phase-5-old-sandbox-container-absence",
+        env: buildAvailabilityProbeEnv(),
+      }),
+    ).toEqual([]);
+    const deletedList = await sandbox.list({
+      artifactName: "phase-5-old-sandbox-openshell-absence",
+      env: {
+        ...buildAvailabilityProbeEnv(),
+        OPENSHELL_GATEWAY: deletedEvidence.target.gatewayName,
+      },
+    });
+    expect(resultText(deletedList)).not.toContain(SANDBOX_NAME);
+    expect(deletedEvidence).toMatchObject({
+      status: "active",
+      phase: "old_deleted",
+      receipts: { backup: true, oldSandboxDeletion: true, replacement: false },
+      replacement: null,
+    });
+    await artifacts.writeJson("phase-5-old-deleted-interruption.json", deletedEvidence);
+    await expect(deletedProcess.kill()).resolves.toMatchObject({ signal: "SIGKILL" });
+
     await lifecycle.rebuildSandbox(instance, {
-      artifactName: "phase-5-nemoclaw-rebuild",
+      artifactName: "phase-6-resume-old-deleted-through-public-command",
       env: sandboxRebuildEnv(apiKey),
       redactionValues: [apiKey],
       timeoutMs: REBUILD_TIMEOUT_MS,
     });
     await lifecycle.assertSandboxReadyAfterRebuild(instance, {
-      artifactNamePrefix: "phase-5-sandbox-ready-after-rebuild",
+      artifactNamePrefix: "phase-6-sandbox-ready-after-recovery",
       env: buildAvailabilityProbeEnv(),
       attempts: 12,
       delayMs: 5_000,
     });
 
     await stateValidation.expectMarkerFileContent(instance, MARKER_FILE, MARKER_CONTENT, {
-      artifactName: "phase-6-read-marker-after-rebuild",
+      artifactName: "phase-6-read-marker-after-recovery",
       env: buildAvailabilityProbeEnv(),
       timeoutMs: 60_000,
     });
+    const firstCompleted = readCompletedRebuildEvidence(SANDBOX_NAME, home);
+    await artifacts.writeJson("phase-6-first-completed-tombstone.json", firstCompleted);
 
     const updatedVersion = stateValidation.expectRegistryAgentVersionUpdated(
       SANDBOX_NAME,
@@ -213,14 +278,110 @@ test(
       updatedVersion,
     });
 
-    const backupDir = latestRebuildBackupDir(SANDBOX_NAME);
-    const leaks = listCredentialLeakPaths(backupDir, { extraSecrets: [apiKey] });
-    await artifacts.writeJson("phase-8-backup-credential-scan.json", {
-      backupDir: backupDir ?? null,
-      leaks,
-      note: backupDir ? undefined : "No backup directory found; former shell skipped this check.",
+    const replacementProcess = await startRebuildAtDurableBoundary({
+      artifacts,
+      artifactName: "phase-8-rebuild-interrupt-replacement-unjournaled",
+      commandPath: host.commandPath,
+      env: sandboxRebuildEnv(apiKey),
+      phase: "replacement_unjournaled",
+      redact: (text) => secrets.redact(text, [apiKey]),
+      sandboxName: SANDBOX_NAME,
+      timeoutMs: REBUILD_TIMEOUT_MS,
     });
-    expect(leaks, "backup files must not contain credential-shaped values").toEqual([]);
+    cleanup.add("kill replacement_unjournaled rebuild process", async () => {
+      await replacementProcess.kill();
+    });
+    await expectStoppedRebuild(host, replacementProcess.pid, "phase-8-stopped-process-state");
+    const replacementEvidence = readInterruptedRebuildEvidence(
+      SANDBOX_NAME,
+      "replacement_unjournaled",
+      home,
+    );
+    expect(replacementEvidence.transactionId).not.toBe(firstCompleted.transactionId);
+    const replacementContainers = await sandboxContainerIds(host, SANDBOX_NAME, {
+      artifactName: "phase-8-replacement-container-identity",
+      env: buildAvailabilityProbeEnv(),
+    });
+    expect(replacementContainers).toHaveLength(1);
+    const replacementList = await sandbox.list({
+      artifactName: "phase-8-replacement-ready",
+      env: {
+        ...buildAvailabilityProbeEnv(),
+        OPENSHELL_GATEWAY: replacementEvidence.target.gatewayName,
+      },
+    });
+    expect(resultText(replacementList)).toMatch(
+      new RegExp(`${SANDBOX_NAME}.*(?:Ready|Running)`, "u"),
+    );
+    expect(replacementEvidence.replacement).toMatchObject({
+      registryGatewayName: replacementEvidence.target.gatewayName,
+      registryGatewayPort: replacementEvidence.target.gatewayPort,
+      sessionTransactionId: replacementEvidence.transactionId,
+      sessionImageFingerprint: replacementEvidence.target.imageFingerprint,
+      sessionConfigurationFingerprint: replacementEvidence.target.configurationFingerprint,
+    });
+    await artifacts.writeJson(
+      "phase-8-replacement-unjournaled-interruption.json",
+      replacementEvidence,
+    );
+    await expect(replacementProcess.kill()).resolves.toMatchObject({ signal: "SIGKILL" });
+
+    const adoptedContainerId = replacementContainers[0]!;
+    const adopted = await lifecycle.rebuildSandbox(instance, {
+      artifactName: "phase-9-adopt-replacement-through-public-command",
+      env: sandboxRebuildEnv(apiKey),
+      redactionValues: [apiKey],
+      timeoutMs: REBUILD_TIMEOUT_MS,
+    });
+    expect(resultText(adopted)).not.toMatch(/Deleting old sandbox|Creating new sandbox/u);
+    await lifecycle.assertSandboxReadyAfterRebuild(instance, {
+      artifactNamePrefix: "phase-9-sandbox-ready-after-adoption",
+      env: buildAvailabilityProbeEnv(),
+      attempts: 12,
+      delayMs: 5_000,
+    });
+    expect(
+      await sandboxContainerIds(host, SANDBOX_NAME, {
+        artifactName: "phase-9-adopted-container-identity",
+        env: buildAvailabilityProbeEnv(),
+      }),
+    ).toEqual([adoptedContainerId]);
+    await stateValidation.expectMarkerFileContent(instance, MARKER_FILE, MARKER_CONTENT, {
+      artifactName: "phase-9-read-marker-after-adoption",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 60_000,
+    });
+
+    const secondCompleted = readCompletedRebuildEvidence(SANDBOX_NAME, home);
+    expect(secondCompleted.transactionId).toBe(replacementEvidence.transactionId);
+    expect(secondCompleted.transactionId).not.toBe(firstCompleted.transactionId);
+    await artifacts.writeJson("phase-10-completed-generations.json", {
+      retainedCompletedTombstones: [firstCompleted, secondCompleted],
+    });
+
+    const finalRegistry = readRebuildRegistryEvidence(SANDBOX_NAME, home);
+    expect(finalRegistry).toMatchObject({
+      agent: initialRegistry.agent,
+      defaultSandbox: initialRegistry.defaultSandbox,
+      gatewayName: initialRegistry.gatewayName,
+      gatewayPort: initialRegistry.gatewayPort,
+      agentVersion: updatedVersion,
+      nemoclawVersion: initialRegistry.nemoclawVersion,
+      observabilityEnabled: initialRegistry.observabilityEnabled,
+      policies: initialRegistry.policies,
+      toolDisclosure: initialRegistry.toolDisclosure,
+    });
+
+    const backupScans = listRebuildBackupDirs(SANDBOX_NAME).map((backupDir) => ({
+      backupDir,
+      leaks: listCredentialLeakPaths(backupDir, { extraSecrets: [apiKey] }),
+    }));
+    await artifacts.writeJson("phase-11-backup-credential-scans.json", backupScans);
+    expect(backupScans.length).toBeGreaterThanOrEqual(2);
+    expect(
+      backupScans.flatMap(({ leaks }) => leaks),
+      "backup files must not contain credential-shaped values",
+    ).toEqual([]);
 
     async function stateValidationWriteMarker(): Promise<void> {
       await stateValidation.writeMarkerFile(instance, MARKER_FILE, MARKER_CONTENT, {
@@ -235,5 +396,5 @@ test(
       });
     }
   },
-  TEST_TIMEOUT_MS * 3,
+  TEST_TIMEOUT_MS * 5,
 );

--- a/test/e2e/live/sandbox-rebuild.test.ts
+++ b/test/e2e/live/sandbox-rebuild.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/command.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
+import type { SandboxClient } from "../fixtures/clients/sandbox.ts";
 import { expect, test } from "../fixtures/e2e-test.ts";
 import {
   listCredentialLeakPaths,
@@ -19,8 +20,6 @@ import {
 import {
   readCompletedRebuildEvidence,
   readInterruptedRebuildEvidence,
-  readRebuildRegistryEvidence,
-  sandboxContainerIds,
   startRebuildAtDurableBoundary,
 } from "../fixtures/rebuild-recovery.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
@@ -83,6 +82,62 @@ async function expectStoppedRebuild(
   });
   expect(state.exitCode, resultText(state)).toBe(0);
   expect(state.stdout.trim()).toMatch(/^T/u);
+}
+
+async function sandboxContainerIds(host: HostCliClient, artifactName: string): Promise<string[]> {
+  const result = await host.command(
+    "docker",
+    [
+      "ps",
+      "-a",
+      "--filter",
+      `label=openshell.ai/sandbox-name=${SANDBOX_NAME}`,
+      "--format",
+      "{{.ID}}",
+    ],
+    { artifactName, env: buildAvailabilityProbeEnv() },
+  );
+  expect(result.exitCode, resultText(result)).toBe(0);
+  return result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function expectOpenClawVersion(
+  sandbox: SandboxClient,
+  expectedVersion: string,
+  artifactName: string,
+): Promise<void> {
+  const result = await sandbox.exec(SANDBOX_NAME, ["openclaw", "--version"], {
+    artifactName,
+    env: buildAvailabilityProbeEnv(),
+    timeoutMs: 60_000,
+  });
+  expect(result.exitCode, resultText(result)).toBe(0);
+  expect(resultText(result)).toContain(expectedVersion);
+}
+
+function registryEvidence(home: string) {
+  const entry = readRegistrySandboxEntry(SANDBOX_NAME);
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(home, ".nemoclaw", "sandboxes.json"), "utf8"),
+  ) as { defaultSandbox?: string | null };
+  const policies = entry.policies;
+  if (!Array.isArray(policies) || !policies.every((policy) => typeof policy === "string")) {
+    throw new Error("registry policies must be a string array");
+  }
+  return {
+    agent: entry.agent ?? null,
+    defaultSandbox: registry.defaultSandbox ?? null,
+    gatewayName: entry.gatewayName,
+    gatewayPort: entry.gatewayPort,
+    agentVersion: entry.agentVersion,
+    nemoclawVersion: entry.nemoclawVersion,
+    observabilityEnabled: entry.observabilityEnabled === true,
+    policies: [...policies].sort(),
+    toolDisclosure: entry.toolDisclosure,
+  };
 }
 
 test(
@@ -174,7 +229,7 @@ test(
       timeoutMs: ONBOARD_TIMEOUT_MS,
     });
     const home = process.env.HOME ?? os.homedir();
-    const initialRegistry = readRebuildRegistryEvidence(SANDBOX_NAME, home);
+    const initialRegistry = registryEvidence(home);
 
     const status = await host.nemoclaw([SANDBOX_NAME, "status"], {
       artifactName: "phase-2-status-version-detection",
@@ -224,12 +279,7 @@ test(
     });
     await expectStoppedRebuild(host, deletedProcess.pid, "phase-5-stopped-process-state");
     const deletedEvidence = readInterruptedRebuildEvidence(SANDBOX_NAME, "old_deleted", home);
-    expect(
-      await sandboxContainerIds(host, SANDBOX_NAME, {
-        artifactName: "phase-5-old-sandbox-container-absence",
-        env: buildAvailabilityProbeEnv(),
-      }),
-    ).toEqual([]);
+    expect(await sandboxContainerIds(host, "phase-5-old-sandbox-container-absence")).toEqual([]);
     const deletedList = await sandbox.list({
       artifactName: "phase-5-old-sandbox-openshell-absence",
       env: {
@@ -272,6 +322,11 @@ test(
       SANDBOX_NAME,
       STALE_AGENT_VERSION,
     );
+    await expectOpenClawVersion(
+      sandbox,
+      updatedVersion,
+      "phase-7-openclaw-version-after-old-deleted-recovery",
+    );
     await artifacts.writeJson("phase-7-registry-version-summary.json", {
       sandboxName: SANDBOX_NAME,
       staleVersion: STALE_AGENT_VERSION,
@@ -298,10 +353,10 @@ test(
       home,
     );
     expect(replacementEvidence.transactionId).not.toBe(firstCompleted.transactionId);
-    const replacementContainers = await sandboxContainerIds(host, SANDBOX_NAME, {
-      artifactName: "phase-8-replacement-container-identity",
-      env: buildAvailabilityProbeEnv(),
-    });
+    const replacementContainers = await sandboxContainerIds(
+      host,
+      "phase-8-replacement-container-identity",
+    );
     expect(replacementContainers).toHaveLength(1);
     const replacementList = await sandbox.list({
       artifactName: "phase-8-replacement-ready",
@@ -340,26 +395,29 @@ test(
       attempts: 12,
       delayMs: 5_000,
     });
-    expect(
-      await sandboxContainerIds(host, SANDBOX_NAME, {
-        artifactName: "phase-9-adopted-container-identity",
-        env: buildAvailabilityProbeEnv(),
-      }),
-    ).toEqual([adoptedContainerId]);
+    expect(await sandboxContainerIds(host, "phase-9-adopted-container-identity")).toEqual([
+      adoptedContainerId,
+    ]);
     await stateValidation.expectMarkerFileContent(instance, MARKER_FILE, MARKER_CONTENT, {
       artifactName: "phase-9-read-marker-after-adoption",
       env: buildAvailabilityProbeEnv(),
       timeoutMs: 60_000,
     });
+    await expectOpenClawVersion(
+      sandbox,
+      updatedVersion,
+      "phase-9-openclaw-version-after-replacement-adoption",
+    );
 
     const secondCompleted = readCompletedRebuildEvidence(SANDBOX_NAME, home);
     expect(secondCompleted.transactionId).toBe(replacementEvidence.transactionId);
     expect(secondCompleted.transactionId).not.toBe(firstCompleted.transactionId);
     await artifacts.writeJson("phase-10-completed-generations.json", {
-      retainedCompletedTombstones: [firstCompleted, secondCompleted],
+      observedCompletedGenerations: [firstCompleted, secondCompleted],
+      durableRetention: "latest-generation-only",
     });
 
-    const finalRegistry = readRebuildRegistryEvidence(SANDBOX_NAME, home);
+    const finalRegistry = registryEvidence(home);
     expect(finalRegistry).toMatchObject({
       agent: initialRegistry.agent,
       defaultSandbox: initialRegistry.defaultSandbox,

--- a/test/e2e/support/rebuild-recovery.test.ts
+++ b/test/e2e/support/rebuild-recovery.test.ts
@@ -10,7 +10,6 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ArtifactSink } from "../fixtures/artifacts.ts";
 import {
-  readCompletedRebuildEvidence,
   readInterruptedRebuildEvidence,
   startRebuildAtDurableBoundary,
 } from "../fixtures/rebuild-recovery.ts";
@@ -43,7 +42,7 @@ function statePaths(home: string) {
   };
 }
 
-function writeState(home: string): ReturnType<typeof statePaths> {
+function writeState(home: string): void {
   const paths = statePaths(home);
   for (const file of Object.values(paths)) fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(
@@ -103,7 +102,6 @@ function writeState(home: string): ReturnType<typeof statePaths> {
       },
     }),
   );
-  return paths;
 }
 
 afterEach(() => {
@@ -119,10 +117,12 @@ describe("live rebuild interruption evidence", () => {
       command,
       `#!/usr/bin/env node
 const phase = process.env.NEMOCLAW_E2E_FORCE_FAIL_AT_STEP.replace("rebuild_", "");
-console.error(process.env.INJECTED_SECRET);
-console.error(\`[e2e] Rebuild interruption point '\${phase}' (pid \${process.pid}).\`);
-process.kill(process.pid, "SIGSTOP");
-setInterval(() => undefined, 1000);
+const marker = "[e2e] Rebuild interruption point '" + phase + "' (pid " + process.pid + ").";
+const output = "x".repeat(300000) + process.env.INJECTED_SECRET + "\\n" + marker + "\\n";
+process.stderr.write(output, () => {
+  process.kill(process.pid, "SIGSTOP");
+  setInterval(() => undefined, 1000);
+});
 `,
       { mode: 0o755 },
     );
@@ -140,16 +140,20 @@ setInterval(() => undefined, 1000);
     });
 
     expect(
-      execFileSync("ps", ["-o", "stat=", "-p", String(paused.pid)], { encoding: "utf8" }).trim(),
+      execFileSync("ps", ["-o", "stat=", "-p", String(paused.pid)], {
+        encoding: "utf8",
+      }).trim(),
     ).toMatch(/^T/u);
     await expect(paused.kill()).resolves.toMatchObject({ signal: "SIGKILL" });
-    expect(
-      fs.readFileSync(path.join(artifacts.rootDir, "process-death.stderr.txt"), "utf8"),
-    ).toContain("[REDACTED]");
-    expect(
-      fs.readFileSync(path.join(artifacts.rootDir, "process-death.stderr.txt"), "utf8"),
-    ).not.toContain(secret);
-  });
+    const stderr = fs.readFileSync(
+      path.join(artifacts.rootDir, "process-death.stderr.txt"),
+      "utf8",
+    );
+    expect(stderr).toContain("[earlier output truncated]");
+    expect(stderr).toContain("[REDACTED]");
+    expect(stderr).not.toContain(secret);
+    expect(stderr.length).toBeLessThanOrEqual(256 * 1024);
+  }, 15_000);
 
   it("projects only allow-listed recovery identity at replacement_unjournaled (#6437)", () => {
     const home = createHome();
@@ -178,28 +182,5 @@ setInterval(() => undefined, 1000);
     expect(serialized).not.toContain("secret-model-name");
     expect(serialized).not.toContain("SECRET_API_KEY");
     expect(serialized).not.toContain("secret.invalid");
-  });
-
-  it("keeps the completed tombstone projection after required receipts publish (#6437)", () => {
-    const home = createHome();
-    const paths = writeState(home);
-    const record = JSON.parse(fs.readFileSync(paths.transaction, "utf8"));
-    record.revision = 4;
-    record.status = "completed";
-    record.phase = "completed";
-    record.completedAt = "2026-07-09T00:03:00.000Z";
-    record.receipts.replacement = {
-      identityFingerprint: fingerprintC,
-      observedAt: "2026-07-09T00:02:00.000Z",
-    };
-    fs.writeFileSync(paths.transaction, JSON.stringify(record));
-
-    expect(readCompletedRebuildEvidence(sandboxName, home)).toMatchObject({
-      transactionId,
-      revision: 4,
-      status: "completed",
-      phase: "completed",
-      receipts: { backup: true, oldSandboxDeletion: true, replacement: true },
-    });
   });
 });

--- a/test/e2e/support/rebuild-recovery.test.ts
+++ b/test/e2e/support/rebuild-recovery.test.ts
@@ -20,6 +20,45 @@ const transactionId = "11111111-1111-4111-8111-111111111111";
 const fingerprintA = `sha256:${"a".repeat(64)}`;
 const fingerprintB = `sha256:${"b".repeat(64)}`;
 const fingerprintC = `sha256:${"c".repeat(64)}`;
+const fingerprintD = `sha256:${"d".repeat(64)}`;
+const otherTransactionId = "22222222-2222-4222-8222-222222222222";
+const replacementField = `"replacementFingerprint":"${fingerprintC}"`;
+const sessionMismatch = /replacement session correlation does not match/u;
+const gatewayMismatch = /replacement registry gateway does not match/u;
+type InvalidEvidenceCase = [string, "registry" | "session", string | RegExp, string, RegExp];
+const invalidEvidenceCases: InvalidEvidenceCase[] = [
+  [
+    "missing session correlation",
+    "session",
+    /"rebuild":\{[^{}]+\}/u,
+    '"rebuild":null',
+    sessionMismatch,
+  ],
+  ["transaction mismatch", "session", transactionId, otherTransactionId, sessionMismatch],
+  [
+    "missing replacement fingerprint",
+    "session",
+    replacementField,
+    '"replacementFingerprint":null',
+    sessionMismatch,
+  ],
+  ["image mismatch", "session", fingerprintA, fingerprintD, sessionMismatch],
+  ["configuration mismatch", "session", fingerprintB, fingerprintD, sessionMismatch],
+  [
+    "gateway name mismatch",
+    "registry",
+    '"gatewayName":"nemoclaw"',
+    '"gatewayName":"other-gateway"',
+    gatewayMismatch,
+  ],
+  [
+    "gateway port mismatch",
+    "registry",
+    '"gatewayPort":8080',
+    '"gatewayPort":8181',
+    gatewayMismatch,
+  ],
+];
 
 function createHome(): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-e2e-rebuild-recovery-"));
@@ -42,7 +81,7 @@ function statePaths(home: string) {
   };
 }
 
-function writeState(home: string): void {
+function writeState(home: string): ReturnType<typeof statePaths> {
   const paths = statePaths(home);
   for (const file of Object.values(paths)) fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(
@@ -102,6 +141,7 @@ function writeState(home: string): void {
       },
     }),
   );
+  return paths;
 }
 
 afterEach(() => {
@@ -182,5 +222,20 @@ process.stderr.write(output, () => {
     expect(serialized).not.toContain("secret-model-name");
     expect(serialized).not.toContain("SECRET_API_KEY");
     expect(serialized).not.toContain("secret.invalid");
+  });
+
+  it.each(
+    invalidEvidenceCases,
+  )("fails closed for %s (#6437)", (_label, file, search, replacement, error) => {
+    const home = createHome();
+    const paths = writeState(home);
+    const before = fs.readFileSync(paths[file], "utf8");
+    const after = before.replace(search, replacement);
+    expect(after).not.toBe(before);
+    fs.writeFileSync(paths[file], after);
+
+    expect(() =>
+      readInterruptedRebuildEvidence(sandboxName, "replacement_unjournaled", home),
+    ).toThrow(error);
   });
 });

--- a/test/e2e/support/rebuild-recovery.test.ts
+++ b/test/e2e/support/rebuild-recovery.test.ts
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { ArtifactSink } from "../fixtures/artifacts.ts";
+import {
+  readCompletedRebuildEvidence,
+  readInterruptedRebuildEvidence,
+  startRebuildAtDurableBoundary,
+} from "../fixtures/rebuild-recovery.ts";
+
+const roots: string[] = [];
+const sandboxName = "e2e-sandbox-rebuild-test";
+const transactionId = "11111111-1111-4111-8111-111111111111";
+const fingerprintA = `sha256:${"a".repeat(64)}`;
+const fingerprintB = `sha256:${"b".repeat(64)}`;
+const fingerprintC = `sha256:${"c".repeat(64)}`;
+
+function createHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-e2e-rebuild-recovery-"));
+  roots.push(home);
+  return home;
+}
+
+function statePaths(home: string) {
+  const transactionStem = crypto.createHash("sha256").update(sandboxName).digest("hex");
+  return {
+    transaction: path.join(
+      home,
+      ".nemoclaw",
+      "state",
+      "rebuild-transactions",
+      `${transactionStem}.json`,
+    ),
+    registry: path.join(home, ".nemoclaw", "sandboxes.json"),
+    session: path.join(home, ".nemoclaw", "onboard-session.json"),
+  };
+}
+
+function writeState(home: string): ReturnType<typeof statePaths> {
+  const paths = statePaths(home);
+  for (const file of Object.values(paths)) fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    paths.transaction,
+    JSON.stringify({
+      version: 1,
+      transactionId,
+      revision: 2,
+      status: "active",
+      phase: "old_deleted",
+      intent: {
+        sandboxName,
+        target: {
+          provider: "secret-provider-name",
+          model: "secret-model-name",
+          credentialEnv: "SECRET_API_KEY",
+          endpointUrl: "https://secret.invalid/token",
+          gatewayName: "nemoclaw",
+          gatewayPort: 8080,
+          imageFingerprint: fingerprintA,
+          configurationFingerprint: fingerprintB,
+        },
+      },
+      receipts: {
+        backup: { manifestTimestamp: "2026-07-09T00-00-00-000Z" },
+        oldSandboxDeletion: { observedAt: "2026-07-09T00:01:00.000Z" },
+      },
+      createdAt: "2026-07-09T00:00:00.000Z",
+      completedAt: null,
+    }),
+  );
+  fs.writeFileSync(
+    paths.registry,
+    JSON.stringify({
+      defaultSandbox: sandboxName,
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          gatewayName: "nemoclaw",
+          gatewayPort: 8080,
+          agentVersion: "2026.7.1",
+        },
+      },
+    }),
+  );
+  fs.writeFileSync(
+    paths.session,
+    JSON.stringify({
+      sandboxName,
+      metadata: {
+        rebuild: {
+          transactionId,
+          imageFingerprint: fingerprintA,
+          configurationFingerprint: fingerprintB,
+          replacementFingerprint: fingerprintC,
+        },
+      },
+    }),
+  );
+  return paths;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("live rebuild interruption evidence", () => {
+  it("returns control only after the guarded child is stopped and captures SIGKILL (#6437)", async () => {
+    const home = createHome();
+    const command = path.join(home, "fake-nemoclaw");
+    const secret = "fixture-secret-value";
+    fs.writeFileSync(
+      command,
+      `#!/usr/bin/env node
+const phase = process.env.NEMOCLAW_E2E_FORCE_FAIL_AT_STEP.replace("rebuild_", "");
+console.error(process.env.INJECTED_SECRET);
+console.error(\`[e2e] Rebuild interruption point '\${phase}' (pid \${process.pid}).\`);
+process.kill(process.pid, "SIGSTOP");
+setInterval(() => undefined, 1000);
+`,
+      { mode: 0o755 },
+    );
+    const artifacts = new ArtifactSink(path.join(home, "artifacts"), [secret]);
+
+    const paused = await startRebuildAtDurableBoundary({
+      artifacts,
+      artifactName: "process-death",
+      commandPath: command,
+      env: { HOME: home, PATH: process.env.PATH, INJECTED_SECRET: secret },
+      phase: "old_deleted",
+      redact: (text) => text.replaceAll(secret, "[REDACTED]"),
+      sandboxName,
+      timeoutMs: 10_000,
+    });
+
+    expect(
+      execFileSync("ps", ["-o", "stat=", "-p", String(paused.pid)], { encoding: "utf8" }).trim(),
+    ).toMatch(/^T/u);
+    await expect(paused.kill()).resolves.toMatchObject({ signal: "SIGKILL" });
+    expect(
+      fs.readFileSync(path.join(artifacts.rootDir, "process-death.stderr.txt"), "utf8"),
+    ).toContain("[REDACTED]");
+    expect(
+      fs.readFileSync(path.join(artifacts.rootDir, "process-death.stderr.txt"), "utf8"),
+    ).not.toContain(secret);
+  });
+
+  it("projects only allow-listed recovery identity at replacement_unjournaled (#6437)", () => {
+    const home = createHome();
+    writeState(home);
+
+    const evidence = readInterruptedRebuildEvidence(sandboxName, "replacement_unjournaled", home);
+    const serialized = JSON.stringify(evidence);
+
+    expect(evidence).toMatchObject({
+      transactionId,
+      status: "active",
+      phase: "old_deleted",
+      receipts: { backup: true, oldSandboxDeletion: true, replacement: false },
+      target: {
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+        imageFingerprint: fingerprintA,
+        configurationFingerprint: fingerprintB,
+      },
+      replacement: {
+        sessionTransactionId: transactionId,
+        replacementFingerprint: fingerprintC,
+      },
+    });
+    expect(serialized).not.toContain("secret-provider-name");
+    expect(serialized).not.toContain("secret-model-name");
+    expect(serialized).not.toContain("SECRET_API_KEY");
+    expect(serialized).not.toContain("secret.invalid");
+  });
+
+  it("keeps the completed tombstone projection after required receipts publish (#6437)", () => {
+    const home = createHome();
+    const paths = writeState(home);
+    const record = JSON.parse(fs.readFileSync(paths.transaction, "utf8"));
+    record.revision = 4;
+    record.status = "completed";
+    record.phase = "completed";
+    record.completedAt = "2026-07-09T00:03:00.000Z";
+    record.receipts.replacement = {
+      identityFingerprint: fingerprintC,
+      observedAt: "2026-07-09T00:02:00.000Z",
+    };
+    fs.writeFileSync(paths.transaction, JSON.stringify(record));
+
+    expect(readCompletedRebuildEvidence(sandboxName, home)).toMatchObject({
+      transactionId,
+      revision: 4,
+      status: "completed",
+      phase: "completed",
+      receipts: { backup: true, oldSandboxDeletion: true, replacement: true },
+    });
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This stacked draft turns the existing `sandbox-rebuild` live target into the rollout proof for both destructive recovery forks: recreation after durable deletion and adoption after unjournaled replacement creation. It uses the public rebuild command for both resumes and adds no workflow job or recovery engine. After review-driven fixture consolidation and the production defects found by the live test, the full PR is `+1104/-193` (net `+911`), almost entirely test and fixture coverage; production code is `+15/-9` (net `+6`) versus #6522.

## Related Issue
Closes #6437.
Part of #6433.

## Changes
- Add a fully guarded live-E2E pause immediately after the durable `old_deleted` transition while preserving the existing hermetic interruption points.
- Add a focused detached-process fixture that returns only after the CLI is `SIGSTOP`ped, captures redacted artifacts, and verifies the subsequent `SIGKILL`.
- Extend the existing `sandbox-rebuild` target to recover two distinct generations on one provisioned sandbox, prove workspace restoration, both observed completions with latest-only durable tombstone semantics, host/runtime version agreement, exact registry/default ownership, and replacement adoption without another create/delete.
- Extend `upgrade-sandboxes` recovery coverage to prove an existing `old_deleted` transaction reaches completion through the installer runner and that a real unsupported transaction file blocks only its sandbox while an unrelated transaction completes; extract its shared harness so the prior monolith shrinks from 566 to 427 lines.
- Bound interrupted-process evidence to 256 KiB per stream plus a 16 KiB error tail, while preserving marker detection, redaction, and detached-group `SIGKILL` verification.
- Exclude display-only `snapshotVersion` metadata from durable backup receipt fingerprints; the live test proved that otherwise a process restart rejects its own valid `old_deleted` transaction before recovery.
- Recreate an absent `old_deleted` sandbox when the preserved registry row matches the transaction's normalized target; this remains a create path, not adoption, and still refuses uncorrelated live replacements.
- Treat only active records as interrupted recovery in the orchestrator so a later intentional rebuild replaces a completed tombstone with a new transaction generation; remove the now-redundant pre-prepare deletion reconciliation.
- Keep the 283-line recovery fixture separate because its stopped-child/SIGKILL/redaction/bounded-output contract is exercised hermetically by the support test; inlining those OS and secret-handling boundaries into the already large live scenario would remove that proof. Review reduced it from 387 lines and kept only process supervision plus allow-listed transaction/session evidence.
- Keep the current PR at production `+15/-9` (net `+6`), tests `+1085/-184` (net `+901`), and test-only config `+4/-0`; no workflow files change.
- Report the cumulative epic stack at production net `+2055`, tests net `+3396`, and total net `+5459`; #6433 therefore still requires a concrete consolidation child before completion.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the public interface and configuration are unchanged; this corrects internal durable-recovery fingerprinting and adds repository test coverage.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending automated and human review on this draft.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run typecheck:cli`; 78 focused CLI tests; 43 E2E-support tests; 6 process-death integration tests; `npm run test:projects:check`; `npm run test:titles:check`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not claimed: `npm run test:fast` deterministically loses the generated oclif manifest after `clean:cli` on both this branch and exact base #6522; a build-first local pass reached 8510/8533 with the remaining failures attributable to local macOS/PyYAML prerequisites and parallel five-second timeouts. Required CI remains authoritative.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
