### PR TITLE
fix(dcode): allow managed OTLP collector endpoint

### DIFF
--- a/agents/langchain-deepagents-code/dcode-wrapper.sh
+++ b/agents/langchain-deepagents-code/dcode-wrapper.sh
@@ -119,6 +119,9 @@ run_dcode() {
 #       TELEGRAM_BOT_TOKEN, DISCORD_BOT_TOKEN) are allowed only when the value
 #       matches the platform-specific token shape AND does not embed a
 #       non-platform canonical secret prefix.
+#     * Managed observability endpoint values are allowed only for the
+#       credential-free local OpenShell OTLP collector and only from the
+#       runtime environment. Mutable .env files still fail closed.
 #     * The env-file parser strips a leading `export ` keyword (mirroring
 #       python-dotenv) and rejects values containing dotenv expansion ($VAR,
 #       ${VAR}), command substitution ($(...) or backticks), because upstream
@@ -261,6 +264,23 @@ is_managed_token_value_for_name() {
       ;;
   esac
   return 1
+}
+
+is_managed_observability_endpoint_value() {
+  local name="$1"
+  local value="${2%/}"
+  case "$name" in
+    OTEL_EXPORTER_OTLP_ENDPOINT)
+      [ "$value" = "http://host.openshell.internal:4318" ] \
+        || [ "$value" = "http://host.openshell.internal:4318/v1/traces" ]
+      ;;
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+      [ "$value" = "http://host.openshell.internal:4318/v1/traces" ]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 trim_whitespace() {
@@ -440,6 +460,9 @@ assert_no_secret_runtime_env() {
       refuse_invalid_openshell_placeholder "runtime environment variable" "$name"
     fi
     if is_managed_token_value_for_name "$name" "$value"; then
+      continue
+    fi
+    if is_managed_observability_endpoint_value "$name" "$value"; then
       continue
     fi
     if is_secret_shaped_value "$value"; then

--- a/agents/langchain-deepagents-code/managed-dcode-runtime.py
+++ b/agents/langchain-deepagents-code/managed-dcode-runtime.py
@@ -57,6 +57,15 @@ _ECMASCRIPT_NON_WHITESPACE_SECRET_CHAR = (
     r"[^\t\n\v\f\r \u00a0\u1680\u2000-\u200a\u2028\u2029"
     r"\u202f\u205f\u3000\ufeff'\"]"
 )
+_MANAGED_OBSERVABILITY_ENDPOINTS = {
+    "OTEL_EXPORTER_OTLP_ENDPOINT": {
+        "http://host.openshell.internal:4318",
+        "http://host.openshell.internal:4318/v1/traces",
+    },
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": {
+        "http://host.openshell.internal:4318/v1/traces",
+    },
+}
 _OPENSHELL_ENV_PLACEHOLDER_PREFIX = "openshell:resolve:env:"
 _UPSTREAM_PROVIDER_ENV = "NEMOCLAW_UPSTREAM_PROVIDER"
 _MANAGED_ADAPTER_PROVIDER = "openai"
@@ -200,6 +209,9 @@ def _is_managed_value(name: str, value: str) -> bool:
         return value == "nemoclaw-managed-inference"
     if name == "OPENSHELL_TLS_KEY":
         return value == "/etc/openshell/tls/client/tls.key"
+    if name in _MANAGED_OBSERVABILITY_ENDPOINTS:
+        normalized_value = value.removesuffix("/")
+        return normalized_value in _MANAGED_OBSERVABILITY_ENDPOINTS[name]
     if name == "SLACK_BOT_TOKEN":
         return bool(re.fullmatch(r"xoxb-[A-Za-z0-9_-]{10,}", value)) and not _contains_other_platform_secret(value, "slack")
     if name == "SLACK_APP_TOKEN":

--- a/test/langchain-deepagents-code-direct-module-patch.test.ts
+++ b/test/langchain-deepagents-code-direct-module-patch.test.ts
@@ -368,6 +368,8 @@ check("disabled", False)
         LANGCHAIN_TRACING: "true",
         LANGCHAIN_TRACING_V2: "true",
         OTEL_ENABLED: "true",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.openshell.internal:4318",
+        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://host.openshell.internal:4318/v1/traces",
       },
       encoding: "utf8",
     });

--- a/test/langchain-deepagents-code-managed-entrypoints.test.ts
+++ b/test/langchain-deepagents-code-managed-entrypoints.test.ts
@@ -153,6 +153,25 @@ describe("LangChain Deep Agents Code managed entrypoints", () => {
   });
 
   it.each([
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://host.openshell.internal:4318"],
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://host.openshell.internal:4318/"],
+    ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://host.openshell.internal:4318/v1/traces"],
+  ])("allows the local managed OTLP collector endpoint in %s", (name, value) => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-otel-endpoint-"));
+    const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
+    const result = spawnSync("bash", [wrapperPath, "-n", "hi"], {
+      env: {
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        [name]: value,
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.existsSync(ranMarker)).toBe(true);
+  });
+
+  it.each([
     "LANGSMITH_RUNS_ENDPOINTS",
     "LANGCHAIN_RUNS_ENDPOINTS",
     "OTEL_EXPORTER_OTLP_ENDPOINT",


### PR DESCRIPTION
## Summary
Allows the NemoClaw-managed Deep Agents Code runtime to accept the fixed, credential-free local OTLP collector endpoint without tripping the secret scanner. The change keeps arbitrary OTEL endpoints and OTEL headers blocked, and managed runtime setup still strips ambient OTEL configuration before child/server execution.

## Related Issue
Fixes #6466

## Changes
- Add a narrow runtime allowlist for `OTEL_EXPORTER_OTLP_ENDPOINT=http://host.openshell.internal:4318` and the local `/v1/traces` endpoint in the Bash DCode wrapper.
- Mirror the same allowlist in the Python managed runtime guard for direct-module execution.
- Cover the allowed local collector endpoint while retaining existing rejection coverage for external endpoints, headers, and tracing replica configs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no new user setting or collector contract; existing docs already describe the fixed local OTLP endpoint and no custom/auth headers.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: contributor security review completed; allowlist is limited to the local OpenShell OTLP collector, `.env` remains fail-closed, external OTEL endpoints and headers remain rejected, and targeted security/observability tests pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable — command/result: DGX Spark Linux exact commit `d6a7c52064b2f0e4e1bcfef94b1f6b719dfa5cfe`: `npm run check:diff` passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: DGX Spark Linux exact commit `d6a7c52064b2f0e4e1bcfef94b1f6b719dfa5cfe`: `npx vitest run --project integration test/langchain-deepagents-code-managed-entrypoints.test.ts test/langchain-deepagents-code-direct-module-patch.test.ts` passed, 87 tests; `npx vitest run --project integration test/langchain-deepagents-code-secret-pattern-parity.test.ts test/langchain-deepagents-code-observability.test.ts` passed, 10 tests. Actual OpenShell sandbox smoke against local vLLM `Qwen/Qwen3.6-35B-A3B` passed: `dcode status` accepted `OTEL_EXPORTER_OTLP_ENDPOINT=http://host.openshell.internal:4318`, rejected `OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.test:4318`, and `dcode -n 'Reply with exactly OK.'` returned `OK`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: HwangJohn <angelic805@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Allowed approved local OpenTelemetry endpoint settings to pass environment safety checks.
  * Improved handling of observability-related environment values so valid runtime settings are no longer blocked.
  * Added coverage to confirm managed runs succeed when using the supported local telemetry collector endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->