### PR TITLE
docs(policy): replace developer walkthrough command

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -233,13 +233,13 @@ The flow has these steps:
 4. The operator approves or denies the request.
 5. If approved, the endpoint is added to the running policy for the session.
 
-To try this, run the walkthrough:
+To monitor requests as the agent runs, open the TUI:
 
 ```bash
-./scripts/walkthrough.sh
+openshell term
 ```
 
-This opens a split tmux session with the TUI on the left and the agent on the right.
+For step-by-step navigation and approval controls, refer to [Approve or Deny Agent Network Requests](../network-policy/approve-network-requests).
 
 ## Modifying the Policy
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Replaces the source-checkout-only `./scripts/walkthrough.sh` command in the network policy reference with the operator-facing `openshell term` command.
The reference had retained a developer helper even after a user-facing approval guide existed, and docs validation checked syntax and routes rather than whether the command was available to installed users.
The page now routes readers to the existing approval how-to for detailed navigation and controls.

## Related Issue
Closes #6557

## Changes
- Replaced the developer walkthrough command with `openshell term` in `docs/reference/network-policies.mdx`.
- Linked the operator approval flow to the existing user-facing approval guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: doc-only command correction with no runtime behavior or targeted test contract change.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: docs-only network policy reference correction reviewed against the current operator approval guide; no policy enforcement or security behavior changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: tests are not applicable because only a documentation command sample and route-style link changed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this focused doc-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors; Fern reported one hidden warning and an upgrade notice.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Operator Approval Flow guide with clearer steps for opening the TUI during request monitoring.
  * Added a direct link to the step-by-step approval controls for easier navigation.
  * Removed an outdated walkthrough reference from the instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->