### PR TITLE
test(e2e): enforce brew Git policy boundary

### DIFF
--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -637,6 +637,16 @@ test("network-policy: restricted sandbox enforces live allow/deny policy probes"
   });
   expect(connectProbe.exitCode, text(connectProbe)).toBe(0);
 
+  const brewGitDenied = await sandboxBash(
+    sandbox,
+    "GIT_TERMINAL_PROMPT=0 git ls-remote https://github.com/Homebrew/brew.git HEAD >/dev/null",
+    { artifactName: "tc-net-11-brew-git-denied" },
+  );
+  const brewGitDeniedText = text(brewGitDenied);
+  expect(brewGitDenied.timedOut, brewGitDeniedText).toBe(false);
+  expect(brewGitDenied.exitCode, brewGitDeniedText).not.toBe(0);
+  expect(brewGitDeniedText).toMatch(/\b403\b|denied|forbidden/i);
+
   const brewProbe = await sandboxBash(
     sandbox,
     String.raw`
@@ -654,8 +664,6 @@ check_status() {
 }
 check_status formulae https://formulae.brew.sh
 check_status raw https://raw.githubusercontent.com/Homebrew/brew/HEAD/README.md
-git ls-remote https://github.com/Homebrew/brew.git HEAD >/dev/null
-echo "BREW_ENDPOINT_github_OK"
 check_status ghcr https://ghcr.io/v2/
 command -v brew
 brew --prefix
@@ -668,12 +676,27 @@ hello
   const brewText = text(brewProbe);
   expect(brewText).toContain("BREW_ENDPOINT_formulae_OK_");
   expect(brewText).toContain("BREW_ENDPOINT_raw_OK_");
-  expect(brewText).toContain("BREW_ENDPOINT_github_OK");
   expect(brewText).toContain("BREW_ENDPOINT_ghcr_OK_");
   expect(brewText).toContain("/usr/local/bin/brew");
   expect(brewText).toContain("/home/linuxbrew/.linuxbrew");
   expect(brewText).toContain("/home/linuxbrew/.linuxbrew/bin/hello");
   expect(brewText).toContain("Hello, world!");
+
+  const githubApply = await applyPreset(host, "github");
+  expect(githubApply.exitCode, text(githubApply)).toBe(0);
+  const githubGitProbe = await sandboxBash(
+    sandbox,
+    String.raw`
+set -euo pipefail
+GIT_TERMINAL_PROMPT=0 git ls-remote https://github.com/Homebrew/brew.git HEAD >/dev/null
+echo "GITHUB_GIT_OK"
+`,
+    { artifactName: "tc-net-11-github-git-allowed" },
+  );
+  const githubGitText = text(githubGitProbe);
+  expect(githubGitProbe.timedOut, githubGitText).toBe(false);
+  expect(githubGitProbe.exitCode, githubGitText).toBe(0);
+  expect(githubGitText).toContain("GITHUB_GIT_OK");
 
   const pypiApply = await applyPreset(host, "pypi");
   expect(pypiApply.exitCode, text(pypiApply)).toBe(0);

--- a/test/pr-risk-plan.test.ts
+++ b/test/pr-risk-plan.test.ts
@@ -91,6 +91,11 @@ describe("deterministic PR risk plan", () => {
       jobs: ["inference-routing", "network-policy"],
     },
     {
+      file: "nemoclaw-blueprint/policies/presets/brew.yaml",
+      family: "inference-policy",
+      jobs: ["inference-routing", "network-policy"],
+    },
+    {
       file: "src/lib/messaging/applier/agent-config.ts",
       family: "messaging-lifecycle",
       jobs: ["channels-add-remove", "channels-stop-start"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Align the live network-policy E2E with the least-privilege `brew`/`github` split introduced by #6541. The test now proves Homebrew works without granting Git egress, then proves the explicit `github` preset enables that same Git operation.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Refs #6502. Follow-up to #6541.

## Changes
<!-- Bullet list of key changes. -->
- Require a non-timeout policy denial when system Git targets GitHub under `brew` alone.
- Keep the Homebrew install proof before applying `github`, then require Git to succeed after the preset is added.
- Add regression coverage that pins policy preset changes to the deterministic `inference-policy` / `network-policy` E2E floor.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects test coverage for the existing policy contract; CLI behavior, configuration, and user workflows are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-risk-plan.test.ts test/brew-github-policy-boundary.test.ts` (24 passed); live E2E collection listed both network-policy tests; `npm run typecheck` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: J. Yaunches <jmyaunch@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened network access enforcement for the Brew preset, blocking direct GitHub Git repository access where it should not be allowed.
  * Verified that GitHub Git access works only after the appropriate preset is applied, while preserving expected access to approved endpoints and installed tools.
* **Tests**
  * Expanded end-to-end coverage to check both denied and allowed Git operations under the relevant policy presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->