### PR TITLE
docs: prepare v0.0.79 release notes

### DIFF
--- a/docs/about/release-notes.mdx
+++ b/docs/about/release-notes.mdx
@@ -16,6 +16,35 @@ NVIDIA NemoClaw is available in early preview starting March 16, 2026.
 Use this page to track the highlights of the latest release.
 For more detailed release notes, refer to the [NemoClaw GitHub announcements](https://github.com/NVIDIA/NemoClaw/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements).
 
+## v0.0.79
+
+NemoClaw v0.0.79 expands hosted and local inference options, improves operator diagnostics and shell integration, and hardens sandbox recovery, Deep Agents runtime limits, policy boundaries, and release validation.
+The release also refreshes quickstarts and variant rendering so OpenClaw, Hermes, and LangChain Deep Agents Code readers see only the agent-specific setup paths that apply to them.
+
+- OpenRouter is now a first-class onboarding provider for OpenClaw, Hermes, and LangChain Deep Agents Code.
+  NemoClaw validates `sk-or-` credentials, uses OpenRouter's OpenAI-compatible route through `https://inference.local/v1`, and keeps the OpenRouter catalog independent from NVIDIA Endpoints filtering.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options), [Switch Inference Providers](../inference/switch-inference-providers), and [Platform Support and Launch Claims](../reference/platform-support).
+- Local and compatible inference setup is more resilient.
+  Managed vLLM starts with argv-safe Docker arguments, DGX Spark uses the Qwen3.6 `qwen3_coder` tool parser, OpenClaw bounds managed inference compaction, and onboarding uses calibrated provider-validation and gateway-readiness deadlines to avoid hanging or failing too early on slower hosts.
+  For more information, refer to [NemoClaw Inference Options](../inference/inference-options), [Use a Local Inference Server](../inference/use-local-inference), and [Troubleshooting](../reference/troubleshooting).
+- CLI and installer diagnostics are easier to act on.
+  The new `$$nemoclaw completion` command generates Bash, Zsh, and Fish completions, structured logging now supports `--debug` and `NEMOCLAW_LOG_LEVEL`, `status` warns when the live gateway route drifts from the recorded sandbox route, and gateway teardown now recommends and runs `openshell gateway remove` consistently across platforms.
+  Installer and uninstall flows also report preserved orphaned sandboxes more honestly, and DGX Spark express installs use the expected `my-assistant` sandbox name.
+  For more information, refer to [NemoClaw CLI Commands Reference](../reference/commands), [Switch Inference Providers](../inference/switch-inference-providers), and [Host Files and State](../reference/host-files-and-state).
+- Runtime and configuration boundaries are tighter.
+  Managed LangChain Deep Agents Code enforces process and file-descriptor limits, accepted OTLP endpoint URLs no longer trip the secret guard, proxy environment exports stay POSIX-compatible, nested OpenShell PID namespaces are recognized by config guards, and TOML config reads and parsing fail closed instead of accepting ambiguous content.
+  Re-onboarding also removes stale registered extra providers so the sandbox state matches the selected provider set.
+  For more information, refer to [Security Best Practices](../security/best-practices), [Credential Storage](../security/credential-storage), [NemoClaw CLI Commands Reference](../reference/commands), and [Quickstart with LangChain Deep Agents Code](/user-guide/deepagents/get-started/quickstart).
+- Network policy and messaging behavior now preserve narrower boundaries.
+  Homebrew Git operations require the GitHub policy preset for Git egress, Gmail has a documented policy preset and integration example, custom URL-based MCP server allowlists are documented, WhatsApp post-pair gateway restarts no longer require `operator.admin`, and the overview hides messaging-channel guidance from Deep Agents pages where the channel flow is not supported.
+  For more information, refer to [Network Policies](../reference/network-policies), [Common Integration Policy Examples](../network-policy/integration-policy-examples), [Customize the Network Policy](../network-policy/customize-network-policy), and [Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels).
+- Onboarding and recovery paths preserve intent across more interrupted flows.
+  Resume recovery now follows one explicit finite-state path, pending route reservations survive resume, sandbox create-failure reporting is separated from create-step handling, BuildKit progress no longer forces plain output, and null-name resume sessions are covered so canceled or malformed session state does not send users down the wrong recovery path.
+  For more information, refer to [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [NemoClaw CLI Commands Reference](../reference/commands), [Manage Sandbox Lifecycle](../manage-sandboxes/lifecycle), and [Troubleshooting](../reference/troubleshooting).
+- Documentation and release validation are more deterministic.
+  The docs define extension taxonomy and SDK readiness gates, streamline the agent quickstarts, clarify legacy k3s sandbox resources, preserve list spacing in generated agent-variant pages, and add release-train risk planning with post-merge E2E shadow signals, queued Jetson dispatch guards, TUI idle regression coverage, and reusable live-readiness polling primitives.
+  For more information, refer to [Extension Taxonomy and SDK Readiness](../reference/extension-taxonomy-sdk-readiness), [NemoClaw Quickstart with OpenClaw](../get-started/quickstart), [Architecture Details](../reference/architecture), and the [NemoClaw E2E README](https://github.com/NVIDIA/NemoClaw/blob/main/test/e2e/README.md).
+
 ## v0.0.78
 
 NemoClaw v0.0.78 adds opt-in thread-scoped auto-approval and policy-routed repository reads for managed LangChain Deep Agents Code, authoritative agent-visible inference health, round-trippable policy export, and stronger recovery for local inference, custom images, managed MCP, remote dashboards, and credential capture.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Adds the pre-tag v0.0.79 release notes entry to `docs/about/release-notes.mdx` so the release plan can be generated after docs merge.
The entry summarizes the merged v0.0.79 release train across inference, diagnostics, runtime hardening, policies, onboarding recovery, and release validation.

## Changes
- Added the v0.0.79 release notes section with linked follow-up documentation for OpenRouter onboarding, managed vLLM changes, completion and logging, Deep Agents runtime limits, policy updates, onboarding recovery, and release validation.
- Source summary:
  - #6461 -> `docs/about/release-notes.mdx`: Documents OpenRouter onboarding support and links to inference/provider references.
  - #6271 and #6272 -> `docs/about/release-notes.mdx`: Documents shell completion and structured logging highlights.
  - #6465, #6539, #6570, and #6528 -> `docs/about/release-notes.mdx`: Documents status route-drift, orphaned sandbox, gateway cleanup, and DGX Spark express-install diagnostics.
  - #6523, #6551, #6484, #6488, #6324, and #6542 -> `docs/about/release-notes.mdx`: Documents managed vLLM, Qwen3.6 tool parser, compaction, and timeout/readiness improvements.
  - #6559, #6538, #6560, #6568, #6552, #6567, and #6587 -> `docs/about/release-notes.mdx`: Documents runtime, credential, proxy, PID namespace, TOML, and provider-state hardening.
  - #6541, #5415, #6246, #6496, and #6573 -> `docs/about/release-notes.mdx`: Documents GitHub policy, Gmail policy, MCP allowlist, WhatsApp, and messaging-variant updates.
  - #6253, #6572, #6444, #6536, and #5860 -> `docs/about/release-notes.mdx`: Documents onboarding resume and create-step recovery improvements.
  - #6508, #6527, #5506, #6588, #6446, #6447, #6582, #6296, #6367, #6397, and #6505 -> `docs/about/release-notes.mdx`: Documents docs, release-risk, and E2E validation updates.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Release-note prose only.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Tests not applicable, release-note prose only.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Docs validation note: `npm run docs:check-agent-variants && npm run docs:check-routes && git diff --check` passed. Full `npm run docs` is currently blocked before Fern validation because the pinned `fern-api@5.65.2` package is unavailable from npm (`ETARGET No matching version found`).

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.0.79 with a new summary of recent improvements, including onboarding and inference options, operator/CLI diagnostics, sandbox recovery hardening, runtime limits, network policy behavior, and release validation updates.
  * Added updated references and links for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->