### PR TITLE
chore(deps): align TypeScript on 6.0.3

### DIFF
--- a/docs/security/e2e-weather-plugin-fixture-dependency-review.md
+++ b/docs/security/e2e-weather-plugin-fixture-dependency-review.md
@@ -3,7 +3,7 @@
 
 # E2E Weather Plugin Fixture Dependency Review
 
-Review date: 2026-07-08
+Review date: 2026-07-09
 
 Scope: `test/e2e/fixtures/plugins/weather/package-lock.json` and the secret-free OpenClaw custom-plugin lifecycle regression lane.
 
@@ -45,11 +45,11 @@ Run from `test/e2e/fixtures/plugins/weather`:
 npm audit --package-lock-only --ignore-scripts --json
 ```
 
-Revalidated on 2026-07-08: npm audit exited `1` and reported 9 vulnerable packages (3 moderate and 6 high; 0 info, low, or critical) across 374 total dependencies.
+Revalidated on 2026-07-09: npm audit exited `1` and reported 9 vulnerable packages (3 moderate and 6 high; 0 info, low, or critical) across 374 total dependencies.
 The affected packages are `@earendil-works/pi-coding-agent`, `@openclaw/fs-safe`, `hono`, `linkify-it`, `markdown-it`, `openclaw`, `protobufjs`, `tar`, and `undici`.
 The point-in-time advisory set is GHSA-22p9-wv53-3rq4, GHSA-2gcr-mfcq-wcc3, GHSA-35p6-xmwp-9g52, GHSA-38rv-x7px-6hhq, GHSA-3hrh-pfw6-9m5x, GHSA-6v5v-wf23-fmfq, GHSA-7v5m-pr3q-6453, GHSA-88fw-hqm2-52qc, GHSA-94rc-8x27-4472, GHSA-9c3v-684m-579c, GHSA-f38q-mgvj-vph7, GHSA-f577-qrjj-4474, GHSA-g8m3-5g58-fq7m, GHSA-j6c9-x7qj-28xf, GHSA-jfgx-wxx8-mp94, GHSA-mqxh-6gq7-558m, GHSA-p88m-4jfj-68fv, GHSA-pr7r-676h-xcf6, GHSA-r95r-rj6r-c39x, GHSA-rv63-4mwf-qqc2, GHSA-vmf3-w455-68vh, GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q, GHSA-wcpc-wj8m-hjx6, GHSA-wgpf-jwqj-8h8p, GHSA-wwfh-h76j-fc44, and GHSA-xrhx-7g5j-rcj5.
 The advisories are in the release-pinned OpenClaw development graph; the Docker build suppresses lifecycle scripts and prunes development and peer dependencies before copying the plugin into the runtime image.
-The reviewed lockfile has SHA-256 `1fa44d136d4bf5396f592dbf901da2c43740b38f1ebe52d23efc01ca0ba6f3da`, and every non-root package entry records both its resolved registry URL and integrity value.
+The reviewed lockfile has SHA-256 `ea5fcb849fbc39ef2c9dd1d893258d373a9c3eae796306951f8c2e180cf6469c`, and every non-root package entry records both its resolved registry URL and integrity value.
 
 The audit is a point-in-time advisory check, not a substitute for the exact lockfile, lifecycle-script suppression, or secret-free workflow boundary.
 Rerun it whenever `package.json` or `package-lock.json` changes and again before merge if npm advisory state changes.

--- a/nemoclaw/package-lock.json
+++ b/nemoclaw/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^22.0.0",
-        "typescript": "^5.4.0",
+        "typescript": "6.0.3",
         "vitest": "^4.1.0"
       },
       "engines": {
@@ -1578,9 +1578,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/nemoclaw/package.json
+++ b/nemoclaw/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@types/node": "^22.0.0",
-    "typescript": "^5.4.0",
+    "typescript": "6.0.3",
     "vitest": "^4.1.0"
   },
   "engines": {

--- a/nemoclaw/tsconfig.json
+++ b/nemoclaw/tsconfig.json
@@ -13,6 +13,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "types": ["node"],
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ajv": "^8.17.0",
         "fast-check": "^4.8.0",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.2",
+        "typescript": "6.0.3",
         "vitest": "^4.1.9"
       },
       "engines": {
@@ -6472,9 +6472,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "ajv": "^8.17.0",
     "fast-check": "^4.8.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2",
+    "typescript": "6.0.3",
     "vitest": "^4.1.9"
   }
 }

--- a/test/e2e/fixtures/plugins/weather/package-lock.json
+++ b/test/e2e/fixtures/plugins/weather/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "openclaw": "2026.5.27",
-        "typescript": "5.9.3"
+        "typescript": "6.0.3"
       },
       "engines": {
         "node": ">=22.16.0"
@@ -5136,9 +5136,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/test/e2e/fixtures/plugins/weather/package.json
+++ b/test/e2e/fixtures/plugins/weather/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "openclaw": "2026.5.27",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "peerDependencies": {
     "openclaw": ">=2026.5.17"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Aligns every direct TypeScript compiler dependency on 6.0.3, the newest stable release that retains the compiler APIs used by NemoClaw's repository checks and test loaders. This removes the split between TypeScript 5.9 and 6.0 without introducing a second compatibility package.

## Changes

- Pin the root, plugin, and weather E2E fixture TypeScript dependencies and lockfiles to exact version 6.0.3.
- Add the plugin's explicit Node type set required by TypeScript 6 defaults.
- Revalidate the weather fixture dependency audit and update its checked-in lockfile digest.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: compiler-API loading, source transpilation, plugin compilation, and the fixture lock-review contract already have dedicated coverage; the focused four-file integration run passed 130 tests.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this is an internal development-tooling alignment with no CLI or runtime behavior change; the required fixture dependency-review date and digest were refreshed, and `npm run docs` completed with 0 errors and 2 warnings.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: reran `npm audit --package-lock-only --ignore-scripts --json`; the reviewed release-pinned fixture graph remains at 9 known vulnerabilities (3 moderate, 6 high), the advisory set is unchanged, and the lock-digest enforcement test passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/inference-options-docs.test.ts test/nemoclaw-start.test.ts test/source-require-loader.test.ts test/e2e-fixture-dependency-review.test.ts` — 130 passed.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` recorded 15,568 passes and its sole inherited-SSH assertion passed on an environment-clean rerun; the `npm run check` structural/plugin gates passed and the SSH-clean CLI coverage retry passed 13,742 tests with the coverage ratchet satisfied.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript to version 6.0.3 across the project and related test fixtures.
  * Added Node.js type definitions to the TypeScript configuration for more accurate type checking.

* **Documentation**
  * Refreshed the security review record with the latest review date and audit results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->