### PR TITLE
fix(docs): preserve AgentOnly list spacing

### DIFF
--- a/scripts/sync-agent-variant-docs.ts
+++ b/scripts/sync-agent-variant-docs.ts
@@ -85,19 +85,51 @@ function upsertFrontmatterLine(frontmatter: string, key: string, value: string):
 }
 
 function stripAgentOnlyBlocksForVariant(body: string, activeVariant: AgentVariant): string {
-  return body.replace(
-    /\n?<AgentOnly variant="([^"]+)">\n([\s\S]*?)\n<\/AgentOnly>\n?/g,
-    (_match, variant: string, content: string) => {
-      if (
-        !variant
-          .split(",")
-          .map((item) => item.trim())
-          .includes(activeVariant)
-      )
-        return "\n";
-      return `\n${content.trim()}\n`;
-    },
-  );
+  type OpenBlock = {
+    include: boolean;
+    lines: string[];
+    openLine: string;
+  };
+
+  const renderedLines: string[] = [];
+  let openBlock: OpenBlock | undefined;
+
+  for (const line of body.split("\n")) {
+    if (openBlock) {
+      if (line.match(/^<\/AgentOnly>\s*$/)) {
+        if (openBlock.include) renderedLines.push(...openBlock.lines);
+        openBlock = undefined;
+        continue;
+      }
+      openBlock.lines.push(line);
+      continue;
+    }
+
+    const openMatch = line.match(/^<AgentOnly variant="([^"]+)">\s*$/);
+    if (openMatch) {
+      openBlock = {
+        include: agentOnlyVariantMatches(openMatch[1], activeVariant),
+        lines: [],
+        openLine: line,
+      };
+      continue;
+    }
+
+    renderedLines.push(line);
+  }
+
+  if (openBlock) {
+    renderedLines.push(openBlock.openLine, ...openBlock.lines);
+  }
+
+  return renderedLines.join("\n");
+}
+
+function agentOnlyVariantMatches(variant: string, activeVariant: AgentVariant): boolean {
+  return variant
+    .split(",")
+    .map((item) => item.trim())
+    .includes(activeVariant);
 }
 
 export function renderAgentVariantPage(

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -75,6 +75,29 @@ describe("agent variant docs", () => {
     expect(rendered).not.toContain("<AgentOnly");
   });
 
+  it("keeps adjacent list items together after variant filtering", () => {
+    const rendered = renderAgentVariantPage(
+      `---
+title: "Example"
+---
+## Prerequisites
+
+<AgentOnly variant="openclaw">
+- NemoClaw installed.
+</AgentOnly>
+<AgentOnly variant="hermes">
+- NemoHermes installed.
+</AgentOnly>
+- A local model server running.
+`,
+      "openclaw",
+    );
+
+    expect(rendered).toContain("- NemoClaw installed.\n- A local model server running.");
+    expect(rendered).not.toContain("- NemoClaw installed.\n\n- A local model server running.");
+    expect(rendered).not.toContain("NemoHermes installed.");
+  });
+
   it("rewrites relative imports but preserves Fern route links for generated build output", () => {
     const rendered = renderAgentVariantPage(
       `${source}\nSee [Commands](../reference/commands#$$nemoclaw-list).\nSee [Backup](backup-restore).\n![Diagram](images/diagram.png)\n`,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fixes generated agent-variant docs so adjacent Markdown list items stay adjacent when one or more neighboring `<AgentOnly>` blocks are filtered out.
The renderer now strips wrapper lines and skipped block contents without injecting replacement blank lines.

## Changes
- Reworked `scripts/sync-agent-variant-docs.ts` to render `<AgentOnly>` blocks line-by-line instead of replacing skipped blocks with a newline.
- Added a regression test covering adjacent variant-only prerequisite list items.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This fixes docs build-tool rendering behavior and does not add a new user-facing workflow, command, page, or authoring rule.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/agent-variant-docs.test.ts test/sync-agent-variant-docs.test.ts` passed; `npm run docs:check-agent-variants` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of variant-specific content so matching sections keep their original line spacing.
  * Prevented extra blank lines from appearing between adjacent list items after filtering.
  * Ensured content for non-selected variants is no longer shown in the output.

* **Tests**
  * Added coverage for variant-based rendering to verify list formatting and content filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->