### PR TITLE
docs: clarify Deep Agents workspace creation timing

### DIFF
--- a/docs/manage-sandboxes/workspace-files.mdx
+++ b/docs/manage-sandboxes/workspace-files.mdx
@@ -157,6 +157,9 @@ For upstream behavior, refer to the official Deep Agents Code pages for [memory 
 
 ## Important Deep Agents State
 
+The `/sandbox/.deepagents/agent/` paths below do not exist immediately after onboarding.
+Deep Agents Code creates them when you start the first `dcode` session.
+
 | Path | Purpose |
 |---|---|
 | `/sandbox/.deepagents/config.toml` | NemoClaw-generated model and provider configuration for the managed `inference.local` route. |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Clarifies that Deep Agents Code creates the documented `/sandbox/.deepagents/agent/` paths when the first `dcode` session starts, not during NemoClaw onboarding.
The page previously listed these paths without distinguishing their creation time from onboarding-created state, which could lead readers to expect them immediately after onboarding.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Closes #6556.

## Changes
<!-- Bullet list of key changes. -->

- State that `/sandbox/.deepagents/agent/` paths do not exist immediately after onboarding.
- State that Deep Agents Code creates those paths on the first `dcode` session.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: prose-only creation-timing clarification; no code sample, generated behavior, or documented command contract changed
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: tests are not applicable to this prose-only clarification
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this one-file prose-only docs correction
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed with 0 errors and 1 Fern warning
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable; no new page

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when Deep Agents sandbox paths become available during onboarding.
  * Added a note that `/sandbox/.deepagents/agent/` is created only after the first `dcode` session starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->