### PR TITLE
docs(security): replace deprecated Deep Agents deploy command

### DIFF
--- a/docs/security/credential-storage.mdx
+++ b/docs/security/credential-storage.mdx
@@ -117,20 +117,15 @@ It can recreate a missing provider only when the provider name and credential va
 A missing credential or a provider-to-credential mismatch stops recovery before backup or delete.
 For any other missing-provider case, rerun `$$nemoclaw onboard` or re-register the provider first.
 
-## Deploy Reads from Environment Only
+## Onboarding Reads Credentials from Environment
 
-`$$nemoclaw deploy` (which provisions a remote Brev box) cannot read secrets back from the gateway, so it requires every credential to be present in the host environment at invocation time.
-A typical deploy invocation looks like:
+`$$nemoclaw onboard` reads credentials from the host environment, registers them with the OpenShell gateway, and creates the sandbox.
+A typical onboarding invocation looks like:
 
 ```bash
 NVIDIA_INFERENCE_API_KEY=nvapi-... \
-    HF_TOKEN=hf_... \
-    TELEGRAM_BOT_TOKEN=... \
-    $$nemoclaw deploy my-instance
+    $$nemoclaw onboard --name my-instance
 ```
-
-For remote vLLM or Hugging Face workflows that need gated model access, `$$nemoclaw deploy` also forwards `HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN` to the VM when either variable is present.
-If a required credential is missing, deploy aborts before any remote work begins.
 
 ## GitHub Tokens
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
This PR replaces the deprecated Deep Agents `deploy` example in the shared credential-storage page with the supported `onboard --name` flow.
It also removes Brev-only credential-forwarding claims that do not apply to current onboarding.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Closes #6546.

## Changes
<!-- Bullet list of key changes. -->
- Rename the deprecated deploy section to describe current onboarding behavior.
- Render `nemo-deepagents onboard --name my-instance` in the generated Deep Agents guide.
- Remove obsolete `HF_TOKEN`, Telegram, and Brev forwarding guidance from the example.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the shared-agent variant and copyable-command tests cover placeholder rendering and fenced command structure.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending maintainer review of this docs-only credential guidance correction.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/sync-agent-variant-docs.test.ts test/docs-copyable-command-blocks.test.ts` (5 tests passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused docs-only change.
- [ ] Quality Gates section completed with required justifications or waivers — pending sensitive-path review of the credential guidance.
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — command passed with the repository's existing light-mode accent contrast warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated credential storage guidance to describe onboarding behavior for credentials read from the host environment.
  * Added an example showing how to pass an environment-based API key during onboarding.
  * Removed outdated deploy-specific instructions from the affected section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->