### PR TITLE
fix(runtime): route local Ollama through auth proxy

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2065,16 +2065,17 @@ Expected output:
 * connect to 172.17.0.1 port 11434 failed: Connection refused
 ```
 
-For local Ollama, use the auth-proxy URL that NemoClaw's "Local Ollama" onboard
-option configures automatically:
+For local Ollama, select **Local Ollama** during onboarding so NemoClaw configures the sandbox-facing route for the detected runtime.
+On runtimes other than WSL with Docker Desktop, NemoClaw uses the token-gated auth-proxy URL:
 
 ```text
 http://host.openshell.internal:11435/v1
 ```
 
-`host.openshell.internal` resolves to the same gateway IP, and the
-[token-gated Ollama auth proxy](#ollama-auth-proxy-did-not-start) binds port
-`11435` there and forwards requests to `127.0.0.1:11434` on the host.
+`host.openshell.internal` resolves to the same gateway IP, and the [token-gated Ollama auth proxy](#ollama-auth-proxy-did-not-start) binds port `11435` there and forwards requests to `127.0.0.1:11434` on the host.
+On WSL with Docker Desktop, NemoClaw instead uses `http://host.openshell.internal:11434/v1` because Docker Desktop bridges the WSL host loopback into containers.
+Manually created OpenShell providers and direct sandbox requests to `host.docker.internal:11434` remain unsupported.
+Those routes are outside the managed `ollama-local` path and can still fail inside k3s.
 If you need a different host service exposed to the sandbox, route it through
 the OpenShell gateway rather than relying on `host.docker.internal`.
 Refer to issue [#3136](https://github.com/NVIDIA/NemoClaw/issues/3136).

--- a/scripts/lib/runtime.sh
+++ b/scripts/lib/runtime.sh
@@ -112,6 +112,76 @@ infer_container_runtime_from_info() {
   fi
 }
 
+is_wsl_runtime() {
+  # Keep this shell-side WSL check aligned with src/lib/platform.ts:isWsl().
+  # Source boundary (#3136): this script runs before OpenShell network policy is
+  # applied, so it must choose the provider URL that later enters the sandbox.
+  # Remove this local workaround after OpenShell exposes one uniform
+  # sandbox-to-host local-service route for WSL and non-WSL runtimes. Review by
+  # 2026-12-31.
+  local system_name
+  system_name="$(uname -s 2>/dev/null || true)"
+  if [ "$system_name" != "Linux" ]; then
+    return 1
+  fi
+
+  if [ -n "${WSL_DISTRO_NAME:-}" ] || [ -n "${WSL_INTEROP:-}" ]; then
+    return 0
+  fi
+
+  local release proc_version
+  release="$(uname -r 2>/dev/null || true)"
+  proc_version="$(cat /proc/version 2>/dev/null || true)"
+  local normalized
+  normalized="$(printf '%s\n%s' "$release" "$proc_version" | tr '[:upper:]' '[:lower:]')"
+  [[ "$normalized" == *microsoft* ]]
+}
+
+detect_container_runtime_from_docker() {
+  # Best effort only: missing/unhealthy Docker maps to unknown, and callers then
+  # fail safe to the token-gated Ollama auth proxy instead of raw host loopback.
+  local info=""
+  if command -v docker >/dev/null 2>&1; then
+    info="$(docker info --format '{{.OperatingSystem}} {{range .Labels}}{{.}} {{end}}' 2>/dev/null || true)"
+  fi
+  infer_container_runtime_from_info "$info"
+}
+
+container_can_reach_host_loopback() {
+  # Only WSL + Docker Desktop is allowed to use raw host loopback. Every other
+  # runtime, including macOS Docker Desktop, Colima, Podman, and native Docker,
+  # defaults to the auth proxy as the security fail-safe.
+  if ! is_wsl_runtime; then
+    return 1
+  fi
+
+  local runtime
+  runtime="$(detect_container_runtime_from_docker)"
+
+  [ "$runtime" = "docker-desktop" ]
+}
+
+get_ollama_container_port() {
+  local ollama_port="${NEMOCLAW_OLLAMA_PORT:-11434}"
+  local ollama_proxy_port="${NEMOCLAW_OLLAMA_PROXY_PORT:-11435}"
+
+  # Both routes ultimately depend on the host Ollama daemon: the WSL path
+  # reaches it directly, while the managed proxy forwards to this raw port.
+  _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
+  if container_can_reach_host_loopback; then
+    printf '%s\n' "$ollama_port"
+  else
+    # The WSL Docker Desktop loopback path does not use the proxy listener, so
+    # the raw/proxy equality check is only required when both listeners coexist.
+    _validate_port NEMOCLAW_OLLAMA_PROXY_PORT "$ollama_proxy_port" || return 1
+    if [ "$ollama_port" = "$ollama_proxy_port" ]; then
+      printf 'Invalid NEMOCLAW_OLLAMA_PROXY_PORT=%s (must differ from NEMOCLAW_OLLAMA_PORT on non-WSL hosts)\n' "$ollama_proxy_port" >&2
+      return 1
+    fi
+    printf '%s\n' "$ollama_proxy_port"
+  fi
+}
+
 find_podman_socket() {
   local home_dir="${1:-${HOME:-/tmp}}"
   local socket_path
@@ -253,12 +323,14 @@ get_local_provider_base_url() {
   local provider="${1:-}"
 
   local vllm_port="${NEMOCLAW_VLLM_PORT:-8000}"
-  local ollama_port="${NEMOCLAW_OLLAMA_PORT:-11434}"
   _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
-  _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
   case "$provider" in
     vllm-local) printf 'http://host.openshell.internal:%s/v1\n' "$vllm_port" ;;
-    ollama-local) printf 'http://host.openshell.internal:%s/v1\n' "$ollama_port" ;;
+    ollama-local)
+      local ollama_container_port
+      ollama_container_port="$(get_ollama_container_port)" || return 1
+      printf 'http://host.openshell.internal:%s/v1\n' "$ollama_container_port"
+      ;;
     *) return 1 ;;
   esac
 }
@@ -267,15 +339,17 @@ check_local_provider_health() {
   local provider="${1:-}"
 
   local vllm_port="${NEMOCLAW_VLLM_PORT:-8000}"
-  local ollama_port="${NEMOCLAW_OLLAMA_PORT:-11434}"
-  _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
-  _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
   case "$provider" in
     vllm-local)
+      _validate_port NEMOCLAW_VLLM_PORT "$vllm_port" || return 1
       curl -sf "http://localhost:${vllm_port}/v1/models" >/dev/null 2>&1
       ;;
     ollama-local)
-      curl -sf "http://localhost:${ollama_port}/api/tags" >/dev/null 2>&1
+      # Health checks validate the host daemon. The sandbox-facing provider URL
+      # can still use the auth proxy on non-WSL hosts.
+      local ollama_port="${NEMOCLAW_OLLAMA_PORT:-11434}"
+      _validate_port NEMOCLAW_OLLAMA_PORT "$ollama_port" || return 1
+      curl -sf "http://127.0.0.1:${ollama_port}/api/tags" >/dev/null 2>&1
       ;;
     *)
       return 1

--- a/test/runtime-shell.test.ts
+++ b/test/runtime-shell.test.ts
@@ -7,18 +7,62 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { OLLAMA_PORT, OLLAMA_PROXY_PORT } from "../src/lib/core/ports";
+import { type ContainerRuntime, containerCanReachHostLoopback, isWsl } from "../src/lib/platform";
+
 const RUNTIME_SH = path.join(import.meta.dirname, "..", "scripts", "lib", "runtime.sh");
 
 function runShell(
   script: string,
   env: Record<string, string | undefined> = {},
 ): SpawnSyncReturns<string> {
+  const providedEnv = Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+  const cleanEnv: Record<string, string> = {
+    HOME: process.env.HOME ?? os.tmpdir(),
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    TMPDIR: os.tmpdir(),
+    ...providedEnv,
+  };
+
   return spawnSync("bash", ["--noprofile", "--norc", "-c", script], {
     cwd: path.join(import.meta.dirname, ".."),
     encoding: "utf-8",
-    env: { ...process.env, ...env },
+    env: cleanEnv,
   });
 }
+
+function createFakeDockerInfo(info: string): string {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-runtime-bin-"));
+  const escapedInfo = info.replace(/'/g, "'\\''");
+  const dockerPath = path.join(binDir, "docker");
+  fs.writeFileSync(
+    dockerPath,
+    `#!/usr/bin/env bash
+case "$1" in
+  info) printf '%s\\n' '${escapedInfo}' ;;
+  *) exit 1 ;;
+esac
+`,
+  );
+  fs.chmodSync(dockerPath, 0o755);
+  return binDir;
+}
+
+const ROUTING_RUNTIME_FIXTURES: ReadonlyArray<{
+  info: string;
+  runtime: ContainerRuntime;
+}> = [
+  { info: "Docker Desktop 4.42.1", runtime: "docker-desktop" },
+  { info: "Docker Engine - Community 24.0.9", runtime: "docker" },
+  { info: "Docker Engine - Community 25.0.5", runtime: "docker" },
+  { info: "Docker Engine - Community 26.1.4", runtime: "docker" },
+  { info: "Docker Engine - Community 27.5.1", runtime: "docker" },
+  { info: "podman version 5.4.1", runtime: "podman" },
+  { info: "colima 0.8.4 docker", runtime: "colima" },
+  { info: "unrecognized runtime", runtime: "unknown" },
+];
 
 describe("shell runtime helpers", () => {
   it("respects an existing DOCKER_HOST", () => {
@@ -151,10 +195,353 @@ describe("shell runtime helpers", () => {
     expect(result.stdout.trim()).toBe("http://host.openshell.internal:8000/v1");
   });
 
-  it("returns the ollama-local base URL", () => {
-    const result = runShell(`source "${RUNTIME_SH}"; get_local_provider_base_url ollama-local`);
+  it("returns the ollama-local proxy base URL for native Docker-style hosts (#3136)", () => {
+    const result = runShell(
+      `uname() { printf 'Darwin\\n'; }
+       docker() { printf 'unexpected docker call\\n' >&2; return 1; }
+       source "${RUNTIME_SH}"
+       get_local_provider_base_url ollama-local`,
+    );
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("http://host.openshell.internal:11434/v1");
+    expect(result.stdout.trim()).toBe("http://host.openshell.internal:11435/v1");
+    expect(result.stderr).toBe("");
+  });
+
+  it("returns the raw Ollama port only for WSL Docker Desktop loopback routing (#3136)", () => {
+    const binDir = createFakeDockerInfo("Docker Desktop");
+    try {
+      const result = runShell(
+        `uname() {
+           case "$1" in
+             -s) printf 'Linux\\n' ;;
+             -r) printf '5.15.90.1-microsoft-standard-WSL2\\n' ;;
+             *) printf 'Linux\\n' ;;
+           esac
+         }
+         source "${RUNTIME_SH}"
+         get_local_provider_base_url ollama-local`,
+        { PATH: `${binDir}:/usr/bin:/bin` },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("http://host.openshell.internal:11434/v1");
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects WSL from WSL_DISTRO_NAME on Linux (#3136)", () => {
+    const result = runShell(
+      `uname() {
+         case "$1" in
+           -s) printf 'Linux\\n' ;;
+           -r) printf '6.1.0\\n' ;;
+           *) printf 'Linux\\n' ;;
+         esac
+       }
+       source "${RUNTIME_SH}"
+       is_wsl_runtime`,
+      { WSL_DISTRO_NAME: "Ubuntu" },
+    );
+    expect(result.status).toBe(0);
+  });
+
+  it("detects WSL from WSL_INTEROP on Linux (#3136)", () => {
+    const result = runShell(
+      `uname() {
+         case "$1" in
+           -s) printf 'Linux\\n' ;;
+           -r) printf '6.1.0\\n' ;;
+           *) printf 'Linux\\n' ;;
+         esac
+       }
+       source "${RUNTIME_SH}"
+       is_wsl_runtime`,
+      { WSL_INTEROP: "/run/WSL/123_interop" },
+    );
+    expect(result.status).toBe(0);
+  });
+
+  it.each([
+    {
+      env: { WSL_DISTRO_NAME: "Ubuntu", WSL_INTEROP: "" },
+      platform: "linux" as const,
+      procVersion: "",
+      release: "6.1.0",
+      systemName: "Linux",
+    },
+    {
+      env: { WSL_DISTRO_NAME: "", WSL_INTEROP: "/run/WSL/123_interop" },
+      platform: "linux" as const,
+      procVersion: "",
+      release: "6.1.0",
+      systemName: "Linux",
+    },
+    {
+      env: { WSL_DISTRO_NAME: "", WSL_INTEROP: "" },
+      platform: "linux" as const,
+      procVersion: "",
+      release: "5.15.90.1-microsoft-standard-WSL2",
+      systemName: "Linux",
+    },
+    {
+      env: { WSL_DISTRO_NAME: "", WSL_INTEROP: "" },
+      platform: "linux" as const,
+      procVersion: "Linux version 5.15.90.1-microsoft-standard-WSL2",
+      release: "6.1.0-generic",
+      systemName: "Linux",
+    },
+    {
+      env: { WSL_DISTRO_NAME: "", WSL_INTEROP: "" },
+      platform: "linux" as const,
+      procVersion: "",
+      release: "6.1.0",
+      systemName: "Linux",
+    },
+    {
+      env: { WSL_DISTRO_NAME: "Ubuntu", WSL_INTEROP: "/run/WSL/123_interop" },
+      platform: "darwin" as const,
+      procVersion: "Linux version microsoft-standard-WSL2",
+      release: "24.6.0",
+      systemName: "Darwin",
+    },
+  ])("matches TypeScript WSL classification for $systemName $release (#3136)", ({
+    env,
+    platform,
+    procVersion,
+    release,
+    systemName,
+  }) => {
+    const result = runShell(
+      `uname() {
+           case "$1" in
+             -s) printf '%s\\n' '${systemName}' ;;
+             -r) printf '%s\\n' '${release}' ;;
+             *) printf '%s\\n' '${systemName}' ;;
+           esac
+         }
+         cat() {
+           case "$1" in
+             /proc/version) printf '%s\\n' '${procVersion}' ;;
+             *) command cat "$@" ;;
+           esac
+         }
+         source "${RUNTIME_SH}"
+         is_wsl_runtime`,
+      env,
+    );
+
+    const shellDetectedWsl = result.status === 0;
+    const typescriptDetectedWsl = isWsl({ env, platform, procVersion, release });
+    expect(shellDetectedWsl).toBe(typescriptDetectedWsl);
+  });
+
+  it.each(
+    [false, true].flatMap((isWslHost) =>
+      ROUTING_RUNTIME_FIXTURES.map(({ info, runtime }) => ({ info, isWslHost, runtime })),
+    ),
+  )("matches TypeScript Ollama routing for $runtime with isWsl=$isWslHost (#3136)", ({
+    info,
+    isWslHost,
+    runtime,
+  }) => {
+    const binDir = createFakeDockerInfo(info);
+    try {
+      const result = runShell(
+        `uname() {
+             case "$1" in
+               -s) printf 'Linux\\n' ;;
+               -r) printf '6.1.0-generic\\n' ;;
+               *) printf 'Linux\\n' ;;
+             esac
+           }
+           source "${RUNTIME_SH}"
+           get_local_provider_base_url ollama-local`,
+        {
+          NEMOCLAW_OLLAMA_PORT: "",
+          NEMOCLAW_OLLAMA_PROXY_PORT: "",
+          PATH: `${binDir}:/usr/bin:/bin`,
+          WSL_DISTRO_NAME: isWslHost ? "Ubuntu" : "",
+          WSL_INTEROP: "",
+        },
+      );
+      const expectedPort = containerCanReachHostLoopback(runtime, { isWsl: isWslHost })
+        ? OLLAMA_PORT
+        : OLLAMA_PROXY_PORT;
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim()).toBe(
+        `http://host.openshell.internal:${String(expectedPort)}/v1`,
+      );
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores WSL env on non-Linux hosts and keeps ollama-local on the proxy route (#3136)", () => {
+    const binDir = createFakeDockerInfo("Docker Desktop");
+    try {
+      const result = runShell(
+        `uname() {
+           case "$1" in
+             -s) printf 'Darwin\\n' ;;
+             -r) printf '23.0.0-darwin\\n' ;;
+             *) printf 'Darwin\\n' ;;
+           esac
+         }
+         source "${RUNTIME_SH}"
+         get_local_provider_base_url ollama-local`,
+        {
+          PATH: `${binDir}:/usr/bin:/bin`,
+          WSL_DISTRO_NAME: "Ubuntu",
+          WSL_INTEROP: "/run/WSL/123_interop",
+        },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("http://host.openshell.internal:11435/v1");
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("honors the configured Ollama proxy port for sandbox-facing URLs (#3136)", () => {
+    const result = runShell(
+      `uname() { printf '23.0.0-darwin\\n'; }
+       source "${RUNTIME_SH}"
+       get_local_provider_base_url ollama-local`,
+      {
+        NEMOCLAW_OLLAMA_PROXY_PORT: "12435",
+      },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("http://host.openshell.internal:12435/v1");
+  });
+
+  it("rejects an invalid Ollama proxy port without emitting a URL (#3136)", () => {
+    const result = runShell(
+      `uname() { printf '23.0.0-darwin\\n'; }
+       source "${RUNTIME_SH}"
+       get_local_provider_base_url ollama-local`,
+      {
+        NEMOCLAW_OLLAMA_PROXY_PORT: "bad",
+      },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Invalid NEMOCLAW_OLLAMA_PROXY_PORT=bad");
+  });
+
+  it("rejects an invalid Ollama raw port on the WSL Docker Desktop path (#3136)", () => {
+    const binDir = createFakeDockerInfo("Docker Desktop");
+    try {
+      const result = runShell(
+        `uname() {
+           case "$1" in
+             -s) printf 'Linux\\n' ;;
+             -r) printf '5.15.90.1-microsoft-standard-WSL2\\n' ;;
+             *) printf 'Linux\\n' ;;
+           esac
+         }
+         source "${RUNTIME_SH}"
+         get_local_provider_base_url ollama-local`,
+        { NEMOCLAW_OLLAMA_PORT: "bad", PATH: `${binDir}:/usr/bin:/bin` },
+      );
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("Invalid NEMOCLAW_OLLAMA_PORT=bad");
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the Ollama proxy when Docker runtime detection is unavailable (#3136)", () => {
+    const result = runShell(
+      `uname() { printf '23.0.0-darwin\\n'; }
+       source "${RUNTIME_SH}"
+       detect_container_runtime_from_docker
+       get_local_provider_base_url ollama-local`,
+      { PATH: "/usr/bin:/bin" },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("unknown\nhttp://host.openshell.internal:11435/v1");
+  });
+
+  it("rejects equal Ollama raw and proxy ports on non-WSL hosts (#3136)", () => {
+    const result = runShell(
+      `uname() { printf '23.0.0-darwin\\n'; }
+       source "${RUNTIME_SH}"
+       get_local_provider_base_url ollama-local`,
+      {
+        NEMOCLAW_OLLAMA_PORT: "11434",
+        NEMOCLAW_OLLAMA_PROXY_PORT: "11434",
+      },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("must differ from NEMOCLAW_OLLAMA_PORT");
+  });
+
+  it("allows equal ports when WSL Docker Desktop bypasses the proxy listener (#3136)", () => {
+    const binDir = createFakeDockerInfo("Docker Desktop 4.42.1");
+    try {
+      const result = runShell(
+        `uname() {
+           case "$1" in
+             -s) printf 'Linux\\n' ;;
+             -r) printf '6.1.0-generic\\n' ;;
+             *) printf 'Linux\\n' ;;
+           esac
+         }
+         source "${RUNTIME_SH}"
+         get_local_provider_base_url ollama-local`,
+        {
+          NEMOCLAW_OLLAMA_PORT: "11434",
+          NEMOCLAW_OLLAMA_PROXY_PORT: "11434",
+          PATH: `${binDir}:/usr/bin:/bin`,
+          WSL_DISTRO_NAME: "Ubuntu",
+          WSL_INTEROP: "",
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim()).toBe("http://host.openshell.internal:11434/v1");
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("checks ollama-local health on the raw daemon while sandbox URLs use the proxy (#3136)", () => {
+    const result = runShell(
+      `uname() { printf '23.0.0-darwin\\n'; }
+       curl() { [ "$1" = "-sf" ] && [ "$2" = "http://127.0.0.1:11434/api/tags" ]; }
+       source "${RUNTIME_SH}"
+       get_local_provider_base_url ollama-local
+       check_local_provider_health ollama-local`,
+      { NEMOCLAW_OLLAMA_PROXY_PORT: "12435" },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("http://host.openshell.internal:12435/v1");
+  });
+
+  it("keeps non-WSL Docker Desktop on the managed proxy route (#3136)", () => {
+    const binDir = createFakeDockerInfo("Docker Desktop");
+    try {
+      const result = runShell(
+        `uname() {
+           case "$1" in
+             -s) printf 'Darwin\\n' ;;
+             -r) printf '23.0.0-darwin\\n' ;;
+             *) printf 'Darwin\\n' ;;
+           esac
+         }
+         source "${RUNTIME_SH}"
+         get_local_provider_base_url ollama-local`,
+        { PATH: `${binDir}:/usr/bin:/bin` },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe("http://host.openshell.internal:11435/v1");
+    } finally {
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects unknown local providers", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Route the managed `ollama-local` provider through NemoClaw's token-gated auth proxy on non-WSL runtimes while preserving the Docker Desktop loopback exception on WSL. This is a clean, verified replacement for #6337; Chengjie Wang's original implementation is preserved and credited as co-author.

## Related Issue

Refs #3136. Supersedes #6337 because its published commit history cannot satisfy the current GitHub verification requirement.

## Changes

- Detect WSL consistently from environment, kernel release, and `/proc/version` signals.
- Select raw host loopback only for WSL with Docker Desktop; fail safe to the auth-proxy port everywhere else.
- Validate raw and proxy port configuration and keep the host Ollama health check independent from the sandbox-facing route.
- Add shell/TypeScript parity and routing regression coverage.
- Document the managed routes and the unsupported direct-provider case.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — maintainer review confirms that raw loopback is limited to the WSL + Docker Desktop exception and every unknown/non-WSL runtime fails safe to the token-gated proxy.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/runtime-shell.test.ts` (65/65 passed)
- [ ] Applicable broad gate passed — broad CI matrix will run on the PR; focused hooks, CLI type-check, and 110 earlier targeted tests passed locally.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 pre-existing warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local Ollama access in sandboxed environments, with clearer routing for Docker Desktop and WSL setups.
  * Fixed health checks and provider URLs so the app uses the correct local endpoint and proxy path automatically.
  * Added validation to prevent invalid or conflicting Ollama port settings.

* **Documentation**
  * Updated troubleshooting guidance with clearer setup steps for selecting Local Ollama and using the correct managed URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->