### PR TITLE
docs: update host files and state reference

### DIFF
--- a/docs/reference/host-files-and-state.mdx
+++ b/docs/reference/host-files-and-state.mdx
@@ -4,24 +4,24 @@
 title: "Host Files and State"
 sidebar-title: "Host Files and State"
 description: "Reference for NemoClaw host-side files and directories under ~/.nemoclaw."
-description-agent: "Lists host-side NemoClaw config and state files under ~/.nemoclaw. Use when identifying config.json, credentials.json, sandboxes.json, onboard-session.json, backup directories, mounts, or local inference adapter files."
-keywords: ["nemoclaw host files", "nemoclaw state directory", "nemoclaw sandboxes json", "nemoclaw credentials json"]
+description-agent: "Lists host-side NemoClaw config and state files under ~/.nemoclaw. Use when identifying config.json, sandboxes.json, usage-notice.json, legacy credentials.json, operational state, backup directories, mounts, or local inference adapter files."
+keywords: ["nemoclaw host files", "nemoclaw state directory", "nemoclaw sandboxes json", "nemoclaw usage notice"]
 content:
   type: "reference"
 ---
 import { AgentOnly } from "../_components/AgentGuide";
 
 
-NemoClaw stores host-side configuration, credentials, registry metadata, transient install state, and local backups under `~/.nemoclaw/`.
+NemoClaw stores host-side configuration, registry metadata, operational state, transient install state, and local backups under `~/.nemoclaw/`.
 Use this page when you need to identify what a file does before deleting, backing up, or sharing diagnostics.
 
 <AgentOnly variant="deepagents">
-The `nemo-deepagents` alias uses the same host-side `~/.nemoclaw/` configuration, credential registry, sandbox registry, backup, and mount directories as the default NemoClaw CLI.
+The `nemo-deepagents` alias uses the same host-side `~/.nemoclaw/` configuration, sandbox registry, operational state, backup, and mount directories as the default NemoClaw CLI.
 Deep Agents-specific runtime state lives inside the sandbox under `/sandbox/.deepagents`, not in a separate host state root.
 </AgentOnly>
 
 <Warning>
-Do not paste `credentials.json`, provider tokens, bot tokens, proxy tokens, or debug archives containing them into chat or issue comments.
+Do not paste a legacy `credentials.json`, provider tokens, bot tokens, proxy tokens, or debug archives containing them into chat or issue comments.
 Share redacted diagnostics only.
 </Warning>
 
@@ -30,9 +30,10 @@ Share redacted diagnostics only.
 | Path | Purpose | Safe to delete |
 |---|---|---|
 | `~/.nemoclaw/config.json` | Host-level CLI configuration and defaults created by onboarding or config commands. | Only if you want NemoClaw to forget host defaults and rebuild them on the next setup. |
-| `~/.nemoclaw/credentials.json` | Host-side provider and integration credential registry. | Only when you intentionally want to re-enter credentials. |
+| `~/.nemoclaw/credentials.json` | Legacy plaintext credential file from earlier releases. Onboarding stages allowlisted values, registers them with the OpenShell gateway, and securely deletes the file only after verifying their migration. Current releases do not create this file. | No; run `$$nemoclaw onboard` to complete migration and cleanup so you do not lose a credential that is not yet registered with the gateway. |
 | `~/.nemoclaw/sandboxes.json` | Current sandbox registry used by `$$nemoclaw list`, default sandbox selection, rebuild, and recovery commands. | No. Deleting it makes the host forget existing sandboxes and can block state-preserving recovery. |
 | `~/.nemoclaw/onboard-session.json` | Resume marker for an onboarding attempt that failed before completion. | Yes, when you intentionally want to discard the failed session and start over. Prefer `$$nemoclaw onboard --fresh` when available. |
+| `~/.nemoclaw/usage-notice.json` | Records the third-party software notice version in `acceptedVersion` and the acceptance time in `acceptedAt`. Install, onboarding, and rebuild flows consult this file and prompt again when its recorded version differs from the current notice or the file is absent. | Yes; deleting it makes the next applicable install, onboarding, or rebuild flow prompt for acceptance again. |
 | `~/.nemoclaw/ollama-proxy-token` | Local auth token used by the host-side Ollama auth proxy. | Yes, but re-run onboarding afterward so NemoClaw recreates and registers the proxy token. |
 
 `sandboxes.json` is the current registry file name.
@@ -42,6 +43,7 @@ If you see `registry.json` in older tests, notes, or discussions, treat it as le
 
 | Path | Purpose | Safe to delete |
 |---|---|---|
+| `~/.nemoclaw/state/` | Operational coordination and history for lifecycle locks, shields transitions, timers, and audit events, local routing, and port-forward helpers. | No. Deleting it can disrupt an active operation and discard security or recovery context. |
 | `~/.nemoclaw/rebuild-backups/` | Host-side snapshots written by `backup-all`, `snapshot create`, and rebuild flows. | Only after you no longer need rollback or restore points. |
 | `~/.nemoclaw/backups/` | Workspace backups written by legacy backup helpers and some recovery flows. | Only after confirming you no longer need those workspace archives. |
 | `~/.nemoclaw/mounts/` | Default local mount points created by share or mount commands. | Unmount first, then remove unused directories. |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->
Updates the host-files reference to match current credential and state behavior.
It marks `credentials.json` as a legacy migration artifact and documents `usage-notice.json` and the operational `state/` directory.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Closes #6555

## Changes
<!-- Bullet list of key changes. -->

- Clarify that current releases register provider credentials with the OpenShell gateway and do not create `~/.nemoclaw/credentials.json`.
- Document the accepted-version record in `~/.nemoclaw/usage-notice.json` and its deletion behavior.
- Document the operational coordination and history stored under `~/.nemoclaw/state/`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: 52 focused credential migration and usage-notice tests pass across the integration, CLI, and package-contract projects.
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli --project integration --project package-contract src/lib/actions/sandbox/rebuild-usage-notice.test.ts test/credentials.test.ts test/package-contract/onboard/usage-notice.test.ts` passed, 3 files and 52 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — result: passed with 0 errors; Fern reports the existing repository theme accent-color contrast warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the host-state reference for files stored under `~/.nemoclaw/`.
  * Updated guidance for legacy credential data, including safer handling and migration instructions.
  * Added clearer notes for `usage-notice.json` and other host JSON files, including whether they can be deleted.
  * Documented the `~/.nemoclaw/state/` directory and its role in storing operational history and coordination data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->