### PR TITLE
docs: fix Deep Agents troubleshooting security link

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -275,6 +275,9 @@ navigation:
               - page: "Credential Storage"
                 path: _build/agent-variants/security/credential-storage.deepagents.generated.mdx
                 slug: credential-storage
+              - page: "OpenShell 0.0.72 Compatibility Review"
+                path: _build/agent-variants/security/openshell-0.0.72-compatibility-review.deepagents.generated.mdx
+                slug: openshell-0.0.72-compatibility-review
           - section: "Reference"
             slug: reference
             collapsed: open-by-default

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -316,7 +316,7 @@ Leave it unset on supported hosts.
 The compatibility container uses host networking and mounts the host Docker socket read-only.
 A read-only socket mount still permits privileged Docker API operations and can control the host, so do not enable this mode on an untrusted or shared host.
 The gateway remains loopback-bound, and startup fails closed unless the configured Unix socket answers as a Docker daemon.
-See the [OpenShell 0.0.72 compatibility review](/user-guide/openclaw/security/openshell-0.0.72-compatibility-review#source-of-truth-boundaries) for the accepted boundary and removal conditions.
+See the [OpenShell 0.0.72 compatibility review](../security/openshell-0.0.72-compatibility-review#source-of-truth-boundaries) for the accepted boundary and removal conditions.
 
 Refer to [Environment Variables](commands#environment-variables) for the full list of port overrides.
 

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -174,4 +174,24 @@ title: "Example"
       "Deep Agents does not have a NemoClaw-managed web-search feature.",
     );
   });
+
+  it("keeps the troubleshooting security review link within each agent guide (#6558)", () => {
+    const troubleshooting = readFileSync(
+      new URL("../docs/reference/troubleshooting.mdx", import.meta.url),
+      "utf8",
+    );
+
+    for (const variant of ["openclaw", "hermes", "deepagents"] as const) {
+      const rendered = renderAgentVariantPage(troubleshooting, variant, {
+        sourcePath: "/repo/docs/reference/troubleshooting.mdx",
+      });
+
+      expect(rendered).toContain(
+        "[OpenShell 0.0.72 compatibility review](../security/openshell-0.0.72-compatibility-review#source-of-truth-boundaries)",
+      );
+      expect(rendered).not.toMatch(
+        /\/user-guide\/(?:openclaw|hermes|deepagents)\/security\/openshell-0\.0\.72-compatibility-review/,
+      );
+    }
+  });
 });

--- a/test/agent-variant-docs.test.ts
+++ b/test/agent-variant-docs.test.ts
@@ -183,6 +183,7 @@ title: "Example"
 
     for (const variant of ["openclaw", "hermes", "deepagents"] as const) {
       const rendered = renderAgentVariantPage(troubleshooting, variant, {
+        outputPath: `/repo/docs/_build/agent-variants/reference/troubleshooting.${variant}.generated.mdx`,
         sourcePath: "/repo/docs/reference/troubleshooting.mdx",
       });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 sentences: what this PR does and why. -->

Fixes the shared troubleshooting page so the OpenShell compatibility review link stays within the active OpenClaw, Hermes, or Deep Agents guide instead of sending Deep Agents readers to the OpenClaw guide.
The existing route checker accepted the old absolute URL because it resolved to a published page, so this PR also adds a focused variant regression assertion.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Closes #6558.

## Changes
<!-- Bullet list of key changes. -->

- Replace the hard-coded OpenClaw compatibility-review URL in `docs/reference/troubleshooting.mdx` with a route-style relative link.
- Publish the existing OpenShell 0.0.72 compatibility review in the Deep Agents security navigation.
- Verify generated troubleshooting pages keep the review link within each agent guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/agent-variant-docs.test.ts` passed 8/8 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — command passed; Fern reported the existing light-mode accent contrast warning (2.41:1), and the route checker reported all internal links resolve.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Security** page entry for the **OpenShell 0.0.72 Compatibility Review** to the Deep Agents documentation navigation.
* **Bug Fixes**
  * Updated troubleshooting documentation to link directly to the new security review page via the correct relative URL.
* **Tests**
  * Added automated checks to ensure the security review link renders correctly across multiple agent variant guides and is not rewritten into a variant-specific path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->