### PR TITLE
docs(policy): scope approval link to published guides

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -239,7 +239,11 @@ To monitor requests as the agent runs, open the TUI:
 openshell term
 ```
 
+<AgentOnly variant="openclaw,hermes">
+
 For step-by-step navigation and approval controls, refer to [Approve or Deny Agent Network Requests](../network-policy/approve-network-requests).
+
+</AgentOnly>
 
 ## Modifying the Policy
 

--- a/scripts/check-docs-published-routes.ts
+++ b/scripts/check-docs-published-routes.ts
@@ -296,9 +296,13 @@ export function resolvePageLinksByText(
 }
 
 // Pages that have repeatedly regressed on source-path-vs-published-route drift
-// (NemoClaw#5445, #6290, #5465, #5460). Scoped intentionally: the wider docs
+// (NemoClaw#5445, #6290, #5465, #5460, #6601). Scoped intentionally: the wider docs
 // tree has unrelated pre-existing broken links tracked separately.
-const GUARDED_SOURCE_PAGES = ["reference/commands.mdx", "reference/platform-support.mdx"];
+const GUARDED_SOURCE_PAGES = [
+  "reference/commands.mdx",
+  "reference/network-policies.mdx",
+  "reference/platform-support.mdx",
+];
 
 function main(): void {
   const index = buildPublishedRouteIndex();

--- a/test/network-policies-published-routes.test.ts
+++ b/test/network-policies-published-routes.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+  buildPublishedRouteIndex,
+  findBrokenPublishedRoutes,
+  resolvePageLinksByText,
+} from "../scripts/check-docs-published-routes.ts";
+
+const NETWORK_POLICIES_SOURCE = "reference/network-policies.mdx";
+const APPROVAL_LINK_TEXT = "Approve or Deny Agent Network Requests";
+
+describe("shared Network Policies published routes", () => {
+  it("keeps the approval guide link inside variants that publish it (#6601)", () => {
+    const index = buildPublishedRouteIndex();
+
+    expect(findBrokenPublishedRoutes(NETWORK_POLICIES_SOURCE, index)).toEqual([]);
+    expect(
+      [...resolvePageLinksByText(NETWORK_POLICIES_SOURCE, APPROVAL_LINK_TEXT, index)].sort((a, b) =>
+        a.fromRoute.localeCompare(b.fromRoute),
+      ),
+    ).toEqual([
+      {
+        fromRoute: "/user-guide/hermes/reference/network-policies",
+        published: true,
+        resolved: "/user-guide/hermes/network-policy/approve-network-requests",
+        target: "../network-policy/approve-network-requests",
+      },
+      {
+        fromRoute: "/user-guide/openclaw/reference/network-policies",
+        published: true,
+        resolved: "/user-guide/openclaw/network-policy/approve-network-requests",
+        target: "../network-policy/approve-network-requests",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Scopes the approval-guide link introduced by #6601 to OpenClaw and Hermes, the variants that publish that route.
Adds the shared Network Policies page to the published-route guard so a generated Deep Agents guide cannot reintroduce the 404.

## Related Issue
Follow-up to #6601.

## Changes

- Render the approval-guide cross-reference only for OpenClaw and Hermes.
- Guard `reference/network-policies.mdx` in the published-route checker.
- Add a regression test for the exact OpenClaw, Hermes, and Deep Agents variant behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check exactly one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer review confirmed this changes only variant-specific documentation routing; runtime policy enforcement and approval behavior are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes the DCO sign-off declaration and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run check:diff` passed when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/network-policies-published-routes.test.ts test/check-docs-published-routes.test.ts` passed 2 files and 4 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; this is a focused docs route and guard change with targeted coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors; Fern reported 2 existing hidden warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable; no new documentation page.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Network Policies docs so the step-by-step approval guide link only appears for supported variants, reducing broken or irrelevant links.
* **Tests**
  * Added coverage to confirm the published documentation routes resolve correctly for the Network Policies page.
* **Chores**
  * Expanded documentation link checks to include an additional guarded reference page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->