### PR TITLE
ci(e2e): guard queued Jetson dispatches

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,7 +20,7 @@ on:
         default: ""
         type: string
       allow_jetson_runner_queue:
-        description: "Required for jetson-nvmap-gpu: set true only after confirming an online Jetson runner; queued self-hosted jobs do not honor timeout-minutes before assignment."
+        description: "Repository administrators only: before setting true for jetson-nvmap-gpu, confirm an online Jetson runner in the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory; queued jobs do not honor timeout-minutes before assignment."
         required: false
         default: false
         type: boolean
@@ -2795,6 +2795,7 @@ jobs:
           set -euo pipefail
           echo "::error::jetson-nvmap-gpu was selected without allow_jetson_runner_queue=true."
           echo "::error::GitHub Actions does not apply timeout-minutes while a self-hosted job is queued before runner assignment."
+          echo "::error::A repository administrator must confirm the runner is online in the authoritative NVIDIA/NemoClaw Settings -> Actions -> Runners inventory before enabling queueing."
           echo "::error::Confirm an online runner with label ${JETSON_E2E_RUNNER_LABEL}, then re-run with allow_jetson_runner_queue=true."
           exit 1
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,6 +19,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_jetson_runner_queue:
+        description: "Required for jetson-nvmap-gpu: set true only after confirming an online Jetson runner; queued self-hosted jobs do not honor timeout-minutes before assignment."
+        required: false
+        default: false
+        type: boolean
       pr_number:
         description: Optional PR number for selective-dispatch result comments.
         required: false
@@ -2758,7 +2763,10 @@ jobs:
     # Required validation path: dispatch with jobs=jetson-nvmap-gpu or targets=jetson-nvmap-gpu.
     # Re-enable default dispatch only after a stable Jetson runner exists, then remove E2E_DEFAULT_ENABLED.
     if: ${{ contains(format(',{0},', inputs.jobs), ',jetson-nvmap-gpu,') || contains(format(',{0},', inputs.targets), ',jetson-nvmap-gpu,') }}
-    runs-on: ${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}
+    # GitHub does not apply timeout-minutes until after runner assignment. Keep
+    # unconfirmed manual Jetson dispatches on a hosted runner so they fail fast
+    # instead of queueing forever on an offline self-hosted runner label.
+    runs-on: ${{ inputs.allow_jetson_runner_queue && (vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1') || 'ubuntu-latest' }}
     timeout-minutes: 60
     env:
       E2E_JOB: "1"
@@ -2778,6 +2786,17 @@ jobs:
         with:
           ref: ${{ inputs.checkout_sha || github.sha }}
           persist-credentials: false
+
+      - name: Guard Jetson runner dispatch
+        if: ${{ !inputs.allow_jetson_runner_queue }}
+        env:
+          JETSON_E2E_RUNNER_LABEL: ${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}
+        run: |
+          set -euo pipefail
+          echo "::error::jetson-nvmap-gpu was selected without allow_jetson_runner_queue=true."
+          echo "::error::GitHub Actions does not apply timeout-minutes while a self-hosted job is queued before runner assignment."
+          echo "::error::Confirm an online runner with label ${JETSON_E2E_RUNNER_LABEL}, then re-run with allow_jetson_runner_queue=true."
+          exit 1
 
       - *dockerhub-auth
 
@@ -5026,7 +5045,7 @@ jobs:
               'jetson-nvmap-gpu': {
                 job: 'jetson-nvmap-gpu',
                 target: 'jetson-nvmap-gpu',
-                reason: 'default dispatch excludes Jetson until a stable Jetson runner is available',
+                reason: 'default dispatch excludes Jetson; explicit dispatch requires allow_jetson_runner_queue=true after confirming an online Jetson runner because queued jobs do not honor timeout-minutes before assignment',
               },
               'sandbox-rlimits-connect': {
                 job: 'sandbox-rlimits-connect',

--- a/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
+++ b/test/e2e/support/dockerhub-auth-workflow-boundary.test.ts
@@ -89,7 +89,7 @@ function writeExecutable(filePath: string, source: string): void {
 }
 
 describe("shared Docker Hub authentication workflow boundary", () => {
-  it("reuses one auth alias and one explicit audited cleanup step across every image job", () => {
+  it("reuses one auth alias and one explicit audited cleanup step across every image job (#6430)", () => {
     const workflow = loadWorkflow();
     const requiredJobs = imageJobNames(workflow);
     const canonicalAuth = namedStep(workflow.jobs.live, AUTH_STEP_NAME);
@@ -127,7 +127,9 @@ describe("shared Docker Hub authentication workflow boundary", () => {
         -1;
       const authIndex = job.steps?.findIndex((step) => step.name === AUTH_STEP_NAME) ?? -1;
       const cleanupIndex = job.steps?.findIndex((step) => step.name === CLEANUP_STEP_NAME) ?? -1;
-      expect(authIndex, `${jobName} auth order`).toBe(checkoutIndex + 1);
+      const expectedAuthIndex =
+        jobName === "jetson-nvmap-gpu" ? checkoutIndex + 2 : checkoutIndex + 1;
+      expect(authIndex, `${jobName} auth order`).toBe(expectedAuthIndex);
       expect(cleanupIndex, `${jobName} cleanup order`).toBe((job.steps?.length ?? 0) - 1);
     }
     expect(new Set(cleanupSteps).size, "cleanup steps must not consume the YAML alias budget").toBe(

--- a/test/e2e/support/jetson-workflow-boundary.test.ts
+++ b/test/e2e/support/jetson-workflow-boundary.test.ts
@@ -16,6 +16,34 @@ import {
 } from "../../../tools/e2e/workflow-boundary.mts";
 import { readWorkflow } from "../../helpers/e2e-workflow-contract.ts";
 
+function workflowDispatchInputs(): Record<
+  string,
+  { default?: unknown; description?: string; type?: string }
+> {
+  const workflow = readWorkflow();
+  const triggers = (workflow.on ?? workflow[true as unknown as string]) as {
+    workflow_dispatch?: {
+      inputs?: Record<string, { default?: unknown; description?: string; type?: string }>;
+    };
+  };
+  return triggers.workflow_dispatch?.inputs ?? {};
+}
+
+function validateWorkflowMutation(
+  mutate: (workflow: ReturnType<typeof readWorkflow>) => void,
+): string[] {
+  const workflow = readWorkflow();
+  mutate(workflow);
+  const directory = mkdtempSync(join(tmpdir(), "nemoclaw-jetson-guard-"));
+  const workflowPath = join(directory, "workflow.yaml");
+  try {
+    writeFileSync(workflowPath, YAML.stringify(workflow));
+    return validateE2eWorkflowBoundary(workflowPath);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
 describe("Jetson nvmap GPU E2E workflow boundary", () => {
   it("keeps Jetson selectable but excluded from full-suite dispatch", () => {
     const inventory = readFreeStandingJobsInventory();
@@ -56,6 +84,80 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
         registryTargets: [],
       });
     }
+  });
+
+  it("fails explicit Jetson dispatch on hosted runners unless runner queueing is confirmed (#6430)", () => {
+    const workflow = readWorkflow();
+    const job = (workflow.jobs as Record<string, unknown>)["jetson-nvmap-gpu"] as {
+      "runs-on"?: string;
+      steps?: Array<{
+        env?: Record<string, string>;
+        if?: string;
+        name?: string;
+        run?: string;
+        uses?: string;
+      }>;
+    };
+    const inputs = workflowDispatchInputs();
+    const guard = job.steps?.find((step) => step.name === "Guard Jetson runner dispatch");
+    const checkoutIndex =
+      job.steps?.findIndex((step) => String(step.uses ?? "").startsWith("actions/checkout@")) ?? -1;
+    const guardIndex =
+      job.steps?.findIndex((step) => step.name === "Guard Jetson runner dispatch") ?? -1;
+    const dockerAuthIndex =
+      job.steps?.findIndex((step) => step.name === "Authenticate to Docker Hub") ?? -1;
+    const upload = job.steps?.find((step) => step.name === "Upload Jetson nvmap GPU artifacts");
+    const cleanup = job.steps?.find((step) => step.name === "Clean up Docker auth");
+
+    expect(inputs.allow_jetson_runner_queue).toMatchObject({
+      default: false,
+      type: "boolean",
+    });
+    expect(inputs.allow_jetson_runner_queue?.description).toContain("timeout-minutes");
+    expect(job["runs-on"]).toBe(
+      "${{ inputs.allow_jetson_runner_queue && (vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1') || 'ubuntu-latest' }}",
+    );
+    expect(guard?.if).toBe("${{ !inputs.allow_jetson_runner_queue }}");
+    expect(guard?.env?.JETSON_E2E_RUNNER_LABEL).toBe(
+      "${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}",
+    );
+    expect(guard?.run).toContain("allow_jetson_runner_queue=true");
+    expect(guard?.run).toContain("timeout-minutes");
+    expect(guard?.run).toContain("${JETSON_E2E_RUNNER_LABEL}");
+    expect(guard?.run).not.toContain("linux-arm64-gpu-jetson-orin-latest-1");
+    expect(checkoutIndex).toBeLessThan(guardIndex);
+    expect(guardIndex).toBeLessThan(dockerAuthIndex);
+    expect(upload?.if).toBe("always()");
+    expect(cleanup?.if).toBe("always()");
+  });
+
+  it("rejects a Jetson guard that only prints the fallback runner label (#6430)", () => {
+    const errors = validateWorkflowMutation((workflow) => {
+      const job = (workflow.jobs as Record<string, unknown>)["jetson-nvmap-gpu"] as {
+        steps?: Array<{
+          env?: Record<string, string>;
+          name?: string;
+          run?: string;
+        }>;
+      };
+      const guard = job.steps?.find((step) => step.name === "Guard Jetson runner dispatch");
+      expect(guard).toBeDefined();
+      guard!.env = {
+        JETSON_E2E_RUNNER_LABEL: "linux-arm64-gpu-jetson-orin-latest-1",
+      };
+      guard!.run = guard!.run?.replace(
+        "${JETSON_E2E_RUNNER_LABEL}",
+        "linux-arm64-gpu-jetson-orin-latest-1",
+      );
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "jetson-nvmap-gpu dispatch guard must receive the configured Jetson runner label",
+        "step 'Guard Jetson runner dispatch' run script must include ${JETSON_E2E_RUNNER_LABEL}",
+        "step 'Guard Jetson runner dispatch' run script must not include linux-arm64-gpu-jetson-orin-latest-1",
+      ]),
+    );
   });
 
   it("reports default jobs without claiming explicit-only Jetson ran", () => {

--- a/test/e2e/support/jetson-workflow-boundary.test.ts
+++ b/test/e2e/support/jetson-workflow-boundary.test.ts
@@ -113,6 +113,11 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
       default: false,
       type: "boolean",
     });
+    expect(inputs.allow_jetson_runner_queue?.description).toContain("Repository administrators");
+    expect(inputs.allow_jetson_runner_queue?.description).toContain("authoritative");
+    expect(inputs.allow_jetson_runner_queue?.description).toContain(
+      "NVIDIA/NemoClaw Settings -> Actions -> Runners",
+    );
     expect(inputs.allow_jetson_runner_queue?.description).toContain("timeout-minutes");
     expect(job["runs-on"]).toBe(
       "${{ inputs.allow_jetson_runner_queue && (vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1') || 'ubuntu-latest' }}",
@@ -123,6 +128,9 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
     );
     expect(guard?.run).toContain("allow_jetson_runner_queue=true");
     expect(guard?.run).toContain("timeout-minutes");
+    expect(guard?.run).toContain("repository administrator");
+    expect(guard?.run).toContain("authoritative");
+    expect(guard?.run).toContain("NVIDIA/NemoClaw Settings -> Actions -> Runners");
     expect(guard?.run).toContain("${JETSON_E2E_RUNNER_LABEL}");
     expect(guard?.run).not.toContain("linux-arm64-gpu-jetson-orin-latest-1");
     expect(checkoutIndex).toBeLessThan(guardIndex);
@@ -160,7 +168,9 @@ describe("Jetson nvmap GPU E2E workflow boundary", () => {
     );
   });
 
-  it("reports default jobs without claiming explicit-only Jetson ran", () => {
-    expect(validateE2eWorkflowBoundary()).toEqual([]);
+  it("accepts the real workflow without Jetson queue contract errors (#6430)", () => {
+    const errors = validateE2eWorkflowBoundary();
+    expect(errors.filter((error) => /jetson|allow_jetson_runner_queue/iu.test(error))).toEqual([]);
+    expect(errors).toEqual([]);
   });
 });

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2048,8 +2048,14 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
     );
     const authIndex = steps.indexOf(auth);
     const cleanupIndex = steps.indexOf(cleanup);
-    if (checkoutIndex < 0 || authIndex !== checkoutIndex + 1) {
-      errors.push(`${jobName} Docker Hub auth must run immediately after checkout`);
+    const expectedAuthIndex =
+      jobName === "jetson-nvmap-gpu" ? checkoutIndex + 2 : checkoutIndex + 1;
+    if (checkoutIndex < 0 || authIndex !== expectedAuthIndex) {
+      errors.push(
+        jobName === "jetson-nvmap-gpu"
+          ? `${jobName} Docker Hub auth must run immediately after the Jetson dispatch guard`
+          : `${jobName} Docker Hub auth must run immediately after checkout`,
+      );
     }
     if (authIndex < 0 || cleanupIndex <= authIndex) {
       errors.push(`${jobName} Docker Hub cleanup must run after authentication and test work`);
@@ -3393,6 +3399,73 @@ function validateBedrockRuntimeCompatibleAnthropicJob(
   requireRunDoesNotContain(errors, runVitest, "${{ inputs.");
 }
 
+function validateAllowJetsonRunnerQueueInput(
+  errors: string[],
+  dispatchInputs: WorkflowRecord,
+): void {
+  const input = requireInput(errors, dispatchInputs, "allow_jetson_runner_queue");
+  if (input.type !== "boolean") {
+    errors.push("workflow_dispatch allow_jetson_runner_queue input must be boolean");
+  }
+  if (input.default !== false) {
+    errors.push("workflow_dispatch allow_jetson_runner_queue input must default to false");
+  }
+  const description = stringValue(input.description);
+  if (!description.includes("Jetson runner") || !description.includes("timeout-minutes")) {
+    errors.push(
+      "workflow_dispatch allow_jetson_runner_queue input must document runner confirmation and queued timeout behavior",
+    );
+  }
+}
+
+function validateJetsonRunnerDispatchGuard(errors: string[], jobs: WorkflowRecord): void {
+  validateFreeStandingJobSelector(errors, jobs, "jetson-nvmap-gpu", "jetson-nvmap-gpu", true);
+
+  const job = asRecord(jobs["jetson-nvmap-gpu"]);
+  const guardedRunsOn =
+    "${{ inputs.allow_jetson_runner_queue && (vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1') || 'ubuntu-latest' }}";
+  if (job["runs-on"] !== guardedRunsOn) {
+    errors.push(
+      "jetson-nvmap-gpu job must use ubuntu-latest unless allow_jetson_runner_queue is true",
+    );
+  }
+
+  const steps = asSteps(job.steps);
+  const guard = namedStep(steps, "Guard Jetson runner dispatch");
+  const checkoutIndex = steps.findIndex((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  const guardIndex = steps.findIndex((step) => step.name === "Guard Jetson runner dispatch");
+  const dockerAuthIndex = steps.findIndex((step) => step.name === DOCKER_HUB_AUTH_STEP);
+  if (!guard) {
+    errors.push("jetson-nvmap-gpu job missing step: Guard Jetson runner dispatch");
+    return;
+  }
+  if (checkoutIndex < 0 || guardIndex <= checkoutIndex) {
+    errors.push("jetson-nvmap-gpu dispatch guard must run after checkout");
+  }
+  if (dockerAuthIndex >= 0 && guardIndex >= dockerAuthIndex) {
+    errors.push("jetson-nvmap-gpu dispatch guard must run before Docker Hub auth");
+  }
+  if (guard.if !== "${{ !inputs.allow_jetson_runner_queue }}") {
+    errors.push(
+      "jetson-nvmap-gpu dispatch guard must run unless allow_jetson_runner_queue is true",
+    );
+  }
+  if (
+    asRecord(guard.env).JETSON_E2E_RUNNER_LABEL !==
+    "${{ vars.JETSON_E2E_RUNNER_LABEL || 'linux-arm64-gpu-jetson-orin-latest-1' }}"
+  ) {
+    errors.push(
+      "jetson-nvmap-gpu dispatch guard must receive the configured Jetson runner label",
+    );
+  }
+  requireRunContains(errors, guard, "allow_jetson_runner_queue=true");
+  requireRunContains(errors, guard, "timeout-minutes");
+  requireRunContains(errors, guard, "${JETSON_E2E_RUNNER_LABEL}");
+  requireRunDoesNotContain(errors, guard, "linux-arm64-gpu-jetson-orin-latest-1");
+}
+
 export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_PATH): string[] {
   const workflow = readWorkflowRecord(workflowPath);
   const errors: string[] = [];
@@ -3412,6 +3485,7 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
 
   const dispatchInputs = asRecord(workflowDispatch.inputs);
   requireInput(errors, dispatchInputs, "targets");
+  validateAllowJetsonRunnerQueueInput(errors, dispatchInputs);
   const jobsInput = requireInput(errors, dispatchInputs, "jobs");
   const jobsDescription = stringValue(jobsInput.description);
   if (!jobsDescription.includes("default-enabled jobs")) {
@@ -3870,13 +3944,7 @@ export function validateE2eWorkflowBoundary(workflowPath = DEFAULT_E2E_WORKFLOW_
 
   validateFreeStandingJobSelector(errors, jobs, "gateway-health-honest", "gateway-health-honest");
 
-  const jetsonJob = asRecord(jobs["jetson-nvmap-gpu"]);
-  if (jetsonJob.needs !== "generate-matrix") {
-    errors.push("jetson-nvmap-gpu job must depend on generate-matrix");
-  }
-  if (jetsonJob.if !== explicitOnlyFreeStandingJobIf("jetson-nvmap-gpu", "jetson-nvmap-gpu")) {
-    errors.push("jetson-nvmap-gpu job must run only when explicitly selected");
-  }
+  validateJetsonRunnerDispatchGuard(errors, jobs);
 
   const sandboxRlimitConnectJob = asRecord(jobs["sandbox-rlimits-connect"]);
   if (sandboxRlimitConnectJob.needs !== "generate-matrix") {

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -3411,9 +3411,15 @@ function validateAllowJetsonRunnerQueueInput(
     errors.push("workflow_dispatch allow_jetson_runner_queue input must default to false");
   }
   const description = stringValue(input.description);
-  if (!description.includes("Jetson runner") || !description.includes("timeout-minutes")) {
+  if (
+    !description.includes("Repository administrators") ||
+    !description.includes("Jetson runner") ||
+    !description.includes("authoritative") ||
+    !description.includes("NVIDIA/NemoClaw Settings -> Actions -> Runners") ||
+    !description.includes("timeout-minutes")
+  ) {
     errors.push(
-      "workflow_dispatch allow_jetson_runner_queue input must document runner confirmation and queued timeout behavior",
+      "workflow_dispatch allow_jetson_runner_queue input must identify repository administrators and NVIDIA/NemoClaw Settings -> Actions -> Runners as the authoritative runner inventory, and document queued timeout behavior",
     );
   }
 }
@@ -3462,6 +3468,9 @@ function validateJetsonRunnerDispatchGuard(errors: string[], jobs: WorkflowRecor
   }
   requireRunContains(errors, guard, "allow_jetson_runner_queue=true");
   requireRunContains(errors, guard, "timeout-minutes");
+  requireRunContains(errors, guard, "repository administrator");
+  requireRunContains(errors, guard, "authoritative");
+  requireRunContains(errors, guard, "NVIDIA/NemoClaw Settings -> Actions -> Runners");
   requireRunContains(errors, guard, "${JETSON_E2E_RUNNER_LABEL}");
   requireRunDoesNotContain(errors, guard, "linux-arm64-gpu-jetson-orin-latest-1");
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prevent manual Jetson E2E dispatches from waiting indefinitely for an unavailable self-hosted runner by requiring explicit queue confirmation and otherwise routing to a hosted fail-fast guard. This is a clean, verified replacement for #6532; Ho Lim's original implementation is preserved and credited as co-author.

## Related Issue

Fixes #6430. Supersedes #6532 because its PR-level DCO declaration remains invalid and its branch includes unrelated upload-validator changes already superseded on `main`.

## Changes

- Add `allow_jetson_runner_queue` for manual E2E dispatches.
- Use the configured Jetson runner label only after explicit confirmation; otherwise run a hosted guard with actionable guidance.
- Validate the configurable runner-label source and rendered shell variable so the guard cannot silently print an unset label.
- Add focused workflow-boundary coverage with the required `(#6430)` behavior-title suffix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only internal workflow dispatch safeguards and does not alter NemoClaw user commands, configuration, or runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — the guard defaults to a hosted runner, requires explicit confirmation before using the self-hosted Jetson label, and validates the configured label at the workflow boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused E2E-support validation passed 38/38 tests.
- [x] Applicable broad gate passed — `npm run check:diff`, scoped hooks, and CLI type-check passed on the replacement commit.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workflow dispatch flag to explicitly enable queued Jetson self-hosted runner usage.
  * Introduced a Jetson dispatch guard that controls which runners are targeted based on the new flag.

* **Bug Fixes**
  * Prevented Jetson end-to-end runs from stalling indefinitely when the queue option isn’t enabled by enforcing a hosted-runner fallback.

* **Tests & Validation**
  * Updated workflow boundary validation and end-to-end tests to reflect the new runner gating and step ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->